### PR TITLE
fix(sf-daily): export FLOW_DOCTOR_ENABLED=1 in every SSM command block

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -66,6 +66,7 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
             "cd /home/ec2-user/alpha-engine",
             "source .venv/bin/activate",
             "python -m alpha_engine_lib.trading_calendar"
@@ -171,6 +172,7 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
@@ -600,6 +602,7 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
             "cd /home/ec2-user/alpha-engine",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
@@ -694,6 +697,7 @@
         "Parameters": {
           "commands": [
             "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
             "sudo systemctl restart alpha-engine-daemon.service",
             "echo 'Daemon restarted'"
           ],

--- a/tests/test_sf_ssm_pipefail_wiring.py
+++ b/tests/test_sf_ssm_pipefail_wiring.py
@@ -1,20 +1,19 @@
-"""Every SSM RunShellScript command array must start with `set -eo pipefail`.
+"""SSM RunShellScript command-array hygiene checks.
 
-Regression target: 2026-05-11 weekday SF silent MorningEnrich failure.
-`weekly_collector.py --morning-enrich 2>&1 | tee -a /var/log/morning-enrich.log`
-exited 1 from constituents-preflight, but `tee` returned 0 and the
-pipeline ran on its exit code. SSM reported `ResponseCode: 0,
-Status: Success`, the SF moved past MorningEnrich without an order-book
-write, and the morning planner aborted minutes later with
-"daily_data: 46h stale".
+Two rules pinned here:
 
-Without `set -o pipefail`, any `cmd | tee` (or other pipe to a benign
-sink) silently swallows non-zero exits from `cmd`. `set -e` then has
-nothing to react to. Both flags must be present, and they must be the
-first command in the array so they cover everything that follows.
+1. Every command array must START with `set ... pipefail`. Without it,
+   `cmd | tee` silently masks non-zero exits from `cmd` (2026-05-11
+   silent-MorningEnrich incident).
 
-This test walks all three SF defns (saturday + weekday + eod) and
-asserts every `commands` array begins with `set -eo pipefail`.
+2. Every weekday-SF command array must also `export
+   FLOW_DOCTOR_ENABLED=1`. The 2026-05-05 migration from boot-triggered
+   systemd to SF-triggered SSM dropped this env var on the
+   trading-instance SSM path (systemd units had it baked in via
+   `Environment=`). Without it, `alpha_engine_lib.logging.setup_logging`
+   skips attaching `FlowDoctorHandler` and ERROR-level logs go only to
+   stdout — exactly the failure mode on 2026-05-11, where two ERROR
+   logs from `weekly_collector` fired but flow-doctor never escalated.
 """
 
 from __future__ import annotations
@@ -51,6 +50,9 @@ def _iter_ssm_command_blocks(sf_doc: dict):
             yield state_name, cmds
 
 
+_DAILY_SF_PATH = _INFRA / "step_function_daily.json"
+
+
 @pytest.mark.parametrize("sf_path", _SF_PATHS, ids=lambda p: p.name)
 def test_every_ssm_command_block_starts_with_pipefail(sf_path: Path) -> None:
     """Pipe-to-tee + no pipefail silently masks non-zero exits.
@@ -81,4 +83,44 @@ def test_every_ssm_command_block_starts_with_pipefail(sf_path: Path) -> None:
         f"as first command:\n  - " + "\n  - ".join(offenders) + "\n\n"
         "Add 'set -eo pipefail' as the first entry of each `commands` "
         "array. See 2026-05-11 silent-MorningEnrich incident."
+    )
+
+
+def test_weekday_sf_ssm_blocks_export_flow_doctor_enabled() -> None:
+    """Every weekday-SF SSM command array must `export FLOW_DOCTOR_ENABLED=1`.
+
+    `alpha_engine_lib.logging.setup_logging` only attaches
+    `FlowDoctorHandler` when this env var is set; otherwise ERROR-level
+    logs go only to stdout and never enter the dispatch pipeline
+    (email + GitHub issue + S3 changelog).
+
+    Regression target: the 2026-05-05 systemd → SSM migration silently
+    dropped flow-doctor coverage on the trading-instance SSM path. The
+    disabled-but-retained systemd units had `Environment=FLOW_DOCTOR_ENABLED=1`
+    baked in; SSM `RunShellScript` only sources `.alpha-engine.env` and
+    the env file never gained the flag. On 2026-05-11 MorningEnrich
+    emitted two ERROR logs from `weekly_collector` and flow-doctor
+    never escalated.
+
+    Pinning as an `export` in the command array — not as a value in
+    `.alpha-engine.env` — keeps the contract version-controlled and
+    survives env-file drift or instance rebuilds.
+    """
+    sf_doc = json.loads(_DAILY_SF_PATH.read_text())
+    offenders: list[str] = []
+    for state_name, cmds in _iter_ssm_command_blocks(sf_doc):
+        # Match either `export FLOW_DOCTOR_ENABLED=1` or
+        # `FLOW_DOCTOR_ENABLED=1 ...` syntax; both achieve the same
+        # effect in a RunShellScript invocation.
+        has_flag = any(
+            "FLOW_DOCTOR_ENABLED=1" in c for c in cmds
+        )
+        if not has_flag:
+            offenders.append(state_name)
+    assert not offenders, (
+        f"{_DAILY_SF_PATH.name}: SSM command blocks missing "
+        f"`FLOW_DOCTOR_ENABLED=1`:\n  - " + "\n  - ".join(offenders) + "\n\n"
+        "Add `\"export FLOW_DOCTOR_ENABLED=1\"` to each `commands` array. "
+        "See 2026-05-11 incident — flow-doctor silently skipped because "
+        "setup_logging's env-var gate falls through to 'disabled'."
     )


