### PR TITLE
feat(sf): wire rationale-clustering Lambda into Saturday SF

### DIFF
--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -9,6 +9,8 @@
 #   4. Data Phase 2 Lambda (alpha-engine-data-collector) deployed
 #   5. Eval-judge Lambda (alpha-engine-research-eval-judge) deployed via
 #      `infrastructure/deploy.sh eval_judge` from alpha-engine-research
+#      (rolling-mean + rationale-clustering Lambdas auto-deployed by the
+#      same workflow when the research repo's main branch updates)
 #   6. Repos cloned on always-on EC2: alpha-engine-data, alpha-engine-predictor,
 #      alpha-engine-backtester
 #
@@ -103,6 +105,7 @@ POLICY='{
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-runner*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-judge*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-rolling-mean*",
+        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-rationale-clustering*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*"
       ]

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -504,14 +504,14 @@
 
     "CheckSkipEvalJudge": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_eval_judge\": true} bypasses the LLM-as-judge eval step (typically used for ad-hoc reruns where eval cost is unwanted).",
+      "Comment": "Skip-gate. {\"skip_eval_judge\": true} bypasses the LLM-as-judge eval step (typically used for ad-hoc reruns where eval cost is unwanted). Skipping the judge does NOT skip rationale clustering — they're independent observability paths (clustering reads decision_artifacts/, judge reads its own _eval/), so we route to CheckSkipRationaleClustering instead of bypassing both.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_eval_judge", "IsPresent": true},
             {"Variable": "$.skip_eval_judge", "BooleanEquals": true}
           ],
-          "Next": "SaturdayHealthCheck"
+          "Next": "CheckSkipRationaleClustering"
         }
       ],
       "Default": "ComputeEvalCadence"
@@ -628,11 +628,57 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Eval observability layer — failures must NOT halt the pipeline.",
-          "Next": "SaturdayHealthCheck",
+          "Next": "CheckSkipRationaleClustering",
           "ResultPath": "$.eval_rolling_mean_error"
         }
       ],
       "ResultPath": "$.eval_rolling_mean_result",
+      "Next": "CheckSkipRationaleClustering"
+    },
+
+    "CheckSkipRationaleClustering": {
+      "Type": "Choice",
+      "Comment": "Skip-gate. {\"skip_rationale_clustering\": true} bypasses the cross-week rationale clustering Lambda (used during ad-hoc reruns where corpus is in a known-bad state, while iterating on extraction logic, or for post-incident reruns where stale outputs shouldn't hit CloudWatch). Standalone invocation of the Lambda is always available regardless of this flag.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_rationale_clustering", "IsPresent": true},
+            {"Variable": "$.skip_rationale_clustering", "BooleanEquals": true}
+          ],
+          "Next": "SaturdayHealthCheck"
+        }
+      ],
+      "Default": "RationaleClustering"
+    },
+
+    "RationaleClustering": {
+      "Type": "Task",
+      "Comment": "Cross-week rationale clustering Lambda (ROADMAP P0, 2026-05-05). Reads decision_artifacts/ for the trailing 8 weeks, clusters rationales per agent_id via TF-IDF char n-grams + greedy single-linkage with digit-normalization, emits CW metric agent_rationale_template_concentration (% of rationales in top-3 clusters; >0.7 indicates template-generation), and persists per-agent analysis JSON to decision_artifacts/_analysis/{agent_id}/{YYYY-WW}.json. Runs every Saturday after EvalRollingMean — same image-share + observability framing.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-research-rationale-clustering:live",
+        "Payload": {
+          "end_time_iso.$": "$$.Execution.StartTime"
+        }
+      },
+      "TimeoutSeconds": 600,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Eval observability layer — failures must NOT halt the pipeline.",
+          "Next": "SaturdayHealthCheck",
+          "ResultPath": "$.rationale_clustering_error"
+        }
+      ],
+      "ResultPath": "$.rationale_clustering_result",
       "Next": "SaturdayHealthCheck"
     },
 

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -44,6 +44,8 @@ class TestStatesPresent:
             "EvalJudgeFirstSaturday",
             "EvalJudgeWeekly",
             "EvalRollingMean",
