### PR TITLE
fix(infra): switch eval alarm to simple metric (no SEARCH)

### DIFF
--- a/infrastructure/setup_eval_quality_alarm.sh
+++ b/infrastructure/setup_eval_quality_alarm.sh
@@ -2,20 +2,23 @@
 # setup_eval_quality_alarm.sh — One-shot CloudWatch alarm setup for the
 # LLM-as-judge rolling-4-week-mean signal (PR 4c, ROADMAP §1634).
 #
-# Idempotent: safe to re-run after metric or threshold tweaks. The
-# alarm fires when the MIN across all (judged_agent_id, criterion,
-# judge_model) combos of agent_quality_score_4w_mean drops below 3.0.
+# Idempotent: safe to re-run after threshold tweaks. The alarm fires
+# when the dimensionless floor metric agent_quality_score_4w_mean_min
+# (= MIN across every (judged_agent_id, criterion, judge_model)
+# combo's 4-week rolling mean) drops below 3.0.
 #
-# Why a SEARCH expression rather than one alarm per combo: with
-# ~6 sector teams × 3 sub-agents × 4-5 criteria × 2 judge tiers = 150+
-# distinct streams the per-combo alarm count is unwieldy. SEARCH
-# dynamically discovers every matching stream at evaluation time so
-# new agents/criteria added later are auto-monitored without
-# re-running this script.
+# The floor is pre-computed by the rolling-mean Lambda
+# (alpha-engine-research evals/rolling_mean.py) and emitted as a
+# single dimensionless datapoint per weekly run. We must pre-compute
+# rather than reduce in the alarm itself: CloudWatch alarms reject
+# SEARCH expressions ("SEARCH is not supported on Metric Alarms"),
+# so dynamic cross-combo reduction at alarm-evaluation time isn't
+# expressible. This is fine — operator workflow on alarm fire is the
+# same either way (click dashboard to identify the combo).
 #
-# Notification target: reuses the existing alpha-engine-alerts SNS
-# topic (created by deploy_step_function.sh) so eval regressions
-# land in the same operator inbox as pipeline failures.
+# Notification target: reuses the alpha-engine-alerts SNS topic
+# created by deploy_step_function.sh so eval regressions land in the
+# same operator inbox as pipeline failures.
 #
 # Usage: ./infrastructure/setup_eval_quality_alarm.sh
 
@@ -26,14 +29,14 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region 
 SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
 ALARM_NAME="alpha-engine-eval-quality-regression"
 NAMESPACE="AlphaEngine/Eval"
-DERIVED_METRIC="agent_quality_score_4w_mean"
+FLOOR_METRIC="agent_quality_score_4w_mean_min"
 THRESHOLD="3.0"
 
 echo "Configuring CloudWatch alarm: $ALARM_NAME"
 echo "  Region:       $REGION"
 echo "  SNS topic:    $SNS_TOPIC_ARN"
-echo "  Threshold:    < $THRESHOLD (rolling 4-week mean)"
-echo "  Source:       $NAMESPACE / $DERIVED_METRIC"
+echo "  Threshold:    < $THRESHOLD (rolling 4-week-mean floor)"
+echo "  Source:       $NAMESPACE / $FLOOR_METRIC"
 
 # Verify the SNS topic exists — fail fast rather than create an alarm
 # with a broken target.
@@ -44,32 +47,22 @@ if ! aws sns get-topic-attributes \
   exit 1
 fi
 
-# CloudWatch put-metric-alarm with metric math: SEARCH expression
-# scans all streams under the namespace + metric name, then MIN()
-# reduces them to a single time series the threshold compares against.
+# Simple metric alarm against the dimensionless floor — no SEARCH,
+# no metric math. Period 86400 (24h) with EvaluationPeriods=1 means
+# the alarm checks the most recent 24h window; the rolling-mean
+# Lambda emits weekly so any single emission's value is evaluated.
 aws cloudwatch put-metric-alarm \
   --region "$REGION" \
   --alarm-name "$ALARM_NAME" \
