### PR TITLE
feat(morning-enrich): replace wall-clock skip with data-staleness check

### DIFF
--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -160,12 +160,13 @@ def test_morning_enrich_default_date_uses_previous_trading_day():
                 "tickers_captured": 1, "source": "polygon_only"}
 
     # Pin the skip guard to OFF so this test exercises only the
-    # _previous_trading_day fill-in. Without this the test is wall-clock
-    # dependent (would skip when run after 13:30 PT on a trading day).
+    # _previous_trading_day fill-in. Without this the test would depend on
+    # ArcticDB live state (the staleness check reads SPY's last_date).
     with patch("weekly_collector.constituents", fake_constituents), \
          patch("weekly_collector.daily_closes.collect", side_effect=fake_collect), \
          patch("builders.daily_append.daily_append",
                return_value={"status": "ok"}), \
+         patch("weekly_collector._arctic_spy_last_date", return_value=None), \
          patch("weekly_collector._should_skip_morning_enrich",
                return_value=(False, None)), \
          patch("weekly_collector._previous_trading_day", return_value="2026-04-23"):
@@ -470,93 +471,67 @@ def test_morning_enrich_continues_if_prune_fails():
     assert result["status"] == "ok"
 
 
-# ── _should_skip_morning_enrich (post-1:30pm-PT skip guard) ────────────────
+# ── _should_skip_morning_enrich (data-staleness skip guard) ────────────────
 
 
-def test_skip_guard_fires_after_1_30pm_pt_on_trading_day():
-    """Wed 14:00 PT (a trading day, after the 13:30 cutoff) → skip=True.
+def test_skip_guard_fires_when_polygon_target_older_than_arctic():
+    """Wed-PM rerun: polygon target=Tue, ArcticDB last=Wed (yfinance EOD).
 
-    This is the failure case the guard exists to handle: a manual midweek
-    Saturday-SF rerun after market close. polygon free-tier 403's the
-    same-day grouped-daily, and once UTC has rolled past midnight,
-    _previous_trading_day() resolves to today and the polygon call hard-fails.
+    Polygon's T+1 settled day is older than what's already in ArcticDB.
+    Running polygon would overwrite Wed's authoritative yfinance EOD row
+    with a Tue write — wrong row anyway, but more importantly it would not
+    refresh today's data. Skip.
     """
-    # 2026-04-22 is a Wednesday (trading day).
-    now = datetime(2026, 4, 22, 14, 0, 0, tzinfo=_PT)
-    skip, reason = weekly_collector._should_skip_morning_enrich(now=now)
+    from datetime import date
+    skip, reason = weekly_collector._should_skip_morning_enrich(
+        target_date="2026-04-21",  # Tue
+        arctic_last_date=date(2026, 4, 22),  # Wed
+    )
     assert skip is True
     assert reason is not None
-    assert "post_close_midweek" in reason
+    assert "stale_overwrite" in reason
+    assert "2026-04-21" in reason
+    assert "2026-04-22" in reason
 
 
-def test_skip_guard_does_not_fire_before_1_30pm_pt():
-    """Wed 13:29 PT (one minute before cutoff) → skip=False.
+def test_skip_guard_does_not_fire_when_target_equals_arctic_last():
+    """Saturday cron: polygon target=Fri, ArcticDB last=Fri (yfinance EOD).
 
-    The pre-13:30 window is the regular weekday-SF MorningEnrich Lambda's
-    operating zone (it runs ~06:15 PT). Polygon T+1 for the prior session
-    is settled by then, so the polygon path is the right one to take.
+    This is the canonical case the morning enrich exists to handle:
+    overwrite the yfinance EOD row with polygon's authoritative VWAP/OHLCV.
+    Equal dates → run polygon.
     """
-    now = datetime(2026, 4, 22, 13, 29, 0, tzinfo=_PT)
-    skip, reason = weekly_collector._should_skip_morning_enrich(now=now)
+    from datetime import date
+    skip, reason = weekly_collector._should_skip_morning_enrich(
+        target_date="2026-04-24",  # Fri
+        arctic_last_date=date(2026, 4, 24),  # Fri
+    )
     assert skip is False
     assert reason is None
 
 
