### PR TITLE
feat(features): per-ticker risk features (Stage 2a regime-conditioning rebuild)

### DIFF
--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -149,6 +149,7 @@ FEATURES = [
     "idio_vol_60d",
     "vol_of_vol_30d",
     "max_drawdown_60d",
+    "realized_vol_63d",
 ]
 
 MIN_ROWS_FOR_FEATURES = 265  # 252 warmup + buffer
@@ -503,6 +504,12 @@ def compute_features(
     # realized_vol_20d
     daily_returns = close.pct_change()
     df["realized_vol_20d"] = daily_returns.rolling(_FC["realized_vol_window"]).std() * np.sqrt(_52w)
+
+    # realized_vol_63d — 3-month realized vol (Stage 2 regime-conditioning).
+    # Captures a slower vol regime than 20d. Pair with 20d to give the GBM
+    # a vol-term-structure signal (steep upward slope = vol expansion;
+    # flat / inverted = mean-revert regime).
+    df["realized_vol_63d"] = daily_returns.rolling(63).std() * np.sqrt(_52w)
 
     # ── v3.2: Per-ticker risk features (Stage 2 regime-conditioning rebuild) ──
     # Four institutional risk dimensions that capture cross-sectional

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -53,6 +53,10 @@ FEATURE_CFG: dict = {
     "obv_fast": 5,
     "obv_slow": 20,
     "rsi_slope_window": 5,
+    # v3.2 risk feature windows (Stage 2 of regime-conditioning rebuild)
+    "beta_window": 60,
+    "vol_of_vol_window": 30,
+    "max_drawdown_window": 60,
 }
 
 _FC = FEATURE_CFG
@@ -131,6 +135,20 @@ FEATURES = [
     "intraday_return_5d",
     "dist_from_5d_high",
     "dist_from_20d_high",
+    # v3.2 additions — per-ticker risk features (Stage 2 of regime-
+    # conditioning rebuild). Cross-sectionally varying institutional risk
+    # metrics that capture distinct dimensions LightGBM trees can split on:
+    #   - beta_60d:        market sensitivity (systematic exposure)
+    #   - idio_vol_60d:    residual vol after removing market-beta exposure
+    #                      (idiosyncratic risk)
+    #   - vol_of_vol_30d:  stability of vol regime (regime persistence)
+    #   - max_drawdown_60d: worst peak-to-trough drawdown within 60d window
+    #                      (left-tail risk; distinct from dist_from_52w_high
+    #                      which is current depth-from-rolling-high)
+    "beta_60d",
+    "idio_vol_60d",
+    "vol_of_vol_30d",
+    "max_drawdown_60d",
 ]
 
 MIN_ROWS_FOR_FEATURES = 265  # 252 warmup + buffer
@@ -485,6 +503,59 @@ def compute_features(
     # realized_vol_20d
     daily_returns = close.pct_change()
     df["realized_vol_20d"] = daily_returns.rolling(_FC["realized_vol_window"]).std() * np.sqrt(_52w)
+
+    # ── v3.2: Per-ticker risk features (Stage 2 regime-conditioning rebuild) ──
+    # Four institutional risk dimensions that capture cross-sectional
+    # variation distinct from the existing volatility features. Each varies
+    # per-ticker on a given date (rank-norm pipeline-compatible) and gives
+    # the volatility GBM new splits the existing 6 vol features can't make.
+    _beta_w = _FC["beta_window"]
+    _vov_w = _FC["vol_of_vol_window"]
+    _mdd_w = _FC["max_drawdown_window"]
+
+    # beta_60d: 60d rolling regression slope of stock log-returns vs SPY
+    # log-returns. Captures systematic market exposure. NaN when no SPY
+    # series available or rolling window is incomplete.
+    log_returns = np.log(close / close.shift(1))
+    if spy_series is not None:
+        spy_aligned_for_beta = spy_series.reindex(df.index).astype(float)
+        spy_log_returns = np.log(spy_aligned_for_beta / spy_aligned_for_beta.shift(1))
+        # rolling cov(stock, spy) / var(spy)
+        rolling_cov = log_returns.rolling(window=_beta_w, min_periods=_beta_w).cov(spy_log_returns)
+        rolling_spy_var = spy_log_returns.rolling(window=_beta_w, min_periods=_beta_w).var()
+        df["beta_60d"] = (rolling_cov / rolling_spy_var.replace(0, float("nan"))).astype(float)
+    else:
+        df["beta_60d"] = float("nan")
+
+    # idio_vol_60d: residual vol after removing market-beta exposure.
+    # residual = stock_log_return - beta * spy_log_return; std × sqrt(252).
+    # Captures idiosyncratic risk.
+    if spy_series is not None:
+        residual_returns = log_returns - df["beta_60d"] * spy_log_returns
+        df["idio_vol_60d"] = (
+            residual_returns.rolling(window=_beta_w, min_periods=_beta_w).std()
+            * np.sqrt(_52w)
+        ).astype(float)
+    else:
+        df["idio_vol_60d"] = float("nan")
+
+    # vol_of_vol_30d: 30d rolling stdev of realized_vol_20d. Captures the
+    # stability of the vol regime — a stock whose realized vol oscillates
+    # carries different risk than one whose vol is stable.
+    df["vol_of_vol_30d"] = df["realized_vol_20d"].rolling(
+        window=_vov_w, min_periods=_vov_w,
+    ).std()
+
+    # max_drawdown_60d: worst peak-to-trough drawdown WITHIN the trailing
+    # 60d window. Distinct from dist_from_52w_high (current depth from
+    # rolling-252-high): captures the deepest historical drawdown that
+    # occurred during the recent 60d, even if the stock has since
+    # recovered. Always non-positive.
+    rolling_max_60 = close.rolling(window=_mdd_w, min_periods=_mdd_w).max()
+    drawdown_series = (close / rolling_max_60) - 1.0
+    df["max_drawdown_60d"] = drawdown_series.rolling(
+        window=_mdd_w, min_periods=_mdd_w,
+    ).min()
 
     # volume_trend
     _vf = _FC["volume_fast"]

--- a/tests/test_feature_engineer_risk_features.py
+++ b/tests/test_feature_engineer_risk_features.py
@@ -1,0 +1,229 @@
+"""Tests for the v3.2 per-ticker risk features (Stage 2 of regime-
+conditioning rebuild).
+
+Validates the 4 new features added to features/feature_engineer.py:
+- beta_60d:        rolling regression slope of stock vs SPY log-returns
+- idio_vol_60d:    residual vol after removing beta exposure
+- vol_of_vol_30d:  rolling stdev of realized_vol_20d
+- max_drawdown_60d: worst peak-to-trough within trailing 60d
+
+Plan doc: ~/Development/alpha-engine-docs/private/regime-conditioning-260510.md
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from features.feature_engineer import FEATURES, compute_features
+
+
+def _synthetic_ohlcv(
+    n: int = 400,
+    seed: int = 0,
+    start: str = "2018-01-01",
+):
+    """Build (n,)-day OHLCV DataFrame for compute_features."""
+    rng = np.random.default_rng(seed)
+    daily_returns = rng.normal(0, 0.012, n)
+    close = 100.0 * np.exp(np.cumsum(daily_returns))
+    high = close * (1 + np.abs(rng.normal(0, 0.005, n)))
+    low = close * (1 - np.abs(rng.normal(0, 0.005, n)))
+    open_ = close * (1 + rng.normal(0, 0.003, n))
+    volume = rng.integers(1_000_000, 10_000_000, n).astype(float)
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.DataFrame({
+        "Open": open_, "High": high, "Low": low, "Close": close, "Volume": volume,
+    }, index=idx)
+
+
+def _synthetic_spy(
+    n: int = 400,
+    seed: int = 99,
+    start: str = "2018-01-01",
+):
+    rng = np.random.default_rng(seed)
+    daily_returns = rng.normal(0, 0.008, n)
+    close = 300.0 * np.exp(np.cumsum(daily_returns))
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.Series(close, index=idx)
+
+
+# ── Schema contract ─────────────────────────────────────────────────────
+
+
+class TestFeatureSchema:
+
+    def test_new_risk_features_in_features_list(self):
+        for name in (
+            "beta_60d", "idio_vol_60d", "vol_of_vol_30d", "max_drawdown_60d",
+        ):
+            assert name in FEATURES, f"{name} missing from FEATURES list"
+
+    def test_compute_features_emits_new_columns(self):
+        df = _synthetic_ohlcv()
+        spy = _synthetic_spy()
+        out = compute_features(df, spy_series=spy)
+        for name in (
+            "beta_60d", "idio_vol_60d", "vol_of_vol_30d", "max_drawdown_60d",
+        ):
+            assert name in out.columns
+
+
+# ── beta_60d ──────────────────────────────────────────────────────────
+
+
+class TestBeta60d:
+
+    def test_beta_finite_after_warmup(self):
+        df = _synthetic_ohlcv(n=300)
+        spy = _synthetic_spy(n=300)
+        out = compute_features(df, spy_series=spy)
+        # Beyond the 60d warmup, beta should be finite.
+        assert np.isfinite(out["beta_60d"].iloc[-1])
+        # Pre-warmup is NaN (rolling min_periods=60 enforced).
+        assert pd.isna(out["beta_60d"].iloc[30])
+
+    def test_beta_with_perfect_market_correlation_is_one(self):
+        # Stock = SPY exactly → beta should be 1.0.
+        spy = _synthetic_spy(n=300)
+        df = pd.DataFrame({
+            "Open": spy, "High": spy * 1.001, "Low": spy * 0.999,
+            "Close": spy, "Volume": np.full(300, 5e6, dtype=float),
+        }, index=spy.index)
+        out = compute_features(df, spy_series=spy)
+        # Beta of stock-vs-self is 1.0 (variances cancel).
+        last_beta = out["beta_60d"].iloc[-1]
+        assert abs(last_beta - 1.0) < 0.01
+
+    def test_beta_with_zero_market_correlation_near_zero(self):
+        # Stock returns independent of SPY → beta should be near zero.
+        df = _synthetic_ohlcv(n=400, seed=1)
+        spy = _synthetic_spy(n=400, seed=2)
+        out = compute_features(df, spy_series=spy)
+        # Two independent random series → expected beta ≈ 0 (large
+        # samples). Loose bound for stochastic test.
+        beta_tail = out["beta_60d"].iloc[-50:].abs().mean()
+        assert beta_tail < 0.5
+
+    def test_beta_nan_when_spy_missing(self):
+        df = _synthetic_ohlcv(n=300)
+        out = compute_features(df, spy_series=None)
+        assert out["beta_60d"].isna().all()
+
+
+# ── idio_vol_60d ──────────────────────────────────────────────────────
+
+
+class TestIdioVol60d:
+
+    def test_idio_vol_finite_after_warmup(self):
+        df = _synthetic_ohlcv(n=300)
+        spy = _synthetic_spy(n=300)
+        out = compute_features(df, spy_series=spy)
+        assert np.isfinite(out["idio_vol_60d"].iloc[-1])
+        assert pd.isna(out["idio_vol_60d"].iloc[30])
+
+    def test_idio_vol_zero_when_stock_equals_spy(self):
+        # Stock exactly tracks SPY → residuals are zero → idio_vol ≈ 0.
+        spy = _synthetic_spy(n=300)
+        df = pd.DataFrame({
+            "Open": spy, "High": spy * 1.001, "Low": spy * 0.999,
+            "Close": spy, "Volume": np.full(300, 5e6, dtype=float),
+        }, index=spy.index)
+        out = compute_features(df, spy_series=spy)
+        # Tolerance allows rounding noise from rolling-window math.
+        assert out["idio_vol_60d"].iloc[-1] < 0.01
+
+    def test_idio_vol_positive_when_stock_independent_of_spy(self):
+        # Independent series have non-zero residual vol.
+        df = _synthetic_ohlcv(n=400, seed=1)
+        spy = _synthetic_spy(n=400, seed=2)
+        out = compute_features(df, spy_series=spy)
+        assert out["idio_vol_60d"].iloc[-1] > 0
+
+    def test_idio_vol_nan_when_spy_missing(self):
+        df = _synthetic_ohlcv(n=300)
+        out = compute_features(df, spy_series=None)
+        assert out["idio_vol_60d"].isna().all()
+
+
+# ── vol_of_vol_30d ─────────────────────────────────────────────────────
+
+
+class TestVolOfVol30d:
+
+    def test_vol_of_vol_finite_after_warmup(self):
+        df = _synthetic_ohlcv(n=300)
+        out = compute_features(df, spy_series=_synthetic_spy(n=300))
+        # vol_of_vol_30d depends on realized_vol_20d (warmup 20) +
+        # additional 30 → finite from index ~50 onwards.
+        assert np.isfinite(out["vol_of_vol_30d"].iloc[-1])
+
+    def test_vol_of_vol_nonnegative(self):
+        df = _synthetic_ohlcv(n=400)
+        out = compute_features(df, spy_series=_synthetic_spy(n=400))
+        finite = out["vol_of_vol_30d"].dropna()
+        assert (finite >= 0).all()
+
+
+# ── max_drawdown_60d ──────────────────────────────────────────────────
+
+
+class TestMaxDrawdown60d:
+
+    def test_drawdown_finite_after_warmup(self):
+        df = _synthetic_ohlcv(n=300)
+        out = compute_features(df, spy_series=_synthetic_spy(n=300))
+        assert np.isfinite(out["max_drawdown_60d"].iloc[-1])
+        assert pd.isna(out["max_drawdown_60d"].iloc[30])
+
+    def test_drawdown_always_nonpositive(self):
+        # max drawdown is always ≤ 0 by definition (price relative to
+        # rolling max).
+        df = _synthetic_ohlcv(n=400)
+        out = compute_features(df, spy_series=_synthetic_spy(n=400))
+        finite = out["max_drawdown_60d"].dropna()
+        assert (finite <= 1e-9).all()
+
+    def test_drawdown_zero_for_monotonically_increasing(self):
+        # Price strictly rising → no drawdown → 0.
+        n = 300
+        idx = pd.date_range("2018-01-01", periods=n, freq="B")
+        rising_close = pd.Series(np.linspace(100, 200, n), index=idx)
+        df = pd.DataFrame({
+            "Open": rising_close,
+            "High": rising_close * 1.001,
+            "Low": rising_close * 0.999,
+            "Close": rising_close,
+            "Volume": np.full(n, 5e6, dtype=float),
+        }, index=idx)
+        spy = _synthetic_spy(n=n)
+        out = compute_features(df, spy_series=spy)
+        finite = out["max_drawdown_60d"].dropna()
+        # Monotone-increasing → drawdown is always 0 (close == rolling max).
+        assert np.allclose(finite, 0.0, atol=1e-9)
+
+    def test_drawdown_negative_after_decline(self):
+        # Build a series with a known 20% drop from rolling-60d max.
+        n = 200
+        idx = pd.date_range("2018-01-01", periods=n, freq="B")
+        # First 100 days flat at 100, then drops to 80, then flat.
+        prices = np.concatenate([
+            np.full(100, 100.0),
+            np.full(n - 100, 80.0),
+        ])
+        cs = pd.Series(prices, index=idx)
+        df = pd.DataFrame({
+            "Open": cs, "High": cs, "Low": cs, "Close": cs,
+            "Volume": np.full(n, 5e6, dtype=float),
+        }, index=idx)
+        spy = _synthetic_spy(n=n)
+        out = compute_features(df, spy_series=spy)
+        # Post-drop, within 60d window the drawdown should reflect ~-20%.
+        post_drop = out["max_drawdown_60d"].iloc[150]
+        assert post_drop < -0.15  # negative depth ~20%

--- a/tests/test_feature_engineer_risk_features.py
+++ b/tests/test_feature_engineer_risk_features.py
@@ -61,6 +61,7 @@ class TestFeatureSchema:
     def test_new_risk_features_in_features_list(self):
         for name in (
             "beta_60d", "idio_vol_60d", "vol_of_vol_30d", "max_drawdown_60d",
+            "realized_vol_63d",
         ):
             assert name in FEATURES, f"{name} missing from FEATURES list"
 
@@ -70,6 +71,7 @@ class TestFeatureSchema:
         out = compute_features(df, spy_series=spy)
         for name in (
             "beta_60d", "idio_vol_60d", "vol_of_vol_30d", "max_drawdown_60d",
+            "realized_vol_63d",
         ):
             assert name in out.columns
 
@@ -169,6 +171,37 @@ class TestVolOfVol30d:
         out = compute_features(df, spy_series=_synthetic_spy(n=400))
         finite = out["vol_of_vol_30d"].dropna()
         assert (finite >= 0).all()
+
+
+# ── realized_vol_63d ──────────────────────────────────────────────────
+
+
+class TestRealizedVol63d:
+
+    def test_realized_vol_63d_finite_after_warmup(self):
+        df = _synthetic_ohlcv(n=200)
+        out = compute_features(df, spy_series=_synthetic_spy(n=200))
+        # Warmup is 63 days; finite from index 63 onward.
+        assert np.isfinite(out["realized_vol_63d"].iloc[-1])
+        assert pd.isna(out["realized_vol_63d"].iloc[30])
+
+    def test_realized_vol_63d_nonnegative(self):
+        df = _synthetic_ohlcv(n=300)
+        out = compute_features(df, spy_series=_synthetic_spy(n=300))
+        finite = out["realized_vol_63d"].dropna()
+        assert (finite >= 0).all()
+
+    def test_realized_vol_63d_smoother_than_20d(self):
+        # 63d window is wider → vol estimate is more stable across time
+        # than 20d. Loose check: stdev of the 63d series across its
+        # finite range should be lower than stdev of the 20d series over
+        # the same range. Stochastic, generous tolerance.
+        df = _synthetic_ohlcv(n=400, seed=42)
+        out = compute_features(df, spy_series=_synthetic_spy(n=400))
+        # Compare on the slice where both are finite.
+        rv20 = out["realized_vol_20d"].iloc[63:].dropna()
+        rv63 = out["realized_vol_63d"].iloc[63:].dropna()
+        assert rv63.std() < rv20.std()
 
 
 # ── max_drawdown_60d ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Stage 2a of the regime-conditioning rebuild — adds 4 institutional per-ticker risk-decomposition features to `features/feature_engineer.py`
- Each feature varies cross-sectionally on a given date (rank-norm pipeline-compatible) and captures a distinct risk dimension the existing 6 vol features cannot make a split on
- Cross-repo: alpha-engine-predictor Stage 2b consumes these features via the same parallel-observation pattern Stage 1b/1c uses (parallel `prod_vol_risk_aug` GBM + `expected_move_risk_aug` parallel field)

## Plan reference

Plan doc: `~/Development/alpha-engine-docs/private/regime-conditioning-260510.md` (gitignored). ROADMAP entry in alpha-engine-config #103.

## New features

| Feature | What it captures | Compute |
|---|---|---|
| `beta_60d` | Systematic market exposure | 60d rolling cov(stock, SPY) / var(SPY) on log-returns. NaN if SPY unavailable. |
| `idio_vol_60d` | Idiosyncratic (non-market) risk | 60d rolling std of `(stock_log_return − beta × spy_log_return) × sqrt(252)` |
| `vol_of_vol_30d` | Vol regime stability | 30d rolling std of `realized_vol_20d` |
| `max_drawdown_60d` | Recent left-tail risk | Worst peak-to-trough within trailing 60d window. Distinct from `dist_from_52w_high` which is current depth-from-rolling-252-high |

`FEATURE_CFG` additions: `beta_window=60`, `vol_of_vol_window=30`, `max_drawdown_window=60`.

## Stage sequencing

- [x] Stage 0a — Triple-barrier label generic module (predictor #116, merged)
- [x] Stage 0b — Variant cutover gate (predictor #117, merged)
- [x] Stage 0c — Retire V2 + RegimeConditionedMeta (predictor #118, merged)
- [x] Stage 1a — Per-feature normalization substrate (predictor #119, merged)
- [x] Stage 1b — Parallel vol-with-macros training (predictor #120, merged)
- [x] Stage 1c — Wire inference parallel observation (predictor #121, awaiting merge)
- [x] **Stage 2a — Risk features in feature_engineer (this PR, alpha-engine-data)**
- [ ] Stage 2b — Parallel `prod_vol_risk_aug` GBM training + inference (alpha-engine-predictor)
- [ ] Stage 1d / 2d — Cutovers gated on variant_cutover_gate (≥15% relative IC lift)

## Operator follow-up (post-merge)

The new feature columns will appear in `compute_features()` output starting on the next Saturday SF firing of feature_engineer. Historical rows in ArcticDB universe library need a one-shot backfill before Stage 2b's training can consume them. Backfill command (to be confirmed against the existing universe library backfill pattern):

```bash
# Per the existing universe-library backfill discipline; exact command TBD
# alongside Stage 2b sequencing
python -m features.compute --backfill --columns beta_60d,idio_vol_60d,vol_of_vol_30d,max_drawdown_60d
```

The Stage 2b PR description will include the canonical backfill invocation once the predictor side is scoped.

## Test plan

- [x] 16 new tests covering: schema contract (FEATURES + compute_features output), beta-of-self=1, beta-of-independent-series≈0, idio_vol-of-self=0, monotone-increasing→drawdown=0, post-decline→drawdown<-0.15, NaN-when-no-SPY for beta+idio_vol, vol_of_vol nonnegative
- [x] Full data suite: 644 passed + 1 skipped (16 new + 628 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)