### PR TITLE
fix: holiday check false positives on trading days

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -24,7 +24,7 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "NotifyHolidaySkip",
+          "Next": "TradingDayCheckFailed",
           "ResultPath": "$.error"
         }
       ],
@@ -50,7 +50,7 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "NotifyHolidaySkip",
+          "Next": "TradingDayCheckFailed",
           "ResultPath": "$.error"
         }
       ],
@@ -60,20 +60,75 @@
 
     "CheckTradingDayResult": {
       "Type": "Choice",
-      "Comment": "Exit code 0 = trading day (proceed), non-zero = holiday (skip)",
+      "Comment": "Check SSM status first (InProgress/Pending = poll again), then check stdout for TRADING_DAY vs MARKET_CLOSED marker. Script always exits 0 — Failed means a real error.",
       "Choices": [
         {
           "Variable": "$.trading_day_poll.Status",
-          "StringEquals": "Success",
+          "StringEquals": "InProgress",
+          "Next": "TradingDayCheckWait"
+        },
+        {
+          "Variable": "$.trading_day_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "TradingDayCheckWait"
+        },
+        {
+          "Variable": "$.trading_day_poll.Status",
+          "StringEquals": "Failed",
+          "Next": "TradingDayCheckFailed"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.trading_day_poll.Status",
+              "StringEquals": "Success"
+            },
+            {
+              "Variable": "$.trading_day_poll.StandardOutputContent",
+              "StringMatches": "*MARKET_CLOSED*"
+            }
+          ],
+          "Next": "NotifyHolidaySkip"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.trading_day_poll.Status",
+              "StringEquals": "Success"
+            },
+            {
+              "Variable": "$.trading_day_poll.StandardOutputContent",
+              "StringMatches": "*TRADING DAY*"
+            }
+          ],
           "Next": "DailyData"
         }
       ],
-      "Default": "NotifyHolidaySkip"
+      "Default": "TradingDayCheckFailed"
+    },
+
+    "TradingDayCheckWait": {
+      "Type": "Wait",
+      "Seconds": 5,
+      "Next": "WaitForTradingDayCheck"
+    },
+
+    "TradingDayCheckFailed": {
+      "Type": "Task",
+      "Comment": "Trading day check failed for infrastructure reasons — alert and proceed (assume trading day)",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Pipeline — Trading Day Check Failed (Proceeding)",
+        "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. Error: {}', States.JsonToString($.error))"
+      },
+      "ResultPath": "$.trading_day_error_notify",
+      "Next": "DailyData"
     },
 
     "NotifyHolidaySkip": {
       "Type": "Task",
-      "Comment": "Notify that pipeline was skipped due to market holiday",
+      "Comment": "Notify that pipeline was skipped — trading_calendar.py stdout contains MARKET_CLOSED",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",

--- a/trading_calendar.py
+++ b/trading_calendar.py
@@ -9,8 +9,11 @@ Usage:
     python trading_calendar.py 2026-04-03   # check specific date
 
 Exit codes:
-    0 = trading day
-    1 = not a trading day (weekend or holiday)
+    Always exits 0 — Step Function checks stdout markers, not exit code.
+
+Stdout markers:
+    "TRADING DAY"  = NYSE is open (proceed with pipeline)
+    "MARKET_CLOSED" = weekend or holiday (skip pipeline)
 """
 
 from __future__ import annotations
@@ -125,5 +128,7 @@ if __name__ == "__main__":
     else:
         reason = "weekend" if check_date.weekday() > 4 else "NYSE holiday"
         nxt = next_trading_day(check_date)
-        print(f"{check_date} ({day_name}): CLOSED ({reason}) — next trading day: {nxt}")
-        sys.exit(1)
+        print(f"{check_date} ({day_name}): MARKET_CLOSED ({reason}) — next trading day: {nxt}")
+        # Exit 0 so SSM reports Success — Step Function checks stdout marker
+        # instead of exit code to distinguish holidays from script crashes.
+        sys.exit(0)


### PR DESCRIPTION
## Summary
- **Root cause:** `trading_calendar.py` used `sys.exit(1)` for holidays, but SSM reports `Failed` for any non-zero exit — crashes, missing files, venv issues all looked like holidays to the Step Function
- Script now always exits 0 with stdout markers (`TRADING DAY` / `MARKET_CLOSED`). Step Function checks `StandardOutputContent` instead of SSM status
- Added `TradingDayCheckFailed` state: infrastructure errors send an alert but proceed as trading day (fail-open) instead of silently skipping
- Added `InProgress`/`Pending` polling loop — was missing, so unfinished SSM commands defaulted to holiday skip

## Test plan
- [x] All 13 trading calendar tests pass
- [x] Step Function JSON validates
- [ ] After merge: deploy Step Function via `deploy_step_function_daily.sh`
- [ ] After merge: `git pull` on EC2 micro instance
- [ ] Verify next trading day pipeline runs through CheckTradingDay → DailyData

🤖 Generated with [Claude Code](https://claude.com/claude-code)