### PR TITLE
feat(morning-enrich): drift alarm for chronic_polygon_gaps allowlist

### DIFF
--- a/tests/test_chronic_gap_drift_detection.py
+++ b/tests/test_chronic_gap_drift_detection.py
@@ -1,0 +1,185 @@
+"""Regression tests for `weekly_collector._detect_chronic_gap_polygon_recovery`.
+
+The chronic_polygon_gaps allowlist (alpha-engine-config #88, predictor.yaml
+``chronic_polygon_gaps.tickers``) was added because polygon doesn't reliably
+serve BF-B / BRK-B / MOG-A / PSTG. If polygon coverage RECOVERS for any
+of these — e.g. polygon adds a Berkshire B share class CIK or fixes a
+flaky data feed — the allowlist entry becomes operational debt.
+
+This module's drift alarm reads the polygon_only daily_closes parquet
+written by ``daily_closes.collect`` and counts how many chronic tickers
+polygon DID cover today. CW metric
+``AlphaEngine/Data/chronic_gap_polygon_recovery_count`` carries the
+count so an alarm can fire if it's > 0 across multiple cycles
+(operator action: prune the allowlist).
+"""
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+
+def _stub_s3_with_parquet(parquet_df: pd.DataFrame, expected_key: str):
+    """Build an S3 stub that serves a parquet body for ``expected_key`` and
+    raises NoSuchKey for anything else."""
+    s3 = MagicMock()
+
+    class _NoSuchKey(Exception):
+        pass
+
+    s3.exceptions.NoSuchKey = _NoSuchKey
+
+    def _get_object(Bucket, Key):
+        if Key != expected_key:
+            raise _NoSuchKey(f"key={Key} not stubbed")
+        buf = io.BytesIO()
+        parquet_df.to_parquet(buf, engine="pyarrow")
+        buf.seek(0)
+        return {"Body": MagicMock(read=lambda buf=buf: buf.read())}
+
+    s3.get_object.side_effect = _get_object
+    return s3
+
+
+def _daily_closes_frame(tickers: list[str]) -> pd.DataFrame:
+    """Build a daily_closes parquet shape: index=ticker, OHLCV cols."""
+    df = pd.DataFrame(
+        {
+            "Open": [100.0] * len(tickers),
+            "High": [101.0] * len(tickers),
+            "Low":  [99.0] * len(tickers),
+            "Close": [100.5] * len(tickers),
+            "Volume": [1_000_000] * len(tickers),
+        },
+        index=tickers,
+    )
+    df.index.name = "ticker"
+    return df
+
+
+def test_drift_detection_no_recovery_returns_zero():
+    """Steady-state happy path: polygon doesn't cover any chronic ticker
+    (the expected case); recovery count = 0; metric emits 0."""
+    from weekly_collector import _detect_chronic_gap_polygon_recovery
+
+    # 3 normal tickers, no chronic coverage
+    parquet = _daily_closes_frame(["AAPL", "MSFT", "GOOG"])
+    s3 = _stub_s3_with_parquet(parquet, "staging/daily_closes/2026-05-09.parquet")
+
+    cw = MagicMock()
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        result = _detect_chronic_gap_polygon_recovery(
+            bucket="test-bucket",
+            target_date="2026-05-09",
+            chronic_tickers=["BF-B", "BRK-B", "MOG-A", "PSTG"],
+        )
+
+    assert result["status"] == "ok"
+    assert result["chronic_tickers_checked"] == 4
+    assert result["polygon_recovered"] == []
+    assert sorted(result["absent_as_expected"]) == ["BF-B", "BRK-B", "MOG-A", "PSTG"]
+    cw.put_metric_data.assert_called_once()
+    call = cw.put_metric_data.call_args
+    metric_name = call.kwargs["MetricData"][0]["MetricName"]
+    metric_value = call.kwargs["MetricData"][0]["Value"]
+    assert metric_name == "chronic_gap_polygon_recovery_count"
+    assert metric_value == 0.0
+
+
+def test_drift_detection_partial_recovery_logs_and_emits():
+    """Drift signal: polygon covered 2 of 4 chronic tickers. Recovery list
+    surfaces in the result; CW metric emits the count."""
+    from weekly_collector import _detect_chronic_gap_polygon_recovery
+
+    # 3 normal + 2 chronic that recovered (BRK-B, PSTG appear)
+    parquet = _daily_closes_frame(
+        ["AAPL", "MSFT", "GOOG", "BRK-B", "PSTG"]
+    )
+    s3 = _stub_s3_with_parquet(parquet, "staging/daily_closes/2026-05-09.parquet")
+    cw = MagicMock()
+
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        result = _detect_chronic_gap_polygon_recovery(
+            bucket="test-bucket",
+            target_date="2026-05-09",
+            chronic_tickers=["BF-B", "BRK-B", "MOG-A", "PSTG"],
+        )
+
+    assert result["status"] == "ok"
+    assert sorted(result["polygon_recovered"]) == ["BRK-B", "PSTG"]
+    assert sorted(result["absent_as_expected"]) == ["BF-B", "MOG-A"]
+    metric_value = cw.put_metric_data.call_args.kwargs["MetricData"][0]["Value"]
+    assert metric_value == 2.0
+
+
+def test_drift_detection_handles_missing_parquet():
+    """Best-effort: parquet read failure returns status=skipped without
+    raising. MorningEnrich must not be blocked by a transient S3 read
+    error in observability code."""
+    from weekly_collector import _detect_chronic_gap_polygon_recovery
+
+    s3 = MagicMock()
+
+    class _NoSuchKey(Exception):
+        pass
+
+    s3.exceptions.NoSuchKey = _NoSuchKey
+    s3.get_object.side_effect = _NoSuchKey("simulated read failure")
+
+    with patch("weekly_collector.boto3.client", return_value=s3):
+        result = _detect_chronic_gap_polygon_recovery(
+            bucket="test-bucket",
+            target_date="2026-05-09",
+            chronic_tickers=["BF-B", "BRK-B"],
+        )
+
+    assert result["status"] == "skipped"
+    assert len(result["errors"]) == 1
+
+
+def test_drift_detection_empty_chronic_list_is_noop():
+    """No chronic tickers configured → no metric emit, no S3 read."""
+    from weekly_collector import _detect_chronic_gap_polygon_recovery
+
+    s3 = MagicMock()
+    cw = MagicMock()
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        result = _detect_chronic_gap_polygon_recovery(
+            bucket="test-bucket",
+            target_date="2026-05-09",
+            chronic_tickers=[],
+        )
+
+    assert result["status"] == "ok"
+    assert result["chronic_tickers_checked"] == 0
+    assert result["polygon_recovered"] == []
+    s3.get_object.assert_not_called()
+    cw.put_metric_data.assert_not_called()
+
+
+def test_drift_detection_metric_emit_failure_is_swallowed():
+    """CW metric emission failure must not raise — drift alarm is purely
+    observability, never load-bearing. Result still records the recovery
+    count for the manifest."""
+    from weekly_collector import _detect_chronic_gap_polygon_recovery
+
+    parquet = _daily_closes_frame(["AAPL", "BRK-B"])
+    s3 = _stub_s3_with_parquet(parquet, "staging/daily_closes/2026-05-09.parquet")
+    cw = MagicMock()
+    cw.put_metric_data.side_effect = RuntimeError("CW throttled")
+
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        result = _detect_chronic_gap_polygon_recovery(
+            bucket="test-bucket",
+            target_date="2026-05-09",
+            chronic_tickers=["BRK-B"],
+        )
+
+    assert result["status"] == "ok"
+    assert result["polygon_recovered"] == ["BRK-B"]

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -525,6 +525,112 @@ def _should_skip_morning_enrich(
     return False, None
 
 
+def _detect_chronic_gap_polygon_recovery(
+    bucket: str,
+    target_date: str,
+    chronic_tickers: list[str],
+    daily_closes_prefix: str = "staging/daily_closes/",
+) -> dict:
+    """Drift alarm: detect when polygon STARTS covering a chronic-gap ticker.
+
+    Pairs with ``_self_heal_chronic_polygon_gaps``. The chronic_polygon_gaps
+    allowlist (alpha-engine-config #88) was added because polygon doesn't
+    reliably serve these tickers (BF-B/BRK-B/MOG-A/PSTG today). If polygon
+    coverage recovers — e.g. polygon adds a Berkshire B share class CIK
+    or fixes a flaky data feed — the allowlist entry is no longer needed
+    and should be pruned. Without active drift detection the entry would
+    persist indefinitely as a silent piece of operational debt.
+
+    Reads ``staging/daily_closes/{target_date}.parquet`` written by
+    ``daily_closes.collect(source="polygon_only")`` and counts how many
+    chronic_polygon_gaps tickers polygon DID cover today. Emits a
+    CloudWatch gauge ``AlphaEngine/Data/chronic_gap_polygon_recovery_count``
+    so an alarm can fire if the count > 0 for N consecutive Saturdays
+    (operator action: prune the allowlist entry).
+
+    Best-effort: read errors / metric-emit errors log a warning but never
+    raise — this is observability, not a load-bearing path.
+
+    Returns a summary dict; caller logs at INFO + persists in collector
+    results so the manifest carries a record.
+    """
+    summary: dict = {
+        "status": "ok",
+        "chronic_tickers_checked": len(chronic_tickers),
+        "polygon_recovered": [],
+        "absent_as_expected": [],
+        "errors": [],
+    }
+    if not chronic_tickers:
+        return summary
+
+    import io as _io
+
+    try:
+        s3 = boto3.client("s3")
+        key = f"{daily_closes_prefix.rstrip('/')}/{target_date}.parquet"
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        import pandas as _pd
+        df = _pd.read_parquet(_io.BytesIO(obj["Body"].read()))
+    except Exception as exc:
+        logger.warning(
+            "chronic-gap drift check: could not read staging/daily_closes "
+            "parquet for %s — drift alarm skipped this cycle. %s",
+            target_date, exc,
+        )
+        summary["status"] = "skipped"
+        summary["errors"].append({"reason": str(exc)})
+        return summary
+
+    # Index is ticker (collectors/daily_closes.py:251 sets index=ticker).
+    daily_closes_tickers = (
+        set(df.index.astype(str)) if df.index.size else set()
+    )
+
+    for ticker in chronic_tickers:
+        if ticker in daily_closes_tickers:
+            summary["polygon_recovered"].append(ticker)
+        else:
+            summary["absent_as_expected"].append(ticker)
+
+    n_recovered = len(summary["polygon_recovered"])
+    if n_recovered > 0:
+        logger.warning(
+            "chronic-gap drift detected: polygon now covers %d chronic_polygon_gaps "
+            "ticker(s) it did not previously serve: %s. Consider pruning these from "
+            "alpha-engine-config/predictor.yaml chronic_polygon_gaps.tickers if the "
+            "coverage persists across multiple cycles.",
+            n_recovered, summary["polygon_recovered"],
+        )
+    else:
+        logger.info(
+            "chronic-gap drift: 0 of %d chronic tickers showed up in today's "
+            "polygon_only daily_closes — allowlist still load-bearing.",
+            len(chronic_tickers),
+        )
+
+    # Emit CloudWatch metric — best-effort. Always emits (including 0) so
+    # alarm baselines are continuous; CloudWatch missing-data is harder to
+    # alarm against than a steady 0 stream.
+    try:
+        cw = boto3.client("cloudwatch")
+        cw.put_metric_data(
+            Namespace="AlphaEngine/Data",
+            MetricData=[{
+                "MetricName": "chronic_gap_polygon_recovery_count",
+                "Value": float(n_recovered),
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:
+        logger.warning(
+            "chronic_gap_polygon_recovery_count metric emit failed: %s — "
+            "drift alarm cadence may degrade until next cycle.", exc,
+        )
+
+    return summary
+
+
 def _self_heal_chronic_polygon_gaps(
     bucket: str,
     target_date: str,
@@ -900,6 +1006,25 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
     # stale after this step, postflight surfaces it.
     chronic_tickers = _load_chronic_polygon_gaps(config)
     if chronic_tickers:
+        # Drift alarm: detect polygon recovery for chronic tickers (BEFORE
+        # self-heal so the signal is a clean read of what polygon shipped
+        # today, not contaminated by our yfinance backfill). Best-effort,
+        # observability only — never raises.
+        try:
+            drift_result = _detect_chronic_gap_polygon_recovery(
+                bucket=bucket,
+                target_date=target_date,
+                chronic_tickers=chronic_tickers,
+                daily_closes_prefix=daily_cfg.get("s3_prefix", "staging/daily_closes/"),
+            )
+            results["collectors"]["chronic_gap_drift_detection"] = drift_result
+        except Exception as e:
+            logger.warning("Chronic-gap drift detection failed (non-blocking): %s", e)
+            results["collectors"]["chronic_gap_drift_detection"] = {
+                "status": "skipped",
+                "error": str(e),
+            }
+
         logger.info("=" * 60)
         logger.info(
             "SELF-HEAL: chronic polygon coverage gaps (%d ticker(s): %s)",


### PR DESCRIPTION
## Summary

Pairs with the chronic-gap self-heal from PR #193. The allowlist (BF-B / BRK-B / MOG-A / PSTG) was added because polygon doesn't reliably serve them. If polygon coverage RECOVERS, the allowlist entry becomes silent operational debt.

Adds `_detect_chronic_gap_polygon_recovery` running BEFORE self-heal in MorningEnrich. Reads the polygon_only daily_closes parquet, checks chronic-ticker membership, emits CW gauge `AlphaEngine/Data/chronic_gap_polygon_recovery_count`. Operator action when count > 0 across multiple cycles: prune the allowlist.

Best-effort: read errors / CW errors log warning but never raise. Postflight remains the load-bearing freshness gate.

## Test plan
- [x] 5 new tests covering no-recovery / partial-recovery / parquet-failure / empty-list / CW-failure
- [x] Full suite 587 passed (vs 582 on origin/main)
- [ ] First exercise: Sat 5/16 cron — gauge should emit 0 (no chronic ticker recovered today); alarm baseline anchored
- [ ] If a chronic ticker shows up in polygon_only parquet next cycle, manifest's `chronic_gap_drift_detection.polygon_recovered` lists it + CW alarm fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)