### PR TITLE
fix(morning_enrich): refresh constituents + prune stragglers before write

### DIFF
--- a/builders/prune_delisted_tickers.py
+++ b/builders/prune_delisted_tickers.py
@@ -99,6 +99,7 @@ def prune_delisted_tickers(
     absent_days: int = DEFAULT_ABSENT_DAYS,
     apply: bool = False,
     tickers_override: list[str] | None = None,
+    constituents_override: "set[str] | list[str] | None" = None,
     today: pd.Timestamp | None = None,
 ) -> dict:
     """Prune ArcticDB universe symbols that are confirmed delistings.
@@ -116,6 +117,15 @@ def prune_delisted_tickers(
         Skip the constituents-diff and target a specific list. Still
         gated on the last_date staleness check — operator can't blow
         up a fresh symbol via a typo.
+    constituents_override
+        Skip the ``latest_weekly.json`` pointer read and use this set as
+        the authoritative current-constituents reference for the diff.
+        Lets a caller that just refreshed constituents in-process (e.g.
+        the pre-MorningEnrich preflight) prune against the freshest
+        membership without needing to update the public pointer first
+        (which has cross-module read fan-out — alternative/macro/
+        features/compute all depend on it). Mutually exclusive with
+        ``tickers_override``.
     today
         Override the staleness reference date for testing. Defaults to
         UTC midnight today.
@@ -132,6 +142,13 @@ def prune_delisted_tickers(
     arctic_symbols = set(universe_lib.list_symbols())
     log.info("ArcticDB universe holds %d symbols", len(arctic_symbols))
 
+    if tickers_override is not None and constituents_override is not None:
+        raise ValueError(
+            "tickers_override and constituents_override are mutually exclusive — "
+            "the former targets a specific delete list, the latter swaps the "
+            "freshness reference. Pass at most one."
+        )
+
     if tickers_override is not None:
         candidates = sorted(set(tickers_override) & arctic_symbols)
         ignored = sorted(set(tickers_override) - arctic_symbols)
@@ -143,11 +160,19 @@ def prune_delisted_tickers(
             )
         weekly_date = "(override)"
     else:
-        constituents, weekly_date = _load_latest_constituents(s3, bucket)
-        log.info(
-            "Latest constituents (date=%s): %d tickers",
-            weekly_date, len(constituents),
-        )
+        if constituents_override is not None:
+            constituents = set(constituents_override)
+            weekly_date = "(in-process override)"
+            log.info(
+                "Constituents from in-process override: %d tickers",
+                len(constituents),
+            )
+        else:
+            constituents, weekly_date = _load_latest_constituents(s3, bucket)
+            log.info(
+                "Latest constituents (date=%s): %d tickers",
+                weekly_date, len(constituents),
+            )
         # Only stocks can be pruned — never touch macro/index series or
         # sector ETFs (those aren't constituents-tracked but are still
         # required by daily_append's macro-load path).

--- a/tests/test_prune_delisted_tickers.py
+++ b/tests/test_prune_delisted_tickers.py
@@ -470,3 +470,102 @@ def test_audit_failure_does_not_block_prune(monkeypatch):
     # Prune still happened; audit failure was swallowed with WARN.
     assert summary["pruned_count"] == 1
     lib.delete.assert_called_once_with("HOLX")
+
+
+# ── E. constituents_override (in-process freshness reference) ──────────────────
+
+
+def test_constituents_override_uses_in_process_set(monkeypatch):
+    """When the caller passes constituents_override, the latest_weekly.json
+    pointer read is bypassed entirely — the in-process set is authoritative.
+    Lets a caller that just refreshed constituents in-process (e.g.
+    pre-MorningEnrich preflight) prune against the freshest membership
+    without updating the public pointer (which has cross-module fan-out)."""
+    s3 = MagicMock()
+    # If the override is honored, get_object must NOT be called for the pointer
+    # — pointer fetch would hit the side_effect and raise.
+    s3.get_object.side_effect = AssertionError(
+        "pointer S3 read must not happen when constituents_override is set"
+    )
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "STRAGGLER"],
+        last_dates={"AAPL": "2026-04-25", "STRAGGLER": "2026-04-20"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=5, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+        constituents_override={"AAPL"},  # STRAGGLER absent from this set
+    )
+
+    assert summary["pruned_count"] == 1
+    assert summary["pruned"][0]["ticker"] == "STRAGGLER"
+    assert summary["constituents_date"] == "(in-process override)"
+
+
+def test_constituents_override_accepts_list_or_set(monkeypatch):
+    """Accept either set or list for ergonomic caller flexibility — the
+    pre-MorningEnrich code path has the tickers as a list and shouldn't
+    have to convert to a set just to satisfy the parameter type."""
+    s3 = MagicMock()
+    s3.put_object = MagicMock()
+    lib = _stub_universe_lib(
+        symbols=["AAPL"],
+        last_dates={"AAPL": "2026-04-25"},
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    # Both invocations should succeed without TypeError.
+    _mod.prune_delisted_tickers(
+        absent_days=5, apply=False,
+        today=pd.Timestamp("2026-04-28"),
+        constituents_override=["AAPL"],  # list
+    )
+    _mod.prune_delisted_tickers(
+        absent_days=5, apply=False,
+        today=pd.Timestamp("2026-04-28"),
+        constituents_override={"AAPL"},  # set
+    )
+
+
+def test_constituents_override_still_gates_on_last_date(monkeypatch):
+    """Override only swaps the freshness reference — the last_date staleness
+    gate still applies. A ticker absent from the override but with a fresh
+    last_date stays put. Locks the no-flapping invariant for the override
+    code path too."""
+    s3 = MagicMock()
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "FRESH_BUT_ABSENT"],
+        last_dates={
+            "AAPL": "2026-04-25",
+            "FRESH_BUT_ABSENT": "2026-04-27",  # 1 day stale, well under threshold
+        },
+    )
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=5, apply=True,
+        today=pd.Timestamp("2026-04-28"),
+        constituents_override={"AAPL"},
+    )
+
+    assert summary["pruned_count"] == 0
+    assert summary["skipped_recent_count"] == 1
+
+
+def test_tickers_override_and_constituents_override_mutually_exclusive(monkeypatch):
+    """Two semantically distinct overrides must not be mixed — the former
+    targets a delete list, the latter swaps the freshness reference. Mixing
+    them would silently use only one and the other's intent would be lost."""
+    s3 = MagicMock()
+    lib = _stub_universe_lib(symbols=["AAPL"], last_dates={"AAPL": "2026-04-25"})
+    _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _mod.prune_delisted_tickers(
+            absent_days=5, apply=False,
+            today=pd.Timestamp("2026-04-28"),
+            tickers_override=["AAPL"],
+            constituents_override={"AAPL"},
+        )

