### PR TITLE
Fix: exclude alpha-engine-lib from Phase 2 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 
-# Install dependencies (exclude boto3/botocore — pre-installed in Lambda)
+# Install dependencies (exclude boto3/botocore — pre-installed in Lambda).
+# alpha-engine-lib is excluded because the Phase 2 Lambda handler (lambda/handler.py)
+# doesn't import from it — only weekly_collector.main() (the EC2 entry point) does.
+# Including it would require wiring a GitHub PAT into the Docker build as a secret,
+# which is ceremony for zero benefit here. If a future Phase 2 change imports from
+# alpha-engine-lib, remove this filter and add --mount=type=secret,id=lib_token
+# plus the matching deploy.yml build-secrets wiring.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
 RUN pip install --no-cache-dir \
-    $(grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer" requirements.txt) \
+    $(grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt) \
     && rm -rf /root/.cache/pip
 
 # Copy application code


### PR DESCRIPTION
## Summary

Unblocks the broken Phase 2 Lambda build on main after #28 + #29.

The Dockerfile installs requirements by shell-splitting \`grep\` output and passing each line as a positional arg to pip. This breaks on pip URL-style entries like:

\`\`\`
alpha-engine-lib[arcticdb,flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.1
\`\`\`

The shell splits it into three args and pip errors \`Invalid requirement: '@'\`.

## Why exclude vs fix the install

Phase 2 Lambda (\`lambda/handler.py\`) doesn't import from \`alpha-engine-lib\`. Only \`weekly_collector.main()\` does — the EC2 entrypoint. Excluding the dep from the Lambda build is the minimal fix and avoids wiring a GitHub PAT into the Docker build as a build secret.

If a future Phase 2 change imports from \`alpha-engine-lib\`, remove the filter and add \`--mount=type=secret,id=lib_token\` to the RUN step plus matching \`secrets\` wiring in \`deploy.yml\`. Comment in the Dockerfile documents this.

## Test plan
- [ ] Deploy workflow on merge should build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)