### PR TITLE
feat(data): migrate daily_closes parquet to staging/ prefix + lifecycle policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ pytest tests/ -v  # 56 tests
 |------|---------|-----------|
 | `arcticdb/universe/` | 10y OHLCV for 909 tickers | Weekly |
 | `arcticdb/universe_slim/` | 2y OHLCV slices | Weekly |
-| `predictor/daily_closes/{date}.parquet` | Daily OHLCV | Daily |
+| `staging/daily_closes/{date}.parquet` | Daily OHLCV — intermediate staging (7-day lifecycle); canonical home is ArcticDB universe | Daily |
 | `predictor/feature_store/{date}/` | 54 features x 903 tickers | Weekly + Daily |
 | `market_data/weekly/{date}/` | Constituents, macro, alternative data | Weekly |
 | `health/data_phase1.json` | Phase 1 completion marker | Weekly |

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -181,7 +181,7 @@ def _load_daily_closes(s3, bucket: str, date_str: str) -> dict[str, dict]:
     consumers (executor's ``load_daily_vwap``) handle NaN by walking back up
     to 5 trading days for a populated value.
     """
-    key = f"predictor/daily_closes/{date_str}.parquet"
+    key = f"staging/daily_closes/{date_str}.parquet"
     obj = s3.get_object(Bucket=bucket, Key=key)
     buf = io.BytesIO(obj["Body"].read())
     df = pd.read_parquet(buf, engine="pyarrow")

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -1,9 +1,14 @@
 """
 collectors/daily_closes.py — Daily OHLCV archive for all tracked tickers.
 
-Writes one parquet per trading day at predictor/daily_closes/{date}.parquet.
-The predictor inference Lambda uses these to bridge the gap between the
-weekly slim cache and today's prices, avoiding a full 2-year yfinance fetch.
+Writes one parquet per trading day at staging/daily_closes/{date}.parquet.
+The parquet is the in-flight checkpoint between the API fetch (polygon /
+FRED / yfinance) and ArcticDB ingest by ``builders/daily_append.py``.
+Lives under ``staging/`` (not ``predictor/``) because it is intermediate
+state, not authoritative storage — the canonical home for daily OHLCV
+is ArcticDB universe library. S3 lifecycle policy on ``staging/`` expires
+parquets after 7 days; the parquet's only role is restartability when
+daily_append fails after the upstream fetch succeeded.
 
 Two collection modes (selected via the ``source`` parameter):
 
@@ -86,7 +91,7 @@ def collect(
     bucket: str,
     tickers: list[str],
     run_date: str | None = None,
-    s3_prefix: str = "predictor/daily_closes/",
+    s3_prefix: str = "staging/daily_closes/",
     dry_run: bool = False,
     source: str = "auto",
 ) -> dict:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -23,9 +23,10 @@ universe_returns:
   sector_map_key: predictor/price_cache/sector_map.json
   # db_path: /tmp/research.db       # optional: override local DB path (auto-downloaded from S3)
 
-# Daily closes (weekday OHLCV archive)
+# Daily closes (weekday OHLCV archive — intermediate staging,
+# 7-day S3 lifecycle expiration; canonical home is ArcticDB universe library)
 daily_closes:
-  s3_prefix: predictor/daily_closes/
+  s3_prefix: staging/daily_closes/
 
 # Tickers that require a leading caret in yfinance (index/rate tickers)
 # Stored locally WITHOUT the caret (VIX.parquet, not ^VIX.parquet)

--- a/features/compute.py
+++ b/features/compute.py
@@ -14,7 +14,7 @@ Usage:
     python -m features.compute --dry-run                # compute but skip S3 write
 
 Data sources:
-    Prices:       predictor/price_cache_slim/*.parquet + predictor/daily_closes/{date}.parquet
+    Prices:       predictor/price_cache_slim/*.parquet + staging/daily_closes/{date}.parquet
     Macro:        SPY, VIX, TNX, IRX, GLD, USO, VIX3M (from slim cache)
     Sector map:   data/sector_map.json
     Fundamentals: archive/fundamentals/{date}.json (cached by prior inference)
@@ -130,7 +130,7 @@ def _load_delta_from_daily_closes(
 
     n_missing_dates = 0
     for d in delta_dates:
-        key = f"predictor/daily_closes/{d}.parquet"
+        key = f"staging/daily_closes/{d}.parquet"
         try:
             obj = s3.get_object(Bucket=bucket, Key=key)
         except s3.exceptions.NoSuchKey:

--- a/infrastructure/apply_s3_lifecycle.sh
+++ b/infrastructure/apply_s3_lifecycle.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# apply_s3_lifecycle.sh — Apply S3 lifecycle policy on alpha-engine-research.
+#
+# The current policy expires the staging/ prefix after 7 days; see
+# s3_lifecycle_staging.json for rationale. Idempotent — put-bucket-lifecycle-
+# configuration replaces the full policy body, so re-running is safe.
+#
+# Usage:
+#   ./infrastructure/apply_s3_lifecycle.sh                 # apply
+#   ./infrastructure/apply_s3_lifecycle.sh --dry-run       # print planned cmd
+#
+# Prerequisites:
+#   - AWS CLI with s3:PutLifecycleConfiguration on the bucket
+#
+# WARNING: this script REPLACES the full lifecycle policy on the bucket.
+# If other prefixes need lifecycle rules in the future, append them to
+# s3_lifecycle_staging.json (or a successor file) — do not split rules
+# across multiple invocations of this script.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUCKET="${ALPHA_ENGINE_BUCKET:-alpha-engine-research}"
+REGION="${AWS_REGION:-us-east-1}"
+POLICY_FILE="$SCRIPT_DIR/s3_lifecycle_staging.json"
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+  esac
+done
+
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "ERROR: $POLICY_FILE not found" >&2
+  exit 1
+fi
+
+if ! python3 -c "import json; json.load(open('$POLICY_FILE'))" 2>/dev/null; then
+  echo "ERROR: $POLICY_FILE is not valid JSON" >&2
+  exit 1
+fi
+
+echo "Applying lifecycle policy to s3://$BUCKET"
+echo "Policy file: $POLICY_FILE"
+
+if [ "$DRY_RUN" = 1 ]; then
+  echo "  [dry-run] aws s3api put-bucket-lifecycle-configuration --bucket $BUCKET --lifecycle-configuration file://$POLICY_FILE --region $REGION"
+  exit 0
+fi
+
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket "$BUCKET" \
+  --lifecycle-configuration "file://$POLICY_FILE" \
+  --region "$REGION"
+
+echo "  OK"
+echo ""
+echo "Verify:"
+echo "  aws s3api get-bucket-lifecycle-configuration --bucket $BUCKET --region $REGION"

--- a/infrastructure/s3_lifecycle_staging.json
+++ b/infrastructure/s3_lifecycle_staging.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "S3 lifecycle policy for the staging/ prefix on alpha-engine-research bucket. The staging/daily_closes/ parquets are intermediate state between API fetch (polygon/FRED/yfinance) and ArcticDB ingest by builders/daily_append.py — their only role is restartability when daily_append fails after the upstream fetch succeeded. Canonical home for daily OHLCV is the ArcticDB universe library, not S3 parquet. 7-day expiration is generous compared to the typical retry window (same-day) but absorbs cold-storage debugging usage (aws s3 cp parquet locally for incident triage) without letting old parquets accumulate.",
+  "Rules": [
+    {
+      "ID": "expire-staging-after-7-days",
+      "Status": "Enabled",
+      "Filter": {
+        "Prefix": "staging/"
+      },
+      "Expiration": {
+        "Days": 7
+      },
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 1
+      }
+    }
+  ]
+}

--- a/tests/test_staging_prefix_migration.py
+++ b/tests/test_staging_prefix_migration.py
@@ -1,0 +1,139 @@
+"""Regression tests pinning the staging/daily_closes/ prefix migration.
+
+The path was renamed from ``predictor/daily_closes/{date}.parquet`` to
+``staging/daily_closes/{date}.parquet`` to (1) move the intermediate
+parquet out of the ``predictor/`` namespace where it lived alongside
+authoritative artifacts (it's actually intermediate state between API
+fetch and ArcticDB ingest), and (2) make it eligible for an S3 lifecycle
+expiration (``infrastructure/s3_lifecycle_staging.json``).
+
+These tests lock the prefix in place across the writer + both readers
+so a future PR can't silently regress one of the call sites without
+the other.
+
+Coordinated cross-repo cutover:
+
+  - alpha-engine-data (this repo): writer + 2 readers — covered here
+  - alpha-engine-research: ``feature_store_reader.read_latest_daily_closes``
+  - alpha-engine-dashboard: ``health_checker.py`` daily_closes probe +
+    ``pages/4_System_Health.py`` S3 object count
+  - alpha-engine: stale executor IAM grant (separate cleanup PR)
+
+Per ``feedback_no_silent_fails``: hard-cutover, no fallback. If the new
+prefix is missing, every reader fails loud (RuntimeError or NoSuchKey).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _read(path: str) -> str:
+    return (Path(__file__).parent.parent / path).read_text()
+
+
+# ── Writer-side: collectors/daily_closes.py ─────────────────────────────────
+
+
+def test_collector_default_prefix_is_staging():
+    """``collect()`` must default ``s3_prefix`` to ``staging/daily_closes/``."""
+    from collectors.daily_closes import collect
+    import inspect
+    sig = inspect.signature(collect)
+    default = sig.parameters["s3_prefix"].default
+    assert default == "staging/daily_closes/", (
+        f"collect() s3_prefix default regressed to {default!r}. The "
+        f"prefix migration to staging/ is load-bearing for the S3 lifecycle "
+        f"policy + the explicit 'intermediate state' contract."
+    )
+
+
+def test_collector_no_legacy_prefix_in_source():
+    """Belt-and-suspenders: forbid the legacy prefix string anywhere in the
+    collector source, including module docstring + comments. Catches the
+    case where someone reverts the default but leaves a stray legacy string."""
+    src = _read("collectors/daily_closes.py")
+    assert "predictor/daily_closes" not in src, (
+        "collectors/daily_closes.py contains 'predictor/daily_closes' — "
+        "the prefix was migrated to staging/. Update the offending line."
+    )
+
+
+# ── Reader-side: builders/daily_append.py ───────────────────────────────────
+
+
+def test_daily_append_reads_staging_prefix():
+    """``_load_daily_closes`` must read from ``staging/daily_closes/``."""
+    src = _read("builders/daily_append.py")
+    assert 'f"staging/daily_closes/{date_str}.parquet"' in src, (
+        "builders/daily_append.py:_load_daily_closes is not reading from "
+        "staging/daily_closes/{date_str}.parquet. Hard-cutover requires "
+        "this exact f-string per the no-fallback contract."
+    )
+    assert "predictor/daily_closes" not in src, (
+        "builders/daily_append.py contains 'predictor/daily_closes' — "
+        "fallback to the legacy prefix is forbidden per "
+        "feedback_no_silent_fails."
+    )
+
+
+# ── Reader-side: features/compute.py ────────────────────────────────────────
+
+
+def test_features_compute_reads_staging_prefix():
+    """``features/compute.py`` (used by daily_append, backfill,
+    prune_delisted_tickers, promote_ohlcv_only_schema, migrate_universe_vwap,
+    weekly_collector) must read from ``staging/daily_closes/``."""
+    src = _read("features/compute.py")
+    assert 'f"staging/daily_closes/{d}.parquet"' in src, (
+        "features/compute.py is not reading from staging/daily_closes/. "
+        "Hard-cutover requires this exact path; legacy fallback forbidden."
+    )
+    assert "predictor/daily_closes" not in src, (
+        "features/compute.py contains 'predictor/daily_closes' — "
+        "fallback forbidden."
+    )
+
+
+# ── Orchestrator: weekly_collector.py ───────────────────────────────────────
+
+
+def test_weekly_collector_default_prefix_is_staging():
+    """Both call sites in weekly_collector must pass the staging/ default
+    when config doesn't override."""
+    src = _read("weekly_collector.py")
+    n_old = src.count('"predictor/daily_closes/"')
+    n_new = src.count('"staging/daily_closes/"')
+    assert n_old == 0, (
+        f"weekly_collector.py contains {n_old} legacy 'predictor/daily_closes/' "
+        f"defaults — replace with 'staging/daily_closes/'."
+    )
+    assert n_new >= 2, (
+        f"weekly_collector.py expected to pass 'staging/daily_closes/' as the "
+        f"daily_cfg.get fallback in both --daily and --morning-enrich paths "
+        f"(2 sites); found {n_new}."
+    )
+
+
+# ── Lifecycle policy artifact ───────────────────────────────────────────────
+
+
+def test_lifecycle_policy_artifact_exists_and_is_valid_json():
+    import json
+    path = Path(__file__).parent.parent / "infrastructure/s3_lifecycle_staging.json"
+    assert path.exists(), (
+        f"{path} missing. The lifecycle policy artifact is what makes the "
+        f"'7-day expiration' invariant in the README + module docstrings real "
+        f"in production. Operator must run apply_s3_lifecycle.sh after merge."
+    )
+    payload = json.loads(path.read_text())
+    rules = payload.get("Rules", [])
+    assert len(rules) >= 1
+    rule = rules[0]
+    assert rule["Status"] == "Enabled"
+    assert rule["Filter"]["Prefix"] == "staging/", (
+        f"Lifecycle rule must scope to the staging/ prefix; got "
+        f"{rule['Filter'].get('Prefix')!r}. A wider scope (e.g. '/') would "
+        f"silently expire authoritative artifacts."
+    )
+    assert rule["Expiration"]["Days"] == 7

--- a/tests/test_vwap_ingestion.py
+++ b/tests/test_vwap_ingestion.py
@@ -3,7 +3,7 @@
 Phase 7 VWAP centralization contract:
 
   * Polygon grouped-daily produces true volume-weighted VWAP. That value flows
-    via ``collectors/daily_closes.py`` → ``predictor/daily_closes/*.parquet``
+    via ``collectors/daily_closes.py`` → ``staging/daily_closes/*.parquet``
     → ``builders/daily_append.py::_load_daily_closes`` → ArcticDB universe.
   * Any other source (yfinance fallback, FRED single-close, legacy backfill
     price_cache) writes ``None`` / NaN for VWAP. No ``(H+L+C)/3`` proxy.

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -490,7 +490,7 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
             bucket=bucket,
             tickers=tickers,
             run_date=target_date,
-            s3_prefix=daily_cfg.get("s3_prefix", "predictor/daily_closes/"),
+            s3_prefix=daily_cfg.get("s3_prefix", "staging/daily_closes/"),
             dry_run=dry_run,
             source="polygon_only",
         )
@@ -635,7 +635,7 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
             bucket=bucket,
             tickers=tickers,
             run_date=run_date,
-            s3_prefix=daily_cfg.get("s3_prefix", "predictor/daily_closes/"),
+            s3_prefix=daily_cfg.get("s3_prefix", "staging/daily_closes/"),
             dry_run=dry_run,
             source="yfinance_only",
         )


### PR DESCRIPTION
## Summary

First PR of a coordinated 4-PR arc closing ROADMAP P1 "VWAP centralization — Writer" (line 576) staleness + Phase 7e namespace cleanup goal. The VWAP writer itself shipped 2026-04-17 (PR #51) and the universe schema canonicalization shipped 2026-04-28 morning. What's still open is eliminating `predictor/daily_closes/` from the `predictor/` namespace where it lives alongside authoritative artifacts when it's actually intermediate state between API fetch and ArcticDB ingest.

Moving the prefix from `predictor/daily_closes/` → `staging/daily_closes/` makes that role explicit in the path, and the new `infrastructure/s3_lifecycle_staging.json` expires `staging/` objects after 7 days so old parquets stop accumulating.

## Hard-cutover, no fallback (per `feedback_no_silent_fails`)

Reader-side fallback was explicitly rejected as the silent-fail class that has bitten production repeatedly this month. All consumers hard-cut to the new prefix; if it's missing every reader fails loud (`RuntimeError` or `NoSuchKey`) rather than falling through to legacy.

## Coordinated cross-repo cutover (PRs 2 + 3 must merge in same deploy window)

| PR | Repo | Change |
|---|---|---|
| **PR 1 (this)** | alpha-engine-data | writer + 2 readers + orchestrator + lifecycle policy artifact |
| PR 2 | alpha-engine-research | `feature_store_reader.read_latest_daily_closes` cuts to `staging/` (called from `graph/research_graph.py:222-223` in the live Saturday SF Research Lambda) |
| PR 3 | alpha-engine-dashboard | `health_checker.py:158/161` + `pages/4_System_Health.py:266` cut to `staging/` |
| PR 4 | alpha-engine | drop stale `predictor/daily_closes/*` from executor IAM (executor migrated 2026-04-17 in PR #60) |

Brief window between data PR deploy and consumer Lambda redeploys may show 404s on new path — that's the intended "fail loud" signal under the hard-cutover contract.

## Files changed (writer + 2 readers + orchestrator)

- `collectors/daily_closes.py`: default `s3_prefix` `"predictor/daily_closes/"` → `"staging/daily_closes/"`; module docstring rewritten to reflect the intermediate-state role + 7-day lifecycle
- `builders/daily_append.py`: `_load_daily_closes` reads `staging/daily_closes/{date_str}.parquet`
- `features/compute.py`: delta-load loop reads `staging/daily_closes/{d}.parquet` (+ docstring)
- `weekly_collector.py`: both `--daily` and `--morning-enrich` call sites default `daily_cfg.s3_prefix` to `"staging/daily_closes/"`
- `config.yaml.example`: documented default updated; comment explaining intermediate-staging contract
- `README.md`: writes table updated; flags 7-day lifecycle + ArcticDB as canonical home
- `tests/test_vwap_ingestion.py`: docstring path corrected

## New artifacts

- `infrastructure/s3_lifecycle_staging.json`: 7-day expiration scoped to `staging/` prefix; 1-day abort for incomplete multipart uploads
- `infrastructure/apply_s3_lifecycle.sh`: idempotent `put-bucket-lifecycle-configuration` applier; `--dry-run` support

## Operational steps after merge

1. **This PR merges + auto-deploys** to ae-trading via `boot-pull` on next instance start (or manual `git pull`).
2. **Apply lifecycle policy:** `bash infrastructure/apply_s3_lifecycle.sh` from this repo. Pushes the 7-day expiration to alpha-engine-research bucket.
3. **Merge PR 2 + PR 3** in the same window so research Lambda + dashboard cut to the new prefix.
4. **After 1 clean Saturday SF + weekday SF cycle**, delete the old prefix: `aws s3 rm --recursive s3://alpha-engine-research/predictor/daily_closes/`. Closes ROADMAP Phase 7e for this prefix.
5. **Merge PR 4** (alpha-engine IAM cleanup) parallel — drops the stale executor grant.

## Test plan

- [x] `pytest tests/test_staging_prefix_migration.py -v` -> 6 pass (writer default, no legacy strings, both readers, orchestrator, lifecycle artifact valid)
- [x] `pytest tests/` -> 306 pass (was 300), 0 regressions
- [x] `python3 -c 'import json; json.load(open("infrastructure/s3_lifecycle_staging.json"))'` -> valid
- [x] `bash infrastructure/apply_s3_lifecycle.sh --dry-run` -> prints planned put-bucket-lifecycle-configuration command