### PR TITLE
Migrate DataPhase1+RAGIngestion (bundled) and DriftDetection to spot

### DIFF
--- a/infrastructure/spot_data_phase1.sh
+++ b/infrastructure/spot_data_phase1.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# infrastructure/spot_data_phase1.sh — Run weekly DataPhase1 on a spot EC2 instance.
+#
+# Launches a c5.large spot instance, clones alpha-engine-data, runs
+# `python weekly_collector.py --phase 1`, emits a heartbeat on success, and
+# self-terminates.
+#
+# Origin: moved off ae-dashboard (t3.micro, 1 GB RAM) after the 2026-04-16
+# OOM incident in which features/compute.py in the DAILY code path exhausted
+# micro memory. Saturday's Phase 1 uses a different code path and hasn't
+# OOM'd historically, but running heavy data-refresh workloads on a 1 GB
+# instance is fragile-by-design. This spot pattern mirrors the Backtester +
+# PredictorTraining spot launchers so all heavy weekly compute lives on
+# fresh, self-terminating instances instead of the always-on micro.
+#
+# Usage:
+#   ./infrastructure/spot_data_phase1.sh                    # full Phase 1
+#   ./infrastructure/spot_data_phase1.sh --smoke-only       # quick validation, then terminate
+#   ./infrastructure/spot_data_phase1.sh --instance-type c5.xlarge   # override size
+#   ./infrastructure/spot_data_phase1.sh --branch my-branch          # override branch
+#
+# Prerequisites on the launching host (ae-dashboard when invoked by the
+# Saturday Step Function):
+#   - AWS CLI with perms to RunInstances / TerminateInstances / DescribeInstances
+#   - SSH key at ~/.ssh/alpha-engine-key.pem
+#   - .env at /home/ec2-user/.alpha-engine.env (for API keys, ALPHA_ENGINE_LIB_TOKEN)
+#   - alpha-engine-data checked out at the script's parent dir
+
+set -euo pipefail
+
+# SSM RunCommand does not set HOME; default it for the .env/SSH lookups below.
+export HOME="${HOME:-/home/ec2-user}"
+
+# ── Locate .env ──────────────────────────────────────────────────────────────
+# Step Function path first; fall back to repo-local .env for manual runs.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ENV_FILE="$HOME/.alpha-engine.env"
+if [ ! -f "$ENV_FILE" ]; then
+    ENV_FILE="$REPO_ROOT/.env"
+fi
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+    echo "Loaded .env from $ENV_FILE"
+else
+    echo "ERROR: No .env file found (checked ~/.alpha-engine.env, repo/.env)"
+    exit 1
+fi
+
+# ── Spot configuration ──────────────────────────────────────────────────────
+# Values mirror alpha-engine-backtester/infrastructure/spot_backtest.sh so
+# new IAM/security-group/subnet resources aren't introduced. If any of these
+# change in the backtester launcher, this file should change in lockstep.
+AWS_REGION="${AWS_REGION:-us-east-1}"
+S3_BUCKET="${S3_BUCKET:-alpha-engine-research}"
+BRANCH="${BRANCH:-main}"
+INSTANCE_TYPE="c5.large"            # 2 vCPU, 4 GB RAM — DataPhase1 is memory-bound, not CPU-bound
+AMI_ID="ami-0c421724a94bba6d6"      # Amazon Linux 2023 x86_64
+KEY_NAME="alpha-engine-key"
+KEY_FILE="$HOME/.ssh/alpha-engine-key.pem"
+SECURITY_GROUP="sg-03cd3c4bd91e610b0"
+SUBNET_ID="subnet-e07166ec"
+IAM_PROFILE="alpha-engine-executor-profile"
+
+# ── Parse flags ──────────────────────────────────────────────────────────────
+RUN_MODE="full"  # full | smoke-only
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --smoke-only) RUN_MODE="smoke-only"; shift ;;
+        --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        *) echo "Unknown flag: $1"; exit 1 ;;
+    esac
+done
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  DataPhase1 Spot Run — $(date +%Y-%m-%d)"
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Instance type : $INSTANCE_TYPE"
+echo "  AMI           : $AMI_ID"
+echo "  Region        : $AWS_REGION"
+echo "  Branch        : $BRANCH"
+echo "  Run mode      : $RUN_MODE"
+echo "  S3 bucket     : $S3_BUCKET"
+echo ""
+
+# ── Preflight ───────────────────────────────────────────────────────────────
+if [ ! -f "$KEY_FILE" ]; then
+    echo "ERROR: SSH key not found at $KEY_FILE"
+    exit 1
+fi
+
+# ALPHA_ENGINE_LIB_TOKEN required for pip install of the private lib.
+if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
+    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env — required for alpha-engine-lib pip install on spot"
+    exit 1
+fi
+
+# ── Launch spot ──────────────────────────────────────────────────────────────
+echo "==> Requesting spot instance ($INSTANCE_TYPE)..."
+
+INSTANCE_ID=$(aws ec2 run-instances \
+    --image-id "$AMI_ID" \
+    --instance-type "$INSTANCE_TYPE" \
+    --key-name "$KEY_NAME" \
+    --security-group-ids "$SECURITY_GROUP" \
+    --subnet-id "$SUBNET_ID" \
+    --iam-instance-profile Name="$IAM_PROFILE" \
+    --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}' \
+    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-data-phase1-$(date +%Y%m%d)}]" \
+    --region "$AWS_REGION" \
+    --query 'Instances[0].InstanceId' \
+    --output text)
+
+echo "  Instance ID: $INSTANCE_ID"
+
+# Always terminate, even on error.
+cleanup() {
+    echo ""
+    echo "==> Terminating spot instance $INSTANCE_ID..."
+    aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
+    echo "  Instance terminated."
+}
+trap cleanup EXIT
+
+echo "==> Waiting for instance to enter running state..."
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$AWS_REGION"
+
+PUBLIC_IP=$(aws ec2 describe-instances \
+    --instance-ids "$INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text \
+    --region "$AWS_REGION")
+
+if [ "$PUBLIC_IP" = "None" ] || [ -z "$PUBLIC_IP" ]; then
+    echo "ERROR: Instance has no public IP. Check subnet/VPC configuration."
+    exit 1
+fi
+
+echo "  Public IP: $PUBLIC_IP"
+
+# ── Wait for SSH ─────────────────────────────────────────────────────────────
+echo "==> Waiting for SSH to become available..."
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o LogLevel=ERROR"
+
+for i in $(seq 1 30); do
+    if ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "echo ok" 2>/dev/null; then
+        echo "  SSH ready."
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "ERROR: SSH not available after 150s"
+        exit 1
+    fi
+    sleep 5
+done
+
+run_remote() {
+    ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "$@"
+}
+
+# ── Bootstrap spot: python + git ─────────────────────────────────────────────
+echo "==> Bootstrapping spot environment..."
+run_remote bash -s <<'BOOTSTRAP'
+set -euo pipefail
+sudo dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null || \
+    sudo dnf install -y -q python3 python3-pip python3-devel git gcc
+if command -v python3.12 &>/dev/null; then
+    echo "Using: $(python3.12 --version)"
+else
+    echo "Using: $(python3 --version)"
+fi
+mkdir -p ~/.ssh
+ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+BOOTSTRAP
+
+# ── Clone alpha-engine-data on spot ──────────────────────────────────────────
+echo "==> Cloning alpha-engine-data (branch: $BRANCH)..."
+# HTTPS clone with PAT — matches the lib-install pattern below.
+run_remote "git clone --depth 1 --branch $BRANCH https://github.com/cipher813/alpha-engine-data.git /home/ec2-user/alpha-engine-data"
+
+# ── Upload .env BEFORE pip install (for ALPHA_ENGINE_LIB_TOKEN) ──────────────
+echo "==> Uploading .env to spot..."
+scp $SSH_OPTS -i "$KEY_FILE" \
+    "$ENV_FILE" \
+    ec2-user@"$PUBLIC_IP":/home/ec2-user/alpha-engine-data/.env
+
+# ── Install python deps ──────────────────────────────────────────────────────
+echo "==> Installing Python dependencies..."
+run_remote bash -s <<'DEPS'
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+
+set -a
+# shellcheck disable=SC1091
+source /home/ec2-user/alpha-engine-data/.env
+set +a
+if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
+    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env"
+    exit 1
+fi
+git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+
+if command -v python3.12 &>/dev/null; then
+    PIP="python3.12 -m pip"
+else
+    PIP="python3 -m pip"
+fi
+
+$PIP install --upgrade pip -q
+$PIP install -q -r requirements.txt
+
+# numpy<2 pin to match other spot workloads (pyarrow compiled against 1.x).
+$PIP install -q 'numpy<2'
+
+echo "Dependencies installed."
+DEPS
+
+REMOTE_PYTHON=$(run_remote "command -v python3.12 || command -v python3")
+ENV_SOURCE='set -a; [ -f /home/ec2-user/alpha-engine-data/.env ] && source /home/ec2-user/alpha-engine-data/.env; set +a; export XDG_CACHE_HOME=/tmp;'
+
+# ── Smoke-only: imports + --phase 1 --dry-run ────────────────────────────────
+if [ "$RUN_MODE" = "smoke-only" ]; then
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  SMOKE TEST"
+    echo "═══════════════════════════════════════════════════════════════"
+    run_remote bash -s <<SMOKE
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+${ENV_SOURCE}
+
+echo "==> Smoke: python import weekly_collector"
+$REMOTE_PYTHON -c "import weekly_collector; print('import OK')"
+
+echo ""
+echo "==> Smoke: weekly_collector.py --phase 1 --dry-run"
+$REMOTE_PYTHON weekly_collector.py --phase 1 --dry-run 2>&1 | tail -30
+SMOKE
+
+    echo "==> Smoke complete — instance will be terminated."
+    exit 0
+fi
+
+# ── Full DataPhase1 ──────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  FULL DATA PHASE 1"
+echo "═══════════════════════════════════════════════════════════════"
+
+run_remote bash -s <<PHASE1
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+${ENV_SOURCE}
+
+echo "Starting weekly_collector.py --phase 1 at \$(date)"
+if ! $REMOTE_PYTHON weekly_collector.py --phase 1 2>&1; then
+    echo "ERROR: weekly_collector.py --phase 1 failed." >&2
+    exit 1
+fi
+echo "DataPhase1 complete at \$(date)"
+PHASE1
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  DataPhase1 complete. Instance will be terminated."
+echo "═══════════════════════════════════════════════════════════════"
+
+# Heartbeat on successful completion — mirrors backtester pattern so
+# CloudWatch alarms can detect missed runs.
+aws cloudwatch put-metric-data \
+  --namespace "AlphaEngine" \
+  --metric-name "Heartbeat" \
+  --dimensions "Process=data-phase1" \
+  --value 1 --unit "Count" \
+  --region "${AWS_REGION:-us-east-1}" 2>/dev/null \
+  && echo "Heartbeat emitted: data-phase1" \
+  || echo "WARNING: Failed to emit heartbeat (non-fatal)"

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# infrastructure/spot_data_weekly.sh — Run weekly data workloads on a spot EC2.
+#
+# Bundles DataPhase1 + RAGIngestion on a single spot: launches c5.large,
+# clones alpha-engine-data, runs `python weekly_collector.py --phase 1`
+# followed by `bash rag/pipelines/run_weekly_ingestion.sh`, emits a
+# heartbeat on success, and self-terminates.
+#
+# Origin: moved off ae-dashboard (t3.micro, 1 GB RAM) after the 2026-04-16
+# OOM incident (features/compute.py in the DAILY code path exhausted micro
+# memory). Saturday's Phase 1 uses a different code path and hasn't OOM'd
+# historically, but running heavy data-refresh workloads on 1 GB RAM is
+# fragile-by-design. This spot pattern mirrors the Backtester +
+# PredictorTraining launchers so all heavy weekly compute lives on
+# fresh, self-terminating instances instead of the always-on micro.
+#
+# Bundling rationale: Phase 1 and RAG ingestion are sequential SF steps
+# that share the same repo + venv. One spot per bundle saves ~7 min of
+# bootstrap overhead and one spot request. Trade-off: any failure fails
+# both — acceptable since partial Saturday failures typically require a
+# full-pipeline rerun anyway.
+#
+# Usage:
+#   ./infrastructure/spot_data_weekly.sh                   # phase1 + rag
+#   ./infrastructure/spot_data_weekly.sh --smoke-only      # quick validation, then terminate
+#   ./infrastructure/spot_data_weekly.sh --instance-type c5.xlarge   # override size
+#   ./infrastructure/spot_data_weekly.sh --branch my-branch          # override branch
+#
+# Prerequisites on the launching host (ae-dashboard when invoked by the
+# Saturday Step Function):
+#   - AWS CLI with perms to RunInstances / TerminateInstances / DescribeInstances
+#   - SSH key at ~/.ssh/alpha-engine-key.pem
+#   - .env at /home/ec2-user/.alpha-engine.env (for API keys, ALPHA_ENGINE_LIB_TOKEN)
+#   - alpha-engine-data checked out at the script's parent dir
+
+set -euo pipefail
+
+# SSM RunCommand does not set HOME; default it for the .env/SSH lookups below.
+export HOME="${HOME:-/home/ec2-user}"
+
+# ── Locate .env ──────────────────────────────────────────────────────────────
+# Step Function path first; fall back to repo-local .env for manual runs.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ENV_FILE="$HOME/.alpha-engine.env"
+if [ ! -f "$ENV_FILE" ]; then
+    ENV_FILE="$REPO_ROOT/.env"
+fi
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+    echo "Loaded .env from $ENV_FILE"
+else
+    echo "ERROR: No .env file found (checked ~/.alpha-engine.env, repo/.env)"
+    exit 1
+fi
+
+# ── Spot configuration ──────────────────────────────────────────────────────
+# Values mirror alpha-engine-backtester/infrastructure/spot_backtest.sh so
+# new IAM/security-group/subnet resources aren't introduced. If any of these
+# change in the backtester launcher, this file should change in lockstep.
+AWS_REGION="${AWS_REGION:-us-east-1}"
+S3_BUCKET="${S3_BUCKET:-alpha-engine-research}"
+BRANCH="${BRANCH:-main}"
+INSTANCE_TYPE="c5.large"            # 2 vCPU, 4 GB RAM — DataPhase1 is memory-bound, not CPU-bound
+AMI_ID="ami-0c421724a94bba6d6"      # Amazon Linux 2023 x86_64
+KEY_NAME="alpha-engine-key"
+KEY_FILE="$HOME/.ssh/alpha-engine-key.pem"
+SECURITY_GROUP="sg-03cd3c4bd91e610b0"
+SUBNET_ID="subnet-e07166ec"
+IAM_PROFILE="alpha-engine-executor-profile"
+
+# ── Parse flags ──────────────────────────────────────────────────────────────
+RUN_MODE="full"  # full | smoke-only
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --smoke-only) RUN_MODE="smoke-only"; shift ;;
+        --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        *) echo "Unknown flag: $1"; exit 1 ;;
+    esac
+done
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Weekly Data Spot Run (Phase1 + RAG) — $(date +%Y-%m-%d)"
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Instance type : $INSTANCE_TYPE"
+echo "  AMI           : $AMI_ID"
+echo "  Region        : $AWS_REGION"
+echo "  Branch        : $BRANCH"
+echo "  Run mode      : $RUN_MODE"
+echo "  S3 bucket     : $S3_BUCKET"
+echo ""
+
+# ── Preflight ───────────────────────────────────────────────────────────────
+if [ ! -f "$KEY_FILE" ]; then
+    echo "ERROR: SSH key not found at $KEY_FILE"
+    exit 1
+fi
+
+# ALPHA_ENGINE_LIB_TOKEN required for pip install of the private lib.
+if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
+    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env — required for alpha-engine-lib pip install on spot"
+    exit 1
+fi
+
+# ── Launch spot ──────────────────────────────────────────────────────────────
+echo "==> Requesting spot instance ($INSTANCE_TYPE)..."
+
+INSTANCE_ID=$(aws ec2 run-instances \
+    --image-id "$AMI_ID" \
+    --instance-type "$INSTANCE_TYPE" \
+    --key-name "$KEY_NAME" \
+    --security-group-ids "$SECURITY_GROUP" \
+    --subnet-id "$SUBNET_ID" \
+    --iam-instance-profile Name="$IAM_PROFILE" \
+    --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}' \
+    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-data-weekly-$(date +%Y%m%d)}]" \
+    --region "$AWS_REGION" \
+    --query 'Instances[0].InstanceId' \
+    --output text)
+
+echo "  Instance ID: $INSTANCE_ID"
+
+# Always terminate, even on error.
+cleanup() {
+    echo ""
+    echo "==> Terminating spot instance $INSTANCE_ID..."
+    aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
+    echo "  Instance terminated."
+}
+trap cleanup EXIT
+
+echo "==> Waiting for instance to enter running state..."
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$AWS_REGION"
+
+PUBLIC_IP=$(aws ec2 describe-instances \
+    --instance-ids "$INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text \
+    --region "$AWS_REGION")
+
+if [ "$PUBLIC_IP" = "None" ] || [ -z "$PUBLIC_IP" ]; then
+    echo "ERROR: Instance has no public IP. Check subnet/VPC configuration."
+    exit 1
+fi
+
+echo "  Public IP: $PUBLIC_IP"
+
+# ── Wait for SSH ─────────────────────────────────────────────────────────────
+echo "==> Waiting for SSH to become available..."
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o LogLevel=ERROR"
+
+for i in $(seq 1 30); do
+    if ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "echo ok" 2>/dev/null; then
+        echo "  SSH ready."
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "ERROR: SSH not available after 150s"
+        exit 1
+    fi
+    sleep 5
+done
+
+run_remote() {
+    ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "$@"
+}
+
+# ── Bootstrap spot: python + git ─────────────────────────────────────────────
+echo "==> Bootstrapping spot environment..."
+run_remote bash -s <<'BOOTSTRAP'
+set -euo pipefail
+sudo dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null || \
+    sudo dnf install -y -q python3 python3-pip python3-devel git gcc
+if command -v python3.12 &>/dev/null; then
+    echo "Using: $(python3.12 --version)"
+else
+    echo "Using: $(python3 --version)"
+fi
+mkdir -p ~/.ssh
+ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+BOOTSTRAP
+
+# ── Clone alpha-engine-data on spot ──────────────────────────────────────────
+echo "==> Cloning alpha-engine-data (branch: $BRANCH)..."
+# HTTPS clone with PAT — matches the lib-install pattern below.
+run_remote "git clone --depth 1 --branch $BRANCH https://github.com/cipher813/alpha-engine-data.git /home/ec2-user/alpha-engine-data"
+
+# ── Upload .env BEFORE pip install (for ALPHA_ENGINE_LIB_TOKEN) ──────────────
+echo "==> Uploading .env to spot..."
+scp $SSH_OPTS -i "$KEY_FILE" \
+    "$ENV_FILE" \
+    ec2-user@"$PUBLIC_IP":/home/ec2-user/alpha-engine-data/.env
+
+# ── Install python deps ──────────────────────────────────────────────────────
+echo "==> Installing Python dependencies..."
+run_remote bash -s <<'DEPS'
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+
+set -a
+# shellcheck disable=SC1091
+source /home/ec2-user/alpha-engine-data/.env
+set +a
+if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
+    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env"
+    exit 1
+fi
+git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+
+if command -v python3.12 &>/dev/null; then
+    PIP="python3.12 -m pip"
+else
+    PIP="python3 -m pip"
+fi
+
+$PIP install --upgrade pip -q
+$PIP install -q -r requirements.txt
+
+# numpy<2 pin to match other spot workloads (pyarrow compiled against 1.x).
+$PIP install -q 'numpy<2'
+
+echo "Dependencies installed."
+DEPS
+
+REMOTE_PYTHON=$(run_remote "command -v python3.12 || command -v python3")
+ENV_SOURCE='set -a; [ -f /home/ec2-user/alpha-engine-data/.env ] && source /home/ec2-user/alpha-engine-data/.env; set +a; export XDG_CACHE_HOME=/tmp;'
+
+# ── Smoke-only: imports + --phase 1 --dry-run ────────────────────────────────
+if [ "$RUN_MODE" = "smoke-only" ]; then
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  SMOKE TEST"
+    echo "═══════════════════════════════════════════════════════════════"
+    run_remote bash -s <<SMOKE
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+${ENV_SOURCE}
+
+echo "==> Smoke: python import weekly_collector"
+$REMOTE_PYTHON -c "import weekly_collector; print('import OK')"
+
+echo ""
+echo "==> Smoke: weekly_collector.py --phase 1 --dry-run"
+$REMOTE_PYTHON weekly_collector.py --phase 1 --dry-run 2>&1 | tail -30
+SMOKE
+
+    echo "==> Smoke complete — instance will be terminated."
+    exit 0
+fi
+
+# ── Full run: DataPhase1 + RAGIngestion sequentially ────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  FULL RUN: DataPhase1 + RAGIngestion"
+echo "═══════════════════════════════════════════════════════════════"
+
+run_remote bash -s <<WORKLOADS
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+${ENV_SOURCE}
+
+echo "──────────────────────────────────────────────────────────────"
+echo "Starting weekly_collector.py --phase 1 at \$(date)"
+echo "──────────────────────────────────────────────────────────────"
+if ! $REMOTE_PYTHON weekly_collector.py --phase 1 2>&1; then
+    echo "ERROR: weekly_collector.py --phase 1 failed — aborting bundle before RAG." >&2
+    exit 1
+fi
+echo "DataPhase1 complete at \$(date)"
+
+echo ""
+echo "──────────────────────────────────────────────────────────────"
+echo "Starting rag/pipelines/run_weekly_ingestion.sh at \$(date)"
+echo "──────────────────────────────────────────────────────────────"
+if ! bash rag/pipelines/run_weekly_ingestion.sh 2>&1; then
+    echo "ERROR: run_weekly_ingestion.sh failed." >&2
+    exit 1
+fi
+echo "RAGIngestion complete at \$(date)"
+WORKLOADS
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Weekly data bundle complete. Instance will be terminated."
+echo "═══════════════════════════════════════════════════════════════"
+
+# Heartbeat — one metric per sub-workload so CloudWatch alarms can
+# distinguish between a missed Phase 1 and a missed RAG.
+for proc in data-phase1 rag-ingestion; do
+    aws cloudwatch put-metric-data \
+        --namespace "AlphaEngine" \
+        --metric-name "Heartbeat" \
+        --dimensions "Process=$proc" \
+        --value 1 --unit "Count" \
+        --region "${AWS_REGION:-us-east-1}" 2>/dev/null \
+        && echo "Heartbeat emitted: $proc" \
+        || echo "WARNING: Failed to emit heartbeat for $proc (non-fatal)"
+done

--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -1,38 +1,34 @@
 #!/usr/bin/env bash
-# infrastructure/spot_data_phase1.sh — Run weekly DataPhase1 on a spot EC2 instance.
+# infrastructure/spot_drift_detection.sh — Feature + prediction drift check on spot EC2.
 #
-# Launches a c5.large spot instance, clones alpha-engine-data, runs
-# `python weekly_collector.py --phase 1`, emits a heartbeat on success, and
-# self-terminates.
+# Launches a c5.large spot, clones alpha-engine-data AND alpha-engine-predictor
+# (drift_detector reads predictor weights + data slim cache), runs
+# `python -m monitoring.drift_detector --alert`, emits a heartbeat on success,
+# and self-terminates.
 #
-# Origin: moved off ae-dashboard (t3.micro, 1 GB RAM) after the 2026-04-16
-# OOM incident in which features/compute.py in the DAILY code path exhausted
-# micro memory. Saturday's Phase 1 uses a different code path and hasn't
-# OOM'd historically, but running heavy data-refresh workloads on a 1 GB
-# instance is fragile-by-design. This spot pattern mirrors the Backtester +
-# PredictorTraining spot launchers so all heavy weekly compute lives on
-# fresh, self-terminating instances instead of the always-on micro.
+# Origin: moved off ae-dashboard (t3.micro) as part of the 2026-04-16
+# spot-migration push. DriftDetection is lightweight (~5 min workload), so
+# the ~7 min spot bootstrap is disproportionate cost-wise. Accepting that
+# in exchange for removing the heavy alpha-engine-data `.venv` from the
+# micro entirely. Roadmap P2: consider bundling onto the PredictorTraining
+# spot since drift depends on predictor weights produced by that step.
+#
+# Non-blocking: drift failures should not halt the Saturday pipeline — the
+# SF's DriftDetection step has a Catch → Backtester so an error here only
+# fires an alert. This launcher still exits non-zero on failure so the
+# SF receives a signal; the SF's non-blocking catch handles the rest.
 #
 # Usage:
-#   ./infrastructure/spot_data_phase1.sh                    # full Phase 1
-#   ./infrastructure/spot_data_phase1.sh --smoke-only       # quick validation, then terminate
-#   ./infrastructure/spot_data_phase1.sh --instance-type c5.xlarge   # override size
-#   ./infrastructure/spot_data_phase1.sh --branch my-branch          # override branch
-#
-# Prerequisites on the launching host (ae-dashboard when invoked by the
-# Saturday Step Function):
-#   - AWS CLI with perms to RunInstances / TerminateInstances / DescribeInstances
-#   - SSH key at ~/.ssh/alpha-engine-key.pem
-#   - .env at /home/ec2-user/.alpha-engine.env (for API keys, ALPHA_ENGINE_LIB_TOKEN)
-#   - alpha-engine-data checked out at the script's parent dir
+#   ./infrastructure/spot_drift_detection.sh
+#   ./infrastructure/spot_drift_detection.sh --smoke-only
+#   ./infrastructure/spot_drift_detection.sh --instance-type c5.xlarge
+#   ./infrastructure/spot_drift_detection.sh --branch my-branch
 
 set -euo pipefail
 
-# SSM RunCommand does not set HOME; default it for the .env/SSH lookups below.
 export HOME="${HOME:-/home/ec2-user}"
 
 # ── Locate .env ──────────────────────────────────────────────────────────────
-# Step Function path first; fall back to repo-local .env for manual runs.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -52,22 +48,17 @@ else
 fi
 
 # ── Spot configuration ──────────────────────────────────────────────────────
-# Values mirror alpha-engine-backtester/infrastructure/spot_backtest.sh so
-# new IAM/security-group/subnet resources aren't introduced. If any of these
-# change in the backtester launcher, this file should change in lockstep.
 AWS_REGION="${AWS_REGION:-us-east-1}"
-S3_BUCKET="${S3_BUCKET:-alpha-engine-research}"
 BRANCH="${BRANCH:-main}"
-INSTANCE_TYPE="c5.large"            # 2 vCPU, 4 GB RAM — DataPhase1 is memory-bound, not CPU-bound
-AMI_ID="ami-0c421724a94bba6d6"      # Amazon Linux 2023 x86_64
+INSTANCE_TYPE="c5.large"
+AMI_ID="ami-0c421724a94bba6d6"
 KEY_NAME="alpha-engine-key"
 KEY_FILE="$HOME/.ssh/alpha-engine-key.pem"
 SECURITY_GROUP="sg-03cd3c4bd91e610b0"
 SUBNET_ID="subnet-e07166ec"
 IAM_PROFILE="alpha-engine-executor-profile"
 
-# ── Parse flags ──────────────────────────────────────────────────────────────
-RUN_MODE="full"  # full | smoke-only
+RUN_MODE="full"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --smoke-only) RUN_MODE="smoke-only"; shift ;;
@@ -78,14 +69,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "═══════════════════════════════════════════════════════════════"
-echo "  DataPhase1 Spot Run — $(date +%Y-%m-%d)"
+echo "  DriftDetection Spot Run — $(date +%Y-%m-%d)"
 echo "═══════════════════════════════════════════════════════════════"
 echo "  Instance type : $INSTANCE_TYPE"
