### PR TITLE
feat(derived): Wave 1 PR A.2 — news structured aggregates writer (per-ticker per-day parquet)

### DIFF
--- a/data/derived/__init__.py
+++ b/data/derived/__init__.py
@@ -1,0 +1,24 @@
+"""Derived signals — per-(ticker, date) aggregates computed from the
+multi-source raw inputs.
+
+Wave 1 of the institutional data revamp uses this package for:
+
+  news_aggregates    — sentiment / event / entity rollup per ticker per day
+                       (PR A.2 — this PR)
+  revisions          — self-derived analyst estimate revisions from FMP
+                       snapshots (PR C, deferred)
+  insider_aggregates — Form 4 rollup per ticker (PR B)
+  inst_ownership     — 13F rollup per ticker (PR B)
+
+Each derived module:
+
+1. Reads raw producer output (RAG corpus, FMP snapshots, parquet files).
+2. Computes structured per-(ticker, date) rows.
+3. Writes one parquet file per date under
+   ``s3://alpha-engine-research/data/{slot}/{date}.parquet``.
+
+Consumers (alpha-engine-research, backtester) read these parquets to
+populate the snapshot — never re-aggregate from raw producer output.
+
+See ``alpha-engine-docs/private/data-revamp-260513.md`` for full arc.
+"""

