### PR TITLE
fix(backfill): unified short-history path + scope macro rewrite to full-universe runs

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -167,6 +167,7 @@ def backfill(
     dry_run: bool = False,
     ticker_filter: str | None = None,
     validate: bool = False,
+    rebuild_macro: bool = False,
 ) -> dict:
     """
     Run the full historical backfill: load 10y prices, compute features, write to ArcticDB.
@@ -176,6 +177,9 @@ def backfill(
         dry_run: compute but skip ArcticDB writes
         ticker_filter: if set, only process this single ticker (for testing)
         validate: if True, run spot-check validation after backfill
+        rebuild_macro: when ticker_filter is set, also rewrite the macro
+            library from parquet (opt-in override — defaults to False so
+            per-ticker patches don't regress macro freshness)
 
     Returns:
         Summary dict with counts and timing.
@@ -219,23 +223,31 @@ def backfill(
         and not _is_sector_etf(t)
         and price_data[t] is not None
     ]
-    tickers_with_features = {
-        t for t in universe_tickers
-        if len(price_data[t]) >= MIN_ROWS_FOR_FEATURES
-    }
+    # Post-PR-#78: ``compute_features`` returns rows with NaN for features
+    # whose rolling-window warmup exceeds available history (e.g. ATR-14
+    # computes on 14 rows; dist_from_52w_high stays NaN under 252 rows).
+    # We no longer split into "feature" vs "OHLCV-only" paths — every
+    # ticker gets the unified schema with per-feature graceful degrade.
+    # ``n_short_history`` is retained as an observability counter so the
+    # completion log still reports how many tickers got partial features.
+    n_short_history_in_scope = sum(
+        1 for t in universe_tickers
+        if len(price_data[t]) < MIN_ROWS_FOR_FEATURES
+    )
 
     if ticker_filter:
         if ticker_filter not in universe_tickers:
             log.error("Ticker %s not found in universe (no data or in skip list)", ticker_filter)
             return {"status": "error", "error": f"ticker_not_found: {ticker_filter}"}
         universe_tickers = [ticker_filter]
-        # tickers_with_features auto-narrows via set intersection below
+        n_short_history_in_scope = (
+            1 if len(price_data[ticker_filter]) < MIN_ROWS_FOR_FEATURES else 0
+        )
 
     log.info(
-        "Writing %d tickers to ArcticDB (%d with features, %d OHLCV-only fresh listings)",
+        "Writing %d tickers to ArcticDB (%d below MIN_ROWS_FOR_FEATURES — partial-feature rows expected)",
         len(universe_tickers),
-        sum(1 for t in universe_tickers if t in tickers_with_features),
-        sum(1 for t in universe_tickers if t not in tickers_with_features),
+        n_short_history_in_scope,
     )
 
     # ── 3. Extract macro series ──────────────────────────────────────────────
@@ -255,107 +267,132 @@ def backfill(
     n_ok = 0
     n_skip = 0
     n_err = 0
+    n_partial = 0  # written successfully with ≥1 NaN feature (short-history warmup)
     t_compute_start = time.time()
 
-    n_ok_features = 0
-    n_ok_ohlcv_only = 0
     for i, ticker in enumerate(universe_tickers):
         try:
             df = price_data[ticker]
 
-            if ticker in tickers_with_features:
-                sector_etf_sym = sector_map.get(ticker)
-                sector_etf_series = macro.get(sector_etf_sym) if sector_etf_sym else None
-                ticker_alt = alt_data.get(ticker, {})
+            # Unified path (post-PR-#78): every ticker goes through
+            # ``compute_features``. Rolling features whose warmup exceeds
+            # the ticker's available history return NaN for the affected
+            # rows; the row itself is preserved. Downstream consumers
+            # (predictor training, research scanner) apply their own NaN
+            # policy. The previous "OHLCV-only fresh listing" fork would
+            # regress PR #79's schema migration on the next Saturday run
+            # by writing a stripped-column frame that ``lib.update()``
+            # then rejected.
+            sector_etf_sym = sector_map.get(ticker)
+            sector_etf_series = macro.get(sector_etf_sym) if sector_etf_sym else None
+            ticker_alt = alt_data.get(ticker, {})
 
-                featured_df = compute_features(
-                    df,
-                    spy_series=spy_series,
-                    vix_series=vix_series,
-                    sector_etf_series=sector_etf_series,
-                    tnx_series=tnx_series,
-                    irx_series=irx_series,
-                    gld_series=gld_series,
-                    uso_series=uso_series,
-                    vix3m_series=vix3m_series,
-                    earnings_data=ticker_alt.get("earnings"),
-                    revision_data=ticker_alt.get("revisions"),
-                    options_data=ticker_alt.get("options"),
-                    fundamental_data=fundamentals.get(ticker),
+            featured_df = compute_features(
+                df,
+                spy_series=spy_series,
+                vix_series=vix_series,
+                sector_etf_series=sector_etf_series,
+                tnx_series=tnx_series,
+                irx_series=irx_series,
+                gld_series=gld_series,
+                uso_series=uso_series,
+                vix3m_series=vix3m_series,
+                earnings_data=ticker_alt.get("earnings"),
+                revision_data=ticker_alt.get("revisions"),
+                options_data=ticker_alt.get("options"),
+                fundamental_data=fundamentals.get(ticker),
+            )
+
+            if featured_df.empty:
+                n_skip += 1
+                continue
+
+            keep_cols = [c for c in OHLCV_COLS if c in featured_df.columns] + \
+                        [f for f in FEATURES if f in featured_df.columns]
+            symbol_df = featured_df[keep_cols].copy()
+
+            for f in FEATURES:
+                if f in symbol_df.columns:
+                    symbol_df[f] = symbol_df[f].astype("float32")
+
+            symbol_df.index.name = "date"
+
+            feature_cols_present = [f for f in FEATURES if f in symbol_df.columns]
+            last_row_nan_features = [
+                f for f in feature_cols_present
+                if pd.isna(symbol_df[f].iloc[-1])
+            ]
+            if last_row_nan_features:
+                n_partial += 1
+                log.info(
+                    "partial-features ticker=%s rows=%d nan_last_row=%d/%d features=%s",
+                    ticker, len(symbol_df), len(last_row_nan_features),
+                    len(feature_cols_present),
+                    last_row_nan_features[:5] + (["..."] if len(last_row_nan_features) > 5 else []),
                 )
 
-                if featured_df.empty:
-                    n_skip += 1
-                    continue
+            if not dry_run:
+                universe_lib.write(ticker, symbol_df)
 
-                keep_cols = [c for c in OHLCV_COLS if c in featured_df.columns] + \
-                            [f for f in FEATURES if f in featured_df.columns]
-                symbol_df = featured_df[keep_cols].copy()
-
-                for f in FEATURES:
-                    if f in symbol_df.columns:
-                        symbol_df[f] = symbol_df[f].astype("float32")
-
-                symbol_df.index.name = "date"
-
-                if not dry_run:
-                    universe_lib.write(ticker, symbol_df)
-
-                n_ok_features += 1
-            else:
-                # Fresh listing: too little history for features; write raw OHLCV
-                # so Research's 3-month price scan can include it. Predictor
-                # ticker filters skip these until they accumulate MIN_ROWS_FOR_FEATURES.
-                keep_cols = [c for c in OHLCV_COLS if c in df.columns]
-                symbol_df = df[keep_cols].copy()
-                symbol_df.index.name = "date"
-
-                if not dry_run:
-                    universe_lib.write(ticker, symbol_df)
-
-                n_ok_ohlcv_only += 1
-
-            n_ok = n_ok_features + n_ok_ohlcv_only
+            n_ok += 1
 
             if (i + 1) % 100 == 0:
                 log.info(
-                    "Progress: %d / %d tickers processed (%d features, %d OHLCV-only)",
-                    i + 1, len(universe_tickers), n_ok_features, n_ok_ohlcv_only,
+                    "Progress: %d / %d tickers processed (%d ok, %d partial-features)",
+                    i + 1, len(universe_tickers), n_ok, n_partial,
                 )
 
         except Exception as exc:
             log.warning("Failed to write %s: %s", ticker, exc)
             n_err += 1
 
-    n_ok = n_ok_features + n_ok_ohlcv_only
     log.info(
-        "Backfill write complete: %d with features, %d OHLCV-only (fresh listings), %d skipped, %d errors",
-        n_ok_features, n_ok_ohlcv_only, n_skip, n_err,
+        "Backfill write complete: %d ok (%d with partial features on last row), %d skipped, %d errors",
+        n_ok, n_partial, n_skip, n_err,
     )
 
     t_compute = time.time() - t_compute_start
 
     # ── 5. Write macro features ──────────────────────────────────────────────
-    macro_df = _build_macro_features_df(macro)
-    if not macro_df.empty and not dry_run:
-        macro_lib.write("features", macro_df)
-        log.info("Wrote macro features: %d dates", len(macro_df))
+    # Macro writes are a SIDE EFFECT of full-universe backfill. On a
+    # single-ticker invocation (``--ticker X``) we skip them: the parquet
+    # price cache's macro series may be stale relative to what
+    # daily_append has been appending into ArcticDB, so rewriting macro
+    # from parquet during a per-ticker patch would silently regress SPY/
+    # VIX/XL* last_date (this is exactly what happened 2026-04-22 when a
+    # SOLS backfill knocked macro back from 4/20 to 4/17). Operators who
+    # genuinely want to rebuild macro must run a full-universe backfill
+    # (``--rebuild-macro`` opt-in with ``--ticker`` is an explicit override).
+    skip_macro = (ticker_filter is not None) and (not rebuild_macro)
+    macro_df = pd.DataFrame()  # populated below when we do write macro
+    if skip_macro:
+        log.info(
+            "Skipping macro library rewrite — ticker_filter=%s is set and "
+            "--rebuild-macro was not passed. Macro library is preserved as "
+            "last written by daily_append / full-universe backfill.",
+            ticker_filter,
+        )
+    else:
+        macro_df = _build_macro_features_df(macro)
+        if not macro_df.empty and not dry_run:
+            macro_lib.write("features", macro_df)
+            log.info("Wrote macro features: %d dates", len(macro_df))
 
-    # Write raw macro series (SPY, VIX, etc.) for consumers that need them
-    if not dry_run:
-        for key in ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO"]:
-            series = macro.get(key)
-            if series is not None:
-                macro_series_df = pd.DataFrame({"Close": series}, index=series.index)
-                macro_series_df.index.name = "date"
-                macro_lib.write(key, macro_series_df)
+        # Write raw macro series (SPY, VIX, etc.) for consumers that need them
+        if not dry_run:
+            for key in ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO"]:
+                series = macro.get(key)
+                if series is not None:
+                    macro_series_df = pd.DataFrame({"Close": series}, index=series.index)
+                    macro_series_df.index.name = "date"
+                    macro_lib.write(key, macro_series_df)
 
-        # Write sector ETFs
-        for key in macro:
-            if key.startswith("XL"):
-                sector_df = pd.DataFrame({"Close": macro[key]}, index=macro[key].index)
-                sector_df.index.name = "date"
-                macro_lib.write(key, sector_df)
+            # Write sector ETFs
+            for key in macro:
+                if key.startswith("XL"):
+                    sector_df = pd.DataFrame({"Close": macro[key]}, index=macro[key].index)
+                    sector_df.index.name = "date"
+                    macro_lib.write(key, sector_df)
 
     # ── 6. Snapshot ──────────────────────────────────────────────────────────
     if not dry_run:
@@ -474,6 +511,15 @@ def main():
     parser.add_argument("--ticker", default=None, help="Process single ticker (for testing)")
     parser.add_argument("--validate", action="store_true", help="Run spot-check validation after backfill")
     parser.add_argument("--bucket", default=DEFAULT_BUCKET, help=f"S3 bucket (default: {DEFAULT_BUCKET})")
+    parser.add_argument(
+        "--rebuild-macro",
+        action="store_true",
+        help=(
+            "Force macro-library rewrite even when --ticker is set. "
+            "Default: per-ticker invocations SKIP macro writes to avoid "
+            "regressing SPY/XL* freshness from the stale parquet cache."
+        ),
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
 
     args = parser.parse_args()
@@ -489,6 +535,7 @@ def main():
         dry_run=args.dry_run,
         ticker_filter=args.ticker,
         validate=args.validate,
+        rebuild_macro=args.rebuild_macro,
     )
 
     if result["status"] != "ok":

--- a/tests/test_backfill_unified_and_macro_scoping.py
+++ b/tests/test_backfill_unified_and_macro_scoping.py
@@ -1,0 +1,288 @@
+"""Regression tests for builders/backfill.py.
+
+Two invariants locked here (ROADMAP P1, 2026-04-22):
+
+1. **Unified short-history path.** The OHLCV-only fork for fresh-listing
+   tickers was removed when PR #78 made ``compute_features`` return NaN
+   for features whose warmup exceeds available history. Every ticker
+   now goes through ``compute_features`` and writes the full
+   OHLCV+FEATURE schema. Regressing to the fork would silently re-create
+   the 2026-04-21 schema-mismatch class (daily_append's ``update()``
+   fails on OHLCV-only symbols) that PR #79 had to migrate away.
+
+2. **Macro writes gated by ``--ticker``.** A per-ticker backfill must
+   not rewrite the macro library from the parquet cache — the cache's
+   macro series may be stale relative to what daily_append has been
+   appending, and rewriting it silently regresses SPY/VIX/XL* last_date.
+   The 2026-04-22 SOLS patch knocked macro back from 4/20 to 4/17 by
+   exactly this path. Operators who genuinely want to rebuild macro in
+   a ticker-scoped run must pass ``--rebuild-macro`` (explicit opt-in).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+_BACKFILL = Path(__file__).parent.parent / "builders" / "backfill.py"
+
+
+def _source() -> str:
+    return _BACKFILL.read_text()
+
+
+# ── 1. Source-text invariants ──────────────────────────────────────────────────
+
+
+def test_ohlcv_only_branch_removed():
+    """The ``if ticker in tickers_with_features: ... else: <OHLCV-only>``
+    fork must not reappear. Unified path is a hard contract post-PR-#78.
+    """
+    src = _source()
+    # The old fork's sentinel comment / counter / variable names:
+    assert "n_ok_ohlcv_only" not in src, (
+        "Found n_ok_ohlcv_only counter — the OHLCV-only branch has regressed. "
+        "Every ticker must go through compute_features (PR #78 unified path)."
+    )
+    assert "tickers_with_features = {" not in src, (
+        "Found tickers_with_features set construction — the two-tier filter "
+        "has regressed. Post-PR-#78 the filter is unnecessary."
+    )
+    # The old comment's giveaway phrase (stripped columns for fresh listings):
+    assert "write raw OHLCV" not in src, (
+        "Found 'write raw OHLCV' comment — old OHLCV-only fork sentinel. "
+        "Unified path writes OHLCV + FEATURE columns for every ticker."
+    )
+
+
+def test_compute_features_called_unconditionally():
+    """Every ticker must flow through compute_features. Structural check:
+    the write loop must not have a ``len(price_data[ticker]) >= MIN_ROWS_FOR_FEATURES``
+    style gate that skips compute_features. Two call sites are legitimate —
+    one in the write loop (unified path), one in ``validate`` — the
+    assertion below rejects any additional branch-y call inside the loop.
+    """
+    src = _source()
+    # No ``if ticker in tickers_with_features`` style gate around the call:
+    # post-PR-#78 the filter is gone. See also test_ohlcv_only_branch_removed.
+    # Guard against a future refactor reintroducing a different gate name.
+    assert "if ticker in tickers_with_features" not in src, (
+        "Found tickers_with_features gate — the unified write path has regressed."
+    )
+    # Belt-and-suspenders: any new gate that inspects len(price_data[ticker])
+    # in the write loop (not the universe-filter up top) is forbidden.
+    # The write loop is bounded by the "Compute features and write to ArcticDB"
+    # comment and the macro-write section that follows.
+    write_loop_start = src.find("Compute features and write to ArcticDB")
+    write_loop_end = src.find("Write macro features")
+    assert write_loop_start != -1 and write_loop_end != -1, "section markers moved"
+    write_loop = src[write_loop_start:write_loop_end]
+    assert "MIN_ROWS_FOR_FEATURES" not in write_loop, (
+        "Found MIN_ROWS_FOR_FEATURES in the write loop — a per-ticker gate "
+        "has regressed. PR #78 moved that check upstream (universe-filter "
+        "counter only) and made compute_features handle short history."
+    )
+
+
+def test_macro_write_gated_by_ticker_filter():
+    """The macro-library write block must be guarded by a skip_macro
+    computation derived from ticker_filter + rebuild_macro.
+    """
+    src = _source()
+    assert "skip_macro" in src, (
+        "Expected skip_macro flag gating the macro library rewrite."
+    )
+    assert "ticker_filter is not None" in src, (
+        "skip_macro must be derived from ticker_filter, not a standalone flag."
+    )
+    assert "rebuild_macro" in src, (
+        "Expected rebuild_macro opt-in override so operators can still rebuild "
+        "macro in a ticker-scoped run when they explicitly ask for it."
+    )
+
+
+def test_rebuild_macro_cli_flag_wired():
+    """``--rebuild-macro`` must be exposed to operators."""
+    src = _source()
+    assert "--rebuild-macro" in src, (
+        "CLI flag --rebuild-macro missing — operators have no opt-in for "
+        "macro rewrite when --ticker is set."
+    )
+
+
+# ── 2. Functional: macro scoping ───────────────────────────────────────────────
+
+
+def _minimal_ohlcv(n_rows: int = 400) -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=n_rows, freq="B")
+    return pd.DataFrame(
+        {
+            "Open": 100.0,
+            "High": 101.0,
+            "Low": 99.0,
+            "Close": 100.0,
+            "Adj_Close": 100.0,
+            "Volume": 1_000_000,
+        },
+        index=dates,
+    )
+
+
+def _stub_macro(n_rows: int = 400) -> dict[str, pd.Series]:
+    dates = pd.date_range("2024-01-01", periods=n_rows, freq="B")
+    keys = ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO",
+            "XLB", "XLC", "XLE", "XLF", "XLI", "XLK", "XLP", "XLRE", "XLU", "XLV", "XLY"]
+    return {k: pd.Series(100.0, index=dates) for k in keys}
+
+
+def _run_backfill_with_mocks(**backfill_kwargs):
+    """Exercise builders.backfill.backfill with the S3/ArcticDB layer mocked.
+
+    Returns (result, universe_lib_mock, macro_lib_mock).
+    """
+    from builders import backfill as _bf
+
+    price_data = {"AAPL": _minimal_ohlcv(n_rows=400)}
+    macro = _stub_macro(n_rows=400)
+    sector_map = {"AAPL": "XLK"}
+    fundamentals: dict = {}
+    alt_data: dict = {}
+
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+
+    # compute_features is heavy — stub it to return the input plus a few
+    # feature columns so the unified write path has something to save.
+    def _fake_compute_features(df, **_):
+        out = df.copy()
+        # Populate a small subset of FEATURES so the write loop finds them.
+        for col in ("atr_14_pct", "rsi_14", "momentum_60d"):
+            out[col] = 0.5
+        return out
+
+    # _build_macro_features_df needs a non-empty frame to trigger the
+    # ``macro_lib.write("features", ...)`` call we want to observe.
+    fake_macro_df = pd.DataFrame(
+        {"vix_level": [15.0, 16.0]},
+        index=pd.date_range("2024-01-01", periods=2),
+    )
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_extract_macro_series", return_value=macro), \
+         patch.object(_bf, "_load_sector_map", return_value=sector_map), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value=fundamentals), \
+         patch.object(_bf, "_load_cached_alternative", return_value=alt_data), \
+         patch.object(_bf, "_build_macro_features_df", return_value=fake_macro_df), \
+         patch.object(_bf, "compute_features", side_effect=_fake_compute_features), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib), \
+         patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        result = _bf.backfill(**backfill_kwargs)
+
+    return result, universe_lib, macro_lib
+
+
+def test_ticker_filter_without_rebuild_macro_skips_macro_writes():
+    """Regression: SOLS-class side-effect regression. A ``--ticker X``
+    backfill must not touch the macro library by default.
+    """
+    result, universe_lib, macro_lib = _run_backfill_with_mocks(
+        ticker_filter="AAPL", rebuild_macro=False
+    )
+
+    assert result["status"] == "ok"
+    # Universe write happens for the requested ticker.
+    universe_lib.write.assert_called_once()
+    # Macro library must NOT be touched.
+    macro_lib.write.assert_not_called()
+
+
+def test_ticker_filter_with_rebuild_macro_rewrites_macro():
+    """Opt-in override: ``--rebuild-macro`` with ``--ticker`` forces the
+    macro rewrite. Confirms the flag is wired end-to-end.
+    """
+    _, _, macro_lib = _run_backfill_with_mocks(
+        ticker_filter="AAPL", rebuild_macro=True
+    )
+    assert macro_lib.write.call_count >= 1, (
+        "rebuild_macro=True with ticker_filter must still rewrite macro."
+    )
+
+
+def test_full_universe_backfill_rewrites_macro():
+    """Default full-universe backfill (no ticker_filter) must rewrite
+    macro — that's the original ingestion path and the ``_SKIP_TICKERS``
+    sentinel keeps the parquet cache authoritative for weekly rebuilds.
+    """
+    _, _, macro_lib = _run_backfill_with_mocks(
+        ticker_filter=None, rebuild_macro=False
+    )
+    assert macro_lib.write.call_count >= 1, (
+        "Full-universe backfill must still rewrite macro by default."
+    )
+
+
+# ── 3. Functional: unified schema on short-history ticker ──────────────────────
+
+
+def test_short_history_ticker_gets_feature_columns_written():
+    """A ticker with < MIN_ROWS_FOR_FEATURES must still land with OHLCV
+    + whatever FEATURES compute_features returned (NaN allowed). The
+    removed OHLCV-only fork would have written a stripped column set
+    that daily_append.update() then rejects with a schema mismatch.
+    """
+    from builders import backfill as _bf
+    from features.feature_engineer import FEATURES
+
+    # 50 rows — well below MIN_ROWS_FOR_FEATURES (265).
+    price_data = {"NEWCO": _minimal_ohlcv(n_rows=50)}
+    macro = _stub_macro(n_rows=400)
+    sector_map = {"NEWCO": "XLK"}
+
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+
+    def _fake_compute_features(df, **_):
+        out = df.copy()
+        for col in ("atr_14_pct", "rsi_14"):
+            out[col] = 0.5
+        # Simulate a feature whose warmup exceeds the ticker's history —
+        # returned as a column but NaN (compute_features post-PR-#78 contract).
+        # ``dist_from_52w_high`` needs 252 bars; short-history tickers get NaN.
+        out["dist_from_52w_high"] = float("nan")
+        return out
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_extract_macro_series", return_value=macro), \
+         patch.object(_bf, "_load_sector_map", return_value=sector_map), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "_build_macro_features_df", return_value=pd.DataFrame()), \
+         patch.object(_bf, "compute_features", side_effect=_fake_compute_features), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib), \
+         patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        result = _bf.backfill(ticker_filter="NEWCO")
+
+    assert result["status"] == "ok"
+    universe_lib.write.assert_called_once()
+    _, written_df = universe_lib.write.call_args[0]
+    # Feature columns must be present (NaN values allowed).
+    assert "atr_14_pct" in written_df.columns, (
+        "Short-history ticker missing feature columns — OHLCV-only fork regressed."
+    )
+    assert "dist_from_52w_high" in written_df.columns, (
+        "Feature columns with NaN values must still be written — unified schema "
+        "contract per PR #78."
+    )
+    # NaN value must be preserved — not dropped, not zero-filled.
+    assert written_df["dist_from_52w_high"].isna().all(), (
+        "Short-history NaN feature must stay NaN after the write — "
+        "dropna / zero-fill would violate the PR #78 contract."
+    )


