### PR TITLE
Run SF git pull as ec2-user to avoid dubious ownership error

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -13,8 +13,8 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
-            "git pull --ff-only origin main",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "python weekly_collector.py --phase 1 2>&1 | tee /var/log/data-phase1.log"
@@ -108,8 +108,8 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
-            "git pull --ff-only origin main",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "bash rag/pipelines/run_weekly_ingestion.sh 2>&1 | tee /var/log/rag-ingestion.log"
@@ -282,8 +282,8 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-predictor",
-            "git pull --ff-only origin main",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "bash infrastructure/spot_train.sh --full-only 2>&1 | tee /var/log/predictor-training.log"
@@ -379,8 +379,8 @@
           "commands": [
             "set -eo pipefail",
             "export HOME=/home/ec2-user",
-            "cd /home/ec2-user/alpha-engine-data && git pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-predictor && git pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "export PYTHONPATH=/home/ec2-user/alpha-engine-predictor",
             "/home/ec2-user/alpha-engine-data/.venv/bin/python -m monitoring.drift_detector --alert 2>&1 | tee /var/log/drift-detection.log"
@@ -412,8 +412,8 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-backtester",
-            "git pull --ff-only origin main",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "bash infrastructure/spot_backtest.sh 2>&1 | tee /var/log/backtester.log"
@@ -508,8 +508,8 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
-            "git pull --ff-only origin main",
             "source .venv/bin/activate",
             "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
           ],


### PR DESCRIPTION
## Summary
Wrap every \`git pull --ff-only origin main\` in the Saturday Step Function with \`sudo -u ec2-user git -C <path>\` so git runs as the repo owner and doesn't hit the 2.35.2+ safe.directory check.

## Context
#20 added \`git pull\` to every SSM command to auto-pull fresh code before running. When the pipeline kicked off (full-rerun-20260411T211223Z) DataPhase1 failed immediately with:

\`\`\`
fatal: detected dubious ownership in repository at '/home/ec2-user/alpha-engine-data'
failed to run commands: exit status 128
\`\`\`

SSM runs as root, but the /home/ec2-user/alpha-engine-* repos are owned by ec2-user. Git refuses by default.

**Silver lining:** the Step Function's CheckDataPhase1Status gate routed correctly to HandleFailure → FailExecution → SNS, and the SNS email surfaced the real error immediately — proving #20's hard-fail + exit-propagation fix works end-to-end.

## Fix
\`sudo -u ec2-user git -C /path/to/repo pull --ff-only origin main\`

- \`sudo -u ec2-user\` — runs git as the repo owner
- \`git -C <path>\` — explicit working directory, avoids the sudo-subshell pwd issue
- Everything downstream of the git pull (cd, source, Python/bash) keeps running as root, same as before PR #20

All six SSM commands updated consistently. Verified the pattern on a standalone SSM probe before pushing — the probe successfully pulled 292e51e → 0a3a90b.

## Live deployment
Applied directly to the live state machine via \`aws stepfunctions update-state-machine\` (revision \`8acf52b1\`). This PR is the repo-side record.

## Test plan
- [x] JSON validates
- [x] Standalone SSM probe confirms \`sudo -u ec2-user git -C /path pull\` works
- [x] Live state machine updated
- [ ] Fresh execution kicks off cleanly
- [ ] DataPhase1 completes its git pull as ec2-user and runs the latest weekly_collector.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)