### PR TITLE
fix(presentation): trim README + add OVERVIEW.md code index

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,0 +1,79 @@
+# alpha-engine-data — Code Index
+
+> Index of entry points, key files, and data contracts. Companion to [README.md](README.md). System overview lives in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs).
+
+## Module purpose
+
+Centralized data collection — price universe, macro, alternative data, features, RAG ingestion — for the Alpha Engine system.
+
+## Entry points
+
+| File | What it does |
+|---|---|
+| [`weekly_collector.py`](weekly_collector.py) | CLI for Phase 1 + Phase 2 — `--phase 1 / --phase 2 / --only <component>` |
+| [`collectors/daily_closes.py`](collectors/daily_closes.py) | EOD weekday OHLCV capture for all tickers |
+| [`rag/preflight.py`](rag/preflight.py) | RAG ingestion preflight — env vars, DB connectivity, freshness |
+| [`rag/pipelines/run_weekly_ingestion.sh`](rag/pipelines/run_weekly_ingestion.sh) | Top-level shell driver for the RAG ingest pipelines |
+
+## Where things live
+
+| Concept | File |
+|---|---|
+| polygon.io rate-limited client | [`polygon_client.py`](polygon_client.py) |
+| S&P constituents + GICS sectors | [`collectors/constituents.py`](collectors/constituents.py) |
+| 10y OHLCV → ArcticDB | [`collectors/prices.py`](collectors/prices.py) |
+| 2y slim cache (inference) | [`collectors/slim_cache.py`](collectors/slim_cache.py) |
+| FRED macro + market breadth | [`collectors/macro.py`](collectors/macro.py) |
+| Forward returns (full population) | [`collectors/universe_returns.py`](collectors/universe_returns.py) |
+| Per-ticker alternative data (Phase 2) | [`collectors/alternative.py`](collectors/alternative.py) |
+| Short interest (FINRA, bi-monthly) | [`collectors/short_interest.py`](collectors/short_interest.py) |
+| Fundamentals | [`collectors/fundamentals.py`](collectors/fundamentals.py) |
+| Signal-returns collector | [`collectors/signal_returns.py`](collectors/signal_returns.py) |
+| Engineered feature store | [`features/feature_engineer.py`](features/feature_engineer.py) |
+| Feature registry | [`features/registry.py`](features/registry.py) |
+| Feature reader / writer | [`features/reader.py`](features/reader.py), [`features/writer.py`](features/writer.py) |
+| Daily-append builder (ArcticDB) | [`builders/daily_append.py`](builders/daily_append.py) |
+| Backfill builder | [`builders/backfill.py`](builders/backfill.py) |
+| Delisted-ticker pruner | [`builders/prune_delisted_tickers.py`](builders/prune_delisted_tickers.py) |
+| Price quality validator | [`validators/price_validator.py`](validators/price_validator.py) |
+| Postflight validator | [`validators/postflight.py`](validators/postflight.py) |
+| RAG ingestion pipelines | [`rag/pipelines/`](rag/pipelines/) |
+| Per-step completion emails | [`emailer.py`](emailer.py) |
+| Step Function preflight | [`sf_preflight.py`](sf_preflight.py) |
+| SSM secret loader | [`ssm_secrets.py`](ssm_secrets.py) |
+
+## Inputs / outputs
+
+### Reads
+| Source | Path |
+|---|---|
+| Promoted tickers for Phase 2 scope | `s3://alpha-engine-research/signals/{date}/signals.json` |
+
+### Writes
+| Destination | Path |
+|---|---|
+| 10y OHLCV universe | `s3://alpha-engine-research/arcticdb/universe/` |
+| 2y inference slim cache | `s3://alpha-engine-research/arcticdb/universe_slim/` |
+| Daily OHLCV staging (7-day lifecycle) | `s3://alpha-engine-research/staging/daily_closes/{date}.parquet` |
+| Engineered features | `s3://alpha-engine-research/predictor/feature_store/{date}/` |
+| Weekly market data bundle | `s3://alpha-engine-research/market_data/weekly/{date}/` |
+| Phase 1 completion marker | `s3://alpha-engine-research/health/data_phase1.json` |
+| Universe returns table | `s3://alpha-engine-research/research.db` (`universe_returns`) |
+| RAG corpus | Neon pgvector — `rag.documents`, `rag.chunks` (HNSW) |
+
+## Run modes
+
+| Mode | Where | Command |
+|---|---|---|
+| Production Phase 1 | EC2 SSM (always-on micro) | Saturday Step Function |
+| Production Phase 2 | Lambda | Saturday Step Function |
+| Production EOD | EC2 SSM (`ae-trading`) | EOD Step Function |
+| Production RAG ingest | EC2 SSM | Saturday Step Function |
+| Local dry run | venv | `python weekly_collector.py --phase 1 --dry-run` |
+| Single component | venv | `python weekly_collector.py --phase 1 --only macro` |
+
+Deploy: `git push origin main && ae-dashboard "cd ~/alpha-engine-data && git pull"`. Health monitoring runs 6-hourly on the micro instance with SNS alerts on stale data.
+
+## Tests
+
+`pytest tests/` covers collectors, validators, ArcticDB roundtrips, daily-append backfill safety, RAG preflight, and Step Function preflight. No integration tests against live APIs in CI — those run manually pre-deploy.

