### PR TITLE
feat(analyst): Wave 1 PR C — analyst substrate + self-derived revisions

### DIFF
--- a/collectors/analyst_sources/__init__.py
+++ b/collectors/analyst_sources/__init__.py
@@ -1,0 +1,23 @@
+"""Analyst-data adapter implementations.
+
+Concrete adapters implementing the ``alpha_engine_lib.sources.AnalystSource``
+Protocol. Free-tier adapters wired today (yfinance, Finnhub); paid stubs
+(IBES, Visible Alpha) fail loud on construction so a future operator
+wiring them sees the gap immediately.
+
+Architectural pattern: lib defines the contract; this module is the
+producer-side concrete implementation; consumers read producer outputs
+from S3 (via the daily snapshotter + derived revisions module).
+"""
+
+from collectors.analyst_sources.finnhub import FinnhubAnalystAdapter
+from collectors.analyst_sources.ibes import IbesAnalystAdapter
+from collectors.analyst_sources.visible_alpha import VisibleAlphaAnalystAdapter
+from collectors.analyst_sources.yfinance import YfinanceAnalystAdapter
+
+__all__ = [
+    "YfinanceAnalystAdapter",
+    "FinnhubAnalystAdapter",
+    "IbesAnalystAdapter",
+    "VisibleAlphaAnalystAdapter",
+]

--- a/collectors/analyst_sources/finnhub.py
+++ b/collectors/analyst_sources/finnhub.py
@@ -1,0 +1,90 @@
+"""Finnhub analyst adapter — FREE.
+
+Pulls analyst-recommendation buckets (strongBuy/buy/hold/sell/strongSell
+counts) from Finnhub's ``/stock/recommendation`` endpoint. Free tier
+supports US tickers.
+
+Note: Finnhub's `/stock/price-target` endpoint requires a paid tier
+(returns 403 on free). Mean target therefore stays None on this
+adapter — pair with the yfinance adapter for the target via the
+snapshotter's multi-source merge.
+
+Normalizes the per-bucket counts to a single consensus_rating using
+the same plurality rule used in ``collectors/alternative.py::_fetch_analyst``:
+
+  bullish = strongBuy + buy
+  bearish = sell + strongSell
+  bullish > bearish AND bullish >= hold       → "buy"
+  bearish > bullish                            → "sell"
+  otherwise                                    → "hold"
+
+We use the canonical 5-class ladder ("strongBuy" / "buy" / "hold" /
+"sell" / "strongSell"). Today this adapter emits "buy" / "hold" /
+"sell" — the strong tiers require ratio-thresholding which is a
+follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from alpha_engine_lib.sources import AnalystSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class FinnhubAnalystAdapter:
+    """Finnhub analyst data adapter. Implements ``AnalystSource``."""
+
+    name = "finnhub"
+
+    def __init__(self, finnhub_get_fn: Any = None) -> None:
+        self._finnhub_get = finnhub_get_fn
+
+    def _get_fetcher(self):
+        if self._finnhub_get is None:
+            from collectors.finnhub_client import finnhub_get
+            self._finnhub_get = finnhub_get
+        return self._finnhub_get
+
+    def fetch(self, ticker: str) -> AnalystSnapshot | None:
+        try:
+            data = self._get_fetcher()("stock/recommendation", {"symbol": ticker})
+        except Exception as e:
+            logger.warning(
+                "[finnhub_analyst] fetch failed for %s: %s", ticker, e,
+            )
+            return None
+        if not isinstance(data, list) or not data:
+            return None
+
+        latest = data[0]
+        totals = {
+            k: int(latest.get(k, 0) or 0)
+            for k in ("strongBuy", "buy", "hold", "sell", "strongSell")
+        }
+        total = sum(totals.values())
+        if total == 0:
+            return None
+
+        bullish = totals["strongBuy"] + totals["buy"]
+        bearish = totals["sell"] + totals["strongSell"]
+        if bullish > bearish and bullish >= totals["hold"]:
+            rating = "buy"
+        elif bearish > bullish:
+            rating = "sell"
+        else:
+            rating = "hold"
+
+        return AnalystSnapshot(
+            ticker=ticker,
+            source=self.name,
+            fetched_at=datetime.now(timezone.utc),
+            consensus_rating=rating,
+            mean_target=None,  # paid-tier only
+            median_target=None,
+            num_analysts=total,
+            rating_changes_30d=(),  # require trend tracking against prior periods
+        )

--- a/collectors/analyst_sources/ibes.py
+++ b/collectors/analyst_sources/ibes.py
@@ -1,0 +1,28 @@
+"""IBES analyst adapter — PAID, not yet wired.
+
+Stub for Phase 4 subscription upgrade. IBES (Institutional Brokers'
+Estimate System, Refinitiv) is the institutional gold standard for
+consensus + revisions + recommendations data. Drop-in implementation
+when IBES_API_KEY (or Refinitiv Eikon Data API access) lands.
+
+When wired, this adapter's structured output (with full revision
+history) becomes the highest-trust analyst source.
+"""
+
+from __future__ import annotations
+
+from alpha_engine_lib.sources import AnalystSnapshot
+
+
+class IbesAnalystAdapter:
+    name = "ibes"
+
+    def __init__(self) -> None:
+        raise NotImplementedError(
+            "IbesAnalystAdapter is a Phase 4 paid-tier stub. "
+            "Requires Refinitiv Eikon Data API access. "
+            "See ~/Development/alpha-engine-docs/private/data-revamp-260513.md."
+        )
+
+    def fetch(self, ticker: str) -> AnalystSnapshot | None:
+        raise NotImplementedError

--- a/collectors/analyst_sources/visible_alpha.py
+++ b/collectors/analyst_sources/visible_alpha.py
@@ -1,0 +1,25 @@
+"""Visible Alpha analyst adapter — PAID, not yet wired.
+
+Stub for Phase 4. Visible Alpha aggregates sell-side analyst models
+with per-line-item estimates (revenue, EPS, FCF by segment), real-
+time revisions, and a normalized "Standard Estimates" view. When
+wired, this adapter exposes both the headline consensus AND the
+per-segment estimate distribution that other vendors don't expose.
+"""
+
+from __future__ import annotations
+
+from alpha_engine_lib.sources import AnalystSnapshot
+
+
+class VisibleAlphaAnalystAdapter:
+    name = "visible_alpha"
+
+    def __init__(self) -> None:
+        raise NotImplementedError(
+            "VisibleAlphaAnalystAdapter is a Phase 4 paid-tier stub. "
+            "See ~/Development/alpha-engine-docs/private/data-revamp-260513.md."
+        )
+
+    def fetch(self, ticker: str) -> AnalystSnapshot | None:
+        raise NotImplementedError

--- a/collectors/analyst_sources/yfinance.py
+++ b/collectors/analyst_sources/yfinance.py
@@ -1,0 +1,100 @@
+"""yfinance analyst adapter — FREE.
+
+Pulls consensus price target + analyst-opinion count from
+``yfinance.Ticker(ticker).info`` (the ``targetMeanPrice`` /
+``targetMedianPrice`` / ``numberOfAnalystOpinions`` /
+``recommendationKey`` fields).
+
+yfinance scrapes Yahoo Finance's HTML/API, so coverage tracks what
+Yahoo surfaces — usually good for US large/mid-cap and patchy below.
+
+Normalizes Yahoo's recommendationKey strings to the canonical 5-class
+ladder (``strongBuy``/``buy``/``hold``/``sell``/``strongSell``).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from alpha_engine_lib.sources import AnalystSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+# yfinance returns recommendationKey strings in lower_snake_case;
+# normalize to camelCase to match the canonical ladder.
+_RATING_NORMALIZE = {
+    "strong_buy": "strongBuy",
+    "buy": "buy",
+    "hold": "hold",
+    "underperform": "sell",
+    "sell": "sell",
+    "strong_sell": "strongSell",
+}
+
+
+class YfinanceAnalystAdapter:
+    """yfinance analyst data adapter. Implements ``AnalystSource``."""
+
+    name = "yfinance"
+
+    def __init__(self, yf_module: Any = None) -> None:
+        self._yf = yf_module  # default lazy-import
+
+    def _get_yf(self) -> Any:
+        if self._yf is None:
+            import yfinance
+            self._yf = yfinance
+        return self._yf
+
+    def fetch(self, ticker: str) -> AnalystSnapshot | None:
+        try:
+            info = self._get_yf().Ticker(ticker).info
+        except Exception as e:
+            logger.warning(
+                "[yfinance_analyst] fetch failed for %s: %s", ticker, e,
+            )
+            return None
+        if not isinstance(info, dict) or not info:
+            return None
+
+        rec_key = (info.get("recommendationKey") or "").lower()
+        consensus_rating = _RATING_NORMALIZE.get(rec_key)
+
+        mean_target = _as_float(info.get("targetMeanPrice"))
+        median_target = _as_float(info.get("targetMedianPrice"))
+        num_analysts = _as_int(info.get("numberOfAnalystOpinions"))
+
+        return AnalystSnapshot(
+            ticker=ticker,
+            source=self.name,
+            fetched_at=datetime.now(timezone.utc),
+            consensus_rating=consensus_rating,
+            mean_target=mean_target,
+            median_target=median_target,
+            num_analysts=num_analysts,
+            rating_changes_30d=(),  # yfinance.info doesn't expose revisions
+        )
+
+
+def _as_float(v: Any) -> float | None:
+    if v is None:
+        return None
+    try:
+        f = float(v)
+        if f != f:  # NaN
+            return None
+        return round(f, 4)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(v: Any) -> int | None:
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None