-echo "  AMI           : $AMI_ID"
-echo "  Region        : $AWS_REGION"
-echo "  Branch        : $BRANCH"
 echo "  Run mode      : $RUN_MODE"
-echo "  S3 bucket     : $S3_BUCKET"
 echo ""
 
 # ── Preflight ───────────────────────────────────────────────────────────────
@@ -93,16 +80,13 @@ if [ ! -f "$KEY_FILE" ]; then
     echo "ERROR: SSH key not found at $KEY_FILE"
     exit 1
 fi
-
-# ALPHA_ENGINE_LIB_TOKEN required for pip install of the private lib.
 if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
-    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env — required for alpha-engine-lib pip install on spot"
+    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env"
     exit 1
 fi
 
 # ── Launch spot ──────────────────────────────────────────────────────────────
 echo "==> Requesting spot instance ($INSTANCE_TYPE)..."
-
 INSTANCE_ID=$(aws ec2 run-instances \
     --image-id "$AMI_ID" \
     --instance-type "$INSTANCE_TYPE" \
@@ -112,14 +96,13 @@ INSTANCE_ID=$(aws ec2 run-instances \
     --iam-instance-profile Name="$IAM_PROFILE" \
     --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}' \
     --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
-    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-data-phase1-$(date +%Y%m%d)}]" \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-drift-$(date +%Y%m%d)}]" \
     --region "$AWS_REGION" \
     --query 'Instances[0].InstanceId' \
     --output text)
 
 echo "  Instance ID: $INSTANCE_ID"
 
