### PR TITLE
fix(data): promote_ohlcv_only_schema must use a real boto3 S3 client

### DIFF
--- a/builders/promote_ohlcv_only_schema.py
+++ b/builders/promote_ohlcv_only_schema.py
@@ -46,6 +46,7 @@ import sys
 import time
 from datetime import datetime, timezone
 
+import boto3
 import numpy as np
 import pandas as pd
 
@@ -232,13 +233,19 @@ def promote_schemas(
             "dry_run": dry_run,
         }
 
-    # Load supporting data only when we actually have work to do.
-    sector_map = _load_sector_map(None, bucket) if not dry_run or candidates else {}
+    # Load supporting data. Must use a real boto3 S3 client — passing
+    # None causes the loaders to silently default sector_map / fundamentals
+    # / alternative to empty dicts, which would compute_features then
+    # silently write 0 (not NaN) for every sector-relative / fundamental /
+    # alternative feature. Silent zeroing of half the feature schema is
+    # the exact failure mode feedback_no_silent_fails forbids.
+    s3 = boto3.client("s3")
+    sector_map = _load_sector_map(s3, bucket)
     fundamentals = _load_cached_fundamentals(
-        None, bucket,
+        s3, bucket,
         datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-    ) if not dry_run or candidates else {}
-    alt_data = _load_cached_alternative(None, bucket) if not dry_run or candidates else {}
+    )
+    alt_data = _load_cached_alternative(s3, bucket)
     macro = _load_macro_series(macro_lib, bucket)
 
     results: list[dict] = []

--- a/tests/test_promote_ohlcv_only_schema.py
+++ b/tests/test_promote_ohlcv_only_schema.py
@@ -93,6 +93,40 @@ def test_dry_run_does_not_write():
         raise AssertionError("universe_lib.write() call site not found")
 
 
+def test_supporting_data_loaders_get_real_s3_client():
+    """The sector_map / fundamentals / alternative loaders must receive
+    a real boto3 client — not ``None``.
+
+    Regression for the 2026-04-21 PR #79 dry-run: passing ``None`` to
+    the S3-backed loaders caused them to log a warning and return empty
+    dicts. ``compute_features`` then silently computed 0 (not NaN) for
+    every sector-relative, fundamental, and alternative feature (~15
+    of 59 features). The migration would have claimed success while
+    writing the wrong feature values for every candidate. Exactly the
+    failure mode feedback_no_silent_fails forbids — a fallback that
+    quietly bypasses the ideal flow.
+    """
+    src = _source()
+    # A real boto3 client must be constructed and passed to the loaders.
+    assert "boto3.client(\"s3\")" in src, (
+        "promote_ohlcv_only_schema must construct a real boto3 S3 client "
+        "before calling _load_sector_map / _load_cached_fundamentals / "
+        "_load_cached_alternative. Passing None defaults features to 0."
+    )
+    # None must not be passed to any of the supporting-data loaders.
+    forbidden = [
+        "_load_sector_map(None",
+        "_load_cached_fundamentals(\n        None",
+        "_load_cached_fundamentals(None",
+        "_load_cached_alternative(None",
+    ]
+    for bad in forbidden:
+        assert bad not in src, (
+            f"Found `{bad}` — passing None causes silent feature zeroing. "
+            f"Use boto3.client('s3')."
+        )
+
+
 def test_partial_coverage_is_logged_loudly():
     """Symbols promoted with NaN features (short history) must emit a
     structured ``partial-features ticker=X nan=N/total features=[...]``


### PR DESCRIPTION
## Summary

Follow-up to PR #79. The migration passed \`None\` to \`_load_sector_map\` / \`_load_cached_fundamentals\` / \`_load_cached_alternative\`. Those loaders log a warning and return empty dicts when given no client. \`compute_features\` then silently defaulted ~15 of 59 features (every sector-relative, fundamental, and alternative-data feature) to 0 — while the migration reported them as \"ok\" because 0 isn't NaN.

## Why it matters

Caught during the 2026-04-21 \`--dry-run\` on ae-trading:

\`\`\`
WARNING  features.compute — Failed to load sector_map.json: 'NoneType' object has no attribute 'get_object'
WARNING  features.compute — Failed to scan for cached fundamentals: 'NoneType' ...
WARNING  features.compute — No cached alternative data loaded ...

ticker=Q    features_ok=55 features_nan=4
ticker=SOLS features_ok=56 features_nan=3
\`\`\`

Had we applied the migration as-is, Q and SOLS would have been persisted with \`sector_vs_spy_5d/10d/20d\`, \`sector_x_trend\`, and fundamentals-dependent features all set to 0 — silently wrong. Exactly the no-silent-fails preference: a fallback that quietly bypasses the ideal flow.

## Fix

\`\`\`python
s3 = boto3.client("s3")
sector_map = _load_sector_map(s3, bucket)
fundamentals = _load_cached_fundamentals(s3, bucket, today)
alt_data = _load_cached_alternative(s3, bucket)
\`\`\`

## Test plan

- [x] \`pytest tests/test_promote_ohlcv_only_schema.py -v\` — 7/7 pass (new s3-client regression test + 6 prior)
- [x] Full repo suite: \`pytest tests/\` — 120/120 pass
- [ ] Post-merge: re-run \`--dry-run\` on ae-trading — warnings for sector_map / fundamentals / alt_data should be gone, \`features_ok\` count should be higher for Q and SOLS
- [ ] If dry-run looks clean, apply without \`--dry-run\`; re-run \`daily_append --date 2026-04-21\` and confirm \`n_err=0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)