### PR TITLE
fix(daily_closes): date-bound FRED fetcher + repair for 14-BDay clobber

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -769,11 +769,25 @@ def _fetch_fred_closes(
     date_str: str,
     records: list[dict],
 ) -> int:
-    """Fetch the latest close for index tickers from FRED.
+    """Fetch FRED close on-or-before ``date_str`` for index tickers.
 
-    Serves the 4 index symbols not on polygon free tier (VIX, VIX3M, TNX, IRX).
-    Takes the most recent non-missing observation for each series — typically
-    T-1 when the daily pipeline runs at 6:05 AM PT.
+    Serves the index/macro symbols not on polygon free tier
+    (VIX, VIX3M, TNX, IRX, TWO, HYOAS, BAA10Y).
+
+    The query is bounded by ``observation_end=date_str`` so per-date calls
+    from the windowed-reconciliation loop return that date's actual FRED
+    value rather than today's "most recent" — the original unbounded
+    ``sort_order=desc, limit=5`` shape predated window mode and clobbered
+    every historical date in the rolling window with today's latest close
+    (FlowDoctor `polygon_only OVERWRITE VIX` ERROR alerts 2026-05-12 surfaced
+    the regression; the prior parquet's correct historical VIX was
+    overwritten with today's value on every MorningEnrich pass since the
+    2026-05-11 ``window_days: 14`` cutover).
+
+    Same-day morning call (FRED publishes T-1): observation_end=today still
+    returns the most-recent-on-or-before-today observation (typically T-1),
+    so the legacy "today's parquet carries yesterday's FRED value" semantic
+    is preserved for the current-day case.
     """
     api_key = os.environ.get("FRED_API_KEY", "")
     if not api_key:
@@ -791,6 +805,7 @@ def _fetch_fred_closes(
                 "series_id": series_id,
                 "api_key": api_key,
                 "file_type": "json",
+                "observation_end": date_str,
                 "sort_order": "desc",
                 "limit": 5,
             }
@@ -799,7 +814,20 @@ def _fetch_fred_closes(
             obs = resp.json().get("observations", [])
             latest = next((o for o in obs if o.get("value", ".") != "."), None)
             if latest is None:
-                logger.warning("FRED %s → %s: no non-missing observation", store_ticker, series_id)
+                logger.warning(
+                    "FRED %s → %s: no non-missing observation on or before %s",
+                    store_ticker, series_id, date_str,
+                )
+                continue
+            obs_date = latest.get("date")
+            if obs_date and obs_date > date_str:
+                # Defensive: refuse to stamp a future-dated FRED value onto
+                # date_str's parquet even if FRED somehow ignored observation_end.
+                logger.error(
+                    "FRED %s observation date %s > requested %s — refusing to "
+                    "write future value (likely upstream API behavior change)",
+                    store_ticker, obs_date, date_str,
+                )
                 continue
             close = float(latest["value"])
             records.append({

--- a/collectors/daily_closes_fred_repair.py
+++ b/collectors/daily_closes_fred_repair.py
@@ -1,0 +1,350 @@
+"""collectors/daily_closes_fred_repair.py — one-shot repair tool for the
+2026-05-12 FRED-clobber regression.
+
+The windowed-reconciliation cutover (alpha-engine-data PRs #199/#200/#201
++ alpha-engine-config commit flipping ``data/config.yaml`` to
+``daily_closes: { window_days: 14, skip_if_canonical: true }``, activated
+2026-05-11) amplified a pre-existing latent bug in
+``collectors/daily_closes._fetch_fred_closes``: that fetcher queried FRED
+with ``sort_order=desc, limit=5`` and no upper-bound, so per-date calls
+across the 14-BDay rolling window all returned today's most-recent
+observation. Every historical date's ``staging/daily_closes/{date}.parquet``
+got today's VIX/VIX3M/TNX/IRX/TWO/HYOAS/BAA10Y written onto it,
+clobbering the correct historical values.
+
+FlowDoctor surfaced the regression on 2026-05-12 ~13:01 / ~13:04 UTC
+with paired alerts for VIX @ 2026-04-22 and VIX @ 2026-04-28 both
+showing identical pre-fix (18.36) and post-fix (17.19) closes — the
+signature of "every per-date stamp got today's latest".
+
+Companion fix: ``_fetch_fred_closes`` now sends
+``observation_end=date_str`` so per-date calls return that date's
+actual FRED value (or most-recent on-or-before for the same-day case
+where FRED hasn't published yet).
+
+This script re-fetches the correct FRED values across an operator-
+specified date window and rewrites the FRED-ticker rows of each affected
+parquet under ``staging/daily_closes/``. Polygon-sourced stock rows are
+left untouched — polygon's grouped-daily endpoint takes a date parameter
+and was always per-date-correct, so only FRED rows need repair.
+
+Usage::
+
+    python -m collectors.daily_closes_fred_repair \
+        --bucket alpha-engine-research \
+        --start 2026-04-22 --end 2026-05-12
+
+    # dry-run: read + plan only, no S3 writes
+    python -m collectors.daily_closes_fred_repair \
+        --bucket alpha-engine-research \
+        --start 2026-04-22 --end 2026-05-12 --dry-run
+
+Idempotent — re-running on already-repaired parquets is a no-op (writes
+the same correct values back).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta
+from typing import Optional
+
+import boto3
+import pandas as pd
+import requests
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+# Import the ticker → FRED series map from the canonical home so this
+# script never drifts from the live fetcher's coverage set.
+from collectors.daily_closes import _FRED_BASE, _FRED_INDEX_MAP, _FRED_TIMEOUT
+
+
+def _business_days(start: str, end: str) -> list[str]:
+    """Return business-day YYYY-MM-DD strings in ``[start, end]`` inclusive."""
+    s = datetime.strptime(start, "%Y-%m-%d").date()
+    e = datetime.strptime(end, "%Y-%m-%d").date()
+    if s > e:
+        raise ValueError(f"start {start} must be <= end {end}")
+    out: list[str] = []
+    cur = s
+    while cur <= e:
+        if cur.weekday() < 5:
+            out.append(cur.isoformat())
+        cur = cur + timedelta(days=1)
+    return out
+
+
+def _fetch_fred_range(
+    series_id: str,
+    start: str,
+    end: str,
+    api_key: str,
+) -> dict[str, float]:
+    """Single FRED call returning ``{YYYY-MM-DD: value}`` for the range.
+
+    Missing observations (FRED's ``"."``) are dropped. ``end`` is padded
+    out a few days so the per-date most-recent-on-or-before lookup can
+    fall back across calendar gaps.
+    """
+    params = {
+        "series_id": series_id,
+        "api_key": api_key,
+        "file_type": "json",
+        "observation_start": start,
+        "observation_end": end,
+        "sort_order": "asc",
+    }
+    resp = requests.get(_FRED_BASE, params=params, timeout=_FRED_TIMEOUT)
+    resp.raise_for_status()
+    obs = resp.json().get("observations", [])
+    out: dict[str, float] = {}
+    for o in obs:
+        val = o.get("value", ".")
+        if val == "." or val is None:
+            continue
+        date = o.get("date")
+        try:
+            out[date] = float(val)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def _value_on_or_before(
+    fred_values: dict[str, float],
+    date_str: str,
+    sorted_dates: list[str],
+) -> Optional[tuple[str, float]]:
+    """Return ``(obs_date, value)`` for the most recent FRED observation on
+    or before ``date_str``, or None if none exists. Matches the live fetcher's
+    semantic so the repair output is byte-identical to a fresh windowed run."""
+    # sorted_dates is ascending. Binary search would be marginally faster
+    # but the windows we care about are <30 dates — linear scan is fine.
+    candidate: Optional[tuple[str, float]] = None
+    for d in sorted_dates:
+        if d > date_str:
+            break
+        candidate = (d, fred_values[d])
+    return candidate
+
+
+def _read_parquet(s3, bucket: str, key: str) -> Optional[pd.DataFrame]:
+    """Return the parquet at ``s3://bucket/key`` as a DataFrame, or None on 404."""
+    try:
+        obj = s3.get_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        if code in ("404", "NoSuchKey"):
+            return None
+        raise
+    return pd.read_parquet(io.BytesIO(obj["Body"].read()), engine="pyarrow")
+
+
+def _write_parquet(s3, bucket: str, key: str, df: pd.DataFrame) -> None:
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy", index=True)
+    buf.seek(0)
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=buf.getvalue(),
+        ContentType="application/octet-stream",
+    )
+
+
+def repair(
+    bucket: str,
+    start: str,
+    end: str,
+    s3_prefix: str = "staging/daily_closes/",
+    tickers: Optional[list[str]] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Re-fetch correct FRED values for ``[start, end]`` and overwrite the
+    FRED-ticker rows of each daily_closes parquet in the window.
+
+    Returns a per-date summary dict.
+    """
+    api_key = os.environ.get("FRED_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("FRED_API_KEY not set — cannot fetch FRED values")
+
+    if tickers is None:
+        tickers = sorted(_FRED_INDEX_MAP.keys())
+    unknown = [t for t in tickers if t not in _FRED_INDEX_MAP]
+    if unknown:
+        raise ValueError(
+            f"Unknown FRED tickers {unknown}. Known: {sorted(_FRED_INDEX_MAP.keys())}"
+        )
+
+    # Pad the FRED query backward so per-date lookups can fall back across
+    # weekend / holiday gaps without hitting the start-of-range cliff.
+    pad_start = (
+        datetime.strptime(start, "%Y-%m-%d").date() - timedelta(days=14)
+    ).isoformat()
+
+    logger.info(
+        "Fetching FRED ranges %s → %s for %d tickers (padded start %s)",
+        start, end, len(tickers), pad_start,
+    )
+    fred_data: dict[str, dict[str, float]] = {}
+    fred_sorted: dict[str, list[str]] = {}
+    for ticker in tickers:
+        series_id = _FRED_INDEX_MAP[ticker]
+        vals = _fetch_fred_range(series_id, pad_start, end, api_key)
+        if not vals:
+            logger.warning(
+                "FRED %s → %s: no observations in [%s, %s] — skipping ticker",
+                ticker, series_id, pad_start, end,
+            )
+            continue
+        fred_data[ticker] = vals
+        fred_sorted[ticker] = sorted(vals.keys())
+        logger.info(
+            "FRED %s: %d observations from %s to %s",
+            ticker, len(vals), fred_sorted[ticker][0], fred_sorted[ticker][-1],
+        )
+
+    if not fred_data:
+        return {"status": "error", "error": "no FRED data retrieved"}
+
+    s3 = boto3.client("s3")
+    bdays = _business_days(start, end)
+    per_date: dict[str, dict] = {}
+    n_parquets_missing = 0
+    n_parquets_rewritten = 0
+    n_rows_repaired = 0
+
+    for d in bdays:
+        key = f"{s3_prefix}{d}.parquet"
+        df = _read_parquet(s3, bucket, key)
+        if df is None:
+            per_date[d] = {"status": "missing", "rewritten": False}
+            n_parquets_missing += 1
+            continue
+
+        repaired_rows: list[str] = []
+        changes: dict[str, tuple[float, float]] = {}
+        for ticker in tickers:
+            if ticker not in fred_data:
+                continue
+            if ticker not in df.index:
+                continue
+            lookup = _value_on_or_before(fred_data[ticker], d, fred_sorted[ticker])
+            if lookup is None:
+                logger.warning(
+                    "No FRED %s observation on or before %s — leaving row unchanged",
+                    ticker, d,
+                )
+                continue
+            obs_date, value = lookup
+            current_close = float(df.at[ticker, "Close"]) if "Close" in df.columns else None
+            value = round(value, 4)
+            if current_close is not None and abs(current_close - value) < 1e-4:
+                # Already correct — idempotent skip.
+                continue
+            # Overwrite OHLC + Adj_Close with the correct FRED single-value
+            # close. Volume / VWAP / source columns are preserved (already
+            # the FRED defaults 0 / None / "fred" from the prior write).
+            for col in ("Open", "High", "Low", "Close", "Adj_Close"):
+                if col in df.columns:
+                    df.at[ticker, col] = value
+            if "source" in df.columns:
+                df.at[ticker, "source"] = "fred"
+            if "VWAP" in df.columns:
+                df.at[ticker, "VWAP"] = None
+            if "Volume" in df.columns:
+                df.at[ticker, "Volume"] = 0
+            repaired_rows.append(ticker)
+            changes[ticker] = (current_close if current_close is not None else float("nan"), value)
+            logger.info(
+                "Repair %s @ %s: %s → %s (FRED obs date %s)",
+                ticker, d,
+                f"{current_close:.4f}" if current_close is not None else "?",
+                f"{value:.4f}", obs_date,
+            )
+
+        if not repaired_rows:
+            per_date[d] = {"status": "noop", "rewritten": False}
+            continue
+
+        if dry_run:
+            per_date[d] = {
+                "status": "would_rewrite",
+                "rewritten": False,
+                "tickers": repaired_rows,
+                "changes": {t: {"old": old, "new": new} for t, (old, new) in changes.items()},
+            }
+            continue
+
+        _write_parquet(s3, bucket, key, df)
+        per_date[d] = {
+            "status": "rewritten",
+            "rewritten": True,
+            "tickers": repaired_rows,
+            "changes": {t: {"old": old, "new": new} for t, (old, new) in changes.items()},
+        }
+        n_parquets_rewritten += 1
+        n_rows_repaired += len(repaired_rows)
+
+    return {
+        "status": "ok",
+        "bucket": bucket,
+        "prefix": s3_prefix,
+        "start": start,
+        "end": end,
+        "tickers": tickers,
+        "dry_run": dry_run,
+        "business_days_in_window": len(bdays),
+        "parquets_missing": n_parquets_missing,
+        "parquets_rewritten": n_parquets_rewritten,
+        "rows_repaired": n_rows_repaired,
+        "per_date": per_date,
+    }
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--bucket", default="alpha-engine-research")
+    parser.add_argument("--prefix", default="staging/daily_closes/")
+    parser.add_argument(
+        "--start", required=True,
+        help="YYYY-MM-DD inclusive start of repair window",
+    )
+    parser.add_argument(
+        "--end", required=True,
+        help="YYYY-MM-DD inclusive end of repair window",
+    )
+    parser.add_argument(
+        "--tickers", nargs="+", default=None,
+        help=f"Subset of FRED tickers to repair. Default: all of {sorted(_FRED_INDEX_MAP.keys())}",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Plan + log changes without writing to S3",
+    )
+    args = parser.parse_args()
+
+    result = repair(
+        bucket=args.bucket,
+        start=args.start,
+        end=args.end,
+        s3_prefix=args.prefix,
+        tickers=args.tickers,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(result, indent=2, default=str))
+    sys.exit(0 if result.get("status") == "ok" else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_daily_closes_fred_per_date.py
+++ b/tests/test_daily_closes_fred_per_date.py
@@ -1,0 +1,221 @@
+"""Regression tests for the FRED-fetcher per-date semantic.
+
+Pins the fix for the 2026-05-12 FlowDoctor `polygon_only OVERWRITE VIX`
+alerts: the pre-fix ``_fetch_fred_closes`` queried FRED with
+``sort_order=desc, limit=5`` and no upper-bound — it always returned the
+single most-recent non-missing observation across all of FRED history.
+Combined with the windowed-reconciliation arc (PRs #199/#200/#201 +
+alpha-engine-config cutover to ``daily_closes: { window_days: 14,
+skip_if_canonical: true }`` 2026-05-10) that meant every historical date
+in the rolling 14-BDay window got today's latest FRED VIX/VIX3M/TNX/IRX/
+TWO/HYOAS/BAA10Y stamped on it, clobbering correct historical values.
+
+Lock the corrected behavior:
+
+  - per-date calls send ``observation_end=date_str``
+  - the returned observation date must be ≤ ``date_str``
+  - the FRED value, not today's "latest", lands in the per-date record
+  - same-day call (FRED's T-1 publishing lag) still yields the prior
+    business day's value — preserves the legacy "today's parquet carries
+    yesterday's FRED close" semantic
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from collectors import daily_closes
+
+
+def _fred_response(observations: list[dict]) -> MagicMock:
+    """Build a mock ``requests.get`` response with the given observations."""
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"observations": observations}
+    return resp
+
+
+@pytest.fixture
+def fred_api_key(monkeypatch):
+    monkeypatch.setenv("FRED_API_KEY", "test-key-xyz")
+
+
+# ── per-date semantic ────────────────────────────────────────────────────────
+
+
+def test_fred_request_pins_observation_end_to_run_date(fred_api_key):
+    """``observation_end`` must equal the per-date ``date_str`` — bounds the
+    lookup so a historical date in the windowed-reconciliation loop returns
+    that date's FRED observation, not today's latest."""
+    captured_params: list[dict] = []
+
+    def fake_get(url, params=None, timeout=None):
+        captured_params.append(params)
+        return _fred_response([
+            {"date": "2026-04-22", "value": "18.36"},
+        ])
+
+    records: list[dict] = []
+    with patch("collectors.daily_closes.requests.get", side_effect=fake_get):
+        daily_closes._fetch_fred_closes(
+            tickers=["VIX"],
+            date_str="2026-04-22",
+            records=records,
+        )
+
+    assert len(captured_params) == 1
+    assert captured_params[0]["observation_end"] == "2026-04-22"
+    assert captured_params[0]["series_id"] == "VIXCLS"
+    assert len(records) == 1
+    assert records[0]["ticker"] == "VIX"
+    assert records[0]["date"] == "2026-04-22"
+    assert records[0]["Close"] == 18.36
+
+
+def test_fred_writes_per_date_observation_not_latest(fred_api_key):
+    """For a historical date, the per-date FRED value lands in the record,
+    not the most-recent-ever observation. This is the direct regression
+    pin: the bug stamped 17.19 (today's value) onto 2026-04-22's parquet."""
+    historical_obs = {"date": "2026-04-22", "value": "18.36"}
+
+    def fake_get(url, params=None, timeout=None):
+        # FRED with ``observation_end=2026-04-22, sort_order=desc, limit=5``
+        # returns observations on or before 2026-04-22 in desc order.
+        return _fred_response([historical_obs])
+
+    records: list[dict] = []
+    with patch("collectors.daily_closes.requests.get", side_effect=fake_get):
+        daily_closes._fetch_fred_closes(
+            tickers=["VIX"],
+            date_str="2026-04-22",
+            records=records,
+        )
+
+    assert records[0]["Close"] == 18.36  # not 17.19 (today's latest)
+
+
+def test_fred_per_date_calls_return_distinct_values(fred_api_key):
+    """Iterating the windowed reconciliation over multiple dates must
+    yield distinct per-date FRED values — not the same "latest" pasted
+    onto every date. The bug signature was two different trading days
+    with identical Close to the cent in the alert payload."""
+    per_date_values = {
+        "2026-04-22": "18.36",
+        "2026-04-28": "19.50",
+        "2026-05-11": "17.19",
+    }
+
+    def fake_get(url, params=None, timeout=None):
+        end = params["observation_end"]
+        return _fred_response([{"date": end, "value": per_date_values[end]}])
+
+    records: list[dict] = []
+    with patch("collectors.daily_closes.requests.get", side_effect=fake_get):
+        for d in per_date_values:
+            daily_closes._fetch_fred_closes(["VIX"], d, records)
+
+    closes = {r["date"]: r["Close"] for r in records}
+    assert closes == {"2026-04-22": 18.36, "2026-04-28": 19.50, "2026-05-11": 17.19}
+
+
+# ── same-day legacy semantic preserved ───────────────────────────────────────
+
+
+def test_fred_same_day_returns_prior_business_day_when_no_today_obs(fred_api_key):
+    """FRED publishes T-1 — when MorningEnrich runs at 6 AM PT for today's
+    date, FRED has no observation for today yet. The function should
+    fall back to the most recent on-or-before value (typically T-1),
+    preserving the legacy "today's parquet carries yesterday's FRED
+    value" semantic."""
+    def fake_get(url, params=None, timeout=None):
+        # observation_end=2026-05-12 returns 2026-05-11's value because
+        # today's hasn't been published yet.
+        return _fred_response([{"date": "2026-05-11", "value": "17.19"}])
+
+    records: list[dict] = []
+    with patch("collectors.daily_closes.requests.get", side_effect=fake_get):
+        daily_closes._fetch_fred_closes(
+            tickers=["VIX"],
+            date_str="2026-05-12",
+            records=records,
+        )
+
+    assert len(records) == 1
+    assert records[0]["Close"] == 17.19
+    # Record carries the parquet-key date (today), not the FRED-observation
+    # date. Matches the existing single-date contract.
+    assert records[0]["date"] == "2026-05-12"
+
+
+# ── defensive guard ──────────────────────────────────────────────────────────
+
+
+def test_fred_refuses_future_dated_observation(fred_api_key, caplog):
+    """If FRED somehow returns an observation date AFTER date_str (API
+    behavior change, server bug, etc.), refuse to write rather than
+    silently stamp a future value. Belt-and-suspenders for the original
+    bug class."""
+    def fake_get(url, params=None, timeout=None):
+        # date > date_str — should be filtered out.
+        return _fred_response([{"date": "2026-05-11", "value": "17.19"}])
+
+    records: list[dict] = []
+    import logging
+    with caplog.at_level(logging.ERROR, logger="collectors.daily_closes"):
+        with patch("collectors.daily_closes.requests.get", side_effect=fake_get):
+            count = daily_closes._fetch_fred_closes(
+                tickers=["VIX"],
+                date_str="2026-04-22",
+                records=records,
+            )
+
+    assert count == 0
+    assert records == []
+    assert any("> requested 2026-04-22" in rec.message for rec in caplog.records)
+
+
+# ── missing-data path ────────────────────────────────────────────────────────
+
+
+def test_fred_skips_when_no_observation_on_or_before_date(fred_api_key):
+    """If FRED has no non-missing observation on or before date_str,
+    log a warning and skip — don't fabricate a value, and don't fall
+    forward to a later observation (that would re-introduce the bug)."""
+    def fake_get(url, params=None, timeout=None):
+        # Empty observations payload — FRED has nothing in window.
+        return _fred_response([])
+
+    records: list[dict] = []
+    with patch("collectors.daily_closes.requests.get", side_effect=fake_get):
+        count = daily_closes._fetch_fred_closes(
+            tickers=["VIX"],
+            date_str="1990-01-02",
+            records=records,
+        )
+
+    assert count == 0
+    assert records == []
+
+
+def test_fred_skips_missing_value_marker(fred_api_key):
+    """FRED publishes ``"."`` for missing observations — those must be
+    skipped rather than parsed as numeric."""
+    def fake_get(url, params=None, timeout=None):
+        return _fred_response([
+            {"date": "2026-04-22", "value": "."},
+            {"date": "2026-04-21", "value": "18.30"},
+        ])
+
+    records: list[dict] = []
+    with patch("collectors.daily_closes.requests.get", side_effect=fake_get):
+        daily_closes._fetch_fred_closes(["VIX"], "2026-04-22", records)
+
+    # Skipped the missing-marker obs, took the next-most-recent.
+    assert len(records) == 1
+    assert records[0]["Close"] == 18.30

--- a/tests/test_daily_closes_fred_repair.py
+++ b/tests/test_daily_closes_fred_repair.py
@@ -1,0 +1,263 @@
+"""Tests for the FRED-repair one-shot script.
+
+Locks the repair output to be byte-identical to a fresh windowed run of
+the fixed ``_fetch_fred_closes``: per-date FRED value taken from the
+most-recent-on-or-before observation, OHLC + Adj_Close all set to that
+value, Volume=0 / VWAP=None / source=fred.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from collectors import daily_closes_fred_repair as repair_mod
+
+
+@pytest.fixture
+def fred_api_key(monkeypatch):
+    monkeypatch.setenv("FRED_API_KEY", "test-key-xyz")
+
+
+def _existing_parquet(closes: dict[str, dict]) -> bytes:
+    """Build a daily_closes-shape parquet (index=ticker)."""
+    rows = []
+    idx = []
+    for ticker, fields in closes.items():
+        idx.append(ticker)
+        rows.append(fields)
+    df = pd.DataFrame(rows, index=pd.Index(idx, name="ticker"))
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy", index=True)
+    return buf.getvalue()
+
+
+def _s3_with_parquet_bodies(bodies: dict[str, bytes]) -> MagicMock:
+    """S3 mock that returns parquet bodies by key, 404 for unknown keys."""
+    s3 = MagicMock()
+
+    def fake_get_object(Bucket=None, Key=None):
+        if Key not in bodies:
+            err = {"Error": {"Code": "404", "Message": "Not Found"}}
+            raise ClientError(err, "GetObject")
+        return {"Body": MagicMock(read=lambda body=bodies[Key]: body)}
+
+    def fake_put_object(Bucket=None, Key=None, Body=None, **_):
+        bodies[Key] = Body  # capture writes back into the same dict
+
+    s3.get_object.side_effect = fake_get_object
+    s3.put_object.side_effect = fake_put_object
+    return s3
+
+
+# ── business-day enumeration ────────────────────────────────────────────────
+
+
+def test_business_days_inclusive_window():
+    # 2026-04-22 is a Wed; 2026-04-28 is a Tue. The window covers
+    # Wed 4/22, Thu 4/23, Fri 4/24, (skip Sat/Sun), Mon 4/27, Tue 4/28.
+    days = repair_mod._business_days("2026-04-22", "2026-04-28")
+    assert days == ["2026-04-22", "2026-04-23", "2026-04-24", "2026-04-27", "2026-04-28"]
+
+
+def test_business_days_rejects_inverted_range():
+    with pytest.raises(ValueError, match="must be <="):
+        repair_mod._business_days("2026-04-28", "2026-04-22")
+
+
+# ── on-or-before lookup ─────────────────────────────────────────────────────
+
+
+def test_value_on_or_before_picks_exact_date_when_present():
+    fred = {"2026-04-22": 18.36, "2026-04-23": 18.10, "2026-04-24": 17.95}
+    sorted_dates = sorted(fred.keys())
+    obs = repair_mod._value_on_or_before(fred, "2026-04-23", sorted_dates)
+    assert obs == ("2026-04-23", 18.10)
+
+
+def test_value_on_or_before_falls_back_to_prior_date_when_missing():
+    # FRED has no observation for 2026-04-22 (weekend / holiday); the
+    # most recent on or before is 2026-04-21.
+    fred = {"2026-04-21": 18.30, "2026-04-23": 18.10}
+    sorted_dates = sorted(fred.keys())
+    obs = repair_mod._value_on_or_before(fred, "2026-04-22", sorted_dates)
+    assert obs == ("2026-04-21", 18.30)
+
+
+def test_value_on_or_before_returns_none_when_target_predates_all_data():
+    fred = {"2026-04-22": 18.36}
+    sorted_dates = sorted(fred.keys())
+    assert repair_mod._value_on_or_before(fred, "2026-04-21", sorted_dates) is None
+
+
+# ── end-to-end repair ──────────────────────────────────────────────────────
+
+
+def test_repair_overwrites_clobbered_vix_rows(fred_api_key, monkeypatch):
+    """The repair script should rewrite each affected parquet's VIX row
+    with the correct per-date FRED value rather than today's latest."""
+    # Two parquets, each with VIX clobbered to 17.19 (today's value at
+    # the time of the bad windowed run) plus an unrelated AAPL row that
+    # must be left untouched.
+    bodies = {
+        "staging/daily_closes/2026-04-22.parquet": _existing_parquet({
+            "VIX": {
+                "date": "2026-04-22",
+                "Open": 17.19, "High": 17.19, "Low": 17.19, "Close": 17.19,
+                "Adj_Close": 17.19, "Volume": 0, "VWAP": None, "source": "fred",
+            },
+            "AAPL": {
+                "date": "2026-04-22",
+                "Open": 230.10, "High": 232.40, "Low": 229.50, "Close": 231.20,
+                "Adj_Close": 231.20, "Volume": 50_000_000, "VWAP": 231.05, "source": "polygon",
+            },
+        }),
+        "staging/daily_closes/2026-04-28.parquet": _existing_parquet({
+            "VIX": {
+                "date": "2026-04-28",
+                "Open": 17.19, "High": 17.19, "Low": 17.19, "Close": 17.19,
+                "Adj_Close": 17.19, "Volume": 0, "VWAP": None, "source": "fred",
+            },
+        }),
+    }
+    s3 = _s3_with_parquet_bodies(bodies)
+
+    def fake_fetch_range(series_id, start, end, api_key):
+        assert series_id == "VIXCLS"
+        return {"2026-04-22": 18.36, "2026-04-23": 18.10, "2026-04-28": 19.50}
+
+    with patch("collectors.daily_closes_fred_repair.boto3.client", return_value=s3), \
+         patch("collectors.daily_closes_fred_repair._fetch_fred_range", side_effect=fake_fetch_range):
+        result = repair_mod.repair(
+            bucket="b",
+            start="2026-04-22",
+            end="2026-04-28",
+            tickers=["VIX"],
+        )
+
+    assert result["status"] == "ok"
+    assert result["parquets_rewritten"] == 2
+    assert result["rows_repaired"] == 2
+
+    fixed_22 = pd.read_parquet(io.BytesIO(bodies["staging/daily_closes/2026-04-22.parquet"]))
+    assert fixed_22.at["VIX", "Close"] == pytest.approx(18.36)
+    assert fixed_22.at["VIX", "Open"] == pytest.approx(18.36)
+    assert fixed_22.at["VIX", "Adj_Close"] == pytest.approx(18.36)
+    # AAPL untouched (polygon source not in scope for FRED repair).
+    assert fixed_22.at["AAPL", "Close"] == pytest.approx(231.20)
+    assert fixed_22.at["AAPL", "source"] == "polygon"
+
+    fixed_28 = pd.read_parquet(io.BytesIO(bodies["staging/daily_closes/2026-04-28.parquet"]))
+    assert fixed_28.at["VIX", "Close"] == pytest.approx(19.50)
+
+
+def test_repair_idempotent_skips_already_correct_rows(fred_api_key):
+    """Re-running the repair on an already-repaired parquet is a no-op."""
+    bodies = {
+        "staging/daily_closes/2026-04-22.parquet": _existing_parquet({
+            "VIX": {
+                "date": "2026-04-22",
+                "Open": 18.36, "High": 18.36, "Low": 18.36, "Close": 18.36,
+                "Adj_Close": 18.36, "Volume": 0, "VWAP": None, "source": "fred",
+            },
+        }),
+    }
+    s3 = _s3_with_parquet_bodies(bodies)
+    pre_body = bodies["staging/daily_closes/2026-04-22.parquet"]
+
+    def fake_fetch_range(series_id, start, end, api_key):
+        return {"2026-04-22": 18.36}
+
+    with patch("collectors.daily_closes_fred_repair.boto3.client", return_value=s3), \
+         patch("collectors.daily_closes_fred_repair._fetch_fred_range", side_effect=fake_fetch_range):
+        result = repair_mod.repair(
+            bucket="b",
+            start="2026-04-22",
+            end="2026-04-22",
+            tickers=["VIX"],
+        )
+
+    assert result["per_date"]["2026-04-22"]["status"] == "noop"
+    assert result["parquets_rewritten"] == 0
+    # S3 body unchanged since put_object was never invoked.
+    assert bodies["staging/daily_closes/2026-04-22.parquet"] == pre_body
+
+
+def test_repair_dry_run_does_not_write(fred_api_key):
+    bodies = {
+        "staging/daily_closes/2026-04-22.parquet": _existing_parquet({
+            "VIX": {
+                "date": "2026-04-22",
+                "Open": 17.19, "High": 17.19, "Low": 17.19, "Close": 17.19,
+                "Adj_Close": 17.19, "Volume": 0, "VWAP": None, "source": "fred",
+            },
+        }),
+    }
+    s3 = _s3_with_parquet_bodies(bodies)
+    pre_body = bodies["staging/daily_closes/2026-04-22.parquet"]
+
+    with patch("collectors.daily_closes_fred_repair.boto3.client", return_value=s3), \
+         patch(
+             "collectors.daily_closes_fred_repair._fetch_fred_range",
+             return_value={"2026-04-22": 18.36},
+         ):
+        result = repair_mod.repair(
+            bucket="b",
+            start="2026-04-22",
+            end="2026-04-22",
+            tickers=["VIX"],
+            dry_run=True,
+        )
+
+    assert result["per_date"]["2026-04-22"]["status"] == "would_rewrite"
+    assert result["parquets_rewritten"] == 0
+    s3.put_object.assert_not_called()
+    assert bodies["staging/daily_closes/2026-04-22.parquet"] == pre_body
+
+
+def test_repair_skips_missing_parquets_in_window(fred_api_key):
+    """If a parquet doesn't exist (e.g., holiday), repair logs missing and
+    continues — doesn't crash."""
+    bodies: dict[str, bytes] = {}
+    s3 = _s3_with_parquet_bodies(bodies)
+
+    with patch("collectors.daily_closes_fred_repair.boto3.client", return_value=s3), \
+         patch(
+             "collectors.daily_closes_fred_repair._fetch_fred_range",
+             return_value={"2026-04-22": 18.36, "2026-04-23": 18.10},
+         ):
+        result = repair_mod.repair(
+            bucket="b",
+            start="2026-04-22",
+            end="2026-04-23",
+            tickers=["VIX"],
+        )
+
+    assert result["status"] == "ok"
+    assert result["parquets_missing"] == 2
+    assert result["parquets_rewritten"] == 0
+    assert result["per_date"]["2026-04-22"]["status"] == "missing"
+
+
+def test_repair_rejects_unknown_ticker(fred_api_key):
+    with pytest.raises(ValueError, match="Unknown FRED tickers"):
+        repair_mod.repair(
+            bucket="b",
+            start="2026-04-22",
+            end="2026-04-22",
+            tickers=["NOTAFREDTICKER"],
+        )
+
+
+def test_repair_requires_api_key(monkeypatch):
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="FRED_API_KEY not set"):
+        repair_mod.repair(bucket="b", start="2026-04-22", end="2026-04-22")


