### PR TITLE
feat(sf): insert RegimeRetrospectiveEval state into Saturday SF (T1 wiring)

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -14,7 +14,8 @@
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate*"
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval*"
             ]
         },
         {

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -236,14 +236,14 @@
 
     "CheckSkipRegimeSubstrate": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_regime_substrate\": true} bypasses the regime substrate Lambda and jumps to CheckSkipResearch. Independent of skip_research — operators can skip the HMM refit while still running research (or vice versa).",
+      "Comment": "Skip-gate. {\"skip_regime_substrate\": true} bypasses the regime substrate Lambda and jumps to CheckSkipRegimeRetrospectiveEval (which independently honors its own skip flag). Independent of skip_research — operators can skip the HMM refit while still running research (or vice versa).",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_regime_substrate", "IsPresent": true},
             {"Variable": "$.skip_regime_substrate", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipResearch"
+          "Next": "CheckSkipRegimeRetrospectiveEval"
         }
       ],
       "Default": "RegimeSubstrate"
@@ -251,7 +251,7 @@
 
     "RegimeSubstrate": {
       "Type": "Task",
-      "Comment": "Regime substrate Lambda — fits a weekly 3-state HMM + composite z-score + BOCPD on macro feature history (FRED-sourced VIX/HYOAS/TNX/TWO + SPY), writes s3://alpha-engine-research/regime/{YYMMDDHHMM}.json + latest.json sidecar. The macro economist agent (Stage C) will consume this as a strong prior; macro agent remains the final regime authority. Observe-only at this stage — no production consumer reads the artifact yet. Failure is non-blocking (Catch routes to CheckSkipResearch, not HandleFailure) per the Stage A observe-only contract — a regime substrate failure during the 4-week observation period must not halt Research.",
+      "Comment": "Regime substrate Lambda — fits a weekly 3-state HMM + composite z-score + BOCPD on macro feature history (FRED-sourced VIX/HYOAS/TNX/TWO + SPY), writes s3://alpha-engine-research/regime/{YYMMDDHHMM}.json + latest.json sidecar. The macro economist agent (Stage C) will consume this as a strong prior; macro agent remains the final regime authority. Observe-only at this stage — no production consumer reads the artifact yet. Failure is non-blocking (Catch routes to CheckSkipRegimeRetrospectiveEval, not HandleFailure) per the Stage A observe-only contract — a regime substrate failure during the 4-week observation period must not halt Research.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-regime-substrate:live",
@@ -271,11 +271,56 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "CheckSkipResearch",
+          "Next": "CheckSkipRegimeRetrospectiveEval",
           "ResultPath": "$.regime_substrate_error"
         }
       ],
       "ResultPath": "$.regime_substrate_result",
+      "Next": "CheckSkipRegimeRetrospectiveEval"
+    },
+
+    "CheckSkipRegimeRetrospectiveEval": {
+      "Type": "Choice",
+      "Comment": "Skip-gate. {\"skip_regime_retrospective_eval\": true} bypasses the T1 retrospective HMM smoothing eval and jumps to CheckSkipResearch. Independent of skip_regime_substrate — operator can run substrate without eval (or vice versa during ad-hoc replays).",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_regime_retrospective_eval", "IsPresent": true},
+            {"Variable": "$.skip_regime_retrospective_eval", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipResearch"
+        }
+      ],
+      "Default": "RegimeRetrospectiveEval"
+    },
+
+    "RegimeRetrospectiveEval": {
+      "Type": "Task",
+      "Comment": "Stage C.2 T1 retrospective HMM smoothing eval — pairs the macro agent's historical regime calls against the HMM forward-backward smoother's labels (8-week lag, asymmetric loss penalizing bear-misses 2×). Writes s3://alpha-engine-research/regime/retrospective/{YYMMDDHHMM}.json + latest.json sidecar carrying n_pairings + rolling 26-week agreement rate. Observe-only — feeds the dashboard's Regime page, does NOT gate anything. Failure is non-blocking (Catch routes to CheckSkipResearch) — a retrospective-eval failure must not halt Research. Returns n_pairings=0 cleanly during the cold-start window (~8 weeks after substrate Lambda starts running).",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-regime-retrospective-eval:live",
+        "Payload": {
+          "action": "produce"
+        }
+      },
+      "TimeoutSeconds": 660,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "CheckSkipResearch",
+          "ResultPath": "$.regime_retrospective_eval_error"
+        }
+      ],
+      "ResultPath": "$.regime_retrospective_eval_result",
       "Next": "CheckSkipResearch"
     },
 

