### PR TITLE
fix(infra): drop inline EB-SFN role IAM writes

### DIFF
--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -227,7 +227,14 @@ aws events put-rule \
   --description "Saturday 09:00 UTC (02:00 AM PT Sat) — triggers full Alpha Engine pipeline. Schedule chosen so polygon's Friday daily aggregate has settled (T+1 lag) before MorningEnrich + DataPhase1 fetch it." \
   --region "$REGION"
 
-# EventBridge needs a role to start Step Functions executions
+# EventBridge needs a role to start Step Functions executions.
+# Trust policy + role creation kept here (one-time bootstrap); inline IAM
+# policy moved to alpha-engine/infrastructure/iam/ (codified file at
+# alpha-engine-eventbridge-sfn-role/alpha-engine-eventbridge-sfn-role-policy.json).
+# Apply via that repo's `apply.sh`, not here. Prior inline block listed
+# only the saturday SFN ARN — every saturday deploy clobbered the
+# weekday ARN that the daily script had granted, breaking the next
+# weekday auto-fire (recurred 2026-04-21, 2026-05-04, 2026-05-06).
 EB_ROLE_NAME="alpha-engine-eventbridge-sfn-role"
 EB_TRUST='{
   "Version": "2012-10-17",
@@ -244,23 +251,6 @@ aws iam create-role \
   --role-name "$EB_ROLE_NAME" \
   --assume-role-policy-document "$EB_TRUST" \
   --region "$REGION" 2>/dev/null || true
-
-EB_POLICY='{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "states:StartExecution",
-      "Resource": "'"$SM_ARN"'"
-    }
-  ]
-}'
-
-aws iam put-role-policy \
-  --role-name "$EB_ROLE_NAME" \
-  --policy-name "${EB_ROLE_NAME}-policy" \
-  --policy-document "$EB_POLICY" \
-  --region "$REGION"
 
 EB_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${EB_ROLE_NAME}"
 

--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -114,28 +114,14 @@ aws events put-rule \
   --description "Weekday 13:00 UTC (6:00 AM PT) — daily data + predictor + executor start" \
   --region "$REGION"
 
-# Reuse EventBridge role from Saturday pipeline
+# Reuse EventBridge role from Saturday pipeline.
+# IAM policy on this role is codified in alpha-engine/infrastructure/iam/
+# (alpha-engine-eventbridge-sfn-role/) — apply via `apply.sh` from that
+# repo, not inline here. The previous inline block on this script + the
+# saturday script wrote the same role policy with different ARN sets and
+# clobbered each other; the saturday-only write hit prod three times
+# (2026-04-21, 2026-05-04, 2026-05-06) before the role was codified.
 EB_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-eventbridge-sfn-role"
-
-# Update EventBridge role to also allow starting this state machine
-EB_POLICY='{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "states:StartExecution",
-      "Resource": [
-        "arn:aws:states:'"$REGION"':'"$ACCOUNT_ID"':stateMachine:alpha-engine-saturday-pipeline",
-        "'"$SM_ARN"'"
-      ]
-    }
-  ]
-}'
-aws iam put-role-policy \
-  --role-name "alpha-engine-eventbridge-sfn-role" \
-  --policy-name "alpha-engine-eventbridge-sfn-role-policy" \
-  --policy-document "$EB_POLICY" \
-  --region "$REGION"
 
 INPUT_JSON=$(cat <<EOF
 {


### PR DESCRIPTION
## Summary

- Drop the inline `aws iam put-role-policy` blocks against `alpha-engine-eventbridge-sfn-role` from both `deploy_step_function.sh` (saturday) and `deploy_step_function_daily.sh` (weekday). The two scripts wrote conflicting Resource lists and clobbered each other.
- Trust policy + `aws iam create-role` bootstrap stays in the saturday script (one-time setup).
- Role is now codified in alpha-engine/infrastructure/iam/ as the single source of truth.

## Why

Same regression hit prod three times (2026-04-21, 2026-05-04, 2026-05-06). Saturday script granted `states:StartExecution` only on the saturday SFN ARN; weekday script granted both. Each saturday deploy silently dropped the weekday ARN, breaking the next Mon-Fri 13:00 UTC auto-fire.

Same pattern as PR #151 (which removed the inline `alpha-engine-step-functions-role` block for an analogous asymmetric-grant regression).

## Companion

cipher813/alpha-engine#136 — codifies the role in IaC.

## Test plan
- [x] `bash -n` syntax-check both scripts.
- [x] Live IAM unchanged (codified policy already applied).
- [ ] Next saturday deploy (whenever next run) confirms scripts still complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)