### PR TITLE
feat(sf): PredictorTraining auto-syncs predictor.yaml from alpha-engine-config

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -369,6 +369,8 @@
           "commands": [
             "set -eo pipefail",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+            "sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml",
             "cd /home/ec2-user/alpha-engine-predictor",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",


### PR DESCRIPTION
## Summary

Symmetric fix to PR #193 (DataPhase1's alpha-engine-config pull). PredictorTraining task pulls alpha-engine-predictor but relies on the dispatcher's local `alpha-engine-predictor/config/predictor.yaml` (gitignored in predictor repo, staged from alpha-engine-config sibling clone). Nothing was keeping the staged copy in lockstep with origin/main of alpha-engine-config.

The 2026-05-09 horizon migration (alpha-engine-config #90: `forward_days 5 → 21`, `output_distribution_gate_blocking false → true`, `purge_days 5 → 21`) would not have reached the next Saturday training without a manual SSM-side `cp` intervention.

Adds two commands before the spot_train.sh invocation:
- `git -C alpha-engine-config pull --ff-only origin main`
- `cp alpha-engine-config/predictor/predictor.yaml alpha-engine-predictor/config/predictor.yaml`

## Test plan
- [ ] After deploy-infrastructure GHA runs (auto on merge to main), next PredictorTraining state on Sat 5/16 picks up the 21d horizon config without manual intervention
- [x] One-off SSM already applied to the trading instance to ensure THIS Saturday's retrain has the new config (covers the gap before the SF redeploy lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)