### PR TITLE
fix(iam): add eval-judge + eval-rolling-mean to github-actions-lambda-deploy

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -42,6 +42,8 @@
       "Resource": [
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check"
@@ -58,6 +60,10 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",

--- a/tests/test_daily_append_skip_if_exists.py
+++ b/tests/test_daily_append_skip_if_exists.py
@@ -145,7 +145,11 @@ def test_skip_if_exists_true_skips_when_today_in_hist(monkeypatch):
     spend, just a microsecond ``today_ts in hist.index`` check."""
     from builders.daily_append import daily_append
 
-    today_str = "2026-04-28"
+    # Use real "now" so the daily_append freshness scan (5d threshold
+    # against datetime.now(timezone.utc)) doesn't trip as the calendar
+    # advances. Hardcoded dates rot — the 2026-05-04 CI breakage
+    # surfaced because "2026-04-28" had aged 6d past the threshold.
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     universe = ["AAPL", "MSFT", "GOOGL"]
     _, _, write_calls = _patch_targets(
         monkeypatch,
@@ -176,7 +180,11 @@ def test_skip_if_exists_true_writes_when_today_missing(monkeypatch):
     silent-skip bug for tickers with genuinely-missing today rows."""
     from builders.daily_append import daily_append
 
-    today_str = "2026-04-28"
+    # Use real "now" so the daily_append freshness scan (5d threshold
+    # against datetime.now(timezone.utc)) doesn't trip as the calendar
+    # advances. Hardcoded dates rot — the 2026-05-04 CI breakage
+    # surfaced because "2026-04-28" had aged 6d past the threshold.
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     universe = ["AAPL", "MSFT"]
     _, _, write_calls = _patch_targets(
         monkeypatch,
@@ -202,7 +210,11 @@ def test_skip_if_exists_false_writes_even_when_today_in_hist(monkeypatch):
     that the 2026-04-18 commit introduced for the polygon-label incident."""
     from builders.daily_append import daily_append
 
-    today_str = "2026-04-28"
+    # Use real "now" so the daily_append freshness scan (5d threshold
+    # against datetime.now(timezone.utc)) doesn't trip as the calendar
+    # advances. Hardcoded dates rot — the 2026-05-04 CI breakage
+    # surfaced because "2026-04-28" had aged 6d past the threshold.
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     universe = ["AAPL", "MSFT"]
     _, _, write_calls = _patch_targets(
         monkeypatch,


### PR DESCRIPTION
## Summary

Adds `alpha-engine-research-eval-judge` and `alpha-engine-research-eval-rolling-mean` to the `github-actions-lambda-deploy` IAM role's `LambdaUpdate` and `LambdaInvokeCanary` Sid resource lists. These two Lambdas were originally created from Brian's local AWS credentials and never folded into the CI deploy role — every CI deploy attempt against them failed AccessDenied.

## Surfaced 2026-05-04

After cipher813/alpha-engine-research#109 merged (canary payload fix) and cipher813/alpha-engine-research#110 was opened (deploy.yml auto-deploy eval-judge after main), the auto-triggered deploy hit:

```
AccessDeniedException ... is not authorized to perform:
lambda:CreateFunction on resource:
alpha-engine-research-eval-judge ... no identity-based policy
allows the lambda:CreateFunction action
```

The actual missing permission is `lambda:UpdateFunctionCode` — `infrastructure/deploy.sh`'s `if aws lambda get-function ... &>/dev/null` test silently swallowed the AccessDenied on `GetFunction` and fell through to the `create-function` else-branch, which also failed AccessDenied. The symptom shifted to `CreateFunction` but the root cause is the missing entry in `LambdaUpdate`.

## Status

- [x] Edited JSON file (this PR)
- [x] Applied to live role pre-PR via `bash infrastructure/iam/apply.sh github-actions-lambda-deploy` and verified via `aws iam get-role-policy` (eval-judge + eval-rolling-mean ARNs now appear in active policy)
- [ ] Merge → cipher813/alpha-engine-research#110 can be re-run cleanly
- [ ] After both #110 + this merge: every alpha-engine-config push that triggers a `config-changed` dispatch will propagate the new image to BOTH research-runner AND eval-judge in one workflow run

## Test plan

- [ ] Re-run cipher813/alpha-engine-research#110 deploy workflow → both Lambdas update in one job
- [ ] Verify research-runner LastModified bumps + eval-judge LastModified bumps from same workflow run
- [ ] No more AccessDenied on `lambda:UpdateFunctionCode` for eval-judge

## Followup (separate PR, lower priority)

`infrastructure/deploy.sh:437`'s `if aws lambda get-function ... &>/dev/null` masks AccessDenied errors as "function doesn't exist," which causes confusing cascade failures. Should split stderr from the existence-check and surface AccessDenied loudly. Tracked separately — not load-bearing once this PR closes the actual permissions gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)