### PR DESCRIPTION
## Summary

Closes the FlowDoctor `polygon_only OVERWRITE VIX` ERROR alerts that fired 2026-05-12 ~13:01 / ~13:04 UTC on MorningEnrich. The windowed-reconciliation cutover (PRs #199/#200/#201 + alpha-engine-config flip to `daily_closes: {window_days: 14, skip_if_canonical: true}`, activated 2026-05-11) amplified a latent bug in `_fetch_fred_closes`: the FRED query used `sort_order=desc, limit=5` with no upper bound, so per-date calls across the rolling 14-BDay window all returned today's most-recent observation. Every historical date's `staging/daily_closes/{date}.parquet` got today's VIX/VIX3M/TNX/IRX/TWO/HYOAS/BAA10Y stamped on it, clobbering correct historical closes.

Identifying signature in this morning's alerts: 2026-04-22 and 2026-04-28 both showed identical pre (18.36) and post (17.19) closes — two different trading days can't legitimately have the same VIX close to the cent.

## What changed

- **`collectors/daily_closes.py::_fetch_fred_closes`** — sends `observation_end=date_str` so per-date calls return that date's actual FRED observation. Defensive guard refuses to write any returned observation date > date_str. Same-day morning call (FRED's T-1 publishing lag) still falls back to the most-recent on-or-before observation, preserving the legacy "today's parquet carries yesterday's FRED close" semantic.

