### PR TITLE
fix(alternative): source analyst target_price from yfinance (free tier)

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -6,6 +6,7 @@ alternative data for the ~25-30 promoted tickers (buy candidates + tracked).
 
 Data sources:
   - Analyst rating (Finnhub ``/stock/recommendation`` — free tier)
+  - Analyst price target (yfinance ``Ticker.info.targetMeanPrice`` — free)
   - Earnings surprises (Finnhub ``/stock/earnings`` — free tier)
   - EPS estimates (FMP ``/stable/analyst-estimates?period=annual`` — free tier)
   - Options flow (yfinance)
@@ -13,16 +14,17 @@ Data sources:
   - Institutional 13F (edgartools)
   - News headlines (Yahoo RSS + EDGAR 8-K)
 
-Provider notes (2026-04-20)
----------------------------
+Provider notes (updated 2026-04-22)
+-----------------------------------
 FMP v3 sunsetted on 2025-08-31; all FMP calls go to /stable with
 query-string tickers. On /stable, these endpoints are paid-tier (HTTP
-402 / 403 on free), so the corresponding features are sourced elsewhere
-or left null:
+402 / 403 on free), so the corresponding features are sourced elsewhere:
 
   - ``grades-consensus`` → Finnhub ``/stock/recommendation``
-  - ``price-target-consensus`` → no free source available; ``target_price``
-    is left ``None``. Finnhub's ``/stock/price-target`` is also paid.
+  - ``price-target-consensus`` → yfinance ``Ticker.info`` exposes
+    ``targetMeanPrice`` + ``numberOfAnalystOpinions`` on free. Finnhub's
+    ``/stock/price-target`` is paid-only. yfinance ``.info`` is the same
+    per-ticker pattern ``short_interest.py`` uses.
   - ``earnings-surprises-bulk`` → Finnhub ``/stock/earnings`` (richer
     historical data anyway)
   - ``analyst-estimates?period=quarter`` → FMP ``period=annual`` still
@@ -327,11 +329,13 @@ def _finnhub_get(endpoint: str, params: dict | None = None) -> dict | list:
 # ---- 1. Analyst consensus ----
 
 def _fetch_analyst(ticker: str) -> dict:
-    """Fetch analyst rating (Finnhub) + earnings surprises (Finnhub).
+    """Fetch analyst rating + target price + earnings surprises.
 
