### PR TITLE
feat(collectors): BAA10Y full-history credit-regime indicator (Stage 2.5c)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -81,6 +81,12 @@ _FRED_INDEX_MAP = {
     # spikes in many cycles, and stays wide during recoveries when vol
     # has already calmed. Institutional risk-factor models include it.
     "HYOAS": "BAMLH0A0HYM2",
+    # Moody's BAA Corporate Bond Yield Relative to 10Y Treasury, percent.
+    # Full 40y FRED history (1986+) — the credit-regime signal HYOAS can't
+    # provide across the full predictor training corpus (HYOAS is license-
+    # gated to 2023+ on FRED). BBB-rated spread vs HY's below-BBB; both
+    # belong in the institutional credit-regime feature set.
+    "BAA10Y": "BAA10Y",
 }
 
 

--- a/collectors/fred_history.py
+++ b/collectors/fred_history.py
@@ -45,7 +45,17 @@ _FRED_TIMEOUT = 30  # longer than _fred_latest's 15s — date-range responses ar
 # impact daily_closes' single-latest fetch behaviour.
 FRED_HISTORY_MAP: dict[str, str] = {
     "TWO": "DGS2",
+    # ICE BofA US HY Index OAS — only 3y of FRED public history (2023+),
+    # license-restricted. Forward observation grows; recent walk-forward
+    # folds get HY-specific regime conditioning.
     "HYOAS": "BAMLH0A0HYM2",
+    # Moody's BAA Corporate Bond Yield Relative to 10Y Treasury — full
+    # 40y FRED history (1986+), daily, percent. Captures the credit-
+    # regime signal across the full predictor training corpus that
+    # HYOAS can't (BAMLH0A0HYM2 is licence-gated to 2023+ on FRED).
+    # BBB-rated spread vs HY's below-BBB; both belong in the institutional
+    # credit-regime feature set per AQR/Two Sigma factor models.
+    "BAA10Y": "BAA10Y",
 }
 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -95,7 +95,10 @@ caret_symbols:
 # Always-download tickers (benchmarks, macro, sector ETFs)
 # TWO + HYOAS added 2026-05-10 (Stage 2.5 regime-conditioning rebuild) —
 # FRED-only, no yfinance caret. Forward-only collection from this date;
-# historical backfill is a follow-up PR.
+# historical backfill via collectors/fred_history.py (Stage 2.5b).
+# BAA10Y added 2026-05-10 (Stage 2.5c) — full 40y FRED history (1986+),
+# the credit-regime signal HYOAS can't provide across the full training
+# corpus (HYOAS license-gated to 2023+ on FRED).
 always_download:
   - SPY
   - VIX
@@ -104,6 +107,7 @@ always_download:
   - IRX
   - TWO
   - HYOAS
+  - BAA10Y
   - GLD
   - USO
   - XLK

--- a/tests/test_dgs2_hyoas_ingestion.py
+++ b/tests/test_dgs2_hyoas_ingestion.py
@@ -34,23 +34,31 @@ class TestFredIndexMapAdditions:
         # vol spikes in many cycles.
         assert _FRED_INDEX_MAP.get("HYOAS") == "BAMLH0A0HYM2"
 
+    def test_baa10y_maps_to_baa10y(self):
+        # Stage 2.5c: Moody's BAA Corporate Bond Yield Relative to 10Y
+        # Treasury — full 40y FRED history (1986+), the credit-regime
+        # signal HYOAS cannot provide across the full predictor training
+        # corpus.
+        assert _FRED_INDEX_MAP.get("BAA10Y") == "BAA10Y"
+
     def test_existing_mappings_unchanged(self):
-        # Regression: ensure the Stage 2.5 additions didn't perturb the
-        # existing mappings.
+        # Regression: ensure the additions didn't perturb the existing
+        # mappings.
         assert _FRED_INDEX_MAP["VIX"] == "VIXCLS"
         assert _FRED_INDEX_MAP["VIX3M"] == "VXVCLS"
         assert _FRED_INDEX_MAP["TNX"] == "DGS10"
         assert _FRED_INDEX_MAP["IRX"] == "DTB3"
 
     def test_no_yfinance_caret_for_fred_only_symbols(self):
-        # TWO and HYOAS are FRED-only — no yfinance caret prefix should
-        # be configured for them. Verifies the integration path
-        # routes them through FRED fallback only.
+        # TWO, HYOAS, BAA10Y are FRED-only — no yfinance caret prefix.
+        # Verifies the integration path routes them through FRED fallback only.
         from collectors.prices import _CARET_SYMBOLS
         assert "TWO" not in _CARET_SYMBOLS
         assert "HYOAS" not in _CARET_SYMBOLS
