### PR TITLE
Emit daily_data module health stamp after daily_closes.collect

### DIFF
--- a/tests/test_module_health.py
+++ b/tests/test_module_health.py
@@ -1,0 +1,100 @@
+"""Unit tests for weekly_collector._write_module_health.
+
+Validates that the module-scoped health stamp consumed by the executor's
+upstream gate (alpha-engine/executor/health_status.py::check_upstream_health)
+is written with the correct schema and key pattern.
+"""
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+from weekly_collector import _write_module_health
+
+
+def _capture_put() -> MagicMock:
+    """Patch boto3.client('s3') and return the mocked put_object call tracker."""
+    s3 = MagicMock()
+    return s3
+
+
+class TestWriteModuleHealth:
+
+    @patch("weekly_collector.boto3")
+    def test_ok_status_populates_last_success(self, mock_boto3):
+        s3 = _capture_put()
+        mock_boto3.client.return_value = s3
+
+        _write_module_health(
+            "bucket", "daily_data", "2026-04-16", "ok",
+            summary={"tickers_captured": 909},
+            duration_seconds=42.7,
+        )
+
+        s3.put_object.assert_called_once()
+        call_kwargs = s3.put_object.call_args.kwargs
+        assert call_kwargs["Key"] == "health/daily_data.json"
+        assert call_kwargs["Bucket"] == "bucket"
+        payload = json.loads(call_kwargs["Body"].decode("utf-8"))
+        assert payload["module"] == "daily_data"
+        assert payload["status"] == "ok"
+        assert payload["run_date"] == "2026-04-16"
+        assert payload["duration_seconds"] == 42.7
+        assert payload["summary"] == {"tickers_captured": 909}
+        assert payload["warnings"] == []
+        assert payload["error"] is None
+        assert payload["last_success"] is not None
+        # Parseable as ISO timestamp
+        datetime.fromisoformat(payload["last_success"])
+
+    @patch("weekly_collector.boto3")
+    def test_failed_status_nulls_last_success(self, mock_boto3):
+        s3 = _capture_put()
+        mock_boto3.client.return_value = s3
+
+        _write_module_health(
+            "bucket", "daily_data", "2026-04-16", "failed",
+            error="polygon 429 rate-limited",
+        )
+
+        payload = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert payload["status"] == "failed"
+        assert payload["last_success"] is None
+        assert payload["error"] == "polygon 429 rate-limited"
+
+    @patch("weekly_collector.boto3")
+    def test_degraded_status_populates_last_success(self, mock_boto3):
+        """Degraded runs still count as a last_success — partial data is usable."""
+        s3 = _capture_put()
+        mock_boto3.client.return_value = s3
+
+        _write_module_health(
+            "bucket", "daily_data", "2026-04-16", "degraded",
+            warnings=["109 tickers missing from polygon"],
+            summary={"tickers_captured": 800},
+        )
+
+        payload = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert payload["status"] == "degraded"
+        assert payload["last_success"] is not None
+        assert payload["warnings"] == ["109 tickers missing from polygon"]
+
+    @patch("weekly_collector.boto3")
+    def test_key_pattern_matches_executor_contract(self, mock_boto3):
+        """Key must be health/{module_name}.json — matches executor's read_health."""
+        s3 = _capture_put()
+        mock_boto3.client.return_value = s3
+
+        _write_module_health("bucket", "predictor_inference", "2026-04-16", "ok")
+        assert s3.put_object.call_args.kwargs["Key"] == "health/predictor_inference.json"
+
+    @patch("weekly_collector.boto3")
+    def test_default_summary_and_warnings_are_empty_dicts_lists(self, mock_boto3):
+        s3 = _capture_put()
+        mock_boto3.client.return_value = s3
+
+        _write_module_health("bucket", "daily_data", "2026-04-16", "ok")
+        payload = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert payload["summary"] == {}
+        assert payload["warnings"] == []
+        assert payload["error"] is None
+        assert payload["duration_seconds"] == 0.0

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -392,6 +392,7 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
     logger.info("=" * 60)
     logger.info("COLLECTING: daily closes")
     logger.info("=" * 60)
