### PR TITLE
feat(iam): grant github-actions-lambda-deploy access to changelog/ prefix

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -97,6 +97,26 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/infrastructure/*"
     },
     {
+      "Sid": "SystemChangelogAppend",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/changelog/*"
+    },
+    {
+      "Sid": "SystemChangelogList",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["changelog/", "changelog/*"]
+        }
+      }
+    },
+    {
       "Sid": "InfraDeploySFDefinition",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Summary
Adds two Sids to the \`github-actions-lambda-deploy\` OIDC role so every alpha-engine* repo's deploy workflow can append entries to the new system-wide changelog at \`s3://alpha-engine-research/changelog/\`.

- **SystemChangelogAppend**: \`PutObject\` + \`GetObject\` on \`s3://alpha-engine-research/changelog/*\`. Used by the \`append-changelog\` composite action.
- **SystemChangelogList**: \`ListBucket\` scoped via \`s3:prefix\` condition to \`changelog/\`. Used by the daily aggregator cron.

## Companion PR
[alpha-engine-docs PR](https://github.com/cipher813/alpha-engine-docs/pulls) (opening next) — composite action + aggregator cron.

## Apply state
Already applied live via \`infrastructure/iam/apply.sh github-actions-lambda-deploy\`. Smoke-tested via manual \`PutObject\` → \`ListBucket\` → \`DeleteObject\` cycle before committing this codification.

## Why
System-wide deploy provenance is currently scattered across each repo's git log. Cross-repo incident debugging (e.g. 2026-05-01 SF timeout cascade — root cause crossed alpha-engine-data + alpha-engine-predictor) requires reconstructing "what shipped where, when" by querying each repo separately. This grant enables a single chronological log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)