### PR TITLE
weekday SF: add MorningEnrich step (polygon overwrite before predictor inference)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1,5 +1,5 @@
 {
-  "Comment": "Alpha Engine Weekday Pipeline — predictor inference and executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). DailyData moved to post-close (1:05 PM PT) systemd timer on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only.",
+  "Comment": "Alpha Engine Weekday Pipeline — morning polygon enrichment, predictor inference, executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). MorningEnrich (added 2026-04-24) overwrites the prior trading day's ArcticDB row with polygon's authoritative OHLCV+VWAP before predictor inference reads it — fixes the 2026-04-17→2026-04-23 silent VWAP outage where the EOD yfinance pass was the only source. EOD yfinance collection runs via the post-close EOD SF on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only.",
   "StartAt": "InitializeInput",
   "States": {
 
@@ -154,10 +154,95 @@
               "StringMatches": "*TRADING DAY*"
             }
           ],
-          "Next": "PredictorInference"
+          "Next": "MorningEnrich"
         }
       ],
       "Default": "TradingDayCheckFailed"
+    },
+
+    "MorningEnrich": {
+      "Type": "Task",
+      "Comment": "Polygon morning enrichment — overwrites the prior trading day's daily_closes parquet + ArcticDB row with polygon's authoritative OHLCV+VWAP. Hard-fails on PolygonForbiddenError (no yfinance fallback masks polygon outages). Predictor inference reads ArcticDB right after this step and must see polygon-corrected data, so failure → HandleFailure (do NOT proceed to PredictorInference with stale yfinance values). See alpha-engine-data/collectors/daily_closes.py for source-mode contract.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "cd /home/ec2-user/alpha-engine-data",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "python weekly_collector.py --morning-enrich 2>&1 | tee -a /var/log/morning-enrich.log"
+          ],
+          "executionTimeout": ["720"]
+        },
+        "TimeoutSeconds": 720
+      },
+      "TimeoutSeconds": 780,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.morning_enrich_result",
+      "Next": "WaitForMorningEnrich"
+    },
+
+    "WaitForMorningEnrich": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.morning_enrich_result.Command.CommandId",
+        "InstanceId.$": "$.trading_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.morning_enrich_poll",
+      "Next": "CheckMorningEnrichStatus"
+    },
+
+    "CheckMorningEnrichStatus": {
+      "Type": "Choice",
+      "Comment": "Block predictor inference until polygon enrichment confirms the prior trading day's row is overwritten with authoritative VWAP. SSM Failed → HandleFailure (must not proceed to inference on uncorrected data per feedback_no_silent_fails).",
+      "Choices": [
+        {
+          "Variable": "$.morning_enrich_poll.Status",
+          "StringEquals": "Success",
+          "Next": "PredictorInference"
+        },
+        {
+          "Variable": "$.morning_enrich_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "MorningEnrichWait"
+        },
+        {
+          "Variable": "$.morning_enrich_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "MorningEnrichWait"
+        }
+      ],
+      "Default": "HandleFailure"
+    },
+
+    "MorningEnrichWait": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "WaitForMorningEnrich"
     },
 
     "TradingDayCheckWait": {
@@ -168,7 +253,7 @@
 
     "TradingDayCheckFailed": {
       "Type": "Task",
-      "Comment": "Trading day check failed for infrastructure reasons — alert and proceed (assume trading day)",
+      "Comment": "Trading day check failed for infrastructure reasons — alert and proceed (assume trading day). Routes to MorningEnrich same as the trading-day success path; predictor inference still gated on enrichment success.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
@@ -176,7 +261,7 @@
         "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. State: {}', States.JsonToString($))"
       },
       "ResultPath": "$.trading_day_error_notify",
-      "Next": "PredictorInference"
+      "Next": "MorningEnrich"
     },
 
     "StopExecutorOnHoliday": {

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1,27 +1,28 @@
 {
-  "Comment": "Alpha Engine EOD Pipeline — post-market data capture (yfinance OHLCV, VWAP=NaN), reconciliation, instance shutdown. Triggered by daemon shutdown on ae-trading. PostMarketData runs the FULL daily flow (closes + features + ArcticDB append) so this SF is now the sole canonical EOD path — the alpha-engine-daily-data systemd timer was deleted as part of the same change. Daily VWAP gets filled the next morning by the weekday SF's MorningEnrich step (polygon overwrite).",
+  "Comment": "Alpha Engine EOD Pipeline — post-market data capture, reconciliation, instance shutdown. Triggered by daemon shutdown on trading EC2.",
   "StartAt": "PostMarketData",
   "States": {
 
     "PostMarketData": {
       "Type": "Task",
-      "Comment": "Run the full daily flow on ae-trading: yfinance-only daily_closes, feature store snapshot, ArcticDB daily_append. Replaced the prior split-command pattern (closes + append separately) after PR 1 unified --daily under source=yfinance_only. Runs on ae-trading (was micro pre-2026-04-24) so the t3.small RAM avoids the 2026-04-16 OOM regression that originally moved DailyData off the micro instance.",
+      "Comment": "Capture today's closing prices from polygon + append to ArcticDB (runs on micro EC2)",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.trading_instance_id",
+        "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "commands": [
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
-            "python weekly_collector.py --daily 2>&1 | tee -a /var/log/postmarket-data.log"
+            "python weekly_collector.py --daily --only daily_closes 2>&1 | tee /var/log/postmarket-data.log",
+            "python -m builders.daily_append 2>&1 | tee -a /var/log/postmarket-data.log"
           ],
-          "executionTimeout": ["720"]
+          "executionTimeout": ["180"]
         },
-        "TimeoutSeconds": 720
+        "TimeoutSeconds": 180
       },
-      "TimeoutSeconds": 780,
+      "TimeoutSeconds": 240,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],
@@ -47,7 +48,7 @@
       "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
       "Parameters": {
         "CommandId.$": "$.postmarket_result.Command.CommandId",
-        "InstanceId.$": "$.trading_instance_id[0]"
+        "InstanceId.$": "$.ec2_instance_id[0]"
       },
       "Retry": [
         {

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1,28 +1,27 @@
 {
-  "Comment": "Alpha Engine EOD Pipeline — post-market data capture, reconciliation, instance shutdown. Triggered by daemon shutdown on trading EC2.",
+  "Comment": "Alpha Engine EOD Pipeline — post-market data capture (yfinance OHLCV, VWAP=NaN), reconciliation, instance shutdown. Triggered by daemon shutdown on ae-trading. PostMarketData runs the FULL daily flow (closes + features + ArcticDB append) so this SF is now the sole canonical EOD path — the alpha-engine-daily-data systemd timer was deleted as part of the same change. Daily VWAP gets filled the next morning by the weekday SF's MorningEnrich step (polygon overwrite).",
   "StartAt": "PostMarketData",
   "States": {
 
     "PostMarketData": {
       "Type": "Task",
-      "Comment": "Capture today's closing prices from polygon + append to ArcticDB (runs on micro EC2)",
+      "Comment": "Run the full daily flow on ae-trading: yfinance-only daily_closes, feature store snapshot, ArcticDB daily_append. Replaced the prior split-command pattern (closes + append separately) after PR 1 unified --daily under source=yfinance_only. Runs on ae-trading (was micro pre-2026-04-24) so the t3.small RAM avoids the 2026-04-16 OOM regression that originally moved DailyData off the micro instance.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.ec2_instance_id",
+        "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
           "commands": [
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
-            "python weekly_collector.py --daily --only daily_closes 2>&1 | tee /var/log/postmarket-data.log",
-            "python -m builders.daily_append 2>&1 | tee -a /var/log/postmarket-data.log"
+            "python weekly_collector.py --daily 2>&1 | tee -a /var/log/postmarket-data.log"
           ],
-          "executionTimeout": ["180"]
+          "executionTimeout": ["720"]
         },
-        "TimeoutSeconds": 180
+        "TimeoutSeconds": 720
       },
-      "TimeoutSeconds": 240,
+      "TimeoutSeconds": 780,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],
@@ -48,7 +47,7 @@
       "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
       "Parameters": {
         "CommandId.$": "$.postmarket_result.Command.CommandId",
-        "InstanceId.$": "$.ec2_instance_id[0]"
+        "InstanceId.$": "$.trading_instance_id[0]"
       },
       "Retry": [
         {


### PR DESCRIPTION
## Summary

Adds a single new step (`MorningEnrich`) to the weekday Step Function that runs `python weekly_collector.py --morning-enrich` on ae-trading between the trading-day check and `PredictorInference`.

The morning enrichment finds the previous trading day, fetches polygon's grouped-daily for it (hard-fails on `PolygonForbiddenError` — no yfinance fallback), and re-runs `daily_append` to overwrite the prior day's ArcticDB row with polygon's authoritative OHLCV+VWAP. Predictor inference is gated on this succeeding — failure routes to `HandleFailure`, not silent inference on uncorrected data.

This closes the operational loop on the 2026-04-17→2026-04-23 silent VWAP outage where the EOD yfinance pass was the only source.

## Why no other changes

Earlier in the design conversation we discussed deleting the alpha-engine-daily-data systemd timer + retargeting the EOD SF from micro to ae-trading. Both ideas were based on the assumption that the EOD SF was the operational EOD path. **That's no longer true** — alpha-engine PR #94 (2026-04-22) removed `_trigger_eod_pipeline` from `executor/daemon.py`, leaving the EOD SF as a manual-only disaster-recovery artifact. The actual canonical EOD flow is:

- 1:05 PM PT — `alpha-engine-daily-data.timer` (systemd) runs `weekly_collector.py --daily` on ae-trading. After PR #90 lands, this is the yfinance-only EOD pass.
- 1:20 PM PT — `alpha-engine-eod.timer` (systemd) runs `executor/eod_reconcile.py` directly.

The systemd timer + the morning SF step give us the full split-by-source flow with no race. So this PR doesn't touch the systemd units OR the EOD SF — they're either operationally correct already or non-operational.

## Sequencing

1. Merge this PR
2. Run `infrastructure/deploy_step_function_daily.sh` to deploy the SF JSON
3. Verify on Monday's 6:05 AM PT run: MorningEnrich logs show polygon overwrite, ArcticDB has VWAP populated for Friday
4. One-shot historical backfill: `for D in 2026-04-17 2026-04-20 2026-04-21 2026-04-22 2026-04-23 2026-04-24; do python weekly_collector.py --morning-enrich --date $D; done` on ae-trading to repair the affected window

## Test plan

- [x] Both SF JSONs parse cleanly (json.load smoke)
- [x] 153/153 alpha-engine-data unit tests pass
- [ ] After merge + deploy: the next weekday SF run shows MorningEnrich firing successfully
- [ ] Verify ArcticDB row for previous trading day has VWAP populated post-MorningEnrich

🤖 Generated with [Claude Code](https://claude.com/claude-code)