### PR TITLE
fix(backfill): preserve VWAP column when input parquet lacks it

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -307,6 +307,17 @@ def backfill(
                 n_skip += 1
                 continue
 
+            # NaN-fill VWAP when missing from the input parquet so the
+            # written schema is canonical [O,H,L,C,V,VWAP, FEATURES]. The
+            # predictor/price_cache parquets are yfinance-sourced and have
+            # no VWAP column; without this, keep_cols silently drops VWAP
+            # and the next daily_append's update() rejects every ticker
+            # with a column-position mismatch (incident 2026-05-01: full
+            # 904/904 EOD failure traced to backfill-2026-04-30 dropping
+            # VWAP across the universe).
+            if "VWAP" not in featured_df.columns:
+                featured_df["VWAP"] = np.nan
+
             keep_cols = [c for c in OHLCV_COLS if c in featured_df.columns] + \
                         [f for f in FEATURES if f in featured_df.columns]
             symbol_df = featured_df[keep_cols].copy()

--- a/tests/test_backfill_unified_and_macro_scoping.py
+++ b/tests/test_backfill_unified_and_macro_scoping.py
@@ -286,3 +286,83 @@ def test_short_history_ticker_gets_feature_columns_written():
         "Short-history NaN feature must stay NaN after the write — "
         "dropna / zero-fill would violate the PR #78 contract."
     )
+
+
+def test_backfill_writes_vwap_when_input_parquet_lacks_it():
+    """Regression for the 2026-05-01 EOD-pipeline failure.
+
+    The ``predictor/price_cache/{ticker}.parquet`` snapshots are
+    yfinance-sourced and have no VWAP column. ``compute_features`` does
+    not synthesize VWAP either (it's an OHLCV column, not a feature).
+
+    Without an explicit NaN-fill, ``keep_cols`` silently drops VWAP from
+    the written frame. The next daily_append's ``_write_row_backfill_safe``
+    then concats ``existing_no_VWAP`` + ``new_row_with_VWAP`` and
+    ``pd.concat`` appends VWAP at the end of the column list — flipping
+    the universe back to legacy ``[O,H,L,C,V, FEATURES, VWAP]`` ordering.
+    Subsequent ``daily_append.update()`` calls reject every ticker with
+    a column-position mismatch (n_err=904, 100% > 5% gate, EOD SF fails).
+
+    Contract: backfill must write canonical ``[O,H,L,C,V,VWAP, FEATURES]``
+    even when the source parquet has no VWAP. NaN-filled VWAP is correct;
+    a missing VWAP column is not.
+    """
+    from builders import backfill as _bf
+    from features.feature_engineer import FEATURES
+
+    # _minimal_ohlcv produces O/H/L/C/Adj_Close/Volume — no VWAP column,
+    # mirroring the real predictor/price_cache parquet shape.
+    price_data = {"AAPL": _minimal_ohlcv(n_rows=400)}
+    assert "VWAP" not in price_data["AAPL"].columns, (
+        "Test setup invariant: the fixture must not contain VWAP — "
+        "otherwise we're not exercising the regression scenario."
+    )
+
+    macro = _stub_macro(n_rows=400)
+    sector_map = {"AAPL": "XLK"}
+
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+
+    def _fake_compute_features(df, **_):
+        # Mirror real compute_features: returns input + feature columns,
+        # never synthesizes VWAP. The contract under test depends on
+        # backfill itself NaN-filling VWAP before the keep_cols slice.
+        out = df.copy()
+        for col in ("atr_14_pct", "rsi_14"):
+            out[col] = 0.5
+        return out
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_extract_macro_series", return_value=macro), \
+         patch.object(_bf, "_load_sector_map", return_value=sector_map), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "_build_macro_features_df", return_value=pd.DataFrame()), \
+         patch.object(_bf, "compute_features", side_effect=_fake_compute_features), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib), \
+         patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        result = _bf.backfill(ticker_filter="AAPL")
+
+    assert result["status"] == "ok"
+    universe_lib.write.assert_called_once()
+    _, written_df = universe_lib.write.call_args[0]
+
+    cols = list(written_df.columns)
+    assert "VWAP" in cols, (
+        "VWAP must appear in the written schema even when the input "
+        "parquet lacks it — silent drop reproduces the 2026-05-01 incident."
+    )
+    # Canonical position: right after Volume, before any feature column.
+    assert cols.index("VWAP") == 5, (
+        f"VWAP must land at idx=5 (canonical [O,H,L,C,V,VWAP] prefix); "
+        f"got idx={cols.index('VWAP')}, full order={cols[:8]}"
+    )
+    # Values must be NaN (no synthetic (H+L+C)/3 proxy).
+    assert written_df["VWAP"].isna().all(), (
+        "Synthetic VWAP is forbidden — yfinance-sourced rows write NaN. "
+        "See feedback_no_silent_fails: a proxy here would corrupt the "
+        "executor's VWAP-discount entry trigger."
+    )


