### PR TITLE
feat(alternative): per-source ok_ratio gate + Phase 2 postflight

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -50,6 +50,136 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+# ── Per-source populated-ratio gate ──────────────────────────────────────────
+#
+# `_fetch_all_alternative` aggregates 6 heterogeneous sources for each
+# ticker. A single source going dark (Finnhub auth fail, FMP 402, SEC
+# rate-limit ban, etc.) silently nulls out only its sub-section of the
+# output dict — overall `_fetch_all_alternative` still returns successfully,
+# the manifest writes "ok", and downstream Research scoring picks up a
+# mostly-empty alt-data snapshot that degrades the qual sub-score.
+#
+# The gate below tracks per-source "did this ticker get real data?"
+# coverage and hard-fails the run if ANY source's populated ratio falls
+# below its source-specific floor. Thresholds are deliberately
+# heterogeneous because the 6 sources have very different baseline
+# coverage in the S&P 500/400 universe:
+#
+#   - analyst_consensus: most large-caps have analyst coverage → 0.80
+#   - eps_revision:      coverage drops for newer / smaller listings → 0.50
+#   - options_flow:      large-caps mostly options-listed but low-vol
+#                        days produce flat-line metrics → 0.30
+#   - insider_activity:  Form 4 filings are episodic (insiders don't
+#                        trade every quarter) → 0.10
+#   - institutional:     13F filings are quarterly + ~45-day lag, so
+#                        many tickers have no fresh accumulation
+#                        signal in any given week → 0.20
+#   - news:              most names produce some news weekly via
+#                        Yahoo RSS or 8-K → 0.50
+#
+# A FLAT ok_ratio across all sources would false-positive on tickers
+# that are legitimately sparse on a source (a small-cap with no 13F
+# filings is not a provider failure). Source-specific floors avoid that.
+#
+# Override at runtime via the `ALT_MIN_OK_RATIOS` env var (JSON dict),
+# e.g. `{"institutional": 0.05}` to relax the 13F floor during a known
+# edgartools outage without code changes.
+
+_DEFAULT_MIN_OK_RATIOS: dict[str, float] = {
+    "analyst_consensus": 0.80,
+    "eps_revision":      0.50,
+    "options_flow":      0.30,
+    "insider_activity":  0.10,
+    "institutional":     0.20,
+    "news":              0.50,
+}
+
+
+def _load_min_ok_ratios() -> dict[str, float]:
+    """Resolve per-source thresholds. Env override merges over defaults."""
+    overrides_raw = os.environ.get("ALT_MIN_OK_RATIOS", "")
+    if not overrides_raw:
+        return dict(_DEFAULT_MIN_OK_RATIOS)
+    try:
+        overrides = json.loads(overrides_raw)
+    except json.JSONDecodeError as exc:
+        # Malformed override hard-fails — silent fallback to defaults
+        # would leave operators thinking their tuning landed when it
+        # didn't. NoSilentFails.
+        raise RuntimeError(
+            f"ALT_MIN_OK_RATIOS env var is not valid JSON: {exc}. "
+            f"Expected a dict like '{{\"institutional\": 0.05}}'."
+        ) from exc
+    if not isinstance(overrides, dict):
+        raise RuntimeError(
+            f"ALT_MIN_OK_RATIOS must be a JSON object, got {type(overrides).__name__}"
+        )
+    unknown = set(overrides) - set(_DEFAULT_MIN_OK_RATIOS)
+    if unknown:
+        raise RuntimeError(
+            f"ALT_MIN_OK_RATIOS contains unknown sources: {sorted(unknown)}. "
+            f"Valid sources: {sorted(_DEFAULT_MIN_OK_RATIOS)}"
+        )
+    merged = dict(_DEFAULT_MIN_OK_RATIOS)
+    for k, v in overrides.items():
+        if not isinstance(v, (int, float)) or not (0.0 <= v <= 1.0):
+            raise RuntimeError(
+                f"ALT_MIN_OK_RATIOS[{k!r}] must be a number in [0.0, 1.0], "
+                f"got {v!r}"
+            )
+        merged[k] = float(v)
+    return merged
+
+
+# Predicates: did this source produce real (non-default) data for the
+# ticker? "Real" is deliberately loose — any non-empty / non-zero field
+# in the source-specific output schema counts as a populated ticker.
+# The goal is to detect "provider went dark" (every ticker gets
+# defaults) vs "this ticker's sources are sparse" (a few defaults
+# scattered across a mostly-populated batch).
+
+def _has_analyst_data(d: dict) -> bool:
+    return (
+        d.get("rating") is not None
+        or d.get("target_price") is not None
+        or d.get("num_analysts") is not None
+        or bool(d.get("earnings_surprises"))
+    )
+
+
+def _has_revision_data(d: dict) -> bool:
+    return d.get("current_estimate") is not None
+
+
+def _has_options_data(d: dict) -> bool:
+    return any(
+        d.get(k) is not None
+        for k in ("put_call_ratio", "iv_rank", "expected_move_pct")
+    )
+
+
+def _has_insider_data(d: dict) -> bool:
+    return bool(d.get("transactions")) or d.get("net_shares_30d", 0) != 0
+
+
+def _has_institutional_data(d: dict) -> bool:
+    return d.get("funds_increasing", 0) > 0 or d.get("funds_decreasing", 0) > 0
+
+
+def _has_news_data(d: dict) -> bool:
+    return bool(d.get("articles")) or bool(d.get("sec_filings_8k"))
+
+
+_HAS_DATA_PREDICATES = {
+    "analyst_consensus": _has_analyst_data,
+    "eps_revision":      _has_revision_data,
+    "options_flow":      _has_options_data,
+    "insider_activity":  _has_insider_data,
+    "institutional":     _has_institutional_data,
+    "news":              _has_news_data,
+}
+
+
 def collect(
     bucket: str,
     s3_prefix: str,
@@ -97,6 +227,10 @@ def collect(
     succeeded = 0
     failed = 0
     errors = []
+    # Per-source populated counts. Increment only when the source for
+    # this ticker carried real (non-default) data — see _HAS_DATA_PREDICATES
+    # commentary above for the silent-fail surface this protects against.
+    source_ok_counts: dict[str, int] = {k: 0 for k in _HAS_DATA_PREDICATES}
 
     for ticker in tickers:
         try:
@@ -109,18 +243,46 @@ def collect(
                 ContentType="application/json",
             )
             succeeded += 1
+            for source_name, predicate in _HAS_DATA_PREDICATES.items():
+                if predicate(data.get(source_name, {}) or {}):
+                    source_ok_counts[source_name] += 1
             logger.info("Alternative data: %s -> s3://%s/%s", ticker, bucket, key)
         except Exception as e:
             failed += 1
             errors.append({"ticker": ticker, "error": str(e)})
             logger.warning("Alternative data failed for %s: %s", ticker, e)
 
-    # Write manifest
+    # ── Per-source ok_ratio gate ────────────────────────────────────────────
+    # Mirrors `fundamentals.py::_MIN_OK_RATIO` and
+    # `short_interest.py::_MIN_OK_RATIO` patterns — every alt-data source
+    # that has its own potential failure mode (provider auth, quota, schema
+    # change) gets its own threshold. A breach is a hard-fail on the whole
+    # collector return so the orchestrator treats Phase 2 as failed instead
+    # of the manifest landing as "ok" with a silent half-empty payload.
+    min_ok_ratios = _load_min_ok_ratios()
+    n_total = len(tickers)
+    source_ratios: dict[str, float] = {
+        source: source_ok_counts[source] / max(n_total, 1)
+        for source in _HAS_DATA_PREDICATES
+    }
+    breached = [
+        (source, source_ratios[source], min_ok_ratios[source])
+        for source in _HAS_DATA_PREDICATES
+        if source_ratios[source] < min_ok_ratios[source]
+    ]
+
+    # Write manifest BEFORE the gate raises — operators triaging a
+    # gate breach need the manifest's per-source counts to identify
+    # which provider failed. (This mirrors fundamentals.py: status is
+    # the gate decision, but the diagnostic payload always lands.)
     manifest = {
         "run_date": run_date,
-        "tickers_requested": len(tickers),
+        "tickers_requested": n_total,
         "tickers_succeeded": succeeded,
         "tickers_failed": failed,
+        "source_ok_counts": source_ok_counts,
+        "source_ok_ratios": {k: round(v, 4) for k, v in source_ratios.items()},
+        "source_min_ok_ratios": min_ok_ratios,
         "errors": errors[:20],
     }
     manifest_key = f"{s3_prefix}weekly/{run_date}/alternative/manifest.json"
@@ -131,11 +293,47 @@ def collect(
         ContentType="application/json",
     )
 
+    if breached:
+        breach_lines = [
+            f"{src}: {ratio:.1%} < {floor:.0%} threshold "
+            f"({source_ok_counts[src]}/{n_total} populated)"
+            for src, ratio, floor in breached
+        ]
+        msg = (
+            "alternative.collect: per-source populated-ratio gate breached "
+            "for " + str(len(breached)) + " of " + str(len(_HAS_DATA_PREDICATES))
+            + " sources — " + "; ".join(breach_lines)
+            + ". Likely a provider outage (Finnhub auth/quota, FMP 402, SEC "
+            "rate-limit) silently nulled out a sub-section of the alt-data "
+            "snapshot. Refusing to mark Phase 2 as ok with a half-empty "
+            "payload that would degrade the research scoring layer."
+        )
+        logger.error(msg)
+        return {
+            "status": "error",
+            "error": msg,
+            "tickers_processed": succeeded,
+            "tickers_failed": failed,
+            "source_ok_counts": source_ok_counts,
+            "source_ok_ratios": {k: round(v, 4) for k, v in source_ratios.items()},
+            "source_min_ok_ratios": min_ok_ratios,
+            "breached_sources": [src for src, _, _ in breached],
+            "errors": errors[:20],
+        }
+
     status = "ok" if failed == 0 else "partial"
+    logger.info(
+        "alternative.collect: %d tickers, per-source coverage %s",
+        n_total,
+        ", ".join(f"{k}={source_ratios[k]:.0%}" for k in _HAS_DATA_PREDICATES),
+    )
     return {
         "status": status,
         "tickers_processed": succeeded,
         "tickers_failed": failed,
+        "source_ok_counts": source_ok_counts,
+        "source_ok_ratios": {k: round(v, 4) for k, v in source_ratios.items()},
+        "source_min_ok_ratios": min_ok_ratios,
         "errors": errors[:20],
     }
 

--- a/tests/test_alternative_ok_ratio_gate.py
+++ b/tests/test_alternative_ok_ratio_gate.py
@@ -1,0 +1,438 @@
+"""Tests for the per-source ok_ratio gate in ``collectors/alternative.py``.
+
+Background (ROADMAP P1):
+``alternative.collect`` aggregates 6 heterogeneous sub-fetchers per ticker
+(analyst_consensus, eps_revision, options_flow, insider_activity,
+institutional, news). Before this gate, a single source going dark
+(Finnhub auth fail, FMP 402, SEC rate-limit) silently nulled out only its
+sub-section of the output dict; overall ``_fetch_all_alternative`` still
+returned successfully and the manifest landed as ``status="ok"`` with a
+silently degraded payload that flowed into research scoring.
+
+The gate tracks per-source "did this ticker get real data?" coverage and
+hard-fails the run when any source's populated ratio falls below its
+source-specific floor. Heterogeneous floors are the load-bearing design
+choice — a flat ratio would false-positive on legitimate sparsity (e.g.
+small-caps with no 13F filings, low-vol days with flat options metrics).
+
+These tests lock the gate's contract so a future "simplify to flat ratio"
+revert reintroduces the silent-fail surface the gate was built to close.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collectors import alternative
+
+
+# ── Sample populated / unpopulated payloads ──────────────────────────────────
+
+def _populated_alt_payload(ticker: str) -> dict:
+    """A `_fetch_all_alternative` return where every source has real data."""
+    return {
+        "ticker": ticker,
+        "fetched_at": "2026-04-27T20:00:00+00:00",
+        "analyst_consensus": {
+            "rating": "Buy",
+            "target_price": 200.0,
+            "num_analysts": 25,
+            "earnings_surprises": [{"date": "2026-Q1", "surprise_pct": 5.2}],
+        },
+        "eps_revision": {"current_estimate": 6.50, "revision_4w": 1.2, "streak": 2},
+        "options_flow": {"put_call_ratio": 0.7, "iv_rank": 35, "expected_move_pct": 4.5},
+        "insider_activity": {
+            "cluster_buying": True, "net_shares_30d": 50000,
+            "transactions": [{"insider": "CEO", "shares": 50000}],
+        },
+        "institutional": {
+            "accumulation": True, "funds_increasing": 7, "funds_decreasing": 2,
+        },
+        "news": {
+            "articles": [{"headline": "X", "source": "Yahoo"}],
+            "sec_filings_8k": [{"title": "Item 2.02", "date": "2026-04-25"}],
+        },
+    }
+
+
+def _unpopulated_source_payload(ticker: str, dark_sources: list[str]) -> dict:
+    """Return a populated payload with `dark_sources` zeroed out (provider went dark)."""
+    payload = _populated_alt_payload(ticker)
+    defaults = {
+        "analyst_consensus": {
+            "rating": None, "target_price": None,
+            "num_analysts": None, "earnings_surprises": [],
+        },
+        "eps_revision": {"current_estimate": None, "revision_4w": None, "streak": 0},
+        "options_flow": {"put_call_ratio": None, "iv_rank": None, "expected_move_pct": None},
+        "insider_activity": {
+            "cluster_buying": False, "net_shares_30d": 0, "transactions": [],
+        },
+        "institutional": {
+            "accumulation": False, "funds_increasing": 0, "funds_decreasing": 0,
+        },
+        "news": {"articles": [], "sec_filings_8k": []},
+    }
+    for src in dark_sources:
+        payload[src] = defaults[src]
+    return payload
+
+
+# ── Helper: stub the collector's IO surface ──────────────────────────────────
+
+
+def _patch_collect(monkeypatch, *, fetch_returns: list[dict]):
+    """Stub `_fetch_all_alternative` to return the prepared per-ticker payloads
+    in order, plus mock S3 client + ticker resolver."""
+    s3 = MagicMock()
+    monkeypatch.setattr(alternative, "boto3", MagicMock(client=lambda *a, **k: s3))
+    monkeypatch.setattr(
+        alternative, "_load_promoted_tickers",
+        lambda *a, **k: [d["ticker"] for d in fetch_returns],
+    )
+    fetch_iter = iter(fetch_returns)
+    monkeypatch.setattr(
+        alternative, "_fetch_all_alternative",
+        lambda ticker, run_date, bucket: next(fetch_iter),
+    )
+    return s3
+
+
+# ── A. _has_data predicates ──────────────────────────────────────────────────
+
+
+def test_has_analyst_data_truthy_on_any_field():
+    assert alternative._has_analyst_data({"rating": "Buy"}) is True
+    assert alternative._has_analyst_data({"target_price": 200.0}) is True
+    assert alternative._has_analyst_data({"num_analysts": 5}) is True
+    assert alternative._has_analyst_data({"earnings_surprises": [{}]}) is True
+    assert alternative._has_analyst_data({"rating": None}) is False
+    assert alternative._has_analyst_data({}) is False
+
+
+def test_has_revision_data_only_current_estimate():
+    assert alternative._has_revision_data({"current_estimate": 5.0}) is True
+    # streak=0 + revision_4w=None alone shouldn't count — that's the
+    # default shape returned by _fetch_revisions on a complete miss.
+    assert alternative._has_revision_data({"streak": 0, "revision_4w": None}) is False
+
+
+def test_has_options_data_any_metric():
+    assert alternative._has_options_data({"put_call_ratio": 0.5}) is True
+    assert alternative._has_options_data({"iv_rank": 25}) is True
+    # iv_rank=0 IS real data (low-vol periods produce zero rank); only
+    # None (the _fetch_options default) means the source went dark.
+    assert alternative._has_options_data({"iv_rank": 0}) is True
+    assert alternative._has_options_data({
+        "put_call_ratio": None, "iv_rank": None, "expected_move_pct": None,
+    }) is False
+    assert alternative._has_options_data({}) is False
+
+
+def test_has_insider_data_filings_or_net_shares():
+    assert alternative._has_insider_data({"transactions": [{}]}) is True
+    assert alternative._has_insider_data({"net_shares_30d": 100}) is True
+    assert alternative._has_insider_data({
+        "cluster_buying": False, "net_shares_30d": 0, "transactions": [],
+    }) is False
+
+
+def test_has_institutional_data_increasing_or_decreasing():
+    assert alternative._has_institutional_data({"funds_increasing": 1}) is True
+    assert alternative._has_institutional_data({"funds_decreasing": 2}) is True
+    # accumulation=False alone (without fund counts) doesn't count
+    assert alternative._has_institutional_data({
+        "accumulation": False, "funds_increasing": 0, "funds_decreasing": 0,
+    }) is False
+
+
+def test_has_news_data_articles_or_8k():
+    assert alternative._has_news_data({"articles": [{"headline": "X"}]}) is True
+    assert alternative._has_news_data({"sec_filings_8k": [{}]}) is True
+    assert alternative._has_news_data({"articles": [], "sec_filings_8k": []}) is False
+
+
+# ── B. Threshold loader ──────────────────────────────────────────────────────
+
+
+def test_default_thresholds_are_heterogeneous():
+    """The flat-ratio failure mode the ROADMAP warns against would be a
+    bug if any future refactor accidentally collapsed all 6 floors to the
+    same value. Lock the heterogeneity invariant."""
+    ratios = alternative._load_min_ok_ratios()
+    distinct = set(ratios.values())
+    assert len(distinct) >= 4, (
+        f"Per-source thresholds should be heterogeneous (different "
+        f"sources have different baseline coverage); got values: {ratios}"
+    )
+    # Specific anchor values from the design (commentary in alternative.py)
+    assert ratios["analyst_consensus"] == 0.80
+    assert ratios["insider_activity"] == 0.10  # episodic Form 4 filings
+    assert ratios["institutional"] == 0.20  # quarterly 13F lag
+
+
+def test_env_override_merges(monkeypatch):
+    monkeypatch.setenv("ALT_MIN_OK_RATIOS", '{"institutional": 0.05}')
+    ratios = alternative._load_min_ok_ratios()
+    assert ratios["institutional"] == 0.05
+    # Other sources unaffected
+    assert ratios["analyst_consensus"] == 0.80
+
+
+def test_env_override_invalid_json_raises(monkeypatch):
+    """Malformed override must hard-fail — silent fallback to defaults
+    would leave an operator thinking their tuning landed when it didn't."""
+    monkeypatch.setenv("ALT_MIN_OK_RATIOS", "not-json")
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        alternative._load_min_ok_ratios()
+
+
+def test_env_override_unknown_source_raises(monkeypatch):
+    monkeypatch.setenv("ALT_MIN_OK_RATIOS", '{"made_up_source": 0.5}')
+    with pytest.raises(RuntimeError, match="unknown sources"):
+        alternative._load_min_ok_ratios()
+
+
+def test_env_override_out_of_range_raises(monkeypatch):
+    monkeypatch.setenv("ALT_MIN_OK_RATIOS", '{"analyst_consensus": 1.5}')
+    with pytest.raises(RuntimeError, match=r"in \[0.0, 1.0\]"):
+        alternative._load_min_ok_ratios()
+
+
+def test_env_override_non_dict_raises(monkeypatch):
+    monkeypatch.setenv("ALT_MIN_OK_RATIOS", '[0.5, 0.6]')
+    with pytest.raises(RuntimeError, match="must be a JSON object"):
+        alternative._load_min_ok_ratios()
+
+
+# ── C. Gate behavior — happy path ────────────────────────────────────────────
+
+
+def test_all_sources_above_floor_returns_ok(monkeypatch):
+    """All 6 sources fully populated for 10 tickers → status="ok"."""
+    payloads = [_populated_alt_payload(f"TKR{i}") for i in range(10)]
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+
+    assert result["status"] == "ok"
+    assert result["tickers_processed"] == 10
+    # All 6 sources at 100% coverage
+    for source in alternative._HAS_DATA_PREDICATES:
+        assert result["source_ok_ratios"][source] == 1.0
+
+
+def test_legitimate_sparsity_does_not_breach(monkeypatch):
+    """`insider_activity` at 10% floor — even if 9/10 tickers have no
+    insider trades (legitimately sparse), the run must pass."""
+    payloads = [
+        _populated_alt_payload("TKR0"),
+        # 9 tickers with no insider activity (legitimate — Form 4 filings
+        # are episodic) but other sources populated.
+        *(_unpopulated_source_payload(f"TKR{i}", ["insider_activity"])
+          for i in range(1, 10)),
+    ]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+
+    assert result["status"] == "ok", (
+        f"10% insider coverage is at the floor; should pass. "
+        f"Got: {result.get('error', 'ok')}"
+    )
+    assert result["source_ok_ratios"]["insider_activity"] == 0.1
+
+
+# ── D. Gate behavior — breach path ───────────────────────────────────────────
+
+
+def test_finnhub_outage_breaches_analyst_floor(monkeypatch):
+    """0/10 tickers have analyst data (Finnhub recommendation endpoint
+    going dark) → status="error", breached_sources lists analyst_consensus."""
+    payloads = [
+        _unpopulated_source_payload(f"TKR{i}", ["analyst_consensus"])
+        for i in range(10)
+    ]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+
+    assert result["status"] == "error"
+    assert "analyst_consensus" in result["breached_sources"]
+    assert result["source_ok_ratios"]["analyst_consensus"] == 0.0
+    assert "Finnhub" in result["error"]  # remediation hint mentions providers
+
+
+def test_multiple_simultaneous_breaches_listed_together(monkeypatch):
+    """If both Finnhub recs AND FMP estimates die at once, the error
+    must name BOTH so the operator knows which providers to investigate."""
+    payloads = [
+        _unpopulated_source_payload(
+            f"TKR{i}", ["analyst_consensus", "eps_revision"]
+        )
+        for i in range(10)
+    ]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+
+    assert result["status"] == "error"
+    assert set(result["breached_sources"]) == {"analyst_consensus", "eps_revision"}
+
+
+def test_manifest_written_even_on_breach(monkeypatch):
+    """Operators triaging a gate breach need the manifest to identify
+    which provider failed. Mirror fundamentals.py pattern: status is the
+    decision, but the diagnostic payload always lands."""
+    payloads = [
+        _unpopulated_source_payload(f"TKR{i}", ["analyst_consensus"])
+        for i in range(10)
+    ]
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+
+    assert result["status"] == "error"
+    # find the manifest write among s3.put_object calls
+    manifest_calls = [
+        c for c in s3.put_object.call_args_list
+        if c.kwargs.get("Key", "").endswith("/alternative/manifest.json")
+    ]
+    assert len(manifest_calls) == 1, "Manifest must be written exactly once"
+    body = json.loads(manifest_calls[0].kwargs["Body"])
+    assert body["source_ok_counts"]["analyst_consensus"] == 0
+    assert body["source_ok_ratios"]["analyst_consensus"] == 0.0
+
+
+def test_below_floor_just_barely_still_breaches(monkeypatch):
+    """analyst_consensus floor is 0.80. 7/10 tickers populated = 0.70 →
+    breach. Locks the boundary — < not ≤ as the predicate."""
+    payloads = [
+        *(_populated_alt_payload(f"TKR{i}") for i in range(7)),
+        *(_unpopulated_source_payload(f"TKR{i}", ["analyst_consensus"])
+          for i in range(7, 10)),
+    ]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+
+    assert result["status"] == "error"
+    assert result["source_ok_ratios"]["analyst_consensus"] == 0.7
+    assert "analyst_consensus" in result["breached_sources"]
+
+
+def test_at_floor_exactly_does_not_breach(monkeypatch):
+    """analyst_consensus floor is 0.80. 8/10 tickers populated = 0.80 → pass.
+    Must be `< floor` (not `<=`) so a clean 80% coverage isn't a false alarm."""
+    payloads = [
+        *(_populated_alt_payload(f"TKR{i}") for i in range(8)),
+        *(_unpopulated_source_payload(f"TKR{i}", ["analyst_consensus"])
+          for i in range(8, 10)),
+    ]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+
+    assert result["status"] == "ok"
+    assert result["source_ok_ratios"]["analyst_consensus"] == 0.8
+
+
+# ── E. Override interaction ──────────────────────────────────────────────────
+
+
+def test_env_override_can_relax_a_specific_breach(monkeypatch):
+    """Operator-tunable: if a known edgartools outage drops 13F coverage
+    to 5%, the operator can set ALT_MIN_OK_RATIOS to relax that single
+    source without breaking the others."""
+    payloads = [
+        _unpopulated_source_payload(f"TKR{i}", ["institutional"])
+        for i in range(10)
+    ]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    # Default: institutional floor is 0.20, 0/10 → breach.
+    result_default = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+    assert result_default["status"] == "error"
+    assert "institutional" in result_default["breached_sources"]
+
+    # Override: relax institutional to 0.0 → passes.
+    monkeypatch.setenv("ALT_MIN_OK_RATIOS", '{"institutional": 0.0}')
+    fresh_payloads = [
+        _unpopulated_source_payload(f"TKR{i}", ["institutional"])
+        for i in range(10)
+    ]
+    _patch_collect(monkeypatch, fetch_returns=fresh_payloads)
+    result_relaxed = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+    assert result_relaxed["status"] == "ok"
+
+
+# ── F. Dry-run still bypasses ────────────────────────────────────────────────
+
+
+def test_dry_run_does_not_evaluate_gate(monkeypatch):
+    """Dry-run short-circuits before any fetch happens — gate logic
+    can't fire on data that wasn't fetched."""
+    monkeypatch.setattr(
+        alternative, "boto3", MagicMock(client=lambda *a, **k: MagicMock()),
+    )
+    monkeypatch.setattr(
+        alternative, "_load_promoted_tickers",
+        lambda *a, **k: ["AAPL", "MSFT"],
+    )
+    result = alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-04-27",
+        tickers=["AAPL", "MSFT"],
+        dry_run=True,
+    )
+    assert result["status"] == "ok_dry_run"
+    assert "breached_sources" not in result

--- a/tests/test_postflight.py
+++ b/tests/test_postflight.py
@@ -50,12 +50,12 @@ def _block_real_email(monkeypatch):
     monkeypatch.setattr("emailer.send_step_email", MagicMock(return_value=True))
 
 
-def _make_postflight() -> DataPostflight:
+def _make_postflight(phase: int = 1) -> DataPostflight:
     return DataPostflight(
         bucket=BUCKET,
         run_date=RUN_DATE,
         market_prefix=MARKET_PREFIX,
-        phase=1,
+        phase=phase,
     )
 
 
@@ -321,15 +321,148 @@ class TestUniverseSample:
 # ── Phase gating ──────────────────────────────────────────────────────────────
 
 class TestPhaseGating:
-    def test_phase2_is_skipped(self):
+    def test_phase3_or_higher_is_skipped(self):
+        """Unknown phase values short-circuit. Phase 1 and Phase 2 each have
+        their own check sets (see TestPhase2AlternativeManifest below)."""
         pf = DataPostflight(
             bucket=BUCKET,
             run_date=RUN_DATE,
             market_prefix=MARKET_PREFIX,
-            phase=2,
+            phase=3,
         )
-        # No mocks needed — run() should early-return for phase != 1.
+        # No mocks needed — run() should early-return for unknown phases.
         pf.run()
+
+
+# ── Phase 2 alternative manifest contract ────────────────────────────────────
+
+
+def _alt_manifest_payload(
+    *,
+    n_tickers: int = 25,
+    overrides: dict[str, float] | None = None,
+) -> dict:
+    """Build a fully-populated alternative/manifest.json mirroring what
+    ``collectors.alternative.collect`` writes."""
+    floors = {
+        "analyst_consensus": 0.80,
+        "eps_revision":      0.50,
+        "options_flow":      0.30,
+        "insider_activity":  0.10,
+        "institutional":     0.20,
+        "news":              0.50,
+    }
+    # Default: all sources at 100% coverage
+    ratios = {k: 1.0 for k in floors}
+    if overrides:
+        ratios.update(overrides)
+    return {
+        "run_date": RUN_DATE,
+        "tickers_requested": n_tickers,
+        "tickers_succeeded": n_tickers,
+        "tickers_failed": 0,
+        "source_ok_counts": {k: int(ratios[k] * n_tickers) for k in floors},
+        "source_ok_ratios": ratios,
+        "source_min_ok_ratios": floors,
+        "errors": [],
+    }
+
+
+class TestPhase2AlternativeManifest:
+    """The Phase 2 postflight re-verifies the per-source ok_ratio contract
+    Phase 2's collector already enforced. Belt-and-suspenders against a
+    partial write that bypassed the collector's status check."""
+
+    def test_ok_when_all_sources_above_floor(self):
+        pf = _make_postflight(phase=2)
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        payload = _alt_manifest_payload()
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps(payload).encode())),
+        }
+        pf._check_alternative_manifest_contract()  # must not raise
+
+    def test_fails_when_one_source_below_floor(self):
+        pf = _make_postflight(phase=2)
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        payload = _alt_manifest_payload(overrides={"analyst_consensus": 0.4})
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps(payload).encode())),
+        }
+        with pytest.raises(PostflightError, match="analyst_consensus"):
+            pf._check_alternative_manifest_contract()
+
+    def test_fails_with_all_breached_sources_named(self):
+        """Multiple breaches must be listed together so the operator
+        knows every provider that failed in one shot."""
+        pf = _make_postflight(phase=2)
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        payload = _alt_manifest_payload(overrides={
+            "analyst_consensus": 0.0, "eps_revision": 0.0,
+        })
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps(payload).encode())),
+        }
+        with pytest.raises(PostflightError) as excinfo:
+            pf._check_alternative_manifest_contract()
+        assert "analyst_consensus" in str(excinfo.value)
+        assert "eps_revision" in str(excinfo.value)
+
+    def test_fails_when_zero_tickers_requested(self):
+        pf = _make_postflight(phase=2)
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        payload = _alt_manifest_payload()
+        payload["tickers_requested"] = 0
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps(payload).encode())),
+        }
+        with pytest.raises(PostflightError, match="empty payload"):
+            pf._check_alternative_manifest_contract()
+
+    def test_fails_when_schema_missing_floors_block(self):
+        """If the collector writes a manifest without the per-source floors
+        block, the gate's contract is broken — postflight must hard-fail
+        rather than silently pass."""
+        pf = _make_postflight(phase=2)
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        payload = _alt_manifest_payload()
+        del payload["source_min_ok_ratios"]
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps(payload).encode())),
+        }
+        with pytest.raises(PostflightError, match="schema violation"):
+            pf._check_alternative_manifest_contract()
+
+    def test_absent_manifest_skips_check(self):
+        """Soft-launch: if Phase 2 hasn't run for this run_date yet, the
+        manifest doesn't exist — log + skip rather than break a Phase-1-only
+        invocation. Mirrors short_interest opt-out path."""
+        pf = _make_postflight(phase=2)
+        pf._s3 = MagicMock()
+        pf._s3.head_object.side_effect = RuntimeError("NoSuchKey")
+        pf._check_alternative_manifest_contract()  # must not raise
+        pf._s3.get_object.assert_not_called()
+
+    def test_phase2_run_invokes_alternative_check(self):
+        """Calling run() with phase=2 must dispatch to the alternative
+        manifest check (not phase-1's check set)."""
+        pf = _make_postflight(phase=2)
+        pf._s3 = MagicMock()
+        pf._s3.head_object.return_value = {}
+        payload = _alt_manifest_payload()
+        pf._s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=json.dumps(payload).encode())),
+        }
+        pf.run()  # must not raise
+        # Ensure phase-1 ArcticDB checks did NOT run (lazy lib handles
+        # would have been initialized otherwise).
+        assert pf._universe_lib is None
+        assert pf._macro_lib is None
 
 
 # ── _finalize wiring ──────────────────────────────────────────────────────────

