### PR TITLE
Add PredictorHealthCheck to weekday pipeline

### DIFF
--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -48,7 +48,8 @@ POLICY='{
       "Resource": [
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-runner*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*"
+        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*",
+        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-health-check*"
       ]
     },
     {

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -204,6 +204,37 @@
         }
       ],
       "ResultPath": "$.predictor_result",
+      "Next": "PredictorHealthCheck"
+    },
+
+    "PredictorHealthCheck": {
+      "Type": "Task",
+      "Comment": "Daily predictor model health — IC, hit rate, calibration, retrain triggers",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-health-check:live",
+        "Payload": {
+          "action": "check"
+        }
+      },
+      "TimeoutSeconds": 180,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Health check is non-blocking — continue to data health check and executor",
+          "Next": "HealthCheck",
+          "ResultPath": "$.predictor_health_error"
+        }
+      ],
+      "ResultPath": "$.predictor_health_result",
       "Next": "HealthCheck"
     },
 


### PR DESCRIPTION
## Summary
- Insert `PredictorHealthCheck` Lambda invoke between `PredictorInference` and `HealthCheck` in weekday Step Function
- Non-blocking: Catch sends to HealthCheck on failure (doesn't halt trading)
- IAM policy updated with `alpha-engine-predictor-health-check*` Lambda ARN

Companion PR: cipher813/alpha-engine-backtester#5 (Lambda code + deploy script)

## Test plan
- [x] Step Function already redeployed and live
- [x] Lambda canary passed (dry_run=true)
- [ ] Monitor first live run tomorrow 6:05 AM PT

🤖 Generated with [Claude Code](https://claude.com/claude-code)