### PR TITLE
feat(sf): decouple skip_backtester from skip_evaluator

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -503,14 +503,14 @@
 
     "CheckSkipBacktester": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses BOTH the Backtester state (backtest + parity) and the Evaluator state (evaluate.py) — they were split into independent SF states 2026-05-07 (plan: alpha-engine-docs/private/evaluator-split-260507.md), but skipping the backtester implicitly skips the evaluator since evaluate.py reads same-cohort backtest artifacts. Routes to CheckSkipEvalJudge (preserving the LLM-judge eval-pipeline states downstream — the bug fixed 2026-05-03 was that this routed directly to SaturdayHealthCheck, silently bypassing CheckSkipEvalJudge → ComputeEvalCadence → eval-judge → eval-rolling-mean for any operator who passed skip_backtester=true). To skip ONLY the evaluator (keep backtest+parity), use {\"skip_evaluator\": true}. The legacy {\"freeze_evaluator\": true} input is no longer honored; freeze-evaluator is now a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
+      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses ONLY the Backtester state (backtest + parity); the Evaluator state still runs and gracefully degrades on missing same-cohort artifacts (evaluate.py logs a WARNING and continues — verified against the 2026-05-07 v1 validation run, where `Simulation artifact not found in S3: backtest/2026-05-07/sweep_df.parquet — evaluator will run without it` shows up cleanly). Routes to CheckSkipEvaluator so {\"skip_evaluator\": true} composes orthogonally: (a) neither flag → both run, (b) skip_backtester only → Evaluator runs against any pre-existing backtest/{date}/ artifacts, (c) skip_evaluator only → Backtester runs without grading, (d) both → both skipped. Eval-judge chain downstream is preserved in all four cases via CheckSkipEvaluator → CheckSkipEvalJudge (the 2026-05-03 silent-bypass fix is still pinned — both CheckSkipEvaluator paths converge to CheckSkipEvalJudge). The legacy {\"freeze_evaluator\": true} input is not honored; freeze-evaluator is a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_backtester", "IsPresent": true},
             {"Variable": "$.skip_backtester", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipEvalJudge"
+          "Next": "CheckSkipEvaluator"
         }
       ],
       "Default": "Backtester"

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -74,25 +74,48 @@ class TestBacktesterTransition:
 
 
 class TestSkipBacktesterPreservesEvalJudge:
-    """Pins the 2026-05-03 fix: when an operator passes
-    skip_backtester=true (e.g. for SF skip-most validation runs), the
-    skip path must still flow through the eval-judge skip-gate, not
-    leap straight to SaturdayHealthCheck.
+    """Pins the 2026-05-03 fix (eval-judge always reachable from a
+    skip_backtester=true operator) AND the 2026-05-07 simplification
+    (skip_backtester decouples from skip_evaluator). The skip-path now
+    routes to CheckSkipEvaluator, which by construction always converges
+    to CheckSkipEvalJudge regardless of which branch it takes. So the
+    silent-bypass-to-SaturdayHealthCheck class is still impossible while
+    the operator gets independent skip flags.
 
-    Caught by SF eval-pipeline-validation-5 when Research succeeded
-    + new-format captures landed on S3 but the eval-judge state
+    Caught by SF eval-pipeline-validation-5 (2026-05-03) when Research
+    succeeded + new-format captures landed on S3 but the eval-judge state
     silently never fired because skip_backtester=true had been
     short-circuiting past it.
     """
 
-    def test_skip_backtester_routes_to_eval_skip_gate(self, states):
+    def test_skip_backtester_routes_to_evaluator_gate_not_health(self, states):
         skip = states["CheckSkipBacktester"]
         choice = skip["Choices"][0]
-        # The skip-true branch must preserve the eval-judge state path.
-        assert choice["Next"] == "CheckSkipEvalJudge"
+        # The skip-true branch hits CheckSkipEvaluator (decoupled flag
+        # 2026-05-07). CheckSkipEvaluator's both branches still converge
+        # to CheckSkipEvalJudge, so eval-judge stays reachable.
+        assert choice["Next"] == "CheckSkipEvaluator"
         # Critically NOT routed to SaturdayHealthCheck — that was the
-        # silent-bypass bug.
+        # 2026-05-03 silent-bypass bug.
         assert choice["Next"] != "SaturdayHealthCheck"
+
+    def test_evaluator_skip_gate_always_reaches_eval_judge(self, states):
+        """Both branches of CheckSkipEvaluator must keep eval-judge
+        reachable — the skip path goes to CheckSkipEvalJudge directly,
+        and the run path goes to Evaluator → CheckEvaluatorStatus →
+        Success → CheckSkipEvalJudge. Together with the skip_backtester
+        decoupling, this guarantees no skip-flag combination bypasses
+        eval-judge."""
+        gate = states["CheckSkipEvaluator"]
+        skip_choice = gate["Choices"][0]
+        assert skip_choice["Next"] == "CheckSkipEvalJudge"
+        # Default routes to Evaluator, which converges back via
+        # CheckEvaluatorStatus's Success branch.
+        assert gate["Default"] == "Evaluator"
+        assert (
+            states["CheckEvaluatorStatus"]["Choices"][0]["Next"]
+            == "CheckSkipEvalJudge"
+        )
 
 
 class TestSkipEvalJudge:

--- a/tests/test_sf_evaluator_wiring.py
+++ b/tests/test_sf_evaluator_wiring.py
@@ -82,25 +82,26 @@ class TestSkipEvaluator:
         assert states["CheckSkipEvaluator"]["Default"] == "Evaluator"
 
 
-class TestSkipBacktesterAlsoSkipsEvaluator:
-    """Pins the contract that {"skip_backtester": true} skips BOTH
-    Backtester and Evaluator (since the evaluator reads same-cohort
-    backtest artifacts — running it without a fresh backtest would grade
-    against stale data). The CheckSkipBacktester skip path therefore
-    routes to CheckSkipEvalJudge (skipping past CheckSkipEvaluator
-    entirely), preserving the LLM-judge chain downstream.
+class TestSkipBacktesterRoutesThroughEvaluatorGate:
+    """Pins the contract that {"skip_backtester": true} skips ONLY the
+    Backtester state — the Evaluator gate runs next so {"skip_evaluator": true}
+    composes orthogonally. evaluate.py already gracefully degrades on
+    missing same-cohort artifacts (logs WARNING and continues, verified
+    against 2026-05-07 v1 validation run), so coupling skip-backtester to
+    skip-evaluator was over-restrictive. Pre-2026-05-07 wiring jumped
+    skip-backtester directly to CheckSkipEvalJudge, which forced the
+    operator to run a 35-min backtest just to grade existing artifacts.
     """
 
