### PR TITLE
fix(universe_returns): unstick NULL return_5d rows + drop weekend signals

### DIFF
--- a/collectors/universe_returns.py
+++ b/collectors/universe_returns.py
@@ -115,6 +115,14 @@ def collect(
     _ensure_table(db_path)
     existing = _get_existing_dates(db_path)
 
+    # Drop non-trading-day signal folders. Research runs before the
+    # next_trading_day stamping fix (alpha-engine-research 9a94e34, 2026-04-13)
+    # wrote signals/{Sat,Sun}/... which have no market data — attempting to
+    # process them produces rows with NULL return_5d that then get stuck in
+    # the `existing` set and prevent real reprocessing. Keeping the filter
+    # here is also a defense against future misstamping.
+    eval_dates = [d for d in eval_dates if _is_trading_day(d)]
+
     dates_to_process = [d for d in eval_dates if d not in existing]
     if not dates_to_process:
         logger.info("All %d eval_dates already in universe_returns", len(eval_dates))
@@ -261,24 +269,45 @@ def _ensure_table(db_path: str) -> None:
 
 
 def _get_existing_dates(db_path: str) -> set[str]:
-    """Return set of eval_dates already populated."""
+    """Return set of eval_dates that have return_5d fully populated.
+
+    A date is considered "existing" only when at least one row has return_5d
+    set. Dates where rows landed but return_5d stayed NULL (e.g. the 5d
+    forward window hadn't closed when the collector ran, and the date was
+    then frozen out by the prior all-dates-in-DB skip) get reprocessed so
+    the returns can be backfilled.
+    """
     conn = sqlite3.connect(db_path)
     try:
-        rows = conn.execute("SELECT DISTINCT eval_date FROM universe_returns").fetchall()
+        rows = conn.execute(
+            "SELECT DISTINCT eval_date FROM universe_returns "
+            "WHERE return_5d IS NOT NULL"
+        ).fetchall()
         return {r[0] for r in rows}
     finally:
         conn.close()
 
 
+def _is_trading_day(date_str: str) -> bool:
+    """True if YYYY-MM-DD is Mon–Fri. Does not account for market holidays."""
+    return date.fromisoformat(date_str).weekday() < 5
+
+
 def _insert_rows(db_path: str, rows: list[dict]) -> int:
-    """Insert rows into universe_returns, skipping duplicates."""
+    """Insert rows into universe_returns; reprocessed dates overwrite stale rows.
+
+    Uses INSERT OR REPLACE so a date that was previously inserted with NULL
+    forward-return columns (because the 5d window hadn't closed yet) gets
+    its returns filled in on reprocessing. The previous INSERT OR IGNORE
+    behaviour left those NULL rows stuck forever.
+    """
     conn = sqlite3.connect(db_path)
     try:
         inserted = 0
         for row in rows:
             try:
                 conn.execute(
-                    "INSERT OR IGNORE INTO universe_returns "
+                    "INSERT OR REPLACE INTO universe_returns "
                     "(ticker, eval_date, sector, close_price, return_5d, return_10d, return_30d, "
                     "spy_return_5d, spy_return_10d, spy_return_30d, beat_spy_5d, beat_spy_10d, beat_spy_30d, "
                     "sector_etf, sector_etf_return_5d, beat_sector_5d) "


### PR DESCRIPTION
## Summary
Two collector bugs that kept scanner / team / CIO grading pinned at N/A (\`n_passing=0, n_universe=0\`) even though the evaluator's join logic is correct.

## Bug 1 — NULL return_5d rows stuck forever
\`_build_rows_for_date\` returns rows even when forward-window columns are NULL (e.g. when the 5d window hadn't closed at insert time). The next run's \`existing\` set included those dates, so \`dates_to_process\` skipped them — returns were never backfilled. Combined with \`INSERT OR IGNORE\`, they couldn't be overwritten either.

Fix:
- \`_get_existing_dates\` now returns only dates where \`return_5d IS NOT NULL\`.
- \`_insert_rows\` uses \`INSERT OR REPLACE\` so a reprocessed row overwrites the stale NULL one.

Impact: Fri 2026-04-03 (and any future partial-insert) will be backfilled by the next Saturday run.

## Bug 2 — weekend signal folders have no market data
Research runs before \`alpha-engine-research 9a94e34\` (2026-04-13, "Stamp signals with next_trading_day") wrote \`signals/{Sat,Sun}/…\`. Polygon has no grouped-daily data for those dates, so rows landed NULL and hit bug #1. Post-fix research stamps trading days, but the legacy weekend folders remain in S3.

Fix: filter \`eval_dates\` to Mon–Fri before enqueuing.

## Context — the broader eval_date alignment story
The \`universe_returns.eval_date\` ↔ \`scanner_evaluations.eval_date\` mismatch was diagnosed while debugging why \`grading.json\` had \`research.scanner: N/A\` with \`n_passing=0\`. Three layered issues:

1. **Research used to stamp \`eval_date = today\` (weekend possible)** — fixed upstream in \`alpha-engine-research 9a94e34\` (2026-04-13). Going forward both tables write trading days.
2. **universe_returns had NULL-return orphans blocking the overlap** — fixed by this PR.
3. **scanner_evaluations / team_candidates started being written only on 2026-04-12** (schema v8, 2026-04-04) — nothing to do, one week of history today, will accumulate.

## Out of scope
- Market-holiday filtering (e.g. Good Friday). \`_is_trading_day\` only screens weekends; a closed-market weekday will still be attempted and silently skipped at \`_build_rows_for_date\`. Proper NYSE calendar filtering is a follow-up.

## Test plan
- [x] Unit suite (46 passed, 0 failed)
- [x] \`_is_trading_day\` smoke — Mon/Wed/Fri → True, Sat/Sun → False
- [ ] Next Saturday Step Function run populates return_5d for 2026-04-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)