### PR TITLE
Version-control IAM policies; add lambda:InvokeFunction to deploy role

### DIFF
--- a/infrastructure/iam/apply.sh
+++ b/infrastructure/iam/apply.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# apply.sh — Apply all IAM policies in this directory to their matching roles.
+#
+# Each JSON file in this directory is treated as a role policy document. The
+# filename (minus .json) is BOTH the target IAM role name AND the inline
+# policy name. This keeps the mapping trivial: one file == one role == one
+# policy. If you need multiple policies per role, put them in multiple files
+# and accept the duplicate role name.
+#
+# This is intentionally low-ceremony — no CloudFormation, no Terraform. For
+# a 5-module infra-light project, a flat JSON directory + idempotent apply
+# script is the right amount of rigor. If the blast radius grows, migrate
+# to CloudFormation/Terraform.
+#
+# Usage:
+#   ./infrastructure/iam/apply.sh                  # apply every policy
+#   ./infrastructure/iam/apply.sh github-actions-lambda-deploy   # one role
+#   ./infrastructure/iam/apply.sh --dry-run        # print planned commands
+#
+# Prerequisites:
+#   - AWS CLI configured with iam:PutRolePolicy on the target roles
+#   - The target IAM roles already exist (this script only updates inline
+#     policies; it does NOT create the roles themselves, because the trust
+#     policies differ and are outside the scope of a simple flat-file
+#     approach)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REGION="${AWS_REGION:-us-east-1}"
+
+DRY_RUN=0
+TARGET_ROLE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) TARGET_ROLE="$arg" ;;
+  esac
+done
+
+apply_one() {
+  local file="$1"
+  local role
+  role="$(basename "$file" .json)"
+  local policy_name="${role}-policy"
+
+  # Validate JSON locally before shipping it to IAM
+  if ! python3 -c "import json; json.load(open('$file'))" 2>/dev/null; then
+    echo "ERROR: $file is not valid JSON — skipping" >&2
+    return 1
+  fi
+
+  echo "Applying $file -> role=$role policy=$policy_name"
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "  [dry-run] aws iam put-role-policy --role-name $role --policy-name $policy_name --policy-document file://$file --region $REGION"
+    return 0
+  fi
+
+  aws iam put-role-policy \
+    --role-name "$role" \
+    --policy-name "$policy_name" \
+    --policy-document "file://$file" \
+    --region "$REGION"
+  echo "  OK"
+}
+
+cd "$SCRIPT_DIR"
+
+if [ -n "$TARGET_ROLE" ]; then
+  file="${TARGET_ROLE}.json"
+  if [ ! -f "$file" ]; then
+    echo "ERROR: $file not found in $SCRIPT_DIR" >&2
+    exit 1
+  fi
+  apply_one "$file"
+else
+  shopt -s nullglob
+  files=( *.json )
+  if [ ${#files[@]} -eq 0 ]; then
+    echo "No .json policy files found in $SCRIPT_DIR"
+    exit 0
+  fi
+  for file in "${files[@]}"; do
+    apply_one "$file"
+  done
+fi

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -1,0 +1,70 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECRAuth",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ECRPush",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage",
+        "ecr:BatchGetImage",
+        "ecr:DescribeImages",
+        "ecr:DescribeRepositories"
+      ],
+      "Resource": [
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-research-runner",
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-research-alerts",
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-predictor",
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-data-collector",
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-health-check"
+      ]
+    },
+    {
+      "Sid": "LambdaUpdate",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
+        "lambda:PublishVersion",
+        "lambda:UpdateAlias"
+      ],
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check"
+      ]
+    },
+    {
+      "Sid": "LambdaInvokeCanary",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check:*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Tonight's third-in-a-row red deploy surfaced a gap: the GitHub Actions OIDC role \`github-actions-lambda-deploy\` has been missing \`lambda:InvokeFunction\` since #12 introduced it. Every auto-deploy since has looked red, but the underlying Lambda updates actually succeeded — \`infrastructure/deploy.sh\`'s post-update canary step fails with \`AccessDenied\`, the rollback then silently swallows its own error via \`|| true\`, and the alias ends up stranded on whatever version just got published. Three deploys in a row (#13, #14, #16) all looked like failures despite the Lambda being updated.

You also flagged that we're not version-controlling IAM at all, which is how this gap existed without anyone noticing.

## Changes
1. **\`infrastructure/iam/\`** — new home for version-controlled IAM policies. Flat JSON files, one per role, applied by an idempotent shell script. No CloudFormation, no Terraform. For a 5-module infra-light project, this is the right amount of rigor — migrate to CFN later if the blast radius grows.
2. **\`infrastructure/iam/github-actions-lambda-deploy.json\`** — full policy document for the OIDC deploy role. Preserves the existing ECRAuth, ECRPush, and LambdaUpdate statements verbatim, adds a new \`LambdaInvokeCanary\` statement granting \`lambda:InvokeFunction\` on all 5 alpha-engine Lambdas + their aliases/versions.
3. **\`infrastructure/iam/apply.sh\`** — idempotent applier. One policy file per role, filename == role name. Supports \`--dry-run\` and single-role invocation.

## Already applied live
Applied before committing so tonight's next deploy isn't blocked:

\`\`\`
$ infrastructure/iam/apply.sh github-actions-lambda-deploy
Applying github-actions-lambda-deploy.json -> role=github-actions-lambda-deploy policy=github-actions-lambda-deploy-policy
  OK

$ aws iam delete-role-policy --role-name github-actions-lambda-deploy --policy-name deploy-lambdas
# cleaned up the orphaned old inline policy name
\`\`\`

## Blast radius analysis
The new Invoke permission is scoped to exactly the same 5 Lambda ARNs the role already has \`UpdateFunctionCode\` on. An attacker with ECR push + UpdateFunctionCode can already run arbitrary code in these Lambdas — adding InvokeFunction doesn't meaningfully expand what they can do. The alternative (short-circuit canary in CI) would silently skip the safety check in the environment where it matters most (unattended deploys), which is strictly worse.

## Test plan
- [x] JSON validates
- [x] \`apply.sh --dry-run\` generates correct commands
- [x] Applied to live AWS IAM, \`list-role-policies\` shows exactly one inline policy matching the committed file
- [x] Manual canary via local creds still works (\`status: "OK"\`)
- [ ] **Merge this PR → the Deploy workflow run for the merge commit should be the first green auto-deploy since #12**
- [ ] Subsequent deploys should either go fully green or auto-rollback as designed

## Known follow-up (NOT in scope)
\`infrastructure/deploy.sh\`'s rollback block uses \`|| true\` to swallow errors silently (lines 188-193), which is why the stranded alias never got rolled back on the three recent broken canaries. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)