-    def test_skip_backtester_bypasses_evaluator(self, states):
+    def test_skip_backtester_routes_to_evaluator_skip_gate(self, states):
         skip = states["CheckSkipBacktester"]
         choice = skip["Choices"][0]
-        # The skip-true branch must skip past the Evaluator state.
-        # Routing to CheckSkipEvalJudge is correct — CheckSkipEvaluator
-        # is between CheckBacktesterStatus and CheckSkipEvalJudge in
-        # the success path, so jumping straight to CheckSkipEvalJudge
-        # bypasses the evaluator without re-implementing the gate.
-        assert choice["Next"] == "CheckSkipEvalJudge"
-        assert choice["Next"] != "CheckSkipEvaluator"
+        # The skip-true branch must hit the Evaluator skip-gate so the
+        # operator can compose skip flags independently.
+        assert choice["Next"] == "CheckSkipEvaluator"
+        # Critically NOT routed to CheckSkipEvalJudge — that was the
+        # over-coupled wiring that forced backtest+evaluate to bundle.
+        assert choice["Next"] != "CheckSkipEvalJudge"
 
 
 # ── Evaluator task contract ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The 2026-05-07 split shipped Backtester + Evaluator as independent SF states (separate spots, separate failure isolation) but kept `{skip_backtester: true}` routing past the Evaluator gate — which collapsed the orthogonal-flag composition the split was supposed to enable. evaluate.py already handles missing same-cohort artifacts gracefully (logs WARNING and continues — confirmed by today's v1 run where `Simulation artifact not found in S3: backtest/2026-05-07/sweep_df.parquet — evaluator will run without it` shows up cleanly), so the implicit coupling was over-restrictive.

This PR makes the two flags orthogonal:

| Flags | Outcome |
|---|---|
| neither | both run (default) |
| `skip_backtester` only | Evaluator runs against any pre-existing `backtest/{date}/` artifacts |
| `skip_evaluator` only | Backtester runs without grading |
| both | both skipped |

## Wiring change

`CheckSkipBacktester` skip-path: `CheckSkipEvalJudge` → `CheckSkipEvaluator`. Comment rewritten with the truth table.

The 2026-05-03 silent-bypass class (skip-path leaping past eval-judge to SaturdayHealthCheck) stays prevented — both `CheckSkipEvaluator` branches converge to `CheckSkipEvalJudge`, so eval-judge stays reachable in all four flag combinations. New test exercises both branches' convergence to make this explicit.

## Test plan

- [x] `pytest tests/test_sf_evaluator_wiring.py tests/test_sf_eval_judge_wiring.py` — 73/73 pass
- [x] `pytest` (full suite) — 543/543 pass
- [ ] After merge: `deploy-infrastructure.yml` auto-restamps the SF in AWS
- [ ] Verify with a fresh ad-hoc SF run using `{"skip_backtester": true}` — should now run Evaluator

## Tests inverted

- `TestSkipBacktesterAlsoSkipsEvaluator` → `TestSkipBacktesterRoutesThroughEvaluatorGate`. The class docstring captures the rationale shift.
- `TestSkipBacktesterPreservesEvalJudge` keeps the 2026-05-03 invariant (skip-path cannot bypass eval-judge to SaturdayHealthCheck) and adds a new test asserting that both `CheckSkipEvaluator` branches converge to `CheckSkipEvalJudge`. Net: the silent-bypass class is locked down more tightly than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)