### PR TITLE
fix(data): vendor alpha-engine-lib + ship flow-doctor.yaml in Phase 2…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ on:
       - 'ssm_secrets.py'
       - 'lambda/**'
       - 'config.py'
+      - 'flow-doctor.yaml'
       - 'requirements*.txt'
       - 'Dockerfile*'
       - 'infrastructure/deploy.sh'
@@ -36,8 +37,23 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Checkout
+      - name: Checkout data repo
         uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      # deploy.sh stages alpha-engine-lib into vendor/alpha-engine-lib
+      # so the Dockerfile can COPY it. The lib is a private repo —
+      # needs a PAT with Contents: read on cipher813/alpha-engine-lib,
+      # stored as the ALPHA_ENGINE_LIB_TOKEN repository secret. Mirrors
+      # the alpha-engine-research deploy.yml pattern; flow-doctor ships
+      # transitively via alpha-engine-lib[flow_doctor].
+      - name: Checkout alpha-engine-lib
+        uses: actions/checkout@v4
+        with:
+          repository: cipher813/alpha-engine-lib
+          path: alpha-engine-lib
+          token: ${{ secrets.ALPHA_ENGINE_LIB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -55,9 +71,17 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Deploy Phase 2 Lambda (alpha-engine-data-collector)
+        working-directory: alpha-engine-data
+        env:
+          # deploy.sh defaults LIB_REPO_DIR to ../alpha-engine-lib relative
+          # to its CWD — ${{ github.workspace }}/alpha-engine-lib here,
+          # exactly where the checkout step above placed it. Explicit
+          # export is belt-and-suspenders for readers.
+          LIB_REPO_DIR: ${{ github.workspace }}/alpha-engine-lib
         run: bash infrastructure/deploy.sh
 
       - name: Report deployed version
+        working-directory: alpha-engine-data
         run: |
           echo "Deployed commit: ${{ github.sha }}"
           aws lambda get-function \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
 FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 
-# Install dependencies (exclude boto3/botocore — pre-installed in Lambda).
-# alpha-engine-lib is excluded because the Phase 2 Lambda handler (lambda/handler.py)
-# doesn't import from it — only weekly_collector.main() (the EC2 entry point) does.
-# Including it would require wiring a GitHub PAT into the Docker build as a secret,
-# which is ceremony for zero benefit here. If a future Phase 2 change imports from
-# alpha-engine-lib, remove this filter and add --mount=type=secret,id=lib_token
-# plus the matching deploy.yml build-secrets wiring.
+# Stage alpha-engine-lib from a local vendor directory.
+# infrastructure/deploy.sh populates vendor/alpha-engine-lib from a
+# sibling checkout (local dev) or GitHub Actions checkout (CI) before
+# Docker build. Mirrors the alpha-engine-research / alpha-engine-predictor
+# pattern — the private repo reaches the build context without needing a
+# GitHub PAT or Docker build secret. [flow_doctor] pulls flow-doctor
+# transitively for lambda/handler.py's setup_logging call. The arcticdb
+# extra is intentionally NOT pulled here — only weekly_collector.py /
+# builders/ use ArcticDB, and those run on EC2 (not in this Lambda image).
+COPY vendor/alpha-engine-lib /tmp/alpha-engine-lib
+
+# Install dependencies. Exclude pytest / python-dotenv / pre-installed
+# Lambda runtime deps (boto3 etc.). Filter alpha-engine-lib out of
+# requirements.txt and install it from the staged vendor path with the
+# [flow_doctor] extra. Filtered list is written to a requirements file
+# and consumed by `pip install -r` so pip's own parser handles inline
+# comments — `$(grep ...)` shell substitution would word-split a
+# `pkg # comment` line into separate args and pip would reject the
+# bare `#` as an invalid requirement.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir \
-    $(grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt) \
-    && rm -rf /root/.cache/pip
+RUN pip install --no-cache-dir /tmp/alpha-engine-lib[flow_doctor] && \
+    grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
+    pip install --no-cache-dir -r /tmp/req-lambda.txt && \
+    rm -rf /root/.cache/pip /tmp/alpha-engine-lib /tmp/req-lambda.txt
 
 # Copy application code
 COPY collectors/ ${LAMBDA_TASK_ROOT}/collectors/
@@ -18,6 +31,11 @@ COPY polygon_client.py ${LAMBDA_TASK_ROOT}/
 COPY weekly_collector.py ${LAMBDA_TASK_ROOT}/
 COPY store/ ${LAMBDA_TASK_ROOT}/store/
 COPY ssm_secrets.py ${LAMBDA_TASK_ROOT}/
+
+# flow-doctor.yaml at LAMBDA_TASK_ROOT is loaded by setup_logging() at
+# module-top of lambda/handler.py. The path resolves via:
+#   os.environ.get("LAMBDA_TASK_ROOT", os.path.dirname(...)) / "flow-doctor.yaml"
+COPY flow-doctor.yaml ${LAMBDA_TASK_ROOT}/
 
 # NOTE: config.yaml is intentionally NOT copied here. It is gitignored
 # (contains bucket names + prefixes that we keep out of the public repo)

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -68,6 +68,41 @@ LAMBDA_ENV_JSON=$(build_lambda_env_json)
 
 echo "=== Building container image for $FUNCTION_NAME ==="
 
+# Stage alpha-engine-lib into vendor/ so the Dockerfile can COPY it.
+# alpha-engine-lib is a private repo — Dockerfile installs via local pip
+# path rather than git+https to avoid wiring a Docker build secret.
+# flow-doctor is pulled in transitively via the [flow_doctor] extra.
+# Mirrors alpha-engine-research/infrastructure/deploy.sh staging pattern.
+LIB_REPO_DIR="${LIB_REPO_DIR:-$(dirname "$(pwd)")/alpha-engine-lib}"
+LIB_STAGED_FROM_REPO=0
+if [ -d "vendor/alpha-engine-lib" ]; then
+  echo "Using existing vendor/alpha-engine-lib (local dev workflow)"
+elif [ -d "$LIB_REPO_DIR" ]; then
+  echo "Staging vendor/alpha-engine-lib from $LIB_REPO_DIR..."
+  mkdir -p vendor
+  cp -R "$LIB_REPO_DIR" vendor/alpha-engine-lib
+  LIB_STAGED_FROM_REPO=1
+else
+  echo "ERROR: alpha-engine-lib not found — tried:"
+  echo "  vendor/alpha-engine-lib (local dev)"
+  echo "  $LIB_REPO_DIR (sibling checkout)"
+  echo "Hint: clone cipher813/alpha-engine-lib as a sibling directory,"
+  echo "      or set LIB_REPO_DIR=/path/to/alpha-engine-lib"
+  exit 1
+fi
+
+# Always clean up the staged vendor/ on exit so a re-run from a fresh
+# clone doesn't pick up a stale copy. Local-dev workflow with a real
+# vendor/alpha-engine-lib tree present takes the early-return branch
+# above and never sets LIB_STAGED_FROM_REPO=1, so its tree is preserved.
+cleanup_lib_staging() {
+  if [ "$LIB_STAGED_FROM_REPO" = "1" ] && [ -d vendor/alpha-engine-lib ]; then
+    rm -rf vendor/alpha-engine-lib
+    rmdir vendor 2>/dev/null || true
+  fi
+}
+trap cleanup_lib_staging EXIT
+
 docker build --platform linux/amd64 --provenance=false -t "$FUNCTION_NAME:latest" .
 
 echo "Authenticating with ECR..."

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -28,11 +28,19 @@ load_secrets()
 # pattern across all 5 entrypoints; see executor/main.py for reference).
 # When FLOW_DOCTOR_ENABLED=1, attaches a FlowDoctorHandler at ERROR so every
 # log.error() call routes through flow-doctor's dispatch (email + GitHub
-# issue with dedup + rate limits per flow-doctor.yaml at the repo root).
+# issue with dedup + rate limits per flow-doctor.yaml).
+#
+# Path resolution: LAMBDA_TASK_ROOT (=/var/task in the Lambda image,
+# where Dockerfile COPYs flow-doctor.yaml) takes precedence; falls back
+# to two-dirs-up from this file for local dev (lambda/handler.py →
+# repo root). Mirrors alpha-engine-research/lambda/handler.py.
 from alpha_engine_lib.logging import setup_logging
 _FLOW_DOCTOR_EXCLUDE_PATTERNS: list[str] = []
 _FLOW_DOCTOR_YAML = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    os.environ.get(
+        "LAMBDA_TASK_ROOT",
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    ),
     "flow-doctor.yaml",
 )
 setup_logging(

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -93,11 +93,36 @@ class TestFlowDoctorYamlPresence:
         assert (REPO_ROOT / "flow-doctor.yaml").is_file()
 
     def test_yaml_path_resolved_by_lambda_handler_exists(self):
-        # Mirrors lambda/handler.py's path computation:
+        # Mirrors lambda/handler.py's path computation in the local-dev
+        # branch (LAMBDA_TASK_ROOT unset):
         #   os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         handler_path = REPO_ROOT / "lambda" / "handler.py"
         resolved = Path(os.path.dirname(os.path.dirname(os.path.abspath(handler_path)))) / "flow-doctor.yaml"
         assert resolved.is_file(), f"Lambda handler resolves to {resolved}"
+
+    def test_yaml_path_resolved_by_lambda_handler_under_lambda_runtime(self, tmp_path, monkeypatch):
+        # Lambda flattens lambda/handler.py to /var/task/handler.py, so
+        # the original two-dirs-up resolution would land at /var/ — wrong.
+        # The handler must honor LAMBDA_TASK_ROOT first. Simulate by
+        # placing flow-doctor.yaml under a stand-in task root and
+        # asserting the same os.environ.get(...) pattern resolves to it.
+        fake_task_root = tmp_path / "fake_lambda_task_root"
+        fake_task_root.mkdir()
+        (fake_task_root / "flow-doctor.yaml").write_text("flow_name: test\n")
+        monkeypatch.setenv("LAMBDA_TASK_ROOT", str(fake_task_root))
+        # Use the literal expression from lambda/handler.py so any drift
+        # in the source breaks this test.
+        resolved = os.path.join(
+            os.environ.get(
+                "LAMBDA_TASK_ROOT",
+                "/should-not-fall-back",
+            ),
+            "flow-doctor.yaml",
+        )
+        assert os.path.isfile(resolved), (
+            "Lambda handler must honor LAMBDA_TASK_ROOT — flattened image "
+            "layout means dirname(dirname(__file__)) lands at /var, not /var/task"
+        )
 
     def test_yaml_path_resolved_by_weekly_collector_exists(self):
         # Mirrors weekly_collector.py's path computation:


### PR DESCRIPTION
… image

Hotfix for the canary failure on PR #116 (data flow-doctor wiring). v33 cold-start hit ModuleNotFoundError because the original Dockerfile specifically excluded alpha-engine-lib from pip install, and didn't COPY flow-doctor.yaml into LAMBDA_TASK_ROOT — neither side of the build context recognized that PR #116 added a module-top `from alpha_engine_lib.logging import setup_logging` to lambda/handler.py. Canary's "UNKNOWN" status is the parser's fallthrough when Lambda returns its runtime errorType/errorMessage shape (handler never executed).

Mirror alpha-engine-research's lib-vendoring pattern. Phase 2 Lambda doesn't use ArcticDB (only weekly_collector + builders do, on EC2), so install lib with the [flow_doctor] extra only — keeps the image lean.

- infrastructure/deploy.sh: stage vendor/alpha-engine-lib from sibling checkout (LIB_REPO_DIR env var; defaults to ../alpha-engine-lib). Trap-based cleanup on exit so re-runs don't pick up stale copies.
- Dockerfile: COPY vendor/alpha-engine-lib /tmp/alpha-engine-lib + pip install /tmp/alpha-engine-lib[flow_doctor] + COPY flow-doctor.yaml ${LAMBDA_TASK_ROOT}/. Drop the ^alpha-engine-lib filter from the requirements.txt grep. Replace the now-invalid "Phase 2 Lambda doesn't import from alpha-engine-lib" comment block.
- .github/workflows/deploy.yml: restructure checkout into alpha-engine-data/ subdir + add a sibling alpha-engine-lib/ checkout using ALPHA_ENGINE_LIB_TOKEN. Add working-directory + LIB_REPO_DIR env to the deploy step. Add flow-doctor.yaml to the path-filter trigger list so future yaml-only changes redeploy.
- lambda/handler.py: fix LAMBDA_TASK_ROOT path resolution. The Docker COPY flattens lambda/handler.py to /var/task/handler.py, so the original two-dirs-up resolution from PR #116 landed at /var/ instead of /var/task/. Mirror research's pattern: os.environ.get("LAMBDA_TASK_ROOT", os.path.dirname(os.path.dirname(...))) Honors the Lambda-runtime env var first; falls back to the local layout for tests.
- tests/test_flow_doctor_wiring.py: add a regression test that simulates Lambda's flattened layout (sets LAMBDA_TASK_ROOT to a tmp_path, asserts the resolution lands at the env-var path not at the dirname-dirname path).

Local docker build smoke test: image builds clean, handler imports clean with FLOW_DOCTOR_ENABLED=1, FlowDoctorHandler attaches at root (level=ERROR). Test surface 300 -> 301, zero regressions.