### PR TITLE
feat(changelog-mirror): SNS Lambda dual-writes structured entries

### DIFF
--- a/infrastructure/lambdas/changelog-incident-mirror/README.md
+++ b/infrastructure/lambdas/changelog-incident-mirror/README.md
@@ -1,9 +1,21 @@
 # `changelog-incident-mirror` Lambda
 
 Subscribed to `arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts`.
-Mirrors every SNS message as one JSON entry under
-`s3://alpha-engine-research/changelog/incidents/{YYYY}/{MM}/{DD}T{HH-MM-SS}_{topic}_{hash7}.json`
-for the system-wide event-mining changelog.
+For every SNS message, **dual-writes** two JSON entries (PR 2 of the
+schema-discipline arc, 2026-05-01 evening):
+
+1. **Structured corpus** (source-of-truth going forward, schema 1.0.0):
+   `s3://alpha-engine-research/changelog/entries/{YYYY-MM-DD}/{event_id}.json`
+2. **Legacy event-typed prefix** (back-compat window per CLAUDE.md S3 contract):
+   `s3://alpha-engine-research/changelog/incidents/{YYYY}/{MM}/{DD}T{HH-MM-SS}_{topic}_{hash7}.json`
+
+The structured entry carries controlled-vocab fields
+(`severity=high`, `subsystem=infrastructure`, `root_cause_category=infrastructure_failure`,
+`auto_emitted=true`) chosen as sensible defaults — most SNS-mirrored
+alerts are SF/Lambda failures. Operator can refine via a follow-up
+`changelog-log --event-type investigation` entry. Aggregator switches
+to reading `entries/` exclusively in PR 4 of the arc; legacy emits
+stop in PR 5.
 
 ## Why this lives outside CloudFormation
 
@@ -40,7 +52,7 @@ Their config:
 
 | Resource | Identifier | Notes |
 |---|---|---|
-| Function | `alpha-engine-changelog-incident-mirror` | Python 3.12, arm64, 256 MB, 30s, env vars: `CHANGELOG_BUCKET=alpha-engine-research`, `CHANGELOG_PREFIX=changelog/incidents` |
+| Function | `alpha-engine-changelog-incident-mirror` | Python 3.12, arm64, 256 MB, 30s, env vars: `CHANGELOG_BUCKET=alpha-engine-research`, `CHANGELOG_PREFIX=changelog/incidents`, `CHANGELOG_STRUCTURED_PREFIX=changelog/entries` |
 | Execution role | `alpha-engine-changelog-incident-mirror` | Trust: `lambda.amazonaws.com`. Managed: `AWSLambdaBasicExecutionRole`. Inline: `changelog-incident-mirror-s3` (see `iam-policy.json`) |
 | SNS subscription | `alpha-engine-alerts` topic, lambda protocol | Endpoint = function ARN |
 | Lambda permission | `lambda:InvokeFunction` from `sns.amazonaws.com` | SourceArn = AlertsTopic ARN |
@@ -92,7 +104,7 @@ aws lambda create-function \
   --handler index.handler \
   --role "arn:aws:iam::711398986525:role/alpha-engine-changelog-incident-mirror" \
   --timeout 30 --memory-size 256 \
-  --environment "Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_PREFIX=changelog/incidents}" \
+  --environment "Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_PREFIX=changelog/incidents,CHANGELOG_STRUCTURED_PREFIX=changelog/entries}" \
   --zip-file fileb:///tmp/fn.zip
 
 # 3. Subscribe to SNS topic

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -33,7 +33,7 @@ for arg in "$@"; do
   esac
 done
 
-# Validate index.py syntax locally before shipping.
+# Validate index.py syntax + run handler smoke tests locally before shipping.
 python3 -c "
 import ast, sys
 src = open('${SCRIPT_DIR}/index.py').read()
@@ -44,6 +44,17 @@ except SyntaxError as e:
     sys.exit(1)
 print('index.py syntax OK')
 "
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler smoke tests..."
+  python3 "${SCRIPT_DIR}/test_handler.py" >/dev/null
+  echo "  ✓ Smoke tests pass"
+fi
+
+# Ensure the live Lambda env has the new structured-prefix var. Idempotent —
+# overwrites in place, so re-running with no diff is harmless. Skipped on
+# --dry-run.
+ENV_PAYLOAD='Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_PREFIX=changelog/incidents,CHANGELOG_STRUCTURED_PREFIX=changelog/entries}'
 
 # Package the handler into a zip in /tmp.
 PKG=$(mktemp -d)
@@ -68,6 +79,21 @@ aws lambda update-function-code \
 
 # Wait for update to settle.
 echo "Waiting for update to complete..."