-# Always terminate, even on error.
 cleanup() {
     echo ""
     echo "==> Terminating spot instance $INSTANCE_ID..."
@@ -147,7 +130,6 @@ echo "  Public IP: $PUBLIC_IP"
 # ── Wait for SSH ─────────────────────────────────────────────────────────────
 echo "==> Waiting for SSH to become available..."
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o LogLevel=ERROR"
-
 for i in $(seq 1 30); do
     if ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "echo ok" 2>/dev/null; then
         echo "  SSH ready."
@@ -164,33 +146,32 @@ run_remote() {
     ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "$@"
 }
 
-# ── Bootstrap spot: python + git ─────────────────────────────────────────────
+# ── Bootstrap python + git ───────────────────────────────────────────────────
 echo "==> Bootstrapping spot environment..."
 run_remote bash -s <<'BOOTSTRAP'
 set -euo pipefail
 sudo dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null || \
     sudo dnf install -y -q python3 python3-pip python3-devel git gcc
-if command -v python3.12 &>/dev/null; then
-    echo "Using: $(python3.12 --version)"
-else
-    echo "Using: $(python3 --version)"
-fi
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
 BOOTSTRAP
 
-# ── Clone alpha-engine-data on spot ──────────────────────────────────────────
-echo "==> Cloning alpha-engine-data (branch: $BRANCH)..."
-# HTTPS clone with PAT — matches the lib-install pattern below.
-run_remote "git clone --depth 1 --branch $BRANCH https://github.com/cipher813/alpha-engine-data.git /home/ec2-user/alpha-engine-data"
+# ── Clone alpha-engine-data + alpha-engine-predictor ─────────────────────────
+# drift_detector lives in alpha-engine-data/monitoring/ but imports from
+# alpha-engine-predictor via PYTHONPATH. Both must be present.
+echo "==> Cloning alpha-engine-data + alpha-engine-predictor (branch: $BRANCH)..."
+for REPO in alpha-engine-data alpha-engine-predictor; do
+    run_remote "git clone --depth 1 --branch $BRANCH https://github.com/cipher813/$REPO.git /home/ec2-user/$REPO"
+done
 
-# ── Upload .env BEFORE pip install (for ALPHA_ENGINE_LIB_TOKEN) ──────────────
+# ── Upload .env BEFORE pip install ──────────────────────────────────────────
 echo "==> Uploading .env to spot..."
 scp $SSH_OPTS -i "$KEY_FILE" \
     "$ENV_FILE" \
     ec2-user@"$PUBLIC_IP":/home/ec2-user/alpha-engine-data/.env
 
-# ── Install python deps ──────────────────────────────────────────────────────
+# ── Install dependencies (data repo's requirements suffice — drift_detector
+#    uses numpy/boto3/pandas from the shared universe) ───────────────────────
 echo "==> Installing Python dependencies..."
 run_remote bash -s <<'DEPS'
 set -euo pipefail
@@ -200,10 +181,6 @@ set -a
 # shellcheck disable=SC1091
 source /home/ec2-user/alpha-engine-data/.env
 set +a
-if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
-    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env"
-    exit 1
-fi
 git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
 
 if command -v python3.12 &>/dev/null; then
@@ -214,17 +191,15 @@ fi
 
 $PIP install --upgrade pip -q
 $PIP install -q -r requirements.txt
-
-# numpy<2 pin to match other spot workloads (pyarrow compiled against 1.x).
 $PIP install -q 'numpy<2'
 
 echo "Dependencies installed."
 DEPS
 
 REMOTE_PYTHON=$(run_remote "command -v python3.12 || command -v python3")
-ENV_SOURCE='set -a; [ -f /home/ec2-user/alpha-engine-data/.env ] && source /home/ec2-user/alpha-engine-data/.env; set +a; export XDG_CACHE_HOME=/tmp;'
+ENV_SOURCE='set -a; [ -f /home/ec2-user/alpha-engine-data/.env ] && source /home/ec2-user/alpha-engine-data/.env; set +a; export XDG_CACHE_HOME=/tmp; export PYTHONPATH=/home/ec2-user/alpha-engine-predictor;'
 
-# ── Smoke-only: imports + --phase 1 --dry-run ────────────────────────────────
+# ── Smoke-only: imports + --help ─────────────────────────────────────────────
 if [ "$RUN_MODE" = "smoke-only" ]; then
     echo ""
     echo "═══════════════════════════════════════════════════════════════"
@@ -235,49 +210,43 @@ set -euo pipefail
 cd /home/ec2-user/alpha-engine-data
 ${ENV_SOURCE}
 
-echo "==> Smoke: python import weekly_collector"
-$REMOTE_PYTHON -c "import weekly_collector; print('import OK')"
-
-echo ""
-echo "==> Smoke: weekly_collector.py --phase 1 --dry-run"
-$REMOTE_PYTHON weekly_collector.py --phase 1 --dry-run 2>&1 | tail -30
+echo "==> Smoke: python -m monitoring.drift_detector --help"
+$REMOTE_PYTHON -m monitoring.drift_detector --help 2>&1 | head -20
 SMOKE
 
     echo "==> Smoke complete — instance will be terminated."
     exit 0
 fi
 
-# ── Full DataPhase1 ──────────────────────────────────────────────────────────
+# ── Full drift detection ────────────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════════════════════════"
-echo "  FULL DATA PHASE 1"
+echo "  DRIFT DETECTION"
 echo "═══════════════════════════════════════════════════════════════"
 
-run_remote bash -s <<PHASE1
+run_remote bash -s <<DRIFT
 set -euo pipefail
 cd /home/ec2-user/alpha-engine-data
 ${ENV_SOURCE}
 
-echo "Starting weekly_collector.py --phase 1 at \$(date)"
-if ! $REMOTE_PYTHON weekly_collector.py --phase 1 2>&1; then
-    echo "ERROR: weekly_collector.py --phase 1 failed." >&2
+echo "Starting drift_detector at \$(date)"
+if ! $REMOTE_PYTHON -m monitoring.drift_detector --alert 2>&1; then
+    echo "ERROR: drift_detector failed." >&2
     exit 1
 fi
-echo "DataPhase1 complete at \$(date)"
-PHASE1
+echo "DriftDetection complete at \$(date)"
+DRIFT
 
 echo ""
 echo "═══════════════════════════════════════════════════════════════"
-echo "  DataPhase1 complete. Instance will be terminated."
+echo "  DriftDetection complete. Instance will be terminated."
 echo "═══════════════════════════════════════════════════════════════"
 
-# Heartbeat on successful completion — mirrors backtester pattern so
-# CloudWatch alarms can detect missed runs.
 aws cloudwatch put-metric-data \
   --namespace "AlphaEngine" \
   --metric-name "Heartbeat" \
-  --dimensions "Process=data-phase1" \
+  --dimensions "Process=drift-detection" \
   --value 1 --unit "Count" \
   --region "${AWS_REGION:-us-east-1}" 2>/dev/null \
-  && echo "Heartbeat emitted: data-phase1" \
+  && echo "Heartbeat emitted: drift-detection" \
   || echo "WARNING: Failed to emit heartbeat (non-fatal)"

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -5,7 +5,7 @@
 
     "DataPhase1": {
       "Type": "Task",
-      "Comment": "Phase 1: prices, macro, constituents, universe returns (launches spot EC2; micro is the dispatcher)",
+      "Comment": "Bundled weekly data: DataPhase1 + RAGIngestion on a single spot EC2. Micro is the dispatcher (launches spot via bash + AWS CLI; no heavy venv needed). One bootstrap cycle serves both workloads — saves ~7 min vs separate spots.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -17,13 +17,13 @@
             "cd /home/ec2-user/alpha-engine-data",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "bash infrastructure/spot_data_phase1.sh 2>&1 | tee /var/log/data-phase1.log"
+            "bash infrastructure/spot_data_weekly.sh 2>&1 | tee /var/log/data-weekly.log"
           ],
-          "executionTimeout": ["2700"]
+          "executionTimeout": ["3600"]
         },
