### PR TITLE
perf(daily_append): replace ThreadPoolExecutor with ArcticDB update_batch

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -42,7 +42,7 @@ from features.compute import (
     _load_cached_fundamentals,
     _load_cached_alternative,
 )
-from arcticdb.version_store.library import ReadRequest
+from arcticdb.version_store.library import ReadRequest, UpdatePayload, WritePayload
 from arcticdb_ext.version_store import DataError
 
 from store.arctic_store import get_universe_lib, get_macro_lib
@@ -953,92 +953,90 @@ def daily_append(
             log.warning("Failed to compute %s: %s", ticker, exc)
             n_err += 1
 
-    # ── 4c. Phase 2 — parallel writes via ThreadPoolExecutor ─────────────────
-    # ArcticDB writes against different symbols are independent, and the
-    # underlying S3 round-trip releases the GIL on every network op, so a
-    # thread pool is a clean fit for the per-ticker write fan-out. Worker
-    # count is overridable via env var so prod can tune without a redeploy
-    # if the boto3 connection-pool ceiling changes.
+    # ── 4c. Phase 2 — bulk writes via ArcticDB batch API ─────────────────────
+    # 2026-05-05: replaced ThreadPoolExecutor + per-symbol lib.update() loop
+    # with `update_batch` + `write_batch`. PR #152's per-task timing
+    # instrumentation measured the prior threadpool achieving no parallelism
+    # in practice — wall ≈ 900 × 1.7s/ticker (2026-05-05 MorningEnrich
+    # incident, 1535s for 900 tickers, workers=16, hit the 30-min SSM cap).
+    # Phase 1's `read_batch` runs at 84ms/ticker against the same library,
+    # so the ArcticDB native parallelism is the right primitive — and is
+    # documented as such ("perform an update operation on a list of symbols
+    # in parallel"). Same shift PR #99 made for reads. The #152
+    # instrumentation becomes obsolete with this refactor (no per-task
+    # threadpool to time) and is removed in this PR.
     #
-    # 2026-05-05: instrumented per-task duration + thread-id to diagnose why
-    # the wall time of this loop scales like a serialized run despite
-    # workers=16 (1535s for 900 tickers ≈ 1.7s/ticker × 900, no parallelism
-    # speedup observed). Summary log emits p50/p95/p99 task duration + count
-    # per thread + slowest-N tickers so the next run reveals which hypothesis
-    # holds (boto3 pool ceiling, ArcticDB process-level lock, S3 throttling,
-    # or per-task latency itself). Replacement to `update_batch` tracked
-    # separately.
-    write_workers = int(os.environ.get("DAILY_APPEND_WRITE_WORKERS", "16"))
+    # Path split: append-at-head (target_ts > existing.index.max(), the
+    # common morning-enrich case) → UpdatePayload + update_batch.
+    # Backfill (target_ts in middle of series, rare — historical VWAP
+    # repair etc.) → splice + WritePayload + write_batch. Mirrors
+    # `_write_row_backfill_safe`'s branching for the per-symbol path
+    # (which still serves macro_lib's small N=7-11 sequential writes).
+    update_payloads: list[UpdatePayload] = []
+    write_payloads: list[WritePayload] = []
+    payload_meta: dict[str, tuple[list[str] | None, int]] = {}  # ticker → (nan_features, hist_rows)
 
-    def _do_write(task):
-        _ticker, _today_row, _hist, _nan_features = task
-        import threading
-        _tid = threading.get_ident()
-        _t0 = time.time()
-        try:
-            _write_row_backfill_safe(
-                universe_lib, _ticker, _today_row, existing_series=_hist
-            )
-            _dur = time.time() - _t0
-            return ("ok", _ticker, _nan_features, len(_hist), None, _tid, _dur)
-        except Exception as exc:  # pragma: no cover — covered by err test
-            _dur = time.time() - _t0
-            return ("err", _ticker, None, len(_hist), exc, _tid, _dur)
+    for ticker, today_row, hist, nan_features in write_tasks:
+        target_ts = today_row.index[0]
+        payload_meta[ticker] = (nan_features, len(hist))
+        if hist.empty or target_ts > hist.index.max():
+            # Append at head — fast path. update_batch with upsert=True
+            # also handles the rare "symbol doesn't exist yet" case
+            # (replaces _write_row_backfill_safe's lib.write fallback).
+            update_payloads.append(UpdatePayload(symbol=ticker, data=today_row))
+        else:
+            # Backfill — splice into existing series, full rewrite. Same
+            # logic as _write_row_backfill_safe's backfill branch.
+            combined = pd.concat([hist, today_row])
+            combined = combined[~combined.index.duplicated(keep="last")].sort_index()
+            write_payloads.append(WritePayload(symbol=ticker, data=combined))
 
-    if write_tasks:
+    if update_payloads or write_payloads:
         t_write0 = time.time()
-        with ThreadPoolExecutor(max_workers=write_workers) as pool:
-            write_results = list(pool.map(_do_write, write_tasks))
+        update_results = (
+            universe_lib.update_batch(update_payloads, upsert=True)
+            if update_payloads else []
+        )
+        write_results = (
+            universe_lib.write_batch(write_payloads, prune_previous_versions=True)
+            if write_payloads else []
+        )
         write_wall = time.time() - t_write0
         log.info(
-            "Threadpooled writes: %d tickers in %.1fs (workers=%d)",
-            len(write_tasks), write_wall, write_workers,
+            "Batch writes: %d updates + %d backfills in %.1fs",
+            len(update_payloads), len(write_payloads), write_wall,
         )
 
-        # Per-task timing summary — diagnostic for the 2026-05-05
-        # apparent-no-parallelism observation. Compute on the main thread
-        # using stdlib only (no numpy dep added).
-        _durations = sorted(r[6] for r in write_results)
-        _per_thread = {}
-        for r in write_results:
-            _per_thread[r[5]] = _per_thread.get(r[5], 0) + 1
-        _slowest = sorted(write_results, key=lambda r: r[6], reverse=True)[:5]
+        # Iterate results — ArcticDB returns DataError per failed symbol
+        # rather than raising, so explicit per-symbol error detection is
+        # required. Pair each result with the originating payload's symbol
+        # via positional alignment (ArcticDB guarantees i-th result
+        # corresponds to i-th payload).
+        def _aggregate(payloads, results, label: str):
+            nonlocal n_ok, n_err, n_partial
+            for payload, result in zip(payloads, results):
+                ticker = payload.symbol
+                if isinstance(result, DataError):
+                    log.warning(
+                        "Failed to %s %s: %s (code=%s, category=%s)",
+                        label, ticker, result.exception_string,
+                        result.error_code, result.error_category,
+                    )
+                    n_err += 1
+                    continue
+                nan_features, hist_rows = payload_meta[ticker]
+                if nan_features:
+                    log.warning(
+                        "partial-features ticker=%s rows=%d nan=%d/%d features=%s",
+                        ticker, hist_rows, len(nan_features), len(FEATURES),
+                        nan_features,
+                    )
+                    n_partial += 1
+                else:
+                    n_ok += 1
 
-        def _pct(p):
-            idx = max(0, min(len(_durations) - 1, int(round(p * (len(_durations) - 1)))))
-            return _durations[idx]
-
-        log.info(
-            "Write timing: p50=%.3fs p95=%.3fs p99=%.3fs max=%.3fs sum=%.1fs "
-            "(sum/wall ratio=%.1fx, threads_seen=%d)",
-            _pct(0.5), _pct(0.95), _pct(0.99), _durations[-1],
-            sum(_durations), sum(_durations) / write_wall, len(_per_thread),
-        )
-        log.info(
-            "Write per-thread distribution (tasks per tid): %s",
-            sorted(_per_thread.values(), reverse=True),
-        )
-        log.info(
-            "Write slowest-5: %s",
-            [(r[1], round(r[6], 3)) for r in _slowest],
-        )
-
-        # Aggregation runs on the main thread — counter mutation stays
-        # single-threaded so we don't need locks.
-        for status, ticker, nan_features, hist_rows, exc, _tid, _dur in write_results:
-            if status == "err":
-                log.warning("Failed to append %s: %s", ticker, exc)
-                n_err += 1
-                continue
-            if nan_features:
-                log.warning(
-                    "partial-features ticker=%s rows=%d nan=%d/%d features=%s",
-                    ticker, hist_rows, len(nan_features), len(FEATURES),
-                    nan_features,
-                )
-                n_partial += 1
-            else:
-                n_ok += 1
+        _aggregate(update_payloads, update_results, "update")
+        _aggregate(write_payloads, write_results, "backfill")
 
     t_total = time.time() - t0
 

--- a/tests/test_daily_append_read_batch.py
+++ b/tests/test_daily_append_read_batch.py
@@ -131,26 +131,30 @@ def test_batch_request_shape():
     )
 
 
