### PR TITLE
feat(fundamentals): migrate from FMP /stable to Finnhub /stock/metric

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -254,11 +254,7 @@ _fmp_daily_count = 0
 _FMP_DAILY_LIMIT = 250
 _FMP_MIN_INTERVAL = 1.0
 
-_FINNHUB_BASE = "https://finnhub.io/api/v1"
-_finnhub_lock = threading.Lock()
-_finnhub_last_call = 0.0
-# Finnhub free tier: 60 req/min — give ourselves a small margin.
-_FINNHUB_MIN_INTERVAL = 1.1
+# Finnhub state moved to collectors/finnhub_client.py (2026-04-24).
 
 
 def _fmp_get(endpoint: str, params: dict | None = None) -> dict | list:
@@ -299,31 +295,10 @@ def _fmp_get(endpoint: str, params: dict | None = None) -> dict | list:
     return resp.json()
 
 
-def _finnhub_get(endpoint: str, params: dict | None = None) -> dict | list:
-    """Rate-limited Finnhub API call. Returns ``[]`` on missing key."""
-    global _finnhub_last_call
-    api_key = os.environ.get("FINNHUB_API_KEY", "")
-    if not api_key:
-        return []
-
-    url = f"{_FINNHUB_BASE}/{endpoint}"
-    p = {"token": api_key}
-    if params:
-        p.update(params)
-
-    with _finnhub_lock:
-        now = time.monotonic()
-        wait = _FINNHUB_MIN_INTERVAL - (now - _finnhub_last_call)
-        if wait > 0:
-            time.sleep(wait)
-        _finnhub_last_call = time.monotonic()
-
-    resp = requests.get(url, params=p, timeout=10)
-    if resp.status_code == 429:
-        logger.warning("Finnhub 429 rate-limited on %s", endpoint)
-        return []
-    resp.raise_for_status()
-    return resp.json()
+# Finnhub HTTP client extracted to collectors.finnhub_client (2026-04-24)
+# so fundamentals.py can share the same rate-limited state. Local alias
+# preserves call-site readability without duplicating throttle logic.
+from .finnhub_client import finnhub_get as _finnhub_get  # noqa: E402
 
 
 # ---- 1. Analyst consensus ----

--- a/collectors/finnhub_client.py
+++ b/collectors/finnhub_client.py
@@ -1,0 +1,83 @@
+"""
+collectors/finnhub_client.py — shared rate-limited Finnhub HTTP client.
+
+Extracted from ``collectors/alternative.py`` (2026-04-24) so the
+fundamentals collector can share the same throttle + lock state.
+Without a shared client, two collectors importing private copies of
+the helper would each track their own ``_last_call`` timestamp and
+exceed Finnhub's free-tier rate limit (60 req/min) when the
+DataPhase1 orchestrator runs them sequentially in the same process.
+
+Free-tier rate limit: 60 calls/min. Conservative ``_MIN_INTERVAL = 1.1s``
+gives ~54 calls/min — leaves headroom for clock skew and HTTP latency.
+
+Usage::
+
+    from collectors.finnhub_client import finnhub_get
+
+    payload = finnhub_get("stock/metric", {"symbol": "AAPL", "metric": "all"})
+    if payload:
+        metrics = payload.get("metric", {})
+
+Returns ``[]`` (or empty dict if upstream expects ``dict``) when the API
+key is missing or the call hit a 429 — callers must handle the empty
+response. Other errors (5xx, timeouts) propagate via
+``requests.HTTPError``; callers decide whether to retry, fall through,
+or hard-fail per their no-silent-fails policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_FINNHUB_BASE = "https://finnhub.io/api/v1"
+
+# Module-level state — shared across all callers in the same process.
+_finnhub_lock = threading.Lock()
+_finnhub_last_call = 0.0
+_FINNHUB_MIN_INTERVAL = 1.1  # seconds; ~54 calls/min, under 60/min free-tier ceiling
+
+_TIMEOUT = 10
+
+
+def finnhub_get(endpoint: str, params: dict | None = None) -> dict | list:
+    """Rate-limited Finnhub GET.
+
+    Returns the parsed JSON response (dict for object-shaped endpoints,
+    list for array-shaped endpoints), or ``[]`` if:
+      * ``FINNHUB_API_KEY`` is not set
+      * Finnhub returned a 429 rate-limit response
+
+    Raises ``requests.HTTPError`` on other non-2xx responses (5xx,
+    timeouts). Caller decides retry / fall-through / hard-fail.
+    """
+    global _finnhub_last_call
+    api_key = os.environ.get("FINNHUB_API_KEY", "")
+    if not api_key:
+        return []
+
+    url = f"{_FINNHUB_BASE}/{endpoint}"
+    p = {"token": api_key}
+    if params:
+        p.update(params)
+
+    with _finnhub_lock:
+        now = time.monotonic()
+        wait = _FINNHUB_MIN_INTERVAL - (now - _finnhub_last_call)
+        if wait > 0:
+            time.sleep(wait)
+        _finnhub_last_call = time.monotonic()
+
+    resp = requests.get(url, params=p, timeout=_TIMEOUT)
+    if resp.status_code == 429:
+        logger.warning("Finnhub 429 rate-limited on %s", endpoint)
+        return []
+    resp.raise_for_status()
+    return resp.json()

--- a/collectors/fundamentals.py
+++ b/collectors/fundamentals.py
@@ -1,34 +1,61 @@
 """
