### PR TITLE
fix(daily_append): scope post-write freshness scan to expected_tickers

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -141,6 +141,7 @@ def _scan_universe_and_emit_freshness_receipt(
     bucket: str,
     universe_lib,
     max_stale_days: int = UNIVERSE_FRESHNESS_MAX_STALE_DAYS,
+    expected_tickers: list[str] | None = None,
 ) -> dict:
     """Producer-side post-write validation: every universe symbol's
     last-row date must be within ``max_stale_days`` of today (UTC).
@@ -157,15 +158,51 @@ def _scan_universe_and_emit_freshness_receipt(
     where macro/SPY stays fresh while individual tickers stall — is
     exactly what this catches at the producer.
 
+    When ``expected_tickers`` is provided, the scan is scoped to
+    ``arctic_universe ∩ expected_tickers`` — same scoping the pre-write
+    missing-from-closes check uses (see ``daily_append`` docstring for
+    the full rationale). S&P churn-out stragglers (in arctic awaiting
+    prune, no longer in current constituents) are excluded so they don't
+    trip the post-write scan after the pre-write check correctly let
+    them through. 2026-05-02 incident: the pre-write check correctly
+    excluded 8 churn-outs, daily writes completed (n_ok=898), then this
+    scan tripped on the same 8 stragglers (one 25d stale) and halted
+    the SF.
+
     Returns scan metadata (also embedded in the receipt) for logging
     by the caller. Skipped automatically on dry_run.
     """
-    syms = list(universe_lib.list_symbols())
-    if not syms:
+    all_syms = list(universe_lib.list_symbols())
+    if not all_syms:
         raise RuntimeError(
             f"Universe-freshness scan: library is empty on bucket {bucket!r}; "
             "upstream pipeline has not written anything."
         )
+
+    if expected_tickers is not None:
+        expected_set = {
+            t.lstrip("^") for t in expected_tickers
+            if t.lstrip("^") not in _SKIP_TICKERS
+            and not _is_sector_etf(t.lstrip("^"))
+        }
+        syms = [s for s in all_syms if s in expected_set]
+        excluded = [s for s in all_syms if s not in expected_set]
+        if excluded:
+            log.info(
+                "Universe-freshness scan: excluding %d ArcticDB symbols absent "
+                "from expected_tickers (S&P churn-out stragglers, awaiting "
+                "prune): %s",
+                len(excluded), sorted(excluded)[:20],
+            )
+        if not syms:
+            raise RuntimeError(
+                f"Universe-freshness scan: zero symbols after expected_tickers "
+                f"intersection (arctic={len(all_syms)}, expected_set={len(expected_set)}). "
+                "Either expected_tickers is empty or the constituents collector "
+                "broke the schema."
+            )
+    else:
+        syms = all_syms
 
     today = datetime.now(timezone.utc).date()
 
@@ -1012,6 +1049,7 @@ def daily_append(
         # invocation (the cause of the 2026-05-01 SF timeout cascade).
         receipt = _scan_universe_and_emit_freshness_receipt(
             s3, bucket, universe_lib,
+            expected_tickers=expected_tickers,
         )
         result["universe_freshness_receipt"] = {
             "n_symbols_checked": receipt["n_symbols_checked"],

--- a/tests/test_daily_append_universe_freshness.py
+++ b/tests/test_daily_append_universe_freshness.py
@@ -139,3 +139,119 @@ class TestUniverseFreshnessReceipt:
         })
         with pytest.raises(RuntimeError, match="EDGE"):
             _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib2)
