### PR TITLE
feat(orchestration): orphan SNS-mirror Lambda from CF management

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -73,127 +73,16 @@ Resources:
       Protocol: email
       Endpoint: !Ref AlertEmail
 
-  # --------------------------------------------------------------------------
-  # Changelog incident-mirror Lambda — every SNS alert gets mirrored as one
-  # JSON object at s3://alpha-engine-research/changelog/incidents/, parallel
-  # to the deploy entries written by the alpha-engine-docs append-changelog
-  # composite action. Closes the event-mining loop: deploys + incidents +
-  # manual + recovery all interleave by timestamp in the daily-aggregated
-  # CHANGELOG.md.
-  # --------------------------------------------------------------------------
-  ChangelogIncidentMirrorRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: alpha-engine-changelog-incident-mirror
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-            Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      Policies:
-        - PolicyName: changelog-incident-mirror-s3
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action: s3:PutObject
-                Resource: arn:aws:s3:::alpha-engine-research/changelog/incidents/*
-
-  ChangelogIncidentMirrorFunction:
-    Type: AWS::Lambda::Function
-    Properties:
-      FunctionName: alpha-engine-changelog-incident-mirror
-      Description: Mirrors every alpha-engine-alerts SNS message as a JSON entry under s3://alpha-engine-research/changelog/incidents/ for cross-event-source mining.
-      Runtime: python3.12
-      Architectures: [arm64]
-      Handler: index.handler
-      Role: !GetAtt ChangelogIncidentMirrorRole.Arn
-      Timeout: 30
-      MemorySize: 256
-      Environment:
-        Variables:
-          CHANGELOG_BUCKET: alpha-engine-research
-          CHANGELOG_PREFIX: changelog/incidents
-      Code:
-        ZipFile: |
-          """SNS-to-S3 mirror for the system-wide changelog."""
-          import json
-          import os
-          from datetime import datetime, timezone
-          from hashlib import sha1
-
-          import boto3
-
-          _S3 = boto3.client("s3")
-          _BUCKET = os.environ["CHANGELOG_BUCKET"]
-          _PREFIX = os.environ.get("CHANGELOG_PREFIX", "changelog/incidents")
-
-          def handler(event, context):
-              wrote = 0
-              for record in event.get("Records", []):
-                  sns = record.get("Sns", {})
-                  message = sns.get("Message", "") or ""
-                  subject = sns.get("Subject", "") or ""
-                  topic_arn = sns.get("TopicArn", "") or ""
-                  message_id = sns.get("MessageId", "") or ""
-                  ts_iso = sns.get("Timestamp") or datetime.now(timezone.utc).isoformat()
-
-                  ts_iso_clean = ts_iso.replace("Z", "+00:00")
-                  try:
-                      ts = datetime.fromisoformat(ts_iso_clean)
-                  except ValueError:
-                      ts = datetime.now(timezone.utc)
-
-                  ts_utc = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
-                  ts_key = ts.strftime("%Y/%m/%dT%H-%M-%S")
-
-                  topic_name = topic_arn.split(":")[-1] if topic_arn else "sns"
-                  summary_src = subject or (message.splitlines()[0] if message else "(empty)")
-                  summary = summary_src[:240]
-
-                  hash_id = sha1(message_id.encode()).hexdigest()[:7] if message_id else "0000000"
-
-                  entry = {
-                      "ts_utc": ts_utc,
-                      "event_type": "incident",
-                      "source": topic_name,
-                      "subject": subject,
-                      "summary": summary,
-                      "details": message,
-                      "sns_message_id": message_id,
-                      "topic_arn": topic_arn,
-                  }
-
-                  key = f"{_PREFIX}/{ts_key}_{topic_name}_{hash_id}.json"
-                  _S3.put_object(
-                      Bucket=_BUCKET,
-                      Key=key,
-                      Body=json.dumps(entry).encode("utf-8"),
-                      ContentType="application/json",
-                  )
-                  print(f"Wrote s3://{_BUCKET}/{key} subject={subject[:80]!r}")
-                  wrote += 1
-
-              return {"statusCode": 200, "wrote": wrote}
-
-  ChangelogIncidentMirrorSubscription:
-    Type: AWS::SNS::Subscription
-    Properties:
-      TopicArn: !Ref AlertsTopic
-      Protocol: lambda
-      Endpoint: !GetAtt ChangelogIncidentMirrorFunction.Arn
-
-  ChangelogIncidentMirrorPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref ChangelogIncidentMirrorFunction
-      Action: lambda:InvokeFunction
-      Principal: sns.amazonaws.com
-      SourceArn: !Ref AlertsTopic
+  # NOTE: AlertsTopic also has a SECOND subscriber — a Lambda that mirrors
+  # every alert to s3://alpha-engine-research/changelog/incidents/ for the
+  # system-wide event-mining changelog. That Lambda + its IAM role + its
+  # SNS subscription are managed OUTSIDE this CF stack, in
+  # `infrastructure/lambdas/changelog-incident-mirror/`. Reason: when those
+  # resources lived in this stack, every CI deploy hit a perm-cascade on
+  # the github-actions-lambda-deploy OIDC role (iam:TagRole, iam:GetRole,
+  # ...). Orphaning the Lambda kept the OIDC role narrow and removed the
+  # cascade. See ROADMAP "SNS-mirror Lambda — orphan vs CF management"
+  # for the full trade-off + future reconsideration triggers.
 
   # --------------------------------------------------------------------------
   # Step Functions — Saturday Pipeline

--- a/infrastructure/lambdas/changelog-incident-mirror/README.md
+++ b/infrastructure/lambdas/changelog-incident-mirror/README.md
@@ -1,0 +1,139 @@
+# `changelog-incident-mirror` Lambda
+
+Subscribed to `arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts`.
+Mirrors every SNS message as one JSON entry under
+`s3://alpha-engine-research/changelog/incidents/{YYYY}/{MM}/{DD}T{HH-MM-SS}_{topic}_{hash7}.json`
+for the system-wide event-mining changelog.
+
+## Why this lives outside CloudFormation
+
+Originally added to the `alpha-engine-orchestration` CF stack as a
+sibling of `AlertsTopic` (alpha-engine-data PR #122). That triggered a
+perm-cascade on the `github-actions-lambda-deploy` OIDC role — the
+role lacked `iam:TagRole`, `iam:GetRole`, etc. needed by CF to
+introspect the new resources during `update-stack`. Two recovery
+cycles into the cascade, the team decided to orphan the Lambda
+rather than keep expanding the OIDC role to manage one 50-line
+inline-handler Lambda.
+
+Resources kept alive across the orphaning via `DeletionPolicy:
+Retain` (CF removed them from tracking but didn't call any
+service-side delete API). They are now hand-managed via this
+directory.
+
+The decision to orphan + reconsideration triggers are documented in
+`alpha-engine-docs/private/ROADMAP.md` under the Observability
+section.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `index.py` | Lambda handler source (Python 3.12, arm64, 256 MB, 30s) |
+| `iam-policy.json` | Inline policy attached to the function's role |
+| `deploy.sh` | One-shot redeploy script (updates function code only) |
+| `README.md` | this file |
+
+The Lambda's function name, role name, SNS subscription, and Lambda
+permission are all live in AWS but **not** versioned in any IaC.
+Their config:
+
+| Resource | Identifier | Notes |
+|---|---|---|
+| Function | `alpha-engine-changelog-incident-mirror` | Python 3.12, arm64, 256 MB, 30s, env vars: `CHANGELOG_BUCKET=alpha-engine-research`, `CHANGELOG_PREFIX=changelog/incidents` |
+| Execution role | `alpha-engine-changelog-incident-mirror` | Trust: `lambda.amazonaws.com`. Managed: `AWSLambdaBasicExecutionRole`. Inline: `changelog-incident-mirror-s3` (see `iam-policy.json`) |
+| SNS subscription | `alpha-engine-alerts` topic, lambda protocol | Endpoint = function ARN |
+| Lambda permission | `lambda:InvokeFunction` from `sns.amazonaws.com` | SourceArn = AlertsTopic ARN |
+
+## Operations
+
+### Update the handler code
+
+```bash
+bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+# or with smoke test:
+bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh --smoke
+```
+
+The script packages `index.py` into a zip, calls
+`aws lambda update-function-code`, and waits for the update to
+settle. Auth uses your local AWS CLI creds — the personal IAM user
+(`cipher813`) has enough perms; the `github-actions-lambda-deploy`
+OIDC role intentionally does not.
+
+### Recreate from scratch (disaster recovery / new account)
+
+If the resources need to be rebuilt — e.g. in a new AWS account, or
+after an accidental deletion — run these commands in order. The
+Lambda is small enough that recreation is straightforward.
+
+```bash
+# 1. Create execution role
+aws iam create-role \
+  --role-name alpha-engine-changelog-incident-mirror \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+aws iam attach-role-policy \
+  --role-name alpha-engine-changelog-incident-mirror \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+aws iam put-role-policy \
+  --role-name alpha-engine-changelog-incident-mirror \
+  --policy-name changelog-incident-mirror-s3 \
+  --policy-document file://infrastructure/lambdas/changelog-incident-mirror/iam-policy.json
+
+# 2. Package and create function (wait a few seconds after role creation for IAM propagation)
+zip -j /tmp/fn.zip infrastructure/lambdas/changelog-incident-mirror/index.py
+
+aws lambda create-function \
+  --function-name alpha-engine-changelog-incident-mirror \
+  --runtime python3.12 \
+  --architectures arm64 \
+  --handler index.handler \
+  --role "arn:aws:iam::711398986525:role/alpha-engine-changelog-incident-mirror" \
+  --timeout 30 --memory-size 256 \
+  --environment "Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_PREFIX=changelog/incidents}" \
+  --zip-file fileb:///tmp/fn.zip
+
+# 3. Subscribe to SNS topic
+aws sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts \
+  --protocol lambda \
+  --notification-endpoint arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-changelog-incident-mirror
+
+# 4. Allow SNS to invoke the function
+aws lambda add-permission \
+  --function-name alpha-engine-changelog-incident-mirror \
+  --statement-id sns-alerts-invoke \
+  --action lambda:InvokeFunction \
+  --principal sns.amazonaws.com \
+  --source-arn arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts
+```
+
+### Verify
+
+```bash
+# Publish a test message
+aws sns publish \
+  --topic-arn arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts \
+  --subject "Smoke test" --message "Verify mirror works"
+
+# Check the entry landed
+aws s3 ls s3://alpha-engine-research/changelog/incidents/$(date -u +%Y/%m/%d)/ --recursive | tail
+```
+
+### Retire (end-of-life)
+
+```bash
+# Find subscription ARN
+SUB_ARN=$(aws sns list-subscriptions-by-topic \
+  --topic-arn arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts \
+  --query "Subscriptions[?Endpoint=='arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-changelog-incident-mirror'].SubscriptionArn | [0]" \
+  --output text)
+
+aws sns unsubscribe --subscription-arn "$SUB_ARN"
+aws lambda delete-function --function-name alpha-engine-changelog-incident-mirror
+aws iam delete-role-policy --role-name alpha-engine-changelog-incident-mirror --policy-name changelog-incident-mirror-s3
+aws iam detach-role-policy --role-name alpha-engine-changelog-incident-mirror --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+aws iam delete-role --role-name alpha-engine-changelog-incident-mirror
+```

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# deploy.sh — Update the changelog-incident-mirror Lambda's code from
+# index.py in this directory.
+#
+# This Lambda is managed OUTSIDE the alpha-engine-orchestration CF stack
+# (see this directory's README.md for why). The first-time creation +
+# IAM role + SNS subscription were done via CloudFormation back when
+# this lived in the orchestration stack; orphaning preserved the live
+# resources via DeletionPolicy: Retain. As a result, this script only
+# needs to update the function CODE — IAM, subscription, and permission
+# are already wired up.
+#
+# Usage:
+#   bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+#   bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh --dry-run
+#
+# Auth: uses active AWS CLI creds. Personal IAM user (cipher813) has
+# enough perms; the github-actions-lambda-deploy OIDC role does NOT —
+# this script is intentionally NOT wired into CI to avoid expanding the
+# OIDC role's blast radius for one small Lambda.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-changelog-incident-mirror"
+REGION="${AWS_REGION:-us-east-1}"
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+# Validate index.py syntax locally before shipping.
+python3 -c "
+import ast, sys
+src = open('${SCRIPT_DIR}/index.py').read()
+try:
+    ast.parse(src)
+except SyntaxError as e:
+    print(f'index.py syntax error: {e}', file=sys.stderr)
+    sys.exit(1)
+print('index.py syntax OK')
+"
+
+# Package the handler into a zip in /tmp.
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -q "function.zip" index.py)
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+if $DRY_RUN; then
+  echo "(--dry-run) would update Lambda code: ${FUNCTION_NAME}"
+  exit 0
+fi
+
+# Update function code.
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+# Wait for update to settle.
+echo "Waiting for update to complete..."
+aws lambda wait function-updated \
+  --function-name "${FUNCTION_NAME}" \
+  --region "${REGION}"
+
+echo "✓ Deployed."
+
+# Smoke test: publish a single SNS message and verify the entry lands.
+SMOKE_ARG="${1:-}"
+if [[ "${SMOKE_ARG}" == "--smoke" ]]; then
+  echo "Smoke-testing via SNS publish..."
+  TS=$(date -u +%s)
+  aws sns publish \
+    --topic-arn "arn:aws:sns:${REGION}:711398986525:alpha-engine-alerts" \
+    --subject "deploy.sh smoke test ${TS}" \
+    --message "Verifying changelog-incident-mirror after deploy ${TS}" \
+    --query 'MessageId' --output text >/dev/null
+  echo "  → Published. Entry should land in s3://alpha-engine-research/changelog/incidents/ within ~3s."
+  echo "  → Check with: aws s3 ls s3://alpha-engine-research/changelog/incidents/$(date -u +%Y/%m/%d)/ --recursive | tail"
+fi

--- a/infrastructure/lambdas/changelog-incident-mirror/iam-policy.json
+++ b/infrastructure/lambdas/changelog-incident-mirror/iam-policy.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/changelog/incidents/*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/changelog-incident-mirror/index.py
+++ b/infrastructure/lambdas/changelog-incident-mirror/index.py
@@ -1,0 +1,80 @@
+"""SNS-to-S3 mirror for the system-wide changelog.
+
+Subscribed to arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts.
+For every SNS message, writes one JSON entry under
+s3://alpha-engine-research/changelog/incidents/{YYYY}/{MM}/
+{DD}T{HH-MM-SS}_{topic}_{hash7}.json.
+
+This is the "incident" half of the system-wide event-mining changelog
+(deploys are written by the alpha-engine-docs append-changelog
+composite action; manual + recovery entries by the changelog-log CLI).
+
+Managed outside CloudFormation — see ../../README.md and the sibling
+deploy.sh in this directory. The decision to orphan from CF (rather
+than keep it in the alpha-engine-orchestration stack) was made
+2026-05-01 to avoid a perm cascade on the github-actions-lambda-deploy
+OIDC role; trade-off + reconsideration triggers documented in the
+private/ROADMAP.md "Observability" section.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from hashlib import sha1
+
+import boto3
+
+_S3 = boto3.client("s3")
+_BUCKET = os.environ["CHANGELOG_BUCKET"]
+_PREFIX = os.environ.get("CHANGELOG_PREFIX", "changelog/incidents")
+
+
+def handler(event, context):
+    wrote = 0
+    for record in event.get("Records", []):
+        sns = record.get("Sns", {})
+        message = sns.get("Message", "") or ""
+        subject = sns.get("Subject", "") or ""
+        topic_arn = sns.get("TopicArn", "") or ""
+        message_id = sns.get("MessageId", "") or ""
+        ts_iso = sns.get("Timestamp") or datetime.now(timezone.utc).isoformat()
+
+        ts_iso_clean = ts_iso.replace("Z", "+00:00")
+        try:
+            ts = datetime.fromisoformat(ts_iso_clean)
+        except ValueError:
+            ts = datetime.now(timezone.utc)
+
+        ts_utc = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+        ts_key = ts.strftime("%Y/%m/%dT%H-%M-%S")
+
+        topic_name = topic_arn.split(":")[-1] if topic_arn else "sns"
+        summary_src = subject or (message.splitlines()[0] if message else "(empty)")
+        summary = summary_src[:240]
+
+        hash_id = sha1(message_id.encode()).hexdigest()[:7] if message_id else "0000000"
+
+        entry = {
+            "ts_utc": ts_utc,
+            "event_type": "incident",
+            "source": topic_name,
+            "subject": subject,
+            "summary": summary,
+            "details": message,
+            "sns_message_id": message_id,
+            "topic_arn": topic_arn,
+        }
+
+        key = f"{_PREFIX}/{ts_key}_{topic_name}_{hash_id}.json"
+        _S3.put_object(
+            Bucket=_BUCKET,
+            Key=key,
+            Body=json.dumps(entry).encode("utf-8"),
+            ContentType="application/json",
+        )
+        print(f"Wrote s3://{_BUCKET}/{key} subject={subject[:80]!r}")
+        wrote += 1
+
+    return {"statusCode": 200, "wrote": wrote}


### PR DESCRIPTION
## Summary
Removes the \`ChangelogIncidentMirror\*\` resources (Lambda, IAM role, SNS subscription, Lambda permission) from \`alpha-engine-orchestration\` CF stack. Resources stay alive in AWS — they're now hand-managed at \`infrastructure/lambdas/changelog-incident-mirror/\`.

## Why
PR #122 added the SNS-mirror to CF. Every CI deploy since then triggered a perm-cascade on the \`github-actions-lambda-deploy\` OIDC role. Two missing perms surfaced in two recovery cycles (\`iam:TagRole\`, then \`iam:GetRole\`) with no clear bound on what else CF would need. Expanding the OIDC role to manage one 50-line Lambda is more permission than this role should hold.

## Apply state
Already applied live in two changesets via personal creds (CI lacks the perms by design):
1. **orphan-step1-add-retain** — added \`DeletionPolicy: Retain\` + \`UpdateReplacePolicy: Retain\` to all 4 resources. Stack returned to UPDATE_COMPLETE.
2. **orphan-step2-remove-resources** — removed the 4 resources from the template. Stack stayed UPDATE_COMPLETE; resources stayed alive in AWS.

Smoke-tested post-orphan: SNS publish → mirror Lambda → S3 entry within 2s. Cleaned the smoke entry. Mirror still works identically.

## Live IAM
Reverted to match main (the broader read-ops scope I applied live during the cascade troubleshooting is dropped). \`InfraDeployTagOps\` codification from PR #123 stays — it's broader than just the mirror and may be useful for other tagged resources.

## Files
- **CF template** — 4 resource definitions removed; \`AlertsTopic\` block now has a cross-reference comment pointing to the orphan location.
- **\`infrastructure/lambdas/changelog-incident-mirror/index.py\`** — handler source (Python 3.12, 80 lines).
- **\`infrastructure/lambdas/changelog-incident-mirror/iam-policy.json\`** — the role's inline policy, kept for documentation + recreation.
- **\`infrastructure/lambdas/changelog-incident-mirror/deploy.sh\`** — packages \`index.py\` and runs \`update-function-code\`. Optional \`--smoke\` flag publishes a test SNS message.
- **\`infrastructure/lambdas/changelog-incident-mirror/README.md\`** — what's here, why orphan, how to redeploy/recreate-from-scratch/retire.

## ROADMAP
\`alpha-engine-docs/private/ROADMAP.md\` gets a new P3 entry "SNS-mirror Lambda — reconsider orphan vs CF management" listing three triggers that should drive re-folding into CF.

## Test plan
- [x] Stack: \`UPDATE_COMPLETE\` post-orphan
- [x] Lambda: \`Active\` post-orphan
- [x] SNS subscription: 1 lambda subscriber on AlertsTopic
- [x] Smoke: SNS publish → S3 entry landed
- [ ] After this PR merges, the CI deploy on alpha-engine-data triggers a no-op stack update (template + git-sha tag refresh only) — should succeed cleanly without further perm errors. Validates that orphaning resolved the cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)