### PR TITLE
feat(daily_closes): TWO + HYOAS forward-only daily ingestion (Stage 2.5)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -60,12 +60,27 @@ _FRED_TIMEOUT = 15
 # Map our ArcticDB ticker key (after stripping ^) to FRED series id.
 # Both yfinance (^VIX, ^TNX, ...) and FRED (VIXCLS, DGS10, ...) publish
 # these in the same scale (raw index level for VIX/VIX3M, percent for
-# TNX/IRX), so no conversion is needed before appending to ArcticDB.
+# TNX/IRX/TWO/HYOAS), so no conversion is needed before appending to
+# ArcticDB.
+#
+# TWO + HYOAS added 2026-05-10 (Stage 2.5 of regime-conditioning rebuild
+# — plan doc: alpha-engine-docs/private/regime-conditioning-260510.md).
+# Both are FRED-only (no yfinance proxy), so they only flow through the
+# FRED fallback path. Historical backfill is gated on a follow-up PR
+# adding a FRED history fetcher; this PR begins forward-only collection.
 _FRED_INDEX_MAP = {
     "VIX": "VIXCLS",
     "VIX3M": "VXVCLS",
     "TNX": "DGS10",
     "IRX": "DTB3",
+    # 2Y treasury — enables 10Y-2Y curve slope (recession-focused canonical)
+    # alongside the existing 10Y-3M (TNX-IRX cyclical).
+    "TWO": "DGS2",
+    # ICE BofA US High Yield Index Option-Adjusted Spread, percent.
+    # Major regime indicator that VIX misses — credit widens before vol
+    # spikes in many cycles, and stays wide during recoveries when vol
+    # has already calmed. Institutional risk-factor models include it.
+    "HYOAS": "BAMLH0A0HYM2",
 }
 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -93,12 +93,17 @@ caret_symbols:
   - IRX
 
 # Always-download tickers (benchmarks, macro, sector ETFs)
+# TWO + HYOAS added 2026-05-10 (Stage 2.5 regime-conditioning rebuild) —
+# FRED-only, no yfinance caret. Forward-only collection from this date;
+# historical backfill is a follow-up PR.
 always_download:
   - SPY
   - VIX
   - VIX3M
   - TNX
   - IRX
+  - TWO
+  - HYOAS
   - GLD
   - USO
   - XLK

