### PR TITLE
fix(data-lambda): read FMP+FINNHUB via get_secret() — unblock post-PR-9f deploy

### DIFF
--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -66,15 +66,19 @@ def handler(event, context):
     _start = time.time()
 
     try:
-        # Validate required env vars. FINNHUB_API_KEY required since
-        # 2026-04-20 — analyst rating + price target now come from
-        # Finnhub because FMP /stable moved those behind a paid tier.
-        missing = []
-        for name in ("FMP_API_KEY", "FINNHUB_API_KEY"):
-            if not os.environ.get(name):
-                missing.append(name)
-        # EDGAR_IDENTITY and POLYGON_API_KEY are optional (graceful degradation)
-
+        # FINNHUB_API_KEY required since 2026-04-20 — analyst rating + price
+        # target now come from Finnhub because FMP /stable moved those behind
+        # a paid tier. EDGAR_IDENTITY and POLYGON_API_KEY are optional
+        # (graceful degradation in their consumers).
+        #
+        # Read via get_secret() not os.environ.get() — the bulk-load shim
+        # (ssm_secrets.load_secrets) was retired in PR 9f of the .env→SSM
+        # arc (2026-05-14). Secrets now load from SSM at consumer sites.
+        from alpha_engine_lib.secrets import get_secret
+        missing = [
+            name for name in ("FMP_API_KEY", "FINNHUB_API_KEY")
+            if not get_secret(name, required=False, default="")
+        ]
         if missing:
             msg = f"Missing required env vars: {', '.join(missing)}"
             logger.error(msg)


### PR DESCRIPTION
## Summary
- `lambda/handler.py` pre-flight gated on `os.environ.get(name)` for `FMP_API_KEY` + `FINNHUB_API_KEY`. After PR #241 (PR 9f of the `.env` → SSM arc) deleted the `ssm_secrets.load_secrets()` bulk-load shim, nothing populates `os.environ` at cold-start anymore — so the post-merge deploy canary fails with `Missing required env vars: FINNHUB_API_KEY` and rolls back.
- Only `FINNHUB_API_KEY` surfaces (not both) because `FMP_API_KEY` happens to be persisted in the live Lambda env config from a legacy `.env`-deploy; `FINNHUB_API_KEY` was only ever loaded via the shim.
- Switch the handler's pre-flight to `alpha_engine_lib.secrets.get_secret()` — matching the pattern already in use at every other secret-consumer site in this repo (`collectors/fundamentals.py:209`, `collectors/finnhub_client.py:63`, `collectors/alternative.py:469`, `:757`, `:836`).

## Why this slipped past CI
`tests/test_no_secret_environ_reads.py` regex only matches string-literal forms (`os.environ.get("NAME")`). The variable-based loop pattern (`os.environ.get(name)` where `name` iterates a tuple of pinned secret names) doesn't match. Worth tightening the AST in a follow-up, but this fix removes the only remaining read of that shape in the repo.

## Test plan
- [x] `pytest tests/test_no_secret_environ_reads.py tests/test_preflight.py tests/test_fundamentals_finnhub.py -q` → 50 passed
- [x] `import lambda/handler.py` smoke-loads cleanly under `.venv`
- [x] Verified IAM: `alpha-engine-data-role` has `ssm:GetParameter` on `/alpha-engine/*` (inline `alpha-engine-ssm-read` policy)
- [x] Verified SSM: `/alpha-engine/FMP_API_KEY` + `/alpha-engine/FINNHUB_API_KEY` both exist
- [ ] Deploy canary (auto-runs on merge via `.github/workflows/deploy.yml`) — should pass now

🤖 Generated with [Claude Code](https://claude.com/claude-code)