### PR TITLE
hotfix(deploy): install git in Lambda Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 
+# Install git — required for ``pip install git+https://...`` of
+# alpha-engine-lib below. The Lambda Python 3.12 base image does not
+# include git; pip's git-cloning command fails with "Cannot find
+# command 'git'" without this. Same fix applied to alpha-engine-research
+# Dockerfile after PR #105's lib-public flip exposed the gap. Caught
+# in alpha-engine-data 2026-05-05 when PR #159's deploy job failed
+# with the same error. ``microdnf`` is the AL2023 minimal package
+# manager; ``-y`` auto-confirms.
+RUN microdnf install -y git && microdnf clean all
+
 # Install dependencies. alpha-engine-lib is installed from public git+https
 # with the [flow_doctor] extra only — the [arcticdb,rag] extras in
 # requirements.txt are intentionally NOT pulled here, since Lambda only


### PR DESCRIPTION
## Summary
The Phase 2 Lambda deploy job has been failing on:
\`\`\`
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
\`\`\`

The Lambda Python 3.12 base image doesn't ship with git, but the Dockerfile uses \`pip install ... @ git+https://...\` for alpha-engine-lib. Surfaced today by PR #159's post-merge Deploy run against a fresh build.

## Fix
Adds \`RUN microdnf install -y git && microdnf clean all\` before the pip install. Same one-line fix applied to alpha-engine-research Dockerfile after PR #105's lib-public flip exposed the same gap there.

## Test plan
- [x] Diff parity with alpha-engine-research Dockerfile (line-for-line same install)
- [ ] Deploy workflow re-runs cleanly post-merge

## Out of scope
The \`FromPlatformFlagConstDisallowed\` warning on line 1 (`--platform=linux/amd64`) is a separate buildkit lint — doesn't block builds, leave for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)