-collectors/fundamentals.py — FMP quarterly fundamental data collection.
+collectors/fundamentals.py — Finnhub TTM fundamentals collection.
 
 Fetches P/E, P/B, D/E, revenue growth, FCF yield, gross margin, ROE,
-current ratio for all universe tickers from Financial Modeling Prep.
+current ratio for all universe tickers from Finnhub's
+``/stock/metric?symbol=X&metric=all`` endpoint.
 
 Runs weekly in DataPhase1. Cached to S3 at archive/fundamentals/{date}.json.
 Daily pipeline reads the cached file (fundamentals are quarterly — don't
 change within a week).
 
+Migration history
+-----------------
+- v1: FMP v3 (sunset 2025-08-31).
+- v2: FMP /stable (multi-endpoint: key-metrics-ttm + ratios-ttm + income-statement).
+- v3 (this file, 2026-04-24): Finnhub /stock/metric?metric=all — single
+  endpoint replaces the three FMP calls; FMP /stable moved to paid tier
+  on key-metrics-ttm (HTTP 402 observed 2026-04-24 Sat SF run).
+
 Endpoint contract
 -----------------
-FMP sunset the v3 API on 2025-08-31. All calls target the `/stable`
-endpoint with query-string tickers, e.g.:
+Single Finnhub call per ticker::
 
-    /stable/key-metrics-ttm?symbol=AAPL   # FCF yield, current ratio, ROE
-    /stable/ratios-ttm?symbol=AAPL        # P/E, P/B, debt/equity
-    /stable/income-statement?symbol=AAPL&period=quarter&limit=5
+    /stock/metric?symbol=AAPL&metric=all
 
-v3 crammed P/E / P/B / D/E into ``key-metrics-ttm`` alongside the
-efficiency ratios; /stable split them across two endpoints and renamed
-a few fields (``roeTTM`` → ``returnOnEquityTTM``).
+Response shape::
+
+    {
+      "metric": {
+        "peTTM": ..., "pbAnnual": ..., "totalDebt/totalEquityAnnual": ...,
+        "revenueGrowthTTMYoy": ..., "freeCashFlowTTM": ...,
+        "marketCapitalization": ..., "grossMarginTTM": ...,
+        "roeTTM": ..., "currentRatioAnnual": ...,
+        ...
+      },
+      "metricType": "all",
+      "symbol": "AAPL"
+    }
+
+FCF yield isn't directly exposed; computed as ``freeCashFlowTTM /
+marketCapitalization``. Other fields map 1-to-1 to Finnhub names with
+TTM-preferred / annual-fallback semantics for fields where TTM may be
+missing for newer listings.
+
+Rate limiting
+-------------
+Finnhub free tier is 60 req/min. The shared client in
+``collectors.finnhub_client`` enforces a 1.1s minimum interval between
+calls (~54/min). 903 universe tickers × 1 call each = ~17 min total —
+well within DataPhase1's 30-min budget.
 
 Failure semantics
 -----------------
 Per-ticker errors are logged at WARNING and fall through to NEUTRAL
 values, but the collector hard-fails (``status="error"``) if fewer than