+
+
+class TestExpectedTickersScoping:
+    """The 2026-05-02 incident's second-layer fix.
+
+    The pre-write missing-from-closes check (PR #132) correctly excludes
+    S&P churn-out stragglers via expected_tickers. The post-write
+    freshness scan must apply the same scoping or it'll re-trip on the
+    same stragglers (one was 25 days stale on 2026-05-02 — HOLX). With
+    expected_tickers passed through, only the symbols we actually expect
+    to be fresh today get audited; stragglers are excluded and logged at
+    INFO so operators see drift building up between prune cycles.
+    """
+
+    def test_stragglers_excluded_from_scan(self):
+        """ArcticDB has fresh + stragglers; expected_tickers omits stragglers
+        → scan only checks the fresh ones → all_fresh=True, receipt written."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "MSFT": _today_str(1),
+            "ASGN": _today_str(8),    # straggler, 8d stale
+            "HOLX": _today_str(25),   # straggler, 25d stale
+        })
+
+        receipt = _scan_universe_and_emit_freshness_receipt(
+            s3, "test-bucket", lib,
+            expected_tickers=["AAPL", "MSFT"],
+        )
+
+        assert receipt["all_fresh"] is True
+        assert receipt["n_symbols_checked"] == 2  # stragglers excluded from count
+        s3.put_object.assert_called_once()
+
+    def test_stale_symbol_in_expected_still_raises(self):
+        """expected_tickers must NOT mask a real freshness gap. A stale
+        symbol that IS in expected_tickers must still trip the scan."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "MSFT": _today_str(UNIVERSE_FRESHNESS_MAX_STALE_DAYS + 3),  # genuinely stale
+            "STRAGGLER": _today_str(20),  # ignored
+        })
+
+        with pytest.raises(RuntimeError, match="MSFT"):
+            _scan_universe_and_emit_freshness_receipt(
+                s3, "test-bucket", lib,
+                expected_tickers=["AAPL", "MSFT"],
+            )
+        s3.put_object.assert_not_called()
+
+    def test_scoping_logs_excluded_stragglers(self, caplog):
+        """When stragglers are excluded, log them at INFO so operators see
+        drift building up between prune cycles. Silent exclusion = silent fail."""
+        import logging
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "STRAGGLER1": _today_str(8),
+            "STRAGGLER2": _today_str(20),
+        })
+
+        with caplog.at_level(logging.INFO, logger="builders.daily_append"):
+            _scan_universe_and_emit_freshness_receipt(
+                s3, "test-bucket", lib, expected_tickers=["AAPL"],
+            )
+
+        excluded_logs = [r for r in caplog.records if "excluding" in r.message]
+        assert excluded_logs, (
+            f"Expected an INFO log mentioning 'excluding'; got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        msg = excluded_logs[0].message
+        assert "STRAGGLER1" in msg and "STRAGGLER2" in msg
+
+    def test_scoping_strips_caret_prefix(self):
+        """Index tickers (^TNX) carry caret in expected_tickers but arctic
+        symbols don't — same lstrip the pre-write check uses."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+        })
+
+        receipt = _scan_universe_and_emit_freshness_receipt(
+            s3, "test-bucket", lib,
+            expected_tickers=["AAPL", "^VIX", "^TNX"],
+        )
+        assert receipt["all_fresh"] is True
+
+    def test_no_expected_preserves_legacy_full_scan(self):
+        """Backward compat: expected_tickers=None → scan the whole library
+        (the pre-PR behavior). Lets unrelated callers keep working."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "STRAGGLER": _today_str(20),  # would be excluded if scoping fired
+        })
+
+        with pytest.raises(RuntimeError, match="STRAGGLER"):
+            _scan_universe_and_emit_freshness_receipt(s3, "test-bucket", lib)
+
+    def test_empty_intersection_raises(self):
+        """If expected_tickers is non-empty but disjoint from arctic, the
+        scan would silently pass (zero symbols → no stale found). Hard-fail
+        instead so operators catch the misconfiguration loudly."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "ONLY_IN_ARCTIC": _today_str(0),
+        })
+
+        with pytest.raises(RuntimeError, match="zero symbols after expected_tickers"):
+            _scan_universe_and_emit_freshness_receipt(
+                s3, "test-bucket", lib,
+                expected_tickers=["ONLY_IN_EXPECTED"],
+            )
+        s3.put_object.assert_not_called()


### PR DESCRIPTION
## Summary

- Companion to PR #132. The pre-write missing-from-closes check correctly excluded 8 S&P churn-out stragglers on today's redrive, daily writes completed (n_ok=898), and then `_scan_universe_and_emit_freshness_receipt` — the post-write scan that audits every ArcticDB symbol — re-tripped on the same 8 stragglers (HOLX 25d stale, rest 8d stale) and halted the SF a 4th time.
- Plumb `expected_tickers` through to the freshness scan with same semantics as PR #132: scope to `arctic ∩ expected`, log stragglers at INFO, raise on empty intersection. Backward compatible.
- Genuinely-stale symbols still in `expected_tickers` continue to raise — silent-fail rule preserved.

## Test plan

- [x] 6 new tests in `tests/test_daily_append_universe_freshness.py` cover: stragglers excluded; stale-in-expected still raises; INFO log fires; caret-prefix stripping; `None` preserves legacy whole-library scan; empty-intersection raises loudly
- [x] 5 existing freshness-scan tests still pass
- [x] Full suite green: 366 passed
- [ ] Live verification via Saturday SF redrive: MorningEnrich pre-write check excludes 8 stragglers (PR #132) → 898 daily writes succeed → post-write scan also excludes 8 stragglers (this PR) → MorningEnrich completes → Phase 1 → backfill preflight (PR #130) → ArcticDB at 5/1 → postflight passes → Research / Predictor / Backtester run

🤖 Generated with [Claude Code](https://claude.com/claude-code)