### PR TITLE
feat(sf): reorder judge chain to run before predictor training

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1,5 +1,5 @@
 {
-  "Comment": "Alpha Engine Saturday Pipeline — orchestrates weekly data collection, RAG ingestion, research, predictor training, backtesting, and evaluation sequentially with fail-fast error handling. DataPhase1 and RAGIngestion are independent SF states (split 2026-05-06 after a RAG-side import bug failed under the DataPhase1 label, masking that the data layer was healthy). Backtester and Evaluator are independent SF states (split 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md — for failure isolation, per-stage email, and independent CW heartbeats). Each runs on its own spot — accepts +1 bootstrap cycle (~7 min) per split in exchange for failure isolation, redrive granularity, and per-step health markers. RAG still runs before Research so the knowledge base is fresh. Backtester runs AFTER predictor training (depends on model weights); Evaluator runs after Backtester (reads same-cohort backtest artifacts). Supports partial execution via boolean skip_* flags on input (e.g. {\"skip_data_phase1\": true, \"skip_rag_ingestion\": true, \"skip_evaluator\": true}); a missing flag is treated as false, so scheduled runs are unaffected.",
+  "Comment": "Alpha Engine Saturday Pipeline — orchestrates weekly data collection, RAG ingestion, research, eval-judge + agent-justification triple, predictor training, backtesting, and evaluation sequentially with fail-fast error handling. DataPhase1 and RAGIngestion are independent SF states (split 2026-05-06 after a RAG-side import bug failed under the DataPhase1 label, masking that the data layer was healthy). Backtester and Evaluator are independent SF states (split 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md — for failure isolation, per-stage email, and independent CW heartbeats). The eval-judge chain (EvalJudge → EvalRollingMean → RationaleClustering → ReplayConcordance → Counterfactual) runs after DataPhase2 and BEFORE PredictorTraining (reorder shipped 2026-05-07 evening) so its persisted S3 artifacts (decision_artifacts/_eval/, _clustering/, _concordance/, _counterfactual/) are available when Evaluator generates the weekly email — pre-reorder the judge chain ran AFTER Evaluator, so its results were never visible in the operator's primary review surface. Each spot-bearing state runs on its own spot — accepts +1 bootstrap cycle (~7 min) per split in exchange for failure isolation, redrive granularity, and per-step health markers. RAG still runs before Research so the knowledge base is fresh. Judge chain only reads decision_artifacts/ written by Research, so it has no dependency on Predictor or Backtester output. Backtester runs AFTER predictor training (depends on model weights); Evaluator runs after Backtester (reads same-cohort backtest artifacts). Supports partial execution via boolean skip_* flags on input (e.g. {\"skip_data_phase1\": true, \"skip_rag_ingestion\": true, \"skip_evaluator\": true}); a missing flag is treated as false, so scheduled runs are unaffected.",
   "StartAt": "InitializeInput",
   "States": {
 
@@ -299,14 +299,14 @@
 
     "CheckSkipDataPhase2": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_data_phase2\": true} bypasses the Phase 2 Lambda and jumps to PredictorTraining's skip-gate.",
+      "Comment": "Skip-gate. {\"skip_data_phase2\": true} bypasses the Phase 2 Lambda and jumps to the eval-judge skip-gate (post-2026-05-07 reorder — judge chain runs before predictor training so its results are available to evaluator's email).",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_data_phase2", "IsPresent": true},
             {"Variable": "$.skip_data_phase2", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipPredictorTraining"
+          "Next": "CheckSkipEvalJudge"
         }
       ],
       "Default": "DataPhase2"
@@ -314,7 +314,7 @@
 
     "DataPhase2": {
       "Type": "Task",
-      "Comment": "Phase 2: alternative data for promoted tickers (Lambda)",
+      "Comment": "Phase 2: alternative data for promoted tickers (Lambda). Successor is CheckSkipEvalJudge (post-2026-05-07 reorder) — judge + agent-justification triple run on Research's decision_artifacts/, no dependency on Predictor or Backtester output, so they run before predictor training to land their results in S3 before Evaluator generates the weekly email.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-data-collector:live",
@@ -339,7 +339,7 @@
         }
       ],
       "ResultPath": "$.data_phase2_result",
