### PR TITLE
feat(rag): Wave 1 PR A.3 — news → RAG ingest pipeline

### DIFF
--- a/rag/pipelines/ingest_news.py
+++ b/rag/pipelines/ingest_news.py
@@ -1,0 +1,237 @@
+"""Ingest aggregated news articles into the RAG vector store.
+
+Wave 1 PR A.3 of the institutional data-revamp arc (plan doc:
+``~/Development/alpha-engine-docs/private/data-revamp-260513.md``).
+
+Pairs with:
+- PR β (#226) — news source adapters
+- PR A.1 (#227) — NLP pipeline
+- PR A.2 (#228) — structured aggregates writer
+
+The structured aggregates parquet (PR A.2) carries per-(ticker, date)
+numerical signals. This module carries the **full narrative text** of
+each news article into the existing RAG corpus, indexed alongside SEC
+filings + theses. Consumer agents (thesis_update, sector_quant/qual)
+retrieve relevant news at inference time via the hybrid-retrieval API
+that the qual analyst's ``query_filings`` tool already uses.
+
+Architecture:
+
+    [Polygon/GDELT/Yahoo adapters] ──→ NewsAggregator (PR β)
+                                              │
+                                              ▼
+                              AggregatedNewsArticle list
+                                              │
+                       ┌──────────────────────┼──────────────────────┐
+                       ▼                      ▼                      ▼
+              [NLP pipeline]         [aggregates parquet]      [RAG ingest]   ← THIS PR
+              (PR A.1)               (PR A.2)                  (PR A.3)
+                       │                      │                      │
+                       ▼                      ▼                      ▼
+              streams                 S3 parquet              pgvector (with
+              (sentiment +            per-(ticker, date)      SEC filings)
+              events + entities)
+
+Idempotency: pre-checked via the lib's ``document_exists`` — re-runs
+on the same (ticker, date, source) skip the embedding call entirely.
+
+Chunking: news articles are short (title + body excerpt = typically
+<500 tokens). We emit ONE chunk per article per ticker. For longer
+syndicated bodies we'd split, but the current Polygon/GDELT/Yahoo
+adapters only return excerpts so single-chunk is the right shape.
+
+Multi-ticker articles: indexed once per ticker (the RAG schema is
+ticker-keyed; the qual agent's ``query_filings`` tool gates by ticker
+so a sector-wide piece needs to surface for each constituent).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as Date
+from typing import Any, Sequence
+
+from collectors.news_aggregator import AggregatedNewsArticle
+
+logger = logging.getLogger(__name__)
+
+
+# Source slug → canonical RAG `source` field. Joins onto the same
+# source values used by the structured aggregates writer + downstream
+# retrieval gating. We prefix with "news_" so consumer queries can
+# filter "news only" vs "filings only" by source-prefix without
+# enumerating vendors.
+_RAG_SOURCE_PREFIX = "news_"
+
+
+def _rag_source(news_article_source: str) -> str:
+    """Map ``NewsArticle.source`` (vendor slug) → RAG ``source`` field."""
+    return f"{_RAG_SOURCE_PREFIX}{news_article_source}"
+
+
+def _chunk_text(article: AggregatedNewsArticle) -> str:
+    """Build the chunk body text for one aggregated article.
+
+    Composes canonical title + longest variant body excerpt. The
+    longer the input text, the better the embedding's semantic
+    fidelity — pick the longest body across variants the aggregator
+    grouped together.
+    """
+    longest_excerpt = ""
+    for v in article.variants:
+        excerpt = v.body_excerpt or ""
+        if len(excerpt) > len(longest_excerpt):
+            longest_excerpt = excerpt
+    pieces = [article.canonical_title or "", longest_excerpt]
+    return "\n\n".join(p for p in pieces if p).strip()
+
+
+def _canonical_source(article: AggregatedNewsArticle) -> str:
+    """Pick the canonical vendor slug for the aggregated article.
+
+    Prefer the highest-trust variant; ties broken by vendor name
+    alphabetically so the choice is deterministic across re-runs
+    (same article ingested twice produces same document).
+    """
+    if not article.variants:
+        return "unknown"
+    # We don't have access to trust weights here (no aggregator
+    # passed); pick by variant ordering. NewsAggregator's _dedup keeps
+    # variants in the order they were inserted; that's "all sources
+    # for this fingerprint". For deterministic source selection across
+    # runs we pick alphabetically — re-ingests produce the same source.
+    sources = sorted({v.source for v in article.variants})
+    return sources[0] if sources else "unknown"
+
+
+def ingest_articles(
+    articles: Sequence[AggregatedNewsArticle],
+    *,
+    filed_date: Date,
+    ticker_to_sector: dict[str, str] | None = None,
+    embed_texts_fn=None,
+    document_exists_fn=None,
+    ingest_document_fn=None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Ingest aggregated news articles into the RAG corpus.
+
+    One document per (ticker, article) pair — multi-ticker articles
+    are indexed once per ticker so the ticker-keyed RAG schema
+    surfaces them when the qual agent queries by any constituent.
+
+    Returns a stats dict::
+
+        {
+            "n_articles_input": int,
+            "n_documents_attempted": int,
+            "n_documents_skipped_exists": int,
+            "n_documents_skipped_empty_text": int,
+            "n_documents_ingested": int,
+            "n_failures": int,
+        }
+
+    Args:
+        articles: aggregated news articles (from NewsAggregator).
+        filed_date: the canonical filed_date stamped on every document
+            this run. Per the RAG schema this is the dedup key
+            alongside (ticker, doc_type, source). For news, all
+            articles in one ingest batch share a filed_date — typically
+            the calendar date the batch was fetched.
+        ticker_to_sector: optional ticker → GICS sector map. Sector is
+            an optional column on the RAG documents table; omit to
+            skip sector tagging.
+        embed_texts_fn / document_exists_fn / ingest_document_fn:
+            injectable for testing. Production callers pass None and
+            we lazy-import from ``alpha_engine_lib.rag``.
+        dry_run: log the would-be ingest without calling the embedder
+            or the DB writer. Useful for new-batch sanity checks.
+    """
+    if embed_texts_fn is None:
+        from alpha_engine_lib.rag import embed_texts
+        embed_texts_fn = embed_texts
+    if document_exists_fn is None:
+        from alpha_engine_lib.rag import document_exists
+        document_exists_fn = document_exists
+    if ingest_document_fn is None:
+        from alpha_engine_lib.rag import ingest_document
+        ingest_document_fn = ingest_document
+    ticker_to_sector = ticker_to_sector or {}
+
+    stats = {
+        "n_articles_input": len(articles),
+        "n_documents_attempted": 0,
+        "n_documents_skipped_exists": 0,
+        "n_documents_skipped_empty_text": 0,
+        "n_documents_ingested": 0,
+        "n_failures": 0,
+    }
+
+    for article in articles:
+        body = _chunk_text(article)
+        if not body or len(body) < 20:
+            stats["n_documents_skipped_empty_text"] += len(article.tickers)
+            continue
+
+        rag_source = _rag_source(_canonical_source(article))
+
+        for ticker in article.tickers:
+            stats["n_documents_attempted"] += 1
+            if document_exists_fn(ticker, "news", filed_date, rag_source):
+                stats["n_documents_skipped_exists"] += 1
+                continue
+            if dry_run:
+                logger.info(
+                    "[DRY RUN] Would ingest %s news %s (%s): "
+                    "title=%r url=%s",
+                    ticker, filed_date, rag_source,
+                    article.canonical_title[:80], article.canonical_url,
+                )
+                stats["n_documents_ingested"] += 1
+                continue
+            try:
+                # One chunk per news article — short bodies. If the
+                # excerpt grows in a future adapter (e.g. Benzinga full
+                # body), split here at ~400-token windows mirroring
+                # ingest_8k_filings._chunk_text.
+                section_label = (
+                    article.canonical_title[:100] if article.canonical_title
+                    else "news"
+                )
+                chunks = [{
+                    "content": body,
+                    "section_label": section_label,
+                }]
+                embeddings = embed_texts_fn([chunks[0]["content"]])
+                chunks[0]["embedding"] = embeddings[0]
+
+                doc_id = ingest_document_fn(
+                    ticker=ticker,
+                    sector=ticker_to_sector.get(ticker),
+                    doc_type="news",
+                    source=rag_source,
+                    filed_date=filed_date,
+                    title=article.canonical_title or None,
+                    url=article.canonical_url or None,
+                    chunks=chunks,
+                )
+                if doc_id:
+                    stats["n_documents_ingested"] += 1
+                    logger.info(
+                        "Ingested news for %s on %s (%s): %s",
+                        ticker, filed_date, rag_source,
+                        article.canonical_title[:80],
+                    )
+                else:
+                    stats["n_failures"] += 1
+            except Exception as e:
+                stats["n_failures"] += 1
+                logger.warning(
+                    "[news_ingest] failed for %s %s: %s",
+                    ticker, article.canonical_url, e,
+                )
+
+    logger.info(
+        "[news_ingest] complete: %s", stats,
+    )
+    return stats

