### PR TITLE
fix(constituents): find Wikipedia table by columns, not by position

### DIFF
--- a/collectors/constituents.py
+++ b/collectors/constituents.py
@@ -131,6 +131,39 @@ def collect(
     }
 
 
+def _select_constituents_table(tables: list[pd.DataFrame], index_name: str) -> pd.DataFrame:
+    """Pick the constituents DataFrame from pd.read_html output.
+
+    Wikipedia inserts banner/disambiguation tables ahead of the constituents
+    table without notice (S&P 400 page added one ~2026-05; the prior
+    `tables[0]` heuristic returned a 2-col warning banner with integer column
+    names instead of the 400-row constituents table). Find by columns
+    instead of by position: must have a ticker/symbol column AND a GICS
+    sector (not sub-industry) column. Returns the first matching table —
+    on Wikipedia constituent pages this is the live roster; the second-such
+    table (recent additions/removals) lacks a GICS Sector column.
+    """
+    candidates: list[pd.DataFrame] = []
+    for df in tables:
+        if isinstance(df.columns, pd.MultiIndex):
+            df = df.copy()
+            df.columns = [" ".join(str(c) for c in col).strip() for col in df.columns]
+        cols_lower = [str(c).lower() for c in df.columns]
+        has_ticker = any("symbol" in c or "ticker" in c for c in cols_lower)
+        has_gics_sector = any(
+            "gics" in c and "sector" in c and "sub" not in c for c in cols_lower
+        )
+        if has_ticker and has_gics_sector:
+            candidates.append(df)
+    if not candidates:
+        raise RuntimeError(
+            f"No constituents table found in {index_name} Wikipedia page "
+            f"(scanned {len(tables)} tables; need columns matching symbol/ticker "
+            f"AND GICS sector). Wikipedia layout drift — extractor needs update."
+        )
+    return max(candidates, key=len)
+
+
 def _fetch_constituents() -> tuple[list[str], dict[str, str], dict[str, str], int, int]:
     """
     Fetch constituent tickers and sector mappings from Wikipedia.
@@ -151,11 +184,7 @@ def _fetch_constituents() -> tuple[list[str], dict[str, str], dict[str, str], in
             resp = requests.get(url, headers=_HEADERS, timeout=15)
             resp.raise_for_status()
             tables = pd.read_html(StringIO(resp.text))
-            df = tables[0]
-
-            # Flatten multi-level columns if Wikipedia returns them
-            if isinstance(df.columns, pd.MultiIndex):
-                df.columns = [" ".join(str(c) for c in col).strip() for col in df.columns]
+            df = _select_constituents_table(tables, index_name)
 
             col = next(
                 (c for c in df.columns if "symbol" in str(c).lower() or "ticker" in str(c).lower()),

--- a/tests/test_constituents_sector_map.py
+++ b/tests/test_constituents_sector_map.py
@@ -99,6 +99,112 @@ def test_fetch_raises_when_sector_column_missing() -> None:
         assert not sector_map or len(sector_map) < len(tickers)
 
 
+def test_select_constituents_table_skips_banner_table() -> None:
+    """Wikipedia adds banner/disambiguation tables ahead of the constituents
+    table without notice. 2026-05-11 incident: the S&P 400 page inserted a
+    1-row, 2-column disambiguation-warning table at index 0, making
+    `tables[0]` return columns ``[0, 1]`` instead of the constituents
+    table at index 1. _select_constituents_table must scan for the right
+    one by columns, not position.
+    """
+    banner_df = pd.DataFrame({0: [float("nan")], 1: ["This article currently links to a large number of disambiguation pages."]})
+    constituents_df = pd.DataFrame({
+        "Symbol": [f"T{i:03d}" for i in range(100)],
+        "Security": [f"Co {i}" for i in range(100)],
+        "GICS Sector": ["Industrials"] * 100,
+        "GICS Sub-Industry": ["Misc"] * 100,
+    })
+    sub_industry_only_df = pd.DataFrame({
+        "Symbol": ["X"], "GICS Sub-Industry": ["Subindustry-Only"],
+    })
+
+    picked = constituents._select_constituents_table(
+        [banner_df, constituents_df, sub_industry_only_df], "S&P 400"
+    )
+    assert list(picked.columns) == [
+        "Symbol", "Security", "GICS Sector", "GICS Sub-Industry"
+    ]
+    assert len(picked) == 100
+
+
+def test_select_constituents_table_raises_when_no_match() -> None:
+    """If no table on the page has the expected ticker + GICS sector shape,
+    raise loudly rather than silently picking a junk table."""
+    banner_df = pd.DataFrame({0: [1], 1: ["banner"]})
+    nav_df = pd.DataFrame({"vteFoo": ["a"], "vteBar": ["b"]})
+
+    with pytest.raises(RuntimeError, match="No constituents table found"):
+        constituents._select_constituents_table([banner_df, nav_df], "S&P 400")
+
+
+def test_select_constituents_table_picks_largest_candidate() -> None:
+    """When multiple tables have Symbol + GICS Sector columns (e.g. a small
+    example/docs table alongside the live roster), pick the largest. On the
+    real S&P 500/400 pages the roster is the only such table; the largest-
+    wins rule is a defense-in-depth tiebreaker if Wikipedia ever adds an
+    additional schema-matching table."""
+    small_df = pd.DataFrame({
+        "Symbol": ["X", "Y"],
+        "GICS Sector": ["Energy", "Energy"],
+    })
+    real_df = pd.DataFrame({
+        "Symbol": [f"T{i}" for i in range(100)],
+        "GICS Sector": ["Industrials"] * 100,
+    })
+    picked = constituents._select_constituents_table([small_df, real_df], "S&P 500")
+    assert len(picked) == 100
+
+
+def test_select_constituents_table_flattens_multiindex() -> None:
+    """Wikipedia occasionally returns multi-level column headers. The
+    selector must flatten them before matching."""
+    df = pd.DataFrame({
+        ("Stock", "Symbol"): [f"T{i}" for i in range(100)],
+        ("Classification", "GICS Sector"): ["Industrials"] * 100,
+    })
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    picked = constituents._select_constituents_table([df], "S&P 500")
+    assert any("symbol" in str(c).lower() for c in picked.columns)
+    assert any(
+        "gics" in str(c).lower() and "sector" in str(c).lower()
+        for c in picked.columns
+    )
+
+
+def test_fetch_constituents_handles_banner_table_at_index_0() -> None:
+    """End-to-end: Wikipedia page with a banner table at index 0 followed by
+    the constituents table at index 1 must still produce a populated
+    sector_map. Regression for the 2026-05-11 silent-MorningEnrich incident."""
+    banner_df = pd.DataFrame({0: [float("nan")], 1: ["disambiguation banner"]})
+    sp500_df = pd.DataFrame({
+        "Symbol": [f"S5{i:02d}" for i in range(60)],
+        "GICS Sector": ["Information Technology"] * 60,
+    })
+    sp400_df = pd.DataFrame({
+        "Symbol": [f"S4{i:02d}" for i in range(60)],
+        "GICS Sector": ["Industrials"] * 60,
+    })
+
+    sp500_html = banner_df.to_html(index=False) + sp500_df.to_html(index=False)
+    sp400_html = banner_df.to_html(index=False) + sp400_df.to_html(index=False)
+
+    def fake_get(url, **kwargs):
+        return _FakeResp(sp500_html if "500" in url else sp400_html)
+
+    with patch("collectors.constituents.requests.get", side_effect=fake_get):
+        tickers, sector_map, sector_etf_map, sp500_count, sp400_count = (
+            constituents._fetch_constituents()
+        )
+
+    assert sp500_count == 60
+    assert sp400_count == 60
+    assert len(sector_map) == 120
+    assert sector_map["S500"] == "Information Technology"
+    assert sector_map["S400"] == "Industrials"
+    assert sector_etf_map["S500"] == "XLK"
+    assert sector_etf_map["S400"] == "XLI"
+
+
 def test_collect_returns_tickers_in_dict() -> None:
     """``collect()``'s return contract MUST include the ``tickers`` list.
 


