### PR TITLE
refactor(iam): take ownership of shared orchestration roles

### DIFF
--- a/.github/workflows/iam-drift-check.yml
+++ b/.github/workflows/iam-drift-check.yml
@@ -1,0 +1,49 @@
+name: IAM Drift Check
+
+# Catches drift between codified inline policies under
+# infrastructure/iam/<role>.json and the live state on AWS.
+#
+# This repo's codified IAM covers the cross-cutting orchestration roles:
+#   - alpha-engine-step-functions-role (assumed by all 3 SFs)
+#   - alpha-engine-eventbridge-sfn-role (assumed by EventBridge cron rules)
+#   - github-actions-lambda-deploy (assumed by every Lambda deploy workflow)
+#
+# Module-specific roles (executor, predictor, OIDC drift-check) live in
+# their owning repo's infrastructure/iam/ directory and are checked there.
+#
+# Triggers:
+#   - Every PR that touches infrastructure/iam/** (catches code changes
+#     that forgot to apply, or applies that forgot to commit, before merge)
+#   - Daily at 09:30 UTC (catches out-of-band manual IAM edits)
+#   - Manual via workflow_dispatch
+#
+# AWS auth: OIDC → github-actions-iam-drift-check role (defined in
+# alpha-engine; trust policy permits both alpha-engine and alpha-engine-data).
+
+on:
+  pull_request:
+    paths:
+      - 'infrastructure/iam/**'
+      - '.github/workflows/iam-drift-check.yml'
+  schedule:
+    - cron: '30 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # required for OIDC
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-iam-drift-check
+          aws-region: us-east-1
+
+      - name: Run IAM drift check (codified vs live AWS)
+        run: python3 infrastructure/iam/check-drift.py

--- a/infrastructure/add-ssm-policy.sh
+++ b/infrastructure/add-ssm-policy.sh
@@ -37,8 +37,14 @@ POLICY_DOC=$(cat <<EOF
 EOF
 )
 
-# All IAM roles that need SSM access
-ROLES=("alpha-engine-data-role" "alpha-engine-research-role" "alpha-engine-predictor-role" "alpha-engine-executor-role")
+# All IAM roles that need SSM access.
+#
+# Codified roles handle their own SSM-read inline policy via apply.sh in
+# their home repo's infrastructure/iam/ directory:
+#   - alpha-engine-executor-role  → alpha-engine
+#   - alpha-engine-predictor-role → alpha-engine-predictor
+# This script only writes to roles that don't have codified IAM yet.
+ROLES=("alpha-engine-data-role" "alpha-engine-research-role")
 
 DRY_RUN=false
 [ "${1:-}" = "--dry-run" ] && DRY_RUN=true

--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -68,10 +68,21 @@ if [ -z "$EXISTING_SUBS" ]; then
 fi
 
 # ── 2. IAM Role for Step Functions ──────────────────────────────────────────
+#
+# Trust policy + role creation kept here (one-time bootstrap). The inline
+# policy on this role is codified in this repo's infrastructure/iam/
+# directory (alpha-engine-step-functions-role.json) and applied via
+# apply.sh — NOT inline here.
+#
+# This script previously wrote its own inline put-role-policy against
+# this role with a narrower policy than the codified version, which
+# clobbered the codified state every saturday deploy and broke
+# downstream pipelines (4 incidents in 2 months). Codified IAM is now
+# the single writer.
 
-echo "Creating IAM role: $ROLE_NAME..."
+echo "Ensuring IAM role exists: $ROLE_NAME..."
 