+            "CheckSkipRationaleClustering",
+            "RationaleClustering",
         ):
             assert name in states, f"missing SF state: {name}"
 
@@ -86,7 +88,13 @@ class TestSkipBacktesterPreservesEvalJudge:
 
 
 class TestSkipEvalJudge:
-    def test_skip_flag_bypasses_to_health_check(self, states):
+    def test_skip_flag_bypasses_to_rationale_clustering_gate(self, states):
+        """Skipping the judge must NOT also skip rationale clustering —
+        they are independent observability paths reading different
+        sources (clustering reads decision_artifacts/, judge reads its
+        own _eval/). The skip path lands on CheckSkipRationaleClustering
+        rather than SaturdayHealthCheck so the clustering Lambda still
+        fires unless its own skip flag is set."""
         skip = states["CheckSkipEvalJudge"]
         choice = skip["Choices"][0]
         # Both presence + boolean equality must be checked (matches
@@ -97,7 +105,10 @@ class TestSkipEvalJudge:
             and c.get("BooleanEquals") is True
             for c in and_clauses
         )
-        assert choice["Next"] == "SaturdayHealthCheck"
+        assert choice["Next"] == "CheckSkipRationaleClustering"
+        # Critically NOT routed to SaturdayHealthCheck — that would
+        # bundle-skip both observability paths.
+        assert choice["Next"] != "SaturdayHealthCheck"
 
     def test_default_runs_eval(self, states):
         assert states["CheckSkipEvalJudge"]["Default"] == "ComputeEvalCadence"
@@ -239,13 +250,16 @@ class TestEvalRollingMean:
         # TimeoutSeconds must equal that ceiling.
         assert states["EvalRollingMean"]["TimeoutSeconds"] == 300
 
-    def test_success_continues_to_health_check(self, states):
-        assert states["EvalRollingMean"]["Next"] == "SaturdayHealthCheck"
+    def test_success_continues_to_rationale_clustering_gate(self, states):
+        # Rolling-mean converges to CheckSkipRationaleClustering (the
+        # gate in front of the cross-week clustering Lambda) rather
+        # than directly to SaturdayHealthCheck.
+        assert states["EvalRollingMean"]["Next"] == "CheckSkipRationaleClustering"
 
-    def test_catch_routes_to_health_check_not_failure(self, states):
+    def test_catch_routes_to_rationale_clustering_gate_not_failure(self, states):
         catch = states["EvalRollingMean"]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
-        assert catch["Next"] == "SaturdayHealthCheck"
+        assert catch["Next"] == "CheckSkipRationaleClustering"
         assert catch["Next"] != "HandleFailure"
 
     def test_retries_on_transient_lambda_errors(self, states):
@@ -253,6 +267,61 @@ class TestEvalRollingMean:
         # AWS-side transient errors (ServiceException / Throttling),
         # not on application errors.
         retry = states["EvalRollingMean"]["Retry"][0]
