### PR TITLE
feat: short_interest collector + postflight contract (soft-launch ready)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ collectors/slim_cache.py           # 2y slice writer for inference Lambda
 collectors/macro.py                # FRED series + commodity/index prices + market breadth
 collectors/universe_returns.py     # Full-population forward returns (polygon.io)
 collectors/alternative.py          # Analyst, revisions, options, insider, institutional, news
+collectors/short_interest.py       # FINRA short-float (yfinance Ticker.info), bi-monthly cadence
 config.yaml                        # GITIGNORED — local config
 config.yaml.example                # template
 infrastructure/add-cron.sh         # idempotent cron registration on EC2

--- a/collectors/short_interest.py
+++ b/collectors/short_interest.py
@@ -1,0 +1,218 @@
+"""
+short_interest.py — Collect short interest metrics from yfinance and write to S3.
+
+FINRA reports short interest bi-monthly (15th + end-of-month), so a Saturday
+weekly cadence captures every refresh with one cycle of buffer. yfinance
+``Ticker.info`` exposes the three fields research's scoring layer cares about:
+``shortPercentOfFloat`` (the squeeze indicator), ``shortRatio`` (days-to-cover),
+and ``sharesShort`` (raw shares short).
+
+This collector replaces the orphaned ``fetch_short_interest`` in
+``alpha-engine-research/data/fetchers/price_fetcher.py``. Per the
+"research is a pure consumer of alpha-engine-data" principle established
+in Phase 7c, research will read from ``market_data/<date>/short_interest.json``
+instead of calling yfinance inline. The integration on the research side
+ships in a follow-up PR (see ROADMAP).
+
+Output: ``s3://<bucket>/market_data/weekly/<run_date>/short_interest.json``
+
+Schema:
+  {
+    "date": "YYYY-MM-DD",
+    "fetched_at": "ISO-8601 UTC",
+    "ticker_count": int,
+    "ok_count": int,        # tickers with at least one populated field
+    "data": {
+      "<TICKER>": {
+        "short_pct_float": float | null,   # percent (5.0 = 5%)
+        "short_ratio":     float | null,   # days to cover
+        "shares_short":    int | null,     # raw shares short
+      },
+      ...
+    }
+  }
+
+Failure semantics: per-ticker errors are logged and recorded as a row with
+all-null fields. The collector returns ``status="ok"`` as long as at least
+``_MIN_OK_RATIO`` of tickers produce some populated data (default 50%) —
+yfinance's ``Ticker.info`` is rate-limit-sensitive and partial coverage is
+expected. Below that threshold, returns ``status="error"`` so the
+``hard_fail_until_stable`` rule in ``weekly_collector.main`` aborts the run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+# Per-ticker delay between yfinance ``Ticker.info`` calls. yfinance has no
+# documented rate limit; empirically 0.3-0.5s/call avoids HTTP 429 storms
+# while keeping the full-universe collection under ~10 min on the Saturday
+# spot. Adjustable via ``inter_request_delay`` arg.
+_DEFAULT_DELAY_SECS = 0.4
+
+# Minimum fraction of requested tickers that must produce *some* populated
+# field for the run to be considered OK. Below this we suspect a yfinance
+# outage / IP block rather than the bi-monthly FINRA refresh just being
+# old, and hard-fail.
+_MIN_OK_RATIO = 0.50
+
+
+def collect(
+    bucket: str,
+    tickers: list[str],
+    s3_prefix: str = "market_data/",
+    run_date: str | None = None,
+    inter_request_delay: float = _DEFAULT_DELAY_SECS,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Collect short interest for ``tickers`` and write to S3.
+
+    Parameters
+    ----------
+    bucket : str
+        S3 bucket for the JSON output.
+    tickers : list[str]
+        Symbols to fetch. Typically the full S&P 500 + S&P 400 universe
+        produced by the constituents collector earlier in the same run.
+    s3_prefix : str
+        Market-data S3 prefix (typically ``"market_data/"``).
+    run_date : str
+        YYYY-MM-DD stamp; defaults to today (UTC).
+    inter_request_delay : float
+        Seconds to sleep between per-ticker yfinance calls.
+    dry_run : bool
+        If True, fetch ~5 tickers and skip the S3 write.
+
+    Returns
+    -------
+    dict
+        ``{status, ticker_count, ok_count, ...}``. ``status="ok"`` if
+        ok_count >= MIN_OK_RATIO * ticker_count, else ``"error"``.
+    """
+    if run_date is None:
+        run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    if not tickers:
+        return {
+            "status": "error",
+            "error": "no tickers provided — short interest needs the constituents list",
+        }
+
+    # In dry-run, sample the first few tickers to validate yfinance is reachable
+    # without paying the full ~10 min collection cost.
+    fetch_list = tickers[:5] if dry_run else tickers
+
+    try:
+        import yfinance as yf
+    except ImportError as exc:
+        return {
+            "status": "error",
+            "error": f"yfinance not importable: {exc}",
+        }
+
+    payload: dict[str, dict] = {}
+    ok_count = 0
+    err_count = 0
+    started = time.time()
+
+    for i, ticker in enumerate(fetch_list):
+        if i > 0 and inter_request_delay > 0:
+            time.sleep(inter_request_delay)
+        row = {
+            "short_pct_float": None,
+            "short_ratio": None,
+            "shares_short": None,
+        }
+        try:
+            info = yf.Ticker(ticker).info
+            short_pct = info.get("shortPercentOfFloat")
+            short_ratio = info.get("shortRatio")
+            shares_short = info.get("sharesShort")
+
+            # yfinance exposes shortPercentOfFloat as a 0-1 ratio; convert
+            # to percent for the executor / scoring layer's threshold semantics.
+            if short_pct is not None:
+                row["short_pct_float"] = round(float(short_pct) * 100, 2)
+            if short_ratio is not None:
+                row["short_ratio"] = round(float(short_ratio), 2)
+            if shares_short is not None:
+                row["shares_short"] = int(shares_short)
+
+            if any(v is not None for v in row.values()):
+                ok_count += 1
+        except Exception as exc:
+            err_count += 1
+            logger.debug("short interest fetch failed for %s: %s", ticker, exc)
+
+        payload[ticker] = row
+
+        if (i + 1) % 100 == 0:
+            elapsed = time.time() - started
+            logger.info(
+                "short interest progress: %d/%d (%d ok, %d err) in %.0fs",
+                i + 1, len(fetch_list), ok_count, err_count, elapsed,
+            )
+
+    elapsed = time.time() - started
+    ok_ratio = ok_count / max(len(fetch_list), 1)
+    logger.info(
+        "short interest done: %d/%d ok (%.1f%%), %d errors, %.0fs",
+        ok_count, len(fetch_list), ok_ratio * 100, err_count, elapsed,
+    )
+
+    result = {
+        "date": run_date,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "ticker_count": len(fetch_list),
+        "ok_count": ok_count,
+        "data": payload,
+    }
+
+    if dry_run:
+        return {
+            "status": "ok_dry_run",
+            "ticker_count": len(fetch_list),
+            "ok_count": ok_count,
+            "duration_seconds": round(elapsed, 1),
+        }
+
+    if ok_ratio < _MIN_OK_RATIO:
+        return {
+            "status": "error",
+            "error": (
+                f"only {ok_count}/{len(fetch_list)} tickers ({ok_ratio:.1%}) had populated "
+                f"short-interest data — below {_MIN_OK_RATIO:.0%} threshold. yfinance "
+                f"outage or IP block suspected; not writing partial output."
+            ),
+            "ticker_count": len(fetch_list),
+            "ok_count": ok_count,
+        }
+
+    s3 = boto3.client("s3")
+    key = f"{s3_prefix}weekly/{run_date}/short_interest.json"
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(result, indent=2, default=str),
+        ContentType="application/json",
+    )
+    logger.info(
+        "Wrote short_interest.json to s3://%s/%s (%d tickers, %d populated)",
+        bucket, key, len(fetch_list), ok_count,
+    )
+
+    return {
+        "status": "ok",
+        "ticker_count": len(fetch_list),
+        "ok_count": ok_count,
+        "duration_seconds": round(elapsed, 1),
+    }

