### PR TITLE
fix(sf): ship long SSM-step logs to S3 via EXIT trap — close MorningEnrich diagnostic gap

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -43,6 +43,7 @@
             "cd /home/ec2-user/alpha-engine-data",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "trap 'aws s3 cp /var/log/data-weekly.log \"s3://alpha-engine-research/_ssm_logs/data-weekly/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash infrastructure/spot_data_weekly.sh --data-only 2>&1 | tee /var/log/data-weekly.log"
           ],
           "executionTimeout": ["5400"]
@@ -153,6 +154,7 @@
             "cd /home/ec2-user/alpha-engine-data",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "trap 'aws s3 cp /var/log/rag-ingestion.log \"s3://alpha-engine-research/_ssm_logs/rag-ingestion/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash infrastructure/spot_data_weekly.sh --rag-only 2>&1 | tee /var/log/rag-ingestion.log"
           ],
           "executionTimeout": ["3600"]
@@ -464,6 +466,7 @@
             "cd /home/ec2-user/alpha-engine-predictor",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "trap 'aws s3 cp /var/log/predictor-training.log \"s3://alpha-engine-research/_ssm_logs/predictor-training/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash infrastructure/spot_train.sh --full-only 2>&1 | tee /var/log/predictor-training.log"
           ],
           "executionTimeout": ["5400"]
@@ -575,6 +578,7 @@
             "cd /home/ec2-user/alpha-engine-data",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "trap 'aws s3 cp /var/log/drift-detection.log \"s3://alpha-engine-research/_ssm_logs/drift-detection/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash infrastructure/spot_drift_detection.sh 2>&1 | tee /var/log/drift-detection.log"
           ],
           "executionTimeout": ["1200"]
@@ -623,6 +627,7 @@
             "cd /home/ec2-user/alpha-engine-backtester",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "trap 'aws s3 cp /var/log/backtester.log \"s3://alpha-engine-research/_ssm_logs/backtester/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash infrastructure/spot_backtest.sh --skip-stages=evaluator 2>&1 | tee /var/log/backtester.log"
           ],
           "executionTimeout": ["7200"]
@@ -734,6 +739,7 @@
             "cd /home/ec2-user/alpha-engine-backtester",
             "export HOME=/home/ec2-user",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "trap 'aws s3 cp /var/log/evaluator.log \"s3://alpha-engine-research/_ssm_logs/evaluator/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity 2>&1 | tee /var/log/evaluator.log"
           ],
           "executionTimeout": ["3600"]
@@ -1217,6 +1223,7 @@
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-dashboard",
             "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/health-check.log \"s3://alpha-engine-research/_ssm_logs/health-check/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
           ],
           "executionTimeout": ["60"]
@@ -1277,6 +1284,7 @@
             "cd /home/ec2-user/alpha-engine-dashboard",
             "source .venv/bin/activate",
             "pip install --quiet --upgrade -r requirements.txt",
+            "trap 'aws s3 cp /var/log/substrate-health-check.log \"s3://alpha-engine-research/_ssm_logs/substrate-health-check/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python -m alpha_engine_lib.transparency --cadence weekly --alert 2>&1 | tee /var/log/substrate-health-check.log"
           ],
           "executionTimeout": ["180"]

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -176,6 +176,7 @@
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/morning-enrich.log \"s3://alpha-engine-research/_ssm_logs/morning-enrich/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python weekly_collector.py --morning-enrich 2>&1 | tee -a /var/log/morning-enrich.log"
           ],
           "executionTimeout": ["1800"]
@@ -607,6 +608,7 @@
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "/home/ec2-user/alpha-engine/infrastructure/wait-for-ibgateway.sh",
+            "trap 'aws s3 cp /var/log/executor.log \"s3://alpha-engine-research/_ssm_logs/executor/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python executor/main.py 2>&1 | tee -a /var/log/executor.log"
           ],
           "executionTimeout": ["300"]

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -15,6 +15,7 @@
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/postmarket-data.log \"s3://alpha-engine-research/_ssm_logs/postmarket-data/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python weekly_collector.py --daily 2>&1 | tee /var/log/postmarket-data.log"
           ],
           "executionTimeout": ["1200"]
