### PR TITLE
feat(daily_append): producer-side universe-freshness scan + S3 receipt

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -131,6 +131,116 @@ def _emit_missing_from_closes_metric(count: int) -> None:
         )
 
 
+UNIVERSE_FRESHNESS_RECEIPT_KEY = "health/universe_freshness.json"
+UNIVERSE_FRESHNESS_MAX_STALE_DAYS = 5
+_UNIVERSE_SCAN_WORKERS = 20
+
+
+def _scan_universe_and_emit_freshness_receipt(
+    s3,
+    bucket: str,
+    universe_lib,
+    max_stale_days: int = UNIVERSE_FRESHNESS_MAX_STALE_DAYS,
+) -> dict:
+    """Producer-side post-write validation: every universe symbol's
+    last-row date must be within ``max_stale_days`` of today (UTC).
+
+    On all-fresh: writes ``s3://{bucket}/health/universe_freshness.json``
+    so downstream consumers (predictor inference, executor, backtester)
+    read a single O(1) artifact instead of re-running this 200s scan
+    themselves on every Lambda invocation. The 2026-05-01 weekday SF
+    timeout cascade traced back to PR #68 adding this same scan to the
+    predictor inference preflight, multiplying the cost.
+
+    On any stale: hard-raises ``RuntimeError`` so the SF MorningEnrich
+    step fails. The 2026-04-21 ASGN/MOH incident class — partial-write
+    where macro/SPY stays fresh while individual tickers stall — is
+    exactly what this catches at the producer.
+
+    Returns scan metadata (also embedded in the receipt) for logging
+    by the caller. Skipped automatically on dry_run.
+    """
+    syms = list(universe_lib.list_symbols())
+    if not syms:
+        raise RuntimeError(
+            f"Universe-freshness scan: library is empty on bucket {bucket!r}; "
+            "upstream pipeline has not written anything."
+        )
+
+    today = datetime.now(timezone.utc).date()
+
+    def _last_date_for(sym: str) -> tuple[str, "pd.Timestamp | None", "str | None"]:
+        try:
+            df = universe_lib.tail(sym, n=1).data
+        except Exception as exc:  # pragma: no cover — surfaces below
+            return sym, None, f"{type(exc).__name__}: {exc}"
+        if df.empty:
+            return sym, None, "empty frame"
+        last_ts = pd.Timestamp(df.index[-1])
+        if last_ts.tzinfo is not None:
+            last_ts = last_ts.tz_convert("UTC").tz_localize(None)
+        return sym, last_ts.normalize(), None
+
+    t0 = time.time()
+    rows: list[tuple[str, "pd.Timestamp | None", "str | None"]] = []
+    with ThreadPoolExecutor(max_workers=_UNIVERSE_SCAN_WORKERS) as ex:
+        rows = list(ex.map(_last_date_for, syms))
+    scan_seconds = time.time() - t0
+
+    read_errors = [(s, err) for s, _, err in rows if err is not None]
+    if read_errors:
+        head = ", ".join(f"{s}({e[:40]})" for s, e in read_errors[:5])
+        raise RuntimeError(
+            f"Universe-freshness scan: {len(read_errors)} symbol(s) failed to read "
+            f"(threshold 0): {head}"
+            + ("…" if len(read_errors) > 5 else "")
+        )
+
+    ages = []  # (sym, last_date, age_days)
+    for sym, last_date, _ in rows:
+        age_days = (today - last_date.date()).days
+        ages.append((sym, last_date.date().isoformat(), age_days))
+
+    stale = [(s, d, a) for s, d, a in ages if a > max_stale_days]
+    stalest = max(ages, key=lambda r: r[2])
+
+    if stale:
+        stale.sort(key=lambda r: -r[2])
+        head = ", ".join(f"{s}({a}d, last={d})" for s, d, a in stale[:10])
+        raise RuntimeError(
+            f"Universe-freshness scan: {len(stale)} symbol(s) older than "
+            f"{max_stale_days}d threshold (stalest first): {head}"
+            + ("…" if len(stale) > 10 else "")
+        )
+
+    receipt = {
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "library": "universe",
+        "bucket": bucket,
+        "n_symbols_checked": len(syms),
+        "max_stale_days_threshold": max_stale_days,
+        "all_fresh": True,
+        "stalest_symbol": stalest[0],
+        "stalest_last_date": stalest[1],
+        "stalest_age_days": stalest[2],
+        "scan_seconds": round(scan_seconds, 1),
+        "writer": "alpha-engine-data:builders/daily_append.py",
+    }
+
+    s3.put_object(
+        Bucket=bucket,
+        Key=UNIVERSE_FRESHNESS_RECEIPT_KEY,
+        Body=json.dumps(receipt, indent=2).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    log.info(
+        "Universe-freshness receipt written: n=%d all_fresh stalest=%s(%dd) scan=%.1fs",
+        len(syms), stalest[0], stalest[2], scan_seconds,
+    )
+    return receipt
+
+
 def _load_parquet_warmup(s3, bucket: str, ticker: str) -> pd.DataFrame | None:
     """Load a ticker's 10y price-cache parquet for feature warmup.
 
@@ -822,6 +932,22 @@ def daily_append(
                 f"ArcticDB daily_append error rate {err_rate:.1%} exceeds 5% threshold "
                 f"(n_ok={n_ok} n_err={n_err} of {len(stock_tickers)}) — treating as pipeline failure"
             )
+
+        # Producer-side post-write validation. Catches the partial-write
+        # class (2026-04-21 ASGN/MOH) that the per-ticker error-rate gate
+        # above misses — symbols not in today's batch but stale from
+        # earlier silent skips. Emits health/universe_freshness.json so
+        # consumers don't repeat this 200s scan on every Lambda
+        # invocation (the cause of the 2026-05-01 SF timeout cascade).
+        receipt = _scan_universe_and_emit_freshness_receipt(
+            s3, bucket, universe_lib,
+        )
+        result["universe_freshness_receipt"] = {
+            "n_symbols_checked": receipt["n_symbols_checked"],
+            "stalest_symbol": receipt["stalest_symbol"],
+            "stalest_age_days": receipt["stalest_age_days"],
+            "scan_seconds": receipt["scan_seconds"],
+        }
 
     return result
 

--- a/tests/test_daily_append_missing_from_closes.py
+++ b/tests/test_daily_append_missing_from_closes.py
@@ -20,6 +20,7 @@ behavior — same style as the rest of the daily_append test suite.
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -233,6 +234,16 @@ def _patch_targets(monkeypatch, *, universe_symbols: list[str], closes_tickers: 
     universe_lib.read_batch.return_value = [
         MagicMock(spec=[], data=hist_df.copy()) for _ in closes_tickers
     ]
+    # _scan_universe_and_emit_freshness_receipt calls tail(sym, n=1) per
+    # symbol after the daily writes. Mock it to return today's row so the
+    # post-write freshness scan passes (these tests are about the pre-loop
+    # missing-from-closes check, not the post-write scan, which has its
+    # own dedicated test_daily_append_universe_freshness.py).
+    today_row = pd.DataFrame(
+        {"Close": [100.0]},
+        index=[pd.Timestamp(datetime.now(timezone.utc).date())],
+    )
+    universe_lib.tail.return_value = MagicMock(spec=[], data=today_row)
 
     macro_lib = MagicMock()
     # macro reads return a frame with a "Close" column so macro-load passes.

--- a/tests/test_daily_append_universe_freshness.py
+++ b/tests/test_daily_append_universe_freshness.py
@@ -1,0 +1,141 @@
+"""Tests for the producer-side universe-freshness scan + receipt emit
+in builders/daily_append.py.
+
+The scan is the canonical owner for "every universe symbol got
+written today" — replaces the per-Lambda-invocation scans that
+previously lived in predictor inference, executor, and backtester
+preflights. Hard-fails the daily_append run on any stale symbol
+(catches the 2026-04-21 partial-write class). On all-fresh, writes
+a receipt JSON to S3 that downstream consumers read in O(1).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from builders.daily_append import (
+    UNIVERSE_FRESHNESS_RECEIPT_KEY,
+    UNIVERSE_FRESHNESS_MAX_STALE_DAYS,
+    _scan_universe_and_emit_freshness_receipt,
+)
+
+
+def _mock_lib_with_dates(symbol_to_date: dict[str, str]) -> MagicMock:
+    """Build a mock ArcticDB library that responds to list_symbols + tail."""
+    lib = MagicMock()
+    lib.list_symbols.return_value = list(symbol_to_date.keys())
+
+    def _tail(sym, n=1):
+        date_str = symbol_to_date[sym]
+        if date_str is None:
+            df = pd.DataFrame()
+        else:
+            df = pd.DataFrame({"Close": [100.0]}, index=[pd.Timestamp(date_str)])
+        result = MagicMock()
+        result.data = df
+        return result
+
+    lib.tail.side_effect = _tail
+    return lib
+
+
+def _today_str(offset_days: int = 0) -> str:
+    return (datetime.now(timezone.utc).date() - timedelta(days=offset_days)).isoformat()
+
+
+class TestUniverseFreshnessReceipt:
+    def test_all_fresh_emits_receipt(self):
+        """Happy path: every symbol fresh → receipt is written to the
+        canonical S3 key with all_fresh=True and per-symbol metadata."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "MSFT": _today_str(1),
+            "GOOGL": _today_str(2),
+        })
+
+        receipt = _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib)
+
+        assert receipt["all_fresh"] is True
+        assert receipt["n_symbols_checked"] == 3
+        assert receipt["stalest_symbol"] == "GOOGL"
+        assert receipt["stalest_age_days"] == 2
+
+        s3.put_object.assert_called_once()
+        kwargs = s3.put_object.call_args.kwargs
+        assert kwargs["Bucket"] == "test-bucket"
+        assert kwargs["Key"] == UNIVERSE_FRESHNESS_RECEIPT_KEY
+        body = json.loads(kwargs["Body"].decode("utf-8"))
+        assert body["all_fresh"] is True
+        assert body["library"] == "universe"
+
+    def test_stale_symbol_raises_and_does_not_write(self):
+        """Hard-fail mode: if any symbol is older than the threshold,
+        raise RuntimeError and do NOT write the receipt — a bad scan
+        must not leave a stale artifact that consumers would trust."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "STALE": _today_str(UNIVERSE_FRESHNESS_MAX_STALE_DAYS + 2),
+        })
+
+        with pytest.raises(RuntimeError, match="STALE"):
+            _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib)
+
+        s3.put_object.assert_not_called()
+
+    def test_empty_library_raises(self):
+        """Zero symbols means upstream pipeline never wrote anything;
+        consumers must not receive a misleading all_fresh receipt."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({})
+
+        with pytest.raises(RuntimeError, match="library is empty"):
+            _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib)
+
+        s3.put_object.assert_not_called()
+
+    def test_read_error_raises(self):
+        """A single tail() raise means we can't trust our own scan —
+        cannot prove all-fresh, so hard-fail rather than emit the
+        receipt with an asterisk."""
+        s3 = MagicMock()
+        lib = MagicMock()
+        lib.list_symbols.return_value = ["AAPL", "BROKEN"]
+
+        def _tail(sym, n=1):
+            if sym == "BROKEN":
+                raise RuntimeError("simulated arctic read failure")
+            result = MagicMock()
+            result.data = pd.DataFrame(
+                {"Close": [100.0]}, index=[pd.Timestamp(_today_str(0))]
+            )
+            return result
+
+        lib.tail.side_effect = _tail
+
+        with pytest.raises(RuntimeError, match="failed to read"):
+            _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib)
+
+        s3.put_object.assert_not_called()
+
+    def test_threshold_boundary_inclusive(self):
+        """A symbol exactly at the threshold counts as fresh (≤, not <).
+        One day older fails — same boundary as the old preflight gate."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "EDGE": _today_str(UNIVERSE_FRESHNESS_MAX_STALE_DAYS),
+        })
+        receipt = _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib)
+        assert receipt["all_fresh"] is True
+
+        lib2 = _mock_lib_with_dates({
+            "EDGE": _today_str(UNIVERSE_FRESHNESS_MAX_STALE_DAYS + 1),
+        })
+        with pytest.raises(RuntimeError, match="EDGE"):
+            _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib2)


