### PR TITLE
fix: prevent OOM — move DailyData to ae-trading + trim feature compute memory

### DIFF
--- a/features/compute.py
+++ b/features/compute.py
@@ -50,6 +50,12 @@ FEATURE_STORE_PREFIX = "features/"
 # Large-move warning threshold (>45% daily return, e.g. stock splits, VIX spikes)
 _SPLIT_RETURN_THRESHOLD = 0.45
 
+# Rows to keep per ticker before feature computation. The longest rolling
+# window is 252 rows (52w high/low); 280 provides a small buffer. Trimming
+# before the compute loop cuts base memory ~44% vs the full 2y slim cache
+# and lets each ticker's DataFrame be freed incrementally via pop().
+_FEATURE_WARMUP_ROWS = 280
+
 # Tickers that are macro/index series, not stocks
 _SKIP_TICKERS = {
     "SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO",
@@ -407,6 +413,15 @@ def compute_and_write(
         len(fundamentals), len(alt_data),
     )
 
+    # Trim price DataFrames to the last _FEATURE_WARMUP_ROWS rows before the
+    # compute loop. The longest rolling window is 252 rows; keeping 280 is
+    # sufficient. Trimming here reduces peak RSS on t3.micro by ~40%+ vs
+    # holding the full 2y slim cache in memory during feature computation.
+    for _t in list(price_data.keys()):
+        df = price_data[_t]
+        if len(df) > _FEATURE_WARMUP_ROWS:
+            price_data[_t] = df.iloc[-_FEATURE_WARMUP_ROWS:]
+
     # ── 2. Compute features for each ticker ──────────────────────────────────
     store_rows: list[dict] = []
     n_ok = 0
@@ -435,7 +450,7 @@ def compute_and_write(
 
     for ticker in universe_tickers:
         try:
-            df = price_data[ticker]
+            df = price_data.pop(ticker)  # release as we go to avoid holding all 900 DFs
             sector_etf_sym = sector_map.get(ticker)
             sector_etf_series = macro.get(sector_etf_sym) if sector_etf_sym else None
 
@@ -477,6 +492,7 @@ def compute_and_write(
         except Exception as exc:
             log.warning("Feature computation failed for %s: %s", ticker, exc)
             n_err += 1
+            price_data.pop(ticker, None)  # still release on error path
 
     t_compute = time.time() - t0 - t_load
     log.info(

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -101,7 +101,7 @@
               "StringMatches": "*TRADING DAY*"
             }
           ],
-          "Next": "DailyData"
+          "Next": "StartExecutorEC2"
         }
       ],
       "Default": "TradingDayCheckFailed"
@@ -123,7 +123,7 @@
         "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. Error: {}', States.JsonToString($.error))"
       },
       "ResultPath": "$.trading_day_error_notify",
-      "Next": "DailyData"
+      "Next": "StartExecutorEC2"
     },
 
     "NotifyHolidaySkip": {
@@ -139,13 +139,46 @@
       "End": true
     },
 
+    "StartExecutorEC2": {
+      "Type": "Task",
+      "Comment": "Start ae-trading (t3.small) early — needed for both DailyData (data collection) and RunMorningPlanner (executor). No-op if already running.",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:startInstances",
+      "Parameters": {
+        "InstanceIds.$": "$.trading_instance_id"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.ec2_start_result",
+      "Next": "WaitForInstanceReady"
+    },
+
+    "WaitForInstanceReady": {
+      "Type": "Wait",
+      "Comment": "Wait for SSM agent to register (~30s typical). IB Gateway authenticates in the background during DailyData — wait-for-ibgateway.sh handles it before RunMorningPlanner.",
+      "Seconds": 60,
+      "Next": "DailyData"
+    },
+
     "DailyData": {
       "Type": "Task",
-      "Comment": "Capture today's OHLCV closes for all tickers (EC2 via SSM)",
+      "Comment": "Capture today's OHLCV closes for all tickers (runs on ae-trading t3.small — 2 GB RAM for feature computation)",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.ec2_instance_id",
+        "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
           "commands": [
             "set -eo pipefail",
@@ -155,11 +188,11 @@
             "source .venv/bin/activate",
             "python weekly_collector.py --daily 2>&1 | tee /var/log/daily-data.log"
           ],
-          "executionTimeout": ["420"]
+          "executionTimeout": ["600"]
         },
-        "TimeoutSeconds": 420
+        "TimeoutSeconds": 600
       },