+        assert "Lambda.ServiceException" in retry["ErrorEquals"]
+        assert "Lambda.TooManyRequestsException" in retry["ErrorEquals"]
+        assert retry["MaxAttempts"] == 1
+
+
+# ── Rationale clustering skip-gate + state ───────────────────────────────
+
+
+class TestSkipRationaleClustering:
+    def test_skip_flag_bypasses_to_health_check(self, states):
+        skip = states["CheckSkipRationaleClustering"]
+        choice = skip["Choices"][0]
+        and_clauses = choice["And"]
+        assert any(
+            c.get("Variable") == "$.skip_rationale_clustering"
+            and c.get("BooleanEquals") is True
+            for c in and_clauses
+        )
+        assert choice["Next"] == "SaturdayHealthCheck"
+
+    def test_default_runs_clustering(self, states):
+        assert states["CheckSkipRationaleClustering"]["Default"] == "RationaleClustering"
+
+
+class TestRationaleClustering:
+    def test_invokes_live_alias(self, states):
+        params = states["RationaleClustering"]["Parameters"]
+        assert params["FunctionName"] == "alpha-engine-research-rationale-clustering:live"
+
+    def test_payload_passes_execution_start_time(self, states):
+        # SF passes its own start time so the clustering window aligns
+        # with the SF execution date — same alignment principle as the
+        # rolling-mean state above.
+        payload = states["RationaleClustering"]["Parameters"]["Payload"]
+        assert payload["end_time_iso.$"] == "$$.Execution.StartTime"
+
+    def test_timeout_matches_lambda_cap(self, states):
+        # Clustering Lambda is configured with timeout=600s
+        # (alpha-engine-research infrastructure/deploy.sh) — SF state
+        # TimeoutSeconds must equal that ceiling.
+        assert states["RationaleClustering"]["TimeoutSeconds"] == 600
+
+    def test_success_continues_to_health_check(self, states):
+        assert states["RationaleClustering"]["Next"] == "SaturdayHealthCheck"
+
+    def test_catch_routes_to_health_check_not_failure(self, states):
+        # Eval is observability — clustering failures must NOT halt
+        # the pipeline (matches eval-judge + eval-rolling-mean posture).
+        catch = states["RationaleClustering"]["Catch"][0]
+        assert catch["ErrorEquals"] == ["States.ALL"]
+        assert catch["Next"] == "SaturdayHealthCheck"
+        assert catch["Next"] != "HandleFailure"
+
+    def test_retries_on_transient_lambda_errors(self, states):
+        retry = states["RationaleClustering"]["Retry"][0]
         assert "Lambda.ServiceException" in retry["ErrorEquals"]
         assert "Lambda.TooManyRequestsException" in retry["ErrorEquals"]
         assert retry["MaxAttempts"] == 1


### PR DESCRIPTION
## Summary

Adds CheckSkipRationaleClustering choice + RationaleClustering task state after EvalRollingMean, before SaturdayHealthCheck. Companion to alpha-engine-research#118 (cross-week rationale clustering implementation, ROADMAP P0). Sister PR #163 already merged the IAM allowlist for the new Lambda ARN.

## SF chain

\`\`\`
EvalJudge{Weekly,FirstSaturday} → EvalRollingMean
    → CheckSkipRationaleClustering → RationaleClustering
    → SaturdayHealthCheck → ...
\`\`\`

Same observability framing as eval-judge / eval-rolling-mean: \`Catch: States.ALL → Next: SaturdayHealthCheck\` so failures don't halt the pipeline.

## Skip flags (independent observability paths)

- \`{\"skip_rationale_clustering\": true}\` — bypass clustering only
- \`{\"skip_eval_judge\": true}\` — bypass judge but still run clustering. Routing changed: was \`SaturdayHealthCheck\`, now \`CheckSkipRationaleClustering\`. The two Lambdas read different sources (clustering reads \`decision_artifacts/\`, judge reads its own \`_eval/\`), so they should not be bundled.

## Standalone invocation (always available)

Lambda is invokable directly regardless of SF state:
\`\`\`
aws lambda invoke --function-name alpha-engine-research-rationale-clustering:live \\
  --payload '{\"end_time_iso\": \"2026-05-09T00:00:00Z\", \"window_days\": 56, \"dry_run\": false}' /tmp/out.json
\`\`\`

Useful for ad-hoc retrospective analysis, post-incident reruns where \`skip_rationale_clustering=true\` was set on the production SF, or smoke testing against any week's corpus with \`dry_run: true\`.

## deploy_step_function.sh

Inline policy LambdaInvoke statement also updated with the new function ARN so the SF execution role can invoke it.

## Test plan

- [ ] Run \`deploy_step_function.sh\` to apply both the SF definition update + the IAM inline policy line for the new Lambda
- [ ] First Sat SF run (5/9) triggers RationaleClustering state; output values will be noisy until corpus reaches ~8 weeks (target ~6/27)
- [ ] Verify standalone invocation works against today's corpus with \`dry_run: true\` before relying on the SF wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)