### PR TITLE
fix(infra): drop inline SF-role IAM write from saturday deploy

### DIFF
--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -68,10 +68,24 @@ if [ -z "$EXISTING_SUBS" ]; then
 fi
 
 # ── 2. IAM Role for Step Functions ──────────────────────────────────────────
+#
+# Trust policy + role creation kept here (one-time bootstrap). The inline
+# policy on this role is codified in alpha-engine/infrastructure/iam/
+# (alpha-engine-step-functions-role/) and applied via that repo's
+# `apply.sh` — NOT inline here.
+#
+# This script previously wrote its own inline `put-role-policy` against
+# this role with a narrower policy than the codified version (missing
+# ssm:DescribeInstanceInformation, ec2:StopInstances, and ssm:SendCommand
+# on the trading instance). Whenever this script ran, it clobbered the
+# codified state and broke a downstream pipeline that depended on the
+# missing grants. PR #151 removed the equivalent block from the weekday
+# script in 2026-05-05, but this Saturday twin survived until the
+# overnight drift-check on 2026-05-06 made the cost visible.
 
-echo "Creating IAM role: $ROLE_NAME..."
+echo "Ensuring IAM role exists: $ROLE_NAME..."
 
-# Trust policy
+# Trust policy (one-time bootstrap; safe to re-run)
 TRUST_POLICY='{
   "Version": "2012-10-17",
   "Statement": [
@@ -88,88 +102,10 @@ aws iam create-role \
   --assume-role-policy-document "$TRUST_POLICY" \
   --region "$REGION" 2>/dev/null || echo "  Role already exists"
 
-# Inline policy: Lambda invoke, SSM, SNS, CloudWatch
-# Trading instance ID for weekday pipeline EC2 start
-TRADING_INSTANCE="${AE_TRADING_INSTANCE_ID:-i-018eb3307a21329bf}"
-
-# Shared policy for BOTH Saturday and Weekday pipelines.
-# Both deploy scripts write to the same role/policy — keep them in sync.
-POLICY='{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "LambdaInvoke",
-      "Effect": "Allow",
-      "Action": ["lambda:InvokeFunction"],
-      "Resource": [
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-runner*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-judge*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-rolling-mean*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-rationale-clustering*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-replay-concordance*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-replay-counterfactual*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*"
-      ]
-    },
-    {
-      "Sid": "SSMRunCommand",
-      "Effect": "Allow",
-      "Action": [
-        "ssm:SendCommand",
-        "ssm:GetCommandInvocation"
-      ],
-      "Resource": [
-        "arn:aws:ssm:'"$REGION"'::document/AWS-RunShellScript",
-        "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$EC2_INSTANCE_ID"'",
-        "arn:aws:ssm:'"$REGION"':'"$ACCOUNT_ID"':*"
-      ]
-    },
-    {
-      "Sid": "EC2Start",
-      "Effect": "Allow",
-      "Action": ["ec2:StartInstances"],
-      "Resource": "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$TRADING_INSTANCE"'"
-    },
-    {
-      "Sid": "SNSPublish",
-      "Effect": "Allow",
-      "Action": ["sns:Publish"],
-      "Resource": "'"$SNS_TOPIC_ARN"'"
-    },
-    {
-      "Sid": "CloudWatchLogs",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries",
-        "logs:PutResourcePolicy",
-        "logs:DescribeResourcePolicies",
-        "logs:DescribeLogGroups"
-      ],
-      "Resource": "*"
-    }
-  ]
-}'
-
-aws iam put-role-policy \
-  --role-name "$ROLE_NAME" \
-  --policy-name "${ROLE_NAME}-policy" \
-  --policy-document "$POLICY" \
-  --region "$REGION"
-
 ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
 echo "  Role ARN: $ROLE_ARN"
-
-# Wait for IAM propagation
-echo "  Waiting for IAM propagation..."
-sleep 10
+echo "  Inline policy is codified in alpha-engine/infrastructure/iam/"
+echo "  Apply via: cd ~/Development/alpha-engine && ./infrastructure/iam/apply.sh --role $ROLE_NAME"
 
 # ── 3. State Machine ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Drop the inline `aws iam put-role-policy` block against `alpha-engine-step-functions-role` from `deploy_step_function.sh` (Saturday). Trust policy + `aws iam create-role` bootstrap stay inline (one-time setup). The role's inline policy is codified in `alpha-engine/infrastructure/iam/` — `apply.sh` is now the sole writer.

## Why

PR #151 removed the equivalent block from `deploy_step_function_daily.sh` (the weekday twin) on 2026-05-05, but missed this Saturday twin. Today's overnight drift-check caught the consequence: the saturday script's inline policy was a stale, narrower version of the codified one — missing `ssm:DescribeInstanceInformation` + `ec2:StopInstances` + the trading instance in `ssm:SendCommand`. Whenever this script ran, it clobbered the codified state and broke whichever pipeline relied on the missing grants. Same regression class hit prod 4 times in 2 months.

## Companion

cipher813/alpha-engine#137 — adds the static guard that prevents this regression class from merging again.

## Test plan
- [x] `bash -n infrastructure/deploy_step_function.sh` syntax-clean.
- [x] Live IAM unchanged (codified policy already applied).
- [ ] Next saturday deploy (whenever next run) confirms script still completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)