### PR TITLE
feat(spot): fetch RAG secrets from SSM instead of sourcing .env

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -303,6 +303,29 @@ echo "DataPhase1 complete at \$(date)"
 
 echo ""
 echo "──────────────────────────────────────────────────────────────"
+echo "Fetching RAG secrets from SSM at \$(date)"
+echo "──────────────────────────────────────────────────────────────"
+# Phase 2 SSM migration — RAG secrets come from SSM Parameter Store, NOT
+# from the SCP'd .env. Origin: 2026-04-17 Saturday Step Function failure
+# where RAG_DATABASE_URL silently truncated at an unquoted & in the .env
+# (a Postgres DSN query-param). Bash source on AL2023 spots dropped the
+# tail of the value after the shell metachar. SSM stores the value as an
+# opaque string — no shell-parse fragility, no cross-instance sync via
+# push-secrets.sh needed, and the spot's IAM profile already has
+# ssm:GetParameter (pattern already in use above for /alpha-engine/lib-token).
+for name in VOYAGE_API_KEY FINNHUB_API_KEY EDGAR_IDENTITY RAG_DATABASE_URL; do
+    val=\$(aws ssm get-parameter --name /alpha-engine/\$name --with-decryption --query 'Parameter.Value' --output text --region "\${AWS_REGION:-us-east-1}" 2>/dev/null || echo "")
+    if [ -z "\$val" ]; then
+        echo "ERROR: could not fetch /alpha-engine/\$name from SSM — required for RAG ingestion" >&2
+        exit 1
+    fi
+    export \$name="\$val"
+    unset val
+done
+echo "RAG secrets fetched: VOYAGE_API_KEY, FINNHUB_API_KEY, EDGAR_IDENTITY, RAG_DATABASE_URL"
+
+echo ""
+echo "──────────────────────────────────────────────────────────────"
 echo "Starting rag/pipelines/run_weekly_ingestion.sh at \$(date)"
 echo "──────────────────────────────────────────────────────────────"
 if ! bash rag/pipelines/run_weekly_ingestion.sh 2>&1; then


### PR DESCRIPTION
2026-04-17 Saturday Step Function failed at RAG preflight with `RAG_DATABASE_URL missing`, even though the secret was present in /home/ec2-user/.alpha-engine.env on the dispatcher and correctly SCP'd to the spot. Root cause: the Postgres DSN value contained an unquoted `&` (standard query-param separator, e.g. ?sslmode=require&channel_binding=require). Bash's `source` on AL2023 treats `&` as a background-process operator and silently truncates the value at the metachar. SSM Parameter Store had the full 147-char value all along — it's stored as an opaque string, so no shell-parse layer ever sees it.

This patch starts Phase 2 of the SSM migration: `spot_data_weekly.sh` now fetches the 4 RAG-required secrets (VOYAGE_API_KEY, FINNHUB_API_KEY, EDGAR_IDENTITY, RAG_DATABASE_URL) from SSM right before invoking run_weekly_ingestion.sh, using the same `aws ssm get-parameter` pattern already in use for /alpha-engine/lib-token. Hard-fails if any secret is missing — no NEUTRAL-style silent fallback.

Scope is intentionally narrow: only RAG secrets migrate in this PR. DataPhase1 (POLYGON_API_KEY, FRED_API_KEY) still loads from .env — that migration is tracked in the ROADMAP P1 "Complete Phase 2 SSM migration across remaining consumers" so each repo/callsite moves independently.

Wins:
- Eliminates the class of "shell metachar silently drops value" bug
- SSM becomes the source of truth for RAG secrets — no .env drift
- Rotation becomes a one-step SSM update, not a 4-way push
- Smaller attack surface: no SCP of secrets-bearing .env onto transient spots

Tests: bash -n clean, 89/89 unit suite green. No code-path change to weekly_collector.py or the RAG script — only the env-var provisioning layer moves from .env source to SSM fetch.