### PR TITLE
feat(preflight): add Research-side static checks (price cards + recursion budget)

### DIFF
--- a/sf_preflight.py
+++ b/sf_preflight.py
@@ -681,6 +681,215 @@ def check_postflight_contracts(ctx: PreflightContext) -> CheckResult:
 # ── Orchestrator ──────────────────────────────────────────────────────────────
 
 
+# ── Research-side static checks (added 2026-05-02 after the cost-telemetry
+# + recursion-budget incidents) ───────────────────────────────────────────────
+
+
+def _sibling_repo(name: str) -> "Path | None":
+    """Resolve a sibling clone of an alpha-engine-* repo from this file's
+    location. Returns None if the sibling isn't checked out — checks that
+    depend on it then SKIP rather than fail (operator may be running the
+    preflight in an environment without sibling clones)."""
+    from pathlib import Path
+    here = Path(__file__).resolve().parent  # alpha-engine-data
+    candidate = here.parent / name
+    return candidate if candidate.is_dir() else None
+
+
+_ANTHROPIC_SNAPSHOT_RE = __import__("re").compile(r"-\d{8}$")
+
+
+def _normalize_model_for_pricing(model_name: str) -> str:
+    """Strip Anthropic ``-YYYYMMDD`` snapshot suffix. Mirrors the function
+    in ``alpha-engine-research/graph/llm_cost_tracker.py`` (PR #77). Kept
+    here as a static copy so the preflight doesn't need to import the
+    research module (which transitively pulls in heavy deps)."""
+    return _ANTHROPIC_SNAPSHOT_RE.sub("", model_name)
+
+
+def check_price_cards_cover_all_models(ctx: PreflightContext) -> CheckResult:
+    """Catches the 2026-05-02 PR #77 class: cost-telemetry hard-fail when
+    a runtime model name (often a snapshot ID like ``claude-haiku-4-5-
+    20251001``) doesn't normalize to any price card.
+
+    Walks every model name referenced by alpha-engine-research's runtime
+    config + hardcoded fallbacks, normalizes via the same logic the
+    Lambda uses (snapshot-suffix strip), and asserts each maps to a
+    card in alpha-engine-config/cost/model_pricing.yaml.
+
+    Pure file I/O, zero LLM cost. Skips if sibling repos aren't checked
+    out (CI / restricted environments)."""
+    import time
+    import yaml as _yaml
+    from pathlib import Path
+    t0 = time.time()
+
+    config_repo = _sibling_repo("alpha-engine-config")
+    research_repo = _sibling_repo("alpha-engine-research")
+    if config_repo is None or research_repo is None:
+        return CheckResult(
+            name="price_cards_cover_all_models",
+            status="warn",
+            message=(
+                f"Sibling repos not checked out (config={config_repo is not None}, "
+                f"research={research_repo is not None}) — skipped."
+            ),
+            elapsed_seconds=time.time() - t0,
+        )
+
+    pricing_path = config_repo / "cost" / "model_pricing.yaml"
+    if not pricing_path.is_file():
+        return CheckResult(
+            name="price_cards_cover_all_models",
+            status="fail",
+            message=f"Missing {pricing_path}",
+            elapsed_seconds=time.time() - t0,
+        )
+    pricing = _yaml.safe_load(pricing_path.read_text())
+    card_names = {c["model_name"] for c in pricing.get("cards", [])}
+
+    universe_path = config_repo / "research" / "universe.yaml"
+    runtime_models: dict[str, str] = {}
+    if universe_path.is_file():
+        universe = _yaml.safe_load(universe_path.read_text()) or {}
+        sector_cfg = universe.get("sector_teams") or {}
+        for k in ("per_stock_model", "strategic_model"):
+            v = sector_cfg.get(k) or universe.get(k)
+            if v:
+                runtime_models[f"sector_teams.{k}"] = v
+
+    # Also scan research_graph.py's hardcoded fallback dict — these names
+    # are used when track_llm_cost wiring is incomplete.
+    rg_path = research_repo / "graph" / "research_graph.py"
+    if rg_path.is_file():
+        src = rg_path.read_text()
+        # Parse _FALLBACK_AGENT_MODEL_NAMES dict literal — small enough that
+        # a regex is fine (vs full AST). Tolerates whitespace + quote style.
+        import re as _re
+        block = _re.search(
+            r"_FALLBACK_AGENT_MODEL_NAMES[^=]*=\s*\{(.*?)\}",
+            src, _re.DOTALL,
+        )
+        if block:
+            for m in _re.finditer(r'"([^"]+)"\s*:\s*"([^"]+)"', block.group(1)):
+                runtime_models[f"_FALLBACK_AGENT_MODEL_NAMES[{m.group(1)}]"] = m.group(2)
+
+    if not runtime_models:
+        return CheckResult(
+            name="price_cards_cover_all_models",
+            status="warn",
+            message="No runtime model names discovered — schema drift in research config?",
+            elapsed_seconds=time.time() - t0,
+        )
+
+    misses: list[str] = []
+    for source, model_name in runtime_models.items():
+        normalized = _normalize_model_for_pricing(model_name)
+        if normalized not in card_names:
+            misses.append(f"{source}={model_name!r} (normalized={normalized!r})")
+
+    if misses:
+        return CheckResult(
+            name="price_cards_cover_all_models",
+            status="fail",
+            message=(
+                f"{len(misses)} runtime model(s) have no matching price card — "
+                f"recompute_cost would raise PriceCardLookupError on the SF run"
+            ),
+            details={
+                "missing": misses,
+                "available_cards": sorted(card_names),
+            },
+            elapsed_seconds=time.time() - t0,
+        )
+
+    return CheckResult(
+        name="price_cards_cover_all_models",
+        status="ok",
+        message=(
+            f"All {len(runtime_models)} runtime model(s) map to price cards "
+            f"(after snapshot-suffix normalization)"
+        ),
+        details={"runtime_models": runtime_models},
+        elapsed_seconds=time.time() - t0,
+    )
+
+
+def check_recursion_budget_for_response_format(ctx: PreflightContext) -> CheckResult:
+    """Catches the 2026-05-02 PR #78 class: ReAct agents using
+    ``response_format=...`` need ``recursion_limit > MAX_ITERATIONS * 2``
+    because the post-loop structured-extraction call counts against the
+    same budget.
+
+    Static scan of the analyst modules; no imports, no LLM. Asserts that
+    every file using ``response_format=`` in ``create_react_agent`` also
+    sets ``recursion_limit`` with a ``+ 2`` buffer (or higher). The bare
+    ``MAX_ITERATIONS * 2`` formula crashes the SF on the structured-output
+    extraction call."""
+    import time
+    import re as _re
+    from pathlib import Path
+    t0 = time.time()
+
+    research_repo = _sibling_repo("alpha-engine-research")
+    if research_repo is None:
+        return CheckResult(
+            name="recursion_budget_for_response_format",
+            status="warn",
+            message="alpha-engine-research sibling not checked out — skipped.",
+            elapsed_seconds=time.time() - t0,
+        )
+
+    targets = [
+        research_repo / "agents" / "sector_teams" / "quant_analyst.py",
+        research_repo / "agents" / "sector_teams" / "qual_analyst.py",
+    ]
+    issues: list[str] = []
+    checked: list[str] = []
+
+    for path in targets:
+        if not path.is_file():
+            issues.append(f"{path.name} missing")
+            continue
+        src = path.read_text()
+        uses_response_format = "response_format=" in src
+        if not uses_response_format:
+            checked.append(f"{path.name}: no response_format — skipped")
+            continue
+        # Look for any recursion_limit assignment that's NOT bare ``× 2``.
+        # Acceptable shapes: ``MAX_ITERATIONS * 2 + 2``, ``MAX_ITERATIONS * 2 + N``,
+        # explicit numeric ≥ 18, or a named constant we can resolve.
+        bare_x2 = _re.search(
+            r"recursion_limit[\"']?\s*:\s*\w+_MAX_ITERATIONS\s*\*\s*2(?!\s*\+)",
+            src,
+        )
+        if bare_x2:
+            issues.append(
+                f"{path.name}: uses response_format= but recursion_limit is "
+                f"bare MAX_ITERATIONS * 2 (no +N buffer) — SF will halt on "
+                f"the structured-extraction call"
+            )
+            continue
+        checked.append(f"{path.name}: response_format + buffered recursion_limit ✓")
+
+    if issues:
+        return CheckResult(
+            name="recursion_budget_for_response_format",
+            status="fail",
+            message=f"{len(issues)} ReAct site(s) at risk of GraphRecursionError",
+            details={"issues": issues, "checked": checked},
+            elapsed_seconds=time.time() - t0,
+        )
+
+    return CheckResult(
+        name="recursion_budget_for_response_format",
+        status="ok",
+        message=f"All {len(targets)} ReAct site(s) have buffered recursion_limit",
+        details={"checked": checked},
+        elapsed_seconds=time.time() - t0,
+    )
+
+
 # ArcticDB on macOS crashes in ``Aws::S3::S3Client::S3Client`` if boto3 has
 # already initialized the AWS SDK in the process — the arcticdb-bundled
 # AWS SDK conflicts with the system one. Initializing arctic FIRST avoids
