### PR TITLE
Split daily collection by source: yfinance EOD + polygon morning enrichment

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -79,11 +79,25 @@ def _load_parquet_warmup(s3, bucket: str, ticker: str) -> pd.DataFrame | None:
 def _load_daily_closes(s3, bucket: str, date_str: str) -> dict[str, dict]:
     """Load today's daily_closes parquet from S3. Raises if the file is missing or unreadable.
 
-    VWAP (2026-04-17): extracted from the parquet alongside OHLCV so it materializes
-    into ArcticDB as a first-class column. Source is polygon grouped-daily's `vw`
-    field when available, else `(H+L+C)/3` typical-price proxy — both are populated
-    upstream in ``collectors/daily_closes.py``. Missing VWAP for a ticker becomes
-    ``NaN`` in the output (not an error); downstream consumers handle NaN.
+    VWAP semantics (per the 2026-04-17 Phase 7 VWAP centralization decision,
+    refined by the 2026-04-23 split-by-source PR):
+
+      * Polygon grouped-daily (collected via ``daily_closes --source polygon_only``
+        in the morning enrichment pass) → true volume-weighted VWAP from
+        polygon's ``vw`` field.
+
+      * yfinance EOD pass (``daily_closes --source yfinance_only``, ~1:05 PM PT)
+        → VWAP=None. yfinance does not expose true VWAP and the (H+L+C)/3
+        typical-price proxy was explicitly REJECTED in 2026-04-17 because it
+        misrepresented arithmetic typical price as volume-weighted VWAP.
+        Morning polygon enrichment overwrites the row to fill VWAP.
+
+      * FRED fallback for indices (VIX/VIX3M/TNX/IRX) → VWAP=None. Single
+        daily Close value with no trade distribution to weight.
+
+    Missing VWAP becomes ``NaN`` in the output (not an error); downstream
+    consumers (executor's ``load_daily_vwap``) handle NaN by walking back up
+    to 5 trading days for a populated value.
     """
     key = f"predictor/daily_closes/{date_str}.parquet"
     obj = s3.get_object(Bucket=bucket, Key=key)

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -5,10 +5,26 @@ Writes one parquet per trading day at predictor/daily_closes/{date}.parquet.
 The predictor inference Lambda uses these to bridge the gap between the
 weekly slim cache and today's prices, avoiding a full 2-year yfinance fetch.
 
-Data source priority:
-  1. polygon.io grouped-daily (1 API call, covers all US stocks + ETFs)
-  2. FRED (covers the 4 index tickers not on polygon free tier: VIX, VIX3M, TNX, IRX)
-  3. yfinance batch download (fallback for whatever remains)
+Two collection modes (selected via the ``source`` parameter):
+
+  * ``yfinance_only`` (EOD pass, ~1:05 PM PT) — same-day OHLCV via yfinance
+    for stocks + FRED for the 4 index tickers (VIX/VIX3M/TNX/IRX). Polygon
+    is skipped entirely because free tier returns 403 "before end of day"
+    for same-day grouped-daily. ``VWAP`` writes as ``None`` for everything;
+    the morning enrichment fills it. Hard-fails on yfinance failure.
+
+  * ``polygon_only`` (morning pass, ~5:30 AM PT next trading day) —
+    polygon.io grouped-daily for stocks (with VWAP) + FRED for indices.
+    ``PolygonForbiddenError`` propagates loudly — no yfinance fallback
+    masks the failure. When an existing parquet is being overwritten
+    (the yfinance EOD pass wrote first), per-ticker Close discrepancy
+    is logged so corporate-action drift / data-quality issues are visible.
+
+  * ``auto`` (default, legacy) — historical behavior: polygon → FRED →
+    yfinance fallback chain. Kept for backfill and one-shot scripts that
+    don't care about the source distinction. Per-PR-1 design decision:
+    operational pipelines (EOD SF, morning SF) MUST specify a mode
+    explicitly so the failure semantics are deterministic.
 
 Schema: index=ticker (str), columns=[date, Open, High, Low, Close, Adj_Close, Volume, VWAP]
 """
@@ -59,15 +75,23 @@ def _is_post_close_write(last_modified: datetime, run_date: str) -> bool:
     return last_modified >= close_et
 
 
+_VALID_SOURCES = ("auto", "yfinance_only", "polygon_only")
+_YFINANCE_MIN_COVERAGE = 0.95   # below this, yfinance_only mode hard-fails
+_POLYGON_MIN_COVERAGE = 0.95    # below this, polygon_only mode hard-fails
+_DISCREPANCY_WARN_PCT = 0.01    # |polygon_close - yfinance_close| / yfinance_close
+_DISCREPANCY_ERROR_PCT = 0.05
+
+
 def collect(
     bucket: str,
     tickers: list[str],
     run_date: str | None = None,
     s3_prefix: str = "predictor/daily_closes/",
     dry_run: bool = False,
+    source: str = "auto",
 ) -> dict:
     """
-    Fetch today's OHLCV for all tickers and write to S3.
+    Fetch OHLCV for all tickers and write to S3.
 
     Args:
         bucket: S3 bucket name
