### PR TITLE
fix(daily_append): re-project today_row to match persisted column order

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -1132,6 +1132,26 @@ def daily_append(
                 # passthrough behaviour.
                 today_row[PROVENANCE_COL] = new_row.iloc[0][PROVENANCE_COL]
 
+                # Match the persisted ArcticDB column order so update_batch
+                # passes its strict descriptor-equality check. Existing
+                # universe symbols were laid down with `source` between
+                # VWAP and the first feature (idx 7 in the storage layout)
+                # via `_write_row_backfill_safe` + earlier per-ticker
+                # write paths. The bare `today_row[PROVENANCE_COL] = ...`
+                # assignment above appends `source` at the END of the
+                # frame, which is fine for write_batch (full rewrite) but
+                # ArcticDB's update_batch raises StreamDescriptorMismatch
+                # when the incoming column order differs from the existing
+                # version — observed 2026-05-14 EOD: 99.9% error rate
+                # (903 / 904 tickers) with `existing` showing source idx=7
+                # and `new_val` showing source idx=71.
+                ordered_cols = (
+                    [c for c in OHLCV_COLS if c in today_row.columns]
+                    + ([PROVENANCE_COL] if PROVENANCE_COL in today_row.columns else [])
+                    + [f for f in FEATURES if f in today_row.columns]
+                )
+                today_row = today_row[ordered_cols]
+
                 # Per-ticker coverage observability: count NaN features now
                 # so the eventual log + counter reflects exactly what's
                 # being written. Silent partial coverage is forbidden

--- a/tests/test_arctic_write_contract.py
+++ b/tests/test_arctic_write_contract.py
@@ -216,3 +216,37 @@ def test_backfill_wraps_macro_writes():
     assert "macro_lib.write(\"features\", to_arctic_safe(macro_df))" in _BACKFILL_SRC
     assert "macro_lib.write(key, to_arctic_safe(macro_series_df))" in _BACKFILL_SRC
     assert "macro_lib.write(key, to_arctic_safe(sector_df))" in _BACKFILL_SRC
+
+
+def test_daily_append_today_row_column_order_matches_storage():
+    """Pin the today_row column order to [OHLCV, source, FEATURES].
+
+    2026-05-14 EOD failure: 99.9% (903 / 904) of update_batch calls failed
+    with ``StreamDescriptorMismatch`` because today_row was being built as
+    [OHLCV, FEATURES, source] (source appended at the end via the bare
+    ``today_row[PROVENANCE_COL] = …`` assignment) while every persisted
+    universe symbol carries source at idx 7 (between VWAP and the first
+    feature). ArcticDB's update_batch enforces strict column-order match
+    against the existing version's descriptor; the backfill-branch
+    write_batch path masks this because full rewrite ignores prior
+    descriptor.
+
+    The fix re-projects today_row via an explicit column order before the
+    write queue. If a future PR removes that re-projection, this test
+    fails — preventing a silent re-introduction of the same EOD outage.
+    """
+    assert (
+        "ordered_cols = (\n"
+        "                    [c for c in OHLCV_COLS if c in today_row.columns]\n"
+        "                    + ([PROVENANCE_COL] if PROVENANCE_COL in today_row.columns else [])\n"
+        "                    + [f for f in FEATURES if f in today_row.columns]\n"
+        "                )\n"
+        "                today_row = today_row[ordered_cols]"
+    ) in _DAILY_APPEND_SRC, (
+        "daily_append.py must re-project today_row to "
+        "[OHLCV, source, FEATURES] before queuing the UpdatePayload — "
+        "matches the persisted ArcticDB descriptor (source at idx 7). "
+        "The bare `today_row[PROVENANCE_COL] = …` assignment alone "
+        "appends source at the end, which trips StreamDescriptorMismatch "
+        "on update_batch (2026-05-14 EOD)."
+    )


### PR DESCRIPTION
## Summary
- 2026-05-14 EOD pipeline failure: `weekly_collector.py --daily` exited 1 in the ArcticDB append stage with **99.9% (903 / 904)** tickers raising `arcticdb::StreamDescriptorMismatch` on `universe_lib.update_batch`.
- Root cause: the bare `today_row[PROVENANCE_COL] = …` assignment at `builders/daily_append.py:1133` appends `source` at the END of the frame, but every persisted universe symbol carries `source` at idx 7 (between VWAP and the first feature). ArcticDB's `update_batch` enforces strict column-order match.
- Fix: explicit re-projection to `[OHLCV, source, FEATURES]` before the write queue. Pinned by a source-level regression test.

## Why MorningEnrich didn't trip
MorningEnrich today went all-backfill path (`Batch writes: 0 updates + 150 backfills` × 6) — `WritePayload` does full rewrite and ignores the prior descriptor, so the column-order regression was invisible there. EOD's append-at-head path is the unique surface that fails; yesterday's EOD slipped under the 5% error-rate threshold by hitting a different schema vintage on enough symbols.

## Verification
- Sampled 80 universe symbols on the trading EBS (LAD / LEA / AAPL …): all show `source` at pandas col position 6 (= storage idx 7), last_idx 2026-05-13.
- Full test suite: **1026 passed, 1 skipped** (was 1025; +1 column-order pin in `test_arctic_write_contract.py`).
- Targeted: `test_daily_append_*` (47 passed), `test_arctic_write_contract.py` (11 passed).

## Test plan
- [x] `pytest tests/test_arctic_write_contract.py` (column-order pin enforces re-projection block at the source level)
- [x] `pytest tests/` (full suite 1026 passed)
- [ ] Tonight: in-place patch on `i-018eb3307a21329bf`, manual `weekly_collector.py --daily` for 2026-05-14, then EOD reconcile + stop-instance via SF or direct script.
- [ ] Tomorrow's MorningEnrich first-pass on the merged code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)