### PR TITLE
fix(backfill): filter universe writes by current constituents + escalate preflight

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -62,6 +62,32 @@ log = logging.getLogger(__name__)
 OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
 
 
+def _load_current_constituents(s3, bucket: str) -> set[str]:
+    """Load the current S&P 500 / 400 constituents set via the
+    ``market_data/latest_weekly.json`` pointer.
+
+    Used by ``backfill`` to filter out tickers absent from the current
+    investable universe before writing arctic rows. Mirrors the
+    ``prune_delisted_tickers`` lookup so the two sites agree on what's
+    "in the universe today".
+    """
+    pointer_obj = s3.get_object(Bucket=bucket, Key="market_data/latest_weekly.json")
+    pointer = json.loads(pointer_obj["Body"].read())
+    weekly_date = pointer["date"]
+    prefix = pointer["s3_prefix"].rstrip("/")
+    cons_obj = s3.get_object(Bucket=bucket, Key=f"{prefix}/constituents.json")
+    payload = json.loads(cons_obj["Body"].read())
+    tickers = payload.get("tickers")
+    if not tickers:
+        raise RuntimeError(
+            f"constituents.json at s3://{bucket}/{prefix}/constituents.json "
+            f"(weekly_date={weekly_date}) has no `tickers` field — refusing "
+            f"to filter against an empty constituents set (would write zero "
+            f"tickers to arctic universe)."
+        )
+    return set(tickers)
+
+
 def _load_full_cache(s3, bucket: str, prefix: str = "predictor/price_cache/") -> dict[str, pd.DataFrame]:
     """Load all 10-year price cache parquets from S3 (concurrent)."""
     keys = []
