### PR TITLE
chore(changelog-incident-mirror): update ROADMAP path references

### DIFF
--- a/infrastructure/lambdas/changelog-incident-mirror/README.md
+++ b/infrastructure/lambdas/changelog-incident-mirror/README.md
@@ -34,7 +34,7 @@ service-side delete API). They are now hand-managed via this
 directory.
 
 The decision to orphan + reconsideration triggers are documented in
-`alpha-engine-docs/private/ROADMAP.md` under the Observability
+`alpha-engine-config/private-docs/ROADMAP.md` under the Observability
 section.
 
 ## What's here

--- a/infrastructure/lambdas/changelog-incident-mirror/index.py
+++ b/infrastructure/lambdas/changelog-incident-mirror/index.py
@@ -37,7 +37,7 @@ deploy.sh in this directory. The decision to orphan from CF (rather
 than keep it in the alpha-engine-orchestration stack) was made
 2026-05-01 to avoid a perm cascade on the github-actions-lambda-deploy
 OIDC role; trade-off + reconsideration triggers documented in the
-private/ROADMAP.md "Observability" section.
+alpha-engine-config/private-docs/ROADMAP.md "Observability" section.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Comment / documentation edits only. ROADMAP.md moved from `alpha-engine-docs/private/` to `alpha-engine-config/private-docs/` on 2026-05-06 (version-tracking move). Updates two references in the changelog-incident-mirror Lambda:
- `index.py:40` module docstring
- `README.md:37` Observability section pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)