-``_MIN_OK_RATIO`` of tickers produced real (non-NEUTRAL) data — which
-catches a recurrence of the silent-zeros bug that went undetected for
-two weeks in April 2026 when the v3 endpoints started returning 403.
-Matches the ``short_interest`` collector's guard.
+``_MIN_OK_RATIO`` of tickers produced real (non-NEUTRAL) data — catches
+silent zero outputs (matches the short_interest collector's guard,
+matches the original FMP version's no-silent-fails behavior).
 """
 
 from __future__ import annotations
@@ -38,30 +65,16 @@ import logging
 import os
 import time
 
-import requests
+from .finnhub_client import finnhub_get
 
 logger = logging.getLogger(__name__)
 
-_FMP_BASE = "https://financialmodelingprep.com/stable"
-_TIMEOUT = 10
-_RATE_LIMIT_DELAY = 0.25  # 4 req/sec
-
 # Minimum fraction of requested tickers that must produce real fundamentals
 # (at least one non-zero field) for the run to be considered OK. Below
-# this threshold the endpoint is probably broken (sunsetted, paid-tier,
-# quota hit) — don't let a silently-zeroed output flow into the predictor
+# this threshold the endpoint is probably broken (auth, quota, schema
+# change) — don't let a silently-zeroed output flow into the predictor
 # feature store and research scoring.
 _MIN_OK_RATIO = 0.90
-
-
-def _fmp_get(endpoint: str, api_key: str, params: dict | None = None) -> dict | list:
-    url = f"{_FMP_BASE}/{endpoint}"
-    p = {"apikey": api_key}
-    if params:
-        p.update(params)
-    resp = requests.get(url, params=p, timeout=_TIMEOUT)
-    resp.raise_for_status()
-    return resp.json()
 
 
 def _safe_float(val, default: float = 0.0) -> float:
@@ -77,7 +90,23 @@ def _clip(val: float, lo: float, hi: float) -> float:
     return max(lo, min(hi, val))
 
 
-# Neutral values for tickers where FMP returns nothing
+def _pick(metrics: dict, *keys: str, default: float = 0.0) -> float:
+    """Return the first key with a non-None value, as a float.
+
+    Finnhub exposes most fields with both TTM and Annual variants;
+    callers list TTM first and fall through to Annual / Quarterly when
+    a field isn't populated for the given ticker (newer listings, ADRs,
+    etc.). The same pattern in the legacy FMP collector accepted both
+    ``returnOnEquityTTM`` and ``roeTTM`` for forward compatibility —
+    Finnhub's schema is similar but with different naming.
+    """
+    for key in keys:
+        if key in metrics and metrics[key] is not None:
+            return _safe_float(metrics[key], default=default)
+    return default
+
+
+# Neutral values for tickers where Finnhub returns nothing usable
 NEUTRAL = {
     "pe_ratio": 0.0,
     "pb_ratio": 0.0,
@@ -90,62 +119,73 @@ NEUTRAL = {
 }
 
 
-def _fetch_single_ticker(ticker: str, api_key: str) -> dict:
-    """Fetch and normalize fundamental data for a single ticker."""
-    metrics = _fmp_get("key-metrics-ttm", api_key, params={"symbol": ticker})
-    time.sleep(_RATE_LIMIT_DELAY)
+def _fetch_single_ticker(ticker: str) -> dict:
+    """Fetch and normalize fundamental data for a single ticker via Finnhub.
 
