### PR TITLE
feat(alarms): CloudWatch alarm on AlphaEngine.ParityTestFailure metric

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -297,6 +297,42 @@ Resources:
       AlarmActions:
         - !Ref AlertsTopic
 
+  # Parity-test divergence alarm — pairs with the backtester spot stage's
+  # AlphaEngine.ParityTestFailure metric (emitted by infrastructure/spot_backtest.sh
+  # on every Saturday SF run; value=1 on parity failure, value=0 on pass).
+  #
+  # Parity is a diagnostic gate post-2026-04-24 soft-fail consolidation:
+  # the backtester ↔ executor replay diff is reported but does NOT block the
+  # downstream evaluator stage. This alarm gives parity its own alerting
+  # channel so divergence is visible without conflating with real pipeline
+  # failures (which still fire alpha-engine-saturday-sf-failed).
+  #
+  # Investigation entry point on alarm: review
+  #   s3://alpha-engine-research/backtest/{run_date}/parity_report.json
+  # for trade_count / ticker_set / field-level violations. Common causes:
+  # date-tagging drift (DATE_CONVENTIONS migration not yet complete),
+  # universe-drop tickers in historical signals, score-data scrubbing.
+  ParityTestFailure:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alpha-engine-parity-test-failure
+      AlarmDescription: |
+        Backtester ↔ executor parity replay detected divergence. Diagnostic
+        only (does not block pipeline). Review parity_report.json in S3.
+      Namespace: AlphaEngine
+      MetricName: ParityTestFailure
+      Dimensions:
+        - Name: Process
+          Value: backtester
+      Statistic: Maximum
+      Period: 3600  # 1 hour — matches UnscoredBuyCandidatesGap pattern
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching  # weekly cadence — off-cycle hours are expected
+      AlarmActions:
+        - !Ref AlertsTopic
+
   # Heartbeat alarms for EC2-based processes
   ExecutorMorningHeartbeat:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Summary
Pairs with [alpha-engine-backtester #78](https://github.com/cipher813/alpha-engine-backtester/pull/78) (parity stage soft-fails). Adds a CloudWatch alarm on the `AlphaEngine.ParityTestFailure` metric so parity divergence has its own dedicated alerting channel.

## Why
Without this alarm, PR #78's soft-fail behavior would create a silent-failure window: parity could fail, the metric would emit, and **no operator would be notified** because no alarm consumes the metric.

This PR closes that window. After deploy:
- Parity failure → metric value=1 emitted → CloudWatch alarm fires → SNS → operator email.
- Parity success → metric value=0 emitted → alarm transitions to OK on next evaluation.
- Off-cycle hours (no Sat SF) → no metric → `notBreaching` (no spurious alerts).

## Alarm shape (matches established `UnscoredBuyCandidatesGap` pattern)

```yaml
AlarmName: alpha-engine-parity-test-failure
Namespace: AlphaEngine
MetricName: ParityTestFailure
Dimensions:
  - Name: Process
    Value: backtester
Statistic: Maximum
Period: 3600  # 1 hour
EvaluationPeriods: 1
Threshold: 1
ComparisonOperator: GreaterThanOrEqualToThreshold
TreatMissingData: notBreaching
AlarmActions: [alpha-engine-alerts SNS topic]
```

## Two-alarm contract (post-deploy)

| Failure type | Alarm |
|--------------|-------|
| Pipeline correctness (backtest crash, evaluator config error) | `alpha-engine-saturday-sf-failed` (existing — fires on SF state failure) |
| Diagnostic divergence (parity) | `alpha-engine-parity-test-failure` (new, this PR) |

Both route to `alpha-engine-alerts` SNS. Operator distinguishes by alarm name — same triage process, separate signals.

## Deploy
Via existing path: `bash infrastructure/deploy-infrastructure.sh`. CF stack update; no Lambda or EC2 changes.

## Test plan
- [x] `aws cloudformation validate-template` passes
- [x] Alarm shape matches existing `UnscoredBuyCandidatesGap` pattern (proven in production)
- [ ] After deploy + alpha-engine-backtester #78 merge: tonight's Sat SF parity failure (expected per ROADMAP P1) emits metric → fires this alarm → operator email arrives
- [ ] Verify alarm transitions to OK on a subsequent successful run (post date-convention migration)

## Sequencing for tonight
1. Merge **alpha-engine-backtester #78** (parity soft-fail, emits metric)
2. Merge **this PR**
3. Run `bash infrastructure/deploy-infrastructure.sh`
4. Sat 00:00 UTC SF: parity reports divergence, doesn't block evaluator/health-check, fires this alarm → email arrives → operator triages via the linked parity_report.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)