### PR TITLE
feat(daily_closes): window_days parameter for backward-window OHLCV reconciliation (PR 1/5)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -40,7 +40,7 @@ import io
 import logging
 import os
 import time
-from datetime import datetime, time as dtime, timezone
+from datetime import datetime, time as dtime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import boto3
@@ -87,6 +87,37 @@ _DISCREPANCY_WARN_PCT = 0.01    # |polygon_close - yfinance_close| / yfinance_cl
 _DISCREPANCY_ERROR_PCT = 0.05
 
 
+def _previous_business_days(run_date: str, n: int) -> list[str]:
+    """Return ``n`` business days ending on ``run_date`` (inclusive),
+    newest first. ``n=1`` returns the most-recent business day at or
+    before ``run_date``.
+
+    Used by :func:`collect` in window-scan mode to enumerate the dates
+    each pass will reconcile. Polygon's free-tier rate-limit is honored
+    by the caller — one ``grouped-daily`` call per date in the returned
+    list, total ``n`` polygon calls regardless of universe size.
+
+    Saturday / Sunday ``run_date`` walks back to the prior Friday before
+    starting the window, so a Sat SF firing at 02:00 PT doesn't burn a
+    slot on a non-trading day. NYSE holiday handling lives downstream —
+    holidays return zero rows from polygon and an empty yfinance batch,
+    which the per-date skip logic handles gracefully.
+    """
+    if n < 1:
+        raise ValueError(f"window n must be >= 1, got {n}")
+    cur = datetime.strptime(run_date, "%Y-%m-%d").date()
+    # Normalize the starting point to a business day.
+    while cur.weekday() >= 5:  # Sat=5, Sun=6
+        cur = cur - timedelta(days=1)
+    dates: list[str] = [cur.isoformat()]
+    for _ in range(n - 1):
+        cur = cur - timedelta(days=1)
+        while cur.weekday() >= 5:
+            cur = cur - timedelta(days=1)
+        dates.append(cur.isoformat())
+    return dates
+
+
 def collect(
     bucket: str,
     tickers: list[str],
@@ -94,6 +125,7 @@ def collect(
     s3_prefix: str = "staging/daily_closes/",
     dry_run: bool = False,
     source: str = "auto",
+    window_days: int = 1,
 ) -> dict:
     """
     Fetch OHLCV for all tickers and write to S3.
@@ -108,12 +140,31 @@ def collect(
                 ``polygon_only`` (morning pass — polygon required, FRED for indices,
                 no yfinance fallback), or ``auto`` (legacy chain). See module
                 docstring for full rationale.
+        window_days: int = 1
+                Number of business days to scan, ending on ``run_date``
+                inclusive. Default 1 preserves single-date legacy behavior.
+                When > 1: iterate from oldest → newest over the window
+                (i.e. ``run_date - (window_days - 1) BDays`` → ``run_date``)
+                and call this collector once per date. Polygon stays bounded
+                at ``window_days`` ``grouped-daily`` calls in total — one
+                per date — which is the only way to honor the free-tier
+                rate limit. Per-cell skip-if-canonical logic for cost
+                minimization on yfinance is a follow-up PR.
 
     Returns:
-        dict with status, tickers_captured, method breakdown.
+        Single-date mode (``window_days=1``): dict with ``status``,
+        ``tickers_captured``, ``polygon``/``fred``/``yfinance`` counts,
+        ``source``.
+
+        Window mode (``window_days > 1``): dict with ``status``
+        (``"ok"`` if every date succeeded, ``"partial"`` if any date
+        errored), aggregated ``tickers_captured`` / ``polygon`` /
+        ``fred`` / ``yfinance`` counters across the window, ``source``,
+        ``window_days``, ``per_date`` (date → per-date result dict),
+        ``skipped_dates`` (post-close already-written dates).
 
     Raises:
-        ValueError: invalid ``source``
+        ValueError: invalid ``source`` or ``window_days < 1``
         PolygonForbiddenError: polygon 403 in ``polygon_only`` or ``auto`` mode
         RuntimeError: per-mode coverage threshold breached
     """
@@ -121,8 +172,22 @@ def collect(
         raise ValueError(
             f"Invalid source={source!r}. Must be one of {_VALID_SOURCES}."
         )
+    if window_days < 1:
+        raise ValueError(f"window_days must be >= 1, got {window_days}")
 
     run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    if window_days > 1:
+        return _collect_window(
+            bucket=bucket,
+            tickers=tickers,
+            run_date=run_date,
+            s3_prefix=s3_prefix,
+            dry_run=dry_run,
+            source=source,
+            window_days=window_days,
+        )
+
     s3 = boto3.client("s3")
     key = f"{s3_prefix}{run_date}.parquet"
 
@@ -299,6 +364,89 @@ def collect(
             "tickers_captured": len(closes_df),
             "source": source,
         }
+
+
+def _collect_window(
+    bucket: str,
+    tickers: list[str],
+    run_date: str,
+    s3_prefix: str,
+    dry_run: bool,
+    source: str,
+    window_days: int,
+) -> dict:
+    """Iterate ``collect`` over a backward-looking business-day window.
+
+    Calls :func:`collect` with ``window_days=1`` per date so the
+    per-date branch reuses the existing fetch / coverage-gate / write
+    pipeline unchanged. Iterates oldest → newest so the most recent
+    date's parquet is the last one written; idempotent on re-run since
+    each per-date call goes through the same skip-on-exists path the
+    legacy single-date flow uses.
+
+    Polygon call rate is bounded at ``window_days`` ``grouped-daily``
+    calls total — one per date — which is the contract the free-tier
+    rate limit requires. Per-cell skip-if-canonical (skipping yfinance
+    fetches for cells that already carry an authoritative source) is a
+    follow-up PR; this PR's value is purely the structural window
+    orchestration so the SF wiring can flip ``window_days=14`` once the
+    rest of the arc lands.
+
+    Returns an aggregate dict; see ``collect`` docstring's "Window mode"
+    return-shape section for the schema.
+    """
+    window_dates = _previous_business_days(run_date, n=window_days)
+    aggregate: dict = {
+        "status": "ok",
+        "source": source,
+        "window_days": window_days,
+        "per_date": {},
+        "tickers_captured": 0,
+        "polygon": 0,
+        "fred": 0,
+        "yfinance": 0,
+        "skipped_dates": [],
+    }
+    # Iterate oldest → newest so the most recent date's parquet is the
+    # last one written. Matches the operator mental model "the latest
+    # date's data is the freshest on disk."
+    for d in reversed(window_dates):
+        try:
+            result = collect(
+                bucket=bucket,
+                tickers=tickers,
+                run_date=d,
+                s3_prefix=s3_prefix,
+                dry_run=dry_run,
+                source=source,
+                window_days=1,
+            )
+        except Exception as exc:
+            # Per-date failures don't kill the rest of the window; record
+            # the failure and continue. This matches the existing single-
+            # date semantics where a coverage-gate / API failure on one
+            # day doesn't block subsequent days when re-run.
+            logger.warning(
+                "[daily_closes window] date=%s source=%s failed: %s — "
+                "recording and continuing window",
+                d, source, exc,
+            )
+            aggregate["per_date"][d] = {
+                "status": "error",
+                "error": str(exc),
+                "source": source,
+            }
+            aggregate["status"] = "partial"
+            continue
+        aggregate["per_date"][d] = result
+        for k in ("tickers_captured", "polygon", "fred", "yfinance"):
+            if k in result and isinstance(result[k], int):
+                aggregate[k] += result[k]
+        if result.get("status") == "error":
+            aggregate["status"] = "partial"
+        if result.get("skipped"):
+            aggregate["skipped_dates"].append(d)
+    return aggregate
 
 
 def _fetch_polygon_closes(

--- a/tests/test_daily_closes_window_days.py
+++ b/tests/test_daily_closes_window_days.py
@@ -1,0 +1,328 @@
+"""Tests for the ``window_days`` parameter on collectors.daily_closes.collect.
+
+PR 1 of the windowed-data-reconciliation arc (plan doc:
+``alpha-engine-docs/private/windowed-data-reconciliation-260510.md``).
+This PR adds the structural orchestration only — default
+``window_days=1`` preserves all existing single-date behavior.
+Per-cell skip-if-canonical optimization lands in PR 2.
+
+These tests pin:
+
+1. ``window_days=1`` is byte-identical to the legacy single-date code
+   path (no orchestration overhead, no result-shape change).
+2. ``window_days > 1`` fans out to ``window_days`` per-date calls,
+   newest written last. Polygon's ``grouped-daily`` is invoked at most
+   once per date (the free-tier rate-limit contract).
+3. The per-date result dicts aggregate into a stable window-mode
+   return shape with ``per_date`` keyed by ISO date.
+4. Per-date failures don't take down the rest of the window — the
+   aggregate's ``status`` flips to ``"partial"`` but every other date
+   completes.
+5. ``_previous_business_days`` skips weekends and respects ``n``.
+6. Invalid ``window_days`` (< 1) raises ``ValueError`` early.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+from collectors import daily_closes
+
+
+# ── Helper: minimal polygon stub ────────────────────────────────────────────
+
+
+def _polygon_grouped_records(date: str, ticker: str, close: float) -> dict:
+    return {
+        "open": close, "high": close, "low": close, "close": close,
+        "vwap": close, "volume": 1000,
+    }
+
+
+def _no_existing_parquet_s3():
+    s3 = MagicMock()
+    s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}},
+        "HeadObject",
+    )
+    return s3
+
+
+# ── _previous_business_days helper ──────────────────────────────────────────
+
+
+class TestPreviousBusinessDays:
+    def test_n_eq_1_returns_run_date_only(self):
+        # 2026-05-08 is a Friday.
+        assert daily_closes._previous_business_days("2026-05-08", n=1) == [
+            "2026-05-08"
+        ]
+
+    def test_n_eq_5_walks_back_through_weekends(self):
+        # Friday 5/8 → Thu 5/7 → Wed 5/6 → Tue 5/5 → Mon 5/4 (5 BDays).
+        assert daily_closes._previous_business_days("2026-05-08", n=5) == [
+            "2026-05-08", "2026-05-07", "2026-05-06",
+            "2026-05-05", "2026-05-04",
+        ]
+
+    def test_walks_across_weekend(self):
+        # Monday 5/11 → Fri 5/8 → Thu 5/7 (3 BDays).
+        assert daily_closes._previous_business_days("2026-05-11", n=3) == [
+            "2026-05-11", "2026-05-08", "2026-05-07",
+        ]
+
+    def test_n_lt_1_raises(self):
+        with pytest.raises(ValueError, match="n must be >= 1"):
+            daily_closes._previous_business_days("2026-05-08", n=0)
+
+    def test_14_bday_window(self):
+        """Production default — ROADMAP-spec'd 14 BDays. Pin shape."""
+        # 2026-05-08 (Friday) is a representative weekday run_date.
+        dates = daily_closes._previous_business_days("2026-05-08", n=14)
+        assert len(dates) == 14
+        assert dates[0] == "2026-05-08"  # newest first
+        assert dates[-1] == "2026-04-21"  # 14 BDays back from Fri 5/8
+        # All dates are weekdays.
+        for d in dates:
+            assert datetime.strptime(d, "%Y-%m-%d").weekday() < 5
+
+    def test_saturday_run_date_normalizes_to_friday(self):
+        """Saturday SF firing at 02:00 PT shouldn't burn a slot on the
+        non-trading Saturday; the function walks back to Friday."""
+        # 2026-05-09 is a Saturday → first window date should be Fri 5/8.
+        dates = daily_closes._previous_business_days("2026-05-09", n=3)
+        assert dates == ["2026-05-08", "2026-05-07", "2026-05-06"]
+
+    def test_sunday_run_date_normalizes_to_friday(self):
+        # 2026-05-10 is a Sunday → first window date should also be Fri 5/8.
+        dates = daily_closes._previous_business_days("2026-05-10", n=3)
+        assert dates == ["2026-05-08", "2026-05-07", "2026-05-06"]
+
+
+# ── window_days < 1 validation ──────────────────────────────────────────────
+
+
+class TestWindowDaysValidation:
+    def test_window_days_lt_1_raises(self):
+        with pytest.raises(ValueError, match="window_days must be >= 1"):
+            daily_closes.collect(
+                bucket="b", tickers=["AAPL"], run_date="2026-05-08",
+                source="yfinance_only", window_days=0,
+            )
+
+    def test_window_days_negative_raises(self):
+        with pytest.raises(ValueError, match="window_days must be >= 1"):
+            daily_closes.collect(
+                bucket="b", tickers=["AAPL"], run_date="2026-05-08",
+                source="yfinance_only", window_days=-3,
+            )
+
+
+# ── window_days=1: legacy parity ────────────────────────────────────────────
+
+
+class TestWindowDays1Parity:
+    """Default ``window_days=1`` must produce a byte-identical result to
+    the legacy single-date call path. This is the no-behavior-change
+    guarantee for PR 1.
+    """
+
+    def test_window_days_1_returns_single_date_shape(self):
+        s3 = _no_existing_parquet_s3()
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", return_value=1
+            ) as yf_mock, patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ):
+                # Make yfinance "fetch" populate the records list.
+                def _yf_side(missing, run_date, records):
+                    records.append({
+                        "ticker": "AAPL", "date": run_date,
+                        "Open": 100.0, "High": 100.0, "Low": 100.0,
+                        "Close": 100.0, "Adj_Close": 100.0,
+                        "Volume": 1000, "VWAP": None, "source": "yfinance",
+                    })
+                    return 1
+                yf_mock.side_effect = _yf_side
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL"], run_date="2026-05-08",
+                    source="yfinance_only", window_days=1,
+                )
+        # Single-date shape — no per_date, no window_days, no skipped_dates.
+        assert "per_date" not in result
+        assert "window_days" not in result
+        assert "skipped_dates" not in result
+        assert result["status"] == "ok"
+        assert result["source"] == "yfinance_only"
+        assert result["tickers_captured"] == 1
+
+    def test_window_days_default_is_1(self):
+        """Existing call sites (no ``window_days`` argument) must continue
+        to behave as single-date.
+        """
+        s3 = _no_existing_parquet_s3()
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes",
+            ) as yf_mock, patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ):
+                def _yf_side(missing, run_date, records):
+                    records.append({
+                        "ticker": "AAPL", "date": run_date,
+                        "Open": 100.0, "High": 100.0, "Low": 100.0,
+                        "Close": 100.0, "Adj_Close": 100.0,
+                        "Volume": 1000, "VWAP": None, "source": "yfinance",
+                    })
+                    return 1
+                yf_mock.side_effect = _yf_side
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL"], run_date="2026-05-08",
+                    source="yfinance_only",
+                )
+        assert "per_date" not in result  # default = single-date
+
+
+# ── window_days > 1: orchestration ──────────────────────────────────────────
+
+
+class TestWindowOrchestration:
+    """Window mode fans out to ``window_days`` per-date calls."""
+
+    def _stub_fetches_each_date(self, captured_calls: list):
+        """Build patches so each per-date call appends one record + tracks
+        which run_date was passed."""
+        def _yf_side(missing, run_date, records):
+            captured_calls.append(("yfinance", run_date))
+            for t in missing:
+                records.append({
+                    "ticker": t.lstrip("^"), "date": run_date,
+                    "Open": 100.0, "High": 100.0, "Low": 100.0,
+                    "Close": 100.0, "Adj_Close": 100.0,
+                    "Volume": 1000, "VWAP": None, "source": "yfinance",
+                })
+            return len(missing)
+
+        def _polygon_side(tickers, run_date, records, source):
+            captured_calls.append(("polygon_grouped_daily", run_date))
+            for t in tickers:
+                records.append({
+                    "ticker": t.lstrip("^"), "date": run_date,
+                    "Open": 100.0, "High": 100.0, "Low": 100.0,
+                    "Close": 100.0, "Adj_Close": 100.0,
+                    "Volume": 1000, "VWAP": 100.0, "source": "polygon",
+                })
+            return len(tickers)
+        return _yf_side, _polygon_side
+
+    def test_window_days_3_yfinance_calls_3_dates(self):
+        """yfinance_only window mode triggers exactly window_days
+        per-date calls, oldest → newest."""
+        captured = []
+        yf_side, _ = self._stub_fetches_each_date(captured)
+        s3 = _no_existing_parquet_s3()
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", side_effect=yf_side,
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ):
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL"], run_date="2026-05-08",
+                    source="yfinance_only", window_days=3,
+                )
+        # 3 yfinance per-date fetches, oldest first.
+        yf_dates = [d for kind, d in captured if kind == "yfinance"]
+        assert yf_dates == ["2026-05-06", "2026-05-07", "2026-05-08"]
+        # Aggregate result shape.
+        assert result["status"] == "ok"
+        assert result["window_days"] == 3
+        assert set(result["per_date"].keys()) == {
+            "2026-05-06", "2026-05-07", "2026-05-08",
+        }
+        assert result["tickers_captured"] == 3  # 1 ticker × 3 dates
+        assert result["source"] == "yfinance_only"
+        assert result["yfinance"] == 3
+
+    def test_polygon_only_window_makes_one_grouped_daily_per_date(self):
+        """Polygon free-tier rate-limit contract: ``window_days``
+        ``grouped-daily`` calls in total, one per date — the only way
+        to honor 14/day at the free tier."""
+        captured = []
+        _, polygon_side = self._stub_fetches_each_date(captured)
+        s3 = _no_existing_parquet_s3()
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes", side_effect=polygon_side,
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ):
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL", "MSFT"],
+                    run_date="2026-05-08",
+                    source="polygon_only", window_days=14,
+                )
+        polygon_dates = [d for kind, d in captured if kind == "polygon_grouped_daily"]
+        # Exactly window_days grouped-daily calls — the free-tier ceiling.
+        assert len(polygon_dates) == 14
+        assert result["window_days"] == 14
+        assert result["polygon"] == 14 * 2  # 2 tickers × 14 dates
+        assert len(result["per_date"]) == 14
+
+    def test_per_date_failure_does_not_block_window(self):
+        """If one date errors (e.g. a coverage-gate trip on a non-trading
+        day), the rest of the window completes. Aggregate status flips
+        to ``partial``."""
+        captured = []
+        s3 = _no_existing_parquet_s3()
+
+        def _yf_side(missing, run_date, records):
+            captured.append(run_date)
+            if run_date == "2026-05-07":
+                # Simulate yfinance returning nothing on this date — the
+                # coverage gate should fire and the date's call raises.
+                return 0
+            for t in missing:
+                records.append({
+                    "ticker": t.lstrip("^"), "date": run_date,
+                    "Open": 100.0, "High": 100.0, "Low": 100.0,
+                    "Close": 100.0, "Adj_Close": 100.0,
+                    "Volume": 1000, "VWAP": None, "source": "yfinance",
+                })
+            return len(missing)
+
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", side_effect=_yf_side,
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ):
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL"], run_date="2026-05-08",
+                    source="yfinance_only", window_days=3,
+                )
+        # All 3 dates were attempted.
+        assert sorted(captured) == ["2026-05-06", "2026-05-07", "2026-05-08"]
+        # Aggregate flagged partial because 5/7 hit the coverage gate.
+        assert result["status"] == "partial"
+        assert "2026-05-07" in result["per_date"]
+        assert result["per_date"]["2026-05-07"]["status"] == "error"
+        # Other dates still succeeded.
+        assert result["per_date"]["2026-05-06"]["status"] == "ok"
+        assert result["per_date"]["2026-05-08"]["status"] == "ok"


