### PR TITLE
Pin alpha-engine-lib to v0.1.1 for Python 3.9 compat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
-alpha-engine-lib[arcticdb,flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.0
+alpha-engine-lib[arcticdb,flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.1


### PR DESCRIPTION
## Summary

One-line pin bump from v0.1.0 → v0.1.1 in requirements.txt. v0.1.1 relaxes the lib's Python floor to \`>=3.9\` so it installs on the EC2 micro instance. No code change needed on this side.

## Why

First manual EC2 test after #28 merged failed with \`ModuleNotFoundError: No module named 'alpha_engine_lib'\`. Root cause: v0.1.0 declared \`requires-python = >=3.11\`, and EC2 runs 3.9 — pip silently skipped the install.

## Test plan
- [ ] EC2: re-run the same \`ae-dashboard\` command that failed earlier. \`pip install -r requirements.txt\` must succeed. weekly_collector.py must hit the preflight and proceed (or fail at the preflight's actual check, not the import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)