### PR TITLE
fix(presentation): refer to weekly SF, drop day-specific scheduling refs

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -65,10 +65,10 @@ Centralized data collection — price universe, macro, alternative data, feature
 
 | Mode | Where | Command |
 |---|---|---|
-| Production Phase 1 | EC2 SSM (always-on micro) | Saturday Step Function |
-| Production Phase 2 | Lambda | Saturday Step Function |
+| Production Phase 1 | EC2 SSM (always-on micro) | weekly Step Function |
+| Production Phase 2 | Lambda | weekly Step Function |
 | Production EOD | EC2 SSM (`ae-trading`) | EOD Step Function |
-| Production RAG ingest | EC2 SSM | Saturday Step Function |
+| Production RAG ingest | EC2 SSM | weekly Step Function |
 | Local dry run | venv | `python weekly_collector.py --phase 1 --dry-run` |
 | Single component | venv | `python weekly_collector.py --phase 1 --only macro` |
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ flowchart LR
     APIs --> P2
     APIs --> EOD
 
-    P1[Phase 1 · Sat<br/>prices · macro · constituents · features]
-    RAG[RAG ingestion · Sat<br/>filings · transcripts · theses]
-    P2[Phase 2 · Sat<br/>alt data — promoted tickers only]
+    P1[Phase 1 · weekly<br/>prices · macro · constituents · features]
+    RAG[RAG ingestion · weekly<br/>filings · transcripts · theses]
+    P2[Phase 2 · weekly<br/>alt data — promoted tickers only]
     EOD[EOD · weekday<br/>daily closes · macro refresh]
 
     P1 --> Arctic[(ArcticDB universe<br/>+ universe_slim)]


### PR DESCRIPTION
## Summary

Per review: presentation surfaces should refer to "the weekly Step Function" rather than tying to a specific day (Saturday). Schedule specifics belong in CLAUDE.md, not user-facing READMEs — keeps the doc resilient if the schedule ever shifts.

## Changes

- README architecture diagram: `Phase 1 · Sat` → `Phase 1 · weekly` (also RAG ingestion + Phase 2 boxes)
- OVERVIEW.md run modes table: `Saturday Step Function` → `weekly Step Function` (3 references)

Same change is being made across the other module repos that landed in PR #144's wake — keeps presentation language consistent across the system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)