### PR TITLE
feat(sf): wire counterfactual rule fit Lambda into Saturday SF

### DIFF
--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -107,6 +107,7 @@ POLICY='{
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-rolling-mean*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-rationale-clustering*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-replay-concordance*",
+        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-replay-counterfactual*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
         "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*"
       ]

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -48,6 +48,7 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check"
@@ -72,6 +73,8 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -684,14 +684,14 @@
 
     "CheckSkipReplayConcordance": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_replay_concordance\": true} bypasses the cheap-model concordance Lambda (used for ad-hoc reruns where Anthropic spend is unwanted, or while iterating on the comparison scorers in alpha-engine-backtester replay/comparison.py). Independent of skip_rationale_clustering — the two are different agent-justification signals (clustering = cross-week templating; concordance = same-input cross-model agreement). Standalone invocation of the Lambda is always available regardless of this flag.",
+      "Comment": "Skip-gate. {\"skip_replay_concordance\": true} bypasses the cheap-model concordance Lambda (used for ad-hoc reruns where Anthropic spend is unwanted, or while iterating on the comparison scorers in alpha-engine-backtester replay/comparison.py). Independent of skip_rationale_clustering and skip_counterfactual — the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_replay_concordance", "IsPresent": true},
             {"Variable": "$.skip_replay_concordance", "BooleanEquals": true}
           ],
-          "Next": "SaturdayHealthCheck"
+          "Next": "CheckSkipCounterfactual"
         }
       ],
       "Default": "ReplayConcordance"
@@ -723,11 +723,59 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Eval observability layer — concordance failure must NOT halt the pipeline. Same Catch pattern as eval-judge / eval-rolling-mean / rationale-clustering.",
-          "Next": "SaturdayHealthCheck",
+          "Next": "CheckSkipCounterfactual",
           "ResultPath": "$.replay_concordance_error"
         }
       ],
       "ResultPath": "$.replay_concordance_result",
+      "Next": "CheckSkipCounterfactual"
+    },
+
+    "CheckSkipCounterfactual": {
+      "Type": "Choice",
+      "Comment": "Skip-gate. {\"skip_counterfactual\": true} bypasses the counterfactual rule fit Lambda (used for ad-hoc reruns while iterating on the per-agent feature extractors in alpha-engine-backtester replay/counterfactual.py). Independent of skip_rationale_clustering and skip_replay_concordance — the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_counterfactual", "IsPresent": true},
+            {"Variable": "$.skip_counterfactual", "BooleanEquals": true}
+          ],
+          "Next": "SaturdayHealthCheck"
+        }
+      ],
+      "Default": "Counterfactual"
+    },
+
+    "Counterfactual": {
+      "Type": "Task",
+      "Comment": "Weekly counterfactual rule fit Lambda (ROADMAP P0, agent-justification gate signal #2 — does the agent reduce to a 3-deep decision tree?). Trains DecisionTreeClassifier(max_depth=3) per supported agent on (input → decision) pairs from the trailing 8-week decision_artifacts/ corpus; emits CW metric agent_counterfactual_rule_fit per (judged_agent_id); persists per-agent JSON to decision_artifacts/_counterfactual/{agent_id_base}/{YYYY-WW}.json including tree_text + feature_importances. v1 covers ic_cio + macro_economist; other agents emit UNSUPPORTED markers. $0 ongoing — no LLM calls. Runs every Saturday after ReplayConcordance.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-replay-counterfactual:live",
+        "Payload": {
+          "end_time_iso.$": "$$.Execution.StartTime",
+          "window_days": 56,
+          "max_depth": 3
+        }
+      },
+      "TimeoutSeconds": 600,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Eval observability layer — counterfactual failure must NOT halt the pipeline. Same Catch pattern as the rest of the agent-justification triple.",
+          "Next": "SaturdayHealthCheck",
+          "ResultPath": "$.counterfactual_error"
+        }
+      ],
+      "ResultPath": "$.counterfactual_result",
       "Next": "SaturdayHealthCheck"
     },
 

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -48,6 +48,8 @@ class TestStatesPresent:
             "RationaleClustering",
             "CheckSkipReplayConcordance",
             "ReplayConcordance",
+            "CheckSkipCounterfactual",
+            "Counterfactual",
         ):
             assert name in states, f"missing SF state: {name}"
 
@@ -337,7 +339,14 @@ class TestRationaleClustering:
 
 
 class TestSkipReplayConcordance:
-    def test_skip_flag_bypasses_to_health_check(self, states):
+    def test_skip_flag_bypasses_to_counterfactual_gate(self, states):
+        """Skipping concordance must NOT also skip counterfactual —
+        they are independent agent-justification signals (concordance
+        = same-input cross-model agreement; counterfactual = 3-deep
+        decision-tree match). The skip path lands on
+        CheckSkipCounterfactual rather than SaturdayHealthCheck so the
+        counterfactual Lambda still fires unless its own skip flag is
+        set."""
         skip = states["CheckSkipReplayConcordance"]
         choice = skip["Choices"][0]
         and_clauses = choice["And"]
@@ -346,7 +355,8 @@ class TestSkipReplayConcordance:
             and c.get("BooleanEquals") is True
             for c in and_clauses
         )
-        assert choice["Next"] == "SaturdayHealthCheck"
+        assert choice["Next"] == "CheckSkipCounterfactual"
+        assert choice["Next"] != "SaturdayHealthCheck"
 
     def test_default_runs_concordance(self, states):
         assert states["CheckSkipReplayConcordance"]["Default"] == "ReplayConcordance"
@@ -359,37 +369,85 @@ class TestReplayConcordance:
 
     def test_payload_carries_required_fields(self, states):
         payload = states["ReplayConcordance"]["Parameters"]["Payload"]
-        # SF execution start time aligns the window with the SF run date.
         assert payload["end_time_iso.$"] == "$$.Execution.StartTime"
-        # Default target_models pinned at the Saturday SF level so the
-        # production cadence is reproducible — operator overrides via
-        # SF input parameters when running ad-hoc against a different
-        # target model.
         assert payload["target_models"] == ["claude-haiku-4-5"]
-        assert payload["window_days"] == 56  # 8 weeks
-        # max_artifacts cap fits the 900s Lambda timeout at ~3-5 sec
-        # per replay call (150 × 5 = 750s, comfortable).
+        assert payload["window_days"] == 56
         assert payload["max_artifacts"] == 150
 
     def test_timeout_matches_lambda_cap(self, states):
-        # Concordance Lambda is configured with timeout=900s
-        # (alpha-engine-backtester infrastructure/deploy_concordance.sh).
         assert states["ReplayConcordance"]["TimeoutSeconds"] == 900
 
+    def test_success_continues_to_counterfactual_gate(self, states):
+        # Concordance converges to CheckSkipCounterfactual rather than
+        # directly to SaturdayHealthCheck — counterfactual is the next
+        # leg of the agent-justification triple.
+        assert states["ReplayConcordance"]["Next"] == "CheckSkipCounterfactual"
+
+    def test_catch_routes_to_counterfactual_gate_not_failure(self, states):
+        catch = states["ReplayConcordance"]["Catch"][0]
+        assert catch["ErrorEquals"] == ["States.ALL"]
+        assert catch["Next"] == "CheckSkipCounterfactual"
+        assert catch["Next"] != "HandleFailure"
+
+    def test_retries_on_transient_lambda_errors(self, states):
+        retry = states["ReplayConcordance"]["Retry"][0]
+        assert "Lambda.ServiceException" in retry["ErrorEquals"]
+        assert "Lambda.TooManyRequestsException" in retry["ErrorEquals"]
+        assert retry["MaxAttempts"] == 1
+
+
+# ── Counterfactual rule fit skip-gate + state ────────────────────────────
+
+
+class TestSkipCounterfactual:
+    def test_skip_flag_bypasses_to_health_check(self, states):
+        skip = states["CheckSkipCounterfactual"]
+        choice = skip["Choices"][0]
+        and_clauses = choice["And"]
+        assert any(
+            c.get("Variable") == "$.skip_counterfactual"
+            and c.get("BooleanEquals") is True
+            for c in and_clauses
+        )
+        assert choice["Next"] == "SaturdayHealthCheck"
+
+    def test_default_runs_counterfactual(self, states):
+        assert states["CheckSkipCounterfactual"]["Default"] == "Counterfactual"
+
+
+class TestCounterfactual:
+    def test_invokes_live_alias(self, states):
+        params = states["Counterfactual"]["Parameters"]
+        assert params["FunctionName"] == "alpha-engine-replay-counterfactual:live"
+
+    def test_payload_carries_required_fields(self, states):
+        payload = states["Counterfactual"]["Parameters"]["Payload"]
+        assert payload["end_time_iso.$"] == "$$.Execution.StartTime"
+        # 8-week trailing window — same as concordance + clustering.
+        assert payload["window_days"] == 56
+        # Default tree depth pinned at the SF level so the production
+        # cadence is reproducible.
+        assert payload["max_depth"] == 3
+
+    def test_timeout_matches_lambda_cap(self, states):
+        # Counterfactual Lambda is configured with timeout=600s
+        # (alpha-engine-backtester infrastructure/deploy_counterfactual.sh).
+        # Lighter than concordance (no LLM calls — sklearn fits run
+        # in seconds; 600s is comfortable headroom for S3 listing
+        # across 8 weeks of corpus).
+        assert states["Counterfactual"]["TimeoutSeconds"] == 600
+
     def test_success_continues_to_health_check(self, states):