### PR DESCRIPTION
## Summary
Two ROADMAP P1 fixes to `builders/backfill.py`:

1. **Unified short-history path.** The `if ticker in tickers_with_features: <features> else: <OHLCV-only>` fork is removed. Every ticker now goes through `compute_features`, which returns partial-NaN rows for features whose warmup exceeds available history (PR #78 contract). The fork would otherwise regress PR #79's schema migration on next Saturday's weekly backfill by writing stripped-column frames that `daily_append.update()` rejects.

2. **Macro writes gated by `--ticker`.** A per-ticker backfill now skips the macro library rewrite by default. New `--rebuild-macro` flag is the explicit opt-in for operators who actually want macro rewritten during a ticker-scoped run. Default full-universe backfill still rewrites macro as before.

## Why
The SOLS patch on 2026-04-22 ran `--ticker SOLS`, which ran backfill's full side-effect macro rewrite from parquet. Parquet macro was stale (4/17), so this regressed ArcticDB macro SPY/VIX/XL* from 4/20 → 4/17 and broke the predictor's macro-freshness preflight. Same-shaped gap as the 2026-04-20 SOLS / Q universe-library gap that just got cleaned up.

Next Saturday's weekly backfill run would also regress PR #79's schema migration — the OHLCV-only fork writes column sets that `daily_append.update()` rejects with schema mismatch (same class as the PR #76/#77/#79 chain we just finished).

## Observability
Per-ticker `partial-features ticker=X rows=N nan_last_row=M/total features=[...]` INFO log for any ticker whose last row has NaN features. Completion log reports `n_partial` in addition to `n_ok` / `n_skip` / `n_err`.

## Test plan
- [x] Source-text assertions: `n_ok_ohlcv_only` + `tickers_with_features = {` + "write raw OHLCV" all absent; `MIN_ROWS_FOR_FEATURES` not present inside the write loop; `skip_macro` + `ticker_filter is not None` + `rebuild_macro` present; `--rebuild-macro` CLI flag present
- [x] Functional: `ticker_filter="AAPL", rebuild_macro=False` → `macro_lib.write` NOT called
- [x] Functional: `ticker_filter="AAPL", rebuild_macro=True` → `macro_lib.write` IS called
- [x] Functional: `ticker_filter=None` → `macro_lib.write` IS called (default preserved)
- [x] Functional: short-history ticker writes include `dist_from_52w_high` column with NaN preserved (unified schema)
- [x] Full suite: 151/151 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)