--- a/data/derived/news_aggregates.py
+++ b/data/derived/news_aggregates.py
@@ -1,0 +1,429 @@
+"""News aggregates — per-(ticker, date) sentiment + event + entity rollup.
+
+Wave 1 PR A.2 of the institutional data-revamp arc (plan doc:
+``~/Development/alpha-engine-docs/private/data-revamp-260513.md``).
+
+Joins the three NLP-pipeline output streams (sentiment_scores,
+entity_mentions, event_flags) with the aggregator's source-provenance
+information and produces one row per (ticker, aggregate_date). This is
+the canonical structured signal that downstream consumers read into
+``input_data_snapshot`` for thesis_update, sector_quant, and
+sector_qual agents.
+
+Schema design notes:
+
+- ``schema_version`` column on every row so consumers can shim through
+  schema evolution. Bump on any breaking change. Additive changes
+  bump the minor version comment but not the column.
+- Source-provenance preserved as ``n_articles_by_source`` (JSON-
+  serialized dict, since parquet handles dicts via pyarrow struct but
+  pandas DataFrame.to_parquet flattens awkwardly — JSON string is
+  more portable).
+- Numerical aggregates use trust-weighted means as the primary
+  "headline" metric (``lm_sentiment_trusted_mean``); raw mean kept as
+  ``lm_sentiment_mean`` for audit + diagnostics.
+- Top event descriptions kept as a list-string so the snapshot's
+  glance-text panel can render them without retrieving each event flag
+  separately. Capped at 3 by severity descending.
+
+Why one parquet file per date (vs per ticker):
+
+- ~25 held tickers × ~50 universe tickers ≈ 75 rows/day. Pandas
+  reads a 75-row parquet faster than 75 separate files.
+- Single S3 object per day = cheaper LIST + atomic write (overwrite
+  is atomic at the object level).
+- Schema evolution is easier — one schema migration per file, not 75.
+
+Idempotent: re-running for the same date overwrites the parquet. Each
+write is a complete snapshot of that date's aggregates; no
+append-merge logic needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import date as Date
+from datetime import datetime
+from io import BytesIO
+from typing import Any, Iterable, Sequence
+
+import pandas as pd
+
+from collectors.news_aggregator import AggregatedNewsArticle, NewsAggregator
+from collectors.nlp.pipeline import NewsNLPOutput
+from collectors.nlp.protocols import EventFlag, SentimentScore
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = 1
+"""Bump on any breaking change to the row schema. Consumers should
+gate on this column."""
+
+
+# Top-N event descriptions to keep on the per-(ticker, date) row.
+# Sorted by severity desc; ties broken by appearance order.
+TOP_EVENT_DESCRIPTIONS_N = 3
+
+
+# ── Row shape ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class NewsTickerDailyAggregate:
+    """One row in the structured aggregates parquet.
+
+    Field semantics mirror what consumers join into the snapshot:
+
+    - ``n_articles``: raw count of unique aggregated articles
+      mentioning this ticker.
+    - ``n_articles_trusted_weighted``: sum of source trust weights
+      (one per variant) across this ticker's articles. Higher = more
+      institutional-quality coverage. Cross-source-deduped.
+    - ``lm_sentiment_*``: Loughran-McDonald composite stats. Mean is
+      simple mean across articles; ``trusted_mean`` weights each
+      article's sentiment by its highest-trust source variant.
+    - ``event_count``: total event flags surfaced across all articles
+      mentioning this ticker.
+    - ``event_severity_max``: max severity in [0,1] across events.
+    - ``event_categories``: comma-joined sorted list of unique
+      categories surfaced for this ticker on this date.
+    - ``top_event_descriptions``: top-N event descriptions by
+      severity desc (1-sentence summaries from the LLM extractor).
+      Useful for glance-text in the snapshot.
+    """
+
+    ticker: str
+    aggregate_date: Date
+    schema_version: int
+    n_articles: int
+    n_articles_trusted_weighted: float
+    n_articles_by_source_json: str
+    lm_sentiment_mean: float
+    lm_sentiment_max: float
+    lm_sentiment_min: float
+    lm_sentiment_trusted_mean: float
+    lm_positive_words_total: int
+    lm_negative_words_total: int
+    lm_uncertainty_words_total: int
+    lm_total_tokens: int
+    event_count: int
+    event_severity_max: float
+    event_severity_mean: float
+    event_categories: str
+    top_event_descriptions: str
+    entity_mentions_count: int
+
+
+# ── Aggregation ────────────────────────────────────────────────────────
+
+
+def build_news_aggregates_df(
+    articles: Sequence[AggregatedNewsArticle],
+    nlp_output: NewsNLPOutput,
+    *,
+    aggregate_date: Date,
+    aggregator: NewsAggregator | None = None,
+    trust_weights: dict[str, float] | None = None,
+) -> pd.DataFrame:
+    """Produce a DataFrame with one row per ticker mentioned across the
+    article set.
+
+    ``trust_weights`` (or ``aggregator.trust_weights`` if provided) is
+    used to compute trusted-mean sentiment + n_articles_trusted_weighted.
+    Falls back to a flat-1.0 weighting if neither is passed.
+    """
+    weight_fn = _make_trust_weight_fn(aggregator, trust_weights)
+
+    # Index NLP output streams by article fingerprint for O(1) lookups
+    sentiment_by_fp: dict[str, list[SentimentScore]] = {}
+    for s in nlp_output.sentiment_scores:
+        sentiment_by_fp.setdefault(s.article_fingerprint, []).append(s)
+
+    events_by_fp: dict[str, list[EventFlag]] = {}
+    for e in nlp_output.event_flags:
+        events_by_fp.setdefault(e.article_fingerprint, []).append(e)
+
+    entities_by_fp: dict[str, int] = {}
+    for em in nlp_output.entity_mentions:
+        entities_by_fp[em.article_fingerprint] = (
+            entities_by_fp.get(em.article_fingerprint, 0) + 1
+        )
+
+    # Group articles by ticker; one ticker may appear in many articles,
+    # and one article may concern many tickers (multi-mention pieces).
+    per_ticker_articles: dict[str, list[AggregatedNewsArticle]] = {}
+    for article in articles:
+        for ticker in article.tickers:
+            per_ticker_articles.setdefault(ticker, []).append(article)
+
+    rows: list[NewsTickerDailyAggregate] = []
+    for ticker in sorted(per_ticker_articles):
+        ticker_articles = per_ticker_articles[ticker]
+        rows.append(_build_row(
+            ticker=ticker,
+            ticker_articles=ticker_articles,
+            sentiment_by_fp=sentiment_by_fp,
+            events_by_fp=events_by_fp,
+            entities_by_fp=entities_by_fp,
+            aggregate_date=aggregate_date,
+            weight_fn=weight_fn,
+        ))
+
+    if not rows:
+        return _empty_df()
+    return pd.DataFrame([r.__dict__ for r in rows])
+
+
+def _make_trust_weight_fn(
+    aggregator: NewsAggregator | None,
+    trust_weights: dict[str, float] | None,
+):
+    if aggregator is not None:
+        return aggregator.trust_weight
+    if trust_weights is not None:
+        return lambda src: trust_weights.get(src, 0.5)
+    return lambda src: 1.0
+
+
+def _build_row(
+    *,
+    ticker: str,
+    ticker_articles: list[AggregatedNewsArticle],
+    sentiment_by_fp: dict[str, list[SentimentScore]],
+    events_by_fp: dict[str, list[EventFlag]],
+    entities_by_fp: dict[str, int],
+    aggregate_date: Date,
+    weight_fn,
+) -> NewsTickerDailyAggregate:
+    n_articles = len(ticker_articles)
+
+    # Per-source coverage + trust-weighted article count
+    source_counts: dict[str, int] = {}
+    trusted_sum = 0.0
+    for art in ticker_articles:
+        for variant in art.variants:
+            source_counts[variant.source] = source_counts.get(variant.source, 0) + 1
+            trusted_sum += weight_fn(variant.source)
+
+    # Sentiment aggregates — use LM scorer's output where present
+    lm_scores: list[float] = []
+    lm_trusted_scores: list[tuple[float, float]] = []  # (score, weight)
+    pos_total = neg_total = unc_total = tok_total = 0
+    for art in ticker_articles:
+        fp = art.canonical_fingerprint
+        for s in sentiment_by_fp.get(fp, []):
+            if s.scorer != "loughran_mcdonald":
+                continue
+            lm_scores.append(s.composite)
+            # Weight by highest-trust source for this article
+            article_trust = max(
+                (weight_fn(v.source) for v in art.variants),
+                default=0.5,
+            )
+            lm_trusted_scores.append((s.composite, article_trust))
+            pos_total += s.positive_word_count or 0
+            neg_total += s.negative_word_count or 0
+            unc_total += s.uncertainty_word_count or 0
+            tok_total += s.total_token_count or 0
+
+    if lm_scores:
+        lm_mean = sum(lm_scores) / len(lm_scores)
+        lm_max = max(lm_scores)
+        lm_min = min(lm_scores)
+    else:
+        lm_mean = lm_max = lm_min = 0.0
+
+    if lm_trusted_scores:
+        total_w = sum(w for _, w in lm_trusted_scores)
+        lm_trusted_mean = (
+            sum(s * w for s, w in lm_trusted_scores) / total_w
+            if total_w > 0 else lm_mean
+        )
+    else:
+        lm_trusted_mean = 0.0
+
+    # Event aggregates — only events whose tickers list contains this ticker
+    # (when tickers list is non-empty); empty-tickers events fall back to
+    # "article concerns this ticker" semantics.
+    relevant_events: list[EventFlag] = []
+    for art in ticker_articles:
+        fp = art.canonical_fingerprint
+        for e in events_by_fp.get(fp, []):
+            if e.tickers:
+                if ticker in e.tickers:
+                    relevant_events.append(e)
+            else:
+                # Event extractor didn't tag tickers; inherit from article
+                relevant_events.append(e)
+
+    if relevant_events:
+        event_count = len(relevant_events)
+        severities = [e.severity for e in relevant_events]
+        event_severity_max = max(severities)
+        event_severity_mean = sum(severities) / len(severities)
+        categories = sorted({e.category for e in relevant_events})
+        # Top-N descriptions by severity desc
+        top_descs = sorted(
+            relevant_events, key=lambda e: -e.severity
+        )[:TOP_EVENT_DESCRIPTIONS_N]
+        top_descriptions = " | ".join(e.description for e in top_descs)
+        categories_str = ",".join(categories)
+    else:
+        event_count = 0
+        event_severity_max = 0.0
+        event_severity_mean = 0.0
+        categories_str = ""
+        top_descriptions = ""
+
+    # Entity mentions count
+    entity_count = sum(
+        entities_by_fp.get(art.canonical_fingerprint, 0)
+        for art in ticker_articles
+    )
+
+    return NewsTickerDailyAggregate(
+        ticker=ticker,
+        aggregate_date=aggregate_date,
+        schema_version=SCHEMA_VERSION,
+        n_articles=n_articles,
+        n_articles_trusted_weighted=round(trusted_sum, 4),
+        n_articles_by_source_json=json.dumps(
+            dict(sorted(source_counts.items())), separators=(",", ":")
+        ),
+        lm_sentiment_mean=round(lm_mean, 6),
+        lm_sentiment_max=round(lm_max, 6),
+        lm_sentiment_min=round(lm_min, 6),
+        lm_sentiment_trusted_mean=round(lm_trusted_mean, 6),
+        lm_positive_words_total=pos_total,
+        lm_negative_words_total=neg_total,
+        lm_uncertainty_words_total=unc_total,
+        lm_total_tokens=tok_total,
+        event_count=event_count,
+        event_severity_max=round(event_severity_max, 4),
+        event_severity_mean=round(event_severity_mean, 4),
+        event_categories=categories_str,
+        top_event_descriptions=top_descriptions,
+        entity_mentions_count=entity_count,
+    )
+
+
+def _empty_df() -> pd.DataFrame:
+    """Empty DataFrame with the canonical column order so consumers
+    reading an empty-day parquet don't crash on missing columns."""
+    cols = list(NewsTickerDailyAggregate.__dataclass_fields__.keys())
+    return pd.DataFrame(columns=cols)
+
+
+# ── S3 parquet writer ──────────────────────────────────────────────────
+
+
+DEFAULT_S3_BUCKET = "alpha-engine-research"
+DEFAULT_S3_PREFIX = "data/news_aggregates"
+
+
+def s3_key_for_date(aggregate_date: Date, *, prefix: str = DEFAULT_S3_PREFIX) -> str:
+    """Canonical S3 key for one date's aggregates parquet.
+
+    Format: ``{prefix}/{YYYY-MM-DD}.parquet``. Consumers read by
+    composing date → key with this same function.
+    """
+    return f"{prefix}/{aggregate_date.isoformat()}.parquet"
+
+
+def write_news_aggregates_parquet(
+    df: pd.DataFrame,
+    *,
+    aggregate_date: Date,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> str:
+    """Write the aggregates DataFrame to S3 as parquet. Returns the key.
+
+    Overwrites any existing object at the key (idempotent re-run).
+    Uses pyarrow engine — no compression argument so we get default
+    snappy; safe across pyarrow/pandas versions.
+    """
+    key = s3_key_for_date(aggregate_date, prefix=prefix)
+    buf = BytesIO()
+    df.to_parquet(buf, engine="pyarrow", index=False)
+    buf.seek(0)
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=buf.getvalue(),
+        ContentType="application/octet-stream",
+    )
+    logger.info(
+        "[news_aggregates] wrote %d rows to s3://%s/%s",
+        len(df), bucket, key,
+    )
+    return key
+
+
+def read_news_aggregates_parquet(
+    aggregate_date: Date,
+    *,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> pd.DataFrame:
+    """Consumer-side read. Returns the parquet's DataFrame, or an
+    empty DataFrame with the canonical schema if no parquet exists for
+    the date.
+
+    Schema-version-aware: callers should check the ``schema_version``
+    column and apply forward-compat shims if needed.
+    """
+    key = s3_key_for_date(aggregate_date, prefix=prefix)
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
+    except Exception as e:
+        logger.info(
+            "[news_aggregates] no parquet at s3://%s/%s (%s) — "
+            "returning empty DataFrame",
+            bucket, key, type(e).__name__,
+        )
+        return _empty_df()
+    buf = BytesIO(obj["Body"].read())
+    return pd.read_parquet(buf, engine="pyarrow")
+
+
+# ── Orchestrator-friendly helper ──────────────────────────────────────
+
+
+def aggregate_and_write(
+    articles: Iterable[AggregatedNewsArticle],
+    nlp_output: NewsNLPOutput,
+    *,
+    aggregate_date: Date | datetime,
+    aggregator: NewsAggregator | None,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> tuple[str, pd.DataFrame]:
+    """End-to-end: build aggregates DataFrame + write to S3.
+
+    Returns ``(s3_key, dataframe)``. The DataFrame is returned for
+    immediate downstream use (e.g. logging row counts, emitting CW
+    metrics) so the caller doesn't need to re-read from S3.
+    """
+    if isinstance(aggregate_date, datetime):
+        aggregate_date = aggregate_date.date()
+    df = build_news_aggregates_df(
+        articles=list(articles),
+        nlp_output=nlp_output,
+        aggregate_date=aggregate_date,
+        aggregator=aggregator,
+    )
+    key = write_news_aggregates_parquet(
+        df,
+        aggregate_date=aggregate_date,
+        s3_client=s3_client,
+        bucket=bucket,
+        prefix=prefix,
+    )
+    return key, df

--- a/tests/test_news_aggregates.py
+++ b/tests/test_news_aggregates.py
@@ -1,0 +1,466 @@
+"""Tests for the news structured-aggregates writer (Wave 1 PR A.2).
+
+Covers:
+  - Per-ticker aggregation from NewsNLPOutput streams
+  - Trust-weighted sentiment mean
+  - Event filtering by ticker (event.tickers set vs empty)
+  - Multi-ticker article counted under each ticker
+  - Top-N event descriptions sorted by severity desc
+  - Empty aggregation produces well-formed empty DataFrame
+  - S3 parquet write + read round-trip (in-memory moto-style mock)
+  - Schema version pinned to column
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from io import BytesIO
+
+import pandas as pd
+import pytest
+
+from alpha_engine_lib.sources import NewsArticle
+
+from collectors.news_aggregator import (
+    AggregatedNewsArticle,
+    DEFAULT_TRUST_WEIGHTS,
+    NewsAggregator,
+)
+from collectors.nlp.pipeline import NewsNLPOutput
+from collectors.nlp.protocols import EventFlag, SentimentScore
+
+from data.derived.news_aggregates import (
+    DEFAULT_S3_PREFIX,
+    SCHEMA_VERSION,
+    TOP_EVENT_DESCRIPTIONS_N,
+    NewsTickerDailyAggregate,
+    aggregate_and_write,
+    build_news_aggregates_df,
+    read_news_aggregates_parquet,
+    s3_key_for_date,
+    write_news_aggregates_parquet,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_variant(source: str, title: str = "t", url: str = "https://x/1") -> NewsArticle:
+    return NewsArticle(
+        tickers=("AAPL",),
+        title=title,
+        body_excerpt="body",
+        url=url,
+        published_at=_now(),
+        source=source,
+        fetched_at=_now(),
+    )
+
+
+def _make_aggregated(
+    *,
+    fingerprint: str,
+    tickers: tuple[str, ...] = ("AAPL",),
+    sources: tuple[str, ...] = ("polygon",),
+    title: str = "Story",
+) -> AggregatedNewsArticle:
+    variants = tuple(_make_variant(s, title=title) for s in sources)
+    return AggregatedNewsArticle(
+        canonical_title=title,
+        canonical_url="https://x.com/a",
+        tickers=tickers,
+        earliest_published_at=_now(),
+        variants=variants,
+        canonical_fingerprint=fingerprint,
+    )
+
+
+def _lm_score(fp: str, *, composite: float, pos: int = 0, neg: int = 0, total: int = 10) -> SentimentScore:
+    return SentimentScore(
+        scorer="loughran_mcdonald",
+        article_fingerprint=fp,
+        composite=composite,
+        positive_word_count=pos,
+        negative_word_count=neg,
+        uncertainty_word_count=0,
+        total_token_count=total,
+    )
+
+
+def _event(
+    fp: str,
+    *,
+    category: str = "earnings_release",
+    description: str = "Q4 results released.",
+    tickers: tuple[str, ...] = (),
+    severity: float = 0.5,
+) -> EventFlag:
+    return EventFlag(
+        extractor="anthropic_haiku",
+        article_fingerprint=fp,
+        category=category,
+        description=description,
+        tickers=tickers,
+        severity=severity,
+        extracted_at=_now(),
+    )
+
+
+# ── Per-ticker aggregation ─────────────────────────────────────────────
+
+
+class TestBuildNewsAggregatesDf:
+    def test_one_article_one_ticker_one_row(self):
+        articles = [_make_aggregated(fingerprint="fp1", tickers=("AAPL",))]
+        out = NewsNLPOutput(
+            sentiment_scores=[_lm_score("fp1", composite=0.5, pos=3, total=10)],
+            event_flags=[_event("fp1", severity=0.7)],
+        )
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["ticker"] == "AAPL"
+        assert row["aggregate_date"] == date(2026, 5, 13)
+        assert row["schema_version"] == SCHEMA_VERSION
+        assert row["n_articles"] == 1
+        assert row["lm_sentiment_mean"] == pytest.approx(0.5)
+        assert row["lm_positive_words_total"] == 3
+        assert row["event_count"] == 1
+        assert row["event_severity_max"] == 0.7
+
+    def test_multi_ticker_article_emits_one_row_per_ticker(self):
+        articles = [_make_aggregated(
+            fingerprint="fp1", tickers=("AAPL", "MSFT", "GOOGL"),
+        )]
+        out = NewsNLPOutput(
+            sentiment_scores=[_lm_score("fp1", composite=0.3)],
+        )
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        assert len(df) == 3
+        tickers = sorted(df["ticker"].tolist())
+        assert tickers == ["AAPL", "GOOGL", "MSFT"]
+        # All three rows reference the same article — sentiment mirrored
+        for _, row in df.iterrows():
+            assert row["n_articles"] == 1
+            assert row["lm_sentiment_mean"] == pytest.approx(0.3)
+
+    def test_multiple_articles_per_ticker_aggregate(self):
+        articles = [
+            _make_aggregated(fingerprint="a", tickers=("AAPL",)),
+            _make_aggregated(fingerprint="b", tickers=("AAPL",)),
+            _make_aggregated(fingerprint="c", tickers=("AAPL",)),
+        ]
+        out = NewsNLPOutput(
+            sentiment_scores=[
+                _lm_score("a", composite=0.6),
+                _lm_score("b", composite=0.0),
+                _lm_score("c", composite=-0.3),
+            ],
+        )
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["n_articles"] == 3
+        assert row["lm_sentiment_mean"] == pytest.approx(0.1)
+        assert row["lm_sentiment_max"] == pytest.approx(0.6)
+        assert row["lm_sentiment_min"] == pytest.approx(-0.3)
+
+    def test_empty_articles_produces_empty_df_with_schema(self):
+        df = build_news_aggregates_df(
+            articles=[],
+            nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        assert len(df) == 0
+        # Empty DF still has canonical columns so consumers don't break
+        for col in NewsTickerDailyAggregate.__dataclass_fields__:
+            assert col in df.columns
+
+
+class TestTrustWeighting:
+    def test_trusted_mean_weights_by_highest_source_trust(self):
+        # Two articles: one from polygon (high trust), one from yahoo_rss
+        # (low trust). Same sentiment magnitudes — trusted_mean should
+        # lean toward the polygon article.
+        articles = [
+            _make_aggregated(fingerprint="a", tickers=("AAPL",), sources=("polygon",)),
+            _make_aggregated(fingerprint="b", tickers=("AAPL",), sources=("yahoo_rss",)),
+        ]
+        out = NewsNLPOutput(sentiment_scores=[
+            _lm_score("a", composite=0.8),
+            _lm_score("b", composite=-0.4),
+        ])
+        agg = NewsAggregator(sources=[])
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out,
+            aggregate_date=date(2026, 5, 13), aggregator=agg,
+        )
+        row = df.iloc[0]
+        # Raw mean = (0.8 + (-0.4)) / 2 = 0.2
+        assert row["lm_sentiment_mean"] == pytest.approx(0.2)
+        # Trusted mean = (0.8 * polygon_trust + -0.4 * yahoo_trust) /
+        # (polygon_trust + yahoo_trust)
+        polygon_w = DEFAULT_TRUST_WEIGHTS["polygon"]  # 0.9
+        yahoo_w = DEFAULT_TRUST_WEIGHTS["yahoo_rss"]  # 0.5
+        expected = (0.8 * polygon_w + -0.4 * yahoo_w) / (polygon_w + yahoo_w)
+        assert row["lm_sentiment_trusted_mean"] == pytest.approx(expected, rel=1e-3)
+
+    def test_n_articles_trusted_weighted_counts_variants(self):
+        # Article 'a' has 2 source variants (polygon + gdelt); the
+        # trusted-weighted count should sum BOTH variants' trust weights.
+        articles = [_make_aggregated(
+            fingerprint="a", tickers=("AAPL",),
+            sources=("polygon", "gdelt"),
+        )]
+        out = NewsNLPOutput()
+        agg = NewsAggregator(sources=[])
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out,
+            aggregate_date=date(2026, 5, 13), aggregator=agg,
+        )
+        row = df.iloc[0]
+        expected = DEFAULT_TRUST_WEIGHTS["polygon"] + DEFAULT_TRUST_WEIGHTS["gdelt"]
+        assert row["n_articles_trusted_weighted"] == pytest.approx(expected)
+
+    def test_source_counts_json_per_variant(self):
+        articles = [_make_aggregated(
+            fingerprint="a", tickers=("AAPL",),
+            sources=("polygon", "gdelt", "gdelt"),  # 1 polygon + 2 gdelt variants
+        )]
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        counts = json.loads(df.iloc[0]["n_articles_by_source_json"])
+        assert counts == {"gdelt": 2, "polygon": 1}
+
+
+class TestEventAggregation:
+    def test_event_with_tickers_set_only_attaches_to_those_tickers(self):
+        # Article concerns AAPL + MSFT; event tags only AAPL.
+        articles = [_make_aggregated(
+            fingerprint="a", tickers=("AAPL", "MSFT"),
+        )]
+        out = NewsNLPOutput(event_flags=[
+            _event("a", tickers=("AAPL",), severity=0.8),
+        ])
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        by_ticker = {r["ticker"]: r for _, r in df.iterrows()}
+        assert by_ticker["AAPL"]["event_count"] == 1
+        assert by_ticker["MSFT"]["event_count"] == 0
+
+    def test_event_without_tickers_inherits_from_article(self):
+        # Empty event.tickers means "ungated; applies to whatever
+        # article(s) it appeared in".
+        articles = [_make_aggregated(
+            fingerprint="a", tickers=("AAPL", "MSFT"),
+        )]
+        out = NewsNLPOutput(event_flags=[_event("a", tickers=(), severity=0.5)])
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        # Both tickers see the event since extractor didn't gate
+        for _, row in df.iterrows():
+            assert row["event_count"] == 1
+
+    def test_top_event_descriptions_sorted_by_severity_desc(self):
+        articles = [_make_aggregated(fingerprint="a", tickers=("AAPL",))]
+        out = NewsNLPOutput(event_flags=[
+            _event("a", description="low-severity event", severity=0.2),
+            _event("a", description="high-severity event", severity=0.95),
+            _event("a", description="mid-severity event", severity=0.5),
+            _event("a", description="another mid event", severity=0.4),
+        ])
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        descs = df.iloc[0]["top_event_descriptions"]
+        # Top-N = 3, separated by " | "
+        parts = descs.split(" | ")
+        assert len(parts) == TOP_EVENT_DESCRIPTIONS_N
+        assert parts[0] == "high-severity event"  # highest severity first
+        assert "low-severity event" not in descs  # dropped (4th place)
+
+    def test_event_categories_comma_joined_sorted(self):
+        articles = [_make_aggregated(fingerprint="a", tickers=("AAPL",))]
+        out = NewsNLPOutput(event_flags=[
+            _event("a", category="merger_or_acquisition"),
+            _event("a", category="earnings_release"),
+            _event("a", category="earnings_release"),  # dedup
+        ])
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        cats = df.iloc[0]["event_categories"]
+        # Sorted + deduped
+        assert cats == "earnings_release,merger_or_acquisition"
+
+    def test_event_severity_mean_computed(self):
+        articles = [_make_aggregated(fingerprint="a", tickers=("AAPL",))]
+        out = NewsNLPOutput(event_flags=[
+            _event("a", severity=0.2),
+            _event("a", severity=0.8),
+        ])
+        df = build_news_aggregates_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        assert df.iloc[0]["event_severity_mean"] == pytest.approx(0.5)
+
+
+# ── S3 parquet round-trip (in-memory mock; no moto dep) ────────────────
+
+
+class _InMemoryS3:
+    """Minimal in-memory S3 mock supporting put_object + get_object.
+
+    Avoids adding moto as a test dep. Sufficient for the round-trip
+    + missing-key + overwrite tests we run here.
+    """
+
+    class _NoSuchKey(Exception):
+        pass
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self._store[(Bucket, Key)] = Body
+        return {"ETag": "stub"}
+
+    def get_object(self, *, Bucket, Key):
+        if (Bucket, Key) not in self._store:
+            raise self._NoSuchKey(f"NoSuchKey: {Bucket}/{Key}")
+        return {"Body": BytesIO(self._store[(Bucket, Key)])}
+
+
+class TestS3ParquetRoundTrip:
+    def test_write_then_read_preserves_rows(self):
+        s3 = _InMemoryS3()
+        articles = [_make_aggregated(fingerprint="a", tickers=("AAPL",))]
+        out = NewsNLPOutput(sentiment_scores=[
+            _lm_score("a", composite=0.42, pos=2, neg=0, total=10),
+        ])
+        df_in = build_news_aggregates_df(
+            articles=articles, nlp_output=out,
+            aggregate_date=date(2026, 5, 13),
+        )
+        key = write_news_aggregates_parquet(
+            df_in, aggregate_date=date(2026, 5, 13), s3_client=s3,
+        )
+        assert key == "data/news_aggregates/2026-05-13.parquet"
+
+        df_out = read_news_aggregates_parquet(
+            aggregate_date=date(2026, 5, 13), s3_client=s3,
+        )
+        assert len(df_out) == 1
+        assert df_out.iloc[0]["ticker"] == "AAPL"
+        assert df_out.iloc[0]["lm_sentiment_mean"] == pytest.approx(0.42)
+
+    def test_missing_parquet_returns_empty_schema_df(self):
+        s3 = _InMemoryS3()
+        df = read_news_aggregates_parquet(
+            aggregate_date=date(2026, 1, 1), s3_client=s3,
+        )
+        assert len(df) == 0
+        for col in NewsTickerDailyAggregate.__dataclass_fields__:
+            assert col in df.columns
+
+    def test_overwrite_existing_parquet(self):
+        s3 = _InMemoryS3()
+        # v1: 1 row
+        articles_v1 = [_make_aggregated(fingerprint="a", tickers=("AAPL",))]
+        df_v1 = build_news_aggregates_df(
+            articles=articles_v1, nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        write_news_aggregates_parquet(
+            df_v1, aggregate_date=date(2026, 5, 13), s3_client=s3,
+        )
+        # v2: 2 rows (overwrite)
+        articles_v2 = [
+            _make_aggregated(fingerprint="a", tickers=("AAPL",)),
+            _make_aggregated(fingerprint="b", tickers=("MSFT",)),
+        ]
+        df_v2 = build_news_aggregates_df(
+            articles=articles_v2, nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        write_news_aggregates_parquet(
+            df_v2, aggregate_date=date(2026, 5, 13), s3_client=s3,
+        )
+        df_read = read_news_aggregates_parquet(
+            aggregate_date=date(2026, 5, 13), s3_client=s3,
+        )
+        assert len(df_read) == 2
+
+    def test_s3_key_format(self):
+        assert (
+            s3_key_for_date(date(2026, 5, 13))
+            == "data/news_aggregates/2026-05-13.parquet"
+        )
+
+    def test_s3_key_custom_prefix(self):
+        assert (
+            s3_key_for_date(date(2026, 1, 1), prefix="alt/path")
+            == "alt/path/2026-01-01.parquet"
+        )
+
+
+# ── End-to-end orchestrator helper ─────────────────────────────────────
+
+
+class TestAggregateAndWrite:
+    def test_end_to_end_returns_key_and_df(self):
+        s3 = _InMemoryS3()
+        articles = [_make_aggregated(fingerprint="a", tickers=("AAPL",))]
+        out = NewsNLPOutput(sentiment_scores=[
+            _lm_score("a", composite=0.3),
+        ])
+        agg = NewsAggregator(sources=[])
+        key, df = aggregate_and_write(
+            articles=articles, nlp_output=out,
+            aggregate_date=date(2026, 5, 13),
+            aggregator=agg, s3_client=s3,
+        )
+        assert key.endswith("2026-05-13.parquet")
+        assert len(df) == 1
+
+    def test_accepts_datetime_for_aggregate_date(self):
+        s3 = _InMemoryS3()
+        key, _ = aggregate_and_write(
+            articles=[], nlp_output=NewsNLPOutput(),
+            aggregate_date=datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc),
+            aggregator=None, s3_client=s3,
+        )
+        assert "2026-05-13" in key
+
+
+# ── Schema version pin ────────────────────────────────────────────────
+
+
+def test_schema_version_pinned_to_int_constant():
+    assert isinstance(SCHEMA_VERSION, int)
+    # Pin value so consumers checking for v1 don't break on accidental bump
+    assert SCHEMA_VERSION == 1
+
+
+def test_schema_version_on_every_row():
+    articles = [
+        _make_aggregated(fingerprint="a", tickers=("AAPL",)),
+        _make_aggregated(fingerprint="b", tickers=("MSFT",)),
+    ]
+    df = build_news_aggregates_df(
+        articles=articles, nlp_output=NewsNLPOutput(),
+        aggregate_date=date(2026, 5, 13),
+    )
+    assert (df["schema_version"] == SCHEMA_VERSION).all()


### PR DESCRIPTION
## Summary

**Wave 1 PR A.2** of the institutional data-revamp arc. Joins the 3 NLP-pipeline output streams (sentiment_scores, entity_mentions, event_flags) with the aggregator's source-provenance information and produces one row per (ticker, aggregate_date) in S3 parquet.

This is the **canonical structured signal** that downstream consumers (research's `fetch_data`) read into `input_data_snapshot` for thesis_update + sector_quant + sector_qual agents.

## What's in

New module `data/derived/news_aggregates.py`:

### `NewsTickerDailyAggregate` row shape (19 columns)

| Group | Columns |
|---|---|
| Identity | `ticker`, `aggregate_date`, `schema_version` |
| Volume | `n_articles`, `n_articles_trusted_weighted`, `n_articles_by_source_json` |
| LM sentiment | `lm_sentiment_mean/max/min/trusted_mean`, `lm_positive/negative/uncertainty_words_total`, `lm_total_tokens` |
| Events | `event_count`, `event_severity_max/mean`, `event_categories` (sorted comma-joined), `top_event_descriptions` (top-N by severity desc, ` \| `-joined) |
| Entities | `entity_mentions_count` |

`schema_version=1` pinned to column so consumers can shim through future evolution.

### Aggregation semantics
- **Multi-ticker article emits one row per ticker** (each row sees the full article)
- **`event.tickers` gates per-ticker event attachment**; empty tickers list means "inherit from article"
- **Trust-weighted sentiment** weights each article by max trust across its source variants
- **`n_articles_trusted_weighted` sums trust per VARIANT** (so 3-source dedup counts 3× its trust contribution)
- **Top-3 event descriptions** chosen by severity desc; stored as `" | "`-joined string

### S3 layout
- `write_news_aggregates_parquet()` / `read_news_aggregates_parquet()` — I/O at `s3://alpha-engine-research/data/news_aggregates/{YYYY-MM-DD}.parquet`
- Idempotent overwrite (single file per day vs per-ticker — cheaper LIST, atomic write, simpler schema migration)
- `aggregate_and_write()` — orchestrator-friendly end-to-end helper returning `(key, df)`

## What's deferred

- **PR A.3** — RAG ingest path (full article text → chunked → embedded → pgvector alongside SEC filings)
- **PR D** — Async + S3 cache + per-vendor rate limiters
- **PR F** — Wire substrate into research's `fetch_data` (supersedes #170's per-ticker pre-fetch)
- **PRs B / C / E** — Filings expansion, analyst substrate, RAG-as-tool in research

## Test plan

- [x] +21 unit tests covering: per-ticker aggregation (one-article-one-ticker / multi-ticker emits per-ticker / multiple articles per ticker / empty produces empty-with-schema), trust weighting (trusted mean / weighted count / per-variant source counts JSON), event aggregation (ticker-filter / no-tickers-inherits / top-N sorted desc / categories sorted+joined / severity mean), S3 round-trip (write→read / missing-parquet returns empty-schema-df / overwrite / key format / custom prefix), end-to-end `aggregate_and_write` + datetime tolerance, `schema_version` pinned to int constant + on every row.
- [x] **In-memory S3 mock** used for round-trip tests — no moto dep added.
- [x] Full data suite: **911 passing** (1 skipped) in 4s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)