### PR TITLE
fix(features): per-feature graceful degrade, no whole-row dropna

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -27,7 +27,6 @@ import pandas as pd
 
 from features.feature_engineer import (
     FEATURES,
-    MIN_ROWS_FOR_FEATURES,
     compute_features,
 )
 from features.compute import (
@@ -178,10 +177,10 @@ def daily_append(
         if t not in _SKIP_TICKERS and not _is_sector_etf(t)
     ]
 
-    n_ok = 0
-    n_skip = 0
-    n_err = 0
-    n_partial = 0  # short-history tickers: OHLCV-only written, features NaN
+    n_ok = 0       # fully-featured rows (all FEATURES finite)
+    n_skip = 0     # legitimate skips (dry_run, NaN close from upstream)
+    n_err = 0      # ArcticDB read failures
+    n_partial = 0  # rows written with ≥1 NaN feature (short-history, etc.)
 
     for ticker in stock_tickers:
         try:
@@ -197,68 +196,17 @@ def daily_append(
                 n_err += 1
                 continue
 
-            if len(hist) < MIN_ROWS_FOR_FEATURES:
-                # Short-history tickers (new listings, IPOs, spinoffs — e.g.
-                # SNDK after the 2026 WDC flash-memory spinoff) are a
-                # first-class supported state, not a skip. Below the feature
-                # warmup threshold we write an OHLCV-only row with NaN for
-                # every feature column. Downstream consumers that need
-                # features (training, inference) see NaN and handle
-                # accordingly; consumers that only read prices (EOD
-                # reconcile, attribution) get the authoritative close.
-                #
-                # Prior behavior silently skipped the row entirely — no
-                # OHLCV written, no warning — which made EOD reconcile
-                # hard-fail on every held short-history ticker. See
-                # 2026-04-21 SNDK incident.
-                bar = closes[ticker]
-                if np.isnan(bar["Close"]):
-                    n_skip += 1
-                    continue
-
-                new_row = pd.DataFrame(
-                    [{col: bar.get(col, np.nan) for col in OHLCV_COLS}],
-                    index=pd.DatetimeIndex([today_ts], name="date"),
-                )
-                # Align to the stored schema: NaN for every non-OHLCV column
-                # the library already has for this ticker, and match the
-                # stored dtype per-column. ArcticDB rejects updates whose
-                # column dtypes don't match the existing version — and the
-                # schema varies across tickers (some store Volume as int64,
-                # others as float64, depending on when they were first
-                # backfilled). Matching ``hist.dtypes[col]`` is the only
-                # way to stay compatible with every ticker's current
-                # storage. Regression of the 2026-04-21 shipped fix where
-                # hardcoded Volume→int64 rejected writes for SOLS, ULS,
-                # and one other ticker whose stored Volume was float64.
-                for col in hist.columns:
-                    if col not in new_row.columns:
-                        new_row[col] = np.nan
-                new_row = new_row[hist.columns]
-                for col in new_row.columns:
-                    new_row[col] = new_row[col].astype(hist.dtypes[col])
-
-                log.warning(
-                    "short-history ticker=%s rows=%d min_required=%d "
-                    "— writing OHLCV-only row with NaN features",
-                    ticker, len(hist), MIN_ROWS_FOR_FEATURES,
-                )
-                universe_lib.update(ticker, new_row)
-                n_partial += 1
-                continue
-
             # Re-running daily_append for the same date MUST overwrite the
             # existing row, not skip it. universe_lib.update() is idempotent
-            # (same-date rows replace instead of accumulate — see the comment
-            # at the update() call below), so there's nothing to guard against.
+            # (same-date rows replace instead of accumulate), so there's
+            # nothing to guard against.
             #
-            # Prior to 2026-04-18, a `today_ts in hist.index: skip` guard here
-            # silently no-op'd every re-run. That masked the 2026-04-17 label
-            # incident: after Polygon-grouped-daily returned T-1 data stamped
-            # as T in the morning DailyData run, a re-run with fresh polygon
-            # data couldn't repair the poisoned rows — every ticker was
-            # skipped. Removing the guard restores the idempotency guarantee
-            # that update() was chosen to provide.
+            # Prior to 2026-04-18, a `today_ts in hist.index: skip` guard
+            # silently no-op'd every re-run. That masked the 2026-04-17
+            # label incident: after Polygon returned T-1 data stamped as T
+            # in the morning DailyData run, a re-run with fresh polygon
+            # data couldn't repair the poisoned rows. Removing the guard
+            # restores the idempotency guarantee that update() provides.
 
             # Build today's OHLCV row
             bar = closes[ticker]
@@ -276,7 +224,12 @@ def daily_append(
             combined = pd.concat([hist_ohlcv, new_row])
             combined = combined[~combined.index.duplicated(keep="last")].sort_index()
 
-            # Compute features on the combined series
+            # Compute features on the combined series. `compute_features`
+            # returns rows with NaN for features whose rolling-window
+            # warmup exceeds the available history (short-history tickers
+            # get ATR-14 computed on ≥14 rows, while 252-day features
+            # stay NaN). Rows are never dropped — see 2026-04-21 docstring
+            # in features/feature_engineer.py.
             sector_etf_sym = sector_map.get(ticker)
             sector_etf_series = macro.get(sector_etf_sym) if sector_etf_sym else None
             ticker_alt = alt_data.get(ticker, {})
@@ -297,18 +250,48 @@ def daily_append(
                 fundamental_data=fundamentals.get(ticker),
             )
 
-            if featured.empty or today_ts not in featured.index:
-                n_skip += 1
+            if today_ts not in featured.index:
+                # Only possible if combined had a genuine upstream data
+                # issue (today's row disappeared during feature compute).
+                log.warning(
+                    "Ticker %s: today_ts missing from featured frame — "
+                    "unexpected after compute_features stopped dropping rows",
+                    ticker,
+                )
+                n_err += 1
                 continue
 
-            # Extract today's row with OHLCV + features
+            # Extract today's row with OHLCV + every feature that has
+            # a column in the featured frame. Features that failed to
+            # compute arrive as NaN and are written as NaN — first-class
+            # support for partial coverage.
             keep_cols = [c for c in OHLCV_COLS if c in featured.columns] + \
                         [f for f in FEATURES if f in featured.columns]
             today_row = featured.loc[[today_ts], keep_cols].copy()
 
-            for f in FEATURES:
-                if f in today_row.columns:
-                    today_row[f] = today_row[f].astype("float32")
+            # Per-ticker coverage observability: count NaN features now
+            # so the eventual log + counter reflects exactly what's
+            # being written. Silent partial coverage is forbidden
+            # (feedback_no_silent_fails). Increment is deferred until
+            # after universe_lib.update() so an exception rolls back
+            # cleanly into n_err.
+            nan_features = [
+                f for f in FEATURES
+                if f in today_row.columns and today_row[f].isna().iloc[0]
+            ]
+
+            # Match stored schema dtype per-column. ArcticDB rejects
+            # updates whose column dtypes don't match the existing
+            # version; stored dtype varies across tickers (some Volume
+            # int64, some float64 depending on backfill vintage).
+            # hist.dtypes[col] is authoritative by construction.
+            # Feature columns that aren't yet in storage default to
+            # float32 — matches the predictor training schema.
+            for col in today_row.columns:
+                if col in hist.columns:
+                    today_row[col] = today_row[col].astype(hist.dtypes[col])
+                elif col in FEATURES:
+                    today_row[col] = today_row[col].astype("float32")
 
             today_row.index.name = "date"
 
@@ -316,12 +299,21 @@ def daily_append(
             # date overwrites instead of accumulating duplicate rows.
             # 2026-04-15: diagnosed as root cause of the predictor training
             # failure where 904/909 tickers had duplicate date rows when
-            # read back from ArcticDB. The read-check at line 195 was the
-            # only dedup guard; a race or concurrent pipeline invocation
-            # defeats it. update() is idempotent — same-date rows replace
-            # instead of append, regardless of race conditions.
+            # read back from ArcticDB. update() is idempotent — same-date
+            # rows replace instead of append, regardless of race conditions.
             universe_lib.update(ticker, today_row)
-            n_ok += 1
+
+            # Increment coverage counter + emit the partial-features log
+            # only after the write landed.
+            if nan_features:
+                log.warning(
+                    "partial-features ticker=%s rows=%d nan=%d/%d features=%s",
+                    ticker, len(hist), len(nan_features), len(FEATURES),
+                    nan_features,
+                )
+                n_partial += 1
+            else:
+                n_ok += 1
 
         except Exception as exc:
             log.warning("Failed to append %s: %s", ticker, exc)

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -217,8 +217,19 @@ def compute_features(
 
     Returns
     -------
-    pd.DataFrame with original columns plus feature columns. Rows without
-    sufficient history are dropped.
+    pd.DataFrame with original columns plus feature columns. Features
+    whose rolling-window warmup exceeds the available history stay NaN
+    for the affected rows; no rows are dropped. Callers apply their own
+    policy — daily_append writes partial-feature rows with loud
+    per-ticker coverage logging; training may dropna at its layer.
+
+    2026-04-21: removed the implicit ``df.dropna(subset=FEATURES)``
+    epilogue. It caused every row of short-history tickers (new
+    listings, spinoffs — e.g. SNDK with 44 rows) to be dropped because
+    252-day features were always NaN, which cascaded into the executor
+    crashing at ``load_atr_14_pct`` despite ATR-14 being computable on
+    ≥14 rows. First-class support for partial features requires
+    returning them.
     """
     if df.empty:
         return df.copy()
@@ -575,9 +586,11 @@ def compute_features(
         df["roe"] = 0.0
         df["current_ratio"] = 0.0
 
-    # ── Drop rows with any NaN in the feature columns ─────────────────────────
-    df = df.dropna(subset=FEATURES)
-
+    # Rows with NaN features are NOT dropped — see module docstring. A
+    # feature whose rolling-window warmup exceeds the available history
+    # stays NaN for the affected rows; short-history tickers therefore
+    # produce rows with partial feature coverage rather than being
+    # filtered out entirely.
     return df
 
 

--- a/tests/test_daily_append_semantics.py
+++ b/tests/test_daily_append_semantics.py
@@ -72,55 +72,83 @@ def test_sector_etfs_iterate_explicit_list():
     assert 'sector_etfs = ["XLB"' in src or 'sector_etfs = [\n' in src
 
 
-def test_short_history_writes_ohlcv_not_skipped():
-    """Short-history tickers (new listings, spinoffs) must get an OHLCV-only
-    row written, never silently skipped.
+def test_unified_path_no_min_rows_gate():
+    """daily_append must have ONE loop path for all tickers — no
+    ``len(hist) < MIN_ROWS_FOR_FEATURES`` branch that bypasses
+    ``compute_features``.
 
-    Regression for 2026-04-21 SNDK incident: the 2026 WDC flash-memory
-    spinoff re-listed SNDK with ~44 rows of history. daily_append's
-    `len(hist) < MIN_ROWS_FOR_FEATURES` branch silently n_skip++'d without
-    writing any row. EOD reconcile then hard-failed on every held
-    short-history ticker because authoritative close was missing from
-    ArcticDB. New listings are a normal market event (20-40 S&P
-    constituent changes/year; every spinoff creates one). They are a
-    first-class supported state.
+    The Phase 2 fix (2026-04-21) removed the implicit
+    ``df.dropna(subset=FEATURES)`` in ``compute_features`` and the
+    corresponding short-history-only write branch in daily_append. Every
+    ticker now runs through the same pipeline: compute whatever features
+    are computable, write the row with NaN for the rest, log loudly.
 
-    The fix writes OHLCV + NaN-for-every-feature-column when below the
-    warmup threshold, logs loudly with a structured `short-history
-    ticker=X rows=N` message, and increments a dedicated ``n_partial``
-    counter (not ``n_skip``, not ``n_err`` — short history is neither).
+    A regression that re-introduces the gate would undo first-class
+    short-history support and resurrect the 2026-04-21 SNDK executor
+    crash (NaN ``atr_14_pct`` from a ticker that WAS supposed to get
+    one because ATR-14 only needs ≥14 rows).
     """
     src = _source()
-
-    # Loud warning with structured key=val tags so coverage gaps surface.
-    assert "short-history ticker=" in src, (
-        "short-history branch must log `short-history ticker=X rows=N` — "
-        "silent fallback is forbidden (feedback_no_silent_fails)."
-    )
-
-    # Write path must exist — ticker gets OHLCV, not a skip.
-    assert "n_partial" in src, (
-        "short-history path must track a dedicated n_partial counter, "
-        "distinct from n_skip (legitimate skips) and n_err (read errors)."
-    )
-
-    # Skip-only pattern (the bug) must be gone: the old `if len(hist) <
-    # MIN_ROWS_FOR_FEATURES: n_skip += 1; continue` with no write.
-    # Check the short-history branch reaches universe_lib.update().
     lines = src.splitlines()
     for i, line in enumerate(lines):
-        if "len(hist) < MIN_ROWS_FOR_FEATURES" in line:
-            window = "\n".join(lines[i:i + 60])
-            assert "universe_lib.update(ticker" in window, (
-                "short-history branch must reach universe_lib.update() — "
-                "writing OHLCV-only is the whole point of the fix."
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "len(hist) < MIN_ROWS_FOR_FEATURES" in stripped:
+            raise AssertionError(
+                f"Line {i+1}: re-introduced the `len(hist) < "
+                f"MIN_ROWS_FOR_FEATURES` gate. This branches short-history "
+                f"tickers away from compute_features and brings back the "
+                f"2026-04-21 SNDK executor crash. Let every ticker go "
+                f"through the unified path; compute_features no longer "
+                f"drops rows."
             )
-            assert "n_partial" in window, (
-                "short-history branch must increment n_partial."
-            )
+
+
+def test_partial_features_are_loudly_logged():
+    """Every row written with ≥1 NaN feature must emit a structured
+    ``partial-features ticker=X rows=N nan=M/... features=[...]`` log.
+
+    Silent partial coverage is forbidden per feedback_no_silent_fails.
+    The log message shape (key=value tags + feature list) is what lets
+    us grep production logs for coverage drift.
+    """
+    src = _source()
+    assert "partial-features ticker=" in src, (
+        "daily_append must log `partial-features ticker=X rows=N` when a "
+        "row is written with NaN features — silent fallback is forbidden."
+    )
+    assert "n_partial" in src, (
+        "dedicated n_partial counter required, distinct from n_skip "
+        "(legitimate skips) and n_err (read errors)."
+    )
+
+
+def test_counters_increment_after_successful_write():
+    """n_ok and n_partial must be incremented AFTER universe_lib.update()
+    so an exception rolls the iteration back cleanly into n_err.
+
+    Locks the 2026-04-21 rewrite where counters were hoisted post-write
+    to prevent double-counting when update() throws.
+    """
+    src = _source()
+    # The update() call site + increments must appear in that order.
+    # Find the update call for universe_lib.update(ticker, today_row) —
+    # the committed increment happens on the same side.
+    lines = src.splitlines()
+    update_idx = None
+    for i, line in enumerate(lines):
+        if "universe_lib.update(ticker, today_row)" in line:
+            update_idx = i
             break
-    else:
-        raise AssertionError("short-history branch not found in daily_append.py")
+    assert update_idx is not None, (
+        "universe_lib.update(ticker, today_row) call site not found"
+    )
+    window_after = "\n".join(lines[update_idx:update_idx + 20])
+    assert "n_partial += 1" in window_after and "n_ok += 1" in window_after, (
+        "n_ok / n_partial must be incremented AFTER the update() call, "
+        "not before. Increments before write cause miscount on exception."
+    )
 
 
 def test_short_history_matches_stored_dtype():


### PR DESCRIPTION
## Summary

- \`compute_features\` no longer ends with \`df.dropna(subset=FEATURES)\`. Rows with NaN for features that exceed available history are returned, not dropped.
- \`daily_append\` collapses into one uniform path — no more short-history gate. Every ticker writes today's row with whatever features were computable. Partial coverage is logged per-ticker (\`partial-features ticker=X rows=N nan=M/... features=[...]\`) and counted as \`n_partial\`.
- Counter increments hoisted past \`universe_lib.update()\` so exceptions roll back cleanly into \`n_err\`.
- \`MIN_ROWS_FOR_FEATURES\` import removed from \`daily_append\` (no longer referenced).

## Why

The dropna in \`compute_features\` was all-or-nothing: ANY NaN feature → entire row dropped. Short-history tickers always had 252-day features NaN → every row dropped → zero features stored → downstream crashes. SNDK (40 rows post-2026 WDC spinoff) produced NaN \`atr_14_pct\` in ArcticDB even though ATR-14 only needs 14 rows. The executor's \`load_atr_14_pct\` hard-failed on every morning run where SNDK was held.

Per-feature graceful degrade is the arch-correct semantic (\"only features marked n/a if not enough data\"): features that CAN compute, do; features that CAN'T return NaN; callers apply their own policy. New listings (IPOs, spinoffs) are a normal, recurring market event and now produce actionable per-ticker rows from day 1.

## Verified locally

On a synthetic 44-row ticker:
\`\`\`
atr_14_pct            0.0086   (non-NaN — computable on 14 rows)
rsi_14               32.0473   (non-NaN — computable on 14 rows)
ema_cross_8_21       -0.0099   (non-NaN)
momentum_5d / 20d     computed
dist_from_52w_high    NaN      (correctly — needs 252 rows)
return_120d           NaN      (correctly — needs 120 rows)
price_vs_ma200        NaN      (correctly — needs 200 rows)
\`\`\`

## Downstream impact

- **Executor** (\`load_atr_14_pct\` + any other feature reader): now gets real numbers for short-history tickers. Tomorrow's 6:15 AM PT morning planner works for SNDK.
- **Training** (weekly GBM retrain): will see rows with some NaN features. LightGBM handles NaN natively. A follow-up should validate training behavior on short-history subsamples with a named baseline + promotion gate (per \`feedback_component_baseline_validation.md\`).
- **Backfill** (\`builders/backfill.py\`): uses \`compute_features\` too; currently has an \`if featured_df.empty: skip\` branch that used to trigger for short-history tickers. Post-fix it won't trigger, and short-history tickers will get partial-feature rows in their backfilled history as well. This is intended.

## What is NOT in this PR (follow-ups)

- Predictor training short-history subsample validation + named baseline.
- Executor position sizer coverage derate (scale size by feature completeness).
- Executor admission gate (refuse tickers the full pipeline can't score to required coverage).
- Backfill-specific behavior review if the backfill \`dropna\`-like guards surface issues.

## Test plan

- [x] \`pytest tests/\` — 112/112 pass (3 new behavioral locks + 109 prior)
- [x] Synthetic 44-row compute_features call produces finite ATR-14
- [ ] Post-merge: rerun \`daily_append --date 2026-04-21\` on ae-trading so SNDK's ArcticDB row picks up real features
- [ ] Post-merge: verify executor \`--simulate --dry-run\` passes (unblocks the pre-push hook for alpha-engine PR \`fix/boot-pull-timer-reconcile\`)
- [ ] Tomorrow's unattended 6:15 AM PT morning planner runs cleanly for SNDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)