### PR TITLE
fix(arctic): normalize Categorical columns at every ArcticDB write boundary

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -48,7 +48,7 @@ from features.compute import (
     _load_cached_alternative,
     make_source_series,
 )
-from store.arctic_store import get_universe_lib, get_macro_lib
+from store.arctic_store import get_universe_lib, get_macro_lib, to_arctic_safe
 
 log = logging.getLogger(__name__)
 
@@ -598,7 +598,9 @@ def backfill(
                 )
 
             if not dry_run:
-                universe_lib.write(ticker, symbol_df)
+                # to_arctic_safe strips the Categorical ``source`` dtype
+                # (PR #211) before write — ArcticDB rejects categoricals.
+                universe_lib.write(ticker, to_arctic_safe(symbol_df))
 
             n_ok += 1
 
@@ -641,7 +643,7 @@ def backfill(
     else:
         macro_df = _build_macro_features_df(macro)
         if not macro_df.empty and not dry_run:
-            macro_lib.write("features", macro_df)
+            macro_lib.write("features", to_arctic_safe(macro_df))
             log.info("Wrote macro features: %d dates", len(macro_df))
 
         # Write raw macro series (SPY, VIX, etc.) for consumers that need them
@@ -651,14 +653,14 @@ def backfill(
                 if series is not None:
                     macro_series_df = pd.DataFrame({"Close": series}, index=series.index)
                     macro_series_df.index.name = "date"
-                    macro_lib.write(key, macro_series_df)
+                    macro_lib.write(key, to_arctic_safe(macro_series_df))
 
             # Write sector ETFs
             for key in macro:
                 if key.startswith("XL"):
                     sector_df = pd.DataFrame({"Close": macro[key]}, index=macro[key].index)
                     sector_df.index.name = "date"
-                    macro_lib.write(key, sector_df)
+                    macro_lib.write(key, to_arctic_safe(sector_df))
 
     # ── 6. Snapshot ──────────────────────────────────────────────────────────
     if not dry_run:

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -46,7 +46,7 @@ from features.compute import (
 from arcticdb.version_store.library import ReadRequest, UpdatePayload, WritePayload
 from arcticdb_ext.version_store import DataError
 
-from store.arctic_store import get_universe_lib, get_macro_lib
+from store.arctic_store import get_universe_lib, get_macro_lib, to_arctic_safe
 from store.parquet_loader import load_parquet_from_s3
 from validators.price_validator import (
     ALL_ANOMALY_TYPES,
@@ -1245,13 +1245,19 @@ def daily_append(
                 # Append at head — fast path. update_batch with upsert=True
                 # also handles the rare "symbol doesn't exist yet" case
                 # (replaces _write_row_backfill_safe's lib.write fallback).
-                update_payloads.append(UpdatePayload(symbol=ticker, data=today_row))
+                # to_arctic_safe strips Categorical ``source`` dtype (PR #211)
+                # which ArcticDB's update_batch rejects.
+                update_payloads.append(
+                    UpdatePayload(symbol=ticker, data=to_arctic_safe(today_row))
+                )
             else:
                 # Backfill — splice into existing series, full rewrite. Same
                 # logic as _write_row_backfill_safe's backfill branch.
                 combined = pd.concat([hist, today_row])
                 combined = combined[~combined.index.duplicated(keep="last")].sort_index()
-                write_payloads.append(WritePayload(symbol=ticker, data=combined))
+                write_payloads.append(
+                    WritePayload(symbol=ticker, data=to_arctic_safe(combined))
+                )
 
         if update_payloads or write_payloads:
             t_write0 = time.time()

--- a/store/arctic_store.py
+++ b/store/arctic_store.py
@@ -21,6 +21,7 @@ import logging
 import os
 
 import arcticdb as adb
+import pandas as pd
 
 log = logging.getLogger(__name__)
 
@@ -61,3 +62,31 @@ def reset_connection():
     """Reset the singleton (useful for testing or credential rotation)."""
     global _arctic_instance
     _arctic_instance = None
+
+
+def to_arctic_safe(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize a DataFrame to dtypes ArcticDB accepts on write/update.
+
+    ArcticDB's ``_handle_categorical_columns`` raises
+    ``ArcticDbNotYetImplemented`` on any ``CategoricalDtype`` column during
+    ``update_batch`` / ``write_batch`` (verified 2026-05-12 EOD incident on
+    BRK-B). Callers may keep Categorical in-memory for memory savings
+    (PR #211: ~108MB reduction across the universe pass in
+    ``_apply_daily_delta``) — this helper is the *single* boundary between
+    that in-memory representation and the ArcticDB storage contract.
+
+    Call exactly once, immediately before every ``update_batch`` /
+    ``write_batch`` / ``write`` invocation. Empty frames and frames with no
+    categorical columns return unchanged (no copy); frames with categoricals
+    are copied + cast to object dtype (matches PR #196's pre-#211 storage
+    representation, which round-trips cleanly through ArcticDB).
+    """
+    if df.empty:
+        return df
+    cat_cols = [c for c in df.columns if isinstance(df[c].dtype, pd.CategoricalDtype)]
+    if not cat_cols:
+        return df
+    df = df.copy()
+    for col in cat_cols:
+        df[col] = df[col].astype(object)
+    return df

--- a/tests/test_arctic_write_contract.py
+++ b/tests/test_arctic_write_contract.py
@@ -1,0 +1,218 @@
+"""Regression: store.arctic_store.to_arctic_safe must strip Categorical dtypes.
+
+2026-05-12 EOD incident: ``builders/daily_append.py``'s ``update_batch`` call
+raised ``arcticdb.exceptions.ArcticDbNotYetImplemented`` on BRK-B because
+PR #211 ("perf(provenance): categorical dtype for source column") had
+converted the ``source`` column to ``pd.CategoricalDtype`` for memory savings
+in ``_apply_daily_delta``, and ArcticDB's ``_handle_categorical_columns``
+rejects categoricals on every append/update path.
+
+The institutional fix keeps PR #211's in-memory memory win (~108MB across
+the universe pass) and converts to object dtype only at the storage
+boundary, via ``store.arctic_store.to_arctic_safe`` — a single named
+helper called immediately before every ``update_batch`` / ``write_batch`` /
+``write`` invocation.
+
+This test pins the contract: the helper must convert Categorical → object
+without mutating the caller's frame, must preserve values + index, and
+must short-circuit on empty / no-categorical frames (no needless copies).
+A regression that re-introduces categoricals at the write boundary —
+either by removing the wrap or by changing the helper's behavior — should
+fail loudly here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from store.arctic_store import to_arctic_safe
+
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+
+def _make_payload_with_categorical_source(n: int = 5) -> pd.DataFrame:
+    """Mimic the shape produced by ``features.compute._apply_daily_delta``:
+    OHLCV + ``source`` as ``CategoricalDtype`` per PR #211."""
+    idx = pd.date_range("2026-05-08", periods=n, freq="B", name="date")
+    return pd.DataFrame(
+        {
+            "Open": range(100, 100 + n),
+            "High": range(101, 101 + n),
+            "Low": range(99, 99 + n),
+            "Close": range(100, 100 + n),
+            "Volume": [1_000_000] * n,
+            "source": pd.Categorical(
+                ["yfinance"] * n,
+                categories=("polygon", "yfinance", "fred", "unknown"),
+            ),
+        },
+        index=idx,
+    )
+
+
+def test_to_arctic_safe_strips_categorical_source_column():
+    """The 2026-05-12 EOD failure mode: Categorical ``source`` column must
+    be converted to object dtype before ArcticDB sees the payload.
+
+    Without this conversion ArcticDB raises
+    ``ArcticDbNotYetImplemented: DataFrame/Series contains categorical
+    data, cannot append or update``.
+    """
+    df = _make_payload_with_categorical_source()
+    assert isinstance(df["source"].dtype, pd.CategoricalDtype), (
+        "test fixture precondition: payload must start with Categorical "
+        "source column (this mirrors features.compute.make_source_series)"
+    )
+
+    out = to_arctic_safe(df)
+
+    assert not isinstance(out["source"].dtype, pd.CategoricalDtype), (
+        "to_arctic_safe must strip CategoricalDtype — ArcticDB's "
+        "update_batch / write_batch reject categoricals."
+    )
+    assert out["source"].dtype == object, (
+        "Cast target must be object dtype (matches PR #196's pre-#211 "
+        "storage representation that round-trips cleanly through ArcticDB)."
+    )
+
+
+def test_to_arctic_safe_preserves_values_and_index():
+    """Conversion is dtype-only; ticker values, index, and ordering must
+    survive untouched. Downstream readers (predictor inference, backtester)
+    rely on ``source`` round-tripping as the same string label.
+    """
+    df = _make_payload_with_categorical_source(n=5)
+    df.loc[df.index[2], "source"] = "polygon"  # mix two categories
+    df.loc[df.index[4], "source"] = "fred"
+
+    out = to_arctic_safe(df)
+
+    assert list(out["source"]) == ["yfinance", "yfinance", "polygon", "yfinance", "fred"]
+    assert list(out.index) == list(df.index)
+    assert list(out.columns) == list(df.columns)
+
+
+def test_to_arctic_safe_does_not_mutate_input():
+    """The helper must return a new DataFrame when conversion is needed.
+    Mutating the caller's frame would defeat PR #211's memory win
+    (the Categorical representation must survive intact in the in-memory
+    compute path; only the write-bound copy gets cast).
+    """
+    df = _make_payload_with_categorical_source()
+    before_dtype = df["source"].dtype
+
+    _ = to_arctic_safe(df)
+
+    assert df["source"].dtype == before_dtype, (
+        "to_arctic_safe must not mutate the caller's frame — PR #211's "
+        "in-memory Categorical representation is the source of the "
+        "~108MB memory saving and must survive intact through the "
+        "compute path."
+    )
+    assert isinstance(df["source"].dtype, pd.CategoricalDtype)
+
+
+def test_to_arctic_safe_returns_input_unchanged_when_no_categoricals():
+    """Fast path: frames with no Categorical columns return unchanged
+    (no copy). This keeps the wrap cheap to apply uniformly at every
+    write site, including the macro_lib writes that have never used
+    Categorical.
+    """
+    idx = pd.date_range("2026-05-08", periods=3, freq="B", name="date")
+    df = pd.DataFrame({"Close": [400.0, 401.5, 402.0]}, index=idx)
+
+    out = to_arctic_safe(df)
+
+    assert out is df, (
+        "Fast path must return the same object (no copy) when there's "
+        "nothing to convert — keeps the wrap free for macro/sector writes."
+    )
+
+
+def test_to_arctic_safe_returns_input_unchanged_when_empty():
+    """Empty frame fast path. Empty payloads can appear in dry-run paths
+    and on tickers with no rows after filtering."""
+    df = pd.DataFrame()
+
+    out = to_arctic_safe(df)
+
+    assert out is df
+    assert out.empty
+
+
+def test_to_arctic_safe_handles_multiple_categorical_columns():
+    """Defensive against future writers that add additional categoricals
+    (e.g. a per-row ``quality`` flag, a ``vendor`` enum). The helper must
+    strip every CategoricalDtype column it finds, not just ``source``.
+    """
+    idx = pd.date_range("2026-05-08", periods=3, freq="B", name="date")
+    df = pd.DataFrame(
+        {
+            "Close": [100.0, 101.0, 102.0],
+            "source": pd.Categorical(["yfinance"] * 3, categories=("yfinance", "polygon")),
+            "quality": pd.Categorical(["clean"] * 3, categories=("clean", "warned", "blocked")),
+        },
+        index=idx,
+    )
+
+    out = to_arctic_safe(df)
+
+    assert not isinstance(out["source"].dtype, pd.CategoricalDtype)
+    assert not isinstance(out["quality"].dtype, pd.CategoricalDtype)
+    assert out["source"].dtype == object
+    assert out["quality"].dtype == object
+
+
+# ── Call-site regressions ────────────────────────────────────────────────────
+# Source-level checks that pin the wrap at every ArcticDB write site. A future
+# PR that removes the wrap (or adds a new write site without it) trips here.
+
+_DAILY_APPEND_SRC = (_REPO_ROOT / "builders" / "daily_append.py").read_text()
+_BACKFILL_SRC = (_REPO_ROOT / "builders" / "backfill.py").read_text()
+
+
+def test_daily_append_wraps_update_batch_payload():
+    """update_batch payload must go through to_arctic_safe — this is the
+    exact site that failed 2026-05-12 on BRK-B.
+    """
+    assert "UpdatePayload(symbol=ticker, data=to_arctic_safe(today_row))" in _DAILY_APPEND_SRC, (
+        "daily_append.py's UpdatePayload data must be wrapped in "
+        "to_arctic_safe — bare today_row carries Categorical 'source' "
+        "(PR #211) which ArcticDB update_batch rejects."
+    )
+
+
+def test_daily_append_wraps_write_batch_payload():
+    """The backfill-branch WritePayload also concatenates today_row's
+    Categorical source into a combined frame — same wrap required.
+    """
+    assert "WritePayload(symbol=ticker, data=to_arctic_safe(combined))" in _DAILY_APPEND_SRC, (
+        "daily_append.py's WritePayload (backfill branch) must wrap "
+        "combined in to_arctic_safe."
+    )
+
+
+def test_backfill_wraps_universe_write():
+    """Saturday SF backfill writes per-ticker symbol_df with the same
+    Categorical 'source' (PR #211). Must wrap before lib.write.
+    """
+    assert "universe_lib.write(ticker, to_arctic_safe(symbol_df))" in _BACKFILL_SRC, (
+        "backfill.py's universe_lib.write must wrap symbol_df in "
+        "to_arctic_safe — PR #211's Categorical source column flows "
+        "through here on Saturday SF."
+    )
+
+
+def test_backfill_wraps_macro_writes():
+    """Macro writes never use Categorical today, but uniform wrapping
+    keeps the contract single-source — and defends against a future
+    writer that adds one. Cheap because the helper short-circuits on
+    no-categorical frames.
+    """
+    assert "macro_lib.write(\"features\", to_arctic_safe(macro_df))" in _BACKFILL_SRC
+    assert "macro_lib.write(key, to_arctic_safe(macro_series_df))" in _BACKFILL_SRC
+    assert "macro_lib.write(key, to_arctic_safe(sector_df))" in _BACKFILL_SRC


### PR DESCRIPTION
## Summary

- **Closes the 2026-05-12 EOD failure mode.** `weekly_collector.py --daily` exited 1 in the ArcticDB append stage with `ArcticDbNotYetImplemented: ... DataFrame/Series contains categorical data, cannot append or update` on BRK-B. PR #211's Categorical `source` column leaked from the in-memory compute path into `update_batch`.
- Adds `store.arctic_store.to_arctic_safe(df)` — a single named helper at the ArcticDB storage boundary that strips `CategoricalDtype` columns to object dtype (matches PR #196's pre-#211 storage representation).
- Wraps every ArcticDB write call site: 2× in `builders/daily_append.py` (`update_batch` + `write_batch`), 3× in `builders/backfill.py` (`universe_lib.write` + 3× `macro_lib.write`). Uniform wrapping is single-source-of-truth; the fast path returns the input unchanged when there's nothing to convert, so wrapping at the macro paths is free.
- Keeps PR #211's ~108MB in-memory memory win intact — the Categorical representation survives through `_apply_daily_delta` and `compute_and_write`; only the write-bound copy gets cast.

## Why this shape

Institutional pattern: in-memory representations can be optimized (categoricals for compactness); the storage boundary enforces a strict contract that matches what the storage system accepts. The cast happens at exactly one named point. Same shape as JSON serialization, DataFrame→Parquet schema validation, ORM→SQL boundaries. Defends future writers (a new PR that adds another Categorical column — e.g. a `quality` flag or `vendor` enum — automatically gets normalized without changing the writer).

Bare `.astype(str)` at each call site would solve the immediate failure but encode the rule "ArcticDB doesn't accept Categorical" as folklore. The helper encodes it as code.

## Test plan

- [x] `python -m pytest tests/test_arctic_write_contract.py -v` — all 10 new tests pass
- [x] Full suite: 811 passed, 1 skipped, 5 warnings (warnings pre-existing, unrelated to this PR; suite 802 → 812)
- [x] Source-level call-site regressions pin the wrap at every ArcticDB write site — a future revert or new unwrapped write site fails loudly
- [ ] Tomorrow's 2026-05-13 MorningEnrich exercises `update_batch` in production (first post-merge live exercise)
- [ ] Saturday SF 2026-05-16 exercises `backfill.py`'s `universe_lib.write` + macro writes (first post-merge backfill exercise)

## Refs

- PR #211 (2026-05-11) introduced the Categorical `source` dtype that broke `update_batch`
- PR #196 — original object-dtype `source` column, the pre-#211 storage representation that round-trips cleanly through ArcticDB
- `feedback_test_fixture_shape_must_match_production` — same institutional principle (shape-validation at storage boundaries), different boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)