@@ -75,38 +99,79 @@ def collect(
         run_date: YYYY-MM-DD (defaults to today)
         s3_prefix: S3 key prefix for daily closes
         dry_run: if True, fetch but don't write to S3
+        source: ``yfinance_only`` (EOD pass — polygon skipped, no VWAP),
+                ``polygon_only`` (morning pass — polygon required, FRED for indices,
+                no yfinance fallback), or ``auto`` (legacy chain). See module
+                docstring for full rationale.
 
     Returns:
-        dict with status, tickers_captured, method breakdown
+        dict with status, tickers_captured, method breakdown.
+
+    Raises:
+        ValueError: invalid ``source``
+        PolygonForbiddenError: polygon 403 in ``polygon_only`` or ``auto`` mode
+        RuntimeError: per-mode coverage threshold breached
     """
+    if source not in _VALID_SOURCES:
+        raise ValueError(
+            f"Invalid source={source!r}. Must be one of {_VALID_SOURCES}."
+        )
+
     run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
     s3 = boto3.client("s3")
-
-    # Check if already written for this date. Only skip if the existing
-    # parquet was written AFTER the NYSE close for run_date — a pre-close
-    # write is a morning-side stale fetch (polygon returns T-1's aggregate
-    # stamped under today's key) and must not shadow the authoritative
-    # post-close collection. See 2026-04-20 incident / ROADMAP P0.
     key = f"{s3_prefix}{run_date}.parquet"
-    if not dry_run:
-        from botocore.exceptions import ClientError
-        try:
-            head = s3.head_object(Bucket=bucket, Key=key)
-        except ClientError as exc:
-            err_code = exc.response.get("Error", {}).get("Code")
-            if err_code not in ("404", "NoSuchKey"):
-                # Auth failure, throttling, or network — not "file doesn't exist".
-                # Don't silently paper over it.
-                raise
-            # 404/NoSuchKey: expected case — file doesn't exist, proceed to write.
-        else:
-            last_modified = head["LastModified"]
-            if _is_post_close_write(last_modified, run_date):
+
+    # Existing-parquet inspection — mode-aware. Runs in both dry_run and live
+    # mode so dry_run can surface "this would skip" / "this would overwrite
+    # with these discrepancies" before the user commits to a real write.
+    #
+    # Skip-on-exists short-circuit (yfinance_only + auto only) returns inside
+    # the live branch since dry_run by definition isn't going to write.
+    existing_close_for_discrepancy: dict[str, float] | None = None
+    from botocore.exceptions import ClientError
+    head = None
+    try:
+        head = s3.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        err_code = exc.response.get("Error", {}).get("Code")
+        if err_code not in ("404", "NoSuchKey"):
+            # Auth failure, throttling, or network — not "file doesn't exist".
+            # Don't silently paper over it.
+            raise
+        # 404/NoSuchKey: expected case — file doesn't exist, proceed to write.
+
+    if head is not None:
+        last_modified = head["LastModified"]
+        if source == "polygon_only":
+            # Read existing rows so we can log Close-discrepancy after the
+            # polygon overwrite. Failures here are non-fatal — discrepancy
+            # logging is observability, not a write blocker.
+            try:
+                obj = s3.get_object(Bucket=bucket, Key=key)
+                existing_df = pd.read_parquet(io.BytesIO(obj["Body"].read()), engine="pyarrow")
+                existing_close_for_discrepancy = {
+                    str(t): float(existing_df.loc[t, "Close"])
+                    for t in existing_df.index
+                    if pd.notna(existing_df.loc[t, "Close"])
+                }
                 logger.info(
-                    "Daily closes already exist for %s (post-close at %s) — skipping",
-                    run_date, last_modified.isoformat(),
+                    "polygon_only: found existing parquet (last_modified=%s, %d tickers) — "
+                    "will overwrite and log Close discrepancies",
+                    last_modified.isoformat(), len(existing_close_for_discrepancy),
                 )
-                return {"status": "ok", "tickers_captured": 0, "skipped": True}
+            except Exception as exc:
+                logger.warning(
+                    "polygon_only: failed to read existing parquet for discrepancy logging "
+                    "(%s) — proceeding with overwrite without discrepancy comparison",
+                    exc,
+                )
+        elif not dry_run and _is_post_close_write(last_modified, run_date):
+            logger.info(
+                "Daily closes already exist for %s (post-close at %s, source=%s) — skipping",
+                run_date, last_modified.isoformat(), source,
+            )
+            return {"status": "ok", "tickers_captured": 0, "skipped": True, "source": source}
+        elif not dry_run:
             logger.warning(
                 "Existing %s was written pre-close at %s — refusing to skip; "
                 "re-collecting authoritative post-close data",
@@ -115,40 +180,22 @@ def collect(
             # fall through to re-fetch + overwrite
 
     if not tickers:
-        return {"status": "error", "error": "no tickers provided"}
+        return {"status": "error", "error": "no tickers provided", "source": source}
 
     records: list[dict] = []
 
-    # ── Step 1: Try polygon.io grouped-daily (1 API call for all US stocks) ──
+    # ── Step 1: polygon.io grouped-daily ─────────────────────────────────────
+    # Skipped in yfinance_only mode (free tier returns 403 same-day; deferring
+    # to the morning polygon_only enrichment is the canonical path).
     polygon_count = 0
-    try:
-        from polygon_client import polygon_client
-        grouped = polygon_client().get_grouped_daily(run_date)
-        if grouped:
-            for ticker in tickers:
-                store_ticker = ticker.lstrip("^")
-                g = grouped.get(store_ticker)
-                if g:
-                    records.append({
-                        "ticker": store_ticker,
-                        "date": run_date,
-                        "Open": round(g["open"], 4),
-                        "High": round(g["high"], 4),
-                        "Low": round(g["low"], 4),
-                        "Close": round(g["close"], 4),
-                        "Adj_Close": round(g["close"], 4),
-                        "Volume": int(g["volume"]),
-                        "VWAP": round(g["vwap"], 4) if g.get("vwap") else None,
-                    })
-            polygon_count = len(records)
-            logger.info("Polygon grouped-daily: %d/%d tickers", polygon_count, len(tickers))
-    except Exception as e:
-        logger.warning("Polygon grouped-daily failed: %s — falling back to yfinance", e)
+    if source != "yfinance_only":
+        polygon_count = _fetch_polygon_closes(tickers, run_date, records, source=source)
 
-    # ── Step 2: FRED fallback for index tickers ──────────────────────────────
-    # VIX/VIX3M/TNX/IRX are not on polygon free tier. FRED has same-scale
-    # equivalents (VIXCLS/VXVCLS/DGS10/DTB3) that typically publish T-1 values
-    # by the time the daily pipeline runs at 6:05 AM PT.
+    # ── Step 2: FRED for the 4 indices polygon never serves ──────────────────
+    # VIX/VIX3M/TNX/IRX are not on polygon free tier (and won't be on paid either
+    # for the index symbols we use). FRED has same-scale equivalents
+    # (VIXCLS/VXVCLS/DGS10/DTB3) that publish T-1 values reliably. Runs in
+    # every mode — these tickers have no other source.
     captured_tickers = {r["ticker"] for r in records}
     fred_missing = [
         t for t in tickers
@@ -158,23 +205,53 @@ def collect(
     if fred_missing:
         fred_count = _fetch_fred_closes(fred_missing, run_date, records)
 
-    # ── Step 3: yfinance fallback for anything still missing ─────────────────
+    # ── Step 3: yfinance — only in auto + yfinance_only modes ────────────────
+    # polygon_only refuses yfinance fallback per feedback_no_silent_fails: a
+    # silent yfinance fill would hide polygon outages and re-introduce the
+    # 2026-04-17 → 2026-04-23 VWAP=None contamination.
     captured_tickers = {r["ticker"] for r in records}
     missing = [t for t in tickers if t.lstrip("^") not in captured_tickers]
     yfinance_count = 0
-
-    if missing:
+    if missing and source != "polygon_only":
         yfinance_count = _fetch_yfinance_closes(missing, run_date, records)
 
+    # ── Coverage gates — per-mode hard-fails ─────────────────────────────────
+    n_stock_tickers = sum(1 for t in tickers if t.lstrip("^") not in _FRED_INDEX_MAP)
+    n_stock_records = sum(
+        1 for r in records if r["ticker"] not in _FRED_INDEX_MAP
+    )
+    stock_coverage = (n_stock_records / n_stock_tickers) if n_stock_tickers else 1.0
+
+    if source == "yfinance_only" and stock_coverage < _YFINANCE_MIN_COVERAGE:
+        raise RuntimeError(
+            f"yfinance_only mode for {run_date}: stock coverage {stock_coverage:.1%} "
+            f"below {_YFINANCE_MIN_COVERAGE:.0%} threshold ({n_stock_records}/{n_stock_tickers}). "
+            f"yfinance batch download must be failing — investigate before letting "
+            f"the EOD pipeline write a sparse parquet that EOD reconcile + tomorrow's "
+            f"morning enrichment will both have to compensate for."
+        )
+    if source == "polygon_only" and stock_coverage < _POLYGON_MIN_COVERAGE:
+        raise RuntimeError(
+            f"polygon_only mode for {run_date}: stock coverage {stock_coverage:.1%} "
+            f"below {_POLYGON_MIN_COVERAGE:.0%} threshold ({n_stock_records}/{n_stock_tickers}). "
+            f"Polygon grouped-daily returned fewer tickers than expected — check "
+            f"polygon API status / quota / date validity. NOT falling back to yfinance "
+            f"by design (per feedback_no_silent_fails)."
+        )
+
     if not records:
-        logger.warning("No closes captured for %s", run_date)
-        return {"status": "error", "error": "no data fetched", "tickers_captured": 0}
+        logger.warning("No closes captured for %s (source=%s)", run_date, source)
+        return {"status": "error", "error": "no data fetched", "tickers_captured": 0, "source": source}
 
     closes_df = pd.DataFrame(records).set_index("ticker")
     logger.info(
-        "Daily closes: %d tickers for %s (polygon=%d, fred=%d, yfinance=%d)",
-        len(closes_df), run_date, polygon_count, fred_count, yfinance_count,
+        "Daily closes: %d tickers for %s source=%s (polygon=%d, fred=%d, yfinance=%d)",
+        len(closes_df), run_date, source, polygon_count, fred_count, yfinance_count,
     )
+
+    # Discrepancy logging (polygon_only mode, when overwriting an existing parquet)
+    if existing_close_for_discrepancy and polygon_count > 0:
+        _log_close_discrepancies(closes_df, existing_close_for_discrepancy, run_date)
 
     if dry_run:
         return {
@@ -183,9 +260,10 @@ def collect(
             "polygon": polygon_count,
             "fred": fred_count,
             "yfinance": yfinance_count,
+            "source": source,
         }
 
-    # ── Step 3: Write to S3 ──────────────────────────────────────────────────
+    # ── Step 4: Write to S3 ──────────────────────────────────────────────────
     try:
         buf = io.BytesIO()
         closes_df.to_parquet(buf, engine="pyarrow", compression="snappy", index=True)
@@ -196,17 +274,136 @@ def collect(
             Body=buf.getvalue(),
             ContentType="application/octet-stream",
         )
-        logger.info("Written to s3://%s/%s (%d tickers)", bucket, key, len(closes_df))
+        logger.info(
+            "Written to s3://%s/%s (%d tickers, source=%s)",
+            bucket, key, len(closes_df), source,
+        )
         return {
             "status": "ok",
             "tickers_captured": len(closes_df),
             "polygon": polygon_count,
             "fred": fred_count,
             "yfinance": yfinance_count,
+            "source": source,
         }
     except Exception as e:
         logger.error("Failed to write daily closes: %s", e)
-        return {"status": "error", "error": str(e), "tickers_captured": len(closes_df)}
+        return {
+            "status": "error",
+            "error": str(e),
+            "tickers_captured": len(closes_df),
+            "source": source,
+        }
+
+
+def _fetch_polygon_closes(
+    tickers: list[str],
+    run_date: str,
+    records: list[dict],
+    source: str,
+) -> int:
+    """Fetch OHLCV+VWAP from polygon grouped-daily.
+
+    In ``polygon_only`` mode, ``PolygonForbiddenError`` propagates — caller
+    must handle (no silent yfinance fallback).
+
+    In ``auto`` mode, polygon failures are caught and logged so the legacy
+    chain (FRED → yfinance) can fill the gap. Note: this is the historical
+    silent-fall-through behavior. New operational code paths should use
+    ``polygon_only`` or ``yfinance_only`` to make failure semantics explicit.
+    """
+    from polygon_client import polygon_client, PolygonForbiddenError
+
+    try:
+        grouped = polygon_client().get_grouped_daily(run_date)
+    except PolygonForbiddenError:
+        if source == "polygon_only":
+            raise
+        logger.warning(
+            "Polygon 403 in auto mode — falling back to FRED+yfinance "
+            "(this is the historical silent-fallback path; new pipelines "
+            "should use --source polygon_only to surface the failure)"
+        )
+        return 0
+    except Exception as e:
+        if source == "polygon_only":
+            raise
+        logger.warning("Polygon grouped-daily failed in auto mode: %s — falling back", e)
+        return 0
+
+    if not grouped:
+        if source == "polygon_only":
+            raise RuntimeError(
+                f"polygon grouped-daily returned 0 tickers for {run_date} — "
+                f"likely a non-trading day or polygon API outage. polygon_only "
+                f"mode refuses to fall through (see feedback_no_silent_fails)."
+            )
+        return 0
+
+    polygon_count = 0
+    for ticker in tickers:
+        store_ticker = ticker.lstrip("^")
+        g = grouped.get(store_ticker)
+        if g:
+            records.append({
+                "ticker": store_ticker,
+                "date": run_date,
+                "Open": round(g["open"], 4),
+                "High": round(g["high"], 4),
+                "Low": round(g["low"], 4),
+                "Close": round(g["close"], 4),
+                "Adj_Close": round(g["close"], 4),
+                "Volume": int(g["volume"]),
+                "VWAP": round(g["vwap"], 4) if g.get("vwap") else None,
+            })
+            polygon_count += 1
+    logger.info("Polygon grouped-daily: %d/%d tickers", polygon_count, len(tickers))
+    return polygon_count
+
+
+def _log_close_discrepancies(
+    new_df: pd.DataFrame,
+    prior_close: dict[str, float],
+    run_date: str,
+) -> None:
+    """Log per-ticker Close discrepancy when polygon overwrites yfinance.
+
+    A small drift (<1%) is normal — different feeds, slight tick-time offsets,
+    consolidated tape coverage variance. Larger drifts (>1% WARN, >5% ERROR)
+    typically indicate corporate-action timing differences or one-source data
+    quality issues worth a human eyeball.
+    """
+    n_compared = 0
+    n_warn = 0
+    n_error = 0
+    biggest: tuple[str, float] = ("", 0.0)
+    for ticker in new_df.index:
+        prior = prior_close.get(str(ticker))
+        new_close = new_df.loc[ticker, "Close"]
+        if prior is None or pd.isna(new_close) or prior == 0:
+            continue
+        n_compared += 1
+        pct_diff = abs(float(new_close) - prior) / prior
+        if pct_diff > _DISCREPANCY_ERROR_PCT:
+            logger.error(
+                "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f (%.2f%% diff vs prior parquet) — "
+                "investigate before downstream consumers re-read",
+                ticker, run_date, prior, float(new_close), pct_diff * 100,
+            )
+            n_error += 1
+        elif pct_diff > _DISCREPANCY_WARN_PCT:
+            logger.warning(
+                "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f (%.2f%% diff vs prior parquet)",
+                ticker, run_date, prior, float(new_close), pct_diff * 100,
+            )
+            n_warn += 1
+        if pct_diff > biggest[1]:
+            biggest = (str(ticker), pct_diff)
+    logger.info(
+        "polygon_only discrepancy summary for %s: compared=%d warn(>1%%)=%d error(>5%%)=%d "
+        "biggest=%s@%.2f%%",
+        run_date, n_compared, n_warn, n_error, biggest[0] or "n/a", biggest[1] * 100,
+    )
 
 
 def _fetch_fred_closes(

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -39,6 +39,17 @@ class PolygonRateLimitError(Exception):
     """Raised when rate limit is exhausted and caller should backoff."""
 
 
+class PolygonForbiddenError(Exception):
+    """Raised when polygon returns 403 (free-tier "before end of day", missing/invalid key, etc.).
+
+    Previously `_get` swallowed 403's and returned an empty `{"results": []}` dict,
+    which caused `collectors/daily_closes.py` to silently fall through to yfinance —
+    masking the real failure (free tier can't access today's data) and silently
+    writing VWAP=None for every stock. Per `feedback_no_silent_fails`, callers
+    must see the failure and decide whether to abort or escalate.
+    """
+
+
 class PolygonClient:
     """Rate-limited polygon.io REST client with dividend adjustment."""
 
@@ -89,10 +100,20 @@ class PolygonClient:
                 self._call_times.clear()  # Reset window after forced wait
                 continue
             if resp.status_code == 403:
-                data = resp.json()
-                msg = data.get("message", "Not authorized")
-                logger.warning("Polygon 403: %s (path=%s)", msg, path)
-                return {"results": [], "resultsCount": 0, "status": "FORBIDDEN"}
+                # Free tier returns 403 for same-day grouped-daily ("before end
+                # of day"). Raise so callers can decide whether to abort the
+                # whole pipeline or fall back to a different source — never
+                # silently return an empty result set (the prior behavior
+                # masked the 2026-04-17 → 2026-04-23 VWAP outage by letting
+                # daily_closes.collect fall through to yfinance, which writes
+                # VWAP=None).
+                try:
+                    msg = resp.json().get("message", "Not authorized")
+                except (ValueError, KeyError):
+                    msg = resp.text[:200] or "Not authorized"
+                raise PolygonForbiddenError(
+                    f"Polygon 403 on {path}: {msg}"
+                )
             resp.raise_for_status()
             return resp.json()
         raise PolygonRateLimitError("Rate limited after 3 retries")

--- a/tests/test_daily_closes_source_modes.py
+++ b/tests/test_daily_closes_source_modes.py
@@ -1,0 +1,292 @@
+"""Tests for the ``source`` parameter on collectors.daily_closes.collect.
+
+Three modes:
+
+  * ``yfinance_only`` (EOD pass) — polygon skipped entirely. yfinance + FRED only.
+    VWAP=None for everything. Used by the EOD SF post-close.
+  * ``polygon_only`` (morning pass) — polygon required (raises on failure).
+    No yfinance fallback for stocks. FRED still serves the 4 indices polygon
+    never provides. Used by the new MorningEnrich step in the weekday SF.
+  * ``auto`` (legacy) — historical chain: polygon → FRED → yfinance fallback.
+    Kept for backfill scripts.
+
+These guard against the 2026-04-17 → 2026-04-23 silent-fail incident where
+polygon's 403 caused yfinance to silently substitute, writing VWAP=None
+across the entire universe.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+from collectors import daily_closes
+from polygon_client import PolygonForbiddenError
+
+
+def _no_existing_parquet_s3():
+    """S3 mock where head_object always returns 404 — fresh-day path."""
+    s3 = MagicMock()
+    s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}},
+        "HeadObject",
+    )
+    return s3
+
+
+def _existing_parquet_s3(closes_by_ticker: dict[str, float], last_modified: datetime | None = None):
+    """S3 mock with a pre-existing parquet that head_object/get_object surface."""
+    s3 = MagicMock()
+    s3.head_object.return_value = {
+        "LastModified": last_modified or datetime(2026, 4, 22, 21, 0, 0, tzinfo=timezone.utc),
+        "ContentLength": 12345,
+        "ContentType": "application/octet-stream",
+    }
+    df = pd.DataFrame(
+        [{"Open": v, "High": v, "Low": v, "Close": v, "Adj_Close": v, "Volume": 0, "VWAP": None}
+         for v in closes_by_ticker.values()],
+        index=pd.Index(list(closes_by_ticker.keys()), name="ticker"),
+    )
+    import io
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy", index=True)
+    buf.seek(0)
+    s3.get_object.return_value = {"Body": MagicMock(read=lambda: buf.getvalue())}
+    return s3
+
+
+# ── source validation ───────────────────────────────────────────────────────
+
+
+def test_invalid_source_raises_value_error():
+    with pytest.raises(ValueError, match="Invalid source"):
+        daily_closes.collect(
+            bucket="b", tickers=["AAPL"], run_date="2026-04-23", source="bogus"
+        )
+
+
+# ── yfinance_only mode ──────────────────────────────────────────────────────
+
+
+def test_yfinance_only_skips_polygon_entirely():
+    """yfinance_only must not call polygon (avoids the 403 + silent-fall-through path)."""
+    s3 = _no_existing_parquet_s3()
+
+    fake_yf_records = [
+        {"ticker": "AAPL", "date": "2026-04-23",
+         "Open": 100.0, "High": 105.0, "Low": 99.0, "Close": 103.0,
+         "Adj_Close": 103.0, "Volume": 1_000_000, "VWAP": None}
+    ]
+
+    def fake_yf(_tickers, _date, records_out):
+        records_out.extend(fake_yf_records)
+        return len(fake_yf_records)
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("collectors.daily_closes._fetch_yfinance_closes", side_effect=fake_yf), \
+         patch("collectors.daily_closes._fetch_polygon_closes") as polygon_spy:
+        result = daily_closes.collect(
+            bucket="b", tickers=["AAPL"], run_date="2026-04-23",
+            source="yfinance_only", dry_run=True,
+        )
+
+    polygon_spy.assert_not_called()
+    assert result["status"] == "ok_dry_run"
+    assert result["source"] == "yfinance_only"
+    assert result["polygon"] == 0
+
+
+def test_yfinance_only_hard_fails_below_coverage_threshold():
+    """yfinance_only must hard-fail if yfinance returns fewer stocks than threshold."""
+    s3 = _no_existing_parquet_s3()
+    # 100 tickers, yfinance returns only 50 → 50% coverage, well below 95% threshold
+    tickers = [f"T{i:03d}" for i in range(100)]
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("collectors.daily_closes._fetch_yfinance_closes", return_value=0), \
+         patch("collectors.daily_closes._fetch_fred_closes", return_value=0):
+        with pytest.raises(RuntimeError, match="below 95% threshold"):
+            daily_closes.collect(
+                bucket="b", tickers=tickers, run_date="2026-04-23",
+                source="yfinance_only", dry_run=True,
+            )
+
+
+# ── polygon_only mode ───────────────────────────────────────────────────────
+
+
+def test_polygon_only_propagates_polygon_forbidden():
+    """polygon_only must propagate PolygonForbiddenError — no silent yfinance fallback."""
+    s3 = _no_existing_parquet_s3()
+
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.side_effect = PolygonForbiddenError("403 simulation")
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client), \
+         patch("collectors.daily_closes._fetch_yfinance_closes") as yf_spy:
+        with pytest.raises(PolygonForbiddenError):
+            daily_closes.collect(
+                bucket="b", tickers=["AAPL"], run_date="2026-04-23",
+                source="polygon_only", dry_run=True,
+            )
+    yf_spy.assert_not_called()
+
+
+def test_polygon_only_does_not_call_yfinance():
+    """polygon_only must never call yfinance — even when polygon coverage is partial."""
+    s3 = _no_existing_parquet_s3()
+
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.return_value = {
+        "AAPL": {"open": 100, "high": 105, "low": 99, "close": 103, "volume": 1_000_000, "vwap": 102.5},
+        "MSFT": {"open": 200, "high": 210, "low": 199, "close": 206, "volume": 2_000_000, "vwap": 205.0},
+    }
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client), \
+         patch("collectors.daily_closes._fetch_yfinance_closes") as yf_spy:
+        result = daily_closes.collect(
+            bucket="b", tickers=["AAPL", "MSFT"], run_date="2026-04-23",
+            source="polygon_only", dry_run=True,
+        )
+
+    yf_spy.assert_not_called()
+    assert result["polygon"] == 2
+    assert result["yfinance"] == 0
+
+
+def test_polygon_only_hard_fails_on_empty_polygon_response():
+    """polygon_only must hard-fail (not skip) when polygon returns empty for stocks."""
+    s3 = _no_existing_parquet_s3()
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.return_value = {}
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client):
+        with pytest.raises(RuntimeError, match="0 tickers"):
+            daily_closes.collect(
+                bucket="b", tickers=["AAPL", "MSFT"], run_date="2026-04-23",
+                source="polygon_only", dry_run=True,
+            )
+
+
+def test_polygon_only_writes_vwap_from_polygon():
+    """When polygon returns a VWAP, it must land in the parquet."""
+    s3 = _no_existing_parquet_s3()
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.return_value = {
+        "AAPL": {"open": 100, "high": 105, "low": 99, "close": 103, "volume": 1_000_000, "vwap": 102.5},
+    }
+
+    captured = {}
+    def capture_put(**kwargs):
+        captured.update(kwargs)
+        return {}
+    s3.put_object.side_effect = capture_put
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client):
+        result = daily_closes.collect(
+            bucket="b", tickers=["AAPL"], run_date="2026-04-23",
+            source="polygon_only",
+        )
+
+    assert result["status"] == "ok"
+    assert result["polygon"] == 1
+    # Decode and verify VWAP populated
+    import io
+    df = pd.read_parquet(io.BytesIO(captured["Body"]), engine="pyarrow")
+    assert df.loc["AAPL", "VWAP"] == 102.5
+
+
+# ── overwrite + discrepancy logging ─────────────────────────────────────────
+
+
+def test_polygon_only_always_overwrites_existing_parquet():
+    """polygon_only must NEVER skip on existing parquet — overwrite is the design."""
+    s3 = _existing_parquet_s3(
+        {"AAPL": 103.0, "MSFT": 206.0},
+        last_modified=datetime(2026, 4, 22, 21, 0, 0, tzinfo=timezone.utc),  # post-close
+    )
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.return_value = {
+        "AAPL": {"open": 100, "high": 105, "low": 99, "close": 103.5, "volume": 1_000_000, "vwap": 102.5},
+        "MSFT": {"open": 200, "high": 210, "low": 199, "close": 206.5, "volume": 2_000_000, "vwap": 205.0},
+    }
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client):
+        result = daily_closes.collect(
+            bucket="b", tickers=["AAPL", "MSFT"], run_date="2026-04-22",
+            source="polygon_only", dry_run=True,
+        )
+
+    assert result["status"] == "ok_dry_run"
+    assert result["polygon"] == 2
+    assert result.get("skipped") is not True
+
+
+def test_polygon_only_logs_close_discrepancy(caplog):
+    """When polygon overwrites yfinance, large Close discrepancies must be logged."""
+    s3 = _existing_parquet_s3(
+        {"AAPL": 100.0, "MSFT": 200.0},  # yfinance prior values
+    )
+    mock_pg_client = MagicMock()
+    # AAPL ~5% drift — should log ERROR. MSFT ~0.5% drift — below threshold.
+    mock_pg_client.get_grouped_daily.return_value = {
+        "AAPL": {"open": 105, "high": 110, "low": 104, "close": 105.5, "volume": 1_000_000, "vwap": 105.0},
+        "MSFT": {"open": 200, "high": 210, "low": 199, "close": 201.0, "volume": 2_000_000, "vwap": 200.5},
+    }
+
+    import logging
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client), \
+         caplog.at_level(logging.INFO, logger="collectors.daily_closes"):
+        daily_closes.collect(
+            bucket="b", tickers=["AAPL", "MSFT"], run_date="2026-04-22",
+            source="polygon_only", dry_run=True,
+        )
+
+    aapl_records = [r for r in caplog.records if "AAPL" in r.message and "OVERWRITE" in r.message]
+    assert aapl_records, "expected AAPL discrepancy log (5% drift > 5% error threshold)"
+    assert aapl_records[0].levelno >= logging.ERROR
+    summary = [r for r in caplog.records if "discrepancy summary" in r.message]
+    assert summary, "expected discrepancy summary log"
+
+
+# ── auto mode preserves legacy behavior ─────────────────────────────────────
+
+
+def test_auto_mode_falls_back_through_chain_on_polygon_403():
+    """auto mode (legacy) must keep the silent fallback for backwards compat."""
+    s3 = _no_existing_parquet_s3()
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.side_effect = PolygonForbiddenError("403 simulation")
+
+    fake_yf_records = [
+        {"ticker": "AAPL", "date": "2026-04-23",
+         "Open": 100.0, "High": 105.0, "Low": 99.0, "Close": 103.0,
+         "Adj_Close": 103.0, "Volume": 1_000_000, "VWAP": None}
+    ]
+
+    def fake_yf(_tickers, _date, records_out):
+        records_out.extend(fake_yf_records)
+        return len(fake_yf_records)
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client), \
+         patch("collectors.daily_closes._fetch_yfinance_closes", side_effect=fake_yf):
+        result = daily_closes.collect(
+            bucket="b", tickers=["AAPL"], run_date="2026-04-23",
+            source="auto", dry_run=True,
+        )
+
+    # auto mode masks the failure — historical behavior preserved
+    assert result["status"] == "ok_dry_run"
+    assert result["polygon"] == 0
+    assert result["yfinance"] == 1