### PR DESCRIPTION
## Summary
- Root cause of the 2026-05-01 EOD pipeline failure (n_err=904, 100% > 5% gate).
- backfill.py silently dropped VWAP when input parquet lacked it; the next MorningEnrich's pd.concat then pushed VWAP to the end of the column list across the entire universe.
- Adds an explicit NaN-fill before the `keep_cols` slice so the canonical `[O,H,L,C,V,VWAP, FEATURES]` schema is preserved.

## Incident chronology
1. **2026-04-28 14:35 UTC** — `migrate_universe_vwap --apply` normalized all 904 tickers to canonical schema (VWAP at idx=5).
2. **2026-04-30 16:06 UTC** — `manual-validation-20260430-081027` Saturday SF ran. Its `backfill.py` step rewrote all 904 tickers from `predictor/price_cache/{ticker}.parquet`. The parquets are yfinance-sourced (no VWAP), `compute_features` doesn't synthesize VWAP, and `keep_cols = [c for c in OHLCV_COLS if c in featured_df.columns] + ...` silently dropped VWAP. Universe went 64-col, no VWAP.
3. **2026-05-01 14:11 UTC** — Today's MorningEnrich ran `daily_append` for the prior trading day. Hit `_write_row_backfill_safe` "backfill" path: `pd.concat(existing_no_VWAP, new_row_with_VWAP)` preserved existing's column order first and appended VWAP at the end → 65 cols with VWAP at idx=64.
4. **2026-05-01 20:15 UTC** — Post-market `daily_append` tried `lib.update()` with canonical `[O,H,L,C,V,VWAP, FEATURES]`. Storage had `[O,H,L,C,V, FEATURES, VWAP]`. Column-position mismatch on all 904 tickers; 5% err-rate gate raised RuntimeError → SSM exit 1 → EOD SF FAILED.

## Why this fix
- NaN-fill is the documented Phase 7 contract for non-Polygon sources (per `tests/test_vwap_ingestion.py` and the `backfill.py:53` docstring).
- An explicit `df["VWAP"] = np.nan` before `keep_cols` makes the schema invariant load-bearing in code, not implicit.
- The recurring weekly Saturday SF would re-break the universe every week without this; the 4/27 `migrate_universe_vwap` was a one-shot fix that gets undone every backfill.

## Operational status
- Immediate fix on prod (`migrate_universe_vwap --apply` on ae-trading) is in flight to unblock today's EOD; this PR prevents recurrence on future Saturday SFs.
- All 22 backfill / VWAP / daily_append-backfill-safe tests pass locally.

## Test plan
- [x] `pytest tests/test_backfill_unified_and_macro_scoping.py tests/test_vwap_ingestion.py tests/test_daily_append_backfill_safe.py` — 22/22 pass
- [x] New regression test `test_backfill_writes_vwap_when_input_parquet_lacks_it` — asserts VWAP lands at idx=5 with NaN values when input lacks VWAP
- [ ] Saturday 2026-05-02 SF runs cleanly with VWAP preserved at idx=5 across all 904 tickers (post-deploy validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)