### PR TITLE
feat(infra): wire rationale-clustering Lambda — IAM allowlist + SF state

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -44,6 +44,7 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check"
@@ -64,6 +65,8 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",


### PR DESCRIPTION
## Summary

Two-part companion to alpha-engine-research#118 (cross-week rationale clustering implementation, ROADMAP P0):

1. **IAM allowlist** — adds \`alpha-engine-research-rationale-clustering\` ARN to LambdaUpdate + LambdaInvokeCanary statements on the github-actions-lambda-deploy role so the GH Actions workflow can update + canary-invoke this Lambda. Same shape as PR #149 (eval-judge + eval-rolling-mean). Asymmetric-IAM-grant antipattern compliance.

2. **Saturday SF wiring** — \`CheckSkipRationaleClustering\` choice + \`RationaleClustering\` task state inserted after \`EvalRollingMean\`, before \`SaturdayHealthCheck\`. Same observability framing as eval-judge / eval-rolling-mean: \`Catch: States.ALL → Next: SaturdayHealthCheck\` so failures don't halt the pipeline.

   New chain:
   \`\`\`
   EvalJudge{Weekly,FirstSaturday} → EvalRollingMean
       → CheckSkipRationaleClustering → RationaleClustering
       → SaturdayHealthCheck → ...
   \`\`\`

   Skip flags:
   - \`{\"skip_rationale_clustering\": true}\` — bypass clustering only
   - \`{\"skip_eval_judge\": true}\` — bypass judge but still run clustering (they read different sources, were previously bundled, now independent)
   - \`{\"skip_backtester\": true}\` — already routes through eval pipeline (PR fixed 2026-05-03)

   \`deploy_step_function.sh\` inline policy LambdaInvoke also updated with the new function ARN so the SF execution role can invoke it.

## Standalone invocation (still available)

Lambda is invokable directly regardless of SF state:
\`\`\`
aws lambda invoke --function-name alpha-engine-research-rationale-clustering:live \\
  --payload '{\"end_time_iso\": \"2026-05-09T00:00:00Z\", \"window_days\": 56, \"dry_run\": false}' /tmp/out.json
\`\`\`

Useful for ad-hoc retrospective (\"what was concentration at end-of-Q1?\"), post-incident reruns where \`skip_rationale_clustering=true\` was set on the production SF, or smoke testing against any week's corpus with \`dry_run: true\`.

## Test plan

- [ ] Apply IAM via \`apply.sh\` on the live role pre-merge of alpha-engine-research#118
- [ ] Apply SF inline policy via \`deploy_step_function.sh\` (no-op for everything except the new Lambda ARN line)
- [ ] First-time Lambda creation may need a one-time manual bootstrap if lambda:CreateFunction is not on the deploy role (same path eval-judge took)
- [ ] First Sat SF run (5/9) triggers RationaleClustering state; output values will be noisy until corpus reaches ~8 weeks (target ~6/27)
- [ ] Verify standalone invocation works against today's corpus with \`dry_run: true\` before relying on the SF wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)