--- a/tests/test_ingest_news.py
+++ b/tests/test_ingest_news.py
@@ -1,0 +1,396 @@
+"""Tests for the news → RAG ingest pipeline (Wave 1 PR A.3).
+
+Covers:
+  - One document per (ticker, article) — multi-ticker articles emit
+    one doc per ticker
+  - Idempotency: document_exists short-circuits the embed + ingest call
+  - Empty / too-short bodies skipped
+  - Chunk text = title + longest body excerpt across variants
+  - Canonical source picks deterministically (alphabetical fallback)
+  - RAG `source` field prefixed with 'news_'
+  - dry_run mode skips embed/ingest
+  - sector lookup uses optional ticker_to_sector map
+  - Failures isolated per-document, batch continues
+  - Stats dict shape
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from alpha_engine_lib.sources import NewsArticle
+
+from collectors.news_aggregator import AggregatedNewsArticle
+from rag.pipelines.ingest_news import (
+    _canonical_source,
+    _chunk_text,
+    _rag_source,
+    ingest_articles,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_variant(source: str = "polygon", body: str = "lead paragraph") -> NewsArticle:
+    return NewsArticle(
+        tickers=("AAPL",),
+        title="t",
+        body_excerpt=body,
+        url="https://x.com/a",
+        published_at=_now(),
+        source=source,
+        fetched_at=_now(),
+    )
+
+
+def _make_article(
+    *,
+    fingerprint: str = "fp1",
+    title: str = "Apple Q4 Beat",
+    tickers: tuple[str, ...] = ("AAPL",),
+    variants: tuple[NewsArticle, ...] | None = None,
+    body: str = "Strong quarterly results across all segments.",
+) -> AggregatedNewsArticle:
+    if variants is None:
+        variants = (_make_variant(body=body),)
+    return AggregatedNewsArticle(
+        canonical_title=title,
+        canonical_url="https://x.com/a",
+        tickers=tickers,
+        earliest_published_at=_now(),
+        variants=variants,
+        canonical_fingerprint=fingerprint,
+    )
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_rag_source_prefixed(self):
+        assert _rag_source("polygon") == "news_polygon"
+        assert _rag_source("gdelt") == "news_gdelt"
+        assert _rag_source("yahoo_rss") == "news_yahoo_rss"
+
+    def test_chunk_text_combines_title_and_longest_body(self):
+        article = _make_article(
+            title="Apple beats",
+            variants=(
+                _make_variant(source="polygon", body="short"),
+                _make_variant(source="gdelt", body="much longer body with more semantic context"),
+            ),
+        )
+        text = _chunk_text(article)
+        assert "Apple beats" in text
+        assert "much longer body with more semantic context" in text
+        # Picks longest, drops shorter
+        assert "short" not in text
+
+    def test_chunk_text_handles_missing_title(self):
+        article = AggregatedNewsArticle(
+            canonical_title="",
+            canonical_url="https://x",
+            tickers=("AAPL",),
+            earliest_published_at=_now(),
+            variants=(_make_variant(body="body"),),
+            canonical_fingerprint="fp",
+        )
+        assert _chunk_text(article) == "body"
+
+    def test_chunk_text_empty_when_all_empty(self):
+        article = AggregatedNewsArticle(
+            canonical_title="",
+            canonical_url="https://x",
+            tickers=("AAPL",),
+            earliest_published_at=_now(),
+            variants=(_make_variant(body=""),),
+            canonical_fingerprint="fp",
+        )
+        assert _chunk_text(article) == ""
+
+    def test_canonical_source_deterministic_alphabetical(self):
+        """Re-ingesting the same article on different runs must
+        produce the same source — pick alphabetically across variants."""
+        article = _make_article(
+            variants=(
+                _make_variant(source="polygon"),
+                _make_variant(source="gdelt"),
+                _make_variant(source="yahoo_rss"),
+            ),
+        )
+        assert _canonical_source(article) == "gdelt"
+
+    def test_canonical_source_single_variant(self):
+        article = _make_article(variants=(_make_variant(source="polygon"),))
+        assert _canonical_source(article) == "polygon"
+
+
+# ── Single-ticker happy path ───────────────────────────────────────────
+
+
+class TestSingleTickerIngest:
+    def test_one_article_one_ticker_one_document(self):
+        article = _make_article(tickers=("AAPL",))
+        embed = MagicMock(return_value=[[0.1, 0.2, 0.3]])
+        exists = MagicMock(return_value=False)
+        ingest = MagicMock(return_value="doc-id-1")
+
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=exists,
+            ingest_document_fn=ingest,
+        )
+
+        assert stats["n_documents_ingested"] == 1
+        assert stats["n_failures"] == 0
+        # Embedder called once with one chunk's content
+        embed.assert_called_once()
+        # ingest_document called with the expected shape
+        ingest.assert_called_once()
+        kwargs = ingest.call_args.kwargs
+        assert kwargs["ticker"] == "AAPL"
+        assert kwargs["doc_type"] == "news"
+        assert kwargs["source"] == "news_polygon"
+        assert kwargs["filed_date"] == date(2026, 5, 13)
+        assert len(kwargs["chunks"]) == 1
+        assert kwargs["chunks"][0]["embedding"] == [0.1, 0.2, 0.3]
+
+    def test_idempotency_via_document_exists(self):
+        """document_exists returning True short-circuits both the
+        embedder + ingest_document — saves vector-API cost on re-runs."""
+        article = _make_article()
+        embed = MagicMock()
+        exists = MagicMock(return_value=True)
+        ingest = MagicMock()
+
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=exists,
+            ingest_document_fn=ingest,
+        )
+
+        assert stats["n_documents_skipped_exists"] == 1
+        assert stats["n_documents_ingested"] == 0
+        # Embedder NOT called (cost-saving)
+        embed.assert_not_called()
+        ingest.assert_not_called()
+
+    def test_empty_body_skipped(self):
+        article = AggregatedNewsArticle(
+            canonical_title="",
+            canonical_url="https://x",
+            tickers=("AAPL",),
+            earliest_published_at=_now(),
+            variants=(_make_variant(body=""),),
+            canonical_fingerprint="empty",
+        )
+        embed = MagicMock()
+        ingest = MagicMock()
+
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+        )
+        assert stats["n_documents_skipped_empty_text"] == 1
+        assert stats["n_documents_ingested"] == 0
+        embed.assert_not_called()
+
+    def test_too_short_body_skipped(self):
+        article = _make_article(title="", body="hi")
+        embed = MagicMock()
+        ingest = MagicMock()
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+        )
+        # Title="" + body="hi" → text < 20 chars → skipped
+        assert stats["n_documents_skipped_empty_text"] == 1
+        embed.assert_not_called()
+
+
+# ── Multi-ticker article ────────────────────────────────────────────────
+
+
+class TestMultiTickerArticle:
+    def test_indexes_once_per_ticker(self):
+        """Sector-piece concerning AAPL + MSFT + GOOGL produces 3
+        documents (one per ticker)."""
+        article = _make_article(
+            title="Tech earnings season recap",
+            tickers=("AAPL", "MSFT", "GOOGL"),
+        )
+        embed = MagicMock(return_value=[[0.0, 0.0, 0.0]])
+        ingest = MagicMock(return_value="doc-id")
+
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+        )
+        assert stats["n_documents_attempted"] == 3
+        assert stats["n_documents_ingested"] == 3
+        # ingest_document called 3× with different tickers
+        tickers_called = {
+            call.kwargs["ticker"] for call in ingest.call_args_list
+        }
+        assert tickers_called == {"AAPL", "MSFT", "GOOGL"}
+
+    def test_per_ticker_existence_check(self):
+        """If AAPL is already indexed but MSFT isn't, only MSFT gets
+        embedded + ingested."""
+        article = _make_article(tickers=("AAPL", "MSFT"))
+        existing = {"AAPL"}
+        exists = MagicMock(side_effect=lambda t, *a, **k: t in existing)
+        embed = MagicMock(return_value=[[0.1, 0.2]])
+        ingest = MagicMock(return_value="doc")
+
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=exists,
+            ingest_document_fn=ingest,
+        )
+        assert stats["n_documents_skipped_exists"] == 1
+        assert stats["n_documents_ingested"] == 1
+        # Only MSFT got ingested
+        ingest.assert_called_once()
+        assert ingest.call_args.kwargs["ticker"] == "MSFT"
+
+
+# ── Sector lookup ──────────────────────────────────────────────────────
+
+
+class TestSectorLookup:
+    def test_ticker_to_sector_passed_through(self):
+        article = _make_article(tickers=("AAPL",))
+        ingest = MagicMock(return_value="doc")
+        ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            ticker_to_sector={"AAPL": "Technology"},
+            embed_texts_fn=MagicMock(return_value=[[0.0]]),
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+        )
+        assert ingest.call_args.kwargs["sector"] == "Technology"
+
+    def test_missing_sector_passes_none(self):
+        article = _make_article(tickers=("UNKNOWN",))
+        ingest = MagicMock(return_value="doc")
+        ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            ticker_to_sector={"AAPL": "Technology"},  # UNKNOWN not in map
+            embed_texts_fn=MagicMock(return_value=[[0.0]]),
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+        )
+        assert ingest.call_args.kwargs["sector"] is None
+
+
+# ── dry_run ────────────────────────────────────────────────────────────
+
+
+class TestDryRun:
+    def test_dry_run_skips_embed_and_ingest_but_counts(self):
+        article = _make_article(tickers=("AAPL", "MSFT"))
+        embed = MagicMock()
+        ingest = MagicMock()
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+            dry_run=True,
+        )
+        embed.assert_not_called()
+        ingest.assert_not_called()
+        # Counters still increment so dry-run shows what would happen
+        assert stats["n_documents_ingested"] == 2
+
+
+# ── Failure isolation ──────────────────────────────────────────────────
+
+
+class TestFailureIsolation:
+    def test_per_document_failure_continues_batch(self):
+        """One article failing in ingest_document doesn't stop the rest."""
+        a1 = _make_article(fingerprint="a", tickers=("AAPL",))
+        a2 = _make_article(fingerprint="b", tickers=("MSFT",))
+        a3 = _make_article(fingerprint="c", tickers=("GOOGL",))
+
+        def ingest_side_effect(*, ticker, **kw):
+            if ticker == "MSFT":
+                raise RuntimeError("pgvector temporary failure")
+            return f"doc-{ticker}"
+
+        embed = MagicMock(return_value=[[0.0]])
+        ingest = MagicMock(side_effect=ingest_side_effect)
+
+        stats = ingest_articles(
+            [a1, a2, a3],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=embed,
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+        )
+        assert stats["n_documents_ingested"] == 2
+        assert stats["n_failures"] == 1
+
+    def test_ingest_returning_none_counts_as_failure(self):
+        """If ingest_document returns None (lib's failure signal),
+        count as failure without crashing the batch."""
+        article = _make_article(tickers=("AAPL",))
+        ingest = MagicMock(return_value=None)
+        stats = ingest_articles(
+            [article],
+            filed_date=date(2026, 5, 13),
+            embed_texts_fn=MagicMock(return_value=[[0.0]]),
+            document_exists_fn=MagicMock(return_value=False),
+            ingest_document_fn=ingest,
+        )
+        assert stats["n_documents_ingested"] == 0
+        assert stats["n_failures"] == 1
+
+
+# ── Stats shape ────────────────────────────────────────────────────────
+
+
+def test_stats_shape_has_canonical_keys():
+    stats = ingest_articles(
+        [],
+        filed_date=date(2026, 5, 13),
+        embed_texts_fn=MagicMock(),
+        document_exists_fn=MagicMock(),
+        ingest_document_fn=MagicMock(),
+    )
+    expected_keys = {
+        "n_articles_input",
+        "n_documents_attempted",
+        "n_documents_skipped_exists",
+        "n_documents_skipped_empty_text",
+        "n_documents_ingested",
+        "n_failures",
+    }
+    assert set(stats.keys()) == expected_keys
+    # Empty input → all zero
+    assert all(v == 0 for v in stats.values())


