### PR TITLE
feat: VWAP column in ArcticDB universe writer (additive, blast-radius zero)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -49,8 +49,32 @@ from store.arctic_store import get_universe_lib, get_macro_lib
 
 log = logging.getLogger(__name__)
 
-# OHLCV columns to keep alongside features in ArcticDB
-OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume"]
+# OHLCV columns to keep alongside features in ArcticDB.
+# VWAP added 2026-04-17 — backfill source (``predictor/price_cache/*.parquet``)
+# is OHLCV only, so historical VWAP is populated via the ``(H+L+C)/3``
+# typical-price proxy below (same proxy used in ``collectors/daily_closes.py:293``
+# when yfinance is the source and polygon's true ``vw`` isn't available).
+# Production daily_append uses polygon's true VWAP when available — proxy is
+# only used for historical backfill rows predating polygon adoption.
+OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
+
+
+def _ensure_vwap_column(df: pd.DataFrame) -> pd.DataFrame:
+    """Populate VWAP column with ``(H+L+C)/3`` typical-price proxy if absent.
+
+    The legacy ``predictor/price_cache/`` parquets used by backfill are OHLCV
+    only. Populating a proxy here ensures ArcticDB's VWAP column has coverage
+    across the full 10y history, so downstream consumers never encounter
+    unexpected NaN for pre-polygon dates.
+    """
+    if "VWAP" in df.columns:
+        return df
+    required = {"High", "Low", "Close"}
+    if not required.issubset(df.columns):
+        return df
+    out = df.copy()
+    out["VWAP"] = ((out["High"] + out["Low"] + out["Close"]) / 3.0).round(4)
+    return out
 
 
 def _load_full_cache(s3, bucket: str, prefix: str = "predictor/price_cache/") -> dict[str, pd.DataFrame]:
