### PR TITLE
fix(daily_closes): scrub FRED api_key from error logs + retry FRED 5xx

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import re
 import time
 from datetime import datetime, time as dtime, timedelta, timezone
 from zoneinfo import ZoneInfo
@@ -48,6 +49,19 @@ import pandas as pd
 import requests
 
 logger = logging.getLogger(__name__)
+
+_FRED_API_KEY_RE = re.compile(r"api_key=[^&\s]+")
+
+
+def _scrub_api_key(msg: object) -> str:
+    """Mask the FRED ``api_key=...`` querystring fragment in any error string.
+
+    ``requests.exceptions.HTTPError`` embeds the full request URL — including
+    the ``api_key`` querystring — in its ``str()`` representation. Logging
+    that to CloudWatch leaks the credential. Always pass FRED-fetch
+    exceptions through this scrubber before logging.
+    """
+    return _FRED_API_KEY_RE.sub("api_key=***", str(msg))
 
 _NYSE_TZ = ZoneInfo("America/New_York")
 
@@ -847,7 +861,10 @@ def _fetch_fred_closes(
             })
             count += 1
         except Exception as e:
-            logger.warning("FRED fetch failed for %s (%s): %s", store_ticker, series_id, e)
+            logger.warning(
+                "FRED fetch failed for %s (%s): %s",
+                store_ticker, series_id, _scrub_api_key(e),
+            )
 
     logger.info("FRED fallback: %d/%d index tickers captured", count, len(tickers))
     return count

--- a/collectors/daily_closes_fred_repair.py
+++ b/collectors/daily_closes_fred_repair.py
@@ -51,6 +51,7 @@ import json
 import logging
 import os
 import sys
+import time
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -63,7 +64,12 @@ logger = logging.getLogger(__name__)
 
 # Import the ticker → FRED series map from the canonical home so this
 # script never drifts from the live fetcher's coverage set.
-from collectors.daily_closes import _FRED_BASE, _FRED_INDEX_MAP, _FRED_TIMEOUT
+from collectors.daily_closes import (
+    _FRED_BASE,
+    _FRED_INDEX_MAP,
+    _FRED_TIMEOUT,
+    _scrub_api_key,
+)
 
 
 def _business_days(start: str, end: str) -> list[str]:
@@ -101,9 +107,31 @@ def _fetch_fred_range(
         "observation_end": end,
         "sort_order": "asc",
     }
-    resp = requests.get(_FRED_BASE, params=params, timeout=_FRED_TIMEOUT)
-    resp.raise_for_status()
-    obs = resp.json().get("observations", [])
+    last_err: Exception | None = None
+    obs: list[dict] = []
+    for attempt in range(1, 4):
+        try:
+            resp = requests.get(_FRED_BASE, params=params, timeout=_FRED_TIMEOUT)
+            resp.raise_for_status()
+            obs = resp.json().get("observations", [])
+            break
+        except requests.exceptions.RequestException as e:
+            last_err = e
+            if attempt < 3:
+                logger.warning(
+                    "FRED %s range attempt %d failed: %s — retrying in %ds",
+                    series_id, attempt, _scrub_api_key(e), attempt * 3,
+                )
+                time.sleep(attempt * 3)
+            else:
+                logger.error(
+                    "FRED %s range failed after 3 attempts: %s",
+                    series_id, _scrub_api_key(e),
+                )
+                raise RuntimeError(
+                    f"FRED range fetch failed for {series_id} after retries: "
+                    f"{_scrub_api_key(last_err)}"
+                ) from None
     out: dict[str, float] = {}
     for o in obs:
         val = o.get("value", ".")