--- a/data/derived/analyst_revisions.py
+++ b/data/derived/analyst_revisions.py
@@ -1,0 +1,366 @@
+"""Self-derived analyst-estimate revisions.
+
+Wave 1 PR C of the institutional data-revamp arc. Reads the daily
+analyst-consensus snapshot time series (written by
+``data/snapshotter/analyst_daily.py``) and computes
+revisions deltas:
+
+  - ``mean_target_delta_7d``    — mean target now minus 7 trailing days
+  - ``mean_target_delta_30d``   — mean target now minus 30 trailing days
+  - ``num_analysts_delta_30d``  — coverage change (additions vs drops)
+  - ``rating_changed_30d``      — boolean: consensus_rating different
+                                  from 30d-ago snapshot
+
+Why self-derived (vs a paid IBES revisions feed):
+
+- IBES is a Phase 4 paid subscription. We own the time series via
+  the snapshotter — sufficient for 7/30-day deltas at no extra cost.
+- Composes with the IbesAnalystAdapter stub when subscription lands:
+  this module's outputs add to (don't conflict with) IBES's native
+  revision history.
+
+Acceptance: ≥14 days of accumulated daily snapshots produce useful
+revisions output. Earlier days emit None deltas (degraded gracefully).
+
+S3 layout::
+
+    s3://alpha-engine-research/data/analyst_revisions/{YYYY-MM-DD}.parquet
+
+One parquet per as-of-date holds all tickers (similar to news_aggregates).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from datetime import date as Date
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from typing import Any, Iterable
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = 1
+DEFAULT_S3_BUCKET = "alpha-engine-research"
+DEFAULT_S3_PREFIX = "data/analyst_revisions"
+
+
+@dataclass(frozen=True)
+class AnalystRevisionRow:
+    """Per-(ticker, as_of_date) revision row.
+
+    None values mean "insufficient history" — common in the first 30
+    days of snapshotter operation. Downstream consumers should treat
+    None as "no signal yet" rather than "signal is zero".
+    """
+
+    ticker: str
+    as_of_date: Date
+    schema_version: int
+    primary_source: str
+    """The source ``mean_target`` was read from (yfinance preferred;
+    falls back to first available)."""
+    mean_target_current: float | None
+    mean_target_7d_ago: float | None
+    mean_target_30d_ago: float | None
+    mean_target_delta_7d: float | None
+    mean_target_delta_30d: float | None
+    mean_target_pct_change_30d: float | None
+    num_analysts_current: int | None
+    num_analysts_30d_ago: int | None
+    num_analysts_delta_30d: int | None
+    consensus_rating_current: str | None
+    consensus_rating_30d_ago: str | None
+    rating_changed_30d: bool
+    n_snapshot_days_observed: int
+    """How many distinct snapshot dates contributed to this row.
+    Useful for downstream confidence weighting."""
+
+
+# ── Source preference ─────────────────────────────────────────────────
+
+
+# Source preference order for mean_target. yfinance is the most reliable
+# free source for the headline consensus number. Finnhub free doesn't
+# expose target; IBES / Visible Alpha would override when wired.
+_SOURCE_PREFERENCE_FOR_TARGET = ("ibes", "visible_alpha", "yfinance", "finnhub")
+_SOURCE_PREFERENCE_FOR_RATING = ("ibes", "visible_alpha", "finnhub", "yfinance")
+
+
+def _pick_field(
+    snapshots_by_source: dict, *, sources: tuple[str, ...], field: str,
+) -> tuple[Any, str | None]:
+    """Look up the first non-None ``field`` across ``sources`` in
+    preference order. Returns (value, source_name) or (None, None)."""
+    for src in sources:
+        snap = snapshots_by_source.get(src)
+        if not snap:
+            continue
+        value = snap.get(field)
+        if value is not None:
+            return value, src
+    return None, None
+
+
+# ── Build revision rows ───────────────────────────────────────────────
+
+
+def build_revision_row(
+    *,
+    ticker: str,
+    as_of_date: Date,
+    snapshot_documents_by_date: dict[Date, dict],
+) -> AnalystRevisionRow:
+    """Compute one revision row from a ticker's snapshot time series.
+
+    ``snapshot_documents_by_date`` maps Date → the JSON document the
+    snapshotter wrote that day. Missing dates are tolerated (callers
+    pass whatever the S3 listing returned). Deltas degrade to None
+    when the historical anchor doesn't exist.
+    """
+    today_doc = snapshot_documents_by_date.get(as_of_date)
+    today_snapshots = (today_doc or {}).get("snapshots_by_source") or {}
+
+    target_today, target_source = _pick_field(
+        today_snapshots,
+        sources=_SOURCE_PREFERENCE_FOR_TARGET, field="mean_target",
+    )
+    num_analysts_today, _ = _pick_field(
+        today_snapshots,
+        sources=_SOURCE_PREFERENCE_FOR_TARGET, field="num_analysts",
+    )
+    rating_today, _ = _pick_field(
+        today_snapshots,
+        sources=_SOURCE_PREFERENCE_FOR_RATING, field="consensus_rating",
+    )
+
+    target_7d = _historical_target(
+        snapshot_documents_by_date, as_of_date, days_back=7,
+    )
+    target_30d, num_analysts_30d, rating_30d = _historical_at(
+        snapshot_documents_by_date, as_of_date, days_back=30,
+    )
+
+    delta_7d = _safe_subtract(target_today, target_7d)
+    delta_30d = _safe_subtract(target_today, target_30d)
+    pct_30d = _safe_pct_change(target_today, target_30d)
+
+    num_delta_30d = _safe_subtract_int(num_analysts_today, num_analysts_30d)
+    rating_changed_30d = (
+        rating_today is not None
+        and rating_30d is not None
+        and rating_today != rating_30d
+    )
+
+    return AnalystRevisionRow(
+        ticker=ticker,
+        as_of_date=as_of_date,
+        schema_version=SCHEMA_VERSION,
+        primary_source=target_source or "",
+        mean_target_current=target_today,
+        mean_target_7d_ago=target_7d,
+        mean_target_30d_ago=target_30d,
+        mean_target_delta_7d=delta_7d,
+        mean_target_delta_30d=delta_30d,
+        mean_target_pct_change_30d=pct_30d,
+        num_analysts_current=num_analysts_today,
+        num_analysts_30d_ago=num_analysts_30d,
+        num_analysts_delta_30d=num_delta_30d,
+        consensus_rating_current=rating_today,
+        consensus_rating_30d_ago=rating_30d,
+        rating_changed_30d=rating_changed_30d,
+        n_snapshot_days_observed=len(snapshot_documents_by_date),
+    )
+
+
+def _historical_target(
+    docs_by_date: dict[Date, dict],
+    as_of: Date,
+    *,
+    days_back: int,
+) -> float | None:
+    """Look up mean_target on (as_of - days_back). Tolerates missing
+    exact-day match by walking back a few days (handles weekends /
+    holidays / snapshotter outages)."""
+    for offset in range(days_back, days_back + 7):
+        d = as_of - timedelta(days=offset)
+        doc = docs_by_date.get(d)
+        if not doc:
+            continue
+        target, _ = _pick_field(
+            doc.get("snapshots_by_source") or {},
+            sources=_SOURCE_PREFERENCE_FOR_TARGET, field="mean_target",
+        )
+        if target is not None:
+            return float(target)
+    return None
+
+
+def _historical_at(
+    docs_by_date: dict[Date, dict],
+    as_of: Date,
+    *,
+    days_back: int,
+) -> tuple[float | None, int | None, str | None]:
+    """Like _historical_target but also returns num_analysts + rating
+    from the SAME historical snapshot (so all three deltas are
+    apples-to-apples). Walks back a few days for weekend/holiday gaps."""
+    for offset in range(days_back, days_back + 7):
+        d = as_of - timedelta(days=offset)
+        doc = docs_by_date.get(d)
+        if not doc:
+            continue
+        snaps = doc.get("snapshots_by_source") or {}
+        target, _ = _pick_field(
+            snaps, sources=_SOURCE_PREFERENCE_FOR_TARGET, field="mean_target",
+        )
+        num, _ = _pick_field(
+            snaps, sources=_SOURCE_PREFERENCE_FOR_TARGET, field="num_analysts",
+        )
+        rating, _ = _pick_field(
+            snaps, sources=_SOURCE_PREFERENCE_FOR_RATING, field="consensus_rating",
+        )
+        if target is not None or rating is not None or num is not None:
+            return (
+                float(target) if target is not None else None,
+                int(num) if num is not None else None,
+                rating,
+            )
+    return None, None, None
+
+
+def _safe_subtract(a: float | None, b: float | None) -> float | None:
+    if a is None or b is None:
+        return None
+    return round(float(a) - float(b), 4)
+
+
+def _safe_subtract_int(a: int | None, b: int | None) -> int | None:
+    if a is None or b is None:
+        return None
+    return int(a) - int(b)
+
+
+def _safe_pct_change(a: float | None, b: float | None) -> float | None:
+    if a is None or b is None or float(b) == 0:
+        return None
+    return round((float(a) - float(b)) / float(b), 6)
+
+
+# ── Time-series loader from S3 ────────────────────────────────────────
+
+
+def load_snapshot_time_series(
+    ticker: str,
+    *,
+    as_of_date: Date,
+    days_back: int = 30,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    snapshot_prefix: str = "data/analyst_snapshots",
+) -> dict[Date, dict]:
+    """Load all snapshot documents for ``ticker`` in the window
+    [as_of - days_back, as_of]. Returns a mapping Date → JSON document.
+
+    Missing dates are simply absent from the mapping — caller logic in
+    ``build_revision_row`` tolerates this.
+
+    Uses S3 GetObject per-date (small JSON docs, cheap). For very long
+    windows (>365 days) a list-prefix + batch read would be cheaper;
+    not needed for 30-day windows.
+    """
+    out: dict[Date, dict] = {}
+    for offset in range(days_back + 7 + 1):
+        d = as_of_date - timedelta(days=offset)
+        key = f"{snapshot_prefix}/{ticker.upper()}/{d.isoformat()}.json"
+        try:
+            obj = s3_client.get_object(Bucket=bucket, Key=key)
+        except Exception:
+            continue
+        import json as _json
+        try:
+            out[d] = _json.loads(obj["Body"].read())
+        except Exception as e:
+            logger.warning(
+                "[analyst_revisions] failed to parse %s: %s", key, e,
+            )
+    return out
+
+
+# ── Parquet writer ─────────────────────────────────────────────────────
+
+
+def s3_key_for_date(
+    as_of_date: Date, *, prefix: str = DEFAULT_S3_PREFIX,
+) -> str:
+    return f"{prefix}/{as_of_date.isoformat()}.parquet"
+
+
+def rows_to_dataframe(rows: Iterable[AnalystRevisionRow]) -> pd.DataFrame:
+    rows_list = list(rows)
+    if not rows_list:
+        cols = list(AnalystRevisionRow.__dataclass_fields__.keys())
+        return pd.DataFrame(columns=cols)
+    return pd.DataFrame([asdict(r) for r in rows_list])
+
+
+def write_revisions_parquet(
+    rows: Iterable[AnalystRevisionRow],
+    *,
+    as_of_date: Date,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> str:
+    df = rows_to_dataframe(rows)
+    key = s3_key_for_date(as_of_date, prefix=prefix)
+    buf = BytesIO()
+    df.to_parquet(buf, engine="pyarrow", index=False)
+    buf.seek(0)
+    s3_client.put_object(
+        Bucket=bucket, Key=key, Body=buf.getvalue(),
+        ContentType="application/octet-stream",
+    )
+    logger.info(
+        "[analyst_revisions] wrote %d rows to s3://%s/%s",
+        len(df), bucket, key,
+    )
+    return key
+
+
+# ── End-to-end orchestrator ────────────────────────────────────────────
+
+
+def compute_and_write_revisions(
+    tickers: list[str],
+    *,
+    as_of_date: Date,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    snapshot_prefix: str = "data/analyst_snapshots",
+    revisions_prefix: str = DEFAULT_S3_PREFIX,
+) -> tuple[str, list[AnalystRevisionRow]]:
+    """Load time-series for each ticker, build revision rows, write
+    parquet. Returns (s3_key, rows)."""
+    rows: list[AnalystRevisionRow] = []
+    for ticker in tickers:
+        docs = load_snapshot_time_series(
+            ticker,
+            as_of_date=as_of_date,
+            s3_client=s3_client,
+            bucket=bucket,
+            snapshot_prefix=snapshot_prefix,
+        )
+        rows.append(build_revision_row(
+            ticker=ticker,
+            as_of_date=as_of_date,
+            snapshot_documents_by_date=docs,
+        ))
+    key = write_revisions_parquet(
+        rows, as_of_date=as_of_date,
+        s3_client=s3_client, bucket=bucket, prefix=revisions_prefix,
+    )
+    return key, rows

--- a/data/snapshotter/__init__.py
+++ b/data/snapshotter/__init__.py
@@ -1,0 +1,19 @@
+"""Daily snapshot writers — own the time-series state required by
+self-derived signals.
+
+Some signals (analyst-estimate revisions, sentiment trends) require
+knowing yesterday's value to compute today's delta. The producers
+(yfinance, Finnhub, FMP) don't expose historical revisions on their
+free tiers — so we own the time series by snapshotting the current
+state daily.
+
+Each snapshotter writes one JSON / parquet to S3 per day. The matching
+``data/derived/`` module reads the time series and computes deltas.
+
+Modules:
+
+  analyst_daily — analyst consensus + price target snapshot (PR C)
+
+See ``~/Development/alpha-engine-docs/private/data-revamp-260513.md``
+for the full institutional data-revamp arc context.
+"""

--- a/data/snapshotter/analyst_daily.py
+++ b/data/snapshotter/analyst_daily.py
@@ -1,0 +1,221 @@
+"""Daily analyst-consensus snapshotter.
+
+Wave 1 PR C of the institutional data-revamp arc. Writes one JSON
+per (ticker, date) capturing today's analyst consensus + price target
+across multiple sources. The matching ``data/derived/analyst_revisions.py``
+reads the time series and computes self-derived 7d/30d revision deltas
+without needing a paid revisions feed.
+
+S3 layout::
+
+    s3://alpha-engine-research/data/analyst_snapshots/{ticker}/{YYYY-MM-DD}.json
+
+Per-ticker subfolder keeps a coherent per-ticker time series readable
+in O(prefix-list) — important since downstream revisions computation
+reads multiple dates per ticker.
+
+Each daily snapshot is a small JSON document containing one
+``AnalystSnapshot`` record per source. Multi-source preservation
+matters because (a) sources disagree on coverage; (b) some metrics
+require cross-source merge (yfinance has mean_target, finnhub has
+rating bucket counts — neither alone is sufficient).
+
+Idempotent: re-writing the same date overwrites.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import date as Date
+from datetime import datetime, timezone
+from typing import Any, Sequence
+
+from alpha_engine_lib.sources import AnalystSnapshot, AnalystSource
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = 1
+DEFAULT_S3_BUCKET = "alpha-engine-research"
+DEFAULT_S3_PREFIX = "data/analyst_snapshots"
+
+
+# ── On-disk shape ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AnalystSnapshotDocument:
+    """Daily JSON document layout — one per (ticker, snapshot_date).
+
+    ``snapshots_by_source`` keeps every adapter's full record. The
+    derived-revisions module computes deltas by reading multiple days'
+    documents and pivoting on ``snapshots_by_source[source].mean_target``
+    (or any other field of interest).
+    """
+
+    ticker: str
+    snapshot_date: Date
+    schema_version: int
+    snapshots_by_source: dict[str, dict]
+    fetched_at: datetime
+
+
+# ── Snapshot the universe ──────────────────────────────────────────────
+
+
+def snapshot_one_ticker(
+    ticker: str,
+    sources: Sequence[AnalystSource],
+) -> dict[str, AnalystSnapshot]:
+    """Run each adapter for one ticker. Returns mapping source.name → snapshot.
+
+    Source failures (transient API hiccup, ticker not covered) skip
+    that source rather than crash the batch — matches the Protocol
+    contract.
+    """
+    out: dict[str, AnalystSnapshot] = {}
+    for source in sources:
+        try:
+            snap = source.fetch(ticker)
+        except Exception as e:
+            logger.warning(
+                "[analyst_snapshotter] %s adapter raised for %s: %s",
+                source.name, ticker, e,
+            )
+            continue
+        if snap is not None:
+            out[source.name] = snap
+    return out
+
+
+def write_snapshot_document(
+    *,
+    ticker: str,
+    snapshot_date: Date,
+    snapshots: dict[str, AnalystSnapshot],
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> str:
+    """Write the per-day snapshot document for ``ticker`` to S3. Returns
+    the key.
+
+    Empty ``snapshots`` still writes a document with an empty
+    ``snapshots_by_source`` map — that's signal (no adapter covered
+    the ticker that day) which revisions logic uses to skip stale-vs-
+    missing distinction."""
+    key = s3_key_for(ticker, snapshot_date, prefix=prefix)
+    body = {
+        "ticker": ticker,
+        "snapshot_date": snapshot_date.isoformat(),
+        "schema_version": SCHEMA_VERSION,
+        "fetched_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "snapshots_by_source": {
+            name: _serialize_snapshot(snap)
+            for name, snap in snapshots.items()
+        },
+    }
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(body, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+    logger.info(
+        "[analyst_snapshotter] wrote %s [%d sources] to s3://%s/%s",
+        ticker, len(snapshots), bucket, key,
+    )
+    return key
+
+
+def snapshot_universe(
+    tickers: Sequence[str],
+    sources: Sequence[AnalystSource],
+    *,
+    snapshot_date: Date,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """End-to-end: for each ticker, run each adapter, write per-ticker
+    snapshot document to S3. Returns stats dict.
+    """
+    stats = {
+        "n_tickers": len(tickers),
+        "n_documents_written": 0,
+        "n_source_calls_attempted": 0,
+        "n_source_calls_succeeded": 0,
+        "n_tickers_with_zero_coverage": 0,
+    }
+    for ticker in tickers:
+        snapshots = snapshot_one_ticker(ticker, sources)
+        stats["n_source_calls_attempted"] += len(sources)
+        stats["n_source_calls_succeeded"] += len(snapshots)
+        if not snapshots:
+            stats["n_tickers_with_zero_coverage"] += 1
+        if dry_run:
+            logger.info(
+                "[DRY RUN] would snapshot %s with %d sources",
+                ticker, len(snapshots),
+            )
+            stats["n_documents_written"] += 1
+            continue
+        write_snapshot_document(
+            ticker=ticker,
+            snapshot_date=snapshot_date,
+            snapshots=snapshots,
+            s3_client=s3_client,
+            bucket=bucket,
+            prefix=prefix,
+        )
+        stats["n_documents_written"] += 1
+    return stats
+
+
+# ── S3 key + serialization helpers ────────────────────────────────────
+
+
+def s3_key_for(
+    ticker: str, snapshot_date: Date, *, prefix: str = DEFAULT_S3_PREFIX,
+) -> str:
+    """Canonical key for one (ticker, date) snapshot document."""
+    return f"{prefix}/{ticker.upper()}/{snapshot_date.isoformat()}.json"
+
+
+def _serialize_snapshot(snap: AnalystSnapshot) -> dict:
+    """Pydantic AnalystSnapshot → JSON-safe dict.
+
+    Uses model_dump(mode='json') so datetime/date/tuple fields encode
+    consistently across Python versions and the round-trip back to
+    Pydantic during read is loss-free.
+    """
+    return snap.model_dump(mode="json")
+
+
+def read_snapshot_document(
+    ticker: str,
+    snapshot_date: Date,
+    *,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> dict | None:
+    """Read one snapshot document by (ticker, date). Returns the raw
+    JSON dict or None if no document exists.
+
+    Consumer of the derived-revisions module (PR C tail) — also useful
+    for ad-hoc inspection.
+    """
+    key = s3_key_for(ticker, snapshot_date, prefix=prefix)
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
+    except Exception as e:
+        logger.debug(
+            "[analyst_snapshotter] no document at s3://%s/%s (%s)",
+            bucket, key, type(e).__name__,
+        )
+        return None
+    return json.loads(obj["Body"].read())

--- a/tests/test_analyst_substrate.py
+++ b/tests/test_analyst_substrate.py
@@ -1,0 +1,502 @@
+"""Tests for the analyst substrate (Wave 1 PR C).
+
+Covers:
+  - YfinanceAnalystAdapter (rating normalization, missing fields, fetch failures)
+  - FinnhubAnalystAdapter (bucket → consensus rating ladder, totals=0 returns None)
+  - Paid stubs raise NotImplementedError
+  - Protocol structural subtyping
+  - Daily snapshotter (per-ticker write + multi-source merge + round-trip)
+  - Self-derived revisions (deltas / missing history → None / weekend gap walk-back)
+  - End-to-end compute_and_write_revisions
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from alpha_engine_lib.sources import AnalystSnapshot, AnalystSource
+
+from collectors.analyst_sources.finnhub import FinnhubAnalystAdapter
+from collectors.analyst_sources.ibes import IbesAnalystAdapter
+from collectors.analyst_sources.visible_alpha import VisibleAlphaAnalystAdapter
+from collectors.analyst_sources.yfinance import YfinanceAnalystAdapter
+from data.derived.analyst_revisions import (
+    SCHEMA_VERSION as REVISIONS_SCHEMA_VERSION,
+    AnalystRevisionRow,
+    build_revision_row,
+    compute_and_write_revisions,
+    rows_to_dataframe,
+    s3_key_for_date,
+)
+from data.snapshotter.analyst_daily import (
+    SCHEMA_VERSION as SNAPSHOT_SCHEMA_VERSION,
+    read_snapshot_document,
+    s3_key_for,
+    snapshot_one_ticker,
+    snapshot_universe,
+    write_snapshot_document,
+)
+
+
+# ── In-memory S3 mock (reused pattern) ─────────────────────────────────
+
+
+class _InMemoryS3:
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[(Bucket, Key)] = Body
+        return {"ETag": "stub"}
+
+    def get_object(self, *, Bucket, Key):
+        if (Bucket, Key) not in self.store:
+            raise RuntimeError("NoSuchKey")
+        return {"Body": BytesIO(self.store[(Bucket, Key)])}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ── yfinance adapter ──────────────────────────────────────────────────
+
+
+class TestYfinanceAdapter:
+    def test_normalizes_rating_strings(self):
+        fake_yf = MagicMock()
+        fake_yf.Ticker.return_value.info = {
+            "recommendationKey": "strong_buy",
+            "targetMeanPrice": 250.0,
+            "targetMedianPrice": 248.5,
+            "numberOfAnalystOpinions": 18,
+        }
+        adapter = YfinanceAnalystAdapter(yf_module=fake_yf)
+        snap = adapter.fetch("AAPL")
+        assert snap.ticker == "AAPL"
+        assert snap.source == "yfinance"
+        assert snap.consensus_rating == "strongBuy"
+        assert snap.mean_target == 250.0
+        assert snap.median_target == 248.5
+        assert snap.num_analysts == 18
+
+    def test_handles_buy_underperform_sell_strong_sell(self):
+        cases = [
+            ("buy", "buy"),
+            ("hold", "hold"),
+            ("underperform", "sell"),
+            ("sell", "sell"),
+            ("strong_sell", "strongSell"),
+        ]
+        for yf_key, canonical in cases:
+            fake_yf = MagicMock()
+            fake_yf.Ticker.return_value.info = {
+                "recommendationKey": yf_key,
+                "numberOfAnalystOpinions": 10,
+            }
+            adapter = YfinanceAnalystAdapter(yf_module=fake_yf)
+            snap = adapter.fetch("X")
+            assert snap.consensus_rating == canonical
+
+    def test_unrecognized_rating_returns_none(self):
+        fake_yf = MagicMock()
+        fake_yf.Ticker.return_value.info = {
+            "recommendationKey": "completely-unknown",
+            "numberOfAnalystOpinions": 5,
+        }
+        adapter = YfinanceAnalystAdapter(yf_module=fake_yf)
+        snap = adapter.fetch("X")
+        assert snap.consensus_rating is None
+        assert snap.num_analysts == 5
+
+    def test_nan_target_handled_as_none(self):
+        fake_yf = MagicMock()
+        fake_yf.Ticker.return_value.info = {
+            "targetMeanPrice": float("nan"),
+            "numberOfAnalystOpinions": 1,
+        }
+        adapter = YfinanceAnalystAdapter(yf_module=fake_yf)
+        snap = adapter.fetch("X")
+        assert snap.mean_target is None
+
+    def test_fetch_failure_returns_none(self):
+        fake_yf = MagicMock()
+        fake_yf.Ticker.side_effect = RuntimeError("yfinance down")
+        adapter = YfinanceAnalystAdapter(yf_module=fake_yf)
+        assert adapter.fetch("X") is None
+
+    def test_empty_info_returns_none(self):
+        fake_yf = MagicMock()
+        fake_yf.Ticker.return_value.info = {}
+        adapter = YfinanceAnalystAdapter(yf_module=fake_yf)
+        assert adapter.fetch("X") is None
+
+
+# ── Finnhub adapter ────────────────────────────────────────────────────
+
+
+class TestFinnhubAdapter:
+    def test_bullish_recommendation_returns_buy(self):
+        fetcher = MagicMock(return_value=[{
+            "strongBuy": 3, "buy": 8, "hold": 2, "sell": 1, "strongSell": 0,
+        }])
+        adapter = FinnhubAnalystAdapter(finnhub_get_fn=fetcher)
+        snap = adapter.fetch("AAPL")
+        assert snap.consensus_rating == "buy"
+        assert snap.num_analysts == 14
+        assert snap.mean_target is None  # paid-tier only
+
+    def test_bearish_returns_sell(self):
+        fetcher = MagicMock(return_value=[{
+            "strongBuy": 0, "buy": 1, "hold": 3, "sell": 5, "strongSell": 2,
+        }])
+        adapter = FinnhubAnalystAdapter(finnhub_get_fn=fetcher)
+        assert adapter.fetch("X").consensus_rating == "sell"
+
+    def test_balanced_returns_hold(self):
+        fetcher = MagicMock(return_value=[{
+            "strongBuy": 1, "buy": 2, "hold": 5, "sell": 2, "strongSell": 1,
+        }])
+        adapter = FinnhubAnalystAdapter(finnhub_get_fn=fetcher)
+        assert adapter.fetch("X").consensus_rating == "hold"
+
+    def test_zero_coverage_returns_none(self):
+        fetcher = MagicMock(return_value=[{
+            "strongBuy": 0, "buy": 0, "hold": 0, "sell": 0, "strongSell": 0,
+        }])
+        adapter = FinnhubAnalystAdapter(finnhub_get_fn=fetcher)
+        assert adapter.fetch("X") is None
+
+    def test_empty_response_returns_none(self):
+        fetcher = MagicMock(return_value=[])
+        adapter = FinnhubAnalystAdapter(finnhub_get_fn=fetcher)
+        assert adapter.fetch("X") is None
+
+    def test_fetch_failure_returns_none(self):
+        fetcher = MagicMock(side_effect=RuntimeError("finnhub 429"))
+        adapter = FinnhubAnalystAdapter(finnhub_get_fn=fetcher)
+        assert adapter.fetch("X") is None
+
+
+# ── Paid stubs ─────────────────────────────────────────────────────────
+
+
+class TestPaidStubs:
+    def test_ibes_stub_raises_on_init(self):
+        with pytest.raises(NotImplementedError, match="Phase 4"):
+            IbesAnalystAdapter()
+
+    def test_visible_alpha_stub_raises_on_init(self):
+        with pytest.raises(NotImplementedError, match="Phase 4"):
+            VisibleAlphaAnalystAdapter()
+
+
+# ── Protocol structural subtyping ──────────────────────────────────────
+
+
+def test_yfinance_satisfies_analyst_source():
+    assert isinstance(
+        YfinanceAnalystAdapter(yf_module=MagicMock()), AnalystSource,
+    )
+
+
+def test_finnhub_satisfies_analyst_source():
+    assert isinstance(
+        FinnhubAnalystAdapter(finnhub_get_fn=MagicMock()), AnalystSource,
+    )
+
+
+# ── Daily snapshotter ──────────────────────────────────────────────────
+
+
+class _StaticSource:
+    """Test helper: an AnalystSource that returns a pre-built snapshot."""
+    def __init__(self, name: str, snapshot: AnalystSnapshot | None) -> None:
+        self.name = name
+        self._snapshot = snapshot
+
+    def fetch(self, ticker: str) -> AnalystSnapshot | None:
+        return self._snapshot
+
+
+def _make_snapshot(
+    *, source: str = "yfinance", ticker: str = "AAPL",
+    rating: str | None = "buy", target: float | None = 250.0,
+    num: int | None = 12,
+) -> AnalystSnapshot:
+    return AnalystSnapshot(
+        ticker=ticker, source=source, fetched_at=_now(),
+        consensus_rating=rating, mean_target=target,
+        num_analysts=num,
+    )
+
+
+class TestSnapshotter:
+    def test_snapshot_one_ticker_calls_each_source(self):
+        snap_a = _make_snapshot(source="yfinance", target=250.0)
+        snap_b = _make_snapshot(source="finnhub", rating="hold", target=None)
+        sources = [_StaticSource("yfinance", snap_a), _StaticSource("finnhub", snap_b)]
+        result = snapshot_one_ticker("AAPL", sources)
+        assert set(result.keys()) == {"yfinance", "finnhub"}
+
+    def test_snapshot_skips_sources_that_return_none(self):
+        sources = [
+            _StaticSource("yfinance", _make_snapshot()),
+            _StaticSource("missing", None),
+        ]
+        result = snapshot_one_ticker("AAPL", sources)
+        assert "yfinance" in result
+        assert "missing" not in result
+
+    def test_snapshot_isolated_per_source_exception(self):
+        good = _StaticSource("yfinance", _make_snapshot())
+
+        class _Broken:
+            name = "broken"
+
+            def fetch(self, ticker):
+                raise RuntimeError("kaboom")
+
+        result = snapshot_one_ticker("AAPL", [good, _Broken()])
+        assert "yfinance" in result
+        assert "broken" not in result
+
+    def test_write_and_read_snapshot_document(self):
+        s3 = _InMemoryS3()
+        snap = _make_snapshot()
+        key = write_snapshot_document(
+            ticker="AAPL",
+            snapshot_date=date(2026, 5, 13),
+            snapshots={"yfinance": snap},
+            s3_client=s3,
+        )
+        assert key == "data/analyst_snapshots/AAPL/2026-05-13.json"
+        doc = read_snapshot_document(
+            "AAPL", date(2026, 5, 13), s3_client=s3,
+        )
+        assert doc is not None
+        assert doc["ticker"] == "AAPL"
+        assert doc["schema_version"] == SNAPSHOT_SCHEMA_VERSION
+        assert "yfinance" in doc["snapshots_by_source"]
+        assert doc["snapshots_by_source"]["yfinance"]["mean_target"] == 250.0
+
+    def test_read_missing_document_returns_none(self):
+        s3 = _InMemoryS3()
+        assert read_snapshot_document("X", date(2026, 1, 1), s3_client=s3) is None
+
+    def test_universe_orchestrator(self):
+        s3 = _InMemoryS3()
+        sources = [_StaticSource("yfinance", _make_snapshot())]
+        stats = snapshot_universe(
+            ["AAPL", "MSFT"], sources,
+            snapshot_date=date(2026, 5, 13), s3_client=s3,
+        )
+        assert stats["n_documents_written"] == 2
+        assert ("alpha-engine-research",
+                "data/analyst_snapshots/AAPL/2026-05-13.json") in s3.store
+        assert ("alpha-engine-research",
+                "data/analyst_snapshots/MSFT/2026-05-13.json") in s3.store
+
+    def test_universe_orchestrator_dry_run_skips_writes(self):
+        s3 = _InMemoryS3()
+        stats = snapshot_universe(
+            ["AAPL"], [_StaticSource("yfinance", _make_snapshot())],
+            snapshot_date=date(2026, 5, 13), s3_client=s3, dry_run=True,
+        )
+        assert stats["n_documents_written"] == 1
+        assert len(s3.store) == 0
+
+    def test_universe_orchestrator_counts_zero_coverage(self):
+        s3 = _InMemoryS3()
+        sources = [_StaticSource("yfinance", None)]
+        stats = snapshot_universe(
+            ["X"], sources,
+            snapshot_date=date(2026, 5, 13), s3_client=s3,
+        )
+        assert stats["n_tickers_with_zero_coverage"] == 1
+
+
+# ── Self-derived revisions ────────────────────────────────────────────
+
+
+def _doc(target: float | None, rating: str | None = "buy", num: int | None = 12) -> dict:
+    """Build a snapshot document as the snapshotter would write."""
+    snaps: dict[str, dict] = {}
+    if target is not None or rating is not None or num is not None:
+        snaps["yfinance"] = {
+            "ticker": "AAPL", "source": "yfinance",
+            "consensus_rating": rating, "mean_target": target,
+            "median_target": None, "num_analysts": num,
+            "rating_changes_30d": [], "fetched_at": _now().isoformat(),
+        }
+    return {
+        "ticker": "AAPL", "snapshot_date": "x",
+        "schema_version": 1, "fetched_at": "x",
+        "snapshots_by_source": snaps,
+    }
+
+
+class TestRevisionRowBuilder:
+    def test_30d_revision_computes_deltas(self):
+        as_of = date(2026, 5, 13)
+        docs = {
+            as_of: _doc(target=260.0, num=14),
+            as_of - timedelta(days=30): _doc(target=240.0, num=12),
+        }
+        row = build_revision_row(
+            ticker="AAPL", as_of_date=as_of,
+            snapshot_documents_by_date=docs,
+        )
+        assert row.mean_target_current == 260.0
+        assert row.mean_target_30d_ago == 240.0
+        assert row.mean_target_delta_30d == 20.0
+        assert row.mean_target_pct_change_30d == pytest.approx(20.0 / 240.0, rel=1e-3)
+        assert row.num_analysts_delta_30d == 2
+
+    def test_no_history_yields_none_deltas(self):
+        """First day of snapshotter operation: only today's doc exists."""
+        as_of = date(2026, 5, 13)
+        docs = {as_of: _doc(target=250.0)}
+        row = build_revision_row(
+            ticker="AAPL", as_of_date=as_of,
+            snapshot_documents_by_date=docs,
+        )
+        assert row.mean_target_current == 250.0
+        assert row.mean_target_30d_ago is None
+        assert row.mean_target_delta_30d is None
+        assert row.mean_target_pct_change_30d is None
+
+    def test_weekend_gap_walks_back(self):
+        """30 days ago was a Sunday; the snapshotter has a doc 31 days
+        ago — walk back to find a usable historical anchor."""
+        as_of = date(2026, 5, 13)
+        docs = {
+            as_of: _doc(target=260.0),
+            as_of - timedelta(days=31): _doc(target=240.0),
+            # day -30 explicitly missing
+        }
+        row = build_revision_row(
+            ticker="AAPL", as_of_date=as_of,
+            snapshot_documents_by_date=docs,
+        )
+        assert row.mean_target_30d_ago == 240.0
+        assert row.mean_target_delta_30d == 20.0
+
+    def test_rating_changed_30d_flag(self):
+        as_of = date(2026, 5, 13)
+        docs = {
+            as_of: _doc(target=260.0, rating="buy"),
+            as_of - timedelta(days=30): _doc(target=240.0, rating="hold"),
+        }
+        row = build_revision_row(
+            ticker="AAPL", as_of_date=as_of,
+            snapshot_documents_by_date=docs,
+        )
+        assert row.consensus_rating_current == "buy"
+        assert row.consensus_rating_30d_ago == "hold"
+        assert row.rating_changed_30d is True
+
+    def test_same_rating_no_change_flag(self):
+        as_of = date(2026, 5, 13)
+        docs = {
+            as_of: _doc(target=260.0, rating="buy"),
+            as_of - timedelta(days=30): _doc(target=250.0, rating="buy"),
+        }
+        row = build_revision_row(
+            ticker="AAPL", as_of_date=as_of,
+            snapshot_documents_by_date=docs,
+        )
+        assert row.rating_changed_30d is False
+
+    def test_n_snapshot_days_observed(self):
+        as_of = date(2026, 5, 13)
+        docs = {
+            as_of: _doc(target=260.0),
+            as_of - timedelta(days=5): _doc(target=255.0),
+            as_of - timedelta(days=10): _doc(target=250.0),
+        }
+        row = build_revision_row(
+            ticker="AAPL", as_of_date=as_of,
+            snapshot_documents_by_date=docs,
+        )
+        assert row.n_snapshot_days_observed == 3
+
+    def test_schema_version_pinned(self):
+        as_of = date(2026, 5, 13)
+        row = build_revision_row(
+            ticker="X", as_of_date=as_of, snapshot_documents_by_date={},
+        )
+        assert row.schema_version == REVISIONS_SCHEMA_VERSION
+
+
+class TestRevisionsDataFrame:
+    def test_empty_yields_empty_df_with_schema(self):
+        df = rows_to_dataframe([])
+        assert len(df) == 0
+        for col in AnalystRevisionRow.__dataclass_fields__:
+            assert col in df.columns
+
+    def test_round_trip(self):
+        row = AnalystRevisionRow(
+            ticker="AAPL", as_of_date=date(2026, 5, 13),
+            schema_version=1, primary_source="yfinance",
+            mean_target_current=260.0, mean_target_7d_ago=255.0,
+            mean_target_30d_ago=240.0, mean_target_delta_7d=5.0,
+            mean_target_delta_30d=20.0, mean_target_pct_change_30d=0.083,
+            num_analysts_current=14, num_analysts_30d_ago=12,
+            num_analysts_delta_30d=2,
+            consensus_rating_current="buy",
+            consensus_rating_30d_ago="hold",
+            rating_changed_30d=True, n_snapshot_days_observed=15,
+        )
+        df = rows_to_dataframe([row])
+        assert len(df) == 1
+        assert df.iloc[0]["mean_target_delta_30d"] == 20.0
+
+
+# ── End-to-end orchestrator ───────────────────────────────────────────
+
+
+class TestComputeAndWriteRevisions:
+    def test_end_to_end(self):
+        s3 = _InMemoryS3()
+        # Seed S3 with two days of snapshots for AAPL
+        as_of = date(2026, 5, 13)
+        for d, target in [
+            (as_of, 260.0),
+            (as_of - timedelta(days=30), 240.0),
+        ]:
+            doc = _doc(target=target)
+            doc["snapshot_date"] = d.isoformat()
+            s3.store[(
+                "alpha-engine-research",
+                f"data/analyst_snapshots/AAPL/{d.isoformat()}.json",
+            )] = json.dumps(doc).encode("utf-8")
+
+        key, rows = compute_and_write_revisions(
+            ["AAPL"],
+            as_of_date=as_of,
+            s3_client=s3,
+        )
+        assert key == "data/analyst_revisions/2026-05-13.parquet"
+        assert len(rows) == 1
+        assert rows[0].mean_target_delta_30d == 20.0
+        # Parquet written
+        assert ("alpha-engine-research", key) in s3.store
+
+
+def test_s3_key_format():
+    assert (
+        s3_key_for_date(date(2026, 5, 13))
+        == "data/analyst_revisions/2026-05-13.parquet"
+    )
+    assert (
+        s3_key_for("AAPL", date(2026, 5, 13))
+        == "data/analyst_snapshots/AAPL/2026-05-13.json"
+    )


### PR DESCRIPTION
## Summary

**Wave 1 PR C** of the institutional data-revamp arc. Wires the `AnalystSource` Protocol (defined in lib v0.15.0) for the free-tier sources we already have credentials for, adds a daily snapshotter that owns the time-series state, and a derived module that computes 7d/30d revision deltas **without needing a paid IBES feed**.

The institutional insight: real alpha is in the **delta** (estimate revisions), not the level. We own the time series via daily snapshots → derive deltas locally → IBES drops in at Phase 4 for ground-truth revisions.

## What's in

### Adapters (`collectors/analyst_sources/`)
| Adapter | Tier | What it surfaces |
|---|---|---|
| `yfinance.py` | FREE | targetMean/Median + numberOfAnalystOpinions + normalized recommendationKey (lower_snake_case → canonical 5-class ladder) |
| `finnhub.py` | FREE | `/stock/recommendation` bucket counts → consensus via plurality rule (bullish > bearish AND bullish >= hold → buy) |
| `ibes.py` | PAID stub | Refinitiv Eikon Data API drop-in |
| `visible_alpha.py` | PAID stub | Per-segment estimate distribution |

### Daily snapshotter (`data/snapshotter/analyst_daily.py`)
- `snapshot_one_ticker(ticker, sources)` runs every adapter, returns `{source.name: AnalystSnapshot}`
- `write_snapshot_document(...)` writes JSON to `s3://alpha-engine-research/data/analyst_snapshots/{ticker}/{YYYY-MM-DD}.json`
- `snapshot_universe(...)` end-to-end orchestrator with stats (n_documents_written, n_tickers_with_zero_coverage, etc.)
- Multi-source preserved per-day for cross-source merge

### Self-derived revisions (`data/derived/analyst_revisions.py`)
- `build_revision_row(ticker, as_of_date, snapshot_documents_by_date)` — pure computation
- Source preference (target): `ibes > visible_alpha > yfinance > finnhub` — yfinance wins today; ibes/visible_alpha auto-override once wired
- Source preference (rating): `ibes > visible_alpha > finnhub > yfinance` — finnhub's plurality rule on bucket counts beats yfinance's scrape
- **Outputs:** `mean_target_delta_7d/30d`, `mean_target_pct_change_30d`, `num_analysts_delta_30d`, `rating_changed_30d`
- **None deltas** when history is insufficient (degraded gracefully — first 30 days of snapshotter operation)
- **Weekend/holiday gaps** walk back up to +7d to find a usable historical anchor

### S3 layout

```
data/analyst_snapshots/{ticker}/{YYYY-MM-DD}.json   ← per-ticker time series
data/analyst_revisions/{YYYY-MM-DD}.parquet         ← per as-of-date, all tickers
```

## Test plan

- [x] **+35 unit tests**:
  - yfinance adapter: 5 rating-ladder mappings, NaN target, fetch failure, empty info, unrecognized rating
  - finnhub adapter: bullish/bearish/balanced classification, zero coverage, empty response, fetch failure
  - Paid stubs raise `NotImplementedError`
  - Protocol structural subtyping for both free adapters
  - Snapshotter: per-source orchestration, None skipped, exception isolated, write-read round-trip, missing-doc, universe-level orchestrator, dry-run, zero-coverage counter
  - Revisions: 30d deltas computed, no history yields None, weekend-gap walk-back finds anchor at -31d, rating_changed flag, n_snapshot_days_observed, schema_version pinned
  - DataFrame: empty-schema preserved, round-trip
  - End-to-end `compute_and_write_revisions`
  - S3 key formats
- [x] Full data suite: **980 passing** (1 skipped) in 4s

## Acceptance

≥14 days of accumulated daily snapshots produce useful revisions output. Earlier days emit `None` deltas (degraded gracefully). Snapshotter cron-schedules in a follow-up sub-PR (or Saturday SF wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)