-      "Next": "CheckSkipPredictorTraining"
+      "Next": "CheckSkipEvalJudge"
     },
 
     "CheckSkipPredictorTraining": {
@@ -614,14 +614,14 @@
 
     "CheckSkipEvaluator": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_evaluator\": true} bypasses ONLY the Evaluator state (evaluate.py against today's backtest+parity artifacts) and routes to CheckSkipEvalJudge so the LLM-judge eval-pipeline downstream still fires. Use this when iterating on evaluator code mid-week without re-running the 121-min backtest. To skip the entire backtester+evaluator pair, use {\"skip_backtester\": true} on CheckSkipBacktester instead.",
+      "Comment": "Skip-gate. {\"skip_evaluator\": true} bypasses ONLY the Evaluator state (evaluate.py against today's backtest+parity artifacts) and routes to SaturdayHealthCheck. Post-2026-05-07 reorder, the eval-judge chain runs BEFORE predictor (after DataPhase2), so by the time we reach this skip-gate, judge results are already in S3 and Evaluator either consumed them (default path) or is being skipped. To skip the entire backtester+evaluator pair, use {\"skip_backtester\": true} on CheckSkipBacktester instead.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_evaluator", "IsPresent": true},
             {"Variable": "$.skip_evaluator", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipEvalJudge"
+          "Next": "SaturdayHealthCheck"
         }
       ],
       "Default": "Evaluator"
@@ -701,7 +701,7 @@
         {
           "Variable": "$.evaluator_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipEvalJudge"
+          "Next": "SaturdayHealthCheck"
         },
         {
           "Variable": "$.evaluator_poll.Status",
@@ -954,14 +954,14 @@
 
     "CheckSkipCounterfactual": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_counterfactual\": true} bypasses the counterfactual rule fit Lambda (used for ad-hoc reruns while iterating on the per-agent feature extractors in alpha-engine-backtester replay/counterfactual.py). Independent of skip_rationale_clustering and skip_replay_concordance — the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag.",
+      "Comment": "Skip-gate. {\"skip_counterfactual\": true} bypasses the counterfactual rule fit Lambda (used for ad-hoc reruns while iterating on the per-agent feature extractors in alpha-engine-backtester replay/counterfactual.py). Independent of skip_rationale_clustering and skip_replay_concordance — the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag. Post-2026-05-07 reorder, exits to CheckSkipPredictorTraining (was SaturdayHealthCheck) — the judge chain now runs before predictor so its results are available to evaluator's email.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_counterfactual", "IsPresent": true},
             {"Variable": "$.skip_counterfactual", "BooleanEquals": true}
           ],
-          "Next": "SaturdayHealthCheck"
+          "Next": "CheckSkipPredictorTraining"
         }
       ],
       "Default": "Counterfactual"
