### PR TITLE
feat(secrets): migrate to alpha_engine_lib.secrets.get_secret() — PR 2 of arc

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -45,6 +45,8 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
 import boto3
+
+from alpha_engine_lib.secrets import get_secret
 import requests
 
 logger = logging.getLogger(__name__)
@@ -464,7 +466,7 @@ def _fmp_get(endpoint: str, params: dict | None = None) -> dict | list:
     endpoint sunsets (the 2026-04 incident) can't hide.
     """
     global _fmp_last_call, _fmp_daily_count
-    api_key = os.environ.get("FMP_API_KEY", "")
+    api_key = get_secret("FMP_API_KEY", required=False, default="")
     if not api_key:
         return []
 
@@ -752,7 +754,7 @@ def _fetch_insider(ticker: str, run_date: str) -> dict:
         "transactions": [],
     }
 
-    identity = os.environ.get("EDGAR_IDENTITY", "")
+    identity = get_secret("EDGAR_IDENTITY", required=False, default="")
     if not identity:
         return result
 
@@ -831,7 +833,7 @@ def _fetch_institutional(ticker: str) -> dict:
         "funds_decreasing": 0,
     }
 
-    identity = os.environ.get("EDGAR_IDENTITY", "")
+    identity = get_secret("EDGAR_IDENTITY", required=False, default="")
     if not identity:
         return result
 

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import io
 import logging
-import os
 import re
 import time
 from datetime import datetime, time as dtime, timedelta, timezone
@@ -47,6 +46,8 @@ from zoneinfo import ZoneInfo
 import boto3
 import pandas as pd
 import requests
+
+from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -803,7 +804,7 @@ def _fetch_fred_closes(
     so the legacy "today's parquet carries yesterday's FRED value" semantic
     is preserved for the current-day case.
     """
-    api_key = os.environ.get("FRED_API_KEY", "")
+    api_key = get_secret("FRED_API_KEY", required=False, default="")
     if not api_key:
         logger.warning("FRED_API_KEY not set — skipping FRED fallback for %d tickers", len(tickers))
         return 0

--- a/collectors/daily_closes_fred_repair.py
+++ b/collectors/daily_closes_fred_repair.py
@@ -49,11 +49,12 @@ import argparse
 import io
 import json
 import logging
-import os
 import sys
 import time
 from datetime import datetime, timedelta
 from typing import Optional
+
+from alpha_engine_lib.secrets import get_secret
 
 import boto3
 import pandas as pd