-# Trust policy
+# Trust policy (one-time bootstrap; safe to re-run)
 TRUST_POLICY='{
   "Version": "2012-10-17",
   "Statement": [
@@ -88,88 +99,10 @@ aws iam create-role \
   --assume-role-policy-document "$TRUST_POLICY" \
   --region "$REGION" 2>/dev/null || echo "  Role already exists"
 
-# Inline policy: Lambda invoke, SSM, SNS, CloudWatch
-# Trading instance ID for weekday pipeline EC2 start
-TRADING_INSTANCE="${AE_TRADING_INSTANCE_ID:-i-018eb3307a21329bf}"
-
-# Shared policy for BOTH Saturday and Weekday pipelines.
-# Both deploy scripts write to the same role/policy — keep them in sync.
-POLICY='{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "LambdaInvoke",
-      "Effect": "Allow",
-      "Action": ["lambda:InvokeFunction"],
-      "Resource": [
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-runner*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-judge*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-eval-rolling-mean*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-research-rationale-clustering*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-replay-concordance*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-replay-counterfactual*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-data-collector*",
-        "arn:aws:lambda:'"$REGION"':'"$ACCOUNT_ID"':function:alpha-engine-predictor-inference*"
-      ]
-    },
-    {
-      "Sid": "SSMRunCommand",
-      "Effect": "Allow",
-      "Action": [
-        "ssm:SendCommand",
-        "ssm:GetCommandInvocation"
-      ],
-      "Resource": [
-        "arn:aws:ssm:'"$REGION"'::document/AWS-RunShellScript",
-        "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$EC2_INSTANCE_ID"'",
-        "arn:aws:ssm:'"$REGION"':'"$ACCOUNT_ID"':*"
-      ]
-    },
-    {
-      "Sid": "EC2Start",
-      "Effect": "Allow",
-      "Action": ["ec2:StartInstances"],
-      "Resource": "arn:aws:ec2:'"$REGION"':'"$ACCOUNT_ID"':instance/'"$TRADING_INSTANCE"'"
-    },
-    {
-      "Sid": "SNSPublish",
-      "Effect": "Allow",
-      "Action": ["sns:Publish"],
-      "Resource": "'"$SNS_TOPIC_ARN"'"
-    },
-    {
-      "Sid": "CloudWatchLogs",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:CreateLogDelivery",
-        "logs:GetLogDelivery",
-        "logs:UpdateLogDelivery",
-        "logs:DeleteLogDelivery",
-        "logs:ListLogDeliveries",
-        "logs:PutResourcePolicy",
-        "logs:DescribeResourcePolicies",
-        "logs:DescribeLogGroups"
-      ],
-      "Resource": "*"
-    }
-  ]
-}'
-
-aws iam put-role-policy \
-  --role-name "$ROLE_NAME" \
-  --policy-name "${ROLE_NAME}-policy" \
-  --policy-document "$POLICY" \
-  --region "$REGION"
-
 ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
 echo "  Role ARN: $ROLE_ARN"
-
-# Wait for IAM propagation
-echo "  Waiting for IAM propagation..."
-sleep 10
+echo "  Inline policy is codified in infrastructure/iam/${ROLE_NAME}.json"
+echo "  Apply via: ./infrastructure/iam/apply.sh $ROLE_NAME"
 
 # ── 3. State Machine ───────────────────────────────────────────────────────
 
@@ -228,13 +161,13 @@ aws events put-rule \
   --region "$REGION"
 
 # EventBridge needs a role to start Step Functions executions.
-# Trust policy + role creation kept here (one-time bootstrap); inline IAM
-# policy moved to alpha-engine/infrastructure/iam/ (codified file at
-# alpha-engine-eventbridge-sfn-role/alpha-engine-eventbridge-sfn-role-policy.json).
-# Apply via that repo's `apply.sh`, not here. Prior inline block listed
-# only the saturday SFN ARN — every saturday deploy clobbered the
-# weekday ARN that the daily script had granted, breaking the next
-# weekday auto-fire (recurred 2026-04-21, 2026-05-04, 2026-05-06).
+# Trust policy + role creation kept here (one-time bootstrap); inline
+# policy is codified in this repo's infrastructure/iam/ directory
+# (alpha-engine-eventbridge-sfn-role.json). Apply via apply.sh, not
+# here. Prior inline block listed only the saturday SFN ARN — every
+# saturday deploy clobbered the weekday ARN that the daily script had
+# granted, breaking the next weekday auto-fire (recurred 2026-04-21,
+# 2026-05-04, 2026-05-06).
 EB_ROLE_NAME="alpha-engine-eventbridge-sfn-role"
 EB_TRUST='{
   "Version": "2012-10-17",