--- a/tests/test_fred_api_key_scrub.py
+++ b/tests/test_fred_api_key_scrub.py
@@ -1,0 +1,193 @@
+"""Regression tests pinning api_key scrubbing on FRED-fetch error paths.
+
+A FRED 500 during MorningEnrich or the repair script propagates a
+``requests.exceptions.HTTPError`` whose ``str()`` embeds the full
+request URL, including ``api_key=<live-credential>`` in the
+querystring. Logging that to CloudWatch is a credential leak.
+
+Surfaced 2026-05-12 during the post-merge repair run for PR #219 — a
+transient FRED 500 on VXVCLS dumped the key to the operator terminal /
+conversation transcript.
+
+These tests lock the contract that:
+
+  - ``_scrub_api_key`` masks the ``api_key=...`` fragment in any string
+  - ``_fetch_fred_closes`` (production daily-pipeline fetcher) routes
+    exceptions through the scrubber before logging
+  - ``_fetch_fred_range`` (repair-script fetcher) does the same on its
+    retry and final-failure paths
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from collectors import daily_closes
+from collectors import daily_closes_fred_repair as repair_mod
+
+
+# ── _scrub_api_key ─────────────────────────────────────────────────────────
+
+
+def test_scrub_masks_api_key_in_url():
+    msg = (
+        "500 Server Error: Internal Server Error for url: "
+        "https://api.stlouisfed.org/fred/series/observations"
+        "?series_id=VIXCLS&api_key=4509846484a78c3ee667a118d5179de7"
+        "&file_type=json"
+    )
+    scrubbed = daily_closes._scrub_api_key(msg)
+    assert "4509846484a78c3ee667a118d5179de7" not in scrubbed
+    assert "api_key=***" in scrubbed
+
+
+def test_scrub_handles_exception_object_directly():
+    """The helper must accept an exception object (not just str) — that's
+    how it'll be invoked at the ``logger.warning("... %s", e)`` site."""
+    try:
+        resp = requests.Response()
+        resp.status_code = 500
+        resp.url = (
+            "https://api.stlouisfed.org/fred/series/observations"
+            "?series_id=VIXCLS&api_key=SECRETVALUEXYZ&file_type=json"
+        )
+        resp.reason = "Internal Server Error"
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        scrubbed = daily_closes._scrub_api_key(e)
+
+    assert "SECRETVALUEXYZ" not in scrubbed
+    assert "api_key=***" in scrubbed
+
+
+def test_scrub_passthrough_when_no_api_key():
+    msg = "FRED returned empty observations for VIXCLS"
+    assert daily_closes._scrub_api_key(msg) == msg
+
+
+def test_scrub_terminates_at_ampersand_not_eating_other_querystring():
+    """Make sure the regex stops at ``&`` so it doesn't eat unrelated
+    querystring fragments after the key (e.g. ``&file_type=json``)."""
+    msg = "url: https://x/?api_key=SECRET&file_type=json"
+    scrubbed = daily_closes._scrub_api_key(msg)
+    assert scrubbed == "url: https://x/?api_key=***&file_type=json"
+
+
+# ── _fetch_fred_closes error-log path ──────────────────────────────────────
+
+
+def test_fetch_fred_closes_scrubs_api_key_on_http_error(
+    monkeypatch, caplog,
+):
+    """The production daily-pipeline fetcher's except-block must not log
+    the raw HTTPError string (which contains api_key=...)."""
+    monkeypatch.setenv("FRED_API_KEY", "live-test-key-1234567890")
+
+    class _ExplodingResponse:
+        def raise_for_status(self):
+            err_msg = (
+                "500 Server Error: Internal Server Error for url: "
+                "https://api.stlouisfed.org/fred/series/observations"
+                "?series_id=VIXCLS&api_key=live-test-key-1234567890"
+                "&file_type=json&observation_end=2026-05-12"
+                "&sort_order=desc&limit=5"
+            )
+            raise requests.exceptions.HTTPError(err_msg)
+
+    records: list[dict] = []
+    with caplog.at_level(logging.WARNING, logger="collectors.daily_closes"):
+        with patch(
+            "collectors.daily_closes.requests.get",
+            return_value=_ExplodingResponse(),
+        ):
+            daily_closes._fetch_fred_closes(
+                tickers=["VIX"],
+                date_str="2026-05-12",
+                records=records,
+            )
+
+    assert records == []
+    combined = "\n".join(rec.message for rec in caplog.records)
+    assert "live-test-key-1234567890" not in combined
+    assert "api_key=***" in combined
+
+
+# ── _fetch_fred_range retry + final-error path ─────────────────────────────
+
+
+def test_fetch_fred_range_scrubs_api_key_on_retry_log(monkeypatch, caplog):
+    """First-attempt 500 must log via scrubbed retry warning, never the
+    raw URL with api_key=..."""
+    class _ExplodingResponse:
+        def __init__(self):
+            self.calls = 0
+
+        def raise_for_status(self):
+            self.calls += 1
+            if self.calls < 2:
+                raise requests.exceptions.HTTPError(
+                    "500 Server Error for url: "
+                    "https://api.stlouisfed.org/fred/?series_id=DGS10"
+                    "&api_key=secret-leak-test-abc&file_type=json"
+                )
+
+        def json(self):
+            return {"observations": [{"date": "2026-04-22", "value": "4.34"}]}
+
+    resp = _ExplodingResponse()
+
+    with caplog.at_level(logging.WARNING, logger="collectors.daily_closes_fred_repair"):
+        with patch(
+            "collectors.daily_closes_fred_repair.requests.get",
+            return_value=resp,
+        ), patch("collectors.daily_closes_fred_repair.time.sleep"):
+            out = repair_mod._fetch_fred_range(
+                series_id="DGS10",
+                start="2026-04-15",
+                end="2026-04-22",
+                api_key="secret-leak-test-abc",
+            )
+
+    assert out == {"2026-04-22": 4.34}
+    combined = "\n".join(rec.message for rec in caplog.records)
+    assert "secret-leak-test-abc" not in combined
+    assert "api_key=***" in combined
+
+
+def test_fetch_fred_range_scrubs_api_key_on_final_failure(monkeypatch, caplog):
+    """After 3 failed attempts, the RuntimeError + the final ``logger.error``
+    line must both be scrubbed — that's the surface that bubbles into
+    operator terminals."""
+    class _ExplodingResponse:
+        def raise_for_status(self):
+            raise requests.exceptions.HTTPError(
+                "500 Server Error for url: "
+                "https://api.stlouisfed.org/fred/?series_id=DGS10"
+                "&api_key=secret-final-failure-xyz&file_type=json"
+            )
+
+    with caplog.at_level(logging.ERROR, logger="collectors.daily_closes_fred_repair"):
+        with patch(
+            "collectors.daily_closes_fred_repair.requests.get",
+            return_value=_ExplodingResponse(),
+        ), patch("collectors.daily_closes_fred_repair.time.sleep"):
+            with pytest.raises(RuntimeError) as excinfo:
+                repair_mod._fetch_fred_range(
+                    series_id="DGS10",
+                    start="2026-04-15",
+                    end="2026-04-22",
+                    api_key="secret-final-failure-xyz",
+                )
+
+    assert "secret-final-failure-xyz" not in str(excinfo.value)
+    assert "api_key=***" in str(excinfo.value)
+    combined = "\n".join(rec.message for rec in caplog.records)
+    assert "secret-final-failure-xyz" not in combined


