### PR TITLE
feat(daily-closes): stamp source column on every row

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -360,6 +360,7 @@ def _fetch_polygon_closes(
                 "Adj_Close": round(g["close"], 4),
                 "Volume": int(g["volume"]),
                 "VWAP": round(g["vwap"], 4) if g.get("vwap") else None,
+                "source": "polygon",
             })
             polygon_count += 1
     logger.info("Polygon grouped-daily: %d/%d tickers", polygon_count, len(tickers))
@@ -427,6 +428,7 @@ def _fetch_polygon_closes_per_ticker(
             "Adj_Close": round(bar["close"], 4),
             "Volume": int(bar["volume"]),
             "VWAP": round(bar["vwap"], 4) if bar.get("vwap") else None,
+            "source": "polygon",
         })
         recovered += 1
     return recovered
@@ -528,6 +530,7 @@ def _fetch_fred_closes(
                 # across trades). FRED single-value closes give us no distribution
                 # to VWAP, so None rather than passing Close off as VWAP.
                 "VWAP": None,
+                "source": "fred",
             })
             count += 1
         except Exception as e:
@@ -603,6 +606,7 @@ def _fetch_yfinance_closes(
                         "Adj_Close": round(adj_close, 4),
                         "Volume": int(last["Volume"]) if pd.notna(last.get("Volume")) else 0,
                         "VWAP": None,
+                        "source": "yfinance",
                     })
                     count += 1
                 except Exception as e:


### PR DESCRIPTION
## Summary
The `staging/daily_closes/{date}.parquet` writer threads a `--source` CLI arg (polygon_only / yfinance_only / fred / auto) and knows definitively which provider each row came from, but doesn't persist the label. Downstream consumers that need to know the canonical source resort to heuristics ("is VWAP populated?" — coincidentally reliable today because polygon writes VWAP and yfinance doesn't, but it's not contractual).

This PR stamps a `source` string column on every record:

| Writer site | source value |
|---|---|
| polygon grouped-daily (`_fetch_polygon_closes`) | `"polygon"` |
| polygon per-ticker fallback (`_fetch_polygon_closes_per_ticker`) | `"polygon"` |
| FRED single-value index closes (`_fetch_fred_index_closes`) | `"fred"` |
| yfinance EOD batch (`_fetch_yfinance_closes`) | `"yfinance"` |

## Backward compatibility
Schema change is **additive** (new column only) per CLAUDE.md S3 contract rules. Verified downstream consumers handle this gracefully:

- `builders/daily_append.py` — explicit column-select via `OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]` filter at lines 851/854/869/915. New `source` column is silently ignored.
- `features/compute.py` — reads selected columns by name, doesn't iterate.
- `sf_preflight.py` — only checks SPY existence in the index, doesn't iterate columns.

## Companion
Dashboard PR #51 (alpha-engine-dashboard) reads this column directly to populate the per-feature `Source` column on `/Feature_Store`. It currently uses a VWAP-presence heuristic as a fallback for older parquets that pre-date this schema bump; once a few morning/EOD passes write labeled parquets, the heuristic becomes the never-fires fallback path.

## Test plan
- [x] AST parse OK
- [ ] Next polygon morning pass: `source=polygon` populated for all rows
- [ ] Next yfinance EOD pass: `source=yfinance` populated for all rows
- [ ] Smoke after first labeled write: `python -c "import boto3,io,pandas as pd; df = pd.read_parquet(io.BytesIO(boto3.client('s3').get_object(Bucket='alpha-engine-research', Key='staging/daily_closes/<date>.parquet')['Body'].read())); print(df.source.value_counts())"`
- [ ] Verify daily_append + features/compute + sf_preflight don't barf on the new column

🤖 Generated with [Claude Code](https://claude.com/claude-code)