### PR TITLE
fix(iam): grant deploy role update + invoke on regime Lambdas

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -53,6 +53,8 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check"
       ]
@@ -86,6 +88,10 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check",


### PR DESCRIPTION
## Summary

The codified `github-actions-lambda-deploy` policy missed the two regime Lambdas added 2026-05-14:
- `alpha-engine-predictor-regime-substrate` (Stage A)
- `alpha-engine-predictor-regime-retrospective-eval` (Stage C.2 T1)

## Symptom

Today's predictor deploy.yml run ([CI 25884911718](https://github.com/cipher813/alpha-engine-predictor/actions/runs/25884911718)) logged \"NOT FOUND — skipping\" for both functions in deploy.sh Step 9 + 10. That branch was protective at the time (the functions hadn't been created yet via the setup scripts), but it masked the fact that even if they DID exist, the deploy role couldn't update them.

## Fix

Add explicit ARNs to two statements:
- `LambdaUpdate` (`CreateFunction` / `UpdateFunctionCode` / `PublishVersion` / `UpdateAlias` / `CreateAlias` — needed for auto-create + update path)
- `LambdaInvokeCanary` (`InvokeFunction` on both bare + versioned ARNs — needed for `deploy.sh`'s post-update `dry_run` canary)

Composes with parallel alpha-engine-predictor PR that adds create-function fall-through to deploy.sh Step 9 + 10, so the manual `setup-regime-{lambda,retrospective-eval-lambda}.sh` operator step becomes break-glass-only.

## Applied + verified

```
bash infrastructure/iam/apply.sh github-actions-lambda-deploy
  → Applying ... OK
python3 infrastructure/iam/check-drift.py
  → OK: no IAM drift
pytest tests/test_sf_iam_lambda_grants.py
  → 2 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)