--- a/tests/test_postflight.py
+++ b/tests/test_postflight.py
@@ -158,6 +158,61 @@ class TestConstituentsJson:
             pf._check_constituents_json_contract()
 
 
+# ── short_interest.json shape check ───────────────────────────────────────────
+
+class TestShortInterestJson:
+    def test_ok_with_well_populated_payload(self):
+        pf = _make_postflight()
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}  # exists
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps({
+                "ticker_count": 900,
+                "ok_count": 700,  # 78% populated
+                "data": {f"T{i}": {"short_pct_float": 5.0} for i in range(900)},
+            }).encode()))
+        }
+        pf._check_short_interest_json_contract()
+
+    def test_fails_below_50pct_populated(self):
+        pf = _make_postflight()
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps({
+                "ticker_count": 900,
+                "ok_count": 300,  # 33% populated
+                "data": {},
+            }).encode()))
+        }
+        with pytest.raises(PostflightError, match="yfinance outage suspected"):
+            pf._check_short_interest_json_contract()
+
+    def test_fails_when_data_dict_missing(self):
+        pf = _make_postflight()
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps({
+                "ticker_count": 900,
+                "ok_count": 700,
+                # data dict missing
+            }).encode()))
+        }
+        with pytest.raises(PostflightError, match="missing 'data' dict"):
+            pf._check_short_interest_json_contract()
+
+    def test_absent_file_skips_check(self):
+        """Soft-launch path: collector disabled → file missing → skip."""
+        pf = _make_postflight()
+        pf._s3 = MagicMock()
+        pf._s3.head_object.side_effect = RuntimeError("NoSuchKey")
+        # No raise — should log + skip
+        pf._check_short_interest_json_contract()
+        # get_object should never be called when head_object fails
+        pf._s3.get_object.assert_not_called()
+
+
 # ── ArcticDB macro.SPY freshness ──────────────────────────────────────────────
 
 class TestMacroSpyFresh:

