### PR TITLE
fix(sf-daily): set -eo pipefail on every SSM RunShellScript block

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -65,6 +65,7 @@
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine",
             "source .venv/bin/activate",
             "python -m alpha_engine_lib.trading_calendar"
@@ -169,6 +170,7 @@
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
@@ -597,6 +599,7 @@
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "cd /home/ec2-user/alpha-engine",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
@@ -690,6 +693,7 @@
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
           "commands": [
+            "set -eo pipefail",
             "sudo systemctl restart alpha-engine-daemon.service",
             "echo 'Daemon restarted'"
           ],

--- a/tests/test_sf_ssm_pipefail_wiring.py
+++ b/tests/test_sf_ssm_pipefail_wiring.py
@@ -1,0 +1,84 @@
+"""Every SSM RunShellScript command array must start with `set -eo pipefail`.
+
+Regression target: 2026-05-11 weekday SF silent MorningEnrich failure.
+`weekly_collector.py --morning-enrich 2>&1 | tee -a /var/log/morning-enrich.log`
+exited 1 from constituents-preflight, but `tee` returned 0 and the
+pipeline ran on its exit code. SSM reported `ResponseCode: 0,
+Status: Success`, the SF moved past MorningEnrich without an order-book
+write, and the morning planner aborted minutes later with
+"daily_data: 46h stale".
+
+Without `set -o pipefail`, any `cmd | tee` (or other pipe to a benign
+sink) silently swallows non-zero exits from `cmd`. `set -e` then has
+nothing to react to. Both flags must be present, and they must be the
+first command in the array so they cover everything that follows.
+
+This test walks all three SF defns (saturday + weekday + eod) and
+asserts every `commands` array begins with `set -eo pipefail`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+_SF_PATHS = [
+    _INFRA / "step_function.json",
+    _INFRA / "step_function_daily.json",
+    _INFRA / "step_function_eod.json",
+]
+
+
+def _iter_ssm_command_blocks(sf_doc: dict):
+    """Yield (state_name, commands_list) for every SSM RunShellScript task."""
+    for state_name, state in sf_doc.get("States", {}).items():
+        if state.get("Type") != "Task":
+            continue
+        resource = state.get("Resource", "")
+        if "ssm:sendCommand" not in resource:
+            continue
+        params = state.get("Parameters", {})
+        if params.get("DocumentName") != "AWS-RunShellScript":
+            continue
+        inner = params.get("Parameters", {})
+        cmds = inner.get("commands")
+        if isinstance(cmds, list):
+            yield state_name, cmds
+
+
+@pytest.mark.parametrize("sf_path", _SF_PATHS, ids=lambda p: p.name)
+def test_every_ssm_command_block_starts_with_pipefail(sf_path: Path) -> None:
+    """Pipe-to-tee + no pipefail silently masks non-zero exits.
+
+    Every SSM RunShellScript invocation in the SF must set `pipefail`
+    as its first command. `pipefail` is the load-bearing fix: it
+    propagates non-zero exits through pipes (notably
+    `python ... 2>&1 | tee -a /var/log/foo.log`). Without it, SSM
+    reports `ResponseCode: 0` for failed scripts and the SF treats
+    the state as Success.
+
+    Both `set -eo pipefail` (Saturday + weekday convention; preferred —
+    `set -e` also aborts on the first non-zero exit) and `set -o
+    pipefail` (EOD convention) are accepted. The bug being prevented
+    is the absence of `pipefail` entirely.
+    """
+    sf_doc = json.loads(sf_path.read_text())
+    offenders: list[str] = []
+    for state_name, cmds in _iter_ssm_command_blocks(sf_doc):
+        first = cmds[0] if cmds else None
+        # Accept any `set -...o... pipefail` first line. The simple
+        # substring check is sufficient given the controlled shape of
+        # these command arrays.
+        if not first or "pipefail" not in first or not first.startswith("set "):
+            offenders.append(f"{state_name}: first cmd = {first!r}")
+    assert not offenders, (
+        f"{sf_path.name}: SSM command blocks missing `pipefail` "
+        f"as first command:\n  - " + "\n  - ".join(offenders) + "\n\n"
+        "Add 'set -eo pipefail' as the first entry of each `commands` "
+        "array. See 2026-05-11 silent-MorningEnrich incident."
+    )


### PR DESCRIPTION
## Summary

- Add `set -eo pipefail` as the first command of every SSM `RunShellScript` block in `infrastructure/step_function_daily.json`: `CheckTradingDay`, `MorningEnrich`, `RunMorningPlanner`, `RunDaemon`.
- New wiring test `tests/test_sf_ssm_pipefail_wiring.py` parametrizes over all three SF defns (Saturday + weekday + EOD) and asserts every SSM `commands` array begins with a `set ... pipefail` line. Catches future regressions where a state is added or rewritten without the flag.

## Why

Without `pipefail`, `python ... 2>&1 | tee -a /var/log/foo.log` silently masks any non-zero exit from `python` because `tee` returns 0. SSM `RunShellScript` then reports `ResponseCode: 0, Status: Success` and the SF moves past the failure.

This was the load-bearing cause of the 2026-05-11 silent-MorningEnrich cascade:
1. `python weekly_collector.py --morning-enrich` exited 1 (constituents-preflight raise)
2. `| tee` returned 0 → SSM Success → SF advanced through PredictorInference + RunMorningPlanner against stale ArcticDB / S3 daily_data
3. Morning planner aborted with `daily_data: 46h stale` → no order book written → daemon Telegram alert

Adding `set -eo pipefail` makes any future MorningEnrich / planner failure propagate to SSM `ResponseCode != 0`, which the SF's existing `Catch[States.ALL]` already routes to `HandleFailure` / `MorningEnrichFailed`. Saturday SF already uses this convention in every state (8 instances); this PR brings the daily SF in line.

## Test plan

- [x] `pytest tests/test_sf_ssm_pipefail_wiring.py` — 3/3 pass (parametrized over saturday/weekday/eod SF defns)
- [x] Full suite: `pytest tests/` — 714 passed, 1 skipped
- [x] JSON syntax verified: `python -c "import json; json.load(open('infrastructure/step_function_daily.json'))"`
- [ ] Post-merge: deploy-infrastructure workflow updates the live weekday SF defn; next weekday SF firing (or manual `start-execution`) will exercise the new flag end-to-end.

## Independent of #207, #208

This PR touches only `infrastructure/step_function_daily.json` + a new test file. No conflict with #207 (constituents.py) or #208 (constituents.py + .gitignore). All three can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)