### PR TITLE
feat(data): parquet-context warmup for short-history tickers in daily_append

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -25,8 +25,11 @@ import boto3
 import numpy as np
 import pandas as pd
 
+from botocore.exceptions import ClientError
+
 from features.feature_engineer import (
     FEATURES,
+    MIN_ROWS_FOR_FEATURES,
     compute_features,
 )
 from features.compute import (
@@ -38,10 +41,39 @@ from features.compute import (
     _load_cached_alternative,
 )
 from store.arctic_store import get_universe_lib, get_macro_lib
+from store.parquet_loader import load_parquet_from_s3
 
 log = logging.getLogger(__name__)
 
 OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
+PRICE_CACHE_PREFIX = "predictor/price_cache/"
+
+
+def _load_parquet_warmup(s3, bucket: str, ticker: str) -> pd.DataFrame | None:
+    """Load a ticker's 10y price-cache parquet for feature warmup.
+
+    Returns None when the parquet doesn't exist (new constituent that hasn't
+    been picked up by the weekly backfill yet). Hard-fails on any other
+    error shape — NoSilentFails.
+    """
+    key = f"{PRICE_CACHE_PREFIX}{ticker}.parquet"
+    try:
+        df = load_parquet_from_s3(s3, bucket, key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "404"):
+            return None
+        raise RuntimeError(
+            f"parquet-warmup read failed for {ticker} (bucket={bucket}, "
+            f"key={key}): {exc}"
+        ) from exc
+
+    if df.empty or "Close" not in df.columns:
+        raise RuntimeError(
+            f"parquet-warmup for {ticker}: parquet exists but invalid shape "
+            f"(empty={df.empty}, cols={list(df.columns)[:6]})"
+        )
+    return df
 
 
 def _load_daily_closes(s3, bucket: str, date_str: str) -> dict[str, dict]:
@@ -177,10 +209,11 @@ def daily_append(
         if t not in _SKIP_TICKERS and not _is_sector_etf(t)
     ]
 
-    n_ok = 0       # fully-featured rows (all FEATURES finite)
-    n_skip = 0     # legitimate skips (dry_run, NaN close from upstream)
-    n_err = 0      # ArcticDB read failures
-    n_partial = 0  # rows written with ≥1 NaN feature (short-history, etc.)
+    n_ok = 0              # fully-featured rows (all FEATURES finite)
+    n_skip = 0            # legitimate skips (dry_run, NaN close from upstream)
+    n_err = 0             # ArcticDB read failures
+    n_partial = 0         # rows written with ≥1 NaN feature (short-history, etc.)
+    n_parquet_warmup = 0  # rows whose feature compute used parquet-enriched context
 
     for ticker in stock_tickers:
         try:
@@ -219,8 +252,61 @@ def daily_append(
                 index=pd.DatetimeIndex([today_ts]),
             )
 
-            # Combine history OHLCV + today's bar for feature computation
-            hist_ohlcv = hist[[c for c in OHLCV_COLS if c in hist.columns]]
+            # Warmup context — ArcticDB by default; parquet-enriched when the
+            # ArcticDB history is too short for full feature warmup.
+            #
+            # Before this change, short-history tickers (new listings, spinoffs,
+            # recent constituent adds) accumulated feature coverage one day at
+            # a time — features with 252-day rolling windows stayed NaN for
+            # up to a year after the ticker entered ArcticDB, even though the
+            # weekly backfill's 10y parquet held the full series. That state
+            # routinely caused manual polygon backfills (8 tickers in one day,
+            # 2026-04-22) just to unblock downstream consumers.
+            #
+            # When len(hist) is below the feature-warmup threshold we union
+            # the ticker's `predictor/price_cache/{T}.parquet` (full 10y
+            # adjusted OHLCV, rebuilt every Saturday by backfill.py) with
+            # ArcticDB by date. ArcticDB wins on overlapping dates because
+            # daily_append writes there every weekday — it's fresher than a
+            # parquet that can be up to 6 days old. Full-history tickers
+            # (~99% of the universe on a steady-state day) skip the parquet
+            # read entirely.
+            #
+            # `hist` (the original ArcticDB read) remains authoritative for
+            # the write schema (dtype matching via hist.dtypes[col] at the
+            # update() call below). Only the feature-compute context is
+            # enriched.
+            warmup_source = hist
+            if len(hist) < MIN_ROWS_FOR_FEATURES:
+                parquet_df = _load_parquet_warmup(s3, bucket, ticker)
+                if parquet_df is None:
+                    log.warning(
+                        "short-history-no-parquet ticker=%s arctic_rows=%d "
+                        "— falling through to NaN-feature degrade",
+                        ticker, len(hist),
+                    )
+                else:
+                    parquet_ohlcv = parquet_df[
+                        [c for c in OHLCV_COLS if c in parquet_df.columns]
+                    ]
+                    arctic_ohlcv = hist[
+                        [c for c in OHLCV_COLS if c in hist.columns]
+                    ]
+                    warmup_source = pd.concat([parquet_ohlcv, arctic_ohlcv])
+                    warmup_source = warmup_source[
+                        ~warmup_source.index.duplicated(keep="last")
+                    ].sort_index()
+                    n_parquet_warmup += 1
+                    log.info(
+                        "parquet-warmup ticker=%s arctic_rows=%d "
+                        "parquet_rows=%d stitched_rows=%d",
+                        ticker, len(hist), len(parquet_df), len(warmup_source),
+                    )
+
+            # Combine warmup OHLCV + today's bar for feature computation
+            hist_ohlcv = warmup_source[
+                [c for c in OHLCV_COLS if c in warmup_source.columns]
+            ]
             combined = pd.concat([hist_ohlcv, new_row])
             combined = combined[~combined.index.duplicated(keep="last")].sort_index()
 
@@ -433,15 +519,16 @@ def daily_append(
         "tickers_partial": n_partial,
         "tickers_skipped": n_skip,
         "tickers_errored": n_err,
+        "tickers_parquet_warmup": n_parquet_warmup,
         "load_seconds": round(t_load, 1),
         "total_seconds": round(t_total, 1),
         "dry_run": dry_run,
     }
 
     log.info(
-        "ArcticDB daily_append: stocks n_ok=%d n_partial=%d n_skip=%d n_err=%d (of %d) | "
-        "macro_updated=%d sector_updated=%d | %.1fs total",
-        n_ok, n_partial, n_skip, n_err, len(stock_tickers),
+        "ArcticDB daily_append: stocks n_ok=%d n_partial=%d n_skip=%d n_err=%d "
+        "n_parquet_warmup=%d (of %d) | macro_updated=%d sector_updated=%d | %.1fs total",
+        n_ok, n_partial, n_skip, n_err, n_parquet_warmup, len(stock_tickers),
         len(macro_updated) if not dry_run else 0,
         len(sector_updated) if not dry_run else 0,
         t_total,

--- a/tests/test_daily_append_parquet_warmup.py
+++ b/tests/test_daily_append_parquet_warmup.py
@@ -1,0 +1,271 @@
+"""Tests for the 2026-04-22 parquet-warmup path in builders/daily_append.py.
+
+Before this change, short-history tickers (new listings, spinoffs, recent
+constituent adds) accumulated feature coverage one day at a time — features
+with 252-day rolling windows stayed NaN for up to a year after the ticker
+entered ArcticDB, even though the weekly backfill's 10y parquet held the
+full series. 8 manual polygon backfills in a single day (2026-04-22 Saturday
+SF dry-run) traced to this gap.
+
+When ArcticDB history is below the feature-warmup threshold, daily_append
+now unions the ticker's ``predictor/price_cache/{T}.parquet`` (full 10y
+adjusted OHLCV) with the ArcticDB rows before handing the result to
+``compute_features``. ArcticDB wins on overlapping dates — it's updated
+daily, the parquet is rebuilt weekly.
+
+The path is gated on ``len(hist) < MIN_ROWS_FOR_FEATURES`` so full-history
+tickers (~99% on a steady-state day) skip the extra S3 read. Missing
+parquet (brand-new constituent not yet picked up by a weekly backfill)
+degrades gracefully to PR #78's NaN-feature path with a loud log. Any
+other S3 error shape hard-fails — NoSilentFails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+from builders import daily_append
+
+
+_DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
+
+
+def _source() -> str:
+    return _DAILY_APPEND.read_text()
+
+
+# ── Source-inspection invariants ────────────────────────────────────────────
+
+
+def test_parquet_warmup_helper_exists():
+    """``_load_parquet_warmup`` must be defined at module scope so the per-
+    ticker loop can call it.
+    """
+    src = _source()
+    assert "def _load_parquet_warmup(" in src, (
+        "daily_append must define _load_parquet_warmup helper for the "
+        "short-history path added 2026-04-22."
+    )
+
+
+def test_parquet_warmup_gated_on_short_history():
+    """The warmup branch must be gated on
+    ``len(hist) < MIN_ROWS_FOR_FEATURES`` so the parquet read fires only
+    when ArcticDB history is short. Full-history tickers must skip the
+    extra S3 round-trip.
+    """
+    src = _source()
+    assert "len(hist) < MIN_ROWS_FOR_FEATURES" in src, (
+        "Short-history gate missing. The warmup branch must condition "
+        "on len(hist) < MIN_ROWS_FOR_FEATURES so full-history tickers "
+        "don't pay the parquet read cost."
+    )
+
+
+def test_parquet_warmup_falls_through_to_compute_features():
+    """The warmup branch must NOT ``continue`` past compute_features.
+
+    Locks the NoSilentFails / first-class-short-history invariant: the
+    warmup path enriches context, then the same feature pipeline runs.
+    An early ``continue`` would resurrect the 2026-04-21 SNDK-style
+    bypass bug.
+    """
+    src = _source()
+    lines = src.splitlines()
+
+    # Find the warmup branch line
+    gate_idx = None
+    for i, line in enumerate(lines):
+        if (
+            "len(hist) < MIN_ROWS_FOR_FEATURES" in line
+            and line.strip().startswith("if ")
+        ):
+            gate_idx = i
+            break
+    assert gate_idx is not None, (
+        "Short-history gate not found as an executable `if` statement."
+    )
+
+    # Inspect the branch body for ~25 lines. It must not bare-`continue`
+    # and it must not increment n_skip / n_partial inside the branch.
+    body = "\n".join(lines[gate_idx + 1:gate_idx + 25])
+
+    assert "\n                    continue" not in body, (
+        "Warmup branch has a bare `continue` — it must fall through to "
+        "compute_features, not skip past it."
+    )
+
+
+def test_parquet_missing_logs_warn_not_hard_fail():
+    """A missing parquet (NoSuchKey) must log a structured warning and
+    fall through to graceful NaN-feature degrade, NOT hard-fail.
+
+    Reason: a brand-new constituent may land in ``daily_closes.parquet``
+    before the next Saturday backfill produces its ``price_cache``
+    parquet. Hard-failing on that transient state would block the whole
+    daily_append run.
+    """
+    src = _source()
+    assert "short-history-no-parquet" in src, (
+        "The missing-parquet fall-through must emit a structured "
+        "`short-history-no-parquet ticker=X ...` log line so the gap "
+        "surfaces in CloudWatch."
+    )
+
+
+def test_parquet_warmup_structured_log():
+    """Every parquet-warmup hit must emit a structured log so coverage
+    surfaces in CloudWatch Logs Insights.
+    """
+    src = _source()
+    assert "parquet-warmup ticker=" in src, (
+        "Parquet-warmup path must emit structured `parquet-warmup "
+        "ticker=X arctic_rows=N parquet_rows=M ...` log for observability."
+    )
+
+
+def test_parquet_warmup_counter_in_summary():
+    """``n_parquet_warmup`` must be counted and surfaced in the result
+    dict + final log line — operators need to see how many tickers
+    took the warmup path each run.
+    """
+    src = _source()
+    assert "n_parquet_warmup" in src, "n_parquet_warmup counter missing."
+    assert "tickers_parquet_warmup" in src, (
+        "Result dict must expose `tickers_parquet_warmup` — it's the "
+        "post-run signal that tells operators how many tickers still "
+        "need the ArcticDB-backfill catch-up."
+    )
+
+
+def test_arctic_read_still_authoritative_for_dtypes():
+    """The per-column dtype match must still reference ``hist.dtypes``
+    (the original ArcticDB read), not the stitched warmup frame.
+
+    ArcticDB's stored schema is authoritative for the write; the parquet
+    is only enrichment for compute. Breaking this invariant would make
+    update() reject writes with dtype-mismatch errors (SOLS/ULS
+    regression from 2026-04-21 PR #77).
+    """
+    src = _source()
+    assert "astype(hist.dtypes[col])" in src, (
+        "hist.dtypes[col] dtype-match still required — ArcticDB enforces "
+        "schema match on update()."
+    )
+
+
+# ── Runtime unit tests for _load_parquet_warmup ─────────────────────────────
+
+
+def _fake_client_error(code: str) -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": "mock"}},
+        operation_name="GetObject",
+    )
+
+
+def test_load_parquet_warmup_returns_none_on_nosuchkey(monkeypatch):
+    """Missing parquet (``NoSuchKey``) returns None — caller falls
+    through to PR #78 graceful degrade.
+    """
+    mock_s3 = MagicMock()
+
+    def _raise_nosuchkey(*_a, **_kw):
+        raise _fake_client_error("NoSuchKey")
+
+    monkeypatch.setattr(
+        daily_append, "load_parquet_from_s3", _raise_nosuchkey
+    )
+
+    result = daily_append._load_parquet_warmup(mock_s3, "alpha-engine-research", "NEWIPO")
+    assert result is None
+
+
+def test_load_parquet_warmup_returns_none_on_404(monkeypatch):
+    """Some boto3 versions surface a missing key as error code ``404``
+    rather than ``NoSuchKey``. Both shapes must be treated as "not
+    found" so a library version bump doesn't quietly start hard-failing.
+    """
+    mock_s3 = MagicMock()
+
+    def _raise_404(*_a, **_kw):
+        raise _fake_client_error("404")
+
+    monkeypatch.setattr(daily_append, "load_parquet_from_s3", _raise_404)
+
+    result = daily_append._load_parquet_warmup(mock_s3, "b", "NEWIPO")
+    assert result is None
+
+
+def test_load_parquet_warmup_raises_on_access_denied(monkeypatch):
+    """Non-NotFound ``ClientError`` (e.g. AccessDenied, throttling) must
+    hard-fail. Swallowing those would silently regress every short-
+    history ticker to the NaN-degrade path on an IAM misconfig.
+    """
+    mock_s3 = MagicMock()
+
+    def _raise_denied(*_a, **_kw):
+        raise _fake_client_error("AccessDenied")
+
+    monkeypatch.setattr(daily_append, "load_parquet_from_s3", _raise_denied)
+
+    with pytest.raises(RuntimeError, match="parquet-warmup read failed"):
+        daily_append._load_parquet_warmup(mock_s3, "b", "AAPL")
+
+
+def test_load_parquet_warmup_raises_on_empty_frame(monkeypatch):
+    """An empty parquet is a storage-layer corruption signal, not a
+    legitimate "ticker hasn't traded yet" state. Hard-fail rather than
+    return an empty frame upstream.
+    """
+    mock_s3 = MagicMock()
+    monkeypatch.setattr(
+        daily_append, "load_parquet_from_s3",
+        lambda *a, **k: pd.DataFrame(),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid shape"):
+        daily_append._load_parquet_warmup(mock_s3, "b", "AAPL")
+
+
+def test_load_parquet_warmup_raises_on_missing_close_col(monkeypatch):
+    """A parquet without a Close column is corrupt for feature warmup —
+    every downstream feature expects it. Hard-fail.
+    """
+    mock_s3 = MagicMock()
+    bad_df = pd.DataFrame(
+        {"Open": [1.0], "High": [1.0]},
+        index=pd.DatetimeIndex(["2026-04-20"]),
+    )
+    monkeypatch.setattr(daily_append, "load_parquet_from_s3", lambda *a, **k: bad_df)
+
+    with pytest.raises(RuntimeError, match="invalid shape"):
+        daily_append._load_parquet_warmup(mock_s3, "b", "AAPL")
+
+
+def test_load_parquet_warmup_returns_valid_frame(monkeypatch):
+    """Happy path: valid parquet with OHLCV columns round-trips through
+    the helper unchanged.
+    """
+    mock_s3 = MagicMock()
+    good_df = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0],
+            "High": [102.0, 103.0],
+            "Low": [99.0, 100.0],
+            "Close": [101.0, 102.0],
+            "Volume": [1_000_000, 1_100_000],
+        },
+        index=pd.DatetimeIndex(["2016-01-04", "2016-01-05"]),
+    )
+    monkeypatch.setattr(daily_append, "load_parquet_from_s3", lambda *a, **k: good_df)
+
+    result = daily_append._load_parquet_warmup(mock_s3, "b", "AAPL")
+    assert result is not None
+    assert len(result) == 2
+    assert "Close" in result.columns

--- a/tests/test_daily_append_semantics.py
+++ b/tests/test_daily_append_semantics.py
@@ -72,21 +72,26 @@ def test_sector_etfs_iterate_explicit_list():
     assert 'sector_etfs = ["XLB"' in src or 'sector_etfs = [\n' in src
 
 
-def test_unified_path_no_min_rows_gate():
-    """daily_append must have ONE loop path for all tickers — no
-    ``len(hist) < MIN_ROWS_FOR_FEATURES`` branch that bypasses
-    ``compute_features``.
+def test_unified_path_no_min_rows_skip():
+    """daily_append must not BYPASS ``compute_features`` for short-history
+    tickers. A branch that ENRICHES the warmup context (e.g. the
+    parquet-warmup path added 2026-04-22) and then falls through to the
+    shared compute_features / update() is allowed — what's forbidden is
+    a branch that sets ``n_skip`` / writes an OHLCV-only row and
+    ``continue``s past compute_features.
 
-    The Phase 2 fix (2026-04-21) removed the implicit
+    History: the Phase 2 fix (2026-04-21) removed the implicit
     ``df.dropna(subset=FEATURES)`` in ``compute_features`` and the
-    corresponding short-history-only write branch in daily_append. Every
-    ticker now runs through the same pipeline: compute whatever features
-    are computable, write the row with NaN for the rest, log loudly.
+    short-history-only write branch. Every ticker runs through the same
+    feature pipeline and writes whatever's computable. The parquet-warmup
+    branch added 2026-04-22 preserves that invariant — it unions the
+    weekly 10y parquet into the warmup frame but still hands the result
+    to compute_features.
 
-    A regression that re-introduces the gate would undo first-class
-    short-history support and resurrect the 2026-04-21 SNDK executor
-    crash (NaN ``atr_14_pct`` from a ticker that WAS supposed to get
-    one because ATR-14 only needs ≥14 rows).
+    A regression that re-introduces the SKIP / OHLCV-only-and-continue
+    branch would undo first-class short-history support and resurrect
+    the 2026-04-21 SNDK executor crash (NaN ``atr_14_pct`` from a ticker
+    that WAS supposed to get one because ATR-14 only needs ≥14 rows).
     """
     src = _source()
     lines = src.splitlines()
@@ -94,14 +99,29 @@ def test_unified_path_no_min_rows_gate():
         stripped = line.strip()
         if stripped.startswith("#"):
             continue
-        if "len(hist) < MIN_ROWS_FOR_FEATURES" in stripped:
+        if "MIN_ROWS_FOR_FEATURES" not in stripped:
+            continue
+        if not stripped.startswith("if "):
+            continue
+        # Found an `if ... MIN_ROWS_FOR_FEATURES ...:` branch. Look at the
+        # next ~6 lines. If that block increments n_skip / n_partial /
+        # writes to universe_lib AND then `continue`s — it's the forbidden
+        # bypass pattern. If it reassigns the warmup source and falls
+        # through — it's the allowed parquet-warmup pattern.
+        window = "\n".join(lines[i:i + 30])
+        bypass_signals = (
+            "n_skip += 1" in window
+            or "n_partial += 1" in window
+            or "universe_lib.update(" in window
+        )
+        if bypass_signals and "continue" in window:
             raise AssertionError(
-                f"Line {i+1}: re-introduced the `len(hist) < "
-                f"MIN_ROWS_FOR_FEATURES` gate. This branches short-history "
-                f"tickers away from compute_features and brings back the "
-                f"2026-04-21 SNDK executor crash. Let every ticker go "
-                f"through the unified path; compute_features no longer "
-                f"drops rows."
+                f"Line {i+1}: re-introduced the `MIN_ROWS_FOR_FEATURES` "
+                f"SKIP branch. Any branch gated on MIN_ROWS_FOR_FEATURES "
+                f"must enrich warmup context and fall through to the "
+                f"shared compute_features / update() path — it must not "
+                f"`continue` past compute_features. See the 2026-04-22 "
+                f"parquet-warmup design."
             )
 
 


### PR DESCRIPTION
## Summary

- Short-history tickers (new listings, spinoffs, recent constituent adds) previously accumulated feature coverage one day at a time. 8 manual polygon backfills in one day (2026-04-22) traced to this gap.
- When `len(hist) < MIN_ROWS_FOR_FEATURES`, `daily_append` now unions the ticker's `predictor/price_cache/{T}.parquet` (10y adjusted OHLCV, weekly rebuild) with the ArcticDB frame before handing it to `compute_features`. ArcticDB wins on overlapping dates.
- Full-history tickers (~99% on a steady-state day) skip the extra S3 read entirely. `hist` (original ArcticDB read) remains authoritative for the write schema.

## Behavior

| State | Old behavior | New behavior |
|---|---|---|
| Full-history ticker | Full features | Unchanged (no extra S3 read) |
| Short-history, parquet exists | NaN for 252d features (PR #78 degrade) | Full features from parquet warmup |
| Short-history, parquet missing | NaN-degrade | Unchanged + `short-history-no-parquet` WARN log |
| Parquet read fails (non-NotFound) | N/A | Hard-fail (NoSilentFails) |

## Observability

- New structured log on warmup hit: `parquet-warmup ticker=X arctic_rows=N parquet_rows=M stitched_rows=K`
- New structured log on miss: `short-history-no-parquet ticker=X arctic_rows=N`
- `n_parquet_warmup` counter surfaced in result dict + final log line.

## Roadmap

Backtester P1: `builders/daily_append.py` parquet-context warmup — the actual root-cause for repeated ticker backfills (escalated 2026-04-22).

## Test plan

- [x] 133/133 local pytest pass (23 daily_append-specific, 13 new for parquet warmup).
- [x] Runtime unit tests for `_load_parquet_warmup`: NoSuchKey/404 → None; AccessDenied/empty/missing-Close → RuntimeError; happy path → DataFrame.
- [x] Source-inspection locks: helper exists, gated on MIN_ROWS_FOR_FEATURES, falls through to compute_features, missing-parquet logs warn (not hard-fail), hist.dtypes authoritative for write.
- [ ] Saturday SF dry-run to validate end-to-end.

Generated with Claude Code