### PR TITLE
feat(lambda): changelog-cloudwatch-mirror — Lambda errors → S3

### DIFF
--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/README.md
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/README.md
@@ -1,0 +1,120 @@
+# changelog-cloudwatch-mirror Lambda
+
+Closes the **Lambda errors directly to S3** half of the system-wide event-mining coverage matrix (ROADMAP > Observability > line ~2121).
+
+## What it does
+
+CloudWatch Logs subscription filters on every alpha-engine Lambda match `ERROR / CRITICAL / "Task timed out"` patterns and deliver matched log events to this relay Lambda. The relay decodes the gzipped subscription-filter event payload, parses each `logEvent`, and writes one structured incident entry per event to:
+
+```
+s3://alpha-engine-research/changelog/entries/{YYYY-MM-DD}/{event_id}.json
+```
+
+Schema 1.0.0 per `alpha-engine-config/changelog/vocab.yaml`. Same shape as the SNS-mirror Lambda's entries; downstream aggregator + retro-candidate filter consume both transparently.
+
+## Why a separate Lambda from the SNS-mirror
+
+- SNS-mirror covers events that land on the `alpha-engine-alerts` topic (Step Function failures, EOD failures, CloudWatch alarm state-changes wired to SNS).
+- This Lambda covers events that land **only in CloudWatch Logs** — Lambda crashes (cold-start failures, OOM, timeouts, Python exceptions) are the canonical example. These never reach SNS by default.
+- Decoder shape differs (gzipped + base64 logs payload vs. plain SNS message), so split handlers keep both clean.
+
+## Per-Lambda inferred subsystem
+
+Log-group prefix → vocab.yaml subsystem (matching order; first-match wins):
+
+| Log group prefix | subsystem |
+|---|---|
+| `/aws/lambda/alpha-engine-predictor*` | `predictor` |
+| `/aws/lambda/alpha-engine-research*` | `research` |
+| `/aws/lambda/alpha-engine-data*` | `data_pipeline` |
+| `/aws/lambda/alpha-engine-replay*` | `eval` |
+| (default) | `infrastructure` |
+
+## Defaults applied to auto-emitted entries
+
+| Field | Value |
+|---|---|
+| `severity` | `high` |
+| `subsystem` | inferred (see above) |
+| `root_cause_category` | `infrastructure_failure` |
+| `auto_emitted` | `true` |
+| `source` | `cloudwatch-mirror` |
+| `actor` | source Lambda's function name |
+| `machine` | `lambda:changelog-cloudwatch-mirror` |
+
+Operator can refine via a follow-up `changelog-log --event-type investigation` entry whose `git_refs` reference the original event_id.
+
+## Subscription targets (11 Lambdas)
+
+The deploy script wires subscription filters to every alpha-engine Lambda **except** the two changelog-mirror Lambdas (recursion guard — if this Lambda errors, its log lines must not feed back into itself).
+
+```
+alpha-engine-data-collector
+alpha-engine-ec2-lifecycle
+alpha-engine-predictor-health-check
+alpha-engine-predictor-inference
+alpha-engine-replay-concordance
+alpha-engine-replay-counterfactual
+alpha-engine-research-alerts
+alpha-engine-research-eval-judge
+alpha-engine-research-eval-rolling-mean
+alpha-engine-research-rationale-clustering
+alpha-engine-research-runner
+```
+
+## Recursion guard
+
+Two layers:
+1. **Target list excludes self.** The deploy script's `TARGET_FUNCTIONS` array does not include `alpha-engine-changelog-cloudwatch-mirror` or `alpha-engine-changelog-incident-mirror`.
+2. **Pattern is narrow.** Filter pattern `?ERROR ?CRITICAL ?"Task timed out"` does not match this Lambda's normal log lines (`Wrote structured=...`).
+
+If this Lambda's own errors need to be captured, write a separate downstream surface — do not subscribe a Lambda to its own log group.
+
+## Operator deploy steps
+
+**First time (creates IAM role + Lambda + all 11 subscription filters):**
+```
+bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --bootstrap
+bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --smoke
+```
+
+**Code update (after PR merge):**
+```
+bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
+```
+
+**Re-apply subscription filters only (e.g., after adding a new target Lambda):**
+```
+bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --wire-subs
+```
+
+**Dry-run any action:**
+```
+bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --dry-run --bootstrap
+```
+
+## Smoke test verification
+
+After `--smoke` runs (synthetic ERROR delivered via direct Lambda invoke), check:
+
+```
+aws s3 ls s3://alpha-engine-research/changelog/entries/$(date -u +%Y-%m-%d)/ --recursive | grep cloudwatch-mirror
+```
+
+Expect one entry with `source: cloudwatch-mirror` and `actor: alpha-engine-predictor-inference` (the synthetic payload's source).
+
+## "Done" signal
+
+Every observable Lambda failure mode in the system surfaces as an entry in `s3://alpha-engine-research/changelog/entries/`, regardless of whether it originated as an SNS alert, flow-doctor diagnose call, or Lambda crash. Closes the original ROADMAP P1 line ~2099 entry end-to-end (Gap 1 closed by flow-doctor 0.4.0 S3Notifier 2026-05-01; Gap 2 closes here).
+
+## Cost
+
+11 subscription filters × paper-trading error frequency (~few/week) ≈ negligible (<$0.01/month). Each filter invocation transfers <1KB to the relay Lambda, which executes in <100ms.
+
+## Tests
+
+```
+python3 infrastructure/lambdas/changelog-cloudwatch-mirror/test_handler.py
+```
+
+14 tests cover: subscription event decode, per-logEvent fan-out, structured payload shape, subsystem inference (predictor / research / data_pipeline / eval / default), event_id format, event_id distinctness for same-second errors, control-message no-op, empty-events no-op, empty-message skip, missing-timestamp fallback.

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the changelog-cloudwatch-mirror Lambda
+# and wire per-Lambda CloudWatch Logs subscription filters.
+#
+# This Lambda is the second half of the changelog event-mining coverage
+# matrix (sibling SNS-mirror Lambda is the first half). It receives
+# CloudWatch Logs subscription-filter events for every alpha-engine
+# Lambda's error patterns and writes one structured incident entry
+# per matched log event.
+#
+# Managed outside CloudFormation, same rationale as the SNS-mirror
+# Lambda — keeps the github-actions-lambda-deploy OIDC role's blast
+# radius narrow.
+#
+# Usage:
+#   bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh           # update code only
+#   bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --bootstrap   # first-time create + wire all subscriptions
+#   bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --wire-subs   # (re)apply subscription filters only
+#   bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --dry-run     # show actions, do not apply
+#   bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --smoke       # publish a synthetic ERROR log + verify entry
+#
+# Auth: uses active AWS CLI creds. Personal IAM user (cipher813) has
+# enough perms; this script is intentionally NOT wired into CI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-changelog-cloudwatch-mirror"
+ROLE_NAME="alpha-engine-changelog-cloudwatch-mirror-role"
+POLICY_NAME="alpha-engine-changelog-cloudwatch-mirror-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+SUBSCRIPTION_FILTER_NAME="alpha-engine-error-mirror"
+# Subscription filter pattern — matches lines containing any of:
+#   ERROR, CRITICAL, "Task timed out". Quoted strings are required for
+#   patterns containing spaces per AWS subscription-filter syntax.
+FILTER_PATTERN='?ERROR ?CRITICAL ?"Task timed out"'
+
+# Target Lambdas — every alpha-engine-* function EXCEPT the two
+# changelog-mirror Lambdas (recursion guard: if the mirror Lambda
+# itself errors, its log lines that contain "ERROR" must not feed
+# back into itself).
+TARGET_FUNCTIONS=(
+  "alpha-engine-data-collector"
+  "alpha-engine-ec2-lifecycle"
+  "alpha-engine-predictor-health-check"
+  "alpha-engine-predictor-inference"
+  "alpha-engine-replay-concordance"
+  "alpha-engine-replay-counterfactual"
+  "alpha-engine-research-alerts"
+  "alpha-engine-research-eval-judge"
+  "alpha-engine-research-eval-rolling-mean"
+  "alpha-engine-research-rationale-clustering"
+  "alpha-engine-research-runner"
+)
+
+DRY_RUN=false
+BOOTSTRAP=false
+WIRE_SUBS=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --wire-subs) WIRE_SUBS=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler ---------------------------------------------------
+
+python3 -c "
+import ast, sys
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler smoke tests..."
+  python3 "${SCRIPT_DIR}/test_handler.py" >/dev/null 2>&1 && echo "  ✓ Smoke tests pass"
+fi
+
+# ----- 1. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # 1a. IAM role with Lambda trust policy
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  # 1b. Inline policy (S3 PutObject + Lambda log writing)
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  # 1c. Wait for IAM role to propagate (eventually-consistent)
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  # 1d. Package + create function
+  PKG=$(mktemp -d)
+  trap "rm -rf '$PKG'" EXIT
+  cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+  ZIP="${PKG}/function.zip"
+  (cd "${PKG}" && zip -q "function.zip" index.py)
+  echo "  Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 30 \
+      --memory-size 128 \
+      --environment 'Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_STRUCTURED_PREFIX=changelog/entries}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  fi
+fi
+
+# ----- 2. Update function code (always) -------------------------------------
+
+if ! $BOOTSTRAP; then
+  PKG=$(mktemp -d)
+  trap "rm -rf '$PKG'" EXIT
+  cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+  ZIP="${PKG}/function.zip"
+  (cd "${PKG}" && zip -q "function.zip" index.py)
+  echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+  echo "Updating Lambda function code: ${FUNCTION_NAME}"
+  run aws lambda update-function-code \
+    --function-name "${FUNCTION_NAME}" \
+    --zip-file "fileb://${ZIP}" \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text
+
+  if ! $DRY_RUN; then
+    aws lambda wait function-updated \
+      --function-name "${FUNCTION_NAME}" \
+      --region "${REGION}"
+  fi
+
+  echo "Ensuring env config..."
+  run aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment 'Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_STRUCTURED_PREFIX=changelog/entries}' \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text
+
+  if ! $DRY_RUN; then
+    aws lambda wait function-updated \
+      --function-name "${FUNCTION_NAME}" \
+      --region "${REGION}"
+  fi
+fi
+
+echo "✓ Code deployed."
+
+# ----- 3. Wire per-Lambda subscription filters ------------------------------
+
+if $BOOTSTRAP || $WIRE_SUBS; then
+  RELAY_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  echo ""
+  echo "Wiring CloudWatch Logs subscription filters..."
+  for fn in "${TARGET_FUNCTIONS[@]}"; do
+    LOG_GROUP="/aws/lambda/${fn}"
+
+    # Ensure log group exists (Lambda creates it on first invocation; if
+    # the function has never run, the group won't exist yet).
+    if ! aws logs describe-log-groups --log-group-name-prefix "${LOG_GROUP}" --region "${REGION}" \
+        --query "logGroups[?logGroupName=='${LOG_GROUP}']" --output text | grep -q "${LOG_GROUP}"; then
+      echo "  ⊘ ${fn} — log group does not exist yet (Lambda hasn't run). Skipping."
+      continue
+    fi
+
+    # Per-source-Lambda permission allowing CloudWatch Logs to invoke the relay.
+    # StatementId per source — idempotent only if removed-then-added; ignore
+    # ResourceConflictException on re-runs.
+    PERM_SID="cwlogs-invoke-${fn}"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "${PERM_SID}" \
+      --action lambda:InvokeFunction \
+      --principal "logs.${REGION}.amazonaws.com" \
+      --source-arn "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${LOG_GROUP}:*" \
+      --region "${REGION}" 2>/dev/null || true
+
+    # Subscription filter — idempotent, AWS overwrites by name.
+    echo "  → ${fn}"
+    run aws logs put-subscription-filter \
+      --log-group-name "${LOG_GROUP}" \
+      --filter-name "${SUBSCRIPTION_FILTER_NAME}" \
+      --filter-pattern "${FILTER_PATTERN}" \
+      --destination-arn "${RELAY_ARN}" \
+      --region "${REGION}"
+  done
+  echo "✓ Subscription filters applied."
+fi
+
+# ----- 4. Smoke test --------------------------------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct Lambda invoke (synthetic payload)..."
+  TS=$(date -u +%s)
+  # Build a synthetic CloudWatch Logs subscription filter event payload.
+  # Keep this in sync with index.py's expected shape.
+  PAYLOAD_DECODED='{"messageType":"DATA_MESSAGE","owner":"'${ACCOUNT_ID}'","logGroup":"/aws/lambda/alpha-engine-predictor-inference","logStream":"smoke-test","subscriptionFilters":["alpha-engine-error-mirror"],"logEvents":[{"id":"smoke-'${TS}'","timestamp":'${TS}'000,"message":"[ERROR] deploy.sh smoke test '${TS}'"}]}'
+  PAYLOAD_BLOB=$(printf '%s' "${PAYLOAD_DECODED}" | gzip | base64)
+  EVENT='{"awslogs":{"data":"'${PAYLOAD_BLOB}'"}}'
+
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload "${EVENT}" \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  echo "  → Check entry at: aws s3 ls s3://alpha-engine-research/changelog/entries/$(date -u +%Y-%m-%d)/ --recursive | grep '${TS}'"
+fi

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/iam-policy.json
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/iam-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "WriteStructuredChangelogEntries",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/changelog/entries/*"
+    },
+    {
+      "Sid": "WriteOwnLambdaLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/index.py
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/index.py
@@ -1,0 +1,175 @@
+"""CloudWatch Logs subscription filter → S3 mirror for the system-wide changelog.
+
+Subscribed via per-Lambda CloudWatch Logs subscription filters that match
+ERROR / CRITICAL / "Task timed out" patterns. For every matched log event,
+writes one structured incident entry to:
+
+  s3://alpha-engine-research/changelog/entries/{YYYY-MM-DD}/{event_id}.json
+
+Schema 1.0.0 per alpha-engine-config/changelog/vocab.yaml. Closes the
+"Lambda errors directly to S3" gap from the system-wide event-mining
+coverage matrix (ROADMAP > Observability > Gap 2, line ~2121) — Lambda
+crashes land in CloudWatch Logs but not (by default) in SNS, so the
+SNS-mirror Lambda misses them.
+
+Defaults applied to auto-emitted entries (operator can refine via a
+follow-up `changelog-log --event-type investigation` referencing the
+emitted event_id):
+
+  severity            = "high"
+  subsystem           = inferred from log group name (see _infer_subsystem)
+  root_cause_category = "infrastructure_failure"
+  auto_emitted        = true
+  source              = "cloudwatch-mirror"
+
+CloudWatch Logs subscription-filter event payloads arrive as base64-encoded
+gzip blobs under `event.awslogs.data`. After decode/decompress, the JSON
+shape is:
+
+    {
+      "messageType": "DATA_MESSAGE",
+      "owner": "...",
+      "logGroup": "/aws/lambda/<function-name>",
+      "logStream": "...",
+      "subscriptionFilters": ["alpha-engine-error-mirror"],
+      "logEvents": [
+        {"id": "...", "timestamp": <epoch_ms>, "message": "..."}
+      ]
+    }
+
+One structured incident entry is written per matched logEvent.
+
+Managed outside CloudFormation alongside the SNS-mirror Lambda — see
+sibling deploy.sh + README.md.
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import os
+from datetime import datetime, timezone
+from hashlib import sha1
+
+import boto3
+
+_S3 = boto3.client("s3")
+_BUCKET = os.environ["CHANGELOG_BUCKET"]
+_STRUCTURED_PREFIX = os.environ.get("CHANGELOG_STRUCTURED_PREFIX", "changelog/entries")
+
+SCHEMA_VERSION = "1.0.0"
+
+# Map log-group prefix → vocab.yaml subsystem. Order matters — first match
+# wins. The default for unmatched groups is "infrastructure" (covers
+# ec2-lifecycle, changelog-mirror, anything else operator hasn't classified).
+_SUBSYSTEM_MAP: tuple[tuple[str, str], ...] = (
+    ("/aws/lambda/alpha-engine-predictor", "predictor"),
+    ("/aws/lambda/alpha-engine-research", "research"),
+    ("/aws/lambda/alpha-engine-data", "data_pipeline"),
+    ("/aws/lambda/alpha-engine-replay", "eval"),
+)
+
+
+def _infer_subsystem(log_group: str) -> str:
+    for prefix, subsystem in _SUBSYSTEM_MAP:
+        if log_group.startswith(prefix):
+            return subsystem
+    return "infrastructure"
+
+
+def _put(key: str, body: dict) -> None:
+    _S3.put_object(
+        Bucket=_BUCKET,
+        Key=key,
+        Body=json.dumps(body).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _decode_payload(event: dict) -> dict:
+    """Decode CloudWatch Logs subscription filter event → raw JSON dict."""
+    blob = event["awslogs"]["data"]
+    raw = gzip.decompress(base64.b64decode(blob))
+    return json.loads(raw)
+
+
+def handler(event, context):
+    payload = _decode_payload(event)
+    if payload.get("messageType") != "DATA_MESSAGE":
+        # Subscription-filter control messages (e.g., CONTROL_MESSAGE on
+        # initial wiring) carry no logEvents — silently no-op.
+        return {"statusCode": 200, "wrote": 0, "skipped": payload.get("messageType")}
+
+    log_group = payload.get("logGroup", "")
+    log_stream = payload.get("logStream", "")
+    function_name = log_group.split("/")[-1] if log_group else "unknown"
+    subsystem = _infer_subsystem(log_group)
+
+    wrote = 0
+    for log_event in payload.get("logEvents", []):
+        message = (log_event.get("message") or "").rstrip()
+        if not message:
+            continue
+        ts_ms = log_event.get("timestamp") or 0
+        ts = datetime.fromtimestamp(ts_ms / 1000.0, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+        ts_utc = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+        entry_date = ts.strftime("%Y-%m-%d")
+
+        # First non-empty line is the summary; full message is the description.
+        first_line = next((ln for ln in message.splitlines() if ln.strip()), message)
+        summary = first_line[:240]
+
+        # event_id format mirrors the SNS-mirror + composite-action scheme:
+        # {ts}_{actor}_{7-hex}. Actor here is the source Lambda's function
+        # name (sanitized).
+        ts_id = ts_utc.replace(":", "-").rstrip("Z")
+        actor_safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in function_name)
+        # log_event.id is already unique per event in the source log stream;
+        # hashing it (rather than ts+summary) prevents two errors-at-the-
+        # same-second from colliding into one event_id.
+        event_hash = sha1(
+            f"{log_event.get('id', '')}|{message}".encode()
+        ).hexdigest()[:7]
+        event_id = f"{ts_id}_{actor_safe}_{event_hash}"
+
+        structured_entry = {
+            "schema_version": SCHEMA_VERSION,
+            "event_id": event_id,
+            "ts_utc": ts_utc,
+            "event_type": "incident",
+            "severity": "high",
+            "subsystem": subsystem,
+            "root_cause_category": "infrastructure_failure",
+            "resolution_type": None,
+            "started_at": None,
+            "detected_at": ts_utc,
+            "resolved_at": None,
+            "verified_at": None,
+            "summary": summary,
+            "description": message,
+            "resolution_notes": None,
+            "actor": function_name,
+            "machine": "lambda:changelog-cloudwatch-mirror",
+            "source": "cloudwatch-mirror",
+            "auto_emitted": True,
+            "git_refs": [],
+            "prompt_version": None,
+            "run_id": None,
+            "eval_run_ref": None,
+            "cloudwatch": {
+                "log_group": log_group,
+                "log_stream": log_stream,
+                "log_event_id": log_event.get("id", ""),
+            },
+        }
+        structured_key = f"{_STRUCTURED_PREFIX}/{entry_date}/{event_id}.json"
+        _put(structured_key, structured_entry)
+        print(
+            f"Wrote structured=s3://{_BUCKET}/{structured_key} "
+            f"function={function_name} subsystem={subsystem} "
+            f"summary={summary[:80]!r}"
+        )
+        wrote += 1
+
+    return {"statusCode": 200, "wrote": wrote}

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/test_handler.py
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/test_handler.py
@@ -1,0 +1,222 @@
+"""Smoke tests for the CloudWatch-mirror Lambda handler.
+
+Mocks boto3.client('s3').put_object so the handler runs end-to-end without
+needing AWS creds. Verifies decode + structured-entry shape + per-logEvent
+fan-out + log-group → subsystem inference.
+
+Run from the repo root:
+
+  python3 infrastructure/lambdas/changelog-cloudwatch-mirror/test_handler.py
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+HERE = Path(__file__).resolve().parent
+
+
+def _import_handler():
+    """Import index.py with boto3.client + env vars stubbed."""
+    os.environ.setdefault("CHANGELOG_BUCKET", "test-bucket")
+    sys.path.insert(0, str(HERE))
+
+    fake_boto3 = MagicMock()
+    fake_s3_client = MagicMock()
+    fake_boto3.client = MagicMock(return_value=fake_s3_client)
+
+    sys.modules["boto3"] = fake_boto3
+    if "index" in sys.modules:
+        del sys.modules["index"]
+    import index
+    return index, fake_s3_client
+
+
+def _encode_subscription_event(payload: dict) -> dict:
+    """Wrap a CloudWatch Logs payload as a subscription-filter Lambda event."""
+    raw = json.dumps(payload).encode("utf-8")
+    blob = base64.b64encode(gzip.compress(raw)).decode("ascii")
+    return {"awslogs": {"data": blob}}
+
+
+def _sample_payload(
+    log_group: str = "/aws/lambda/alpha-engine-predictor-inference",
+    log_events: list[dict] | None = None,
+    message_type: str = "DATA_MESSAGE",
+) -> dict:
+    if log_events is None:
+        log_events = [
+            {
+                "id": "37155797159871123456789012345678901234567890123456",
+                "timestamp": 1778198400000,  # 2026-05-08T00:00:00Z
+                "message": "[ERROR] Cold start exceeded 60s\nTraceback (most recent call last):\n  File ...",
+            }
+        ]
+    return {
+        "messageType": message_type,
+        "owner": "711398986525",
+        "logGroup": log_group,
+        "logStream": "2026/05/08/[$LATEST]abcd1234",
+        "subscriptionFilters": ["alpha-engine-error-mirror"],
+        "logEvents": log_events,
+    }
+
+
+class HandlerTests(unittest.TestCase):
+    def setUp(self):
+        self.index, self.s3 = _import_handler()
+
+    # --- happy path -------------------------------------------------
+
+    def test_writes_one_entry_per_log_event(self):
+        result = self.index.handler(
+            _encode_subscription_event(_sample_payload()), context=None
+        )
+        self.assertEqual(result["wrote"], 1)
+        self.assertEqual(self.s3.put_object.call_count, 1)
+        key = self.s3.put_object.call_args_list[0].kwargs["Key"]
+        self.assertTrue(key.startswith("changelog/entries/2026-05-08/"))
+        self.assertTrue(key.endswith(".json"))
+
+    def test_multiple_log_events_fan_out(self):
+        payload = _sample_payload(log_events=[
+            {"id": "id-a", "timestamp": 1778198400000, "message": "[ERROR] one"},
+            {"id": "id-b", "timestamp": 1778198401000, "message": "[CRITICAL] two"},
+            {"id": "id-c", "timestamp": 1778198402000, "message": "Task timed out after 60s"},
+        ])
+        result = self.index.handler(_encode_subscription_event(payload), context=None)
+        self.assertEqual(result["wrote"], 3)
+        self.assertEqual(self.s3.put_object.call_count, 3)
+
+    def test_structured_entry_payload(self):
+        self.index.handler(_encode_subscription_event(_sample_payload()), context=None)
+        call = self.s3.put_object.call_args_list[0]
+        body = json.loads(call.kwargs["Body"].decode())
+
+        self.assertEqual(body["schema_version"], "1.0.0")
+        self.assertEqual(body["event_type"], "incident")
+        self.assertEqual(body["severity"], "high")
+        self.assertEqual(body["subsystem"], "predictor")
+        self.assertEqual(body["root_cause_category"], "infrastructure_failure")
+        self.assertEqual(body["source"], "cloudwatch-mirror")
+        self.assertTrue(body["auto_emitted"])
+        self.assertEqual(body["detected_at"], "2026-05-08T00:00:00Z")
+        self.assertIsNone(body["resolved_at"])
+        self.assertEqual(body["actor"], "alpha-engine-predictor-inference")
+        self.assertEqual(body["machine"], "lambda:changelog-cloudwatch-mirror")
+        self.assertEqual(
+            body["cloudwatch"]["log_group"],
+            "/aws/lambda/alpha-engine-predictor-inference",
+        )
+        # First non-empty line is the summary
+        self.assertEqual(body["summary"], "[ERROR] Cold start exceeded 60s")
+        # Full multiline message preserved in description
+        self.assertIn("Traceback", body["description"])
+
+    # --- subsystem inference ---------------------------------------
+
+    def test_subsystem_inference_predictor(self):
+        self.index.handler(_encode_subscription_event(
+            _sample_payload(log_group="/aws/lambda/alpha-engine-predictor-health-check")
+        ), context=None)
+        body = json.loads(self.s3.put_object.call_args_list[0].kwargs["Body"].decode())
+        self.assertEqual(body["subsystem"], "predictor")
+
+    def test_subsystem_inference_research(self):
+        self.index.handler(_encode_subscription_event(
+            _sample_payload(log_group="/aws/lambda/alpha-engine-research-runner")
+        ), context=None)
+        body = json.loads(self.s3.put_object.call_args_list[0].kwargs["Body"].decode())
+        self.assertEqual(body["subsystem"], "research")
+
+    def test_subsystem_inference_data_pipeline(self):
+        self.index.handler(_encode_subscription_event(
+            _sample_payload(log_group="/aws/lambda/alpha-engine-data-collector")
+        ), context=None)
+        body = json.loads(self.s3.put_object.call_args_list[0].kwargs["Body"].decode())
+        self.assertEqual(body["subsystem"], "data_pipeline")
+
+    def test_subsystem_inference_eval(self):
+        self.index.handler(_encode_subscription_event(
+            _sample_payload(log_group="/aws/lambda/alpha-engine-replay-concordance")
+        ), context=None)
+        body = json.loads(self.s3.put_object.call_args_list[0].kwargs["Body"].decode())
+        self.assertEqual(body["subsystem"], "eval")
+
+    def test_subsystem_inference_default(self):
+        self.index.handler(_encode_subscription_event(
+            _sample_payload(log_group="/aws/lambda/alpha-engine-ec2-lifecycle")
+        ), context=None)
+        body = json.loads(self.s3.put_object.call_args_list[0].kwargs["Body"].decode())
+        self.assertEqual(body["subsystem"], "infrastructure")
+
+    # --- event_id format -------------------------------------------
+
+    def test_event_id_format(self):
+        self.index.handler(_encode_subscription_event(_sample_payload()), context=None)
+        body = json.loads(self.s3.put_object.call_args_list[0].kwargs["Body"].decode())
+        # Format: 2026-05-08T00-00-00_alpha-engine-predictor-inference_<7-hex>
+        parts = body["event_id"].split("_")
+        self.assertEqual(parts[0], "2026-05-08T00-00-00")
+        self.assertEqual(parts[1], "alpha-engine-predictor-inference")
+        self.assertEqual(len(parts[2]), 7)
+
+    def test_event_id_distinct_for_same_timestamp(self):
+        """Two errors at the same epoch ms must produce distinct event_ids
+        (hashed on log_event.id, not ts+summary)."""
+        payload = _sample_payload(log_events=[
+            {"id": "id-a", "timestamp": 1778198400000, "message": "[ERROR] x"},
+            {"id": "id-b", "timestamp": 1778198400000, "message": "[ERROR] x"},
+        ])
+        self.index.handler(_encode_subscription_event(payload), context=None)
+        keys = [c.kwargs["Key"] for c in self.s3.put_object.call_args_list]
+        self.assertEqual(len(set(keys)), 2, "event_ids collided")
+
+    # --- edge cases ------------------------------------------------
+
+    def test_control_message_no_op(self):
+        result = self.index.handler(
+            _encode_subscription_event(_sample_payload(message_type="CONTROL_MESSAGE")),
+            context=None,
+        )
+        self.assertEqual(result["wrote"], 0)
+        self.assertEqual(self.s3.put_object.call_count, 0)
+
+    def test_empty_log_events_no_op(self):
+        result = self.index.handler(
+            _encode_subscription_event(_sample_payload(log_events=[])),
+            context=None,
+        )
+        self.assertEqual(result["wrote"], 0)
+
+    def test_skips_empty_message(self):
+        payload = _sample_payload(log_events=[
+            {"id": "id-a", "timestamp": 1778198400000, "message": ""},
+            {"id": "id-b", "timestamp": 1778198400000, "message": "   "},
+            {"id": "id-c", "timestamp": 1778198400000, "message": "[ERROR] real"},
+        ])
+        result = self.index.handler(_encode_subscription_event(payload), context=None)
+        self.assertEqual(result["wrote"], 1)
+
+    def test_handles_missing_timestamp(self):
+        payload = _sample_payload(log_events=[
+            {"id": "id-a", "message": "[ERROR] no ts"},
+        ])
+        # Should fall back to current UTC, not crash
+        result = self.index.handler(_encode_subscription_event(payload), context=None)
+        self.assertEqual(result["wrote"], 1)
+        body = json.loads(self.s3.put_object.call_args_list[0].kwargs["Body"].decode())
+        # ts_utc format still valid
+        import re
+        self.assertRegex(body["ts_utc"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Closes ROADMAP P0 (line 2121) — **system-wide changelog coverage Gap 2: Lambda errors directly to S3**. Lambda crashes (cold-start, OOM, timeouts, Python exceptions) land in CloudWatch Logs but not in SNS, so the SNS-mirror Lambda misses them. This relay subscribes to per-Lambda CloudWatch Logs filters (`?ERROR ?CRITICAL ?\"Task timed out\"`) and writes one structured incident entry per matched log event to `s3://alpha-engine-research/changelog/entries/{date}/{event_id}.json`.

Schema 1.0.0 — same shape as SNS-mirror entries; aggregator + retro-candidate filter consume both transparently.

## What's in this PR

- **`index.py`** — handler decodes gzipped+b64 awslogs blob, fans out per `logEvent`, writes one structured entry per matched event with subsystem inferred from log group prefix (predictor / research / data_pipeline / eval / infrastructure)
- **`test_handler.py`** — 14 mocked-boto3 unit tests. All passing.
- **`iam-policy.json`** — S3 PutObject on `changelog/entries/*` + Lambda log writing
- **`deploy.sh`** — code update + `--bootstrap` (first-time IAM role + Lambda + 11 subscription filters) + `--wire-subs` (re-apply only) + `--dry-run` + `--smoke` (synthetic ERROR via direct invoke)
- **`README.md`** — operator playbook + recursion guard + cost estimate

## Recursion guard

1. `TARGET_FUNCTIONS` excludes both changelog-mirror Lambdas (this one + SNS-mirror)
2. Filter pattern is narrow; does not match this Lambda's own normal logs

## 11 target Lambdas

Every alpha-engine-* function except the two changelog-mirror Lambdas — see README for full list.

## Operator deploy step (post-merge, requires explicit confirmation)

This deploy script CREATES live AWS resources (IAM role + Lambda + 11 CloudWatch Logs subscription filters). It is NOT wired into CI — operator runs locally:

```
bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --bootstrap
bash infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh --smoke
```

Cost estimate: <\$0.01/month.

## Test plan

- [x] 14/14 handler unit tests pass (decode + fan-out + payload shape + subsystem inference + event_id format + collision-resistance + control-message no-op + edge cases)
- [x] `deploy.sh --dry-run --bootstrap` shows correct AWS API call shape for IAM role + Lambda create + 11 add-permission + 11 put-subscription-filter calls
- [ ] Operator runs `--bootstrap` post-merge, then `--smoke` — verify entry lands at `s3://alpha-engine-research/changelog/entries/{today}/` with `source: cloudwatch-mirror`
- [ ] First real-world capture: any Lambda ERROR within ~24h of bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)