@@ -695,6 +904,8 @@ CHECKS = [
     check_predicted_missing_from_closes,
     check_backfill_source_freshness,
     check_postflight_contracts,
+    check_price_cards_cover_all_models,
+    check_recursion_budget_for_response_format,
 ]
 
 

--- a/tests/test_sf_preflight.py
+++ b/tests/test_sf_preflight.py
@@ -360,3 +360,205 @@ def test_run_preflight_returns_failure_count():
         n_fail, results = sfp.run_preflight(bucket="test-bucket")
     assert n_fail == 2
     assert len(results) == 3
+
+
+# ── Research-side static checks (PR #77, #78 prevention) ──────────────────────
+
+
+import tempfile
+from pathlib import Path
+
+
+def _make_sibling_repos(tmp_path: Path, *, pricing_yaml: str,
+                        universe_yaml: str | None = None,
+                        research_graph_src: str | None = None,
+                        quant_analyst_src: str | None = None,
+                        qual_analyst_src: str | None = None) -> Path:
+    """Build a tmp sibling-clone directory layout for the static checks
+    to walk. Returns the path that should be passed as the 'parent' dir
+    (i.e. tmp_path / 'siblings' simulates ~/Development).
+
+    Each yaml/source param is optional — pass None to omit the file
+    entirely (e.g. test the missing-file branch)."""
+    siblings = tmp_path / "siblings"
+    config = siblings / "alpha-engine-config"
+    research = siblings / "alpha-engine-research"
+    (config / "cost").mkdir(parents=True)
+    (config / "research").mkdir(parents=True)
+    (research / "agents" / "sector_teams").mkdir(parents=True)
+    (research / "graph").mkdir(parents=True)
+    # alpha-engine-data placeholder so _sibling_repo's parent-resolution
+    # has the right layout (sibling lookup is from this file's parent).
+    (siblings / "alpha-engine-data").mkdir()
+
+    (config / "cost" / "model_pricing.yaml").write_text(pricing_yaml)
+    if universe_yaml is not None:
+        (config / "research" / "universe.yaml").write_text(universe_yaml)
+    if research_graph_src is not None:
+        (research / "graph" / "research_graph.py").write_text(research_graph_src)
+    if quant_analyst_src is not None:
+        (research / "agents" / "sector_teams" / "quant_analyst.py").write_text(quant_analyst_src)
+    if qual_analyst_src is not None:
+        (research / "agents" / "sector_teams" / "qual_analyst.py").write_text(qual_analyst_src)
+
+    return siblings
+
+
+@pytest.fixture
+def patched_sibling(monkeypatch, tmp_path):
+    """Returns a callable that builds a tmp sibling layout + monkeypatches
+    sf_preflight._sibling_repo to resolve into it. Tests build the layout
+    they need then call the check."""
+    def _build(**kwargs) -> Path:
+        siblings = _make_sibling_repos(tmp_path, **kwargs)
+        def _fake_sibling(name: str):
+            candidate = siblings / name
+            return candidate if candidate.is_dir() else None
+        monkeypatch.setattr(sfp, "_sibling_repo", _fake_sibling)
+        return siblings
+    return _build
+
+
+# ── check_price_cards_cover_all_models ─────────────────────────────────────────
+
+
+def test_price_cards_check_passes_when_all_models_have_cards(patched_sibling):
+    """Happy path: every runtime model (after snapshot normalization) has
+    a card. PR #77's normalization is honored."""
+    patched_sibling(
+        pricing_yaml="cards:\n"
+                     "  - {model_name: claude-haiku-4-5, effective_from: 2026-01-01,"
+                     " input_per_1m: 1.0, output_per_1m: 5.0,"
+                     " cache_read_per_1m: 0.1, cache_create_per_1m: 1.25}\n"
+                     "  - {model_name: claude-sonnet-4-6, effective_from: 2026-01-01,"
+                     " input_per_1m: 3.0, output_per_1m: 15.0,"
+                     " cache_read_per_1m: 0.3, cache_create_per_1m: 3.75}\n",
+        universe_yaml="sector_teams:\n"
+                      "  per_stock_model: claude-haiku-4-5-20251001\n"  # snapshot suffix
+                      "  strategic_model: claude-sonnet-4-6\n",
+        research_graph_src='_FALLBACK_AGENT_MODEL_NAMES = {"sector_team": "claude-haiku-4-5"}\n',
+    )
+    result = sfp.check_price_cards_cover_all_models(_ctx())
+    assert result.status == "ok"
+
+
+def test_price_cards_check_fails_when_runtime_model_missing(patched_sibling):
+    """The 2026-05-02 PR #77 scenario exactly: per_stock_model is
+    'claude-haiku-4-5-20251001' (snapshot ID) but no card for the
+    family 'claude-haiku-4-5' exists. SHOULD be caught here."""
+    patched_sibling(
+        pricing_yaml="cards:\n"
+                     "  - {model_name: claude-sonnet-4-6, effective_from: 2026-01-01,"
+                     " input_per_1m: 3.0, output_per_1m: 15.0,"
+                     " cache_read_per_1m: 0.3, cache_create_per_1m: 3.75}\n",
+        universe_yaml="sector_teams:\n"
+                      "  per_stock_model: claude-haiku-4-5-20251001\n",
+        research_graph_src="",  # no fallbacks
+    )
+    result = sfp.check_price_cards_cover_all_models(_ctx())
+    assert result.status == "fail"
+    assert "haiku" in result.message.lower() or "no matching price card" in result.message.lower()
+
+
+def test_price_cards_check_warns_when_sibling_repo_absent(monkeypatch):
+    monkeypatch.setattr(sfp, "_sibling_repo", lambda name: None)
+    result = sfp.check_price_cards_cover_all_models(_ctx())
+    assert result.status == "warn"
+
+
+def test_price_cards_check_handles_fallback_models_in_research_graph(patched_sibling):
+    """Models in _FALLBACK_AGENT_MODEL_NAMES must also be checked — the
+    fallback path runs when track_llm_cost wiring is incomplete and would
+    crash if its model isn't in the price table."""
+    patched_sibling(
+        pricing_yaml="cards: []\n",  # empty cards
+        universe_yaml="",
+        research_graph_src='_FALLBACK_AGENT_MODEL_NAMES = {\n'
+                          '    "sector_team": "claude-haiku-4-5",\n'
+                          '    "ic_cio": "claude-sonnet-4-6",\n'
+                          '}\n',
+    )
+    result = sfp.check_price_cards_cover_all_models(_ctx())
+    assert result.status == "fail"
+    # Both fallback models should be flagged as missing.
+    assert "sector_team" in str(result.details) and "ic_cio" in str(result.details)
+
+
+# ── check_recursion_budget_for_response_format ────────────────────────────────
+
+
+def test_recursion_budget_check_passes_when_buffered(patched_sibling):
+    """Happy path: ReAct site uses response_format AND has +2 buffer in
+    recursion_limit. Mirrors today's PR #78 fix."""
+    patched_sibling(
+        pricing_yaml="cards: []\n",
+        quant_analyst_src=(
+            "from langgraph.prebuilt import create_react_agent\n"
+            "QUANT_MAX_ITERATIONS = 8\n"
+            "_QUANT_RECURSION_LIMIT = QUANT_MAX_ITERATIONS * 2 + 2\n"
+            "agent = create_react_agent(model, tools, response_format=Output)\n"
+            "agent.invoke({}, config={'recursion_limit': _QUANT_RECURSION_LIMIT})\n"
+        ),
+        qual_analyst_src=(
+            "from langgraph.prebuilt import create_react_agent\n"
+            "QUAL_MAX_ITERATIONS = 8\n"
+            "_QUAL_RECURSION_LIMIT = QUAL_MAX_ITERATIONS * 2 + 2\n"
+            "agent = create_react_agent(model, tools, response_format=Output)\n"
+            "agent.invoke({}, config={'recursion_limit': _QUAL_RECURSION_LIMIT})\n"
+        ),
+    )
+    result = sfp.check_recursion_budget_for_response_format(_ctx())
+    assert result.status == "ok"
+
+
+def test_recursion_budget_check_fails_on_bare_x2(patched_sibling):
+    """The 2026-05-02 PR #78 regression: ReAct uses response_format= but
+    recursion_limit is bare ``MAX_ITERATIONS * 2`` (no +N buffer). SF
+    crashes on the structured-extraction call. SHOULD be caught here."""
+    patched_sibling(
+        pricing_yaml="cards: []\n",
+        quant_analyst_src=(
+            "from langgraph.prebuilt import create_react_agent\n"
+            "QUANT_MAX_ITERATIONS = 8\n"
+            "agent = create_react_agent(model, tools, response_format=Output)\n"
+            "agent.invoke({}, config={'recursion_limit': QUANT_MAX_ITERATIONS * 2})\n"
+        ),
+        qual_analyst_src=(
+            "from langgraph.prebuilt import create_react_agent\n"
+            "QUAL_MAX_ITERATIONS = 8\n"
+            "_QUAL_RECURSION_LIMIT = QUAL_MAX_ITERATIONS * 2 + 2\n"
+            "agent = create_react_agent(model, tools, response_format=Output)\n"
+            "agent.invoke({}, config={'recursion_limit': _QUAL_RECURSION_LIMIT})\n"
+        ),
+    )
+    result = sfp.check_recursion_budget_for_response_format(_ctx())
+    assert result.status == "fail"
+    assert "quant_analyst" in str(result.details)
+
+
+def test_recursion_budget_check_skips_files_without_response_format(patched_sibling):
+    """Files that don't use response_format= aren't subject to the +2 rule."""
+    patched_sibling(
+        pricing_yaml="cards: []\n",
+        quant_analyst_src=(
+            "from langgraph.prebuilt import create_react_agent\n"
+            "QUANT_MAX_ITERATIONS = 8\n"
+            "agent = create_react_agent(model, tools)\n"  # no response_format
+            "agent.invoke({}, config={'recursion_limit': QUANT_MAX_ITERATIONS * 2})\n"
+        ),
+        qual_analyst_src=(
+            "from langgraph.prebuilt import create_react_agent\n"
+            "QUAL_MAX_ITERATIONS = 8\n"
+            "agent = create_react_agent(model, tools)\n"  # no response_format
+            "agent.invoke({}, config={'recursion_limit': QUAL_MAX_ITERATIONS * 2})\n"
+        ),
+    )
+    result = sfp.check_recursion_budget_for_response_format(_ctx())
+    assert result.status == "ok"
+    assert all("no response_format" in c for c in result.details["checked"])
+
+
+def test_recursion_budget_check_warns_when_sibling_absent(monkeypatch):
+    monkeypatch.setattr(sfp, "_sibling_repo", lambda name: None)
+    result = sfp.check_recursion_budget_for_response_format(_ctx())
+    assert result.status == "warn"