@@ -969,7 +969,7 @@
 
     "Counterfactual": {
       "Type": "Task",
-      "Comment": "Weekly counterfactual rule fit Lambda (ROADMAP P0, agent-justification gate signal #2 — does the agent reduce to a 3-deep decision tree?). Trains DecisionTreeClassifier(max_depth=3) per supported agent on (input → decision) pairs from the trailing 8-week decision_artifacts/ corpus; emits CW metric agent_counterfactual_rule_fit per (judged_agent_id); persists per-agent JSON to decision_artifacts/_counterfactual/{agent_id_base}/{YYYY-WW}.json including tree_text + feature_importances. v1 covers ic_cio + macro_economist; other agents emit UNSUPPORTED markers. $0 ongoing — no LLM calls. Runs every Saturday after ReplayConcordance.",
+      "Comment": "Weekly counterfactual rule fit Lambda (ROADMAP P0, agent-justification gate signal #2 — does the agent reduce to a 3-deep decision tree?). Trains DecisionTreeClassifier(max_depth=3) per supported agent on (input → decision) pairs from the trailing 8-week decision_artifacts/ corpus; emits CW metric agent_counterfactual_rule_fit per (judged_agent_id); persists per-agent JSON to decision_artifacts/_counterfactual/{agent_id_base}/{YYYY-WW}.json including tree_text + feature_importances. v1 covers ic_cio + macro_economist; other agents emit UNSUPPORTED markers. $0 ongoing — no LLM calls. Post-2026-05-07 reorder, runs after ReplayConcordance and exits to CheckSkipPredictorTraining (was SaturdayHealthCheck), so its persisted artifacts are available to Evaluator downstream.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-replay-counterfactual:live",
@@ -991,13 +991,13 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Comment": "Eval observability layer — counterfactual failure must NOT halt the pipeline. Same Catch pattern as the rest of the agent-justification triple.",
-          "Next": "SaturdayHealthCheck",
+          "Comment": "Eval observability layer — counterfactual failure must NOT halt the pipeline. Same Catch pattern as the rest of the agent-justification triple. Routes to CheckSkipPredictorTraining (post-2026-05-07 reorder).",
+          "Next": "CheckSkipPredictorTraining",
           "ResultPath": "$.counterfactual_error"
         }
       ],
       "ResultPath": "$.counterfactual_result",
-      "Next": "SaturdayHealthCheck"
+      "Next": "CheckSkipPredictorTraining"
     },
 
     "SaturdayHealthCheck": {

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -99,22 +99,30 @@ class TestSkipBacktesterPreservesEvalJudge:
         # 2026-05-03 silent-bypass bug.
         assert choice["Next"] != "SaturdayHealthCheck"
 
-    def test_evaluator_skip_gate_always_reaches_eval_judge(self, states):
-        """Both branches of CheckSkipEvaluator must keep eval-judge
-        reachable — the skip path goes to CheckSkipEvalJudge directly,
-        and the run path goes to Evaluator → CheckEvaluatorStatus →
-        Success → CheckSkipEvalJudge. Together with the skip_backtester
-        decoupling, this guarantees no skip-flag combination bypasses
-        eval-judge."""
+    def test_evaluator_skip_gate_always_reaches_health_check(self, states):
+        """Both branches of CheckSkipEvaluator must converge into the
+        health-check observability tail — the skip path goes to
+        SaturdayHealthCheck directly, and the run path goes to
+        Evaluator → CheckEvaluatorStatus → Success → SaturdayHealthCheck.
+
+        Post-2026-05-07 reorder: the eval-judge chain runs UPSTREAM of
+        Evaluator (after DataPhase2, before PredictorTraining), so the
+        question this class previously asked (does eval-judge stay
+        reachable from any skip-flag combination?) is now answered at
+        the upstream junction (CheckSkipDataPhase2 → CheckSkipEvalJudge
+        regardless of skip_data_phase2). At THIS junction, both
+        branches simply exit to the health-check tail; no judge gate
+        downstream to protect.
+        """
         gate = states["CheckSkipEvaluator"]
         skip_choice = gate["Choices"][0]
-        assert skip_choice["Next"] == "CheckSkipEvalJudge"
-        # Default routes to Evaluator, which converges back via
-        # CheckEvaluatorStatus's Success branch.
+        assert skip_choice["Next"] == "SaturdayHealthCheck"
         assert gate["Default"] == "Evaluator"
+        # Run path success also exits to SaturdayHealthCheck (judge
+        # already ran upstream).
         assert (
             states["CheckEvaluatorStatus"]["Choices"][0]["Next"]
-            == "CheckSkipEvalJudge"
+            == "SaturdayHealthCheck"
         )
 
 
@@ -427,7 +435,11 @@ class TestReplayConcordance:
 
 
 class TestSkipCounterfactual:
-    def test_skip_flag_bypasses_to_health_check(self, states):
+    def test_skip_flag_bypasses_to_predictor_training_gate(self, states):
+        """Skipping Counterfactual is the chain-exit path — post-2026-05-07
+        reorder, the judge chain runs upstream of PredictorTraining, so
+        bypassing Counterfactual exits to CheckSkipPredictorTraining
+        (was SaturdayHealthCheck pre-reorder)."""
         skip = states["CheckSkipCounterfactual"]
         choice = skip["Choices"][0]
         and_clauses = choice["And"]
@@ -436,7 +448,7 @@ class TestSkipCounterfactual:
             and c.get("BooleanEquals") is True
             for c in and_clauses
         )
