### PR TITLE
Surface data email send failures as ERROR instead of silent drop

### DIFF
--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -492,14 +492,29 @@ def _finalize(
         duration,
     )
 
-    # Send completion email (non-blocking)
+    # Send completion email.
+    # send_step_email never raises (see emailer.py docstring) — it returns
+    # True/False. The old try/except was dead code, AND the False return
+    # was being silently dropped. If Gmail SMTP AND SES both fail, the
+    # caller needs to know so monitoring isn't blind to a successful run
+    # that silently had no notification.
     if not dry_run and only is None:
-        try:
-            from emailer import send_step_email
-            step_name = f"Data Phase {phase}" if phase else "Data Collection"
-            send_step_email(step_name, results, run_date)
-        except Exception as exc:
-            logger.warning("Step email failed (non-fatal): %s", exc)
+        from emailer import send_step_email
+        step_name = f"Data Phase {phase}" if phase else "Data Collection"
+        sent = send_step_email(step_name, results, run_date)
+        if not sent:
+            # Log at ERROR so CloudWatch alarms (if wired to ERROR-level)
+            # surface the missed email. Not raising because the data
+            # collection itself succeeded — only monitoring is affected.
+            # Downstream Step Function steps can still consume the S3 output.
+            logger.error(
+                "Step email '%s' failed to send — both Gmail SMTP and SES "
+                "fallback returned failure. Monitoring will be blind to "
+                "this run's result summary. Check EMAIL_SENDER, "
+                "EMAIL_RECIPIENTS, GMAIL_APP_PASSWORD env vars and SES "
+                "identity verification.",
+                step_name,
+            )
 
 
 def _write_manifest(bucket: str, s3_prefix: str, run_date: str, results: dict) -> None:


### PR DESCRIPTION
## Summary
Fix a silent-fail in \`weekly_collector._finalize\` where a failed \`send_step_email\` would log WARNING and continue, giving the run no visible indication that monitoring was blind to it.

## Context
\`_finalize\`'s email block:
\`\`\`python
if not dry_run and only is None:
    try:
        from emailer import send_step_email
        step_name = f\"Data Phase {phase}\" if phase else \"Data Collection\"
        send_step_email(step_name, results, run_date)
    except Exception as exc:
        logger.warning(\"Step email failed (non-fatal): %s\", exc)
\`\`\`

Two problems:
1. **Dead try/except** — \`send_step_email\` is explicitly documented as \"Never raises\" (see \`emailer.py:20\`) and returns \`True\`/\`False\`. No exception ever propagates out of it.
2. **Discarded return value** — when both Gmail SMTP and SES fallback failed inside \`send_step_email\`, the function returned \`False\`. The caller ignored it.

Net effect: a successful data collection with a broken emailer recorded in S3 correctly but emitted no notification. Monitoring couldn't distinguish \"ran and emailed\" from \"ran and silently dropped the notification\".

## Fix
- Remove the dead \`try/except\`
- Check the boolean return value
- On \`False\`, log ERROR with enough context to diagnose (which env vars / SES identity to check)

Not raising on email-send failure because the data itself is valid in S3 and downstream Step Function steps still consume it — email is a monitoring layer, not a data dependency. If CloudWatch alarms are wired to ERROR-level log events on this Lambda, the missed email surfaces naturally.

## Audit of other silent-fail patterns in weekly_collector.py

- **Lines 130, 363, 369** — S3→Wikipedia fallback for constituents. Intentional. Downstream \`if not tickers: return failed\` catches the empty case.
- **Lines 443, 483** — duration formatting \`try/except: pass\`. Cosmetic. Acceptable.
- **run_daily status logic (lines 428-432)** — only produces \`ok\` or \`failed\`, no \`partial\`. \`main()\` hard-fails on anything != \`ok\`. Already correct.

No other silent-fails found in this file worth addressing.

## Test plan
- [x] 61 existing tests pass locally
- [ ] CI green
- [ ] If a future emailer misconfiguration occurs, the next Saturday DataPhase1 run logs \`Step email '...' failed to send\` at ERROR level

🤖 Generated with [Claude Code](https://claude.com/claude-code)