--- a/README.md
+++ b/README.md
@@ -9,133 +9,47 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
 [![Phase 2 · Reliability](https://img.shields.io/badge/Phase_2-Reliability-e9c46a?style=flat-square)](https://github.com/cipher813/alpha-engine-docs#phase-trajectory)
 
-Centralized data collection, storage, and distribution. Owns the price universe (ArcticDB), macro indicators, universe returns, the engineered feature store, and per-ticker alternative data. Runs as the first step of the weekly pipeline and the daily EOD pipeline.
+Centralized data collection, storage, and distribution. Owns the price universe (ArcticDB), macro indicators, universe returns, the engineered feature store, the RAG ingestion step, and per-ticker alternative data.
 
-> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs).
+> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs). Code index lives in [`OVERVIEW.md`](OVERVIEW.md).
 
 ## What this does
 
 - Maintains a 10-year ArcticDB price universe across ~900 S&P 500+400 tickers, refreshed weekly with daily EOD appends
 - Ingests macro indicators from FRED (rates, VIX, commodities) and computes derived signals (yield-curve slope, VIX term slope, market breadth)
 - Pulls per-ticker alternative data (analyst consensus, EPS revisions, options chains, insider filings, 13F holdings, news sentiment) only for tickers promoted by Research — keeps API spend bounded
-- Computes the engineered feature store (~50 features × ~900 tickers) used by the Predictor for both training and inference
-- Runs the RAG ingestion step: SEC 10-K/10-Q/8-K filings, earnings transcripts, and thesis history embedded into the pgvector knowledge base that Research's qual-analyst agents query via tool calls
-- Runs OHLC validation, zero-price detection, extreme-return filtering, and trading-day-gap detection on every refresh; anomalies surface in completion emails
+- Computes the engineered feature store used by the Predictor for both training and inference
+- Runs the RAG ingestion step: SEC 10-K/10-Q/8-K, earnings transcripts, and thesis history embedded into the pgvector knowledge base that Research's qual-analyst agents query
 
 ## Phase 2 measurement contribution
 
-Data is the substrate everything else measures against. Phase 2 contribution: feature coverage, freshness tracking, and per-feature drift detection that downstream modules can rely on. Every signal, prediction, and trade traces back to inputs that have been validated, freshness-checked, and tagged with quality flags. If the substrate is wrong, every metric above it is wrong.
+Data is the substrate everything else measures against. Phase 2 contribution: feature coverage, freshness tracking, and per-feature drift detection that downstream modules can rely on. Every signal, prediction, and trade traces back to inputs that have been validated, freshness-checked, and tagged with quality flags.
 
 ## Architecture
 
