### PR TITLE
perf(daily_append): instrument Phase 2 write loop with per-task timing

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -959,30 +959,73 @@ def daily_append(
     # thread pool is a clean fit for the per-ticker write fan-out. Worker
     # count is overridable via env var so prod can tune without a redeploy
     # if the boto3 connection-pool ceiling changes.
+    #
+    # 2026-05-05: instrumented per-task duration + thread-id to diagnose why
+    # the wall time of this loop scales like a serialized run despite
+    # workers=16 (1535s for 900 tickers ≈ 1.7s/ticker × 900, no parallelism
+    # speedup observed). Summary log emits p50/p95/p99 task duration + count
+    # per thread + slowest-N tickers so the next run reveals which hypothesis
+    # holds (boto3 pool ceiling, ArcticDB process-level lock, S3 throttling,
+    # or per-task latency itself). Replacement to `update_batch` tracked
+    # separately.
     write_workers = int(os.environ.get("DAILY_APPEND_WRITE_WORKERS", "16"))
 
     def _do_write(task):
         _ticker, _today_row, _hist, _nan_features = task
+        import threading
+        _tid = threading.get_ident()
+        _t0 = time.time()
         try:
             _write_row_backfill_safe(
                 universe_lib, _ticker, _today_row, existing_series=_hist
             )
-            return ("ok", _ticker, _nan_features, len(_hist), None)
+            _dur = time.time() - _t0
+            return ("ok", _ticker, _nan_features, len(_hist), None, _tid, _dur)
         except Exception as exc:  # pragma: no cover — covered by err test
-            return ("err", _ticker, None, len(_hist), exc)
+            _dur = time.time() - _t0
+            return ("err", _ticker, None, len(_hist), exc, _tid, _dur)
 
     if write_tasks:
         t_write0 = time.time()
         with ThreadPoolExecutor(max_workers=write_workers) as pool:
             write_results = list(pool.map(_do_write, write_tasks))
+        write_wall = time.time() - t_write0
         log.info(
             "Threadpooled writes: %d tickers in %.1fs (workers=%d)",
-            len(write_tasks), time.time() - t_write0, write_workers,
+            len(write_tasks), write_wall, write_workers,
+        )
+
+        # Per-task timing summary — diagnostic for the 2026-05-05
+        # apparent-no-parallelism observation. Compute on the main thread
+        # using stdlib only (no numpy dep added).
+        _durations = sorted(r[6] for r in write_results)
+        _per_thread = {}
+        for r in write_results:
+            _per_thread[r[5]] = _per_thread.get(r[5], 0) + 1
+        _slowest = sorted(write_results, key=lambda r: r[6], reverse=True)[:5]
+
+        def _pct(p):
+            idx = max(0, min(len(_durations) - 1, int(round(p * (len(_durations) - 1)))))
+            return _durations[idx]
+
+        log.info(
+            "Write timing: p50=%.3fs p95=%.3fs p99=%.3fs max=%.3fs sum=%.1fs "
+            "(sum/wall ratio=%.1fx, threads_seen=%d)",
+            _pct(0.5), _pct(0.95), _pct(0.99), _durations[-1],
+            sum(_durations), sum(_durations) / write_wall, len(_per_thread),
+        )
+        log.info(
+            "Write per-thread distribution (tasks per tid): %s",
+            sorted(_per_thread.values(), reverse=True),
+        )
+        log.info(
+            "Write slowest-5: %s",
+            [(r[1], round(r[6], 3)) for r in _slowest],
         )
 
         # Aggregation runs on the main thread — counter mutation stays
         # single-threaded so we don't need locks.
-        for status, ticker, nan_features, hist_rows, exc in write_results:
+        for status, ticker, nan_features, hist_rows, exc, _tid, _dur in write_results:
             if status == "err":
                 log.warning("Failed to append %s: %s", ticker, exc)
                 n_err += 1


### PR DESCRIPTION
## Summary

Adds per-task timing + thread-id instrumentation to `daily_append`'s Phase 2 ThreadPoolExecutor write loop. Diagnostic for the 2026-05-05 MorningEnrich timeout.

## Why

Today's run hit the 30-min SSM cap. Internal logs showed Phase 2 consumed 90% of the budget:

```
Threadpooled writes: 900 tickers in 1535.4s (workers=16)
```

Wall ≈ 900 × 1.7 s ≈ serialized rate. Phase 1's `read_batch` runs at 84 ms/ticker against the same library + same 900 symbols — 20× faster per-ticker than the threaded `lib.update()` path. That's a strong signal the threadpool isn't actually parallelizing.

Hypotheses (ranked):

1. boto3 connection-pool ceiling (default 10 < workers 16)
2. ArcticDB process-level write lock
3. S3 PUT throttling on shared `arctic/universe/...` prefix
4. Per-task latency itself anomalous

## What this PR adds

Per-task timing inside `_do_write`, summary logs after the threadpool drains:

```
Write timing: p50=X.XXXs p95=X.XXXs p99=X.XXXs max=X.XXXs sum=XXXX.Xs (sum/wall ratio=N.Nx, threads_seen=N)
Write per-thread distribution (tasks per tid): [...]
Write slowest-5: [(ticker, dur), ...]
```

`sum/wall ratio` is the diagnostic: 1.0 ⇒ true serial, ~16 ⇒ ideal parallelism. Tomorrow's run reveals which hypothesis holds.

Stdlib only — no new deps.

## Companion PR

Replacement to `lib.update_batch` (ArcticDB's documented "perform an update operation on a list of symbols in parallel" API) tracks in a follow-up PR. This instrumentation provides the baseline for the speedup claim.

## Test plan

- [x] 78 daily_append tests pass
- [x] Result-tuple shape change propagates to the existing aggregation loop
- [ ] Live: tomorrow's 13:00 UTC weekday SF MorningEnrich run logs the new timing summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)