### PR TITLE
fix(sf): poll SSM-agent readiness before SSM SendCommand on weekday SF

### DIFF
--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -71,6 +71,12 @@ POLICY='{
       "Resource": "*"
     },
     {
+      "Sid": "SSMDescribeInstanceInformation",
+      "Effect": "Allow",
+      "Action": ["ssm:DescribeInstanceInformation"],
+      "Resource": "*"
+    },
+    {
       "Sid": "EC2StartStop",
       "Effect": "Allow",
       "Action": ["ec2:StartInstances", "ec2:StopInstances"],

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -324,9 +324,90 @@
 
     "WaitForInstanceReady": {
       "Type": "Wait",
-      "Comment": "Wait for SSM agent to register (~30s typical). IB Gateway authenticates in the background; wait-for-ibgateway.sh handles it before RunMorningPlanner.",
-      "Seconds": 60,
-      "Next": "CheckTradingDay"
+      "Comment": "Initial settle before polling for SSM-agent registration. EC2 stopped→running takes ~15-25s; polling describeInstanceInformation any earlier just burns API calls.",
+      "Seconds": 15,
+      "Next": "InitSSMPollCounter"
+    },
+
+    "InitSSMPollCounter": {
+      "Type": "Pass",
+      "Comment": "Initialize attempts counter for the SSM-readiness poll loop.",
+      "Result": {"attempts": 0},
+      "ResultPath": "$.ssm_poll",
+      "Next": "DescribeInstanceInfo"
+    },
+
+    "DescribeInstanceInfo": {
+      "Type": "Task",
+      "Comment": "Poll SSM-agent registration on the trading instance. Replaces the prior fixed Wait 60s, which was insufficient on cold-boot t3.small (race observed 2026-05-05 morning — Ssm.InvalidInstanceIdException at CheckTradingDay because PingStatus had not yet flipped to Online when the SSM SendCommand fired). SSMReadyChoice routes to CheckTradingDay when PingStatus=Online or HandleFailure when the bounded retry budget (~3 min) is exhausted.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:describeInstanceInformation",
+      "Parameters": {
+        "Filters": [
+          {
+            "Key": "InstanceIds",
+            "Values.$": "$.trading_instance_id"
+          }
+        ]
+      },
+      "TimeoutSeconds": 15,
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.SdkClientException", "States.Timeout"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.ssm_describe_result",
+      "Next": "SSMReadyChoice"
+    },
+
+    "SSMReadyChoice": {
+      "Type": "Choice",
+      "Comment": "PingStatus=Online → CheckTradingDay. Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail when budget exhausted (per feedback_no_silent_fails — agent not registering after 3 min indicates a real boot problem, not just timing).",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus",
+              "StringEquals": "Online"
+            }
+          ],
+          "Next": "CheckTradingDay"
+        },
+        {
+          "Variable": "$.ssm_poll.attempts",
+          "NumericGreaterThanEquals": 12,
+          "Next": "HandleFailure"
+        }
+      ],
+      "Default": "WaitSSMPoll"
+    },
+
+    "WaitSSMPoll": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "IncrementSSMPoll"
+    },
+
+    "IncrementSSMPoll": {
+      "Type": "Pass",
+      "Parameters": {
+        "attempts.$": "States.MathAdd($.ssm_poll.attempts, 1)"
+      },
+      "ResultPath": "$.ssm_poll",
+      "Next": "DescribeInstanceInfo"
     },
 
     "PredictorInference": {


### PR DESCRIPTION
## Summary

Replace the fixed `WaitForInstanceReady: 60s` between `StartExecutorEC2` and `CheckTradingDay` with a bounded polling loop on `ssm:DescribeInstanceInformation`. Closes the SSM-agent-readiness race that took down the 2026-05-05 morning weekday pipeline.

**Race observed:** StartInstances flipped `i-018eb3307a21329bf` `stopped`→`pending`; the 60s wait elapsed; `CheckTradingDay`'s SSM SendCommand fired and got `Ssm.InvalidInstanceIdException` ("Instances not in a valid state for account"). `TradingDayCheckFailed` alert fired, `MorningEnrich` (next SSM step) hit the same race ~5s later → `HandleFailure`.

## New state graph (replaces single 60s Wait)

```
StartExecutorEC2
  → WaitForInstanceReady (15s settle — EC2 stopped→running takes ~15-25s)
  → InitSSMPollCounter (attempts=0)
  → DescribeInstanceInfo (aws-sdk:ssm:describeInstanceInformation)
  → SSMReadyChoice
       ├─ PingStatus=Online              → CheckTradingDay
       ├─ attempts >= 12 (~3 min budget) → HandleFailure
       └─ else                           → WaitSSMPoll (15s) → IncrementSSMPoll → DescribeInstanceInfo
```

Total budget ~3 min (15s settle + 12×15s polls). Fast-exits when agent registers (typical 30-90s on cold-boot t3.small). Hard-fail on budget exhaustion per `feedback_no_silent_fails` — agent not registering after 3 min indicates a real boot problem, not just timing.

## IAM

Adds `ssm:DescribeInstanceInformation` to the inline policy `deploy_step_function_daily.sh` re-applies. Companion update to the codified policy in `alpha-engine/infrastructure/iam/alpha-engine-step-functions-role/` ships as a separate cross-repo PR (drift-checked source of truth).

## Scope

- **Weekday SF:** fixed.
- **Saturday SF:** unaffected — runs entirely against the always-on micro instance, no `startInstances`.
- **EOD SF:** unaffected — operates on an already-running instance.

## Test plan

- [x] `python3 -m json.tool step_function_daily.json` validates
- [ ] Live verification on next 13:00 UTC auto-fire (cold-boot ae-trading after EOD stop): SSMReadyChoice routes to CheckTradingDay within ~30-90s of StartExecutorEC2; no `Ssm.InvalidInstanceIdException`
- [ ] Manual smoke: SF execution against an already-warm instance → DescribeInstanceInfo returns Online on first poll → CheckTradingDay fires immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)