-        assert choice["Next"] == "SaturdayHealthCheck"
+        assert choice["Next"] == "CheckSkipPredictorTraining"
 
     def test_default_runs_counterfactual(self, states):
         assert states["CheckSkipCounterfactual"]["Default"] == "Counterfactual"
@@ -464,13 +476,21 @@ class TestCounterfactual:
         # across 8 weeks of corpus).
         assert states["Counterfactual"]["TimeoutSeconds"] == 600
 
-    def test_success_continues_to_health_check(self, states):
-        assert states["Counterfactual"]["Next"] == "SaturdayHealthCheck"
+    def test_success_exits_to_predictor_training_gate(self, states):
+        # Post-2026-05-07 reorder: Counterfactual is the last state in
+        # the judge chain; success exits to CheckSkipPredictorTraining
+        # (was SaturdayHealthCheck pre-reorder), so its persisted
+        # artifacts are available to Evaluator downstream.
+        assert states["Counterfactual"]["Next"] == "CheckSkipPredictorTraining"
 
-    def test_catch_routes_to_health_check_not_failure(self, states):
+    def test_catch_routes_to_predictor_training_gate_not_failure(self, states):
+        # Same Catch posture as the rest of the agent-justification
+        # triple — Counterfactual is observability, not load-bearing,
+        # so failures fall through to the next stage rather than
+        # halting the pipeline.
         catch = states["Counterfactual"]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
-        assert catch["Next"] == "SaturdayHealthCheck"
+        assert catch["Next"] == "CheckSkipPredictorTraining"
         assert catch["Next"] != "HandleFailure"
 
     def test_retries_on_transient_lambda_errors(self, states):
@@ -478,3 +498,70 @@ class TestCounterfactual:
         assert "Lambda.ServiceException" in retry["ErrorEquals"]
         assert "Lambda.TooManyRequestsException" in retry["ErrorEquals"]
         assert retry["MaxAttempts"] == 1
