### PR TITLE
feat(data): wire flow-doctor into all entrypoints via alpha-engine-lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
 # Config (contains bucket names, API keys)
 config.yaml
 
-# Flow Doctor config — references repo names + secrets via env var substitution.
-# The real file is staged from alpha-engine-config at deploy time (or copied
-# from flow-doctor.yaml.example locally).
-flow-doctor.yaml
+# flow-doctor.yaml was previously gitignored because it held inline credentials.
+# As of flow-doctor 0.2.0 + FLOW_DOCTOR_* env var contract, all secrets come from
+# the environment and the YAML contains only ${VAR} references — safe to commit.
 
 # Python
 __pycache__/

--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -1,0 +1,21 @@
+flow_name: data-collector
+repo: cipher813/alpha-engine-data
+owner: "@brianmcmahon"
+notify:
+  - type: email
+    sender: ${EMAIL_SENDER}
+    recipients: ${EMAIL_RECIPIENTS}
+    smtp_host: smtp.gmail.com
+    smtp_port: 587
+    smtp_password: ${GMAIL_APP_PASSWORD}
+  - type: github
+    repo: cipher813/alpha-engine-data
+    token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+store:
+  type: sqlite
+  path: /tmp/flow_doctor.db
+dedup_cooldown_minutes: 60
+rate_limits:
+  max_alerts_per_day: 10
+  max_issues_per_day: 3
+  max_diagnosed_per_day: 3

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -17,10 +17,29 @@ import sys
 import time
 import traceback
 
-# Load secrets from SSM Parameter Store (must run before any os.environ.get)
+# Load secrets from SSM Parameter Store (must run before any os.environ.get
+# AND before setup_logging — flow-doctor.yaml's ${FLOW_DOCTOR_GITHUB_TOKEN}
+# resolves at flow_doctor.init() time inside setup_logging).
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from ssm_secrets import load_secrets
 load_secrets()
+
+# Structured logging + flow-doctor singleton via alpha-engine-lib (shared
+# pattern across all 5 entrypoints; see executor/main.py for reference).
+# When FLOW_DOCTOR_ENABLED=1, attaches a FlowDoctorHandler at ERROR so every
+# log.error() call routes through flow-doctor's dispatch (email + GitHub
+# issue with dedup + rate limits per flow-doctor.yaml at the repo root).
+from alpha_engine_lib.logging import setup_logging
+_FLOW_DOCTOR_EXCLUDE_PATTERNS: list[str] = []
+_FLOW_DOCTOR_YAML = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "flow-doctor.yaml",
+)
+setup_logging(
+    "data-phase2",
+    flow_doctor_yaml=_FLOW_DOCTOR_YAML,
+    exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/rag/preflight.py
+++ b/rag/preflight.py
@@ -20,6 +20,22 @@ import sys
 from alpha_engine_lib.logging import setup_logging
 from alpha_engine_lib.preflight import BasePreflight
 
+# Structured logging + flow-doctor singleton via alpha-engine-lib (shared
+# pattern across all 5 entrypoints; see executor/main.py for reference).
+# Module-top so any import-time error in BasePreflight or downstream
+# pipelines invoked after preflight is captured by flow-doctor's ERROR
+# handler. flow-doctor.yaml lives at the repo root (one dir above rag/).
+_FLOW_DOCTOR_EXCLUDE_PATTERNS: list[str] = []
+_FLOW_DOCTOR_YAML = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "flow-doctor.yaml",
+)
+setup_logging(
+    "rag-preflight",
+    flow_doctor_yaml=_FLOW_DOCTOR_YAML,
+    exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -53,13 +69,8 @@ class RAGPreflight(BasePreflight):
 
 def main() -> int:
     """CLI entrypoint invoked by run_weekly_ingestion.sh."""
-    setup_logging(
-        "rag-preflight",
-        flow_doctor_yaml=os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "flow-doctor.yaml",
-        ),
-    )
+    # setup_logging already ran at module-top (see comment near the
+    # alpha_engine_lib.logging import).
     bucket = os.environ.get("ALPHA_ENGINE_BUCKET", "alpha-engine-research")
     RAGPreflight(bucket).run()
     log.info("RAG pre-flight OK")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
