### PR TITLE
fix(collectors): daily_closes skip only if existing parquet is post-close

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -19,13 +19,16 @@ import io
 import logging
 import os
 import time
-from datetime import datetime, timezone
+from datetime import datetime, time as dtime, timezone
+from zoneinfo import ZoneInfo
 
 import boto3
 import pandas as pd
 import requests
 
 logger = logging.getLogger(__name__)
+
+_NYSE_TZ = ZoneInfo("America/New_York")
 
 _YFINANCE_BATCH_SIZE = 100
 _YFINANCE_BATCH_DELAY = 2  # seconds between batches
@@ -43,6 +46,17 @@ _FRED_INDEX_MAP = {
     "TNX": "DGS10",
     "IRX": "DTB3",
 }
+
+
+def _is_post_close_write(last_modified: datetime, run_date: str) -> bool:
+    """Return True if ``last_modified`` is at or after the NYSE close for ``run_date``.
+
+    NYSE closes at 16:00 America/New_York. ``zoneinfo`` resolves EST/EDT
+    automatically so this is correct year-round without explicit DST logic.
+    """
+    run_day = datetime.strptime(run_date, "%Y-%m-%d").date()
+    close_et = datetime.combine(run_day, dtime(16, 0), tzinfo=_NYSE_TZ)
+    return last_modified >= close_et
 
 
 def collect(
@@ -68,14 +82,16 @@ def collect(
     run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
     s3 = boto3.client("s3")
 
-    # Check if already written for this date
+    # Check if already written for this date. Only skip if the existing
+    # parquet was written AFTER the NYSE close for run_date — a pre-close
+    # write is a morning-side stale fetch (polygon returns T-1's aggregate
+    # stamped under today's key) and must not shadow the authoritative
+    # post-close collection. See 2026-04-20 incident / ROADMAP P0.
     key = f"{s3_prefix}{run_date}.parquet"
     if not dry_run:
         from botocore.exceptions import ClientError
         try:
-            s3.head_object(Bucket=bucket, Key=key)
-            logger.info("Daily closes already exist for %s — skipping", run_date)
-            return {"status": "ok", "tickers_captured": 0, "skipped": True}
+            head = s3.head_object(Bucket=bucket, Key=key)
         except ClientError as exc:
             err_code = exc.response.get("Error", {}).get("Code")
             if err_code not in ("404", "NoSuchKey"):
@@ -83,6 +99,20 @@ def collect(
                 # Don't silently paper over it.
                 raise
             # 404/NoSuchKey: expected case — file doesn't exist, proceed to write.
+        else:
+            last_modified = head["LastModified"]
+            if _is_post_close_write(last_modified, run_date):
+                logger.info(
+                    "Daily closes already exist for %s (post-close at %s) — skipping",
+                    run_date, last_modified.isoformat(),
+                )
+                return {"status": "ok", "tickers_captured": 0, "skipped": True}
+            logger.warning(
+                "Existing %s was written pre-close at %s — refusing to skip; "
+                "re-collecting authoritative post-close data",
+                key, last_modified.isoformat(),
+            )
+            # fall through to re-fetch + overwrite
 
     if not tickers:
         return {"status": "error", "error": "no tickers provided"}

--- a/tests/test_daily_closes_preclose_guard.py
+++ b/tests/test_daily_closes_preclose_guard.py
@@ -1,0 +1,148 @@
+"""Regression tests for the daily_closes pre-close skip guard.
+
+Contract: ``collect()`` must only short-circuit with ``skipped=True`` when
+the existing ``{run_date}.parquet`` was written AFTER the NYSE close for
+``run_date``. A pre-close write is a morning-side stale fetch (polygon
+returns T-1's aggregate stamped under today's key) and must be overwritten
+by the authoritative post-close collection.
+
+Incident that forced this: 2026-04-20. The predictor's morning DailyData
+Step Function wrote the parquet at 06:07 PT with Friday's closes stamped
+as Monday. The 16:14 PT post-close rerun hit the old ``head_object →
+skip`` short-circuit and propagated the stale data through daily_append
+into ArcticDB for every ticker, producing a false α = −1.33% on the EOD
+email vs the real +0.08%.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collectors import daily_closes
+
+
+def _head_object_response(last_modified: datetime) -> dict:
+    return {
+        "LastModified": last_modified,
+        "ContentLength": 12345,
+        "ContentType": "application/octet-stream",
+    }
+
+
+def test_post_close_write_is_skipped():
+    """If the parquet exists and was written after NYSE close, skip."""
+    # 2026-04-20 is EDT; NYSE close = 20:00 UTC. Post-close write = 23:14 UTC.
+    post_close = datetime(2026, 4, 20, 23, 14, 0, tzinfo=timezone.utc)
+
+    mock_s3 = MagicMock()
+    mock_s3.head_object.return_value = _head_object_response(post_close)
+
+    with patch("collectors.daily_closes.boto3.client", return_value=mock_s3):
+        result = daily_closes.collect(
+            bucket="test-bucket",
+            tickers=["AAPL"],
+            run_date="2026-04-20",
+        )
+
+    assert result["skipped"] is True
+    assert result["status"] == "ok"
+    # No write attempted — we trusted the post-close file.
+    mock_s3.put_object.assert_not_called()
+
+
+def test_pre_close_write_forces_refetch():
+    """If the parquet exists but was written pre-close, refuse to skip."""
+    # 2026-04-20 morning write at 13:07 UTC (06:07 PT) — well before 20:00 UTC close.
+    pre_close = datetime(2026, 4, 20, 13, 7, 0, tzinfo=timezone.utc)
+
+    mock_s3 = MagicMock()
+    mock_s3.head_object.return_value = _head_object_response(pre_close)
+
+    # Force polygon+yfinance paths to return nothing so collect() bails with
+    # "no data fetched" — we only need to prove the early-skip was NOT taken.
+    with patch("collectors.daily_closes.boto3.client", return_value=mock_s3), \
+         patch("collectors.daily_closes._fetch_yfinance_closes", return_value=0):
+        result = daily_closes.collect(
+            bucket="test-bucket",
+            tickers=["AAPL"],
+            run_date="2026-04-20",
+        )
+
+    # Early-skip path would have returned {"skipped": True, "status": "ok"}.
+    # We should have fallen through to the fetch path instead.
+    assert result.get("skipped") is not True
+    assert "skipped" not in result or result["skipped"] is not True
+
+
+def test_is_post_close_write_edt():
+    """2026-04-20 is in EDT. NYSE close = 20:00 UTC."""
+    run_date = "2026-04-20"
+    # 1s before close → pre-close
+    assert not daily_closes._is_post_close_write(
+        datetime(2026, 4, 20, 19, 59, 59, tzinfo=timezone.utc), run_date
+    )
+    # Exactly at close → post-close (boundary is inclusive)
+    assert daily_closes._is_post_close_write(
+        datetime(2026, 4, 20, 20, 0, 0, tzinfo=timezone.utc), run_date
+    )
+    # 1h after close → post-close
+    assert daily_closes._is_post_close_write(
+        datetime(2026, 4, 20, 21, 0, 0, tzinfo=timezone.utc), run_date
+    )
+
+
+def test_is_post_close_write_est():
+    """2026-01-15 is in EST. NYSE close = 21:00 UTC."""
+    run_date = "2026-01-15"
+    # 20:00 UTC in EST is 15:00 ET — still pre-close
+    assert not daily_closes._is_post_close_write(
+        datetime(2026, 1, 15, 20, 0, 0, tzinfo=timezone.utc), run_date
+    )
+    # 21:00 UTC = 16:00 ET → at close
+    assert daily_closes._is_post_close_write(
+        datetime(2026, 1, 15, 21, 0, 0, tzinfo=timezone.utc), run_date
+    )
+
+
+def test_missing_object_proceeds_to_fetch():
+    """404 on head_object is the expected fresh-day case — proceed to write."""
+    from botocore.exceptions import ClientError
+
+    mock_s3 = MagicMock()
+    mock_s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}},
+        "HeadObject",
+    )
+
+    with patch("collectors.daily_closes.boto3.client", return_value=mock_s3), \
+         patch("collectors.daily_closes._fetch_yfinance_closes", return_value=0):
+        result = daily_closes.collect(
+            bucket="test-bucket",
+            tickers=["AAPL"],
+            run_date="2026-04-20",
+        )
+
+    # Should not have short-circuited as skipped; fell through to fetch path.
+    assert result.get("skipped") is not True
+
+
+def test_head_object_auth_failure_propagates():
+    """Non-404 errors on head_object must not silently fall through."""
+    from botocore.exceptions import ClientError
+
+    mock_s3 = MagicMock()
+    mock_s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "403", "Message": "Forbidden"}},
+        "HeadObject",
+    )
+
+    with patch("collectors.daily_closes.boto3.client", return_value=mock_s3):
+        with pytest.raises(ClientError):
+            daily_closes.collect(
+                bucket="test-bucket",
+                tickers=["AAPL"],
+                run_date="2026-04-20",
+            )


### PR DESCRIPTION
## Summary
- ROADMAP P0: close the stale-parquet recurrence window. The `head_object → skip` short-circuit in `collectors/daily_closes.py` now only fires when `LastModified >= NYSE_close(run_date)`.
- Pre-close writes log a warning and fall through to re-collect the authoritative post-close data. Eliminates the silent α-attribution corruption class behind the 2026-04-20 EOD email (reported α = −1.33% vs real +0.08%).
- Uses `zoneinfo.ZoneInfo("America/New_York")` so EST/EDT resolve automatically — no explicit DST handling.

## Why
The 2026-04-20 incident had a morning DailyData SF run writing the parquet at 06:07 PT with polygon's T-1 aggregate under today's key; my 16:14 PT post-close rerun skipped the file (it existed!) and daily_append propagated Friday's closes into ArcticDB for every ticker. Forward-fix (moving DailyData to post-close systemd timer) isn't sufficient — anything that writes pre-close permanently shadows the authoritative post-close data.

## Test plan
- [x] `test_post_close_write_is_skipped` — post-close LastModified short-circuits
- [x] `test_pre_close_write_forces_refetch` — pre-close LastModified falls through to fetch
- [x] `test_is_post_close_write_edt` — 2026-04-20 EDT: 20:00 UTC boundary
- [x] `test_is_post_close_write_est` — 2026-01-15 EST: 21:00 UTC boundary
- [x] `test_missing_object_proceeds_to_fetch` — 404 path unchanged
- [x] `test_head_object_auth_failure_propagates` — non-404 errors still raise
- [x] Full suite: 139/139 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)