### PR TITLE
fix(ci): grant GHA role full resource CRUD for CF stack updates

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -112,18 +112,32 @@
       ]
     },
     {
-      "Sid": "InfraDeployTagPropagation",
+      "Sid": "InfraDeployResourceCRUD",
       "Effect": "Allow",
       "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DeleteAlarms",
         "cloudwatch:TagResource",
         "cloudwatch:UntagResource",
         "cloudwatch:ListTagsForResource",
+        "events:PutRule",
+        "events:DeleteRule",
+        "events:PutTargets",
+        "events:RemoveTargets",
         "events:TagResource",
         "events:UntagResource",
         "events:ListTagsForResource",
+        "sns:CreateTopic",
+        "sns:DeleteTopic",
+        "sns:SetTopicAttributes",
+        "sns:Subscribe",
+        "sns:Unsubscribe",
         "sns:TagResource",
         "sns:UntagResource",
         "sns:ListTagsForResource",
+        "scheduler:CreateSchedule",
+        "scheduler:UpdateSchedule",
+        "scheduler:DeleteSchedule",
         "scheduler:TagResource",
         "scheduler:UntagResource",
         "scheduler:ListTagsForResource"
@@ -155,13 +169,17 @@
       "Resource": "*"
     },
     {
-      "Sid": "InfraDeployPassSFRole",
+      "Sid": "InfraDeployPassRole",
       "Effect": "Allow",
       "Action": "iam:PassRole",
-      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-step-functions-role",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-*",
       "Condition": {
         "StringEquals": {
-          "iam:PassedToService": "states.amazonaws.com"
+          "iam:PassedToService": [
+            "states.amazonaws.com",
+            "scheduler.amazonaws.com",
+            "events.amazonaws.com"
+          ]
         }
       }
     }


### PR DESCRIPTION
## Summary

Third and final policy extension — reconciles main's JSON with the live IAM role applied during the 14:13 UTC recovery.

## Root cause — I was wrong twice

- **PR #86** (initial policy): assumed CF only needed tag-action perms for tag-only stack updates. Change-set showed `Scope: [Tags]` on all 22 resources, which I mistakenly took as the full IAM surface.
- **PR #87** (first fix): added Describe/Get + `iam:PassRole` on the SF role. Still missing resource put/update perms.
- **This PR**: CF calls **full put/update APIs** on every resource on every stack update, regardless of whether the resource actually changed. `PutMetricAlarm`, `PutRule`, `SetTopicAttributes`, etc. The `Scope: [Tags]` change-set output is an abstraction — the underlying CF→service call is a full resource update.

Both failed deploys landed the stack in `UPDATE_ROLLBACK_FAILED` because rollback also needed the same missing perms. Recovered each time via `continue-update-rollback` under admin creds.

## Changes

Replaces `InfraDeployTagPropagation` (narrow, tag-only) with `InfraDeployResourceCRUD` covering full CRUD on the 5 non-IAM resource services the template manages:

- `cloudwatch`: `PutMetricAlarm`, `DeleteAlarms`, plus tag actions
- `events`: `PutRule`, `DeleteRule`, `PutTargets`, `RemoveTargets`, plus tag actions
- `sns`: `CreateTopic`, `DeleteTopic`, `SetTopicAttributes`, `Subscribe`, `Unsubscribe`, plus tag actions
- `scheduler`: `Create/Update/DeleteSchedule`, plus tag actions

Broadens `InfraDeployPassRole` from single SF role → `alpha-engine-*` pattern with `PassedToService` condition covering `states | scheduler | events`. Prevents the same class of failure when future template changes add a pass-role-dependent resource.

## Current live state (already applied, this PR just reconciles source)

- Stack: `UPDATE_COMPLETE`, tag = `b5c2d537` (PR #87's merge commit)
- SF Comments: both stamped `b5c2d537`
- Weekday SF: executed successfully at 14:18 UTC (manual-full-20260423-071834) — all 4 steps ran, drift probe returned `has_drift: false`
- Live role policy: has this PR's `InfraDeployResourceCRUD` + `InfraDeployPassRole` Sids already (applied during recovery)

## Merging this PR

Safe — the deploy-infrastructure workflow will fire on merge, restamp with the new merge sha, and the update-stack call will be a near no-op (template unchanged, only the tag + SF Comment change to the new merge commit). Expected ~30s.

## Follow-ups

1. **Same problem for alpha-engine-predictor `deploy.yml`** — path filter means IAM-only PRs don't redeploy the Lambda, so predictor self-preflight drift can reform on any non-image main commit. Separate PR.
2. **Change-set-based IAM verification is unreliable.** Added a line to my own mental rubric: never trust `create-change-set` alone for IAM scope. Either start with `AdministratorAccess` and tighten via CloudTrail, or test with a scratch stack.
3. **Stack-role pattern refactor**: giving CF a dedicated service role (passed via `--role-arn`) would move these resource perms off the GHA role and reduce its blast radius. Worth doing as a cleanup — won't block today.
4. **Weekday SF `HandleFailure` bug** (still open): `TopicArn.\$: \$.sns_topic_arn` fails when the preflight errors early. That's why neither #86 nor #87 failures produced SNS alerts. Separate one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)