### PR TITLE
docs(presentation): rewrite README per canonical template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Centralized data collection, storage, and distribution. Owns the price universe 
 - Ingests macro indicators from FRED (rates, VIX, commodities) and computes derived signals (yield-curve slope, VIX term slope, market breadth)
 - Pulls per-ticker alternative data (analyst consensus, EPS revisions, options chains, insider filings, 13F holdings, news sentiment) only for tickers promoted by Research — keeps API spend bounded
 - Computes the engineered feature store (~50 features × ~900 tickers) used by the Predictor for both training and inference
+- Runs the RAG ingestion step: SEC 10-K/10-Q/8-K filings, earnings transcripts, and thesis history embedded into the pgvector knowledge base that Research's qual-analyst agents query via tool calls
 - Runs OHLC validation, zero-price detection, extreme-return filtering, and trading-day-gap detection on every refresh; anomalies surface in completion emails
 
 ## Phase 2 measurement contribution
@@ -38,6 +39,13 @@ External APIs
        │    macro                 FRED + commodities + market breadth
        │    universe_returns      polygon.io grouped-daily → research.db
        │    feature_store         ~50 features × ~900 tickers
+       │
+       ├─ RAG ingestion (between Phase 1 and Research, EC2 SSM) ──────
+       │    SEC 10-K/10-Q/8-K     section extraction + chunking
+       │    earnings transcripts  FMP API
+       │    thesis history        self-ingestion from research.db
+       │                          → Voyage voyage-3-lite embeddings (512d)
+       │                          → Neon pgvector (HNSW index)
        │
        ├─ Phase 2 (post-research, weekly Sat — Lambda) ───────────────
        │    alternative_data      analyst · revisions · options · insider · 13F · news
@@ -76,6 +84,7 @@ python weekly_collector.py --phase 1 --dry-run
 | [`collectors/macro.py`](collectors/macro.py) | FRED + commodities + market breadth |
 | [`collectors/universe_returns.py`](collectors/universe_returns.py) | Full-population forward returns via polygon.io grouped-daily |
 | [`feature_store/compute.py`](feature_store/compute.py) | Engineered feature store builder |
+| [`rag/pipelines/`](rag/pipelines/) | RAG ingestion pipelines — SEC filings, earnings transcripts, theses |
 | [`validators/price_validator.py`](validators/price_validator.py) | 6-check data quality gates |
 
 ## How it runs
@@ -83,6 +92,7 @@ python weekly_collector.py --phase 1 --dry-run
 | Pipeline | When | Where | Trigger |
 |---|---|---|---|
 | Phase 1 | Sat 00:00 UTC | EC2 SSM (always-on micro instance) | Saturday Step Function |
+| RAG ingestion | Sat after Phase 1 | EC2 SSM | Saturday Step Function |
 | Phase 2 | Sat after Research | Lambda | Saturday Step Function |
 | Daily EOD | Mon-Fri ~1:05 PM PT | EC2 SSM (ae-trading) | EOD Step Function |
 | Health monitoring | Every 6 hours | Cron on micro instance | SNS alerts on stale data |
@@ -114,6 +124,7 @@ Environment variables:
 | `market_data/weekly/{date}/` | Constituents, macro, alternative data | Weekly |
 | `health/data_phase1.json` | Phase 1 completion marker | Weekly |
 | `research.db` (`universe_returns` table) | Forward returns for all tickers | Weekly |
+| Neon pgvector (`rag.documents`, `rag.chunks`) | RAG corpus — SEC filings, transcripts, theses with HNSW index | Weekly |
 
 ### Reads
 | Path | Content |

--- a/README.md
+++ b/README.md
@@ -1,174 +1,142 @@
 # alpha-engine-data
 
