### PR TITLE
chore: add gitleaks pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ Thumbs.db
 
 # Design docs
 *-design-*.md
+
+# Gitleaks config (symlink to shared config)
+.gitleaks.toml
+
+.gitleaksbaseline.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.0
+    hooks:
+      - id: gitleaks
+        args: ['--baseline-path', '.gitleaksbaseline.json']


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with gitleaks hook for pre-commit secret scanning
- Update `.gitignore` for gitleaks config and baseline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)