### PR TITLE
Integrate flow-doctor for failure alerting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Config (contains bucket names, API keys)
 config.yaml
 
+# Flow Doctor config — references repo names + secrets via env var substitution.
+# The real file is staged from alpha-engine-config at deploy time (or copied
+# from flow-doctor.yaml.example locally).
+flow-doctor.yaml
+
 # Python
 __pycache__/
 *.pyc

--- a/flow-doctor.yaml.example
+++ b/flow-doctor.yaml.example
@@ -1,0 +1,21 @@
+flow_name: data-collector
+repo: cipher813/alpha-engine-data
+owner: "@brianmcmahon"
+notify:
+  - type: email
+    sender: ${EMAIL_SENDER}
+    recipients: ${EMAIL_RECIPIENTS}
+    smtp_host: smtp.gmail.com
+    smtp_port: 587
+    smtp_password: ${GMAIL_APP_PASSWORD}
+  - type: github
+    repo: cipher813/alpha-engine-data
+    token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+store:
+  type: sqlite
+  path: /tmp/flow_doctor.db
+dedup_cooldown_minutes: 60
+rate_limits:
+  max_alerts_per_day: 10
+  max_issues_per_day: 3
+  max_diagnosed_per_day: 3

--- a/log_config.py
+++ b/log_config.py
@@ -1,8 +1,19 @@
 """
-Structured logging configuration.
+Structured logging + Flow Doctor integration.
 
 JSON mode activates when ALPHA_ENGINE_JSON_LOGS=1.
 Text mode (default) preserves human-readable format for local dev.
+
+Flow Doctor integration owns the single shared FlowDoctor instance for the
+alpha-engine-data process. Entrypoints call ``setup_logging("data-collector")``
+exactly once at startup; subsequent call sites retrieve the instance via
+``get_flow_doctor()`` rather than re-initializing.
+
+Flow Doctor activates only when FLOW_DOCTOR_ENABLED=1 (set on EC2 via the
+DailyData / DataPhase1 SSM commands or the ``.alpha-engine.env``). Local
+dev runs do not fire flow-doctor notifications. Logs at ERROR level or
+above (including exceptions raised out of the hardened collectors) are
+captured by the FlowDoctorHandler and dispatched per ``flow-doctor.yaml``.
 """
 
 from __future__ import annotations
@@ -11,6 +22,16 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
+from typing import Optional
+
+_FLOW_DOCTOR_YAML_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "flow-doctor.yaml"
+)
+
+# Singleton — populated once by setup_logging() and retrieved by call sites
+# via get_flow_doctor(). None until setup_logging() runs with
+# FLOW_DOCTOR_ENABLED=1, or if the init itself failed.
+_fd_instance: Optional[object] = None
 
 
 class JSONFormatter(logging.Formatter):
@@ -29,7 +50,34 @@ class JSONFormatter(logging.Formatter):
         return json.dumps(entry, default=str)
 
 
-def setup_logging(name: str = "alpha-engine") -> None:
+def get_flow_doctor():
+    """Return the shared flow-doctor instance, or None if not initialized."""
+    return _fd_instance
+
+
+def _attach_flow_doctor(name: str) -> None:
+    """Initialize the shared flow-doctor instance and attach a log handler.
+
+    Mirrors the executor's integration (alpha-engine/executor/log_config.py).
+    An ERROR-level log or an uncaught exception propagated through the
+    logging system fires the FlowDoctorHandler, which dispatches per the
+    yaml config (email + GitHub issue with dedup + rate limits).
+    """
+    global _fd_instance
+    import flow_doctor
+    _fd_instance = flow_doctor.init(config_path=_FLOW_DOCTOR_YAML_PATH)
+    handler = flow_doctor.FlowDoctorHandler(_fd_instance, level=logging.ERROR)
+    logging.getLogger().addHandler(handler)
+
+
+def setup_logging(name: str = "data-collector") -> None:
+    """
+    Configure root logger for alpha-engine-data entrypoints.
+
+    JSON mode: ALPHA_ENGINE_JSON_LOGS=1 (for EC2 / production)
+    Text mode: default (for local dev / dry-run)
+    Flow Doctor: FLOW_DOCTOR_ENABLED=1 (for EC2 / production)
+    """
     json_mode = os.environ.get("ALPHA_ENGINE_JSON_LOGS", "0") == "1"
     handler = logging.StreamHandler()
     if json_mode:
@@ -42,3 +90,6 @@ def setup_logging(name: str = "alpha-engine") -> None:
     root.handlers.clear()
     root.addHandler(handler)
     root.setLevel(logging.INFO)
+
+    if os.environ.get("FLOW_DOCTOR_ENABLED", "0") == "1":
+        _attach_flow_doctor(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary>=2.9
 voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11
+flow-doctor[diagnosis]>=0.3.0,<0.4.0


### PR DESCRIPTION
## Summary

PRs #24 + #25 hardened the alpha-engine-data daily production path so failures raise and exit non-zero. But there's no alerting — a 6 AM failure is only visible if someone manually reads CloudWatch / the SSM log. Flow-doctor closes that loop: any ERROR-level log (including traceback-emitting exceptions from \`logger.exception\`) fires email + a deduped GitHub issue.

Mirrors the executor's integration (\`alpha-engine/executor/log_config.py\`, \`alpha-engine/flow-doctor.yaml\`) verbatim.

## Changes

- \`requirements.txt\` — \`flow-doctor[diagnosis]>=0.3.0,<0.4.0\`
- \`log_config.py\` — \`FlowDoctor\` singleton + \`FlowDoctorHandler\` at ERROR level attached to root logger when \`FLOW_DOCTOR_ENABLED=1\`. Lazy import so local dev without the dep installed still works.
- \`flow-doctor.yaml.example\` — committed template. Points at \`cipher813/alpha-engine-data\` for GitHub issues and uses the same shared SMTP env vars as the executor config.
- \`.gitignore\` — \`flow-doctor.yaml\` ignored (real file will be staged from \`alpha-engine-config\`).

## Deployment steps (user action — out of scope for this PR)

1. Add \`flow-doctor.yaml\` to \`alpha-engine-config\` repo at a path the deploy pipeline can stage from.
2. Confirm \`FLOW_DOCTOR_ENABLED=1\` and \`FLOW_DOCTOR_GITHUB_TOKEN\` are already in \`/home/ec2-user/.alpha-engine.env\`. The executor uses the same vars, so likely yes — needs confirmation.
3. First live fire: next daily or Saturday Step Function run. If any of the hard-fail paths added in PRs #24 + #25 trigger, expect an email + an issue on this repo.

## Out of scope (tracked for follow-up)

- Same integration for predictor Lambda (different deploy model — flow-doctor needs to be packaged into the Lambda image or a layer).
- Same integration for research Lambda.

## Test plan

- [x] \`pytest tests/ --ignore=tests/integration -q\` — 41 passed
- [x] \`python -c 'from log_config import setup_logging; setup_logging(\"test\")'\` — no-op when \`FLOW_DOCTOR_ENABLED\` unset, matches local-dev expectation
- [ ] EC2 install flow-doctor after PR merge (\`pip install -r requirements.txt\`)
- [ ] Stage \`flow-doctor.yaml\` from alpha-engine-config
- [ ] Next pipeline run — confirm flow-doctor init logs at INFO; no spurious errors on healthy run; a forced failure (e.g., \`aws s3 rm\` the daily_closes parquet) produces an email + issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)