--- a/validators/postflight.py
+++ b/validators/postflight.py
@@ -388,22 +388,96 @@ class DataPostflight:
                 f"s3://{self.bucket}/{key} is not valid JSON: {exc}"
             ) from exc
 
+    def _check_alternative_manifest_contract(self) -> None:
+        """Consumer: research scoring's qual sub-score reads
+        ``market_data/weekly/<run_date>/alternative/<TICKER>.json`` per
+        promoted ticker.
+
+        Phase 2's collector (``collectors/alternative.py::collect``) ships
+        a per-source ``ok_ratio`` gate — if any of the 6 sub-fetchers
+        (analyst_consensus, eps_revision, options_flow, insider_activity,
+        institutional, news) drops below its source-specific floor, the
+        collector returns ``status="error"``. This postflight check
+        re-verifies the manifest's per-source ratios meet the same
+        contract — belt-and-suspenders against a partial write that
+        bypassed the collector's own status check.
+
+        Soft-launch tolerance: if the manifest is absent (Phase 2 not yet
+        run for this ``run_date`` on a Phase-1-only postflight invocation,
+        or the alternative collector was disabled), log + skip rather
+        than hard-fail. Mirrors the ``short_interest`` opt-out path.
+        """
+        key = f"{self.market_prefix}weekly/{self.run_date}/alternative/manifest.json"
+        s3 = self._s3_client()
+        try:
+            s3.head_object(Bucket=self.bucket, Key=key)
+        except Exception:
+            log.info(
+                "postflight: alternative/manifest.json absent (Phase 2 likely "
+                "not yet run for %s) — skipping check.", self.run_date,
+            )
+            return
+
+        data = self._fetch_json(key, name="alternative/manifest.json")
+        n_tickers = data.get("tickers_requested", 0)
+        if n_tickers == 0:
+            raise PostflightError(
+                f"s3://{self.bucket}/{key} tickers_requested=0 — "
+                f"Phase 2 collector wrote an empty payload."
+            )
+
+        floors = data.get("source_min_ok_ratios") or {}
+        observed = data.get("source_ok_ratios") or {}
+        if not floors or not observed:
+            raise PostflightError(
+                f"s3://{self.bucket}/{key} missing source_min_ok_ratios "
+                f"or source_ok_ratios — schema violation. Phase 2 collector "
+                f"must emit both fields per the per-source ok_ratio gate."
+            )
+
+        breached: list[str] = []
+        for source, floor in floors.items():
+            ratio = observed.get(source)
+            if ratio is None:
+                breached.append(f"{source}: missing from manifest")
+            elif ratio < floor:
+                breached.append(
+                    f"{source}: {ratio:.1%} < {floor:.0%} threshold"
+                )
+
+        if breached:
+            raise PostflightError(
+                f"s3://{self.bucket}/{key} per-source ok_ratio gate breached "
+                f"for {len(breached)} of {len(floors)} sources — {breached}. "
+                f"Research scoring would silently degrade. Phase 2 collector "
+                f"already returned status=error; this check is the "
+                f"belt-and-suspenders verification."
+            )
+        log.info(
+            "postflight: alternative/manifest.json OK (%d tickers, %d sources "
+            "all above per-source floors)",
+            n_tickers, len(floors),
+        )
+
     # ── Entry point ──────────────────────────────────────────────────────────
 
     def run(self) -> None:
         """Run every check in sequence. Fail on the first contract violation."""
