### PR TITLE
chore: bump DataPhase1 timeout 60min → 90min

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -19,11 +19,11 @@
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "bash infrastructure/spot_data_weekly.sh 2>&1 | tee /var/log/data-weekly.log"
           ],
-          "executionTimeout": ["3600"]
+          "executionTimeout": ["5400"]
         },
-        "TimeoutSeconds": 3600
+        "TimeoutSeconds": 5400
       },
-      "TimeoutSeconds": 3660,
+      "TimeoutSeconds": 5460,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],


### PR DESCRIPTION
## Summary
- DataPhase1 SSM command + state timeouts bumped from 3600s/3600s/3660s → 5400s/5400s/5460s.
- Purely defensive — bundled DataPhase1 + RAGIngestion + short_interest workload runs ~55-60 min today, <5 min headroom vs the old 60-min ceiling. short_interest (PR #53) adds ~6 min and will clip on a slow week.
- No business reason for 60 min specifically; inherited default. Saturday pipeline total is ~3h, nothing downstream is gated on DataPhase1 finishing fast.

## Test plan
- [ ] After merge, deploy via \`bash infrastructure/deploy_step_function.sh\` before Saturday 2026-04-18 00:00 UTC fires.
- [ ] Verify SF console reflects new DataPhase1 timeout = 5460s.
- [ ] Watch Saturday run — if DataPhase1 completes well under 90 min, leave as-is; if it still clips, investigate bootstrap path rather than raising further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)