@@ -362,12 +388,61 @@ def backfill(
     #     computation (rolling 252-day vol/momentum etc.). Only these get
     #     OHLCV + feature columns written; short-history tickers get OHLCV
     #     only, and are skipped by feature-consuming predictors downstream.
+    #
+    # Constituents filter: drop any price_cache ticker that isn't in the
+    # current S&P 500 / 400 constituents. Without this, backfill recreates
+    # ArcticDB rows for tickers that were just pruned by
+    # ``builders.prune_delisted_tickers`` because their parquet files still
+    # exist in ``predictor/price_cache/`` (price_cache parquets are kept for
+    # historical lookup; arctic represents the active investable universe).
+    # The 2026-05-02 SF redrive #6 caught this: pre-MorningEnrich prune
+    # dropped 8 stragglers, then Phase 1 step 8 (this function) recreated
+    # them, then Backtester's universe-freshness preflight halted on 7 of
+    # them being 8 days stale. Filtering here closes the loop so prune +
+    # backfill stay coherent.
+    if not dry_run:
+        try:
+            constituents_set = _load_current_constituents(s3, bucket)
+            log.info(
+                "Loaded current constituents: %d tickers — backfill will only "
+                "write tickers in this set",
+                len(constituents_set),
+            )
+        except Exception as exc:
+            # Fail loud — without a constituents reference we'd silently
+            # recreate every parquet-backed ticker, undoing prune work.
+            raise RuntimeError(
+                f"Backfill could not load current constituents (needed to "
+                f"filter the universe write set): {exc}. Without this, "
+                f"backfill would recreate any pruned ticker that still has "
+                f"a price_cache parquet — see PR closing the prune+backfill "
+                f"loop. Refresh constituents.json upstream and retry."
+            ) from exc
+    else:
+        constituents_set = set(price_data)  # dry-run: don't restrict
+
     universe_tickers = [
         t for t in price_data
         if t not in _SKIP_TICKERS
         and not _is_sector_etf(t)
         and price_data[t] is not None
+        and t in constituents_set
     ]
+    excluded_by_constituents = sorted(
+        t for t in price_data
+        if t not in _SKIP_TICKERS
+        and not _is_sector_etf(t)
+        and price_data[t] is not None
+        and t not in constituents_set
+    )
+    if excluded_by_constituents:
+        log.info(
+            "Backfill skipping %d price_cache ticker(s) absent from current "
+            "constituents (parquet preserved for historical lookup; arctic "
+            "row not written): %s",
+            len(excluded_by_constituents),
+            excluded_by_constituents[:20],
+        )
     # Post-PR-#78: ``compute_features`` returns rows with NaN for features
     # whose rolling-window warmup exceeds available history (e.g. ATR-14
     # computes on 14 rows; dist_from_52w_high stays NaN under 252 rows).

--- a/sf_preflight.py
+++ b/sf_preflight.py
@@ -272,10 +272,24 @@ def check_universe_drift(ctx: PreflightContext) -> CheckResult:
         else:
             will_skip.append({**entry, "reason": "below_5d_threshold"})
 
+    # Escalate to FAIL if any straggler is "old enough to prune" (>5d stale)
+    # AND we're about to launch a recovery SF that skips MorningEnrich (the
+    # only place prune currently runs). The 2026-05-02 SF redrive #6 caught
+    # this: skip_data_phase1=true bypassed prune, Backtester preflight
+    # halted on the same stragglers. The post-PR-loop fix in backfill.py
+    # closes the regenerative loop on the DataPhase1 path; this check
+    # gates the manual-recovery path so operators don't burn a 120-min
+    # spot to re-discover stragglers we can see right here.
+    status = "fail" if will_prune else "ok"
+    message_prefix = (
+        f"{len(will_prune)} ticker(s) need pruning before any SF launch — "
+        if will_prune else ""
+    )
     return CheckResult(
         name="universe_drift",
-        status="ok",
+        status=status,
         message=(
+            f"{message_prefix}"
             f"{len(candidates)} arctic stragglers; {len(will_prune)} would be pruned, "
             f"{len(will_skip)} too fresh to drop"
         ),
@@ -284,6 +298,11 @@ def check_universe_drift(ctx: PreflightContext) -> CheckResult:
             "would_prune_count": len(will_prune),
             "would_prune": will_prune[:20],
             "would_skip_count": len(will_skip),
+            "remediation": (
+                "Run MorningEnrich (full SF) OR manually invoke "
+                "prune_delisted_tickers --apply --absent-days 5 against the "
+                "would_prune list before launching Backtester / recovery SFs."
+            ) if will_prune else None,
         },
         elapsed_seconds=time.time() - t0,
     )

--- a/tests/test_backfill_no_regression.py
+++ b/tests/test_backfill_no_regression.py
@@ -178,6 +178,7 @@ def test_full_backfill_calls_apply_daily_delta():
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", delta_mock), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
+         patch.object(_bf, "_load_current_constituents", return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value=macro), \
          patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
@@ -208,6 +209,7 @@ def test_full_backfill_calls_regression_preflight():
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
+         patch.object(_bf, "_load_current_constituents", return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value={}), \
          patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
@@ -240,6 +242,7 @@ def test_ticker_filter_skips_regression_preflight():
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
+         patch.object(_bf, "_load_current_constituents", return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value={}), \
          patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
@@ -269,6 +272,7 @@ def test_dry_run_skips_delta_and_preflight():
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", delta_mock), \
          patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
+         patch.object(_bf, "_load_current_constituents", return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value={}), \
          patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
@@ -280,3 +284,100 @@ def test_dry_run_skips_delta_and_preflight():
 
     delta_mock.assert_not_called()
     regression_mock.assert_not_called()
