### PR TITLE
fix(sf): skip_backtester preserves eval-judge skip-gate path

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -393,14 +393,14 @@
 
     "CheckSkipBacktester": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses the backtester step (which runs backtest + parity + evaluator as consolidated spot stages post-2026-04-24) and jumps directly to the Saturday health check. The legacy {\"skip_evaluator\": true} and {\"freeze_evaluator\": true} inputs are no longer honored; freeze-evaluator is now a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
+      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses the backtester step (which runs backtest + parity + evaluator as consolidated spot stages post-2026-04-24) and jumps to the eval-judge skip-gate (preserving the eval-pipeline states downstream — the bug fixed 2026-05-03 was that this routed directly to SaturdayHealthCheck, silently bypassing CheckSkipEvalJudge → ComputeEvalCadence → eval-judge → eval-rolling-mean for any operator who passed skip_backtester=true). The legacy {\"skip_evaluator\": true} and {\"freeze_evaluator\": true} inputs are no longer honored; freeze-evaluator is now a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_backtester", "IsPresent": true},
             {"Variable": "$.skip_backtester", "BooleanEquals": true}
           ],
-          "Next": "SaturdayHealthCheck"
+          "Next": "CheckSkipEvalJudge"
         }
       ],
       "Default": "Backtester"

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -63,6 +63,28 @@ class TestBacktesterTransition:
 # ── Skip gate ─────────────────────────────────────────────────────────────
 
 
+class TestSkipBacktesterPreservesEvalJudge:
+    """Pins the 2026-05-03 fix: when an operator passes
+    skip_backtester=true (e.g. for SF skip-most validation runs), the
+    skip path must still flow through the eval-judge skip-gate, not
+    leap straight to SaturdayHealthCheck.
+
+    Caught by SF eval-pipeline-validation-5 when Research succeeded
+    + new-format captures landed on S3 but the eval-judge state
+    silently never fired because skip_backtester=true had been
+    short-circuiting past it.
+    """
+
+    def test_skip_backtester_routes_to_eval_skip_gate(self, states):
+        skip = states["CheckSkipBacktester"]
+        choice = skip["Choices"][0]
+        # The skip-true branch must preserve the eval-judge state path.
+        assert choice["Next"] == "CheckSkipEvalJudge"
+        # Critically NOT routed to SaturdayHealthCheck — that was the
+        # silent-bypass bug.
+        assert choice["Next"] != "SaturdayHealthCheck"
+
+
 class TestSkipEvalJudge:
     def test_skip_flag_bypasses_to_health_check(self, states):
         skip = states["CheckSkipEvalJudge"]


### PR DESCRIPTION
## Summary

Caught 2026-05-03 in SF \`eval-pipeline-validation-5\`: Research succeeded and wrote new-format captures to S3, but the eval-judge state silently never fired because the operator had passed \`skip_backtester=true\` to skip the long-running backtester for validation purposes.

\`CheckSkipBacktester.skip\` routed **directly** to \`SaturdayHealthCheck\`, bypassing the eval-pipeline entirely.

## Fix

\`skip_backtester=true\` now routes to \`CheckSkipEvalJudge\` instead of \`SaturdayHealthCheck\`.

## Production Sat 5/9 impact

**None** — \`skip_backtester\` defaults false on scheduled runs.

## Test plan

- [x] \`pytest tests/ -q\` → 434 passed (was 433; +1 \`TestSkipBacktesterPreservesEvalJudge\`).
- [x] Pin asserts \`CheckSkipBacktester.Choices[0].Next == "CheckSkipEvalJudge"\` AND \`!= "SaturdayHealthCheck"\`.

## Pairs with

[\`alpha-engine-research\` PR #104](https://github.com/cipher813/alpha-engine-research/pull/104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)