### PR TITLE
fix(deploy): remove SF-role IAM block from deploy_step_function_daily.sh

### DIFF
--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -35,79 +35,27 @@ echo "  Micro EC2:       $MICRO_INSTANCE"
 echo "  Trading EC2:     $TRADING_INSTANCE"
 echo ""
 
-# ── Update Step Functions role with EC2 start permission ─────────────────────
-
-echo "Updating IAM role with EC2 start + predictor Lambda permissions..."
-POLICY='{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "LambdaInvoke",
-      "Effect": "Allow",
-      "Action": ["lambda:InvokeFunction"],
-      "Resource": [
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-runner*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-judge*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-rolling-mean*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-health-check*"
-      ]
-    },
-    {
-      "Sid": "SSMSendCommand",
-      "Effect": "Allow",
-      "Action": ["ssm:SendCommand"],
-      "Resource": [
-        "arn:aws:ssm:'"$REGION"'::document/AWS-RunShellScript",
-        "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$MICRO_INSTANCE"'",
-        "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$TRADING_INSTANCE"'"
-      ]
-    },
-    {
-      "Sid": "SSMGetCommandInvocation",
-      "Effect": "Allow",
-      "Action": ["ssm:GetCommandInvocation"],
-      "Resource": "*"
-    },
-    {
-      "Sid": "SSMDescribeInstanceInformation",
-      "Effect": "Allow",
-      "Action": ["ssm:DescribeInstanceInformation"],
-      "Resource": "*"
-    },
-    {
-      "Sid": "EC2StartStop",
-      "Effect": "Allow",
-      "Action": ["ec2:StartInstances", "ec2:StopInstances"],
-      "Resource": "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$TRADING_INSTANCE"'"
-    },
-    {
-      "Sid": "SNSPublish",
-      "Effect": "Allow",
-      "Action": ["sns:Publish"],
-      "Resource": "'"$SNS_TOPIC_ARN"'"
-    },
-    {
-      "Sid": "CloudWatchLogs",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents",
-        "logs:CreateLogDelivery", "logs:GetLogDelivery", "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery", "logs:ListLogDeliveries",
-        "logs:PutResourcePolicy", "logs:DescribeResourcePolicies", "logs:DescribeLogGroups"
-      ],
-      "Resource": "*"
-    }
-  ]
-}'
-
-aws iam put-role-policy \
-  --role-name "$ROLE_NAME" \
-  --policy-name "${ROLE_NAME}-policy" \
-  --policy-document "$POLICY" \
-  --region "$REGION"
-echo "  Role updated"
+# ── Step Functions role IAM ─────────────────────────────────────────────────
+#
+# IAM for `alpha-engine-step-functions-role` is managed in the alpha-engine
+# repo as the codified single source of truth:
+#
+#   alpha-engine/infrastructure/iam/alpha-engine-step-functions-role/alpha-engine-step-functions-role-policy.json
+#
+# Apply via:
+#
+#   cd ~/Development/alpha-engine && \
+#     ./infrastructure/iam/apply.sh --role alpha-engine-step-functions-role
+#
+# This script no longer writes the role's inline policy. Two writers (here +
+# apply.sh) drifted in shape (Sid presence, statement granularity, Lambda
+# resource list) — drift detector flapped each time either ran. Single
+# source of truth (codified IAM + apply.sh) eliminates the pattern.
+#
+# When this deploy script runs, it assumes the role policy is already current.
+# CI's check-drift.py will fail loud if codified ↔ live drifts, so a missed
+# apply.sh run gets caught before the next SF execution depends on the missing
+# permission.
 
 ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
 


### PR DESCRIPTION
## Summary

Removes the SF role IAM-update block from `deploy_step_function_daily.sh`. Codified IAM (`alpha-engine/infrastructure/iam/alpha-engine-step-functions-role/` + `apply.sh`) is the single source of truth.

## Why

Pre-existing dual-source-of-truth: this script's inline policy and the codified policy in alpha-engine diverged in shape (Sid presence, statement granularity, Lambda resource list, SSM resource list). Each writer overwrote the other's structure, leaving `check-drift.py` to flap cosmetically every time either ran.

Removing the inline block here closes the divergence permanently. CI's drift detector will fail loud if codified ↔ live drifts, so a missed `apply.sh` run gets caught before the next SF execution depends on a missing grant.

## Operator workflow now

| Change | Run |
|---|---|
| IAM | `cd alpha-engine && ./infrastructure/iam/apply.sh --role <role>` |
| SF JSON | `cd alpha-engine-data && ./infrastructure/deploy_step_function_daily.sh` |

## Follow-up to #150

This commit was in #150's branch but didn't make it before merge. Reopened as its own PR per request.

## Test plan

- [x] `bash -n` validates shell syntax
- [x] Dry-run alpha-engine `./infrastructure/iam/apply.sh --role alpha-engine-step-functions-role` confirms IAM is now sourced from codified file
- [x] `check-drift.py` reports clean across all 3 codified roles after applying
- [ ] Next operator run of `deploy_step_function_daily.sh` succeeds without rewriting the SF role policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)