### PR DESCRIPTION
## Summary

Closes a latent credential-leak class in the FRED fetcher's error-log path. ``requests.exceptions.HTTPError.str()`` embeds the full request URL — including ``api_key=<credential>`` — and ``_fetch_fred_closes`` logged it verbatim via ``logger.warning("... %s", e)``. Any FRED 5xx in production MorningEnrich / EOD would dump the key to CloudWatch logs.

Surfaced 2026-05-12 during the post-merge operator step for PR #219 — a transient FRED 500 on VXVCLS during the repair-script run leaked the key to the conversation transcript. The FRED key is being rotated separately; this PR closes the underlying leak.

## What changed

- **``collectors/daily_closes.py``** — new ``_scrub_api_key(msg) -> str`` helper masks the ``api_key=...`` querystring fragment with ``api_key=***``. ``_fetch_fred_closes``'s warn-log routes the exception through the scrubber.
- **``collectors/daily_closes_fred_repair.py``** — adds retry (3 attempts, 3s/6s backoff) on transient FRED 5xx + imports the shared ``_scrub_api_key`` from ``daily_closes`` (regex defined once, no drift across files).
- **``tests/test_fred_api_key_scrub.py``** (new, +7 tests) — pins the scrubbing contract on ``_scrub_api_key`` directly + on ``_fetch_fred_closes`` warn path + on ``_fetch_fred_range`` retry-warn + final-error paths.

Suite 792 → 799.

## Test plan

- [x] Local ``pytest -q`` clean (799 passed, 1 skipped pre-existing)
- [ ] Confirm tomorrow's Wed 2026-05-13 MorningEnrich logs (CloudWatch) — if FRED 5xx fires, the log line should read ``api_key=***`` not the raw key.
- [ ] Operator: rotate the FRED key on https://fred.stlouisfed.org/, update ``.env`` locally + ``alpha-engine-config/data/.env`` + the AWS SSM ``/alpha-engine/FRED_API_KEY`` parameter (or wherever the Lambda env loader reads from). Rotation is independent of this PR — the PR closes the future leak surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)