### PR TITLE
Grant ec2:StopInstances to shared step-functions role

### DIFF
--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -69,9 +69,9 @@ POLICY='{
       "Resource": "*"
     },
     {
-      "Sid": "EC2Start",
+      "Sid": "EC2StartStop",
       "Effect": "Allow",
-      "Action": ["ec2:StartInstances"],
+      "Action": ["ec2:StartInstances", "ec2:StopInstances"],
       "Resource": "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$TRADING_INSTANCE"'"
     },
     {


### PR DESCRIPTION
## Summary
- Today's EOD pipeline (`alpha-engine-eod-pipeline`) failed at `StopTradingInstance` with a 403: `User ... alpha-engine-step-functions-role ... is not authorized to perform: ec2:StopInstances on ... i-018eb3307a21329bf`.
- The EOD state machine (`infrastructure/step_function_eod.json`, added 2026-04-07) calls `aws-sdk:ec2:stopInstances` in both the success path (`StopTradingInstance`) and the failure path (`ForceStopInstance`), but never had a matching IAM update — the shared role policy only granted `ec2:StartInstances`.
- Fold `StopInstances` into the existing `EC2*` statement for the same trading-instance ARN. Statement is now `EC2StartStop`.

## Deploy
After merge, re-apply the policy on AWS:

```
cd ~/Development/alpha-engine-data && ./infrastructure/deploy_step_function_daily.sh
```

`aws iam put-role-policy` is idempotent; no state-machine or EventBridge changes needed.

## Test plan
- [ ] Re-run `deploy_step_function_daily.sh` and confirm the role policy now contains both `ec2:StartInstances` and `ec2:StopInstances` on the trading instance ARN.
- [ ] Manually trigger `alpha-engine-eod-pipeline` (or wait for tomorrow's daemon-triggered run) and confirm `StopTradingInstance` completes without the 403.
- [ ] Verify `i-018eb3307a21329bf` transitions to `stopped` after the EOD execution finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)