### PR TITLE
fix(backfill): apply daily_closes delta + regression preflight

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -39,6 +39,7 @@ from features.feature_engineer import (
 from features.compute import (
     DEFAULT_BUCKET,
     _SKIP_TICKERS,
+    _apply_daily_delta,
     _is_sector_etf,
     _load_parquet_from_s3,
     _load_sector_map,
@@ -162,6 +163,132 @@ def _build_macro_features_df(macro: dict[str, pd.Series]) -> pd.DataFrame:
     return df
 
 
+# Universe sample size for the regression preflight. Matches postflight's
+# _UNIVERSE_SAMPLE_SIZE so the same set of tickers gates both ends of the
+# pipeline. 20 tickers catches any systematic regression with ~certainty
+# (a one-day clobber across the whole universe would land in 100% of
+# samples) while keeping the preflight ArcticDB-read budget tiny.
+_REGRESSION_PREFLIGHT_SAMPLE_SIZE = 20
+
+
+def _planned_last_date(series_or_df) -> "pd.Timestamp | None":
+    """Last index date of a Series or DataFrame, normalized to midnight UTC."""
+    if series_or_df is None:
+        return None
+    idx = series_or_df.index
+    if idx is None or len(idx) == 0:
+        return None
+    last = pd.Timestamp(idx[-1])
+    if last.tzinfo is not None:
+        last = last.tz_convert("UTC").tz_localize(None)
+    return last.normalize()
+
+
+def _existing_last_date(lib, symbol: str) -> "pd.Timestamp | None":
+    """Last existing date in ArcticDB for ``symbol``, or None if not present."""
+    try:
+        df = lib.tail(symbol, n=1).data
+    except Exception:
+        return None
+    if df is None or df.empty:
+        return None
+    last = pd.Timestamp(df.index[-1])
+    if last.tzinfo is not None:
+        last = last.tz_convert("UTC").tz_localize(None)
+    return last.normalize()
+
+
+def _assert_no_arctic_regression(
+    bucket: str,
+    planned_macro: dict[str, "pd.Series"],
+    planned_universe: dict[str, "pd.DataFrame"],
+    run_date: str,
+    sample_size: int = _REGRESSION_PREFLIGHT_SAMPLE_SIZE,
+) -> None:
+    """Refuse to run backfill if its planned data is older than what ArcticDB has.
+
+    Backfill rewrites every macro/sector and (sampled) universe symbol with
+    full-series ``lib.write()`` calls, so any regression at the source
+    instantly knocks every downstream consumer stale. Postflight catches
+    the symptom afterwards but by then the damage is done — this preflight
+    fails BEFORE any feature compute or write so the operator gets a clean
+    actionable error and ArcticDB stays at its current freshness.
+
+    Origin: 2026-05-02 weekly SF. MorningEnrich appended Friday's polygon
+    fill to ArcticDB; price cache passed the mtime "current" check (cache
+    parquets refreshed 4/30) so neither prices nor slim_cache rewrote the
+    cache; backfill loaded that 4/30-ending cache, computed features over
+    it, and ``lib.write()`` regressed every macro/sector/universe symbol
+    from 5/1 → 4/30. Postflight rejected. Pipeline halted at DataPhase1.
+
+    The check is sampled on the universe side (matching
+    ``validators/postflight._UNIVERSE_SAMPLE_SIZE``) because exhaustive
+    ``tail()`` over 900 symbols would dominate backfill runtime on every
+    Saturday. Sample seed is the run_date so reruns hit the same tickers.
+    """
+    import random as _rand
+
+    macro_lib = get_macro_lib(bucket)
+    universe_lib = get_universe_lib(bucket)
+
+    regressions: list[str] = []
+
+    for key, series in planned_macro.items():
+        planned_last = _planned_last_date(series)
+        existing_last = _existing_last_date(macro_lib, key)
+        if planned_last is None or existing_last is None:
+            continue
+        if planned_last < existing_last:
+            regressions.append(
+                f"macro.{key}: planned={planned_last.date()} < existing={existing_last.date()}"
+            )
+
+    try:
+        arctic_syms = set(universe_lib.list_symbols())
+    except Exception as exc:
+        raise RuntimeError(
+            f"Backfill regression preflight: could not list ArcticDB universe symbols: {exc}"
+        ) from exc
+
+    candidates = sorted(
+        t for t in planned_universe
+        if t in arctic_syms and t not in _SKIP_TICKERS and not _is_sector_etf(t)
+    )
+    if len(candidates) > sample_size:
+        rng = _rand.Random(run_date)
+        sample = rng.sample(candidates, sample_size)
+    else:
+        sample = candidates
+
+    for ticker in sample:
+        planned_last = _planned_last_date(planned_universe.get(ticker))
+        existing_last = _existing_last_date(universe_lib, ticker)
+        if planned_last is None or existing_last is None:
+            continue
+        if planned_last < existing_last:
+            regressions.append(
+                f"universe.{ticker}: planned={planned_last.date()} < existing={existing_last.date()}"
+            )
+
+    if regressions:
+        raise RuntimeError(
+            f"Backfill regression preflight failed: {len(regressions)} symbols would regress "
+            f"if backfill proceeded. Source data (predictor/price_cache + daily_closes delta) "
+            f"ends earlier than what ArcticDB already has. Most common cause: the price cache "
+            f"mtime 'current' check skipped the weekly refresh, so the cache lags "
+            f"MorningEnrich/daily_append writes. To recover: run the prices collector with a "
+            f"forced refresh (e.g. delete or touch S3 mtime to invalidate) so the cache "
+            f"includes the prior trading day, then re-invoke backfill. "
+            f"Regressions detected (showing first 10 of {len(regressions)}): {regressions[:10]}"
+        )
+
+    log.info(
+        "Backfill regression preflight: OK — %d macro/sector + %d sampled universe symbols "
+        "all >= existing ArcticDB last_date.",
+        len(planned_macro), len(sample),
+    )
+
+
 def backfill(
     bucket: str = DEFAULT_BUCKET,
     dry_run: bool = False,
@@ -187,19 +314,37 @@ def backfill(
     s3 = boto3.client("s3")
     t0 = time.time()
 
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
     # ── 1. Load data ─────────────────────────────────────────────────────────
     log.info("Loading full 10-year price cache...")
     price_data = _load_full_cache(s3, bucket)
     if not price_data:
         return {"status": "error", "error": "no_price_data"}
 
+    # Apply daily_closes delta on top of the 10y cache so the backfill source
+    # captures rows written between the last cache refresh and today (e.g.
+    # MorningEnrich's polygon-T+1 fill, weekday EOD CaptureSnapshot). Without
+    # this, a price cache that's "current" by S3 mtime can still source data
+    # older than what daily_append already pushed into ArcticDB, and the
+    # full-series ``lib.write()`` calls below regress every symbol. Mirrors
+    # ``features/compute.py::_apply_daily_delta`` so both feature-snapshot and
+    # backfill share the same freshness semantics.
+    if not dry_run:
+        price_data, _split_tickers = _apply_daily_delta(s3, bucket, today_str, price_data)
+
     macro = _extract_macro_series(price_data)
     sector_map = _load_sector_map(s3, bucket)
 
-    # Use today's date for fundamentals/alt data lookup
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     fundamentals = _load_cached_fundamentals(s3, bucket, today_str)
     alt_data = _load_cached_alternative(s3, bucket)
+
+    # Defense-in-depth: refuse to write if planned data is older than what
+    # ArcticDB has. Skipped on per-ticker invocations (those route through
+    # ``skip_macro`` and don't touch the universe sample). Cheap (a handful
+    # of tail() reads) so it runs before the multi-minute feature compute.
+    if not dry_run and ticker_filter is None:
+        _assert_no_arctic_regression(bucket, macro, price_data, today_str)
 
     t_load = time.time() - t0
     log.info(

--- a/tests/test_backfill_no_regression.py
+++ b/tests/test_backfill_no_regression.py
@@ -1,0 +1,282 @@
+"""Regression tests for builders/backfill.py freshness preflight.
+
+Locks the 2026-05-02 incident invariant: a full-universe backfill must
+NOT silently regress ArcticDB macro/universe last_date when its source
+data (predictor/price_cache + daily_closes delta) ends earlier than what
+ArcticDB already has. Two layers gate this:
+
+1. ``_apply_daily_delta`` runs against the loaded price cache so backfill
+   sees the same delta-merged data that the feature snapshot does. Without
+   this, the price cache mtime "current" check can leave the cache 1+ day
+   behind MorningEnrich's polygon-T+1 fill.
+2. ``_assert_no_arctic_regression`` reads SPY + a 20-symbol universe sample
+   from ArcticDB and refuses to write if planned data is older. Cheap
+   defense-in-depth: catches the regression class even when delta isn't
+   enough (e.g. delta file missing, source cache regressed for some
+   reason).
+
+Both layers exist because the underlying full-series ``lib.write()`` calls
+in backfill clobber every existing row — there is no path to recover from
+a silent regression once the writes land.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+def _series(start: str, n: int = 5) -> pd.Series:
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.Series([100.0 + i for i in range(n)], index=idx)
+
+
+def _ohlcv(start: str, n: int = 5) -> pd.DataFrame:
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.DataFrame(
+        {"Open": 100.0, "High": 101.0, "Low": 99.0, "Close": 100.0, "Volume": 1_000_000},
+        index=idx,
+    )
+
+
+def _arctic_lib_with(symbols_to_last_date: dict[str, str]):
+    """Stub an ArcticDB library whose ``tail(sym, n=1)`` returns a single-row
+    frame ending on the given date. ``list_symbols`` returns the keys."""
+    lib = MagicMock()
+
+    def _tail(sym, n=1):
+        if sym not in symbols_to_last_date:
+            raise RuntimeError(f"symbol {sym} not found")
+        df = pd.DataFrame(
+            {"Close": [100.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(symbols_to_last_date[sym])]),
+        )
+        result = MagicMock()
+        result.data = df
+        return result
+
+    lib.tail.side_effect = _tail
+    lib.list_symbols.return_value = list(symbols_to_last_date.keys())
+    return lib
+
+
+def test_assert_no_regression_passes_when_planned_matches_existing():
+    """Equal last_date is fine: backfill rewrite preserves freshness."""
+    from builders import backfill as _bf
+
+    planned_macro = {"SPY": _series("2026-04-25"), "VIX": _series("2026-04-25")}
+    planned_universe = {"AAPL": _ohlcv("2026-04-25")}
+
+    macro_lib = _arctic_lib_with({"SPY": "2026-04-25", "VIX": "2026-04-25"})
+    universe_lib = _arctic_lib_with({"AAPL": "2026-04-25"})
+
+    with patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib):
+        _bf._assert_no_arctic_regression(
+            "test-bucket", planned_macro, planned_universe, run_date="2026-04-26"
+        )  # must not raise
+
+
+def test_assert_no_regression_passes_when_planned_is_newer():
+    """Newer planned data is the happy path — strictly forward-progressing."""
+    from builders import backfill as _bf
+
+    planned_macro = {"SPY": _series("2026-04-29")}
+    planned_universe = {"AAPL": _ohlcv("2026-04-29")}
+
+    macro_lib = _arctic_lib_with({"SPY": "2026-04-25"})
+    universe_lib = _arctic_lib_with({"AAPL": "2026-04-25"})
+
+    with patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib):
+        _bf._assert_no_arctic_regression(
+            "test-bucket", planned_macro, planned_universe, run_date="2026-04-30"
+        )
+
+
+def test_assert_no_regression_raises_on_macro_regression():
+    """The 2026-05-02 incident exact path: planned macro ends 4/30,
+    ArcticDB has 5/1 from MorningEnrich. Must hard-fail BEFORE any
+    feature compute or write runs.
+    """
+    from builders import backfill as _bf
+
+    planned_macro = {"SPY": _series("2026-04-26", n=4)}  # ends 4/29 BDay
+    planned_universe = {"AAPL": _ohlcv("2026-04-26", n=4)}
+
+    macro_lib = _arctic_lib_with({"SPY": "2026-05-01"})
+    universe_lib = _arctic_lib_with({"AAPL": "2026-05-01"})
+
+    with patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib):
+        with pytest.raises(RuntimeError, match="regression preflight failed"):
+            _bf._assert_no_arctic_regression(
+                "test-bucket", planned_macro, planned_universe, run_date="2026-05-02"
+            )
+
+
+def test_assert_no_regression_raises_on_universe_regression():
+    """Universe regression alone (macro fresh) is also a hard-fail.
+
+    Catches the case where macro got refreshed by some path but the
+    universe writes would still clobber daily_append's appends.
+    """
+    from builders import backfill as _bf
+
+    planned_macro = {"SPY": _series("2026-05-01")}  # fresh
+    planned_universe = {"AAPL": _ohlcv("2026-04-26", n=4)}  # stale
+
+    macro_lib = _arctic_lib_with({"SPY": "2026-05-01"})
+    universe_lib = _arctic_lib_with({"AAPL": "2026-05-01"})
+
+    with patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib):
+        with pytest.raises(RuntimeError, match="regression preflight failed"):
+            _bf._assert_no_arctic_regression(
+                "test-bucket", planned_macro, planned_universe, run_date="2026-05-02"
+            )
+
+
+def test_assert_no_regression_skips_symbols_absent_from_arctic():
+    """First-write case: a planned symbol with no existing ArcticDB row
+    must not be treated as a regression (existing_last is None → skip).
+    """
+    from builders import backfill as _bf
+
+    planned_macro = {"SPY": _series("2026-04-25")}
+    planned_universe = {"NEWCO": _ohlcv("2026-04-25")}
+
+    macro_lib = _arctic_lib_with({"SPY": "2026-04-25"})
+    # NEWCO not in ArcticDB universe yet — list_symbols returns empty
+    universe_lib = _arctic_lib_with({})
+
+    with patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib):
+        _bf._assert_no_arctic_regression(
+            "test-bucket", planned_macro, planned_universe, run_date="2026-04-26"
+        )  # must not raise
+
+
+def test_full_backfill_calls_apply_daily_delta():
+    """The 2026-05-02 fix: full-universe backfill must apply daily_closes
+    delta on top of the 10y price cache so the source picks up
+    MorningEnrich's polygon-T+1 fill. Skipping this leaves the source 1
+    day behind ArcticDB whenever the price cache passes the mtime
+    'current' check.
+    """
+    from builders import backfill as _bf
+
+    price_data = {"AAPL": _ohlcv("2024-01-01", n=400)}
+    macro: dict = {}
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+
+    delta_mock = MagicMock(side_effect=lambda s3, b, d, pd_: (pd_, set()))
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", delta_mock), \
+         patch.object(_bf, "_assert_no_arctic_regression"), \
+         patch.object(_bf, "_extract_macro_series", return_value=macro), \
+         patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "_build_macro_features_df", return_value=pd.DataFrame()), \
+         patch.object(_bf, "compute_features", side_effect=lambda df, **_: df), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib), \
+         patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        _bf.backfill(ticker_filter=None)
+
+    delta_mock.assert_called_once()
+
+
+def test_full_backfill_calls_regression_preflight():
+    """The 2026-05-02 fix: full-universe backfill must run the regression
+    preflight before any compute or write so a stale source aborts loudly
+    instead of silently clobbering ArcticDB.
+    """
+    from builders import backfill as _bf
+
+    price_data = {"AAPL": _ohlcv("2024-01-01", n=400)}
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+    regression_mock = MagicMock()
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
+         patch.object(_bf, "_extract_macro_series", return_value={}), \
+         patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "_build_macro_features_df", return_value=pd.DataFrame()), \
+         patch.object(_bf, "compute_features", side_effect=lambda df, **_: df), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib), \
+         patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        _bf.backfill(ticker_filter=None)
+
+    regression_mock.assert_called_once()
+
+
+def test_ticker_filter_skips_regression_preflight():
+    """Per-ticker backfill (--ticker X) skips the regression preflight —
+    it doesn't touch the macro library by default and only writes a single
+    universe symbol, so the cross-symbol freshness check is moot. Avoids
+    a spurious failure from a stale-cache --ticker patch when the rest of
+    ArcticDB has moved forward.
+    """
+    from builders import backfill as _bf
+
+    price_data = {"AAPL": _ohlcv("2024-01-01", n=400)}
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+    regression_mock = MagicMock()
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
+         patch.object(_bf, "_extract_macro_series", return_value={}), \
+         patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "_build_macro_features_df", return_value=pd.DataFrame()), \
+         patch.object(_bf, "compute_features", side_effect=lambda df, **_: df), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib), \
+         patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        _bf.backfill(ticker_filter="AAPL")
+
+    regression_mock.assert_not_called()
+
+
+def test_dry_run_skips_delta_and_preflight():
+    """``--dry-run`` is a CI / local validation path: must not require S3
+    daily_closes parquets to exist or ArcticDB to be reachable. Both the
+    delta load and the preflight read are gated behind ``not dry_run``.
+    """
+    from builders import backfill as _bf
+
+    price_data = {"AAPL": _ohlcv("2024-01-01", n=400)}
+    delta_mock = MagicMock()
+    regression_mock = MagicMock()
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", delta_mock), \
+         patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
+         patch.object(_bf, "_extract_macro_series", return_value={}), \
+         patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "compute_features", side_effect=lambda df, **_: df), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        _bf.backfill(dry_run=True)
+
+    delta_mock.assert_not_called()
+    regression_mock.assert_not_called()

--- a/tests/test_backfill_unified_and_macro_scoping.py
+++ b/tests/test_backfill_unified_and_macro_scoping.py
@@ -172,6 +172,8 @@ def _run_backfill_with_mocks(**backfill_kwargs):
     )
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_extract_macro_series", return_value=macro), \
          patch.object(_bf, "_load_sector_map", return_value=sector_map), \
          patch.object(_bf, "_load_cached_fundamentals", return_value=fundamentals), \
@@ -258,6 +260,8 @@ def test_short_history_ticker_gets_feature_columns_written():
         return out
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_extract_macro_series", return_value=macro), \
          patch.object(_bf, "_load_sector_map", return_value=sector_map), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
@@ -334,6 +338,8 @@ def test_backfill_writes_vwap_when_input_parquet_lacks_it():
         return out
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_extract_macro_series", return_value=macro), \
          patch.object(_bf, "_load_sector_map", return_value=sector_map), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \


### PR DESCRIPTION
## Summary

- DataPhase1 step 8 (`builders.backfill`) silently regressed ArcticDB macro+universe last_date by 1d on the 2026-05-02 Saturday SF run. Postflight caught it; SF halted.
- Root cause: backfill loaded the 10y price cache (which passed the mtime "current" check today and skipped its weekly refresh, so internal data ended 4/30), computed features, and full-series `lib.write()` clobbered the 5/1 row MorningEnrich had appended at 09:18.
- Fix adds two layers: (1) merge `staging/daily_closes/{date}.parquet` on top of the cache before any compute (mirrors `features/compute.py::_apply_daily_delta`), and (2) defense-in-depth `_assert_no_arctic_regression` preflight that hard-fails before compute if planned data is older than what's already in ArcticDB.

The 2026-04-22 SOLS regression was patched same-day with a `ticker_filter`-only `skip_macro` guard; this PR closes the full-universe path that the same bug class still ran through.

## Test plan

- [x] `tests/test_backfill_no_regression.py` — 8 new tests cover the preflight (pass / macro-regression / universe-regression / first-write absent-from-arctic) and the wiring (delta call / preflight call / ticker_filter skip / dry_run skip)
- [x] `tests/test_backfill_unified_and_macro_scoping.py` — existing 9 tests still pass after extending mock setups with delta + preflight stubs
- [x] `tests/test_daily_append_backfill_safe.py` — 5 existing tests unaffected
- [x] Full suite green in CI (344 passed)
- [ ] Live verification via Saturday SF redrive (after merge): MorningEnrich appends 5/1 → backfill applies delta + preflight passes → ArcticDB lands at 5/1 → postflight passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)