### PR TITLE
feat(prune): orchestrated ArcticDB universe pruner for delisted tickers

### DIFF
--- a/builders/prune_delisted_tickers.py
+++ b/builders/prune_delisted_tickers.py
@@ -1,0 +1,308 @@
+"""builders/prune_delisted_tickers.py — orchestrated delisted-ticker cleanup.
+
+Removes ArcticDB universe symbols that meet BOTH conditions:
+
+  (A) Absent from the latest ``market_data/weekly/{date}/constituents.json``
+      ``tickers`` list (S&P 500 + 400, ~903 names). Wikipedia is the
+      authoritative source there; if a ticker has been removed, the
+      weekly constituents fetch reflects it.
+
+  (B) ArcticDB ``last_date`` for the symbol is older than ``--absent-days``
+      (default 14 = 2 weeks). Confirms the symbol is genuinely
+      stale on the data side too — daily_closes upstream stops emitting
+      a ticker shortly after delisting.
+
+Both conditions together prevent flapping:
+  - Constituents-only check would over-prune on a Wikipedia parsing
+    hiccup (legitimate ticker temporarily missing from the JSON).
+  - last_date-only check would over-prune on a multi-week daily_closes
+    outage (e.g. polygon free-tier 403 streak from 2026-04-23).
+
+Composes with ``daily_append`` PR #101's missing-from-closes hard-fail:
+the named ticker list in that error message is the operator's
+investigation surface; this builder is the auto-triage tool that closes
+the loop on legitimate delistings (so the threshold doesn't have to keep
+getting bumped or the symbol manually deleted).
+
+Usage:
+    python -m builders.prune_delisted_tickers                   # dry-run
+    python -m builders.prune_delisted_tickers --apply           # actually prune
+    python -m builders.prune_delisted_tickers --absent-days 7   # tighter window
+    python -m builders.prune_delisted_tickers --apply --tickers HOLX,RACE  # one-off
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import pandas as pd
+
+from features.compute import DEFAULT_BUCKET, _SKIP_TICKERS, _is_sector_etf
+from store.arctic_store import get_universe_lib
+
+log = logging.getLogger(__name__)
+
+DEFAULT_ABSENT_DAYS = 14
+AUDIT_PREFIX = "builders/prune_audit/"
+
+
+def _load_latest_constituents(s3, bucket: str) -> tuple[set[str], str]:
+    """Return (tickers_set, weekly_date_str) from the latest constituents.json."""
+    pointer_key = "market_data/latest_weekly.json"
+    obj = s3.get_object(Bucket=bucket, Key=pointer_key)
+    pointer = json.loads(obj["Body"].read())
+    weekly_date = pointer["date"]
+    prefix = pointer["s3_prefix"].rstrip("/")
+    constituents_key = f"{prefix}/constituents.json"
+
+    obj = s3.get_object(Bucket=bucket, Key=constituents_key)
+    payload = json.loads(obj["Body"].read())
+    tickers = payload.get("tickers")
+    if not tickers:
+        raise RuntimeError(
+            f"constituents.json at s3://{bucket}/{constituents_key} has no "
+            f"`tickers` field — refusing to prune against an empty universe "
+            f"(would delete every symbol)."
+        )
+    return set(tickers), weekly_date
+
+
+def _read_last_date(universe_lib, ticker: str) -> pd.Timestamp | None:
+    """Return the most recent index date for a symbol, or None if unreadable.
+
+    Uses ``tail(1)`` to avoid pulling the full series — every read is a
+    separate S3 round-trip and we may scan dozens of stale candidates.
+    """
+    try:
+        df = universe_lib.tail(ticker, 1).data
+    except Exception as exc:
+        log.warning(
+            "Could not read tail(1) for %s — assuming readable but treating "
+            "as not-stale-enough-to-prune (refuse to delete data we can't "
+            "verify): %s",
+            ticker, exc,
+        )
+        return None
+    if df.empty:
+        return None
+    return pd.Timestamp(df.index[-1]).normalize()
+
+
+def prune_delisted_tickers(
+    *,
+    bucket: str = DEFAULT_BUCKET,
+    absent_days: int = DEFAULT_ABSENT_DAYS,
+    apply: bool = False,
+    tickers_override: list[str] | None = None,
+    today: pd.Timestamp | None = None,
+) -> dict:
+    """Prune ArcticDB universe symbols that are confirmed delistings.
+
+    Parameters
+    ----------
+    bucket
+        S3 bucket holding both ArcticDB and constituents.json.
+    absent_days
+        Minimum days since last_date before a candidate is pruned. Pairs
+        with the constituents-absence check to prevent flapping.
+    apply
+        If True, actually delete from ArcticDB. Default False (dry-run).
+    tickers_override
+        Skip the constituents-diff and target a specific list. Still
+        gated on the last_date staleness check — operator can't blow
+        up a fresh symbol via a typo.
+    today
+        Override the staleness reference date for testing. Defaults to
+        UTC midnight today.
+
+    Returns
+    -------
+    summary dict with the action plan and outcome.
+    """
+    s3 = boto3.client("s3")
+    universe_lib = get_universe_lib(bucket)
+    today = today or pd.Timestamp(datetime.now(timezone.utc).date())
+    threshold_date = today - timedelta(days=absent_days)
+
+    arctic_symbols = set(universe_lib.list_symbols())
+    log.info("ArcticDB universe holds %d symbols", len(arctic_symbols))
+
+    if tickers_override is not None:
+        candidates = sorted(set(tickers_override) & arctic_symbols)
+        ignored = sorted(set(tickers_override) - arctic_symbols)
+        if ignored:
+            log.warning(
+                "Skipping %d tickers from --tickers override that aren't in "
+                "ArcticDB: %s",
+                len(ignored), ignored,
+            )
+        weekly_date = "(override)"
+    else:
+        constituents, weekly_date = _load_latest_constituents(s3, bucket)
+        log.info(
+            "Latest constituents (date=%s): %d tickers",
+            weekly_date, len(constituents),
+        )
+        # Only stocks can be pruned — never touch macro/index series or
+        # sector ETFs (those aren't constituents-tracked but are still
+        # required by daily_append's macro-load path).
+        candidates = sorted(
+            t for t in arctic_symbols
+            if t not in constituents
+            and t not in _SKIP_TICKERS
+            and not _is_sector_etf(t)
+        )
+        log.info(
+            "Constituents-absent candidates (before last_date check): %d",
+            len(candidates),
+        )
+
+    pruned: list[dict] = []
+    skipped_recent: list[dict] = []
+    skipped_unreadable: list[str] = []
+
+    for ticker in candidates:
+        last_date = _read_last_date(universe_lib, ticker)
+        if last_date is None:
+            # Read failed or empty series — refuse to delete what we
+            # can't verify. Operator must investigate manually.
+            skipped_unreadable.append(ticker)
+            continue
+        if last_date > threshold_date:
+            skipped_recent.append({
+                "ticker": ticker,
+                "last_date": last_date.strftime("%Y-%m-%d"),
+                "threshold": threshold_date.strftime("%Y-%m-%d"),
+            })
+            continue
+        # Both conditions met — prune.
+        record = {
+            "ticker": ticker,
+            "last_date": last_date.strftime("%Y-%m-%d"),
+            "days_stale": int((today - last_date).days),
+            "constituents_date": weekly_date,
+        }
+        if apply:
+            try:
+                universe_lib.delete(ticker)
+            except Exception as exc:
+                # Fail loudly — we don't want a half-pruned universe
+                # silently passing as "done".
+                raise RuntimeError(
+                    f"Failed to delete {ticker} from ArcticDB universe "
+                    f"(others already pruned: {[p['ticker'] for p in pruned]}): "
+                    f"{exc}"
+                ) from exc
+            log.warning(
+                "PRUNED ticker=%s last_date=%s days_stale=%d",
+                ticker, record["last_date"], record["days_stale"],
+            )
+        else:
+            log.info(
+                "DRY-RUN would prune ticker=%s last_date=%s days_stale=%d",
+                ticker, record["last_date"], record["days_stale"],
+            )
+        pruned.append(record)
+
+    summary = {
+        "status": "ok",
+        "applied": apply,
+        "today": today.strftime("%Y-%m-%d"),
+        "absent_days_threshold": absent_days,
+        "constituents_date": weekly_date,
+        "arctic_universe_size_before": len(arctic_symbols),
+        "candidates_count": len(candidates),
+        "pruned_count": len(pruned),
+        "skipped_recent_count": len(skipped_recent),
+        "skipped_unreadable_count": len(skipped_unreadable),
+        "pruned": pruned,
+        "skipped_recent": skipped_recent,
+        "skipped_unreadable": skipped_unreadable,
+    }
+
+    log.info(
+        "prune_delisted_tickers: applied=%s candidates=%d pruned=%d "
+        "skipped_recent=%d skipped_unreadable=%d",
+        apply, len(candidates), len(pruned),
+        len(skipped_recent), len(skipped_unreadable),
+    )
+
+    # Always write the audit, even on dry-run + zero-prune — gives Sat
+    # SF reviewers a per-week artifact they can grep across runs.
+    _write_audit(s3, bucket, summary)
+
+    return summary
+
+
+def _write_audit(s3, bucket: str, summary: dict) -> None:
+    """Write a per-run audit JSON to S3 for forensic review."""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+    suffix = "apply" if summary["applied"] else "dryrun"
+    key = f"{AUDIT_PREFIX}{summary['today']}-{ts}-{suffix}.json"
+    try:
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=json.dumps(summary, indent=2).encode(),
+            ContentType="application/json",
+        )
+        log.info("Audit written: s3://%s/%s", bucket, key)
+    except Exception as exc:
+        log.warning(
+            "Failed to write audit to s3://%s/%s: %s. "
+            "Pruning result still authoritative — audit is observability.",
+            bucket, key, exc,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually delete from ArcticDB. Default is dry-run.",
+    )
+    parser.add_argument(
+        "--absent-days", type=int, default=DEFAULT_ABSENT_DAYS,
+        help=f"Min days since last_date for prune candidacy "
+             f"(default {DEFAULT_ABSENT_DAYS}).",
+    )
+    parser.add_argument(
+        "--tickers", type=str, default=None,
+        help="Comma-separated ticker override (skip constituents diff). "
+             "Last-date staleness check still applies.",
+    )
+    parser.add_argument(
+        "--bucket", default=DEFAULT_BUCKET,
+        help=f"S3 bucket (default: {DEFAULT_BUCKET}).",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    tickers_override = None
+    if args.tickers:
+        tickers_override = [t.strip().upper() for t in args.tickers.split(",") if t.strip()]
+
+    summary = prune_delisted_tickers(
+        bucket=args.bucket,
+        absent_days=args.absent_days,
+        apply=args.apply,
+        tickers_override=tickers_override,
+    )
+
+    print(json.dumps(summary, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -293,6 +293,10 @@ echo "==> Smoke: python import weekly_collector"
 $REMOTE_PYTHON -c "import weekly_collector; print('import OK')"
 
 echo ""
+echo "==> Smoke: python import builders.prune_delisted_tickers"
+$REMOTE_PYTHON -c "from builders import prune_delisted_tickers; print('import OK')"
+
+echo ""
 echo "==> Smoke: weekly_collector.py --phase 1 --dry-run"
 # Show full output (was tail -30 — truncated error tracebacks from early
 # collectors so their failure mode was invisible during debugging).
@@ -440,6 +444,23 @@ echo "DataPhase1 complete at \$(date)"
 
 echo ""
 echo "──────────────────────────────────────────────────────────────"
+echo "Starting builders.prune_delisted_tickers at \$(date)"
+echo "──────────────────────────────────────────────────────────────"
+# Prune delisted tickers from ArcticDB universe. Two-condition guard
+# (constituents-absent AND last_date stale) prevents flapping; audit
+# JSON is written to s3://alpha-engine-research/builders/prune_audit/.
+# Composes with daily_append's missing-from-closes hard-fail (PR #101)
+# — closes the loop on legit delistings so the threshold doesn't keep
+# getting bumped or symbols manually deleted. Constituents.json was
+# just refreshed by Phase 1 above, so this read is fresh.
+if ! $REMOTE_PYTHON -m builders.prune_delisted_tickers --apply 2>&1; then
+    echo "ERROR: prune_delisted_tickers failed — aborting bundle before RAG." >&2
+    exit 1
+fi
+echo "UniversePrune complete at \$(date)"
+
+echo ""
+echo "──────────────────────────────────────────────────────────────"
 echo "Fetching RAG secrets from SSM at \$(date)"
 echo "──────────────────────────────────────────────────────────────"
 # Phase 2 SSM migration — RAG secrets come from SSM Parameter Store, NOT
@@ -478,8 +499,8 @@ echo "  Weekly data bundle complete. Instance will be terminated."
 echo "═══════════════════════════════════════════════════════════════"
 
 # Heartbeat — one metric per sub-workload so CloudWatch alarms can
-# distinguish between a missed Phase 1 and a missed RAG.
-for proc in data-phase1 rag-ingestion; do
+# distinguish between a missed Phase 1, a missed prune, and a missed RAG.
+for proc in data-phase1 universe-prune rag-ingestion; do
     aws cloudwatch put-metric-data \
         --namespace "AlphaEngine" \
         --metric-name "Heartbeat" \

--- a/tests/test_prune_delisted_tickers.py
+++ b/tests/test_prune_delisted_tickers.py
@@ -1,0 +1,472 @@
+"""Tests for builders/prune_delisted_tickers.py.
+
+Two-condition guard:
+  (A) ticker absent from latest constituents.json::tickers
+  (B) last_date older than --absent-days threshold
+
+Either condition alone must NOT prune — that's the no-flapping invariant.
+A Wikipedia parsing hiccup (constituents missing a real ticker) or a
+multi-week daily_closes outage (last_date stale on a still-listed ticker)
+would otherwise blow up valid universe entries.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from builders import prune_delisted_tickers as _mod
+
+
+def _build_pointer_payload(weekly_date: str = "2026-04-25") -> dict:
+    return {
+        "date": weekly_date,
+        "s3_prefix": f"market_data/weekly/{weekly_date}/",
+    }
+
+
+def _build_constituents_payload(tickers: list[str]) -> dict:
+    return {
+        "date": "2026-04-25",
+        "tickers": list(tickers),
+        "sector_map": {t: "Industrials" for t in tickers},
+    }
+
+
+def _stub_s3(*, constituents_tickers: list[str], weekly_date: str = "2026-04-25"):
+    """Return a MagicMock s3 client whose get_object serves pointer +
+    constituents.json + records put_object calls."""
+    s3 = MagicMock()
+    pointer_body = json.dumps(_build_pointer_payload(weekly_date)).encode()
+    constituents_body = json.dumps(_build_constituents_payload(constituents_tickers)).encode()
+
+    def fake_get_object(**kwargs):
+        key = kwargs["Key"]
+        if key == "market_data/latest_weekly.json":
+            return {"Body": MagicMock(read=lambda: pointer_body)}
+        if key.endswith("/constituents.json"):
+            return {"Body": MagicMock(read=lambda: constituents_body)}
+        raise KeyError(f"unexpected key {key}")
+
+    s3.get_object.side_effect = fake_get_object
+    return s3
+
+
+def _stub_universe_lib(*, symbols: list[str], last_dates: dict[str, str]):
+    """Return a MagicMock universe_lib whose tail() returns a frame with
+    a single row at the given last_date for each symbol."""
+    lib = MagicMock()
+    lib.list_symbols.return_value = symbols
+
+    def fake_tail(symbol, n):
+        if symbol not in last_dates:
+            return MagicMock(data=pd.DataFrame())
+        idx = pd.DatetimeIndex([last_dates[symbol]])
+        return MagicMock(data=pd.DataFrame({"Close": [100.0]}, index=idx))
+
+    lib.tail.side_effect = fake_tail
+    return lib
+
+
+def _patch_targets(monkeypatch, *, s3_mock, universe_lib_mock):
+    """Common patch surface — stub boto3.client + get_universe_lib."""
+    monkeypatch.setattr(
+        _mod, "boto3", MagicMock(client=lambda *a, **k: s3_mock),
+    )
+    monkeypatch.setattr(_mod, "get_universe_lib", lambda *a, **k: universe_lib_mock)
+
+
+# ── A. Two-condition invariant ─────────────────────────────────────────────────
+
+
+def test_absent_from_constituents_AND_stale_prunes(monkeypatch):
+    """Both conditions met → ticker pruned."""
+    s3 = _stub_s3(constituents_tickers=["AAPL", "MSFT"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "MSFT", "HOLX"],
+        last_dates={
+            "AAPL": "2026-04-25", "MSFT": "2026-04-25",
+            "HOLX": "2026-04-06",  # 22 days stale @ today=2026-04-28
+        },
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 1
+    assert summary["pruned"][0]["ticker"] == "HOLX"
+    lib.delete.assert_called_once_with("HOLX")
+
+
+def test_absent_but_recent_does_not_prune(monkeypatch):
+    """Absent from constituents but last_date is recent → flapping
+    guard fires, no prune. This is the 'Wikipedia hiccup' scenario."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "MSFT"],
+        # MSFT is missing from constituents (simulated parsing miss)
+        # but its data is fresh — must not be deleted.
+        last_dates={"AAPL": "2026-04-25", "MSFT": "2026-04-25"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    assert summary["skipped_recent_count"] == 1
+    assert summary["skipped_recent"][0]["ticker"] == "MSFT"
+    lib.delete.assert_not_called()
+
+
+def test_present_in_constituents_but_stale_does_not_prune(monkeypatch):
+    """Present in constituents → never a candidate, even if last_date
+    is stale. This is the 'daily_closes outage' scenario."""
+    s3 = _stub_s3(constituents_tickers=["AAPL", "MSFT"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "MSFT"],
+        # MSFT is in constituents but data is 22d old (e.g. polygon
+        # 403 streak). Must not delete a still-listed ticker.
+        last_dates={"AAPL": "2026-04-25", "MSFT": "2026-04-06"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    assert summary["candidates_count"] == 0
+    lib.delete.assert_not_called()
+
+
+# ── B. Macro / sector ETF protection ───────────────────────────────────────────
+
+
+def test_macro_keys_never_pruned(monkeypatch):
+    """SPY, VIX, etc. live in macro_lib, but if any leaked into
+    universe_lib by accident, they must never be touched here. Their
+    absence from the equity constituents list is by design."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "SPY", "VIX", "GLD"],
+        last_dates={
+            "AAPL": "2026-04-25", "SPY": "2026-04-06",
+            "VIX": "2026-04-06", "GLD": "2026-04-06",
+        },
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    lib.delete.assert_not_called()
+
+
+def test_sector_etfs_never_pruned(monkeypatch):
+    """XLK / XLE / XLF / etc. — same protection as macro keys."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "XLK", "XLE", "XLF"],
+        last_dates={
+            "AAPL": "2026-04-25",
+            "XLK": "2026-04-06", "XLE": "2026-04-06", "XLF": "2026-04-06",
+        },
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    lib.delete.assert_not_called()
+
+
+# ── C. Dry-run vs apply ────────────────────────────────────────────────────────
+
+
+def test_dry_run_does_not_call_delete(monkeypatch):
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "HOLX"],
+        last_dates={"AAPL": "2026-04-25", "HOLX": "2026-04-06"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=False,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 1  # plan still records it
+    assert summary["applied"] is False
+    lib.delete.assert_not_called()
+
+
+def test_apply_calls_delete_per_ticker(monkeypatch):
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "HOLX", "RACE"],
+        last_dates={
+            "AAPL": "2026-04-25",
+            "HOLX": "2026-04-06", "RACE": "2026-04-01",
+        },
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 2
+    assert lib.delete.call_count == 2
+    deleted = sorted(call.args[0] for call in lib.delete.call_args_list)
+    assert deleted == ["HOLX", "RACE"]
+
+
+# ── D. Override path ───────────────────────────────────────────────────────────
+
+
+def test_tickers_override_skips_constituents_diff(monkeypatch):
+    """--tickers HOLX bypasses the constituents diff but still gates on
+    last_date staleness — operator can't blow up a fresh symbol via typo."""
+    # Note: constituents could even contain HOLX — override skips that check.
+    s3 = _stub_s3(constituents_tickers=["AAPL", "HOLX"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "HOLX"],
+        last_dates={"AAPL": "2026-04-25", "HOLX": "2026-04-06"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        tickers_override=["HOLX"],
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 1
+    assert summary["pruned"][0]["ticker"] == "HOLX"
+
+
+def test_tickers_override_still_gates_on_staleness(monkeypatch):
+    """Even with explicit override, a fresh-data ticker is NOT deleted —
+    refuses to blow up a still-active symbol via operator typo."""
+    s3 = _stub_s3(constituents_tickers=["AAPL", "MSFT"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "MSFT"],
+        last_dates={"AAPL": "2026-04-25", "MSFT": "2026-04-25"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        tickers_override=["MSFT"],  # operator typo — MSFT is fresh + listed
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    assert summary["skipped_recent_count"] == 1
+    lib.delete.assert_not_called()
+
+
+def test_tickers_override_ignores_unknown_symbols(monkeypatch):
+    """A symbol not in ArcticDB gets logged but doesn't raise — the
+    override is a hint, not a contract."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL"], last_dates={"AAPL": "2026-04-25"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        tickers_override=["NONEXISTENT"],
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    assert summary["candidates_count"] == 0
+
+
+# ── E. Refuse-to-delete-what-we-cant-verify ────────────────────────────────────
+
+
+def test_unreadable_tail_skips_not_prunes(monkeypatch):
+    """If tail(1) raises, refuse to delete — we can't verify staleness.
+    Operator must investigate manually."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = MagicMock()
+    lib.list_symbols.return_value = ["AAPL", "BROKEN"]
+    # AAPL reads fine; BROKEN raises.
+    def fake_tail(symbol, n):
+        if symbol == "AAPL":
+            idx = pd.DatetimeIndex(["2026-04-25"])
+            return MagicMock(data=pd.DataFrame({"Close": [100.0]}, index=idx))
+        raise RuntimeError("ArcticDB read failed")
+    lib.tail.side_effect = fake_tail
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    assert summary["skipped_unreadable_count"] == 1
+    assert "BROKEN" in summary["skipped_unreadable"]
+    lib.delete.assert_not_called()
+
+
+def test_empty_series_skips(monkeypatch):
+    """Empty DataFrame from tail(1) → can't verify last_date → skip."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = MagicMock()
+    lib.list_symbols.return_value = ["AAPL", "EMPTYSYMB"]
+    def fake_tail(symbol, n):
+        if symbol == "AAPL":
+            idx = pd.DatetimeIndex(["2026-04-25"])
+            return MagicMock(data=pd.DataFrame({"Close": [100.0]}, index=idx))
+        return MagicMock(data=pd.DataFrame())
+    lib.tail.side_effect = fake_tail
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    assert summary["skipped_unreadable_count"] == 1
+
+
+# ── F. Hard-fail on bad input ──────────────────────────────────────────────────
+
+
+def test_empty_constituents_raises(monkeypatch):
+    """An empty constituents.json::tickers list would mean every ArcticDB
+    symbol becomes a candidate — refuse loudly. This is a defensive check
+    against a constituents-fetch regression."""
+    s3 = MagicMock()
+    pointer_body = json.dumps(_build_pointer_payload()).encode()
+    bad_constituents = json.dumps({"tickers": [], "date": "2026-04-25"}).encode()
+
+    def fake_get_object(**kwargs):
+        if kwargs["Key"] == "market_data/latest_weekly.json":
+            return {"Body": MagicMock(read=lambda: pointer_body)}
+        return {"Body": MagicMock(read=lambda: bad_constituents)}
+    s3.get_object.side_effect = fake_get_object
+
+    lib = _stub_universe_lib(symbols=["AAPL"], last_dates={"AAPL": "2026-04-25"})
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    with pytest.raises(RuntimeError, match="empty universe"):
+        _mod.prune_delisted_tickers(
+            absent_days=14, apply=True,
+            today=pd.Timestamp("2026-04-28"),
+        )
+
+
+def test_arctic_delete_failure_propagates(monkeypatch):
+    """If lib.delete() raises mid-loop, propagate so the operator sees a
+    half-pruned state and investigates rather than silently 'completing'."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = MagicMock()
+    lib.list_symbols.return_value = ["AAPL", "HOLX", "RACE"]
+
+    def fake_tail(symbol, n):
+        if symbol == "AAPL":
+            idx = pd.DatetimeIndex(["2026-04-25"])
+        else:
+            idx = pd.DatetimeIndex(["2026-04-06"])
+        return MagicMock(data=pd.DataFrame({"Close": [100.0]}, index=idx))
+
+    lib.tail.side_effect = fake_tail
+    # First delete succeeds, second raises
+    lib.delete.side_effect = [None, RuntimeError("S3 5xx")]
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    with pytest.raises(RuntimeError, match="Failed to delete"):
+        _mod.prune_delisted_tickers(
+            absent_days=14, apply=True,
+            today=pd.Timestamp("2026-04-28"),
+        )
+
+
+# ── G. Audit trail ─────────────────────────────────────────────────────────────
+
+
+def test_audit_written_on_dry_run(monkeypatch):
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "HOLX"],
+        last_dates={"AAPL": "2026-04-25", "HOLX": "2026-04-06"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    _mod.prune_delisted_tickers(
+        absent_days=14, apply=False,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    s3.put_object.assert_called_once()
+    call = s3.put_object.call_args
+    assert call.kwargs["Key"].startswith("builders/prune_audit/2026-04-28-")
+    assert call.kwargs["Key"].endswith("-dryrun.json")
+    body = json.loads(call.kwargs["Body"])
+    assert body["pruned_count"] == 1
+    assert body["pruned"][0]["ticker"] == "HOLX"
+
+
+def test_audit_written_on_apply(monkeypatch):
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "HOLX"],
+        last_dates={"AAPL": "2026-04-25", "HOLX": "2026-04-06"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    s3.put_object.assert_called_once()
+    call = s3.put_object.call_args
+    assert call.kwargs["Key"].endswith("-apply.json")
+
+
+def test_audit_failure_does_not_block_prune(monkeypatch):
+    """put_object failure is observability — must not cause the prune
+    operation to roll back. The operator already saw the WARN log of the
+    delete; the audit miss is a downstream concern."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    s3.put_object.side_effect = RuntimeError("S3 down")
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "HOLX"],
+        last_dates={"AAPL": "2026-04-25", "HOLX": "2026-04-06"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+    )
+
+    # Prune still happened; audit failure was swallowed with WARN.
+    assert summary["pruned_count"] == 1
+    lib.delete.assert_called_once_with("HOLX")


### PR DESCRIPTION
## Summary

- Adds `builders/prune_delisted_tickers.py` + wires into Saturday DataPhase1 spot bundle (between Phase 1 and RAG, where constituents.json was just refreshed).
- Two-condition guard prevents flapping: (A) symbol absent from latest `constituents.json::tickers` AND (B) ArcticDB `last_date` older than `--absent-days` (default 14). Either alone is insufficient — Wikipedia hiccup or multi-week daily_closes outage would otherwise blow up valid entries.
- Composes with daily_append PR #101: that hard-fail names tickers; this builder is the auto-triage tool that closes the loop on legit delistings (HOLX/RACE class) so the threshold doesn't keep getting bumped or symbols manually deleted across sessions.

## Behavior

| Condition | Action |
|---|---|
| Absent from constituents AND last_date stale | Prune (apply mode) / log (dry-run) |
| Absent from constituents BUT last_date recent | Skip; logged as `skipped_recent` (Wikipedia hiccup safety) |
| In constituents BUT last_date stale | Skip; never a candidate (daily_closes outage safety) |
| Macro key (SPY/VIX/...) or sector ETF (XL*) | Never pruned regardless |
| `tail(1)` raises or empty | Skip; `skipped_unreadable` (refuse to delete what we can't verify) |
| `lib.delete()` raises mid-loop | Propagate `RuntimeError` (operator sees half-pruned state, not silent "ok") |
| Empty constituents.json | `RuntimeError` defensive guard (would otherwise prune everything) |
| `--tickers HOLX` override | Skips constituents diff, still gates on staleness (typo-proof) |

## Audit trail

Every run writes `s3://alpha-engine-research/builders/prune_audit/{today}-{ts}-{apply|dryrun}.json` with the full decision record (pruned, skipped_recent, skipped_unreadable, candidates_count, etc.). Audit-write failure WARN-logs but doesn't roll back the prune.

## SF wiring

Inserted into `spot_data_weekly.sh` between Phase 1 and RAG. Atomic bundle — failure aborts before RAG, mirroring the existing pattern. Plus `universe-prune` heartbeat metric so CloudWatch distinguishes missed-prune from missed-Phase1 / missed-RAG. Smoke mode imports the new module so a deploy regression surfaces in the ~30s smoke window.

No new SF state, no new IAM, no new instance — pruner runs on the same DataPhase1 spot, same Python venv, same `alpha-engine-executor-role` instance profile that already has S3 + ArcticDB access.

## Test plan

- [x] `pytest tests/test_prune_delisted_tickers.py` — 17 new tests
- [x] Full repo suite: 234 → 251 pass
- [x] CLI `--help` renders cleanly (smoke)
- [x] `bash -n infrastructure/spot_data_weekly.sh` — shell syntax validates
- [ ] Live verification on next Saturday SF: `s3://alpha-engine-research/builders/prune_audit/2026-05-02-*-apply.json` exists; CloudWatch `AlphaEngine/Heartbeat Process=universe-prune` data point present

## Closes

ROADMAP P2 "ArcticDB universe pruning — orchestrated delisted-ticker cleanup" (added 2026-04-22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)