### PR TITLE
Fix DataPreflight: SPY lives in macro library, not universe

### DIFF
--- a/preflight.py
+++ b/preflight.py
@@ -43,6 +43,10 @@ class DataPreflight(BasePreflight):
         self.check_s3_bucket()
 
         if self.mode == "daily":
-            # 4-day threshold would have caught the 2026-04-14 bug
-            # (ArcticDB silently not writing) by 2026-04-17.
-            self.check_arcticdb_fresh("universe", "SPY", max_stale_days=4)
+            # SPY lives in the `macro` library (market-wide series). The
+            # `universe` library holds per-stock OHLCV for S&P 500/400
+            # constituents. daily_append writes to both libraries, so
+            # macro/SPY freshness is a sufficient signal for the write
+            # path being healthy end-to-end.
+            # 4-day threshold covers Fri→Tue long weekends + 1 day of buffer.
+            self.check_arcticdb_fresh("macro", "SPY", max_stale_days=4)


### PR DESCRIPTION
## Summary

The daily-mode preflight was checking ArcticDB \`universe/SPY\` freshness, but SPY (and other market-wide series) lives in the \`macro\` library. Caught by the first real run on EC2:

\`\`\`
RuntimeError: Pre-flight: ArcticDB universe/SPY read failed:
E_NO_SUCH_VERSION ... version matching query 'latest' not found for symbol 'SPY'
\`\`\`

One-line fix: \`"universe"\` → \`"macro"\`. The primitive already takes library+symbol as args.

## Why macro/SPY is sufficient

\`daily_append\` writes to both the \`universe\` (per-stock OHLCV + features) and \`macro\` (market-wide series) libraries in the same run. If daily_append fails, neither library gets today's row. Checking one library is enough signal.

If we later want asymmetric coverage (macro write succeeds but universe doesn't, or vice versa), we can add a second \`check_arcticdb_fresh\` call pointed at a universe ticker like AAPL. Not needed for the bug we were actually trying to catch.

## Test plan
- [x] pytest 41/41 pass (no test added — DataPreflight isn't unit-tested at the consumer level; lib tests already cover the primitive)
- [ ] EC2 re-run: \`ae-dashboard "... python weekly_collector.py --daily --dry-run ..."\` — preflight should now pass and subsequent steps execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)