### PR TITLE
fix(orchestration): bump DeployDriftCheck timeout 60s -> 300s

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -23,7 +23,7 @@
           "action": "check_deploy_drift"
         }
       },
-      "TimeoutSeconds": 60,
+      "TimeoutSeconds": 300,
       "Retry": [
         {
           "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],


### PR DESCRIPTION
## Summary
- Bumps `DeployDriftCheck` SF state's `TimeoutSeconds` from 60 -> 300 to absorb the ~200s preflight regression introduced by predictor PR #68.
- This morning's weekday SF (2026-05-01 13:00 UTC) tripped `States.Timeout` on this gate despite no actual drift; this fix unblocks scheduled runs.

## Why
PR #68 in alpha-engine-predictor added `check_arcticdb_universe_fresh` (~900 tickers x tail(1) x 20 threads) to inference preflight. Measured cost: **~190s on Lambda, ~218s on EC2** — the lib's "5-10s" docstring estimate is off by ~25x. Every predictor Lambda invocation pays this cost now, including `action=check_deploy_drift` which the SF expects to be a fast gate.

The 60s timeout was correctly sized for the pre-#68 preflight (~2.5s post-image-SHA). It is structurally impossible to pass post-#68. 300s gives ~50% headroom over observed scan cost.

## Holding measure, not the root fix
This unblocks scheduled runs. The real fix is to move the universe-freshness scan to its producer (DataPhase1 write-time) and have downstream Lambdas read a cheap S3 receipt instead of re-scanning. That work is scoped as a follow-up PR arc across alpha-engine-data + alpha-engine-lib + predictor + executor + backtester.

## Test plan
- [x] Manually patched live SF and re-ran weekday pipeline — drift-check completed in ~190s (well under 300s ceiling), pipeline progressed past gate.
- [ ] After merge, `deploy-infrastructure.yml` will re-stamp SF with this change baked in.
- [ ] Tomorrow's scheduled 06:05 PT run validates end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)