-alpha-engine-lib[arcticdb,flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@main
+alpha-engine-lib[arcticdb,flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.2

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -1,0 +1,270 @@
+"""Verify flow-doctor wiring in data-module entrypoints.
+
+Asserts that the canonical alpha-engine-lib pattern (setup_logging at
+module-top, exclude_patterns plumbed, yaml resolvable from the entrypoint
+location) is in place for the three data entrypoints:
+
+- ``lambda/handler.py``     — Phase 2 alternative-data Lambda
+- ``weekly_collector.py``   — Phase 1 / MorningEnrich / daily on EC2
+- ``rag/preflight.py``      — RAG ingestion preflight CLI
+
+Runs without firing any LLM diagnosis: ``setup_logging`` is exercised with
+FLOW_DOCTOR_ENABLED=1 + stub env vars + a real yaml, but no ERROR records
+are emitted (so flow-doctor's report() / diagnose() pipeline is never
+triggered — no Anthropic calls, no email, no GitHub issue).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def stub_flow_doctor_env(monkeypatch):
+    """Populate the env vars that flow-doctor.yaml's ${VAR} refs resolve.
+
+    flow_doctor.init() substitutes these at load time. Stubs are non-empty
+    strings; nothing actually contacts SMTP/GitHub since no report() fires.
+    """
+    monkeypatch.setenv("FLOW_DOCTOR_ENABLED", "1")
+    monkeypatch.setenv("EMAIL_SENDER", "test@example.com")
+    monkeypatch.setenv("EMAIL_RECIPIENTS", "test@example.com")
+    monkeypatch.setenv("GMAIL_APP_PASSWORD", "stub-password")
+    monkeypatch.setenv("FLOW_DOCTOR_GITHUB_TOKEN", "stub-token")
+
+
+@pytest.fixture
+def temp_flow_doctor_yaml(tmp_path):
+    """Write a copy of the production flow-doctor.yaml with store.path
+    redirected into the test's tmp_path. Returns the temp yaml path.
+
+    The production yaml hardcodes /tmp/flow_doctor.db (Lambda ephemeral
+    convention) which isn't writable in every CI/sandbox env. Tests that
+    actually invoke flow_doctor.init() need a redirectable path.
+    """
+    import yaml as yamllib
+    with open(REPO_ROOT / "flow-doctor.yaml") as f:
+        cfg = yamllib.safe_load(f)
+    cfg["store"]["path"] = str(tmp_path / "flow_doctor_test.db")
+    yaml_path = tmp_path / "flow-doctor.yaml"
+    with open(yaml_path, "w") as f:
+        yamllib.safe_dump(cfg, f)
+    return str(yaml_path)
+
+
+@pytest.fixture
+def reset_root_logger():
+    """Snapshot + restore root logger handlers around each test."""
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    yield
+    root.handlers = saved
+
+
+def _flow_doctor_available() -> bool:
+    try:
+        import flow_doctor  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+flow_doctor_required = pytest.mark.skipif(
+    not _flow_doctor_available(),
+    reason="flow-doctor not installed (pip install alpha-engine-lib[flow_doctor])",
+)
+
+
+class TestFlowDoctorYamlPresence:
+    """The yaml file each entrypoint resolves must exist at that path.
+
+    Catches the specific 2026-05-01 bug: flow-doctor.yaml was gitignored,
+    only flow-doctor.yaml.example existed, and weekly_collector.py/main()
+    pointed at the missing path — silent flow-doctor disable for months.
+    """
+
+    def test_yaml_at_repo_root_exists(self):
+        assert (REPO_ROOT / "flow-doctor.yaml").is_file()
+
+    def test_yaml_path_resolved_by_lambda_handler_exists(self):
+        # Mirrors lambda/handler.py's path computation:
+        #   os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        handler_path = REPO_ROOT / "lambda" / "handler.py"
+        resolved = Path(os.path.dirname(os.path.dirname(os.path.abspath(handler_path)))) / "flow-doctor.yaml"
+        assert resolved.is_file(), f"Lambda handler resolves to {resolved}"
+
+    def test_yaml_path_resolved_by_weekly_collector_exists(self):
+        # Mirrors weekly_collector.py's path computation:
+        #   Path(__file__).parent / "flow-doctor.yaml"
+        wc_path = REPO_ROOT / "weekly_collector.py"
+        resolved = wc_path.parent / "flow-doctor.yaml"
+        assert resolved.is_file(), f"weekly_collector resolves to {resolved}"
+
+    def test_yaml_path_resolved_by_rag_preflight_exists(self):
+        # Mirrors rag/preflight.py's path computation:
+        #   os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        rp_path = REPO_ROOT / "rag" / "preflight.py"
+        resolved = Path(os.path.dirname(os.path.dirname(os.path.abspath(rp_path)))) / "flow-doctor.yaml"
+        assert resolved.is_file(), f"rag/preflight resolves to {resolved}"
+
+
+class TestFlowDoctorYamlSchema:
+    """flow-doctor.yaml must declare the required keys for the Saturday SF.
+
+    Drift between repos has surfaced in past PRs (research missing github
+    notify, predictor missing rate-limit cap fields). Lock the data-module
+    yaml to the executor-canonical shape.
+    """
+
+    def test_yaml_has_required_top_level_keys(self):
+        import yaml
+        with open(REPO_ROOT / "flow-doctor.yaml") as f:
+            cfg = yaml.safe_load(f)
+        for key in ("flow_name", "repo", "notify", "store", "rate_limits"):
+            assert key in cfg, f"missing top-level key: {key}"
+        assert cfg["flow_name"] == "data-collector"
+        assert cfg["repo"] == "cipher813/alpha-engine-data"
+
+    def test_yaml_has_email_and_github_notify_channels(self):
+        import yaml
+        with open(REPO_ROOT / "flow-doctor.yaml") as f:
+            cfg = yaml.safe_load(f)
+        types = {n.get("type") for n in cfg.get("notify", [])}
+        assert "email" in types, "email channel required for ops alerts"
+        assert "github" in types, "github issue channel required for diagnosis"
+
+    def test_yaml_has_per_day_caps(self):
+        import yaml
+        with open(REPO_ROOT / "flow-doctor.yaml") as f:
+            cfg = yaml.safe_load(f)
+        rl = cfg.get("rate_limits", {})
+        for key in ("max_alerts_per_day", "max_issues_per_day", "max_diagnosed_per_day"):
+            assert key in rl, f"rate_limits.{key} required (Anthropic-cost cap)"
+
+
+@flow_doctor_required
+class TestSetupLoggingAttach:
+    """setup_logging() should attach FlowDoctorHandler when ENABLED=1.
+
+    Does NOT fire any ERROR records, so flow-doctor's diagnose() / Anthropic
+    calls are never invoked. Verifies wiring shape only.
+    """
+
+    def test_disabled_attaches_no_flow_doctor_handler(self, monkeypatch, reset_root_logger):
+        monkeypatch.setenv("FLOW_DOCTOR_ENABLED", "0")
+        from alpha_engine_lib.logging import setup_logging
+        setup_logging(
+            "data-collector-test-disabled",
+            flow_doctor_yaml=str(REPO_ROOT / "flow-doctor.yaml"),
+            exclude_patterns=[],
+        )
+        import flow_doctor
+        attached = [h for h in logging.getLogger().handlers
+                    if isinstance(h, flow_doctor.FlowDoctorHandler)]
+        assert attached == [], "FlowDoctorHandler should NOT attach when DISABLED"
+
+    def test_enabled_attaches_flow_doctor_handler(
+        self, stub_flow_doctor_env, reset_root_logger, temp_flow_doctor_yaml
+    ):
+        from alpha_engine_lib.logging import setup_logging, get_flow_doctor
+        setup_logging(
+            "data-collector-test-enabled",
+            flow_doctor_yaml=temp_flow_doctor_yaml,
+            exclude_patterns=[],
+        )
+        import flow_doctor
+        attached = [h for h in logging.getLogger().handlers
+                    if isinstance(h, flow_doctor.FlowDoctorHandler)]
+        assert len(attached) == 1, (
+            f"exactly one FlowDoctorHandler expected, got {len(attached)}"
+        )
+        assert get_flow_doctor() is not None, "shared singleton not populated"
+
+    def test_exclude_patterns_plumbed_to_handler(
+        self, stub_flow_doctor_env, reset_root_logger, temp_flow_doctor_yaml
+    ):
+        from alpha_engine_lib.logging import setup_logging
+        patterns = [r"polygon transient 5\d\d", r"yfinance possibly delisted"]
+        setup_logging(
+            "data-collector-test-patterns",
+            flow_doctor_yaml=temp_flow_doctor_yaml,
+            exclude_patterns=patterns,
+        )
+        import flow_doctor
+        attached = [h for h in logging.getLogger().handlers
+                    if isinstance(h, flow_doctor.FlowDoctorHandler)]
+        assert len(attached) == 1
+        # FlowDoctorHandler compiles exclude_patterns into _exclude_re
+        # (re.Pattern objects). Verify the regexes round-trip.
+        compiled = attached[0]._exclude_re
+        assert [p.pattern for p in compiled] == patterns
+
+
+class TestEntrypointModuleTopWiring:
+    """Each entrypoint must call setup_logging at MODULE-TOP, not inside a
+    function. Module-top is the canonical alpha-engine-lib pattern (mirrors
+    executor/main.py:67) so cold-start / import-time errors are captured.
+
+    These are source-text checks: they verify the structural property
+    without exercising flow_doctor.init() (which writes to /tmp and isn't
+    portable across CI sandboxes — runtime behavior is covered by
+    TestSetupLoggingAttach above using a redirectable yaml).
+    """
+
+    @staticmethod
+    def _index_of(needle: str, text: str) -> int:
+        idx = text.find(needle)
+        assert idx != -1, f"missing required text: {needle!r}"
+        return idx
+
+    def test_lambda_handler_calls_setup_logging_at_module_top(self):
+        text = (REPO_ROOT / "lambda" / "handler.py").read_text()
+        # setup_logging call appears before the def of handler()
+        setup_idx = self._index_of("setup_logging(", text)
+        handler_def_idx = self._index_of("def handler(", text)
+        assert setup_idx < handler_def_idx, (
+            "setup_logging must be called at module-top, before def handler()"
+        )
+        # exclude_patterns is plumbed (even if empty list)
+        assert "exclude_patterns=" in text[setup_idx:handler_def_idx]
+
+    def test_weekly_collector_calls_setup_logging_at_module_top(self):
+        text = (REPO_ROOT / "weekly_collector.py").read_text()
+        setup_idx = self._index_of("setup_logging(", text)
+        main_def_idx = self._index_of("def main()", text)
+        assert setup_idx < main_def_idx, (
+            "setup_logging must be called at module-top, before def main()"
+        )
+        # No leftover setup_logging call inside main()
+        # Strip comments / docstrings so the check ignores informational
+        # references to "setup_logging() already ran" left in main()'s body.
+        body = "\n".join(
+            line for line in text[main_def_idx:].splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "setup_logging(" not in body, (
+            "duplicate setup_logging call inside main() — should only run once"
+        )
+
+    def test_rag_preflight_calls_setup_logging_at_module_top(self):
+        text = (REPO_ROOT / "rag" / "preflight.py").read_text()
+        setup_idx = self._index_of("setup_logging(", text)
+        main_def_idx = self._index_of("def main()", text)
+        assert setup_idx < main_def_idx, (
+            "setup_logging must be called at module-top, before def main()"
+        )
+        # Strip comments / docstrings so the check ignores informational
+        # references to "setup_logging() already ran" left in main()'s body.
+        body = "\n".join(
+            line for line in text[main_def_idx:].splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "setup_logging(" not in body, (
+            "duplicate setup_logging call inside main() — should only run once"
+        )

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -33,8 +33,47 @@ from pathlib import Path
 import boto3
 import yaml
 
+def _load_dotenv() -> None:
+    """Load .env file into os.environ (lightweight, no dependency).
+
+    Defined at module-top so it can run before setup_logging() — local-dev
+    workflows put FLOW_DOCTOR_ENABLED + FLOW_DOCTOR_GITHUB_TOKEN in .env,
+    and the flow-doctor handler attach reads those at import time.
+    Production (Lambda/EC2) gets env from SSM/systemd before Python starts;
+    .env is the local-dev fallback.
+    """
+    env_path = Path(".env")
+    if not env_path.exists():
+        return
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            key, val = key.strip(), val.strip()
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+                val = val[1:-1]
+            if key and val and key not in os.environ:
+                os.environ[key] = val
+
+
 from ssm_secrets import load_secrets
 load_secrets()
+_load_dotenv()
+
+# Structured logging + flow-doctor singleton via alpha-engine-lib (shared
+# pattern across all 5 entrypoints; see executor/main.py for reference).
+# Module-top so import-time errors in the collectors block below are also
+# captured by flow-doctor's ERROR handler.
+from alpha_engine_lib.logging import setup_logging
+_FLOW_DOCTOR_EXCLUDE_PATTERNS: list[str] = []
+_FLOW_DOCTOR_YAML = str(Path(__file__).parent / "flow-doctor.yaml")
+setup_logging(
+    "data-collector",
+    flow_doctor_yaml=_FLOW_DOCTOR_YAML,
+    exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
+)
 
 from collectors import constituents, prices, slim_cache, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest
 
@@ -967,33 +1006,10 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _load_dotenv() -> None:
-    """Load .env file into os.environ (lightweight, no dependency)."""
-    env_path = Path(".env")
-    if not env_path.exists():
-        return
-    with open(env_path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, val = line.split("=", 1)
-            key, val = key.strip(), val.strip()
-            if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
-                val = val[1:-1]
-            if key and val and key not in os.environ:
-                os.environ[key] = val
-
-
 def main() -> None:
     args = _parse_args()
-    _load_dotenv()
-
-    from alpha_engine_lib.logging import setup_logging
-    setup_logging(
-        "data-collector",
-        flow_doctor_yaml=str(Path(__file__).parent / "flow-doctor.yaml"),
-    )
+    # _load_dotenv() + setup_logging() already ran at module-top so import-time
+    # errors in the collectors block are captured. Apply user-requested level.
     logging.getLogger().setLevel(getattr(logging, args.log_level))
 
     config = load_config(args.config)


### PR DESCRIPTION
Phase 2 Lambda had no setup_logging at all (logger.error bypassed flow-doctor entirely); weekly_collector + rag/preflight pointed at a nonexistent flow-doctor.yaml. Aligns the data module on the canonical executor pattern (module-top setup_logging + exclude_patterns + lib v0.2.2 pin). Yaml de-gitignored to match the post-flow-doctor-0.2.0 env-var-only secret contract used by every other repo.

- Add flow-doctor.yaml at repo root (executor-canonical shape: email + github notify, full daily caps).
- Hoist setup_logging to module-top in weekly_collector.py and rag/preflight.py; remove duplicated calls from main().
- Add module-top setup_logging block to lambda/handler.py (post-load_secrets so SSM-derived FLOW_DOCTOR_GITHUB_TOKEN is in env when flow_doctor.init() resolves the yaml).
- Pin alpha-engine-lib @main -> @v0.2.2 (matches executor + predictor; closes the lib drift class flagged in the 5-repo wire audit).
- Hoist _load_dotenv definition to module-top so local-dev .env workflows still set FLOW_DOCTOR_ENABLED before setup_logging fires.
- 13 new wiring tests in tests/test_flow_doctor_wiring.py cover yaml presence + required schema keys + handler-attach behavior + exclude_patterns plumbing + module-top placement structural check. Tests don't fire any ERROR records, so flow-doctor's diagnose() / Anthropic call path is never triggered (zero LLM cost in CI).

Test surface 289 -> 300, zero regressions.