### PR TITLE
fix(spot): fall through to laptop config path when dispatcher path missing

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -201,7 +201,10 @@ scp $SSH_OPTS -i "$KEY_FILE" \
 # require broader git-auth setup than the lib-only insteadOf we use here).
 CONFIG_SRC="/home/ec2-user/alpha-engine-config/data/config.yaml"
 if [ ! -f "$CONFIG_SRC" ]; then
-    echo "ERROR: dispatcher config not found at $CONFIG_SRC — is alpha-engine-config cloned + pulled?"
+    CONFIG_SRC="$HOME/Development/alpha-engine-config/data/config.yaml"
+fi
+if [ ! -f "$CONFIG_SRC" ]; then
+    echo "ERROR: dispatcher config not found at /home/ec2-user/alpha-engine-config/data/config.yaml or $HOME/Development/alpha-engine-config/data/config.yaml — is alpha-engine-config cloned + pulled?"
     exit 1
 fi
 echo "==> Uploading alpha-engine-config/data/config.yaml to spot..."


### PR DESCRIPTION
## Summary
- \`spot_data_weekly.sh\` hardcoded \`/home/ec2-user/alpha-engine-config/data/config.yaml\` (dispatcher EC2 path). Running from a laptop with the config checked out at \`\$HOME/Development/alpha-engine-config/\` fails with \"dispatcher config not found\" even though the file is right there.
- Mirror the dual-path pattern already in \`ENV_FILE\` resolution: try dispatcher path first, fall back to laptop path. Error message lists both paths when neither exists.
- Surfaced during today's RAG smoke test iterations from my laptop.

## Test plan
- [x] Smoke test ran end-to-end green from laptop with this patch applied (RAG Weekly Ingestion Complete — 2026-04-20 01:00 UTC)
- [x] Dispatcher path still takes precedence (no behavior change on ae-dashboard / ae-trading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)