### PR TITLE
Remove tail -30 truncation in spot smoke output

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -267,7 +267,9 @@ $REMOTE_PYTHON -c "import weekly_collector; print('import OK')"
 
 echo ""
 echo "==> Smoke: weekly_collector.py --phase 1 --dry-run"
-$REMOTE_PYTHON weekly_collector.py --phase 1 --dry-run 2>&1 | tail -30
+# Show full output (was tail -30 — truncated error tracebacks from early
+# collectors so their failure mode was invisible during debugging).
+$REMOTE_PYTHON weekly_collector.py --phase 1 --dry-run 2>&1
 SMOKE
 
     echo "==> Smoke complete — instance will be terminated."


### PR DESCRIPTION
Smoke mode's \`python weekly_collector.py --phase 1 --dry-run 2>&1 | tail -30\` was dropping per-collector error tracebacks from the visible output. When \`universe_returns.collect()\` errored in dry-run, only the summary line \`universe_returns=error\` reached the terminal — the actual exception had scrolled off.

Removes \`| tail -30\`. Full output (~200 lines for a 909-ticker feature compute) is fine for a smoke path; production runs log separately via the SF step.

Blocking investigation of the universe_returns dry-run error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)