### PR TITLE
feat(rag-manifest): add by_date_source for date×doc_type pivot

### DIFF
--- a/rag/pipelines/emit_manifest.py
+++ b/rag/pipelines/emit_manifest.py
@@ -16,7 +16,9 @@ What lands in the manifest:
 - ``totals``: documents, chunks, tickers
 - ``embedding``: model name + dimension + chunk vector dimension from the
   ``rag.chunks.embedding`` column
-- ``ingestion``: latest ``ingested_at`` overall + per ``doc_type``
+- ``ingestion``: latest ``ingested_at`` overall + per ``doc_type``, plus
+  per-(date, doc_type) document/chunk counts so the dashboard can render
+  the inventory as a date×doc_type pivot
 
 What is intentionally *not* in the manifest (disclosure boundary):
 per-ticker doc lists, individual document titles, chunk content. Those
@@ -123,6 +125,39 @@ def _totals() -> dict[str, int]:
     }
 
 
+def _by_date_source() -> list[dict[str, Any]]:
+    """Per (ingestion calendar date, doc_type): documents + chunks.
+
+    Powers the dashboard's date×doc_type pivot. Aggregates only — no
+    titles, no per-ticker breakdown — so it stays inside the public-safe
+    disclosure boundary alongside the rest of the manifest.
+    """
+    rows = execute_query(
+        """
+        SELECT
+            DATE(d.ingested_at)         AS ingestion_date,
+            d.doc_type                  AS doc_type,
+            COUNT(DISTINCT d.id)        AS documents,
+            COUNT(c.id)                 AS chunks
+        FROM rag.documents d
+        LEFT JOIN rag.chunks c ON c.document_id = d.id
+        WHERE d.ingested_at IS NOT NULL
+        GROUP BY DATE(d.ingested_at), d.doc_type
+        ORDER BY ingestion_date DESC, doc_type
+        """
+    )
+    out = []
+    for r in rows:
+        d = r["ingestion_date"]
+        out.append({
+            "date": d.isoformat() if hasattr(d, "isoformat") else str(d),
+            "doc_type": r["doc_type"],
+            "documents": int(r["documents"] or 0),
+            "chunks": int(r["chunks"] or 0),
+        })
+    return out
+
+
 def _ingestion() -> dict[str, Any]:
     rows = execute_query(
         """
@@ -137,6 +172,7 @@ def _ingestion() -> dict[str, Any]:
     return {
         "last_run_ts": overall,
         "by_source_last_ts": by_source_last_ts,
+        "by_date_source": _by_date_source(),
     }
 
 
@@ -144,7 +180,7 @@ def build_manifest() -> dict[str, Any]:
     """Assemble the manifest dict by querying pgvector."""
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "totals": _totals(),
         "by_source": _by_source(),
         "by_ticker_coverage": _by_ticker_coverage(),

--- a/tests/test_emit_manifest.py
+++ b/tests/test_emit_manifest.py
@@ -8,7 +8,7 @@ shape, the per-source rollup math, and the S3 put-object key pattern.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -32,9 +32,21 @@ _FAKE_INGESTION = [
     {"doc_type": "10-Q", "last_ts": datetime(2026, 5, 2, 9, 24, 1, tzinfo=timezone.utc)},
     {"doc_type": "earnings_transcript", "last_ts": datetime(2026, 5, 2, 9, 25, 12, tzinfo=timezone.utc)},
 ]
+_FAKE_BY_DATE_SOURCE = [
+    {"ingestion_date": date(2026, 5, 2), "doc_type": "10-K", "documents": 12, "chunks": 348},
+    {"ingestion_date": date(2026, 5, 2), "doc_type": "10-Q", "documents": 31, "chunks": 905},
+    {"ingestion_date": date(2026, 5, 2), "doc_type": "earnings_transcript", "documents": 18, "chunks": 540},
+    {"ingestion_date": date(2026, 4, 25), "doc_type": "10-K", "documents": 9, "chunks": 261},
+    {"ingestion_date": date(2026, 4, 25), "doc_type": "8-K", "documents": 22, "chunks": 137},
+]
 
 
 def _fake_execute_query(sql: str, *args, **kwargs):
+    # Order matters: the date pivot also contains "GROUP BY d.doc_type" as a
+    # substring (it groups by `DATE(d.ingested_at), d.doc_type`), so dispatch
+    # the more specific match first.
+    if "DATE(d.ingested_at)" in sql:
+        return _FAKE_BY_DATE_SOURCE
     if "GROUP BY d.doc_type" in sql:
         return _FAKE_BY_SOURCE
     if "WITHIN GROUP (ORDER BY doc_count)" in sql:
@@ -58,7 +70,7 @@ def test_top_level_keys(manifest):
         "generated_at", "schema_version", "totals", "by_source",
         "by_ticker_coverage", "embedding", "ingestion",
     }
-    assert manifest["schema_version"] == "1.0.0"
+    assert manifest["schema_version"] == "1.1.0"
 
 
 def test_totals_match_fake(manifest):
@@ -98,6 +110,23 @@ def test_ingestion_overall_picks_max(manifest):
     assert set(manifest["ingestion"]["by_source_last_ts"]) == {
         "10-K", "10-Q", "earnings_transcript",
     }
+
+
+def test_ingestion_by_date_source_pivot_rows(manifest):
+    # Powers the dashboard's date×doc_type pivot.
+    rows = manifest["ingestion"]["by_date_source"]
+    assert len(rows) == 5
+    # ISO-format dates so the manifest stays JSON-serializable without
+    # default=str fallback.
+    assert all(isinstance(r["date"], str) for r in rows)
+    assert {r["date"] for r in rows} == {"2026-05-02", "2026-04-25"}
+    # Counts surface as plain ints (no Decimal leakage).
+    for r in rows:
+        assert isinstance(r["documents"], int)
+        assert isinstance(r["chunks"], int)
+    # Spot-check one cell.
+    cell = next(r for r in rows if r["date"] == "2026-05-02" and r["doc_type"] == "10-Q")
+    assert cell == {"date": "2026-05-02", "doc_type": "10-Q", "documents": 31, "chunks": 905}
 
 
 def test_manifest_is_json_serializable(manifest):


### PR DESCRIPTION
## Summary
- Adds `ingestion.by_date_source` to the RAG corpus manifest — a flat list of `{date, doc_type, documents, chunks}` rows aggregated by calendar ingestion date and doc_type
- Powers the dashboard's RAG Inventory freshness pivot (rows=date, cols=doc_type, cells=document/chunk count) — paired with alpha-engine-dashboard PR
- Schema bump 1.0.0 → 1.1.0 (additive field, backwards compatible)

Aggregates only — stays inside the public-safe disclosure boundary (no titles, no per-ticker breakdown). Same boundary the rest of the manifest already enforces.

## Test plan
- [x] `tests/test_emit_manifest.py` — added `test_ingestion_by_date_source_pivot_rows`; bumped `schema_version` assertion. 9/9 pass
- [x] Full suite green (443 passed)
- [ ] First emission validated on Sat 2026-05-09 SF run (unchanged from prior plan — first manifest fires that day either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)