### PR TITLE
feat(sf): coverage-gap self-heal between Predictor and executor

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -274,6 +274,29 @@ Resources:
       AlarmActions:
         - !Ref AlertsTopic
 
+  # Research↔Predictor coverage gap. Emitted by the executor's signal_reader
+  # on every run (value 0 on success, >0 when buy_candidates have no
+  # prediction row). A positive value means the weekday Step Function's
+  # coverage-gap self-heal (CheckPredictorCoverage → ReinvokePredictor) also
+  # failed to close the gap before the executor read predictions.json —
+  # indicates a regression of that orchestration. First observed as a silent
+  # veto bypass on 2026-04-20 (4 of 5 entries bypassed the GBM veto).
+  UnscoredBuyCandidatesGap:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alpha-engine-predictor-unscored-buy-candidates
+      AlarmDescription: Executor saw buy_candidates without a prediction row — Step Function coverage-gap self-heal may have regressed
+      Namespace: AlphaEngine/Predictor
+      MetricName: unscored_buy_candidates_count
+      Statistic: Maximum
+      Period: 3600  # 1 hour
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching  # executor not running off-hours is expected
+      AlarmActions:
+        - !Ref AlertsTopic
+
   # Heartbeat alarms for EC2-based processes
   ExecutorMorningHeartbeat:
     Type: AWS::CloudWatch::Alarm

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -218,7 +218,124 @@
         }
       ],
       "ResultPath": "$.predictor_result",
-      "Next": "PredictorHealthCheck"
+      "Next": "CheckPredictorCoverage"
+    },
+
+    "CheckPredictorCoverage": {
+      "Type": "Task",
+      "Comment": "Self-healing coverage gate: detect buy_candidates in signals.json that lack a prediction row. Primary guard against the 2026-04-20 silent-veto-bypass bug. If any are missing, ReinvokePredictor scores them and RecheckCoverage verifies before we proceed to executor.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_coverage"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.coverage_result",
+      "Next": "CoverageGapChoice"
+    },
+
+    "CoverageGapChoice": {
+      "Type": "Choice",
+      "Comment": "If buy_candidates have unscored tickers, re-invoke the predictor with --tickers. Otherwise advance to PredictorHealthCheck.",
+      "Choices": [
+        {
+          "Variable": "$.coverage_result.Payload.has_gap",
+          "BooleanEquals": true,
+          "Next": "ReinvokePredictor"
+        }
+      ],
+      "Default": "PredictorHealthCheck"
+    },
+
+    "ReinvokePredictor": {
+      "Type": "Task",
+      "Comment": "Supplemental-scoring re-invoke for the tickers CheckPredictorCoverage flagged as missing. Predictor merges the new predictions into predictions/{date}.json (re-ranks the union).",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "predict",
+          "tickers.$": "$.coverage_result.Payload.missing_tickers"
+        }
+      },
+      "TimeoutSeconds": 900,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.reinvoke_result",
+      "Next": "RecheckCoverage"
+    },
+
+    "RecheckCoverage": {
+      "Type": "Task",
+      "Comment": "Second coverage check after ReinvokePredictor. If the gap persists (e.g. some ticker genuinely cannot be scored), bail out instead of looping — HandleFailure fires the SNS alert.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_coverage"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.coverage_recheck_result",
+      "Next": "FinalCoverageGate"
+    },
+
+    "FinalCoverageGate": {
+      "Type": "Choice",
+      "Comment": "After one re-invocation attempt, either coverage is complete (proceed) or we have a deeper problem (fail). No further retry loop — prevents runaway invocations if a ticker is un-scorable by the model.",
+      "Choices": [
+        {
+          "Variable": "$.coverage_recheck_result.Payload.has_gap",
+          "BooleanEquals": true,
+          "Next": "HandleFailure"
+        }
+      ],
+      "Default": "PredictorHealthCheck"
     },
 
     "PredictorHealthCheck": {


### PR DESCRIPTION
**Phase 2 of the Research↔Predictor coverage-gap closure.** Pairs with:
- alpha-engine-predictor #42 — `--tickers` flag + `check_coverage` action
- alpha-engine #72 — executor read-time guard + CloudWatch metric

## Summary
Adds 5 new states between `PredictorInference` and `PredictorHealthCheck`:
- `CheckPredictorCoverage` — Lambda invoke with `action=check_coverage`, returns `{missing_tickers, has_gap, ...}`
- `CoverageGapChoice` — if `has_gap=true`, go to `ReinvokePredictor`; else straight to `PredictorHealthCheck`
- `ReinvokePredictor` — Lambda invoke with `action=predict` + `tickers=$.missing_tickers`. Predictor PR #42 merges these predictions into the existing `predictions/{date}.json`.
- `RecheckCoverage` — second coverage check after re-invoke
- `FinalCoverageGate` — if gap STILL exists after one re-run, fail hard. No infinite-loop path.

## Why
2026-04-20: executor bought SNDK/WDC/BIIB/XEL at market open. 4 of 5 live entries bypassed the GBM veto gate because Research had produced buy_candidates that the first PredictorInference run didn't score. The invariant "every buy_candidate has a prediction before the executor sees signals.json" was enforced nowhere. This PR enforces it in orchestration.

## Validation
- [x] JSON parses
- [x] All 24 states have valid Next/Default/Catch targets (no missing, no unreachable)
- [x] Single-retry design prevents runaway Lambda invocations
- [ ] Deploy + dry-run on tomorrow's weekday SF execution (blocked on predictor #42 + executor #72 merging first)

## Deploy order
1. alpha-engine-predictor #42 (merge + deploy Lambda — `check_coverage` action must exist before SF calls it)
2. alpha-engine #72 (merge + deploy executor)
3. This PR (merge + deploy SF definition)

Deploying out of order leaves a window where the SF calls a Lambda action that doesn't exist → SF failure on the next weekday run.

## Status
**Draft** until predictor #42 is merged + the Lambda `live` alias is bumped to include `check_coverage`. Promoting out of draft is the signal for the SF deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)