### PR TITLE
feat(regime): Stage A PR 1 — regime substrate core modules

### DIFF
--- a/features/regime/__init__.py
+++ b/features/regime/__init__.py
@@ -1,0 +1,44 @@
+"""
+features/regime/ — Quantitative regime substrate (v3).
+
+Produces a structured S3 artifact each Saturday SF run that the macro
+economist agent consumes as a strong prior for its regime classification.
+The macro agent remains the final authority; this substrate is informational.
+
+Three independent quant components ensemble into the substrate JSON:
+
+- ``hmm``       — 3-state Gaussian HMM (Hamilton 1989). Filter-only at
+                  inference (no look-ahead). Smoother reserved for T1
+                  retrospective ground-truth labeling with explicit lag.
+- ``composite`` — AQR-style risk-on/risk-off macro z-score intensity.
+                  Pure rule-based, zero estimation risk.
+- ``bocpd``     — Adams & MacKay 2007 Bayesian online change-point
+                  detection. Surfaces regime transitions.
+
+The substrate orchestrator (``substrate.py``) assembles all three plus
+guardrail flags (mirroring the macro agent's ``_validate_regime`` rules)
+and writes the canonical-shape eval_artifacts JSON to S3.
+
+Reference: ``alpha-engine-docs/private/regime-v3-260514.md``.
+"""
+
+from features.regime.composite import compute_composite_intensity
+from features.regime.hmm import HMMRegimeClassifier, REGIME_STATES
+from features.regime.bocpd import BOCPDDetector
+from features.regime.substrate import (
+    REGIME_FEATURES,
+    SCHEMA_VERSION,
+    build_regime_substrate,
+    write_regime_substrate,
+)
+
+__all__ = [
+    "compute_composite_intensity",
+    "HMMRegimeClassifier",
+    "REGIME_STATES",
+    "BOCPDDetector",
+    "REGIME_FEATURES",
+    "SCHEMA_VERSION",
+    "build_regime_substrate",
+    "write_regime_substrate",
+]

--- a/features/regime/bocpd.py
+++ b/features/regime/bocpd.py
@@ -1,0 +1,218 @@
+"""
+features/regime/bocpd.py — Bayesian online change-point detection.
+
+Adams & MacKay 2007 algorithm. Maintains a run-length distribution
+P(r_t | obs_{1:t}) — distribution over how long the current regime has
+lasted. The most-likely run length collapsing to a small value signals
+a regime change.
+
+Used here as a complement to the HMM:
+
+- HMM says   "current state is X with confidence p"
+- BOCPD says "the regime changed at time t with confidence q"
+
+The two are independent signals. HMM probabilities can stay stable
+across a brief regime shift if the new state's emission distribution
+overlaps the old one; BOCPD detects the shift via predictive likelihood
+breakdown even when HMM is slow to update.
+
+Implementation: closed-form Gaussian observation model with a
+Normal-Inverse-Gamma conjugate prior. Constant hazard function
+(default 1/100 ≈ regime change every ~100 weeks on average). Hand-rolled
+rather than packaged to keep Lambda footprint small and the algorithm
+explicit + testable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class BOCPDState:
+    """Sufficient statistics for the run-length posterior + Gaussian
+    observation model. Persisted between updates for online use.
+
+    The four arrays grow by one element per ``update()`` call (one new
+    possible run length is added each step). In production we cap growth
+    at ``max_runlength_horizon`` (default 520 weeks ≈ 10y) — beyond that
+    the run-length tail is collapsed to release memory without changing
+    the change-point signal.
+    """
+    runlength_probs: np.ndarray   # shape (R,) — P(r_t | obs_{1:t})
+    mu_t: np.ndarray              # shape (R,) — posterior mean per run length
+    kappa_t: np.ndarray           # shape (R,) — pseudo-count per run length
+    alpha_t: np.ndarray           # shape (R,) — IG shape per run length
+    beta_t: np.ndarray            # shape (R,) — IG scale per run length
+
+
+class BOCPDDetector:
+    """Bayesian online change-point detector — Gaussian observation model.
+
+    Maintains run-length posterior over a univariate observation series.
+    For multivariate input, ``update()`` reduces the observation vector
+    to a scalar via ``observation_projection`` (default: take the
+    composite z-score scalar).
+
+    Parameters
+    ----------
+    hazard
+        Constant hazard rate per time step. Default 1/100. Higher values
+        make the detector more sensitive (regimes change more often a
+        priori).
+    mu_0
+        Prior mean. Default 0.0 (z-score-normalized observation).
+    kappa_0
+        Prior pseudo-count. Default 1.0.
+    alpha_0
+        Inverse-Gamma shape prior. Default 1.0.
+    beta_0
+        Inverse-Gamma scale prior. Default 1.0.
+    max_runlength_horizon
+        Cap on the run-length grid before tail collapse. Default 520.
+    """
+
+    def __init__(
+        self,
+        hazard: float = 1.0 / 100.0,
+        mu_0: float = 0.0,
+        kappa_0: float = 1.0,
+        alpha_0: float = 1.0,
+        beta_0: float = 1.0,
+        max_runlength_horizon: int = 520,
+    ) -> None:
+        self.hazard = hazard
+        self.mu_0 = mu_0
+        self.kappa_0 = kappa_0
+        self.alpha_0 = alpha_0
+        self.beta_0 = beta_0
+        self.max_runlength_horizon = max_runlength_horizon
+
+    def initial_state(self) -> BOCPDState:
+        """Return the prior state — no observations yet, run length 0
+        has probability 1."""
+        return BOCPDState(
+            runlength_probs=np.array([1.0]),
+            mu_t=np.array([self.mu_0]),
+            kappa_t=np.array([self.kappa_0]),
+            alpha_t=np.array([self.alpha_0]),
+            beta_t=np.array([self.beta_0]),
+        )
+
+    def update(self, state: BOCPDState, observation: float) -> BOCPDState:
+        """Advance the run-length posterior by one observation.
+
+        Implements equations 1-8 of Adams & MacKay 2007 for the
+        Normal-Inverse-Gamma conjugate Gaussian model.
+        """
+        x = float(observation)
+
+        # Predictive distribution: Student-t with parameters derived from
+        # the per-run-length NIG posterior.
+        df = 2.0 * state.alpha_t
+        scale = np.sqrt(state.beta_t * (state.kappa_t + 1.0) / (state.alpha_t * state.kappa_t))
+        pred_probs = _student_t_pdf(x, df=df, loc=state.mu_t, scale=scale)
+
+        # Growth probabilities (no change-point): P(r_t = r_{t-1}+1)
+        growth_probs = state.runlength_probs * pred_probs * (1.0 - self.hazard)
+        # Change-point probability: P(r_t = 0) = sum over previous r * pred * hazard
+        cp_prob = float((state.runlength_probs * pred_probs * self.hazard).sum())
+
+        new_runlength_probs = np.concatenate([[cp_prob], growth_probs])
+
+        # Update sufficient statistics — equations 6-7 of Adams & MacKay.
+        new_mu = np.concatenate([
+            [self.mu_0],
+            (state.kappa_t * state.mu_t + x) / (state.kappa_t + 1.0),
+        ])
+        new_kappa = np.concatenate([[self.kappa_0], state.kappa_t + 1.0])
+        new_alpha = np.concatenate([[self.alpha_0], state.alpha_t + 0.5])
+        new_beta = np.concatenate([
+            [self.beta_0],
+            state.beta_t + (state.kappa_t * (x - state.mu_t) ** 2) / (2.0 * (state.kappa_t + 1.0)),
+        ])
+
+        # Normalize run-length posterior
+        Z = new_runlength_probs.sum()
+        if Z > 0:
+            new_runlength_probs = new_runlength_probs / Z
+
+        # Tail collapse — beyond max_runlength_horizon, fold the tail
+        # mass into the last slot to keep memory bounded.
+        if len(new_runlength_probs) > self.max_runlength_horizon:
+            tail_mass = new_runlength_probs[self.max_runlength_horizon:].sum()
+            new_runlength_probs = new_runlength_probs[:self.max_runlength_horizon].copy()
+            new_runlength_probs[-1] += tail_mass
+            new_mu = new_mu[:self.max_runlength_horizon]
+            new_kappa = new_kappa[:self.max_runlength_horizon]
+            new_alpha = new_alpha[:self.max_runlength_horizon]
+            new_beta = new_beta[:self.max_runlength_horizon]
+
+        return BOCPDState(
+            runlength_probs=new_runlength_probs,
+            mu_t=new_mu,
+            kappa_t=new_kappa,
+            alpha_t=new_alpha,
+            beta_t=new_beta,
+        )
+
+    def change_signal(
+        self,
+        state: BOCPDState,
+        *,
+        min_runlength_for_change: int = 4,
+        change_threshold: float = 0.5,
+    ) -> dict:
+        """Surface change-point signal from a run-length posterior.
+
+        A change is declared when the run-length posterior places more
+        than ``change_threshold`` mass on run lengths shorter than
+        ``min_runlength_for_change``.
+
+        Returns
+        -------
+        dict with:
+
+        - ``change_signal``: bool
+        - ``max_runlength_prob``: float — probability mass on most-likely
+          run length (high values = settled regime)
+        - ``change_confidence``: float — mass on short run lengths
+
+        These three fields land directly in the substrate JSON.
+        """
+        probs = state.runlength_probs
+        if len(probs) == 0:
+            return {
+                "change_signal": False,
+                "max_runlength_prob": 0.0,
+                "change_confidence": 0.0,
+            }
+        short_horizon = min(min_runlength_for_change, len(probs))
+        change_confidence = float(probs[:short_horizon].sum())
+        max_runlength_prob = float(probs.max())
+        return {
+            "change_signal": bool(change_confidence > change_threshold),
+            "max_runlength_prob": max_runlength_prob,
+            "change_confidence": change_confidence,
+        }
+
+    def run_offline(self, observations: np.ndarray) -> tuple[BOCPDState, list[dict]]:
+        """Run the detector over a complete observation sequence.
+
+        Returns the final state plus a list of per-step change-signal
+        dicts. Useful for backtesting + the historical-backfill script.
+        """
+        state = self.initial_state()
+        signals: list[dict] = []
+        for obs in observations:
+            state = self.update(state, float(obs))
+            signals.append(self.change_signal(state))
+        return state, signals
+
+
+def _student_t_pdf(x: float, df: np.ndarray, loc: np.ndarray, scale: np.ndarray) -> np.ndarray:
+    """Vectorized Student-t pdf — closed-form predictive distribution
+    for the Normal-Inverse-Gamma conjugate Gaussian observation model."""
+    from scipy.stats import t as student_t
+    return student_t.pdf(x, df=df, loc=loc, scale=scale)

--- a/features/regime/composite.py
+++ b/features/regime/composite.py
@@ -1,0 +1,127 @@
+"""
+features/regime/composite.py — AQR-style risk-on/risk-off intensity.
+
+Pure rule-based composite z-score over macro features. Zero estimation
+risk — no fit, no parameters to learn beyond the equal-weight default.
+Serves as the always-available regime fallback when HMM is unfit or
+disagrees catastrophically with consensus.
+
+Output convention: ``intensity_z`` is a scalar in roughly ``[-3, +3]``
+where:
+
+- Positive  → risk-off / bearish (high VIX, wide credit spreads, etc.)
+- Negative  → risk-on  / bullish (low VIX, tight spreads, etc.)
+- Magnitude → standard deviations from rolling-window mean.
+
+The sign convention is deliberately the opposite of "regime intensity"
+in the downstream contract — downstream consumers expect higher values
+to mean "more risk-on." We invert at the substrate-orchestrator layer
+(``substrate.py``) so this module stays interpretable as "stress index"
+in isolation.
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+import numpy as np
+import pandas as pd
+
+
+# Equal-weight default. Each feature contributes the same to the
+# composite intensity. Tuning these is a deliberate research exercise —
+# they live here as named constants so future revisions are explicit.
+DEFAULT_WEIGHTS: dict[str, float] = {
+    "vix_level": 1.0,
+    "hy_oas_bps": 1.0,
+    "yield_curve_slope": -1.0,  # inversion is bearish → negative slope is risk-off
+    "spy_20d_return": -1.0,     # positive return is risk-on → negative weight
+    "market_breadth": -1.0,     # high breadth is risk-on → negative weight
+    "vix_term_slope": -1.0,     # backwardation (negative slope) is risk-off
+}
+
+
+def _zscore(value: float, history: pd.Series) -> float:
+    """Standard z-score of ``value`` against ``history``'s mean + std.
+
+    Returns 0.0 when ``history`` is empty or has zero std (degenerate
+    case — no signal to extract).
+    """
+    if len(history) == 0:
+        return 0.0
+    mu = float(history.mean())
+    sigma = float(history.std(ddof=0))
+    if sigma == 0.0 or not np.isfinite(sigma):
+        return 0.0
+    return (float(value) - mu) / sigma
+
+
+def compute_composite_intensity(
+    current: Mapping[str, float],
+    history: pd.DataFrame,
+    weights: Mapping[str, float] | None = None,
+    rolling_window_weeks: int | None = 260,
+) -> dict:
+    """Compute composite risk-on/risk-off intensity from macro features.
+
+    Parameters
+    ----------
+    current
+        Feature row at the inference timestamp — mapping of feature name
+        to scalar value. Missing features are skipped (excluded from
+        the weighted sum).
+    history
+        Historical feature DataFrame indexed by date. Used to compute
+        z-score normalization. Must contain at least the features
+        present in ``current`` and ``weights``.
+    weights
+        Per-feature weight dict. Defaults to ``DEFAULT_WEIGHTS``.
+    rolling_window_weeks
+        Lookback window for z-score normalization. None = use full
+        history. Default 260 weeks (~5y) follows AQR convention.
+
+    Returns
+    -------
+    Dict with keys:
+
+    - ``intensity_z``: scalar composite z-score (stress orientation —
+      positive = risk-off).
+    - ``per_feature_z``: dict of feature name → individual z-score
+      (debugging + dashboard observability).
+    - ``features_used``: list of features that contributed (excludes
+      missing-from-current or missing-from-history).
+    """
+    w = dict(weights or DEFAULT_WEIGHTS)
+
+    # Scope history window
+    if rolling_window_weeks is not None and len(history) > rolling_window_weeks:
+        history_window = history.tail(rolling_window_weeks)
+    else:
+        history_window = history
+
+    per_feature_z: dict[str, float] = {}
+    features_used: list[str] = []
+    weighted_sum = 0.0
+    weight_norm = 0.0
+
+    for feat, weight in w.items():
+        if feat not in current:
+            continue
+        if feat not in history_window.columns:
+            continue
+        value = current[feat]
+        if value is None or not np.isfinite(float(value)):
+            continue
+        feat_history = history_window[feat].dropna()
+        z = _zscore(float(value), feat_history)
+        per_feature_z[feat] = z
+        features_used.append(feat)
+        weighted_sum += weight * z
+        weight_norm += abs(weight)
+
+    intensity_z = weighted_sum / weight_norm if weight_norm > 0 else 0.0
+
+    return {
+        "intensity_z": float(intensity_z),
+        "per_feature_z": per_feature_z,
+        "features_used": features_used,
+    }

