### PR TITLE
fix(daily_append): scope missing-from-closes check to caller's request list

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -320,6 +320,7 @@ def daily_append(
     bucket: str = DEFAULT_BUCKET,
     dry_run: bool = False,
     skip_if_exists: bool = False,
+    expected_tickers: list[str] | None = None,
 ) -> dict:
     """
     Append today's features to ArcticDB universe.
@@ -348,6 +349,24 @@ def daily_append(
         904 × ~1.5s = ~22 min — over the SSM 1200s timeout. The 2026-05-01
         EOD SF rerun timed out exactly here after our manual recovery
         run had already written today's rows.
+    expected_tickers
+        When provided, the missing-from-closes hard-fail at step 2b is
+        scoped to ``arctic_universe ∩ expected_tickers`` instead of the
+        full ArcticDB universe. Lets the caller (MorningEnrich /
+        weekday DailyData) say "these are the tickers I asked polygon
+        for" so S&P churn-out stragglers (still in ArcticDB awaiting a
+        prune cycle, no longer in current constituents.json) don't trip
+        the threshold. 2026-05-02 incident: 8 tickers got dropped from
+        the index this past week (ASGN, GTM, HOLX, KMPR, LW, MOH,
+        MTCH, PAYC); ArcticDB universe still had them; MorningEnrich
+        no longer requested them; missing-from-closes saw 12 vs the
+        threshold of 5 and halted the SF. With expected_tickers passed,
+        only the 4 chronic polygon-coverage gaps (BF-B, BRK-B, MOG-A,
+        PSTG) trip the check, all under threshold.
+
+        When None (default — preserves the prior behavior for any caller
+        not yet updated), the check uses the full ArcticDB universe as
+        the expected set.
 
     Returns summary dict.
     """
@@ -550,7 +569,32 @@ def daily_append(
             t for t in closes
             if t not in _SKIP_TICKERS and not _is_sector_etf(t)
         }
-        missing_from_closes = sorted(arctic_stock_symbols - closes_stock_keys)
+        # Scope "expected" to the intersection of ArcticDB universe and the
+        # caller's request list. A ticker dropped from S&P this week (still
+        # in ArcticDB awaiting prune, no longer in constituents.json) was
+        # never asked for from polygon — its absence from closes is by
+        # design, not a data gap. Without this, every S&P churn week trips
+        # the threshold (2026-05-02: 8 churn-out tickers + 4 chronic =
+        # 12 > 5 → SF halt). With it, only tickers we both want to track
+        # AND have history for can flag the alarm.
+        if expected_tickers is not None:
+            expected_stocks = {
+                t.lstrip("^") for t in expected_tickers
+                if t.lstrip("^") not in _SKIP_TICKERS
+                and not _is_sector_etf(t.lstrip("^"))
+            }
+            relevant_arctic = arctic_stock_symbols & expected_stocks
+            stragglers = arctic_stock_symbols - expected_stocks
+            if stragglers:
+                log.info(
+                    "daily_append: %d ArcticDB stock symbols absent from "
+                    "expected_tickers (S&P churn-out stragglers, awaiting "
+                    "prune) — excluded from missing-from-closes check: %s",
+                    len(stragglers), sorted(stragglers)[:20],
+                )
+        else:
+            relevant_arctic = arctic_stock_symbols
+        missing_from_closes = sorted(relevant_arctic - closes_stock_keys)
         n_missing_from_closes = len(missing_from_closes)
         # Always emit a metric — silent regression in the slow-drift band
         # (1-2 tickers) won't trip the hard-fail but is still observable.

--- a/tests/test_daily_append_missing_from_closes.py
+++ b/tests/test_daily_append_missing_from_closes.py
@@ -403,3 +403,142 @@ def test_metric_emitted_even_when_zero(monkeypatch):
 
     daily_append(date_str="2026-04-28")
     metric_emit.assert_called_once_with(0)