--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -1,0 +1,100 @@
+# IAM policies (alpha-engine-data — orchestration infra)
+
+Source-of-truth for inline IAM policies on the cross-cutting orchestration
+roles. This repo owns these roles because the **grants are derived from
+code that lives in this repo**:
+
+- `alpha-engine-step-functions-role` — grants reflect the Lambdas the SF
+  JSON invokes + the EC2 instances it sends SSM to + the trading
+  instance it starts/stops. Source: `infrastructure/cloudformation/`
+  + `infrastructure/deploy_step_function*.sh`.
+- `alpha-engine-eventbridge-sfn-role` — grants reflect which Step
+  Functions the EventBridge cron rules target. Source: same as above.
+- `github-actions-lambda-deploy` — grants reflect the set of Lambdas
+  any GitHub Action in any alpha-engine-* repo can deploy. Cross-cutting
+  by design.
+
+Module-specific roles live in their owning repo's `infrastructure/iam/`:
+
+| Role | Home repo |
+|---|---|
+| `alpha-engine-executor-role` | `alpha-engine` |
+| `alpha-engine-predictor-role` | `alpha-engine-predictor` |
+| `github-actions-iam-drift-check` | `alpha-engine` (workflow-specific) |
+
+## Layout
+
+Flat one-file-per-role:
+
+```
+infrastructure/iam/
+├── apply.sh
+├── check-drift.py
+├── README.md
+├── alpha-engine-step-functions-role.json
+├── alpha-engine-eventbridge-sfn-role.json
+└── github-actions-lambda-deploy.json
+```
+
+The filename (minus `.json`) is the IAM role name; the inline policy
+name on AWS is `{role-name}-policy` (enforced by `apply.sh`).
+
+## Usage
+
+```bash
+# Apply every policy
+./infrastructure/iam/apply.sh
+
+# Apply one specific role
+./infrastructure/iam/apply.sh alpha-engine-step-functions-role
+
+# Print planned commands without executing
+./infrastructure/iam/apply.sh --dry-run
+
+# Check drift against live AWS
+./infrastructure/iam/check-drift.py
+```
+
+`apply.sh` calls `aws iam put-role-policy`, which is idempotent —
+re-running overwrites the existing inline policy on the role.
+
+## Single-writer rule
+
+Each codified role must have **exactly one writer** — `apply.sh` in the
+home repo. Any deploy script that calls `aws iam put-role-policy` against
+a codified role from anywhere else is a regression risk.
+
+This rule is enforced by `check-no-foreign-writers.py` in the alpha-engine
+repo, which scans every sibling alpha-engine-* repo on every PR + daily.
+4 IAM-clobber incidents in 2 months traced to this exact pattern (PR
+review missed inline `put-role-policy` blocks in alpha-engine-data deploy
+scripts that competed with codified state); the static check closes that
+regression class.
+
+## Trust policies + role creation
+
+Out of scope for this directory. Trust policies + initial role creation
+are handled inline in the deploy scripts that need them
+(`infrastructure/deploy_step_function.sh` for the SF + EB-SFN roles).
+This directory only manages the **inline policy documents** on roles
+that already exist.
+
+## Drift detection
+
+`.github/workflows/iam-drift-check.yml` runs `check-drift.py` on every
+PR touching `infrastructure/iam/**`, daily at 09:30 UTC, and on
+manual `workflow_dispatch`.
+
+Auth: OIDC via the shared `github-actions-iam-drift-check` role (defined
+in alpha-engine; trust policy permits both alpha-engine and
+alpha-engine-data); read-only `iam:ListRolePolicies` + `iam:GetRolePolicy`
+scoped to the codified roles only.
+
+## When you add a new inline policy
+
+1. Apply it to AWS first (e.g. via `aws iam put-role-policy ...`)
+2. Save the JSON document as `<role-name>.json` in this directory
+3. Commit the file with a description of why the grant was needed
+
+If the role is module-specific rather than orchestration-shared, codify
+it in the owning module's repo instead.

