### PR TITLE
fix(backfill): use min(valid_dates) so single fresh ticker can't suppress delta load

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -302,10 +302,12 @@ def _assert_no_arctic_regression(
             f"if backfill proceeded. Source data (predictor/price_cache + daily_closes delta) "
             f"ends earlier than what ArcticDB already has. Most common cause: the price cache "
             f"mtime 'current' check skipped the weekly refresh, so the cache lags "
-            f"MorningEnrich/daily_append writes. To recover: run the prices collector with a "
-            f"forced refresh (e.g. delete or touch S3 mtime to invalidate) so the cache "
-            f"includes the prior trading day, then re-invoke backfill. "
-            f"Regressions detected (showing first 10 of {len(regressions)}): {regressions[:10]}"
+            f"MorningEnrich/daily_append writes — and ``_apply_daily_delta`` failed to bridge "
+            f"the gap (e.g. its ``slim_last_date`` was poisoned by a single freshly-refreshed "
+            f"ticker, leaving ``bdate_range`` empty on a Saturday). To recover: redrive the "
+            f"failed SF execution after confirming ``features/compute.py::_apply_daily_delta`` "
+            f"uses ``min(valid_dates)`` so per-ticker mtime variation can't suppress delta "
+            f"loading. Regressions detected (showing first 10 of {len(regressions)}): {regressions[:10]}"
         )
 
     log.info(

--- a/features/compute.py
+++ b/features/compute.py
@@ -186,13 +186,24 @@ def _apply_daily_delta(
 
     Returns (updated_price_data, split_tickers).
     """
-    # Find the slim cache's last date (most common across all tickers)
+    # Find the OLDEST ticker's last_date so the delta load covers every
+    # ticker that needs catching up. ``min`` not ``max``: if even one
+    # ticker is freshly refreshed (e.g. ``prices.collect`` flagged a single
+    # stale ticker via mtime check on yfinance refresh), ``max`` would
+    # advance ``slim_last_date`` to that one ticker's end — and on a
+    # Saturday run that's exactly when ``bdate_range(slim_last_date+1,
+    # today)`` yields zero business days, so the loader returns empty and
+    # every OTHER ticker stays stuck at its older cache last_date.
+    # Origin: 2026-05-09 weekly SF — VEEV got refreshed via yfinance to
+    # 5/8, every other parquet ended at 5/6, ``max`` picked 5/8 → today
+    # 5/9 → empty bdate_range → backfill regression preflight failed at
+    # planned=5/6 < existing=5/8 across SPY/VIX/XL*/sampled-universe.
     candidate_dates = [_safe_last_date(df.index) for df in price_data.values()]
     valid_dates = [d for d in candidate_dates if d is not None]
     if not valid_dates:
         return price_data, set()
 
-    slim_last_date = max(valid_dates)
+    slim_last_date = min(valid_dates)
     today = pd.Timestamp(date_str).normalize()
 
     # Load all delta files between slim cache last date and target date

--- a/tests/test_apply_daily_delta_min_last_date.py
+++ b/tests/test_apply_daily_delta_min_last_date.py
@@ -1,0 +1,139 @@
+"""Regression test for ``features/compute.py::_apply_daily_delta``.
+
+Locks the 2026-05-09 weekly-SF DataPhase1 incident: when ``prices.collect``
+flagged a single ticker as stale and refreshed it via yfinance to the
+prior trading day, every OTHER cache parquet still ended at an older
+date. The legacy ``max(valid_dates)`` lookup picked the freshly-refreshed
+ticker's date as ``slim_last_date``, and on a Saturday run that turned
+``bdate_range(slim_last_date+1, today)`` into an empty range — the
+delta loader returned ``{}``, every other ticker stayed stuck at the
+older cache date, and the backfill regression preflight rejected the
+write because planned (5/6) < existing-in-ArcticDB (5/8) across all
+macro / sector ETF / sampled-universe symbols.
+
+The fix uses ``min(valid_dates)`` so even one fresh ticker can't
+suppress the delta load for the others. Duplicate dates that result
+from overlap with the fresh ticker are deduped by ``keep="last"`` in
+``_apply_daily_delta``'s combine step (already covered by the existing
+backfill happy-path tests).
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+
+
+def _ohlcv(end_date: str, n: int = 5) -> pd.DataFrame:
+    idx = pd.bdate_range(end=end_date, periods=n)
+    return pd.DataFrame(
+        {"Open": 100.0, "High": 101.0, "Low": 99.0, "Close": 100.0, "Volume": 1_000_000},
+        index=idx,
+    )
+
+
+def _stub_s3_with_daily_closes(daily_closes_by_date: dict[str, pd.DataFrame]):
+    """Build an S3 stub whose ``get_object`` serves parquet bytes for the
+    given ``staging/daily_closes/{date}.parquet`` keys; raises NoSuchKey
+    for anything else (matches the live boto3 contract)."""
+    s3 = MagicMock()
+
+    class _NoSuchKey(Exception):
+        pass
+
+    s3.exceptions.NoSuchKey = _NoSuchKey
+
+    def _get_object(Bucket, Key):
+        for date, df in daily_closes_by_date.items():
+            if Key == f"staging/daily_closes/{date}.parquet":
+                buf = io.BytesIO()
+                df.to_parquet(buf, engine="pyarrow")
+                buf.seek(0)
+                return {"Body": MagicMock(read=lambda buf=buf: buf.read())}
+        raise _NoSuchKey(f"key={Key} not stubbed")
+
+    s3.get_object.side_effect = _get_object
+    return s3
+
+
+def _daily_closes_frame(rows: dict[str, dict]) -> pd.DataFrame:
+    """Build a daily_closes parquet body shape: index=ticker, columns
+    include Open/High/Low/Close/Volume."""
+    df = pd.DataFrame.from_dict(rows, orient="index")
+    df.index.name = "ticker"
+    return df
+
+
+def test_apply_daily_delta_uses_min_last_date_when_one_ticker_freshly_refreshed():
+    """The 2026-05-09 incident: VEEV got freshly refreshed by yfinance to
+    Friday's close, every other parquet still ended at Wednesday's close.
+    The delta load must still pick up Thu + Fri so SPY/VIX/XL*/universe
+    advance to Friday — without this, backfill's regression preflight
+    rejects the write.
+    """
+    from features import compute as _c
+
+    # 920 tickers stuck at 5/6 (Wed), 1 ticker freshly refreshed to 5/8 (Fri)
+    price_data = {
+        "SPY": _ohlcv("2026-05-06", n=10),
+        "XLF": _ohlcv("2026-05-06", n=10),
+        "AAPL": _ohlcv("2026-05-06", n=10),
+        "VEEV": _ohlcv("2026-05-08", n=10),  # the freshly-refreshed ticker
+    }
+
+    # daily_closes for 5/7 + 5/8 carry every ticker (matches MorningEnrich
+    # polygon-T+1 fill shape)
+    daily_closes = {
+        "2026-05-07": _daily_closes_frame({
+            "SPY":  {"Open": 730.0, "High": 732.0, "Low": 729.0, "Close": 731.0, "Volume": 1},
+            "XLF":  {"Open": 50.0,  "High": 51.0,  "Low": 49.0,  "Close": 50.5,  "Volume": 1},
+            "AAPL": {"Open": 200.0, "High": 202.0, "Low": 199.0, "Close": 201.0, "Volume": 1},
+            "VEEV": {"Open": 250.0, "High": 252.0, "Low": 249.0, "Close": 251.0, "Volume": 1},
+        }),
+        "2026-05-08": _daily_closes_frame({
+            "SPY":  {"Open": 734.0, "High": 738.0, "Low": 733.0, "Close": 737.0, "Volume": 1},
+            "XLF":  {"Open": 51.0,  "High": 52.0,  "Low": 50.0,  "Close": 51.5,  "Volume": 1},
+            "AAPL": {"Open": 202.0, "High": 204.0, "Low": 201.0, "Close": 203.0, "Volume": 1},
+            "VEEV": {"Open": 252.0, "High": 254.0, "Low": 251.0, "Close": 253.0, "Volume": 1},
+        }),
+    }
+    s3 = _stub_s3_with_daily_closes(daily_closes)
+
+    # Saturday run: today=5/9, no business day range with max=5/8 + 1 = 5/9
+    out, _splits = _c._apply_daily_delta(s3, "test-bucket", "2026-05-09", price_data)
+
+    # Every ticker must end at 5/8 — the frozen ones must NOT remain stuck at 5/6
+    assert out["SPY"].index[-1] == pd.Timestamp("2026-05-08"), (
+        f"SPY stuck at {out['SPY'].index[-1]} — delta loader skipped 5/7 + 5/8 "
+        f"because slim_last_date was poisoned by VEEV's fresh 5/8 mtime"
+    )
+    assert out["XLF"].index[-1] == pd.Timestamp("2026-05-08")
+    assert out["AAPL"].index[-1] == pd.Timestamp("2026-05-08")
+    assert out["VEEV"].index[-1] == pd.Timestamp("2026-05-08")
+
+    # VEEV's overlapping 5/8 row must dedupe to one (keep="last"). Sanity:
+    # no duplicate index entries.
+    assert not out["VEEV"].index.has_duplicates
+    assert not out["SPY"].index.has_duplicates
+
+
+def test_apply_daily_delta_returns_early_when_all_tickers_already_at_today():
+    """Sanity: if EVERY ticker is already at today, ``min`` equals today
+    and the bdate_range is empty — early-return is fine, no clobber."""
+    from features import compute as _c
+
+    price_data = {
+        "SPY": _ohlcv("2026-05-08", n=5),
+        "XLF": _ohlcv("2026-05-08", n=5),
+    }
+
+    s3 = MagicMock()  # never called: bdate_range is empty so loader short-circuits
+
+    out, _splits = _c._apply_daily_delta(s3, "test-bucket", "2026-05-09", price_data)
+
+    assert out["SPY"].index[-1] == pd.Timestamp("2026-05-08")
+    assert out["XLF"].index[-1] == pd.Timestamp("2026-05-08")
+    s3.get_object.assert_not_called()


### PR DESCRIPTION
## Summary
- Closes the 2026-05-09 weekly-SF DataPhase1 PARTIAL incident: `_apply_daily_delta` used `max(valid_dates)` to pick `slim_last_date`, so a single freshly-refreshed ticker (VEEV, refreshed by `prices.collect`'s mtime check to 5/8 while every other parquet ended at 5/6) became the lookup anchor. On a Saturday run that turned `bdate_range(slim_last_date+1, today)` into an empty range — the delta loader returned `{}`, every other cache parquet stayed at 5/6, and the backfill regression preflight rejected the write because planned 5/6 < existing-in-ArcticDB 5/8 across 38 symbols (SPY/VIX/XL*/sampled-universe).
- Switched to `min(valid_dates)` so the load always covers the oldest ticker; the existing `keep="last"` dedupe in the combine step handles the overlap with any freshly-refreshed ticker.
- Updated the preflight error message in `builders/backfill.py` so the recovery hint actually addresses the underlying cause (the legacy text blamed the cache mtime check, which was working as designed — the bug was downstream in delta loading).
- New regression test `tests/test_apply_daily_delta_min_last_date.py` pins the multi-mtime case + the all-tickers-current early-return.

## Test plan
- [x] `pytest tests/test_apply_daily_delta_min_last_date.py -v` (2 new tests pass)
- [x] `pytest` full suite (574 passed, 1 skipped — same as origin/main)
- [ ] After merge + boot-pull, redrive failed Sat SF execution `ce500327-cf08-6731-5d44-882f5b380a30_0ae54554-5564-587a-5947-5cb99bf1130f` and verify DataPhase1 → RAGIngestion → Research → ... chain completes
- [ ] Verify `_apply_daily_delta` log line shows non-empty delta range on next Sat SF firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)