### PR TITLE
feat(daily_append): wire price_validator into canonical write path with severity gating (ROADMAP L940)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -48,6 +48,11 @@ from arcticdb_ext.version_store import DataError
 
 from store.arctic_store import get_universe_lib, get_macro_lib
 from store.parquet_loader import load_parquet_from_s3
+from validators.price_validator import (
+    ALL_ANOMALY_TYPES,
+    DEFAULT_BLOCK_ANOMALY_TYPES,
+    validate_today_row,
+)
 
 log = logging.getLogger(__name__)
 
@@ -213,6 +218,82 @@ def _emit_missing_from_closes_metric(count: int) -> None:
 UNIVERSE_FRESHNESS_RECEIPT_KEY = "health/universe_freshness.json"
 UNIVERSE_FRESHNESS_MAX_STALE_DAYS = 5
 _UNIVERSE_SCAN_WORKERS = 20
+
+
+def _load_block_anomaly_types() -> frozenset[str]:
+    """Read ``DAILY_APPEND_BLOCK_ANOMALY_TYPES`` env var or fall back to defaults.
+
+    Format: JSON list of anomaly type strings, e.g. ``'["bad_ohlc",
+    "negative_or_zero_close", "extreme_daily_move"]'``. Unknown types
+    raise — silent typo would let bad rows through. Empty/unset uses the
+    conservative default set (only definitely-bad rows block).
+    """
+    raw = os.environ.get("DAILY_APPEND_BLOCK_ANOMALY_TYPES", "").strip()
+    if not raw:
+        return DEFAULT_BLOCK_ANOMALY_TYPES
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"DAILY_APPEND_BLOCK_ANOMALY_TYPES is not valid JSON: {exc}. "
+            f"Expected a JSON list of anomaly type strings."
+        ) from exc
+    if not isinstance(parsed, list) or not all(isinstance(x, str) for x in parsed):
+        raise RuntimeError(
+            f"DAILY_APPEND_BLOCK_ANOMALY_TYPES must be a JSON list of strings, "
+            f"got {parsed!r}"
+        )
+    unknown = set(parsed) - ALL_ANOMALY_TYPES
+    if unknown:
+        raise RuntimeError(
+            f"DAILY_APPEND_BLOCK_ANOMALY_TYPES contains unknown anomaly types: "
+            f"{sorted(unknown)}. Known types: {sorted(ALL_ANOMALY_TYPES)}"
+        )
+    return frozenset(parsed)
+
+
+def _emit_quality_gate_metrics(
+    counts_by_type: dict[str, int], n_blocked: int, n_warned: int
+) -> None:
+    """Emit ``AlphaEngine/Data/daily_append_quality_*`` gauges.
+
+    Best-effort: CloudWatch errors WARN but don't fail the pipeline — the
+    per-anomaly logger.error calls above are the load-bearing Flow Doctor
+    surface; the metric catches slow drift so a chronic 1-2-ticker-per-day
+    anomaly stream surfaces before it cumulates into a regression.
+    Mirrors ``_emit_missing_from_closes_metric``.
+    """
+    if not counts_by_type and n_blocked == 0 and n_warned == 0:
+        return
+    try:
+        cw = boto3.client("cloudwatch")
+        metric_data: list[dict] = [
+            {
+                "MetricName": "daily_append_quality_blocked_count",
+                "Value": float(n_blocked),
+                "Unit": "Count",
+            },
+            {
+                "MetricName": "daily_append_quality_warned_count",
+                "Value": float(n_warned),
+                "Unit": "Count",
+            },
+        ]
+        for atype, count in counts_by_type.items():
+            metric_data.append({
+                "MetricName": "daily_append_quality_anomaly_count",
+                "Dimensions": [{"Name": "anomaly_type", "Value": atype}],
+                "Value": float(count),
+                "Unit": "Count",
+            })
+        cw.put_metric_data(Namespace="AlphaEngine/Data", MetricData=metric_data)
+    except Exception as exc:
+        log.warning(
+            "CloudWatch daily_append_quality_* metric failed: %s. "
+            "Not blocking daily_append — the per-anomaly logger.error calls "
+            "above are the load-bearing Flow Doctor surface.",
+            exc,
+        )
 
 
 def _scan_universe_and_emit_freshness_receipt(
@@ -818,6 +899,13 @@ def daily_append(
     n_err = 0             # ArcticDB read failures
     n_partial = 0         # rows written with ≥1 NaN feature (short-history, etc.)
     n_parquet_warmup = 0  # rows whose feature compute used parquet-enriched context
+    n_quality_blocked = 0  # rows refused by validate_today_row (block severity)
+    n_quality_warned = 0   # rows written but flagged by validate_today_row (warn)
+    quality_counts_by_type: dict[str, int] = {}
+
+    # Read DAILY_APPEND_BLOCK_ANOMALY_TYPES once per run (raises on malformed
+    # JSON / unknown types — fail fast before the chunked pass begins).
+    block_anomaly_types = _load_block_anomaly_types()
 
     # ── 4. Chunked universe pass ─────────────────────────────────────────────
     # The full-universe Phase 1+2 in one shot holds ~900 ticker histories in
@@ -1077,6 +1165,45 @@ def daily_append(
 
                 today_row.index.name = "date"
 
+                # ── Write-time quality gate ──────────────────────────────
+                # Runs after today_row is fully shaped (OHLCV + features +
+                # provenance + dtypes aligned) but before the row is queued
+                # for batch write. Two outcomes: block (skip queue + log
+                # error so Flow Doctor surfaces) or warn (queue write +
+                # log warning + count). DEFAULT_BLOCK_ANOMALY_TYPES
+                # blocks only definitely-bad rows (High<Low, Close<=0);
+                # operators can upgrade types via the
+                # DAILY_APPEND_BLOCK_ANOMALY_TYPES env var.
+                qg = validate_today_row(today_row, hist, ticker)
+                blocking_anomalies = [
+                    a for a in qg["anomalies"] if a["type"] in block_anomaly_types
+                ]
+                if blocking_anomalies:
+                    for a in blocking_anomalies:
+                        # logger.error so the FlowDoctorHandler picks this
+                        # up — return-dicts are invisible to it per
+                        # feedback_collector_return_dict_invisible_to_flow_doctor.
+                        log.error(
+                            "Quality gate BLOCK %s.%s: %s",
+                            ticker, a["type"], a["detail"],
+                        )
+                        quality_counts_by_type[a["type"]] = (
+                            quality_counts_by_type.get(a["type"], 0) + 1
+                        )
+                    n_quality_blocked += 1
+                    continue  # do not queue this row for write
+                if qg["anomalies"]:
+                    # All anomalies present but none blocking — warn-only.
+                    for a in qg["anomalies"]:
+                        log.warning(
+                            "Quality gate WARN %s.%s: %s",
+                            ticker, a["type"], a["detail"],
+                        )
+                        quality_counts_by_type[a["type"]] = (
+                            quality_counts_by_type.get(a["type"], 0) + 1
+                        )
+                    n_quality_warned += 1
+
                 # Defer the actual ArcticDB write — collected here so Phase 2
                 # can run them in parallel via a thread pool. The previous
                 # sequential per-ticker `_write_row_backfill_safe` call took
@@ -1194,6 +1321,10 @@ def daily_append(
         "tickers_errored": n_err,
         "tickers_parquet_warmup": n_parquet_warmup,
         "tickers_missing_from_closes": n_missing_from_closes,
+        "tickers_quality_blocked": n_quality_blocked,
+        "tickers_quality_warned": n_quality_warned,
+        "quality_anomaly_counts": dict(quality_counts_by_type),
+        "quality_block_anomaly_types": sorted(block_anomaly_types),
         "load_seconds": round(t_load, 1),
         "total_seconds": round(t_total, 1),
         "dry_run": dry_run,
@@ -1201,14 +1332,21 @@ def daily_append(
 
     log.info(
         "ArcticDB daily_append: stocks n_ok=%d n_partial=%d n_skip=%d n_err=%d "
-        "n_parquet_warmup=%d n_missing_from_closes=%d (of %d) | "
+        "n_parquet_warmup=%d n_missing_from_closes=%d (of %d) "
+        "quality_blocked=%d quality_warned=%d anomaly_counts=%s | "
         "macro_updated=%d sector_updated=%d | %.1fs total",
         n_ok, n_partial, n_skip, n_err, n_parquet_warmup,
         n_missing_from_closes, len(stock_tickers),
+        n_quality_blocked, n_quality_warned, dict(quality_counts_by_type),
         len(macro_updated) if not dry_run else 0,
         len(sector_updated) if not dry_run else 0,
         t_total,
     )
+
+    if not dry_run:
+        _emit_quality_gate_metrics(
+            quality_counts_by_type, n_quality_blocked, n_quality_warned,
+        )
 
     # Hard-fail on high error rate. ``n_ok == 0`` alone is NOT a failure
     # signal — it correctly occurs when every ticker hit the

--- a/tests/test_daily_append_quality_gates.py
+++ b/tests/test_daily_append_quality_gates.py
@@ -1,0 +1,255 @@
+"""Regression tests for the write-time quality gate in builders/daily_append.py.
+
+Background (ROADMAP L940 "Data quality gates"):
+``validators/price_validator.py`` shipped earlier with thresholds for 50%
+daily moves / 10x volume spikes / OHLC inversions / zero close / zero
+volume, but was wired only into ``collectors/slim_cache.py`` +
+``collectors/prices.py`` as non-blocking observation. The canonical write
+path (``builders/daily_append.py``) had no validation — definitely-bad
+rows (Close<=0, High<Low) could land in ArcticDB and silently pollute
+downstream feature compute + predictor training.
+
+This wave wires ``validate_today_row`` into the per-symbol write_tasks
+loop with per-anomaly-type severity semantics: ``block`` definitely-bad
+rows by default (refuse the queue + log error so Flow Doctor surfaces),
+``warn`` legitimately-rare-but-possible signals (queue write + log
+warning + emit metric). Operators upgrade types to block via
+``DAILY_APPEND_BLOCK_ANOMALY_TYPES``.
+
+Source-text invariants pin the wiring shape; functional cases through
+``_load_block_anomaly_types`` cover the env-var loader.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from validators.price_validator import (
+    ANOMALY_BAD_OHLC,
+    ANOMALY_EXTREME_DAILY_MOVE,
+    ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+    ANOMALY_VOLUME_SPIKE,
+    ANOMALY_ZERO_VOLUME,
+    DEFAULT_BLOCK_ANOMALY_TYPES,
+)
+from builders.daily_append import (
+    _emit_quality_gate_metrics,
+    _load_block_anomaly_types,
+)
+
+
+_DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
+
+
+def _source() -> str:
+    return _DAILY_APPEND.read_text()
+
+
+# ── 1. Source-text invariants ──────────────────────────────────────────────────
+
+
+def test_validator_imported_from_price_validator():
+    """The validator must come from validators.price_validator — divergent
+    re-implementations would let block-set / threshold changes drift."""
+    src = _source()
+    assert "from validators.price_validator import" in src
+    assert "validate_today_row" in src
+    assert "DEFAULT_BLOCK_ANOMALY_TYPES" in src
+    assert "ALL_ANOMALY_TYPES" in src
+
+
+def test_validate_today_row_called_before_write_queue():
+    """The validation call must precede ``write_tasks.append(...)`` — wiring
+    it after the append would let bad rows reach update_batch/write_batch."""
+    src = _source()
+    validate_idx = src.find("validate_today_row(today_row, hist, ticker)")
+    append_idx = src.find("write_tasks.append((ticker, today_row, hist, nan_features))")
+    assert validate_idx > 0
+    assert append_idx > 0
+    assert validate_idx < append_idx, (
+        "validate_today_row must run before write_tasks.append — otherwise "
+        "blocking-severity rows would be queued for write before the gate "
+        "decides to refuse them."
+    )
+
+
+def test_block_path_uses_logger_error_not_warning():
+    """Blocking anomalies must emit logger.error so the FlowDoctorHandler
+    picks them up — per feedback_collector_return_dict_invisible_to_flow_doctor,
+    only logger.error / logger.critical cross the logging boundary."""
+    src = _source()
+    # The block branch must use log.error
+    assert 'log.error(\n                            "Quality gate BLOCK %s.%s: %s"' in src or \
+        'log.error(\n                            "Quality gate BLOCK' in src, (
+            "Block path must call log.error so Flow Doctor surfaces the "
+            "anomaly via SNS / GitHub issue."
+        )
+
+
+def test_block_path_skips_write_via_continue():
+    """The block branch must ``continue`` past write_tasks.append — otherwise
+    refused rows still land in ArcticDB."""
+    src = _source()
+    # The block branch must continue out of the loop iteration
+    assert "n_quality_blocked += 1\n                    continue" in src
+
+
+def test_env_var_loader_present():
+    """DAILY_APPEND_BLOCK_ANOMALY_TYPES must be operator-tunable without
+    a code redeploy — mirrors ALT_MIN_OK_RATIOS in collectors/alternative.py."""
+    src = _source()
+    assert "_load_block_anomaly_types" in src
+    assert "DAILY_APPEND_BLOCK_ANOMALY_TYPES" in src
+    assert "DEFAULT_BLOCK_ANOMALY_TYPES" in src
+
+
+def test_quality_metric_helper_emits_namespace():
+    """CW metric helper must emit under AlphaEngine/Data with the gauge
+    names alarms can target."""
+    src = _source()
+    assert "_emit_quality_gate_metrics" in src
+    assert "AlphaEngine/Data" in src
+    assert "daily_append_quality_blocked_count" in src
+    assert "daily_append_quality_warned_count" in src
+    assert "daily_append_quality_anomaly_count" in src
+    assert "anomaly_type" in src  # CW dimension key for per-type partition
+
+
+def test_result_dict_exposes_quality_counts():
+    """The return dict surfaces per-run quality stats for postflight readers
+    and the Saturday SF completion email."""
+    src = _source()
+    assert '"tickers_quality_blocked": n_quality_blocked' in src
+    assert '"tickers_quality_warned": n_quality_warned' in src
+    assert '"quality_anomaly_counts": dict(quality_counts_by_type)' in src
+    assert '"quality_block_anomaly_types": sorted(block_anomaly_types)' in src
+
+
+def test_metric_emit_called_when_not_dry_run():
+    """The metric emit must be gated on ``not dry_run`` — dry runs shouldn't
+    pollute the production CW namespace."""
+    src = _source()
+    assert "if not dry_run:\n        _emit_quality_gate_metrics(" in src
+
+
+# ── 2. Functional: _load_block_anomaly_types ──────────────────────────────────
+
+
+class TestLoadBlockAnomalyTypes:
+    def test_unset_returns_defaults(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DAILY_APPEND_BLOCK_ANOMALY_TYPES", None)
+            assert _load_block_anomaly_types() == DEFAULT_BLOCK_ANOMALY_TYPES
+
+    def test_empty_string_returns_defaults(self):
+        with patch.dict(os.environ, {"DAILY_APPEND_BLOCK_ANOMALY_TYPES": ""}):
+            assert _load_block_anomaly_types() == DEFAULT_BLOCK_ANOMALY_TYPES
+
+    def test_explicit_empty_list_yields_pure_observability(self):
+        """Setting `[]` flips to pure observability — nothing blocks, all
+        anomalies warn-only. Operator escape hatch for known-noisy days."""
+        with patch.dict(os.environ, {"DAILY_APPEND_BLOCK_ANOMALY_TYPES": "[]"}):
+            assert _load_block_anomaly_types() == frozenset()
+
+    def test_explicit_block_set(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DAILY_APPEND_BLOCK_ANOMALY_TYPES": json.dumps([
+                    ANOMALY_BAD_OHLC, ANOMALY_EXTREME_DAILY_MOVE,
+                ])
+            },
+        ):
+            assert _load_block_anomaly_types() == frozenset({
+                ANOMALY_BAD_OHLC, ANOMALY_EXTREME_DAILY_MOVE,
+            })
+
+    def test_malformed_json_raises(self):
+        with patch.dict(
+            os.environ, {"DAILY_APPEND_BLOCK_ANOMALY_TYPES": "not-json"}
+        ):
+            with pytest.raises(RuntimeError, match="not valid JSON"):
+                _load_block_anomaly_types()
+
+    def test_non_list_raises(self):
+        with patch.dict(
+            os.environ, {"DAILY_APPEND_BLOCK_ANOMALY_TYPES": '{"a": 1}'}
+        ):
+            with pytest.raises(RuntimeError, match="JSON list of strings"):
+                _load_block_anomaly_types()
+
+    def test_non_string_items_raise(self):
+        with patch.dict(
+            os.environ, {"DAILY_APPEND_BLOCK_ANOMALY_TYPES": "[1, 2]"}
+        ):
+            with pytest.raises(RuntimeError, match="JSON list of strings"):
+                _load_block_anomaly_types()
+
+    def test_unknown_anomaly_type_raises(self):
+        with patch.dict(
+            os.environ,
+            {"DAILY_APPEND_BLOCK_ANOMALY_TYPES": '["typo_anomaly"]'},
+        ):
+            with pytest.raises(RuntimeError, match="unknown anomaly types"):
+                _load_block_anomaly_types()
+
+
+# ── 3. Functional: _emit_quality_gate_metrics ─────────────────────────────────
+
+
+class TestEmitQualityGateMetrics:
+    def test_no_op_when_nothing_to_report(self):
+        """Zero counts → no CW call (avoids per-day useless data points)."""
+        with patch("builders.daily_append.boto3") as mock_boto:
+            _emit_quality_gate_metrics({}, 0, 0)
+            mock_boto.client.assert_not_called()
+
+    def test_emits_blocked_and_warned_gauges(self):
+        with patch("builders.daily_append.boto3") as mock_boto:
+            cw = mock_boto.client.return_value
+            _emit_quality_gate_metrics(
+                {ANOMALY_BAD_OHLC: 1, ANOMALY_EXTREME_DAILY_MOVE: 3},
+                n_blocked=1,
+                n_warned=3,
+            )
+            cw.put_metric_data.assert_called_once()
+            call = cw.put_metric_data.call_args
+            assert call.kwargs["Namespace"] == "AlphaEngine/Data"
+            metric_names = {m["MetricName"] for m in call.kwargs["MetricData"]}
+            assert "daily_append_quality_blocked_count" in metric_names
+            assert "daily_append_quality_warned_count" in metric_names
+            assert "daily_append_quality_anomaly_count" in metric_names
+
+    def test_per_type_dimension_present(self):
+        with patch("builders.daily_append.boto3") as mock_boto:
+            cw = mock_boto.client.return_value
+            _emit_quality_gate_metrics(
+                {ANOMALY_VOLUME_SPIKE: 5}, n_blocked=0, n_warned=5,
+            )
+            metric_data = cw.put_metric_data.call_args.kwargs["MetricData"]
+            anomaly_count = next(
+                m for m in metric_data
+                if m["MetricName"] == "daily_append_quality_anomaly_count"
+            )
+            dims = anomaly_count["Dimensions"]
+            assert any(
+                d["Name"] == "anomaly_type" and d["Value"] == ANOMALY_VOLUME_SPIKE
+                for d in dims
+            )
+
+    def test_cloudwatch_failure_swallowed(self):
+        """Pipeline must not fail on CW IAM / network errors — the load-bearing
+        observability surface is the logger.error calls, not the metric."""
+        with patch("builders.daily_append.boto3") as mock_boto:
+            mock_boto.client.return_value.put_metric_data.side_effect = (
+                RuntimeError("CW unavailable")
+            )
+            # Should not raise
+            _emit_quality_gate_metrics(
+                {ANOMALY_BAD_OHLC: 1}, n_blocked=1, n_warned=0,
+            )

--- a/tests/test_price_validator.py
+++ b/tests/test_price_validator.py
@@ -3,7 +3,16 @@
 import pandas as pd
 import pytest
 
-from validators.price_validator import validate_parquet
+from validators.price_validator import (
+    ANOMALY_BAD_OHLC,
+    ANOMALY_EXTREME_DAILY_MOVE,
+    ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+    ANOMALY_VOLUME_SPIKE,
+    ANOMALY_ZERO_VOLUME,
+    DEFAULT_BLOCK_ANOMALY_TYPES,
+    validate_parquet,
+    validate_today_row,
+)
 
 
 def _make_ohlcv(n=30, base_close=100.0):
@@ -88,3 +97,130 @@ class TestValidateParquet:
         result = validate_parquet(df, "MULTI")
         assert result["status"] == "anomaly"
         assert len(result["anomalies"]) >= 2
+
+
+def _make_today_row(
+    close=100.0, high=101.0, low=99.0, volume=1_000_000, vwap=100.0,
+):
+    ts = pd.Timestamp("2026-05-12")
+    return pd.DataFrame(
+        {
+            "Open": [close - 0.1],
+            "High": [high],
+            "Low": [low],
+            "Close": [close],
+            "Volume": [volume],
+            "VWAP": [vwap],
+        },
+        index=pd.DatetimeIndex([ts], name="date"),
+    )
+
+
+class TestValidateTodayRow:
+    def test_clean_row_no_anomalies(self):
+        hist = _make_ohlcv(n=30, base_close=100.0)
+        today = _make_today_row(close=100.0)
+        result = validate_today_row(today, hist, "AAPL")
+        assert result == {"ticker": "AAPL", "anomalies": []}
+
+    def test_empty_today_row(self):
+        result = validate_today_row(pd.DataFrame(), pd.DataFrame(), "EMPTY")
+        assert result == {"ticker": "EMPTY", "anomalies": []}
+
+    def test_bad_ohlc_blocks(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(high=98.0, low=99.0, close=98.5)
+        result = validate_today_row(today, hist, "BADHL")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_BAD_OHLC in types
+        bad_ohlc = next(a for a in result["anomalies"] if a["type"] == ANOMALY_BAD_OHLC)
+        assert bad_ohlc["severity"] == "block"
+
+    def test_zero_close_blocks(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(close=0.0, high=1.0, low=0.0)
+        result = validate_today_row(today, hist, "ZERO")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_NEGATIVE_OR_ZERO_CLOSE in types
+        zero = next(a for a in result["anomalies"] if a["type"] == ANOMALY_NEGATIVE_OR_ZERO_CLOSE)
+        assert zero["severity"] == "block"
+
+    def test_negative_close_blocks(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(close=-5.0, high=1.0, low=-10.0)
+        result = validate_today_row(today, hist, "NEG")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_NEGATIVE_OR_ZERO_CLOSE in types
+
+    def test_extreme_daily_move_warns(self):
+        # hist last close is 100 + 29*0.5 = 114.5 (base_close=100, n=30)
+        hist = _make_ohlcv(n=30, base_close=100.0)
+        prior_close = hist["Close"].iloc[-1]
+        today = _make_today_row(close=prior_close * 1.61)  # +61% move
+        result = validate_today_row(today, hist, "MOVE")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_EXTREME_DAILY_MOVE in types
+        move = next(a for a in result["anomalies"] if a["type"] == ANOMALY_EXTREME_DAILY_MOVE)
+        assert move["severity"] == "warn"
+
+    def test_no_extreme_move_flag_when_hist_empty(self):
+        # First write for a symbol — no prior close to compare against.
+        today = _make_today_row(close=999.0)
+        result = validate_today_row(today, pd.DataFrame(), "NEW")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_EXTREME_DAILY_MOVE not in types
+
+    def test_zero_volume_warns(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(volume=0)
+        result = validate_today_row(today, hist, "NOVOL")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_ZERO_VOLUME in types
+        zv = next(a for a in result["anomalies"] if a["type"] == ANOMALY_ZERO_VOLUME)
+        assert zv["severity"] == "warn"
+
+    def test_volume_spike_warns(self):
+        hist = _make_ohlcv(n=30)
+        median_vol = hist["Volume"].tail(20).median()
+        today = _make_today_row(volume=int(median_vol * 15))
+        result = validate_today_row(today, hist, "VOL")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_VOLUME_SPIKE in types
+
+    def test_volume_spike_skipped_when_hist_too_short(self):
+        # hist <20 rows → no baseline available, skip volume spike check.
+        hist = _make_ohlcv(n=10)
+        today = _make_today_row(volume=999_999_999)
+        result = validate_today_row(today, hist, "SHORT")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_VOLUME_SPIKE not in types
+
+    def test_multiple_anomalies_stack(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(close=0.0, high=0.5, low=0.0, volume=0)
+        result = validate_today_row(today, hist, "MULTI")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_NEGATIVE_OR_ZERO_CLOSE in types
+        assert ANOMALY_ZERO_VOLUME in types
+
+    def test_nan_close_skipped(self):
+        # Upstream-NaN close shouldn't trip the gate — it's handled earlier.
+        hist = _make_ohlcv()
+        today = _make_today_row(close=float("nan"))
+        result = validate_today_row(today, hist, "NAN")
+        # No close-based anomalies should fire; volume/OHLC checks may still
+        # run independently — assert specifically that the close-anomaly
+        # types are absent.
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_NEGATIVE_OR_ZERO_CLOSE not in types
+        assert ANOMALY_EXTREME_DAILY_MOVE not in types
+
+    def test_default_block_set_constants(self):
+        # Lock the default-block contract — operators reading the env-var
+        # docs should be able to trust that flipping the env to "[]" gives
+        # them pure observability mode, while leaving it unset blocks
+        # bad_ohlc + negative_or_zero_close.
+        assert DEFAULT_BLOCK_ANOMALY_TYPES == frozenset({
+            ANOMALY_BAD_OHLC,
+            ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+        })

--- a/validators/price_validator.py
+++ b/validators/price_validator.py
@@ -1,9 +1,16 @@
 """
 validators/price_validator.py — Data quality checks for price data.
 
-Validates OHLCV data after collection. Non-blocking — logs warnings and
-returns anomaly summary for inclusion in manifest and completion emails.
-Never blocks data writes.
+Two surfaces:
+
+- ``validate_parquet`` / ``validate_batch`` / ``validate_refreshed`` — full-history
+  inspection used by ``collectors/slim_cache.py`` + ``collectors/prices.py``;
+  non-blocking, returns anomaly summary for manifest + email rollups.
+- ``validate_today_row`` — write-time per-symbol gate used by
+  ``builders/daily_append.py``; returns structured anomalies with per-type
+  severity so the caller can hard-fail on definitely-bad rows (negative
+  prices, High<Low) while only warning on legitimately-rare-but-possible
+  signals (>50% moves on event days, single-day volume spikes).
 """
 
 from __future__ import annotations
@@ -19,6 +26,132 @@ logger = logging.getLogger(__name__)
 MAX_DAILY_RETURN = 0.50       # Flag >50% single-day price move
 MAX_VOLUME_SPIKE = 10.0       # Flag volume >10x 20-day rolling median
 MAX_GAP_TRADING_DAYS = 3      # Flag gaps >3 trading days in a parquet
+
+# ── Write-time anomaly type catalog ────────────────────────────────────────
+# Severity: "block" definitely-bad, refuse the write; "warn" allow the write
+# but emit a metric so chronic drift is visible. Caller can upgrade types via
+# the DAILY_APPEND_BLOCK_ANOMALY_TYPES env var.
+ANOMALY_BAD_OHLC = "bad_ohlc"                       # default block
+ANOMALY_NEGATIVE_OR_ZERO_CLOSE = "negative_or_zero_close"  # default block
+ANOMALY_EXTREME_DAILY_MOVE = "extreme_daily_move"   # default warn
+ANOMALY_ZERO_VOLUME = "zero_volume"                 # default warn
+ANOMALY_VOLUME_SPIKE = "volume_spike"               # default warn
+
+DEFAULT_BLOCK_ANOMALY_TYPES: frozenset[str] = frozenset({
+    ANOMALY_BAD_OHLC,
+    ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+})
+
+ALL_ANOMALY_TYPES: frozenset[str] = frozenset({
+    ANOMALY_BAD_OHLC,
+    ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+    ANOMALY_EXTREME_DAILY_MOVE,
+    ANOMALY_ZERO_VOLUME,
+    ANOMALY_VOLUME_SPIKE,
+})
+
+
+def validate_today_row(
+    today_row: pd.DataFrame,
+    hist: pd.DataFrame,
+    ticker: str,
+) -> dict:
+    """
+    Inspect a single-row write against its prior history for write-time gating.
+
+    ``today_row`` is the 1-row DataFrame about to be written via
+    ``universe_lib.update_batch`` / ``write_batch``; ``hist`` is the existing
+    series read via ``read_batch`` in the same pass.
+
+    Returns ``{"ticker": ..., "anomalies": [{"type", "severity", "detail"}, ...]}``.
+    Severities are *defaults* — the caller decides final block/warn behavior
+    by consulting its configured block set (allowing operators to upgrade
+    e.g. ``extreme_daily_move`` to block during a known-quiet observation
+    window).
+    """
+    anomalies: list[dict] = []
+
+    if today_row is None or today_row.empty:
+        return {"ticker": ticker, "anomalies": anomalies}
+
+    row = today_row.iloc[0]
+
+    # ── 1. OHLC relationship (bad_ohlc — default block) ────────────────────
+    if all(c in today_row.columns for c in ("High", "Low")):
+        high = row.get("High")
+        low = row.get("Low")
+        if pd.notna(high) and pd.notna(low) and high < low:
+            anomalies.append({
+                "type": ANOMALY_BAD_OHLC,
+                "severity": "block",
+                "detail": f"High={high:.4f} < Low={low:.4f}",
+            })
+
+    # ── 2. Zero or negative close (negative_or_zero_close — default block) ──
+    if "Close" in today_row.columns:
+        close = row.get("Close")
+        if pd.notna(close) and close <= 0:
+            anomalies.append({
+                "type": ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+                "severity": "block",
+                "detail": f"Close={close:.4f}",
+            })
+
+    # ── 3. Extreme daily return vs prior close (extreme_daily_move — warn) ──
+    # Compared against hist.iloc[-1]["Close"] rather than within today_row
+    # because today_row is single-row. Skipped when hist is empty (first
+    # write for this symbol — no prior close to compare against).
+    if (
+        "Close" in today_row.columns
+        and "Close" in getattr(hist, "columns", [])
+        and not hist.empty
+    ):
+        today_close = row.get("Close")
+        prior_close = hist["Close"].iloc[-1]
+        if pd.notna(today_close) and pd.notna(prior_close) and prior_close > 0:
+            pct_change = abs(today_close - prior_close) / prior_close
+            if pct_change > MAX_DAILY_RETURN:
+                anomalies.append({
+                    "type": ANOMALY_EXTREME_DAILY_MOVE,
+                    "severity": "warn",
+                    "detail": (
+                        f"|{today_close:.4f}-{prior_close:.4f}|/{prior_close:.4f} "
+                        f"= {pct_change:.1%} > {MAX_DAILY_RETURN:.0%}"
+                    ),
+                })
+
+    # ── 4. Zero volume on trading day (zero_volume — warn) ─────────────────
+    if "Volume" in today_row.columns:
+        vol = row.get("Volume")
+        if pd.notna(vol) and vol == 0:
+            anomalies.append({
+                "type": ANOMALY_ZERO_VOLUME,
+                "severity": "warn",
+                "detail": "Volume=0",
+            })
+
+    # ── 5. Volume spike vs hist 20-day median (volume_spike — warn) ────────
+    if (
+        "Volume" in today_row.columns
+        and "Volume" in getattr(hist, "columns", [])
+        and len(hist) >= 20
+    ):
+        today_vol = row.get("Volume")
+        recent_vols = hist["Volume"].tail(20)
+        baseline = recent_vols[recent_vols > 0].median()
+        if pd.notna(today_vol) and pd.notna(baseline) and baseline > 0:
+            ratio = today_vol / baseline
+            if ratio > MAX_VOLUME_SPIKE:
+                anomalies.append({
+                    "type": ANOMALY_VOLUME_SPIKE,
+                    "severity": "warn",
+                    "detail": (
+                        f"Volume={today_vol:.0f} vs 20d-median={baseline:.0f} "
+                        f"(ratio={ratio:.1f}x > {MAX_VOLUME_SPIKE:.0f}x)"
+                    ),
+                })
+
+    return {"ticker": ticker, "anomalies": anomalies}
 
 
 def validate_parquet(df: pd.DataFrame, ticker: str) -> dict:


### PR DESCRIPTION
## Summary
Closes the half-shipped half of ROADMAP L940 (\"Data quality gates — price reasonableness / volume sanity / gap detection on ingest\"). `validators/price_validator.py` already had the thresholds but was wired only as non-blocking observation in `collectors/slim_cache.py` + `collectors/prices.py`. The canonical write path (`builders/daily_append.py`) had no validation — definitely-bad rows (Close<=0, High<Low) could land in ArcticDB silently.

### What changed
- **`validators/price_validator.py`** — new `validate_today_row(today_row, hist, ticker)` returning structured anomalies with per-type severity. Five types: `bad_ohlc` + `negative_or_zero_close` (default block); `extreme_daily_move` + `zero_volume` + `volume_spike` (default warn).
- **`builders/daily_append.py`**:
  - `_load_block_anomaly_types()` reads `DAILY_APPEND_BLOCK_ANOMALY_TYPES` env var (JSON list, validated, raises on typos) — operator can upgrade types without redeploy.
  - Validation runs after `today_row` is shaped but before `write_tasks.append(...)`. Block-severity rows are refused via `continue`; warn-only rows queue + count + log.
  - Block path uses `log.error` so FlowDoctorHandler surfaces it.
  - `_emit_quality_gate_metrics()` → CW namespace `AlphaEngine/Data`: `daily_append_quality_{blocked,warned}_count` gauges + `daily_append_quality_anomaly_count` dimensioned by `anomaly_type`. CW errors warn-only (load-bearing surface is the logger.error calls).
  - Result dict gains `tickers_quality_{blocked,warned}` / `quality_anomaly_counts` / `quality_block_anomaly_types`.
- **Tests:** +31 (suite 743 → 774, all green).

### Default behavior
Conservative: only `bad_ohlc` + `negative_or_zero_close` block. Rare-but-possible signals warn-only so the gate doesn't drop legitimate event-day moves. Flip behavior via env var (e.g. observe for a week, then add `extreme_daily_move` to the block set).

### Memory composition
- `feedback_collector_return_dict_invisible_to_flow_doctor` — block path uses `logger.error` so it crosses the logging boundary.
- `feedback_no_silent_fails` — definitely-bad rows hard-fail by default; observability metric emits even on clean runs (when warn-counts >0).
- `feedback_default_institutional_production_arch` — operator-tunable thresholds, CW metric + dimension per type, manifest entry, no silent skips.

## Test plan
- [x] `python -m pytest tests/test_price_validator.py tests/test_daily_append_quality_gates.py` — 42 pass
- [x] Full suite `python -m pytest` — 774 pass, 1 pre-existing skip, no new failures
- [ ] **First production exercise:** next MorningEnrich on 2026-05-12 — expect `quality_blocked=0`, `quality_warned=N` baseline. Watch CW `AlphaEngine/Data/daily_append_quality_*` for first datapoint.
- [ ] Saturday SF 2026-05-16 DataPhase1 — same metrics across the full universe pass; postflight reads the new result-dict fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)