--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -98,3 +98,5 @@ scoped to the codified roles only.
 
 If the role is module-specific rather than orchestration-shared, codify
 it in the owning module's repo instead.
+
+<!-- ci-trigger -->

--- a/infrastructure/iam/alpha-engine-eventbridge-sfn-role.json
+++ b/infrastructure/iam/alpha-engine-eventbridge-sfn-role.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "states:StartExecution",
+            "Resource": [
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+            ]
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -1,0 +1,64 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "lambda:InvokeFunction",
+            "Resource": [
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:SendCommand",
+                "ssm:GetCommandInvocation"
+            ],
+            "Resource": [
+                "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
+                "arn:aws:ec2:us-east-1:711398986525:instance/i-09b539c844515d549",
+                "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf",
+                "arn:aws:ssm:us-east-1:711398986525:*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ssm:DescribeInstanceInformation",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:StartInstances",
+                "ec2:StopInstances"
+            ],
+            "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "sns:Publish",
+            "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:CreateLogDelivery",
+                "logs:GetLogDelivery",
+                "logs:UpdateLogDelivery",
+                "logs:DeleteLogDelivery",
+                "logs:ListLogDeliveries",
+                "logs:PutResourcePolicy",
+                "logs:DescribeResourcePolicies",
+                "logs:DescribeLogGroups"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/infrastructure/iam/check-drift.py
+++ b/infrastructure/iam/check-drift.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""check-drift.py — Diff codified IAM inline policies against live AWS state.
+
+Walks every `infrastructure/iam/<role>.json` in this directory and compares
+against `aws iam get-role-policy --role-name <role> --policy-name <role>-policy`
+(the `{role}-policy` naming convention enforced by apply.sh).
+
+Drift cases (all exit non-zero):
+  * Source JSON differs from AWS document       (content-drift)
+  * AWS role has no inline policy by that name  (missing-in-aws)
+
+JSON is compared after normalization (sorted keys, no extra whitespace),
+so cosmetic-only differences in indentation or key order don't trip the check.
+
+Usage:
+  ./infrastructure/iam/check-drift.py             # check every codified role
+  ./infrastructure/iam/check-drift.py --role X    # check one role
+
+Requires AWS creds with iam:ListRolePolicies + iam:GetRolePolicy on the
+target roles. Locally: any admin profile. In CI: the OIDC role
+`github-actions-iam-drift-check` (alpha-engine repo owns it; trust policy
+allows this repo too).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+
+
+def _aws_iam(*args: str) -> dict | list | str:
+    """Call aws iam ... and return the parsed JSON output."""
+    result = subprocess.run(
+        ["aws", "iam", *args, "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"AWS CLI failed: aws iam {' '.join(args)}\n"
+            f"stderr: {result.stderr}\n"
+        )
+        sys.exit(2)
+    return json.loads(result.stdout) if result.stdout.strip() else {}
+
+
+def _canonical_json(doc: dict) -> str:
+    """Canonical JSON for byte-stable comparison: sorted keys, no extra ws."""
+    return json.dumps(doc, sort_keys=True, separators=(",", ":"))
+
+
+def _check_role(role_file: Path) -> list[str]:
+    """Return list of drift findings for one role. Empty means clean."""
+    role_name = role_file.stem
+    policy_name = f"{role_name}-policy"
+    findings: list[str] = []
+
+    try:
+        source_doc = json.loads(role_file.read_text())
+    except json.JSONDecodeError as exc:
+        return [f"{role_name}: source JSON invalid ({exc})"]
+
+    aws_resp = _aws_iam(
+        "get-role-policy",
+        "--role-name", role_name,
+        "--policy-name", policy_name,
+    )
+    aws_doc = aws_resp.get("PolicyDocument")
+
+    if not aws_doc:
+        return [
+            f"{role_name}: codified in source but inline policy "
+            f"'{policy_name}' not found on AWS role (run apply.sh to push)"
+        ]
+
+    if _canonical_json(source_doc) != _canonical_json(aws_doc):
+        findings.append(
+            f"{role_name}/{policy_name}: source document differs from "
+            f"AWS document (content drift)"
+        )
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--role", help="Check one role (default: every codified role)"
+    )
+    args = parser.parse_args()
+
+    if args.role:
+        role_files = [SCRIPT_DIR / f"{args.role}.json"]
+        if not role_files[0].is_file():
+            sys.stderr.write(f"ERROR: {role_files[0]} not found\n")
+            return 2
+    else:
+        role_files = sorted(SCRIPT_DIR.glob("*.json"))
+
+    if not role_files:
+        print(f"No codified role files found under {SCRIPT_DIR} — nothing to check.")
+        return 0
+
+    total_findings: list[str] = []
+    for role_file in role_files:
+        findings = _check_role(role_file)
+        total_findings.extend(findings)
+
+    if total_findings:
+        print(f"IAM drift detected ({len(total_findings)} finding(s)):")
+        for f in total_findings:
+            print(f"  - {f}")
+        return 1
+
+    role_names = ", ".join(f.stem for f in role_files)
+    print(f"OK: no IAM drift for {role_names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Move the codified inline policies for `alpha-engine-step-functions-role` and `alpha-engine-eventbridge-sfn-role` from `alpha-engine/infrastructure/iam/` to this repo. Their grants are derived from code that lives here (SF JSON Lambda invoke targets, EC2 instances the SF SSMs, EventBridge SFN target ARNs) — co-locating tightens the coupling so a single PR can change SF behavior + matching IAM atomically.

Also drops the last surviving inline `put-role-policy` block from `deploy_step_function.sh` (Saturday script — PR #170 dropped its EB-SFN twin, PR #151 dropped the daily script's SF role twin; this completes the trio) and scopes `add-ssm-policy.sh` to non-codified Lambda execution roles only.

## What's added

```
infrastructure/iam/
├── alpha-engine-step-functions-role.json    # NEW
├── alpha-engine-eventbridge-sfn-role.json   # NEW
├── github-actions-lambda-deploy.json        # was already here
├── apply.sh                                 # was already here
├── check-drift.py                           # NEW (flat-layout variant)
└── README.md                                # NEW

.github/workflows/iam-drift-check.yml         # NEW
```

## Live operations performed

OIDC trust policy on `github-actions-iam-drift-check` widened live to also permit `repo:cipher813/alpha-engine-data:*` (added 2 sub patterns alongside the existing 2 for alpha-engine). Trust policies + role creation stay out-of-band per existing convention.

## Companion / supersedes

- Companion: cipher813/alpha-engine#137 — removes the codified directories from alpha-engine + updates the cross-repo foreign-writer guard to handle multi-repo discovery + flat layout.
- Supersedes: cipher813/alpha-engine-data#171 (closed; broader relocation includes its scope).

## Predictor follow-up (NOT in this PR)

`add-ssm-policy.sh`'s ROLES list drops `alpha-engine-predictor-role` along with `alpha-engine-executor-role`. Executor's `alpha-engine-ssm-read` is already codified in alpha-engine. Predictor's live `alpha-engine-ssm-read` inline grant **stays live** (nothing deletes it) but is no longer maintained by this script. Codifying it on the predictor side is a separate small PR — alpha-engine-predictor's `infrastructure/iam/` would need a directory-per-role refactor first to support multiple inline policies on the same role.

## Test plan
- [x] `bash -n` syntax-clean on both deploy scripts.
- [x] `python3 infrastructure/iam/check-drift.py` clean against live AWS for all 3 roles owned here (lambda-deploy, SF, EB-SFN).
- [x] Foreign-writer guard from companion PR runs clean against this branch.
- [ ] CI runs both checks on this PR.
- [ ] Saturday SF auto-fire (Sat 2026-05-09) confirms no regression.
- [ ] Weekday SF auto-fire (Thu 2026-05-07) confirms no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)