### PR DESCRIPTION
## Summary

- Add `"export FLOW_DOCTOR_ENABLED=1"` as the second line of every SSM `RunShellScript` block in `step_function_daily.json` (right after `set -eo pipefail` from #209): `CheckTradingDay`, `MorningEnrich`, `RunMorningPlanner`, `RunDaemon`.
- Extend `test_sf_ssm_pipefail_wiring.py` with `test_weekday_sf_ssm_blocks_export_flow_doctor_enabled` to pin the flag in every command array.

## Why

`alpha_engine_lib.logging.setup_logging` only attaches `FlowDoctorHandler` when `FLOW_DOCTOR_ENABLED=1` is set in env (lib `logging.py:138`). Otherwise ERROR-level logs go only to stdout — never entering flow-doctor's dispatch pipeline (email + GitHub issue + S3 changelog).

I just confirmed via SSM that the trading instance's `/home/ec2-user/.alpha-engine.env` has `ANTHROPIC_API_KEY` + `FLOW_DOCTOR_GITHUB_TOKEN` but **does NOT have `FLOW_DOCTOR_ENABLED`**.

### Regression timeline

`FLOW_DOCTOR_ENABLED=1` was originally injected by two systemd units:
- `alpha-engine/infrastructure/systemd/alpha-engine-morning.service:19`
- `alpha-engine/infrastructure/systemd/alpha-engine-daemon.service:22`

Both via `Environment=FLOW_DOCTOR_ENABLED=1`.

Per `alpha-engine/CLAUDE.md` these units were **disabled on 2026-05-05** when the morning planner + daemon migrated from boot-triggered systemd to SF-triggered SSM. The `alpha-engine-daemon` unit is still systemd-managed (the SF does `systemctl restart`), so the daemon process inherits `FLOW_DOCTOR_ENABLED=1` ✓. But MorningEnrich + RunMorningPlanner became direct SSM `RunShellScript` commands that only `source .alpha-engine.env`, and the env file never gained the flag ✗.

### Smoking gun

On 2026-05-11 MorningEnrich emitted two ERROR-level logs from `weekly_collector`:
1. `"Pre-MorningEnrich constituents refresh failed"` (RuntimeError sector-mapping-incomplete traceback)
2. `"Weekly collection finished with non-ok status=failed — exiting 1 to halt the pipeline. Per-collector statuses: {'constituents_preflight': 'error'}"`

Neither fired flow-doctor. Zero flow-doctor entries exist in the 624-entry S3 changelog corpus since the s3 sink was wired ~2026-05-01 — same regression hiding the past ~2 weeks of silent MorningEnrich failures.

## Test plan

- [x] `pytest tests/test_sf_ssm_pipefail_wiring.py` — 4/4 pass (3 existing + 1 new)
- [x] Full suite: `pytest tests/` — 715 passed, 1 skipped
- [x] JSON syntax verified

## Stacked on #209

This PR's diff is on top of #209 (`set -eo pipefail`). If #209 merges first, this rebases cleanly. Both touch the same SF JSON and the same wiring test file. **Recommended merge order: #207 → #208 → #209 → this PR (#210).**

## Scope deliberately narrow

Saturday + EOD SF SSM command arrays NOT modified here. Those run on different instances (Saturday spot, dashboard) where module-side flow-doctor wiring may not be uniformly present — setting `FLOW_DOCTOR_ENABLED=1` for a module whose `setup_logging` call doesn't pass `flow_doctor_yaml` raises `RuntimeError` at startup. A separate audit PR can extend coverage once each module's setup_logging call site is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)