--- a/tests/test_short_interest.py
+++ b/tests/test_short_interest.py
@@ -1,0 +1,151 @@
+"""Tests for collectors/short_interest.py.
+
+Mocks yfinance ``Ticker.info`` to exercise the collector without hitting the
+network. Locks four invariants:
+  1. Polygon-style well-populated info dict produces correctly-typed output.
+  2. shortPercentOfFloat is converted from 0-1 ratio to percent.
+  3. Per-ticker exceptions don't crash the run; row gets NaN/None fields.
+  4. Below-threshold ok_ratio returns status=error rather than writing
+     a partial payload to S3.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collectors import short_interest
+
+
+def _make_yf(info_by_ticker: dict[str, dict]) -> MagicMock:
+    """Build a yfinance mock where Ticker(t).info returns info_by_ticker[t]."""
+    yf_mock = MagicMock()
+
+    def ticker_factory(t):
+        ticker_obj = MagicMock()
+        ticker_obj.info = info_by_ticker.get(t, {})
+        return ticker_obj
+
+    yf_mock.Ticker.side_effect = ticker_factory
+    return yf_mock
+
+
+def test_well_populated_info_produces_typed_output():
+    yf_mock = _make_yf({
+        "AAPL": {
+            "shortPercentOfFloat": 0.025,  # 2.5%
+            "shortRatio": 1.8,
+            "sharesShort": 50_000_000,
+        }
+    })
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.short_interest.boto3.client", return_value=fake_s3):
+        result = short_interest.collect(
+            bucket="test-bucket",
+            tickers=["AAPL"],
+            run_date="2026-04-18",
+            inter_request_delay=0.0,
+        )
+
+    assert result["status"] == "ok"
+    assert result["ok_count"] == 1
+    assert fake_s3.put_object.called
+    written_body = json.loads(fake_s3.put_object.call_args.kwargs["Body"])
+    aapl = written_body["data"]["AAPL"]
+    assert aapl["short_pct_float"] == 2.5  # 0.025 * 100
+    assert aapl["short_ratio"] == 1.8
+    assert aapl["shares_short"] == 50_000_000
+
+
+def test_per_ticker_exception_does_not_crash():
+    yf_mock = MagicMock()
+
+    def ticker_factory(t):
+        if t == "BAD":
+            raise RuntimeError("yfinance internal error")
+        ticker_obj = MagicMock()
+        ticker_obj.info = {"shortPercentOfFloat": 0.10, "shortRatio": 5.0, "sharesShort": 1_000_000}
+        return ticker_obj
+
+    yf_mock.Ticker.side_effect = ticker_factory
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.short_interest.boto3.client", return_value=fake_s3):
+        result = short_interest.collect(
+            bucket="test-bucket",
+            tickers=["GOOD1", "BAD", "GOOD2"],
+            run_date="2026-04-18",
+            inter_request_delay=0.0,
+        )
+
+    assert result["status"] == "ok"
+    assert result["ok_count"] == 2  # GOOD1 + GOOD2
+    written_body = json.loads(fake_s3.put_object.call_args.kwargs["Body"])
+    assert written_body["data"]["BAD"] == {
+        "short_pct_float": None,
+        "short_ratio": None,
+        "shares_short": None,
+    }
+
+
+def test_below_threshold_returns_error_no_s3_write():
+    """If <50% of tickers populate any field, status=error and no S3 write."""
+    yf_mock = MagicMock()
+
+    def ticker_factory(t):
+        # Only AAPL gets populated info; the other 4 return empty dicts.
+        ticker_obj = MagicMock()
+        ticker_obj.info = (
+            {"shortPercentOfFloat": 0.05, "shortRatio": 2.0, "sharesShort": 100}
+            if t == "AAPL" else {}
+        )
+        return ticker_obj
+
+    yf_mock.Ticker.side_effect = ticker_factory
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.short_interest.boto3.client", return_value=fake_s3):
+        result = short_interest.collect(
+            bucket="test-bucket",
+            tickers=["AAPL", "MSFT", "GOOG", "AMZN", "META"],
+            run_date="2026-04-18",
+            inter_request_delay=0.0,
+        )
+
+    assert result["status"] == "error"
+    assert "below 50% threshold" in result["error"].lower()
+    fake_s3.put_object.assert_not_called()
+
+
+def test_dry_run_samples_first_five_no_s3_write():
+    yf_mock = _make_yf({
+        t: {"shortPercentOfFloat": 0.03, "shortRatio": 1.5, "sharesShort": 1_000_000}
+        for t in ["A", "B", "C", "D", "E", "F", "G"]
+    })
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.short_interest.boto3.client", return_value=fake_s3):
+        result = short_interest.collect(
+            bucket="test-bucket",
+            tickers=["A", "B", "C", "D", "E", "F", "G"],
+            run_date="2026-04-18",
+            inter_request_delay=0.0,
+            dry_run=True,
+        )
+
+    assert result["status"] == "ok_dry_run"
+    assert result["ticker_count"] == 5  # capped to first 5
+    fake_s3.put_object.assert_not_called()
+
+
+def test_empty_tickers_list_errors_immediately():
+    result = short_interest.collect(
+        bucket="test-bucket",
+        tickers=[],
+        run_date="2026-04-18",
+    )
+    assert result["status"] == "error"
+    assert "no tickers" in result["error"].lower()

--- a/validators/postflight.py
+++ b/validators/postflight.py
@@ -257,6 +257,54 @@ class DataPostflight:
             )
         log.info("postflight: macro.json OK (fed_funds_rate=%s)", data["fed_funds_rate"])
 
+    def _check_short_interest_json_contract(self) -> None:
+        """Consumer: research short-interest reader (Phase 7c follow-up).
+
+        Asserts ``market_data/weekly/<run_date>/short_interest.json`` exists,
+        is parseable JSON, and has at least 50% of its requested tickers
+        populated. Mirrors the collector's ``_MIN_OK_RATIO`` gate so an upstream
+        partial-write that bypassed the collector's own status check still
+        fails postflight.
+
+        Soft-launch tolerance: if the file is absent (collector disabled via
+        ``config["short_interest"]["enabled"] = false``), log + skip rather
+        than hard-fail. Once research wires up the consumer, missing-file
+        will become a hard-fail — but until then, the collector is an
+        opt-out feature that shouldn't break the pipeline by being absent.
+        """
+        key = f"{self.market_prefix}weekly/{self.run_date}/short_interest.json"
+        s3 = self._s3_client()
+        try:
+            s3.head_object(Bucket=self.bucket, Key=key)
+        except Exception:
+            log.info(
+                "postflight: short_interest.json absent (collector likely disabled) "
+                "— skipping check. Will become hard-fail once research consumer ships."
+            )
+            return
+
+        data = self._fetch_json(key, name="short_interest.json")
+        if not isinstance(data.get("data"), dict):
+            raise PostflightError(
+                f"s3://{self.bucket}/{key} missing 'data' dict — schema violation."
+            )
+        ticker_count = data.get("ticker_count", 0)
+        ok_count = data.get("ok_count", 0)
+        if ticker_count == 0:
+            raise PostflightError(
+                f"s3://{self.bucket}/{key} ticker_count=0 — collector wrote an empty payload."
+            )
+        ok_ratio = ok_count / ticker_count
+        if ok_ratio < 0.50:
+            raise PostflightError(
+                f"s3://{self.bucket}/{key} only {ok_count}/{ticker_count} tickers "
+                f"populated ({ok_ratio:.1%}) — yfinance outage suspected."
+            )
+        log.info(
+            "postflight: short_interest.json OK (%d/%d tickers populated, %.1f%%)",
+            ok_count, ticker_count, ok_ratio * 100,
+        )
+
     def _check_constituents_json_contract(self) -> None:
         """Consumer: research ``price_fetcher.fetch_sp500_sp400_with_sectors``.
 
