### PR TITLE
fix(substrate): tighten alarm Period 86400 → 3600 to close 24-37h state lag

### DIFF
--- a/infrastructure/setup_substrate_alarms.sh
+++ b/infrastructure/setup_substrate_alarms.sh
@@ -17,11 +17,16 @@
 #   Fires when SubstrateChecksFailed > 0 in the trailing 24h window —
 #   safety net in case a row alarm gets accidentally deleted.
 #
-# Period 86400 (24h) with EvaluationPeriods=1 means each alarm checks
-# the most recent 24h window. treat-missing-data=notBreaching keeps
-# weekly-cadence rows quiet between emissions (a row that emits once
-# per Sat SF only has a datapoint every 7 days; missing days are not
-# alarms, only emitted-and-failed days are).
+# Period 3600 (1h) with EvaluationPeriods=24 + DatapointsToAlarm=1 keeps
+# the trailing 24h evaluation window but bumps the refresh cadence to
+# hourly. Pre-2026-05-08 the alarms used Period=86400 + EvalPeriods=1,
+# which evaluated only at 24h boundaries — Sat SF emissions at 12:00 UTC
+# Sat were not visible in alarm state until ~17:05 PT Sun (~37h lag).
+# Hourly evaluation closes the lag to <1h. treat-missing-data=notBreaching
+# keeps weekly-cadence rows quiet between emissions: a row that emits
+# once per Sat SF has a datapoint in only one of the 24 hourly periods,
+# the other 23 are treated as not-breaching, the alarm fires iff that one
+# real datapoint is < 1. Cost: 24× more eval reads/day; bounded.
 #
 # Row enumeration is sourced from the lib's transparency_inventory.yaml
 # so this script stays in sync with the inventory automatically — no
@@ -81,10 +86,11 @@ for row_id in $ROW_IDS; do
   aws cloudwatch put-metric-alarm \
     --region "$REGION" \
     --alarm-name "$alarm_name" \
-    --alarm-description "Fires when the transparency-substrate row '$row_id' fails to emit a passing measurement. The check is row-driven (alpha_engine_lib.transparency); the SF Sat pipeline runs --cadence weekly which sweeps weekly + daily rows. This alarm decrements the Phase 2 → 3 observation gate denominator for this row when it fires. treat-missing-data=notBreaching keeps weekly-cadence rows quiet between Sat-SF emissions." \
+    --alarm-description "Fires when the transparency-substrate row '$row_id' fails to emit a passing measurement. The check is row-driven (alpha_engine_lib.transparency); the SF Sat pipeline runs --cadence weekly which sweeps weekly + daily rows. This alarm decrements the Phase 2 → 3 observation gate denominator for this row when it fires. Period=3600 + EvalPeriods=24 + DatapointsToAlarm=1 keeps the trailing 24h evaluation window but evaluates hourly so alarm state reflects the most recent SF emission within ~1h instead of ~24h. treat-missing-data=notBreaching keeps weekly-cadence rows quiet between emissions." \
     --comparison-operator "LessThanThreshold" \
-    --evaluation-periods 1 \
-    --period 86400 \
+    --evaluation-periods 24 \
+    --datapoints-to-alarm 1 \
+    --period 3600 \
     --statistic "Minimum" \
     --threshold 1 \
     --treat-missing-data "notBreaching" \
@@ -103,10 +109,11 @@ echo "==> $aggregate_name"
 aws cloudwatch put-metric-alarm \
   --region "$REGION" \
   --alarm-name "$aggregate_name" \