-        "TimeoutSeconds": 2700
+        "TimeoutSeconds": 3600
       },
-      "TimeoutSeconds": 2760,
+      "TimeoutSeconds": 3660,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],
@@ -76,7 +76,7 @@
         {
           "Variable": "$.data_phase1_poll.Status",
           "StringEquals": "Success",
-          "Next": "RAGIngestion"
+          "Next": "Research"
         },
         {
           "Variable": "$.data_phase1_poll.Status",
@@ -96,101 +96,6 @@
       "Type": "Wait",
       "Seconds": 30,
       "Next": "WaitForDataPhase1"
-    },
-
-    "RAGIngestion": {
-      "Type": "Task",
-      "Comment": "RAG ingestion — SEC filings, 8-Ks, earnings, theses, filing changes (EC2 via SSM). Must run before Research so RAG data is fresh.",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-      "Parameters": {
-        "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.ec2_instance_id",
-        "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-data",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
-            "bash rag/pipelines/run_weekly_ingestion.sh 2>&1 | tee /var/log/rag-ingestion.log"
-          ],
-          "executionTimeout": ["1800"]
-        },
-        "TimeoutSeconds": 1800
-      },
-      "TimeoutSeconds": 1860,
-      "Retry": [
-        {
-          "ErrorEquals": ["States.TaskFailed"],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 60,
-          "BackoffRate": 1.0
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "HandleFailure",
-          "ResultPath": "$.error"
-        }
-      ],
-      "ResultPath": "$.rag_result",
-      "Next": "WaitForRAGIngestion"
-    },
-
-    "WaitForRAGIngestion": {
-      "Type": "Task",
-      "Comment": "Poll SSM command until RAG ingestion complete",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-      "Parameters": {
-        "CommandId.$": "$.rag_result.Command.CommandId",
-        "InstanceId.$": "$.ec2_instance_id[0]"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
-          "MaxAttempts": 10,
-          "IntervalSeconds": 30,
-          "BackoffRate": 1.5
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "HandleFailure",
-          "ResultPath": "$.error"
-        }
-      ],
-      "ResultPath": "$.rag_poll",
-      "Next": "CheckRAGStatus"
-    },
-
-    "CheckRAGStatus": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.rag_poll.Status",
-          "StringEquals": "Success",
-          "Next": "Research"
-        },
-        {
-          "Variable": "$.rag_poll.Status",
-          "StringEquals": "InProgress",
-          "Next": "RAGWait"
-        },
-        {
-          "Variable": "$.rag_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "RAGWait"
-        }
-      ],
-      "Default": "ExtractRAGError"
-    },
-
-    "RAGWait": {
-      "Type": "Wait",
-      "Seconds": 30,
-      "Next": "WaitForRAGIngestion"
     },
 
     "Research": {
@@ -370,7 +275,7 @@
 
     "DriftDetection": {
       "Type": "Task",
-      "Comment": "Check feature + prediction drift after training (non-blocking). Uses data venv for numpy/boto3, PYTHONPATH for predictor module.",
+      "Comment": "Feature + prediction drift check on spot EC2 (non-blocking). Micro is the dispatcher; launcher clones data + predictor on a fresh spot, runs monitoring.drift_detector, terminates.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -378,18 +283,17 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
-            "export HOME=/home/ec2-user",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-data",
+            "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "export PYTHONPATH=/home/ec2-user/alpha-engine-predictor",
-            "/home/ec2-user/alpha-engine-data/.venv/bin/python -m monitoring.drift_detector --alert 2>&1 | tee /var/log/drift-detection.log"
+            "bash infrastructure/spot_drift_detection.sh 2>&1 | tee /var/log/drift-detection.log"
           ],
-          "executionTimeout": ["300"]
+          "executionTimeout": ["1200"]
         },