--- a/features/regime/hmm.py
+++ b/features/regime/hmm.py
@@ -1,0 +1,255 @@
+"""
+features/regime/hmm.py — 3-state Gaussian HMM regime classifier.
+
+Canonical institutional regime detection primitive (Hamilton 1989). Used
+here to produce continuous posterior probabilities P(bull/neutral/bear)
+at inference time — never argmax-routed (per the 2026-05-10 directive
+against per-regime sub-models).
+
+LOOK-AHEAD DISCIPLINE
+---------------------
+Two inference modes, structurally distinct:
+
+- ``predict_proba_filter()`` — **Hamilton-Kim filter (forward-only)**.
+  Posterior P(state_t | obs_{1:t}). Uses ONLY data up to time t. This
+  is the inference-time API and the only mode that should ever be
+  consumed by production substrate writes.
+- ``predict_proba_smoother()`` — **forward-backward smoother**.
+  Posterior P(state_t | obs_{1:T}) using full sequence. By construction
+  this uses *future* observations (t+1, ..., T) to refine the estimate
+  at time t. Intended **exclusively** for retrospective T1 ground-truth
+  labeling per regime-v3-260514.md §5.3.3 — must NEVER be invoked at
+  inference time. The substrate orchestrator does not call this method;
+  only the retrospective labeling pipeline does.
+
+A regression test pins this contract: any code path that consumes
+smoothed probabilities must read from a *lagged* artifact location
+(``regime/retrospective/{run_id}/``), never the contemporaneous artifact
+written by the substrate orchestrator.
+
+STATE PINNING
+-------------
+Raw HMM fits have label-switching: across re-fits the "bull" state may
+end up at index 0 in week N and index 2 in week N+1. ``_pin_states``
+sorts the fitted states by mean SPY 20-day return — highest mean = bull,
+lowest = bear — and remaps so the output order is always (bear, neutral,
+bull). Regression test pins this in the substrate orchestrator.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+# Canonical state order in returned probability vectors. Pinned post-fit
+# via _pin_states() so consumers can trust positional access.
+REGIME_STATES: tuple[str, ...] = ("bear", "neutral", "bull")
+
+
+# The pinning feature must be present in every fit. SPY 20d return is
+# the cleanest single-feature partition of regime severity historically.
+PIN_FEATURE: str = "spy_20d_return"
+
+
+class HMMRegimeClassifier:
+    """3-state Gaussian HMM regime classifier with state pinning.
+
+    Wraps ``hmmlearn.hmm.GaussianHMM`` with:
+
+    - State-order pinning by mean ``spy_20d_return`` (stable across refits).
+    - Filter-only inference (forward, no look-ahead) as the default
+      production API.
+    - Forward-backward smoother as an explicitly-named retrospective-only
+      method.
+
+    Parameters
+    ----------
+    n_states
+        Number of latent states. Default 3 (bear/neutral/bull).
+    n_iter
+        EM iteration cap. Default 100.
+    covariance_type
+        ``hmmlearn`` covariance type. Default "full".
+    random_state
+        Seed for reproducibility across refits.
+    """
+
+    def __init__(
+        self,
+        n_states: int = 3,
+        n_iter: int = 100,
+        covariance_type: str = "full",
+        random_state: int = 42,
+    ) -> None:
+        self.n_states = n_states
+        self.n_iter = n_iter
+        self.covariance_type = covariance_type
+        self.random_state = random_state
+        self._model = None
+        self._feature_names: list[str] | None = None
+        self._state_permutation: np.ndarray | None = None
+
+    def fit(self, features: pd.DataFrame, feature_columns: Sequence[str]) -> "HMMRegimeClassifier":
+        """Fit the HMM on a historical feature matrix.
+
+        Parameters
+        ----------
+        features
+            DataFrame of macro feature history. One row per observation
+            (typically weekly). Must contain ``PIN_FEATURE`` and every
+            entry in ``feature_columns``.
+        feature_columns
+            Ordered list of feature column names to feed the emission
+            model. The order is preserved at inference time.
+
+        Returns
+        -------
+        self
+        """
+        from hmmlearn.hmm import GaussianHMM
+
+        missing = [c for c in feature_columns if c not in features.columns]
+        if missing:
+            raise ValueError(f"Missing feature columns: {missing}")
+        if PIN_FEATURE not in features.columns:
+            raise ValueError(
+                f"Pinning feature '{PIN_FEATURE}' missing from features DataFrame; "
+                f"required for stable state-order pinning across refits."
+            )
+
+        X = features[list(feature_columns)].dropna().to_numpy()
+        if len(X) < self.n_states * 20:
+            raise ValueError(
+                f"Insufficient observations for HMM fit: got {len(X)}, "
+                f"need at least {self.n_states * 20} for stable EM convergence."
+            )
+
+        model = GaussianHMM(
+            n_components=self.n_states,
+            covariance_type=self.covariance_type,
+            n_iter=self.n_iter,
+            random_state=self.random_state,
+        )
+        model.fit(X)
+
+        # Compute state permutation that orders states bear < neutral < bull
+        # by mean spy_20d_return inside each state's posterior assignment.
+        viterbi_states = model.predict(X)
+        pin_values = features.loc[features[list(feature_columns)].dropna().index, PIN_FEATURE].to_numpy()
+        state_pin_means = np.array([
+            pin_values[viterbi_states == s].mean() if (viterbi_states == s).any() else np.nan
+            for s in range(self.n_states)
+        ])
+        # Ascending sort of state pin means → bear (lowest) → neutral → bull (highest).
+        # state_permutation[i] = original-state-index-now-at-position-i
+        state_permutation = np.argsort(state_pin_means)
+
+        self._model = model
+        self._feature_names = list(feature_columns)
+        self._state_permutation = state_permutation
+        logger.info(
+            "[hmm] fit complete: %d observations, pinned state order means=%s",
+            len(X), state_pin_means[state_permutation].tolist(),
+        )
+        return self
+
+    def predict_proba_filter(self, features: pd.DataFrame) -> np.ndarray:
+        """Filter posterior probabilities — forward-only, no look-ahead.
+
+        Computes P(state_t | obs_{1:t}) for every t in ``features``. The
+        last row's probabilities are the inference-time output for the
+        most recent observation. **This is the only inference API safe
+        for production substrate writes.**
+
+        Returns an array of shape ``(len(features), n_states)`` with
+        rows ordered chronologically and columns in pinned order
+        (bear, neutral, bull). Probabilities sum to 1.0 per row.
+        """
+        if self._model is None or self._state_permutation is None:
+            raise RuntimeError("HMM not fitted — call fit() first.")
+
+        X = features[self._feature_names].to_numpy()
+        # hmmlearn exposes the filter via the framelogprob + forwardpass
+        # API; for clarity we use the wrapper `score_samples` which
+        # returns log_prob + smoothed posteriors but we need *filtered*
+        # not smoothed. Re-implement filter directly using log_probs.
+        log_prob_obs = self._model._compute_log_likelihood(X)  # shape (T, K)
+        log_start = np.log(self._model.startprob_ + 1e-300)
+        log_trans = np.log(self._model.transmat_ + 1e-300)
+
+        T, K = log_prob_obs.shape
+        log_alpha = np.zeros((T, K))
+        log_alpha[0] = log_start + log_prob_obs[0]
+        for t in range(1, T):
+            # log_alpha[t, j] = log_prob_obs[t, j] + logsumexp_i(log_alpha[t-1, i] + log_trans[i, j])
+            log_alpha[t] = log_prob_obs[t] + _logsumexp_axis0(
+                log_alpha[t - 1][:, None] + log_trans
+            )
+        # Normalize per row
+        log_alpha_norm = log_alpha - _logsumexp_axis1(log_alpha)[:, None]
+        filtered = np.exp(log_alpha_norm)
+        return filtered[:, self._state_permutation]
+
+    def predict_proba_smoother(self, features: pd.DataFrame) -> np.ndarray:
+        """Forward-backward smoothed posteriors — RETROSPECTIVE USE ONLY.
+
+        Computes P(state_t | obs_{1:T}) using the full sequence. By
+        construction this uses *future* observations (t+1, ..., T) to
+        refine the estimate at time t.
+
+        **Do not call from any inference / substrate-write path.** This
+        method is reserved for the retrospective T1 ground-truth labeling
+        pipeline (regime-v3-260514.md §5.3.3) which writes to a
+        ``regime/retrospective/`` prefix with explicit ≥8-week lag.
+
+        Same return shape as ``predict_proba_filter`` (pinned state order).
+        """
+        if self._model is None or self._state_permutation is None:
+            raise RuntimeError("HMM not fitted — call fit() first.")
+        X = features[self._feature_names].to_numpy()
+        # hmmlearn's predict_proba uses forward-backward (smoothed).
+        smoothed = self._model.predict_proba(X)
+        return smoothed[:, self._state_permutation]
+
+    def log_likelihood(self, features: pd.DataFrame) -> float:
+        """Sequence log-likelihood under the fitted model. Used for
+        held-out validation (regime-v3-260514.md §5.5 gate #2)."""
+        if self._model is None:
+            raise RuntimeError("HMM not fitted — call fit() first.")
+        X = features[self._feature_names].to_numpy()
+        return float(self._model.score(X))
+
+    def pinned_state_means(self, features: pd.DataFrame) -> np.ndarray:
+        """Return per-state mean of ``PIN_FEATURE`` in pinned order.
+
+        Used by tests to verify the bear < neutral < bull invariant and
+        by the substrate orchestrator to surface state diagnostics.
+        """
+        if self._model is None or self._state_permutation is None:
+            raise RuntimeError("HMM not fitted — call fit() first.")
+        viterbi_states = self._model.predict(features[self._feature_names].to_numpy())
+        pin_values = features[PIN_FEATURE].to_numpy()
+        means = np.array([
+            pin_values[viterbi_states == s].mean() if (viterbi_states == s).any() else np.nan
+            for s in range(self.n_states)
+        ])
+        return means[self._state_permutation]
+
+
+def _logsumexp_axis0(arr: np.ndarray) -> np.ndarray:
+    """Numerically-stable logsumexp along axis 0."""
+    m = arr.max(axis=0)
+    return m + np.log(np.exp(arr - m).sum(axis=0))
+
+
+def _logsumexp_axis1(arr: np.ndarray) -> np.ndarray:
+    """Numerically-stable logsumexp along axis 1."""
+    m = arr.max(axis=1)
+    return m + np.log(np.exp(arr - m[:, None]).sum(axis=1))

--- a/features/regime/substrate.py
+++ b/features/regime/substrate.py
@@ -1,0 +1,391 @@
+"""
+features/regime/substrate.py — regime substrate orchestrator + S3 writer.
+
+Assembles HMM + composite + BOCPD + guardrail outputs into the canonical
+``regime_substrate.json`` payload and writes it via the canonical
+``alpha_engine_lib.eval_artifacts`` shape (YYMMDDHHMM run_id + latest.json
+sidecar pointer).
+
+The Lambda handler is a thin wrapper that:
+
+1. Fetches the historical feature DataFrame + current row from upstream
+   data sources (data/macro/, ArcticDB macro library, etc.).
+2. Calls ``build_regime_substrate()`` to assemble the payload.
+3. Calls ``write_regime_substrate()`` to publish to S3.
+
+This separation keeps the orchestrator pure-pandas and testable in
+isolation (no S3 / no fetcher dependencies).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Any, Mapping
+
+import numpy as np
+import pandas as pd
+
+from features.regime.bocpd import BOCPDDetector, BOCPDState
+from features.regime.composite import compute_composite_intensity
+from features.regime.hmm import HMMRegimeClassifier, REGIME_STATES
+
+
+logger = logging.getLogger(__name__)
+
+
+# Schema version stamped onto every artifact. Bump on breaking changes.
+SCHEMA_VERSION: int = 1
+
+
+# The canonical six-feature input set. Mirrors the macro economist's
+# guardrail features + the existing predictor META_FEATURES macros.
+REGIME_FEATURES: tuple[str, ...] = (
+    "spy_20d_return",
+    "vix_level",
+    "vix_term_slope",
+    "hy_oas_bps",
+    "yield_curve_slope",
+    "market_breadth",
+)
+
+
+# Default S3 layout. Override at Lambda-handler layer if needed.
+DEFAULT_S3_BUCKET: str = "alpha-engine-research"
+DEFAULT_S3_PREFIX: str = "regime"
+
+
+# Guardrail thresholds. Mirror the existing
+# ``alpha-engine-research/agents/macro_agent.py:_validate_regime`` rules
+# so the substrate exposes the same severity flags the macro agent's
+# guardrail layer would compute. The macro agent still owns the final
+# escalation; the substrate just surfaces the flags for observability.
+GUARDRAIL_DEFAULTS = {
+    "vix_caution_threshold": 22.0,
+    "vix_bear_threshold": 30.0,
+    "spy_30d_caution_threshold": -5.0,   # percent
+    "spy_30d_bear_threshold": -10.0,     # percent
+    "hy_oas_caution_threshold_bps": 500.0,
+}
+
+
+def _compute_guardrail_flags(
+    current: Mapping[str, float],
+    thresholds: Mapping[str, float] | None = None,
+) -> dict:
+    """Compute the same severity flags the macro agent's
+    ``_validate_regime`` would compute. Surfaces them for observability;
+    macro agent still owns the final regime call.
+
+    Note: ``spy_30d_return`` is not in REGIME_FEATURES (the HMM uses
+    20d). The guardrail check accepts either a ``spy_30d_return`` key
+    in ``current`` or falls back to scaling 20d return.
+    """
+    t = dict(thresholds or GUARDRAIL_DEFAULTS)
+    vix = float(current.get("vix_level", np.nan))
+    hy_oas = float(current.get("hy_oas_bps", np.nan))
+    spy_30d_raw = current.get("spy_30d_return")
+    if spy_30d_raw is None:
+        spy_20d = float(current.get("spy_20d_return", np.nan))
+        # Best-effort 20d → 30d scaling for the guardrail check only;
+        # macro agent reads true 30d return when computing its own
+        # guardrails downstream.
+        spy_30d = spy_20d * (30.0 / 20.0) if np.isfinite(spy_20d) else np.nan
+    else:
+        spy_30d = float(spy_30d_raw)
+    # Convert to percent if it looks like a decimal
+    if np.isfinite(spy_30d) and abs(spy_30d) < 1.0:
+        spy_30d_pct = spy_30d * 100.0
+    else:
+        spy_30d_pct = spy_30d
+
+    vix_caution = bool(np.isfinite(vix) and vix > t["vix_caution_threshold"])
+    vix_bear = bool(np.isfinite(vix) and vix > t["vix_bear_threshold"])
+    spy_30d_caution = bool(np.isfinite(spy_30d_pct) and spy_30d_pct < t["spy_30d_caution_threshold"])
+    spy_30d_bear = bool(np.isfinite(spy_30d_pct) and spy_30d_pct < t["spy_30d_bear_threshold"])
+    hy_oas_caution = bool(np.isfinite(hy_oas) and hy_oas > t["hy_oas_caution_threshold_bps"])
+
+    # Severity floor — what the macro agent's guardrail would force as
+    # a minimum. Reported as a hint, not authoritative.
+    active_severity_floor: str | None = None
+    if vix_bear and spy_30d_bear:
+        active_severity_floor = "bear"
+    elif vix_caution and spy_30d_caution:
+        active_severity_floor = "caution"
+    elif hy_oas_caution:
+        active_severity_floor = "caution"
+
+    return {
+        "vix_caution_breached": vix_caution,
+        "vix_bear_breached": vix_bear,
+        "spy_30d_caution_breached": spy_30d_caution,
+        "spy_30d_bear_breached": spy_30d_bear,
+        "hy_oas_caution_breached": hy_oas_caution,
+        "active_severity_floor": active_severity_floor,
+    }
+
+
+def build_regime_substrate(
+    *,
+    feature_history: pd.DataFrame,
+    current_features: Mapping[str, float],
+    hmm: HMMRegimeClassifier,
+    bocpd_state: BOCPDState | None = None,
+    bocpd_detector: BOCPDDetector | None = None,
+    run_id: str | None = None,
+    calendar_date: str | None = None,
+    trading_day: str | None = None,
+    fit_window_start: str | None = None,
+    fit_window_end: str | None = None,
+    hmm_weights_s3_key: str | None = None,
+) -> dict[str, Any]:
+    """Assemble the regime substrate payload.
+
+    Parameters
+    ----------
+    feature_history
+        Historical macro feature DataFrame. Must contain all of
+        ``REGIME_FEATURES`` as columns plus an index per observation
+        (typically weekly). The HMM may have been fit on a subset of
+        this history; ``feature_history`` here is used for the composite
+        z-score's rolling window normalization and for the HMM filter
+        path (the last row drives the inference).
+    current_features
+        Mapping of feature name → scalar value for the inference
+        timestamp. Must contain all of ``REGIME_FEATURES``.
+    hmm
+        Fitted ``HMMRegimeClassifier``.
+    bocpd_state
+        BOCPD state carried over from prior runs. Pass ``None`` to start
+        from the prior — the first weeks of a new pipeline will not
+        produce meaningful change signals until enough history has
+        accumulated.
+    bocpd_detector
+        Optional pre-configured detector. Defaults to ``BOCPDDetector()``.
+    run_id
+        ``YYMMDDHHMM`` run identifier. When None, minted via
+        ``new_eval_run_id()`` from the lib.
+    calendar_date, trading_day
+        Dual-tracked dates per ``DATE_CONVENTIONS.md``. When None,
+        derived via ``alpha_engine_lib.dates.now_dual()``.
+    fit_window_start, fit_window_end
+        Diagnostic metadata about the HMM's training window. Optional.
+    hmm_weights_s3_key
+        Pointer to where the HMM weights live in S3, for replay /
+        forensic recovery. Optional.
+
+    Returns
+    -------
+    Substrate JSON payload as a dict. Serializable via ``json.dumps``.
+    """
+    from alpha_engine_lib.dates import now_dual
+    from alpha_engine_lib.eval_artifacts import new_eval_run_id
+
+    if run_id is None:
+        run_id = new_eval_run_id()
+    if calendar_date is None or trading_day is None:
+        dual = now_dual()
+        calendar_date = calendar_date or dual.calendar_date
+        trading_day = trading_day or dual.trading_day
+
+    # ─ HMM filter inference (forward-only, no look-ahead) ────────────
+    # Use the full feature_history so the filter can warm up, then take
+    # the last row's posterior as the current-week classification.
+    hmm_input = feature_history[list(hmm._feature_names)].dropna()
+    if len(hmm_input) == 0:
+        raise ValueError("feature_history is empty after dropna on HMM features.")
+    filter_probs = hmm.predict_proba_filter(hmm_input)
+    current_probs = filter_probs[-1]
+    hmm_argmax_idx = int(np.argmax(current_probs))
+    hmm_argmax = REGIME_STATES[hmm_argmax_idx]
+    log_likelihood = hmm.log_likelihood(hmm_input)
+
+    # Weeks in current state — walk back through the filter argmax until
+    # the state changes.
+    argmax_path = np.argmax(filter_probs, axis=1)
+    weeks_in_state = 1
+    for i in range(len(argmax_path) - 2, -1, -1):
+        if argmax_path[i] == hmm_argmax_idx:
+            weeks_in_state += 1
+        else:
+            break
+
+    hmm_block = {
+        "probs": {
+            "bear": float(current_probs[0]),
+            "neutral": float(current_probs[1]),
+            "bull": float(current_probs[2]),
+        },
+        "argmax": hmm_argmax,
+        "weeks_in_current_state": int(weeks_in_state),
+        "log_likelihood": float(log_likelihood),
+    }
+
+    # ─ Composite z-score intensity ───────────────────────────────────
+    composite_result = compute_composite_intensity(
+        current=current_features,
+        history=feature_history,
+    )
+    # The composite's intensity_z is "stress orientation" (positive =
+    # risk-off). Downstream consumers expect higher = risk-on, so we
+    # invert here to align the substrate output with the contract.
+    composite_block = {
+        "intensity_z": -composite_result["intensity_z"],
+        "per_feature_z": composite_result["per_feature_z"],
+        "features_used": composite_result["features_used"],
+        "implied_severity": _classify_intensity(-composite_result["intensity_z"]),
+    }
+
+    # ─ BOCPD (optional; first-run = uninformative) ───────────────────
+    if bocpd_detector is None:
+        bocpd_detector = BOCPDDetector()
+    if bocpd_state is None:
+        bocpd_state = bocpd_detector.initial_state()
+        # Warm up on history so the first emitted artifact has a
+        # meaningful change signal. Use the composite intensity series
+        # as the observation projection.
+        for _, row in feature_history.iterrows():
+            row_intensity = compute_composite_intensity(
+                current=row.to_dict(),
+                history=feature_history,
+            )
+            bocpd_state = bocpd_detector.update(bocpd_state, -row_intensity["intensity_z"])
+    else:
+        # Incremental update with the current observation
+        bocpd_state = bocpd_detector.update(bocpd_state, composite_block["intensity_z"])
+    bocpd_block = bocpd_detector.change_signal(bocpd_state)
+
+    # ─ Guardrail flags ───────────────────────────────────────────────
+    guardrails = _compute_guardrail_flags(current_features)
+
+    # ─ Assemble ──────────────────────────────────────────────────────
+    payload: dict[str, Any] = {
+        "calendar_date": calendar_date,
+        "trading_day": trading_day,
+        "run_id": run_id,
+        "schema_version": SCHEMA_VERSION,
+        "hmm": hmm_block,
+        "composite": composite_block,
+        "bocpd": bocpd_block,
+        "guardrails": guardrails,
+        "features": {f: float(current_features[f]) for f in REGIME_FEATURES if f in current_features},
+        "model_metadata": {
+            "hmm_weights_s3": hmm_weights_s3_key,
+            "hmm_feature_columns": list(hmm._feature_names) if hmm._feature_names else None,
+            "composite_weights_version": "v1.0",
+            "fit_window_start": fit_window_start,
+            "fit_window_end": fit_window_end,
+            "written_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+    }
+    return payload
+
+
+def _classify_intensity(intensity_z: float) -> str:
+    """Map the inverted composite intensity to a coarse severity label.
+
+    Note: the substrate's authoritative label is computed by the macro
+    agent downstream. This is a hint surfaced for observability.
+    """
+    if intensity_z > 1.0:
+        return "risk_on"
+    if intensity_z > 0.3:
+        return "risk_on_tilted"
+    if intensity_z > -0.3:
+        return "neutral"
+    if intensity_z > -1.0:
+        return "risk_off_tilted"
+    return "risk_off"
+
+
+def write_regime_substrate(
+    payload: Mapping[str, Any],
+    *,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> dict[str, str]:
+    """Publish substrate payload to S3 in canonical eval_artifacts shape.
+
+    Writes:
+
+    - ``{prefix}/{run_id}.json`` — forensic dated artifact
+    - ``{prefix}/latest.json``    — operator-UX sidecar pointer
+
+    Returns dict with ``artifact_key`` and ``latest_key``.
+    """
+    from alpha_engine_lib.eval_artifacts import (
+        eval_artifact_key,
+        eval_latest_key,
+    )
+
+    run_id = payload["run_id"]
+    artifact_key = eval_artifact_key(prefix, run_id)  # default basename → {run_id}.json
+    latest_key = eval_latest_key(prefix)
+
+    body = json.dumps(payload, default=str).encode("utf-8")
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=artifact_key,
+        Body=body,
+        ContentType="application/json",
+    )
+
+    sidecar = {
+        "run_id": run_id,
+        "artifact_key": artifact_key,
+        "calendar_date": payload["calendar_date"],
+        "trading_day": payload["trading_day"],
+        "schema_version": payload["schema_version"],
+        "hmm_argmax": payload["hmm"]["argmax"],
+        "composite_intensity_z": payload["composite"]["intensity_z"],
+        "regime_change_signal": payload["bocpd"]["change_signal"],
+        "written_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=latest_key,
+        Body=json.dumps(sidecar).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    logger.info(
+        "[regime_substrate] wrote run_id=%s → s3://%s/%s (latest=%s)",
+        run_id, bucket, artifact_key, latest_key,
+    )
+    return {"artifact_key": artifact_key, "latest_key": latest_key}
+
+
+def read_regime_substrate(
+    *,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> dict[str, Any] | None:
+    """Consumer-side read — resolves ``latest.json`` → artifact.
+
+    Returns the substrate payload dict, or ``None`` if no artifact has
+    been written yet. Used by the macro economist agent (Stage C) and
+    the predictor L2 feature loader (Stage D).
+    """
+    from alpha_engine_lib.eval_artifacts import eval_latest_key
+
+    latest_key = eval_latest_key(prefix)
+    try:
+        sidecar_obj = s3_client.get_object(Bucket=bucket, Key=latest_key)
+    except Exception as e:
+        logger.info(
+            "[regime_substrate] latest.json read failed at s3://%s/%s (%s) — "
+            "no substrate available yet",
+            bucket, latest_key, type(e).__name__,
+        )
+        return None
+
+    sidecar = json.loads(sidecar_obj["Body"].read())
+    artifact_key = sidecar.get("artifact_key")
+    if not artifact_key:
+        return None
+
+    body_obj = s3_client.get_object(Bucket=bucket, Key=artifact_key)
+    return json.loads(body_obj["Body"].read())

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,10 @@ pgvector>=0.2
 voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11
+# Regime substrate (features/regime/) — HMM via hmmlearn, BOCPD uses
+# scipy.stats.t closed-form predictive distribution.
+hmmlearn>=0.3
+scipy>=1.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
 # [rag] (added in lib v0.3.0) consolidates psycopg2-binary + pgvector + numpy
 # previously listed above as direct deps; kept those direct lines for now to

--- a/tests/test_regime_bocpd.py
+++ b/tests/test_regime_bocpd.py
@@ -1,0 +1,112 @@
+"""Tests for features/regime/bocpd.py — Bayesian online change-point detection."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from features.regime.bocpd import BOCPDDetector, BOCPDState
+
+
+pytest.importorskip("scipy")
+
+
+def test_bocpd_initial_state_well_formed() -> None:
+    detector = BOCPDDetector()
+    state = detector.initial_state()
+    assert isinstance(state, BOCPDState)
+    assert len(state.runlength_probs) == 1
+    assert state.runlength_probs[0] == pytest.approx(1.0)
+
+
+def test_bocpd_run_length_grows_by_one_per_update() -> None:
+    detector = BOCPDDetector()
+    state = detector.initial_state()
+    for n in range(1, 6):
+        state = detector.update(state, observation=0.5 * n)
+        assert len(state.runlength_probs) == n + 1
+
+
+def test_bocpd_run_length_probs_sum_to_one() -> None:
+    detector = BOCPDDetector()
+    state = detector.initial_state()
+    for x in np.random.default_rng(0).normal(0.0, 1.0, 30):
+        state = detector.update(state, observation=float(x))
+        assert state.runlength_probs.sum() == pytest.approx(1.0, abs=1e-9)
+
+
+def test_bocpd_detects_step_change_in_observation_series() -> None:
+    """Synthetic step-change: 50 obs around mean=0, then 50 obs around
+    mean=3 — change confidence should spike shortly after the shift."""
+    detector = BOCPDDetector(hazard=1.0 / 50.0)
+    rng = np.random.default_rng(0)
+    pre_change = rng.normal(0.0, 0.5, 50)
+    post_change = rng.normal(3.0, 0.5, 50)
+    observations = np.concatenate([pre_change, post_change])
+
+    state = detector.initial_state()
+    confidences = []
+    for x in observations:
+        state = detector.update(state, observation=float(x))
+        sig = detector.change_signal(state)
+        confidences.append(sig["change_confidence"])
+    confidences = np.array(confidences)
+
+    # Pre-change confidence (latter half of the calm regime) should be low
+    pre_change_conf = confidences[40:50].mean()
+    # Post-change confidence (immediately after the shift) should be high
+    post_change_conf = confidences[50:55].max()
+    assert post_change_conf > pre_change_conf + 0.3, (
+        f"pre-change conf {pre_change_conf:.3f} → post-change conf {post_change_conf:.3f}; "
+        f"expected a sharp jump after the regime shift."
+    )
+
+
+def test_bocpd_no_false_alarm_on_stationary_series() -> None:
+    """50 obs from a single Gaussian — change_signal should not fire
+    after the algorithm's warm-up period.
+
+    Early observations naturally produce inflated change_confidence
+    because the run-length posterior has little mass to spread across
+    long run lengths. Skip the first 15 obs (warm-up) and require zero
+    false alarms in the stationary tail.
+    """
+    detector = BOCPDDetector()
+    rng = np.random.default_rng(0)
+    observations = rng.normal(0.0, 1.0, 50)
+
+    state = detector.initial_state()
+    fired_after_warmup = 0
+    for i, x in enumerate(observations):
+        state = detector.update(state, observation=float(x))
+        sig = detector.change_signal(state, change_threshold=0.5)
+        if i >= 15 and sig["change_signal"]:
+            fired_after_warmup += 1
+    assert fired_after_warmup == 0, (
+        f"expected zero false alarms on stationary tail after warm-up, got {fired_after_warmup}"
+    )
+
+
+def test_bocpd_tail_collapse_bounds_memory() -> None:
+    """After many observations the run-length array should be bounded
+    by ``max_runlength_horizon``."""
+    detector = BOCPDDetector(max_runlength_horizon=20)
+    state = detector.initial_state()
+    for _ in range(100):
+        state = detector.update(state, observation=0.5)
+    assert len(state.runlength_probs) <= 20
+    assert state.runlength_probs.sum() == pytest.approx(1.0, abs=1e-9)
+
+
+def test_bocpd_run_offline_returns_signal_per_step() -> None:
+    detector = BOCPDDetector()
+    rng = np.random.default_rng(0)
+    obs = rng.normal(0.0, 1.0, 25)
+    final_state, signals = detector.run_offline(obs)
+    assert len(signals) == 25
+    assert isinstance(final_state, BOCPDState)
+    for sig in signals:
+        assert set(sig.keys()) == {
+            "change_signal",
+            "max_runlength_prob",
+            "change_confidence",
+        }

--- a/tests/test_regime_composite.py
+++ b/tests/test_regime_composite.py
@@ -1,0 +1,108 @@
+"""Tests for features/regime/composite.py — composite z-score intensity."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from features.regime.composite import (
+    DEFAULT_WEIGHTS,
+    compute_composite_intensity,
+)
+
+
+def _build_history(n: int = 260, seed: int = 0) -> pd.DataFrame:
+    """Synthetic 5y weekly macro history with realistic ranges."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({
+        "spy_20d_return": rng.normal(0.01, 0.04, n),
+        "vix_level": rng.normal(18.0, 5.0, n).clip(min=9.0),
+        "vix_term_slope": rng.normal(1.0, 0.3, n),
+        "hy_oas_bps": rng.normal(400.0, 100.0, n).clip(min=200.0),
+        "yield_curve_slope": rng.normal(0.5, 0.4, n),
+        "market_breadth": rng.normal(0.55, 0.15, n).clip(0.0, 1.0),
+    })
+
+
+def test_composite_returns_required_keys() -> None:
+    history = _build_history()
+    current = {f: history[f].iloc[-1] for f in DEFAULT_WEIGHTS}
+    result = compute_composite_intensity(current=current, history=history)
+    assert {"intensity_z", "per_feature_z", "features_used"} <= set(result)
+    assert isinstance(result["intensity_z"], float)
+    assert isinstance(result["per_feature_z"], dict)
+    assert isinstance(result["features_used"], list)
+
+
+def test_composite_intensity_sign_under_stress() -> None:
+    """High VIX + wide HY OAS + negative SPY return → positive intensity (risk-off)."""
+    history = _build_history()
+    current = {
+        "spy_20d_return": -0.10,    # extreme drawdown
+        "vix_level": 40.0,          # extreme stress
+        "vix_term_slope": -0.5,     # backwardation
+        "hy_oas_bps": 800.0,        # wide credit spreads
+        "yield_curve_slope": -0.5,  # inverted
+        "market_breadth": 0.20,     # narrow breadth
+    }
+    result = compute_composite_intensity(current=current, history=history)
+    assert result["intensity_z"] > 1.0, (
+        f"expected strong risk-off signal, got {result['intensity_z']}"
+    )
+
+
+def test_composite_intensity_sign_under_calm() -> None:
+    """Low VIX + tight HY OAS + positive SPY return → negative intensity (risk-on)."""
+    history = _build_history()
+    current = {
+        "spy_20d_return": 0.08,
+        "vix_level": 11.0,
+        "vix_term_slope": 1.5,
+        "hy_oas_bps": 250.0,
+        "yield_curve_slope": 1.2,
+        "market_breadth": 0.85,
+    }
+    result = compute_composite_intensity(current=current, history=history)
+    assert result["intensity_z"] < -1.0, (
+        f"expected strong risk-on signal, got {result['intensity_z']}"
+    )
+
+
+def test_composite_handles_missing_features_gracefully() -> None:
+    """Subset of features still returns a sensible composite — graceful degradation."""
+    history = _build_history()
+    current = {"vix_level": 30.0, "spy_20d_return": -0.05}
+    result = compute_composite_intensity(current=current, history=history)
+    assert set(result["features_used"]) == {"vix_level", "spy_20d_return"}
+    assert np.isfinite(result["intensity_z"])
+
+
+def test_composite_zero_when_no_history() -> None:
+    """Empty history → intensity_z falls back to 0 (no signal to extract)."""
+    history = pd.DataFrame(columns=list(DEFAULT_WEIGHTS))
+    current = {f: 1.0 for f in DEFAULT_WEIGHTS}
+    result = compute_composite_intensity(current=current, history=history)
+    assert result["intensity_z"] == 0.0
+
+
+def test_composite_per_feature_z_signs() -> None:
+    """Each per-feature z-score has the correct sign relative to history."""
+    history = _build_history()
+    # Pick a current row that's at the high end of every feature
+    current = {f: history[f].quantile(0.99) for f in DEFAULT_WEIGHTS}
+    result = compute_composite_intensity(current=current, history=history)
+    # All raw z-scores should be positive (high-end input vs historical
+    # distribution); per-feature signs are pre-weight.
+    for feat, z in result["per_feature_z"].items():
+        assert z > 0, f"expected positive z for {feat} at q99, got {z}"
+
+
+def test_composite_rolling_window_caps_history() -> None:
+    """rolling_window_weeks=N truncates history to the most recent N rows."""
+    history = _build_history(n=500)
+    current = {f: history[f].iloc[-1] for f in DEFAULT_WEIGHTS}
+    full = compute_composite_intensity(current=current, history=history)
+    windowed = compute_composite_intensity(current=current, history=history, rolling_window_weeks=52)
+    # The two intensities should differ because the normalization
+    # mean/std change with the window.
+    assert full["intensity_z"] != windowed["intensity_z"]

