### PR TITLE
fix(infra): preserve feature-store-retention rule in lifecycle JSON

### DIFF
--- a/infrastructure/apply_s3_lifecycle.sh
+++ b/infrastructure/apply_s3_lifecycle.sh
@@ -2,9 +2,18 @@
 #
 # apply_s3_lifecycle.sh — Apply S3 lifecycle policy on alpha-engine-research.
 #
-# The current policy expires the staging/ prefix after 7 days; see
-# s3_lifecycle_staging.json for rationale. Idempotent — put-bucket-lifecycle-
-# configuration replaces the full policy body, so re-running is safe.
+# The policy file (s3_lifecycle_staging.json) is the single source of truth
+# for ALL bucket lifecycle rules — put-bucket-lifecycle-configuration replaces
+# the entire document on apply. Current rules:
+#
+#   - staging/        7-day expiration (added 2026-04-29 in PR #112; the
+#                     daily_closes parquet is intermediate state between API
+#                     fetch and ArcticDB ingest by builders/daily_append.py).
+#   - features/       90-day STANDARD_IA transition + 365-day expiration
+#                     (pre-existing rule, preserved when staging/ was added).
+#
+# Add new rules INTO this file's Rules array — never split across files.
+# Idempotent — re-running pushes the same policy.
 #
 # Usage:
 #   ./infrastructure/apply_s3_lifecycle.sh                 # apply

--- a/infrastructure/s3_lifecycle_staging.json
+++ b/infrastructure/s3_lifecycle_staging.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "S3 lifecycle policy for the staging/ prefix on alpha-engine-research bucket. The staging/daily_closes/ parquets are intermediate state between API fetch (polygon/FRED/yfinance) and ArcticDB ingest by builders/daily_append.py — their only role is restartability when daily_append fails after the upstream fetch succeeded. Canonical home for daily OHLCV is the ArcticDB universe library, not S3 parquet. 7-day expiration is generous compared to the typical retry window (same-day) but absorbs cold-storage debugging usage (aws s3 cp parquet locally for incident triage) without letting old parquets accumulate.",
   "Rules": [
     {
       "ID": "expire-staging-after-7-days",
@@ -12,6 +11,22 @@
       },
       "AbortIncompleteMultipartUpload": {
         "DaysAfterInitiation": 1
+      }
+    },
+    {
+      "ID": "feature-store-retention",
+      "Status": "Enabled",
+      "Filter": {
+        "Prefix": "features/"
+      },
+      "Transitions": [
+        {
+          "Days": 90,
+          "StorageClass": "STANDARD_IA"
+        }
+      ],
+      "Expiration": {
+        "Days": 365
       }
     }
   ]


### PR DESCRIPTION
## Summary

Follow-up to PR #112 — caught while running `apply_s3_lifecycle.sh` against the live bucket.

`put-bucket-lifecycle-configuration` **replaces the full document** on apply. PR #112 shipped the lifecycle JSON with only the new `staging/` rule, so running the apply as shipped would have clobbered the pre-existing `feature-store-retention` rule on the `features/` prefix (90-day STANDARD_IA transition + 365-day expiration).

## What I did

1. Inspected current bucket lifecycle BEFORE applying — `aws s3api get-bucket-lifecycle-configuration` showed the existing `feature-store-retention` rule
2. Merged both rules into the JSON file (this PR)
3. Applied — verified post-apply via `get-bucket-lifecycle-configuration`: both rules present (staging/ 7d expiration + features/ 365d / 90d→STANDARD_IA)

## Other change in this PR

Dropped `_comment` fields from the JSON. AWS S3 lifecycle config schema doesn't recognize them — they'd have been rejected at apply time. Comments now live in `apply_s3_lifecycle.sh`'s docstring instead, with an explicit "this file is the single source of truth for ALL bucket lifecycle rules" warning to stop a future contributor from making the same mistake.

## Test plan

- [x] `python3 -c 'import json; json.load(...)'` -> valid (2 rules)
- [x] `bash infrastructure/apply_s3_lifecycle.sh --dry-run` -> shows planned put command
- [x] **Already applied to live bucket** — verified via `get-bucket-lifecycle-configuration`
- [x] Live bucket state: staging/ 7d expiration + features/ 90d-IA + 365d expiration