+
+
+# ── Pipeline ordering invariant ──────────────────────────────────────────
+
+
+class TestJudgeChainBeforePredictor:
+    """Pins the 2026-05-07 reorder — the eval-judge + agent-justification
+    triple (judge, rolling-mean, clustering, concordance, counterfactual)
+    must run AFTER Research/DataPhase2 and BEFORE PredictorTraining, so
+    their persisted S3 artifacts are available to Evaluator's email when
+    it runs at the end of the pipeline.
+
+    Pre-reorder ordering: Research → ... → Predictor → Backtester →
+    Evaluator → judge chain → SaturdayHealthCheck. The Evaluator email
+    was generated BEFORE judge results landed in S3, so the operator's
+    weekly review never saw rubric scores / clustering / concordance /
+    counterfactual outcomes — that was the user-surfaced gap that
+    motivated this reorder.
+
+    Post-reorder ordering: Research → DataPhase2 → judge chain →
+    Predictor → Backtester → Evaluator → SaturdayHealthCheck. The
+    judge chain's S3 outputs (decision_artifacts/_eval/, _clustering/,
+    _concordance/, _counterfactual/) are populated for the current
+    run_date by the time Evaluator's reporter.build_report() runs, so
+    they can be pulled into the weekly email.
+    """
+
+    def test_data_phase2_exits_to_judge_skip_gate_not_predictor(self, states):
+        """DataPhase2's success path enters the judge chain, not
+        predictor training. This is the load-bearing invariant — if
+        someone ever rewires DataPhase2.Next to CheckSkipPredictorTraining
+        (the pre-reorder target), the judge chain bypass is silent."""
+        assert states["DataPhase2"]["Next"] == "CheckSkipEvalJudge"
+        assert (
+            states["CheckSkipDataPhase2"]["Choices"][0]["Next"]
+            == "CheckSkipEvalJudge"
+        )
+
+    def test_counterfactual_exits_to_predictor_skip_gate(self, states):
+        """Counterfactual is the last state in the judge chain; its
+        Next + Catch + the skip-gate above it all converge to
+        CheckSkipPredictorTraining (the entry to the next pipeline
+        stage). Pre-reorder this was SaturdayHealthCheck."""
+        assert states["Counterfactual"]["Next"] == "CheckSkipPredictorTraining"
+        assert (
+            states["Counterfactual"]["Catch"][0]["Next"]
+            == "CheckSkipPredictorTraining"
+        )
+        assert (
+            states["CheckSkipCounterfactual"]["Choices"][0]["Next"]
+            == "CheckSkipPredictorTraining"
+        )
+
+    def test_evaluator_exits_directly_to_health_check(self, states):
+        """Evaluator's success path no longer enters the judge chain
+        (judge ran upstream). It exits to SaturdayHealthCheck."""
+        success = next(
+            c for c in states["CheckEvaluatorStatus"]["Choices"]
+            if c.get("StringEquals") == "Success"
+        )
+        assert success["Next"] == "SaturdayHealthCheck"
+        # And the skip-evaluator path also goes to SaturdayHealthCheck
+        # (the previous pre-reorder target was CheckSkipEvalJudge).
+        assert (
+            states["CheckSkipEvaluator"]["Choices"][0]["Next"]
+            == "SaturdayHealthCheck"
+        )

--- a/tests/test_sf_evaluator_wiring.py
+++ b/tests/test_sf_evaluator_wiring.py
@@ -56,13 +56,15 @@ class TestStatesPresent:
 
 
 class TestSkipEvaluator:
-    def test_skip_flag_bypasses_to_eval_judge_gate(self, states):
-        """Skipping the Evaluator state must NOT also skip the LLM-judge
-        chain — they're independent (evaluator = per-signal grading +
-        optimizer auto-apply against backtest artifacts; eval-judge =
-        LLM rubric scoring of decision_artifacts/). The skip path lands
-        on CheckSkipEvalJudge so the judge chain still fires unless its
-        own skip flag is set.
+    def test_skip_flag_bypasses_to_health_check(self, states):
+        """Skipping the Evaluator state routes to SaturdayHealthCheck.
+
+        Post-2026-05-07 reorder: the eval-judge chain runs BEFORE
+        Evaluator (after DataPhase2, before PredictorTraining), so by
+        the time we reach this skip-gate, judge results are already
+        persisted to S3 — there's no eval-judge chain downstream of
+        Evaluator to skip. Skipping evaluator just exits the success
+        path to the health-check observability tail.
         """
         skip = states["CheckSkipEvaluator"]
         choice = skip["Choices"][0]
@@ -72,11 +74,11 @@ class TestSkipEvaluator:
             and c.get("BooleanEquals") is True
             for c in and_clauses
         )
-        assert choice["Next"] == "CheckSkipEvalJudge"
-        # Critically NOT routed to SaturdayHealthCheck — that would
-        # bundle-skip both the evaluator and the entire eval-judge
-        # observability chain.
-        assert choice["Next"] != "SaturdayHealthCheck"
+        assert choice["Next"] == "SaturdayHealthCheck"
+        # Pre-reorder this routed to CheckSkipEvalJudge; post-reorder
+        # judge chain is upstream of Evaluator so there's nothing to
+        # gate downstream — exit straight to the health-check tail.
+        assert choice["Next"] != "CheckSkipEvalJudge"
 
     def test_default_runs_evaluator(self, states):
         assert states["CheckSkipEvaluator"]["Default"] == "Evaluator"
@@ -171,14 +173,17 @@ class TestEvaluatorPollLoop:
     def test_wait_for_evaluator_routes_to_check_status(self, states):
         assert states["WaitForEvaluator"]["Next"] == "CheckEvaluatorStatus"
 
-    def test_check_status_success_continues_to_eval_judge(self, states):
-        # On evaluator success the pipeline picks up the LLM-judge chain
-        # at the same skip-gate that pre-split Backtester success used.
+    def test_check_status_success_continues_to_health_check(self, states):
+        # On evaluator success the pipeline exits to the health-check
+        # observability tail. Post-2026-05-07 reorder, the eval-judge
+        # chain runs upstream of Evaluator, so there's no judge gate
+        # downstream — Evaluator is the last analytics-producing stage
+        # before health checks.
         bt = states["CheckEvaluatorStatus"]
         success_choice = next(
             c for c in bt["Choices"] if c.get("StringEquals") == "Success"
         )
-        assert success_choice["Next"] == "CheckSkipEvalJudge"
+        assert success_choice["Next"] == "SaturdayHealthCheck"
 
     def test_check_status_in_progress_loops_to_wait(self, states):
         bt = states["CheckEvaluatorStatus"]


### PR DESCRIPTION
## Summary

Pre-reorder the eval-judge + agent-justification triple ran AFTER Evaluator, which meant the operator's weekly evaluator email never showed rubric scores / clustering / concordance / counterfactual results — `reporter.build_report()` runs before those Lambdas write to S3. User-surfaced gap reviewing the 2026-05-07 eval email.

This PR moves the judge chain upstream so its persisted S3 artifacts are available when Evaluator generates the email.

```
Pre:  Research → DataPhase2 → Predictor → Backtester → Evaluator
      → judge chain → SaturdayHealthCheck

Post: Research → DataPhase2 → judge chain → Predictor → Backtester
      → Evaluator → SaturdayHealthCheck
```

## Why this is safe

Verified the judge chain only reads `decision_artifacts/` written by Research:
- `lambda/eval_judge_handler.py` — only reads `decision_artifacts/{Y}/{M}/{D}/`
- `lambda/rationale_clustering_handler.py` — same
- ReplayConcordance + Counterfactual Lambdas read `decision_artifacts/` by design (per the agent-justification arc shipped 2026-05-06)

No reference to `predictor/predictions`, `predictor/weights`, `backtest/`, or `score_performance` in any of the four. Moving them upstream of PredictorTraining is structurally safe.

## Wiring

7 transitions edited:
- `CheckSkipDataPhase2` skip path: → `CheckSkipEvalJudge`
- `DataPhase2.Next`: → `CheckSkipEvalJudge`
- `CheckSkipCounterfactual` skip path: → `CheckSkipPredictorTraining`
- `Counterfactual.Next`: → `CheckSkipPredictorTraining`
- `Counterfactual.Catch`: → `CheckSkipPredictorTraining`
- `CheckSkipEvaluator` skip path: → `SaturdayHealthCheck` (judge runs upstream now, no chain to gate)
- `CheckEvaluatorStatus.Success`: → `SaturdayHealthCheck`

## Test plan

- [x] `pytest tests/test_sf_evaluator_wiring.py tests/test_sf_eval_judge_wiring.py` — 73/73 pass
- [x] `pytest` (full suite) — 546/546 pass (+3 new tests for ordering invariant)
- [x] 6 pre-reorder tests inverted (transitions changed); kept the historical context in renamed docstrings
- [x] New `TestJudgeChainBeforePredictor` class pins the invariant against future regressions

## Companion PR

A companion `alpha-engine-backtester` PR will wire `evaluate.py` to read the judge S3 artifacts and pass them through `build_report()` for rendering in the weekly email. Without it, the reorder moves data into S3 in time but doesn't pull it into the email — both are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)