-        if self.phase != 1:
+        if self.phase == 1:
+            # Ordered so the cheapest + most-likely-to-fail checks run first.
+            self._check_latest_weekly_pointer()
+            self._check_macro_json_contract()
+            self._check_constituents_json_contract()
+            self._check_short_interest_json_contract()
+            self._check_macro_spy_fresh()
+            self._check_universe_sample_fresh()
+            log.info("postflight: all DataPhase1 consumer contracts satisfied")
+        elif self.phase == 2:
+            self._check_alternative_manifest_contract()
+            log.info("postflight: all DataPhase2 consumer contracts satisfied")
+        else:
             log.info(
-                "postflight: phase=%d is not gated today (only Phase 1). Skipping.",
+                "postflight: phase=%d is not gated today. Skipping.",
                 self.phase,
             )
             return
-
-        # Ordered so the cheapest + most-likely-to-fail checks run first.
-        self._check_latest_weekly_pointer()
-        self._check_macro_json_contract()
-        self._check_constituents_json_contract()
-        self._check_short_interest_json_contract()
-        self._check_macro_spy_fresh()
-        self._check_universe_sample_fresh()
-        log.info("postflight: all DataPhase1 consumer contracts satisfied")


### PR DESCRIPTION
## Summary

Closes the largest open silent-fail surface in Phase 2.