@@ -355,6 +403,7 @@ class DataPostflight:
         self._check_latest_weekly_pointer()
         self._check_macro_json_contract()
         self._check_constituents_json_contract()
+        self._check_short_interest_json_contract()
         self._check_macro_spy_fresh()
         self._check_universe_sample_fresh()
         log.info("postflight: all DataPhase1 consumer contracts satisfied")

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -34,7 +34,7 @@ import yaml
 from ssm_secrets import load_secrets
 load_secrets()
 
-from collectors import constituents, prices, slim_cache, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals
+from collectors import constituents, prices, slim_cache, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +188,46 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
         except Exception as e:
             logger.error("Macro collection failed: %s", e)
             results["collectors"]["macro"] = {"status": "error", "error": str(e)}
+
+    # ── 4b. Short interest ───────────────────────────────────────────────────
+    # Per-ticker yfinance Ticker.info scrape for the full S&P 500+400 universe.
+    # FINRA data is bi-monthly (15th + EoM) so weekly Saturday cadence captures
+    # every refresh with a buffer. ~10 min on the spot; the constituents list
+    # was already fetched earlier in this phase.
+    #
+    # Gated by config["short_interest"]["enabled"] (default True). Disabling
+    # lets the operator soft-launch a new collector without blocking the
+    # whole pipeline if yfinance has trouble on the first Saturday — set
+    # enabled=false in config, run once manually with --only short_interest,
+    # then flip back to true once stable.
+    si_cfg = config.get("short_interest", {})
+    si_enabled = si_cfg.get("enabled", True)
+    if only in (None, "short_interest") and si_enabled:
+        logger.info("=" * 60)
+        logger.info("COLLECTING: short interest")
+        logger.info("=" * 60)
+        if not tickers:
+            logger.warning("No tickers available — skipping short interest")
+            results["collectors"]["short_interest"] = {
+                "status": "skipped", "reason": "no tickers",
+            }
+        else:
+            try:
+                si_result = short_interest.collect(
+                    bucket=bucket,
+                    tickers=tickers,
+                    s3_prefix=market_prefix,
+                    run_date=run_date,
+                    inter_request_delay=si_cfg.get("inter_request_delay", 0.4),
+                    dry_run=dry_run,
+                )
+                results["collectors"]["short_interest"] = si_result
+            except Exception as e:
+                logger.error("Short interest collection failed: %s", e)
+                results["collectors"]["short_interest"] = {"status": "error", "error": str(e)}
+    elif only in (None, "short_interest") and not si_enabled:
+        logger.info("short_interest collector disabled via config — skipping")
+        results["collectors"]["short_interest"] = {"status": "ok", "skipped": "disabled_in_config"}
 
     # ── 5. Universe returns ──────────────────────────────────────────────────
     if only in (None, "universe_returns"):
