### PR TITLE
fix(rag): correct voyage-3-lite dimension from 1024 to 512 in manifest

### DIFF
--- a/rag/pipelines/emit_manifest.py
+++ b/rag/pipelines/emit_manifest.py
@@ -41,10 +41,11 @@ from alpha_engine_lib.rag.db import execute_query
 
 logger = logging.getLogger(__name__)
 
-# Hardcoded; ``rag.embeddings.embed_*`` defaults to voyage-3-lite (1024d).
+# Hardcoded; ``rag.embeddings.embed_*`` defaults to voyage-3-lite (512d,
+# matches the ``embedding vector(512)`` column in ``rag/schema.sql``).
 # Surfaced in the manifest so consumers don't have to re-derive it.
 _EMBEDDING_MODEL = "voyage-3-lite"
-_EMBEDDING_DIMENSION = 1024
+_EMBEDDING_DIMENSION = 512
 
 
 def _by_source() -> dict[str, dict[str, int]]:

--- a/tests/test_emit_manifest.py
+++ b/tests/test_emit_manifest.py
@@ -86,7 +86,9 @@ def test_coverage_percentiles(manifest):
 
 
 def test_embedding_metadata(manifest):
-    assert manifest["embedding"] == {"model": "voyage-3-lite", "dimension": 1024}
+    # voyage-3-lite is 512d — matches `embedding vector(512)` in the lib's
+    # rag/schema.sql. pgvector enforces dim on INSERT.
+    assert manifest["embedding"] == {"model": "voyage-3-lite", "dimension": 512}
 
 
 def test_ingestion_overall_picks_max(manifest):


### PR DESCRIPTION
## Summary

Follow-up to PR #154 (already merged). The manifest emitter shipped with `_EMBEDDING_DIMENSION = 1024`, taking the alpha-engine-lib `embeddings.py` docstring at face value. The docstring was wrong: `schema.sql:31` declares `embedding vector(512)` and pgvector enforces dimension on INSERT, so the production column is 512 (the system has been ingesting documents successfully for weeks).

Companion fix: alpha-engine-lib PR #17 corrects the docstring.

## Changes

- `rag/pipelines/emit_manifest.py` — `_EMBEDDING_DIMENSION` 1024 → 512, comment updated to point at the schema as the source of truth
- `tests/test_emit_manifest.py` — `test_embedding_metadata` asserts 512 with a comment explaining the pgvector enforcement

## Why a separate PR

PR #154 was squash-merged before this fix landed.

## Test plan

- [x] `pytest tests/test_emit_manifest.py -q` — 8/8 pass
- [ ] Next Saturday SF run produces `s3://alpha-engine-research/rag/manifest/latest.json` with `embedding.dimension: 512`

🤖 Generated with [Claude Code](https://claude.com/claude-code)