### PR TITLE
feat(sf): PR 4c rolling-mean SF wiring + CloudWatch alarm

### DIFF
--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -102,6 +102,7 @@ POLICY='{
       "Resource": [
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-runner*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-judge*",
+        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-rolling-mean*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*"
       ]

--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -48,6 +48,7 @@ POLICY='{
       "Resource": [
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-runner*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-judge*",
+        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-rolling-mean*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-health-check*"

--- a/infrastructure/setup_eval_quality_alarm.sh
+++ b/infrastructure/setup_eval_quality_alarm.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# setup_eval_quality_alarm.sh — One-shot CloudWatch alarm setup for the
+# LLM-as-judge rolling-4-week-mean signal (PR 4c, ROADMAP §1634).
+#
+# Idempotent: safe to re-run after metric or threshold tweaks. The
+# alarm fires when the MIN across all (judged_agent_id, criterion,
+# judge_model) combos of agent_quality_score_4w_mean drops below 3.0.
+#
+# Why a SEARCH expression rather than one alarm per combo: with
+# ~6 sector teams × 3 sub-agents × 4-5 criteria × 2 judge tiers = 150+
+# distinct streams the per-combo alarm count is unwieldy. SEARCH
+# dynamically discovers every matching stream at evaluation time so
+# new agents/criteria added later are auto-monitored without
+# re-running this script.
+#
+# Notification target: reuses the existing alpha-engine-alerts SNS
+# topic (created by deploy_step_function.sh) so eval regressions
+# land in the same operator inbox as pipeline failures.
+#
+# Usage: ./infrastructure/setup_eval_quality_alarm.sh
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
+SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
+ALARM_NAME="alpha-engine-eval-quality-regression"
+NAMESPACE="AlphaEngine/Eval"
+DERIVED_METRIC="agent_quality_score_4w_mean"
+THRESHOLD="3.0"
+
+echo "Configuring CloudWatch alarm: $ALARM_NAME"
+echo "  Region:       $REGION"
+echo "  SNS topic:    $SNS_TOPIC_ARN"
+echo "  Threshold:    < $THRESHOLD (rolling 4-week mean)"
+echo "  Source:       $NAMESPACE / $DERIVED_METRIC"
+
+# Verify the SNS topic exists — fail fast rather than create an alarm
+# with a broken target.
+if ! aws sns get-topic-attributes \
+    --topic-arn "$SNS_TOPIC_ARN" \
+    --region "$REGION" > /dev/null 2>&1; then
+  echo "ERROR: SNS topic $SNS_TOPIC_ARN not found. Run deploy_step_function.sh first." >&2
+  exit 1
+fi
+
+# CloudWatch put-metric-alarm with metric math: SEARCH expression
+# scans all streams under the namespace + metric name, then MIN()
+# reduces them to a single time series the threshold compares against.
+aws cloudwatch put-metric-alarm \
+  --region "$REGION" \
+  --alarm-name "$ALARM_NAME" \
+  --alarm-description "Fires when the MIN rolling-4-week-mean of any agent/criterion/judge combo of $NAMESPACE/$DERIVED_METRIC drops below $THRESHOLD. Surfaces silent regressions in LLM agent output quality before they show up in alpha. Eval is observability per ROADMAP §1635 — alarm names a regression but does not gate any deploy." \
+  --comparison-operator "LessThanThreshold" \
+  --evaluation-periods 1 \
+  --threshold "$THRESHOLD" \
+  --treat-missing-data "ignore" \
+  --metrics "[
+    {
+      \"Id\": \"q1\",
+      \"Expression\": \"SEARCH('Namespace=\\\"$NAMESPACE\\\" MetricName=\\\"$DERIVED_METRIC\\\"', 'Average', 86400)\",
+      \"ReturnData\": false,
+      \"Period\": 86400
+    },
+    {
+      \"Id\": \"min_across_combos\",
+      \"Expression\": \"MIN(q1)\",
+      \"Label\": \"min rolling-4w mean across all (agent, criterion, judge) combos\",
+      \"ReturnData\": true,
+      \"Period\": 86400
+    }
+  ]" \
+  --alarm-actions "$SNS_TOPIC_ARN" \
+  --ok-actions "$SNS_TOPIC_ARN"
+
+echo ""
+echo "Alarm $ALARM_NAME configured."
+echo ""
+echo "Validation: aws cloudwatch describe-alarms --alarm-names $ALARM_NAME --region $REGION --query 'MetricAlarms[0].StateValue' --output text"
+echo ""
+echo "First firing eligibility: 4 weeks after the eval-judge Lambda starts emitting raw scores. Until then, treat-missing-data=ignore keeps the alarm in INSUFFICIENT_DATA without paging."

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -565,12 +565,12 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Eval is observability — failures must NOT halt the pipeline. The handler already returns OK/PARTIAL/ERROR rather than throwing on per-artifact issues; this Catch covers infra-level failures (Lambda timeout, transient AWS errors).",
-          "Next": "SaturdayHealthCheck",
+          "Next": "EvalRollingMean",
           "ResultPath": "$.eval_judge_error"
         }
       ],
       "ResultPath": "$.eval_judge_result",
