### PR TITLE
feat(iam): grant tag-management ops on alpha-engine-* roles + Lambdas

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -175,6 +175,21 @@
       "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
     },
     {
+      "Sid": "InfraDeployTagOps",
+      "Effect": "Allow",
+      "Action": [
+        "iam:TagRole",
+        "iam:UntagRole",
+        "lambda:TagResource",
+        "lambda:UntagResource",
+        "lambda:ListTags"
+      ],
+      "Resource": [
+        "arn:aws:iam::711398986525:role/alpha-engine-*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
+      ]
+    },
+    {
       "Sid": "InfraDeployResourceRead",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Summary
Adds \`iam:TagRole\`, \`iam:UntagRole\`, \`lambda:TagResource\`, \`lambda:UntagResource\`, \`lambda:ListTags\` to the \`github-actions-lambda-deploy\` OIDC role, scoped to \`alpha-engine-*\` roles and Lambdas. Fixes the CF update-stack rollback failure caught on PR #122 merge today.

## Why
CF refreshes resource tags during \`update-stack\` even on no-op updates. Without the Tag* permissions, every CF update via CI fails. Today's specific failure: TagRole during no-op refresh of \`ChangelogIncidentMirrorRole\` → triggered rollback → rollback also failed → \`UPDATE_ROLLBACK_FAILED\` (recovered manually).

## Scope
Deliberately NARROW: tag ops only, not Create/Delete. New Lambda + IAM resources still require a personal-creds changeset apply. Trade-off: keeps the OIDC role's blast radius small while fixing the actual failure mode (no-op tag refresh).

## Apply state
Already applied live via \`bash infrastructure/iam/apply.sh github-actions-lambda-deploy\`. This PR codifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)