+aws lambda wait function-updated \
+  --function-name "${FUNCTION_NAME}" \
+  --region "${REGION}"
+
+# Update env config to include CHANGELOG_STRUCTURED_PREFIX (added in PR 2 of
+# the schema-discipline arc). Idempotent — overwriting in place is a no-op
+# if all 3 vars already match. --query suppresses the JSON dump that would
+# otherwise leak env values to stdout per CLAUDE.md "CLI Output Safety".
+echo "Ensuring env config includes CHANGELOG_STRUCTURED_PREFIX..."
+aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment "${ENV_PAYLOAD}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
 aws lambda wait function-updated \
   --function-name "${FUNCTION_NAME}" \
   --region "${REGION}"

--- a/infrastructure/lambdas/changelog-incident-mirror/index.py
+++ b/infrastructure/lambdas/changelog-incident-mirror/index.py
@@ -1,13 +1,36 @@
 """SNS-to-S3 mirror for the system-wide changelog.
 
 Subscribed to arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts.
-For every SNS message, writes one JSON entry under
-s3://alpha-engine-research/changelog/incidents/{YYYY}/{MM}/
-{DD}T{HH-MM-SS}_{topic}_{hash7}.json.
+For every SNS message, writes TWO JSON entries:
+
+1. Legacy event-typed prefix (preserved for the back-compat window per
+   the CLAUDE.md S3 contract — "write to BOTH old and new paths for at
+   least 1 week before removing the old path"). Aggregator still reads
+   this path until PR 4 of the schema-discipline arc.
+
+     s3://alpha-engine-research/changelog/incidents/{YYYY}/{MM}/
+     {DD}T{HH-MM-SS}_{topic}_{hash7}.json
+
+2. Structured corpus (source-of-truth going forward, schema 1.0.0 per
+   alpha-engine-config/changelog/vocab.yaml). Carries the controlled-
+   vocab fields required by the schema-discipline arc.
+
+     s3://alpha-engine-research/changelog/entries/{YYYY-MM-DD}/{event_id}.json
 
 This is the "incident" half of the system-wide event-mining changelog
 (deploys are written by the alpha-engine-docs append-changelog
 composite action; manual + recovery entries by the changelog-log CLI).
+
+Defaults applied to auto-emitted incident entries:
+  severity            = "high"                  (alerts are high by default)
+  subsystem           = "infrastructure"        (most SNS alerts are SF/Lambda failures)
+  root_cause_category = "infrastructure_failure" (default; operator can override
+                                                 with a follow-up changelog-log entry)
+  auto_emitted        = true                    (so future aggregation can flag
+                                                 entries needing human review)
+
+Operator can refine these via a follow-up `changelog-log --event-type
+investigation` entry whose `git_refs` reference the original event_id.
 
 Managed outside CloudFormation — see ../../README.md and the sibling
 deploy.sh in this directory. The decision to orphan from CF (rather
@@ -28,7 +51,19 @@ import boto3
 
 _S3 = boto3.client("s3")
 _BUCKET = os.environ["CHANGELOG_BUCKET"]
-_PREFIX = os.environ.get("CHANGELOG_PREFIX", "changelog/incidents")
+_LEGACY_PREFIX = os.environ.get("CHANGELOG_PREFIX", "changelog/incidents")
+_STRUCTURED_PREFIX = os.environ.get("CHANGELOG_STRUCTURED_PREFIX", "changelog/entries")
+
+SCHEMA_VERSION = "1.0.0"
+
+
+def _put(key: str, body: dict) -> None:
+    _S3.put_object(
+        Bucket=_BUCKET,
+        Key=key,
+        Body=json.dumps(body).encode("utf-8"),
+        ContentType="application/json",
+    )
 
 
 def handler(event, context):
@@ -49,6 +84,7 @@ def handler(event, context):
 
         ts_utc = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
         ts_key = ts.strftime("%Y/%m/%dT%H-%M-%S")
+        entry_date = ts.strftime("%Y-%m-%d")
 
         topic_name = topic_arn.split(":")[-1] if topic_arn else "sns"
         summary_src = subject or (message.splitlines()[0] if message else "(empty)")
@@ -56,7 +92,8 @@ def handler(event, context):
 
         hash_id = sha1(message_id.encode()).hexdigest()[:7] if message_id else "0000000"
 
-        entry = {
+        # Legacy entry — preserved verbatim from pre-schema-discipline.
+        legacy_entry = {
             "ts_utc": ts_utc,
             "event_type": "incident",
             "source": topic_name,
@@ -66,15 +103,56 @@ def handler(event, context):
             "sns_message_id": message_id,
             "topic_arn": topic_arn,
         }
+        legacy_key = f"{_LEGACY_PREFIX}/{ts_key}_{topic_name}_{hash_id}.json"
+        _put(legacy_key, legacy_entry)
 
-        key = f"{_PREFIX}/{ts_key}_{topic_name}_{hash_id}.json"
-        _S3.put_object(
-            Bucket=_BUCKET,
-            Key=key,
-            Body=json.dumps(entry).encode("utf-8"),
-            ContentType="application/json",
+        # Structured entry — schema 1.0.0 for downstream mining.
+        # event_id matches the changelog-log CLI scheme so legacy +
+        # structured entries are joinable on (ts + actor + summary).
+        ts_id = ts_utc.replace(":", "-").rstrip("Z")
+        digest_input = f"{ts_utc}|{topic_name}|{summary}".encode()
+        event_hash = sha1(digest_input).hexdigest()[:7]
+        actor_safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in topic_name)
+        event_id = f"{ts_id}_{actor_safe}_{event_hash}"
+
+        structured_entry = {
+            "schema_version": SCHEMA_VERSION,
+            "event_id": event_id,
+            "ts_utc": ts_utc,
+            "event_type": "incident",
+            "severity": "high",
+            "subsystem": "infrastructure",
+            "root_cause_category": "infrastructure_failure",
+            "resolution_type": None,
+            "started_at": None,
+            "detected_at": ts_utc,
+            "resolved_at": None,
+            "verified_at": None,
+            "summary": summary,
+            "description": message,
+            "resolution_notes": None,
+            "actor": topic_name,
+            "machine": "lambda:changelog-incident-mirror",
+            "source": "sns-mirror",
+            "auto_emitted": True,
+            "git_refs": [],
+            "prompt_version": None,
+            "run_id": None,
+            "eval_run_ref": None,
+            "sns": {
+                "subject": subject,
+                "topic_arn": topic_arn,
+                "message_id": message_id,
+            },
+        }
+        structured_key = f"{_STRUCTURED_PREFIX}/{entry_date}/{event_id}.json"
+        _put(structured_key, structured_entry)
+
+        print(
+            f"Wrote legacy=s3://{_BUCKET}/{legacy_key} "
+            f"structured=s3://{_BUCKET}/{structured_key} "
+            f"subject={subject[:80]!r}"
         )
-        print(f"Wrote s3://{_BUCKET}/{key} subject={subject[:80]!r}")
         wrote += 1
 
     return {"statusCode": 200, "wrote": wrote}

--- a/infrastructure/lambdas/changelog-incident-mirror/test_handler.py
+++ b/infrastructure/lambdas/changelog-incident-mirror/test_handler.py
@@ -1,0 +1,135 @@
+"""Smoke tests for the SNS-mirror Lambda handler.
+
+Mocks boto3.client('s3').put_object so the handler runs end-to-end
+without needing AWS creds. Verifies both the legacy + structured
+entries are emitted with correct keys + payloads.
+
+Run from the repo root:
+
+  python3 infrastructure/lambdas/changelog-incident-mirror/test_handler.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+HERE = Path(__file__).resolve().parent
+
+
+def _import_handler():
+    """Import index.py with boto3.client + env vars stubbed.
+
+    The module imports boto3 at top-level + reads CHANGELOG_BUCKET from env;
+    we patch both before import so the import succeeds in a vanilla
+    Python environment without boto3 installed.
+    """
+    os.environ.setdefault("CHANGELOG_BUCKET", "test-bucket")
+    sys.path.insert(0, str(HERE))
+
+    fake_boto3 = MagicMock()
+    fake_s3_client = MagicMock()
+    fake_boto3.client = MagicMock(return_value=fake_s3_client)
+
+    sys.modules["boto3"] = fake_boto3
+    if "index" in sys.modules:
+        del sys.modules["index"]
+    import index
+    return index, fake_s3_client
+
+
+def _sample_event() -> dict:
+    return {
+        "Records": [
+            {
+                "Sns": {
+                    "Message": "DeployDriftCheck timed out after 60s\nFunction: alpha-engine-deploy-drift",
+                    "Subject": "Step Function failure: DeployDriftCheck",
+                    "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+                    "MessageId": "abcd1234-5678-9012-3456-7890abcdef00",
+                    "Timestamp": "2026-05-01T13:00:00.000Z",
+                }
+            }
+        ]
+    }
+
+
+class HandlerTests(unittest.TestCase):
+    def setUp(self):
+        self.index, self.s3 = _import_handler()
+
+    def test_writes_two_entries_per_message(self):
+        result = self.index.handler(_sample_event(), context=None)
+        self.assertEqual(result["wrote"], 1)
+        self.assertEqual(self.s3.put_object.call_count, 2)
+
+    def test_legacy_entry_payload(self):
+        self.index.handler(_sample_event(), context=None)
+        calls = self.s3.put_object.call_args_list
+        legacy_call = next(c for c in calls if "incidents/" in c.kwargs["Key"])
+        body = json.loads(legacy_call.kwargs["Body"].decode())
+        self.assertEqual(body["event_type"], "incident")
+        self.assertEqual(body["source"], "alpha-engine-alerts")
+        self.assertIn("DeployDriftCheck", body["details"])
+        self.assertIn("Step Function failure", body["subject"])
+
+    def test_structured_entry_payload(self):
+        self.index.handler(_sample_event(), context=None)
+        calls = self.s3.put_object.call_args_list
+        structured_call = next(c for c in calls if "entries/" in c.kwargs["Key"])
+        key = structured_call.kwargs["Key"]
+        body = json.loads(structured_call.kwargs["Body"].decode())
+
+        self.assertTrue(key.startswith("changelog/entries/2026-05-01/"))
+        self.assertTrue(key.endswith(".json"))
+        self.assertEqual(body["schema_version"], "1.0.0")
+        self.assertEqual(body["event_type"], "incident")
+        self.assertEqual(body["severity"], "high")
+        self.assertEqual(body["subsystem"], "infrastructure")
+        self.assertEqual(body["root_cause_category"], "infrastructure_failure")
+        self.assertEqual(body["source"], "sns-mirror")
+        self.assertTrue(body["auto_emitted"])
+        self.assertEqual(body["detected_at"], "2026-05-01T13:00:00Z")
+        self.assertIsNone(body["resolved_at"])
+        self.assertEqual(body["actor"], "alpha-engine-alerts")
+        self.assertEqual(body["machine"], "lambda:changelog-incident-mirror")
+        self.assertEqual(body["sns"]["message_id"], "abcd1234-5678-9012-3456-7890abcdef00")
+
+    def test_event_id_format(self):
+        self.index.handler(_sample_event(), context=None)
+        calls = self.s3.put_object.call_args_list
+        structured_call = next(c for c in calls if "entries/" in c.kwargs["Key"])
+        body = json.loads(structured_call.kwargs["Body"].decode())
+        # Format: 2026-05-01T13-00-00_alpha-engine-alerts_<7-hex>
+        parts = body["event_id"].split("_")
+        self.assertEqual(parts[0], "2026-05-01T13-00-00")
+        self.assertEqual(parts[1], "alpha-engine-alerts")
+        self.assertEqual(len(parts[2]), 7)
+
+    def test_handles_missing_subject(self):
+        ev = _sample_event()
+        ev["Records"][0]["Sns"]["Subject"] = ""
+        self.index.handler(ev, context=None)
+        calls = self.s3.put_object.call_args_list
+        structured_call = next(c for c in calls if "entries/" in c.kwargs["Key"])
+        body = json.loads(structured_call.kwargs["Body"].decode())
+        # Falls back to first line of message
+        self.assertEqual(body["summary"], "DeployDriftCheck timed out after 60s")
+
+    def test_handles_invalid_timestamp(self):
+        ev = _sample_event()
+        ev["Records"][0]["Sns"]["Timestamp"] = "not-a-date"
+        self.index.handler(ev, context=None)
+        calls = self.s3.put_object.call_args_list
+        structured_call = next(c for c in calls if "entries/" in c.kwargs["Key"])
+        body = json.loads(structured_call.kwargs["Body"].decode())
+        # Falls back to current UTC; format is still correct
+        self.assertRegex(body["ts_utc"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
PR 2 of the schema-discipline arc (ROADMAP > Observability > "System-wide changelog: schema discipline + artifact linking + aggregation layer", line 1729). Pairs with the alpha-engine-docs PR that updates the deploy composite action — together they close the auto-emit source side so every CI deploy + every SNS-mirrored alert lands in the structured corpus going forward.

Structured incident entry defaults (auto_emitted=true so future aggregation can surface entries needing operator refinement):
- severity=high (alerts are high by default)
- subsystem=infrastructure (most SNS alerts are SF/Lambda failures)
- root_cause_category=infrastructure_failure (placeholder; operator refines via follow-up `changelog-log --event-type investigation`)
- detected_at = SNS Timestamp (or current UTC if unparseable)
- resolved_at = null until human or alarm-clear handler annotates

Both writes use the same event_id scheme as the alpha-engine-docs changelog-log CLI + composite action so cross-source joins work on (ts, actor, summary).

Operational changes:
- New env var: CHANGELOG_STRUCTURED_PREFIX=changelog/entries (Lambda config override path); deploy.sh now applies this in the same call that updates code so the var lands without a separate manual step.
- deploy.sh now runs test_handler.py (6 unit cases mocking boto3) as a pre-deploy gate; ships only if tests pass. --content-type-style output suppression preserved per CLAUDE.md "CLI Output Safety".
- README.md updated: new dual-write description + env var added to the recreate-from-scratch snippet.

Legacy `changelog/incidents/` writes preserved per CLAUDE.md S3 contract; aggregator keeps reading legacy paths until PR 4 cuts over.