### PR TITLE
feat(sf): split Evaluator into independent SF state

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -407,6 +407,25 @@ Resources:
       AlarmActions:
         - !Ref AlertsTopic
 
+  EvaluatorHeartbeat:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alpha-engine-evaluator-no-heartbeat
+      AlarmDescription: Evaluator did not emit heartbeat (expected weekly — split from Backtester 2026-05-07)
+      Namespace: AlphaEngine
+      MetricName: Heartbeat
+      Dimensions:
+        - Name: Process
+          Value: evaluator
+      Statistic: Sum
+      Period: 604800
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - !Ref AlertsTopic
+
   RAGIngestionHeartbeat:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1,5 +1,5 @@
 {
-  "Comment": "Alpha Engine Saturday Pipeline — orchestrates weekly data collection, RAG ingestion, research, predictor training, and backtesting sequentially with fail-fast error handling. DataPhase1 and RAGIngestion are independent SF states (split 2026-05-06 after a RAG-side import bug failed under the DataPhase1 label, masking that the data layer was healthy). Each runs on its own spot — accepts +1 bootstrap cycle (~7 min) in exchange for failure isolation, redrive granularity, and per-step health markers. RAG still runs before Research so the knowledge base is fresh. Backtester runs AFTER predictor training (depends on model weights). Supports partial execution via boolean skip_* flags on input (e.g. {\"skip_data_phase1\": true, \"skip_rag_ingestion\": true}); a missing flag is treated as false, so scheduled runs are unaffected.",
+  "Comment": "Alpha Engine Saturday Pipeline — orchestrates weekly data collection, RAG ingestion, research, predictor training, backtesting, and evaluation sequentially with fail-fast error handling. DataPhase1 and RAGIngestion are independent SF states (split 2026-05-06 after a RAG-side import bug failed under the DataPhase1 label, masking that the data layer was healthy). Backtester and Evaluator are independent SF states (split 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md — for failure isolation, per-stage email, and independent CW heartbeats). Each runs on its own spot — accepts +1 bootstrap cycle (~7 min) per split in exchange for failure isolation, redrive granularity, and per-step health markers. RAG still runs before Research so the knowledge base is fresh. Backtester runs AFTER predictor training (depends on model weights); Evaluator runs after Backtester (reads same-cohort backtest artifacts). Supports partial execution via boolean skip_* flags on input (e.g. {\"skip_data_phase1\": true, \"skip_rag_ingestion\": true, \"skip_evaluator\": true}); a missing flag is treated as false, so scheduled runs are unaffected.",
   "StartAt": "InitializeInput",
   "States": {
 
@@ -503,7 +503,7 @@
 
     "CheckSkipBacktester": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses the backtester step (which runs backtest + parity + evaluator as consolidated spot stages post-2026-04-24) and jumps to the eval-judge skip-gate (preserving the eval-pipeline states downstream — the bug fixed 2026-05-03 was that this routed directly to SaturdayHealthCheck, silently bypassing CheckSkipEvalJudge → ComputeEvalCadence → eval-judge → eval-rolling-mean for any operator who passed skip_backtester=true). The legacy {\"skip_evaluator\": true} and {\"freeze_evaluator\": true} inputs are no longer honored; freeze-evaluator is now a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
+      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses BOTH the Backtester state (backtest + parity) and the Evaluator state (evaluate.py) — they were split into independent SF states 2026-05-07 (plan: alpha-engine-docs/private/evaluator-split-260507.md), but skipping the backtester implicitly skips the evaluator since evaluate.py reads same-cohort backtest artifacts. Routes to CheckSkipEvalJudge (preserving the LLM-judge eval-pipeline states downstream — the bug fixed 2026-05-03 was that this routed directly to SaturdayHealthCheck, silently bypassing CheckSkipEvalJudge → ComputeEvalCadence → eval-judge → eval-rolling-mean for any operator who passed skip_backtester=true). To skip ONLY the evaluator (keep backtest+parity), use {\"skip_evaluator\": true}. The legacy {\"freeze_evaluator\": true} input is no longer honored; freeze-evaluator is now a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
       "Choices": [
         {
           "And": [
@@ -518,7 +518,7 @@
 
     "Backtester": {
       "Type": "Task",
-      "Comment": "Consolidated backtest + parity + evaluator on spot instance (after predictor training). Post-2026-04-24 spot_backtest.sh runs all three stages in sequence; the previous dedicated Evaluator SF state was retired. Evaluator runs in live-apply mode by default (no --freeze-evaluator flag passed); for diagnostic-only off-cycle runs, invoke spot_backtest.sh manually with --freeze-evaluator and --skip-stages=backtest,parity.",
+      "Comment": "Backtest + parity on spot instance (after predictor training). Post-2026-05-07 the evaluator stage was split into a separate Evaluator SF state for failure isolation + per-stage email + independent heartbeat (plan: alpha-engine-docs/private/evaluator-split-260507.md). spot_backtest.sh is invoked with --skip-stages=evaluator so this state runs only backtest + parity; the Evaluator state runs evaluate.py against the same backtest/{date}/ S3 prefix. If this state fails, Evaluator is NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -530,7 +530,7 @@
             "cd /home/ec2-user/alpha-engine-backtester",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "bash infrastructure/spot_backtest.sh 2>&1 | tee /var/log/backtester.log"
+            "bash infrastructure/spot_backtest.sh --skip-stages=evaluator 2>&1 | tee /var/log/backtester.log"
           ],
           "executionTimeout": ["7200"]
         },
@@ -590,7 +590,7 @@
         {
           "Variable": "$.backtester_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipEvalJudge"
+          "Next": "CheckSkipEvaluator"
         },
         {
           "Variable": "$.backtester_poll.Status",
@@ -610,6 +610,117 @@
       "Type": "Wait",
       "Seconds": 60,
       "Next": "WaitForBacktester"
+    },
+
+    "CheckSkipEvaluator": {
+      "Type": "Choice",
+      "Comment": "Skip-gate. {\"skip_evaluator\": true} bypasses ONLY the Evaluator state (evaluate.py against today's backtest+parity artifacts) and routes to CheckSkipEvalJudge so the LLM-judge eval-pipeline downstream still fires. Use this when iterating on evaluator code mid-week without re-running the 121-min backtest. To skip the entire backtester+evaluator pair, use {\"skip_backtester\": true} on CheckSkipBacktester instead.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_evaluator", "IsPresent": true},
+            {"Variable": "$.skip_evaluator", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipEvalJudge"
+        }
+      ],
+      "Default": "Evaluator"
+    },
+
+    "Evaluator": {
+      "Type": "Task",
+      "Comment": "Evaluator on a separate spot instance (split from Backtester 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md). Reads s3://alpha-engine-research/backtest/{RUN_DATE}/ artifacts produced by the prior Backtester state and runs evaluate.py --mode all --upload, which sends the per-signal grading email and auto-applies optimizer configs. Reuses spot_backtest.sh with --skip-stages=backtest,parity; the script is the canonical dispatch surface (existing CSV vocabulary). Live-apply mode by default; for diagnostic-only off-cycle runs, invoke spot_backtest.sh manually with --freeze-evaluator and --skip-stages=backtest,parity.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.ec2_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -eo pipefail",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-backtester",
+            "export HOME=/home/ec2-user",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity 2>&1 | tee /var/log/evaluator.log"
+          ],
+          "executionTimeout": ["3600"]
+        },
+        "TimeoutSeconds": 3600
+      },
+      "TimeoutSeconds": 3660,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed", "States.Timeout"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 180,
+          "BackoffRate": 2.0,
+          "Comment": "Retry on failure/timeout — handles spot interruption (new instance on retry). Mirrors Backtester retry posture for symmetry."
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.evaluator_result",
+      "Next": "WaitForEvaluator"
+    },
+
+    "WaitForEvaluator": {
+      "Type": "Task",
+      "Comment": "Poll SSM command until evaluator complete",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.evaluator_result.Command.CommandId",
+        "InstanceId.$": "$.ec2_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.evaluator_poll",
+      "Next": "CheckEvaluatorStatus"
+    },
+
+    "CheckEvaluatorStatus": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.evaluator_poll.Status",
+          "StringEquals": "Success",
+          "Next": "CheckSkipEvalJudge"
+        },
+        {
+          "Variable": "$.evaluator_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "EvaluatorWait"
+        },
+        {
+          "Variable": "$.evaluator_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "EvaluatorWait"
+        }
+      ],
+      "Default": "ExtractEvaluatorError"
+    },
+
+    "EvaluatorWait": {
+      "Type": "Wait",
+      "Seconds": 60,
+      "Next": "WaitForEvaluator"
     },
 
     "CheckSkipEvalJudge": {
@@ -1076,6 +1187,18 @@
         "phase": "Backtester",
         "source": "CheckBacktesterStatus.Default",
         "poll.$": "$.backtester_poll"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+
+    "ExtractEvaluatorError": {
+      "Type": "Pass",
+      "Comment": "Normalize Evaluator SSM non-Success poll into $.error.",
+      "Parameters": {
+        "phase": "Evaluator",
+        "source": "CheckEvaluatorStatus.Default",
+        "poll.$": "$.evaluator_poll"
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -54,16 +54,20 @@ class TestStatesPresent:
             assert name in states, f"missing SF state: {name}"
 
 
-# ── Backtester success → eval-judge skip-gate ─────────────────────────────
+# ── Backtester success → evaluator skip-gate ──────────────────────────────
 
 
 class TestBacktesterTransition:
-    def test_success_routes_to_eval_skip_gate(self, states):
+    def test_success_routes_to_evaluator_skip_gate(self, states):
+        # Post-2026-05-07 split: Backtester success now routes to
+        # CheckSkipEvaluator (the new gate in front of the standalone
+        # Evaluator state) instead of CheckSkipEvalJudge. The evaluator
+        # then converges back into the eval-judge chain on success.
         bt = states["CheckBacktesterStatus"]
         success_choice = next(
             c for c in bt["Choices"] if c.get("StringEquals") == "Success"
         )
-        assert success_choice["Next"] == "CheckSkipEvalJudge"
+        assert success_choice["Next"] == "CheckSkipEvaluator"
 
 
 # ── Skip gate ─────────────────────────────────────────────────────────────

--- a/tests/test_sf_evaluator_wiring.py
+++ b/tests/test_sf_evaluator_wiring.py
@@ -1,0 +1,209 @@
+"""Pins the Evaluator state wiring in the Saturday Step Functions JSON.
+
+The Evaluator state was split from the consolidated Backtester state on
+2026-05-07 (plan: alpha-engine-docs/private/evaluator-split-260507.md)
+for failure isolation, per-stage email, and independent CloudWatch
+heartbeats. This test pins the split topology so a future operator
+doesn't accidentally reroute Backtester success straight back to
+CheckSkipEvalJudge (the pre-split shape) or merge the two states again
+without a deliberate ROADMAP item.
+
+Distinct from test_sf_eval_judge_wiring.py: that file pins the
+LLM-as-judge Lambda chain (Haiku/Sonnet rubric scoring); this one pins
+the spot-based evaluate.py state (per-signal grading + optimizer
+auto-apply).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    return sf["States"]
+
+
+# ── State presence ────────────────────────────────────────────────────────
+
+
+class TestStatesPresent:
+    def test_all_evaluator_states_exist(self, states):
+        for name in (
+            "CheckSkipEvaluator",
+            "Evaluator",
+            "WaitForEvaluator",
+            "CheckEvaluatorStatus",
+            "EvaluatorWait",
+            "ExtractEvaluatorError",
+        ):
+            assert name in states, f"missing SF state: {name}"
+
+
+# ── Skip gate ─────────────────────────────────────────────────────────────
+
+
+class TestSkipEvaluator:
+    def test_skip_flag_bypasses_to_eval_judge_gate(self, states):
+        """Skipping the Evaluator state must NOT also skip the LLM-judge
+        chain — they're independent (evaluator = per-signal grading +
+        optimizer auto-apply against backtest artifacts; eval-judge =
+        LLM rubric scoring of decision_artifacts/). The skip path lands
+        on CheckSkipEvalJudge so the judge chain still fires unless its
+        own skip flag is set.
+        """
+        skip = states["CheckSkipEvaluator"]
+        choice = skip["Choices"][0]
+        and_clauses = choice["And"]
+        assert any(
+            c.get("Variable") == "$.skip_evaluator"
+            and c.get("BooleanEquals") is True
+            for c in and_clauses
+        )
+        assert choice["Next"] == "CheckSkipEvalJudge"
+        # Critically NOT routed to SaturdayHealthCheck — that would
+        # bundle-skip both the evaluator and the entire eval-judge
+        # observability chain.
+        assert choice["Next"] != "SaturdayHealthCheck"
+
+    def test_default_runs_evaluator(self, states):
+        assert states["CheckSkipEvaluator"]["Default"] == "Evaluator"
+
+
+class TestSkipBacktesterAlsoSkipsEvaluator:
+    """Pins the contract that {"skip_backtester": true} skips BOTH
+    Backtester and Evaluator (since the evaluator reads same-cohort
+    backtest artifacts — running it without a fresh backtest would grade
+    against stale data). The CheckSkipBacktester skip path therefore
+    routes to CheckSkipEvalJudge (skipping past CheckSkipEvaluator
+    entirely), preserving the LLM-judge chain downstream.
+    """
+
+    def test_skip_backtester_bypasses_evaluator(self, states):
+        skip = states["CheckSkipBacktester"]
+        choice = skip["Choices"][0]
+        # The skip-true branch must skip past the Evaluator state.
+        # Routing to CheckSkipEvalJudge is correct — CheckSkipEvaluator
+        # is between CheckBacktesterStatus and CheckSkipEvalJudge in
+        # the success path, so jumping straight to CheckSkipEvalJudge
+        # bypasses the evaluator without re-implementing the gate.
+        assert choice["Next"] == "CheckSkipEvalJudge"
+        assert choice["Next"] != "CheckSkipEvaluator"
+
+
+# ── Evaluator task contract ───────────────────────────────────────────────
+
+
+class TestEvaluatorTask:
+    def test_invokes_ssm_send_command(self, states):
+        assert (
+            states["Evaluator"]["Resource"]
+            == "arn:aws:states:::aws-sdk:ssm:sendCommand"
+        )
+
+    def test_command_passes_skip_stages_backtest_parity(self, states):
+        # The Evaluator state reuses spot_backtest.sh — the canonical
+        # dispatch surface — and skips the backtest + parity stages so
+        # only evaluate.py runs. If a future operator drops --skip-stages
+        # the spot will re-run the full 121-min backtest and the split
+        # collapses silently.
+        cmds = states["Evaluator"]["Parameters"]["Parameters"]["commands"]
+        spot_cmd = next(c for c in cmds if "spot_backtest.sh" in c)
+        assert "--skip-stages=backtest,parity" in spot_cmd
+
+    def test_writes_to_evaluator_log(self, states):
+        # Tee output into /var/log/evaluator.log so it's distinguishable
+        # from /var/log/backtester.log on the spot host.
+        cmds = states["Evaluator"]["Parameters"]["Parameters"]["commands"]
+        spot_cmd = next(c for c in cmds if "spot_backtest.sh" in c)
+        assert "/var/log/evaluator.log" in spot_cmd
+
+    def test_timeout_is_60_min(self, states):
+        # Evaluator runtime is ~30 min for full mode (per evaluate.py
+        # historical runs). 3600s ceiling gives 2x headroom + bootstrap.
+        assert states["Evaluator"]["Parameters"]["TimeoutSeconds"] == 3600
+        # SF state TimeoutSeconds wraps with +60s safety buffer (matches
+        # Backtester's 7200/7260 ratio).
+        assert states["Evaluator"]["TimeoutSeconds"] == 3660
+
+    def test_retry_mirrors_backtester_posture(self, states):
+        # Spot interruption handling: 2 attempts, 180s initial backoff,
+        # 2.0x multiplier — matches Backtester for symmetry.
+        retry = states["Evaluator"]["Retry"][0]
+        assert retry["MaxAttempts"] == 2
+        assert retry["IntervalSeconds"] == 180
+        assert retry["BackoffRate"] == 2.0
+
+    def test_catch_routes_to_handle_failure(self, states):
+        # Evaluator failure halts the pipeline (unlike eval-judge which
+        # is observability-only). The optimizer auto-apply contract
+        # means a silent evaluator failure could leave stale configs in
+        # production — fail loud.
+        catch = states["Evaluator"]["Catch"][0]
+        assert catch["ErrorEquals"] == ["States.ALL"]
+        assert catch["Next"] == "HandleFailure"
+
+
+# ── Poll loop ─────────────────────────────────────────────────────────────
+
+
+class TestEvaluatorPollLoop:
+    def test_evaluator_routes_to_wait_state(self, states):
+        assert states["Evaluator"]["Next"] == "WaitForEvaluator"
+
+    def test_wait_for_evaluator_polls_evaluator_command(self, states):
+        params = states["WaitForEvaluator"]["Parameters"]
+        assert params["CommandId.$"] == "$.evaluator_result.Command.CommandId"
+
+    def test_wait_for_evaluator_routes_to_check_status(self, states):
+        assert states["WaitForEvaluator"]["Next"] == "CheckEvaluatorStatus"
+
+    def test_check_status_success_continues_to_eval_judge(self, states):
+        # On evaluator success the pipeline picks up the LLM-judge chain
+        # at the same skip-gate that pre-split Backtester success used.
+        bt = states["CheckEvaluatorStatus"]
+        success_choice = next(
+            c for c in bt["Choices"] if c.get("StringEquals") == "Success"
+        )
+        assert success_choice["Next"] == "CheckSkipEvalJudge"
+
+    def test_check_status_in_progress_loops_to_wait(self, states):
+        bt = states["CheckEvaluatorStatus"]
+        ip_choice = next(
+            c for c in bt["Choices"] if c.get("StringEquals") == "InProgress"
+        )
+        assert ip_choice["Next"] == "EvaluatorWait"
+
+    def test_check_status_default_extracts_error(self, states):
+        assert states["CheckEvaluatorStatus"]["Default"] == "ExtractEvaluatorError"
+
+    def test_evaluator_wait_loops_back_to_poll(self, states):
+        assert states["EvaluatorWait"]["Next"] == "WaitForEvaluator"
+
+
+# ── Failure normalization ────────────────────────────────────────────────
+
+
+class TestExtractEvaluatorError:
+    def test_phase_label_is_evaluator(self, states):
+        params = states["ExtractEvaluatorError"]["Parameters"]
+        assert params["phase"] == "Evaluator"
+
+    def test_carries_evaluator_poll_into_error(self, states):
+        params = states["ExtractEvaluatorError"]["Parameters"]
+        assert params["poll.$"] == "$.evaluator_poll"
+
+    def test_routes_to_handle_failure(self, states):
+        assert states["ExtractEvaluatorError"]["Next"] == "HandleFailure"


### PR DESCRIPTION
## Summary
- Split the consolidated `Backtester` state (backtest + parity + evaluator since 2026-04-24) into two independent SF states: `Backtester` (backtest + parity) and `Evaluator` (evaluate.py only). Both reuse `spot_backtest.sh` with different `--skip-stages` flags, each on its own c5.large spot.
- Add `EvaluatorHeartbeat` CloudWatch alarm (mirrors `BacktesterHeartbeat`, `Process=evaluator` dimension).
- New `skip_evaluator` SF input skips only the evaluator state; existing `skip_backtester` skips both (evaluator depends on cohort artifacts).
- 20 new wiring tests pinning the state contract; updates 1 existing test for the renamed Backtester-success transition.

## Why
- Last evaluator email was 2026-05-02 — a backtester or parity flake silently blanks the evaluator email + optimizer auto-apply on the same week.
- Mirrors the DataPhase1 / RAGIngestion split shipped 2026-05-06: accepts a +bootstrap cycle (~7 min) for failure isolation, redrive granularity, per-stage email, and independent CW heartbeats. Cost delta ~$0.18/year.
- Plan: `alpha-engine-docs/private/evaluator-split-260507.md`.

## Failure semantics
- `Backtester` fail → `Evaluator` NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).
- `Evaluator` fail → backtest+parity artifacts + email already shipped; evaluator failure is now isolated to its own SF state.
- `{"skip_backtester": true}` skips both stages.
- `{"skip_evaluator": true}` (NEW) skips only evaluator — useful for iterating on evaluator code without re-running 121-min backtest.

## Pairs with
- `alpha-engine-backtester` PR #150 — per-stage CW heartbeats. Land that one first so the spot script emits both `Process=backtester` (when backtest+parity ran) and `Process=evaluator` (when evaluator ran) heartbeats. This PR is forward-compatible with the unsplit heartbeat behavior, but post-merge ordering of #150 → this PR avoids a one-Saturday window where the new `EvaluatorHeartbeat` alarm fires red because the spot script hasn't been updated.

## Test plan
- [x] `pytest tests/test_sf_evaluator_wiring.py tests/test_sf_eval_judge_wiring.py -v` — 72 passed
- [x] Full `pytest` suite — 542 passed (5 unrelated FutureWarnings)
- [x] JSON parse validates; 58 SF states; new state names confirmed present
- [ ] Post-merge: SF-vs-CFN drift scan should pass (existing SaturdayHealthCheck job covers this)
- [ ] First Saturday SF firing: confirm both `Process=backtester` and `Process=evaluator` heartbeats green; both backtester and evaluator emails arrive
- [ ] Operator dry-run with `{"skip_evaluator": true}` — Backtester runs, Evaluator skipped, CheckSkipEvalJudge entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)