--- a/tests/test_polygon_client.py
+++ b/tests/test_polygon_client.py
@@ -3,15 +3,19 @@
 Focus: response caching on get_grouped_daily, which dedup's calendar-date
 repeats across overlapping eval_date windows in universe_returns and cuts
 the free-tier 5 calls/min rate-limit tax by ~3.5x on backfill runs.
+
+Also covers the 403-raises contract (PolygonForbiddenError) — see
+2026-04-23 incident where the prior return-empty-on-403 silently masked
+free-tier "before end of day" rejections for stocks for a week.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from polygon_client import PolygonClient
+from polygon_client import PolygonClient, PolygonForbiddenError
 
 
 def _make_client() -> PolygonClient:
@@ -72,3 +76,56 @@ def test_cache_is_per_instance():
         c2.get_grouped_daily("2026-01-05")
     assert m1.call_count == 1
     assert m2.call_count == 1
+
+
+def _make_403_response(message: str = "Attempted to request today's data before end of day. Please upgrade your plan at https://polygon.io/pricing"):
+    """Build a fake requests.Response with status 403 + polygon's standard message."""
+    resp = MagicMock()
+    resp.status_code = 403
+    resp.json.return_value = {"message": message, "status": "FORBIDDEN"}
+    resp.text = '{"status":"FORBIDDEN","message":"' + message + '"}'
+    return resp
+
+
+def test_403_raises_polygon_forbidden_error():
+    """403 must raise PolygonForbiddenError, not silently return empty dict.
+
+    Prior behavior (logged warning + returned {"results": []}) masked the
+    2026-04-17 → 2026-04-23 VWAP outage by letting daily_closes.collect
+    fall through to yfinance, which writes VWAP=None for every stock.
+    """
+    client = _make_client()
+    with patch.object(client._session, "get", return_value=_make_403_response()):
+        with pytest.raises(PolygonForbiddenError) as excinfo:
+            client.get_grouped_daily("2026-04-23")
+    assert "before end of day" in str(excinfo.value).lower() or "403" in str(excinfo.value)
+    assert "/v2/aggs/grouped" in str(excinfo.value)
+
+
+def test_403_raises_even_when_response_body_is_not_json():
+    """Defensive: 403 with malformed/non-JSON body must still raise (not crash on .json())."""
+    client = _make_client()
+    bad_resp = MagicMock()
+    bad_resp.status_code = 403
+    bad_resp.json.side_effect = ValueError("not JSON")
+    bad_resp.text = "Forbidden"
+    with patch.object(client._session, "get", return_value=bad_resp):
+        with pytest.raises(PolygonForbiddenError):
+            client.get_grouped_daily("2026-04-23")
+
+
+def test_403_does_not_pollute_grouped_daily_cache():
+    """A 403 must not leave a 'cached empty result' that hides the failure on retry."""
+    client = _make_client()
+    with patch.object(client._session, "get", return_value=_make_403_response()):
+        with pytest.raises(PolygonForbiddenError):
+            client.get_grouped_daily("2026-04-23")
+    # Retry must hit the network again, not a cached empty dict
+    with patch.object(client._session, "get", return_value=_make_403_response()) as second:
+        with pytest.raises(PolygonForbiddenError):
+            client.get_grouped_daily("2026-04-23")
+        assert second.called, (
+            "Cache must NOT have stored the 403 outcome — every retry must "
+            "re-hit the API so an upgraded plan / different time window "
+            "succeeds without manual cache busting."
+        )