-      "TimeoutSeconds": 480,
+      "TimeoutSeconds": 660,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],
@@ -184,7 +217,7 @@
       "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
       "Parameters": {
         "CommandId.$": "$.daily_data_result.Command.CommandId",
-        "InstanceId.$": "$.ec2_instance_id[0]"
+        "InstanceId.$": "$.trading_instance_id[0]"
       },
       "Retry": [
         {
@@ -316,7 +349,7 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Health check failure is non-blocking — log and continue to executor",
-          "Next": "StartExecutorEC2",
+          "Next": "RunMorningPlanner",
           "ResultPath": "$.health_check_error"
         }
       ],
@@ -343,44 +376,11 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Non-blocking — continue even if health check polling fails",
-          "Next": "StartExecutorEC2",
+          "Next": "RunMorningPlanner",
           "ResultPath": "$.health_check_error"
         }
       ],
       "ResultPath": "$.health_check_poll",
-      "Next": "StartExecutorEC2"
-    },
-
-    "StartExecutorEC2": {
-      "Type": "Task",
-      "Comment": "Start the trading EC2 instance (no-op if already running)",
-      "Resource": "arn:aws:states:::aws-sdk:ec2:startInstances",
-      "Parameters": {
-        "InstanceIds.$": "$.trading_instance_id"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": ["States.TaskFailed"],
-          "MaxAttempts": 2,
-          "IntervalSeconds": 30,
-          "BackoffRate": 1.0
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "HandleFailure",
-          "ResultPath": "$.error"
-        }
-      ],
-      "ResultPath": "$.ec2_start_result",
-      "Next": "WaitForInstanceReady"
-    },
-
-    "WaitForInstanceReady": {
-      "Type": "Wait",
-      "Comment": "Wait for instance to boot + IB Gateway to authenticate (~90s cold boot, ~0s if already running)",
-      "Seconds": 120,
       "Next": "RunMorningPlanner"
     },
 


### PR DESCRIPTION
## Summary

Two fixes in one PR, both targeting the same OOM incident (2026-04-16 13:08 UTC alarm, SSM exit 137):

**Commit 1 — `features/compute.py` memory optimization (defense-in-depth)**
- Trim all price DataFrames to last 280 rows before the feature compute loop (longest window = 252; saves ~44% base memory vs 2y slim cache)
- `price_data.pop(ticker)` releases each DataFrame as soon as its last row is extracted — prevents holding all 900 simultaneously

**Commit 2 — Step Function restructure (architectural fix)**
- Move `StartExecutorEC2` + `WaitForInstanceReady` from after HealthCheck to immediately after `CheckTradingDay`
- Switch `DailyData` target from `ec2_instance_id` (ae-dashboard, t3.micro, 1 GB RAM) to `trading_instance_id` (ae-trading, t3.small, 2 GB RAM)
- Increase `DailyData` executionTimeout from 420s to 600s
- `WaitForInstanceReady` reduced from 120s to 60s (SSM agent only; IB Gateway authenticates during DailyData, handled by `wait-for-ibgateway.sh` before `RunMorningPlanner`)
- Remove redundant `StartExecutorEC2` from the HealthCheck → RunMorningPlanner path
- `HealthCheck` stays on ae-dashboard (alpha-engine-data lives there)

## Root cause
SSM command `932951a4` on `i-09b539c844515d549` (ae-dashboard t3.micro): `ResponseCode=137`, `ExecutionTimedOut` after `PT7M0.011S`. Last log line: `Computing features for 909 tickers...`. Feature computation loads all 900+ slim cache DataFrames into memory simultaneously — 1 GB RAM can't hold them. Not the macro staleness issue from 2026-04-15.

## Validation
Dry-run on ae-trading completed successfully: 909 tickers in 41.5s (vs OOM after 5.5 min on ae-dashboard), total 176s, exit 0.

## One-time setup (already done)
ae-trading: alpha-engine-data cloned, venv created, deps installed, env vars confirmed.

## Test plan
- [ ] Merge PR
- [ ] Deploy: `export PATH="/opt/homebrew/bin:$PATH" && bash infrastructure/deploy_step_function_daily.sh`
- [ ] Trigger manual run and confirm DailyData step succeeds on ae-trading
- [ ] Confirm `predictor/daily_closes/2026-04-16.parquet` exists in S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)