### PR TITLE
daily_append: use update() instead of append() (dedup at source)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -248,7 +248,15 @@ def daily_append(
 
             today_row.index.name = "date"
 
-            universe_lib.append(ticker, today_row)
+            # Use update() rather than append() so a re-run on the same
+            # date overwrites instead of accumulating duplicate rows.
+            # 2026-04-15: diagnosed as root cause of the predictor training
+            # failure where 904/909 tickers had duplicate date rows when
+            # read back from ArcticDB. The read-check at line 195 was the
+            # only dedup guard; a race or concurrent pipeline invocation
+            # defeats it. update() is idempotent — same-date rows replace
+            # instead of append, regardless of race conditions.
+            universe_lib.update(ticker, today_row)
             n_ok += 1
 
         except Exception as exc:
@@ -256,6 +264,9 @@ def daily_append(
             n_err += 1
 
     # ── 5. Update macro series ───────────────────────────────────────────────
+    # update() semantics: same-date rows overwrite instead of appending. See
+    # commentary at the universe_lib.update() call above for the 2026-04-15
+    # duplicate-row diagnosis.
     if not dry_run:
         for key in macro_keys:
             bar = closes.get(key)
@@ -266,10 +277,10 @@ def daily_append(
                         index=pd.DatetimeIndex([today_ts]),
                     )
                     new_row.index.name = "date"
-                    macro_lib.append(key, new_row)
+                    macro_lib.update(key, new_row)
                 except Exception as exc:
                     raise RuntimeError(
-                        f"Failed to append macro {key} bar for {date_str}: {exc}"
+                        f"Failed to update macro {key} bar for {date_str}: {exc}"
                     ) from exc
 
         # Sector ETFs
@@ -283,10 +294,10 @@ def daily_append(
                             index=pd.DatetimeIndex([today_ts]),
                         )
                         new_row.index.name = "date"
-                        macro_lib.append(sym, new_row)
+                        macro_lib.update(sym, new_row)
                     except Exception as exc:
                         raise RuntimeError(
-                            f"Failed to append sector ETF {sym} bar for {date_str}: {exc}"
+                            f"Failed to update sector ETF {sym} bar for {date_str}: {exc}"
                         ) from exc
 
     t_total = time.time() - t0

--- a/tests/test_daily_append_semantics.py
+++ b/tests/test_daily_append_semantics.py
@@ -1,0 +1,42 @@
+"""Regression: builders/daily_append.py must use ArcticDB update(), not append().
+
+2026-04-15: 904/909 tickers in the production universe library had
+duplicate date rows when read back from ArcticDB. Root cause traced to
+daily_append calling `lib.append()` which does not dedupe — a race or
+re-run would produce same-date duplicates. Fix: swap to `lib.update()`
+which is idempotent for same-date rows (input overlap replaces existing).
+
+This test locks the semantic. A future revert to `append()` on any of
+the three write sites (universe, macro, sector ETF) would reintroduce
+the accumulation bug and should fail loudly here.
+"""
+
+from pathlib import Path
+
+
+_DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
+
+
+def _source() -> str:
+    return _DAILY_APPEND.read_text()
+
+
+def test_universe_lib_uses_update_not_append():
+    src = _source()
+    assert "universe_lib.update(ticker, today_row)" in src, (
+        "daily_append must call universe_lib.update() — append() accumulates "
+        "duplicate same-date rows and caused the 2026-04-15 retrain outage."
+    )
+    assert "universe_lib.append(ticker, today_row)" not in src, (
+        "Found universe_lib.append() — this is the duplicate-row bug. "
+        "Use update() instead."
+    )
+
+
+def test_macro_lib_uses_update_not_append():
+    src = _source()
+    # Both key-path and sym-path (sector ETFs) must use update.
+    assert "macro_lib.update(key, new_row)" in src
+    assert "macro_lib.update(sym, new_row)" in src
+    assert "macro_lib.append(key," not in src
+    assert "macro_lib.append(sym," not in src


### PR DESCRIPTION
## Summary

Root cause fix for the 2026-04-15 predictor retrain outage: 904/909 tickers in the production universe library had duplicate date rows when read back from ArcticDB.

The workaround landed in alpha-engine-predictor (#26 — defensive dedup in the training loader, mirroring inference's long-standing defensive dedup at \`inference/stages/load_prices.py:403\`). This PR fixes the accumulation at the write site so both defenses become unnecessary going forward.

**Change:** swap three \`lib.append(symbol, today_row)\` calls for \`lib.update(symbol, today_row)\` in \`builders/daily_append.py\` (universe, macro key, macro sym-path for sector ETFs). \`append()\` adds rows without dedup; \`update()\` replaces any existing rows whose dates overlap with the input, which is idempotent under re-runs, races, or concurrent pipeline invocations.

**Why duplicates accumulated:** the read-check at line 195 (\`if today_ts in hist.index: skip\`) was the only dedup guard. It fails under any of:
- Concurrent Saturday + Sunday pipeline invocations (already flagged in ROADMAP under Research: weekend-dated signals)
- Retries during partial failures
- Read reflecting a cache slightly behind the actual write state

\`update()\` removes all three failure modes by making the write itself idempotent.

## Test plan

- [x] Source-level regression test: \`tests/test_daily_append_semantics.py\` locks the \`update()\` semantic — a future revert to \`append()\` on any of the 3 sites fails the test.
- [x] Full suite: 43 passed.
- [ ] Next weekday pipeline run (2026-04-16 Thu): confirm no accumulation in universe_lib. Spot check: \`lib.read('AAPL').data.index.has_duplicates\` should be False.
- [ ] After 1-2 full Saturday cycles have cleaned state, remove the defensive dedup in alpha-engine-predictor \`data/dataset.py:_load_ticker_parquet\` (tracked on ROADMAP).

## Related

- alpha-engine-predictor #26 (merged) — defensive dedup workaround in training loader.
- alpha-engine-docs ROADMAP Data Platform / P1 — "Eliminate duplicate-date rows in ArcticDB writes" (this PR resolves the write-side half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)