--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -180,6 +180,10 @@ def test_morning_enrich_refreshes_daily_data_stamp_on_success():
 
     fake_constituents = MagicMock()
     fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+    # Pre-MorningEnrich preflight: refresh constituents in-process.
+    fake_constituents.collect.return_value = {
+        "status": "ok", "tickers": ["AAPL"], "date": "2026-04-24",
+    }
 
     health_calls = []
     def fake_write_health(bucket, module_name, run_date, status, **kwargs):
@@ -189,6 +193,9 @@ def test_morning_enrich_refreshes_daily_data_stamp_on_success():
         })
 
     with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.prune_delisted_tickers.prune_delisted_tickers",
+               return_value={"status": "ok", "pruned_count": 0,
+                             "skipped_recent_count": 0}), \
          patch("weekly_collector.daily_closes.collect",
                return_value={"status": "ok", "polygon": 913, "fred": 4,
                              "yfinance": 0, "tickers_captured": 917,
@@ -217,12 +224,18 @@ def test_morning_enrich_does_not_stamp_on_polygon_failure():
 
     fake_constituents = MagicMock()
     fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+    fake_constituents.collect.return_value = {
+        "status": "ok", "tickers": ["AAPL"], "date": "2026-04-24",
+    }
 
     health_calls = []
     def fake_write_health(*args_, **kwargs):
         health_calls.append(kwargs)
 
     with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.prune_delisted_tickers.prune_delisted_tickers",
+               return_value={"status": "ok", "pruned_count": 0,
+                             "skipped_recent_count": 0}), \
          patch("weekly_collector.daily_closes.collect",
                side_effect=PolygonForbiddenError("403 simulation")), \
          patch("weekly_collector._write_module_health", side_effect=fake_write_health):
@@ -294,3 +307,183 @@ def test_daily_mode_calls_collect_with_yfinance_only_source():
         "(per the 2026-04-23 split-by-source design — polygon free-tier 403's "
         "same-day, morning enrichment fills VWAP overnight)."
     )