@@ -109,6 +110,7 @@
             "cd /home/ec2-user/alpha-engine",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/snapshot.log \"s3://alpha-engine-research/_ssm_logs/snapshot/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python executor/snapshot_capturer.py 2>&1 | tee /var/log/snapshot.log"
           ],
           "executionTimeout": ["120"]
@@ -203,6 +205,7 @@
             "cd /home/ec2-user/alpha-engine",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/eod.log \"s3://alpha-engine-research/_ssm_logs/eod/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python executor/eod_reconcile.py 2>&1 | tee /var/log/eod.log"
           ],
           "executionTimeout": ["120"]
@@ -297,6 +300,7 @@
             "cd /home/ec2-user/alpha-engine-dashboard",
             "source .venv/bin/activate",
             "pip install --quiet --upgrade -r requirements.txt",
+            "trap 'aws s3 cp /var/log/substrate-health-check-daily.log \"s3://alpha-engine-research/_ssm_logs/substrate-health-check-daily/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python -m alpha_engine_lib.transparency --cadence daily --alert 2>&1 | tee /var/log/substrate-health-check-daily.log"
           ],
           "executionTimeout": ["180"]

--- a/tests/test_sf_ssm_pipefail_wiring.py
+++ b/tests/test_sf_ssm_pipefail_wiring.py
@@ -1,6 +1,6 @@
 """SSM RunShellScript command-array hygiene checks.
 
-Two rules pinned here:
+Three rules pinned here:
 
 1. Every command array must START with `set ... pipefail`. Without it,
    `cmd | tee` silently masks non-zero exits from `cmd` (2026-05-11
@@ -14,11 +14,22 @@ Two rules pinned here:
    skips attaching `FlowDoctorHandler` and ERROR-level logs go only to
    stdout — exactly the failure mode on 2026-05-11, where two ERROR
    logs from `weekly_collector` fired but flow-doctor never escalated.
+
+3. Every command block that pipes its work to `| tee /var/log/X.log`
+   must arm an EXIT trap that ships that log to S3 before the work line.
+   SSM's `StandardOutputContent` is capped at 24KB and `StandardOutputUrl`
+   is empty (no CloudWatchOutputConfig), so when a long step exits 1 on a
+   stopped/terminated instance the actual error is unrecoverable. This is
+   a recurring diagnostic gap (MorningEnrich 2026-05-15, DataPhase1
+   2026-05-03, backtester 2026-04-22). The trap must be `|| true` so it
+   never alters the script's real exit status (the SF Catch must still
+   see the true failure).
 """
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -123,4 +134,63 @@ def test_weekday_sf_ssm_blocks_export_flow_doctor_enabled() -> None:
         "Add `\"export FLOW_DOCTOR_ENABLED=1\"` to each `commands` array. "
         "See 2026-05-11 incident — flow-doctor silently skipped because "
         "setup_logging's env-var gate falls through to 'disabled'."