-        assert states["ReplayConcordance"]["Next"] == "SaturdayHealthCheck"
+        assert states["Counterfactual"]["Next"] == "SaturdayHealthCheck"
 
     def test_catch_routes_to_health_check_not_failure(self, states):
-        # Eval is observability — concordance failures must NOT halt
-        # the pipeline (matches eval-judge + eval-rolling-mean +
-        # rationale-clustering posture).
-        catch = states["ReplayConcordance"]["Catch"][0]
+        catch = states["Counterfactual"]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
         assert catch["Next"] == "SaturdayHealthCheck"
         assert catch["Next"] != "HandleFailure"
 
     def test_retries_on_transient_lambda_errors(self, states):
-        retry = states["ReplayConcordance"]["Retry"][0]
+        retry = states["Counterfactual"]["Retry"][0]
         assert "Lambda.ServiceException" in retry["ErrorEquals"]
         assert "Lambda.TooManyRequestsException" in retry["ErrorEquals"]
         assert retry["MaxAttempts"] == 1


### PR DESCRIPTION
## Summary

Companion to alpha-engine-backtester [#140](https://github.com/cipher813/alpha-engine-backtester/pull/140) (counterfactual Lambda implementation). **Closes the agent-justification triple end-to-end** — all three signals now fire from the Saturday SF on the same trailing-8-week corpus.

## SF chain after this PR

\`\`\`
... → EvalJudge{Weekly,FirstSaturday} → EvalRollingMean
    → CheckSkipRationaleClustering → RationaleClustering
    → CheckSkipReplayConcordance → ReplayConcordance
    → CheckSkipCounterfactual → Counterfactual
    → SaturdayHealthCheck → ...
\`\`\`

## Three independent skip-gates

Each lands on the next signal's gate rather than SaturdayHealthCheck — skipping one signal doesn't bundle-skip the others:

| Flag | Routes to |
|---|---|
| \`skip_rationale_clustering: true\` | \`CheckSkipReplayConcordance\` |
| \`skip_replay_concordance: true\` | \`CheckSkipCounterfactual\` |
| \`skip_counterfactual: true\` | \`SaturdayHealthCheck\` |

## Default Counterfactual payload

\`\`\`json
{
  "end_time_iso.$": "$$.Execution.StartTime",
  "window_days":    56,
  "max_depth":      3
}
\`\`\`

No \`target_models\` — counterfactual doesn't replay against a target model; sklearn fits a tree on actual (input → decision) pairs.

## IAM updates

- \`github-actions-lambda-deploy.json\` — \`alpha-engine-replay-counterfactual\` added to LambdaUpdate + LambdaInvokeCanary. Durable CreateFunction grant from data #165 already covers create + update.
- \`deploy_step_function.sh\` — SF role inline LambdaInvoke list updated.

## Test plan

- [x] 8 new SF wiring tests; suite 459 → 467
  - States present (CheckSkipCounterfactual + Counterfactual)
  - SkipReplayConcordance reroute (now → CheckSkipCounterfactual)
  - ReplayConcordance success + Catch reroute (same)
  - SkipCounterfactual: skip_counterfactual → SaturdayHealthCheck
  - Counterfactual: live alias, payload required fields, 600s timeout, success + Catch routes, retry posture
- [ ] Apply IAM via \`apply.sh\` (resource-list update)
- [ ] Run \`deploy_step_function.sh\` to push the new SF definition + inline policy
- [ ] First Sat SF run after backtester #140 merges (and Lambda deploys via \`bash infrastructure/deploy_counterfactual.sh\`) fires the counterfactual state

## Agent-justification dashboard surface

All five metrics emit under \`AlphaEngine/Eval\`:

| Metric | Source |
|---|---|
| \`agent_quality_score\` | eval-judge |
| \`agent_quality_score_4w_mean\` | eval-rolling-mean |
| \`agent_rationale_template_concentration\` | clustering |
| \`agent_cheap_model_concordance\` | concordance |
| **\`agent_counterfactual_rule_fit\`** | counterfactual |

🤖 Generated with [Claude Code](https://claude.com/claude-code)