### PR TITLE
fix(cloudwatch-mirror): tolerate IAM propagation lag in deploy.sh

### DIFF
--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
@@ -205,22 +205,42 @@ if $BOOTSTRAP || $WIRE_SUBS; then
     # StatementId per source — idempotent only if removed-then-added; ignore
     # ResourceConflictException on re-runs.
     PERM_SID="cwlogs-invoke-${fn}"
-    run aws lambda add-permission \
+    PERM_OUT=$(aws lambda add-permission \
       --function-name "${FUNCTION_NAME}" \
       --statement-id "${PERM_SID}" \
       --action lambda:InvokeFunction \
       --principal "logs.${REGION}.amazonaws.com" \
       --source-arn "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${LOG_GROUP}:*" \
-      --region "${REGION}" 2>/dev/null || true
+      --region "${REGION}" 2>&1) || true
 
-    # Subscription filter — idempotent, AWS overwrites by name.
+    # IAM/Lambda permission propagation is eventually consistent —
+    # put-subscription-filter validates the resource policy and fails
+    # fast if it hasn't replicated yet. Sleep only when we just added a
+    # NEW permission (not on idempotent re-runs).
+    if echo "${PERM_OUT}" | grep -q '"Statement"'; then
+      if ! $DRY_RUN; then
+        sleep 5
+      fi
+    fi
+
+    # Subscription filter — idempotent, AWS overwrites by name. Retry once
+    # on InvalidParameterException to ride out residual IAM propagation lag.
     echo "  → ${fn}"
-    run aws logs put-subscription-filter \
+    if ! run aws logs put-subscription-filter \
       --log-group-name "${LOG_GROUP}" \
       --filter-name "${SUBSCRIPTION_FILTER_NAME}" \
       --filter-pattern "${FILTER_PATTERN}" \
       --destination-arn "${RELAY_ARN}" \
-      --region "${REGION}"
+      --region "${REGION}" 2>&1; then
+      echo "    (retrying after 10s — IAM propagation)"
+      if ! $DRY_RUN; then sleep 10; fi
+      run aws logs put-subscription-filter \
+        --log-group-name "${LOG_GROUP}" \
+        --filter-name "${SUBSCRIPTION_FILTER_NAME}" \
+        --filter-pattern "${FILTER_PATTERN}" \
+        --destination-arn "${RELAY_ARN}" \
+        --region "${REGION}"
+    fi
   done
   echo "✓ Subscription filters applied."
 fi


### PR DESCRIPTION
## Summary

Surfaced live during PR #183 bootstrap: the very first \`put-subscription-filter\` call after a fresh \`add-permission\` failed with \`InvalidParameterException: Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function.\` — resource-based policy hadn't replicated yet.

Two changes inside the per-Lambda loop:

1. **Sleep 5s only when add-permission actually wrote a new statement.** Capture the API response; if it returned a \`Statement\` field (fresh permission), sleep 5s before put-subscription-filter to let IAM replicate. Idempotent re-runs (ResourceConflictException) skip the sleep — no penalty.
2. **Single retry-after-10s on put-subscription-filter failure.** Rides out residual propagation lag past the initial 5s window.

Live verification post-fix: \`--wire-subs\` ran clean across all 10 target Lambdas with existing log groups; \`--smoke\` wrote a structured entry to S3 with full schema 1.0.0 (\`source=cloudwatch-mirror\`, \`subsystem=predictor\`, \`severity=high\`).

## Test plan

- [x] Live operator validation: \`bash deploy.sh --wire-subs\` clean across 10 Lambdas
- [x] Live operator validation: \`bash deploy.sh --smoke\` writes entry to S3 with correct schema
- [x] Handler smoke tests still pass (14/14)
- [ ] Next operator who runs \`--bootstrap\` from scratch validates the propagation handling end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)