### PR TITLE
feat(drift): stamp git-sha at deploy + DeployDriftCheck SF gate (Phase 2+3)

### DIFF
--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -16,11 +16,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUCKET="alpha-engine-research"
 STACK_NAME="alpha-engine-orchestration"
 TEMPLATE="$SCRIPT_DIR/cloudformation/alpha-engine-orchestration.yaml"
 REGION="us-east-1"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+# Git SHA stamp — baked into the SF Comment field and the CF stack tags so
+# the deploy-drift preflight can detect when main has moved past the deployed
+# artifact. CI supplies $GITHUB_SHA; local dev falls back to HEAD.
+GIT_SHA="${GITHUB_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+echo "  Stamping deploy with GIT_SHA=${GIT_SHA}"
 
 DRY_RUN=false
 for arg in "$@"; do
@@ -49,11 +56,42 @@ if $DRY_RUN; then
     exit 0
 fi
 
-# ── 2. Upload Step Function definitions to S3 ────────────────────────────────
+# ── 2. Stamp SF definitions with git SHA + upload to S3 ──────────────────────
+# Prepend `[git:<sha>] ` to the top-level `Comment` field so the preflight
+# drift check can extract + compare against origin/main. The stamped JSON is
+# what gets uploaded to S3 AND fed to update-state-machine, so S3 copy and
+# live definition stay in lockstep.
+echo ""
+echo "==> Stamping Step Function definitions with git SHA..."
+SAT_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
+DAILY_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
+trap "rm -f '$SAT_STAMPED' '$DAILY_STAMPED'" EXIT
+python3 -c "
+import json, sys
+path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(path_in))
+orig = d.get('Comment', '')
+# Strip any existing [git:…] prefix so re-stamping is idempotent
+if orig.startswith('[git:'):
+    orig = orig.split(' ', 1)[1] if ' ' in orig else ''
+d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
+json.dump(d, open(path_out, 'w'), indent=2)
+" "$SCRIPT_DIR/step_function.json" "$SAT_STAMPED" "$GIT_SHA"
+python3 -c "
+import json, sys
+path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(path_in))
+orig = d.get('Comment', '')
+if orig.startswith('[git:'):
+    orig = orig.split(' ', 1)[1] if ' ' in orig else ''
+d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
+json.dump(d, open(path_out, 'w'), indent=2)
+" "$SCRIPT_DIR/step_function_daily.json" "$DAILY_STAMPED" "$GIT_SHA"
+
 echo ""
 echo "==> Uploading Step Function definitions to S3..."
-aws s3 cp "$SCRIPT_DIR/step_function.json" "s3://$BUCKET/infrastructure/step_function.json" --quiet
-aws s3 cp "$SCRIPT_DIR/step_function_daily.json" "s3://$BUCKET/infrastructure/step_function_daily.json" --quiet
+aws s3 cp "$SAT_STAMPED" "s3://$BUCKET/infrastructure/step_function.json" --quiet
+aws s3 cp "$DAILY_STAMPED" "s3://$BUCKET/infrastructure/step_function_daily.json" --quiet
 echo "  Uploaded to s3://$BUCKET/infrastructure/"
 
 # ── 3. Update Step Functions directly ────────────────────────────────────────
@@ -63,10 +101,10 @@ echo "==> Updating Step Function definitions..."
 SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
 DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-weekday-pipeline"
 
-aws stepfunctions update-state-machine --state-machine-arn "$SAT_ARN" --definition "$(cat "$SCRIPT_DIR/step_function.json")" --query "updateDate" --output text
+aws stepfunctions update-state-machine --state-machine-arn "$SAT_ARN" --definition "$(cat "$SAT_STAMPED")" --query "updateDate" --output text
 echo "  Saturday pipeline updated."
 
-aws stepfunctions update-state-machine --state-machine-arn "$DAILY_ARN" --definition "$(cat "$SCRIPT_DIR/step_function_daily.json")" --query "updateDate" --output text
+aws stepfunctions update-state-machine --state-machine-arn "$DAILY_ARN" --definition "$(cat "$DAILY_STAMPED")" --query "updateDate" --output text
 echo "  Weekday pipeline updated."
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────
@@ -82,6 +120,7 @@ if [ "$STACK_STATUS" = "DOES_NOT_EXIST" ]; then
         --stack-name "$STACK_NAME" \
         --template-body "file://$TEMPLATE" \
         --capabilities CAPABILITY_NAMED_IAM \
+        --tags "Key=git-sha,Value=$GIT_SHA" \
         --query "StackId" --output text
     echo "  Waiting for stack creation..."
     aws cloudformation wait stack-create-complete --stack-name "$STACK_NAME"