-def test_skip_guard_does_not_fire_on_non_trading_day_after_cutoff():
-    """Sat 14:00 PT → skip=False, even though the wall-clock is past 13:30.
-
-    The Saturday SF cron itself fires at 02:00 PT, well below the cutoff,
-    so this case only applies to manual reruns. On a non-trading day,
-    _previous_trading_day() resolves to a settled prior session (e.g.,
-    Friday) — polygon T+1 is fine, no skip needed.
-    """
-    # 2026-04-25 is a Saturday.
-    now = datetime(2026, 4, 25, 14, 0, 0, tzinfo=_PT)
-    skip, reason = weekly_collector._should_skip_morning_enrich(now=now)
+def test_skip_guard_does_not_fire_when_target_newer_than_arctic():
+    """ArcticDB lags target (e.g., a fresh universe with no recent rows).
+    polygon should run to extend history."""
+    from datetime import date
+    skip, reason = weekly_collector._should_skip_morning_enrich(
+        target_date="2026-04-24",
+        arctic_last_date=date(2026, 4, 17),
+    )
     assert skip is False
     assert reason is None
 
 
-def test_skip_guard_does_not_fire_on_saturday_cron_window():
-    """Sat 02:00 PT (the scheduled Saturday SF cron time) → skip=False.
-
-    Defensive: confirms the guard does not interfere with the scheduled
-    Saturday SF path. This is the regression case for "we accidentally
-    broke the Saturday cron path."
-    """
-    # 2026-04-25 is a Saturday.
-    now = datetime(2026, 4, 25, 2, 0, 0, tzinfo=_PT)
-    skip, reason = weekly_collector._should_skip_morning_enrich(now=now)
+def test_skip_guard_falls_through_when_arctic_read_unavailable():
+    """If we couldn't read ArcticDB SPY last_date, fall through to running
+    polygon. Polygon will surface its own 403/availability failures loudly.
+    Better to fail loudly downstream than silently skip without evidence."""
+    skip, reason = weekly_collector._should_skip_morning_enrich(
+        target_date="2026-04-24",
+        arctic_last_date=None,
+    )
     assert skip is False
     assert reason is None
-
-
-def test_skip_guard_does_not_fire_on_holiday_after_cutoff():
-    """Christmas 14:00 PT → skip=False (NYSE closed).
-
-    Same logic as the Saturday case: on a non-trading day the guard
-    doesn't apply because polygon T+1 for the prior session is already
-    settled.
-    """
-    # 2026-12-25 is Christmas (NYSE closed).
-    now = datetime(2026, 12, 25, 14, 0, 0, tzinfo=_PT)
-    skip, reason = weekly_collector._should_skip_morning_enrich(now=now)
-    assert skip is False
-    assert reason is None
-
-
-def test_skip_guard_accepts_utc_input_via_astimezone():
-    """A UTC-aware datetime that lands past 13:30 PT after conversion fires.
-
-    Real callers pass nothing (helper grabs `datetime.now(PT)` itself), but
-    callers that DO pass a `now` may pass it in any tz — the helper must
-    convert. Wed 22:00 UTC = Wed 15:00 PT (during DST) = past cutoff.
-    """
-    # 2026-04-22 22:00 UTC = 15:00 PT (DST in effect)
-    now_utc = datetime(2026, 4, 22, 22, 0, 0, tzinfo=timezone.utc)
-    skip, reason = weekly_collector._should_skip_morning_enrich(now=now_utc)
-    assert skip is True
-    assert "post_close_midweek" in reason
 
 
 # ── _run_morning_enrich integration with the skip guard ────────────────────