### PR DESCRIPTION
## Summary

**Wave 1 PR A.3** of the institutional data-revamp arc. Indexes aggregated news articles into the existing pgvector RAG corpus alongside SEC filings. Consumer agents (thesis_update, sector_quant/qual) retrieve relevant news at inference time via the same hybrid-retrieval API the qual analyst's `query_filings` tool already uses.

**Completes the Wave 1 producer-side news substrate.** Consumer-side tool wiring (PR E) and `fetch_data` integration (PR F) follow.

## Composition chain (full Wave 1 dataflow)

```
PolygonNewsAdapter + GdeltNewsAdapter + YahooRssNewsAdapter (PR β #226)
                              │
                              ▼
                  NewsAggregator.fetch() — fan-in + dedup + trust
                              │
                              ▼
                    AggregatedNewsArticle list
                              │
            ┌─────────────────┼─────────────────┐
            ▼                 ▼                 ▼
  NewsNLPPipeline       aggregate_and_write    ingest_articles
  (PR A.1 #227)         (PR A.2 #228)          (PR A.3 — THIS PR)
            │                 │                 │
            ▼                 ▼                 ▼
  sentiment+events       per-ticker per-day    pgvector docs
  +entities streams      structured parquet    alongside filings
```

## What's in

New module `rag/pipelines/ingest_news.py`:

- `ingest_articles(articles, *, filed_date, ticker_to_sector, embed_texts_fn, document_exists_fn, ingest_document_fn, dry_run)` returning a stats dict
- Mirrors the canonical `ingest_8k_filings.py` pattern (consistent RAG-pipeline shape across the repo)
- **One document per (ticker, article) pair** — multi-ticker articles index once per ticker so the ticker-keyed RAG schema surfaces them when the qual agent queries by any constituent
- **Idempotent** via `document_exists` pre-check — re-runs skip the embedding call entirely (saves vector-API cost)
- **Chunking:** one chunk per article (title + longest body excerpt across variants). Polygon/GDELT/Yahoo bodies are short (<500 tokens); multi-chunk splitting can land in a follow-up if Benzinga or a full-body adapter joins
- **Source labeling:** RAG `source` field prefixed `news_` (e.g. `news_polygon`, `news_gdelt`) so consumer queries can filter "news only" vs "filings only" by source-prefix without enumerating vendors
- **Canonical source selection:** alphabetical across variants so re-ingests produce the same document (deterministic across runs)
- **Failure isolation:** per-document failures (transient pgvector / embed-API hiccup) isolated; batch continues. `ingest_document` returning None (lib's failure signal) counts as a failure without crashing

## Test plan

- [x] **+18 unit tests** (`tests/test_ingest_news.py`):
  - Helpers: `_rag_source` prefix / `_chunk_text` combines title+longest body / handles missing title / all-empty edge / `_canonical_source` deterministic alphabetical + single variant
  - Single-ticker happy path: embed + ingest called with right shape
  - **Idempotency:** `document_exists` short-circuits embed AND ingest
  - Empty / too-short bodies skipped (counter increments)
  - Multi-ticker: emits one doc per ticker
  - Multi-ticker per-ticker existence check (one exists, one new)
  - Sector lookup: `ticker_to_sector` passed through; missing → None
  - `dry_run` mode skips embed/ingest but counts
  - **Failure isolation:** one bad doc continues batch
  - `ingest_document` returning None counts as failure not crash
  - Stats dict shape pinned to 6 canonical keys
- [x] Full data suite: **929 passing** (1 skipped) in 4s

## What's remaining in Wave 1

- **PR B** — Filings substrate expansion (EDGAR full coverage — Form 4, 13F, 10-K/Q/14A/S-1/13D/G)
- **PR C** — Analyst substrate (yfinance + FMP adapters + self-derived revisions)
- **PR D** — Async + S3 cache + per-vendor rate limiters
- **PR E** — RAG retrieval tools in research (`search_news`, `search_filings`, etc. — wires existing corpus to thesis_update + sector agents)
- **PR F** — Wire substrate into research's `fetch_data` (supersedes #170's per-ticker pre-fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)