### PR TITLE
feat(presentation): add SECURITY.md — security@nousergon.ai contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+Nous Ergon / Alpha Engine is a single-developer portfolio project running paper-account trading. No customer funds, no production user data.
+
+## Reporting a vulnerability
+
+Email **[security@nousergon.ai](mailto:security@nousergon.ai)** for code-level vulnerabilities, credential leaks in commit history, or dependency CVEs.
+
+Please don't file public issues for security-sensitive disclosures. Cross-repo concerns reach the same inbox; we'll triage to the right module.
+
+Best-effort acknowledgement within 7 days.


### PR DESCRIPTION
GitHub-standard security policy file. Tells security researchers where to report vulnerabilities. Single contact (`security@nousergon.ai`) across all 8 public repos. Per the revamp plan §1.6.7 spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)