### PR TITLE
test(postflight): stop test fixture from leaking a real failure email

### DIFF
--- a/tests/test_postflight.py
+++ b/tests/test_postflight.py
@@ -30,6 +30,26 @@ BUCKET = "test-bucket"
 MARKET_PREFIX = "market_data/"
 
 
+@pytest.fixture(autouse=True)
+def _block_real_email(monkeypatch):
+    """Hard guarantee no test in this module emits a real completion email.
+
+    Background: on 2026-04-22 a test with a hardcoded "polygon 503" fixture
+    and dry_run=False was run locally with EMAIL_SENDER/EMAIL_RECIPIENTS/
+    GMAIL_APP_PASSWORD in the shell env. _finalize() unconditionally called
+    send_step_email and a real "Alpha Engine Data Phase 1 | 2026-04-18 |
+    FAILED" email landed in the operator's inbox. Patching inside each test
+    is error-prone; this autouse fixture makes the safety net module-wide.
+    """
+    from unittest.mock import MagicMock
+    monkeypatch.setattr(
+        "weekly_collector.send_step_email",
+        MagicMock(return_value=True),
+        raising=False,
+    )
+    monkeypatch.setattr("emailer.send_step_email", MagicMock(return_value=True))
+
+
 def _make_postflight() -> DataPostflight:
     return DataPostflight(
         bucket=BUCKET,
@@ -378,6 +398,7 @@ class TestFinalizeWiring:
         with patch("weekly_collector._write_manifest"), \
              patch("weekly_collector._write_validation_json"), \
              patch("weekly_collector._write_health_marker"), \
+             patch("weekly_collector.send_step_email", create=True) as _mock_email, \
              patch("validators.postflight.DataPostflight.run") as mock_run:
             _finalize(
                 results=results,


### PR DESCRIPTION
## Summary

\`tests/test_postflight.py::TestPostflightIntegration::test_postflight_skipped_when_collection_failed\` hits \`_finalize()\` with \`dry_run=False, only=None\` and a hardcoded failed-results fixture. \`_finalize()\` unconditionally calls \`send_step_email\` on that path and the test did not mock it. Running the suite locally with \`EMAIL_SENDER\`/\`EMAIL_RECIPIENTS\`/\`GMAIL_APP_PASSWORD\` set (i.e. a normal dev loop that sources \`.env\`) sends a real email with the test fixture values.

## Incident

On 2026-04-22 at 07:01 PT, an email arrived in the operator's inbox:

> Alpha Engine Data Phase 1 | 2026-04-18 | FAILED
> Status: FAILED | Duration: 30.0 min
> prices — error — Error: polygon 503

No production DataPhase1 ran at that time — the Saturday SF didn't fire (skip flags set on today's dry-run), no matching SSM send-command, no scheduled timer on the EC2 runs \`weekly_collector.py\`. The email values match exactly the hardcoded fixture in this test:

\`\`\`python
\"started_at\":   \"2026-04-18T00:00:00+00:00\",   # → subject date
\"completed_at\": \"2026-04-18T00:30:00+00:00\",   # → 30.0 min duration
\"status\":       \"failed\",                      # → FAILED
\"collectors\":   {\"prices\": {\"status\": \"error\", \"error\": \"polygon 503\"}},
\`\`\`

## Fix

1. Patch \`weekly_collector.send_step_email\` inside the specific leaky test — documents the missing mock at the call site, matches the pattern the sister test \`test_postflight_failure_flips_status\` above it already uses.
2. Add a module-scoped autouse fixture that monkeypatches both \`weekly_collector.send_step_email\` and \`emailer.send_step_email\` for every test in this file. Safety net so the next person adding a \`_finalize\`-touching test can't regress this.

## Test plan

- [x] \`pytest tests/test_postflight.py -v\` — 22 pass
- [x] \`pytest\` full suite — 133 pass
- [x] Pre-push gitleaks hook clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)