@@ -726,7 +766,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--only",
-        choices=["constituents", "prices", "slim", "macro", "universe_returns", "alternative", "daily_closes", "features", "arcticdb"],
+        choices=["constituents", "prices", "slim", "macro", "short_interest", "universe_returns", "alternative", "daily_closes", "features", "arcticdb"],
         help="Run a single collector instead of all",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

Establishes the producer side of the short-interest data path so research can become a pure consumer of upstream data (Phase 7c follow-up). Surfaced an audit finding mid-build: research's existing \`fetch_short_interest\` was orphaned — defined but never called by the live LangGraph pipeline (\`scoring/aggregator.py::aggregate_all\` is also dead; live scoring goes through \`scoring/composite.py\`). Per 2026-04-17 decision, treated as oversight rather than intent — short interest **should** be a live signal.

## Scope: writer side only

This PR ships the data side. Research-side integration (S3 reader + composite.py wire-up + dead-code cleanup of orphaned aggregator) ships in a follow-up PR after a design call on where the short_interest_adj boost slots into composite scoring.

## Files

- \`collectors/short_interest.py\` — yfinance \`Ticker.info\` per-ticker scrape, rate-limited (default 0.4s/ticker → ~6 min for ~900 tickers). Writes \`market_data/weekly/<run_date>/short_interest.json\` with shape \`{date, fetched_at, ticker_count, ok_count, data: {ticker: {short_pct_float, short_ratio, shares_short}}}\`. Hard-fails to status='error' if <50% of requested tickers populate any field. Per-ticker exceptions don't crash the run.
- \`weekly_collector.py\` — wired into \`_run_phase1\` after macro. Gated by \`config["short_interest"]["enabled"]\` (default True) for soft-launch tolerance — flip to false if first Saturday hits yfinance issues.
- \`validators/postflight.py\` — new \`_check_short_interest_json_contract\` in DataPhase1 postflight chain. Asserts JSON shape + ≥50% populated. **Tolerant of file absence** (collector disabled → log + skip), so the postflight gate is additive: enforced when collector runs, skipped when collector disabled.
- \`tests/test_short_interest.py\` — 5 tests (well-populated, per-ticker exception isolation, below-threshold error, dry-run sampling, empty-tickers).
- \`tests/test_postflight.py\` — 4 new tests for the short_interest contract (well-populated OK, below-50% error, missing-data-dict error, absent-file skip).
- \`CLAUDE.md\` — Key files updated.
- **Full suite: 80/80 green** (was 71, +9).

## Cadence

FINRA reports short interest bi-monthly (15th + EoM). Saturday weekly collection captures every refresh with one cycle of buffer. Cost on the spot: ~6 min for full S&P 500 + 400.

## Soft-launch tolerance

Two-layer safety since this is the first new pipeline-blocking collector since hard-fail-until-stable was adopted:
1. **Config gate** — \`config["short_interest"]["enabled"] = false\` in the live config to skip the collector entirely.
2. **Postflight tolerance** — postflight check skips if file is absent (collector disabled). Becomes hard-fail once research consumer ships and the file is required.

If first Saturday hits yfinance trouble: flip \`enabled: false\` in config, re-run pipeline manually with the rest of the collectors, debug short_interest in isolation with \`--only short_interest\`.

## Sequencing

1. **This PR** — collector + postflight gate. No consumer wired.
2. **Follow-up (alpha-engine-research)** — \`short_interest_reader.py\` + composite.py integration + orphan deletion + offline_stubs update.

## Validation

- [x] 80/80 tests green locally.
- [ ] Saturday 2026-04-18 DataPhase1: collector either succeeds (~6 min, status='ok') or fails cleanly with named yfinance error. Postflight gate enforces shape + populated ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)