### PR DESCRIPTION
## Summary

Today's incident chain proved the existing dry-run/stub-LLM gate catches structural issues but is by-design blind to runtime LLM behavior — bugs in cost-telemetry lookup and recursion budget only surface when real LLM calls happen.

Two new static checks (zero LLM cost) catch today's exact failure modes at preflight time:

### `check_price_cards_cover_all_models`
Walks runtime model names from research config (`per_stock_model`, `strategic_model`, `_FALLBACK_AGENT_MODEL_NAMES`), normalizes via the same snapshot-suffix strip PR #77 added, and asserts each maps to a card in `alpha-engine-config/cost/model_pricing.yaml`. Pre-empts `PriceCardLookupError`.

### `check_recursion_budget_for_response_format`
Static regex scan of `agents/sector_teams/{quant,qual}_analyst.py`. For every site using `response_format=`, asserts `recursion_limit` includes a `+N` buffer (not bare `MAX_ITERATIONS * 2`). Pre-empts `GraphRecursionError` from the structured-extraction call.

Both WARN (don't FAIL) when sibling repos aren't checked out — preserves "useful even when partial" property.

## Validation against current state

```
[OK]   price_cards_cover_all_models     3 runtime models map to cards
[OK]   recursion_budget_for_response_format   2 ReAct sites buffered
```

Both pass after PR #77 + #78 merged.

## Test plan

- [x] 8 new tests in `test_sf_preflight.py`: happy path, failure path (reproducing today's exact incidents in tmp sibling layout), absent-sibling skip, snapshot-suffix normalization round-trip
- [x] Full suite: 403 passed
- [ ] Live run on Friday before next Saturday SF — should catch any drift before launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)