### PR TITLE
fix(daily_append): write macro before universe-coverage guard

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -242,6 +242,150 @@ def daily_append(
         universe_lib = None
         macro_lib = None
 
+    # ── 2a. Update macro / sector-ETF series in ArcticDB ─────────────────────
+    # This block was previously the final write step (old "step 5") and ran
+    # AFTER the universe-coverage guard at step 2b. That ordering coupled
+    # macro/SPY freshness to stock-coverage correctness: a 7-stock universe
+    # gap on 2026-04-27 raised at the guard before SPY ever got written, which
+    # then hard-failed the EOD reconcile (alpha against stale SPY is by-design
+    # rejected) and blacked out the EOD email + alpha tracking for the day.
+    #
+    # Macro keys are a fixed list of ~18 well-known tickers (SPY, VIX, sector
+    # ETFs); their freshness has nothing to do with whether 5 or 50 stocks
+    # went missing in the universe collection. Doing the macro write FIRST
+    # decouples the two concerns: macro lands in ArcticDB regardless of
+    # downstream stock-side issues, and the universe guard still raises
+    # non-zero so operators get paged on the universe gap. Net effect on
+    # 2026-04-27-style failures: EOD email goes out, daily-data still exits 1.
+    #
+    # update() semantics: same-date rows overwrite instead of appending. See
+    # _write_row_backfill_safe — it routes append vs backfill correctly.
+    #
+    # Per feedback_hard_fail_until_stable: count which keys got updated vs
+    # silently skipped due to missing closes data, verify the writes actually
+    # landed, and raise with a named reject list if anything went missing.
+    # Previous behavior: if closes.get(key) returned None (upstream collection
+    # gap), the update was silently skipped. Combined with stock tickers all
+    # hitting the "today already exists" skip path after a backfill, a run
+    # could return status="ok" with ZERO data actually written. 2026-04-15
+    # 08:39 PT manual rerun reproduced this — Step Function marked SUCCEEDED,
+    # macro/SPY stayed at 4/10 for 5 days until an inference-side preflight
+    # caught it.
+    macro_missing_from_closes: list[str] = []
+    macro_updated: list[str] = []
+    sector_updated: list[str] = []
+
+    # Track per-symbol write mode (append vs backfill) so the verification
+    # check below can apply the right correctness assertion. Append: last
+    # readback row should equal target_ts. Backfill: target_ts should be
+    # in the readback index (could be anywhere in the middle).
+    macro_write_modes: dict[str, str] = {}
+
+    macro_keys = ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO"]
+
+    if not dry_run:
+        for key in macro_keys:
+            bar = closes.get(key)
+            if bar is None or np.isnan(bar.get("Close", np.nan)):
+                macro_missing_from_closes.append(key)
+                continue
+            try:
+                new_row = pd.DataFrame(
+                    [{"Close": bar["Close"]}],
+                    index=pd.DatetimeIndex([today_ts]),
+                )
+                new_row.index.name = "date"
+                mode = _write_row_backfill_safe(macro_lib, key, new_row)
+                macro_updated.append(key)
+                macro_write_modes[key] = mode
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Failed to update macro {key} bar for {date_str}: {exc}"
+                ) from exc
+
+        # Sector ETFs — iterate the expected list explicitly rather than
+        # filtering closes.keys(), so a missing XL* key surfaces as a loud
+        # reject instead of a silent skip.
+        sector_etfs = ["XLB", "XLC", "XLE", "XLF", "XLI", "XLK",
+                       "XLP", "XLRE", "XLU", "XLV", "XLY"]
+        for sym in sector_etfs:
+            bar = closes.get(sym)
+            if bar is None or np.isnan(bar.get("Close", np.nan)):
+                macro_missing_from_closes.append(sym)
+                continue
+            try:
+                new_row = pd.DataFrame(
+                    [{"Close": bar["Close"]}],
+                    index=pd.DatetimeIndex([today_ts]),
+                )
+                new_row.index.name = "date"
+                mode = _write_row_backfill_safe(macro_lib, sym, new_row)
+                sector_updated.append(sym)
+                macro_write_modes[sym] = mode
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Failed to update sector ETF {sym} bar for {date_str}: {exc}"
+                ) from exc
+
+        # Hard-fail on any missing key — macro inputs are not optional.
+        # downstream feature compute + predictor preflight both depend on
+        # these being fresh.
+        if macro_missing_from_closes:
+            raise RuntimeError(
+                f"Macro/sector-ETF keys missing from today's daily_closes "
+                f"parquet: {macro_missing_from_closes}. Upstream daily_closes "
+                f"collection (polygon → FRED → yfinance fallback chain) did "
+                f"not produce bars for these tickers on {date_str}. Macro "
+                f"data is critical for downstream inference (SPY for "
+                f"return_vs_spy_5d, VIX for vix_level, sector ETFs for "
+                f"sector-relative features). Fix the upstream collection "
+                f"before claiming pipeline success."
+            )
+
+        # Verify writes landed. The update() / write() calls above are
+        # fire-and-forget (no return value surfaces a success flag), so
+        # we read back each key and assert target_ts is present. The
+        # check is mode-aware:
+        #   - append mode: last readback row should equal target_ts
+        #     (catches the 2026-04-15 silent-stale failure where SSM
+        #     reported SUCCEEDED but macro/SPY stayed 5 days behind)
+        #   - backfill mode: target_ts should be IN the readback index,
+        #     anywhere (last date is naturally future relative to
+        #     target_ts when we backfill an old date)
+        target_ts_norm = today_ts.normalize()
+        verification_failures: list[tuple[str, str]] = []
+        for key in macro_updated + sector_updated:
+            try:
+                readback = macro_lib.read(key).data
+            except Exception as exc:
+                verification_failures.append((key, f"readback error: {exc}"))
+                continue
+            if readback.empty:
+                verification_failures.append((key, "readback empty"))
+                continue
+            mode = macro_write_modes.get(key, "append")
+            if mode == "backfill":
+                # Target date should be present somewhere in the series.
+                index_norm = pd.DatetimeIndex(readback.index).normalize()
+                if target_ts_norm not in index_norm:
+                    verification_failures.append(
+                        (key, f"backfill target {target_ts_norm.date()} not in readback index "
+                              f"(last={pd.Timestamp(readback.index[-1]).date()})")
+                    )
+            else:
+                last_ts = pd.Timestamp(readback.index[-1]).normalize()
+                if last_ts != target_ts_norm:
+                    verification_failures.append(
+                        (key, f"last date {last_ts.date()} != expected {target_ts_norm.date()}")
+                    )
+        if verification_failures:
+            raise RuntimeError(
+                f"Macro update verification failed for {date_str}: "
+                f"{verification_failures}. update()/write() calls completed without "
+                f"exception but readback shows the row is missing. Investigate "
+                f"ArcticDB commit / consistency semantics."
+            )
+
     # ── 2b. Detect tickers that exist in ArcticDB universe but are missing
     #        from today's daily_closes parquet ─────────────────────────────────
     # Without this guard, the line ~274 ``stock_tickers = [t for t in closes ...]``
