### PR TITLE
fix(constituents): include tickers in collect() return dict

### DIFF
--- a/collectors/constituents.py
+++ b/collectors/constituents.py
@@ -92,7 +92,11 @@ def collect(
             "[dry-run] constituents: %d tickers (%d S&P500, %d S&P400), %d sector mappings",
             len(tickers), sp500_count, sp400_count, len(sector_etf_map),
         )
-        return {"status": "ok_dry_run", "count": len(tickers)}
+        return {
+            "status": "ok_dry_run",
+            "count": len(tickers),
+            "tickers": tickers,
+        }
 
     # Write to S3
     s3 = boto3.client("s3")
@@ -114,7 +118,17 @@ def collect(
         )
     logger.info("Wrote sector_map.json to data/ and predictor/ paths")
 
-    return {"status": "ok", "count": len(tickers)}
+    # tickers is included in the return so callers don't need an S3 round-trip
+    # to re-read what they just wrote. Pre-MorningEnrich preflight (PR #134)
+    # consumes this directly to feed prune_delisted_tickers' constituents_override
+    # and to populate the daily_closes request list for the same run. Existing
+    # _run_phase1 caller (line 156) just stores the dict — the extra key is
+    # additive, no breakage.
+    return {
+        "status": "ok",
+        "count": len(tickers),
+        "tickers": tickers,
+    }
 
 
 def _fetch_constituents() -> tuple[list[str], dict[str, str], dict[str, str], int, int]:

--- a/tests/test_constituents_sector_map.py
+++ b/tests/test_constituents_sector_map.py
@@ -97,3 +97,45 @@ def test_fetch_raises_when_sector_column_missing() -> None:
     # collect() will hard-fail on this state. That's the contract.
     if tickers:
         assert not sector_map or len(sector_map) < len(tickers)
+
+
+def test_collect_returns_tickers_in_dict() -> None:
+    """``collect()``'s return contract MUST include the ``tickers`` list.
+
+    Pre-MorningEnrich preflight (PR #134, weekly_collector._run_morning_enrich)
+    feeds these tickers directly to prune_delisted_tickers' constituents_override
+    and to the daily_closes request list. Without ``tickers`` in the return,
+    the caller silently gets [] and either prunes nothing or asks polygon for
+    nothing. 2026-05-02 SF redrive #5 was this exact regression: collect()
+    returned only ``{"status": "ok", "count": 903}``, the preflight logged
+    'Pre-MorningEnrich constituents refresh: 0 tickers', and MorningEnrich
+    aborted with 'No tickers available for morning enrichment'.
+
+    Locks both happy paths (ok + ok_dry_run).
+    """
+    sp500_html = _fake_html(["AAPL", "MSFT"], ["Information Technology", "Information Technology"])
+    sp400_html = _fake_html(["JHG", "WSO"], ["Financials", "Industrials"])
+
+    def fake_get(url, **kwargs):
+        return _FakeResp(sp500_html if "500" in url else sp400_html)
+
+    # Dry-run path
+    with patch("collectors.constituents.requests.get", side_effect=fake_get):
+        result = constituents.collect(bucket="any", dry_run=True)
+    assert result["status"] == "ok_dry_run"
+    assert "tickers" in result, (
+        "ok_dry_run return MUST include tickers — preflight callers feed "
+        "this directly into prune_delisted_tickers + daily_closes"
+    )
+    assert set(result["tickers"]) == {"AAPL", "MSFT", "JHG", "WSO"}
+
+    # Non-dry-run path (S3 write mocked)
+    with patch("collectors.constituents.requests.get", side_effect=fake_get), \
+         patch("collectors.constituents.boto3"):
+        result = constituents.collect(bucket="any", dry_run=False)
+    assert result["status"] == "ok"
+    assert "tickers" in result, (
+        "ok return MUST include tickers — same contract as ok_dry_run; "
+        "the count is only useful as observability, not as a tickers source"
+    )
+    assert set(result["tickers"]) == {"AAPL", "MSFT", "JHG", "WSO"}

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -155,17 +155,9 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
             )
             results["collectors"]["constituents"] = const_result
 
-            # Load the just-written constituents for downstream use
-            if not dry_run:
-                s3 = boto3.client("s3")
-                key = f"{market_prefix}weekly/{run_date}/constituents.json"
-                resp = s3.get_object(Bucket=bucket, Key=key)
-                const_data = json.loads(resp["Body"].read())
-                tickers = const_data.get("tickers", [])
-            else:
-                # In dry-run, fetch tickers directly for counting
-                t, _, _, _, _ = constituents._fetch_constituents()
-                tickers = t
+            # Use the tickers returned by collect() directly — saves the S3
+            # round-trip we previously needed to re-read what we just wrote.
+            tickers = const_result.get("tickers", [])
         except Exception as e:
             logger.error("Constituents collection failed: %s", e)
             results["collectors"]["constituents"] = {"status": "error", "error": str(e)}


### PR DESCRIPTION
## Summary

- PR #134's pre-MorningEnrich preflight reads `cons_result.get("tickers", [])` to feed `prune_delisted_tickers` and the daily_closes request list. But `collect()` was returning only `{"status": "ok", "count": N}` — no tickers. Preflight got `[]` → "No tickers available for morning enrichment" → SF halt.
- 2026-05-02 SF redrive #5 was the live evidence: **the architectural fix worked** (prune correctly dropped all 8 churn-out stragglers — ASGN, GTM, HOLX, KMPR, LW, MOH, MTCH, PAYC). But the empty tickers killed the rest of MorningEnrich.
- Add `tickers` to both happy-path returns (ok + ok_dry_run). Additive — no caller breaks.
- `_run_phase1` previously workaround was an S3 round-trip (re-read what was just written). Cleaned up to use `const_result["tickers"]` directly.

## Test plan

- [x] New contract test `test_collect_returns_tickers_in_dict` locks both return shapes — sneaks-back protection for this exact regression class
- [x] Existing 4 constituents tests + 17 morning_enrich tests still pass
- [x] Full suite green: 376 passed
- [ ] Live verification via Saturday SF redrive: constituents.collect → 903 tickers in return ✓ → prune drops 8 stragglers ✓ → daily_closes called with 921 tickers ✓ → daily_append clean ✓ → Phase 1 → backfill (PR #130) → ArcticDB at 5/1 → postflight → Research / Predictor / Backtester

🤖 Generated with [Claude Code](https://claude.com/claude-code)