@@ -233,7 +257,7 @@ def backfill(
 
     for i, ticker in enumerate(universe_tickers):
         try:
-            df = price_data[ticker]
+            df = _ensure_vwap_column(price_data[ticker])
             sector_etf_sym = sector_map.get(ticker)
             sector_etf_series = macro.get(sector_etf_sym) if sector_etf_sym else None
 

--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -50,31 +50,15 @@ from store.arctic_store import get_universe_lib, get_macro_lib
 log = logging.getLogger(__name__)
 
 # OHLCV columns to keep alongside features in ArcticDB.
-# VWAP added 2026-04-17 — backfill source (``predictor/price_cache/*.parquet``)
-# is OHLCV only, so historical VWAP is populated via the ``(H+L+C)/3``
-# typical-price proxy below (same proxy used in ``collectors/daily_closes.py:293``
-# when yfinance is the source and polygon's true ``vw`` isn't available).
-# Production daily_append uses polygon's true VWAP when available — proxy is
-# only used for historical backfill rows predating polygon adoption.
+# VWAP added 2026-04-17 (Phase 7 VWAP centralization). Backfill source
+# (``predictor/price_cache/*.parquet``) is OHLCV only and predates polygon
+# adoption, so historical rows have no source for true volume-weighted VWAP.
+# Per the 2026-04-17 decision, we do NOT synthesize a ``(H+L+C)/3`` proxy —
+# that misrepresents arithmetic typical price as VWAP. Historical rows get
+# NaN VWAP; the column becomes populated from the first daily_append run
+# against a polygon-sourced daily_closes parquet. See ROADMAP "VWAP
+# centralization" for the full rationale.
 OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
-
-
-def _ensure_vwap_column(df: pd.DataFrame) -> pd.DataFrame:
-    """Populate VWAP column with ``(H+L+C)/3`` typical-price proxy if absent.
-
-    The legacy ``predictor/price_cache/`` parquets used by backfill are OHLCV
-    only. Populating a proxy here ensures ArcticDB's VWAP column has coverage
-    across the full 10y history, so downstream consumers never encounter
-    unexpected NaN for pre-polygon dates.
-    """
-    if "VWAP" in df.columns:
-        return df
-    required = {"High", "Low", "Close"}
-    if not required.issubset(df.columns):
-        return df
-    out = df.copy()
-    out["VWAP"] = ((out["High"] + out["Low"] + out["Close"]) / 3.0).round(4)
-    return out
 
 
 def _load_full_cache(s3, bucket: str, prefix: str = "predictor/price_cache/") -> dict[str, pd.DataFrame]:
@@ -257,7 +241,7 @@ def backfill(
 
     for i, ticker in enumerate(universe_tickers):
         try:
-            df = _ensure_vwap_column(price_data[ticker])
+            df = price_data[ticker]
             sector_etf_sym = sector_map.get(ticker)
             sector_etf_series = macro.get(sector_etf_sym) if sector_etf_sym else None
 

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -42,11 +42,18 @@ from store.arctic_store import get_universe_lib, get_macro_lib
 
 log = logging.getLogger(__name__)
 
-OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume"]
+OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
 
 
 def _load_daily_closes(s3, bucket: str, date_str: str) -> dict[str, dict]:
-    """Load today's daily_closes parquet from S3. Raises if the file is missing or unreadable."""
+    """Load today's daily_closes parquet from S3. Raises if the file is missing or unreadable.
+
+    VWAP (2026-04-17): extracted from the parquet alongside OHLCV so it materializes
+    into ArcticDB as a first-class column. Source is polygon grouped-daily's `vw`
+    field when available, else `(H+L+C)/3` typical-price proxy — both are populated
+    upstream in ``collectors/daily_closes.py``. Missing VWAP for a ticker becomes
+    ``NaN`` in the output (not an error); downstream consumers handle NaN.
+    """
     key = f"predictor/daily_closes/{date_str}.parquet"
     obj = s3.get_object(Bucket=bucket, Key=key)
     buf = io.BytesIO(obj["Body"].read())
@@ -54,12 +61,14 @@ def _load_daily_closes(s3, bucket: str, date_str: str) -> dict[str, dict]:
 
     records = {}
     for ticker, row in df.iterrows():
+        vwap_raw = row.get("VWAP")
         records[str(ticker)] = {
             "Open": float(row.get("Open", np.nan)),
             "High": float(row.get("High", np.nan)),
             "Low": float(row.get("Low", np.nan)),
             "Close": float(row.get("Close", np.nan)),
             "Volume": int(row.get("Volume", 0)),
+            "VWAP": float(vwap_raw) if pd.notna(vwap_raw) else np.nan,
         }
     if not records:
         raise RuntimeError(

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -226,7 +226,10 @@ def _fetch_fred_closes(
                 "Close": round(close, 4),
                 "Adj_Close": round(close, 4),
                 "Volume": 0,
-                "VWAP": round(close, 4),
+                # VWAP only meaningful from polygon grouped-daily (volume-weighted
+                # across trades). FRED single-value closes give us no distribution
+                # to VWAP, so None rather than passing Close off as VWAP.
+                "VWAP": None,
             })
             count += 1
         except Exception as e:
@@ -284,13 +287,14 @@ def _fetch_yfinance_closes(
                     high = float(last["High"])
                     low = float(last["Low"])
                     close = float(last["Close"])
-                    # Typical-price proxy for VWAP: (H + L + C) / 3. yfinance
-                    # does not expose true intraday VWAP for free, so we fall
-                    # back to the standard pre-tick-data proxy. Executor entry
-                    # triggers use this as a prior-day reference level, not
-                    # an intraday VWAP — the proxy is accurate enough for
-                    # that purpose and materially better than None.
-                    vwap_proxy = round((high + low + close) / 3.0, 4)
+                    # VWAP is None on yfinance fallback. yfinance does not expose
+                    # true volume-weighted VWAP; the previous (H+L+C)/3 proxy
+                    # misrepresented proxy values as VWAP and contaminated the
+                    # ArcticDB universe column once Phase 7 migration started
+                    # materializing VWAP there. Per 2026-04-17 decision: only
+                    # polygon-sourced true VWAP is written. See ROADMAP "VWAP
+                    # centralization". Executor `load_daily_vwap` already handles
+                    # None by looking back up to 5 prior trading days.
                     records.append({
                         "ticker": store_ticker,
                         "date": date_str,
@@ -300,7 +304,7 @@ def _fetch_yfinance_closes(
                         "Close": round(close, 4),
                         "Adj_Close": round(adj_close, 4),
                         "Volume": int(last["Volume"]) if pd.notna(last.get("Volume")) else 0,
-                        "VWAP": vwap_proxy,
+                        "VWAP": None,
                     })
                     count += 1
                 except Exception as e:

--- a/tests/test_daily_closes_vwap.py
+++ b/tests/test_daily_closes_vwap.py
@@ -1,11 +1,23 @@
-"""Regression tests for the daily_closes VWAP fallback.
+"""Regression tests for the daily_closes VWAP semantics.
 
-Pins the behavior added after the 2026-04-10 incident: when polygon.io
-fails (rate limit, auth, empty response) and the collector falls back to
-yfinance, the VWAP column must be populated with a typical-price proxy
-instead of None. The old code set VWAP=None on all yfinance rows, which
-caused the executor to log "has no VWAP column — skipping" for up to 5
-consecutive days whenever polygon was unhealthy.
+Contract as of 2026-04-17 (Phase 7 VWAP centralization):
+
+  * Polygon grouped-daily (`vw` field) → true volume-weighted VWAP is written.
+  * yfinance fallback → VWAP is None. yfinance does not expose true VWAP and
+    the previous `(H+L+C)/3` typical-price proxy silently misrepresented
+    arithmetic typical price as VWAP, which contaminated the ArcticDB
+    universe column once Phase 7 migration started materializing VWAP there.
+  * FRED fallback → VWAP is None. FRED returns a single daily close value;
+    there is no trade distribution to weight, so passing Close off as VWAP
+    would be misrepresentation.
+
+The previous contract (introduced after the 2026-04-10 incident) populated
+VWAP with the proxy on yfinance fallback to prevent the executor from logging
+"no VWAP column — skipping" for up to 5 consecutive days during polygon
+outages. Per the 2026-04-17 decision, we accept that consequence rather than
+perpetuate the proxy. `executor/price_cache.py::load_daily_vwap` already
+looks back up to 5 prior trading days for a populated VWAP, which covers the
+rare polygon-outage-on-multiple-consecutive-days scenario.
 """
 
 import pandas as pd
@@ -32,8 +44,8 @@ def _make_yf_frame(rows):
     return df
 
 
-def test_yfinance_fallback_populates_vwap_with_typical_price():
-    """The yfinance fallback should compute VWAP as (H + L + C) / 3."""
+def test_yfinance_fallback_writes_none_vwap():
+    """yfinance fallback must write VWAP=None, not a (H+L+C)/3 proxy."""
     records = []
     fake_frame = _make_yf_frame([
         ("2026-04-10", 100.0, 105.0, 99.0, 103.0, 1_000_000),
@@ -51,16 +63,16 @@ def test_yfinance_fallback_populates_vwap_with_typical_price():
     assert len(records) == 1
     row = records[0]
     assert row["ticker"] == "AAPL"
-    # VWAP should be typical price: (105 + 99 + 103) / 3 = 102.333...
-    expected_vwap = round((105.0 + 99.0 + 103.0) / 3.0, 4)
-    assert row["VWAP"] == expected_vwap
-    assert row["VWAP"] is not None
+    assert row["VWAP"] is None, (
+        "yfinance fallback must write VWAP=None. Writing (H+L+C)/3 as VWAP "
+        "silently misrepresents arithmetic typical price as volume-weighted "
+        "VWAP — see 2026-04-17 Phase 7 VWAP centralization decision."
+    )
 
 
-def test_yfinance_fallback_vwap_not_none_multi_ticker():
-    """VWAP must be non-None for every row produced by the fallback."""
+def test_yfinance_fallback_multi_ticker_vwap_none():
+    """VWAP must be None for every row produced by the fallback."""
     records = []
-    # yfinance returns a MultiIndex-columned frame for multi-ticker downloads
     index = pd.DatetimeIndex(["2026-04-10"])
     multi = pd.DataFrame(
         {
@@ -91,6 +103,4 @@ def test_yfinance_fallback_vwap_not_none_multi_ticker():
 
     assert count == 2
     for row in records:
-        assert row["VWAP"] is not None, f"VWAP is None for {row['ticker']}"
-        # Typical-price invariant: Low <= VWAP <= High
-        assert row["Low"] <= row["VWAP"] <= row["High"]
+        assert row["VWAP"] is None, f"VWAP should be None (not proxy) for {row['ticker']}"

--- a/tests/test_vwap_ingestion.py
+++ b/tests/test_vwap_ingestion.py
@@ -1,20 +1,28 @@
 """Regression tests for VWAP ingestion into ArcticDB universe library (2026-04-17).
 
-VWAP is added as a first-class column in both ``builders/daily_append.py`` and
-``builders/backfill.py``. daily_append reads VWAP from the daily_closes parquet
-(populated upstream by either polygon's true ``vw`` or the ``(H+L+C)/3`` proxy
-in ``collectors/daily_closes.py``). backfill computes the proxy inline since
-the legacy ``predictor/price_cache/`` parquets pre-date VWAP.
+Phase 7 VWAP centralization contract:
 
-These tests lock two contracts:
-  1. ``OHLCV_COLS`` contains ``"VWAP"`` in both files (prevents a future PR
-     from silently dropping VWAP from the ArcticDB write).
-  2. ``_ensure_vwap_column`` produces the typical-price proxy correctly and is
-     idempotent (already-populated VWAP is preserved).
+  * Polygon grouped-daily produces true volume-weighted VWAP. That value flows
+    via ``collectors/daily_closes.py`` → ``predictor/daily_closes/*.parquet``
+    → ``builders/daily_append.py::_load_daily_closes`` → ArcticDB universe.
+  * Any other source (yfinance fallback, FRED single-close, legacy backfill
+    price_cache) writes ``None`` / NaN for VWAP. No ``(H+L+C)/3`` proxy.
+
+These tests lock two invariants:
+
+  1. ``OHLCV_COLS`` contains ``"VWAP"`` in both ``daily_append`` and
+     ``backfill`` — prevents a future PR from silently dropping VWAP from
+     the ArcticDB write.
+  2. ``_load_daily_closes`` passes NaN VWAP through as NaN (not coerced to
+     0.0 or the typical-price proxy).
 """
 
 from __future__ import annotations
 
+import io
+from unittest.mock import MagicMock, patch
+
+import numpy as np
 import pandas as pd
 
 
@@ -31,45 +39,56 @@ def test_backfill_ohlcv_cols_include_vwap():
     assert "VWAP" in OHLCV_COLS
 
 
-def test_ensure_vwap_column_computes_typical_price_proxy():
-    from builders.backfill import _ensure_vwap_column
+def test_load_daily_closes_extracts_polygon_vwap():
+    """Polygon-sourced VWAP flows through _load_daily_closes unchanged."""
+    from builders.daily_append import _load_daily_closes
 
-    df = pd.DataFrame({
-        "Open": [100.0],
-        "High": [110.0],
-        "Low": [95.0],
-        "Close": [105.0],
-        "Volume": [1_000_000],
-    })
-    out = _ensure_vwap_column(df)
-    assert "VWAP" in out.columns
-    # (110 + 95 + 105) / 3 = 103.3333...
-    assert out["VWAP"].iloc[0] == 103.3333
-
-
-def test_ensure_vwap_column_is_idempotent():
-    """If VWAP is already populated (e.g. from polygon ``vw``), don't overwrite it."""
-    from builders.backfill import _ensure_vwap_column
-
-    df = pd.DataFrame({
-        "Open": [100.0],
-        "High": [110.0],
-        "Low": [95.0],
-        "Close": [105.0],
-        "Volume": [1_000_000],
-        "VWAP": [104.5],  # true polygon VWAP — not the (H+L+C)/3 proxy
-    })
-    out = _ensure_vwap_column(df)
-    assert out["VWAP"].iloc[0] == 104.5, (
-        "_ensure_vwap_column overwrote an existing VWAP value — proxy should only "
-        "fill in when the column is absent."
+    fake_df = pd.DataFrame(
+        {
+            "Open": [100.0],
+            "High": [110.0],
+            "Low": [95.0],
+            "Close": [105.0],
+            "Volume": [1_000_000],
+            "VWAP": [104.5],  # true polygon vw
+        },
+        index=pd.Index(["AAPL"], name="ticker"),
     )
 
+    buf = io.BytesIO()
+    fake_df.to_parquet(buf, engine="pyarrow", index=True)
+    buf.seek(0)
 
-def test_ensure_vwap_column_noop_when_hlc_missing():
-    """No-op when required columns aren't all present — don't fabricate a proxy from incomplete data."""
-    from builders.backfill import _ensure_vwap_column
+    mock_s3 = MagicMock()
+    mock_s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=buf.getvalue()))}
 
-    df = pd.DataFrame({"Open": [100.0], "Close": [105.0]})  # missing High/Low
-    out = _ensure_vwap_column(df)
-    assert "VWAP" not in out.columns
+    records = _load_daily_closes(mock_s3, "test-bucket", "2026-04-17")
+    assert records["AAPL"]["VWAP"] == 104.5
+
+
+def test_load_daily_closes_passes_none_vwap_as_nan():
+    """Rows with VWAP=None (yfinance / FRED fallback) become NaN, not 0.0 or proxy."""
+    from builders.daily_append import _load_daily_closes
+
+    fake_df = pd.DataFrame(
+        {
+            "Open": [100.0],
+            "High": [110.0],
+            "Low": [95.0],
+            "Close": [105.0],
+            "Volume": [1_000_000],
+            "VWAP": [None],  # yfinance fallback semantics
+        },
+        index=pd.Index(["AAPL"], name="ticker"),
+    )
+
+    buf = io.BytesIO()
+    fake_df.to_parquet(buf, engine="pyarrow", index=True)
+    buf.seek(0)
+
+    mock_s3 = MagicMock()
+    mock_s3.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=buf.getvalue()))}
+
+    records = _load_daily_closes(mock_s3, "test-bucket", "2026-04-17")
+    vwap = records["AAPL"]["VWAP"]
+    assert np.isnan(vwap), f"Expected NaN VWAP, got {vwap!r}"

--- a/tests/test_vwap_ingestion.py
+++ b/tests/test_vwap_ingestion.py
@@ -1,0 +1,75 @@
+"""Regression tests for VWAP ingestion into ArcticDB universe library (2026-04-17).
+
+VWAP is added as a first-class column in both ``builders/daily_append.py`` and
+``builders/backfill.py``. daily_append reads VWAP from the daily_closes parquet
+(populated upstream by either polygon's true ``vw`` or the ``(H+L+C)/3`` proxy
+in ``collectors/daily_closes.py``). backfill computes the proxy inline since
+the legacy ``predictor/price_cache/`` parquets pre-date VWAP.
+
+These tests lock two contracts:
+  1. ``OHLCV_COLS`` contains ``"VWAP"`` in both files (prevents a future PR
+     from silently dropping VWAP from the ArcticDB write).
+  2. ``_ensure_vwap_column`` produces the typical-price proxy correctly and is
+     idempotent (already-populated VWAP is preserved).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def test_daily_append_ohlcv_cols_include_vwap():
+    from builders.daily_append import OHLCV_COLS
+    assert "VWAP" in OHLCV_COLS, (
+        "daily_append.OHLCV_COLS must include VWAP — executor's VWAP-discount "
+        "entry trigger depends on this column being present in ArcticDB universe."
+    )
+
+
+def test_backfill_ohlcv_cols_include_vwap():
+    from builders.backfill import OHLCV_COLS
+    assert "VWAP" in OHLCV_COLS
+
+
+def test_ensure_vwap_column_computes_typical_price_proxy():
+    from builders.backfill import _ensure_vwap_column
+
+    df = pd.DataFrame({
+        "Open": [100.0],
+        "High": [110.0],
+        "Low": [95.0],
+        "Close": [105.0],
+        "Volume": [1_000_000],
+    })
+    out = _ensure_vwap_column(df)
+    assert "VWAP" in out.columns
+    # (110 + 95 + 105) / 3 = 103.3333...
+    assert out["VWAP"].iloc[0] == 103.3333
+
+
+def test_ensure_vwap_column_is_idempotent():
+    """If VWAP is already populated (e.g. from polygon ``vw``), don't overwrite it."""
+    from builders.backfill import _ensure_vwap_column
+
+    df = pd.DataFrame({
+        "Open": [100.0],
+        "High": [110.0],
+        "Low": [95.0],
+        "Close": [105.0],
+        "Volume": [1_000_000],
+        "VWAP": [104.5],  # true polygon VWAP — not the (H+L+C)/3 proxy
+    })
+    out = _ensure_vwap_column(df)
+    assert out["VWAP"].iloc[0] == 104.5, (
+        "_ensure_vwap_column overwrote an existing VWAP value — proxy should only "
+        "fill in when the column is absent."
+    )
+
+
+def test_ensure_vwap_column_noop_when_hlc_missing():
+    """No-op when required columns aren't all present — don't fabricate a proxy from incomplete data."""
+    from builders.backfill import _ensure_vwap_column
+
+    df = pd.DataFrame({"Open": [100.0], "Close": [105.0]})  # missing High/Low
+    out = _ensure_vwap_column(df)
+    assert "VWAP" not in out.columns


### PR DESCRIPTION
## Summary

First of the VWAP-centralization PRs. **Writer side only, purely additive for ArcticDB consumers** — no consumer reads VWAP from ArcticDB yet.

**Contract (amended 2026-04-17):** ArcticDB universe gets **true volume-weighted VWAP only**, sourced from polygon grouped-daily's `vw` field. Rows where VWAP cannot be sourced from a trade-weighted distribution (yfinance fallback, FRED single-close, legacy backfill) write `None` / NaN — no `(H+L+C)/3` proxy. See commit messages for the full rationale.

## Changes

- `builders/daily_append.py::OHLCV_COLS` includes `VWAP`. `_load_daily_closes` extracts VWAP and converts None → NaN.
- `builders/backfill.py::OHLCV_COLS` includes `VWAP`. No proxy — historical backfill rows (legacy `price_cache/`) get no VWAP.
- `collectors/daily_closes.py` — yfinance fallback and FRED fallback both write `VWAP=None`. Polygon path unchanged (true `vw` preserved).
- `tests/test_daily_closes_vwap.py` — inverted to assert `VWAP=None` on fallback, with documented rationale.
- `tests/test_vwap_ingestion.py` — 4 new tests lock the contract (OHLCV_COLS in both files, polygon-true passthrough, None→NaN conversion).
- Full suite: **53/53 green.**

## Why no proxy

`(H+L+C)/3` is arithmetic typical price, not volume-weighted VWAP. Real example: stock gaps to $90 low, closes $91 on heavy volume at $90-91 → true VWAP ≈ $91, proxy = $93.67 (2.6% error, biased toward opening print). Propagating that through 10y of backfilled history into training data would embed the distortion. Per `feedback_no_silent_fails` + correctness-over-scope-minimization: ArcticDB gets true VWAP only, consumers handle NaN explicitly.

## Behavior change for current daily_closes consumer

Executor's `load_daily_vwap` previously saw a proxy on polygon-outage days. It now sees None and falls through to the 5-day look-back already implemented in `executor/price_cache.py:load_daily_vwap`. Polygon-happy-path (99%+ of days) is unchanged.

## Sequencing

1. **This PR** — writer (alpha-engine-data). No ArcticDB consumer yet.
2. **Follow-up** — executor reader migration (VWAP + eod_reconcile Close + main.py freshness gate all move to ArcticDB, hard-fail on miss).
3. **Follow-up** — retire `collectors/daily_closes.py` entirely after 1 week of clean executor runs.
4. **Phase 7e** — delete legacy S3 prefixes.

## Validation

- [x] 53/53 tests green locally.
- [ ] Next Saturday (2026-04-18) DataPhase1 run: verify VWAP populated in ArcticDB universe for polygon-sourced tickers. Verify yfinance-fallback rows (if any) have NaN VWAP, not proxy values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)