--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -1,0 +1,202 @@
+"""Tests for the --morning-enrich path in weekly_collector.
+
+Covers:
+  * _previous_trading_day finds the most recent trading day before today,
+    walking back over weekends + holidays correctly.
+  * _run_morning_enrich invokes daily_closes with source='polygon_only'
+    (no yfinance fallback masking polygon failures) and follows up with
+    daily_append on the same date.
+  * Hard-fail propagation when polygon raises PolygonForbiddenError.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import weekly_collector
+from polygon_client import PolygonForbiddenError
+
+
+# ── _previous_trading_day ───────────────────────────────────────────────────
+
+
+def test_previous_trading_day_walks_back_over_weekend():
+    """Monday morning should resolve to Friday's date, not Sunday's."""
+    # 2026-04-27 is a Monday. Previous trading day = 2026-04-24 (Friday).
+    monday = datetime(2026, 4, 27, 13, 0, 0, tzinfo=timezone.utc)
+    result = weekly_collector._previous_trading_day(reference=monday)
+    assert result == "2026-04-24"
+
+
+def test_previous_trading_day_skips_holiday():
+    """Day after a market holiday should resolve to the trading day before it."""
+    # 2026-12-25 is Christmas (NYSE closed). 2026-12-28 (Mon) → 2026-12-24 (Thu).
+    day_after = datetime(2026, 12, 28, 13, 0, 0, tzinfo=timezone.utc)
+    result = weekly_collector._previous_trading_day(reference=day_after)
+    assert result == "2026-12-24"
+
+
+def test_previous_trading_day_strict_inequality():
+    """Always returns a date STRICTLY before the reference, never the same day."""
+    # Even if today is a trading day, --morning-enrich is for prior session enrichment.
+    # 2026-04-23 is a Thursday (trading day). Result should be 2026-04-22 (Wednesday).
+    thursday = datetime(2026, 4, 23, 13, 0, 0, tzinfo=timezone.utc)
+    result = weekly_collector._previous_trading_day(reference=thursday)
+    assert result == "2026-04-22"
+
+
+def test_previous_trading_day_raises_on_runaway():
+    """Defensive: if is_trading_day returns False for 10 days straight, raise."""
+    with patch("alpha_engine_lib.trading_calendar.is_trading_day", return_value=False):
+        with pytest.raises(RuntimeError, match="trading_calendar.is_trading_day appears broken"):
+            weekly_collector._previous_trading_day(
+                reference=datetime(2026, 4, 23, 13, 0, 0, tzinfo=timezone.utc)
+            )
+
+
+# ── _run_morning_enrich orchestration ───────────────────────────────────────
+
+
+@pytest.fixture
+def enrich_args():
+    return SimpleNamespace(date=None, dry_run=True, morning_enrich=True)
+
+
+@pytest.fixture
+def enrich_args_with_date():
+    return SimpleNamespace(date="2026-04-22", dry_run=True, morning_enrich=True)
+
+
+def test_morning_enrich_uses_polygon_only_source(enrich_args_with_date):
+    """The morning enrichment must call daily_closes with source='polygon_only'."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+
+    captured = {}
+    def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok_dry_run", "polygon": 100, "fred": 4, "yfinance": 0,
+                "tickers_captured": 104, "source": kwargs["source"]}
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL", "MSFT", "NVDA"]}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect", side_effect=fake_collect), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}):
+        result = weekly_collector._run_morning_enrich(config, enrich_args_with_date)
+
+    assert captured["source"] == "polygon_only"
+    assert captured["run_date"] == "2026-04-22"
+    assert result["status"] == "ok"
+    assert result["mode"] == "morning_enrich"
+    assert result["date"] == "2026-04-22"
+
+
+def test_morning_enrich_hard_fails_on_polygon_forbidden(enrich_args_with_date):
+    """If polygon raises PolygonForbiddenError, the enrich step must report failed."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch(
+             "weekly_collector.daily_closes.collect",
+             side_effect=PolygonForbiddenError("403 simulation"),
+         ):
+        result = weekly_collector._run_morning_enrich(config, enrich_args_with_date)
+
+    assert result["status"] == "failed"
+    assert result["collectors"]["daily_closes"]["status"] == "error"
+    assert "403" in result["collectors"]["daily_closes"]["error"]
+    # daily_append should NOT have run after polygon failed
+    assert "arcticdb" not in result["collectors"]
+
+
+def test_morning_enrich_calls_daily_append_after_polygon_succeeds(enrich_args_with_date):
+    """daily_append must run after polygon-only daily_closes lands the parquet."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    daily_append_calls = []
+    def fake_daily_append(**kwargs):
+        daily_append_calls.append(kwargs)
+        return {"status": "ok", "tickers_appended": 1}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok_dry_run", "polygon": 1, "fred": 0, "yfinance": 0,
+                             "tickers_captured": 1, "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append", side_effect=fake_daily_append):
+        result = weekly_collector._run_morning_enrich(config, enrich_args_with_date)
+
+    assert result["status"] == "ok"
+    assert len(daily_append_calls) == 1
+    assert daily_append_calls[0]["date_str"] == "2026-04-22"
+
+
+def test_morning_enrich_default_date_uses_previous_trading_day():
+    """When --date is not specified, _previous_trading_day fills in."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date=None, dry_run=True, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    captured = {}
+    def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok_dry_run", "polygon": 1, "fred": 0, "yfinance": 0,
+                "tickers_captured": 1, "source": "polygon_only"}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect", side_effect=fake_collect), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}), \
+         patch("weekly_collector._previous_trading_day", return_value="2026-04-23"):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert captured["run_date"] == "2026-04-23"
+    assert result["date"] == "2026-04-23"
+
+
+# ── --daily routes through yfinance_only ────────────────────────────────────
+
+
+def test_daily_mode_calls_collect_with_yfinance_only_source():
+    """--daily must invoke daily_closes with source='yfinance_only' (no polygon attempt)."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(
+        date="2026-04-23", dry_run=True, morning_enrich=False,
+        daily=True, only=None,
+    )
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    captured = {}
+    def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok_dry_run", "polygon": 0, "fred": 4, "yfinance": 1,
+                "tickers_captured": 5, "source": kwargs["source"]}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect", side_effect=fake_collect), \
+         patch("features.compute.compute_and_write",
+               return_value={"status": "ok"}), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}):
+        weekly_collector._run_daily(config, args)
+
+    assert captured["source"] == "yfinance_only", (
+        "--daily must use source='yfinance_only' to skip polygon entirely "
+        "(per the 2026-04-23 split-by-source design — polygon free-tier 403's "
+        "same-day, morning enrichment fills VWAP overnight)."
+    )

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -14,8 +14,10 @@ Usage:
     python weekly_collector.py --phase 1 --dry-run    # validate Phase 1
     python weekly_collector.py --phase 1 --only prices # single collector
     python weekly_collector.py --phase 2 --only alternative  # explicit
