### PR TITLE
fix(sf): layer sns_topic_arn default in weekday pipeline

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1,7 +1,17 @@
 {
   "Comment": "Alpha Engine Weekday Pipeline — predictor inference and executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). DailyData moved to post-close (1:05 PM PT) systemd timer on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only.",
-  "StartAt": "DeployDriftCheck",
+  "StartAt": "InitializeInput",
   "States": {
+
+    "InitializeInput": {
+      "Type": "Pass",
+      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + trading_instance_id explicitly; manual reruns (which happened multiple times 2026-04-23) often omit sns_topic_arn, which caused HandleFailure to error on missing $.sns_topic_arn JSONPath. Mirrors the Saturday SF InitializeInput pattern — States.JsonMerge with user-input as the second arg lets explicit values win.",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'), $$.Execution.Input, false)"
+      },
+      "OutputPath": "$.merged",
+      "Next": "DeployDriftCheck"
+    },
 
     "DeployDriftCheck": {
       "Type": "Task",


### PR DESCRIPTION
## Summary

Mirrors the existing Saturday SF `InitializeInput` pattern (step_function.json:6-14). Closes a weekday-SF-specific footgun where manual reruns without execution input hit AccessDenied-style errors inside HandleFailure itself, meaning no SNS alert fires on pipeline failure.

## Root cause

Weekday SF's `HandleFailure` state references `$.sns_topic_arn` from execution input:

```json
"Parameters": {
  "TopicArn.$": "$.sns_topic_arn",
  ...
}
```

EventBridge scheduled runs pass this explicitly. But manual reruns don't — three of them today (2026-04-23) during drift/IAM recovery hit:

```
An error occurred while executing the state 'HandleFailure'. The JSONPath '$.sns_topic_arn' specified for the field 'TopicArn.$' could not be found in the input '{"error":{...}}'
```

When HandleFailure's own `Parameters` resolution fails, the SF errors out with no alert sent. That's why today's rollback failures produced no SNS emails — HandleFailure was supposed to send them but couldn't construct the request.

## Fix

New `InitializeInput` Pass state at the front of the weekday SF. `States.JsonMerge` with the default `sns_topic_arn` as the first arg and `$$.Execution.Input` as the second, so explicit input values override defaults but missing fields get the default.

```json
"InitializeInput": {
  "Type": "Pass",
  "Parameters": {
    "merged.$": "States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'), $$.Execution.Input, false)"
  },
  "OutputPath": "$.merged",
  "Next": "DeployDriftCheck"
}
```

Same pattern Saturday SF uses (step_function.json:6-14).

## What's intentionally NOT defaulted

`trading_instance_id` stays required-input. A stale default could silently start the wrong instance if ae-trading is ever recreated. The trade-off: manual reruns still need `--input '{"trading_instance_id": ["i-..."]}'`, but failures never land on the wrong EC2.

## Deploy

`deploy-infrastructure.yml` auto-triggers on merge (no path filter) — SF definition will update via `update-state-machine` within ~1 min of merge. No CF template change needed (only definition, not structure).

## Test plan

- [ ] Merge triggers `deploy-infrastructure.yml`; workflow succeeds; SF `definition` contains `InitializeInput`
- [ ] Manual `start-execution` without input succeeds past HandleFailure (i.e. SNS publish actually fires) — validate by running `aws stepfunctions start-execution --state-machine-arn ...:alpha-engine-weekday-pipeline --input '{}'` and checking the execution history
- [ ] Tomorrow's scheduled 13:05 UTC run unchanged — EventBridge still passes full input, JsonMerge lets it win

🤖 Generated with [Claude Code](https://claude.com/claude-code)