### PR DESCRIPTION
## Summary
- Adds a post-write universe-freshness validation pass to \`daily_append()\`. Scans every symbol's last-row date with a 20-thread tail(1) sweep; on all-fresh, writes \`s3://{bucket}/health/universe_freshness.json\`.
- Producer-side ownership of the partial-write guard. Consumers (predictor inference, executor, backtester) will swap their 200s scans for O(1) receipt reads in follow-up PRs.

## Why
On 2026-05-01 the weekday SF tripped \`DeployDriftCheck\` States.Timeout because PR #68 added \`check_arcticdb_universe_fresh\` to the predictor inference preflight, which runs on **every** Lambda invocation including \`action=check_deploy_drift\`. Measured: ~191s on Lambda, ~218s on EC2.

The lib's "5-10s scan" docstring estimate was off by ~25x. Paying that cost N times across N consumers is the wrong shape — the producer is the natural canonical owner for "every write I just performed succeeded." This PR moves the work there.

The 2026-04-21 ASGN/MOH partial-write incident class is exactly what the scan catches: symbols not in today's batch but stale from earlier silent skips. Producer-side hard-fail surfaces it immediately at the source instead of deep in a consumer's preflight.

## Hard-fail semantics
| condition | behavior |
|---|---|
| empty library | RuntimeError (upstream broken) |
| any tail() raise | RuntimeError (cannot prove fresh) |
| any symbol > 5d stale | RuntimeError (partial-write class) |
| all fresh | emit receipt, return normally |

## Receipt schema
\`\`\`json
{
  "checked_at": "2026-05-01T13:30:00Z",
  "library": "universe",
  "n_symbols_checked": 904,
  "max_stale_days_threshold": 5,
  "all_fresh": true,
  "stalest_symbol": "AAPL",
  "stalest_last_date": "2026-04-30",
  "stalest_age_days": 1,
  "scan_seconds": 218.4,
  "writer": "alpha-engine-data:builders/daily_append.py"
}
\`\`\`

## Follow-up arc
Consumers will swap their scans for receipt-reads in separate PRs:
1. \`alpha-engine-predictor\`: handler short-circuit for \`action=check_deploy_drift\` + receipt-read for \`action=predict\`. Restores fast drift-check (3s) without losing the partial-write guard.
2. \`alpha-engine\` executor preflight: receipt-read swap.
3. \`alpha-engine-backtester\` preflight: receipt-read swap.

## Test plan
- [x] 5 new tests in \`tests/test_daily_append_universe_freshness.py\` (happy path, stale-raise, empty-library, read-error, threshold edge). All green.
- [x] Existing daily_append tests updated to stub \`lib.tail()\`. 55 pass.
- [x] Full unit suite: 306 pass.
- [ ] Once merged + deployed, verify \`s3://alpha-engine-research/health/universe_freshness.json\` lands after the next MorningEnrich run.

## Note on PR #118
Closes/supersedes [#118](https://github.com/cipher813/alpha-engine-data/pull/118) (DeployDriftCheck timeout 60→300). That PR was treating the symptom — bumping a SF gate to absorb a consumer-side scan that we're now removing. With consumers swapping to receipt-reads, drift-check returns to its fast band naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)