--- a/tests/test_sf_regime_substrate_wiring.py
+++ b/tests/test_sf_regime_substrate_wiring.py
@@ -66,6 +66,10 @@ def test_regime_substrate_payload_is_produce_action() -> None:
 
 
 def test_check_skip_regime_substrate_routes_correctly() -> None:
+    """Skip path lands on CheckSkipRegimeRetrospectiveEval (not directly
+    on CheckSkipResearch) so the T1 eval still gets its own independent
+    skip-gate evaluation. Honors the "each regime step has its own
+    skip flag" invariant introduced with T1 wiring."""
     sf = _sf()
     assert "CheckSkipRegimeSubstrate" in sf["States"]
     state = sf["States"]["CheckSkipRegimeSubstrate"]
@@ -74,7 +78,7 @@ def test_check_skip_regime_substrate_routes_correctly() -> None:
     skip_choice = state["Choices"][0]
     skip_vars = skip_choice["And"]
     assert any(c.get("Variable") == "$.skip_regime_substrate" for c in skip_vars)
-    assert skip_choice["Next"] == "CheckSkipResearch"
+    assert skip_choice["Next"] == "CheckSkipRegimeRetrospectiveEval"
 
 
 def test_post_rag_control_flow_lands_on_regime_skip_gate() -> None:
@@ -99,25 +103,27 @@ def test_post_rag_control_flow_lands_on_regime_skip_gate() -> None:
 
 def test_regime_substrate_failure_is_non_blocking() -> None:
     """Stage A observe-only contract: RegimeSubstrate failure must NOT
-    halt the pipeline. The Catch[States.ALL] routes to CheckSkipResearch
-    (not HandleFailure) so Research still runs and the next Saturday
-    has another chance to fit the HMM."""
+    halt the pipeline. The Catch[States.ALL] routes to
+    CheckSkipRegimeRetrospectiveEval (not HandleFailure) so the T1 eval
+    + Research still get a chance to run."""
     sf = _sf()
     catches = sf["States"]["RegimeSubstrate"]["Catch"]
     states_all = next(c for c in catches if c["ErrorEquals"] == ["States.ALL"])
-    assert states_all["Next"] == "CheckSkipResearch", (
-        "RegimeSubstrate Catch[States.ALL] must route to CheckSkipResearch "
-        "(non-blocking), not HandleFailure (blocking). Stage A is observe-only; "
-        "a regime substrate failure during the 4-week observation period must "
-        "not halt Research."
+    assert states_all["Next"] == "CheckSkipRegimeRetrospectiveEval", (
+        "RegimeSubstrate Catch[States.ALL] must route to "
+        "CheckSkipRegimeRetrospectiveEval (non-blocking), not HandleFailure "
+        "(blocking). Stage A is observe-only; a regime substrate failure "
+        "during the 4-week observation period must not halt downstream."
     )
 
 
-def test_regime_substrate_next_is_check_skip_research() -> None:
-    """Success path also lands on CheckSkipResearch — substrate is
-    observe-only at Stage A, so it's parallel to research, not gating."""
+def test_regime_substrate_next_is_eval_skip_gate() -> None:
+    """Success path lands on CheckSkipRegimeRetrospectiveEval so the
+    T1 eval gets a chance to run (it independently honors its own
+    skip flag). Substrate + eval are sibling observe-only steps,
+    neither gates the other."""
     sf = _sf()
-    assert sf["States"]["RegimeSubstrate"]["Next"] == "CheckSkipResearch"
+    assert sf["States"]["RegimeSubstrate"]["Next"] == "CheckSkipRegimeRetrospectiveEval"
 
 
 def test_regime_substrate_timeout_is_reasonable() -> None:
