### PR TITLE
fix(spot): tee DataPhase1 stdout to S3 for post-mortem debugging

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -426,6 +426,26 @@ set -euo pipefail
 cd /home/ec2-user/alpha-engine-data
 ${ENV_SOURCE}
 
+# ── Spot-side log capture ────────────────────────────────────────────
+# SSM RunCommand truncates StandardOutputContent at 24KB and the spot
+# terminates before the dispatcher can scp logs back, so post-mortem
+# debugging requires the full log to land somewhere durable. Tee
+# everything below into /tmp/data-phase1.log + upload to S3 on ANY exit
+# path (success, hard-fail, signal). Origin: 2026-05-03 SF failure where
+# the postflight error message was past the SSM truncation cutoff and
+# the spot was already gone by the time triage started.
+LOG_FILE=/tmp/data-phase1.log
+exec > >(tee -a "\$LOG_FILE") 2>&1
+
+upload_log() {
+    local exit_code=\$?
+    local s3_key="health/data_phase1_log/\$(date +%Y-%m-%d)/\$(date +%Y%m%dT%H%M%SZ -u)-exit\${exit_code}.log"
+    aws s3 cp "\$LOG_FILE" "s3://${S3_BUCKET}/\$s3_key" --region "\${AWS_REGION:-us-east-1}" 2>/dev/null \\
+        && echo "[log-upload] s3://${S3_BUCKET}/\$s3_key" \\
+        || echo "[log-upload] WARNING: failed to upload \$LOG_FILE to S3"
+}
+trap upload_log EXIT
+
 # ── Morning enrich (Saturday-morning polygon-T+1 fill) ────────────────
 # Polygon's grouped-daily aggregate for date T isn't fully settled
 # until the next calendar day (T+1). The Friday weekday-SF run


### PR DESCRIPTION
## Summary
- Adds `tee` to `/tmp/data-phase1.log` + `aws s3 cp` upload-on-exit inside the spot's `WORKLOADS` heredoc
- Log lands at `s3://alpha-engine-research/health/data_phase1_log/{date}/{timestamp}-exit{code}.log` on any exit path
- Closes diagnostic gap from 2026-05-03 SF failure where the postflight error message was past SSM's 24KB truncation cutoff and the spot was already gone by triage time

## Why
SSM RunCommand truncates `StandardOutputContent` at 24KB. The dispatcher script runs via SSM RunCommand on ae-dashboard, so all its stdout (including SSH-forwarded stdout from the spot's WORKLOADS heredoc) is subject to that limit. When the spot self-terminates after `exit 1`, anything past 24KB is lost forever. Today's incident (`eval-pipeline-validation-20260503-115927`) had collectors-OK + postflight-failed; the actual postflight error was past the cutoff. Triage stalled.

## Why this approach
- Spot-side capture (vs dispatcher-side scp) survives spot termination
- IAM already in place via `alpha-engine-executor-profile` — no new grants needed
- `EXIT` trap fires on success, hard-fail, AND signal — covers all the cases that matter for post-mortem
- Filename includes exit code for quick skim of "what mode did this run end in"

## Roadmap
Closes ROADMAP P0 "DataPhase1 postflight failure — collectors all ok but SSM exits 1" (added 2026-05-03). Root-cause investigation explicitly gated on this log-capture work landing first per `feedback_no_silent_fails`.

## Test plan
- [ ] Bash syntax check passes (`bash -n` confirmed locally)
- [ ] Manual smoke on a spot via `--smoke-only` mode (next opportunity)
- [ ] Production validation: next Saturday SF DataPhase1 step lands a log at the new S3 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)