### PR TITLE
Remove over-eager n_ok==0 guard in daily_append

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -307,14 +307,16 @@ def daily_append(
         n_ok, n_skip, n_err, len(stock_tickers), t_total,
     )
 
-    # Hard-fail guards — prevent silently returning a no-op as success.
+    # Hard-fail on high error rate. ``n_ok == 0`` alone is NOT a failure
+    # signal — it correctly occurs when every ticker hit the
+    # "today already in ArcticDB" skip path (a second same-day invocation,
+    # or a Step Function retry that runs after the first one succeeded).
+    # The real silent-fail we're guarding against (ArcticDB-wide auth /
+    # connectivity failure making every read throw) now registers as
+    # ``n_err`` rather than ``n_skip`` after PR #24, so the 5% error-rate
+    # threshold catches it without false positives on no-op reruns.
     # dry_run is exempt because it short-circuits the per-ticker loop.
     if not dry_run:
-        if n_ok == 0:
-            raise RuntimeError(
-                f"ArcticDB daily_append wrote zero tickers "
-                f"(n_skip={n_skip} n_err={n_err} of {len(stock_tickers)}) — treating as pipeline failure"
-            )
         err_rate = n_err / max(len(stock_tickers), 1)
         if err_rate > 0.05:
             raise RuntimeError(


### PR DESCRIPTION
## Summary

Live run on 2026-04-14 exposed a false positive in my hard-fail guard from #24.

When 900/902 tickers already had today's row in ArcticDB (because this morning's Step Function run succeeded), \`daily_append\` correctly took the "today already exists" skip path on each one → \`n_ok=0, n_skip=900, n_err=2\` (2 newly-listed tickers Q + SOLS not yet backfilled, 0.22% error rate). My guard raised \`RuntimeError\` on \`n_ok == 0\`, treating "nothing to write because all done" as "failed to write anything."

## What was over-broad

The \`n_ok == 0\` guard was meant to catch: ArcticDB-wide auth/connectivity failure → every ticker read throws → n_err=902, n_ok=0. But that case was already handled correctly after #24 converted per-ticker read exceptions from \`n_skip\` to \`n_err\`. Now a blanket auth failure registers as \`n_err=902\` → \`err_rate=100%\` → the existing 5% threshold fires.

So \`n_ok == 0\` alone doesn't distinguish "all done" from "all failed." Removing the guard and relying on err_rate is correct.

## Net behavior

| n_ok | n_skip | n_err | Outcome |
|---|---|---|---|
| 0 | 902 | 0 | **Pass** (idempotent rerun — everyone already wrote) |
| 900 | 0 | 2 | **Pass** (normal run with 2 missing tickers) |
| 0 | 0 | 902 | **Fail** (ArcticDB auth broken — err_rate=100%) |
| 800 | 0 | 102 | **Fail** (err_rate 11% > 5% threshold) |

## Secondary finding from this run

My earlier claim that ArcticDB was "stale since 2026-04-12" was wrong. I was reading S3 \`LastModified\` on ArcticDB's internal \`tdata/\` / \`vref/\` prefixes as a "last append" signal, but ArcticDB batches/compacts — those timestamps don't monotonically increase on every append. The 900 tickers with today's row are ground truth: this morning's Step Function actually did write ArcticDB successfully.

## Test plan

- [x] pytest 41/41
- [ ] Re-run live command on EC2 after merge — expect pass with \`n_ok=0 n_skip=900 n_err=2\` (or n_err=0 if the 2 missing tickers got backfilled meanwhile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)