### PR TITLE
Upload alpha-engine-config/data/config.yaml to spot

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -187,11 +187,27 @@ echo "==> Cloning alpha-engine-data (branch: $BRANCH)..."
 # HTTPS clone with PAT — matches the lib-install pattern below.
 run_remote "git clone --depth 1 --branch $BRANCH https://github.com/cipher813/alpha-engine-data.git /home/ec2-user/alpha-engine-data"
 
-# ── Upload .env BEFORE pip install (for ALPHA_ENGINE_LIB_TOKEN) ──────────────
+# ── Upload .env BEFORE pip install ──────────────────────────────────────────
 echo "==> Uploading .env to spot..."
 scp $SSH_OPTS -i "$KEY_FILE" \
     "$ENV_FILE" \
     ec2-user@"$PUBLIC_IP":/home/ec2-user/alpha-engine-data/.env
+
+# ── Upload alpha-engine-config/data/config.yaml ─────────────────────────────
+# weekly_collector.py's load_config() searches /home/ec2-user/alpha-engine-config/data/config.yaml
+# first. Private config repo — SCP from the dispatcher's clone (pulled daily by
+# ae-dashboard's boot-pull) rather than cloning it on the spot (which would
+# require broader git-auth setup than the lib-only insteadOf we use here).
+CONFIG_SRC="/home/ec2-user/alpha-engine-config/data/config.yaml"
+if [ ! -f "$CONFIG_SRC" ]; then
+    echo "ERROR: dispatcher config not found at $CONFIG_SRC — is alpha-engine-config cloned + pulled?"
+    exit 1
+fi
+echo "==> Uploading alpha-engine-config/data/config.yaml to spot..."
+run_remote "mkdir -p /home/ec2-user/alpha-engine-config/data"
+scp $SSH_OPTS -i "$KEY_FILE" \
+    "$CONFIG_SRC" \
+    ec2-user@"$PUBLIC_IP":/home/ec2-user/alpha-engine-config/data/config.yaml
 
 # ── Install python deps ──────────────────────────────────────────────────────
 # The spot pulls its own alpha-engine-lib PAT from SSM (same pattern as


### PR DESCRIPTION
## Summary

Followup #2 on the spot migration (stacked after #44 + #45). Smoke test of \`spot_data_weekly.sh\` surfaced \`FileNotFoundError: Config not found\` on the fresh spot — \`weekly_collector.py\`'s \`load_config()\` searches \`/home/ec2-user/alpha-engine-config/data/config.yaml\` first, which isn't present on a fresh spot clone.

## Change

SCP the dispatcher's already-cloned config file (ae-dashboard's \`boot-pull.timer\` refreshes alpha-engine-config daily) onto the spot at the expected path. Cheaper than cloning the private config repo on the spot, which would require broader git-auth setup than the \`alpha-engine-lib\`-scoped insteadOf rewrite the launcher already uses.

\`spot_drift_detection.sh\` unchanged — \`drift_detector.py\` has no config.yaml refs.

## Test plan

- [x] \`bash -n\` on spot_data_weekly.sh
- [ ] Post-merge: rerun \`bash infrastructure/spot_data_weekly.sh --smoke-only\` on ae-dashboard — should complete through \`weekly_collector.py --phase 1 --dry-run\` and terminate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)