### PR TITLE
feat(sf): retire dedicated Evaluator states, consolidate into Backtester

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -393,14 +393,14 @@
 
     "CheckSkipBacktester": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses the backtester and jumps to Evaluator's skip-gate.",
+      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses the backtester step (which runs backtest + parity + evaluator as consolidated spot stages post-2026-04-24) and jumps directly to the Saturday health check. The legacy {\"skip_evaluator\": true} and {\"freeze_evaluator\": true} inputs are no longer honored; freeze-evaluator is now a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_backtester", "IsPresent": true},
             {"Variable": "$.skip_backtester", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipEvaluator"
+          "Next": "SaturdayHealthCheck"
         }
       ],
       "Default": "Backtester"
@@ -408,7 +408,7 @@
 
     "Backtester": {
       "Type": "Task",
-      "Comment": "Signal quality + param optimization on spot instance (after predictor training)",
+      "Comment": "Consolidated backtest + parity + evaluator on spot instance (after predictor training). Post-2026-04-24 spot_backtest.sh runs all three stages in sequence; the previous dedicated Evaluator SF state was retired. Evaluator runs in live-apply mode by default (no --freeze-evaluator flag passed); for diagnostic-only off-cycle runs, invoke spot_backtest.sh manually with --freeze-evaluator and --skip-stages=backtest,parity.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -480,7 +480,7 @@
         {
           "Variable": "$.backtester_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipEvaluator"
+          "Next": "SaturdayHealthCheck"
         },
         {
           "Variable": "$.backtester_poll.Status",
@@ -500,186 +500,6 @@
       "Type": "Wait",
       "Seconds": 60,
       "Next": "WaitForBacktester"
-    },
-
-    "CheckSkipEvaluator": {
-      "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_evaluator\": true} bypasses the evaluator and jumps to the Saturday health check. SaturdayHealthCheck is always run.",
-      "Choices": [
-        {
-          "And": [
-            {"Variable": "$.skip_evaluator", "IsPresent": true},
-            {"Variable": "$.skip_evaluator", "BooleanEquals": true}
-          ],
-          "Next": "SaturdayHealthCheck"
-        }
-      ],
-      "Default": "CheckEvaluatorFreeze"
-    },
-
-    "CheckEvaluatorFreeze": {
-      "Type": "Choice",
-      "Comment": "Freeze-gate. {\"freeze_evaluator\": true} routes to EvaluatorFrozen (--freeze flag suppresses per-optimizer S3 config writes; report artifacts + email still upload). Use for off-cycle test runs so mid-week sweeps don't auto-promote weights/params/thresholds against Monday trading.",
-      "Choices": [
-        {
-          "And": [
-            {"Variable": "$.freeze_evaluator", "IsPresent": true},
-            {"Variable": "$.freeze_evaluator", "BooleanEquals": true}
-          ],
-          "Next": "EvaluatorFrozen"
-        }
-      ],
-      "Default": "Evaluator"
-    },
-
-    "EvaluatorFrozen": {
-      "Type": "Task",
-      "Comment": "Frozen evaluator — same runtime as Evaluator but with --freeze. Per-optimizer config writes (scoring_weights.json, executor_params.json, predictor_params.json, etc.) are skipped; apply_result reports 'frozen (--freeze flag)'. Report CSVs + markdown + email still upload via --upload.",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-      "Parameters": {
-        "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.ec2_instance_id",
-        "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "export HOME=/home/ec2-user",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-backtester",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
-            "python evaluate.py --mode all --upload --freeze --log-level INFO 2>&1 | tee /var/log/evaluator.log"
-          ],
-          "executionTimeout": ["1800"]
-        },
-        "TimeoutSeconds": 1800
-      },
-      "TimeoutSeconds": 1860,
-      "Retry": [
-        {
-          "ErrorEquals": ["States.TaskFailed"],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 30,
-          "BackoffRate": 1.0
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "HandleFailure",
-          "ResultPath": "$.error"
-        }
-      ],
-      "ResultPath": "$.evaluator_result",
-      "Next": "WaitForEvaluator"
-    },
-
-    "Evaluator": {
-      "Type": "Task",
-      "Comment": "Signal quality, attribution, grading, config optimization. Runs on always-on EC2 (not spot) — reads simulation artifacts from S3. Split from Backtester step on 2026-04-12 so eval can run at a different cadence.",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-      "Parameters": {
-        "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.ec2_instance_id",
-        "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "export HOME=/home/ec2-user",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-backtester",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
-            "python evaluate.py --mode all --upload --log-level INFO 2>&1 | tee /var/log/evaluator.log"
-          ],
-          "executionTimeout": ["1800"]
-        },
-        "TimeoutSeconds": 1800
-      },
-      "TimeoutSeconds": 1860,
-      "Retry": [
-        {
-          "ErrorEquals": ["States.TaskFailed"],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 30,
-          "BackoffRate": 1.0
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "HandleFailure",
-          "ResultPath": "$.error"
-        }
-      ],
-      "ResultPath": "$.evaluator_result",
-      "Next": "WaitForEvaluator"
-    },
-
-    "WaitForEvaluator": {
-      "Type": "Task",
-      "Comment": "Poll SSM command until evaluator complete",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-      "Parameters": {
-        "CommandId.$": "$.evaluator_result.Command.CommandId",
-        "InstanceId.$": "$.ec2_instance_id[0]"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
-          "MaxAttempts": 10,
-          "IntervalSeconds": 10,
-          "BackoffRate": 1.5
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "HandleFailure",
-          "ResultPath": "$.error"
-        }
-      ],
-      "ResultPath": "$.evaluator_poll",
-      "Next": "CheckEvaluatorStatus"
-    },
-
-    "CheckEvaluatorStatus": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.evaluator_poll.Status",
-          "StringEquals": "Success",
-          "Next": "SaturdayHealthCheck"
-        },
-        {
-          "Variable": "$.evaluator_poll.Status",
-          "StringEquals": "InProgress",
-          "Next": "EvaluatorWait"
-        },
-        {
-          "Variable": "$.evaluator_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "EvaluatorWait"
-        }
-      ],
-      "Default": "ExtractEvaluatorError"
-    },
-
-    "EvaluatorWait": {
-      "Type": "Wait",
-      "Seconds": 15,
-      "Next": "WaitForEvaluator"
-    },
-
-    "ExtractEvaluatorError": {
-      "Type": "Pass",
-      "Comment": "Normalize Evaluator SSM non-Success poll into $.error.",
-      "Result": {},
-      "ResultPath": "$.error",
-      "Parameters": {
-        "phase": "Evaluator",
-        "source": "CheckEvaluatorStatus.Default",
-        "poll.$": "$.evaluator_poll"
-      },
-      "Next": "HandleFailure"
     },
 
     "SaturdayHealthCheck": {


### PR DESCRIPTION
## Summary
Consolidates the 8-state dedicated Evaluator subflow into the Backtester step. Spot becomes the authoritative runner for backtest + parity + evaluator as a single atomic SSM command.

## Deleted states (180 lines)
- `CheckSkipEvaluator`
- `CheckEvaluatorFreeze`
- `EvaluatorFrozen`
- `Evaluator`
- `WaitForEvaluator`
- `CheckEvaluatorStatus`
- `EvaluatorWait`
- `ExtractEvaluatorError`

## Rewired transitions
- `CheckSkipBacktester` skip path: `CheckSkipEvaluator` → `SaturdayHealthCheck`
- `CheckBacktesterStatus` success path: `CheckSkipEvaluator` → `SaturdayHealthCheck`

## Motivation
The Evaluator was originally split from Backtester on 2026-04-12 "so eval can run at a different cadence." In production it has only ever run as the Sat SF tail — the cadence flexibility was never exercised. The split cost 2× IAM/SSM/CloudWatch wiring, 2× venv drift surface, and ~3–5 min of extra wall-clock per run for a capability that wasn't used.

Cadence flexibility is a trigger-side question (add an EventBridge rule → SSM or → `spot_backtest.sh --skip-stages=backtest,parity`, ~15 min of CF work) rather than a pipeline-shape question. Consolidating doesn't remove that flexibility — it just decouples it from the weekly shape.

## Breaking input-contract changes
- `skip_evaluator: true` — no longer honored (use `skip_backtester: true` to skip all three stages)
- `freeze_evaluator: true` — no longer honored (use `--freeze-evaluator` on `spot_backtest.sh` manually)
- `skip_backtester: true` — now skips evaluator too (previously ran evaluator on old artifacts via `CheckSkipEvaluator` side-path)

## Coordination
Coordinated with **alpha-engine-backtester PR #74** — `spot_backtest.sh` gains `--skip-stages` + `--freeze-evaluator` + evaluator as 3rd default-on stage.

**Deploy sequencing** (order matters):
1. Merge alpha-engine-backtester PR #74
2. Merge this PR
3. Run `bash infrastructure/deploy-infrastructure.sh` from always-on EC2 or laptop

If reversed: next Sat SF hits old `spot_backtest.sh` (no evaluator stage) + new SF (no dedicated step) → no evaluator run that week.

## Validation
- [x] `python3 -m json.tool` — valid JSON
- [x] 0 dangling references to deleted states (verified via grep)
- [x] Line count: 824 → 644 (-180)
- [ ] Deploy-infrastructure.sh dry-run
- [ ] First Sat SF run with consolidated shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)