### PR TITLE
feat(infra): spot-instance orphan prevention — watchdog completion + reaper Lambda

### DIFF
--- a/infrastructure/lambdas/spot-orphan-reaper/README.md
+++ b/infrastructure/lambdas/spot-orphan-reaper/README.md
@@ -1,0 +1,73 @@
+# alpha-engine-spot-orphan-reaper
+
+Hourly backstop Lambda that terminates orphan `alpha-engine-*` tagged spot
+instances. Backs up the spot-side `systemd-run` watchdog installed by each
+of the four spot launcher scripts:
+
+| Launcher                              | Tag prefix                  | Budget (s) |
+|---------------------------------------|-----------------------------|-----------:|
+| `spot_data_weekly.sh`                 | `alpha-engine-data-weekly-` |       5400 |
+| `spot_drift_detection.sh`             | `alpha-engine-drift-`       |       1800 |
+| `spot_train.sh` (predictor)           | `alpha-engine-gbm-train-`   |       5400 |
+| `spot_backtest.sh`                    | `alpha-engine-backtest-`    |       7200 |
+
+Plus a default `7200` budget for unrecognised `alpha-engine-*` tags so a new
+launcher added without updating the table fails safe.
+
+Each tagged instance whose `LaunchTime` is older than `(budget + 1800s grace)`
+is terminated. The grace buffer (default 30 minutes via `GRACE_SECONDS`)
+covers the gap between launcher MAX_RUNTIME_SECONDS and the reaper's
+hourly cron firing cadence — workloads that legitimately push their budget
+get one extra hour before the reaper fires.
+
+## Defense in depth
+
+The reaper is **Layer 2** of the orphan-prevention stack. Layers:
+
+1. **Spot-side watchdog** (in each launcher): `systemd-run --on-active=$MAX_RUNTIME_SECONDS` fires `shutdown -h now`. Combined with `InstanceInitiatedShutdownBehavior=terminate` (also set by each launcher) this terminates the instance. Fires regardless of dispatcher state.
+2. **This Lambda**: hourly scan + termination for the case where the watchdog itself never installed (dispatcher SSM cancelled before reaching the `systemd-run` step, package manager interrupted bootstrap, AMI issue, etc.).
+3. **CloudWatch billing alarm** (`AlphaEngine-Monthly` budget, $50/month): catches anything the other two missed and signals via SNS.
+
+## CloudWatch metric
+
+`AlphaEngine/Infra/spot_orphans_terminated` (Count, sum) with `tag_prefix`
+dimension. Zero is the expected steady-state; any non-zero value is a
+process-quality signal worth investigating (most likely cause: a launcher
+shipped without the watchdog install step, or the budget table here is
+stale).
+
+## Deploying
+
+```bash
+# First-time: create role, policy, Lambda, EventBridge rule + permission
+bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --bootstrap
+
+# Subsequent code-only updates
+bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+
+# Smoke (flips DRY_RUN=true, invokes once, prints scan output, flips back)
+bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --smoke
+
+# Dry-run the deploy itself
+bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --dry-run
+```
+
+Managed outside CloudFormation by deliberate choice — same rationale as
+the `changelog-cloudwatch-mirror` Lambda: this function has destructive
+`ec2:TerminateInstances` permission so the `github-actions-lambda-deploy`
+OIDC role's blast radius stays narrow.
+
+## IAM
+
+The role's inline policy (`iam-policy.json`):
+
+- `ec2:DescribeInstances *` — global read for the scan
+- `ec2:TerminateInstances` scoped to instances with `tag:Name` matching `alpha-engine-*` — defence in depth so even with a buggy reaper run it cannot terminate anything outside the alpha-engine tag prefix
+- `cloudwatch:PutMetricData` scoped to namespace `AlphaEngine/Infra`
+- Standard Lambda logging perms
+
+## Updating budgets
+
+When a launcher's `MAX_RUNTIME_SECONDS` default changes, update the
+`TAG_BUDGETS` dict in `index.py` in the same commit. Out-of-sync values
+will cause the reaper to terminate live workloads.

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-spot-orphan-reaper Lambda
+# and wire its hourly EventBridge trigger.
+#
+# Backstop for the spot-side watchdog installed by the four spot launcher
+# scripts. Hourly scan terminates any alpha-engine-* tagged spot instance
+# whose age exceeds its per-tag-prefix budget + 30-min grace.
+#
+# Managed outside CloudFormation — same rationale as the
+# changelog-cloudwatch-mirror Lambda (keeps the github-actions-lambda-deploy
+# OIDC role's blast radius narrow; this Lambda has destructive ec2:Terminate
+# permission and should be operator-deployed only).
+#
+# Usage:
+#   bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh             # update code only
+#   bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --bootstrap # first-time create + wire EventBridge
+#   bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --smoke     # invoke once with DRY_RUN=true and print scan output
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-spot-orphan-reaper"
+ROLE_NAME="alpha-engine-spot-orphan-reaper-role"
+POLICY_NAME="alpha-engine-spot-orphan-reaper-policy"
+RULE_NAME="alpha-engine-spot-orphan-reaper-hourly"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler ---------------------------------------------------
+
+python3 -c "
+import ast, sys
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  PKG=$(mktemp -d)
+  trap "rm -rf '$PKG'" EXIT
+  cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+  ZIP="${PKG}/function.zip"
+  (cd "${PKG}" && zip -q "function.zip" index.py)
+  echo "  Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 128 \
+      --environment 'Variables={GRACE_SECONDS=1800,DRY_RUN=false}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  fi
+
+  # EventBridge hourly trigger
+  echo "  Creating EventBridge rule: ${RULE_NAME}"
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --schedule-expression "cron(15 * * * ? *)" \
+    --description "Hourly scan for orphan alpha-engine spot instances" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 2. Update function code (always) -------------------------------------
+
+if ! $BOOTSTRAP; then
+  PKG=$(mktemp -d)
+  trap "rm -rf '$PKG'" EXIT
+  cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+  ZIP="${PKG}/function.zip"
+  (cd "${PKG}" && zip -q "function.zip" index.py)
+  echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+  echo "Updating Lambda function code: ${FUNCTION_NAME}"
+  run aws lambda update-function-code \
+    --function-name "${FUNCTION_NAME}" \
+    --zip-file "fileb://${ZIP}" \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text
+
+  if ! $DRY_RUN; then
+    aws lambda wait function-updated \
+      --function-name "${FUNCTION_NAME}" \
+      --region "${REGION}"
+  fi
+fi
+
+echo "✓ Code deployed."
+
+# ----- 3. Smoke (dry-run scan) ----------------------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (DRY_RUN override)..."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  # Override DRY_RUN at the env layer for the smoke invoke
+  aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment 'Variables={GRACE_SECONDS=1800,DRY_RUN=true}' \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text > /dev/null
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{}' \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+
+  # Restore production DRY_RUN=false
+  aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment 'Variables={GRACE_SECONDS=1800,DRY_RUN=false}' \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text > /dev/null
+fi