-    python weekly_collector.py --daily                # weekday daily closes
+    python weekly_collector.py --daily                # weekday EOD pass (yfinance OHLCV, no VWAP)
     python weekly_collector.py --daily --dry-run      # validate daily
+    python weekly_collector.py --morning-enrich       # morning polygon overwrite (prior trading day)
+    python weekly_collector.py --morning-enrich --date 2026-04-23  # backfill specific date
 """
 
 from __future__ import annotations
@@ -58,6 +60,9 @@ def load_config(path: str = "config.yaml") -> dict:
 
 def run_weekly(config: dict, args: argparse.Namespace) -> dict:
     """Run collectors based on mode selection."""
+    if getattr(args, "morning_enrich", False):
+        return _run_morning_enrich(config, args)
+
     if args.daily:
         return _run_daily(config, args)
 
@@ -396,6 +401,145 @@ def _run_phase2(config: dict, args: argparse.Namespace) -> dict:
     return results
 
 
+def _previous_trading_day(reference: datetime | None = None) -> str:
+    """Find the most recent trading day strictly before ``reference`` (UTC).
+
+    Used by --morning-enrich to determine which date polygon's grouped-daily
+    should be fetched for. Free tier won't serve today's data, so we always
+    enrich the prior session. Walks back at most 10 calendar days as a
+    runaway guard against a broken trading-calendar implementation.
+    """
+    from alpha_engine_lib.trading_calendar import is_trading_day
+    from datetime import timedelta
+
+    ref = reference or datetime.now(timezone.utc)
+    d = ref.date() - timedelta(days=1)
+    for _ in range(10):
+        if is_trading_day(d):
+            return d.strftime("%Y-%m-%d")
+        d -= timedelta(days=1)
+    raise RuntimeError(
+        f"Could not find a trading day in the 10 calendar days before {ref.date()} — "
+        f"trading_calendar.is_trading_day appears broken or NYSE has been closed for >1 week."
+    )
+
+
+def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
+    """Morning polygon enrichment: overwrite the prior trading day's parquet
+    + ArcticDB row with polygon's authoritative OHLCV+VWAP.
+
+    Called by the new MorningEnrich Lambda step in the weekday SF (and
+    available via --morning-enrich for backfills). Hard-fails on any polygon
+    failure — predictor inference reads ArcticDB right after this runs and
+    must see polygon-corrected data, not silently-stale yfinance values.
+
+    Skips the feature_store snapshot step (that already ran with yfinance EOD;
+    re-running it is expensive and the polygon delta on OHLCV is typically <1%).
+    daily_append's per-ticker compute_features call recomputes per-ticker
+    features inside ArcticDB based on the polygon-overwritten row, which is
+    what downstream consumers actually read.
+    """
+    bucket = config["bucket"]
+    target_date = args.date or _previous_trading_day()
+    dry_run = args.dry_run
+    daily_cfg = config.get("daily_closes", {})
+
+    results: dict = {
+        "mode": "morning_enrich",
+        "date": target_date,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "collectors": {},
+    }
+
+    # Reuse the same ticker-loading logic as _run_daily so the polygon overwrite
+    # covers exactly the same universe.
+    tickers: list[str] = []
+    market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
+    try:
+        existing = constituents.load_from_s3(bucket, market_prefix)
+        if existing:
+            tickers = existing.get("tickers", [])
+            logger.info("Loaded %d tickers from S3 constituents", len(tickers))
+    except Exception as exc:
+        logger.warning("S3 constituents load failed — will try Wikipedia fallback: %s", exc)
+    if not tickers:
+        try:
+            tickers, _, _, _, _ = constituents._fetch_constituents()
+            logger.info("Loaded %d tickers from Wikipedia (S3 fallback)", len(tickers))
+        except Exception as exc:
+            logger.error("Wikipedia constituents fallback failed: %s", exc)
+
+    if not tickers:
+        logger.error("No tickers available for morning enrichment")
+        results["status"] = "failed"
+        return results
+
+    MACRO_DAILY_TICKERS = [
+        "SPY", "GLD", "USO",
+        "XLB", "XLC", "XLE", "XLF", "XLI", "XLK",
+        "XLP", "XLRE", "XLU", "XLV", "XLY",
+        "^VIX", "^VIX3M", "^TNX", "^IRX",
+    ]
+    tickers = list(dict.fromkeys(tickers + MACRO_DAILY_TICKERS))
+
+    logger.info("=" * 60)
+    logger.info("MORNING ENRICH: polygon overwrite for %s (prior trading day)", target_date)
+    logger.info("=" * 60)
+    try:
+        dc_result = daily_closes.collect(
+            bucket=bucket,
+            tickers=tickers,
+            run_date=target_date,
+            s3_prefix=daily_cfg.get("s3_prefix", "predictor/daily_closes/"),
+            dry_run=dry_run,
+            source="polygon_only",
+        )
+        results["collectors"]["daily_closes"] = dc_result
+    except Exception as e:
+        logger.exception("Morning polygon enrichment failed for %s", target_date)
+        results["collectors"]["daily_closes"] = {"status": "error", "error": str(e)}
+        results["status"] = "failed"
+        results["completed_at"] = datetime.now(timezone.utc).isoformat()
+        return results
+
+    # ── Re-append to ArcticDB so the polygon-overwritten row replaces the
+    # yfinance row written at EOD. universe_lib.update() is idempotent for
+    # same-date overwrites (see daily_append.py:232-242 for the design intent).
+    logger.info("=" * 60)
+    logger.info("APPENDING: ArcticDB universe (morning enrich, %s)", target_date)
+    logger.info("=" * 60)
+    try:
+        from builders.daily_append import daily_append
+        arctic_result = daily_append(
+            date_str=target_date,
+            bucket=bucket,
+            dry_run=dry_run,
+        )
+        results["collectors"]["arcticdb"] = arctic_result
+    except Exception as e:
+        logger.exception("ArcticDB daily_append (morning enrich) failed for %s", target_date)
+        results["collectors"]["arcticdb"] = {"status": "error", "error": str(e)}
+
+    results["completed_at"] = datetime.now(timezone.utc).isoformat()
+    statuses = [r.get("status", "unknown") for r in results["collectors"].values()]
+    results["status"] = "ok" if all(s in ("ok", "ok_dry_run") for s in statuses) else "failed"
+
+    duration = ""
+    try:
+        start = datetime.fromisoformat(results["started_at"])
+        end = datetime.fromisoformat(results["completed_at"])
+        duration = f" in {(end - start).total_seconds():.0f}s"
+    except Exception:
+        pass
+    logger.info(
+        "Morning enrichment %s for %s: %s%s",
+        results["status"].upper(), target_date,
+        ", ".join(f"{k}={v.get('status', '?')}" for k, v in results["collectors"].items()),
+        duration,
+    )
+    return results
+
+
 def _run_daily(config: dict, args: argparse.Namespace) -> dict:
     """Daily mode: capture today's OHLCV closes for all tracked tickers."""
     bucket = config["bucket"]
