### PR TITLE
fix(step-function-daily): alert handlers tolerate missing $.error

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -120,7 +120,7 @@
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekday Pipeline — Trading Day Check Failed (Proceeding)",
-        "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. Error: {}', States.JsonToString($.error))"
+        "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. State: {}', States.JsonToString($))"
       },
       "ResultPath": "$.trading_day_error_notify",
       "Next": "StartExecutorEC2"
@@ -423,7 +423,7 @@
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekday Pipeline — FAILED",
-        "Message.$": "States.Format('Weekday pipeline failed. Error: {}', States.JsonToString($.error))"
+        "Message.$": "States.Format('Weekday pipeline failed. State: {}', States.JsonToString($))"
       },
       "ResultPath": "$.failure_notify",
       "Next": "FailExecution"


### PR DESCRIPTION
HandleFailure and TradingDayCheckFailed both formatted their SNS message via States.JsonToString($.error). $.error is populated on Catch paths but NOT on Choice Default transitions (Choice states don't produce an error object). When a Choice Default routed to one of these handlers, the States.Format call exploded on $.error lookup and the SF reported "could not find $.error" instead of the actual state of the pipeline.

Observed on weekday SF 2026-04-20 06:13:20 PT: CheckDailyDataStatus (live deployment, pre-PR #56) hit its Default branch after polling abandoned WaitForDailyData, and the alert handler crashed rather than surfacing useful context. Morning trading window was lost while the failure reason remained opaque.

Fix: format the full state instead of just $.error. Full-state dump always works (the state is the root object the Task receives), and still contains $.error when it's been populated on a Catch path. Less elegant than adding a Pass state per Choice Default to populate $.error with context, but covers every current and future Default transition with two small edits.

Note: this repo's version of step_function_daily.json already removed the DailyData polling states in PR #56, but that deployment never reached AWS — today's failure was on the live pre-#56 definition. Deploying this PR also resolves that drift (deploy_step_function_daily.sh pushes the current definition, which removes DailyData from the morning pipeline; DailyData now runs post-close via the new systemd timer on ae-trading).