### PR TITLE
perf(daily_append): threadpool the per-ticker write fan-out

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -17,8 +17,10 @@ import argparse
 import io
 import json
 import logging
+import os
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
 import boto3
@@ -311,6 +313,12 @@ def daily_append(
             len(hists_by_ticker), len(stock_tickers), time.time() - t_read0,
         )
 
+    # ── 4b. Phase 1 — sequential compute pass ────────────────────────────────
+    # Per-ticker feature compute stays sequential so we don't have to reason
+    # about pandas/numpy thread safety on the shared macro series. The
+    # bottleneck this PR targets is the I/O-bound write phase below; CPU
+    # parallelism is a separate (higher-risk) lever to pull later if needed.
+    write_tasks: list[tuple[str, pd.DataFrame, pd.DataFrame, list[str]]] = []
     for ticker in stock_tickers:
         try:
             # Read recent history from ArcticDB (need ~265 rows for feature warmup)
@@ -476,34 +484,60 @@ def daily_append(
 
             today_row.index.name = "date"
 
-            # Backfill-safe write — picks update() when target_date is at
-            # the head of the series (the steady-state daily pass), and
-            # falls back to read+splice+write() when target_date is in
-            # the middle (historical backfill). The 2026-04-24 polygon
-            # VWAP repair surfaced the need: ArcticDB's update() raises
-            # "index must be monotonic increasing or decreasing" when
-            # asked to insert behind the latest stored date.
-            # `hist` is already in scope from the per-ticker warmup read
-            # above, so the helper reuses it instead of double-reading.
-            _write_row_backfill_safe(
-                universe_lib, ticker, today_row, existing_series=hist
-            )
+            # Defer the actual ArcticDB write — collected here so Phase 2
+            # can run them in parallel via a thread pool. The previous
+            # sequential per-ticker `_write_row_backfill_safe` call took
+            # ~300-400ms × 900 = ~5 minutes wall time, the residual half
+            # of the budget after the read_batch optimization in PR #99.
+            write_tasks.append((ticker, today_row, hist, nan_features))
 
-            # Increment coverage counter + emit the partial-features log
-            # only after the write landed.
+        except Exception as exc:
+            log.warning("Failed to compute %s: %s", ticker, exc)
+            n_err += 1
+
+    # ── 4c. Phase 2 — parallel writes via ThreadPoolExecutor ─────────────────
+    # ArcticDB writes against different symbols are independent, and the
+    # underlying S3 round-trip releases the GIL on every network op, so a
+    # thread pool is a clean fit for the per-ticker write fan-out. Worker
+    # count is overridable via env var so prod can tune without a redeploy
+    # if the boto3 connection-pool ceiling changes.
+    write_workers = int(os.environ.get("DAILY_APPEND_WRITE_WORKERS", "16"))
+
+    def _do_write(task):
+        _ticker, _today_row, _hist, _nan_features = task
+        try:
+            _write_row_backfill_safe(
+                universe_lib, _ticker, _today_row, existing_series=_hist
+            )
+            return ("ok", _ticker, _nan_features, len(_hist), None)
+        except Exception as exc:  # pragma: no cover — covered by err test
+            return ("err", _ticker, None, len(_hist), exc)
+
+    if write_tasks:
+        t_write0 = time.time()
+        with ThreadPoolExecutor(max_workers=write_workers) as pool:
+            write_results = list(pool.map(_do_write, write_tasks))
+        log.info(
+            "Threadpooled writes: %d tickers in %.1fs (workers=%d)",
+            len(write_tasks), time.time() - t_write0, write_workers,
+        )
+
+        # Aggregation runs on the main thread — counter mutation stays
+        # single-threaded so we don't need locks.
+        for status, ticker, nan_features, hist_rows, exc in write_results:
+            if status == "err":
+                log.warning("Failed to append %s: %s", ticker, exc)
+                n_err += 1
+                continue
             if nan_features:
                 log.warning(
                     "partial-features ticker=%s rows=%d nan=%d/%d features=%s",
-                    ticker, len(hist), len(nan_features), len(FEATURES),
+                    ticker, hist_rows, len(nan_features), len(FEATURES),
                     nan_features,
                 )
                 n_partial += 1
             else:
                 n_ok += 1
-
-        except Exception as exc:
-            log.warning("Failed to append %s: %s", ticker, exc)
-            n_err += 1
 
     # ── 5. Update macro series ───────────────────────────────────────────────
     # update() semantics: same-date rows overwrite instead of appending. See

--- a/tests/test_daily_append_read_batch.py
+++ b/tests/test_daily_append_read_batch.py
@@ -129,3 +129,28 @@ def test_batch_request_shape():
         "ReadRequest list must preserve stock_tickers order so the "
         "zip(stock_tickers, read_results) loop pairs them correctly."
     )