-      "Next": "SaturdayHealthCheck"
+      "Next": "EvalRollingMean"
     },
 
     "EvalJudgeWeekly": {
@@ -597,11 +597,42 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Eval is observability — failures must NOT halt the pipeline.",
-          "Next": "SaturdayHealthCheck",
+          "Next": "EvalRollingMean",
           "ResultPath": "$.eval_judge_error"
         }
       ],
       "ResultPath": "$.eval_judge_result",
+      "Next": "EvalRollingMean"
+    },
+
+    "EvalRollingMean": {
+      "Type": "Task",
+      "Comment": "Rolling-4-week-mean derived metric Lambda (PR 4b) — runs after both eval-judge branches converge. Reads AlphaEngine/Eval/agent_quality_score for the trailing 28 days, computes the mean per (judged_agent_id, criterion, judge_model) combo, and emits agent_quality_score_4w_mean which a CloudWatch alarm fires against (per ROADMAP §1634). Runs every Saturday — even on weeks where eval-judge had infra failures, the mean across the prior 4 weeks of available data is still the most-current calibration signal.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-research-eval-rolling-mean:live",
+        "Payload": {
+          "end_time_iso.$": "$$.Execution.StartTime"
+        }
+      },
+      "TimeoutSeconds": 300,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Eval observability layer — failures must NOT halt the pipeline.",
+          "Next": "SaturdayHealthCheck",
+          "ResultPath": "$.eval_rolling_mean_error"
+        }
+      ],
+      "ResultPath": "$.eval_rolling_mean_result",
       "Next": "SaturdayHealthCheck"
     },
 

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -43,6 +43,7 @@ class TestStatesPresent:
             "CheckMonthlyCadence",
             "EvalJudgeFirstSaturday",
             "EvalJudgeWeekly",
+            "EvalRollingMean",
         ):
             assert name in states, f"missing SF state: {name}"
 
@@ -174,19 +175,62 @@ class TestEvalJudgeNonBlocking:
         "state_name",
         ["EvalJudgeFirstSaturday", "EvalJudgeWeekly"],
     )
-    def test_success_continues_to_health_check(self, states, state_name):
-        assert states[state_name]["Next"] == "SaturdayHealthCheck"
+    def test_success_continues_to_rolling_mean(self, states, state_name):
+        # Eval-judge branches converge to EvalRollingMean (PR 4c)
+        # rather than SaturdayHealthCheck — ensures the rolling-mean
+        # derived metric runs every week with the freshest raw data.
+        assert states[state_name]["Next"] == "EvalRollingMean"
 
     @pytest.mark.parametrize(
         "state_name",
         ["EvalJudgeFirstSaturday", "EvalJudgeWeekly"],
     )
-    def test_catch_routes_to_health_check_not_failure(self, states, state_name):
+    def test_catch_routes_to_rolling_mean_not_failure(self, states, state_name):
         # Eval is observability per ROADMAP §1635 — failures must NOT
-        # halt the pipeline. Routing to HandleFailure here would be a
-        # regression that shoots the whole Saturday run on a 5xx from
-        # Anthropic on the eval Lambda specifically.
+        # halt the pipeline. Even if eval-judge errors out at the infra
+        # level, rolling-mean still runs against whatever historical
+        # data IS available (the prior 4 weeks are unaffected).
         catch = states[state_name]["Catch"][0]