+        assert "BAA10Y" not in _CARET_SYMBOLS
 
     def test_index_map_total_size(self):
-        # Stage 2.5 adds exactly 2 entries — TWO + HYOAS. Lock so a
-        # future drive-by addition doesn't slip through unreviewed.
-        assert len(_FRED_INDEX_MAP) == 6
+        # Stage 2.5 (TWO + HYOAS) + 2.5c (BAA10Y) add 3 entries on top of
+        # the original 4 (VIX/VIX3M/TNX/IRX). Lock so a future drive-by
+        # addition doesn't slip through unreviewed.
+        assert len(_FRED_INDEX_MAP) == 7

--- a/tests/test_fred_history_fetcher.py
+++ b/tests/test_fred_history_fetcher.py
@@ -40,10 +40,17 @@ class TestFredHistoryMap:
     def test_hyoas_maps_to_bamlh0a0hym2(self):
         assert FRED_HISTORY_MAP["HYOAS"] == "BAMLH0A0HYM2"
 
+    def test_baa10y_maps_to_baa10y(self):
+        # Stage 2.5c: Moody's BAA Corporate Bond Yield Relative to 10Y
+        # Treasury. Full 40y FRED history (1986+) — full-corpus credit
+        # regime signal that HYOAS cannot provide (license-gated to 2023+).
+        assert FRED_HISTORY_MAP["BAA10Y"] == "BAA10Y"
+
     def test_no_unintended_entries(self):
-        # Stage 2.5b adds exactly TWO + HYOAS. Lock so a future drive-by
-        # addition doesn't slip through unreviewed.
-        assert set(FRED_HISTORY_MAP.keys()) == {"TWO", "HYOAS"}
+        # Stage 2.5b shipped TWO + HYOAS; Stage 2.5c added BAA10Y.
+        # Lock so a future drive-by addition doesn't slip through
+        # unreviewed.
+        assert set(FRED_HISTORY_MAP.keys()) == {"TWO", "HYOAS", "BAA10Y"}
 
 
 # ── fetch_fred_history ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds Moody's BAA Corporate Bond Yield Relative to 10Y Treasury (FRED `BAA10Y`) alongside HYOAS to provide credit-regime signal across the **full predictor training corpus**
- HYOAS (PR #203) is license-gated to 2023-05-09+ on FRED — only ~3y available. The predictor's walk-forward training spans 2018-2025; most folds had no credit-regime signal
- BAA10Y has **40 years** of FRED history (1986-01-02+), daily, percent
- BBB-rated spread vs HY's below-BBB — different part of the credit spectrum, both are institutional-canonical regime indicators (AQR, Two Sigma, BlackRock Aladdin factor models include both)

## Plan reference

Plan doc: `~/Development/alpha-engine-docs/private/regime-conditioning-260510.md` (gitignored). ROADMAP entry in alpha-engine-config #103.

## What ships

- `collectors/fred_history.py` `FRED_HISTORY_MAP`: `BAA10Y → BAA10Y` (FRED series ID matches our ticker key)
- `collectors/daily_closes.py` `_FRED_INDEX_MAP`: BAA10Y added so daily ingestion picks it up alongside TWO + HYOAS
- `config.yaml.example` `always_download`: BAA10Y added
- 2 new tests + updated existing assertions for the new total counts (7 in `_FRED_INDEX_MAP`, 3 in `FRED_HISTORY_MAP`)

## Stage sequencing

- [x] Stage 0 → 2.5b (data + predictor stages 0-2.5b shipped)
- [x] **Stage 2.5c (this PR)**
- [ ] Operator backfill — `python -m collectors.fred_history --bucket alpha-engine-research` (one-shot, fetches all 3: TWO + HYOAS + BAA10Y)
- [ ] Stage 2c-full — predictor consumption (yield_curve_10y_2y, hy_oas_level, hy_oas_change_21d, baa10y_level, baa10y_change_21d)
- [ ] Stage 2b — predictor parallel `prod_vol_risk_aug` GBM (uses #202 risk features)

## Test plan

- [x] 2 new tests for BAA10Y entries in both maps
- [x] Updated total-count locks (7 in `_FRED_INDEX_MAP`, 3 in `FRED_HISTORY_MAP`)
- [x] Existing tests still pass — 674 passed + 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)