### PR TITLE
perf(provenance): categorical dtype for source column (~108MB memory reduction)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -38,6 +38,7 @@ from features.feature_engineer import (
 )
 from features.compute import (
     DEFAULT_BUCKET,
+    SOURCE_CATEGORIES,
     _SKIP_TICKERS,
     _apply_daily_delta,
     _is_sector_etf,
@@ -45,6 +46,7 @@ from features.compute import (
     _load_sector_map,
     _load_cached_fundamentals,
     _load_cached_alternative,
+    make_source_series,
 )
 from store.arctic_store import get_universe_lib, get_macro_lib
 
@@ -560,7 +562,13 @@ def backfill(
             # still the yfinance baseline if the delta loader hasn't
             # tagged it).
             if PROVENANCE_COL not in featured_df.columns:
-                featured_df[PROVENANCE_COL] = "yfinance"
+                # Default-fill as categorical to keep per-ticker memory
+                # ~50x smaller than object dtype (~125KB → ~2.5KB per
+                # 10y series). Saturday backfill rewrites 900 tickers
+                # universe-wide; the savings is ~108MB peak.
+                featured_df[PROVENANCE_COL] = make_source_series(
+                    ["yfinance"] * len(featured_df), index=featured_df.index,
+                )
 
             keep_cols = (
                 [c for c in OHLCV_COLS if c in featured_df.columns]

--- a/features/compute.py
+++ b/features/compute.py
@@ -50,6 +50,34 @@ FEATURE_STORE_PREFIX = "features/"
 # Large-move warning threshold (>45% daily return, e.g. stock splits, VIX spikes)
 _SPLIT_RETURN_THRESHOLD = 0.45
 
+# Closed-set of provenance source values written to the `source` column on
+# universe rows. Stored as a pandas Categorical so the in-memory cost is
+# ~1 byte per row (category code) instead of ~50 bytes per row (object
+# string pointer). On a full-universe pass through ``_apply_daily_delta``
+# (900 tickers × 2500 rows of 10y history each) the savings is ~108MB
+# peak resident memory — material on the 2GB t3.small trading instance
+# where daily_append sits alongside SSM agent + IB Gateway + (any
+# transient daemon restarts) and OOM is a real constraint. Order is
+# stable so the category codes don't shift between writers; "unknown"
+# anchors the unset / pre-migration case.
+SOURCE_CATEGORIES: tuple[str, ...] = ("polygon", "yfinance", "fred", "unknown")
+
+
+def make_source_series(values: list[str] | pd.Series, index: pd.Index | None = None) -> pd.Series:
+    """Build a categorical Series for the ``source`` provenance column.
+
+    Use this instead of `pd.Series(["yfinance"] * n)` or
+    `df["source"] = "yfinance"` anywhere the assignment covers a full-
+    history slice. Values outside SOURCE_CATEGORIES are coerced to
+    "unknown" rather than added to the category — keeps the category
+    set fixed across all writers so downstream readers can rely on it.
+    """
+    if isinstance(values, pd.Series):
+        values = values.astype(str).tolist()
+    cleaned = [v if v in SOURCE_CATEGORIES else "unknown" for v in values]
+    cat = pd.Categorical(cleaned, categories=SOURCE_CATEGORIES)
+    return pd.Series(cat, index=index)
+
 # Rows to keep per ticker before feature computation. The longest rolling
 # window is 252 rows (52w high/low); 280 provides a small buffer. Trimming
 # before the compute loop cuts base memory ~44% vs the full 2y slim cache
@@ -229,8 +257,11 @@ def _apply_daily_delta(
         # Tag pre-delta rows as yfinance-origin (price_cache parquets are
         # yfinance-sourced) so the merged frame carries provenance per
         # row. Delta rows below override this on overlap via dedup
-        # keep="last".
-        base["source"] = "yfinance"
+        # keep="last". Categorical dtype (vs object/string) cuts the
+        # per-ticker memory of this column from ~125KB to ~2.5KB — across
+        # 900 tickers that's ~108MB less peak resident memory on the
+        # universe-wide pass.
+        base["source"] = make_source_series(["yfinance"] * len(base), index=base.index)
 
         delta = ticker_rows.get(ticker, [])
         if not delta:
@@ -240,13 +271,13 @@ def _apply_daily_delta(
         # Build delta DataFrame with capitalized columns (matches slim cache schema)
         delta_df = pd.DataFrame(
             [
-                {
-                    **{k: r[k] for k in ["Open", "High", "Low", "Close", "Volume"]},
-                    "source": r.get("source", "unknown"),
-                }
+                {k: r[k] for k in ["Open", "High", "Low", "Close", "Volume"]}
                 for r in delta
             ],
             index=pd.DatetimeIndex([r["date"] for r in delta]),
+        )
+        delta_df["source"] = make_source_series(
+            [r.get("source", "unknown") for r in delta], index=delta_df.index,
         )
 
         combined = pd.concat([base, delta_df])

--- a/tests/test_provenance_source_column.py
+++ b/tests/test_provenance_source_column.py
@@ -243,6 +243,97 @@ def test_apply_daily_delta_tags_pre_delta_yfinance_and_delta_from_parquet():
     assert pd.Timestamp("2026-05-08") in polygon_dates
 
 
+def test_source_categories_constant_is_closed_set():
+    """``SOURCE_CATEGORIES`` is the closed set of values writers may assign
+    to the ``source`` column. Pinned so a writer that adds a new source
+    type (e.g. polygon flat-files) updates the categorical first instead
+    of falling through to ``"unknown"`` silently."""
+    from features.compute import SOURCE_CATEGORIES
+
+    assert SOURCE_CATEGORIES == ("polygon", "yfinance", "fred", "unknown")
+
+
+def test_make_source_series_returns_categorical_dtype():
+    """The helper must build a Categorical so callers don't accidentally
+    end up with object dtype on full-history assignments. Categorical
+    dtype is the load-bearing optimization (~50x memory reduction per
+    column on a 10y series) that makes daily_append + backfill fit on
+    a 2GB t3.small alongside daemon + IB Gateway."""
+    from features.compute import SOURCE_CATEGORIES, make_source_series
+
+    index = pd.bdate_range("2026-01-01", periods=100)
+    out = make_source_series(["yfinance"] * 100, index=index)
+    assert isinstance(out.dtype, pd.CategoricalDtype)
+    assert tuple(out.cat.categories) == SOURCE_CATEGORIES
+    assert (out == "yfinance").all()
+
+
+def test_make_source_series_coerces_unknown_values_to_unknown_category():
+    """Values not in SOURCE_CATEGORIES are remapped to "unknown" rather
+    than expanding the category set. Guarantees a fixed category code
+    space across writers — downstream readers can rely on the codes."""
+    from features.compute import SOURCE_CATEGORIES, make_source_series
+
+    out = make_source_series(["polygon", "garbage", "yfinance", "made-up"])
+    assert tuple(out.cat.categories) == SOURCE_CATEGORIES
+    assert list(out) == ["polygon", "unknown", "yfinance", "unknown"]
+
+
+def test_apply_daily_delta_produces_categorical_source_column():
+    """The biggest memory consumer: ``base["source"] = "yfinance"`` on a
+    2500-row 10y series × 900 tickers. The categorical dtype keeps the
+    per-ticker column size at ~2.5KB instead of ~125KB. Pin the dtype
+    so a future refactor that strips the categorical doesn't silently
+    regress peak memory by ~108MB on the universe-wide pass."""
+    from features.compute import _apply_daily_delta
+
+    price_data = {
+        "SPY": pd.DataFrame(
+            {
+                "Open": np.arange(100.0, 110.0),
+                "High": np.arange(101.0, 111.0),
+                "Low": np.arange(99.0, 109.0),
+                "Close": np.arange(100.5, 110.5),
+                "Volume": [1_000_000] * 10,
+            },
+            # Cache ends 2026-05-06; delta range will be 5/7 + 5/8 + 5/11.
+            index=pd.bdate_range(end="2026-05-06", periods=10),
+        ),
+    }
+    s3 = MagicMock()
+
+    class _NoSuchKey(Exception):
+        pass
+
+    s3.exceptions.NoSuchKey = _NoSuchKey
+
+    delta_5_7 = pd.DataFrame(
+        {
+            "Open": [110.0], "High": [111.0], "Low": [109.0],
+            "Close": [110.5], "Volume": [1_500_000], "source": ["polygon"],
+        },
+        index=["SPY"],
+    )
+    delta_5_7.index.name = "ticker"
+
+    def _get_object(Bucket, Key):
+        if Key == "staging/daily_closes/2026-05-07.parquet":
+            buf = io.BytesIO()
+            delta_5_7.to_parquet(buf, engine="pyarrow")
+            buf.seek(0)
+            return {"Body": MagicMock(read=lambda: buf.read())}
+        raise _NoSuchKey(Key)
+
+    s3.get_object.side_effect = _get_object
+
+    out, _ = _apply_daily_delta(s3, "test-bucket", "2026-05-08", price_data)
+    assert "source" in out["SPY"].columns
+    assert isinstance(out["SPY"]["source"].dtype, pd.CategoricalDtype)
+    # Verify both pre-delta yfinance rows and delta polygon row carry through
+    assert (out["SPY"]["source"] == "yfinance").sum() == 10
+    assert (out["SPY"]["source"] == "polygon").sum() == 1
+
+
 def test_apply_daily_delta_no_delta_files_keeps_yfinance_default():
     """When no delta files exist (e.g. the cache is current), pre-delta
     rows still get the ``yfinance`` provenance tag — the merged frame


### PR DESCRIPTION
## Summary

- Convert the `source` provenance column from object/string dtype to pandas Categorical with a closed-set 4-value category space (`polygon`, `yfinance`, `fred`, `unknown`).
- Add `SOURCE_CATEGORIES` constant + `make_source_series()` helper in `features/compute.py`.
- Apply at the three high-volume sites: `_apply_daily_delta`'s `base["source"]` + `delta_df["source"]`, and `backfill._build_symbol_df`'s default-fill.

## Why

PR #196's per-row source column (object dtype) bloats memory ~125KB per ticker on the full-history universe pass — across 900 tickers that's ~110MB. Categorical dtype with the closed-set categories cuts it to ~1 byte per row (category code) + ~50 bytes per series (category metadata), so ~2.5KB per ticker / ~2MB universe-wide. **~108MB saved.**

This was a contributing factor in the 2026-05-11 MorningEnrich OOM on the t3.small trading instance: daily_append's working set ran ~1GB, +~110MB from the new object-dtype source columns in `_apply_daily_delta`, alongside a crash-looping daemon (~200-300MB transient × 38s churn from flow-doctor s3-notifier ConfigError, addressed separately in alpha-engine#151) on a 2GB box. Both contributors needed addressing; this PR closes the source-column half.

`make_source_series` coerces values outside the category set to `"unknown"` rather than expanding the categories, keeping codes stable across writers so downstream readers can rely on them.

Categorical dtype is preserved through ArcticDB write/read, so storage savings carry forward to the predictor's read path too — though the load-bearing benefit is in-memory during the write pass on the t3.small.

## Test plan

- [x] `pytest tests/test_provenance_source_column.py` — 12/12 pass (8 existing + 4 new)
- [x] Full suite: `pytest tests/` — 728 passed, 1 skipped
- [ ] Post-merge on EC2: re-run MorningEnrich, observe peak memory via `free -m` mid-run (expect <1.5GB used vs prior ~1.9GB+)

## Composes with

- alpha-engine#151 — daemon flow-doctor crash-loop fix (stops the 200-300MB transient churn). Both must ship for the t3.small to stay viable.
- (Next PR) chunked daily_append universe loop with explicit gc.collect() between batches — defense-in-depth memory cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)