### PR TITLE
Embed git pull + hard-fail exit propagation in Saturday Step Function SSM

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -12,11 +12,12 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine-data",
+            "git pull --ff-only origin main",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
-            "python weekly_collector.py --phase 1 2>&1 | tee /var/log/data-phase1.log",
-            "echo \"EXIT_CODE=$?\""
+            "python weekly_collector.py --phase 1 2>&1 | tee /var/log/data-phase1.log"
           ],
           "executionTimeout": ["1800"]
         },
@@ -106,11 +107,12 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine-data",
+            "git pull --ff-only origin main",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
-            "bash rag/pipelines/run_weekly_ingestion.sh 2>&1 | tee /var/log/rag-ingestion.log",
-            "echo \"EXIT_CODE=$?\""
+            "bash rag/pipelines/run_weekly_ingestion.sh 2>&1 | tee /var/log/rag-ingestion.log"
           ],
           "executionTimeout": ["1800"]
         },
@@ -279,10 +281,11 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine-predictor",
+            "git pull --ff-only origin main",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "set -o pipefail",
             "bash infrastructure/spot_train.sh --full-only 2>&1 | tee /var/log/predictor-training.log"
           ],
           "executionTimeout": ["5400"]
@@ -374,9 +377,11 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "export HOME=/home/ec2-user",
+            "cd /home/ec2-user/alpha-engine-data && git pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-predictor && git pull --ff-only origin main",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "set -o pipefail",
             "export PYTHONPATH=/home/ec2-user/alpha-engine-predictor",
             "/home/ec2-user/alpha-engine-data/.venv/bin/python -m monitoring.drift_detector --alert 2>&1 | tee /var/log/drift-detection.log"
           ],
@@ -406,10 +411,11 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine-backtester",
+            "git pull --ff-only origin main",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "set -o pipefail",
             "bash infrastructure/spot_backtest.sh 2>&1 | tee /var/log/backtester.log"
           ],
           "executionTimeout": ["7200"]
@@ -501,7 +507,9 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine-data",
+            "git pull --ff-only origin main",
             "source .venv/bin/activate",
             "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
           ],


### PR DESCRIPTION
## Summary
Fix three stacked bugs in every SSM command the Saturday Step Function issues to the ops EC2 instance:

1. **No `git pull`** — commands ran whatever was last manually checked out on \`/home/ec2-user/alpha-engine-{data,predictor,backtester}\`. PR #18 had been merged hours ago but the pipeline was still executing pre-#18 code. Now every SSM command starts with \`git pull --ff-only origin main\`.
2. **\`| tee\` without \`set -o pipefail\`** (DataPhase1, RAGIngestion, HealthCheck) — \`tee\`'s exit code masked Python's, so even SystemExit(1) reported as Success to SSM. Now every command starts with \`set -eo pipefail\`.
3. **Cosmetic \`echo \"EXIT_CODE=$?\"\` as the final line** (DataPhase1, RAGIngestion) — made the shell script's exit code \`echo\`'s exit code (always 0), losing whatever had happened earlier. Removed.

## Live deployment
Applied directly to the live state machine via:
\`\`\`
aws stepfunctions update-state-machine --state-machine-arn ... --definition file://infrastructure/step_function.json
\`\`\`
Revision: \`ac2011c6\`. This PR is the repo-side record.

## Answers to the \"what can we do to prevent this issue?\" question
- **Now (this PR):** git pull + set -eo pipefail + drop cosmetic echo — inside the Step Function itself so every run picks up main automatically.
- **Medium-term:** emit \`git rev-parse HEAD\` into every phase's manifest so drift between deployed code and expected code is monitorable.
- **Long-term:** immutable artifacts — build a tar/container with a git-SHA tag, upload to S3 on merge, SSM extracts. Eliminates the git-on-EC2 model entirely.

## Test plan
- [x] JSON validates
- [x] Live state machine updated
- [ ] Fresh execution kicks off cleanly
- [ ] DataPhase1 runs new code from PR #18; any non-ok collector fast-fails the pipeline
- [ ] CloudWatch logs contain \"Already up to date.\" or a valid \"Fast-forward\" line, not a silent skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)