### PR TITLE
Remove dead IAM bootstrap block from deploy.sh

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -196,45 +196,19 @@ if [ "$CANARY_STATUS" != "OK" ] && [ "$CANARY_STATUS" != "SKIPPED" ]; then
 fi
 echo "  Canary passed (status=$CANARY_STATUS)"
 
-# ── IAM role setup (create if doesn't exist) ──────────────────────────────
-
-echo ""
-echo "Checking IAM role: alpha-engine-data-role..."
-if ! aws iam get-role --role-name "alpha-engine-data-role" --region "$REGION" &>/dev/null; then
-  echo "  Creating IAM role..."
-  aws iam create-role \
-    --role-name "alpha-engine-data-role" \
-    --assume-role-policy-document '{
-      "Version": "2012-10-17",
-      "Statement": [
-        {"Effect": "Allow", "Principal": {"Service": "lambda.amazonaws.com"}, "Action": "sts:AssumeRole"}
-      ]
-    }' --region "$REGION" > /dev/null
-
-  aws iam put-role-policy \
-    --role-name "alpha-engine-data-role" \
-    --policy-name "alpha-engine-data-policy" \
-    --policy-document '{
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Sid": "S3Access",
-          "Effect": "Allow",
-          "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
-          "Resource": ["arn:aws:s3:::alpha-engine-research", "arn:aws:s3:::alpha-engine-research/*"]
-        },
-        {
-          "Sid": "CloudWatchLogs",
-          "Effect": "Allow",
-          "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-          "Resource": "arn:aws:logs:*:*:*"
-        }
-      ]
-    }' --region "$REGION"
-  echo "  Created alpha-engine-data-role with S3 + CloudWatch access"
-else
-  echo "  Role exists"
-fi
+# NOTE: IAM role `alpha-engine-data-role` is a prerequisite (see header).
+# It currently exists in AWS and is the execution role for the live
+# alpha-engine-data-collector Lambda. A prior version of this script
+# tried to `aws iam get-role` as a "create-if-missing" bootstrap and
+# fell through to CreateRole when the GetRole call lacked permission —
+# masking the permission error as "role not found" (silent fail) and
+# then dying loudly on CreateRole. The github-actions-lambda-deploy
+# role intentionally lacks iam:* permissions (principle of least
+# privilege), so the bootstrap block had been dead code since day one
+# of the auto-deploy path. Provisioning this role is a one-time
+# operation — do it out of band with a privileged principal, ideally
+# by extending infrastructure/iam/ the way #17 did for
+# github-actions-lambda-deploy.
 
 echo ""
 echo "Deployment complete."


### PR DESCRIPTION
## Summary
Delete the \`Checking IAM role: alpha-engine-data-role\` bootstrap block at the end of \`infrastructure/deploy.sh\`. It's dead code with a silent-fail trap inside it, and it broke today's auto-deploy after the Lambda itself had already succeeded.

## Context
Today's Deploy workflow run (triggered by #18 merge) produced:

\`\`\`
Alias 'live' -> version 4
Canary passed (status=OK)              ← Lambda deploy SUCCEEDED

Checking IAM role: alpha-engine-data-role...
  Creating IAM role...                 ← dead-code path
Error: ... iam:CreateRole ... AccessDenied
\`\`\`

Two layers:

1. **Dead code.** \`alpha-engine-data-role\` has existed in AWS for months and is the live Lambda's execution role. The get-role check at line 203 should always succeed in steady state. The entire \`else\` branch (create role + attach inline policy) has never fired in steady state and never should. The header comments already list the role as a *prerequisite*.

2. **Silent fail inside the dead code.** The \`aws iam get-role\` call was followed by \`&>/dev/null\`, which swallows BOTH \"role not found\" and \"permission denied\". The deploy role (\`github-actions-lambda-deploy\`) intentionally lacks \`iam:*\` permissions (principle of least privilege). So the check treated every permission denial as \"role doesn't exist\" and fell through to CreateRole, which then failed explicitly. Classic no-silent-fails antipattern at the IAM layer.

## Fix
Delete the whole block. Replace with a comment explaining that the role is a one-time out-of-band provisioning concern. The version-controlled IAM pattern added in #17 (\`infrastructure/iam/apply.sh\`) is the right home for any future provisioning; this deploy path should never touch IAM.

## Impact
- Next push to main (or merging this PR) triggers a Deploy workflow run that should complete cleanly — Lambda deploys + canary + done.
- No behavioral change to the Lambda itself (version 4 already live and healthy).
- No IAM permissions added to the deploy role (good — minimum privilege preserved).

## Test plan
- [x] \`bash -n infrastructure/deploy.sh\` passes syntax check
- [x] 61 tests pass
- [ ] Merge → Deploy workflow completes green
- [ ] Next DataPhase1 run picks up the new hard-fail + features + universe fixes from #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)