### PR TITLE
feat(secrets): EMAIL_* via get_secret() (PR 8a of arc)

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -20,8 +20,12 @@ log = logging.getLogger(__name__)
 
 def send_step_email(step_name: str, results: dict, date_str: str) -> bool:
     """Send a completion email for a pipeline step. Never raises."""
-    sender = os.environ.get("EMAIL_SENDER", "").strip()
-    recipients = [r.strip() for r in os.environ.get("EMAIL_RECIPIENTS", "").split(",") if r.strip()]
+    sender = (get_secret("EMAIL_SENDER", required=False, default="") or "").strip()
+    recipients = [
+        r.strip()
+        for r in (get_secret("EMAIL_RECIPIENTS", required=False, default="") or "").split(",")
+        if r.strip()
+    ]
 
     if not sender or not recipients:
         log.info("Step email skipped — EMAIL_SENDER/EMAIL_RECIPIENTS not set")

--- a/tests/test_no_secret_environ_reads.py
+++ b/tests/test_no_secret_environ_reads.py
@@ -18,6 +18,10 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Secret names that must NEVER be read via os.environ.get / os.getenv.
+# EMAIL_SENDER + EMAIL_RECIPIENTS aren't secrets per se but live in SSM
+# under /alpha-engine/* and route through get_secret() — pinning them
+# here prevents regressions to the bulk-load-into-os.environ shim
+# pattern that PR 8 of the .env→SSM arc retired.
 _PINNED_SECRETS = frozenset(
     [
         "ANTHROPIC_API_KEY",
@@ -33,6 +37,8 @@ _PINNED_SECRETS = frozenset(
         "EDGAR_IDENTITY",
         "TELEGRAM_BOT_TOKEN",
         "TELEGRAM_CHAT_ID",
+        "EMAIL_SENDER",
+        "EMAIL_RECIPIENTS",
     ]
 )
 


### PR DESCRIPTION
## Summary
- Migrate `EMAIL_SENDER` + `EMAIL_RECIPIENTS` reads in `emailer.py` to `get_secret()`.
- Pin both in the regression-test secret set.

## Why
PR 8a of the `.env`-to-SSM arc — narrows the bulk-load-shim dependency surface. Both EMAIL_* values already live in `/alpha-engine/*` SSM; this just routes the reads through `get_secret()` like the other secret values, so `emailer.py` doesn't need `ssm_secrets.py::load_secrets()` to have populated `os.environ` first.

`ssm_secrets.py` shim stays alive in this PR — full deletion + `.env` cleanup is queued for PR 9.

## Test plan
- [x] Suite 801/801 passing
- [x] Regression test confirms zero `os.environ.get("EMAIL_*")` reads
- [ ] **Wed 2026-05-13 MorningEnrich step-email** — first live exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)