+
+
+# ── constituents filter (PR closing the prune+backfill loop) ─────────────────
+
+
+def test_backfill_skips_tickers_absent_from_constituents():
+    """The 2026-05-02 SF redrive #6 root cause: pre-MorningEnrich prune
+    drops 8 stragglers, then Phase 1 step 8 (this function) recreates
+    them because their parquet files still exist in price_cache. With
+    the constituents filter, backfill writes only tickers in the current
+    investable universe. Stragglers stay pruned."""
+    from builders import backfill as _bf
+
+    price_data = {
+        "AAPL": _ohlcv("2024-01-01", n=400),
+        "MSFT": _ohlcv("2024-01-01", n=400),
+        "STRAGGLER": _ohlcv("2024-01-01", n=400),  # parquet exists, not in constituents
+    }
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_assert_no_arctic_regression"), \
+         patch.object(_bf, "_load_current_constituents",
+                      return_value={"AAPL", "MSFT"}), \
+         patch.object(_bf, "_extract_macro_series", return_value={}), \
+         patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK", "MSFT": "XLK"}), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "_build_macro_features_df", return_value=pd.DataFrame()), \
+         patch.object(_bf, "compute_features", side_effect=lambda df, **_: df), \
+         patch.object(_bf, "get_universe_lib", return_value=universe_lib), \
+         patch.object(_bf, "get_macro_lib", return_value=macro_lib), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        result = _bf.backfill(ticker_filter=None)
+
+    # universe_lib.write should be called for AAPL + MSFT only — NOT STRAGGLER.
+    written_tickers = {
+        call.args[0] for call in universe_lib.write.call_args_list
+    }
+    assert "AAPL" in written_tickers
+    assert "MSFT" in written_tickers
+    assert "STRAGGLER" not in written_tickers, (
+        "STRAGGLER absent from constituents must NOT be written to arctic — "
+        "would undo the prune and re-trip Backtester preflight"
+    )
+    assert result["status"] == "ok"
+
+
+def test_backfill_hard_fails_when_constituents_load_fails():
+    """Failing to load constituents must NOT silently proceed (which would
+    write everything in price_cache and undo all prune work). Hard-fail
+    per feedback_no_silent_fails."""
+    from builders import backfill as _bf
+
+    price_data = {"AAPL": _ohlcv("2024-01-01", n=400)}
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_assert_no_arctic_regression"), \
+         patch.object(_bf, "_load_current_constituents",
+                      side_effect=RuntimeError("S3 503")), \
+         patch.object(_bf, "_extract_macro_series", return_value={}), \
+         patch.object(_bf, "_load_sector_map", return_value={}), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        with pytest.raises(RuntimeError, match="could not load current constituents"):
+            _bf.backfill(ticker_filter=None)
+
+
+def test_backfill_dry_run_does_not_filter_by_constituents():
+    """Dry-run must work even without S3 constituents access (CI / local
+    smoke). Falls back to writing everything in price_cache (since dry-run
+    doesn't actually write)."""
+    from builders import backfill as _bf
+
+    price_data = {"AAPL": _ohlcv("2024-01-01", n=400)}
+    constituents_calls = MagicMock()
+
+    with patch.object(_bf, "_load_full_cache", return_value=price_data), \
+         patch.object(_bf, "_load_current_constituents", constituents_calls), \
+         patch.object(_bf, "_extract_macro_series", return_value={}), \
+         patch.object(_bf, "_load_sector_map", return_value={"AAPL": "XLK"}), \
+         patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
+         patch.object(_bf, "_load_cached_alternative", return_value={}), \
+         patch.object(_bf, "compute_features", side_effect=lambda df, **_: df), \
+         patch("builders.backfill.boto3.client") as mock_boto:
+        mock_boto.return_value = MagicMock()
+        _bf.backfill(dry_run=True)
+
+    # In dry_run, _load_current_constituents must NOT be called — we use
+    # the price_data keys directly so dry-run works without S3.
+    constituents_calls.assert_not_called()

--- a/tests/test_backfill_unified_and_macro_scoping.py
+++ b/tests/test_backfill_unified_and_macro_scoping.py
@@ -174,6 +174,8 @@ def _run_backfill_with_mocks(**backfill_kwargs):
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
+         patch.object(_bf, "_load_current_constituents",
+                      return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value=macro), \
          patch.object(_bf, "_load_sector_map", return_value=sector_map), \
          patch.object(_bf, "_load_cached_fundamentals", return_value=fundamentals), \
