### PR TITLE
feat(infra): Wave 1 PR D — async aggregator + S3 TTL cache + per-vendor rate limiters

### DIFF
--- a/collectors/news_aggregator_async.py
+++ b/collectors/news_aggregator_async.py
@@ -1,0 +1,291 @@
+"""Async news aggregator — anyio-based parallel fan-in with per-vendor
+rate limits + tenacity retry.
+
+Wave 1 PR D of the institutional data-revamp arc.
+
+Wraps the sync :class:`NewsSource` adapters (defined in alpha-engine-lib
+sources Protocols, implemented in ``collectors/news_sources/``) in an
+async fan-in pattern using ``anyio.to_thread.run_sync`` — adapters stay
+synchronous (existing tests + Lambda dispatch unchanged); aggregation
+becomes concurrent.
+
+Production design:
+
+  - **Per-vendor concurrency limit** via ``anyio.Semaphore``. Polygon's
+    free tier is 5 req/min; setting concurrency=2 keeps us comfortably
+    under the limit. GDELT has no documented rate cap but we hold
+    concurrency=1 + adapter-side 1s sleep per ticker. Per-vendor knobs
+    in the constructor so each vendor's posture is independent.
+
+  - **Tenacity retry per vendor** with exponential backoff. Wraps the
+    individual ``adapter.fetch(tickers, hours)`` call. Up to 3 attempts
+    with 2s/4s/8s backoff. Permanent failures (auth, config) raise on
+    final attempt; transient (timeouts, 5xx) absorbed.
+
+  - **Optional cache** via :class:`data.cache.S3TtlCache`. When passed,
+    each adapter's output is cached under
+    ``cache_key="news/{vendor}/{sorted-tickers-hash}/{hours}"`` for a
+    configurable TTL. Default 1h — agents calling within the same
+    session see the same fan-in result without redundant vendor hits.
+
+  - **Reuses sync aggregator's dedup + trust weighting** —
+    :class:`NewsAggregator._dedup` and ``DEFAULT_TRUST_WEIGHTS`` are
+    composed verbatim. Same canonical output shape
+    (``AggregatedNewsArticle``); same downstream consumers.
+
+Reuse pattern: the existing sync :class:`NewsAggregator.fetch` stays
+in place for callers that don't have an event loop. The async variant
+is what the production fetch_data wiring (PR F) will call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from typing import Iterable
+
+import anyio
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from alpha_engine_lib.sources import NewsArticle, NewsSource
+
+from collectors.news_aggregator import (
+    AggregatedNewsArticle,
+    DEFAULT_TRUST_WEIGHTS,
+    NewsAggregator,
+)
+from data.cache import S3TtlCache
+
+logger = logging.getLogger(__name__)
+
+
+# Default concurrency per source — conservative free-tier safe defaults.
+# Override per-deployment via the ``per_source_concurrency`` constructor
+# arg.
+DEFAULT_PER_SOURCE_CONCURRENCY: dict[str, int] = {
+    "polygon": 2,     # Polygon free tier: 5 req/min — concurrency=2
+                      # holds us under the limit alongside the inter-
+                      # call rate limiter on PolygonClient
+    "gdelt": 1,       # GDELT "be polite" guidance + 1s adapter sleep
+    "yahoo_rss": 4,   # Yahoo RSS has no documented hard limit
+    "edgar_press": 2, # EDGAR is 10 req/sec; concurrency=2 is safe
+    "benzinga": 4,    # Paid tier when wired — assume higher quota
+    "ravenpack": 4,   # Paid tier
+    "bloomberg": 4,   # Paid tier
+}
+
+
+# Default per-source cache TTLs (seconds). News is fresh-sensitive so
+# 1h is the typical default; some sources update less often.
+DEFAULT_PER_SOURCE_TTL_SECONDS: dict[str, int] = {
+    "polygon": 1_800,     # 30 min — Polygon news churns fast
+    "gdelt": 3_600,       # 1h — GDELT batches ~15 min behind wall-clock
+    "yahoo_rss": 3_600,   # 1h
+    "edgar_press": 14_400,  # 4h — EDGAR is daily
+    "benzinga": 1_800,
+    "ravenpack": 1_800,
+    "bloomberg": 1_800,
+}
+
+
+def _cache_key(vendor: str, tickers: list[str], hours: int) -> str:
+    """Stable cache key for one (vendor, tickers, hours) fan-in call."""
+    sorted_tickers = sorted(tickers)
+    fingerprint = ",".join(sorted_tickers)
+    h = hashlib.sha1(
+        f"news|{vendor}|{fingerprint}|{hours}".encode("utf-8"),
+    ).hexdigest()[:16]
+    return f"news/{vendor}/{h}"
+
+
+class AsyncNewsAggregator:
+    """Async fan-in across NewsSource adapters with rate limits, retry,
+    and optional cache.
+
+    Args:
+        sources: enabled NewsSource adapters.
+        trust_weights: per-vendor trust weights (composes with the
+                       sync aggregator's defaults).
+        per_source_concurrency: max parallel ``fetch()`` calls per
+                                vendor name. Defaults to
+                                :data:`DEFAULT_PER_SOURCE_CONCURRENCY`.
+        cache: optional :class:`S3TtlCache`. When set, per-vendor
+               outputs are cached.
+        per_source_ttl_seconds: TTL per vendor when caching. Defaults
+                                to :data:`DEFAULT_PER_SOURCE_TTL_SECONDS`.
+        max_retry_attempts: total adapter call attempts (1 = no retry).
+                            Default 3.
+        retry_initial_wait: seconds for first retry backoff (doubled
+                            each subsequent attempt). Default 2.
+    """
+
+    def __init__(
+        self,
+        sources: Iterable[NewsSource],
+        *,
+        trust_weights: dict[str, float] | None = None,
+        per_source_concurrency: dict[str, int] | None = None,
+        cache: S3TtlCache | None = None,
+        per_source_ttl_seconds: dict[str, int] | None = None,
+        max_retry_attempts: int = 3,
+        retry_initial_wait: float = 2.0,
+    ) -> None:
+        self._sources = tuple(sources)
+        # Wrap a sync NewsAggregator so dedup + canonical-pick logic is
+        # reused verbatim. Same output contract as the sync path.
+        self._sync_aggregator = NewsAggregator(
+            sources=[], trust_weights=trust_weights or DEFAULT_TRUST_WEIGHTS,
+        )
+        self._concurrency = dict(
+            per_source_concurrency or DEFAULT_PER_SOURCE_CONCURRENCY,
+        )
+        self._semaphores: dict[str, anyio.Semaphore] = {}
+        self._cache = cache
+        self._ttl = dict(
+            per_source_ttl_seconds or DEFAULT_PER_SOURCE_TTL_SECONDS,
+        )
+        self._max_retry_attempts = max_retry_attempts
+        self._retry_initial_wait = retry_initial_wait
+
+    @property
+    def source_names(self) -> tuple[str, ...]:
+        return tuple(s.name for s in self._sources)
+
+    def _semaphore_for(self, vendor: str) -> anyio.Semaphore:
+        if vendor not in self._semaphores:
+            limit = self._concurrency.get(vendor, 2)
+            self._semaphores[vendor] = anyio.Semaphore(limit)
+        return self._semaphores[vendor]
+
+    async def fetch(
+        self, tickers: list[str], *, hours: int = 48,
+    ) -> list[AggregatedNewsArticle]:
+        """Async fan-in across all enabled adapters. Returns the
+        deduped + trust-weighted aggregated list.
+
+        Per-adapter:
+          1. Check cache (if configured)
+          2. Run with semaphore + tenacity retry
+          3. Write to cache (if configured)
+
+        One adapter raising on final retry attempt logs + continues
+        with the rest — defense-in-depth matching the sync path.
+        """
+        all_articles: list[NewsArticle] = []
+        results: dict[str, list[NewsArticle]] = {}
+
+        async def _run_one(source: NewsSource) -> None:
+            try:
+                articles = await self._fetch_one(source, tickers, hours)
+            except Exception as e:
+                logger.exception(
+                    "[async_news_aggregator] %s raised on final retry: %s",
+                    source.name, e,
+                )
+                articles = []
+            results[source.name] = articles
+
+        async with anyio.create_task_group() as tg:
+            for source in self._sources:
+                tg.start_soon(_run_one, source)
+
+        for source_name in self.source_names:
+            batch = results.get(source_name, [])
+            logger.info(
+                "[async_news_aggregator] %s returned %d articles",
+                source_name, len(batch),
+            )
+            all_articles.extend(batch)
+
+        if not all_articles:
+            return []
+        return self._sync_aggregator._dedup(all_articles)
+
+    async def _fetch_one(
+        self, source: NewsSource, tickers: list[str], hours: int,
+    ) -> list[NewsArticle]:
+        """Cache-aware, semaphore-gated, retry-wrapped per-source fetch."""
+        cache_key = _cache_key(source.name, tickers, hours)
+        ttl = self._ttl.get(source.name)
+
+        # Cache check (sync — S3 get is fast)
+        if self._cache is not None:
+            cached_bytes = self._cache.get(cache_key)
+            if cached_bytes is not None:
+                try:
+                    return [
+                        NewsArticle(**row)
+                        for row in json.loads(cached_bytes)
+                    ]
+                except Exception as e:
+                    logger.warning(
+                        "[async_news_aggregator] cache hit but "
+                        "deserialization failed for %s: %s",
+                        source.name, e,
+                    )
+
+        sem = self._semaphore_for(source.name)
+
+        async def _call():
+            async with sem:
+                return await anyio.to_thread.run_sync(
+                    source.fetch, tickers, lambda: hours,
+                )
+
+        # tenacity AsyncRetrying — wraps the call with exp backoff.
+        # We retry on any non-RetryError exception. Authentication
+        # errors propagate after final attempt (loud failure).
+        articles: list[NewsArticle]
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(self._max_retry_attempts),
+                wait=wait_exponential(
+                    multiplier=self._retry_initial_wait, min=1, max=30,
+                ),
+                retry=retry_if_exception_type(Exception),
+                reraise=True,
+            ):
+                with attempt:
+                    articles = await self._invoke_adapter(
+                        source, tickers, hours, sem,
+                    )
+        except RetryError:
+            return []
+
+        # Cache write
+        if self._cache is not None and articles:
+            try:
+                serialized = json.dumps(
+                    [a.model_dump(mode="json") for a in articles],
+                    default=str,
+                ).encode("utf-8")
+                self._cache.set(cache_key, serialized, ttl_seconds=ttl)
+            except Exception as e:
+                logger.warning(
+                    "[async_news_aggregator] cache write failed for "
+                    "%s: %s", source.name, e,
+                )
+
+        return articles
+
+    async def _invoke_adapter(
+        self,
+        source: NewsSource,
+        tickers: list[str],
+        hours: int,
+        sem: anyio.Semaphore,
+    ) -> list[NewsArticle]:
+        """Run one adapter under the per-vendor semaphore. Adapters are
+        sync; offload to thread via anyio."""
+        async with sem:
+            def _call_with_hours():
+                return source.fetch(tickers, hours=hours)
+            return await anyio.to_thread.run_sync(_call_with_hours)

--- a/data/cache.py
+++ b/data/cache.py
@@ -1,0 +1,258 @@
+"""S3-backed TTL cache for producer-side fetchers.
+
+Wave 1 PR D of the institutional data-revamp arc (plan doc:
+``~/Development/alpha-engine-docs/private/data-revamp-260513.md``).
+
+Generic cache utility used by news / analyst / filings fetchers to
+avoid re-hitting upstream vendor APIs within a session. Idempotent:
+the same key + within-TTL window returns the cached body without
+calling the upstream.
+
+Storage layout::
+
+    s3://{bucket}/{prefix}/{key_hash}.bin
+
+Each cached object carries S3 metadata:
+
+    cache-key            : original cache key (for debugging)
+    cache-cached-at      : ISO-8601 UTC timestamp at write time
+    cache-ttl-seconds    : integer TTL applied
+    cache-expires-at     : ISO-8601 UTC timestamp at which the entry expires
+
+The key is sha1-hashed for S3-key-safe encoding; the original key is
+retained in metadata for grep-from-AWS-console debugging.
+
+Why S3-backed (vs in-memory):
+
+- Process boundary — Lambda invocations + spot-instance restarts both
+  pick up the cache from a fresh process. In-memory dict caches lose
+  on cold start.
+- Cross-runtime — the news Lambda + the Saturday SF spot can share a
+  cache for the same ticker's news without independent reaches.
+- Cheap: S3 PUT/GET on tiny cache bodies dominates over the avoided
+  vendor API call.
+
+Configurable per-source TTL: news fetches typically 1-6h; analyst
+24h; filings 24h. Caller passes the TTL at .get/.set time, so a
+single cache instance serves multiple source types.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_S3_BUCKET = "alpha-engine-research"
+DEFAULT_S3_PREFIX = "data/_cache"
+DEFAULT_TTL_SECONDS = 3_600  # 1 hour
+
+
+@dataclass(frozen=True)
+class _CacheMetadata:
+    cache_key: str
+    cached_at: datetime
+    ttl_seconds: int
+    expires_at: datetime
+
+    @property
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) > self.expires_at
+
+
+def _hash_key(key: str) -> str:
+    """Hash the user-facing cache key to an S3-safe filename.
+
+    SHA1 is fine here — collision resistance isn't security-critical;
+    we just need deterministic filename safety for arbitrary keys
+    (which may contain '/', spaces, query strings, etc.)."""
+    return hashlib.sha1(key.encode("utf-8")).hexdigest()
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+class S3TtlCache:
+    """S3-backed TTL cache.
+
+    Args:
+        s3_client: boto3 S3 client (or a test mock with put_object /
+                   get_object / head_object).
+        bucket: S3 bucket name.
+        prefix: S3 key prefix; one cache instance per logical scope
+                (one for news, one for analyst, etc.) keeps caches
+                isolated for cheaper LIST + simpler eviction.
+        default_ttl_seconds: TTL applied when callers don't specify.
+    """
+
+    def __init__(
+        self,
+        s3_client: Any,
+        *,
+        bucket: str = DEFAULT_S3_BUCKET,
+        prefix: str = DEFAULT_S3_PREFIX,
+        default_ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> None:
+        self._s3 = s3_client
+        self._bucket = bucket
+        self._prefix = prefix.rstrip("/")
+        self._default_ttl = default_ttl_seconds
+
+    def _key_path(self, cache_key: str) -> str:
+        return f"{self._prefix}/{_hash_key(cache_key)}.bin"
+
+    def get(self, cache_key: str) -> bytes | None:
+        """Return the cached body, or ``None`` if missing or expired.
+
+        Expired entries are NOT deleted on read — eviction is lazy
+        (next overwrite). Saves cost on read-heavy workloads where the
+        expired marker simply isn't returned.
+        """
+        s3_key = self._key_path(cache_key)
+        try:
+            obj = self._s3.get_object(Bucket=self._bucket, Key=s3_key)
+        except Exception:
+            return None
+        metadata = obj.get("Metadata") or {}
+        meta = _parse_metadata(metadata)
+        if meta is None or meta.is_expired:
+            return None
+        body = obj["Body"].read()
+        return body
+
+    def set(
+        self,
+        cache_key: str,
+        value: bytes,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        """Write a cache entry. Overwrites any prior entry for the same
+        key — idempotent."""
+        ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl
+        cached_at = _now_utc()
+        expires_at = cached_at + timedelta(seconds=ttl)
+        # S3 metadata values must be strings; constrained to ASCII.
+        metadata = {
+            "cache-key": cache_key[:1024],  # safety truncation
+            "cache-cached-at": _iso(cached_at),
+            "cache-ttl-seconds": str(ttl),
+            "cache-expires-at": _iso(expires_at),
+        }
+        self._s3.put_object(
+            Bucket=self._bucket,
+            Key=self._key_path(cache_key),
+            Body=value,
+            Metadata=metadata,
+            ContentType="application/octet-stream",
+        )
+
+    def cached_call(
+        self,
+        cache_key: str,
+        *,
+        compute_fn: Callable[[], bytes],
+        ttl_seconds: int | None = None,
+    ) -> bytes:
+        """Fetch-or-compute pattern. Returns cached body if fresh;
+        otherwise calls ``compute_fn`` and caches the result.
+
+        ``compute_fn`` is only called on cache miss / expired entry,
+        so passing an expensive synchronous fetch as the compute fn
+        is safe. Caller must serialize their payload to bytes — the
+        cache is content-agnostic.
+        """
+        cached = self.get(cache_key)
+        if cached is not None:
+            return cached
+        value = compute_fn()
+        self.set(cache_key, value, ttl_seconds=ttl_seconds)
+        return value
+
+    async def cached_acall(
+        self,
+        cache_key: str,
+        *,
+        async_compute_fn: Callable[[], Awaitable[bytes]],
+        ttl_seconds: int | None = None,
+    ) -> bytes:
+        """Async variant of :meth:`cached_call`. Useful from
+        :mod:`collectors.news_aggregator_async` where each adapter
+        call returns a coroutine.
+        """
+        cached = self.get(cache_key)
+        if cached is not None:
+            return cached
+        value = await async_compute_fn()
+        self.set(cache_key, value, ttl_seconds=ttl_seconds)
+        return value
+
+    # ── JSON convenience wrappers ─────────────────────────────────────
+
+    def get_json(self, cache_key: str) -> Any | None:
+        body = self.get(cache_key)
+        if body is None:
+            return None
+        try:
+            return json.loads(body)
+        except Exception as e:
+            logger.warning(
+                "[s3_ttl_cache] failed to deserialize JSON for %s: %s",
+                cache_key, e,
+            )
+            return None
+
+    def set_json(
+        self,
+        cache_key: str,
+        value: Any,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        self.set(
+            cache_key,
+            json.dumps(value, default=str).encode("utf-8"),
+            ttl_seconds=ttl_seconds,
+        )
+
+
+def _parse_metadata(metadata: dict[str, str]) -> _CacheMetadata | None:
+    cache_key = metadata.get("cache-key") or ""
+    cached_at = _parse_iso(metadata.get("cache-cached-at"))
+    expires_at = _parse_iso(metadata.get("cache-expires-at"))
+    ttl = metadata.get("cache-ttl-seconds") or "0"
+    if cached_at is None or expires_at is None:
+        # Entry without our metadata stamp — treat as expired (safer
+        # than treating as fresh; will overwrite on next set).
+        return None
+    try:
+        ttl_int = int(ttl)
+    except ValueError:
+        ttl_int = 0
+    return _CacheMetadata(
+        cache_key=cache_key,
+        cached_at=cached_at,
+        ttl_seconds=ttl_int,
+        expires_at=expires_at,
+    )

--- a/tests/test_async_and_cache.py
+++ b/tests/test_async_and_cache.py
@@ -1,0 +1,423 @@
+"""Tests for the async aggregator + S3 TTL cache (Wave 1 PR D).
+
+Covers:
+  - S3TtlCache: get/set round-trip, expired returns None, JSON helpers,
+    metadata stamping, idempotent overwrite, get_json malformed → None
+  - cached_call + cached_acall: cache hit skips compute; cache miss
+    calls compute + writes
+  - AsyncNewsAggregator: parallel fan-in / cache hit-miss / retry
+    on transient failure / final-failure isolated / semaphore caps
+    concurrency
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import anyio
+import pytest
+
+from alpha_engine_lib.sources import NewsArticle
+
+from collectors.news_aggregator_async import (
+    AsyncNewsAggregator,
+    _cache_key,
+)
+from data.cache import S3TtlCache, _hash_key
+
+
+# ── In-memory S3 mock with metadata support ────────────────────────────
+
+
+class _InMemoryS3:
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], dict] = {}
+
+    def put_object(self, *, Bucket, Key, Body, Metadata=None, ContentType=None):
+        self.store[(Bucket, Key)] = {
+            "Body": Body,
+            "Metadata": dict(Metadata or {}),
+        }
+        return {"ETag": "stub"}
+
+    def get_object(self, *, Bucket, Key):
+        entry = self.store.get((Bucket, Key))
+        if entry is None:
+            raise RuntimeError("NoSuchKey")
+        return {
+            "Body": BytesIO(entry["Body"]),
+            "Metadata": entry["Metadata"],
+        }
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ── Cache helpers ──────────────────────────────────────────────────────
+
+
+class TestCacheHelpers:
+    def test_hash_key_deterministic(self):
+        assert _hash_key("foo") == _hash_key("foo")
+        assert _hash_key("foo") != _hash_key("bar")
+
+    def test_hash_key_handles_special_chars(self):
+        # Slashes, spaces, query strings — all valid input
+        h = _hash_key("news/polygon/AAPL,MSFT?hours=48")
+        assert isinstance(h, str)
+        assert "/" not in h  # output is hex
+
+
+# ── S3TtlCache ─────────────────────────────────────────────────────────
+
+
+class TestS3TtlCache:
+    def test_set_then_get_round_trip(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        cache.set("k1", b"hello world", ttl_seconds=60)
+        assert cache.get("k1") == b"hello world"
+
+    def test_get_missing_returns_none(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        assert cache.get("missing") is None
+
+    def test_expired_returns_none(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        # Manually inject an expired entry
+        past = (_now() - timedelta(seconds=10))
+        s3.put_object(
+            Bucket="b",
+            Key=f"cache/{_hash_key('k')}.bin",
+            Body=b"x",
+            Metadata={
+                "cache-key": "k",
+                "cache-cached-at": (past - timedelta(seconds=60)).isoformat().replace("+00:00", "Z"),
+                "cache-ttl-seconds": "30",
+                "cache-expires-at": past.isoformat().replace("+00:00", "Z"),
+            },
+        )
+        assert cache.get("k") is None
+
+    def test_entry_without_metadata_treated_as_expired(self):
+        """Old entries (or external writes) without our metadata stamp
+        are treated as expired so we don't return stale-or-garbled
+        content."""
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        s3.put_object(
+            Bucket="b", Key=f"cache/{_hash_key('k')}.bin",
+            Body=b"orphan", Metadata={},
+        )
+        assert cache.get("k") is None
+
+    def test_overwrite_extends_ttl(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        cache.set("k", b"v1", ttl_seconds=10)
+        cache.set("k", b"v2", ttl_seconds=100)
+        assert cache.get("k") == b"v2"
+
+    def test_default_ttl_applied(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(
+            s3, bucket="b", prefix="cache", default_ttl_seconds=300,
+        )
+        cache.set("k", b"v")
+        # Inspect the stored metadata
+        entry = s3.store[("b", f"cache/{_hash_key('k')}.bin")]
+        assert entry["Metadata"]["cache-ttl-seconds"] == "300"
+
+    def test_get_json_roundtrip(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        cache.set_json("k", {"foo": "bar", "n": 42}, ttl_seconds=60)
+        assert cache.get_json("k") == {"foo": "bar", "n": 42}
+
+    def test_get_json_malformed_returns_none(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        cache.set("k", b"not-valid-json{", ttl_seconds=60)
+        assert cache.get_json("k") is None
+
+
+class TestCachedCall:
+    def test_miss_calls_compute_and_caches(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        call_count = {"n": 0}
+
+        def compute():
+            call_count["n"] += 1
+            return b"computed value"
+
+        # First call → miss → compute called
+        v1 = cache.cached_call("k", compute_fn=compute, ttl_seconds=60)
+        assert v1 == b"computed value"
+        assert call_count["n"] == 1
+
+        # Second call → hit → compute NOT called
+        v2 = cache.cached_call("k", compute_fn=compute, ttl_seconds=60)
+        assert v2 == b"computed value"
+        assert call_count["n"] == 1  # unchanged
+
+    def test_acall_miss_calls_compute_and_caches(self):
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        call_count = {"n": 0}
+
+        async def acompute():
+            call_count["n"] += 1
+            return b"async value"
+
+        async def run():
+            v1 = await cache.cached_acall(
+                "ak", async_compute_fn=acompute, ttl_seconds=60,
+            )
+            v2 = await cache.cached_acall(
+                "ak", async_compute_fn=acompute, ttl_seconds=60,
+            )
+            return v1, v2
+
+        v1, v2 = asyncio.run(run())
+        assert v1 == v2 == b"async value"
+        assert call_count["n"] == 1
+
+
+# ── Cache key generation ──────────────────────────────────────────────
+
+
+class TestAsyncCacheKey:
+    def test_stable_under_ticker_reorder(self):
+        k1 = _cache_key("polygon", ["AAPL", "MSFT"], 48)
+        k2 = _cache_key("polygon", ["MSFT", "AAPL"], 48)
+        assert k1 == k2
+
+    def test_changes_with_hours(self):
+        assert (
+            _cache_key("polygon", ["AAPL"], 48)
+            != _cache_key("polygon", ["AAPL"], 24)
+        )
+
+    def test_changes_with_vendor(self):
+        assert (
+            _cache_key("polygon", ["AAPL"], 48)
+            != _cache_key("gdelt", ["AAPL"], 48)
+        )
+
+
+# ── AsyncNewsAggregator ───────────────────────────────────────────────
+
+
+def _article(source: str = "polygon", title: str = "T") -> NewsArticle:
+    return NewsArticle(
+        tickers=("AAPL",),
+        title=title,
+        body_excerpt="body",
+        url=f"https://x.com/{source}/{title}",
+        published_at=_now(),
+        source=source,
+        fetched_at=_now(),
+    )
+
+
+class _StaticSource:
+    """Sync adapter conforming to NewsSource Protocol."""
+    def __init__(self, name: str, articles: list[NewsArticle]) -> None:
+        self.name = name
+        self._articles = articles
+        self.call_count = 0
+        self.last_kwargs: dict | None = None
+
+    def fetch(self, tickers, *, hours=48):
+        self.call_count += 1
+        self.last_kwargs = {"tickers": tickers, "hours": hours}
+        return list(self._articles)
+
+
+class _TransientFailingSource:
+    """Adapter that raises N times then succeeds."""
+    def __init__(self, name: str, fail_n_times: int, then_return: list) -> None:
+        self.name = name
+        self._fail_remaining = fail_n_times
+        self._then = then_return
+        self.call_count = 0
+
+    def fetch(self, tickers, *, hours=48):
+        self.call_count += 1
+        if self._fail_remaining > 0:
+            self._fail_remaining -= 1
+            raise RuntimeError("transient")
+        return list(self._then)
+
+
+class TestAsyncAggregatorFanIn:
+    def test_parallel_fan_in_combines_sources(self):
+        polygon = _StaticSource("polygon", [_article("polygon", "A")])
+        gdelt = _StaticSource("gdelt", [_article("gdelt", "B")])
+        agg = AsyncNewsAggregator(sources=[polygon, gdelt])
+
+        async def run():
+            return await agg.fetch(["AAPL"])
+
+        out = asyncio.run(run())
+        assert {a.canonical_title for a in out} == {"A", "B"}
+        assert polygon.call_count == 1
+        assert gdelt.call_count == 1
+
+    def test_per_source_failure_isolated(self):
+        good = _StaticSource("polygon", [_article("polygon", "A")])
+
+        class _AlwaysBroken:
+            name = "broken"
+            call_count = 0
+
+            def fetch(self, tickers, *, hours=48):
+                _AlwaysBroken.call_count += 1
+                raise RuntimeError("permanent")
+
+        agg = AsyncNewsAggregator(
+            sources=[good, _AlwaysBroken()],
+            # Use 1 retry attempt to keep the test fast
+            max_retry_attempts=1,
+            retry_initial_wait=0.0,
+        )
+
+        async def run():
+            return await agg.fetch(["AAPL"])
+
+        out = asyncio.run(run())
+        # Good source's article still surfaces
+        assert len(out) == 1
+        assert out[0].canonical_title == "A"
+
+    def test_retry_recovers_from_transient_failure(self):
+        # Fail 2 times, succeed on 3rd attempt
+        flaky = _TransientFailingSource(
+            "polygon", fail_n_times=2,
+            then_return=[_article("polygon", "OK")],
+        )
+        agg = AsyncNewsAggregator(
+            sources=[flaky],
+            max_retry_attempts=3,
+            retry_initial_wait=0.01,  # fast for tests
+        )
+
+        async def run():
+            return await agg.fetch(["AAPL"])
+
+        out = asyncio.run(run())
+        assert len(out) == 1
+        assert out[0].canonical_title == "OK"
+        assert flaky.call_count == 3  # 2 failures + 1 success
+
+    def test_retry_exhausted_returns_empty(self):
+        flaky = _TransientFailingSource(
+            "polygon", fail_n_times=100,  # never succeeds
+            then_return=[],
+        )
+        agg = AsyncNewsAggregator(
+            sources=[flaky], max_retry_attempts=2,
+            retry_initial_wait=0.01,
+        )
+
+        async def run():
+            return await agg.fetch(["AAPL"])
+
+        out = asyncio.run(run())
+        assert out == []
+        assert flaky.call_count == 2  # exactly max_retry_attempts
+
+
+class TestAsyncAggregatorCaching:
+    def test_cache_hit_skips_adapter_call(self):
+        polygon = _StaticSource("polygon", [_article("polygon", "A")])
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        agg = AsyncNewsAggregator(
+            sources=[polygon], cache=cache,
+        )
+
+        async def run():
+            await agg.fetch(["AAPL"])  # cold — calls adapter
+            await agg.fetch(["AAPL"])  # warm — cache hit
+            return polygon.call_count
+
+        n = asyncio.run(run())
+        assert n == 1  # adapter called once across two fan-ins
+
+    def test_cache_miss_after_expiry_re_runs_adapter(self):
+        polygon = _StaticSource("polygon", [_article("polygon", "A")])
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        # Override per-source TTL to 0 so cache always expires
+        agg = AsyncNewsAggregator(
+            sources=[polygon], cache=cache,
+            per_source_ttl_seconds={"polygon": 0},
+        )
+
+        async def run():
+            await agg.fetch(["AAPL"])
+            await agg.fetch(["AAPL"])
+            return polygon.call_count
+
+        n = asyncio.run(run())
+        assert n == 2  # both fan-ins hit the adapter
+
+    def test_cache_isolated_per_tickers(self):
+        polygon = _StaticSource("polygon", [_article("polygon", "A")])
+        s3 = _InMemoryS3()
+        cache = S3TtlCache(s3, bucket="b", prefix="cache")
+        agg = AsyncNewsAggregator(sources=[polygon], cache=cache)
+
+        async def run():
+            await agg.fetch(["AAPL"])
+            await agg.fetch(["MSFT"])  # different tickers — separate key
+            return polygon.call_count
+
+        assert asyncio.run(run()) == 2
+
+
+class TestSemaphoreConcurrency:
+    def test_semaphore_caps_in_flight_calls(self):
+        """With concurrency=1, two ticker-batches against the same
+        source serialize. Track 'currently in flight' via a counter
+        and assert it never exceeds 1."""
+        in_flight = {"n": 0, "max": 0}
+        lock = threading.Lock()
+
+        class _SlowSource:
+            name = "polygon"
+
+            def fetch(self, tickers, *, hours=48):
+                with lock:
+                    in_flight["n"] += 1
+                    in_flight["max"] = max(in_flight["max"], in_flight["n"])
+                import time
+                time.sleep(0.05)
+                with lock:
+                    in_flight["n"] -= 1
+                return [_article("polygon", "T")]
+
+        # Two adapters sharing the same `name` so they share a semaphore
+        s1, s2 = _SlowSource(), _SlowSource()
+        agg = AsyncNewsAggregator(
+            sources=[s1, s2],
+            per_source_concurrency={"polygon": 1},
+        )
+
+        async def run():
+            return await agg.fetch(["AAPL"])
+
+        asyncio.run(run())
+        # Even though 2 adapters fan out in parallel, semaphore caps
+        # concurrent in-flight calls to 1
+        assert in_flight["max"] == 1


### PR DESCRIPTION
## Summary

**Wave 1 PR D** of the institutional data-revamp arc. Wraps the sync `NewsSource` adapters (PR β) in an async fan-in pattern using `anyio.to_thread.run_sync` — adapters stay synchronous (existing tests + Lambda dispatch unchanged); aggregation becomes concurrent. Adds a generic S3-backed TTL cache available to all producer-side fetchers.

## What's in

### Generic S3-backed TTL cache (`data/cache.py`)
- `S3TtlCache(s3_client, bucket, prefix, default_ttl_seconds)` class
- `get(key)` — returns None on missing OR expired
- `set(key, value, *, ttl_seconds)` — idempotent overwrite
- `cached_call(key, *, compute_fn, ttl_seconds)` — sync fetch-or-compute
- `cached_acall(key, *, async_compute_fn, ttl_seconds)` — async variant
- `get_json` / `set_json` convenience wrappers
- **Storage:** `s3://{bucket}/{prefix}/{sha1(key)}.bin` + S3 metadata (cache-key/cached-at/ttl-seconds/expires-at)
- **Lazy eviction** — expired entries not deleted on read; overwritten on next set
- **Defensive:** entries without our metadata stamp treated as expired (don't return stale/garbled external writes)

### Async news aggregator (`collectors/news_aggregator_async.py`)
- `AsyncNewsAggregator(sources, *, trust_weights, per_source_concurrency, cache, per_source_ttl_seconds, max_retry_attempts, retry_initial_wait)`
- **`anyio.create_task_group`** for parallel adapter fan-in
- **Per-vendor `anyio.Semaphore`** (defaults: polygon=2, gdelt=1, yahoo_rss=4, edgar_press=2, paid=4)
- **Tenacity `AsyncRetrying`** with exp backoff (3 attempts, 2s/4s/8s, max 30s)
- **Optional S3TtlCache** — per-source TTLs default 30m-4h by vendor cadence (polygon=30m, gdelt=1h, yahoo=1h, edgar=4h, paid=30m)
- **Reuses sync `NewsAggregator._dedup` + `DEFAULT_TRUST_WEIGHTS`** verbatim → identical canonical output shape

### Failure modes
- **Transient** (timeout, 5xx): tenacity exp-backoff retry; final-attempt failure returns empty list for that adapter
- **Permanent**: caught at task-group level, logs + continues with remaining adapters (defense in depth matching sync path)
- **Cache deserialization failure**: logs + treats as cache miss

## Test plan

- [x] **+23 unit tests** (`tests/test_async_and_cache.py`):
  - Cache helpers: hash deterministic, handles special chars
  - S3TtlCache: set→get round-trip, missing, expired, entry-without-metadata-as-expired, overwrite, default TTL, JSON round-trip + malformed
  - `cached_call` + `cached_acall`: miss-computes-caches, hit-skips-compute
  - Async cache key: stable under ticker reorder, changes with hours, changes with vendor
  - Async aggregator: parallel fan-in / per-source failure isolated / **retry recovers from transient failure** / retry exhausted returns empty
  - Caching: hit-skips-adapter / expiry re-runs / isolated-per-tickers
  - **Semaphore concurrency:** with concurrency=1, 2 same-named-vendor adapters serialize (max-in-flight=1 verified via lock-tracked counter)
- [x] Full data suite: **1003 passing** (1 skipped) in 7s

🤖 Generated with [Claude Code](https://claude.com/claude-code)