-    ``target_price`` is left ``None`` — no free-tier source is available
-    since FMP moved ``price-target-consensus`` to paid and Finnhub's
-    ``/stock/price-target`` also returns 403 on free.
+    Sources: Finnhub ``/stock/recommendation`` for rating + bull/bear
+    analyst counts; yfinance ``Ticker.info`` for the consensus price
+    target (Finnhub's ``/stock/price-target`` and FMP's
+    ``/stable/price-target-consensus`` are both paid-tier); Finnhub
+    ``/stock/earnings`` for historical surprises.
     """
     result = {
         "rating": None,
@@ -384,6 +388,26 @@ def _fetch_analyst(ticker: str) -> dict:
             result["earnings_surprises"] = surprises
     except Exception as e:
         logger.warning("Finnhub earnings failed for %s: %s", ticker, e)
+
+    # yfinance Ticker.info: ``targetMeanPrice`` is the consensus price target;
+    # ``numberOfAnalystOpinions`` is the count of analysts covering the name
+    # (a different denominator than the Finnhub rating counts above — Finnhub's
+    # ``num_analysts`` is the sum of current-period rating buckets, used for
+    # the Buy/Hold/Sell classification; yfinance's count is the analyst
+    # coverage universe for the price-target aggregation). Populate
+    # ``num_analysts`` from yfinance only if Finnhub did not supply one.
+    try:
+        import yfinance as yf
+        info = yf.Ticker(ticker).info
+        target = info.get("targetMeanPrice")
+        if target is not None:
+            result["target_price"] = round(float(target), 2)
+        if result["num_analysts"] is None:
+            n = info.get("numberOfAnalystOpinions")
+            if n is not None:
+                result["num_analysts"] = int(n)
+    except Exception as e:
+        logger.warning("yfinance target_price failed for %s: %s", ticker, e)
 
     return result
 

--- a/tests/test_alternative_analyst.py
+++ b/tests/test_alternative_analyst.py
@@ -1,0 +1,103 @@
+"""Tests for the analyst sub-collector in ``collectors/alternative.py``.
+
+Contract as of 2026-04-22:
+
+  * Finnhub ``/stock/recommendation`` drives ``rating`` + ``num_analysts``.
+  * yfinance ``Ticker.info`` drives ``target_price`` (Finnhub's
+    ``/stock/price-target`` and FMP's ``price-target-consensus`` are both
+    paid-tier).
+  * Failures on either provider must degrade loudly (WARN) but never
+    raise — ``_fetch_analyst`` is called per-ticker and a provider outage
+    on one ticker must not poison the whole Phase 2 batch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collectors import alternative
+
+
+def _finnhub_recommendation_stub(bullish=8, bearish=1, hold=2):
+    return [
+        {
+            "strongBuy": max(bullish - 2, 0),
+            "buy": min(bullish, 2),
+            "hold": hold,
+            "sell": min(bearish, 1),
+            "strongSell": max(bearish - 1, 0),
+            "period": "2026-04-01",
+            "symbol": "AAPL",
+        }
+    ]
+
+
+def test_target_price_from_yfinance():
+    """When yfinance exposes targetMeanPrice, it must land in target_price."""
+    mock_yf_module = MagicMock()
+    mock_yf_module.Ticker.return_value.info = {
+        "targetMeanPrice": 215.5,
+        "numberOfAnalystOpinions": 42,
+    }
+
+    with patch.object(alternative, "_finnhub_get", return_value=_finnhub_recommendation_stub()), \
+         patch.dict("sys.modules", {"yfinance": mock_yf_module}):
+        out = alternative._fetch_analyst("AAPL")
+
+    assert out["target_price"] == 215.5
+    # Finnhub returned num_analysts → yfinance must NOT clobber it
+    assert out["num_analysts"] == 11  # 8 bullish + 2 hold + 1 bearish stub totals
+
+
+def test_num_analysts_backfilled_from_yfinance_when_finnhub_empty():
+    """If Finnhub returns nothing, yfinance's count populates num_analysts."""
+    mock_yf_module = MagicMock()
+    mock_yf_module.Ticker.return_value.info = {
+        "targetMeanPrice": 300.0,
+        "numberOfAnalystOpinions": 25,
+    }
+
+    # Finnhub returns empty list → no rating / no num_analysts from Finnhub.
+    # ``_finnhub_get`` is called twice (recommendation, earnings), both empty.
+    with patch.object(alternative, "_finnhub_get", return_value=[]), \
+         patch.dict("sys.modules", {"yfinance": mock_yf_module}):
+        out = alternative._fetch_analyst("NEWCO")
+
+    assert out["target_price"] == 300.0
+    assert out["num_analysts"] == 25
+    assert out["rating"] is None  # no Finnhub data → no rating classification
+
+
+def test_yfinance_failure_degrades_loudly_without_raising():
+    """yfinance raising inside _fetch_analyst must not bubble up."""
+    mock_yf_module = MagicMock()
+    mock_yf_module.Ticker.side_effect = RuntimeError("yfinance IP block")
+
+    with patch.object(alternative, "_finnhub_get", return_value=_finnhub_recommendation_stub()), \
+         patch.dict("sys.modules", {"yfinance": mock_yf_module}):
+        out = alternative._fetch_analyst("AAPL")
+
+    # Finnhub path still populated rating + num_analysts
+    assert out["rating"] in ("Buy", "Hold", "Sell")
+    assert out["num_analysts"] == 11
+    # yfinance failed → target_price stays None (degraded but observable via WARN)
+    assert out["target_price"] is None
+
+
+def test_missing_target_mean_price_leaves_target_price_none():
+    """yfinance sometimes returns info without targetMeanPrice (new/illiquid names)."""
+    mock_yf_module = MagicMock()
+    mock_yf_module.Ticker.return_value.info = {
+        "numberOfAnalystOpinions": 3,
+        # no targetMeanPrice
+    }
+
+    with patch.object(alternative, "_finnhub_get", return_value=_finnhub_recommendation_stub()), \
+         patch.dict("sys.modules", {"yfinance": mock_yf_module}):
+        out = alternative._fetch_analyst("THINLY_COVERED")
+
+    assert out["target_price"] is None
+    # Finnhub still authoritative on num_analysts
+    assert out["num_analysts"] == 11


### PR DESCRIPTION
## Summary
- ROADMAP P0 addendum (FMP alternatives, no paid-tier upgrade): restore `target_price` via yfinance `Ticker.info.targetMeanPrice`.
- `numberOfAnalystOpinions` fills `num_analysts` only when Finnhub returned nothing (different denominator — Finnhub's count drives Buy/Hold/Sell classification).
- yfinance failures WARN + leave `target_price=None`; never raise.

## Why
PR #68 migrated FMP v3 → /stable for the bulk of the analyst endpoints, but `price-target-consensus` is paid-only on /stable (HTTP 402) and Finnhub's `/stock/price-target` is also paid. The result: `target_price` has been hardcoded to `None` since 4/20, propagating as `Target: $N/A` into research's R/R-reframe prompts and stripping a required input (`bull_case_upside_pct` derivation) from the qual analyst.

yfinance `Ticker.info` exposes the field free. Same per-ticker pattern `short_interest.py` already uses — Phase 2 only runs on ~30 promoted tickers so the extra `.info` calls add <15s total wall-time.

## Test plan
- [x] `test_target_price_from_yfinance` — happy path populates target_price from yfinance
- [x] `test_num_analysts_backfilled_from_yfinance_when_finnhub_empty` — yfinance backfills num_analysts only when Finnhub is empty
- [x] `test_yfinance_failure_degrades_loudly_without_raising` — yfinance RuntimeError doesn't poison the batch
- [x] `test_missing_target_mean_price_leaves_target_price_none` — thinly-covered names degrade cleanly
- [x] Full suite: 137/137 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)