@@ -452,12 +596,18 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
     logger.info("=" * 60)
     dc_started_at = datetime.now(timezone.utc)
     try:
+        # EOD pass uses yfinance_only — polygon free-tier 403's same-day, and
+        # silently substituting yfinance was the 2026-04-17 → 2026-04-23 VWAP
+        # outage. Morning polygon_only enrichment (separate SF step) fills VWAP
+        # the next morning by overwriting these rows with polygon's authoritative
+        # OHLCV+VWAP. See module docstring on collectors/daily_closes.py.
         dc_result = daily_closes.collect(
             bucket=bucket,
             tickers=tickers,
             run_date=run_date,
             s3_prefix=daily_cfg.get("s3_prefix", "predictor/daily_closes/"),
             dry_run=dry_run,
+            source="yfinance_only",
         )
         results["collectors"]["daily_closes"] = dc_result
     except Exception as e:
@@ -776,7 +926,13 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--date", default=None, help="Override run date (YYYY-MM-DD)")
     parser.add_argument(
         "--daily", action="store_true",
-        help="Daily mode: capture today's OHLCV closes for all tickers.",
+        help="Daily mode: capture today's OHLCV closes for all tickers (yfinance-only EOD pass).",
+    )
+    parser.add_argument(
+        "--morning-enrich", dest="morning_enrich", action="store_true",
+        help="Morning polygon enrichment: overwrite the prior trading day's parquet + ArcticDB row "
+             "with polygon's authoritative OHLCV+VWAP. Hard-fails on polygon failure (no yfinance "
+             "fallback). --date overrides which trading day to enrich (default: previous trading day).",
     )
     parser.add_argument(
         "--phase", type=int, choices=[1, 2], default=None,
@@ -827,7 +983,12 @@ def main() -> None:
     # Pre-flight: fail fast on env / connectivity drift before starting
     # the real collection work. See alpha-engine-lib/README.md.
     from preflight import DataPreflight
-    mode = "daily" if args.daily else f"phase{args.phase or 1}"
+    if getattr(args, "morning_enrich", False):
+        mode = "daily"  # same dep footprint: constituents + polygon + arcticdb
+    elif args.daily:
+        mode = "daily"
+    else:
+        mode = f"phase{args.phase or 1}"
     DataPreflight(config["bucket"], mode).run()
 
     results = run_weekly(config, args)


### PR DESCRIPTION
## Summary

Splits the current daily OHLCV collection into two passes by data source, fixing the 2026-04-17 → 2026-04-23 silent VWAP outage where every weekday wrote `VWAP=None` for every stock in ArcticDB.

**Root cause** (proven from `/var/log/daily-data.log` on ae-trading): polygon free-tier returns 403 "before end of day" when called at 1:05 PM PT, the collector logged a warning and silently fell through to yfinance, yfinance writes `VWAP=None` per `feedback_no_silent_fails` → ArcticDB's VWAP column was universally null across the affected window even though daily_append reported success each day.

**This PR (Phase 1 of the fix):**
- `polygon_client._get`: raise `PolygonForbiddenError` on 403 instead of returning empty dict (silent-fail violation)
- (Subsequent commits will follow on this branch — see Plan below)

## Plan (subsequent commits land here as draft → flipped to ready)

- [x] **Phase 1** — `polygon_client` raises on 403 + tests
- [ ] **Phase 2** — `collectors/daily_closes.py` adds `--source {yfinance_only,polygon_only,auto}` mode. yfinance_only (EOD pass) skips polygon entirely. polygon_only (morning pass) hard-fails on `PolygonForbiddenError`, no yfinance fallback for stocks. polygon_only also overwrites existing parquets and logs Close-discrepancy vs prior yfinance row.
- [ ] **Phase 3** — `weekly_collector.py` routes `--daily` to `--source yfinance_only` and adds new `--morning-enrich` mode that runs polygon-only daily_closes + daily_append for the previous trading day.
- [ ] **Phase 4** — `builders/daily_append.py` docstring fix (lines 82-86 incorrectly claim VWAP falls back to (H+L+C)/3 proxy; collector explicitly refuses that proxy per the 2026-04-17 decision).
- [ ] **Phase 5** — Tests for Phases 2–4.

## Sequencing with PR 2 (separate)

PR 2 in this repo (forthcoming) will wire the two modes into the existing Step Functions — EOD SF runs `--daily` (yfinance), weekday SF gets a new `MorningEnrich` Lambda step that runs `--morning-enrich` before `PredictorInference`. Once both PRs are deployed:
- `alpha-engine` `alpha-engine-daily-data.timer` systemd unit gets removed (no more EC2 timer racing the SF — see task #6 closure)
- A one-shot historical backfill repairs ArcticDB rows for 2026-04-17 → today by re-running `--morning-enrich --date <D>` per weekday

## Test plan

- [x] `tests/test_polygon_client.py` — 7 tests pass, including 3 new ones covering the 403 raise contract
- [ ] After Phase 2: `tests/test_daily_closes_*` regression + new `--source` mode tests
- [ ] After Phase 3: `tests/test_weekly_collector_morning_enrich.py` (new) — finds previous trading day correctly across weekends + holidays
- [ ] Manual: `python weekly_collector.py --morning-enrich --date 2026-04-23 --dry-run` should make exactly one polygon call (no yfinance fallthrough) and report a discrepancy summary vs the existing yfinance parquet

🤖 Generated with [Claude Code](https://claude.com/claude-code)