-        "TimeoutSeconds": 300
+        "TimeoutSeconds": 1200
       },
-      "TimeoutSeconds": 330,
+      "TimeoutSeconds": 1260,
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
@@ -686,18 +590,6 @@
         "phase": "DataPhase1",
         "source": "CheckDataPhase1Status.Default",
         "poll.$": "$.data_phase1_poll"
-      },
-      "ResultPath": "$.error",
-      "Next": "HandleFailure"
-    },
-
-    "ExtractRAGError": {
-      "Type": "Pass",
-      "Comment": "Normalize RAGIngestion SSM non-Success poll into $.error.",
-      "Parameters": {
-        "phase": "RAGIngestion",
-        "source": "CheckRAGStatus.Default",
-        "poll.$": "$.rag_poll"
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -5,7 +5,7 @@
 
     "DataPhase1": {
       "Type": "Task",
-      "Comment": "Phase 1: prices, macro, constituents, universe returns (EC2 via SSM)",
+      "Comment": "Phase 1: prices, macro, constituents, universe returns (launches spot EC2; micro is the dispatcher)",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -15,15 +15,15 @@
             "set -eo pipefail",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
+            "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
-            "python weekly_collector.py --phase 1 2>&1 | tee /var/log/data-phase1.log"
+            "bash infrastructure/spot_data_phase1.sh 2>&1 | tee /var/log/data-phase1.log"
           ],
-          "executionTimeout": ["1800"]
+          "executionTimeout": ["2700"]
         },
-        "TimeoutSeconds": 1800
+        "TimeoutSeconds": 2700
       },
