### PR TITLE
feat(ci): auto-deploy orchestration SF+CF on every push to main

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -1,0 +1,58 @@
+name: Deploy Infrastructure
+
+# Stamp + deploy the orchestration SF + CF stack on every push to main so the
+# deploy-drift preflight never halts the weekday/Saturday pipelines on a stale
+# SHA. The drift probe's contract is "SF/CF stamp == origin/main HEAD" — any
+# commit to main that doesn't rebuild this stack breaks that contract.
+#
+# No path filter: every main commit restamps, regardless of whether the
+# commit touched infrastructure/. This is the deliberate trade-off. 30s of
+# no-op CF update-stack + SF update-state-machine per merge in exchange for
+# eliminating the entire drift class. Cost is ~nothing; benefit is the
+# pipeline never silently halts on stamp drift again.
+#
+# Template-content changes (adding an alarm, modifying a rule) still work
+# here because apply.sh in alpha-engine-data/infrastructure/iam/ is the
+# source of truth for the GHA role's policy and will have been applied
+# before the PR merges.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-infrastructure-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-infrastructure:
+    name: Stamp SF + CF with main HEAD
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Deploy orchestration infrastructure
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: bash infrastructure/deploy-infrastructure.sh
+
+      - name: Report deployed stamp
+        run: |
+          aws cloudformation describe-stacks \
+            --stack-name alpha-engine-orchestration \
+            --query "Stacks[0].[StackStatus,Tags[?Key=='git-sha'].Value|[0]]" \
+            --output text

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -65,6 +65,80 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check:*"
       ]
+    },
+    {
+      "Sid": "InfraDeployValidateTemplate",
+      "Effect": "Allow",
+      "Action": "cloudformation:ValidateTemplate",
+      "Resource": "*"
+    },
+    {
+      "Sid": "InfraDeployStack",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:GetTemplate",
+        "cloudformation:CreateStack",
+        "cloudformation:UpdateStack",
+        "cloudformation:CreateChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:DeleteChangeSet"
+      ],
+      "Resource": "arn:aws:cloudformation:us-east-1:711398986525:stack/alpha-engine-orchestration/*"
+    },
+    {
+      "Sid": "InfraDeployS3",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/infrastructure/*"
+    },
+    {
+      "Sid": "InfraDeploySFDefinition",
+      "Effect": "Allow",
+      "Action": [
+        "states:UpdateStateMachine",
+        "states:DescribeStateMachine",
+        "states:ListTagsForResource",
+        "states:TagResource",
+        "states:UntagResource"
+      ],
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+      ]
+    },
+    {
+      "Sid": "InfraDeployTagPropagation",
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:TagResource",
+        "cloudwatch:UntagResource",
+        "cloudwatch:ListTagsForResource",
+        "events:TagResource",
+        "events:UntagResource",
+        "events:ListTagsForResource",
+        "sns:TagResource",
+        "sns:UntagResource",
+        "sns:ListTagsForResource",
+        "scheduler:TagResource",
+        "scheduler:UntagResource",
+        "scheduler:ListTagsForResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "InfraDeployLambdaPermission",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:AddPermission",
+        "lambda:RemovePermission",
+        "lambda:GetPolicy"
+      ],
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the SF/CF stamp-drift class that halted the weekday pipeline on 2026-04-23. The deploy-drift preflight demands `SF stamp + CF git-sha tag == alpha-engine-data@main HEAD`, but `infrastructure/deploy-infrastructure.sh` had no CI and was manual-only — so every main merge touching anything other than infrastructure/ silently accumulated drift. 11 commits had stacked up before the preflight tripped.

## Changes

**`.github/workflows/deploy-infrastructure.yml`** (new)
- Runs `bash infrastructure/deploy-infrastructure.sh` on every push to main + `workflow_dispatch`
- No path filter — every commit restamps. ~30s of idempotent CF update-stack + SF update-state-machine per merge. Cheap; prevents silent drift.
- Uses existing OIDC role `github-actions-lambda-deploy`.

**`infrastructure/iam/github-actions-lambda-deploy.json`** (policy extension)
- Adds 6 new Sids scoped to what CloudFormation actually calls during a tag-propagating stack update. Verified by running `create-change-set --use-previous-template --tags ...` against the live stack — CF propagates the git-sha tag to all 22 resources, so the role needs `TagResource`-class actions on cloudwatch/events/sns/scheduler + SF `UpdateStateMachine` + `lambda:AddPermission`/`RemovePermission` (Lambda::Permission resources show Conditional replacement for dynamic SourceArn refs).
- Policy **already applied** to the live role before opening this PR, so the workflow will have perms when it fires on merge.
- Template-content changes (adding an alarm, new rule type) still fail loudly with AccessDenied until the specific resource action is added — intentional, same discoverability as existing Lambda deploy role.

## Unblocks

On merge, this workflow fires on the merge commit itself and restamps SF+CF to current main HEAD (`b494b2d` + whatever this PR becomes) → weekday SF's drift probe passes → pipeline can run.

## Test plan

- [ ] IAM applied (done pre-merge): `aws iam get-role-policy --role-name github-actions-lambda-deploy --policy-name github-actions-lambda-deploy-policy --query "PolicyDocument.Statement[].Sid"` shows the 6 new Sids
- [ ] After merge: deploy-infrastructure workflow run completes successfully, reports new git-sha tag on the CF stack
- [ ] `aws cloudformation describe-stacks --stack-name alpha-engine-orchestration --query "Stacks[0].Tags"` shows `git-sha=<merge-commit-sha>`
- [ ] `aws stepfunctions describe-state-machine --state-machine-arn arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline --query "definition"` shows `[git:<merge-commit-sha>]` prefix in Comment
- [ ] Fire a test weekday SF execution — drift probe returns `has_drift: false`, pipeline runs through preflight

## Follow-ups (not this PR)

- Same drift-contract issue exists on alpha-engine-predictor `deploy.yml` (path filter → IAM-only PRs don't redeploy Lambda). Separate PR incoming.
- Minor: the weekday SF's `HandleFailure` state references `\$.sns_topic_arn` but the drift-step failure path doesn't carry that field, so failure emails silently don't fire. Separate one-liner PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)