### PR DESCRIPTION
## Summary

- Replaces `tables[0]` heuristic in `_fetch_constituents` with `_select_constituents_table`, which scans every table from `pd.read_html` and picks the largest one that has both a Symbol/Ticker column AND a GICS Sector (non-sub-industry) column.
- Raises explicitly with a clear "Wikipedia layout drift" message if no candidate matches.
- 5 new unit tests covering: banner-table-at-index-0 skip, no-match raise, largest-candidate tiebreaker, MultiIndex flattening, and end-to-end fetch through the banner.

## Why

S&P 400 Wikipedia page inserted a disambiguation-warning banner table at position 0 on/around 2026-05-11. `tables[0]` then returned a 1-row, 2-column banner (columns: `[0, 1]`) instead of the 400-row constituents table at position 1.

The cascade today (2026-05-11 weekday SF):
1. `_fetch_constituents` raised "GICS sector column missing" on the banner table
2. Fell through to local cache (only stores ticker symbols, no sector mapping)
3. `collect()` raised "Sector mapping incomplete: 903 of 903 tickers missing GICS sector"
4. `weekly_collector` exited 1, but `python ... 2>&1 | tee ...` masked the exit code (no `set -o pipefail`)
5. SF moved on; morning planner aborted with `daily_data: 46h stale`
6. Daemon emitted "upstream health failed..no order book written" Telegram

This PR closes (1). Cache hardening + `pipefail` follow in PRs 2 + 3.

## Test plan

- [x] `pytest tests/test_constituents_sector_map.py` — 9/9 pass (4 prior + 5 new)
- [x] Full suite: `pytest tests/` — 716 passed, 1 skipped
- [x] Live verified against current `https://en.wikipedia.org/wiki/List_of_S%26P_400_companies` — selector returns the 400-row constituents table, `tickers[:3] = ['AA', 'AAL', 'AAON']`
- [ ] Post-merge: Saturday SF DataPhase1 constituents step (or manual `weekly_collector.py --morning-enrich`) succeeds against live Wikipedia

🤖 Generated with [Claude Code](https://claude.com/claude-code)