-      "TimeoutSeconds": 1860,
+      "TimeoutSeconds": 2760,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],
@@ -609,7 +609,7 @@
 
     "SaturdayHealthCheck": {
       "Type": "Task",
-      "Comment": "Check data freshness after full pipeline — non-blocking (alerts on failure but does not halt)",
+      "Comment": "Check data freshness after full pipeline — non-blocking (alerts on failure but does not halt). Runs from alpha-engine-dashboard post-2026-04-16 health_checker migration.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -617,8 +617,8 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-data",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-dashboard",
             "source .venv/bin/activate",
             "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
           ],


### PR DESCRIPTION
## Summary

Moves all three heavy Saturday-pipeline SSM steps off ae-dashboard (t3.micro, 1 GB RAM) onto self-terminating spot EC2 instances. Completes the producer/observability separation started in the DailyData move earlier today — **zero heavy Python workloads run on the micro at any point in the Saturday pipeline.**

## Changes

### Workload migrations (3 steps → 2 spots)

| Step | Before | After |
|---|---|---|
| DataPhase1 | micro, weekly_collector --phase 1 | spot (bundled) |
| RAGIngestion | micro, run_weekly_ingestion.sh | **bundled onto same spot as DataPhase1** |
| DriftDetection | micro, monitoring.drift_detector | separate spot |