-```
-External APIs
-  polygon.io · FRED · Wikipedia · FMP · SEC EDGAR · yfinance
-       │
-       ├─ Phase 1 (pre-research, weekly Sat — EC2 SSM) ───────────────
-       │    constituents          S&P 500+400 tickers + GICS sectors
-       │    prices                10y OHLCV → ArcticDB universe
-       │    slim_cache            2y slices → ArcticDB universe_slim
-       │    macro                 FRED + commodities + market breadth
-       │    universe_returns      polygon.io grouped-daily → research.db
-       │    feature_store         ~50 features × ~900 tickers
-       │
-       ├─ RAG ingestion (between Phase 1 and Research, EC2 SSM) ──────
-       │    SEC 10-K/10-Q/8-K     section extraction + chunking
-       │    earnings transcripts  FMP API
-       │    thesis history        self-ingestion from research.db
-       │                          → Voyage voyage-3-lite embeddings (512d)
-       │                          → Neon pgvector (HNSW index)
-       │
-       ├─ Phase 2 (post-research, weekly Sat — Lambda) ───────────────
-       │    alternative_data      analyst · revisions · options · insider · 13F · news
-       │                          (only for tickers promoted by Research)
-       │
-       └─ EOD (Mon-Fri post-close — EC2 SSM) ─────────────────────────
-            daily_closes          EOD OHLCV → ArcticDB universe
-            macro refresh         yields, VIX, commodities
+```mermaid
+flowchart LR
+    APIs[External APIs<br/>polygon · FRED · FMP · SEC EDGAR · yfinance · Wikipedia] --> P1
+    APIs --> RAG
+    APIs --> P2
+    APIs --> EOD
+
+    P1[Phase 1 · Sat<br/>prices · macro · constituents · features]
+    RAG[RAG ingestion · Sat<br/>filings · transcripts · theses]
+    P2[Phase 2 · Sat<br/>alt data — promoted tickers only]
+    EOD[EOD · weekday<br/>daily closes · macro refresh]
+
+    P1 --> Arctic[(ArcticDB universe<br/>+ universe_slim)]
+    EOD --> Arctic
+    RAG --> Vector[(Neon pgvector)]
+    P2 --> S3stage[(S3 staging)]
 ```
 
-**Quality gates run automatically after each refresh:** OHLC ordering, zero-price detection, extreme returns (>50% daily moves), zero-volume detection, volume-spike detection, trading-day gap detection. Anomalies surface in per-step completion emails.
-
-**Design rationale:** centralizing data collection (vs. each module fetching its own) removes redundant API calls, eliminates rate-limiting risk, and ensures every consumer operates on identical snapshots. The ArcticDB substrate replaces an earlier per-ticker Parquet sprawl that was fragmenting cache reads and slowing inference.
-
-## Quick start
-
-```bash
-git clone https://github.com/cipher813/alpha-engine-data.git
-cd alpha-engine-data
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-
-cp config.yaml.example config.yaml
-# Edit: S3 bucket, API keys (FRED, Polygon, FMP, EDGAR identity)
-
-python weekly_collector.py --phase 1 --dry-run
-```
-
-## Key files
-
-| File | What it does |
-|---|---|
-| [`weekly_collector.py`](weekly_collector.py) | CLI entry point — `--phase 1` / `--phase 2` / `--only <component>` |
-| [`polygon_client.py`](polygon_client.py) | Rate-limited polygon.io client (universe returns) |
-| [`collectors/prices.py`](collectors/prices.py) | 10y OHLCV refresh into ArcticDB universe |
-| [`collectors/macro.py`](collectors/macro.py) | FRED + commodities + market breadth |
-| [`collectors/universe_returns.py`](collectors/universe_returns.py) | Full-population forward returns via polygon.io grouped-daily |
-| [`feature_store/compute.py`](feature_store/compute.py) | Engineered feature store builder |
-| [`rag/pipelines/`](rag/pipelines/) | RAG ingestion pipelines — SEC filings, earnings transcripts, theses |
-| [`validators/price_validator.py`](validators/price_validator.py) | 6-check data quality gates |
-
-## How it runs
-
-| Pipeline | When | Where | Trigger |
-|---|---|---|---|
-| Phase 1 | Sat 00:00 UTC | EC2 SSM (always-on micro instance) | Saturday Step Function |
-| RAG ingestion | Sat after Phase 1 | EC2 SSM | Saturday Step Function |
-| Phase 2 | Sat after Research | Lambda | Saturday Step Function |
-| Daily EOD | Mon-Fri ~1:05 PM PT | EC2 SSM (ae-trading) | EOD Step Function |
-| Health monitoring | Every 6 hours | Cron on micro instance | SNS alerts on stale data |
-
-Deploy: `git push origin main && ae-dashboard "cd ~/alpha-engine-data && git pull"`.
+Quality gates run automatically after each refresh: OHLC ordering, zero-price, extreme returns, zero-volume, volume-spikes, trading-day gaps. Anomalies surface in per-step completion emails.
 
 ## Configuration
 
-`config.yaml` is gitignored. Real values live in the private [`alpha-engine-config`](https://github.com/cipher813/alpha-engine-config) repo (proprietary thresholds + bucket names). Local development copies `config.yaml.example`.
-
-Environment variables:
-
-| Variable | Used by |
-|---|---|
-| `FRED_API_KEY` | Phase 1 macro |
-| `POLYGON_API_KEY` | Phase 1 universe returns + EOD prices |
-| `FMP_API_KEY` | Phase 2 analyst + revisions |
-| `EDGAR_IDENTITY` | Phase 2 SEC EDGAR User-Agent |
-
-## S3 contract
-
-### Writes
-| Path | Content | Cadence |
-|---|---|---|
-| `arcticdb/universe/` | 10y OHLCV for ~900 tickers | Weekly |
-| `arcticdb/universe_slim/` | 2y OHLCV slices | Weekly |
-| `staging/daily_closes/{date}.parquet` | Daily OHLCV staging (7-day lifecycle) — canonical home is ArcticDB universe | Daily |
-| `predictor/feature_store/{date}/` | ~50 features × ~900 tickers | Weekly + Daily |
-| `market_data/weekly/{date}/` | Constituents, macro, alternative data | Weekly |
-| `health/data_phase1.json` | Phase 1 completion marker | Weekly |
-| `research.db` (`universe_returns` table) | Forward returns for all tickers | Weekly |
-| Neon pgvector (`rag.documents`, `rag.chunks`) | RAG corpus — SEC filings, transcripts, theses with HNSW index | Weekly |
-
-### Reads
-| Path | Content |
-|---|---|
-| `signals/{date}/signals.json` | Promoted tickers for Phase 2 alternative-data scope |
-
-## Testing
-
-```bash
-pytest tests/ -v
-```
+This repo is **public**. `config.yaml` is gitignored locally; real values (S3 bucket names, API keys, email recipients) live in the private [`alpha-engine-config`](https://github.com/cipher813/alpha-engine-config) repo. Architecture and approach are public; specific values are private.
 
 ## Sister repos
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #142. Per the canonical-template revisit (alpha-engine-docs PR #20), the locked README target is ~60 lines bird's-eye and detail pushes to a companion OVERVIEW.md code index.

## Changes

**README** (154 → 68 lines): drops Quick start, Key files, How it runs, S3 contract, Testing, env-var enumeration, full ASCII architecture detail, and verbose design-rationale prose. Compresses Configuration to a one-paragraph disclosure boundary. ASCII diagram → 4-flow mermaid (Phase 1 · RAG · Phase 2 · EOD → ArcticDB / pgvector / S3 staging).

**OVERVIEW.md** (new, 79 lines): 7-section index per the locked template — Module purpose · Entry points (4 files) · Where things live (~20 concept→file mappings) · Inputs/outputs (S3 contract) · Run modes (6 rows) · Tests (one paragraph).

## Path correction

Prior README referenced `feature_store/compute.py` — that path doesn't exist (actual: `features/feature_engineer.py`). All file paths in OVERVIEW.md verified against the filesystem before committing.

## Companion

- alpha-engine-docs PR #20 (lean templates) — locked structure
- This is the first prototype OVERVIEW.md; same shape will apply to research / predictor / executor / backtester / dashboard in upcoming PRs

## Test plan

- [ ] All 6 badges render
- [ ] Mermaid architecture diagram renders cleanly on GitHub
- [ ] OVERVIEW.md tables render
- [ ] All file links in OVERVIEW.md resolve
- [ ] No "feature_store/compute.py" or other phantom paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)