### PR TITLE
fix(changelog-mirror): grant s3:PutObject on changelog/entries/* (asymmetric-IAM-grant)

### DIFF
--- a/infrastructure/lambdas/changelog-incident-mirror/iam-policy.json
+++ b/infrastructure/lambdas/changelog-incident-mirror/iam-policy.json
@@ -4,7 +4,10 @@
     {
       "Effect": "Allow",
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::alpha-engine-research/changelog/incidents/*"
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research/changelog/entries/*",
+        "arn:aws:s3:::alpha-engine-research/changelog/incidents/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The Lambda's inline IAM policy `changelog-incident-mirror-s3` granted `s3:PutObject` only on `changelog/incidents/*` — never extended when the schema-discipline arc (2026-05-01) added the structured dual-write to `changelog/entries/`.
- Since 5/2, **every SNS-mirror invocation has silently failed the structured write** with `AccessDenied`. Legacy write succeeded first, masking the failure; downstream consumers couldn't tell the structured side was broken.
- This PR broadens `Resource` to include both prefixes (additive grant only).

## Quantified gap
SNS-mirror entries in `changelog/entries/` over the past 7 days:

| Date | Count |
|---|---|
| 2026-05-01 | 2 |
| 2026-05-02 | 0 |
| 2026-05-03 | 0 |
| 2026-05-04 | 0 |
| 2026-05-05 | 0 |
| 2026-05-06 | 0 |
| 2026-05-07 | 0 (until smoke test post-fix) |

## Surfaced by
[alpha-engine-data#180](https://github.com/cipher813/alpha-engine-data/pull/180) (retired the legacy emit). Smoke test crashed with `AccessDenied`, which exposed the IAM gap that had been masked since 5/1 — classic fix-reveals-masked-bug + asymmetric-IAM-grant antipatterns combined.

## Live state
- Policy applied via `aws iam put-role-policy` at ~13:50 UTC 2026-05-07; this PR codifies the source of truth.
- Smoke verified post-fix: `deploy.sh --smoke` wrote `changelog/entries/2026-05-07/2026-05-07T13-51-59_alpha-engine-alerts_5879b3c.json` with no errors.
- 5th asymmetric-IAM-grant incident in two months (per memory).

## Test plan
- [x] Live policy applied + verified via `get-role-policy`
- [x] `deploy.sh --smoke` wrote a structured entry post-fix
- [ ] Next real SNS publish from `alpha-engine-alerts` lands at `changelog/entries/` (validate via `aws logs filter` for `Wrote structured=` lines + S3 listing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)