--- a/infrastructure/lambdas/spot-orphan-reaper/iam-policy.json
+++ b/infrastructure/lambdas/spot-orphan-reaper/iam-policy.json
@@ -1,0 +1,43 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DescribeAllInstances",
+      "Effect": "Allow",
+      "Action": "ec2:DescribeInstances",
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateAlphaEngineSpotOnly",
+      "Effect": "Allow",
+      "Action": "ec2:TerminateInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/Name": "alpha-engine-*"
+        }
+      }
+    },
+    {
+      "Sid": "EmitOrphanMetric",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "cloudwatch:namespace": "AlphaEngine/Infra"
+        }
+      }
+    },
+    {
+      "Sid": "LambdaLogging",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/spot-orphan-reaper/index.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/index.py
@@ -1,0 +1,165 @@
+"""alpha-engine-spot-orphan-reaper — terminate orphan alpha-engine spot instances.
+
+Backstop for the spot-side watchdog installed by the four spot launcher
+scripts (data_weekly / drift_detection / train / backtest). The watchdog
+fires `shutdown -h now` after MAX_RUNTIME_SECONDS, which combined with
+`InstanceInitiatedShutdownBehavior=terminate` (also set by the launchers)
+terminates the spot. This Lambda catches the residual case where the
+watchdog itself never installed — dispatcher SSM cancelled before reaching
+the `systemd-run` step, package manager interrupted bootstrap, etc.
+
+Hourly EventBridge cron scans `alpha-engine-*` tagged spot instances. Any
+instance whose `LaunchTime` exceeds the per-tag-prefix budget plus a 30
+minute grace window is terminated. Emits CloudWatch custom metric
+`AlphaEngine/Infra/spot_orphans_terminated` (sum) with `tag_prefix`
+dimension for trend observation.
+
+Budgets mirror MAX_RUNTIME_SECONDS in each launcher; grace covers the
+gap between launcher budget and reaper firing cadence.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+GRACE_SECONDS = int(os.environ.get("GRACE_SECONDS", "1800"))
+DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
+
+# Tag-prefix → MAX_RUNTIME_SECONDS. Must stay in lockstep with the launcher
+# scripts' MAX_RUNTIME_SECONDS defaults; if a launcher's budget changes
+# without updating this table the orphan reaper will terminate live workloads.
+TAG_BUDGETS: dict[str, int] = {
+    "alpha-engine-data-weekly-": 5400,    # spot_data_weekly.sh
+    "alpha-engine-drift-": 1800,          # spot_drift_detection.sh
+    "alpha-engine-gbm-train-": 5400,      # spot_train.sh
+    "alpha-engine-backtest-": 7200,       # spot_backtest.sh
+}
+DEFAULT_BUDGET_SECONDS = 7200  # for unrecognised alpha-engine-* tags
+
+
+def _budget_for_name(name: str) -> int:
+    """Return the runtime budget for a spot tagged with this Name value."""
+    for prefix, budget in TAG_BUDGETS.items():
+        if name.startswith(prefix):
+            return budget
+    return DEFAULT_BUDGET_SECONDS
+
+
+def _matched_prefix(name: str) -> str:
+    """Return the matched tag prefix, or 'alpha-engine-other-' for the default branch."""
+    for prefix in TAG_BUDGETS:
+        if name.startswith(prefix):
+            return prefix
+    return "alpha-engine-other-"
+
+
+def _scan_spot_instances(ec2) -> list[dict]:
+    """List running alpha-engine-tagged spot instances."""
+    paginator = ec2.get_paginator("describe_instances")
+    out: list[dict] = []
+    for page in paginator.paginate(
+        Filters=[
+            {"Name": "instance-state-name", "Values": ["running"]},
+            {"Name": "instance-lifecycle", "Values": ["spot"]},
+            {"Name": "tag:Name", "Values": ["alpha-engine-*"]},
+        ],
+    ):
+        for reservation in page.get("Reservations", []):
+            for inst in reservation.get("Instances", []):
+                tags = {t["Key"]: t["Value"] for t in inst.get("Tags", [])}
+                out.append({
+                    "instance_id": inst["InstanceId"],
+                    "name": tags.get("Name", ""),
+                    "launch_time": inst["LaunchTime"],
+                    "instance_type": inst.get("InstanceType", ""),
+                })
+    return out
+
+
+def _emit_metric(cw, tag_prefix: str, count: int) -> None:
+    """Emit one CloudWatch metric data point per terminated instance group."""
+    if count == 0:
+        return
+    try:
+        cw.put_metric_data(
+            Namespace="AlphaEngine/Infra",
+            MetricData=[{
+                "MetricName": "spot_orphans_terminated",
+                "Dimensions": [{"Name": "tag_prefix", "Value": tag_prefix}],
+                "Value": float(count),
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:
+        logger.warning("CloudWatch put_metric_data failed for %s: %s", tag_prefix, exc)
+
+
+def handler(event: dict, context) -> dict:
+    """Hourly orphan scan + termination.
+
+    Returns a summary dict for CloudWatch Logs grep + observability.
+    """
+    ec2 = boto3.client("ec2", region_name=REGION)
+    cw = boto3.client("cloudwatch", region_name=REGION)
+    now = datetime.now(timezone.utc)
+
+    instances = _scan_spot_instances(ec2)
+    logger.info("Scanned %d running alpha-engine spot instances", len(instances))
+
+    orphans: list[dict] = []
+    terminated: list[str] = []
+    per_prefix_terminated: dict[str, int] = {}
+
+    for inst in instances:
+        budget = _budget_for_name(inst["name"])
+        threshold = timedelta(seconds=budget + GRACE_SECONDS)
+        age = now - inst["launch_time"]
+        if age <= threshold:
+            continue
+        orphans.append({
+            "instance_id": inst["instance_id"],
+            "name": inst["name"],
+            "age_seconds": int(age.total_seconds()),
+            "budget_seconds": budget,
+            "grace_seconds": GRACE_SECONDS,
+            "instance_type": inst["instance_type"],
+        })
+        prefix = _matched_prefix(inst["name"])
+        if DRY_RUN:
+            logger.warning(
+                "DRY_RUN orphan %s (%s, age=%ds, budget=%ds): would terminate",
+                inst["instance_id"], inst["name"], int(age.total_seconds()), budget,
+            )
+            continue
+        try:
+            ec2.terminate_instances(InstanceIds=[inst["instance_id"]])
+            terminated.append(inst["instance_id"])
+            per_prefix_terminated[prefix] = per_prefix_terminated.get(prefix, 0) + 1
+            logger.warning(
+                "Terminated orphan %s (%s, age=%ds, budget=%ds, type=%s)",
+                inst["instance_id"], inst["name"], int(age.total_seconds()),
+                budget, inst["instance_type"],
+            )
+        except Exception as exc:
+            logger.error(
+                "terminate_instances failed for %s: %s", inst["instance_id"], exc,
+            )
+
+    for prefix, count in per_prefix_terminated.items():
+        _emit_metric(cw, prefix, count)
+
+    return {
+        "scanned": len(instances),
+        "orphans_detected": len(orphans),
+        "terminated": terminated,
+        "dry_run": DRY_RUN,
+        "orphan_detail": orphans,
+    }

--- a/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
@@ -1,0 +1,164 @@
+"""Unit tests for the alpha-engine-spot-orphan-reaper Lambda handler.
+
+Mocks boto3 EC2 + CloudWatch clients so tests run without AWS calls.
+Locks the budget table, age-threshold + grace math, dry-run semantics,
+and partial-failure resilience.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the handler module is importable from the test file
+SCRIPT_DIR = Path(__file__).parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+@pytest.fixture
+def index_module(monkeypatch):
+    """Reload the handler module with the test env so module-level vars resolve."""
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("GRACE_SECONDS", "1800")
+    monkeypatch.setenv("DRY_RUN", "false")
+    if "index" in sys.modules:
+        del sys.modules["index"]
+    return importlib.import_module("index")
+
+
+def _spot(instance_id: str, name: str, age_seconds: int, instance_type: str = "c5.large"):
+    """Build a mock describe-instances entry."""
+    return {
+        "InstanceId": instance_id,
+        "InstanceType": instance_type,
+        "Tags": [{"Key": "Name", "Value": name}],
+        "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+    }
+
+
+def _describe_instances_paginator(spots: list[dict]):
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{
+        "Reservations": [{"Instances": spots}],
+    }]
+    return paginator
+
+
+class TestBudgetTable:
+    def test_data_weekly_budget(self, index_module):
+        assert index_module._budget_for_name("alpha-engine-data-weekly-20260511") == 5400
+
+    def test_drift_budget(self, index_module):
+        assert index_module._budget_for_name("alpha-engine-drift-20260511") == 1800
+
+    def test_train_budget(self, index_module):
+        assert index_module._budget_for_name("alpha-engine-gbm-train-20260511") == 5400
+
+    def test_backtest_budget(self, index_module):
+        assert index_module._budget_for_name("alpha-engine-backtest-20260511") == 7200
+
+    def test_unknown_falls_to_default(self, index_module):
+        assert index_module._budget_for_name("alpha-engine-mystery-20260511") == 7200
+
+    def test_matched_prefix(self, index_module):
+        assert index_module._matched_prefix("alpha-engine-backtest-20260511") == "alpha-engine-backtest-"
+        assert index_module._matched_prefix("alpha-engine-novel-20260511") == "alpha-engine-other-"
+
+
+class TestHandler:
+    def test_no_orphans_when_all_young(self, index_module):
+        # Both spots are well within budget — none should be terminated.
+        spots = [
+            _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=600),
+            _spot("i-0002", "alpha-engine-data-weekly-20260511", age_seconds=900),
+        ]
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
+        cw = MagicMock()
+
+        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+            out = index_module.handler({}, None)
+
+        assert out["scanned"] == 2
+        assert out["orphans_detected"] == 0
+        assert out["terminated"] == []
+        ec2.terminate_instances.assert_not_called()
+        cw.put_metric_data.assert_not_called()
+
+    def test_terminates_orphan_past_budget_plus_grace(self, index_module):
+        # backtest budget=7200, grace=1800 → threshold 9000s; spot age 10000s → orphan
+        spots = [
+            _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=10000),
+            _spot("i-0002", "alpha-engine-drift-20260511", age_seconds=600),  # young
+        ]
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
+        cw = MagicMock()
+
+        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+            out = index_module.handler({}, None)
+
+        assert out["scanned"] == 2
+        assert out["orphans_detected"] == 1
+        assert out["terminated"] == ["i-0001"]
+        ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-0001"])
+        cw.put_metric_data.assert_called_once()
+
+    def test_grace_buffer_protects_just_over_budget(self, index_module):
+        # backtest budget=7200; spot 7800s old (over budget, within grace) → NOT orphan
+        spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=7800)]
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
+        cw = MagicMock()
+
+        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+            out = index_module.handler({}, None)
+
+        assert out["orphans_detected"] == 0
+        ec2.terminate_instances.assert_not_called()
+
+    def test_dry_run_does_not_terminate(self, monkeypatch):
+        monkeypatch.setenv("DRY_RUN", "true")
+        if "index" in sys.modules:
+            del sys.modules["index"]
+        index_module = importlib.import_module("index")
+
+        spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=10000)]
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
+        cw = MagicMock()
+
+        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+            out = index_module.handler({}, None)
+
+        assert out["dry_run"] is True
+        assert out["orphans_detected"] == 1
+        assert out["terminated"] == []
+        ec2.terminate_instances.assert_not_called()
+
+    def test_terminate_failure_is_logged_but_does_not_crash(self, index_module):
+        spots = [
+            _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=10000),
+            _spot("i-0002", "alpha-engine-backtest-20260511", age_seconds=11000),
+        ]
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
+        # First terminate raises; second succeeds — verify we continue past the first
+        ec2.terminate_instances.side_effect = [
+            Exception("simulated AWS error"),
+            {"TerminatingInstances": [{"InstanceId": "i-0002"}]},
+        ]
+        cw = MagicMock()
+
+        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+            out = index_module.handler({}, None)
+
+        assert out["orphans_detected"] == 2
+        # Only the second succeeds; first's failure does not abort the loop
+        assert out["terminated"] == ["i-0002"]
+        assert ec2.terminate_instances.call_count == 2

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -123,6 +123,7 @@ INSTANCE_ID=$(aws ec2 run-instances \
     --subnet-id "$SUBNET_ID" \
     --iam-instance-profile Name="$IAM_PROFILE" \
     --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}' \
+    --instance-initiated-shutdown-behavior terminate \
     --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-data-weekly-$(date +%Y%m%d)}]" \
     --region "$AWS_REGION" \

