### PR TITLE
refactor(step-function-daily): move all SSM steps to ae-trading, drop…

### DIFF
--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -183,7 +183,6 @@ aws iam put-role-policy \
 
 INPUT_JSON=$(cat <<EOF
 {
-  "ec2_instance_id": ["$MICRO_INSTANCE"],
   "trading_instance_id": ["$TRADING_INSTANCE"],
   "sns_topic_arn": "$SNS_TOPIC_ARN"
 }
@@ -224,6 +223,6 @@ echo ""
 echo "To test manually:"
 echo "  aws stepfunctions start-execution \\"
 echo "    --state-machine-arn $SM_ARN \\"
-echo "    --input '{\"ec2_instance_id\": [\"$MICRO_INSTANCE\"], \"trading_instance_id\": [\"$TRADING_INSTANCE\"], \"sns_topic_arn\": \"$SNS_TOPIC_ARN\"}' \\"
+echo "    --input '{\"trading_instance_id\": [\"$TRADING_INSTANCE\"], \"sns_topic_arn\": \"$SNS_TOPIC_ARN\"}' \\"
 echo "    --region $REGION"
 echo ""

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1,20 +1,20 @@
 {
-  "Comment": "Alpha Engine Weekday Pipeline — predictor inference and executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). DailyData moved to post-close (1:05 PM PT) systemd timer on ae-trading — see alpha-engine repo's alpha-engine-daily-data.timer (2026-04-17 incident: pre-market polygon grouped-daily silently returned T-1 data labeled as T).",
-  "StartAt": "CheckTradingDay",
+  "Comment": "Alpha Engine Weekday Pipeline — predictor inference and executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). DailyData moved to post-close (1:05 PM PT) systemd timer on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only.",
+  "StartAt": "StartExecutorEC2",
   "States": {
 
     "CheckTradingDay": {
       "Type": "Task",
-      "Comment": "Skip pipeline on NYSE holidays (Good Friday, MLK Day, etc.)",
+      "Comment": "Skip pipeline on NYSE holidays. Runs on ae-trading via the alpha-engine-lib trading_calendar module (no repo clone needed — lib is installed in alpha-engine venv).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.ec2_instance_id",
+        "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
           "commands": [
-            "cd /home/ec2-user/alpha-engine-dashboard",
+            "cd /home/ec2-user/alpha-engine",
             "source .venv/bin/activate",
-            "python trading_calendar.py"
+            "python -m alpha_engine_lib.trading_calendar"
           ],
           "executionTimeout": ["30"]
         },
@@ -37,7 +37,7 @@
       "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
       "Parameters": {
         "CommandId.$": "$.trading_day_result.Command.CommandId",
-        "InstanceId.$": "$.ec2_instance_id[0]"
+        "InstanceId.$": "$.trading_instance_id[0]"
       },
       "Retry": [
         {
@@ -88,7 +88,7 @@
               "StringMatches": "*MARKET_CLOSED*"
             }
           ],
-          "Next": "NotifyHolidaySkip"
+          "Next": "StopExecutorOnHoliday"
         },
         {
           "And": [
@@ -101,7 +101,7 @@
               "StringMatches": "*TRADING DAY*"
             }
           ],
-          "Next": "StartExecutorEC2"
+          "Next": "PredictorInference"
         }
       ],
       "Default": "TradingDayCheckFailed"
@@ -123,17 +123,36 @@
         "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. State: {}', States.JsonToString($))"
       },
       "ResultPath": "$.trading_day_error_notify",
-      "Next": "StartExecutorEC2"
+      "Next": "PredictorInference"
+    },
+
+    "StopExecutorOnHoliday": {
+      "Type": "Task",
+      "Comment": "Stop ae-trading on holidays — we started it speculatively before CheckTradingDay, so clean up.",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:stopInstances",
+      "Parameters": {
+        "InstanceIds.$": "$.trading_instance_id"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Stop failure non-fatal — EventBridge Scheduler at 1:30 PM PT is the backstop.",
+          "Next": "NotifyHolidaySkip",
+          "ResultPath": "$.holiday_stop_error"
+        }
+      ],
+      "ResultPath": "$.holiday_stop_result",
+      "Next": "NotifyHolidaySkip"
     },
 
     "NotifyHolidaySkip": {
       "Type": "Task",
-      "Comment": "Notify that pipeline was skipped — trading_calendar.py stdout contains MARKET_CLOSED",
+      "Comment": "Notify that pipeline was skipped — trading_calendar stdout contains MARKET_CLOSED",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekday Pipeline — Skipped (Market Holiday)",
-        "Message": "Daily pipeline skipped — NYSE is closed today (market holiday or weekend). No data collection, inference, or trading."
+        "Message": "Daily pipeline skipped — NYSE is closed today (market holiday or weekend). No inference or trading. ae-trading stopped."
       },
       "ResultPath": "$.holiday_notify",
       "End": true
