### PR TITLE
fix(ci): add Describe/Get + PassRole perms for CF tag propagation

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -139,6 +139,31 @@
         "lambda:GetPolicy"
       ],
       "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
+    },
+    {
+      "Sid": "InfraDeployResourceRead",
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:DescribeAlarms",
+        "events:DescribeRule",
+        "events:ListTargetsByRule",
+        "scheduler:GetSchedule",
+        "sns:GetTopicAttributes",
+        "sns:GetSubscriptionAttributes",
+        "sns:ListSubscriptionsByTopic"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "InfraDeployPassSFRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-step-functions-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "states.amazonaws.com"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Recovery PR for #86. The policy from #86 was scoped to what `create-change-set` reported CF would do, but change-sets don't exercise the full Describe/Get chain CF actually invokes during a real `update-stack`. The 14:05 UTC deploy hit AccessDenied on three gaps — stack landed in `UPDATE_ROLLBACK_FAILED` because rollback itself also hit the same gaps.

## Gaps closed

- **`events:DescribeRule`** — CF reads each EventBridge rule before propagating tags
- **`sns:GetTopicAttributes`** + **`sns:GetSubscriptionAttributes`** — same for SNS Topic + Subscription resources
- **`iam:PassRole`** on `arn:aws:iam::711398986525:role/alpha-engine-step-functions-role` — CF passes the SF execution role through on `AWS::StepFunctions::StateMachine` updates. Scoped with `iam:PassedToService=states.amazonaws.com` condition.
- Also pre-emptively added `cloudwatch:DescribeAlarms`, `scheduler:GetSchedule`, `events:ListTargetsByRule`, `sns:ListSubscriptionsByTopic` — these weren't hit in the 14:05 failure (CF aborted early), but CF calls them for the other resource types in the template.

## Stack state before merge

- **Recovered manually via `continue-update-rollback`** under admin creds — stack is now `UPDATE_ROLLBACK_COMPLETE` (stable, git-sha tag reverted to old `1cfbbc6`, SF Comments still stamped with `7279f94` from PR #86's partial deploy).
- Policy **already applied live** before this PR was opened — 12 Sids on the role verified.
- Probe still shows `cf_drift=true, reason=stack_in_terminal_state` until the next successful deploy.

## What happens on merge

1. Workflow fires on merge commit
2. `deploy-infrastructure.sh` runs — update-stack with complete perms should succeed
3. Stack transitions `UPDATE_ROLLBACK_COMPLETE` → `UPDATE_IN_PROGRESS` → `UPDATE_COMPLETE` at new sha
4. SF Comments + stack tag both at new merge sha
5. Drift probe returns `cf_drift: false, has_drift: false`
6. Weekday SF can run

## Lesson for future (not this PR)

`create-change-set` is insufficient for IAM-scope verification. For future infra-IAM work, either (a) test with a deliberately over-restricted role and iterate on real AccessDenied errors in a staging stack, or (b) start with AdministratorAccess and tighten via AWS CloudTrail lookup of actually-called actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)