+    )
+
+
+_TEE_WORK_RE = re.compile(r"\| tee (?:-a )?(/var/log/[\w.-]+\.log)")
+
+
+@pytest.mark.parametrize("sf_path", _SF_PATHS, ids=lambda p: p.name)
+def test_long_ssm_steps_ship_log_to_s3_before_work(sf_path: Path) -> None:
+    """Every `| tee /var/log/X.log` work line needs a preceding S3 EXIT trap.
+
+    Regression target: the recurring "step exits 1 but the cause is past
+    SSM's 24KB StandardOutputContent cap and the instance is gone" gap
+    (MorningEnrich 2026-05-15, DataPhase1 2026-05-03, backtester
+    2026-04-22). The fix is an EXIT trap that `aws s3 cp`s the local
+    /var/log/X.log to s3://alpha-engine-research/_ssm_logs/... — armed
+    BEFORE the long work command so it fires whether the step succeeds or
+    fails, and `|| true` so it never overrides the script's real exit
+    status (the SF Catch must still see the true failure).
+    """
+    sf_doc = json.loads(sf_path.read_text())
+    offenders: list[str] = []
+    for state_name, cmds in _iter_ssm_command_blocks(sf_doc):
+        work_idx = next(
+            (i for i, c in enumerate(cmds) if _TEE_WORK_RE.search(c)), None
+        )
+        if work_idx is None:
+            continue  # short step, output fits in the 24KB cap
+        logfile = _TEE_WORK_RE.search(cmds[work_idx]).group(1)
+        trap_idx = next(
+            (
+                i
+                for i, c in enumerate(cmds)
+                if c.startswith("trap ")
+                and "_ssm_logs" in c
+                and logfile in c
+                and c.rstrip().endswith("EXIT")
+            ),
+            None,
+        )
+        if trap_idx is None:
+            offenders.append(f"{state_name}: no S3 EXIT trap for {logfile}")
+            continue
+        if trap_idx >= work_idx:
+            offenders.append(
+                f"{state_name}: trap at idx {trap_idx} not before "
+                f"work line at idx {work_idx}"
+            )
+        if "|| true" not in cmds[trap_idx]:
+            offenders.append(
+                f"{state_name}: trap missing `|| true` (would override "
+                f"the real exit status the SF Catch needs to see)"
+            )
+    assert not offenders, (
+        f"{sf_path.name}: long SSM steps missing the S3 log-capture "
+        f"trap:\n  - " + "\n  - ".join(offenders) + "\n\n"
+        "Add `\"trap 'aws s3 cp /var/log/X.log "
+        "\\\"s3://alpha-engine-research/_ssm_logs/<slug>/...\\\" "
+        "--only-show-errors || true' EXIT\"` immediately before the "
+        "`| tee` work line. See 2026-05-15 MorningEnrich ROADMAP P0."
     )


### PR DESCRIPTION
## Summary

Closes the **diagnostic half** of the **P0** "MorningEnrich multi-date-backfill exit-1 + SSM 24KB stdout truncation hides the cause" (ROADMAP, surfaced by the 2026-05-15 weekday-SF recovery).

### The recurring gap
When a long SSM-dispatched step exits 1 on a stopped/terminated instance, the actual error is unrecoverable: SSM's `StandardOutputContent` is capped at **24KB** and `StandardOutputUrl` is empty (no `CloudWatchOutputConfig` on the document). Same diagnostic gap hit on **MorningEnrich 2026-05-15**, **DataPhase1 2026-05-03**, and **backtester 2026-04-22**.

Each long step already `tee`s to `/var/log/X.log`, but that file dies with the instance (Saturday spot terminates; ae-trading stops daily).

### Fix
A failure-safe `EXIT` trap, armed immediately **before** the work line in all **14** long SSM steps across the weekday / Saturday / EOD Step Functions:

```sh
trap 'aws s3 cp /var/log/X.log "s3://alpha-engine-research/_ssm_logs/<slug>/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log" --only-show-errors || true' EXIT
```

**Why the S3 trap over `CloudWatchOutputConfig`:** the executor instance role has **no** CloudWatch Logs grant — enabling CW output would be a silent no-op requiring a separate production IAM change. The role already has `alpha-engine-research` bucket write. The S3 trap is zero-new-IAM, runs **synchronously before exit** (no CW-agent flush race on spot reclamation), and is the ROADMAP's named cheap option.

- `|| true` → the trap never overrides the script's real exit status; the SF `Catch`/status check still sees the true failure.
- `--only-show-errors` (not `>/dev/null`) → an upload failure is visible, not silently swallowed (`feedback_no_silent_fails`).

### Deliberately out of scope
**Root cause** of the re-run exit-1 is deferred per the ROADMAP discipline ("don't invest root-cause time before log capture lands"). The next failure will now leave a complete, queryable log at `s3://alpha-engine-research/_ssm_logs/...`.

### Regression guard
`test_sf_ssm_pipefail_wiring.py` rule 3: every `| tee /var/log/X.log` work line must have a preceding `|| true` S3 `EXIT` trap for the same logfile — so a future SF edit can't silently re-open the gap.

### Testing
- 1038 passed, 1 skipped (full alpha-engine-data suite).
- `test_sf_ssm_pipefail_wiring.py`: 7 passed (pipefail ×3, flow-doctor, log-capture ×3).
- Diff is minimal: +1 line per step (no JSON reformat).

### Deploy (post-merge, operator)
`infrastructure/deploy_step_function_daily.sh`, `deploy_step_function.sh`, `update_eod_pipeline_sf.sh` re-push the updated ASL. First failing long step thereafter leaves a full log in S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)