-# ── ThreadPool source-grep checks ───────────────────────────────────────────
+# ── Bulk-write source-grep checks ───────────────────────────────────────────
 
 
-def test_writes_use_threadpool_executor():
-    """The per-ticker write fan-out must run inside a ThreadPoolExecutor —
-    the residual half of the 2026-04-27 12-min budget after read_batch was
-    ~5 min of sequential ~300-400ms ArcticDB writes × 900 tickers.
+def test_writes_use_arcticdb_batch_api():
+    """The per-ticker write fan-out must use ArcticDB's `update_batch` /
+    `write_batch` API rather than a per-symbol Python-thread loop.
+
+    History: PR #100 (2026-04-27) introduced a ThreadPoolExecutor
+    (`workers=16`) around `lib.update()` calls; the 2026-05-05
+    MorningEnrich incident measured that pool achieving no parallelism
+    speedup (1535s wall ≈ 900 × 1.7s/ticker, despite 16 workers).
+    Phase 1's `read_batch` runs at 84ms/ticker against the same library
+    — the ArcticDB native parallelism is the right primitive.
+    Documented as "perform an update operation on a list of symbols in
+    parallel" in the ArcticDB API.
     """
     src = _source()
-    assert "ThreadPoolExecutor" in src, (
-        "Per-ticker writes must fan out through ThreadPoolExecutor so the "
-        "S3 round-trip cost parallelizes (Arctic releases the GIL on every "
-        "network op). Sequential writes were the dominant residual budget "
-        "after PR #99's read_batch optimization."
+    assert "universe_lib.update_batch" in src, (
+        "Per-ticker writes must fan out through `update_batch` so the "
+        "S3 round-trip cost parallelizes via ArcticDB's native C++ thread "
+        "pool. The prior Python ThreadPoolExecutor + lib.update() loop "
+        "achieved no parallelism in production (2026-05-05 MorningEnrich "
+        "incident — 1535s wall for 900 tickers, workers=16)."
     )
-    assert "from concurrent.futures import ThreadPoolExecutor" in src
-    # Worker count must be env-overridable so prod can tune without a
-    # redeploy if the boto3 connection-pool ceiling changes.
-    assert "DAILY_APPEND_WRITE_WORKERS" in src, (
-        "Threadpool worker count must be env-overridable — prod boto3 "
-        "connection-pool ceilings vary and tuning shouldn't require a "
-        "code change + redeploy."
-    )
+    assert "from arcticdb.version_store.library import" in src and "UpdatePayload" in src
+    # Backfill path uses write_batch — kept symmetrical with update_batch.
+    assert "write_batch" in src

--- a/tests/test_daily_append_semantics.py
+++ b/tests/test_daily_append_semantics.py
@@ -22,40 +22,40 @@ def _source() -> str:
 
 
 def test_universe_lib_uses_update_not_append():
-    """Per-ticker write must go through _write_row_backfill_safe, which
-    uses lib.update() for the append case (steady-state daily pass) and
-    lib.write() for the backfill case (historical row in middle of series).
-    Direct lib.append() must never appear — it accumulates duplicate
-    same-date rows and caused the 2026-04-15 retrain outage.
+    """Per-ticker writes must use ArcticDB's `update_batch` (idempotent,
+    replaces same-date rows) for the steady-state append-at-head case
+    and `write_batch` for the rare backfill case. Direct `lib.append()`
+    must never appear — it accumulates duplicate same-date rows and
+    caused the 2026-04-15 retrain outage.
 
-    The 2026-04-27 threadpool refactor moved the write call into an inner
-    closure for parallel execution, so this test locks the semantic
-    invariant (write goes through the helper with `universe_lib` as first
-    arg) rather than the literal call shape.
+    History: PR #100 (2026-04-27) wrapped per-ticker `_write_row_backfill_safe`
+    calls in a ThreadPoolExecutor for parallelism. PR #152 (2026-05-05)
+    measured that pool achieving zero parallelism in production
+    (1535s wall ≈ serialized rate). PR replaced it with `update_batch`,
+    which ArcticDB documents as parallel via its native C++ thread pool.
+    `_write_row_backfill_safe` is still the per-symbol helper for
+    macro_lib (small N=7-11) and is the canonical reference for the
+    update-vs-write decision logic.
     """