+
+
+# ── ThreadPool source-grep checks ───────────────────────────────────────────
+
+
+def test_writes_use_threadpool_executor():
+    """The per-ticker write fan-out must run inside a ThreadPoolExecutor —
+    the residual half of the 2026-04-27 12-min budget after read_batch was
+    ~5 min of sequential ~300-400ms ArcticDB writes × 900 tickers.
+    """
+    src = _source()
+    assert "ThreadPoolExecutor" in src, (
+        "Per-ticker writes must fan out through ThreadPoolExecutor so the "
+        "S3 round-trip cost parallelizes (Arctic releases the GIL on every "
+        "network op). Sequential writes were the dominant residual budget "
+        "after PR #99's read_batch optimization."
+    )
+    assert "from concurrent.futures import ThreadPoolExecutor" in src
+    # Worker count must be env-overridable so prod can tune without a
+    # redeploy if the boto3 connection-pool ceiling changes.
+    assert "DAILY_APPEND_WRITE_WORKERS" in src, (
+        "Threadpool worker count must be env-overridable — prod boto3 "
+        "connection-pool ceilings vary and tuning shouldn't require a "
+        "code change + redeploy."
+    )

--- a/tests/test_daily_append_semantics.py
+++ b/tests/test_daily_append_semantics.py
@@ -27,11 +27,21 @@ def test_universe_lib_uses_update_not_append():
     lib.write() for the backfill case (historical row in middle of series).
     Direct lib.append() must never appear — it accumulates duplicate
     same-date rows and caused the 2026-04-15 retrain outage.
+
+    The 2026-04-27 threadpool refactor moved the write call into an inner
+    closure for parallel execution, so this test locks the semantic
+    invariant (write goes through the helper with `universe_lib` as first
+    arg) rather than the literal call shape.
     """
+    import re
     src = _source()
-    assert "_write_row_backfill_safe(\n                universe_lib, ticker, today_row" in src or \
-           "_write_row_backfill_safe(universe_lib, ticker, today_row" in src, (
-        "Per-ticker write must call _write_row_backfill_safe(universe_lib, ticker, today_row, ...) "
+    # Match `_write_row_backfill_safe(<whitespace>universe_lib<rest>)` —
+    # tolerates the call being inlined OR moved into a helper closure.
+    assert re.search(
+        r"_write_row_backfill_safe\s*\(\s*universe_lib\b",
+        src,
+    ), (
+        "Per-ticker write must call _write_row_backfill_safe(universe_lib, ...) "
         "— the helper picks update() for append + write() for backfill. "
         "Calling universe_lib.update() directly skips the backfill-safe path "
         "and breaks historical rewrites with 'index must be monotonic' "
@@ -167,31 +177,39 @@ def test_counters_increment_after_successful_write():
     so an exception rolls the iteration back cleanly into n_err.
 
     Locks the 2026-04-21 rewrite where counters were hoisted post-write
-    to prevent double-counting when the write throws.
+    to prevent double-counting when the write throws. After the 2026-04-27
+    threadpool refactor, the write call lives inside an inner closure and
+    the counters increment in a post-pool aggregation loop driven by the
+    closure's status string — same semantic guarantee, different shape.
     """
+    import re
     src = _source()