+        assert catch["ErrorEquals"] == ["States.ALL"]
+        assert catch["Next"] == "EvalRollingMean"
+        assert catch["Next"] != "HandleFailure"
+
+
+# ── EvalRollingMean state (PR 4c) ─────────────────────────────────────────
+
+
+class TestEvalRollingMean:
+    def test_invokes_live_alias(self, states):
+        params = states["EvalRollingMean"]["Parameters"]
+        assert params["FunctionName"] == "alpha-engine-research-eval-rolling-mean:live"
+
+    def test_payload_passes_execution_start_time(self, states):
+        # SF passes its own start time so the rolling-mean window aligns
+        # with the SF execution date — keeps replay/backfill paths
+        # deterministic instead of "whenever the Lambda happened to run."
+        payload = states["EvalRollingMean"]["Parameters"]["Payload"]
+        assert payload["end_time_iso.$"] == "$$.Execution.StartTime"
+
+    def test_timeout_matches_lambda_cap(self, states):
+        # Rolling-mean Lambda is configured with timeout=300s
+        # (alpha-engine-research infrastructure/deploy.sh) — SF state
+        # TimeoutSeconds must equal that ceiling.
+        assert states["EvalRollingMean"]["TimeoutSeconds"] == 300
+
+    def test_success_continues_to_health_check(self, states):
+        assert states["EvalRollingMean"]["Next"] == "SaturdayHealthCheck"
+
+    def test_catch_routes_to_health_check_not_failure(self, states):
+        catch = states["EvalRollingMean"]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
         assert catch["Next"] == "SaturdayHealthCheck"
         assert catch["Next"] != "HandleFailure"
+
+    def test_retries_on_transient_lambda_errors(self, states):
+        # Same retry posture as the eval-judge state — one retry on
+        # AWS-side transient errors (ServiceException / Throttling),
+        # not on application errors.
+        retry = states["EvalRollingMean"]["Retry"][0]
+        assert "Lambda.ServiceException" in retry["ErrorEquals"]
+        assert "Lambda.TooManyRequestsException" in retry["ErrorEquals"]
+        assert retry["MaxAttempts"] == 1


### PR DESCRIPTION
## Summary

Wires the rolling-mean Lambda (research PR #93) into the Saturday SF after the eval-judge converge point, and installs a single CloudWatch alarm that fires when ANY agent's rolling-4-week-mean drops below 3.0.

## SF flow update

Both eval-judge branches now converge to `EvalRollingMean` (instead of `SaturdayHealthCheck` directly):

```
CheckBacktesterStatus (Success)
  → CheckSkipEvalJudge → ComputeEvalCadence → CheckMonthlyCadence
      → EvalJudgeFirstSaturday ─┐
                                ├→ EvalRollingMean → SaturdayHealthCheck → NotifyComplete
      → EvalJudgeWeekly ────────┘
```

`EvalRollingMean` is non-blocking: `Catch States.ALL → SaturdayHealthCheck`. Even when eval-judge has infra failures, rolling-mean still runs — the trailing 4-week window is unaffected by the current week's hiccup.

## Why SF wiring instead of EventBridge

Per session discussion + the codebase convention (`Don't add redundant paths around load-bearing scheduled infra`): the Saturday SF is the single authoritative weekly path. EventBridge would have been an implicit-timing-dependency parallel schedule. SF wiring makes the dependency explicit, runs only after the current week's raw metric was actually emitted, and gives one SF execution trace covering the full eval pipeline.

## Alarm design

`infrastructure/setup_eval_quality_alarm.sh` is idempotent. Creates one alarm `alpha-engine-eval-quality-regression` using a `SEARCH` metric expression that discovers every `(judged_agent_id, criterion, judge_model)` combo at evaluation time and MIN-reduces them — so new agents/criteria added later are auto-monitored without re-running the script. Reuses the existing `alpha-engine-alerts` SNS topic. `treat-missing-data=ignore` keeps the alarm in `INSUFFICIENT_DATA` until 4 weeks of metric history accrue (no false pages on bootstrap).

## Test plan

- [x] `python -m pytest tests/ -q` → 433 passed (was 427).
- [x] 6 new `EvalRollingMean` assertions: alias + start-time payload + 300s timeout + non-blocking Catch + retry posture.
- [x] Existing 21 LLM-judge wiring tests updated to expect the new converge target.
- [x] `bash -n setup_eval_quality_alarm.sh` syntax-clean.

## Deploy order

1. From `alpha-engine-research`: `./infrastructure/deploy.sh eval_rolling_mean` (creates the Lambda alias)
2. From `alpha-engine-data`: `./infrastructure/deploy_step_function.sh` (updates SF JSON + IAM)
3. From `alpha-engine-data`: `./infrastructure/setup_eval_quality_alarm.sh` (installs the alarm)

## Out of scope (PR 4d)

- Streamlit quality-trend dashboard page in `alpha-engine-dashboard` (per-agent line charts × dimensions; prompt-version → quality-score correlation chart per ROADMAP §1633).

🤖 Generated with [Claude Code](https://claude.com/claude-code)