### PR TITLE
fix(iam): grant lambda:CreateFunction + PassRole(lambda) for first deploys

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -37,7 +37,9 @@
         "lambda:GetFunction",
         "lambda:GetFunctionConfiguration",
         "lambda:PublishVersion",
-        "lambda:UpdateAlias"
+        "lambda:UpdateAlias",
+        "lambda:CreateFunction",
+        "lambda:CreateAlias"
       ],
       "Resource": [
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner",
@@ -222,7 +224,8 @@
           "iam:PassedToService": [
             "states.amazonaws.com",
             "scheduler.amazonaws.com",
-            "events.amazonaws.com"
+            "events.amazonaws.com",
+            "lambda.amazonaws.com"
           ]
         }
       }


### PR DESCRIPTION
## Summary

Codifies the durable fix for the \`AccessDeniedException ... lambda:CreateFunction\` failure that surfaced on three first-time Lambda deploys now (eval-judge via #149, eval-rolling-mean, and most recently rationale-clustering on alpha-engine-research#118).

Same family / third incident → fix the role rather than rely on manual one-off bootstraps.

## Changes

- \`LambdaUpdate\` Sid: adds \`lambda:CreateFunction\` + \`lambda:CreateAlias\` to the action list. Resource scope unchanged — still limited to the 8 named alpha-engine-* function ARNs, so the deploy role cannot create arbitrary Lambdas.
- \`InfraDeployPassRole\` Sid: \`lambda.amazonaws.com\` added to \`iam:PassedToService\`. \`CreateFunction --role\` requires \`PassRole\` on the Lambda execution role; the existing Sid scoped \`PassRole\` to states/scheduler/events services only. Resource scope unchanged — still \`alpha-engine-*\` roles only.

## Triggering incident

alpha-engine-research#118 GH Actions deploy run 25404140865 failed with:

\`\`\`
aws: [ERROR]: An error occurred (AccessDeniedException) when calling the
CreateFunction operation: User: arn:aws:sts::...:assumed-role/
github-actions-lambda-deploy/GitHubActions is not authorized to perform:
lambda:CreateFunction on resource: arn:aws:lambda:...:function:
alpha-engine-research-rationale-clustering because no identity-based
policy allows the lambda:CreateFunction action
\`\`\`

## Test plan

- [ ] Apply via \`apply.sh\` on the live role
- [ ] Re-run alpha-engine-research deploy workflow (push a no-op commit or use Actions UI re-run)
- [ ] Verify \`alpha-engine-research-rationale-clustering\` Lambda exists post-deploy
- [ ] Verify standalone invoke works against today's corpus with \`{\"dry_run\": true}\` payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)