- **`collectors/daily_closes_fred_repair.py`** (new) — one-shot operator CLI that re-fetches correct FRED values over a date window and rewrites only the FRED-ticker rows of each affected `staging/daily_closes/` parquet. Polygon stock rows untouched (their fetcher was always per-date-correct). Idempotent.

- **`tests/test_daily_closes_fred_per_date.py`** (new) — 7 regression tests pinning per-date semantics: `observation_end` bound, distinct-value-per-date, same-day fallback, future-date refusal, missing-value skip, missing-observation skip.

- **`tests/test_daily_closes_fred_repair.py`** (new) — 11 tests covering business-day enumeration, most-recent-on-or-before lookup, end-to-end overwrite of clobbered rows leaving polygon rows untouched, idempotent no-op on already-correct parquets, dry-run, missing-parquet skip, unknown-ticker rejection, missing-API-key rejection.

Suite 774 → 792.

## Scope of the clobber

Affected: ~14 BDay rolling window per MorningEnrich firing since 2026-05-11. Two firings so far (Mon 2026-05-11, Tue 2026-05-12). Affected tickers: VIX, VIX3M, TNX, IRX, TWO, HYOAS, BAA10Y. Downstream impact: predictor's 6 macro features (vix_level, vix_term_slope = VIX3M/VIX, yield_curve_slope = TNX-IRX, market_breadth, spy_20d_*) are L2 Ridge inputs; today's predictor inference at 6:15 AM PT consumed contaminated values.

## Test plan

- [ ] Local `pytest -q` clean (792 passed, 1 skipped pre-existing) ✓
- [ ] Confirm via merge + Sat SF firing 2026-05-16 that no `OVERWRITE VIX` ERROR alerts fire
- [ ] **Operator step after merge** — run the repair against the clobbered window:
  ```
  ae-data "cd ~/alpha-engine-data && git pull && python -m collectors.daily_closes_fred_repair --bucket alpha-engine-research --start 2026-04-22 --end 2026-05-12 --dry-run"
  ```
  inspect dry-run output, then re-run without `--dry-run` once changes look correct.
- [ ] Tomorrow's MorningEnrich (Wed 2026-05-13 6 AM PT) should show no FRED-row OVERWRITE alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)