-    if not isinstance(metrics, list) or not metrics:
+    One round-trip replaces the three-endpoint FMP version. Unrecognized
+    or missing tickers (delisted, ADRs without coverage, etc.) return
+    NEUTRAL — same shape as before so downstream consumers don't change.
+    """
+    payload = finnhub_get("stock/metric", {"symbol": ticker, "metric": "all"})
+    if not isinstance(payload, dict):
         return NEUTRAL.copy()
 
-    m = metrics[0]
-    # roeTTM renamed on /stable. Accept both for forward-compat.
-    roe_raw = _safe_float(m.get("returnOnEquityTTM") or m.get("roeTTM"))
-    fcf_yield_raw = _safe_float(m.get("freeCashFlowYieldTTM"))
-    current_ratio_raw = _safe_float(m.get("currentRatioTTM"))
+    metrics = payload.get("metric") or {}
+    if not isinstance(metrics, dict) or not metrics:
+        return NEUTRAL.copy()
 
-    # P/E, P/B, D/E moved to /stable/ratios-ttm (v3 had them in key-metrics).
-    ratios = _fmp_get("ratios-ttm", api_key, params={"symbol": ticker})
-    time.sleep(_RATE_LIMIT_DELAY)
-    if isinstance(ratios, list) and ratios:
-        r = ratios[0]
-        pe_raw = _safe_float(r.get("priceToEarningsRatioTTM") or r.get("peRatioTTM"))
-        pb_raw = _safe_float(r.get("priceToBookRatioTTM") or r.get("pbRatioTTM"))
-        de_raw = _safe_float(r.get("debtToEquityRatioTTM") or r.get("debtToEquityTTM"))
-    else:
-        pe_raw = pb_raw = de_raw = 0.0
+    # P/E: TTM preferred; peExclExtraTTM smooths special-item noise; annual fallback
+    pe_raw = _pick(metrics, "peTTM", "peExclExtraTTM", "peNormalizedAnnual")
 
-    income = _fmp_get(
-        "income-statement",
-        api_key,
-        params={"symbol": ticker, "period": "quarter", "limit": 5},
+    # P/B: annual is the canonical book-value reference; quarterly fallback for newly-listed
+    pb_raw = _pick(metrics, "pbAnnual", "pbQuarterly")
+
+    # D/E: Finnhub uses literal slash in field name. Quarterly fallback when annual missing.
+    de_raw = _pick(
+        metrics,
+        "totalDebt/totalEquityAnnual",
+        "totalDebt/totalEquityQuarterly",
     )
-    time.sleep(_RATE_LIMIT_DELAY)
 
-    revenue_growth = 0.0
-    gross_margin = 0.0
+    # Revenue growth: TTM YoY preferred; quarterly YoY fallback; 5Y last (smooths cycles).
+    revenue_growth_raw = _pick(
+        metrics,
+        "revenueGrowthTTMYoy",
+        "revenueGrowthQuarterlyYoy",
+        "revenueGrowth5Y",
+    )
 
-    if isinstance(income, list) and len(income) >= 5:
-        recent_rev = _safe_float(income[0].get("revenue"))
-        year_ago_rev = _safe_float(income[4].get("revenue"))
-        if year_ago_rev > 0:
-            revenue_growth = (recent_rev - year_ago_rev) / year_ago_rev
-        gross_profit = _safe_float(income[0].get("grossProfit"))
-        if recent_rev > 0:
-            gross_margin = gross_profit / recent_rev
-    elif isinstance(income, list) and income:
-        recent_rev = _safe_float(income[0].get("revenue"))
-        gross_profit = _safe_float(income[0].get("grossProfit"))
-        if recent_rev > 0:
-            gross_margin = gross_profit / recent_rev
+    # Gross margin: TTM preferred; annual fallback; 5Y last.
+    gross_margin_raw = _pick(metrics, "grossMarginTTM", "grossMarginAnnual", "grossMargin5Y")
 
+    # ROE: TTM preferred; Rfy (rolling fiscal year) fallback.
+    roe_raw = _pick(metrics, "roeTTM", "roeRfy")
+
+    # Current ratio: annual; quarterly fallback.
+    current_ratio_raw = _pick(metrics, "currentRatioAnnual", "currentRatioQuarterly")
+
+    # FCF yield: Finnhub doesn't expose this directly. Compute from raw FCF
+    # and market cap. Fall back to NEUTRAL (0.0) when either input is
+    # missing or non-positive — clipping below would silently emit
+    # potentially-meaningful values for negative-FCF firms.
+    fcf_ttm = _pick(metrics, "freeCashFlowTTM", "freeCashFlowAnnual")
+    market_cap = _pick(metrics, "marketCapitalization")
+    if fcf_ttm and market_cap and market_cap > 0:
+        fcf_yield_raw = fcf_ttm / market_cap
+    else:
+        fcf_yield_raw = 0.0
+
+    # Finnhub returns gross margin and ROE as fractions (e.g. 0.42 for 42%);
+    # FMP returned them the same way. Clipping ranges unchanged from the
+    # FMP version so downstream feature-engineering / scoring sees the
+    # same numeric ranges.
     return {
         "pe_ratio": _clip(pe_raw / 30.0, -3.0, 3.0),
         "pb_ratio": _clip(pb_raw / 5.0, -3.0, 3.0),
         "debt_to_equity": _clip(de_raw / 2.0, -3.0, 3.0),
-        "revenue_growth_yoy": _clip(revenue_growth, -1.0, 2.0),
+        "revenue_growth_yoy": _clip(revenue_growth_raw, -1.0, 2.0),
         "fcf_yield": _clip(fcf_yield_raw, -0.5, 0.5),
-        "gross_margin": _clip(gross_margin, 0.0, 1.0),
+        "gross_margin": _clip(gross_margin_raw, 0.0, 1.0),
         "roe": _clip(roe_raw, -1.0, 1.0),
         "current_ratio": _clip(current_ratio_raw / 3.0, 0.0, 3.0),
     }
@@ -165,16 +205,19 @@ def collect(
     """
     import boto3
 
