### PR TITLE
fix(rag): register pgvector adapter on get_connection()

### DIFF
--- a/rag/db.py
+++ b/rag/db.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 
 import psycopg2
 import psycopg2.extras
+from pgvector.psycopg2 import register_vector
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,12 @@ def get_connection():
     server-side). Commits on success, rolls back on exception.
     """
     conn = psycopg2.connect(_get_url())
+    # Register pgvector type codecs so SELECTs on `vector` columns return
+    # numpy arrays instead of stringified lists. Without this, reads like
+    # rag/pipelines/filing_change_detection.py crash with
+    # "could not convert string to float" on np.array(embedding). Must run
+    # per-connection because psycopg2 scopes type adapters to the connection.
+    register_vector(conn)
     try:
         yield conn
         conn.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ beautifulsoup4>=4.12
 lxml>=5.0
 edgartools>=2.0
 psycopg2-binary>=2.9
+pgvector>=0.2
 voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11


### PR DESCRIPTION
## Summary
- Silent-broken-since-day-one fix found during tonight's 2026-04-19 RAG recovery run.
- \`rag.pipelines.filing_change_detection\` reads \`c.embedding\` (pgvector \`vector\` column) and passes to \`np.array(dtype=float32)\`. Without \`pgvector.psycopg2.register_vector(conn)\`, psycopg2 returns the vector as a stringified list and the numpy call raises \`ValueError: could not convert string to float\`. Registered per-connection (psycopg2 scopes type adapters to the connection, not globally).
- Steps 1-4 (ingest_sec_filings, ingest_8k_filings, ingest_earnings_finnhub, ingest_theses) only write vectors — writes serialize Python lists → pgvector's string format fine. Step 5 is the first reader of vector columns, which is why the bug was latent until tonight's real-run reached it.

## Impact
- Every Saturday SF RAG step has been exiting non-zero at step 5 since filing_change_detection was added. Downstream Research was blocked because RAGIngestion SF step failed, even though steps 1-4 had written the embeddings Research actually queries.
- Output \`rag/filing_changes/latest.json\` is not consumed by any code in alpha-engine-research or alpha-engine-data (grepped both). Pure analytic signal for lazy-filing detection. Bug impact = SF state fire, not trading-decision impact.

## Changes
- \`rag/db.py\` — \`register_vector(conn)\` after \`psycopg2.connect()\` in \`get_connection()\` context manager. One-line import, 5-line comment explaining the per-connection scoping.
- \`requirements.txt\` — add \`pgvector>=0.2\` (explicit pin; was transitively available but not declared).

## Test plan
- [x] \`pytest tests/\` — 109 passed
- [ ] Post-merge: re-run RAG ingestion end-to-end, verify step 5 (filing_change_detection) completes and writes \`s3://alpha-engine-research/rag/filing_changes/latest.json\`
- [ ] Verify heartbeat \`AlphaEngine/Heartbeat{Process=rag-ingestion}\` emits (was suppressed by the step-5 crash under \`set -euo pipefail\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)