### PR TITLE
Split Evaluator from Backtester into independent Step Function step

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -508,17 +508,18 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "export HOME=/home/ec2-user",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-backtester",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "python evaluate.py --mode all --upload --log-level INFO 2>&1 | tee /var/log/evaluator.log"
           ],
-          "executionTimeout": ["300"]
+          "executionTimeout": ["1800"]
         },
-        "TimeoutSeconds": 300
+        "TimeoutSeconds": 1800
       },
-      "TimeoutSeconds": 330,
+      "TimeoutSeconds": 1860,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -476,7 +476,7 @@
         {
           "Variable": "$.backtester_poll.Status",
           "StringEquals": "Success",
-          "Next": "SaturdayHealthCheck"
+          "Next": "Evaluator"
         },
         {
           "Variable": "$.backtester_poll.Status",
@@ -496,6 +496,114 @@
       "Type": "Wait",
       "Seconds": 60,
       "Next": "WaitForBacktester"
+    },
+
+    "Evaluator": {
+      "Type": "Task",
+      "Comment": "Signal quality, attribution, grading, config optimization. Runs on always-on EC2 (not spot) — reads simulation artifacts from S3. Split from Backtester step on 2026-04-12 so eval can run at a different cadence.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.ec2_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -eo pipefail",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-backtester",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "python evaluate.py --mode all --upload --log-level INFO 2>&1 | tee /var/log/evaluator.log"
+          ],
+          "executionTimeout": ["300"]
+        },
+        "TimeoutSeconds": 300
+      },
+      "TimeoutSeconds": 330,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.evaluator_result",
+      "Next": "WaitForEvaluator"
+    },
+
+    "WaitForEvaluator": {
+      "Type": "Task",
+      "Comment": "Poll SSM command until evaluator complete",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.evaluator_result.Command.CommandId",
+        "InstanceId.$": "$.ec2_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.evaluator_poll",
+      "Next": "CheckEvaluatorStatus"
+    },
+
+    "CheckEvaluatorStatus": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.evaluator_poll.Status",
+          "StringEquals": "Success",
+          "Next": "SaturdayHealthCheck"
+        },
+        {
+          "Variable": "$.evaluator_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "EvaluatorWait"
+        },
+        {
+          "Variable": "$.evaluator_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "EvaluatorWait"
+        }
+      ],
+      "Default": "ExtractEvaluatorError"
+    },
+
+    "EvaluatorWait": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "WaitForEvaluator"
+    },
+
+    "ExtractEvaluatorError": {
+      "Type": "Pass",
+      "Comment": "Normalize Evaluator SSM non-Success poll into $.error.",
+      "Result": {},
+      "ResultPath": "$.error",
+      "Parameters": {
+        "phase": "Evaluator",
+        "source": "CheckEvaluatorStatus.Default",
+        "poll.$": "$.evaluator_poll"
+      },
+      "Next": "HandleFailure"
     },
 
     "SaturdayHealthCheck": {


### PR DESCRIPTION
## Summary
Add a dedicated Evaluator step to the Saturday Step Function, running evaluate.py on the always-on EC2 (not a spot instance). Reads simulation artifacts from S3 — data-independent from backtest.py.

## Why now
The system is underperforming the market and the evaluator output is the primary tool for diagnosing why — signal quality, attribution, grading, regression detection, optimizer recommendations. Having eval coupled to the backtester meant every evaluate.py bug required a full 10-minute spot relaunch to retest. With the split, eval failures can be retried in seconds.

## Pipeline flow
**Before:** \`... → CheckBacktesterStatus → SaturdayHealthCheck\`
**After:** \`... → CheckBacktesterStatus → Evaluator → WaitForEvaluator → CheckEvaluatorStatus → SaturdayHealthCheck\`

## 5 new states
- **Evaluator**: SSM sendCommand running \`evaluate.py --mode all --upload\` on always-on EC2
- **WaitForEvaluator**: SSM getCommandInvocation poll
- **CheckEvaluatorStatus**: Choice (Success/InProgress/Pending/Default→Error)
- **EvaluatorWait**: 15s poll interval (fast — eval takes ~10s)
- **ExtractEvaluatorError**: Pass → HandleFailure

## Prerequisites
- Backtester venv installed on always-on EC2 (\`python3.11 -m venv .venv\` + \`pip install -r requirements.txt\` + \`pip install -e flow-doctor\`). Done via SSM 2026-04-12.
- \`alpha-engine-backtester\` repo cloned at \`/home/ec2-user/alpha-engine-backtester\` on the always-on instance. Done earlier in 2026-04-11 session.

## Live deployment
Applied directly to the live state machine. This PR is the repo-side record.

## Follow-up
- Remove evaluate.py call from \`spot_backtest.sh\` (currently runs twice — harmless but redundant)
- Add Evaluator to weekday SF for daily eval cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)