@@ -129,4 +135,83 @@ def test_regime_substrate_timeout_is_reasonable() -> None:
     assert sf_timeout >= 300, (
         f"SF TimeoutSeconds for RegimeSubstrate must be >= Lambda timeout "
         f"(300s per setup-regime-lambda.sh); got {sf_timeout}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# T1 retrospective eval state — Stage C.2 T1 wiring (regime-v3 §5.3.3)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_regime_retrospective_eval_state_exists() -> None:
+    sf = _sf()
+    assert "RegimeRetrospectiveEval" in sf["States"], (
+        "Saturday SF must contain a RegimeRetrospectiveEval state — "
+        "Stage C.2 T1 wiring (regime-v3 §5.3.3)."
+    )
+    state = sf["States"]["RegimeRetrospectiveEval"]
+    assert state["Type"] == "Task"
+    assert state["Resource"] == "arn:aws:states:::lambda:invoke"
+    assert state["Parameters"]["FunctionName"] == (
+        "alpha-engine-predictor-regime-retrospective-eval:live"
+    )
+
+
+def test_regime_retrospective_eval_payload_is_produce_action() -> None:
+    """Handler-side dry_run does NOT write the artifact; production
+    SF must always invoke produce so the eval artifact lands in S3."""
+    sf = _sf()
+    payload = sf["States"]["RegimeRetrospectiveEval"]["Parameters"]["Payload"]
+    assert payload.get("action") == "produce", (
+        f"RegimeRetrospectiveEval payload must be action=produce; got {payload!r}"
+    )
+
+
+def test_check_skip_regime_retrospective_eval_routes_correctly() -> None:
+    """{\"skip_regime_retrospective_eval\": true} bypasses to
+    CheckSkipResearch. Independent of skip_regime_substrate so each
+    regime step has its own skip flag."""
+    sf = _sf()
+    assert "CheckSkipRegimeRetrospectiveEval" in sf["States"]
+    state = sf["States"]["CheckSkipRegimeRetrospectiveEval"]
+    assert state["Type"] == "Choice"
+    assert state["Default"] == "RegimeRetrospectiveEval"
+    skip_choice = state["Choices"][0]
+    skip_vars = skip_choice["And"]
+    assert any(
+        c.get("Variable") == "$.skip_regime_retrospective_eval"
+        for c in skip_vars
+    )
+    assert skip_choice["Next"] == "CheckSkipResearch"
+
+
+def test_regime_retrospective_eval_failure_is_non_blocking() -> None:
+    """Observe-only contract: a T1 eval failure must NOT halt the
+    pipeline. The Catch[States.ALL] routes to CheckSkipResearch
+    (not HandleFailure) — T1 is observability, not gating."""
+    sf = _sf()
+    catches = sf["States"]["RegimeRetrospectiveEval"]["Catch"]
+    states_all = next(c for c in catches if c["ErrorEquals"] == ["States.ALL"])
+    assert states_all["Next"] == "CheckSkipResearch", (
+        "RegimeRetrospectiveEval Catch[States.ALL] must route to "
+        "CheckSkipResearch (non-blocking), not HandleFailure (blocking). "
+        "T1 is observability; a failure must not halt Research."
+    )
+
+
+def test_regime_retrospective_eval_next_is_check_skip_research() -> None:
+    sf = _sf()
+    assert sf["States"]["RegimeRetrospectiveEval"]["Next"] == "CheckSkipResearch"
+
+
+def test_regime_retrospective_eval_timeout_accommodates_smoother_fit() -> None:
+    """Lambda timeout is 600s (per setup-regime-retrospective-eval-lambda.sh)
+    — smoother fit + signals/ archive enumeration is heavier than substrate
+    fit. SF TimeoutSeconds must be slightly above the Lambda's own timeout."""
+    sf = _sf()
+    sf_timeout = sf["States"]["RegimeRetrospectiveEval"]["TimeoutSeconds"]
+    assert sf_timeout >= 600, (
+        f"SF TimeoutSeconds for RegimeRetrospectiveEval must be >= Lambda "
+        f"timeout (600s per setup-regime-retrospective-eval-lambda.sh); "
+        f"got {sf_timeout}"
     )


### PR DESCRIPTION
## Summary

Closes the Saturday SF wiring side of **Stage C.2 T1** per [`regime-v3-260514.md`](../alpha-engine-docs/private/regime-v3-260514.md) §5.3.3. The T1 Lambda shipped in [alpha-engine-predictor PR #161](https://github.com/cipher813/alpha-engine-predictor/pull/161); this PR inserts the SF state that invokes it weekly + extends the SF IAM role with the new `lambda:InvokeFunction` grant.

## Topology

**Before:**
```
RegimeSubstrate → CheckSkipResearch
```

**After:**
```
RegimeSubstrate
  → CheckSkipRegimeRetrospectiveEval
    → RegimeRetrospectiveEval
      → CheckSkipResearch
```

The eval runs sequentially after substrate (sharing the same weekly cadence + the same macro feature source), but with its own independent skip flag so operators can run substrate without eval (or vice versa during ad-hoc replays).

## Observe-only contract preserved

- `RegimeRetrospectiveEval` `Catch[States.ALL]` → `CheckSkipResearch` (**NOT** `HandleFailure`). T1 is observability, not gating; a failure must not halt Research. Same non-blocking contract as Stage A's `RegimeSubstrate`.
- All success + skip paths converge on `CheckSkipResearch`.

## Skip-flag taxonomy (independent per regime step)

| Flag | Effect |
|---|---|
| `{"skip_regime_substrate": true}` | bypasses substrate; **eval still runs** if not also skipped |
| `{"skip_regime_retrospective_eval": true}` | bypasses T1 eval; substrate still runs if not skipped |
| `{"skip_research": true}` | bypasses Research (existing) |

Missing flag = run as normal. Each regime step has its own skip path so operator picks granularity.

## Files

| File | Change |
|---|---|
| `infrastructure/step_function.json` | New `CheckSkipRegimeRetrospectiveEval` + `RegimeRetrospectiveEval` states; `RegimeSubstrate.Next` + `Catch.Next` re-routed through the new gate; `CheckSkipRegimeSubstrate` skip path re-targeted |
| `infrastructure/iam/alpha-engine-step-functions-role.json` | `lambda:InvokeFunction` resource list extended with `alpha-engine-predictor-regime-retrospective-eval*` |
| `tests/test_sf_regime_substrate_wiring.py` | +6 new tests for the T1 state contracts; 2 existing tests updated for the retargeted RegimeSubstrate routes |

## Timeouts

`RegimeRetrospectiveEval` SF `TimeoutSeconds=660` to accommodate the Lambda's 600s timeout (smoother fit + `signals/` archive enumeration is heavier than substrate fit). Pinned by `test_regime_retrospective_eval_timeout_accommodates_smoother_fit`.

## Tests (+6 new, +2 updated, 1031 total passing)

**New (T1 state contracts):**
- `RegimeRetrospectiveEval` state exists + invokes the right Lambda
- Payload is `action=produce` (dry_run would skip the S3 write)
- `CheckSkipRegimeRetrospectiveEval` routes correctly
- `Catch[States.ALL]` → `CheckSkipResearch` (non-blocking)
- `Next` → `CheckSkipResearch`
- `TimeoutSeconds ≥ 600` (matches Lambda timeout)

**Updated (RegimeSubstrate's Next/Catch/skip path retargeted):**
- `test_check_skip_regime_substrate_routes_correctly`: skip path now goes to `CheckSkipRegimeRetrospectiveEval`, not `CheckSkipResearch`
- `test_regime_substrate_failure_is_non_blocking`: Catch.Next is now `CheckSkipRegimeRetrospectiveEval` (still non-blocking — same semantic, new intermediate state)
- `test_regime_substrate_next_is_eval_skip_gate`: Next is the new gate state

`test_sf_iam_lambda_grants` passes unchanged — the new Lambda's ARN matches a granted pattern.

## Operator steps (required before next Saturday SF run)

1. `bash infrastructure/iam/apply.sh alpha-engine-step-functions-role` (this repo) — pushes the new ARN grant to AWS
2. Deploy this SF JSON via the orchestration pipeline so the new states materialize in the live state machine
3. `bash infrastructure/setup-regime-retrospective-eval-lambda.sh` (alpha-engine-predictor) — one-time create to bring the Lambda online

After step 3, the next Saturday SF invocation will exercise the T1 eval cleanly. Expected `n_pairings=0` during the ~8-week cold-start lag — substrate Lambda needs to write enough weekly `signals/` history for the eval to have pairings to score.

Reference: `~/Development/alpha-engine-docs/private/regime-v3-260514.md` §5.3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)