+    dc_started_at = datetime.now(timezone.utc)
     try:
         dc_result = daily_closes.collect(
             bucket=bucket,
@@ -404,6 +405,30 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
     except Exception as e:
         logger.error("Daily closes collection failed: %s", e)
         results["collectors"]["daily_closes"] = {"status": "error", "error": str(e)}
+
+    # Module health stamp for daily_data — scoped to daily_closes only. The
+    # executor gate at alpha-engine/executor/main.py reads this key to decide
+    # whether upstream data is fresh. Emitted on both ok and failure paths
+    # so downstream can distinguish "ran and failed" from "hasn't run".
+    if not dry_run:
+        _dc = results["collectors"]["daily_closes"]
+        _dc_status = _dc.get("status", "unknown")
+        _dc_ok = _dc_status in ("ok", "ok_dry_run")
+        _dc_duration = (datetime.now(timezone.utc) - dc_started_at).total_seconds()
+        _write_module_health(
+            bucket,
+            module_name="daily_data",
+            run_date=run_date,
+            status="ok" if _dc_ok else "failed",
+            summary={
+                "tickers_captured": _dc.get("tickers_captured", 0),
+                "polygon": _dc.get("polygon", 0),
+                "fred": _dc.get("fred", 0),
+                "yfinance": _dc.get("yfinance", 0),
+            },
+            error=None if _dc_ok else _dc.get("error", f"daily_closes status={_dc_status}"),
+            duration_seconds=_dc_duration,
+        )
 
     # ── Feature store compute ───────────────────────────────────────────────
     logger.info("=" * 60)
@@ -598,7 +623,7 @@ def _write_validation_json(
 
 
 def _write_health_marker(bucket: str, phase: int, run_date: str, status: str) -> None:
-    """Write health marker for Step Functions dependency checking."""
+    """Write phase-based health marker (legacy) for Step Functions dependency checking."""
     s3 = boto3.client("s3")
     key = f"health/data_phase{phase}.json"
     marker = {
@@ -614,6 +639,48 @@ def _write_health_marker(bucket: str, phase: int, run_date: str, status: str) ->
         ContentType="application/json",
     )
     logger.info("Wrote health marker: s3://%s/%s", bucket, key)
+
+
+def _write_module_health(
+    bucket: str,
+    module_name: str,
+    run_date: str,
+    status: str,
+    *,
+    summary: dict | None = None,
+    warnings: list | None = None,
+    error: str | None = None,
+    duration_seconds: float = 0.0,
+) -> None:
+    """Write module-scoped health stamp consumed by the executor's
+    check_upstream_health() (alpha-engine/executor/health_status.py:91).
+
+    Schema matches executor's write_health() — key pattern
+    `health/{module_name}.json` with `last_success` nulled on failure so
+    downstream staleness checks can distinguish "ran and failed today" from
+    "hasn't run in N hours". Called on both success AND failure paths so the
+    stamp reflects the actual last run outcome.
+    """
+    s3 = boto3.client("s3")
+    key = f"health/{module_name}.json"
+    now_iso = datetime.now(timezone.utc).isoformat()
+    payload = {
+        "module": module_name,
+        "status": status,
+        "last_success": now_iso if status != "failed" else None,
+        "run_date": run_date,
+        "duration_seconds": round(duration_seconds, 1),
+        "summary": summary or {},
+        "warnings": warnings or [],
+        "error": error,
+    }
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(payload, indent=2).encode("utf-8"),
+        ContentType="application/json",
+    )
+    logger.info("Wrote module health: s3://%s/%s (%s)", bucket, key, status)
 
 
 def _parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary

Adds \`health/daily_data.json\` emission after \`daily_closes.collect()\` in \`_run_daily()\`, using the schema consumed by the executor's \`check_upstream_health()\` (\`alpha-engine/executor/health_status.py:91\`).

Belt-and-suspenders with the direct \`LastModified\` gates in [alpha-engine#53](https://github.com/cipher813/alpha-engine/pull/53) and [alpha-engine-predictor#33](https://github.com/cipher813/alpha-engine-predictor/pull/33):

| Check | Catches | Catches that |
|---|---|---|
| Direct \`LastModified\` (already in #53/#33) | "stamp green, blob stale" | — |
| Module health stamp (this PR) | "ran and failed" with structured reason | partial-success \`degraded\` state, observability, post-mortem metadata |

The stamp alone would leave the silent-upstream-staleness hole — stamp says green while the blob is yesterday's. That's why both PRs exist.

## Change

- New \`_write_module_health()\` helper matching executor's \`write_health()\` schema (\`module\`, \`status\`, \`last_success\`, \`run_date\`, \`duration_seconds\`, \`summary\`, \`warnings\`, \`error\`).
- Called in \`_run_daily()\` immediately after \`daily_closes.collect()\`, scoped to that collector alone (feature store + ArcticDB append have their own lifecycle; the executor reads \`daily_closes/{date}.parquet\`, so the stamp reflects only that).
- Emitted on both success AND failure — \`last_success: null\` when status=failed lets readers distinguish "ran and failed today" from "hasn't run in N hours."
- Legacy \`_write_health_marker()\` phase stamps (\`health/data_phase0.json\` etc.) kept untouched for backward compat.

## Test plan

- [x] 5 new unit tests in \`tests/test_module_health.py\` — ok/failed/degraded/key pattern/defaults
- [x] Full suite: **71 passed / 0 failed**
- [ ] Post-merge: first weekday run (Mon 13:05 UTC) emits \`health/daily_data.json\` with status=ok, tickers_captured≈909

## Deploy sequencing

1. **Merge this PR first** — data stamps start emitting on next weekday run
2. **Then merge** follow-up alpha-engine PR that adds \`"daily_data": 24\` to \`_UPSTREAM_MAX_AGE_H\`
3. If executor PR merges first, every executor run fails with \"no health data returned\" until data PR deploys

## Follow-up (not in this PR)

- Migrate Phase 1 and Phase 2 stamp writes from \`_write_health_marker(phase=N)\` to \`_write_module_health(module_name=...)\`. Out of scope for belt-and-suspenders on \`daily_data\`.
- Partial-success semantics (status=degraded when N < threshold tickers captured). Placeholder in schema; policy decision for a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)