### PR TITLE
Point CheckTradingDay + HealthCheck SSM commands at alpha-engine-dashboard

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -12,7 +12,7 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
-            "cd /home/ec2-user/alpha-engine-data",
+            "cd /home/ec2-user/alpha-engine-dashboard",
             "source .venv/bin/activate",
             "python trading_calendar.py"
           ],
@@ -336,7 +336,7 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
-            "cd /home/ec2-user/alpha-engine-data",
+            "cd /home/ec2-user/alpha-engine-dashboard",
             "source .venv/bin/activate",
             "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
           ],


### PR DESCRIPTION
## Summary

Part 2/3 of the ae-dashboard de-bloat split. Updates the Step Function's two SSM commands that currently invoke scripts from \`/home/ec2-user/alpha-engine-data\` to run from \`/home/ec2-user/alpha-engine-dashboard\` instead.

Both scripts (\`trading_calendar.py\`, \`health_checker.py\`) were copied verbatim into the dashboard repo in [cipher813/alpha-engine-dashboard#18](https://github.com/cipher813/alpha-engine-dashboard/pull/18). CLI contract unchanged — \`"TRADING DAY"\` / \`"MARKET_CLOSED"\` stdout markers and \`--alert\` flag behavior are identical.

## Change

\`infrastructure/step_function_daily.json\`, two hunks:

\`\`\`diff
-   "cd /home/ec2-user/alpha-engine-data",
+   "cd /home/ec2-user/alpha-engine-dashboard",
    "source .venv/bin/activate",
    "python trading_calendar.py"
\`\`\`

\`\`\`diff
-   "cd /home/ec2-user/alpha-engine-data",
+   "cd /home/ec2-user/alpha-engine-dashboard",
    "source .venv/bin/activate",
    "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
\`\`\`

No other states touched. No CloudFormation changes needed.

## Pre-merge requirements

- [ ] [cipher813/alpha-engine-dashboard#18](https://github.com/cipher813/alpha-engine-dashboard/pull/18) merged
- [ ] ae-dashboard has pulled the new dashboard files (either via installed \`boot-pull.timer\` or manual \`git -C /home/ec2-user/alpha-engine-dashboard pull\`)

## Deploy

Operator runs the existing deploy script post-merge:

\`\`\`bash
bash infrastructure/deploy_step_function_daily.sh
\`\`\`

## Test plan

- [x] \`python3 -c "import json; json.load(open('infrastructure/step_function_daily.json'))"\` — JSON valid
- [ ] Post-deploy: next weekday run — \`CheckTradingDay\` logs \`/var/log/amazon/ssm/...\` show \`cd /home/ec2-user/alpha-engine-dashboard\`, \`HealthCheck\` writes \`/var/log/health-check.log\` with identical report shape

## Part 3/3

After a clean weekday run validates new paths: separate PR to delete \`trading_calendar.py\` + \`health_checker.py\` + their tests from alpha-engine-data, plus cross-repo update to remove \`alpha-engine-data\` from alpha-engine-dashboard's \`boot-pull.sh\` REPOS list and delete the clone on ae-dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)