### PR TITLE
fix(weekday-sf): bump MorningEnrich SSM timeout 720s → 1800s

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -162,7 +162,7 @@
 
     "MorningEnrich": {
       "Type": "Task",
-      "Comment": "Polygon morning enrichment — overwrites the prior trading day's daily_closes parquet + ArcticDB row with polygon's authoritative OHLCV+VWAP. Hard-fails on PolygonForbiddenError (no yfinance fallback masks polygon outages). Predictor inference reads ArcticDB right after this step and must see polygon-corrected data, so failure → HandleFailure (do NOT proceed to PredictorInference with stale yfinance values). See alpha-engine-data/collectors/daily_closes.py for source-mode contract.",
+      "Comment": "Polygon morning enrichment — overwrites the prior trading day's daily_closes parquet + ArcticDB row with polygon's authoritative OHLCV+VWAP. Hard-fails on PolygonForbiddenError (no yfinance fallback masks polygon outages). Predictor inference reads ArcticDB right after this step and must see polygon-corrected data, so failure → HandleFailure (do NOT proceed to PredictorInference with stale yfinance values). See alpha-engine-data/collectors/daily_closes.py for source-mode contract. Timeout 1800s: 2026-04-27 the prior 720s cap killed the wrapper after the universe append's actual write completed (~12 min); bumping to 30 min absorbs the daily_append tail without masking real hangs (predictor still gated on Success status).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -174,11 +174,11 @@
             "source .venv/bin/activate",
             "python weekly_collector.py --morning-enrich 2>&1 | tee -a /var/log/morning-enrich.log"
           ],
-          "executionTimeout": ["720"]
+          "executionTimeout": ["1800"]
         },
-        "TimeoutSeconds": 720
+        "TimeoutSeconds": 1800
       },
-      "TimeoutSeconds": 780,
+      "TimeoutSeconds": 1860,
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],


### PR DESCRIPTION
## Summary
- Hotfix for today's weekday SF failure (2026-04-27 13:05 UTC). MorningEnrich SSM step hit its 720s cap at 12m0.058s while `daily_append` was finishing the universe write. ArcticDB confirmed to have 4/24 rows for AAPL (universe) + SPY (macro) — the work completed; SSM just killed the wrapper before clean exit. Cascade: SF aborted → PredictorInference never ran → executor's flow-doctor freshness gate aborted at 13:06 UTC.
- Bump `executionTimeout` + `TimeoutSeconds` to 1800s (SDK params), `TimeoutSeconds` to 1860s (state level). Predictor inference still gated on `Status=Success`, so a real hang still surfaces — we just absorb the daily_append tail.

## Root cause (open follow-up, not in this PR)
`daily_append` is taking ~12 min to write one new row × ~900 universe symbols + 18 macro series. That's extreme for an append; deserves its own perf investigation. This PR is the timeout band-aid only.

## Test plan
- [ ] `bash infrastructure/deploy-infrastructure.sh` — stamps SF JSON with merge SHA, uploads to S3, calls `update-state-machine`, refreshes CF stack tag
- [ ] Manually trigger weekday SF and verify MorningEnrich completes cleanly (Status=Success, not TimedOut)
- [ ] Verify drift-check Lambda reports `cf_drift: false` on next run
- [ ] Tomorrow's 13:05 UTC SF runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)