-    api_key = os.environ.get("FMP_API_KEY", "")
+    api_key = os.environ.get("FINNHUB_API_KEY", "")
     if not api_key:
         # Preflight is expected to catch this earlier; hard-fail here too
         # so a missing key can never land as "0 OK / N errors / all-zeros".
         return {
             "status": "error",
-            "error": "FMP_API_KEY not set — refusing to write all-NEUTRAL fundamentals",
+            "error": "FINNHUB_API_KEY not set — refusing to write all-NEUTRAL fundamentals",
         }
 
-    logger.info("Fetching fundamentals for %d tickers from FMP (%s)...", len(tickers), _FMP_BASE)
+    logger.info(
+        "Fetching fundamentals for %d tickers from Finnhub (/stock/metric)...",
+        len(tickers),
+    )
     t0 = time.time()
 
     results: dict[str, dict] = {}
@@ -183,7 +226,7 @@ def collect(
 
     for ticker in tickers:
         try:
-            data = _fetch_single_ticker(ticker, api_key)
+            data = _fetch_single_ticker(ticker)
             results[ticker] = data
             if data != NEUTRAL:
                 n_ok += 1
@@ -202,8 +245,8 @@ def collect(
     if ok_ratio < _MIN_OK_RATIO:
         msg = (
             f"only {n_ok}/{len(tickers)} tickers ({ok_ratio:.1%}) had populated "
-            f"fundamentals — below {_MIN_OK_RATIO:.0%} threshold. FMP endpoint "
-            f"likely sunsetted, moved to paid tier, or quota exhausted. Refusing "
+            f"fundamentals — below {_MIN_OK_RATIO:.0%} threshold. Finnhub endpoint "
+            f"likely auth-failed, quota-exhausted, or schema-changed. Refusing "
             f"to write a mostly-zero fundamentals snapshot that would silently "
             f"degrade the predictor + research scoring layers."
         )
@@ -219,7 +262,14 @@ def collect(
 
     if dry_run:
         logger.info("[dry-run] Would write fundamentals for %d tickers", len(results))
-        return {"status": "ok", "n_tickers": len(results), "n_ok": n_ok, "dry_run": True}
+        return {
+            "status": "ok",
+            "n_tickers": len(results),
+            "n_ok": n_ok,
+            "n_errors": n_err,
+            "elapsed_seconds": round(elapsed, 1),
+            "dry_run": True,
+        }
 
     # Write to S3
     s3 = boto3.client("s3")

--- a/tests/test_fundamentals_finnhub.py
+++ b/tests/test_fundamentals_finnhub.py
@@ -1,0 +1,255 @@
+"""Tests for collectors/fundamentals.py — Finnhub /stock/metric migration.
+
+Covers:
+  * Field mapping from Finnhub schema to the existing 8-field output.
+  * TTM-preferred / annual-fallback logic per field.
+  * FCF yield computation from raw FCF + market cap.
+  * NEUTRAL fallback for missing tickers + malformed payloads.
+  * NEUTRAL fallback when both required FCF inputs are missing.
+  * ok_ratio hard-fail gate (silent-zeros guard).
+  * S3 write only on dry_run=False.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from collectors import fundamentals
+from collectors.fundamentals import (
+    NEUTRAL,
+    _clip,
+    _fetch_single_ticker,
+    _pick,
+    _safe_float,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _aapl_payload(**overrides):
+    """A representative Finnhub /stock/metric response for AAPL."""
+    metric = {
+        "peTTM": 28.5,
+        "peExclExtraTTM": 27.9,
+        "pbAnnual": 35.2,
+        "pbQuarterly": 36.1,
+        "totalDebt/totalEquityAnnual": 1.95,
+        "totalDebt/totalEquityQuarterly": 2.01,
+        "revenueGrowthTTMYoy": 0.025,  # 2.5%
+        "revenueGrowthQuarterlyYoy": 0.018,
+        "freeCashFlowTTM": 100_000_000_000.0,  # $100B
+        "marketCapitalization": 3_000_000_000_000.0,  # $3T → 3.33% yield
+        "grossMarginTTM": 0.42,
+        "grossMarginAnnual": 0.41,
+        "roeTTM": 0.62,  # 62% — extreme but exists
+        "roeRfy": 0.61,
+        "currentRatioAnnual": 0.93,
+        "currentRatioQuarterly": 0.95,
+    }
+    metric.update(overrides)
+    return {"metric": metric, "metricType": "all", "symbol": "AAPL"}
+
+
+# ── _safe_float, _clip, _pick ───────────────────────────────────────────────
+
+
+class TestSafeFloat:
+    def test_none_returns_default(self):
+        assert _safe_float(None) == 0.0
+        assert _safe_float(None, default=1.0) == 1.0
+
+    def test_string_number_parses(self):
+        assert _safe_float("3.14") == 3.14
+
+    def test_invalid_returns_default(self):
+        assert _safe_float("nope") == 0.0
+        assert _safe_float("nope", default=-1.0) == -1.0
+
+
+class TestClip:
+    def test_clip_high(self):
+        assert _clip(5.0, -1.0, 1.0) == 1.0
+
+    def test_clip_low(self):
+        assert _clip(-5.0, -1.0, 1.0) == -1.0
+
+    def test_clip_inside(self):
+        assert _clip(0.5, -1.0, 1.0) == 0.5
+
+
+class TestPick:
+    def test_first_present_wins(self):
+        assert _pick({"a": 1.0, "b": 2.0}, "a", "b") == 1.0
+
+    def test_falls_through_to_next(self):
+        assert _pick({"b": 2.0}, "a", "b") == 2.0
+
+    def test_skips_none_values(self):
+        assert _pick({"a": None, "b": 2.0}, "a", "b") == 2.0
+
+    def test_returns_default_when_all_missing(self):
+        assert _pick({}, "a", "b", default=99.0) == 99.0
+
+
+# ── _fetch_single_ticker — field mapping ────────────────────────────────────
+
+
+class TestFetchSingleTicker:
+    def test_full_payload_maps_all_fields(self):
+        with patch.object(fundamentals, "finnhub_get", return_value=_aapl_payload()):
+            data = _fetch_single_ticker("AAPL")
+        # Each field is non-zero / non-NEUTRAL.
+        assert data["pe_ratio"] != 0.0
+        assert data["pb_ratio"] != 0.0
+        assert data["debt_to_equity"] != 0.0
+        assert data["revenue_growth_yoy"] != 0.0
+        assert data["fcf_yield"] != 0.0
+        assert data["gross_margin"] != 0.0
+        assert data["roe"] != 0.0
+        assert data["current_ratio"] != 0.0
+
+    def test_pe_uses_ttm_preferred(self):
+        with patch.object(fundamentals, "finnhub_get", return_value=_aapl_payload(peTTM=30.0, peExclExtraTTM=999.0)):
+            data = _fetch_single_ticker("AAPL")
+        # 30.0 / 30 = 1.0
+        assert data["pe_ratio"] == pytest.approx(1.0)
+
+    def test_pe_falls_back_to_excl_extra(self):
+        payload = _aapl_payload()
+        payload["metric"]["peTTM"] = None
+        payload["metric"]["peExclExtraTTM"] = 30.0
+        with patch.object(fundamentals, "finnhub_get", return_value=payload):
+            data = _fetch_single_ticker("AAPL")
+        assert data["pe_ratio"] == pytest.approx(1.0)
+
+    def test_debt_equity_handles_slashed_keyname(self):
+        # Finnhub uses literal slash in the field name. Verify _pick handles it.
+        payload = _aapl_payload()
+        payload["metric"]["totalDebt/totalEquityAnnual"] = 4.0
+        with patch.object(fundamentals, "finnhub_get", return_value=payload):
+            data = _fetch_single_ticker("AAPL")
+        # 4.0 / 2 = 2.0
+        assert data["debt_to_equity"] == pytest.approx(2.0)
+
+    def test_fcf_yield_computed_from_raw(self):
+        payload = _aapl_payload(freeCashFlowTTM=10.0, marketCapitalization=200.0)
+        with patch.object(fundamentals, "finnhub_get", return_value=payload):
+            data = _fetch_single_ticker("AAPL")
+        # 10/200 = 0.05
+        assert data["fcf_yield"] == pytest.approx(0.05)
+
+    def test_fcf_yield_neutral_when_market_cap_zero(self):
+        payload = _aapl_payload(freeCashFlowTTM=10.0, marketCapitalization=0.0)
+        with patch.object(fundamentals, "finnhub_get", return_value=payload):
+            data = _fetch_single_ticker("AAPL")
+        assert data["fcf_yield"] == 0.0
+
+    def test_fcf_yield_neutral_when_fcf_missing(self):
+        payload = _aapl_payload()
+        payload["metric"]["freeCashFlowTTM"] = None
+        payload["metric"]["freeCashFlowAnnual"] = None
+        with patch.object(fundamentals, "finnhub_get", return_value=payload):
+            data = _fetch_single_ticker("AAPL")
+        assert data["fcf_yield"] == 0.0
+
+    def test_clipping_extremes(self):
+        # Insanely high P/E should clip to 3.0 (pe_raw / 30 capped at 3)
+        payload = _aapl_payload(peTTM=10000.0)
+        with patch.object(fundamentals, "finnhub_get", return_value=payload):
+            data = _fetch_single_ticker("AAPL")
+        assert data["pe_ratio"] == 3.0
+
+    def test_empty_payload_returns_neutral(self):
+        with patch.object(fundamentals, "finnhub_get", return_value={}):
+            data = _fetch_single_ticker("UNKNOWN")
+        assert data == NEUTRAL
+
+    def test_payload_with_empty_metric_returns_neutral(self):
+        with patch.object(fundamentals, "finnhub_get", return_value={"metric": {}}):
+            data = _fetch_single_ticker("UNKNOWN")
+        assert data == NEUTRAL
+
+    def test_payload_with_null_metric_returns_neutral(self):
+        with patch.object(fundamentals, "finnhub_get", return_value={"metric": None}):
+            data = _fetch_single_ticker("UNKNOWN")
+        assert data == NEUTRAL
+
+    def test_list_response_returns_neutral(self):
+        # Finnhub typically returns dict; defensive: list response = malformed.
+        with patch.object(fundamentals, "finnhub_get", return_value=[]):
+            data = _fetch_single_ticker("UNKNOWN")
+        assert data == NEUTRAL
+
+
+# ── collect() — full collection flow ────────────────────────────────────────
+
+
+class TestCollect:
+    def test_dry_run_does_not_write_to_s3(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        with patch.object(fundamentals, "_fetch_single_ticker", return_value={"pe_ratio": 1.0, **{k: NEUTRAL[k] for k in NEUTRAL if k != "pe_ratio"}}):
+            with patch("boto3.client") as mock_boto:
+                result = fundamentals.collect(
+                    bucket="test", tickers=["AAPL", "MSFT"], run_date="2026-04-25", dry_run=True,
+                )
+        assert result["status"] == "ok"
+        assert result.get("dry_run") is True
+        mock_boto.assert_not_called()
+
+    def test_missing_api_key_returns_error(self, monkeypatch):
+        monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+        result = fundamentals.collect(
+            bucket="test", tickers=["AAPL"], run_date="2026-04-25", dry_run=True,
+        )
+        assert result["status"] == "error"
+        assert "FINNHUB_API_KEY" in result["error"]
+
+    def test_low_ok_ratio_hard_fails(self, monkeypatch):
+        """Most tickers returning NEUTRAL → status=error (silent-zeros guard)."""
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        # Only 1 of 10 returns real data → 10% < 90% threshold
+        side_effect = [{"pe_ratio": 1.0, **{k: NEUTRAL[k] for k in NEUTRAL if k != "pe_ratio"}}] + [NEUTRAL.copy() for _ in range(9)]
+        with patch.object(fundamentals, "_fetch_single_ticker", side_effect=side_effect):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(10)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        assert result["status"] == "error"
+        assert "below" in result["error"].lower() or "threshold" in result["error"].lower()
+
+    def test_high_ok_ratio_passes(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        # 10 of 10 return real data
+        with patch.object(
+            fundamentals, "_fetch_single_ticker",
+            return_value={"pe_ratio": 1.0, **{k: NEUTRAL[k] for k in NEUTRAL if k != "pe_ratio"}}
+        ):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(10)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        assert result["status"] == "ok"
+        assert result["n_ok"] == 10
+
+    def test_per_ticker_exception_falls_through_to_neutral(self, monkeypatch):
+        """A single ticker raising shouldn't kill the whole collection — log + NEUTRAL."""
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        # 9 OK + 1 raises = 90% ok ratio (right at threshold; should still pass)
+        good = {"pe_ratio": 1.0, **{k: NEUTRAL[k] for k in NEUTRAL if k != "pe_ratio"}}
+        side_effect = [good] * 9 + [Exception("network blip")]
+        with patch.object(fundamentals, "_fetch_single_ticker", side_effect=side_effect):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(10)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        # 90% ok ratio passes the 90% threshold (>= test in collect.py)
+        assert result["status"] == "ok"
+        assert result["n_ok"] == 9
+        assert result["n_errors"] == 1


### PR DESCRIPTION
## Summary
DataPhase1 has been failing on the FMP `/stable/key-metrics-ttm` endpoint since 2026-04-24 — FMP moved it to a paid tier (HTTP 402). Observed in tonight's Sat SF run: ~26 min into DataPhase1, hard-fail before parity could even attempt to run.

The 2026-04-22 FMP migration (PR #84) covered analyst-related sub-scores but missed the fundamentals collector, which kept calling FMP for key-metrics + ratios + income-statement. This PR closes that gap.

## Architecture

**New file: `collectors/finnhub_client.py`**
Extracted `finnhub_get` + rate-limit state from `alternative.py`. Both `alternative.py` (analyst signals) and `fundamentals.py` (this PR) now share the same throttle. Without a shared module, two collectors with private copies would each track their own `_last_call` timestamp and exceed Finnhub's free-tier 60/min ceiling when DataPhase1 runs them sequentially in the same process.

**Rewritten: `collectors/fundamentals.py`**
Single `/stock/metric?metric=all` call per ticker (replaces 3 FMP endpoints). Same 8-field output shape so downstream consumers (predictor feature store + research scoring) see no schema change.

## Field mapping (FMP → Finnhub)

| Output field | Finnhub field (preferred + fallbacks) |
|---|---|
| `pe_ratio` | `peTTM` → `peExclExtraTTM` → `peNormalizedAnnual` |
| `pb_ratio` | `pbAnnual` → `pbQuarterly` |
| `debt_to_equity` | `totalDebt/totalEquityAnnual` → `…Quarterly` (note: literal `/` in Finnhub field name) |
| `revenue_growth_yoy` | `revenueGrowthTTMYoy` → `…QuarterlyYoy` → `…5Y` |
| `fcf_yield` | computed: `freeCashFlowTTM / marketCapitalization` (NEUTRAL when either missing or non-positive) |
| `gross_margin` | `grossMarginTTM` → `grossMarginAnnual` → `grossMargin5Y` |
| `roe` | `roeTTM` → `roeRfy` |
| `current_ratio` | `currentRatioAnnual` → `currentRatioQuarterly` |

## Performance
- FMP: 903 tickers × 3 endpoints @ 4 req/s = ~3 min wall-clock
- Finnhub: 903 tickers × 1 endpoint @ ~54 req/min = ~17 min
- Slower per ticker but **well within DataPhase1's 30 min budget**

## Failure semantics (preserved)
- Per-ticker exception → log WARNING + NEUTRAL (8 zeros)
- `ok_ratio < 90%` → `status=error`, hard-fails the orchestrator (silent-zeros guard)
- `FINNHUB_API_KEY` missing → `status=error` before any calls

## Tests (27 new, all passing)
- `_safe_float` / `_clip` / `_pick` helper coverage
- Field mapping per output field, including TTM-preferred / annual-fallback chains
- FCF yield computation, plus NEUTRAL when FCF or market cap is missing/zero
- NEUTRAL fallback for empty / null / list-shaped malformed payloads
- ok_ratio gate (low ratio fails with clear message, high ratio passes)
- Per-ticker exception falls through to NEUTRAL without breaking the run
- API key missing returns error before any calls
- dry_run skips S3 write

**Full data suite: 209/209 pass** (no regressions).

## Not covered in this PR (separate workstreams)
- `collectors/alternative.py` still uses FMP for `analyst-estimates` (line ~225). Separate migration if/when FMP moves that endpoint to paid.
- `preflight.py` FMP probe still hits `/stable/key-metrics-ttm` — will fail if the FMP key is revoked, but that's a preflight concern, not a fundamentals concern. Address in a follow-up if FMP fully sunsets free access.

## Deploy
Merges and ae-trading picks it up via `git pull` on the next DataPhase1 spot bootstrap. No EC2 changes; the spot clones the repo fresh each run.

## Re-test plan
After merge, re-run the Sat SF (or a manual DataPhase1-only invocation) to confirm fundamentals collection completes within budget without 402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)