@@ -577,8 +552,9 @@ def test_morning_enrich_short_circuits_when_skip_guard_fires():
 
     with patch(
         "weekly_collector._should_skip_morning_enrich",
-        return_value=(True, "post_close_midweek (test)"),
+        return_value=(True, "stale_overwrite (test)"),
     ), patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector._arctic_spy_last_date", return_value=None), \
          patch("weekly_collector.daily_closes.collect",
                side_effect=lambda **k: polygon_calls.append(k) or {"status": "ok"}), \
          patch("builders.daily_append.daily_append",
@@ -588,7 +564,7 @@ def test_morning_enrich_short_circuits_when_skip_guard_fires():
         result = weekly_collector._run_morning_enrich(config, args)
 
     assert result["status"] == "skipped"
-    assert "post_close_midweek" in result["skip_reason"]
+    assert "stale_overwrite" in result["skip_reason"]
     assert result["would_have_targeted"]  # _previous_trading_day() filled it in
     assert polygon_calls == [], "polygon must not be called when guard skips"
     assert daily_append_calls == [], "daily_append must not be called when guard skips"
@@ -598,8 +574,8 @@ def test_morning_enrich_short_circuits_when_skip_guard_fires():
 
 def test_morning_enrich_explicit_date_overrides_skip_guard():
     """Explicit --date is operator-driven backfill — must run polygon even
-    after 13:30 PT. Operator knows what they're doing (e.g., backfilling a
-    specific date that polygon T+1 has long since settled)."""
+    when the staleness guard would otherwise fire. Operator knows what they're
+    doing (e.g., backfilling a date polygon T+1 has long since settled)."""
     config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
     args = SimpleNamespace(date="2026-04-22", dry_run=True, morning_enrich=True)
 
@@ -628,6 +604,68 @@ def test_morning_enrich_explicit_date_overrides_skip_guard():
     )
 
 
+def test_morning_enrich_skips_when_arctic_already_has_newer_row():
+    """End-to-end: Wed-PM manual rerun. _previous_trading_day(PT-aware) yields
+    Tue, ArcticDB SPY already has Wed (from Wed EOD yfinance). Skip fires with
+    stale_overwrite reason; no polygon, no daily_append, no health stamp."""
+    from datetime import date
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date=None, dry_run=False, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    polygon_calls = []
+    daily_append_calls = []
+
+    with patch("weekly_collector._previous_trading_day", return_value="2026-04-21"), \
+         patch("weekly_collector._arctic_spy_last_date",
+               return_value=date(2026, 4, 22)), \
+         patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               side_effect=lambda **k: polygon_calls.append(k) or {"status": "ok"}), \
+         patch("builders.daily_append.daily_append",
+               side_effect=lambda **k: daily_append_calls.append(k) or {"status": "ok"}):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert result["status"] == "skipped"
+    assert "stale_overwrite" in result["skip_reason"]
+    assert "2026-04-21" in result["skip_reason"]
+    assert "2026-04-22" in result["skip_reason"]
+    assert result["would_have_targeted"] == "2026-04-21"
+    assert polygon_calls == []
+    assert daily_append_calls == []
+    fake_constituents.collect.assert_not_called()
+
+
+def test_morning_enrich_runs_when_arctic_matches_target_date():
+    """End-to-end: Saturday cron path. target=Fri, arctic=Fri (yfinance EOD).
+    Equal dates → run polygon to overwrite with authoritative VWAP/OHLCV."""
+    from datetime import date
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date=None, dry_run=True, morning_enrich=True)
+
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    polygon_calls = []
+    def fake_collect(**kwargs):
+        polygon_calls.append(kwargs)
+        return {"status": "ok_dry_run", "polygon": 1, "fred": 0, "yfinance": 0,
+                "tickers_captured": 1, "source": "polygon_only"}
+
+    with patch("weekly_collector._previous_trading_day", return_value="2026-04-24"), \
+         patch("weekly_collector._arctic_spy_last_date",
+               return_value=date(2026, 4, 24)), \
+         patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect", side_effect=fake_collect), \
+         patch("builders.daily_append.daily_append", return_value={"status": "ok"}):
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    assert result["status"] == "ok"
+    assert result["date"] == "2026-04-24"
+    assert len(polygon_calls) == 1
+    assert polygon_calls[0]["run_date"] == "2026-04-24"
+
+
 def test_morning_enrich_dry_run_skips_preflight_writes():
     """Dry runs must not refresh constituents.json or prune ArcticDB —
     side-effect-free is the contract."""
@@ -648,7 +686,8 @@ def test_morning_enrich_dry_run_skips_preflight_writes():
                              "yfinance": 0, "tickers_captured": 1,
                              "source": "polygon_only"}), \
          patch("builders.daily_append.daily_append",
-               return_value={"status": "ok"}):
+               return_value={"status": "ok"}), \
+         patch("weekly_collector._arctic_spy_last_date", return_value=None):
         weekly_collector._run_morning_enrich(config, args)
 
     fake_constituents.collect.assert_not_called()

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -443,59 +443,67 @@ def _previous_trading_day(reference: datetime | None = None) -> str:
     )
 
 
-# Cutoff for the "post-close midweek" skip guard: 1:30pm PT (= 30 min after
-# the 1pm-PT close). Yfinance has same-day close populated by this time, so
-# whatever's already in ArcticDB from the morning enrich Lambda + EOD
-# PostMarketData is "good enough" to feed Phase 1 / training / backtester
-# until the next regular Saturday SF re-fetches via polygon T+1.
-_POST_CLOSE_SKIP_HOUR_PT = 13
-_POST_CLOSE_SKIP_MINUTE_PT = 30
+def _arctic_spy_last_date(bucket: str) -> "date | None":
+    """Return SPY's last-indexed date in ArcticDB macro lib, or None on read failure.
+
+    Best-effort: any exception (lib unavailable, empty symbol, transient S3) is
+    logged and resolved as None so the skip decision falls through to "run
+    polygon". Polygon will surface its own failures loudly downstream.
+    """
+    try:
+        from store.arctic_store import get_macro_lib
+        import pandas as pd
+        macro_lib = get_macro_lib(bucket)
+        df = macro_lib.tail("SPY", n=1).data
+        if df.empty:
+            return None
+        return pd.Timestamp(df.index[-1]).date()
+    except Exception as exc:
+        logger.warning(
+            "ArcticDB SPY last_date read failed (%s) — skip-guard will proceed without staleness check",
+            exc,
+        )
+        return None
 
 
 def _should_skip_morning_enrich(
-    now: datetime | None = None,
+    target_date: str,
+    arctic_last_date: "date | None",
 ) -> tuple[bool, str | None]:
-    """Decide whether to skip MorningEnrich based on wall-clock + trading calendar.
+    """Decide whether to skip MorningEnrich based on data staleness.
 
     Returns ``(skip, reason)``. ``skip=True`` means the caller should bail
     out before invoking polygon. Rationale:
 
     Polygon's free tier 403's same-day grouped-daily, and the next session's
-    T+1 settlement isn't visible until ~04:00–05:00 ET the following morning
-    (the Saturday SF cron — 09:00 UTC = 02:00 AM PT — was chosen on this
-    basis). When MorningEnrich is invoked manually after 1:30 PM PT on a
-    trading day (e.g., a Wed-evening "midweek Saturday SF" rerun),
-    ``_previous_trading_day()`` can resolve to today's date once the UTC
-    clock has rolled past midnight — and the polygon call hard-fails 403.
+    T+1 settlement isn't visible until the following morning (the Saturday SF
+    cron — 09:00 UTC = 02:00 AM PT — was chosen on this basis). On a manual
+    midweek "Saturday SF" rerun after the EOD post-market pass has already
+    landed today's yfinance row, polygon's prior-trading-day overwrite would
+    write *older* data over *newer* data already in ArcticDB.
 
-    Skipping leaves the yfinance row already in ArcticDB (from this morning's
-    weekday-SF MorningEnrich Lambda + this afternoon's EOD PostMarketData)
-    intact. The next regular Saturday SF re-fetches the affected sessions
-    from polygon T+1, restoring authoritative VWAP/OHLCV.
+    The check: if polygon's ``target_date`` is strictly before what's already
+    in ArcticDB, skip. The yfinance row written by this afternoon's EOD
+    PostMarketData stays authoritative for this run; the next regular
+    Saturday SF re-fetches the affected sessions from polygon T+1, restoring
+    authoritative VWAP/OHLCV.
 
-    The scheduled Saturday cron (02:00 AM PT) is well below the cutoff and
-    is unaffected. Explicit ``--date`` is handled by the caller and bypasses
-    the guard.
+    The scheduled Saturday 02:00 PT cron and the weekday-SF 06:15 PT
+    MorningEnrich Lambda both target the prior trading day, which equals
+    ArcticDB's last_date at that hour, so the check returns ``skip=False``
+    and polygon runs as normal.
+
+    Explicit ``--date`` is handled by the caller and bypasses the check.
     """
-    from zoneinfo import ZoneInfo
-    from alpha_engine_lib.trading_calendar import is_trading_day
-
-    pt = ZoneInfo("America/Los_Angeles")
-    now_pt = (now.astimezone(pt) if now else datetime.now(pt))
-    if not is_trading_day(now_pt.date()):
+    if arctic_last_date is None:
         return False, None
-    cutoff = now_pt.replace(
-        hour=_POST_CLOSE_SKIP_HOUR_PT,
-        minute=_POST_CLOSE_SKIP_MINUTE_PT,
-        second=0,
-        microsecond=0,
-    )
-    if now_pt >= cutoff:
+    if target_date < arctic_last_date.isoformat():
         return True, (
-            f"post_close_midweek (now={now_pt.strftime('%Y-%m-%d %H:%M %Z')}, "
-            f"cutoff=13:30 PT) — polygon free-tier 403's today's grouped-daily; "
-            f"yfinance row already in ArcticDB stays authoritative for this run, "
-            f"next Saturday SF re-fetches via polygon T+1"
+            f"stale_overwrite (polygon target={target_date}, "
+            f"ArcticDB SPY last={arctic_last_date.isoformat()}) — polygon's "
+            f"T+1 settled day is older than the yfinance EOD row already in "
+            f"ArcticDB; skipping to avoid overwriting newer with older. "
+            f"Next Saturday SF re-fetches via polygon T+1."
         )
     return False, None
 
@@ -518,13 +526,26 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
     bucket = config["bucket"]
     started_at = datetime.now(timezone.utc).isoformat()
 
-    # Skip guard: post-1:30pm-PT manual reruns on a trading day. See
+    # Compute target_date PT-aware so a Wed-evening manual rerun (UTC rolled
+    # past midnight) doesn't resolve "previous trading day" to today PT — that
+    # was the original 403 trap the wall-clock guard worked around.
+    if args.date is None:
+        from zoneinfo import ZoneInfo
+        target_date = _previous_trading_day(
+            reference=datetime.now(ZoneInfo("America/Los_Angeles"))
+        )
+    else:
+        target_date = args.date
+
+    # Skip guard: data-staleness check. If polygon's target_date is older than
+    # what's already in ArcticDB (yfinance EOD already landed today's row),
+    # skip so we don't overwrite newer data with older. See
     # _should_skip_morning_enrich() for full rationale. Explicit --date
     # bypasses the guard so operator-driven backfills still work.
     if args.date is None:
-        skip, reason = _should_skip_morning_enrich()
+        arctic_last_date = _arctic_spy_last_date(bucket)
+        skip, reason = _should_skip_morning_enrich(target_date, arctic_last_date)
         if skip:
-            target_date = _previous_trading_day()
             logger.info(
                 "Skipping MorningEnrich: %s. Would have targeted %s.",
                 reason, target_date,
@@ -538,8 +559,6 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
                 "completed_at": datetime.now(timezone.utc).isoformat(),
                 "collectors": {},
             }
-
-    target_date = args.date or _previous_trading_day()
     dry_run = args.dry_run
     daily_cfg = config.get("daily_closes", {})
 


### PR DESCRIPTION
## Summary
- Replace PR #169's 13:30 PT wall-clock cutoff with a direct date comparison: skip MorningEnrich's polygon overwrite when polygon's `target_date` is strictly older than ArcticDB SPY's `last_date`.
- Fix the root cause that PR #169 was working around: compute `target_date` PT-aware in `_run_morning_enrich` so a Wed-21:00-PT (Thu-04:00-UTC) manual rerun no longer resolves "previous trading day" to today PT.
- Add `_arctic_spy_last_date(bucket)` helper using the same `store.arctic_store.get_macro_lib` primitive `sf_preflight` already uses. Best-effort: read failure → falls through to running polygon (polygon will surface its own failures loudly).

## Why
The 13:30 PT cutoff is a temporal proxy for what we actually care about: never overwrite newer ArcticDB data with an older polygon row. The data-driven check expresses the invariant directly and removes the clock-watching from operator workflow.

Behavior across canonical paths:
- Sat 02:00 PT cron: target=Fri, arctic=Fri → run (canonical yfinance→polygon overwrite)
- Wed 06:15 PT weekday SF: target=Tue, arctic=Tue → run
- Wed 14:00 PT manual rerun: target=Tue, arctic=Wed → **SKIP** (stale_overwrite)
- Wed 21:00 PT manual rerun: target=Tue (no UTC bug now), arctic=Wed → **SKIP**

## Test plan
- [x] 475 tests pass (full `tests/` suite)
- [x] 4 new unit tests for `_should_skip_morning_enrich(target_date, arctic_last_date)`: stale, equal, newer, arctic-read-unavailable
- [x] 2 new end-to-end tests: stale-target → skipped without polygon/daily_append calls; equal-target → polygon runs
- [x] Existing test that pins skip guard OFF updated to also patch `_arctic_spy_last_date` (avoids live ArcticDB dependency in unit tests)
- [ ] Saturday 5/9 02:00 PT regular cron: verify polygon runs and writes Fri's row (canonical path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)