-[![Python](https://img.shields.io/badge/python-3.13+-blue.svg)]()
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-56_passing-brightgreen.svg)]()
+> Part of [**Nous Ergon**](https://nousergon.ai) — Autonomous Multi-Agent Trading System. Repo and S3 names use the underlying project name `alpha-engine`.
 
-> Centralized data collection, storage, and distribution for the Alpha Engine system. Owns price data (ArcticDB), macro indicators, universe returns, and alternative data fetchers. Runs as the first step in both Saturday and daily Step Function pipelines.
+[![Part of Nous Ergon](https://img.shields.io/badge/Part_of-Nous_Ergon-1a73e8?style=flat-square)](https://nousergon.ai)
+[![Python](https://img.shields.io/badge/python-3.13+-blue?style=flat-square)](https://www.python.org/)
+[![ArcticDB](https://img.shields.io/badge/ArcticDB-0e1117?style=flat-square)](https://docs.arcticdb.io/)
+[![Polygon.io](https://img.shields.io/badge/Polygon.io-1a73e8?style=flat-square)](https://polygon.io/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
+[![Phase 2 · Reliability](https://img.shields.io/badge/Phase_2-Reliability-e9c46a?style=flat-square)](https://github.com/cipher813/alpha-engine-docs#phase-trajectory)
 
-**Part of the [Nous Ergon](https://nousergon.ai) autonomous trading system.**
-See the [system overview](https://github.com/cipher813/alpha-engine#readme) for how all modules connect.
+Centralized data collection, storage, and distribution. Owns the price universe (ArcticDB), macro indicators, universe returns, the engineered feature store, and per-ticker alternative data. Runs as the first step of the weekly pipeline and the daily EOD pipeline.
 
-## Table of Contents
+> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs).
 
-- [Architecture](#architecture)
-- [Quick Start](#quick-start)
-- [How It Works](#how-it-works)
-- [Configuration](#configuration)
-- [Key Files](#key-files)
-- [Deployment](#deployment)
-- [Testing](#testing)
-- [S3 Contract](#s3-contract)
-- [Related Modules](#related-modules)
+## What this does
+
+- Maintains a 10-year ArcticDB price universe across ~900 S&P 500+400 tickers, refreshed weekly with daily EOD appends
+- Ingests macro indicators from FRED (rates, VIX, commodities) and computes derived signals (yield-curve slope, VIX term slope, market breadth)
+- Pulls per-ticker alternative data (analyst consensus, EPS revisions, options chains, insider filings, 13F holdings, news sentiment) only for tickers promoted by Research — keeps API spend bounded
+- Computes the engineered feature store (~50 features × ~900 tickers) used by the Predictor for both training and inference
+- Runs OHLC validation, zero-price detection, extreme-return filtering, and trading-day-gap detection on every refresh; anomalies surface in completion emails
+
+## Phase 2 measurement contribution
+
+Data is the substrate everything else measures against. Phase 2 contribution: feature coverage, freshness tracking, and per-feature drift detection that downstream modules can rely on. Every signal, prediction, and trade traces back to inputs that have been validated, freshness-checked, and tagged with quality flags. If the substrate is wrong, every metric above it is wrong.
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  WEEKLY (Saturday, Step Function)                                │
-│                                                                  │
-│  Phase 1 (EC2 SSM, 15-25 min)                                  │
-│    Constituents ──── S&P 500+400 tickers + GICS sectors         │
-│    Prices ──── 10y OHLCV → ArcticDB universe library            │
-│    Slim Cache ──── 2y slices → ArcticDB universe_slim           │
-│    Macro ──── FRED + commodities + market breadth               │
-│    Universe Returns ──── polygon.io grouped-daily → research.db │
-│    Feature Store ──── 54 features for 903 tickers (~20s)        │
-│                                                                  │
-│  Phase 2 (Lambda, after Research)                               │
-│    Alternative Data ──── analyst consensus, EPS revisions,      │
-│      options chains, insider filings, 13F, news sentiment       │
-│      (FMP, yfinance, SEC EDGAR — only for ~30 promoted tickers) │
-└─────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────┐
-│  DAILY (Mon-Fri, Step Function)                                  │
-│                                                                  │
-│  DailyData (EC2 SSM)                                            │
-│    daily_closes/{date}.parquet ──── OHLCV for all tickers       │
-│    Macro refresh ──── yields, VIX, commodities                  │
-│  FeatureStoreCompute (EC2 SSM)                                  │
-│    Pre-compute 54 features for inference                        │
-└─────────────────────────────────────────────────────────────────┘
+External APIs
+  polygon.io · FRED · Wikipedia · FMP · SEC EDGAR · yfinance
+       │
+       ├─ Phase 1 (pre-research, weekly Sat — EC2 SSM) ───────────────
+       │    constituents          S&P 500+400 tickers + GICS sectors
+       │    prices                10y OHLCV → ArcticDB universe
+       │    slim_cache            2y slices → ArcticDB universe_slim
+       │    macro                 FRED + commodities + market breadth
+       │    universe_returns      polygon.io grouped-daily → research.db
+       │    feature_store         ~50 features × ~900 tickers
+       │
+       ├─ Phase 2 (post-research, weekly Sat — Lambda) ───────────────
+       │    alternative_data      analyst · revisions · options · insider · 13F · news
+       │                          (only for tickers promoted by Research)
+       │
+       └─ EOD (Mon-Fri post-close — EC2 SSM) ─────────────────────────
+            daily_closes          EOD OHLCV → ArcticDB universe
+            macro refresh         yields, VIX, commodities
 ```
 
-**Design rationale:** With 6 modules consuming overlapping data, centralizing collection reduces API costs, eliminates rate-limiting issues, and ensures all modules operate on identical data snapshots.
+**Quality gates run automatically after each refresh:** OHLC ordering, zero-price detection, extreme returns (>50% daily moves), zero-volume detection, volume-spike detection, trading-day gap detection. Anomalies surface in per-step completion emails.
 
-## Quick Start
+**Design rationale:** centralizing data collection (vs. each module fetching its own) removes redundant API calls, eliminates rate-limiting risk, and ensures every consumer operates on identical snapshots. The ArcticDB substrate replaces an earlier per-ticker Parquet sprawl that was fragmenting cache reads and slowing inference.
 
-### Prerequisites
-
-- Python 3.13+
-- AWS credentials with S3 read/write
-- API keys: FRED, Polygon.io, FMP, SEC EDGAR identity
-
-### Setup
+## Quick start
 
 ```bash
 git clone https://github.com/cipher813/alpha-engine-data.git
 cd alpha-engine-data
-python -m venv .venv
-source .venv/bin/activate
+python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 
 cp config.yaml.example config.yaml
-# Edit config.yaml — set S3 bucket, API keys
+# Edit: S3 bucket, API keys (FRED, Polygon, FMP, EDGAR identity)
 
 python weekly_collector.py --phase 1 --dry-run
 ```
 
-## How It Works
+## Key files
 
-### Price Data (ArcticDB)
+| File | What it does |
+|---|---|
+| [`weekly_collector.py`](weekly_collector.py) | CLI entry point — `--phase 1` / `--phase 2` / `--only <component>` |
+| [`polygon_client.py`](polygon_client.py) | Rate-limited polygon.io client (universe returns) |
+| [`collectors/prices.py`](collectors/prices.py) | 10y OHLCV refresh into ArcticDB universe |
+| [`collectors/macro.py`](collectors/macro.py) | FRED + commodities + market breadth |
+| [`collectors/universe_returns.py`](collectors/universe_returns.py) | Full-population forward returns via polygon.io grouped-daily |
+| [`feature_store/compute.py`](feature_store/compute.py) | Engineered feature store builder |
+| [`validators/price_validator.py`](validators/price_validator.py) | 6-check data quality gates |
 
-As of 2026-04-07, all price data is stored in ArcticDB (backed by S3), replacing fragmented per-ticker Parquet files. ArcticDB provides versioned time-series storage with deduplication and efficient range queries.
+## How it runs
 
-| Library | S3 Prefix | History | Refresh | Consumers |
-|---------|-----------|---------|---------|-----------|
-| `universe` | `arcticdb/universe/` | 10 years | Weekly (Phase 1) | Predictor training, Backtester |
-| `universe_slim` | `arcticdb/universe_slim/` | 2 years | Weekly (post-training) | Predictor inference, Executor (ATR) |
+| Pipeline | When | Where | Trigger |
+|---|---|---|---|
+| Phase 1 | Sat 00:00 UTC | EC2 SSM (always-on micro instance) | Saturday Step Function |
+| Phase 2 | Sat after Research | Lambda | Saturday Step Function |
+| Daily EOD | Mon-Fri ~1:05 PM PT | EC2 SSM (ae-trading) | EOD Step Function |
+| Health monitoring | Every 6 hours | Cron on micro instance | SNS alerts on stale data |
 
-909 tickers backfilled and validated. Legacy Parquet paths still written during Phase 7 transition (target deprecation ~2026-04-21).
-
-### Data Quality Gates
-
-Price validation runs automatically after each refresh:
-- OHLC relationship checks (open/high/low/close ordering)
-- Zero price detection
-- Extreme return filtering (>50% daily moves)
-- Zero volume detection
-- Volume spike detection
-- Trading day gap detection
-
-Anomalies are surfaced in per-step completion emails.
+Deploy: `git push origin main && ae-dashboard "cd ~/alpha-engine-data && git pull"`.
 
 ## Configuration
 
-`config.yaml` is gitignored. Copy `config.yaml.example` and set:
-- S3 bucket name
-- API keys (FRED, Polygon, FMP, EDGAR)
-- Email settings for completion notifications
+`config.yaml` is gitignored. Real values live in the private [`alpha-engine-config`](https://github.com/cipher813/alpha-engine-config) repo (proprietary thresholds + bucket names). Local development copies `config.yaml.example`.
 
-Modules search `alpha-engine-config` (private repo) first, fall back to local config.
+Environment variables:
 
-## Key Files
+| Variable | Used by |
+|---|---|
+| `FRED_API_KEY` | Phase 1 macro |
+| `POLYGON_API_KEY` | Phase 1 universe returns + EOD prices |
+| `FMP_API_KEY` | Phase 2 analyst + revisions |
+| `EDGAR_IDENTITY` | Phase 2 SEC EDGAR User-Agent |
 
-```
-weekly_collector.py            # CLI entry point (--phase 1 / --phase 2)
-polygon_client.py              # Rate-limited polygon.io client
-collectors/constituents.py     # S&P 500+400 tickers + GICS sectors
-collectors/prices.py           # 10y OHLCV → ArcticDB + legacy Parquet
-collectors/slim_cache.py       # 2y slice writer
-collectors/macro.py            # FRED + commodities + breadth
-collectors/universe_returns.py # Full-population forward returns
-collectors/alternative.py      # Per-ticker alternative data (Phase 2)
-feature_store/compute.py       # 54 features for 903 tickers
-validators/price_validator.py  # 6-check data quality gates
-trading_calendar.py            # NYSE holiday detection (through 2030)
-emailer.py                     # Per-step completion emails
-health_checker.py              # 6-hourly freshness monitoring + SNS
-```
+## S3 contract
 
-## Deployment
+### Writes
+| Path | Content | Cadence |
+|---|---|---|
+| `arcticdb/universe/` | 10y OHLCV for ~900 tickers | Weekly |
+| `arcticdb/universe_slim/` | 2y OHLCV slices | Weekly |
+| `staging/daily_closes/{date}.parquet` | Daily OHLCV staging (7-day lifecycle) — canonical home is ArcticDB universe | Daily |
+| `predictor/feature_store/{date}/` | ~50 features × ~900 tickers | Weekly + Daily |
+| `market_data/weekly/{date}/` | Constituents, macro, alternative data | Weekly |
+| `health/data_phase1.json` | Phase 1 completion marker | Weekly |
+| `research.db` (`universe_returns` table) | Forward returns for all tickers | Weekly |
 
-- **Orchestrated by Step Functions** — Saturday pipeline (Phase 1 + 2) and daily pipeline (DailyData + FeatureStore)
-- **EC2 micro instance** (always-on): Phase 1 runs via SSM RunCommand
-- **Lambda**: Phase 2 runs as Lambda function
-- **Deploy**: `git push origin main && ae-dashboard "cd ~/alpha-engine-data && git pull"`
-- **Health monitoring**: 6-hourly cron on micro instance → SNS alerts on stale/missing data
+### Reads
+| Path | Content |
+|---|---|
+| `signals/{date}/signals.json` | Promoted tickers for Phase 2 alternative-data scope |
 
 ## Testing
 
 ```bash
-pytest tests/ -v  # 56 tests
+pytest tests/ -v
 ```
 
-## S3 Contract
+## Sister repos
 
-### Writes
-| Path | Content | Frequency |
-|------|---------|-----------|
-| `arcticdb/universe/` | 10y OHLCV for 909 tickers | Weekly |
-| `arcticdb/universe_slim/` | 2y OHLCV slices | Weekly |
-| `staging/daily_closes/{date}.parquet` | Daily OHLCV — intermediate staging (7-day lifecycle); canonical home is ArcticDB universe | Daily |
-| `predictor/feature_store/{date}/` | 54 features x 903 tickers | Weekly + Daily |
-| `market_data/weekly/{date}/` | Constituents, macro, alternative data | Weekly |
-| `health/data_phase1.json` | Phase 1 completion marker | Weekly |
-| `research.db` (universe_returns table) | Forward returns for all tickers | Weekly |
-
-### Reads
-| Path | Content |
-|------|---------|
-| `signals/{date}/signals.json` | Promoted tickers for Phase 2 alternative data |
-
-## Related Modules
-
-- [`alpha-engine`](https://github.com/cipher813/alpha-engine) — Executor + system overview
-- [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) — Autonomous LLM research pipeline
-- [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) — Meta-model predictor
-- [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) — Evaluation framework and parameter optimization
-- [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) — Streamlit monitoring dashboard
-- [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) — Documentation index and system audits
+| Module | Repo |
+|---|---|
+| Executor | [`alpha-engine`](https://github.com/cipher813/alpha-engine) |
+| Research | [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) |
+| Predictor | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) |
+| Backtester | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) |
+| Dashboard | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) |
+| Library | [`alpha-engine-lib`](https://github.com/cipher813/alpha-engine-lib) |
+| Docs | [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) |
 
 ## License
 


### PR DESCRIPTION
## Summary

Phase 1 Day 3 of the presentation revamp arc. `alpha-engine-data` is the prototype per-module README — the other 5 modules will follow this shape.

## What changed

**Applied:**
- Brand banner — canonical wording sourced from [`alpha-engine-docs/branding/brand_banner.md`](https://github.com/cipher813/alpha-engine-docs/blob/main/branding/brand_banner.md)
- 6 badges per the standard bar (brand · python · ArcticDB · polygon · MIT · Phase 2)
- Pointer to `alpha-engine-docs` as the system-overview home
- New "Phase 2 measurement contribution" section — names this module's specific role in the measurement substrate (*data is the substrate everything else measures against*)
- Module-internal architecture diagram (external APIs → Phase 1 / Phase 2 / EOD flows + storage targets) — drops the prior diagram's full-Step-Function rendering
- Three-pipeline accuracy: Phase 1 (Sat EC2 SSM) + Phase 2 (Sat Lambda) + EOD (Mon-Fri `ae-trading`) — matches the corrected SF topology in `alpha-engine-docs`
- Sister-repos table is links-only (no role descriptions duplicated — those live in `alpha-engine-docs`); now includes `alpha-engine-lib` (recently flipped public)

**Zones-of-responsibility discipline applied** (from the canonical template at `alpha-engine-docs/templates/README_TEMPLATE.md`). This README does NOT duplicate:
- The full system architecture diagram (lives in docs)
- The all-6-modules table with role descriptions
- The Phase trajectory (Phase 2 badge handles it)
- The Step Function pipeline flowcharts
- The autonomous feedback loop

Each fact appears in one canonical home only.

## Net diff

220 lines → 143 lines (−77 lines, removing duplicated system-level content while adding module-specific clarity).

## Test plan

- [ ] All badges render
- [ ] Brand banner matches canonical wording
- [ ] All 7 sister-repo links resolve (incl. lib)
- [ ] No remaining "GBM retrain" or stale predictor framing
- [ ] Architecture diagram renders cleanly on GitHub
- [ ] Cross-check that no system-level content is duplicated from `alpha-engine-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)