--- a/tests/test_regime_hmm.py
+++ b/tests/test_regime_hmm.py
@@ -1,0 +1,202 @@
+"""Tests for features/regime/hmm.py — HMM regime classifier.
+
+Covers:
+- Fit + filter inference shape + normalization invariants
+- State pinning across re-fits (bear < neutral < bull by spy_20d_return)
+- Filter vs smoother distinction (look-ahead discipline)
+- Insufficient-data guardrail
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from features.regime.hmm import (
+    HMMRegimeClassifier,
+    PIN_FEATURE,
+    REGIME_STATES,
+)
+
+
+pytest.importorskip("hmmlearn")
+
+
+def _synthetic_regime_features(
+    n_bear: int = 80,
+    n_neutral: int = 100,
+    n_bull: int = 80,
+    seed: int = 42,
+) -> pd.DataFrame:
+    """Generate a feature history with three statistically-separable
+    regimes. Emission distributions are deliberately tight so the HMM
+    has a clean shot at recovering ground truth — these tests check
+    implementation correctness, not real-market separability.
+
+    Returns a DataFrame with three feature columns + a clear regime
+    label (column ``_truth``, only used for in-test verification —
+    HMM never sees it).
+    """
+    rng = np.random.default_rng(seed)
+    bear = pd.DataFrame({
+        "spy_20d_return": rng.normal(-0.08, 0.015, n_bear),
+        "vix_level": rng.normal(38.0, 3.0, n_bear),
+        "hy_oas_bps": rng.normal(800.0, 50.0, n_bear),
+        "_truth": ["bear"] * n_bear,
+    })
+    neutral = pd.DataFrame({
+        "spy_20d_return": rng.normal(0.005, 0.010, n_neutral),
+        "vix_level": rng.normal(17.0, 2.0, n_neutral),
+        "hy_oas_bps": rng.normal(400.0, 30.0, n_neutral),
+        "_truth": ["neutral"] * n_neutral,
+    })
+    bull = pd.DataFrame({
+        "spy_20d_return": rng.normal(0.06, 0.010, n_bull),
+        "vix_level": rng.normal(11.0, 1.5, n_bull),
+        "hy_oas_bps": rng.normal(280.0, 25.0, n_bull),
+        "_truth": ["bull"] * n_bull,
+    })
+    df = pd.concat([bear, neutral, bull], ignore_index=True)
+    return df
+
+
+def test_hmm_fit_and_filter_shape() -> None:
+    df = _synthetic_regime_features()
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    hmm = HMMRegimeClassifier(n_states=3, random_state=0).fit(df, feat_cols)
+    probs = hmm.predict_proba_filter(df)
+    assert probs.shape == (len(df), 3)
+
+
+def test_hmm_filter_probabilities_sum_to_one() -> None:
+    df = _synthetic_regime_features()
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    hmm = HMMRegimeClassifier(n_states=3, random_state=0).fit(df, feat_cols)
+    probs = hmm.predict_proba_filter(df)
+    row_sums = probs.sum(axis=1)
+    np.testing.assert_allclose(row_sums, 1.0, atol=1e-6)
+
+
+def test_hmm_state_pinning_bear_lt_neutral_lt_bull() -> None:
+    """Pinned state order means bear < neutral < bull on PIN_FEATURE."""
+    df = _synthetic_regime_features()
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    hmm = HMMRegimeClassifier(n_states=3, random_state=0).fit(df, feat_cols)
+    means = hmm.pinned_state_means(df)
+    # bear < neutral < bull strictly
+    assert means[0] < means[1] < means[2], (
+        f"pinned means not monotone: {means}"
+    )
+
+
+def test_hmm_state_pinning_stable_across_seeds() -> None:
+    """Different random_state should not swap state labels — pinning
+    must produce the same (bear, neutral, bull) order even when EM
+    converges to different local optima with index-permuted states."""
+    df = _synthetic_regime_features()
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    means_by_seed = []
+    for seed in (0, 1, 7, 42):
+        hmm = HMMRegimeClassifier(n_states=3, random_state=seed).fit(df, feat_cols)
+        means = hmm.pinned_state_means(df)
+        means_by_seed.append(means)
+        assert means[0] < means[1] < means[2], f"seed={seed} pinning broke: {means}"
+
+
+def test_hmm_filter_uses_only_past_observations() -> None:
+    """The filter posterior at row t must depend only on rows 0..t.
+
+    Concretely: changing observations AFTER row t cannot affect the
+    filtered posterior at row t. This is the look-ahead-discipline
+    invariant — if it fails, we have leakage from future data.
+    """
+    df = _synthetic_regime_features()
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    hmm = HMMRegimeClassifier(n_states=3, random_state=0).fit(df, feat_cols)
+
+    cut = len(df) // 2
+    probs_full = hmm.predict_proba_filter(df)
+    probs_truncated = hmm.predict_proba_filter(df.iloc[: cut + 1])
+
+    np.testing.assert_allclose(
+        probs_full[: cut + 1],
+        probs_truncated,
+        atol=1e-9,
+        err_msg="filter posterior changed when future observations were added — leakage!",
+    )
+
+
+def test_hmm_smoother_differs_from_filter() -> None:
+    """The smoother uses future observations — its output at any
+    interior row t should differ from the filter's output at row t,
+    confirming the two are not aliases.
+
+    Uses a deliberately noisy fixture with overlapping emission
+    distributions — when regimes are perfectly separable (as in the
+    main fixture) the filter is already certain everywhere and the
+    smoother has no uncertainty to refine. Real-world macro data is
+    more like this noisy fixture than the tight main fixture.
+    """
+    rng = np.random.default_rng(7)
+    n_per = 40
+    noisy = pd.concat([
+        pd.DataFrame({
+            "spy_20d_return": rng.normal(-0.02, 0.04, n_per),
+            "vix_level": rng.normal(25.0, 6.0, n_per),
+            "hy_oas_bps": rng.normal(550.0, 100.0, n_per),
+        }),
+        pd.DataFrame({
+            "spy_20d_return": rng.normal(0.01, 0.03, n_per),
+            "vix_level": rng.normal(20.0, 5.0, n_per),
+            "hy_oas_bps": rng.normal(450.0, 80.0, n_per),
+        }),
+        pd.DataFrame({
+            "spy_20d_return": rng.normal(0.03, 0.035, n_per),
+            "vix_level": rng.normal(15.0, 4.0, n_per),
+            "hy_oas_bps": rng.normal(350.0, 70.0, n_per),
+        }),
+    ], ignore_index=True)
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    hmm = HMMRegimeClassifier(n_states=3, random_state=0).fit(noisy, feat_cols)
+    filtered = hmm.predict_proba_filter(noisy)
+    smoothed = hmm.predict_proba_smoother(noisy)
+    max_abs_diff = np.abs(filtered - smoothed).max()
+    assert max_abs_diff > 0.01, (
+        f"smoother and filter outputs are too similar (max diff {max_abs_diff}) — "
+        f"smoother implementation likely broken."
+    )
+
+
+def test_hmm_raises_on_insufficient_data() -> None:
+    df = _synthetic_regime_features(n_bear=5, n_neutral=5, n_bull=5)
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    with pytest.raises(ValueError, match="Insufficient observations"):
+        HMMRegimeClassifier(n_states=3).fit(df, feat_cols)
+
+
+def test_hmm_raises_when_pin_feature_missing() -> None:
+    """Fitting without the pin feature must fail loudly — silent
+    fallback would risk label-switching across refits."""
+    df = pd.DataFrame({
+        "vix_level": np.random.default_rng(0).normal(18.0, 5.0, 100),
+        "hy_oas_bps": np.random.default_rng(0).normal(400.0, 100.0, 100),
+    })
+    with pytest.raises(ValueError, match=PIN_FEATURE):
+        HMMRegimeClassifier(n_states=3).fit(df, ["vix_level", "hy_oas_bps"])
+
+
+def test_hmm_filter_recovers_regime_argmax_on_synthetic() -> None:
+    """On synthetic data with clear regime separation, the HMM filter's
+    argmax should largely agree with the ground-truth regime label.
+
+    This is a sanity check — not a guarantee of production accuracy.
+    Threshold (60%) is conservative; tightly-separated synthetic
+    regimes typically yield 85%+."""
+    df = _synthetic_regime_features()
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    hmm = HMMRegimeClassifier(n_states=3, random_state=0).fit(df, feat_cols)
+    probs = hmm.predict_proba_filter(df)
+    predicted = np.array([REGIME_STATES[i] for i in probs.argmax(axis=1)])
+    truth = df["_truth"].to_numpy()
+    accuracy = (predicted == truth).mean()
+    assert accuracy > 0.60, f"HMM argmax accuracy on synthetic regimes = {accuracy:.3f}"

--- a/tests/test_regime_substrate.py
+++ b/tests/test_regime_substrate.py
@@ -1,0 +1,221 @@
+"""Tests for features/regime/substrate.py — orchestrator + S3 writer.
+
+Covers:
+- End-to-end substrate assembly against a fitted HMM + synthetic history
+- Schema invariants (required keys, probability normalization, types)
+- Canonical-shape writer (run_id artifact + latest.json sidecar)
+- Round-trip read after write
+- Guardrail flag computation
+"""
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from features.regime.hmm import HMMRegimeClassifier
+from features.regime.substrate import (
+    REGIME_FEATURES,
+    SCHEMA_VERSION,
+    _compute_guardrail_flags,
+    build_regime_substrate,
+    read_regime_substrate,
+    write_regime_substrate,
+)
+
+
+pytest.importorskip("hmmlearn")
+pytest.importorskip("scipy")
+
+
+class _FakeS3:
+    """In-memory S3 stub — supports put_object + get_object only."""
+
+    def __init__(self) -> None:
+        self._objects: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, ContentType: str | None = None) -> dict:
+        self._objects[(Bucket, Key)] = Body if isinstance(Body, bytes) else Body.encode("utf-8")
+        return {}
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict:
+        if (Bucket, Key) not in self._objects:
+            raise KeyError(f"no object at {Bucket}/{Key}")
+        return {"Body": io.BytesIO(self._objects[(Bucket, Key)])}
+
+
+def _build_history(n: int = 260, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    # Two-regime synthetic history — first half calm, second half stressed.
+    # Gives the HMM enough separation to discover meaningful states.
+    halves = []
+    for i, (mean_ret, mean_vix, mean_hy) in enumerate([
+        (0.02, 14.0, 320.0),
+        (-0.02, 28.0, 600.0),
+    ]):
+        halves.append(pd.DataFrame({
+            "spy_20d_return": rng.normal(mean_ret, 0.03, n // 2),
+            "vix_level": rng.normal(mean_vix, 4.0, n // 2),
+            "vix_term_slope": rng.normal(0.8 if i == 0 else -0.3, 0.4, n // 2),
+            "hy_oas_bps": rng.normal(mean_hy, 80.0, n // 2),
+            "yield_curve_slope": rng.normal(0.4 if i == 0 else -0.2, 0.3, n // 2),
+            "market_breadth": rng.normal(0.7 if i == 0 else 0.35, 0.1, n // 2).clip(0, 1),
+        }))
+    return pd.concat(halves, ignore_index=True)
+
+
+def _build_fitted_hmm(history: pd.DataFrame) -> HMMRegimeClassifier:
+    feat_cols = ["spy_20d_return", "vix_level", "hy_oas_bps"]
+    return HMMRegimeClassifier(n_states=3, random_state=0).fit(history, feat_cols)
+
+
+def test_substrate_payload_has_required_top_level_keys() -> None:
+    history = _build_history()
+    hmm = _build_fitted_hmm(history)
+    current = {f: float(history[f].iloc[-1]) for f in REGIME_FEATURES}
+    payload = build_regime_substrate(
+        feature_history=history,
+        current_features=current,
+        hmm=hmm,
+        run_id="2605141200",
+        calendar_date="2026-05-14",
+        trading_day="2026-05-13",
+    )
+    required = {
+        "calendar_date", "trading_day", "run_id", "schema_version",
+        "hmm", "composite", "bocpd", "guardrails", "features", "model_metadata",
+    }
+    assert required <= set(payload)
+    assert payload["schema_version"] == SCHEMA_VERSION
+
+
+def test_substrate_hmm_probs_sum_to_one() -> None:
+    history = _build_history()
+    hmm = _build_fitted_hmm(history)
+    current = {f: float(history[f].iloc[-1]) for f in REGIME_FEATURES}
+    payload = build_regime_substrate(
+        feature_history=history, current_features=current, hmm=hmm,
+    )
+    probs = payload["hmm"]["probs"]
+    assert {"bear", "neutral", "bull"} == set(probs.keys())
+    assert sum(probs.values()) == pytest.approx(1.0, abs=1e-6)
+    assert payload["hmm"]["argmax"] in {"bear", "neutral", "bull"}
+
+
+def test_substrate_composite_intensity_inverted_to_risk_on_orientation() -> None:
+    """Composite module returns positive=risk-off; substrate orchestrator
+    must invert to positive=risk-on for the downstream contract."""
+    history = _build_history()
+    hmm = _build_fitted_hmm(history)
+    # Stressed-regime current row → composite intensity_z should be NEGATIVE
+    # in substrate output (orientation: positive=risk-on, negative=risk-off).
+    stressed = {
+        "spy_20d_return": -0.10,
+        "vix_level": 40.0,
+        "vix_term_slope": -0.6,
+        "hy_oas_bps": 850.0,
+        "yield_curve_slope": -0.6,
+        "market_breadth": 0.20,
+    }
+    payload = build_regime_substrate(
+        feature_history=history, current_features=stressed, hmm=hmm,
+    )
+    assert payload["composite"]["intensity_z"] < -0.5, (
+        f"stressed input should yield negative (risk-off) intensity in substrate output; "
+        f"got {payload['composite']['intensity_z']}"
+    )
+
+
+def test_substrate_guardrail_flags_severity_floor_under_stress() -> None:
+    """High VIX + negative SPY 30d return → guardrail forces at least 'bear'."""
+    stressed = {
+        "spy_20d_return": -0.10,
+        "spy_30d_return": -0.15,  # -15% in 30d
+        "vix_level": 35.0,
+        "hy_oas_bps": 850.0,
+    }
+    flags = _compute_guardrail_flags(stressed)
+    assert flags["vix_bear_breached"] is True
+    assert flags["spy_30d_bear_breached"] is True
+    assert flags["active_severity_floor"] == "bear"
+
+
+def test_substrate_guardrail_flags_no_floor_under_calm() -> None:
+    calm = {
+        "spy_20d_return": 0.03,
+        "spy_30d_return": 0.05,
+        "vix_level": 12.0,
+        "hy_oas_bps": 280.0,
+    }
+    flags = _compute_guardrail_flags(calm)
+    assert flags["vix_bear_breached"] is False
+    assert flags["spy_30d_bear_breached"] is False
+    assert flags["active_severity_floor"] is None
+
+
+def test_substrate_writer_publishes_dated_artifact_and_latest_sidecar() -> None:
+    history = _build_history()
+    hmm = _build_fitted_hmm(history)
+    current = {f: float(history[f].iloc[-1]) for f in REGIME_FEATURES}
+    payload = build_regime_substrate(
+        feature_history=history, current_features=current, hmm=hmm,
+        run_id="2605141200", calendar_date="2026-05-14", trading_day="2026-05-13",
+    )
+    s3 = _FakeS3()
+    keys = write_regime_substrate(payload, s3_client=s3, bucket="test-bucket", prefix="regime")
+    assert keys["artifact_key"] == "regime/2605141200.json"
+    assert keys["latest_key"] == "regime/latest.json"
+    # Round-trip: read back via consumer API
+    read_back = read_regime_substrate(s3_client=s3, bucket="test-bucket", prefix="regime")
+    assert read_back is not None
+    assert read_back["run_id"] == "2605141200"
+    assert read_back["hmm"]["argmax"] in {"bear", "neutral", "bull"}
+
+
+def test_substrate_read_returns_none_when_no_artifact() -> None:
+    s3 = _FakeS3()
+    assert read_regime_substrate(s3_client=s3, bucket="empty", prefix="regime") is None
+
+
+def test_substrate_features_block_contains_inputs() -> None:
+    history = _build_history()
+    hmm = _build_fitted_hmm(history)
+    current = {f: float(history[f].iloc[-1]) for f in REGIME_FEATURES}
+    payload = build_regime_substrate(
+        feature_history=history, current_features=current, hmm=hmm,
+    )
+    # Every REGIME_FEATURE that was in `current` should round-trip
+    # through the features block for forensic replay.
+    for feat in REGIME_FEATURES:
+        assert feat in payload["features"]
+        assert payload["features"][feat] == pytest.approx(current[feat])
+
+
+def test_substrate_writer_does_not_call_hmm_smoother() -> None:
+    """Look-ahead discipline: the substrate orchestrator must NEVER
+    invoke ``predict_proba_smoother``. The smoother is reserved for
+    retrospective T1 ground-truth labeling.
+
+    We pin the contract by monkey-patching the smoother to raise — if
+    the orchestrator calls it, the test fails loudly.
+    """
+    history = _build_history()
+    hmm = _build_fitted_hmm(history)
+
+    def _forbidden(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError(
+            "substrate orchestrator called predict_proba_smoother — "
+            "look-ahead discipline violated! Smoother is for retrospective use only."
+        )
+
+    hmm.predict_proba_smoother = _forbidden  # type: ignore[method-assign]
+    current = {f: float(history[f].iloc[-1]) for f in REGIME_FEATURES}
+    # Should succeed — orchestrator uses filter only.
+    payload = build_regime_substrate(
+        feature_history=history, current_features=current, hmm=hmm,
+    )
+    assert "hmm" in payload


### PR DESCRIPTION
## Summary

Ships the **quantitative regime substrate** computation modules per [`regime-v3-260514.md`](../alpha-engine-docs/private/regime-v3-260514.md) Stage A. Observe-only at this stage — no Lambda, no SF wiring, no downstream consumers. Foundation for the macro economist (Stage C) to consume `regime_substrate.json` as a strong prior; the macro agent remains the final regime authority.

### Modules (`features/regime/`)

- **`hmm.py`** — 3-state Gaussian HMM (`hmmlearn`). Hamilton-Kim **filter-only** inference at production. Forward-backward smoother is a separate named method, **reserved for retrospective T1 ground-truth labeling** per the three-tier eval framework. State pinning by mean `spy_20d_return` keeps (bear, neutral, bull) ordering stable across weekly refits.
- **`composite.py`** — AQR-style risk-on/risk-off z-score intensity. Equal-weight default, 260-week (5y) rolling-window normalization. Zero estimation risk — always-available fallback if HMM is unfit.
- **`bocpd.py`** — Adams & MacKay 2007 Bayesian online change-point detection. Hand-rolled (no package dep) using `scipy.stats.t` for the Normal-Inverse-Gamma conjugate predictive. Tail collapse bounds memory at 520 weeks (~10y).
- **`substrate.py`** — orchestrator + canonical-shape writer. Assembles HMM/composite/BOCPD/guardrail blocks into the substrate JSON and publishes via `alpha_engine_lib.eval_artifacts` shape (YYMMDDHHMM run_id + `latest.json` sidecar). Composite `intensity_z` inverted at the substrate boundary so downstream sees positive=risk-on.

### Tests (+32 new, suite 998 → 1030, all passing)

- HMM filter-vs-smoother divergence pinned as a look-ahead regression
- State pinning stable across `(0, 1, 7, 42)` random_state seeds
- Filter posterior at row `t` unaffected by future observations
- Substrate orchestrator pinned to **never** call smoother (monkeypatched to raise)
- Round-trip read-after-write via canonical sidecar resolution
- BOCPD detects step-change + no false alarms post-warm-up
- Guardrail severity floor under stress + null under calm

### Why this is observe-only

No production behavior changes. No SF state insertion. No consumer wiring. The artifact is not yet written to S3 because the Lambda + SF wiring lands in Stage A PR 2.

## Follow-ups

- **PR 2** — Lambda handler + SF state insertion (`RegimeSubstrate` between RAGIngestion and Research)
- **PR 3** — Dashboard observability tab (HMM probs + intensity_z + change_signal over time)
- **PR 4** — Historical backfill script (10y of weekly substrate artifacts for backtester replay)
- **Stage B** — Serialize macro upstream of sector teams (independent of Stage A; alpha-engine-research)
- **Stage C** — Macro agent consumes substrate as ReAct prior + new `regime_decision_process` rubric dim
- **Stage D** — Predictor L2 `META_FEATURES` consumes `intensity_z`
- **Stage D′** — 5 regime-as-gate wires (sector 0-picks / sizing / drawdown / veto / entry threshold)

## Test plan

- [x] All 1030 tests pass (`pytest --ignore=tests/integration`)
- [x] No new failing tests; no existing tests modified
- [x] `hmmlearn>=0.3` and `scipy>=1.11` added to `requirements.txt`
- [x] Look-ahead discipline pinned by regression test (filter posterior at `t` doesn't change when future observations added)
- [x] Canonical eval_artifacts partition shape (YYMMDDHHMM + `latest.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)