### PR TITLE
Fix macro breadth: compute from slim cache instead of writing null

### DIFF
--- a/collectors/macro.py
+++ b/collectors/macro.py
@@ -25,6 +25,8 @@ import pandas as pd
 import requests
 import yfinance as yf
 
+from store.parquet_loader import load_slim_cache
+
 logger = logging.getLogger(__name__)
 
 _FRED_BASE = "https://api.stlouisfed.org/fred/series/observations"
@@ -69,11 +71,27 @@ def collect(
     market = _fetch_market_prices()
     macro.update(market)
 
-    # Compute breadth if price data is available
+    # Compute breadth. If the caller did not pass in price_data, load the
+    # slim cache that Phase 1 just wrote to S3 so downstream Research still
+    # gets a real breadth reading. If that load fails for any reason, we
+    # OMIT the "breadth" key entirely rather than writing null — Research
+    # has its own fallback and macro_agent reads macro_data.get("breadth", {}),
+    # which only honors the default when the key is missing.
+    if price_data is None:
+        try:
+            s3_read = boto3.client("s3")
+            price_data = load_slim_cache(s3_read, bucket)
+        except Exception as exc:
+            logger.warning("Failed to load slim cache for breadth: %s", exc)
+            price_data = None
+
     if price_data:
         macro["breadth"] = _compute_market_breadth(price_data)
     else:
-        macro["breadth"] = None
+        logger.warning(
+            "No price data available for breadth — omitting breadth key "
+            "(research will fall back to its own computation)"
+        )
 
     macro["fetched_at"] = datetime.now(timezone.utc).isoformat()
 

--- a/features/compute.py
+++ b/features/compute.py
@@ -29,7 +29,6 @@ import json
 import logging
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -76,85 +75,15 @@ def _load_sector_map(s3, bucket: str) -> dict[str, str]:
         return {}
 
 
-def _load_parquet_from_s3(s3, bucket: str, key: str) -> pd.DataFrame:
-    """Download a single parquet file from S3 and return as DataFrame.
-
-    Normalizes to timezone-naive UTC DatetimeIndex, matching the predictor's
-    ``_load_ticker_parquet`` behaviour so that downstream reindex/join calls
-    don't raise TypeError when mixing tz-aware and tz-naive indices.
-    """
-    obj = s3.get_object(Bucket=bucket, Key=key)
-    buf = io.BytesIO(obj["Body"].read())
-    df = pd.read_parquet(buf, engine="pyarrow")
-    # Ensure DatetimeIndex
-    if not isinstance(df.index, pd.DatetimeIndex):
-        if "Date" in df.columns:
-            df["Date"] = pd.to_datetime(df["Date"])
-            df = df.set_index("Date")
-        elif "date" in df.columns:
-            df["date"] = pd.to_datetime(df["date"])
-            df = df.set_index("date")
-        else:
-            df.index = pd.to_datetime(df.index)
-    # Normalize timezone: convert to UTC then strip tz info (match predictor)
-    if isinstance(df.index, pd.DatetimeIndex) and df.index.tz is not None:
-        df.index = df.index.tz_convert("UTC").tz_localize(None)
-    # Ensure sorted
-    if isinstance(df.index, pd.DatetimeIndex) and not df.index.is_monotonic_increasing:
-        df = df.sort_index()
-    return df
-
-
-def _load_slim_cache(s3, bucket: str) -> dict[str, pd.DataFrame]:
-    """
-    Load all parquets from predictor/price_cache_slim/ using concurrent downloads.
-
-    Returns dict of ticker -> DataFrame (OHLCV with DatetimeIndex).
-    """
-    prefix = "predictor/price_cache_slim/"
-
-    # List all parquet keys
-    keys = []
-    paginator = s3.get_paginator("list_objects_v2")
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-        for obj in page.get("Contents", []):
-            if obj["Key"].endswith(".parquet"):
-                keys.append(obj["Key"])
-
-    if not keys:
-        log.warning("No parquets found in s3://%s/%s", bucket, prefix)
-        return {}
-
-    log.info("Downloading %d slim cache parquets...", len(keys))
-
-    price_data: dict[str, pd.DataFrame] = {}
-    errors = 0
-
-    def _download(key: str) -> tuple[str, pd.DataFrame | None]:
-        ticker = key.split("/")[-1].replace(".parquet", "")
-        try:
-            df = _load_parquet_from_s3(s3, bucket, key)
-            if df.empty:
-                return ticker, None
-            return ticker, df
-        except Exception:
-            return ticker, None
-
-    with ThreadPoolExecutor(max_workers=20) as pool:
-        futures = {pool.submit(_download, k): k for k in keys}
-        for fut in as_completed(futures):
-            ticker, df = fut.result()
-            if df is not None:
-                price_data[ticker] = df
-            else:
-                errors += 1
-
-    log.info("Slim cache loaded: %d tickers OK, %d errors", len(price_data), errors)
-    return price_data
-
-
-    # _load_full_cache removed — slim cache (2y) is sufficient for feature computation.
-    # Features only use the latest row; 2y provides enough warmup for all indicators.
+# Shared S3 parquet loaders live in store.parquet_loader so non-feature
+# callers (e.g. collectors.macro's breadth computation) can reuse the same
+# normalized DataFrame shape without importing private helpers. Slim cache
+# (2y) is sufficient here — features only use the latest row and 2y gives
+# enough warmup for every indicator.
+from store.parquet_loader import (
+    load_parquet_from_s3 as _load_parquet_from_s3,
+    load_slim_cache as _load_slim_cache,
+)
 
 
 def _safe_last_date(idx: pd.Index) -> pd.Timestamp | None:

--- a/store/parquet_loader.py
+++ b/store/parquet_loader.py
@@ -1,0 +1,95 @@
+"""
+store/parquet_loader.py — Shared S3 parquet / slim-cache loading helpers.
+
+Extracted from features/compute.py so that non-feature callers (e.g. the
+macro collector's breadth computation) can reuse the same normalized
+DataFrame shape without importing private helpers out of features.*.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+SLIM_CACHE_PREFIX = "predictor/price_cache_slim/"
+
+
+def load_parquet_from_s3(s3, bucket: str, key: str) -> pd.DataFrame:
+    """Download a single parquet from S3 and return a normalized DataFrame.
+
+    Normalizes the index to a tz-naive UTC DatetimeIndex (sorted ascending),
+    matching the convention used by the predictor and feature store so that
+    downstream reindex / join operations never raise on mixed tz.
+    """
+    obj = s3.get_object(Bucket=bucket, Key=key)
+    buf = io.BytesIO(obj["Body"].read())
+    df = pd.read_parquet(buf, engine="pyarrow")
+    if not isinstance(df.index, pd.DatetimeIndex):
+        if "Date" in df.columns:
+            df["Date"] = pd.to_datetime(df["Date"])
+            df = df.set_index("Date")
+        elif "date" in df.columns:
+            df["date"] = pd.to_datetime(df["date"])
+            df = df.set_index("date")
+        else:
+            df.index = pd.to_datetime(df.index)
+    if isinstance(df.index, pd.DatetimeIndex) and df.index.tz is not None:
+        df.index = df.index.tz_convert("UTC").tz_localize(None)
+    if isinstance(df.index, pd.DatetimeIndex) and not df.index.is_monotonic_increasing:
+        df = df.sort_index()
+    return df
+
+
+def load_slim_cache(
+    s3,
+    bucket: str,
+    prefix: str = SLIM_CACHE_PREFIX,
+    max_workers: int = 20,
+) -> dict[str, pd.DataFrame]:
+    """Load every parquet under `prefix` into a ticker -> DataFrame dict.
+
+    Returns an empty dict if the prefix is empty. Individual ticker failures
+    are logged and skipped; the caller decides how to handle a partial load.
+    """
+    keys: list[str] = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".parquet"):
+                keys.append(obj["Key"])
+
+    if not keys:
+        log.warning("No parquets found in s3://%s/%s", bucket, prefix)
+        return {}
+
+    log.info("Downloading %d slim cache parquets...", len(keys))
+
+    price_data: dict[str, pd.DataFrame] = {}
+    errors = 0
+
+    def _download(key: str) -> tuple[str, pd.DataFrame | None]:
+        ticker = key.split("/")[-1].replace(".parquet", "")
+        try:
+            df = load_parquet_from_s3(s3, bucket, key)
+            if df.empty:
+                return ticker, None
+            return ticker, df
+        except Exception:
+            return ticker, None
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_download, k): k for k in keys}
+        for fut in as_completed(futures):
+            ticker, df = fut.result()
+            if df is not None:
+                price_data[ticker] = df
+            else:
+                errors += 1
+
+    log.info("Slim cache loaded: %d tickers OK, %d errors", len(price_data), errors)
+    return price_data

--- a/tests/test_macro_breadth.py
+++ b/tests/test_macro_breadth.py
@@ -1,0 +1,122 @@
+"""
+Tests for collectors.macro breadth handling.
+
+Guards against the regression fixed in this PR: previously the collector
+would write ``breadth: null`` into macro.json whenever price_data wasn't
+supplied, which later crashed alpha-engine-research macro_agent at
+``breadth.get("pct_above_50d_ma")`` (NoneType has no .get).
+
+The contract now is:
+- If we have price_data (either passed in or loaded from slim cache), write
+  a computed breadth dict.
+- If we have no price data, OMIT the "breadth" key entirely — never write
+  null — so downstream consumers fall through to their own computation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from collectors import macro
+
+
+def _synthetic_price_frame(n: int = 220, start: float = 100.0) -> pd.DataFrame:
+    idx = pd.bdate_range(end=pd.Timestamp("2026-04-10"), periods=n)
+    close = np.linspace(start, start * 1.2, n)
+    return pd.DataFrame({"Close": close}, index=idx)
+
+
+def _stub_fetchers(monkeypatch):
+    """Stub out the external FRED/yfinance calls so unit tests stay offline."""
+    monkeypatch.setattr(
+        macro, "_fetch_fred", lambda: {"fed_funds_rate": 3.5, "vix": 18.0}
+    )
+    monkeypatch.setattr(
+        macro,
+        "_fetch_market_prices",
+        lambda: {"sp500_close": 650.0, "sp500_30d_return": 2.0},
+    )
+
+
+def test_breadth_computed_when_price_data_supplied(monkeypatch):
+    _stub_fetchers(monkeypatch)
+    price_data = {
+        "AAPL": _synthetic_price_frame(),
+        "MSFT": _synthetic_price_frame(start=300.0),
+        "GOOG": _synthetic_price_frame(start=140.0),
+    }
+
+    # Intercept S3 writes
+    written = {}
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            written.update(kwargs)
+
+    monkeypatch.setattr(macro.boto3, "client", lambda service: _FakeS3())
+
+    result = macro.collect(
+        bucket="test-bucket",
+        price_data=price_data,
+        run_date="2026-04-11",
+    )
+
+    assert result["status"] == "ok"
+    import json
+    body = json.loads(written["Body"])
+    assert "breadth" in body
+    assert isinstance(body["breadth"], dict)
+    assert "pct_above_50d_ma" in body["breadth"]
+    assert body["breadth"] is not None
+
+
+def test_breadth_key_omitted_when_no_price_data_and_slim_cache_empty(monkeypatch):
+    """The critical regression: breadth must NEVER be serialized as null."""
+    _stub_fetchers(monkeypatch)
+
+    # slim cache load returns empty dict (no parquets in S3)
+    monkeypatch.setattr(macro, "load_slim_cache", lambda s3, bucket: {})
+
+    written = {}
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            written.update(kwargs)
+
+    monkeypatch.setattr(macro.boto3, "client", lambda service: _FakeS3())
+
+    result = macro.collect(
+        bucket="test-bucket",
+        run_date="2026-04-11",
+    )
+
+    assert result["status"] == "ok"
+    import json
+    body = json.loads(written["Body"])
+    # breadth key must be ABSENT — not present with a null value.
+    assert "breadth" not in body
+
+
+def test_breadth_key_omitted_when_slim_cache_load_raises(monkeypatch):
+    _stub_fetchers(monkeypatch)
+
+    def _boom(s3, bucket):
+        raise RuntimeError("S3 unreachable")
+
+    monkeypatch.setattr(macro, "load_slim_cache", _boom)
+
+    written = {}
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            written.update(kwargs)
+
+    monkeypatch.setattr(macro.boto3, "client", lambda service: _FakeS3())
+
+    result = macro.collect(bucket="test-bucket", run_date="2026-04-11")
+    assert result["status"] == "ok"
+    import json
+    body = json.loads(written["Body"])
+    assert "breadth" not in body


### PR DESCRIPTION
## Summary
- Root cause of tonight's Saturday Step Function failure. `collectors/macro.py` was writing `"breadth": null` into `macro.json` whenever `price_data` wasn't passed in (every Phase 1 run). Downstream, research's `macro_agent.run_macro_agent` did `breadth = macro_data.get("breadth", {})` — the `{}` default only applies to *missing* keys, not explicit null — so `breadth.get("pct_above_50d_ma")` blew up with `AttributeError: 'NoneType' object has no attribute 'get'` and the whole pipeline bailed out.
- Fix: `macro.collect` now loads the slim cache from S3 when no `price_data` is supplied (the slim cache is already written by step 3 of Phase 1, so it's always present by the time macro runs at step 4). If that load fails for any reason, the `breadth` key is **omitted** entirely rather than written as null — research has its own fallback and reads `.get("breadth", {})`.
- Extracted the slim cache parquet loader out of `features/compute.py` into a new `store/parquet_loader.py` so `collectors/macro.py` and `features/compute.py` can share it without reaching into a private `_load_slim_cache`.
- 3 new tests guard the regression: breadth dict present when `price_data` is supplied, key absent on empty slim cache, key absent on S3 exception.

## Follow-ups
- Defensive safety-net in `alpha-engine-research/agents/macro_agent.py` lines 176 + 322: `breadth = macro_data.get("breadth") or {}` — separate PR in the research repo.
- Saturday Step Function's `HandleFailure` state references `$.error` on the soft-failure path (where research returns `status:"ERROR"`), but the Lambda result lives at `$.research_result.Payload.error`. That's what masked tonight's real error as a `States.Runtime`. Separate infra PR.

## Test plan
- [x] `pytest tests/ -x -q` — 61 passed (3 new tests)
- [x] Import smoke test — store.parquet_loader, collectors.macro, features.compute
- [ ] After merge + auto-deploy, manually run macro-only Phase 1 on ae-data and confirm macro.json contains a populated breadth dict
- [ ] Restart Saturday Step Function execution from the beginning and confirm Research succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)