### PR TITLE
feat(regime): Stage A PR 2b — Saturday SF state insertion (RegimeSubstrate)

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -13,7 +13,8 @@
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check*"
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate*"
             ]
         },
         {

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -126,14 +126,14 @@
 
     "CheckSkipRAGIngestion": {
       "Type": "Choice",
-      "Comment": "Skip-gate. Input like {\"skip_rag_ingestion\": true} routes past RAG ingestion directly to CheckSkipResearch. Missing flag = run as normal. Useful when DataPhase1 ran fresh but the RAG corpus is already current.",
+      "Comment": "Skip-gate. Input like {\"skip_rag_ingestion\": true} routes past RAG ingestion directly to CheckSkipRegimeSubstrate. Missing flag = run as normal. Useful when DataPhase1 ran fresh but the RAG corpus is already current.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_rag_ingestion", "IsPresent": true},
             {"Variable": "$.skip_rag_ingestion", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipResearch"
+          "Next": "CheckSkipRegimeSubstrate"
         }
       ],
       "Default": "RAGIngestion"
@@ -212,7 +212,7 @@
         {
           "Variable": "$.rag_ingestion_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipResearch"
+          "Next": "CheckSkipRegimeSubstrate"
         },
         {
           "Variable": "$.rag_ingestion_poll.Status",
@@ -232,6 +232,51 @@
       "Type": "Wait",
       "Seconds": 30,
       "Next": "WaitForRAGIngestion"
+    },
+
+    "CheckSkipRegimeSubstrate": {
+      "Type": "Choice",
+      "Comment": "Skip-gate. {\"skip_regime_substrate\": true} bypasses the regime substrate Lambda and jumps to CheckSkipResearch. Independent of skip_research — operators can skip the HMM refit while still running research (or vice versa).",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_regime_substrate", "IsPresent": true},
+            {"Variable": "$.skip_regime_substrate", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipResearch"
+        }
+      ],
+      "Default": "RegimeSubstrate"
+    },
+
+    "RegimeSubstrate": {
+      "Type": "Task",
+      "Comment": "Regime substrate Lambda — fits a weekly 3-state HMM + composite z-score + BOCPD on macro feature history (FRED-sourced VIX/HYOAS/TNX/TWO + SPY), writes s3://alpha-engine-research/regime/{YYMMDDHHMM}.json + latest.json sidecar. The macro economist agent (Stage C) will consume this as a strong prior; macro agent remains the final regime authority. Observe-only at this stage — no production consumer reads the artifact yet. Failure is non-blocking (Catch routes to CheckSkipResearch, not HandleFailure) per the Stage A observe-only contract — a regime substrate failure during the 4-week observation period must not halt Research.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-regime-substrate:live",
+        "Payload": {
+          "action": "produce"
+        }
+      },
+      "TimeoutSeconds": 360,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "CheckSkipResearch",
+          "ResultPath": "$.regime_substrate_error"
+        }
+      ],
+      "ResultPath": "$.regime_substrate_result",
+      "Next": "CheckSkipResearch"
     },
 
     "CheckSkipResearch": {

--- a/tests/test_sf_regime_substrate_wiring.py
+++ b/tests/test_sf_regime_substrate_wiring.py
@@ -1,0 +1,132 @@
+"""tests/test_sf_regime_substrate_wiring.py — pin the Saturday SF wiring
+for the RegimeSubstrate state.
+
+The regime substrate Lambda lives in alpha-engine-predictor; the SF
+state that invokes it lives here. This test verifies the wiring
+contract between the two so silent drift (e.g. a refactor renames the
+Lambda or removes the state) breaks CI rather than the next Saturday SF.
+
+Five invariants:
+
+1. ``RegimeSubstrate`` state exists and is a Task that invokes
+   ``alpha-engine-predictor-regime-substrate:live``.
+2. ``CheckSkipRegimeSubstrate`` state exists and routes to either
+   ``RegimeSubstrate`` (default) or ``CheckSkipResearch`` (when
+   ``skip_regime_substrate: true``).
+3. The post-RAG control flow lands on ``CheckSkipRegimeSubstrate``,
+   not on ``CheckSkipResearch`` directly. Two routes: the
+   ``CheckSkipRAGIngestion`` skip path AND the
+   ``CheckRAGIngestionStatus`` success path.
+4. ``RegimeSubstrate``'s Catch routes to ``CheckSkipResearch``, not
+   ``HandleFailure`` — pins the Stage A observe-only contract that a
+   regime failure must not halt Research.
+5. ``RegimeSubstrate`` payload is ``{"action": "produce"}`` —
+   handler-side ``dry_run`` mode would not write the substrate
+   artifact, so the SF must always invoke ``produce``.
+
+The general SF IAM grants test (``test_sf_iam_lambda_grants.py``)
+covers that the SF role can invoke the regime Lambda; not duplicated
+here.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SF_PATH = REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+def _sf() -> dict:
+    return json.loads(SF_PATH.read_text())
+
+
+def test_regime_substrate_state_exists() -> None:
+    sf = _sf()
+    assert "RegimeSubstrate" in sf["States"], (
+        "Saturday SF must contain a RegimeSubstrate state — Stage A "
+        "ships the substrate Lambda invocation between RAG and Research."
+    )
+    state = sf["States"]["RegimeSubstrate"]
+    assert state["Type"] == "Task"
+    assert state["Resource"] == "arn:aws:states:::lambda:invoke"
+    assert state["Parameters"]["FunctionName"] == "alpha-engine-predictor-regime-substrate:live"
+
+
+def test_regime_substrate_payload_is_produce_action() -> None:
+    """Handler-side ``dry_run`` mode returns the payload without writing
+    to S3. Production SF must always call ``produce`` so the artifact
+    actually lands; pin to catch a misguided debugging change."""
+    sf = _sf()
+    payload = sf["States"]["RegimeSubstrate"]["Parameters"]["Payload"]
+    assert payload.get("action") == "produce", (
+        f"RegimeSubstrate payload must be action=produce; got {payload!r}"
+    )
+
+
+def test_check_skip_regime_substrate_routes_correctly() -> None:
+    sf = _sf()
+    assert "CheckSkipRegimeSubstrate" in sf["States"]
+    state = sf["States"]["CheckSkipRegimeSubstrate"]
+    assert state["Type"] == "Choice"
+    assert state["Default"] == "RegimeSubstrate"
+    skip_choice = state["Choices"][0]
+    skip_vars = skip_choice["And"]
+    assert any(c.get("Variable") == "$.skip_regime_substrate" for c in skip_vars)
+    assert skip_choice["Next"] == "CheckSkipResearch"
+
+
+def test_post_rag_control_flow_lands_on_regime_skip_gate() -> None:
+    """Both post-RAG routes must point at CheckSkipRegimeSubstrate, not
+    CheckSkipResearch directly. Catches a refactor that bypasses the
+    regime state."""
+    sf = _sf()
+    # CheckSkipRAGIngestion's skip-branch
+    skip_choice = sf["States"]["CheckSkipRAGIngestion"]["Choices"][0]
+    assert skip_choice["Next"] == "CheckSkipRegimeSubstrate", (
+        "CheckSkipRAGIngestion skip path must land on CheckSkipRegimeSubstrate"
+    )
+    # CheckRAGIngestionStatus's success branch
+    success_choice = next(
+        c for c in sf["States"]["CheckRAGIngestionStatus"]["Choices"]
+        if c.get("StringEquals") == "Success"
+    )
+    assert success_choice["Next"] == "CheckSkipRegimeSubstrate", (
+        "CheckRAGIngestionStatus success path must land on CheckSkipRegimeSubstrate"
+    )
+
+
+def test_regime_substrate_failure_is_non_blocking() -> None:
+    """Stage A observe-only contract: RegimeSubstrate failure must NOT
+    halt the pipeline. The Catch[States.ALL] routes to CheckSkipResearch
+    (not HandleFailure) so Research still runs and the next Saturday
+    has another chance to fit the HMM."""
+    sf = _sf()
+    catches = sf["States"]["RegimeSubstrate"]["Catch"]
+    states_all = next(c for c in catches if c["ErrorEquals"] == ["States.ALL"])
+    assert states_all["Next"] == "CheckSkipResearch", (
+        "RegimeSubstrate Catch[States.ALL] must route to CheckSkipResearch "
+        "(non-blocking), not HandleFailure (blocking). Stage A is observe-only; "
+        "a regime substrate failure during the 4-week observation period must "
+        "not halt Research."
+    )
+
+
+def test_regime_substrate_next_is_check_skip_research() -> None:
+    """Success path also lands on CheckSkipResearch — substrate is
+    observe-only at Stage A, so it's parallel to research, not gating."""
+    sf = _sf()
+    assert sf["States"]["RegimeSubstrate"]["Next"] == "CheckSkipResearch"
+
+
+def test_regime_substrate_timeout_is_reasonable() -> None:
+    """Lambda timeout is 300s (per setup-regime-lambda.sh); SF
+    TimeoutSeconds must be slightly higher to avoid premature
+    timeout-due-to-SF when the Lambda is still working."""
+    sf = _sf()
+    sf_timeout = sf["States"]["RegimeSubstrate"]["TimeoutSeconds"]
+    assert sf_timeout >= 300, (
+        f"SF TimeoutSeconds for RegimeSubstrate must be >= Lambda timeout "
+        f"(300s per setup-regime-lambda.sh); got {sf_timeout}"
+    )


### PR DESCRIPTION
## Summary

Wires the predictor-side regime Lambda ([alpha-engine-predictor #156](https://github.com/cipher813/alpha-engine-predictor/pull/156)) into the Saturday SF as a new state between RAGIngestion and Research. **Completes Stage A end-to-end**: weekly Saturday SF runs will now produce a `regime_substrate.json` artifact at `s3://alpha-engine-research/regime/{YYMMDDHHMM}.json` + `latest.json` sidecar.

**Still observe-only** — no downstream consumer reads the artifact yet (Stage C wires the macro economist agent to consume it).

### Changes

**`infrastructure/step_function.json`**
- New `CheckSkipRegimeSubstrate` Choice state — `skip_regime_substrate: true` opts out (independent of `skip_research` so operators can skip the HMM refit while still running research)
- New `RegimeSubstrate` Task state invoking `alpha-engine-predictor-regime-substrate:live` with `{"action": "produce"}`. TimeoutSeconds 360 (Lambda timeout 300s + 60s headroom)
- **`Catch[States.ALL]` routes to `CheckSkipResearch`, NOT `HandleFailure`.** Stage A is observe-only — a regime substrate failure during the 4-week observation window must not halt Research. Pinned by regression test.
- Both post-RAG control-flow routes (`CheckSkipRAGIngestion` skip branch + `CheckRAGIngestionStatus` success branch) updated to land on `CheckSkipRegimeSubstrate`

**`infrastructure/iam/alpha-engine-step-functions-role.json`**
- Add `alpha-engine-predictor-regime-substrate*` to `lambda:InvokeFunction` Resource list. Without this grant, the SF would hit `AWSLambdaException.AccessDenied` on the regime state — exactly the 2026-05-07 asymmetric-IAM-grant antipattern that `test_sf_iam_lambda_grants.py` is designed to catch. **That test passes** with the new grant in place.

### Tests (+7 new, suite 998 → 1005, all passing)

- `RegimeSubstrate` state exists, is a Task, invokes the right Lambda with `action=produce`
- `CheckSkipRegimeSubstrate` defaults to `RegimeSubstrate`, skip-flag routes to `CheckSkipResearch`
- Post-RAG control flow lands on regime skip-gate, not research skip-gate (catches refactors that bypass the new state)
- `Catch[States.ALL]` non-blocking — pins the Stage A observe-only contract
- Success `Next` is `CheckSkipResearch` (parallel to research, not gating)
- SF `TimeoutSeconds` ≥ Lambda timeout

The general SF↔IAM symmetry test (`test_sf_iam_lambda_grants.py`) covers the IAM grant; not duplicated in the new regime-specific file.

## Operator deploy sequence (after this PR merges)

1. **alpha-engine-predictor PR 156** must already be merged + deployed (image with `regime/` inside is in ECR `:latest`). ✅ done
2. **Run `bash infrastructure/setup-regime-lambda.sh` once** in alpha-engine-predictor — creates the Lambda function. Idempotent.
3. Merge this PR.
4. **Run `bash infrastructure/deploy_step_function.sh`** in alpha-engine-data to push the SF update.
5. **Run `bash infrastructure/iam/apply.sh`** to push the IAM update for the SF execution role.
6. Next Saturday SF (or ad-hoc execution) exercises the new state. **Failure is non-blocking**; verify by checking `s3://alpha-engine-research/regime/latest.json` afterwards.

## Follow-ups

- **alpha-engine-dashboard** — Observability tab (HMM probs + intensity_z + change_signal over time)
- **alpha-engine-predictor** — Historical backfill script (10y of weekly substrate artifacts for backtester replay)
- **alpha-engine-data** — Source `market_breadth` historical series so the 6th feature joins the HMM input set
- **Stages B / C / D / D′** — graph restructure, macro-agent integration, predictor L2 feature, regime-as-gate wires

## Test plan

- [x] All 1005 tests pass (`pytest --ignore=tests/integration`)
- [x] `infrastructure/step_function.json` is valid JSON
- [x] `test_sf_iam_lambda_grants.py` passes (SF→IAM symmetry preserved)
- [x] 7 new wiring regression tests cover state existence, payload, control flow, non-blocking failure, timeout
- [x] No production behavior changes until operator runs deploy_step_function.sh + iam/apply.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)