-  --alarm-description "Aggregate safety-net alarm for the transparency substrate. Fires when SubstrateChecksFailed > 0 in any 24h window. Catches the case where a per-row alarm has been accidentally deleted — the per-row alarms are authoritative for which row failed; this alarm only confirms the substrate is observing failures. treat-missing-data=notBreaching means a substrate run with all rows passing emits zero failures and the alarm stays OK." \
+  --alarm-description "Aggregate safety-net alarm for the transparency substrate. Fires when SubstrateChecksFailed > 0 in any of the 24 trailing hourly periods. Catches the case where a per-row alarm has been accidentally deleted — the per-row alarms are authoritative for which row failed; this alarm only confirms the substrate is observing failures. Period=3600 + EvalPeriods=24 + DatapointsToAlarm=1 mirrors the per-row alarms. treat-missing-data=notBreaching means a substrate run with all rows passing emits zero failures and the alarm stays OK." \
   --comparison-operator "GreaterThanThreshold" \
-  --evaluation-periods 1 \
-  --period 86400 \
+  --evaluation-periods 24 \
+  --datapoints-to-alarm 1 \
+  --period 3600 \
   --statistic "Maximum" \
   --threshold 0 \
   --treat-missing-data "notBreaching" \

--- a/tests/test_substrate_alarms_script.py
+++ b/tests/test_substrate_alarms_script.py
@@ -133,6 +133,26 @@ class TestAlarmSemantics:
         # don't fire alarms; only emitted-and-failed days fire.
         assert '--treat-missing-data "notBreaching"' in script_text
 
+    def test_period_is_one_hour_for_hourly_refresh(self, script_text):
+        """Period=3600 (1h) is the post-2026-05-08 cadence: alarm state
+        reflects the most recent SF emission within ~1h instead of the
+        ~24-37h lag of the original Period=86400 (24h) cadence.
+        Regression for the cadence-lag P0 (ROADMAP line 2082)."""
+        assert "--period 3600" in script_text
+        # Old daily-period must not creep back in.
+        assert "--period 86400" not in script_text, (
+            "Period=86400 reintroduces the 24-37h alarm-state lag — "
+            "regression of the 2026-05-08 cadence fix"
+        )
+
+    def test_evaluation_window_stays_24_hours(self, script_text):
+        """EvalPeriods=24 × Period=3600 keeps the same 24h trailing
+        window as before — only refresh cadence changes. Pinning the
+        product so a future "tighten Period further" PR doesn't
+        accidentally narrow the actual window."""
+        assert "--evaluation-periods 24" in script_text
+        assert "--datapoints-to-alarm 1" in script_text
+
 
 class TestRegionDefault:
     def test_region_defaults_to_us_east_1(self, script_text):


### PR DESCRIPTION
## Summary

- CloudWatch alarms with Period=86400 + EvaluationPeriods=1 evaluated only at 24h boundaries — Sat SF emissions at 12:00 UTC Sat were invisible in alarm state until ~17:05 PT Sun (~37h lag from cron start to first alarm-state refresh).
- Switch to Period=3600 + EvalPeriods=24 + DatapointsToAlarm=1: same 24h trailing window, hourly refresh cadence, alarm reflects most recent SF emission within ~1h.
- Cost delta: 24× more CW eval reads/day; bounded.

## Live operator step (after merge)

```
cd ~/Development/alpha-engine-data
./infrastructure/setup_substrate_alarms.sh
```

Script is idempotent — applies the new Period semantics to all 10 existing alarms (9 per-row + 1 aggregate).

## Test plan

- [x] `pytest tests/test_substrate_alarms_script.py` (17/17, +3 regression tests pinning Period=3600, EvalPeriods=24, DatapointsToAlarm=1)
- [x] `bash -n infrastructure/setup_substrate_alarms.sh` clean
- [ ] After merge: re-run setup script live; verify `aws cloudwatch describe-alarms --alarm-name-prefix alpha-engine-substrate-` shows `Period: 3600` on all 10 alarms
- [ ] Sat 5/9 SF post-cron: alarm state should refresh by ~03:00-04:00 PT Sat instead of ~17:05 PT Sun

## Related

- Closes ROADMAP P0 line 2082 (substrate-check evaluation cadence vs Sat-SF emission timing)
- Composes with alpha-engine-lib PR #29 (full SF ARNs in pipeline_execution row) — both ride the same Sat 5/9 first-exercise window

🤖 Generated with [Claude Code](https://claude.com/claude-code)