### PR TITLE
EOD Step Function definition

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1,0 +1,248 @@
+{
+  "Comment": "Alpha Engine EOD Pipeline — post-market data capture, reconciliation, instance shutdown. Triggered by daemon shutdown on trading EC2.",
+  "StartAt": "PostMarketData",
+  "States": {
+
+    "PostMarketData": {
+      "Type": "Task",
+      "Comment": "Capture today's closing prices from polygon + append to ArcticDB (runs on micro EC2)",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.ec2_instance_id",
+        "Parameters": {
+          "commands": [
+            "cd /home/ec2-user/alpha-engine-data",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "python weekly_collector.py --daily --only daily_closes 2>&1 | tee /var/log/postmarket-data.log",
+            "python -m builders.daily_append 2>&1 | tee -a /var/log/postmarket-data.log"
+          ],
+          "executionTimeout": ["180"]
+        },
+        "TimeoutSeconds": 180
+      },
+      "TimeoutSeconds": 240,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "PostMarketData failure is non-blocking — EOD can still use IB Gateway prices as fallback",
+          "Next": "EODReconcile",
+          "ResultPath": "$.postmarket_error"
+        }
+      ],
+      "ResultPath": "$.postmarket_result",
+      "Next": "WaitForPostMarketData"
+    },
+
+    "WaitForPostMarketData": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.postmarket_result.Command.CommandId",
+        "InstanceId.$": "$.ec2_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "EODReconcile",
+          "ResultPath": "$.postmarket_error"
+        }
+      ],
+      "ResultPath": "$.postmarket_poll",
+      "Next": "CheckPostMarketStatus"
+    },
+
+    "CheckPostMarketStatus": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.postmarket_poll.Status",
+          "StringEquals": "Success",
+          "Next": "EODReconcile"
+        },
+        {
+          "Variable": "$.postmarket_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "PostMarketWait"
+        },
+        {
+          "Variable": "$.postmarket_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "PostMarketWait"
+        }
+      ],
+      "Default": "EODReconcile"
+    },
+
+    "PostMarketWait": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "WaitForPostMarketData"
+    },
+
+    "EODReconcile": {
+      "Type": "Task",
+      "Comment": "Run EOD reconciliation on trading EC2 — reads closes from S3, computes P&L, sends email",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "cd /home/ec2-user/alpha-engine",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "python executor/eod_reconcile.py 2>&1 | tee /var/log/eod.log"
+          ],
+          "executionTimeout": ["120"]
+        },
+        "TimeoutSeconds": 120
+      },
+      "TimeoutSeconds": 180,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "StopTradingInstance",
+          "ResultPath": "$.eod_error"
+        }
+      ],
+      "ResultPath": "$.eod_result",
+      "Next": "WaitForEOD"
+    },
+
+    "WaitForEOD": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.eod_result.Command.CommandId",
+        "InstanceId.$": "$.trading_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "StopTradingInstance",
+          "ResultPath": "$.eod_error"
+        }
+      ],
+      "ResultPath": "$.eod_poll",
+      "Next": "CheckEODStatus"
+    },
+
+    "CheckEODStatus": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.eod_poll.Status",
+          "StringEquals": "Success",
+          "Next": "StopTradingInstance"
+        },
+        {
+          "Variable": "$.eod_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "EODWait"
+        },
+        {
+          "Variable": "$.eod_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "EODWait"
+        }
+      ],
+      "Default": "StopTradingInstance"
+    },
+
+    "EODWait": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "Next": "WaitForEOD"
+    },
+
+    "StopTradingInstance": {
+      "Type": "Task",
+      "Comment": "Stop trading EC2 instance after EOD completes",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:stopInstances",
+      "Parameters": {
+        "InstanceIds.$": "$.trading_instance_id"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.stop_result",
+      "End": true
+    },
+
+    "HandleFailure": {
+      "Type": "Task",
+      "Comment": "Failure alert via SNS — instance still stops to avoid cost",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine EOD Pipeline — FAILED",
+        "Message.$": "States.Format('EOD pipeline failed. Error: {}', States.JsonToString($.error))"
+      },
+      "ResultPath": "$.failure_notify",
+      "Next": "ForceStopInstance"
+    },
+
+    "ForceStopInstance": {
+      "Type": "Task",
+      "Comment": "Always stop trading instance even on failure — avoid cost overrun",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:stopInstances",
+      "Parameters": {
+        "InstanceIds.$": "$.trading_instance_id"
+      },
+      "ResultPath": "$.force_stop_result",
+      "Next": "FailExecution"
+    },
+
+    "FailExecution": {
+      "Type": "Fail",
+      "Error": "EODPipelineFailure",
+      "Cause": "EOD pipeline failed — trading instance stopped, check logs."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New Step Function: alpha-engine-eod-pipeline
- Triggered by daemon shutdown (not cron/timer)
- PostMarketData (micro EC2) → EODReconcile (trading EC2) → StopInstance
- PostMarketData failure is non-blocking (EOD falls back to IB Gateway prices)
- Instance always stops, even on failure (ForceStopInstance fallback)

## Deployment
After merge, create the Step Function in AWS:
aws stepfunctions create-state-machine --name alpha-engine-eod-pipeline --definition file://infrastructure/step_function_eod.json --role-arn arn:aws:iam::711398986525:role/alpha-engine-step-function-role

## Test plan
- [ ] Step Function created in AWS console
- [ ] Daemon triggers it on shutdown
- [ ] Full pipeline completes: PostMarketData → EOD → StopInstance