--- a/tests/test_dgs2_hyoas_ingestion.py
+++ b/tests/test_dgs2_hyoas_ingestion.py
@@ -1,0 +1,56 @@
+"""Tests for Stage 2.5 of the regime-conditioning rebuild — DGS2 (2Y
+treasury) and HY OAS credit spread added to daily_closes._FRED_INDEX_MAP
+for forward-only daily ingestion. Historical backfill is a follow-up PR.
+
+Plan doc: ~/Development/alpha-engine-docs/private/regime-conditioning-260510.md
+
+These tests lock the contract that:
+- TWO maps to FRED series DGS2 (2Y constant maturity treasury)
+- HYOAS maps to FRED series BAMLH0A0HYM2 (HY OAS, percent)
+- Both are exposed via the same FRED-fallback path the existing index
+  tickers use, so daily_closes will write parquet records when polygon
+  doesn't carry the symbol.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from collectors.daily_closes import _FRED_INDEX_MAP
+
+
+class TestFredIndexMapAdditions:
+
+    def test_two_maps_to_dgs2(self):
+        # 2Y treasury — enables 10Y-2Y curve slope (recession-canonical)
+        # alongside the existing 10Y-3M (TNX-IRX cyclical).
+        assert _FRED_INDEX_MAP.get("TWO") == "DGS2"
+
+    def test_hyoas_maps_to_bamlh0a0hym2(self):
+        # ICE BofA US High Yield Index Option-Adjusted Spread, percent.
+        # Major regime indicator that VIX misses — credit widens before
+        # vol spikes in many cycles.
+        assert _FRED_INDEX_MAP.get("HYOAS") == "BAMLH0A0HYM2"
+
+    def test_existing_mappings_unchanged(self):
+        # Regression: ensure the Stage 2.5 additions didn't perturb the
+        # existing mappings.
+        assert _FRED_INDEX_MAP["VIX"] == "VIXCLS"
+        assert _FRED_INDEX_MAP["VIX3M"] == "VXVCLS"
+        assert _FRED_INDEX_MAP["TNX"] == "DGS10"
+        assert _FRED_INDEX_MAP["IRX"] == "DTB3"
+
+    def test_no_yfinance_caret_for_fred_only_symbols(self):
+        # TWO and HYOAS are FRED-only — no yfinance caret prefix should
+        # be configured for them. Verifies the integration path
+        # routes them through FRED fallback only.
+        from collectors.prices import _CARET_SYMBOLS
+        assert "TWO" not in _CARET_SYMBOLS
+        assert "HYOAS" not in _CARET_SYMBOLS
+
+    def test_index_map_total_size(self):
+        # Stage 2.5 adds exactly 2 entries — TWO + HYOAS. Lock so a
+        # future drive-by addition doesn't slip through unreviewed.
+        assert len(_FRED_INDEX_MAP) == 6


### PR DESCRIPTION
## Summary

- Stage 2.5 of the regime-conditioning rebuild — adds 2 FRED series to `daily_closes._FRED_INDEX_MAP` for forward-only daily ingestion
- `TWO → DGS2` (2Y constant-maturity treasury, percent) — enables 10Y-2Y curve slope (recession-focused canonical)
- `HYOAS → BAMLH0A0HYM2` (HY OAS credit spread, percent) — major regime indicator VIX misses
- Forward-only daily collection. Historical backfill is **Stage 2.5b** (separate PR — requires new FRED history fetcher; current `_fetch_fred_closes` is single-latest-only)

## Plan reference

Plan doc: `~/Development/alpha-engine-docs/private/regime-conditioning-260510.md` (gitignored). ROADMAP entry in alpha-engine-config #103.

## Why credit spreads matter

The predictor's current macro set captures vol regime (VIX, vix_term_slope) and rates regime (10Y-3M curve via TNX-IRX), but is silent on **credit regime**. Credit typically widens before vol spikes in macro-driven cycles (HY OAS leads VIX), and stays wide during recoveries when vol has already calmed. AQR, Two Sigma, BlackRock Aladdin all include credit in their regime taxonomy. The 2Y treasury enables 10Y-2Y curve (recession-canonical) alongside the existing 10Y-3M (cyclical).

## Stage decomposition

- [x] **Stage 2.5 (this PR)** — forward-only daily collection
- [ ] **Stage 2.5b** — FRED history fetcher + historical backfill of TWO + HYOAS time-series parquets
- [ ] **Stage 2c** — predictor-side wiring: extend `compute_features` + `regime_predictor.build_features` to consume the new series; add `yield_curve_10y_2y`, `hy_oas_level`, `hy_oas_change_21d` to `MACRO_NORM_FEATURES`. Also adds `market_breadth_200d` (alongside existing 50d) and `vix_vix3m_ratio` (alongside existing slope) — predictor-side macro additions queued from the original Stage 2a-extended discussion.

## What ships in this PR

- `_FRED_INDEX_MAP` extended with TWO + HYOAS
- `config.yaml.example` `always_download` list extended (config.yaml is gitignored — operator must update production config separately, see follow-up below)
- 5 tests locking the new mappings + the no-caret-for-FRED-only contract

## Test plan

- [x] 5 new tests: TWO→DGS2 mapping, HYOAS→BAMLH0A0HYM2 mapping, existing mappings unchanged, no caret for FRED-only symbols, total map size locked
- [x] Full data suite: 633 passed + 1 skipped (5 new + 628 existing)

## Operator follow-up (post-merge)

- Update production `config.yaml` to include TWO + HYOAS in `always_download` (config.yaml is gitignored — this PR only touches the example).
- Stage 2.5b PR will add FRED history fetcher + run historical backfill before Stage 2c (predictor consumption) lands. Without that, predictor training has no historical TWO/HYOAS data to learn from — only forward-collected rows from this PR's deploy date onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)