### PR TITLE
feat(morning-enrich): chronic-polygon-gap self-heal via yfinance backfill

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -28,6 +28,29 @@ universe_returns:
 daily_closes:
   s3_prefix: staging/daily_closes/
 
+# Chronic polygon coverage gaps — tickers polygon does not reliably serve.
+# MorningEnrich's `_self_heal_chronic_polygon_gaps` step yfinance-backfills
+# any ArcticDB row gap from `last_date+1` to `target_date` for each ticker
+# in this list. Adding a ticker is a deliberate operational decision (it
+# weakens the "no silent fails" stance for that ticker specifically); a
+# follow-up drift alarm flags entries here that start getting polygon
+# coverage so they can be removed. Tickers absent from this list still
+# hard-fail polygon_only when missing — preserves the strict default.
+chronic_polygon_gaps:
+  tickers:
+    BF-B:
+      reason: "Class B share — polygon serves BF.B (dot), our universe uses BF-B (dash)"
+      since: "2025-04-01"
+    BRK-B:
+      reason: "Class B share — polygon serves BRK.B, our universe uses BRK-B"
+      since: "2025-04-01"
+    MOG-A:
+      reason: "Class A share — polygon serves MOG.A, our universe uses MOG-A"
+      since: "2025-04-01"
+    PSTG:
+      reason: "Polygon coverage flaky since ~2026-04 (no clear cause)"
+      since: "2026-04-01"
+
 # Tickers that require a leading caret in yfinance (index/rate tickers)
 # Stored locally WITHOUT the caret (VIX.parquet, not ^VIX.parquet)
 caret_symbols:

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -39,6 +39,7 @@
           "commands": [
             "set -eo pipefail",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",

--- a/tests/test_chronic_polygon_gap_self_heal.py
+++ b/tests/test_chronic_polygon_gap_self_heal.py
@@ -1,0 +1,319 @@
+"""Regression tests for `weekly_collector._self_heal_chronic_polygon_gaps`
+and the chronic-polygon-gaps config loader.
+
+Locks the 2026-05-09 weekly-SF DataPhase1 postflight failure: PSTG ended
+at 5/5 in ArcticDB while SPY was at 5/8 (3d stale, > 2d threshold).
+Polygon doesn't reliably serve PSTG (one of 4 known chronic gaps —
+BF-B/BRK-B/MOG-A/PSTG), so MorningEnrich's polygon_only daily_append
+left it stuck at whatever the prior EOD yfinance pass landed; on days
+when EOD also dropped it the gap compounded. The self-heal step
+yfinance-backfills any [last_date+1, target_date] gap for each chronic
+ticker so postflight passes uniformly without ad-hoc allowlists.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+# ── Config loader ────────────────────────────────────────────────────────────
+
+
+def test_load_chronic_polygon_gaps_returns_sorted_keys():
+    from weekly_collector import _load_chronic_polygon_gaps
+
+    config = {
+        "chronic_polygon_gaps": {
+            "tickers": {
+                "PSTG": {"reason": "polygon coverage flaky"},
+                "BF-B": {"reason": "class B share dot-vs-dash"},
+                "MOG-A": {"reason": "class A share dot-vs-dash"},
+                "BRK-B": {"reason": "class B share dot-vs-dash"},
+            }
+        }
+    }
+    assert _load_chronic_polygon_gaps(config) == ["BF-B", "BRK-B", "MOG-A", "PSTG"]
+
+
+def test_load_chronic_polygon_gaps_empty_when_section_missing():
+    """Missing config section means no self-heal — pre-PR strict
+    polygon_only behavior preserved as the safe default."""
+    from weekly_collector import _load_chronic_polygon_gaps
+
+    assert _load_chronic_polygon_gaps({}) == []
+    assert _load_chronic_polygon_gaps({"chronic_polygon_gaps": {}}) == []
+    assert _load_chronic_polygon_gaps(
+        {"chronic_polygon_gaps": {"tickers": None}}
+    ) == []
+
+
+def test_load_chronic_polygon_gaps_empty_when_section_malformed():
+    """A list (instead of dict) under `tickers` is malformed config — be
+    permissive (return empty) rather than crash MorningEnrich at boot."""
+    from weekly_collector import _load_chronic_polygon_gaps
+
+    assert _load_chronic_polygon_gaps(
+        {"chronic_polygon_gaps": {"tickers": ["BF-B", "PSTG"]}}
+    ) == []
+
+
+# ── Self-heal helper ─────────────────────────────────────────────────────────
+
+
+def _stub_universe_lib(ticker_to_last_date: dict[str, str | None]):
+    """Build an ArcticDB stub whose ``tail(sym, n=1)`` returns a single-row
+    frame ending on the given date (None → empty frame, simulating a
+    ticker absent from the library)."""
+    lib = MagicMock()
+
+    def _tail(sym, n=1):
+        last = ticker_to_last_date.get(sym)
+        if last is None:
+            empty = MagicMock()
+            empty.data = pd.DataFrame()
+            return empty
+        df = pd.DataFrame(
+            {"Close": [100.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(last)]),
+        )
+        result = MagicMock()
+        result.data = df
+        return result
+
+    lib.tail.side_effect = _tail
+    return lib
+
+
+def _stub_s3_with_pcache(parquet_dfs_by_ticker: dict[str, pd.DataFrame]):
+    """S3 stub that serves predictor/price_cache/{T}.parquet from a dict
+    of in-memory DataFrames; raises NoSuchKey for absent tickers."""
+    s3 = MagicMock()
+
+    class _NoSuchKey(Exception):
+        pass
+
+    s3.exceptions.NoSuchKey = _NoSuchKey
+
+    written: dict[str, bytes] = {}
+
+    def _get_object(Bucket, Key):
+        for ticker, df in parquet_dfs_by_ticker.items():
+            if Key == f"predictor/price_cache/{ticker}.parquet":
+                buf = io.BytesIO()
+                df.to_parquet(buf, engine="pyarrow")
+                buf.seek(0)
+                return {"Body": MagicMock(read=lambda buf=buf: buf.read())}
+        raise _NoSuchKey(f"key={Key} not stubbed")
+
+    def _put_object(Bucket, Key, Body, **_kwargs):
+        written[Key] = Body
+        return {}
+
+    s3.get_object.side_effect = _get_object
+    s3.put_object.side_effect = _put_object
+    s3.written = written  # accessible to assertions
+    return s3
+
+
+def _yf_df(start: str, n_business_days: int) -> pd.DataFrame:
+    """Build a yfinance-shaped OHLCV frame (columns: Open/High/Low/Close/Volume)."""
+    idx = pd.bdate_range(start=start, periods=n_business_days)
+    return pd.DataFrame(
+        {"Open": 100.0, "High": 101.0, "Low": 99.0, "Close": 100.0, "Volume": 1_000_000},
+        index=idx,
+    )
+
+
+def test_self_heal_skips_already_fresh_tickers():
+    """Idempotence: if ArcticDB last_date >= target_date the ticker is
+    skipped — no yfinance fetch, no parquet write, no backfill call."""
+    from weekly_collector import _self_heal_chronic_polygon_gaps
+
+    universe_lib = _stub_universe_lib({"BF-B": "2026-05-08"})
+    s3 = _stub_s3_with_pcache({})
+
+    yf_download = MagicMock()
+    backfill_mock = MagicMock()
+
+    with patch("weekly_collector.boto3.client", return_value=s3), \
+         patch("store.arctic_store.get_universe_lib", return_value=universe_lib), \
+         patch("yfinance.download", yf_download), \
+         patch("builders.backfill.backfill", backfill_mock):
+        result = _self_heal_chronic_polygon_gaps(
+            bucket="test-bucket",
+            target_date="2026-05-08",
+            chronic_tickers=["BF-B"],
+        )
+
+    assert result["checked"] == 1
+    assert len(result["healed"]) == 0
+    assert len(result["skipped_already_fresh"]) == 1
+    assert result["skipped_already_fresh"][0] == {"ticker": "BF-B", "last_date": "2026-05-08"}
+    yf_download.assert_not_called()
+    backfill_mock.assert_not_called()
+    assert s3.written == {}
+
+
+def test_self_heal_backfills_pstg_via_yfinance_and_invokes_per_ticker_backfill():
+    """The 2026-05-09 incident exact path: PSTG at 5/5 in ArcticDB,
+    target=5/8, yfinance has 5/6 + 5/7 + 5/8. Self-heal must:
+      - yfinance-fetch [5/6, 5/8]
+      - patch predictor/price_cache/PSTG.parquet with new rows (deduped)
+      - invoke builders.backfill(ticker_filter='PSTG') so the ArcticDB
+        write goes through the same per-ticker compute_features path.
+    """
+    from weekly_collector import _self_heal_chronic_polygon_gaps
+
+    universe_lib = _stub_universe_lib({"PSTG": "2026-05-05"})
+    existing_pcache = pd.DataFrame(
+        {"Open": 70.0, "High": 71.0, "Low": 69.0, "Close": 70.0, "Volume": 1_000},
+        index=pd.bdate_range(end="2026-05-05", periods=10),
+    )
+    s3 = _stub_s3_with_pcache({"PSTG": existing_pcache})
+
+    fresh_yf = pd.DataFrame(
+        {"Open": [73.0, 74.0, 78.0], "High": [75.0, 78.0, 79.0],
+         "Low":  [73.0, 74.0, 75.0], "Close": [74.5, 76.0, 78.2],
+         "Volume": [1_500, 2_000, 3_000]},
+        index=pd.DatetimeIndex(["2026-05-06", "2026-05-07", "2026-05-08"]),
+    )
+
+    backfill_mock = MagicMock()
+
+    with patch("weekly_collector.boto3.client", return_value=s3), \
+         patch("store.arctic_store.get_universe_lib", return_value=universe_lib), \
+         patch("yfinance.download", return_value=fresh_yf), \
+         patch("builders.backfill.backfill", backfill_mock):
+        result = _self_heal_chronic_polygon_gaps(
+            bucket="test-bucket",
+            target_date="2026-05-08",
+            chronic_tickers=["PSTG"],
+        )
+
+    assert result["checked"] == 1
+    assert len(result["healed"]) == 1
+    healed = result["healed"][0]
+    assert healed["ticker"] == "PSTG"
+    assert healed["previous_last_date"] == "2026-05-05"
+    assert healed["rows_added"] == 3
+    assert healed["new_last_date"] == "2026-05-08"
+    assert len(result["errors"]) == 0
+
+    # Patched parquet got written with the fresh rows merged in
+    pcache_key = "predictor/price_cache/PSTG.parquet"
+    assert pcache_key in s3.written
+    written_df = pd.read_parquet(io.BytesIO(s3.written[pcache_key]))
+    assert pd.Timestamp("2026-05-08") in written_df.index
+    assert pd.Timestamp("2026-05-06") in written_df.index
+
+    backfill_mock.assert_called_once_with(
+        bucket="test-bucket", ticker_filter="PSTG", dry_run=False
+    )
+
+
+def test_self_heal_dry_run_skips_writes_and_backfill_invocation():
+    """``dry_run=True`` exercises the read paths + computes the healed
+    summary, but writes nothing to S3 and invokes no per-ticker backfill."""
+    from weekly_collector import _self_heal_chronic_polygon_gaps
+
+    universe_lib = _stub_universe_lib({"PSTG": "2026-05-05"})
+    s3 = _stub_s3_with_pcache({
+        "PSTG": pd.DataFrame(
+            {"Open": 70.0, "Close": 70.0, "High": 71.0, "Low": 69.0, "Volume": 1_000},
+            index=pd.bdate_range(end="2026-05-05", periods=5),
+        )
+    })
+
+    backfill_mock = MagicMock()
+    fresh_yf = _yf_df("2026-05-06", n_business_days=3)
+
+    with patch("weekly_collector.boto3.client", return_value=s3), \
+         patch("store.arctic_store.get_universe_lib", return_value=universe_lib), \
+         patch("yfinance.download", return_value=fresh_yf), \
+         patch("builders.backfill.backfill", backfill_mock):
+        result = _self_heal_chronic_polygon_gaps(
+            bucket="test-bucket",
+            target_date="2026-05-08",
+            chronic_tickers=["PSTG"],
+            dry_run=True,
+        )
+
+    assert len(result["healed"]) == 1
+    assert s3.written == {}  # no writes in dry-run
+    backfill_mock.assert_not_called()
+
+
+def test_self_heal_per_ticker_failure_is_isolated():
+    """A yfinance hiccup on one chronic ticker logs an error for that
+    ticker but does not block the others — postflight is the load-bearing
+    gate, this step is best-effort."""
+    from weekly_collector import _self_heal_chronic_polygon_gaps
+
+    universe_lib = _stub_universe_lib({"PSTG": "2026-05-05", "BF-B": "2026-05-06"})
+    existing_pcache = pd.DataFrame(
+        {"Open": 70.0, "High": 71.0, "Low": 69.0, "Close": 70.0, "Volume": 1_000},
+        index=pd.bdate_range(end="2026-05-06", periods=10),
+    )
+    s3 = _stub_s3_with_pcache({"PSTG": existing_pcache, "BF-B": existing_pcache})
+
+    def _yf_side_effect(ticker, **_kwargs):
+        if ticker == "PSTG":
+            raise RuntimeError("yfinance: rate-limited (HTTP 429)")
+        return pd.DataFrame(
+            {"Open": [101.0, 102.0], "High": [102.0, 103.0],
+             "Low":  [100.0, 101.0], "Close": [101.5, 102.5],
+             "Volume": [1_000, 1_000]},
+            index=pd.DatetimeIndex(["2026-05-07", "2026-05-08"]),
+        )
+
+    backfill_mock = MagicMock()
+
+    with patch("weekly_collector.boto3.client", return_value=s3), \
+         patch("store.arctic_store.get_universe_lib", return_value=universe_lib), \
+         patch("yfinance.download", side_effect=_yf_side_effect), \
+         patch("builders.backfill.backfill", backfill_mock):
+        result = _self_heal_chronic_polygon_gaps(
+            bucket="test-bucket",
+            target_date="2026-05-08",
+            chronic_tickers=["PSTG", "BF-B"],
+        )
+
+    assert result["checked"] == 2
+    assert len(result["healed"]) == 1
+    assert result["healed"][0]["ticker"] == "BF-B"
+    assert len(result["errors"]) == 1
+    assert result["errors"][0]["ticker"] == "PSTG"
+    # BF-B's backfill was still invoked despite PSTG's failure
+    backfill_mock.assert_called_once_with(
+        bucket="test-bucket", ticker_filter="BF-B", dry_run=False
+    )
+
+
+def test_self_heal_empty_chronic_tickers_is_noop():
+    """No chronic-gap config → empty list → no work done. Preserves the
+    pre-PR behavior when the config section is absent."""
+    from weekly_collector import _self_heal_chronic_polygon_gaps
+
+    s3 = MagicMock()
+    universe_lib = MagicMock()
+
+    with patch("weekly_collector.boto3.client", return_value=s3), \
+         patch("store.arctic_store.get_universe_lib", return_value=universe_lib):
+        result = _self_heal_chronic_polygon_gaps(
+            bucket="test-bucket",
+            target_date="2026-05-08",
+            chronic_tickers=[],
+        )
+
+    assert result == {
+        "checked": 0,
+        "healed": [],
+        "skipped_already_fresh": [],
+        "errors": [],
+    }
+    universe_lib.tail.assert_not_called()
+    s3.get_object.assert_not_called()

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -97,6 +97,23 @@ def load_config(path: str = "config.yaml") -> dict:
     )
 
 
+def _load_chronic_polygon_gaps(config: dict) -> list[str]:
+    """Return the sorted list of chronic-polygon-gap tickers from config.
+
+    Empty list when the config section is missing or malformed: the
+    chronic-gap self-heal step then becomes a no-op, preserving the
+    pre-PR strict ``polygon_only`` behavior. Adding/removing a ticker
+    requires a deliberate edit to ``data/config.yaml`` in the
+    alpha-engine-config repo (private), surfaced by drift detection if
+    polygon coverage recovers for an entry.
+    """
+    section = config.get("chronic_polygon_gaps") or {}
+    tickers = section.get("tickers") or {}
+    if not isinstance(tickers, dict):
+        return []
+    return sorted(tickers.keys())
+
+
 def run_weekly(config: dict, args: argparse.Namespace) -> dict:
     """Run collectors based on mode selection."""
     if getattr(args, "morning_enrich", False):
@@ -508,6 +525,153 @@ def _should_skip_morning_enrich(
     return False, None
 
 
+def _self_heal_chronic_polygon_gaps(
+    bucket: str,
+    target_date: str,
+    chronic_tickers: list[str],
+    dry_run: bool = False,
+) -> dict:
+    """Yfinance-backfill any ArcticDB row gap for chronic-polygon-gap tickers.
+
+    For each ticker in ``chronic_tickers``:
+      1. Read ArcticDB universe ``last_date``.
+      2. If ``last_date >= target_date``, skip (already fresh — common case
+         after the first heal lands).
+      3. Else yfinance-fetch ``[last_date+1, target_date]`` OHLCV.
+      4. Append the new rows to ``predictor/price_cache/{ticker}.parquet``
+         (dedupe by date keep="last" so repeated heals are idempotent).
+      5. Invoke ``builders.backfill(ticker_filter=ticker)`` — reuses the
+         per-ticker compute_features + ArcticDB write path so the new
+         rows get the same feature schema as every other ticker.
+
+    Closes the multi-day rot caused by polygon never serving the chronic
+    gaps + the EOD yfinance pass occasionally dropping a day. Origin:
+    2026-05-09 weekly SF DataPhase1 postflight failure — PSTG ended at
+    5/5 (ArcticDB) vs SPY at 5/8 (3d stale, > 2d threshold), every other
+    chronic ticker at 5/6 (2d, just under threshold). Without this step
+    the only recovery was hand-running a yfinance backfill script.
+
+    Idempotent: tickers already at target_date are skipped, so re-running
+    after a partial completion costs only the freshness reads. Best-effort
+    per-ticker — one ticker's yfinance failure does not block the others.
+
+    Returns a summary dict with per-ticker outcomes; the caller should
+    log it (not raise) so a yfinance hiccup on a chronic gap doesn't
+    halt the whole pipeline. Postflight will catch any remaining staleness
+    via its uniform check.
+    """
+    import io as _io
+
+    import yfinance as _yf
+
+    from store.arctic_store import get_universe_lib
+
+    s3 = boto3.client("s3")
+    universe_lib = get_universe_lib(bucket)
+    target_ts = __import__("pandas").Timestamp(target_date).normalize()
+
+    summary: dict = {
+        "checked": len(chronic_tickers),
+        "healed": [],
+        "skipped_already_fresh": [],
+        "errors": [],
+    }
+
+    if not chronic_tickers:
+        return summary
+
+    import pandas as _pd
+
+    for ticker in chronic_tickers:
+        try:
+            try:
+                df_tail = universe_lib.tail(ticker, n=1).data
+                existing_last = (
+                    _pd.Timestamp(df_tail.index[-1]).normalize()
+                    if df_tail is not None and not df_tail.empty
+                    else None
+                )
+            except Exception:
+                existing_last = None
+
+            if existing_last is not None and existing_last >= target_ts:
+                summary["skipped_already_fresh"].append(
+                    {"ticker": ticker, "last_date": str(existing_last.date())}
+                )
+                continue
+
+            start_ts = (
+                (existing_last + _pd.Timedelta(days=1))
+                if existing_last is not None
+                else (target_ts - _pd.Timedelta(days=30))
+            )
+            end_excl = target_ts + _pd.Timedelta(days=1)
+
+            yf_df = _yf.download(
+                ticker,
+                start=start_ts.strftime("%Y-%m-%d"),
+                end=end_excl.strftime("%Y-%m-%d"),
+                progress=False,
+                auto_adjust=True,
+            )
+            if isinstance(yf_df.columns, _pd.MultiIndex):
+                yf_df.columns = yf_df.columns.get_level_values(0)
+
+            yf_df = yf_df[(yf_df.index >= start_ts) & (yf_df.index <= target_ts)]
+            if yf_df.empty:
+                summary["errors"].append(
+                    {"ticker": ticker, "reason": "yfinance returned no rows in target range"}
+                )
+                continue
+
+            ohlcv_cols = ["Open", "High", "Low", "Close", "Volume"]
+            new_rows = yf_df[[c for c in ohlcv_cols if c in yf_df.columns]].copy()
+
+            pcache_key = f"predictor/price_cache/{ticker}.parquet"
+            try:
+                obj = s3.get_object(Bucket=bucket, Key=pcache_key)
+                existing_pcache = _pd.read_parquet(_io.BytesIO(obj["Body"].read()))
+            except s3.exceptions.NoSuchKey:
+                existing_pcache = _pd.DataFrame(columns=ohlcv_cols)
+
+            combined_pcache = _pd.concat([existing_pcache, new_rows])
+            combined_pcache = combined_pcache[
+                ~combined_pcache.index.duplicated(keep="last")
+            ].sort_index()
+
+            if not dry_run:
+                buf = _io.BytesIO()
+                combined_pcache.to_parquet(buf, engine="pyarrow", compression="snappy")
+                buf.seek(0)
+                s3.put_object(Bucket=bucket, Key=pcache_key, Body=buf.getvalue())
+
+                from builders.backfill import backfill as _backfill
+                _backfill(bucket=bucket, ticker_filter=ticker, dry_run=False)
+
+            summary["healed"].append(
+                {
+                    "ticker": ticker,
+                    "previous_last_date": (
+                        str(existing_last.date()) if existing_last is not None else None
+                    ),
+                    "rows_added": int(len(new_rows)),
+                    "new_last_date": str(new_rows.index[-1].date()),
+                }
+            )
+            logger.info(
+                "chronic-gap self-heal: %s healed (prev=%s → new=%s, +%d rows)",
+                ticker,
+                existing_last.date() if existing_last is not None else "none",
+                new_rows.index[-1].date(),
+                len(new_rows),
+            )
+        except Exception as exc:
+            logger.exception("chronic-gap self-heal failed for %s", ticker)
+            summary["errors"].append({"ticker": ticker, "reason": str(exc)})
+
+    return summary
+
+
 def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
     """Morning polygon enrichment: overwrite the prior trading day's parquet
     + ArcticDB row with polygon's authoritative OHLCV+VWAP.
@@ -720,6 +884,57 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
     except Exception as e:
         logger.exception("ArcticDB daily_append (morning enrich) failed for %s", target_date)
         results["collectors"]["arcticdb"] = {"status": "error", "error": str(e)}
+
+    # ── Chronic-polygon-gap self-heal ────────────────────────────────────────
+    # Yfinance-backfills any ArcticDB universe row gap for the chronic-gap
+    # tickers (BF-B/BRK-B/MOG-A/PSTG by default — see config). Polygon does
+    # not reliably serve these, so the polygon_only daily_append above leaves
+    # them at whatever the prior EOD yfinance pass landed; on days when EOD
+    # also dropped them, the row gap compounds and postflight catches them
+    # as stale. This step closes that loop without weakening polygon_only's
+    # "no silent fails" stance for the other ~900 tickers.
+    #
+    # Best-effort: a yfinance hiccup on one chronic ticker logs + records in
+    # the result but does not halt the morning enrich. Postflight remains
+    # the load-bearing gate on freshness — if a chronic ticker is still
+    # stale after this step, postflight surfaces it.
+    chronic_tickers = _load_chronic_polygon_gaps(config)
+    if chronic_tickers:
+        logger.info("=" * 60)
+        logger.info(
+            "SELF-HEAL: chronic polygon coverage gaps (%d ticker(s): %s)",
+            len(chronic_tickers), ", ".join(chronic_tickers),
+        )
+        logger.info("=" * 60)
+        try:
+            heal_result = _self_heal_chronic_polygon_gaps(
+                bucket=bucket,
+                target_date=target_date,
+                chronic_tickers=chronic_tickers,
+                dry_run=dry_run,
+            )
+            # Always "ok" by design — chronic-gap self-heal is best-effort.
+            # Postflight is the load-bearing gate; if a chronic ticker is
+            # still stale after this step, postflight raises. Marking it
+            # "partial" on per-ticker yfinance failures would halt
+            # MorningEnrich on a transient yfinance hiccup, which would
+            # block the entire weekly pipeline for ~5 ms of yfinance flake.
+            results["collectors"]["chronic_gap_self_heal"] = {
+                "status": "ok",
+                **heal_result,
+            }
+            logger.info(
+                "chronic-gap self-heal: %d healed, %d already-fresh, %d errors",
+                len(heal_result["healed"]),
+                len(heal_result["skipped_already_fresh"]),
+                len(heal_result["errors"]),
+            )
+        except Exception as e:
+            logger.exception("Chronic-gap self-heal step failed for %s", target_date)
+            results["collectors"]["chronic_gap_self_heal"] = {
+                "status": "error",
+                "error": str(e),
+            }
 
     results["completed_at"] = datetime.now(timezone.utc).isoformat()
     statuses = [r.get("status", "unknown") for r in results["collectors"].values()]


### PR DESCRIPTION
## Summary

Root-cause fix for the 2026-05-09 weekly-SF DataPhase1 postflight failure. After alpha-engine-data PR #192 fixed the arcticdb backfill regression, postflight failed at PSTG = 3d stale vs SPY (`>2d` threshold) — exposing a deeper problem: **polygon does not reliably serve 4 known chronic-gap tickers (BF-B / BRK-B / MOG-A / PSTG), so they accumulate multi-day rot whenever the EOD yfinance pass also drops a day**.

The current design conflates two orthogonal concerns into a binary `source=polygon_only`:
1. Source preference (polygon authoritative > yfinance fallback)
2. Coverage expectation (which tickers polygon supplies vs doesn't)

This PR separates them: coverage expectation moves to config (`chronic_polygon_gaps.tickers`), and a new self-heal step in MorningEnrich yfinance-backfills any ArcticDB row gap for chronic-gap tickers. Tickers absent from the allowlist still hard-fail polygon_only collection — preserving the strict "no silent fails" default for the ~900 healthy tickers.

Companion config update in alpha-engine-config (private repo) at `data/config.yaml`.

This is PR A of a 3-PR root-cause arc:
- **PR A (this)** — chronic-gap config + self-heal in MorningEnrich
- **PR B** — provenance `source` column on ArcticDB OHLCV rows so postflight + downstream consumers can distinguish polygon vs yfinance origin per row
- **PR C** — postflight uniformity (drop ad-hoc allowlists; rely on freshness only) + drift alarm for chronic-gap tickers that start getting polygon coverage (signals the allowlist entry should be pruned)

## Test plan
- [x] 8 new tests in `tests/test_chronic_polygon_gap_self_heal.py` cover the config loader (sorted/missing/malformed) + self-heal helper (already-fresh skip, yfinance + parquet patch + backfill invocation, dry-run, per-ticker error isolation, empty-list no-op)
- [x] `pytest` full suite (582 passed, 1 skipped — vs 574 on origin/main)
- [ ] After merge, fresh Saturday SF execution: MorningEnrich self-heals PSTG to 5/8, daily_append succeeds, postflight passes 20/20 tickers fresh
- [ ] Verify CW logs show `chronic-gap self-heal: 1 healed, 3 already-fresh, 0 errors` (or similar) on the rerun
- [ ] Confirm subsequent weekday SF MorningEnrich logs show all 4 chronic tickers `already_fresh` (no work after the initial heal)

## Followups (separate PRs)
- PR B: provenance `source` column on ArcticDB rows (additive schema)
- PR C: postflight uniformity + chronic-gap drift alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)