@@ -91,8 +130,11 @@ else
         --stack-name "$STACK_NAME" \
         --template-body "file://$TEMPLATE" \
         --capabilities CAPABILITY_NAMED_IAM \
+        --tags "Key=git-sha,Value=$GIT_SHA" \
         --query "StackId" --output text 2>/dev/null || {
-        echo "  No updates needed (stack is current)."
+        # update-stack refuses when template AND tags are both unchanged. In
+        # that case the SHA is already current — no-op is correct.
+        echo "  No updates needed (template + git-sha tag both current)."
     }
 fi
 

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1,7 +1,50 @@
 {
   "Comment": "Alpha Engine Weekday Pipeline — predictor inference and executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). DailyData moved to post-close (1:05 PM PT) systemd timer on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only.",
-  "StartAt": "StartExecutorEC2",
+  "StartAt": "DeployDriftCheck",
   "States": {
+
+    "DeployDriftCheck": {
+      "Type": "Task",
+      "Comment": "Verify the deployed SF definition + CloudFormation stack SHAs match alpha-engine-data@main HEAD. Halts the pipeline when infrastructure code has merged but deploy-infrastructure.sh never ran. Degraded modes (missing stamps, GitHub outage) set has_drift=false so legacy artifacts and API outages do not block trading-hours runs.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_deploy_drift"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.drift_result",
+      "Next": "DeployDriftGate"
+    },
+
+    "DeployDriftGate": {
+      "Type": "Choice",
+      "Comment": "Hard-fail when the drift probe reports has_drift=true. Surfaces deploy lag loudly instead of silently running new SF definitions against stale Lambda images (or vice versa).",
+      "Choices": [
+        {
+          "Variable": "$.drift_result.Payload.has_drift",
+          "BooleanEquals": true,
+          "Next": "HandleFailure"
+        }
+      ],
+      "Default": "StartExecutorEC2"
+    },
 
     "CheckTradingDay": {
       "Type": "Task",


### PR DESCRIPTION
**Phase 2+3 of the deploy-drift architecture.** Pairs with alpha-engine-predictor #44 (Phase 1 preflight + Phase 2+3 Lambda-side probe).

## Summary
- `deploy-infrastructure.sh` stamps git SHA into BOTH Step Function Comment fields (`[git:<sha>] ` prefix, re-stamp-idempotent) and CloudFormation stack tags (\`Key=git-sha,Value=<sha>\`).
- New `DeployDriftCheck` first state in the weekday SF invokes the predictor Lambda's `action=check_deploy_drift`, which returns has_drift/sf_drift/cf_drift + diagnostic fields.
- New `DeployDriftGate` Choice state routes to HandleFailure on drift; else falls through to prior StartAt (StartExecutorEC2).

## Why
2026-04-20 evening exposed that predictor Lambda auto-deploys on merge but SF + CF need manual \`deploy-infrastructure.sh\`. Impossible to track by hand. Structural fix: stamp artifacts, verify at preflight.

## Degraded modes (explicitly non-blocking)
- Missing SF stamp (legacy deploy predates this PR) → no drift flag
- Missing CF tag (legacy stack) → no drift flag
- GitHub API outage → no drift flag

These matter because the bootstrap deploy of this PR itself won't have the stamps in the currently-running artifacts. First deploy of \`deploy-infrastructure.sh\` with this PR stamps forward; subsequent drift is caught.

## Test plan
- [x] SF JSON validates: 26 states, no dangling refs, no unreachable
- [x] Python JSON-munging for stamp injection is idempotent (re-running deploy.sh strips prior prefix before re-prepending)
- [ ] **Bootstrap deploy:** run \`bash infrastructure/deploy-infrastructure.sh\` once to ship the stamped SF + tagged stack
- [ ] **First live validation:** next weekday SF run should log \`DeployDriftCheck\` with has_drift=false
- [ ] **Negative validation:** before calling this fully battle-tested, manually tweak the SF Comment prefix to a non-matching SHA and confirm the SF fails at DeployDriftGate

## Rollout order
1. Merge alpha-engine-predictor #44 first (adds \`action=check_deploy_drift\` to the Lambda)
2. Wait for auto-deploy to publish new predictor Lambda version
3. Then merge this PR + run \`bash infrastructure/deploy-infrastructure.sh\` once to stamp

Merging this PR before #44 leaves a window where SF calls a Lambda action that doesn't exist → DeployDriftCheck task fails → HandleFailure fires → SF pipeline blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)