### PR TITLE
fix(sf): default sns_topic_arn so manual invocations don't crash HandleFailure

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1,7 +1,17 @@
 {
   "Comment": "Alpha Engine Saturday Pipeline — orchestrates weekly data collection, RAG ingestion, research, predictor training, and backtesting sequentially with fail-fast error handling. RAG runs before Research (fresh knowledge base). Backtester runs AFTER predictor training (depends on model weights). Supports partial execution via boolean skip_* flags on input (e.g. {\"skip_data_phase1\": true}); a missing flag is treated as false, so scheduled runs are unaffected.",
-  "StartAt": "CheckSkipDataPhase1",
+  "StartAt": "InitializeInput",
   "States": {
+
+    "InitializeInput": {
+      "Type": "Pass",
+      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + ec2_instance_id explicitly; manual runs for partial-execution testing often omit sns_topic_arn, which previously caused HandleFailure/NotifyComplete to error on missing JSONPath. States.JsonMerge with user-input as the second arg lets explicit values win.",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'), $$.Execution.Input, false)"
+      },
+      "OutputPath": "$.merged",
+      "Next": "CheckSkipDataPhase1"
+    },
 
     "CheckSkipDataPhase1": {
       "Type": "Choice",


### PR DESCRIPTION
## Summary

During the 2026-04-20 partial-execution SF dry-run, the actual pipeline failure (backtester pip install) cascaded into a second, more confusing failure: `HandleFailure` itself crashed with `States.Runtime` because `$.sns_topic_arn` wasn't in the input. Scheduled EventBridge runs pass that field explicitly (confirmed via `list-targets-by-rule` on `alpha-engine-saturday`), but manual partial-pipeline invocations don't.

Visible symptom: the SF status was `FAILED` but no SNS failure email fired. The operator had to rely on the CloudWatch alarm instead of the named failure notification.

## Fix

New `InitializeInput` Pass state at the top of the SF. Uses `States.JsonMerge` to layer a default `sns_topic_arn` under the execution input. Explicit values still win — `JsonMerge(defaults, user_input, shallow)` overrides defaults with later fields from user input.

```diff
+    "InitializeInput": {
+      "Type": "Pass",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'), $$.Execution.Input, false)"
+      },
+      "OutputPath": "$.merged",
+      "Next": "CheckSkipDataPhase1"
+    },
```

`OutputPath: $.merged` replaces `$` with the unified shape for the rest of the pipeline, so every downstream state sees one input contract regardless of invocation path.

## Compatibility

| Invocation | Before | After |
|---|---|---|
| Scheduled EventBridge (passes `sns_topic_arn`) | works | works (same value, user input wins) |
| Manual with `sns_topic_arn` | works | works (user value wins) |
| Manual without `sns_topic_arn` | crashes HandleFailure | **gets default ARN, emails fire** |

## Deploy

```bash
cd ~/Development/alpha-engine-data && bash infrastructure/deploy-infrastructure.sh
```

## Validation

- JSON parses; 40 states (was 39 + new `InitializeInput`)
- `StartAt: InitializeInput`
- All `Next` references resolve

## Follow-on

- Same pattern on `step_function_daily.json` if any of its Task states reference `$.sns_topic_arn` similarly — worth a separate grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)