### PR TITLE
feat(sf): add freeze_evaluator flag to suppress auto-promotion

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -504,7 +504,63 @@
           "Next": "SaturdayHealthCheck"
         }
       ],
+      "Default": "CheckEvaluatorFreeze"
+    },
+
+    "CheckEvaluatorFreeze": {
+      "Type": "Choice",
+      "Comment": "Freeze-gate. {\"freeze_evaluator\": true} routes to EvaluatorFrozen (--freeze flag suppresses per-optimizer S3 config writes; report artifacts + email still upload). Use for off-cycle test runs so mid-week sweeps don't auto-promote weights/params/thresholds against Monday trading.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.freeze_evaluator", "IsPresent": true},
+            {"Variable": "$.freeze_evaluator", "BooleanEquals": true}
+          ],
+          "Next": "EvaluatorFrozen"
+        }
+      ],
       "Default": "Evaluator"
+    },
+
+    "EvaluatorFrozen": {
+      "Type": "Task",
+      "Comment": "Frozen evaluator — same runtime as Evaluator but with --freeze. Per-optimizer config writes (scoring_weights.json, executor_params.json, predictor_params.json, etc.) are skipped; apply_result reports 'frozen (--freeze flag)'. Report CSVs + markdown + email still upload via --upload.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.ec2_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -eo pipefail",
+            "export HOME=/home/ec2-user",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-backtester",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "python evaluate.py --mode all --upload --freeze --log-level INFO 2>&1 | tee /var/log/evaluator.log"
+          ],
+          "executionTimeout": ["1800"]
+        },
+        "TimeoutSeconds": 1800
+      },
+      "TimeoutSeconds": 1860,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.evaluator_result",
+      "Next": "WaitForEvaluator"
     },
 
     "Evaluator": {


### PR DESCRIPTION
## Summary

Companion to PR #70 (partial-execution skip flags). Adds a `freeze_evaluator: true` flag on SF input that routes to a new `EvaluatorFrozen` task running `evaluate.py --mode all --upload --freeze`. Blocks per-optimizer S3 config writes on off-cycle test runs while still producing report artifacts + email.

Motivation: Wednesday's planned partial-pipeline dry-run (`skip_data_phase1`, `skip_research`, `skip_predictor_training` set) would otherwise auto-promote scoring weights / executor params / predictor veto thresholds based on a mid-week sweep — those configs gate Monday paper trading. The freeze flag lets operators inspect the sweep output before promoting.

## Design

- New Choice state `CheckEvaluatorFreeze` between `CheckSkipEvaluator` and `Evaluator`
- Default path unchanged — scheduled Saturday runs still auto-promote
- `EvaluatorFrozen` is a Task sibling to `Evaluator`, same SSM shape, only the `evaluate.py` command differs (adds `--freeze`)
- Both tasks share `WaitForEvaluator` + the existing polling chain

`evaluate.py --freeze` blocks each optimizer's `apply_result` with `reason="frozen (--freeze flag)"`. Report CSVs + markdown + email still upload via `--upload`.

## Wednesday invocation

```bash
aws stepfunctions start-execution \
  --state-machine-arn arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline \
  --name "wed-partial-frozen-$(date +%Y%m%dT%H%M%S)" \
  --input '{
    "ec2_instance_id":["i-09b539c844515d549"],
    "skip_data_phase1": true,
    "skip_research": true,
    "skip_predictor_training": true,
    "freeze_evaluator": true
  }'
```

## Validation

- JSON parses; 39 states (was 37 + new Choice + new Task)
- All 39 `Next` references resolve
- Traced Wednesday scenario with `freeze_evaluator=true`: lands on `EvaluatorFrozen` → `WaitForEvaluator` → `CheckEvaluatorStatus` → `SaturdayHealthCheck`
- Traced Wednesday scenario without `freeze_evaluator`: lands on `Evaluator` (default, auto-promoting), same downstream path

## Test plan

- [x] JSON validation
- [x] Flow trace (skip-partial + frozen → EvaluatorFrozen; skip-partial + no-freeze → Evaluator)
- [ ] Deploy + Wednesday dry-run verifies `frozen (--freeze flag)` appears in evaluator report apply_result sections

## Deploy

```bash
cd ~/Development/alpha-engine-data && bash infrastructure/deploy-infrastructure.sh
```

Or the full `deploy_step_function.sh` if you want IAM/SNS/EventBridge re-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)