--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -57,6 +57,11 @@ KEY_FILE="$HOME/.ssh/alpha-engine-key.pem"
 SECURITY_GROUP="sg-03cd3c4bd91e610b0"
 SUBNET_ID="subnet-e07166ec"
 IAM_PROFILE="alpha-engine-executor-profile"
+# Spot-side watchdog budget: DriftDetection workload is ~5 min; 30 min
+# of headroom covers pip install + preflight + retries. If the workload
+# legitimately needs longer, bump this — don't silently rely on the
+# orphan reaper.
+MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-1800}"
 
 RUN_MODE="full"
 while [[ $# -gt 0 ]]; do
@@ -93,6 +98,7 @@ INSTANCE_ID=$(aws ec2 run-instances \
     --subnet-id "$SUBNET_ID" \
     --iam-instance-profile Name="$IAM_PROFILE" \
     --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}' \
+    --instance-initiated-shutdown-behavior terminate \
     --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-drift-$(date +%Y%m%d)}]" \
     --region "$AWS_REGION" \
@@ -143,6 +149,18 @@ done
 run_remote() {
     ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "$@"
 }
+
+# ── Spot-side watchdog ──────────────────────────────────────────────────────
+# Dispatcher-side `trap cleanup EXIT` only fires when THIS bash script
+# exits cleanly. If the dispatcher SSM command is cancelled, the
+# dispatcher EC2 is stopped mid-run, or the shell gets SIGKILLed, the
+# trap never runs and the spot orphans until manually terminated.
+# Installs a transient systemd timer on the spot that fires
+# shutdown -h now after MAX_RUNTIME_SECONDS regardless of dispatcher
+# state. AL2023's InstanceInitiatedShutdownBehavior=terminate makes
+# the shutdown a termination (matches run-instances flag above).
+echo "==> Installing spot-side watchdog (${MAX_RUNTIME_SECONDS}s = $((MAX_RUNTIME_SECONDS / 60)) min)..."
+run_remote "sudo systemd-run --on-active=${MAX_RUNTIME_SECONDS} --unit=alpha-engine-watchdog --description='alpha-engine spot hard-timeout' /sbin/shutdown -h now"
 
 # ── Bootstrap python + git ───────────────────────────────────────────────────
 echo "==> Bootstrapping spot environment..."


### PR DESCRIPTION
## Summary
Three-layer fix for L2911 spot-instance orphans (the dispatcher-trap-doesn't-fire class that lost ~\$20 to a 14-day gbm-train orphan in April 2026).

### Layer 1 completion (this PR)
- **spot_drift_detection.sh**: adds the systemd-run watchdog + 1800s MAX_RUNTIME_SECONDS (the missing 4th launcher — the other three got watchdogs 2026-04-17)
- **All four launchers** (data_weekly, drift_detection plus companion predictor / backtester PRs): \`--instance-initiated-shutdown-behavior terminate\` on \`run-instances\` so a watchdog \`shutdown -h now\` terminates rather than stops, regardless of AWS spot defaults

### Layer 2 (this PR)
New hourly Lambda \`alpha-engine-spot-orphan-reaper\` under \`infrastructure/lambdas/spot-orphan-reaper/\`:
- EventBridge \`cron(15 * * * ? *)\` scans running \`alpha-engine-*\` tagged spots
- Terminates any whose age exceeds per-tag-prefix budget + 30-min grace
- Per-tag budgets mirror each launcher's MAX_RUNTIME_SECONDS (5400 / 1800 / 5400 / 7200) with a 7200s default for unrecognised tags
- IAM scoped via \`ec2:ResourceTag/Name\` condition — destructive permission cannot reach non-alpha-engine instances
- Emits CW metric \`AlphaEngine/Infra/spot_orphans_terminated\` by tag_prefix (non-zero is a process-quality signal)
- Managed outside CloudFormation (mirrors changelog-cloudwatch-mirror — keeps OIDC role's blast radius narrow)
- 11 unit tests with mocked boto3 covering budget table, grace math, dry-run semantics, partial-failure resilience

### Layer 3 already present
\`AlphaEngine-Monthly\` \$50 budget alarm catches anything Layers 1+2 miss.

## Companion PRs
- alpha-engine-predictor \`feat/spot-orphan-prevention\` — \`InstanceInitiatedShutdownBehavior=terminate\` on spot_train.sh
- alpha-engine-backtester \`feat/spot-orphan-prevention\` — same on spot_backtest.sh

## Test plan
- [x] 11 mocked-boto3 unit tests pass (\`python -m pytest infrastructure/lambdas/spot-orphan-reaper/test_handler.py\`)
- [x] Bash syntax validation in deploy.sh runs at deploy time
- [ ] First-time deploy: \`bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --bootstrap\` (operator step)
- [ ] Smoke: \`bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --smoke\` — confirms DRY_RUN scan succeeds against live AWS, returns scan count
- [ ] First hourly firing emits \`scanned=N orphans_detected=0 terminated=[]\` (steady state)
- [ ] Companion launcher PRs merged on alpha-engine-predictor and alpha-engine-backtester

🤖 Generated with [Claude Code](https://claude.com/claude-code)