### PR TITLE
Fetch alpha-engine-lib PAT from SSM on the spot (not via .env on dispatcher)

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -100,12 +100,8 @@ if [ ! -f "$KEY_FILE" ]; then
     echo "ERROR: SSH key not found at $KEY_FILE"
     exit 1
 fi
-
-# ALPHA_ENGINE_LIB_TOKEN required for pip install of the private lib.
-if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
-    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env — required for alpha-engine-lib pip install on spot"
-    exit 1
-fi
+# Note: alpha-engine-lib PAT is fetched by the spot itself from SSM
+# (/alpha-engine/lib-token) during the DEPS step — dispatcher never touches it.
 
 # ── Launch spot ──────────────────────────────────────────────────────────────
 echo "==> Requesting spot instance ($INSTANCE_TYPE)..."
@@ -198,6 +194,11 @@ scp $SSH_OPTS -i "$KEY_FILE" \
     ec2-user@"$PUBLIC_IP":/home/ec2-user/alpha-engine-data/.env
 
 # ── Install python deps ──────────────────────────────────────────────────────
+# The spot pulls its own alpha-engine-lib PAT from SSM (same pattern as
+# ae-trading's boot-pull.sh). Dispatcher never handles the secret. The
+# spot's IAM profile (alpha-engine-executor-profile) grants ssm:GetParameter
+# on /alpha-engine/*. Token is scoped to a local shell var, never exported
+# or logged.
 echo "==> Installing Python dependencies..."
 run_remote bash -s <<'DEPS'
 set -euo pipefail
@@ -207,11 +208,14 @@ set -a
 # shellcheck disable=SC1091
 source /home/ec2-user/alpha-engine-data/.env
 set +a
-if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
-    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env"
+
+LIB_TOKEN=$(aws ssm get-parameter --name /alpha-engine/lib-token --with-decryption --query 'Parameter.Value' --output text --region us-east-1 2>/dev/null || echo "")
+if [ -z "$LIB_TOKEN" ]; then
+    echo "ERROR: could not fetch /alpha-engine/lib-token from SSM — required for alpha-engine-lib pip install"
     exit 1
 fi
-git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+git config --global url."https://x-access-token:${LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+unset LIB_TOKEN
 
 if command -v python3.12 &>/dev/null; then
     PIP="python3.12 -m pip"

--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -80,10 +80,8 @@ if [ ! -f "$KEY_FILE" ]; then
     echo "ERROR: SSH key not found at $KEY_FILE"
     exit 1
 fi
-if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
-    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in .env"
-    exit 1
-fi
+# Note: alpha-engine-lib PAT is fetched by the spot itself from SSM
+# (/alpha-engine/lib-token) during the DEPS step — dispatcher never touches it.
 
 # ── Launch spot ──────────────────────────────────────────────────────────────
 echo "==> Requesting spot instance ($INSTANCE_TYPE)..."
@@ -170,8 +168,9 @@ scp $SSH_OPTS -i "$KEY_FILE" \
     "$ENV_FILE" \
     ec2-user@"$PUBLIC_IP":/home/ec2-user/alpha-engine-data/.env
 
-# ── Install dependencies (data repo's requirements suffice — drift_detector
-#    uses numpy/boto3/pandas from the shared universe) ───────────────────────
+# ── Install dependencies ─────────────────────────────────────────────────────
+# Spot pulls its own alpha-engine-lib PAT from SSM (/alpha-engine/lib-token),
+# mirroring ae-trading's boot-pull.sh. Dispatcher never handles the secret.
 echo "==> Installing Python dependencies..."
 run_remote bash -s <<'DEPS'
 set -euo pipefail
@@ -181,7 +180,14 @@ set -a
 # shellcheck disable=SC1091
 source /home/ec2-user/alpha-engine-data/.env
 set +a
-git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+
+LIB_TOKEN=$(aws ssm get-parameter --name /alpha-engine/lib-token --with-decryption --query 'Parameter.Value' --output text --region us-east-1 2>/dev/null || echo "")
+if [ -z "$LIB_TOKEN" ]; then
+    echo "ERROR: could not fetch /alpha-engine/lib-token from SSM — required for alpha-engine-lib pip install"
+    exit 1
+fi
+git config --global url."https://x-access-token:${LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+unset LIB_TOKEN
 
 if command -v python3.12 &>/dev/null; then
     PIP="python3.12 -m pip"


### PR DESCRIPTION
## Summary

Followup fix on top of [#44](https://github.com/cipher813/alpha-engine-data/pull/44). The smoke test surfaced that \`spot_data_weekly.sh\` and \`spot_drift_detection.sh\` were requiring \`ALPHA_ENGINE_LIB_TOKEN\` in the dispatcher's \`.env\` — stale pattern copied from \`spot_backtest.sh\`. The correct source is SSM Parameter Store (\`/alpha-engine/lib-token\`), same as ae-trading's \`boot-pull.sh\`.

## Change

Moves the PAT fetch from the dispatcher's \`.env\` (read by the launcher) → onto the spot itself (via \`aws ssm get-parameter\` in the DEPS step). Dispatcher never handles the secret.

- Removed \`ALPHA_ENGINE_LIB_TOKEN\` preflight check from both launchers
- Added SSM \`get-parameter --with-decryption\` inside the DEPS heredoc, scoped to a local shell var \`LIB_TOKEN\`, unset after \`git config --global url.insteadOf\` rewrite
- Dispatcher \`.env\` no longer needs the token line — rotation happens once in SSM, all launchers pick it up

## Why now

Blocks smoke test of the spot migration (#44). Without this the dispatcher fails preflight on missing \`.env\` token.

## Not in this PR

\`spot_backtest.sh\` and \`spot_train.sh\` have the same stale pattern but live in their own repos (alpha-engine-backtester, alpha-engine-predictor). Worth the same refactor for consistency — opening as followups.

## Test plan

- [x] \`bash -n\` on both launchers
- [ ] Post-merge: \`bash infrastructure/spot_data_weekly.sh --smoke-only\` on ae-dashboard completes green (the run that failed pre-this-fix)
- [ ] Same for \`spot_drift_detection.sh --smoke-only\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)