### PR TITLE
fix(morning-enrich): refresh daily_data health stamp on success

### DIFF
--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -167,6 +167,100 @@ def test_morning_enrich_default_date_uses_previous_trading_day():
     assert result["date"] == "2026-04-23"
 
 
+# ── daily_data health stamp refresh ─────────────────────────────────────────
+
+
+def test_morning_enrich_refreshes_daily_data_stamp_on_success():
+    """On success, _run_morning_enrich must call _write_module_health to refresh
+    the `daily_data` stamp. Without this the executor's 26h staleness gate trips
+    on Monday mornings (post-close stamp from Friday afternoon → ~65h on Monday
+    open). Regression: 2026-04-27 weekday SF aborted on this exact gap."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=False, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    health_calls = []
+    def fake_write_health(bucket, module_name, run_date, status, **kwargs):
+        health_calls.append({
+            "bucket": bucket, "module_name": module_name,
+            "run_date": run_date, "status": status, **kwargs,
+        })
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok", "polygon": 913, "fred": 4,
+                             "yfinance": 0, "tickers_captured": 917,
+                             "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}), \
+         patch("weekly_collector._write_module_health", side_effect=fake_write_health):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert result["status"] == "ok"
+    assert len(health_calls) == 1, "expected exactly one daily_data stamp write"
+    stamp = health_calls[0]
+    assert stamp["module_name"] == "daily_data"
+    assert stamp["run_date"] == "2026-04-24"
+    assert stamp["status"] == "ok"
+    assert stamp["summary"]["morning_enrich"] is True
+    assert stamp["summary"]["polygon"] == 913
+
+
+def test_morning_enrich_does_not_stamp_on_polygon_failure():
+    """If polygon fails the prior stamp must be left in place — executor's
+    staleness gate then fires correctly. Writing a fresh "ok" stamp on failure
+    would mask the outage."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=False, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    health_calls = []
+    def fake_write_health(*args_, **kwargs):
+        health_calls.append(kwargs)
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               side_effect=PolygonForbiddenError("403 simulation")), \
+         patch("weekly_collector._write_module_health", side_effect=fake_write_health):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert result["status"] == "failed"
+    assert health_calls == [], (
+        "morning_enrich must NOT refresh daily_data stamp on failure — would "
+        "mask outages from the executor's staleness gate"
+    )
+
+
+def test_morning_enrich_does_not_stamp_in_dry_run():
+    """Dry runs (CLI --dry-run, backfill rehearsals) must not touch S3 stamps."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=True, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    health_calls = []
+    def fake_write_health(*args_, **kwargs):
+        health_calls.append(kwargs)
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok_dry_run", "polygon": 1, "fred": 0,
+                             "yfinance": 0, "tickers_captured": 1,
+                             "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}), \
+         patch("weekly_collector._write_module_health", side_effect=fake_write_health):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert result["status"] == "ok"
+    assert health_calls == []
+
+
 # ── --daily routes through yfinance_only ────────────────────────────────────
 
 

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -524,6 +524,36 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
     statuses = [r.get("status", "unknown") for r in results["collectors"].values()]
     results["status"] = "ok" if all(s in ("ok", "ok_dry_run") for s in statuses) else "failed"
 
+    # Refresh the `daily_data` health stamp on success. Without this the
+    # executor's 26h staleness gate trips on Monday mornings (post-close stamp
+    # is from Friday ~13h before market close → ~65h on Monday open). Only
+    # write on success — a failed morning_enrich must leave the prior stamp
+    # in place so the gate fires correctly. Post-close DailyData run still
+    # writes the canonical stamp; this is a refresh after the polygon overwrite.
+    if not dry_run and results["status"] == "ok":
+        _dc = results["collectors"].get("daily_closes", {})
+        try:
+            _morning_duration = (
+                datetime.fromisoformat(results["completed_at"])
+                - datetime.fromisoformat(results["started_at"])
+            ).total_seconds()
+        except Exception:
+            _morning_duration = 0.0
+        _write_module_health(
+            bucket,
+            module_name="daily_data",
+            run_date=target_date,
+            status="ok",
+            summary={
+                "tickers_captured": _dc.get("tickers_captured", 0),
+                "polygon": _dc.get("polygon", 0),
+                "fred": _dc.get("fred", 0),
+                "yfinance": _dc.get("yfinance", 0),
+                "morning_enrich": True,
+            },
+            duration_seconds=_morning_duration,
+        )
+
     duration = ""
     try:
         start = datetime.fromisoformat(results["started_at"])


### PR DESCRIPTION
## Summary
- Closes the latent gap that aborted today's weekday SF after the SSM-timeout fix unblocked the SF: `_run_morning_enrich` never refreshed the `daily_data` health stamp, so on Mondays the executor's 26h staleness gate fired against Friday's post-close stamp (~65h gap). Today was the first Monday since MorningEnrich shipped (PR #91, 2026-04-24).
- Stamp now refreshes on success only. Failure paths intentionally leave the prior stamp in place — writing a fresh "ok" stamp on failure would mask outages from the gate. Dry runs also skip the write.

## Test plan
- 3 new unit tests cover: stamp written on success with `morning_enrich=true` in summary, stamp NOT written on `PolygonForbiddenError`, stamp NOT written in `--dry-run`.
- Full suite: 218/218 passes.
- Tomorrow's 13:05 UTC weekday SF (Tuesday) is the live verification — though Tuesday's case isn't structurally broken (post-close stamp from Monday afternoon will be fresh). The real proof is next Monday morning (2026-05-04).

## Follow-ups (separate PRs)
- `daily_append` perf: ~12 min for one row × ~900 universe symbols is dominated by per-ticker sequential `read()` + `update()` to S3-backed Arctic. `read_batch` with `date_range` tail + threadpooled writes should bring it back under a minute.
- Executor IAM: `alpha-engine-executor-role` lacks `cloudwatch:PutMetricData` — `_emit_unscored_count_metric` warning-logs but doesn't block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)