-    # The write call site + increments must appear in that order.
-    # Find the _write_row_backfill_safe(universe_lib, ticker, today_row) call.
-    lines = src.splitlines()
-    write_idx = None
-    for i, line in enumerate(lines):
-        if "_write_row_backfill_safe(" in line and "universe_lib" in line:
-            write_idx = i
-            break
-        # Multi-line call form: line ends with `_write_row_backfill_safe(`
-        if line.rstrip().endswith("_write_row_backfill_safe("):
-            # Look ahead a few lines for `universe_lib`
-            ahead = "\n".join(lines[i:i+5])
-            if "universe_lib, ticker, today_row" in ahead:
-                write_idx = i
-                break
-    assert write_idx is not None, (
-        "_write_row_backfill_safe(universe_lib, ticker, today_row, ...) call site not found"
+    # Find the write call (now inside the _do_write closure).
+    write_match = re.search(
+        r"_write_row_backfill_safe\s*\(\s*universe_lib\b",
+        src,
     )
-    window_after = "\n".join(lines[write_idx:write_idx + 25])
-    assert "n_partial += 1" in window_after and "n_ok += 1" in window_after, (
-        "n_ok / n_partial must be incremented AFTER the write call, "
+    assert write_match is not None, (
+        "_write_row_backfill_safe(universe_lib, ...) call site not found"
+    )
+    after_write = src[write_match.end():]
+    # The closure must return a status before the aggregation loop touches
+    # n_ok / n_partial — i.e. the increments live AFTER the write site
+    # in source order, not before.
+    assert 'return ("ok"' in after_write, (
+        "Closure must return a success status string from the write path "
+        "so the aggregation loop can route to n_ok / n_partial. Without it "
+        "the threadpool path can't tell ok from err and counters lose the "
+        "exception-rolls-into-n_err invariant."
+    )
+    assert "n_partial += 1" in after_write and "n_ok += 1" in after_write, (
+        "n_ok / n_partial must be incremented AFTER the write call site, "
         "not before. Increments before write cause miscount on exception."
+    )
+    # Exception path must still route to n_err — locks the rollback invariant.
+    assert "n_err += 1" in after_write, (
+        "Aggregation must increment n_err on closure-status='err' so write "
+        "exceptions don't silently inflate n_ok."
     )
 
 


### PR DESCRIPTION
## Summary
- PR #99 batched the warmup reads via `read_batch`. The residual half of the 2026-04-27 12-min `daily_append` budget was the per-ticker write loop — 900 sequential `_write_row_backfill_safe` calls at ~300-400ms each = ~5 min wall time.
- This PR splits the loop into two phases: **Phase 1 sequential compute** (parquet warmup, `compute_features`, dtype-match — CPU-bound, no thread-safety questions) → **Phase 2 parallel writes via `ThreadPoolExecutor(16)`** (each task = one `_write_row_backfill_safe`; ArcticDB writes against different symbols are independent; S3 releases the GIL on every network op).
- Worker count overridable via `DAILY_APPEND_WRITE_WORKERS` env var so prod can tune without redeploy if the boto3 connection-pool ceiling changes.
- Counter aggregation stays on the main thread driven by closure status strings — no locks needed; the "exception in write rolls into `n_err`" invariant from the 2026-04-21 counter rewrite is preserved.

## Expected end state
With PR #99 (read batching) + this PR (write threadpool), full daily_append should run in well under 1 minute on the steady-state 900-ticker universe — the original 12-min wall time was dominated by these two synchronous fan-outs.

## Tests
- `tests/test_daily_append_read_batch.py`: added a source-grep test locking `ThreadPoolExecutor` + `DAILY_APPEND_WRITE_WORKERS` env-var presence.
- `tests/test_daily_append_semantics.py::test_universe_lib_uses_update_not_append`: relaxed the literal call-shape match to a regex on `_write_row_backfill_safe(<ws>universe_lib...)` so the closure indirection passes. Helper-routing intent (no direct `universe_lib.append`) still locked.
- `test_counters_increment_after_successful_write`: same relaxation + added "closure must return ok status" + `n_err` invariant assertion.
- Full suite: **223/223** passes.

## Live verification
Tomorrow's (Tuesday 2026-04-28) weekday SF MorningEnrich step's wall-clock. Combined with PR #99 the full daily_append should clear the SSM cap with significant headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)