**Bundling rationale:** DataPhase1 + RAGIngestion run back-to-back on the same repo (alpha-engine-data) with the same pip install. Sharing one spot saves ~7 min of bootstrap overhead vs two separate spots. Trade-off: any failure fails the bundle — acceptable since partial Saturday failures typically require a full-pipeline rerun anyway.

### New launcher scripts (~280-300 lines each, mirror spot_backtest.sh)

- \`infrastructure/spot_data_weekly.sh\` — clones alpha-engine-data, runs \`weekly_collector.py --phase 1\` then \`run_weekly_ingestion.sh\` sequentially, emits two heartbeats (data-phase1, rag-ingestion), terminates
- \`infrastructure/spot_drift_detection.sh\` — clones alpha-engine-data + alpha-engine-predictor (drift_detector needs both), runs \`python -m monitoring.drift_detector --alert\`, emits heartbeat, terminates

### Step Function edits

- **DataPhase1:** command now invokes \`spot_data_weekly.sh\`. Timeout bumped 1800→3600s (phase1 ~20min + rag ~15min + spot bootstrap ~7min).
- **RAGIngestion chain removed:** RAGIngestion + WaitForRAGIngestion + CheckRAGStatus + RAGWait + ExtractRAGError states all deleted. DataPhase1 success now wires directly to Research. State count: 34 → 30.
- **DriftDetection:** command now invokes \`spot_drift_detection.sh\`. Timeout bumped 300→1200s.
- **SaturdayHealthCheck:** path repointed from \`/home/ec2-user/alpha-engine-data\` to \`/home/ec2-user/alpha-engine-dashboard\` (health_checker lives there now per #43).

## Net effect on ae-dashboard

- \`alpha-engine-data\` still cloned (needed for launcher scripts)
- \`alpha-engine-data/.venv\` can be **deleted permanently post-deploy** (no runtime Python workload references it anymore)
- Micro stays lean — serves as a bash+AWS-CLI dispatcher for three workloads

## Pre-merge / deploy checklist

- [ ] Merge [cipher813/alpha-engine-dashboard#20](https://github.com/cipher813/alpha-engine-dashboard/pull/20) (restores alpha-engine-data in boot-pull REPOS)
- [ ] On ae-dashboard: \`git clone\` alpha-engine-data (not already present after the de-bloat \`rm -rf\` earlier)
- [ ] Merge this PR
- [ ] \`bash infrastructure/deploy_step_function_saturday.sh\` from your laptop (on updated main)
- [ ] **Strongly recommended:** smoke-test both launchers from ae-dashboard before Saturday:
  \`\`\`
  ae-dashboard "cd /home/ec2-user/alpha-engine-data && export HOME=/home/ec2-user && bash infrastructure/spot_data_weekly.sh --smoke-only"
  ae-dashboard "cd /home/ec2-user/alpha-engine-data && export HOME=/home/ec2-user && bash infrastructure/spot_drift_detection.sh --smoke-only"
  \`\`\`
  Each launches a spot, validates imports + \`--dry-run\`, terminates. Catches IAM/AMI/subnet/PAT regressions before the real run.
- [ ] After Saturday's run completes green: \`ae-dashboard "rm -rf /home/ec2-user/alpha-engine-data/.venv"\` to reclaim ~300 MB and validate the zero-heavy-venv end state.

## Followup (roadmap P2)

Bundle DriftDetection onto PredictorTraining's spot — drift reads predictor weights written by training, so they have natural data dependency. Would save another bootstrap cycle. Added to ROADMAP.md for a later session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)