@@ -262,6 +264,8 @@ def test_short_history_ticker_gets_feature_columns_written():
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
+         patch.object(_bf, "_load_current_constituents",
+                      return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value=macro), \
          patch.object(_bf, "_load_sector_map", return_value=sector_map), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \
@@ -340,6 +344,8 @@ def test_backfill_writes_vwap_when_input_parquet_lacks_it():
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
+         patch.object(_bf, "_load_current_constituents",
+                      return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value=macro), \
          patch.object(_bf, "_load_sector_map", return_value=sector_map), \
          patch.object(_bf, "_load_cached_fundamentals", return_value={}), \

--- a/tests/test_sf_preflight.py
+++ b/tests/test_sf_preflight.py
@@ -128,9 +128,13 @@ def test_universe_drift_predicts_prune_outcome():
 
     result = sfp.check_universe_drift(ctx)
 
-    assert result.status == "ok"
+    # Escalated to FAIL when any straggler would be pruned. Operator must
+    # drop them before launching Backtester / recovery SFs (otherwise we
+    # burn a 120-min spot to re-discover them at Backtester preflight).
+    assert result.status == "fail"
     assert result.details["candidates_count"] == 8
     assert result.details["would_prune_count"] == 8
+    assert result.details["remediation"] is not None
 
 
 def test_universe_drift_no_stragglers_passes_quietly():


### PR DESCRIPTION
## Summary

Closes the **prune+backfill loop** that recreated 7 S&P churn-out stragglers on every Saturday SF run. 2026-05-02 redrive #6 surfaced the loop:

1. Pre-MorningEnrich prune (PR #134, `absent_days=5`) drops stragglers ✓
2. Phase 1 step 8 (`builders.backfill`) loads ALL `predictor/price_cache/*.parquet` and writes EVERY ticker to ArcticDB universe — **including the ones we just pruned**, because their parquet files still exist (kept for historical lookup)
3. Loop closes; Backtester preflight ~2 hours later trips on the 8-day-stale rows

## Two fixes

### `builders/backfill.py`: constituents-filter on writes
Load current constituents via the `latest_weekly.json` pointer and filter `universe_tickers` against it. Churn-out parquet preserved (history kept) but no arctic row written. If a ticker returns to S&P, backfill picks it back up automatically. Hard-fails on constituents-load failure (no silent recreate-everything fallback).

### `sf_preflight.check_universe_drift`: WARN → FAIL
Now returns FAIL when any straggler is `>5d stale`. Forces operators to drop stragglers BEFORE launching recovery SFs that skip MorningEnrich (otherwise we burn a 120-min Backtester spot to re-discover them). Result includes remediation hint.

## Validation against current state (post manual prune)

```
[OK]   arctic_connectivity              ArcticDB reachable; universe library has 904 symbols
[OK]   universe_drift                   1 arctic stragglers; 0 would be pruned, 1 too fresh to drop
[OK]   backfill_source_freshness        Backfill source (2026-05-01) ≥ arctic (2026-05-01)
... Predicted SF outcome: PASS
```

## Test plan

- [x] 3 new tests in `test_backfill_no_regression.py`: loop closure, hard-fail on constituents-load failure, dry-run doesn't require S3
- [x] Existing 21 backfill tests still pass (mocks updated)
- [x] Updated test for `check_universe_drift` to expect FAIL on stragglers + remediation hint
- [x] Full suite: 406 passed
- [ ] Live verification: next Saturday SF that runs MorningEnrich → prune drops stragglers → backfill respects + doesn't recreate → no Backtester preflight halt

## Why not also add prune to Backtester?

Considered but rejected — the issue isn't Backtester missing a prune step, it's that the EXISTING DataPhase1 prune was getting undone by DataPhase1's own backfill. Fixing the loop in one place is cleaner than duplicating prune across modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)