+
+
+# ── 3. expected_tickers scoping (2026-05-02 incident) ──────────────────────────
+
+
+def test_expected_tickers_excludes_arctic_only_stragglers_from_check(monkeypatch):
+    """The 2026-05-02 SF-halt scenario:
+
+    8 tickers got dropped from S&P 500/400 this past week (ASGN, GTM, HOLX,
+    KMPR, LW, MOH, MTCH, PAYC). They're still in ArcticDB universe (awaiting
+    next prune cycle); they're absent from the new constituents.json
+    MorningEnrich just rewrote; MorningEnrich didn't request them from
+    polygon, so they're absent from closes. Without expected_tickers
+    scoping, the missing-from-closes check sees 8 + 4 chronic = 12 misses,
+    trips the threshold of 5, and halts the SF.
+
+    With expected_tickers=[the constituents-derived request list], the 8
+    stragglers fall outside the relevant set and only the 4 chronic
+    polygon-coverage tickers (well below threshold) are flagged.
+    """
+    from builders.daily_append import daily_append
+
+    # Universe holds 9 stocks: 4 chronic-missing + 5 churn-out stragglers.
+    chronic = ["BF-B", "BRK-B", "MOG-A", "PSTG"]
+    stragglers = ["ASGN", "GTM", "HOLX", "KMPR", "LW"]
+    constituents = ["AAPL", "MSFT"] + chronic  # what the caller actually requested
+
+    universe_symbols = constituents + stragglers  # 9 in arctic
+    closes_tickers = ["AAPL", "MSFT"]  # polygon returned these (not chronic, not stragglers)
+
+    _patch_targets(
+        monkeypatch,
+        universe_symbols=universe_symbols,
+        closes_tickers=closes_tickers,
+    )
+
+    # Must NOT raise: 4 chronic missing (in constituents but absent from closes)
+    # is below the threshold of 5; 5 stragglers are excluded entirely.
+    result = daily_append(date_str="2026-04-28", expected_tickers=constituents)
+    assert result["status"] == "ok"
+    assert result["tickers_missing_from_closes"] == 4
+
+
+def test_expected_tickers_still_raises_on_real_constituents_gap(monkeypatch):
+    """expected_tickers must NOT silence genuine data gaps. If polygon drops
+    8 real S&P 500 names from one call, those are in expected_tickers AND in
+    arctic AND missing from closes — the threshold must still trip.
+    """
+    from builders.daily_append import daily_append
+
+    constituents = ["AAPL", "MSFT"] + [f"REAL{i}" for i in range(8)]
+    universe_symbols = constituents  # all in arctic
+    closes_tickers = ["AAPL", "MSFT"]  # 8 REAL* tickers missing from closes
+
+    with pytest.raises(RuntimeError, match=r"missing from today's daily_closes"):
+        _patch_targets(
+            monkeypatch,
+            universe_symbols=universe_symbols,
+            closes_tickers=closes_tickers,
+        )
+        daily_append(date_str="2026-04-28", expected_tickers=constituents)
+
+
+def test_expected_tickers_strips_caret_prefix(monkeypatch):
+    """Caller may pass index tickers (^TNX/^VIX) in expected_tickers; the
+    scoping comparison must apply the same lstrip the per-ticker fallback
+    + closes_stock_keys filter use, so '^TNX' in expected matches 'TNX' in
+    arctic — even though indices are FRED-handled and rarely in arctic
+    anyway, mismatched key shapes would silently break the scoping."""
+    from builders.daily_append import daily_append
+
+    constituents = ["AAPL", "MSFT", "^TNX", "^VIX"]
+    universe_symbols = ["AAPL", "MSFT", "STRAGGLER"]
+    closes_tickers = ["AAPL", "MSFT"]
+
+    _patch_targets(
+        monkeypatch,
+        universe_symbols=universe_symbols,
+        closes_tickers=closes_tickers,
+    )
+
+    # STRAGGLER is in arctic but not in expected (after lstrip both ways) →
+    # excluded. AAPL/MSFT both in expected and in closes → no missing.
+    # No raise, missing count = 0.
+    result = daily_append(date_str="2026-04-28", expected_tickers=constituents)
+    assert result["tickers_missing_from_closes"] == 0
+
+
+def test_expected_tickers_none_preserves_legacy_behavior(monkeypatch):
+    """Backward compat: callers that don't pass expected_tickers get the
+    pre-PR behavior (scope = whole arctic universe). Lets unrelated callers
+    (older entry points, tests) keep working."""
+    from builders.daily_append import daily_append
+
+    # 8 stragglers in arctic, none in closes → without scoping, 8 missing
+    # which is above threshold (5) → raise.
+    universe_symbols = [f"TKR{i}" for i in range(8)] + ["AAPL"]
+
+    with pytest.raises(RuntimeError, match=r"missing from today's daily_closes"):
+        _patch_targets(
+            monkeypatch,
+            universe_symbols=universe_symbols,
+            closes_tickers=["AAPL"],
+        )
+        # No expected_tickers → legacy path → all 8 TKR* count → raise.
+        daily_append(date_str="2026-04-28")
+
+
+def test_expected_tickers_logs_straggler_count(monkeypatch, caplog):
+    """When stragglers are excluded, log them at INFO so operators see
+    drift building up between prune cycles. Silent exclusion is its own
+    silent-fail risk."""
+    import logging
+    from builders.daily_append import daily_append
+
+    chronic = ["BF-B"]
+    stragglers = ["ASGN", "HOLX", "PAYC"]
+    constituents = ["AAPL"] + chronic
+    universe_symbols = constituents + stragglers
+    closes_tickers = ["AAPL"]
+
+    _patch_targets(
+        monkeypatch,
+        universe_symbols=universe_symbols,
+        closes_tickers=closes_tickers,
+    )
+
+    with caplog.at_level(logging.INFO, logger="builders.daily_append"):
+        daily_append(date_str="2026-04-28", expected_tickers=constituents)
+
+    straggler_logs = [r for r in caplog.records if "stragglers" in r.message]
+    assert straggler_logs, (
+        f"Expected an INFO log mentioning 'stragglers'; got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+    # All 3 stragglers should appear in the logged sample (≤20 cap).
+    msg = straggler_logs[0].message
+    for s in stragglers:
+        assert s in msg, f"straggler {s} missing from log: {msg}"

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -541,6 +541,7 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
             date_str=target_date,
             bucket=bucket,
             dry_run=dry_run,
+            expected_tickers=tickers,
         )
         results["collectors"]["arcticdb"] = arctic_result
     except Exception as e:
@@ -729,6 +730,7 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
             bucket=bucket,
             dry_run=dry_run,
             skip_if_exists=True,
+            expected_tickers=tickers,
         )
         results["collectors"]["arcticdb"] = arctic_result
     except Exception as e:


### PR DESCRIPTION
## Summary

- MorningEnrich's missing-from-closes hard-fail was tripping every S&P churn week. Today (2026-05-02): 8 tickers got dropped from the index this past week (ASGN, GTM, HOLX, KMPR, LW, MOH, MTCH, PAYC). Still in ArcticDB universe (awaiting prune cycle); absent from the new constituents.json Phase 1 wrote at 09:20; MorningEnrich no longer requests them from polygon. Check saw 8 churn-outs + 4 chronic polygon gaps = 12 missing > threshold 5 → SF halt.
- Fix adds optional `expected_tickers` to `daily_append`. When caller passes its request list, the check scopes to `arctic ∩ expected` instead of the full ArcticDB universe. Stragglers excluded from the alarm but logged at INFO so operators see drift building up between prune cycles.
- Backward compatible: callers not passing `expected_tickers` retain the prior whole-universe behavior.
- Both call sites (`_run_morning_enrich`, `_run_daily`) updated — ticker list was already in scope at both.

Net effect on 2026-05-02 redrive: missing-from-closes count drops 12 → 4 (only chronic BF-B/BRK-B/MOG-A/PSTG remain — well under the 5-threshold WARN-only path).

## Test plan

- [x] 5 new tests in `tests/test_daily_append_missing_from_closes.py` cover: stragglers excluded; real constituents-gap still raises; caret-prefix stripping; `None` preserves legacy behavior; straggler-count INFO log fires
- [x] 13 existing tests still pass (whole-universe legacy path)
- [x] Full suite green: 360 passed
- [ ] Live verification via Saturday SF redrive (after merge): MorningEnrich completes (4 missing < threshold) → Phase 1 → PR #130's backfill preflight passes → ArcticDB at 5/1 → postflight passes → Research / Predictor Training / Backtester run

🤖 Generated with [Claude Code](https://claude.com/claude-code)