### PR DESCRIPTION
## Summary

PR 1 of the **windowed-data-reconciliation arc**. Plan doc: `alpha-engine-docs/private/windowed-data-reconciliation-260510.md`.

**Origin:** 2026-05-09 evaluator email "121 tickers with >5d gap" diagnostic. 110 of those 121 are matrix-pivot artifacts (front-of-history mismatches + tail drift from the chronic-polygon-gap self-heal widening the gap between 5 daily-healed tickers and the rest of the universe). Spec: institutional two-pass windowed reconciliation with source-precedence ladder `NaN < "yfinance" < "polygon"` — every cell self-heals to the highest-authority source available within ≤24h.

**This PR's scope:** structural orchestration only. Default `window_days=1` preserves all legacy single-date behavior — no consumer call sites change shape.

- New `window_days: int = 1` parameter on `collect()`.
- New `_previous_business_days(run_date, n)` helper enumerating N BDays ending at `run_date` (inclusive), newest first. Saturday/Sunday run_date normalizes to the prior Friday so a Sat SF firing at 02:00 PT doesn't burn a slot.
- New `_collect_window()` helper iterating oldest → newest, calling `collect(window_days=1)` per date so all fetch / coverage-gate / write logic reuses unchanged. Per-date failures don't kill the rest of the window.

## Polygon free-tier rate-limit contract

One `grouped-daily` call per date in the window — `window_days` polygon calls total — the only way to honor 14/day at the free tier. Per-ticker polygon endpoints are explicitly avoided in this code path. Test `test_polygon_only_window_makes_one_grouped_daily_per_date` pins this invariant.

## Out of scope (later PRs in the arc)

- PR 2: per-cell skip-if-canonical optimization on the yfinance side
- PR 3: SF wiring + `window_days=14` config knob
- PR 4: simulator gap-warning metric refactor reading the `source` column
- PR 5: `chronic_polygon_gaps` allowlist deprecation (replaces with low-polygon-coverage dashboard metric)

## Test plan

- [x] `pytest tests/test_daily_closes_window_days.py` — 14 tests pinning: legacy-parity at `window_days=1`, orchestration shape at `window_days > 1`, polygon-rate-limit invariant, per-date-failure non-blocking behavior, weekend-run_date normalization to prior Friday
- [x] Full data suite: 633 passed, 1 skipped (no regressions)
- [ ] Live exercise: not yet — gated on PR 3's SF wiring + flag flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)