`collectors/alternative.py::collect` aggregates 6 heterogeneous sub-fetchers per ticker (analyst_consensus, eps_revision, options_flow, insider_activity, institutional, news). Before this PR, a single source going dark (Finnhub auth fail, FMP 402, SEC rate-limit ban) silently nulled out only its sub-section of the output dict — overall `_fetch_all_alternative` still returned successfully, the manifest landed `status="ok"` with `failed=0`, and the half-empty payload flowed into research scoring's qual sub-score. Same surface that `fundamentals.py`'s 90% ok_ratio gate closed for the homogeneous case (alpha-engine-data #68).

## Why per-source thresholds (not flat)

The 6 sources have very different baseline coverage in S&P 500/400. A flat ratio would false-positive on legitimate sparsity:
- Analyst coverage is near-universal → 0.80
- 13F filings are quarterly + 45d lag → 0.20
- Form 4 filings are episodic → 0.10
- Options-flow zero rows on low-vol days → 0.30
- News mostly weekly via Yahoo RSS / 8-K → 0.50
- EPS estimates drop for newer / smaller listings → 0.50

## Operator overrides

`ALT_MIN_OK_RATIOS` env var takes a JSON dict, e.g. `{"institutional": 0.05}` to relax a known edgartools-outage without code changes. Loader hard-fails on malformed JSON, unknown sources, or out-of-range values per NoSilentFails.

## Implementation

| Layer | Change |
|---|---|
| `_HAS_DATA_PREDICATES` registry | 6 predicates returning True iff a source produced real (non-default) data |
| `collect()` loop | Increment per-source counter inside existing ticker loop |
| Gate decision | Post-loop, status=error if any source breaches; manifest written first so operators see the diagnostic |
| Manifest schema | Added `source_ok_counts`, `source_ok_ratios`, `source_min_ok_ratios` (additive-only per S3 contract) |
| Phase 2 postflight | New `_check_alternative_manifest_contract` re-verifies the ratios; absent manifest soft-skips like `short_interest` |
| `postflight.run()` | Dispatches by phase (1 → existing checks, 2 → alternative manifest, else → skip) |

## Test plan

- [x] `pytest tests/test_alternative_ok_ratio_gate.py` — 21 new tests
  - Predicate semantics per source (incl. `iv_rank=0` is real data, not default)
  - Heterogeneity invariant + 5 env-override validation paths
  - Happy path, legitimate sparsity, breach paths, < not <= boundary, at-floor passes
  - Override-relaxes-specific-breach
  - Dry-run bypasses
- [x] `pytest tests/test_postflight.py` — 7 new tests for Phase 2 manifest contract
- [x] Full repo suite: 251 → 279 pass, no regressions
- [ ] Live verification on next Saturday SF Phase 2 run: `manifest.json` includes `source_ok_counts`/`source_ok_ratios`/`source_min_ok_ratios`; CloudWatch logs the per-source coverage line; postflight phase=2 path runs on the new structure

## Closes

ROADMAP P1 "ok_ratio gate on `collectors/alternative.py`" (added 2026-04-20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)