-  --alarm-description "Fires when the MIN rolling-4-week-mean of any agent/criterion/judge combo of $NAMESPACE/$DERIVED_METRIC drops below $THRESHOLD. Surfaces silent regressions in LLM agent output quality before they show up in alpha. Eval is observability per ROADMAP §1635 — alarm names a regression but does not gate any deploy." \
+  --alarm-description "Fires when the floor (MIN across all combos) of $NAMESPACE/$FLOOR_METRIC drops below $THRESHOLD. Surfaces silent regressions in LLM agent output quality before they show up in alpha. The floor is pre-computed by the rolling-mean Lambda — operator clicks the dashboard quality-trend page to identify which (agent, criterion, judge) combo triggered. Eval is observability per ROADMAP §1635 — alarm names a regression but does not gate any deploy." \
   --comparison-operator "LessThanThreshold" \
   --evaluation-periods 1 \
+  --period 86400 \
+  --statistic Minimum \
   --threshold "$THRESHOLD" \
   --treat-missing-data "ignore" \
-  --metrics "[
-    {
-      \"Id\": \"q1\",
-      \"Expression\": \"SEARCH('Namespace=\\\"$NAMESPACE\\\" MetricName=\\\"$DERIVED_METRIC\\\"', 'Average', 86400)\",
-      \"ReturnData\": false,
-      \"Period\": 86400
-    },
-    {
-      \"Id\": \"min_across_combos\",
-      \"Expression\": \"MIN(q1)\",
-      \"Label\": \"min rolling-4w mean across all (agent, criterion, judge) combos\",
-      \"ReturnData\": true,
-      \"Period\": 86400
-    }
-  ]" \
+  --namespace "$NAMESPACE" \
+  --metric-name "$FLOOR_METRIC" \
   --alarm-actions "$SNS_TOPIC_ARN" \
   --ok-actions "$SNS_TOPIC_ARN"
 
@@ -78,4 +71,4 @@ echo "Alarm $ALARM_NAME configured."
 echo ""
 echo "Validation: aws cloudwatch describe-alarms --alarm-names $ALARM_NAME --region $REGION --query 'MetricAlarms[0].StateValue' --output text"
 echo ""
-echo "First firing eligibility: 4 weeks after the eval-judge Lambda starts emitting raw scores. Until then, treat-missing-data=ignore keeps the alarm in INSUFFICIENT_DATA without paging."
+echo "First firing eligibility: 4 weeks after the eval-judge Lambda starts emitting raw scores (the rolling-mean Lambda needs 4 weeks of source data before the floor metric reflects a real 4-week mean). Until then, treat-missing-data=ignore keeps the alarm in INSUFFICIENT_DATA without paging."


### PR DESCRIPTION
## Summary

Caught at deploy — PR 4c's alarm script failed with \`ValidationError: SEARCH is not supported on Metric Alarms\`. CloudWatch dashboards support SEARCH; alarms don't. Switched to a simple metric alarm against the new \`agent_quality_score_4w_mean_min\` floor metric (paired with research PR #96).

\`\`\`
--namespace AlphaEngine/Eval
--metric-name agent_quality_score_4w_mean_min
--statistic Minimum --period 86400 --evaluation-periods 1
--threshold 3.0 --comparison-operator LessThanThreshold
\`\`\`

## Operator workflow unchanged

Alarm fires → operator clicks dashboard quality-trend page to identify which combo triggered. The SEARCH design wouldn't have surfaced per-combo identity in the alarm body anyway.

## Pairs with

[\`alpha-engine-research\` PR #96](https://github.com/cipher813/alpha-engine-research/pull/96) — emits the floor metric this alarm reads.

## Deploy after merge

\`./infrastructure/setup_eval_quality_alarm.sh\` (idempotent, overwrites in place).

## Test plan

- [x] \`bash -n setup_eval_quality_alarm.sh\` syntax-clean.
- [x] \`pytest tests/ -q\` → 433 passed (no test logic affected).
- [ ] After research PR #96 merges + Lambda redeploys + this PR merges + alarm script re-runs: \`aws cloudwatch describe-alarms --alarm-names alpha-engine-eval-quality-regression\` returns \`StateValue: INSUFFICIENT_DATA\` (no firing — first emission ~Sat 5/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)