### PR TITLE
chore(eod-sf): remove redundant python -m builders.daily_append invocation

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -15,8 +15,7 @@
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
-            "python weekly_collector.py --daily --only daily_closes 2>&1 | tee /var/log/postmarket-data.log",
-            "python -m builders.daily_append 2>&1 | tee -a /var/log/postmarket-data.log"
+            "python weekly_collector.py --daily 2>&1 | tee /var/log/postmarket-data.log"
           ],
           "executionTimeout": ["180"]
         },

--- a/infrastructure/update_eod_pipeline_sf.sh
+++ b/infrastructure/update_eod_pipeline_sf.sh
@@ -41,8 +41,7 @@ DEFN=$(cat <<'JSON'
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
-            "python weekly_collector.py --daily --only daily_closes 2>&1 | tee /var/log/postmarket-data.log",
-            "python -m builders.daily_append 2>&1 | tee -a /var/log/postmarket-data.log"
+            "python weekly_collector.py --daily 2>&1 | tee /var/log/postmarket-data.log"
           ],
           "executionTimeout": ["1200"]
         },

--- a/tests/test_daily_append_skip_if_exists.py
+++ b/tests/test_daily_append_skip_if_exists.py
@@ -297,10 +297,40 @@ def test_cli_skip_if_exists_flag_present():
     )
 
 
-# NOTE: SF-JSON wiring (passing --skip-if-exists in the deployed SSM
-# command) is intentionally out of scope for this PR. The EOD SF
-# definition lives in two infrastructure files
-# (infrastructure/step_function_eod.json + update_eod_pipeline_sf.sh)
-# and updating them requires a redeploy via update_eod_pipeline_sf.sh.
-# That's tracked separately so this PR can land cleanly behind
-# weekly_collector wiring while the SF-redeploy is sequenced.
+def test_eod_ssm_script_has_no_redundant_daily_append():
+    """The deployed SSM script for the EOD SF must not invoke
+    ``python -m builders.daily_append`` after ``weekly_collector --daily``.
+
+    History: the EOD SSM had two python invocations back-to-back —
+    ``weekly_collector --daily --only daily_closes`` followed by a bare
+    ``python -m builders.daily_append``. The second one was redundant
+    (``_run_daily`` runs ``daily_closes`` + ``feature_store`` +
+    ``daily_append`` regardless of ``--only``, so the second invocation
+    just ran daily_append again — without ``skip_if_exists`` exposed via
+    a flag, so on re-runs it took the slow backfill path on every ticker
+    and timed out the SSM 1200s ceiling on the 2026-05-01 EOD recovery).
+
+    Locks the simplification: a single ``weekly_collector --daily``
+    invocation is canonical; the redundant second call must not return.
+    """
+    sf_eod = Path(__file__).parent.parent / "infrastructure" / "step_function_eod.json"
+    deploy_sh = Path(__file__).parent.parent / "infrastructure" / "update_eod_pipeline_sf.sh"
+    for src_path in (sf_eod, deploy_sh):
+        if not src_path.exists():
+            continue
+        src = src_path.read_text()
+        # The bare CLI invocation appearing as an SSM command line is the
+        # redundant pattern. Allow the substring in comments / other
+        # contexts but not as an executable command (`tee` marks the SSM
+        # runner pattern).
+        executable_lines = [
+            line for line in src.splitlines()
+            if "python -m builders.daily_append" in line
+            and "tee" in line
+        ]
+        assert executable_lines == [], (
+            f"{src_path.name} still contains redundant invocation(s): "
+            f"{executable_lines}. weekly_collector._run_daily already "
+            f"runs daily_append; the second SSM call is dead weight and "
+            f"reintroduces the 2026-05-01 timeout regression."
+        )


### PR DESCRIPTION
## Summary
- Follow-up to #128. The EOD SF's `PostMarketData` step ran `daily_append` twice back-to-back: once via `weekly_collector --daily` (which #128 made source-aware) and again via a bare `python -m builders.daily_append` CLI call (which still defaulted to `skip_if_exists=False`).
- The second invocation was a no-op duplicate. `_run_daily` already runs daily_closes + feature_store + daily_append regardless of `--only` (the flag only filters in `_run_phase1`).
- Removes the redundant invocation. Re-runs of the EOD SF should now be ~3 min instead of ~25 min, well under the 1200s SSM timeout.

## Why now
The 2026-05-01 EOD SF rerun (after PR #126 merged + the universe was re-migrated) timed out at the SSM 1200s ceiling. With #128 deployed, the first invocation completes in seconds when today's row is already written. The second bare-CLI invocation still hits the slow `lib.write` backfill path on every ticker (~22 min) and re-introduces the timeout. Removing it drops total wall time below 3 min on re-runs and gets us back the 5/1 EOD reconcile run cleanly.

## Also dropped
The `--only daily_closes` qualifier on the remaining invocation. It was misleading — `--only` is only wired into `_run_phase1`, not `_run_daily`, so the qualifier did nothing. The bare `--daily` is the canonical invocation.

## Test plan
- [x] `pytest tests/test_daily_append_skip_if_exists.py` — 8/8 pass (new `test_eod_ssm_script_has_no_redundant_daily_append` regression locks the simplification).
- [ ] Run `infrastructure/update_eod_pipeline_sf.sh` on ae-trading after merge to redeploy the SF.
- [ ] Trigger EOD SF rerun for 2026-05-01 to verify CaptureSnapshot + EODReconcile now run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)