### PR TITLE
chore(infra): shift weekday SF trigger to 13:00 UTC (6:00 AM PT)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -127,8 +127,8 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: alpha-engine-weekday
-      Description: Weekday 13:05 UTC (6:05 AM PT) — daily data + predictor + executor
-      ScheduleExpression: 'cron(5 13 ? * MON-FRI *)'
+      Description: Weekday 13:00 UTC (6:00 AM PT) — daily data + predictor + executor
+      ScheduleExpression: 'cron(0 13 ? * MON-FRI *)'
       State: ENABLED
       Targets:
         - Id: weekday-pipeline

--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -150,12 +150,12 @@ echo "  State machine ARN: $SM_ARN"
 
 echo "Creating EventBridge rule: $EVENTBRIDGE_RULE..."
 
-# 13:05 UTC = 6:05 AM PT (Mon-Fri)
+# 13:00 UTC = 6:00 AM PT (Mon-Fri)
 aws events put-rule \
   --name "$EVENTBRIDGE_RULE" \
-  --schedule-expression "cron(5 13 ? * MON-FRI *)" \
+  --schedule-expression "cron(0 13 ? * MON-FRI *)" \
   --state ENABLED \
-  --description "Weekday 13:05 UTC (6:05 AM PT) — daily data + predictor + executor start" \
+  --description "Weekday 13:00 UTC (6:00 AM PT) — daily data + predictor + executor start" \
   --region "$REGION"
 
 # Reuse EventBridge role from Saturday pipeline
@@ -199,7 +199,7 @@ aws events put-targets \
   }]' \
   --region "$REGION"
 
-echo "  EventBridge rule: cron(5 13 ? * MON-FRI *) -> $STATE_MACHINE_NAME"
+echo "  EventBridge rule: cron(0 13 ? * MON-FRI *) -> $STATE_MACHINE_NAME"
 
 # ── Disable old rules (optional) ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Move `alpha-engine-weekday` EventBridge rule from `cron(5 13 ? * MON-FRI *)` → `cron(0 13 ? * MON-FRI *)` (13:05 → 13:00 UTC, 6:05 → 6:00 AM PT).
- Updates the CloudFormation template (source of truth) and the legacy `deploy_step_function_daily.sh` for parity.
- Buys ~5 minutes of headroom between SF start and market open. Today's run took ~26 min end-to-end (MorningEnrich 22 min) so the prior 6:05 → 6:30 PT window was too tight on slow days.

## Test plan
- [ ] After merge, run `bash infrastructure/deploy-infrastructure.sh` from main
- [ ] Verify rule: `aws events describe-rule --name alpha-engine-weekday`
- [ ] Confirm tomorrow's invocation timestamp is 13:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)