@@ -169,7 +188,7 @@
       "Type": "Wait",
       "Comment": "Wait for SSM agent to register (~30s typical). IB Gateway authenticates in the background; wait-for-ibgateway.sh handles it before RunMorningPlanner.",
       "Seconds": 60,
-      "Next": "PredictorInference"
+      "Next": "CheckTradingDay"
     },
 
     "PredictorInference": {
@@ -224,69 +243,12 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Comment": "Health check is non-blocking — continue to data health check and executor",
-          "Next": "HealthCheck",
+          "Comment": "Predictor health check is non-blocking — continue to morning planner. Executor's own upstream-health gate catches real data-freshness problems before placing orders.",
+          "Next": "RunMorningPlanner",
           "ResultPath": "$.predictor_health_error"
         }
       ],
       "ResultPath": "$.predictor_health_result",
-      "Next": "HealthCheck"
-    },
-
-    "HealthCheck": {
-      "Type": "Task",
-      "Comment": "Check data freshness — non-blocking (alerts on failure but does not halt pipeline)",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-      "Parameters": {
-        "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.ec2_instance_id",
-        "Parameters": {
-          "commands": [
-            "cd /home/ec2-user/alpha-engine-dashboard",
-            "source .venv/bin/activate",
-            "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
-          ],
-          "executionTimeout": ["60"]
-        },
-        "TimeoutSeconds": 60
-      },
-      "TimeoutSeconds": 90,
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Comment": "Health check failure is non-blocking — log and continue to executor",
-          "Next": "RunMorningPlanner",
-          "ResultPath": "$.health_check_error"
-        }
-      ],
-      "ResultPath": "$.health_check_result",
-      "Next": "WaitForHealthCheck"
-    },
-
-    "WaitForHealthCheck": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-      "Parameters": {
-        "CommandId.$": "$.health_check_result.Command.CommandId",
-        "InstanceId.$": "$.ec2_instance_id[0]"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
-          "MaxAttempts": 5,
-          "IntervalSeconds": 5,
-          "BackoffRate": 1.5
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Comment": "Non-blocking — continue even if health check polling fails",
-          "Next": "RunMorningPlanner",
-          "ResultPath": "$.health_check_error"
-        }
-      ],
-      "ResultPath": "$.health_check_poll",
       "Next": "RunMorningPlanner"
     },
 


### PR DESCRIPTION
… HealthCheck

Morning pipeline still referenced ae-dashboard (i-09b539c844515d549) for CheckTradingDay and HealthCheck. Policy is ae-dashboard is reserved for Streamlit + nginx + spot-launcher — anything operational belongs on ae-trading. Also: ae-dashboard is t3.micro (1 GB RAM) and has been OOM- prone under load, so running pipeline-critical commands on it is fragile.

## Structural changes

- Flip StartExecutorEC2 + WaitForInstanceReady to the front of the SF so ae-trading is available for SSM by the time CheckTradingDay runs.
- CheckTradingDay now runs on ae-trading via `python -m alpha_engine_lib.trading_calendar`. No repo clone required — the lib is already installed in alpha-engine's venv.
- Drop HealthCheck + WaitForHealthCheck. Both lived on ae-dashboard and were marked non-blocking (all catches transitioned to RunMorningPlanner). The executor's own upstream-health gate (PR #53/#54) does the real data-freshness checking before placing any orders, so the SF-level HealthCheck was redundant.
- Add StopExecutorOnHoliday: ae-trading is now started before the holiday check, so stop it on MARKET_CLOSED rather than leaving it running until the 1:30 PM PT scheduler. EventBridge Scheduler remains as the backstop via Catch.

## Consumer-visible changes

- SF input shape: `ec2_instance_id` no longer required (and no longer used anywhere in the state machine). `trading_instance_id` is the only required instance reference. deploy script's rule Input updated to match.

## Verified

- JSON parses
- All Next / Default / Catch references resolve to declared states
- No remaining references to ec2_instance_id or alpha-engine-dashboard