### PR TITLE
fix(data): short-history branch matches stored dtype per-column

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -221,19 +221,22 @@ def daily_append(
                     index=pd.DatetimeIndex([today_ts], name="date"),
                 )
                 # Align to the stored schema: NaN for every non-OHLCV column
-                # the library already has for this ticker.
+                # the library already has for this ticker, and match the
+                # stored dtype per-column. ArcticDB rejects updates whose
+                # column dtypes don't match the existing version — and the
+                # schema varies across tickers (some store Volume as int64,
+                # others as float64, depending on when they were first
+                # backfilled). Matching ``hist.dtypes[col]`` is the only
+                # way to stay compatible with every ticker's current
+                # storage. Regression of the 2026-04-21 shipped fix where
+                # hardcoded Volume→int64 rejected writes for SOLS, ULS,
+                # and one other ticker whose stored Volume was float64.
                 for col in hist.columns:
                     if col not in new_row.columns:
                         new_row[col] = np.nan
                 new_row = new_row[hist.columns]
                 for col in new_row.columns:
-                    if col in OHLCV_COLS:
-                        if col == "Volume":
-                            new_row[col] = new_row[col].astype("int64")
-                        else:
-                            new_row[col] = new_row[col].astype("float64")
-                    else:
-                        new_row[col] = new_row[col].astype("float32")
+                    new_row[col] = new_row[col].astype(hist.dtypes[col])
 
                 log.warning(
                     "short-history ticker=%s rows=%d min_required=%d "

--- a/tests/test_daily_append_semantics.py
+++ b/tests/test_daily_append_semantics.py
@@ -123,6 +123,37 @@ def test_short_history_writes_ohlcv_not_skipped():
         raise AssertionError("short-history branch not found in daily_append.py")
 
 
+def test_short_history_matches_stored_dtype():
+    """Short-history branch must astype every column to ``hist.dtypes[col]``
+    — never hardcode a dtype.
+
+    Regression for 2026-04-21 shipping of PR #76: the short-history
+    branch hardcoded ``Volume → int64``. ArcticDB rejects updates whose
+    column dtypes don't match the existing version. Stored Volume dtype
+    varies across tickers (some int64, some float64, depending on when
+    they were first backfilled) — SOLS, ULS, and one other short-history
+    ticker all failed the update with a FLOAT64/INT64 mismatch.
+
+    The only correct approach is to match the stored dtype per-column
+    via ``hist.dtypes[col]``, which is authoritative by construction.
+    """
+    src = _source()
+
+    # The per-column astype loop must reference hist.dtypes so every
+    # column matches the ticker's current storage schema.
+    assert "astype(hist.dtypes[col])" in src, (
+        "short-history branch must astype(hist.dtypes[col]) to match "
+        "the stored schema — hardcoded dtypes cause ArcticDB to reject "
+        "updates when stored dtype differs (SOLS/ULS 2026-04-21)."
+    )
+
+    # Hardcoded Volume casts are forbidden — they were the original bug.
+    assert 'astype("int64")' not in src, (
+        "hardcoded astype(\"int64\") — almost certainly the Volume-dtype "
+        "regression. Use hist.dtypes[col] instead."
+    )
+
+
 def test_no_skip_guard_on_existing_today_row():
     """daily_append must NOT skip tickers whose history already contains today_ts.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #76. The short-history write path hardcoded \`Volume → int64\`; stored ArcticDB schema varies per-ticker (some int64, some float64 depending on backfill vintage). Fix: astype every column to \`hist.dtypes[col]\`, authoritative by construction.

## Why

PR #76 shipped + validated today — today's EOD email sent successfully because SNDK's stored Volume was already int64 (matching the hardcode). Three other short-history tickers (SOLS, ULS, +1) failed the update with \`FLOAT64/INT64\` mismatch and contributed n_err=4 in the daily_append summary. Tomorrow's unattended 13:05 PT daily_append would repeat the same failures every day until fixed.

## Change

\`\`\`python
# before (PR #76)
for col in new_row.columns:
    if col in OHLCV_COLS:
        if col == "Volume":
            new_row[col] = new_row[col].astype("int64")
        else:
            new_row[col] = new_row[col].astype("float64")
    else:
        new_row[col] = new_row[col].astype("float32")

# after
for col in new_row.columns:
    new_row[col] = new_row[col].astype(hist.dtypes[col])
\`\`\`

## Test plan

- [x] \`pytest tests/test_daily_append_semantics.py -v\` — 8/8 pass (new dtype test + 7 prior)
- [x] Full repo suite: \`pytest tests/\` — 111/111 pass
- [ ] Tomorrow's unattended 13:05 PT daily_append: expect n_partial count to increase + n_err to drop by 3 (SOLS, ULS, +1 previously failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)