@@ -252,8 +396,11 @@ def daily_append(
     # writes for it across many weekdays, and the regression only surfaces
     # when an unrelated freshness preflight catches it days later.
     #
-    # Mirrors the macro/sector hard-fail at line ~614 — same architectural
-    # rule, just for the larger stock set. Threshold default (5) matches the
+    # Runs AFTER the macro write at step 2a so a stock-universe gap can't
+    # block macro/SPY freshness — see the rationale on the 2a header for the
+    # 2026-04-27 EOD blackout that motivated decoupling these two concerns.
+    # This guard still raises non-zero on threshold violations; pipelines
+    # exit 1 and operators get paged. Threshold default (5) matches the
     # absolute count of the 2026-04-25 regression; env-overridable so prod
     # can tune without a redeploy.
     n_missing_from_closes = 0
@@ -301,9 +448,14 @@ def daily_append(
                 n_missing_from_closes, threshold, missing_from_closes,
             )
 
-    # ── 3. Load macro series from ArcticDB ───────────────────────────────────
+    # ── 3. Load macro series from ArcticDB into in-memory dict ───────────────
+    # Read-only on ArcticDB. Builds a multi-day series per macro key for the
+    # per-stock feature loop (return_vs_spy_5d, vix_level, etc., which need
+    # context not just today's value). After step 2a's write, today's row is
+    # already in ArcticDB — the pd.concat below is now redundant in the happy
+    # path, but kept defensively so this block remains correct if step 2a is
+    # ever skipped or factored out.
     macro: dict[str, pd.Series] = {}
-    macro_keys = ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO"]
 
     if not dry_run:
         for key in macro_keys:
@@ -626,134 +778,6 @@ def daily_append(
                 n_partial += 1
             else:
                 n_ok += 1
-
-    # ── 5. Update macro series ───────────────────────────────────────────────
-    # update() semantics: same-date rows overwrite instead of appending. See
-    # commentary at the universe_lib.update() call above for the 2026-04-15
-    # duplicate-row diagnosis.
-    #
-    # Per feedback_hard_fail_until_stable: count which keys got updated vs
-    # silently skipped due to missing closes data, verify the writes actually
-    # landed, and raise with a named reject list if anything went missing.
-    # Previous behavior: if closes.get(key) returned None (upstream collection
-    # gap), the update was silently skipped. Combined with stock tickers all
-    # hitting the "today already exists" skip path after a backfill, a run
-    # could return status="ok" with ZERO data actually written. 2026-04-15
-    # 08:39 PT manual rerun reproduced this — Step Function marked SUCCEEDED,
-    # macro/SPY stayed at 4/10 for 5 days until an inference-side preflight
-    # caught it.
-    macro_missing_from_closes: list[str] = []
-    macro_updated: list[str] = []
-    sector_updated: list[str] = []
-
-    # Track per-symbol write mode (append vs backfill) so the verification
-    # check below can apply the right correctness assertion. Append: last
-    # readback row should equal target_ts. Backfill: target_ts should be
-    # in the readback index (could be anywhere in the middle).
-    macro_write_modes: dict[str, str] = {}
-
-    if not dry_run:
-        for key in macro_keys:
-            bar = closes.get(key)
-            if bar is None or np.isnan(bar.get("Close", np.nan)):
-                macro_missing_from_closes.append(key)
-                continue
-            try:
-                new_row = pd.DataFrame(
-                    [{"Close": bar["Close"]}],
-                    index=pd.DatetimeIndex([today_ts]),
-                )
-                new_row.index.name = "date"
-                mode = _write_row_backfill_safe(macro_lib, key, new_row)
-                macro_updated.append(key)
-                macro_write_modes[key] = mode
-            except Exception as exc:
-                raise RuntimeError(
-                    f"Failed to update macro {key} bar for {date_str}: {exc}"
-                ) from exc
-
-        # Sector ETFs — iterate the expected list explicitly rather than
-        # filtering closes.keys(), so a missing XL* key surfaces as a loud
-        # reject instead of a silent skip.
-        sector_etfs = ["XLB", "XLC", "XLE", "XLF", "XLI", "XLK",
-                       "XLP", "XLRE", "XLU", "XLV", "XLY"]
-        for sym in sector_etfs:
-            bar = closes.get(sym)
-            if bar is None or np.isnan(bar.get("Close", np.nan)):
-                macro_missing_from_closes.append(sym)
-                continue
-            try:
-                new_row = pd.DataFrame(
-                    [{"Close": bar["Close"]}],
-                    index=pd.DatetimeIndex([today_ts]),
-                )
-                new_row.index.name = "date"
-                mode = _write_row_backfill_safe(macro_lib, sym, new_row)
-                sector_updated.append(sym)
-                macro_write_modes[sym] = mode
-            except Exception as exc:
-                raise RuntimeError(
-                    f"Failed to update sector ETF {sym} bar for {date_str}: {exc}"
-                ) from exc
-
-        # Hard-fail on any missing key — macro inputs are not optional.
-        # downstream feature compute + predictor preflight both depend on
-        # these being fresh.
-        if macro_missing_from_closes:
-            raise RuntimeError(
-                f"Macro/sector-ETF keys missing from today's daily_closes "
-                f"parquet: {macro_missing_from_closes}. Upstream daily_closes "
-                f"collection (polygon → FRED → yfinance fallback chain) did "
-                f"not produce bars for these tickers on {date_str}. Macro "
-                f"data is critical for downstream inference (SPY for "
-                f"return_vs_spy_5d, VIX for vix_level, sector ETFs for "
-                f"sector-relative features). Fix the upstream collection "
-                f"before claiming pipeline success."
-            )
-
-        # Verify writes landed. The update() / write() calls above are
-        # fire-and-forget (no return value surfaces a success flag), so
-        # we read back each key and assert target_ts is present. The
-        # check is mode-aware:
-        #   - append mode: last readback row should equal target_ts
-        #     (catches the 2026-04-15 silent-stale failure where SSM
-        #     reported SUCCEEDED but macro/SPY stayed 5 days behind)
-        #   - backfill mode: target_ts should be IN the readback index,
-        #     anywhere (last date is naturally future relative to
-        #     target_ts when we backfill an old date)
-        target_ts_norm = today_ts.normalize()
-        verification_failures: list[tuple[str, str]] = []
-        for key in macro_updated + sector_updated:
-            try:
-                readback = macro_lib.read(key).data
-            except Exception as exc:
-                verification_failures.append((key, f"readback error: {exc}"))
-                continue
-            if readback.empty:
-                verification_failures.append((key, "readback empty"))
-                continue
-            mode = macro_write_modes.get(key, "append")
-            if mode == "backfill":
-                # Target date should be present somewhere in the series.
-                index_norm = pd.DatetimeIndex(readback.index).normalize()
-                if target_ts_norm not in index_norm:
-                    verification_failures.append(
-                        (key, f"backfill target {target_ts_norm.date()} not in readback index "
-                              f"(last={pd.Timestamp(readback.index[-1]).date()})")
-                    )
-            else:
-                last_ts = pd.Timestamp(readback.index[-1]).normalize()
-                if last_ts != target_ts_norm:
-                    verification_failures.append(
-                        (key, f"last date {last_ts.date()} != expected {target_ts_norm.date()}")
-                    )
-        if verification_failures:
-            raise RuntimeError(
-                f"Macro update verification failed for {date_str}: "
-                f"{verification_failures}. update()/write() calls completed without "
-                f"exception but readback shows the row is missing. Investigate "
-                f"ArcticDB commit / consistency semantics."
-            )
 
     t_total = time.time() - t0
 

--- a/tests/test_daily_append_missing_from_closes.py
+++ b/tests/test_daily_append_missing_from_closes.py
@@ -103,6 +103,85 @@ def test_missing_from_closes_counter_in_summary():
     )
 
 
+def test_macro_write_runs_before_universe_coverage_guard():
+    """Macro / sector-ETF write must execute BEFORE the universe-coverage
+    guard so a stock-universe gap can't blackout SPY/VIX freshness.
+
+    Regression for 2026-04-27: 7 stock tickers (PAYC, ASGN, LW, GTM, MOH,
+    KMPR, MTCH) went missing from daily_closes; the universe-coverage guard
+    raised at threshold>5 BEFORE the macro write block ran, so SPY never
+    landed in ArcticDB for the day. The EOD reconcile then hard-failed on
+    stale SPY (by design — alpha against stale SPY is meaningless) and the
+    EOD email did not go out. Independent macro freshness + loud universe
+    failure is the intent: macro writes first, universe guard still raises
+    on threshold violations, pipeline still exits non-zero.
+
+    Locks the source-order invariant: the offset of the macro write site
+    must precede the offset of the missing-from-closes raise.
+    """
+    src = _source()
+    macro_write_idx = src.find("_write_row_backfill_safe(macro_lib, key, new_row)")
+    guard_raise_idx = src.find("missing from today's daily_closes parquet")
+    assert macro_write_idx != -1, "macro write call site not found"
+    assert guard_raise_idx != -1, "missing-from-closes raise not found"
+    assert macro_write_idx < guard_raise_idx, (
+        f"Macro write at offset {macro_write_idx} must precede the "
+        f"missing-from-closes guard at offset {guard_raise_idx}. The "
+        f"reordered design ensures SPY/VIX/sector freshness is independent "
+        f"of stock-universe coverage — a regression here resurrects the "
+        f"2026-04-27 EOD-email blackout."
+    )
+
+
+def test_macro_write_does_not_block_on_universe_coverage(monkeypatch):
+    """Functional: even when stock universe coverage trips the hard-fail,
+    the macro write must have completed first (SPY/VIX/sector ETFs land
+    in ArcticDB before the guard raises).
+
+    Direct simulation of the 2026-04-27 failure mode: 10 stocks missing
+    from closes (well above threshold 5), but macro keys + sector ETFs are
+    all present. The function must raise on the universe guard, but the
+    macro_lib must have received its writes first.
+    """
+    from builders import daily_append as _da
+    from builders.daily_append import daily_append
+
+    universe = [f"TKR{i}" for i in range(12)] + ["AAPL", "MSFT"]
+    universe_lib, macro_lib = _patch_targets(
+        monkeypatch,
+        universe_symbols=universe,
+        closes_tickers=["AAPL", "MSFT"],
+    )
+
+    # Spy on the macro write helper so we can confirm it ran before the raise.
+    write_calls: list[tuple] = []
+
+    def _spy_write(lib, sym, df, existing_series=None):
+        write_calls.append((lib, sym))
+        return "append"
+
+    monkeypatch.setattr(_da, "_write_row_backfill_safe", _spy_write)
+
+    with pytest.raises(RuntimeError, match=r"missing from today's daily_closes"):
+        daily_append(date_str="2026-04-28")
+
+    # Macro keys (7) + sector ETFs (11) = 18 expected writes BEFORE the
+    # universe-coverage raise. If the macro write were still ordered
+    # AFTER the guard, write_calls would be empty.
+    macro_keys = {"SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO"}
+    sector_etfs = {"XLB", "XLC", "XLE", "XLF", "XLI", "XLK",
+                   "XLP", "XLRE", "XLU", "XLV", "XLY"}
+    written_syms = {sym for _, sym in write_calls}
+    assert macro_keys.issubset(written_syms), (
+        f"Macro keys not all written before universe-guard raise. "
+        f"Missing: {macro_keys - written_syms}. write_calls={write_calls}"
+    )
+    assert sector_etfs.issubset(written_syms), (
+        f"Sector ETFs not all written before universe-guard raise. "
+        f"Missing: {sector_etfs - written_syms}. write_calls={write_calls}"
+    )
+
+
 # ── 2. Functional: end-to-end behavior ─────────────────────────────────────────
 
 


### PR DESCRIPTION
2026-04-27 failure mode: 7 stock tickers (PAYC, ASGN, LW, GTM, MOH, KMPR, MTCH) went missing from daily_closes. The missing-from-closes guard at step 2b raised at threshold>5 BEFORE the macro write block (old "step 5") ran, so SPY/VIX/sector ETFs never landed in ArcticDB for the day. The downstream EOD reconcile then hard-failed on stale SPY (by design — alpha against stale SPY is meaningless) and the EOD email + eod_pnl row did not get produced.

Root cause was an architectural coupling: macro freshness is gated on stock-universe coverage, but the two have nothing to do with each other. Macro keys are a fixed list of ~18 well-known tickers (SPY, VIX, 11 sector ETFs, etc.); whether 5 or 50 stocks went missing in the universe doesn't change whether SPY needs to land.

Fix: reorder the function so the macro/sector-ETF write runs as step 2a (immediately after ArcticDB libs are opened) and the universe-coverage guard remains as step 2b. Macro lands in ArcticDB first, then the guard raises non-zero on threshold violations (operator still gets paged on the stock issue, pipeline still exits 1, downstream Step Function still marks the run failed). Net effect on this class of failure: EOD email goes out, daily-data still exits non-zero — independent loud failure of the actual problem.

Tests:
- test_macro_write_runs_before_universe_coverage_guard — locks source-order invariant (macro write call site precedes the missing-from-closes raise). Future refactors that reverse the ordering fail loudly here.
- test_macro_write_does_not_block_on_universe_coverage — functional simulation of the 2026-04-27 failure: 10 stocks missing from closes (well above threshold 5), but macro keys + sector ETFs all present. Asserts the function raises on the universe guard AND that all 7 macro keys + 11 sector ETFs were written first.
- All 261 existing tests pass (48 daily_append + 213 others).

Operational note: this PR alone does not unblock today's run — ArcticDB is still missing SPY for 2026-04-27 because the previously- ordered code already raised before reaching the write. Need to deploy this PR + rerun daily-data to backfill macros, then rerun EOD to send the email.