### PR TITLE
chore(sf): drop stale forward-reference in WeeklySubstrateHealthCheck…

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -950,7 +950,7 @@
 
     "WeeklySubstrateHealthCheck": {
       "Type": "Task",
-      "Comment": "Phase 2 → 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) — agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (alerts on failure but does not halt pipeline) — same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF will run --cadence daily in a follow-up PR.",
+      "Comment": "Phase 2 → 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) — agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (alerts on failure but does not halt pipeline) — same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF runs --cadence daily on the daily-only subset (PR #178 — DailySubstrateHealthCheck state).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",


### PR DESCRIPTION
… Comment

The Sat-SF substrate state's Comment promised "the weekday EOD SF will run --cadence daily in a follow-up PR." That follow-up shipped today (PR #178 — DailySubstrateHealthCheck SF state on the weekday EOD SF).

Comment-only edit; no behavioral change. Will land in live SF on next deploy_step_function.sh run (idempotent — AWS only bumps the revision when the definition actually changes).

Suite unchanged (15/15 substrate wiring tests still pass; comment text isn't pinned by the wiring tests).