+
+
+# ── Preflight: refresh-constituents + prune-stragglers ─────────────────────────
+
+
+def test_morning_enrich_refreshes_constituents_before_collect():
+    """Pre-flight architectural fix (2026-05-02 incident): MorningEnrich must
+    call constituents.collect() in-process BEFORE the daily_closes call so
+    polygon is asked about the freshest S&P membership, not last week's. The
+    bandage scoping in PR #132/#133 then becomes a quiet no-op rather than
+    the load-bearing path."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=False, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.collect.return_value = {
+        "status": "ok",
+        "tickers": ["AAPL", "MSFT", "NVDA"],  # fresh, post-churn list
+        "date": "2026-04-24",
+    }
+
+    captured_dc = {}
+    def fake_dc_collect(**kwargs):
+        captured_dc.update(kwargs)
+        return {"status": "ok", "polygon": 3, "fred": 0, "yfinance": 0,
+                "tickers_captured": 3, "source": "polygon_only"}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.prune_delisted_tickers.prune_delisted_tickers",
+               return_value={"status": "ok", "pruned_count": 0,
+                             "skipped_recent_count": 0}), \
+         patch("weekly_collector.daily_closes.collect", side_effect=fake_dc_collect), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}), \
+         patch("weekly_collector._write_module_health"):
+        weekly_collector._run_morning_enrich(config, args)
+
+    fake_constituents.collect.assert_called_once()
+    # daily_closes must use the fresh tickers + macro additions, NOT
+    # load_from_s3's stale snapshot.
+    sent_tickers = captured_dc["tickers"]
+    assert "AAPL" in sent_tickers and "MSFT" in sent_tickers and "NVDA" in sent_tickers
+    fake_constituents.load_from_s3.assert_not_called()
+
+
+def test_morning_enrich_prunes_stragglers_before_daily_append():
+    """Prune must run BEFORE daily_closes/daily_append so the missing-from-
+    closes + freshness checks see a coherent universe. Use the in-process
+    constituents_override (not the public latest_weekly.json pointer) so
+    cross-module readers don't see a half-updated pointer mid-SF."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=False, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.collect.return_value = {
+        "status": "ok", "tickers": ["AAPL", "MSFT"], "date": "2026-04-24",
+    }
+
+    prune_calls = []
+    def fake_prune(**kwargs):
+        prune_calls.append(kwargs)
+        return {"status": "ok", "pruned_count": 0, "skipped_recent_count": 0}
+
+    da_calls = []
+    def fake_daily_append(**kwargs):
+        # By the time daily_append fires, prune must already have run.
+        assert prune_calls, "prune must run before daily_append"
+        da_calls.append(kwargs)
+        return {"status": "ok"}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.prune_delisted_tickers.prune_delisted_tickers",
+               side_effect=fake_prune), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok", "polygon": 2, "fred": 0,
+                             "yfinance": 0, "tickers_captured": 2,
+                             "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append", side_effect=fake_daily_append), \
+         patch("weekly_collector._write_module_health"):
+        weekly_collector._run_morning_enrich(config, args)
+
+    assert len(prune_calls) == 1
+    assert prune_calls[0]["apply"] is True
+    assert prune_calls[0]["absent_days"] == 5  # tighter than the 14d default
+    assert prune_calls[0]["constituents_override"] == {"AAPL", "MSFT"}
+    assert len(da_calls) == 1
+
+
+def test_morning_enrich_aborts_if_constituents_refresh_fails():
+    """Constituents refresh is the source of truth for prune + daily_closes
+    request list. If it fails, we cannot proceed safely — Wikipedia outages,
+    schema drift, or sector-mapping completeness failures all warrant a
+    hard-fail per feedback_no_silent_fails."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=False, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.collect.side_effect = RuntimeError("Wikipedia 503")
+
+    dc_calls = []
+    def fake_dc(**kwargs):
+        dc_calls.append(kwargs)
+        return {"status": "ok"}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.prune_delisted_tickers.prune_delisted_tickers"), \
+         patch("weekly_collector.daily_closes.collect", side_effect=fake_dc), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}), \
+         patch("weekly_collector._write_module_health"):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert result["status"] == "failed"
+    assert result["collectors"]["constituents_preflight"]["status"] == "error"
+    assert "Wikipedia 503" in result["collectors"]["constituents_preflight"]["error"]
+    assert dc_calls == [], "daily_closes must NOT run if constituents refresh failed"
+
+
+def test_morning_enrich_continues_if_prune_fails():
+    """Prune is best-effort here — daily_append's expected_tickers scoping
+    (PR #132/#133) still tolerates stragglers as a fallback. A prune failure
+    must surface loudly (ERROR log + result entry) but must NOT block the
+    rest of the enrich pipeline tonight."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=False, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.collect.return_value = {
+        "status": "ok", "tickers": ["AAPL"], "date": "2026-04-24",
+    }
+
+    da_called = []
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.prune_delisted_tickers.prune_delisted_tickers",
+               side_effect=RuntimeError("ArcticDB transient")), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok", "polygon": 1, "fred": 0,
+                             "yfinance": 0, "tickers_captured": 1,
+                             "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append",
+               side_effect=lambda **k: (da_called.append(k), {"status": "ok"})[1]), \
+         patch("weekly_collector._write_module_health"):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert result["prune_preflight_warning"]["status"] == "error"
+    assert "ArcticDB transient" in result["prune_preflight_warning"]["error"]
+    assert "prune_preflight" not in result["collectors"], (
+        "prune failure must NOT land in results['collectors'] — that key feeds "
+        "the status aggregator and would make the whole MorningEnrich fail"
+    )
+    assert len(da_called) == 1, "daily_append must still run when prune fails"
+    assert result["status"] == "ok"
+
+
+def test_morning_enrich_dry_run_skips_preflight_writes():
+    """Dry runs must not refresh constituents.json or prune ArcticDB —
+    side-effect-free is the contract."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-24", dry_run=True, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+    # collect MUST NOT be called in dry-run.
+
+    prune_called = []
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.prune_delisted_tickers.prune_delisted_tickers",
+               side_effect=lambda **k: (prune_called.append(k), {})[1]), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok_dry_run", "polygon": 1, "fred": 0,
+                             "yfinance": 0, "tickers_captured": 1,
+                             "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append",
+               return_value={"status": "ok"}):
+        weekly_collector._run_morning_enrich(config, args)
+
+    fake_constituents.collect.assert_not_called()
+    assert prune_called == []

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -478,23 +478,105 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
         "collectors": {},
     }
 
-    # Reuse the same ticker-loading logic as _run_daily so the polygon overwrite
-    # covers exactly the same universe.
-    tickers: list[str] = []
+    # ── Pre-flight: refresh constituents + prune ArcticDB stragglers ─────────
+    # Order matters. Without these, MorningEnrich loads last week's
+    # constituents.json (Phase 1's writer hasn't run yet this Saturday), so
+    # any S&P churn-out from the past week is invisible — the ticker stays
+    # in the request list, polygon doesn't have it (now-delisted), and the
+    # downstream missing-from-closes + freshness checks have to defend
+    # against the drift via ``expected_tickers`` scoping (PR #132 + PR #133
+    # are exactly that defense). Refreshing constituents + pruning here
+    # makes the universe coherent BEFORE any check fires, so the bandages
+    # become a quiet no-op rather than the load-bearing path.
+    #
+    # 2026-05-02 redrive #4 (after PR #132/#133 shipped) is the validation
+    # window: with the reorder, prune drops the 8 churn-outs (ASGN, GTM,
+    # HOLX, KMPR, LW, MOH, MTCH, PAYC) before MorningEnrich's writes;
+    # downstream checks see a coherent universe without needing the
+    # ``expected_tickers`` scoping at all.
     market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
-    try:
-        existing = constituents.load_from_s3(bucket, market_prefix)
-        if existing:
-            tickers = existing.get("tickers", [])
-            logger.info("Loaded %d tickers from S3 constituents", len(tickers))
-    except Exception as exc:
-        logger.warning("S3 constituents load failed — will try Wikipedia fallback: %s", exc)
-    if not tickers:
+    if not dry_run:
+        logger.info("=" * 60)
+        logger.info("REFRESHING: constituents (pre-MorningEnrich)")
+        logger.info("=" * 60)
         try:
-            tickers, _, _, _, _ = constituents._fetch_constituents()
-            logger.info("Loaded %d tickers from Wikipedia (S3 fallback)", len(tickers))
+            cons_result = constituents.collect(
+                bucket=bucket,
+                s3_prefix=market_prefix,
+                run_date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+                dry_run=False,
+            )
+            results["collectors"]["constituents_preflight"] = cons_result
+            tickers = cons_result.get("tickers", [])
+            logger.info(
+                "Pre-MorningEnrich constituents refresh: %d tickers", len(tickers),
+            )
         except Exception as exc:
-            logger.error("Wikipedia constituents fallback failed: %s", exc)
+            logger.exception("Pre-MorningEnrich constituents refresh failed")
+            results["collectors"]["constituents_preflight"] = {
+                "status": "error", "error": str(exc),
+            }
+            results["status"] = "failed"
+            results["completed_at"] = datetime.now(timezone.utc).isoformat()
+            return results
+
+        logger.info("=" * 60)
+        logger.info("PRUNING: ArcticDB universe stragglers (pre-MorningEnrich)")
+        logger.info("=" * 60)
+        try:
+            from builders.prune_delisted_tickers import prune_delisted_tickers
+            # Use absent_days=5 to match the post-write freshness scan
+            # threshold — consistent with what daily_append considers
+            # "stale enough to drop". The post-Phase-1 prune still runs
+            # later with the conservative 14d default for any newcomers
+            # the SF picked up between MorningEnrich and Phase 1.
+            prune_result = prune_delisted_tickers(
+                bucket=bucket,
+                absent_days=5,
+                apply=True,
+                constituents_override=set(tickers),
+            )
+            results["collectors"]["prune_preflight"] = prune_result
+            logger.info(
+                "Pre-MorningEnrich prune: pruned %d stragglers (skipped_recent=%d)",
+                prune_result.get("pruned_count", 0),
+                prune_result.get("skipped_recent_count", 0),
+            )
+        except Exception as exc:
+            # Prune failure is non-fatal here — the bandage scoping in
+            # daily_append (PR #132/#133) still tolerates stragglers, and
+            # the post-Phase-1 prune gets another shot. Surface it
+            # loudly per feedback_no_silent_fails — operator should
+            # investigate, but the SF can complete tonight on the
+            # bandages alone.
+            #
+            # Recorded under top-level ``prune_preflight_warning`` rather
+            # than ``results["collectors"]`` because the per-collector
+            # status aggregator treats any ``error`` entry there as a
+            # whole-pipeline failure. The prune side-effect is best-effort
+            # observability, not a blocking step.
+            logger.error(
+                "Pre-MorningEnrich prune failed: %s. Falling through to "
+                "MorningEnrich; daily_append's expected_tickers scoping "
+                "will still tolerate stragglers, but please investigate "
+                "the prune failure.", exc,
+            )
+            results["prune_preflight_warning"] = {
+                "status": "error", "error": str(exc),
+            }
+    else:
+        # Dry-run: skip side effects but still load tickers for the
+        # downstream daily_closes call.
+        try:
+            existing = constituents.load_from_s3(bucket, market_prefix)
+            tickers = existing.get("tickers", []) if existing else []
+        except Exception:
+            tickers = []
+        if not tickers:
+            try:
+                tickers, _, _, _, _ = constituents._fetch_constituents()
+            except Exception as exc:
+                logger.error("Wikipedia constituents fallback failed: %s", exc)
 
     if not tickers:
         logger.error("No tickers available for morning enrichment")


### PR DESCRIPTION
## Summary

- Architectural fix for the 2026-05-02 SF-halt class. PR #132/#133 (shipped earlier today) scope the missing-from-closes + freshness checks to tolerate S&P churn-out stragglers gracefully — sound but they're now load-bearing for every MorningEnrich.
- Reorder MorningEnrich so the universe is coherent BEFORE any check fires:
  1. `constituents.collect()` — pulls fresh S&P 500/400, hard-fails on outage
  2. `prune_delisted_tickers(constituents_override=fresh_set, absent_days=5, apply=True)` — drops stragglers absent from fresh constituents AND ≥5d stale (matches the freshness scan threshold). Best-effort: failure logs ERROR + lands on `prune_preflight_warning`, doesn't block.
  3. Existing daily_closes + daily_append against a coherent universe
- New `constituents_override` parameter on `prune_delisted_tickers` swaps the freshness reference without updating the public `latest_weekly.json` pointer (cross-module fan-out: alternative.py, macro.py, features/compute.py all read it).
- Today's failure mode (8 churn-outs missing from polygon, post-write scan tripping on 25d-stale HOLX) becomes impossible: the 8 are pruned before the writes; the bandage scoping in PR #132/#133 stays as defense-in-depth no-ops.

## Test plan

- [x] 5 new tests in `test_weekly_collector_morning_enrich.py`: refreshes constituents before collect; prunes before daily_append (with right args: apply=True, absent_days=5, constituents_override=fresh set); aborts on constituents failure; continues on prune failure (loud ERROR + non-blocking); dry-run skips preflight writes
- [x] 4 new tests in `test_prune_delisted_tickers.py`: `constituents_override` uses in-process set (no S3 pointer read); accepts list or set; still gates on last_date; mutually exclusive with `tickers_override`
- [x] 12 existing morning_enrich + 17 existing prune tests still pass after mock updates
- [x] Full suite green: 369 passed
- [ ] Live verification via Saturday SF redrive: constituents refresh ✓ → prune drops 8 stragglers ✓ → daily_closes ✓ → daily_append (no missing-from-closes warnings, freshness scan all-fresh) ✓ → Phase 1 → backfill preflight (PR #130) ✓ → ArcticDB at 5/1 → postflight ✓ → Research / Predictor / Backtester run

🤖 Generated with [Claude Code](https://claude.com/claude-code)