### PR TITLE
Fix Phase 2 Lambda deploy: drop dead COPY config.yaml, copy store/

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       # (not Lambda) so changes to phase1-only code would still require a
       # separate deploy mechanism — see weekly_collector.py path guard.
       - 'collectors/**'
+      - 'store/**'
       - 'weekly_collector.py'
       - 'polygon_client.py'
       - 'config.py'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,15 @@ RUN pip install --no-cache-dir \
 COPY collectors/ ${LAMBDA_TASK_ROOT}/collectors/
 COPY polygon_client.py ${LAMBDA_TASK_ROOT}/
 COPY weekly_collector.py ${LAMBDA_TASK_ROOT}/
-COPY config.yaml ${LAMBDA_TASK_ROOT}/config.yaml
+COPY store/ ${LAMBDA_TASK_ROOT}/store/
+
+# NOTE: config.yaml is intentionally NOT copied here. It is gitignored
+# (contains bucket names + prefixes that we keep out of the public repo)
+# so there's nothing to copy at build time, and lambda/handler.py already
+# falls back to a hardcoded default ({"bucket": "alpha-engine-research",
+# "market_data": {"s3_prefix": "market_data/"}}) when config.yaml is
+# absent. Including it here was a dead COPY that broke `docker build`
+# on every fresh checkout and blocked the auto-deploy workflow.
 
 # Lambda handler
 COPY lambda/handler.py ${LAMBDA_TASK_ROOT}/handler.py


### PR DESCRIPTION
## Summary
The Phase 2 Lambda `Deploy` workflow has been failing on **every** push to main since #12 merged yesterday — including the #13 merge a few minutes ago. The failure is unrelated to #13; #12 introduced it.

Root cause: the Dockerfile copies `config.yaml` into the image, but `config.yaml` is gitignored per the repo's security policy. There is literally nothing to copy at build time, so `docker build` dies with:

```
ERROR: failed to calculate checksum of ref ...
"/config.yaml": not found
```

`lambda/handler.py` already falls back to a hardcoded default (`{"bucket": "alpha-engine-research", "market_data": {"s3_prefix": "market_data/"}}`) when `config.yaml` is absent, so the COPY was dead weight *and* a build breakage.

## Changes
- **Dockerfile**: drop `COPY config.yaml`, leave an inline comment explaining why it must not come back.
- **Dockerfile**: add `COPY store/ ${LAMBDA_TASK_ROOT}/store/` — the store package is new (from #13) and `collectors/macro.py` imports from it at module top level. `weekly_collector.py` is in the image and does `from collectors import macro`, so any future handler refactor that touches weekly_collector would bomb on `ModuleNotFoundError: store` without this.
- **.github/workflows/deploy.yml**: add `store/**` to the paths filter so future changes to the shared loader retrigger the deploy workflow.

## Test plan
- [x] `pytest tests/ -q` — 61 passed
- [x] Gitleaks pre-commit pass
- [ ] After merge, verify `Deploy` workflow on main turns green
- [ ] Confirm Phase 2 Lambda's `LastModified` timestamp moves forward after the merge

## Follow-up
The `Deploy` workflow only runs on push to `main`, not on PR. Consider adding a `docker build --dry-run` step to `ci.yml` (or a separate `build-check` workflow on PR) so that breakage like this is caught before merge. Not in scope for this hot-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)