@@ -200,7 +201,7 @@ def repair(
 
     Returns a per-date summary dict.
     """
-    api_key = os.environ.get("FRED_API_KEY", "")
+    api_key = get_secret("FRED_API_KEY", required=False, default="")
     if not api_key:
         raise RuntimeError("FRED_API_KEY not set — cannot fetch FRED values")
 

--- a/collectors/finnhub_client.py
+++ b/collectors/finnhub_client.py
@@ -29,11 +29,12 @@ or hard-fail per their no-silent-fails policy.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 
 import requests
+
+from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ def finnhub_get(endpoint: str, params: dict | None = None) -> dict | list:
     timeouts). Caller decides retry / fall-through / hard-fail.
     """
     global _finnhub_last_call
-    api_key = os.environ.get("FINNHUB_API_KEY", "")
+    api_key = get_secret("FINNHUB_API_KEY", required=False, default="")
     if not api_key:
         return []
 

--- a/collectors/fred_history.py
+++ b/collectors/fred_history.py
@@ -22,11 +22,12 @@ parquet contract.
 from __future__ import annotations
 
 import logging
-import os
 import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from alpha_engine_lib.secrets import get_secret
 from typing import Optional
 
 import boto3
@@ -80,7 +81,7 @@ def fetch_fred_history(
         available or the request fails after retries.
     """
     if api_key is None:
-        api_key = os.environ.get("FRED_API_KEY", "")
+        api_key = get_secret("FRED_API_KEY", required=False, default="")
     if not api_key:
         raise RuntimeError(
             "FRED_API_KEY not set — cannot fetch historical FRED series. "

--- a/collectors/fundamentals.py
+++ b/collectors/fundamentals.py
@@ -62,8 +62,9 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
+
+from alpha_engine_lib.secrets import get_secret
 
 from .finnhub_client import finnhub_get
 
@@ -205,7 +206,7 @@ def collect(
     """
     import boto3
 
-    api_key = os.environ.get("FINNHUB_API_KEY", "")
+    api_key = get_secret("FINNHUB_API_KEY", required=False, default="")
     if not api_key:
         # Preflight is expected to catch this earlier; hard-fail here too
         # so a missing key can never land as "0 OK / N errors / all-zeros".

--- a/collectors/macro.py
+++ b/collectors/macro.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from datetime import datetime, timezone
 from typing import Optional
 
 import boto3
 import numpy as np
+
+from alpha_engine_lib.secrets import get_secret
 import pandas as pd
 import requests
 import yfinance as yf
@@ -115,7 +116,7 @@ def collect(
 
 def _fetch_fred() -> dict:
     """Fetch all FRED series + compute derived metrics."""
-    api_key = os.environ.get("FRED_API_KEY", "")
+    api_key = get_secret("FRED_API_KEY", required=False, default="")
     if not api_key:
         logger.warning("FRED_API_KEY not set — skipping FRED data")
         return {k: None for k in _FRED_SERIES}

--- a/emailer.py
+++ b/emailer.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+from alpha_engine_lib.secrets import get_secret
+
 log = logging.getLogger(__name__)
 
 
@@ -31,7 +33,7 @@ def send_step_email(step_name: str, results: dict, date_str: str) -> bool:
         log.warning("Failed to build step email: %s", exc)
         return False
 
-    app_password = os.environ.get("GMAIL_APP_PASSWORD", "").strip()
+    app_password = (get_secret("GMAIL_APP_PASSWORD", required=False, default="") or "").strip()
 
     if app_password:
         try:

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -21,13 +21,14 @@ Usage:
 from __future__ import annotations
 
 import logging
-import os
 import time
 from collections import deque
 from datetime import date, datetime, timedelta
 
 import pandas as pd
 import requests
+
+from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ class PolygonClient:
     """Rate-limited polygon.io REST client with dividend adjustment."""
 
     def __init__(self, api_key: str | None = None, calls_per_min: int = 5):
-        self._api_key = api_key or os.environ.get("POLYGON_API_KEY", "")
+        self._api_key = api_key or get_secret("POLYGON_API_KEY", required=False, default="")
         if not self._api_key:
             raise ValueError("POLYGON_API_KEY not set")
         self._calls_per_min = calls_per_min

--- a/preflight.py
+++ b/preflight.py
@@ -16,11 +16,11 @@ the single source of truth. See alpha-engine-lib README for the
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 from typing import Any
 
 from alpha_engine_lib.preflight import BasePreflight
+from alpha_engine_lib.secrets import get_secret
 
 log = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ class DataPreflight(BasePreflight):
         """
         import requests
 
-        api_key = os.environ.get("FMP_API_KEY", "").strip()
+        api_key = (get_secret("FMP_API_KEY", required=False, default="") or "").strip()
         try:
             resp = requests.get(
                 _FMP_STABLE_PROBE_URL,
@@ -173,7 +173,7 @@ class DataPreflight(BasePreflight):
         """
         import requests
 
-        api_key = os.environ.get("POLYGON_API_KEY", "").strip()
+        api_key = (get_secret("POLYGON_API_KEY", required=False, default="") or "").strip()
         try:
             resp = requests.get(
                 _POLYGON_PROBE_URL,
@@ -206,7 +206,7 @@ class DataPreflight(BasePreflight):
         """Validate FRED network + auth via single-observation DFF call."""
         import requests
 
-        api_key = os.environ.get("FRED_API_KEY", "").strip()
+        api_key = (get_secret("FRED_API_KEY", required=False, default="") or "").strip()
         try:
             resp = requests.get(
                 _FRED_PROBE_URL,

--- a/rag/pipelines/ingest_earnings_finnhub.py
+++ b/rag/pipelines/ingest_earnings_finnhub.py
@@ -21,11 +21,12 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import time
 from datetime import date
 
 import requests
+
+from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ _CHUNK_OVERLAP = 50
 
 
 def _get_api_key() -> str:
-    key = os.environ.get("FINNHUB_API_KEY", "")
+    key = get_secret("FINNHUB_API_KEY", required=False, default="")
     if not key:
         raise RuntimeError("FINNHUB_API_KEY not set — sign up free at finnhub.io")
     return key

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ arcticdb>=6.11
 # previously listed above as direct deps; kept those direct lines for now to
 # avoid breaking pinning during the migration. Drop the duplicate direct
 # pgvector/psycopg2-binary pins once the migration soaks.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.6.2
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.12.0

--- a/sf_preflight.py
+++ b/sf_preflight.py
@@ -408,8 +408,8 @@ def check_polygon_grouped_coverage(ctx: PreflightContext) -> CheckResult:
             elapsed_seconds=time.time() - t0,
         )
 
-    import os
-    if not os.environ.get("POLYGON_API_KEY"):
+    from alpha_engine_lib.secrets import get_secret
+    if not get_secret("POLYGON_API_KEY", required=False):
         # Local-laptop preflight — polygon key lives in .env on the spot
         # and on EC2. Skip without failing so the rest of the report is
         # actionable; on the spot the key is present and this fires.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,35 @@
-"""Add project root to sys.path so module imports work."""
-import sys
+"""Test fixtures + sys.path setup.
+
+Pins ``ALPHA_ENGINE_SECRETS_SOURCE=env`` for every test so
+``alpha_engine_lib.secrets.get_secret()`` reads from monkeypatched
+env vars only — never the real SSM Parameter Store. Without this,
+tests that simulate "missing API key" via ``monkeypatch.delenv``
+would be silently no-op'd by a live SSM read. See
+``alpha-engine-docs/private/env-to-ssm-260512.md`` § Risks.
+"""
+
 import os
+import sys
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_secrets_from_ssm(monkeypatch):
+    """Force every test to read secrets from env only, not SSM.
+
+    Also clears the per-process secret cache before each test so a prior
+    test's reads don't leak into the next test's state.
+    """
+    monkeypatch.setenv("ALPHA_ENGINE_SECRETS_SOURCE", "env")
+    try:
+        from alpha_engine_lib.secrets import clear_cache
+    except ImportError:
+        # Lib not installed (rare — tests that don't import secrets path).
+        yield
+        return
+    clear_cache()
+    yield
+    clear_cache()

--- a/tests/test_no_secret_environ_reads.py
+++ b/tests/test_no_secret_environ_reads.py
@@ -1,0 +1,75 @@
+"""Regression: no module in this repo reads a secret via ``os.environ.get``.
+
+After the 2026-05-12 ``.env`` → SSM migration (PR 2 of the arc), every
+secret-bearing call site routes through ``alpha_engine_lib.secrets.get_secret()``.
+This test re-greps the codebase on every CI run so a future commit can't
+silently re-introduce an ``os.environ.get("POLYGON_API_KEY")`` style read.
+
+Non-secret env vars (``LANGCHAIN_PROJECT``, ``EMAIL_SENDER``, etc.) are
+allowed for now — they migrate to alpha-engine-config YAML in PR 8 of the
+arc. The pin here is only the secret-name set.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Secret names that must NEVER be read via os.environ.get / os.getenv.
+_PINNED_SECRETS = frozenset(
+    [
+        "ANTHROPIC_API_KEY",
+        "LANGCHAIN_API_KEY",
+        "VOYAGE_API_KEY",
+        "POLYGON_API_KEY",
+        "FMP_API_KEY",
+        "FINNHUB_API_KEY",
+        "FRED_API_KEY",
+        "GMAIL_APP_PASSWORD",
+        "GITHUB_TOKEN",
+        "RAG_DATABASE_URL",
+        "EDGAR_IDENTITY",
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_CHAT_ID",
+    ]
+)
+
+# Files that are explicitly allowed to read secrets via os.environ — the
+# legacy ssm_secrets.py bulk-load shim is the only one; it covers
+# non-migrated reads in this repo and other repos pending PRs 3-7. The
+# shim itself is removed in PR 9 of the arc.
+_ALLOWED_FILES = frozenset(["ssm_secrets.py"])
+
+_ENV_READ_RE = re.compile(
+    r'os\.(?:environ\.get|getenv)\(\s*["\']([A-Z_][A-Z0-9_]*)["\']'
+)
+
+
+def _iter_python_files():
+    for path in _REPO_ROOT.rglob("*.py"):
+        # Skip venv / build / tests / dot-dirs.
+        parts = set(path.parts)
+        if parts & {".venv", "build", "tests", "node_modules"}:
+            continue
+        if path.name in _ALLOWED_FILES:
+            continue
+        yield path
+
+
+def test_no_secret_environ_reads():
+    """Grep for ``os.environ.get("SECRET")`` over the codebase."""
+    violations: list[tuple[Path, int, str]] = []
+    for path in _iter_python_files():
+        text = path.read_text()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for match in _ENV_READ_RE.finditer(line):
+                name = match.group(1)
+                if name in _PINNED_SECRETS:
+                    violations.append((path.relative_to(_REPO_ROOT), lineno, name))
+    assert not violations, (
+        "Found os.environ.get reads of pinned secrets — use "
+        "`from alpha_engine_lib.secrets import get_secret` instead:\n"
+        + "\n".join(f"  {p}:{ln}  {name}" for p, ln, name in violations)
+    )


### PR DESCRIPTION
## Summary
- Replaces 16 `os.environ.get('SECRET_X')` call sites across 12 modules with `get_secret()`.
- Bumps lib pin v0.6.2 → v0.12.0.
- Migrated secrets: `POLYGON_API_KEY`, `FMP_API_KEY`, `FRED_API_KEY`, `FINNHUB_API_KEY`, `GMAIL_APP_PASSWORD`, `EDGAR_IDENTITY`.
- Call sites preserve the existing contract (`required=False, default=""`) — SSM round-trip is the only behavior change.
- Autouse conftest fixture pins `ALPHA_ENGINE_SECRETS_SOURCE=env` so tests that simulate "missing API key" via `monkeypatch.delenv` aren't no-op'd by live SSM reads.
- +1 regression test (`test_no_secret_environ_reads`) greps the codebase for secret reads via `os.environ`.

## Why
PR 2 of 9 in the `.env`-deprecation arc — closes ROADMAP P1 line ~2780. Plan doc: `alpha-engine-docs/private/env-to-ssm-260512.md`.

`ssm_secrets.py` stays alive — it still covers non-secret env reads (`LANGCHAIN_PROJECT`, `EMAIL_SENDER`, etc.) that migrate to alpha-engine-config YAML in PR 8 of the arc.

## Test plan
- [x] Suite: 794 → 800 passed (5 prior "missing key" tests recovered by conftest fix)
- [x] `test_no_secret_environ_reads` greps and confirms zero secret reads via `os.environ`
- [ ] **Wed 2026-05-13 MorningEnrich** — first live exercise on the weekday SF
- [ ] Sat 2026-05-16 SF — second exercise (DataPhase1 + RAGIngestion paths)

## Out of scope
- Non-secret env-var migration (`LANGCHAIN_PROJECT`, `EMAIL_*`, `S3_BUCKET`) → PR 8
- `ssm_secrets.py` deletion → PR 9
- Other repos (research / predictor / backtester / executor / dashboard) → PRs 3-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)