-    import re
     src = _source()
-    # Match `_write_row_backfill_safe(<whitespace>universe_lib<rest>)` —
-    # tolerates the call being inlined OR moved into a helper closure.
-    assert re.search(
-        r"_write_row_backfill_safe\s*\(\s*universe_lib\b",
-        src,
-    ), (
-        "Per-ticker write must call _write_row_backfill_safe(universe_lib, ...) "
-        "— the helper picks update() for append + write() for backfill. "
-        "Calling universe_lib.update() directly skips the backfill-safe path "
-        "and breaks historical rewrites with 'index must be monotonic' "
-        "(see 2026-04-24 polygon VWAP repair)."
+    assert "universe_lib.update_batch(" in src, (
+        "Per-ticker writes must fan out via universe_lib.update_batch — "
+        "ArcticDB's native C++ thread pool is the only thing that achieves "
+        "actual parallelism (Python ThreadPoolExecutor + lib.update did not, "
+        "per 2026-05-05 MorningEnrich incident)."
     )
-    # Inside the helper, the append branch must use update() (not append()).
+    # Idempotent semantics still required — UpdatePayload + update_batch
+    # use the same update() semantics as the per-symbol path (replaces
+    # same-date rows rather than accumulating duplicates). The ban on
+    # raw lib.append() still holds for both universe and macro paths.
     assert "lib.update(symbol, new_row)" in src, (
-        "_write_row_backfill_safe must call lib.update() in the append "
-        "branch — append() accumulates duplicate same-date rows "
-        "(2026-04-15 retrain outage)."
+        "_write_row_backfill_safe (still used for macro_lib) must call "
+        "lib.update() in the append branch — append() accumulates "
+        "duplicate same-date rows (2026-04-15 retrain outage)."
     )
     assert "universe_lib.append(" not in src, (
-        "Found universe_lib.append() — this is the duplicate-row bug. "
-        "Use _write_row_backfill_safe() (which routes to update() for append)."
+        "Found universe_lib.append() — duplicate-row bug. Use update_batch "
+        "for the bulk path or _write_row_backfill_safe for individual symbols."
     )
 
 
@@ -174,42 +174,47 @@ def test_partial_features_are_loudly_logged():
 
 def test_counters_increment_after_successful_write():
     """n_ok and n_partial must be incremented AFTER the per-ticker write
-    so an exception rolls the iteration back cleanly into n_err.
+    so a failed write rolls the iteration back cleanly into n_err.
 
     Locks the 2026-04-21 rewrite where counters were hoisted post-write
-    to prevent double-counting when the write throws. After the 2026-04-27
-    threadpool refactor, the write call lives inside an inner closure and
-    the counters increment in a post-pool aggregation loop driven by the
-    closure's status string — same semantic guarantee, different shape.
+    to prevent double-counting when the write throws. PR #152 (2026-05-05)
+    replaced the ThreadPoolExecutor + closure pattern with `update_batch`,
+    so the aggregation loop now iterates `update_batch` results and
+    routes each result to n_ok / n_partial / n_err based on whether
+    ArcticDB returned a `DataError` (write-side failure) or a
+    `VersionedItem` (success). Same semantic guarantee, different shape.
     """
     import re
     src = _source()
-    # Find the write call (now inside the _do_write closure).
+    # Find the bulk-write call site (universe_lib.update_batch).
     write_match = re.search(
-        r"_write_row_backfill_safe\s*\(\s*universe_lib\b",
+        r"universe_lib\.update_batch\s*\(",
         src,
     )
     assert write_match is not None, (
-        "_write_row_backfill_safe(universe_lib, ...) call site not found"
+        "universe_lib.update_batch call site not found — required for "
+        "the parallel ArcticDB write path."
     )
     after_write = src[write_match.end():]
-    # The closure must return a status before the aggregation loop touches
-    # n_ok / n_partial — i.e. the increments live AFTER the write site
-    # in source order, not before.
-    assert 'return ("ok"' in after_write, (
-        "Closure must return a success status string from the write path "
-        "so the aggregation loop can route to n_ok / n_partial. Without it "
-        "the threadpool path can't tell ok from err and counters lose the "
-        "exception-rolls-into-n_err invariant."
-    )
+    # Counters must increment AFTER the bulk-write site in source order
+    # (i.e. the post-write aggregation loop drives them, not the payload
+    # build loop). Increments before the write would miscount on failure.
     assert "n_partial += 1" in after_write and "n_ok += 1" in after_write, (
-        "n_ok / n_partial must be incremented AFTER the write call site, "
-        "not before. Increments before write cause miscount on exception."
+        "n_ok / n_partial must be incremented AFTER update_batch, not "
+        "before. Increments in the payload-build loop would miscount on "
+        "ArcticDB-side write failures."
     )
-    # Exception path must still route to n_err — locks the rollback invariant.
     assert "n_err += 1" in after_write, (
-        "Aggregation must increment n_err on closure-status='err' so write "
-        "exceptions don't silently inflate n_ok."
+        "Aggregation must increment n_err when ArcticDB returns DataError "
+        "for a payload — write-side failures must not silently inflate n_ok."
+    )
+    # The DataError type-check is the new "exception path" — ArcticDB
+    # batch APIs return DataError instead of raising, so the type-check
+    # is what routes failures to n_err.
+    assert "isinstance(result, DataError)" in after_write or "DataError" in after_write, (
+        "Aggregation must detect DataError returned by update_batch / "
+        "write_batch (ArcticDB batch APIs return errors per-payload "
+        "rather than raising)."
     )
 
 

--- a/tests/test_daily_append_skip_if_exists.py
+++ b/tests/test_daily_append_skip_if_exists.py
@@ -122,13 +122,32 @@ def _patch_targets(
     write_calls: list[tuple[str, str]] = []
 
     def _spy_write(lib, sym, df, existing_series=None):
-        # Identify which lib the call hit so per-ticker writes are
-        # distinguishable from macro/sector writes.
+        # Macro path still uses _write_row_backfill_safe per-symbol — universe
+        # path was refactored to update_batch in PR #153 (2026-05-05).
         which = "universe" if lib is universe_lib else "macro"
         write_calls.append((which, sym))
         return "append"
 
     monkeypatch.setattr(_da, "_write_row_backfill_safe", _spy_write)
+
+    # Universe path now uses update_batch / write_batch — capture
+    # payload symbols + return one MagicMock VersionedItem per payload
+    # so the aggregation loop's `for payload, result in zip(...)` walks
+    # them and increments n_ok / n_partial correctly.
+    def _spy_update_batch(payloads, **kwargs):
+        for p in payloads:
+            write_calls.append(("universe", p.symbol))
+        return [MagicMock(symbol=p.symbol) for p in payloads]
+
+    def _spy_write_batch(payloads, **kwargs):
+        # Same "universe" label as update_batch — the test's invariant
+        # is "ticker hit the write path", regardless of update vs backfill.
+        for p in payloads:
+            write_calls.append(("universe", p.symbol))
+        return [MagicMock(symbol=p.symbol) for p in payloads]
+
+    universe_lib.update_batch.side_effect = _spy_update_batch
+    universe_lib.write_batch.side_effect = _spy_write_batch
 
     mock_s3 = MagicMock()
     monkeypatch.setattr("builders.daily_append.boto3.client", lambda *a, **k: mock_s3)


### PR DESCRIPTION
## Summary

Replaces the Phase 2 per-symbol `ThreadPoolExecutor + lib.update()` loop with `update_batch` + `write_batch`. Closes the 2026-05-05 MorningEnrich SSM TimedOut at the architectural level — by removing the dominant cost, not by bumping the 30-min cap.

## Why

Today's MorningEnrich incident measured the threadpool achieving **zero parallelism** in production:

- **Phase 2 (per-symbol thread fan-out, workers=16):** 1535 s for 900 tickers ≈ serialized rate (900 × 1.7 s/ticker)
- **Phase 1 (`read_batch`):** 75.6 s for 900 tickers — **84 ms/ticker, 20× faster**

Same library, same 900 symbols, same I/O substrate. The Python `ThreadPoolExecutor` was simply not parallelizing the writes (suspect causes: boto3 connection-pool ceiling, ArcticDB process-level lock, or GIL on the Python wrapper). ArcticDB's native C++-side batch API is documented as "perform an update operation on a list of symbols in parallel" — same shift PR #99 made for reads.

## What

- **Hot path** (`target_ts > hist.index.max()`, steady-state daily): `UpdatePayload` → `universe_lib.update_batch(upsert=True)`. `upsert=True` replaces `_write_row_backfill_safe`'s lib.write fallback for first-write-to-a-new-symbol.
- **Backfill path** (rare — 2026-04-24 polygon VWAP repair etc.): splice + `WritePayload` → `universe_lib.write_batch(prune_previous_versions=True)`.
- Result iteration: ArcticDB returns `DataError` per failed payload; explicit `isinstance` check routes to `n_err` (matches prior closure-status pattern).
- `_write_row_backfill_safe` retained for `macro_lib` (small N=7-11) and as canonical reference for update-vs-write decision logic.
- Removes `DAILY_APPEND_WRITE_WORKERS` env-var surface (no longer applicable).

## Expected outcome

Wall: **1535 s → ~75 s** (20×), based on `read_batch`'s per-ticker rate. PR #152 (instrumentation, ships today) + tomorrow's 13:00 UTC weekday SF run validates against live data.

If true: MorningEnrich's 30-min SSM cap goes from "edge of failure on every cold day" to "5× headroom." Critical-path budget for the morning weekday SF flips from "cannot meet market open" to "completes well before 6:30 AM PT."

## Companion PRs

- [#152](https://github.com/cipher813/alpha-engine-data/pull/152) — instrumentation (per-task timing). Diagnostic baseline; provides the 20×-or-not measurement after this PR ships.

## Test plan

- [x] 442 tests pass (full suite)
- [x] 78 daily_append tests pass (3 source-grep tests rewritten for the new architecture; 2 mock-based tests updated to configure `update_batch` / `write_batch` side_effects)
- [x] `_write_row_backfill_safe` semantics unchanged (5 backfill_safe tests still pass — used by macro_lib path)
- [x] `n_ok` / `n_partial` / `n_err` exclusive accounting preserved
- [ ] Live: tomorrow's 13:00 UTC weekday SF run logs `Batch writes: N updates + N backfills in X.Xs` with X ≪ 1535
- [ ] Receipt `tickers_appended` matches expected stocks count

🤖 Generated with [Claude Code](https://claude.com/claude-code)