### PR TITLE
feat(data): promote SPY to a full `universe` ArcticDB member (additive)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -40,6 +40,7 @@ from features.compute import (
     DEFAULT_BUCKET,
     SOURCE_CATEGORIES,
     _SKIP_TICKERS,
+    _UNIVERSE_EXTRA,
     _apply_daily_delta,
     _is_sector_etf,
     _load_parquet_from_s3,
@@ -436,10 +437,12 @@ def backfill(
 
     universe_tickers = [
         t for t in price_data
-        if t not in _SKIP_TICKERS
+        if (t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA)
         and not _is_sector_etf(t)
         and price_data[t] is not None
-        and t in constituents_set
+        # _UNIVERSE_EXTRA (SPY) is never in constituents.json — admit it
+        # explicitly; it is still written Close-only to `macro` separately.
+        and (t in constituents_set or t in _UNIVERSE_EXTRA)
     ]
     excluded_by_constituents = sorted(
         t for t in price_data

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -38,6 +38,7 @@ from features.feature_engineer import (
 from features.compute import (
     DEFAULT_BUCKET,
     _SKIP_TICKERS,
+    _UNIVERSE_EXTRA,
     _is_sector_etf,
     _load_sector_map,
     _load_cached_fundamentals,
@@ -889,9 +890,15 @@ def daily_append(
     vix3m_series = macro.get("VIX3M")
 
     # Filter to stock tickers only
+    # _UNIVERSE_EXTRA (SPY) is maintained as a full universe member here too;
+    # it bootstraps into `universe` on the weekly backfill and is skipped
+    # gracefully (hist None) until then. Still written Close-only to `macro`
+    # separately. SPY stays in _SKIP_TICKERS so the coverage-diff / freshness
+    # accounting below keeps treating it as non-stock.
     stock_tickers = [
         t for t in closes
-        if t not in _SKIP_TICKERS and not _is_sector_etf(t)
+        if (t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA)
+        and not _is_sector_etf(t)
     ]
 
     n_ok = 0              # fully-featured rows (all FEATURES finite)

--- a/features/compute.py
+++ b/features/compute.py
@@ -89,6 +89,20 @@ _SKIP_TICKERS = {
     "SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO",
     "^VIX", "^VIX3M", "^TNX", "^IRX",
 }
+
+# Macro/index symbols ALSO promoted to full `universe` members (full OHLCV +
+# engineered features), in addition to their Close-only `macro`-library write.
+# SPY became a held core position with the 2026-05-13 portfolio-optimizer
+# cutover, so every held-position code path (eod_reconcile #181,
+# morning-planner ATR #185) needs SPY's engineered features (atr_14_pct, ...)
+# from `universe`. Members deliberately STAY in _SKIP_TICKERS so
+# prune_delisted_tickers (SPY ∉ constituents.json → would otherwise be a
+# prune candidate) and the daily_append coverage-diff accounting keep
+# treating them as non-stock — _UNIVERSE_EXTRA only widens the universe-WRITE
+# candidate set, nothing else. NOT a macro-lib teardown: VIX/TNX/IRX have no
+# tradeable OHLCV and are never held, so they stay macro-only.
+_UNIVERSE_EXTRA = frozenset({"SPY"})
+
 # Sector ETFs to skip (not individual stocks)
 _SECTOR_ETF_PREFIXES = {"XL"}
 

--- a/tests/test_daily_append_universe_chunking.py
+++ b/tests/test_daily_append_universe_chunking.py
@@ -41,10 +41,10 @@ def test_universe_pass_chunks_read_batch_calls(monkeypatch):
     iteration count against a future refactor accidentally reverting to
     a single big batch.
 
-    Note: _patch_targets' sector_etfs list includes ``XLRE`` (len=4)
-    which escapes the ``_is_sector_etf`` len==3 check and lands in
-    stock_tickers, so the universe-symbol count + 1 is the effective
-    chunk-input size.
+    Effective chunk-input size = universe-symbol count + 2:
+      * ``XLRE`` (len=4) escapes the ``_is_sector_etf`` len==3 check, and
+      * ``SPY`` is now admitted via ``_UNIVERSE_EXTRA`` (full universe
+        member since the 2026-05 SPY-as-held-core promotion).
     """
     from builders import daily_append as _da
     from builders.daily_append import daily_append
@@ -52,7 +52,8 @@ def test_universe_pass_chunks_read_batch_calls(monkeypatch):
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
     today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    universe = ["AAPL", "MSFT", "GOOGL", "AMZN"]  # 4 + XLRE leak = 5 → 3 chunks at K=2
+    # 4 universe + XLRE leak + SPY universe-extra = 6 → 3 chunks at K=2
+    universe = ["AAPL", "MSFT", "GOOGL", "AMZN"]
     universe_lib, _, _ = _patch_targets(
         monkeypatch,
         universe_symbols=universe,
@@ -62,9 +63,9 @@ def test_universe_pass_chunks_read_batch_calls(monkeypatch):
 
     daily_append(date_str=today_str, skip_if_exists=False)
 
-    # ceil(5/2) = 3 chunks → 3 read_batch invocations
+    # ceil(6/2) = 3 chunks → 3 read_batch invocations
     assert universe_lib.read_batch.call_count == 3, (
-        f"Expected 3 chunked read_batch calls (5 effective stock tickers / chunk=2), "
+        f"Expected 3 chunked read_batch calls (6 effective stock tickers / chunk=2), "
         f"got {universe_lib.read_batch.call_count}"
     )
 
@@ -72,7 +73,7 @@ def test_universe_pass_chunks_read_batch_calls(monkeypatch):
     call_sizes = [
         len(call.args[0]) for call in universe_lib.read_batch.call_args_list
     ]
-    assert sum(call_sizes) == 5
+    assert sum(call_sizes) == 6
     assert all(s <= 2 for s in call_sizes)
     # All but the last chunk are at chunk_size
     assert call_sizes[:-1] == [2, 2]
@@ -88,7 +89,7 @@ def test_universe_pass_chunks_write_batches_too(monkeypatch):
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
     today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    # 3 universe + 1 XLRE leak = 4 effective stock tickers → 2 chunks at K=2
+    # 3 universe + XLRE leak + SPY universe-extra = 5 effective → 3 chunks at K=2
     universe = ["AAPL", "MSFT", "GOOGL"]
     universe_lib, _, _ = _patch_targets(
         monkeypatch,
@@ -99,9 +100,9 @@ def test_universe_pass_chunks_write_batches_too(monkeypatch):
 
     daily_append(date_str=today_str, skip_if_exists=False)
 
-    # ceil(4/2) = 2 chunks → 2 update_batch invocations
-    assert universe_lib.update_batch.call_count == 2, (
-        f"Expected 2 chunked update_batch calls (4 effective tickers / chunk=2), "
+    # ceil(5/2) = 3 chunks → 3 update_batch invocations
+    assert universe_lib.update_batch.call_count == 3, (
+        f"Expected 3 chunked update_batch calls (5 effective tickers / chunk=2), "
         f"got {universe_lib.update_batch.call_count}"
     )
     # Read and write call counts should match (1 read + 1 write per chunk)
@@ -159,10 +160,10 @@ def test_universe_pass_n_ok_accumulates_across_chunks(monkeypatch):
 
     result = daily_append(date_str=today_str, skip_if_exists=False)
 
-    # All effective stock tickers (universe + XLRE leak) should land in
-    # n_ok or n_partial. Without correct accumulation across chunks,
-    # only the last chunk's counts survive.
-    expected = len(universe) + 1  # +1 for XLRE leaking through is_sector_etf
+    # All effective stock tickers (universe + XLRE leak + SPY universe-extra)
+    # should land in n_ok or n_partial. Without correct accumulation across
+    # chunks, only the last chunk's counts survive.
+    expected = len(universe) + 2  # +1 XLRE leak, +1 SPY (_UNIVERSE_EXTRA)
     counted = result["tickers_appended"] + result["tickers_partial"]
     assert counted == expected, (
         f"Counter accumulation across chunks broken: "

--- a/tests/test_spy_universe_member.py
+++ b/tests/test_spy_universe_member.py
@@ -1,0 +1,193 @@
+"""SPY-as-full-universe-member contract (additive producer change).
+
+SPY became a held core position with the 2026-05-13 portfolio-optimizer
+cutover. Every held-position code path (eod_reconcile #181, morning-planner
+ATR #185) independently rediscovered "SPY isn't in `universe`" as a separate
+production incident. The durable fix promotes SPY to a full `universe`
+member (full OHLCV + engineered features) while keeping its Close-only
+`macro` write during the transition.
+
+The one-wrong-move risk (audit §E #6/#7): SPY must NOT be removed from
+`_SKIP_TICKERS` to get it written to `universe` — `_SKIP_TICKERS` is also
+the prune-protection / coverage-diff set, and SPY is never in
+`constituents.json`, so dropping it there would make SPY a
+`prune_delisted_tickers` candidate. The correct shape is a SEPARATE
+additive predicate `_UNIVERSE_EXTRA` that ONLY widens the universe-write
+candidate set. These tests pin that invariant so a future refactor can't
+silently re-open the gap.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from builders import prune_delisted_tickers as _prune_mod
+from features.compute import _SKIP_TICKERS, _UNIVERSE_EXTRA, _is_sector_etf
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── A. Constant-contract invariants ────────────────────────────────────────
+
+
+def test_spy_is_a_universe_extra():
+    assert "SPY" in _UNIVERSE_EXTRA
+
+
+def test_universe_extra_members_stay_skip_protected():
+    """Every _UNIVERSE_EXTRA member MUST also be in _SKIP_TICKERS.
+
+    This is the load-bearing invariant. If a member is universe-extra but
+    NOT skip-protected, prune_delisted_tickers (it's ∉ constituents.json)
+    and the daily_append coverage-diff accounting break. Generalised so a
+    future addition to _UNIVERSE_EXTRA can't violate it.
+    """
+    assert _UNIVERSE_EXTRA <= _SKIP_TICKERS, (
+        f"_UNIVERSE_EXTRA members not skip-protected: "
+        f"{sorted(_UNIVERSE_EXTRA - _SKIP_TICKERS)} — these would become "
+        f"prune_delisted_tickers candidates (∉ constituents.json)"
+    )
+
+
+def test_spy_specifically_still_skip_protected():
+    assert "SPY" in _SKIP_TICKERS
+
+
+# ── B. Prune-protection behavioural guard (audit §E risk #6) ────────────────
+
+
+def _stub_s3(*, constituents_tickers, weekly_date="2026-04-25"):
+    s3 = MagicMock()
+    pointer = json.dumps(
+        {"date": weekly_date, "s3_prefix": f"market_data/weekly/{weekly_date}/"}
+    ).encode()
+    cons = json.dumps(
+        {
+            "date": weekly_date,
+            "tickers": list(constituents_tickers),
+            "sector_map": {t: "Industrials" for t in constituents_tickers},
+        }
+    ).encode()
+
+    def fake_get_object(**kwargs):
+        key = kwargs["Key"]
+        if key == "market_data/latest_weekly.json":
+            return {"Body": MagicMock(read=lambda: pointer)}
+        if key.endswith("/constituents.json"):
+            return {"Body": MagicMock(read=lambda: cons)}
+        raise KeyError(key)
+
+    s3.get_object.side_effect = fake_get_object
+    return s3
+
+
+def _stub_universe_lib(*, symbols, last_dates):
+    lib = MagicMock()
+    lib.list_symbols.return_value = symbols
+
+    def fake_tail(symbol, n):
+        if symbol not in last_dates:
+            return MagicMock(data=pd.DataFrame())
+        idx = pd.DatetimeIndex([last_dates[symbol]])
+        return MagicMock(data=pd.DataFrame({"Close": [100.0]}, index=idx))
+
+    lib.tail.side_effect = fake_tail
+    return lib
+
+
+def test_spy_in_universe_is_never_pruned_even_when_absent_and_stale(monkeypatch):
+    """SPY ∉ constituents AND stale — the two-condition prune trigger — yet
+    SPY must survive because it's _SKIP_TICKERS-protected. A genuinely
+    delisted ticker in the same run IS pruned, proving the guard is
+    specific to macro/universe-extra symbols, not a blanket no-prune.
+    """
+    s3 = _stub_s3(constituents_tickers=["AAPL", "MSFT"])
+    lib = _stub_universe_lib(
+        symbols=["AAPL", "MSFT", "SPY", "HOLX"],
+        last_dates={
+            "AAPL": "2026-04-25",
+            "MSFT": "2026-04-25",
+            "SPY": "2026-04-06",  # stale AND absent from constituents
+            "HOLX": "2026-04-06",  # genuinely delisted: stale + absent
+        },
+    )
+    monkeypatch.setattr(
+        _prune_mod, "boto3", MagicMock(client=lambda *a, **k: s3)
+    )
+    monkeypatch.setattr(
+        _prune_mod, "get_universe_lib", lambda *a, **k: lib
+    )
+
+    summary = _prune_mod.prune_delisted_tickers(
+        absent_days=14, apply=True, today=pd.Timestamp("2026-04-28")
+    )
+
+    pruned = {p["ticker"] for p in summary["pruned"]}
+    assert "SPY" not in pruned, "SPY must never be a prune candidate"
+    assert "HOLX" in pruned, "genuinely delisted ticker should still prune"
+    lib.delete.assert_called_once_with("HOLX")
+
+
+# ── C. Universe-write predicate contract (audit §A5) ────────────────────────
+#
+# The two universe-write filters are inline in backfill()/daily_append().
+# Replicate them here as the pinned contract AND assert the production
+# source still references _UNIVERSE_EXTRA, so the replicated predicate
+# can't silently drift from production (repo `assert <expr> in src`
+# convention, cf. test_sf_ssm_pipefail_wiring.py).
+
+
+def _backfill_admits(t, *, price_data, constituents_set):
+    return (
+        (t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA)
+        and not _is_sector_etf(t)
+        and price_data[t] is not None
+        and (t in constituents_set or t in _UNIVERSE_EXTRA)
+    )
+
+
+def _daily_append_admits(t):
+    return (
+        t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA
+    ) and not _is_sector_etf(t)
+
+
+def test_backfill_universe_filter_admits_spy_despite_absent_constituents():
+    price_data = {"AAPL": object(), "SPY": object(), "DELISTED": object()}
+    constituents = {"AAPL"}  # SPY never appears in constituents.json
+    assert _backfill_admits("AAPL", price_data=price_data, constituents_set=constituents)
+    assert _backfill_admits("SPY", price_data=price_data, constituents_set=constituents)
+    assert not _backfill_admits(
+        "DELISTED", price_data=price_data, constituents_set=constituents
+    )
+    assert not _backfill_admits("VIX", price_data={"VIX": object()}, constituents_set=set())
+
+
+def test_daily_append_stock_filter_admits_spy_not_other_macros():
+    assert _daily_append_admits("AAPL")
+    assert _daily_append_admits("SPY")
+    assert not _daily_append_admits("VIX")
+    assert not _daily_append_admits("XLK")  # sector ETF
+
+
+@pytest.mark.parametrize(
+    "rel_path,needle",
+    [
+        ("builders/backfill.py", "t in _UNIVERSE_EXTRA"),
+        ("builders/daily_append.py", "t in _UNIVERSE_EXTRA"),
+    ],
+)
+def test_production_filters_reference_universe_extra(rel_path, needle):
+    """Guard against the replicated predicates above drifting from the
+    real inline filters."""
+    src = (_REPO_ROOT / rel_path).read_text()
+    assert needle in src, (
+        f"{rel_path} no longer references {needle!r} — the universe-write "
+        f"filter changed; update _backfill_admits/_daily_append_admits and "
+        f"re-verify the SPY-admission + prune-protection contract"
+    )


### PR DESCRIPTION
## Summary

**ROADMAP P1** — the durable structural fix for the recurring SPY-as-held-core incident class. Since the 2026-05-13 portfolio-optimizer cutover made SPY a held core position, every held-position code path independently rediscovers "SPY isn't in `universe`" as a separate production incident (eod_reconcile #181, morning-planner ATR #185). SPY lived **Close-only** in the `macro` ArcticDB lib — no engineered features (`atr_14_pct`, …).

This is the **contract-safe first step**: additive, **producer-only**. SPY's full OHLCV + engineered-feature row is written into `universe` **alongside** its existing Close-only `macro` write. No consumer changes — predictor inference's `load_prices.py` already prefers universe→macro for SPY by design (it was written in anticipation of exactly this), so it transparently upgrades to the richer copy once present; `macro.SPY` remains for the freshness gate.

## Shape (the one-wrong-move constraint)

Per the producer/consumer audit (§A5/§E):

- New `_UNIVERSE_EXTRA = frozenset({"SPY"})` in `features/compute.py`.
- `backfill.py` `universe_tickers` + `daily_append.py` `stock_tickers` admit `_UNIVERSE_EXTRA` (backfill also bypasses the constituents requirement for it — SPY is never in `constituents.json`).
- **SPY deliberately STAYS in `_SKIP_TICKERS`.** That set is overloaded as prune-protection + coverage-diff accounting. Removing SPY there to get it into `universe` would make SPY a `prune_delisted_tickers` candidate (SPY ∉ `constituents.json`). `_UNIVERSE_EXTRA` only widens the universe-**write** candidate set, nothing else.
- **Boundary — NOT a macro-lib teardown:** VIX/TNX/IRX have no tradeable OHLCV, are never held, stay macro-only.

## No new fetch

SPY full OHLCV is already in hand: `predictor/price_cache/SPY.parquet` (backfill) and the polygon `daily_closes` row (daily_append). The weekly backfill bootstraps SPY into `universe`; `daily_append` gracefully skips it (`hist` None) until then, then maintains it.

## Testing

- **New `tests/test_spy_universe_member.py`**: the dual-membership invariant (`_UNIVERSE_EXTRA ⊆ _SKIP_TICKERS`), a *behavioural* prune-protection guard (SPY absent-from-constituents + stale yet never pruned, while a genuinely delisted ticker in the same run IS pruned), the universe-write predicate contract, and source-drift guards.
- **Updated `test_daily_append_universe_chunking.py`**: SPY is now an effective universe-write ticker (+1 alongside the pre-existing documented XLRE leak); chunk math recomputed. These are chunk-math pin-tests, not filter tests — updated to the new intended contract.
- **1043 passed, 1 skipped** (full alpha-engine-data suite).

## Transition sequencing (CLAUDE.md S3 Contract Safety — write-both ≥1 week)

This PR = **write both**. Gated follow-ups, **not** in this PR:

1. *(this PR)* Producer writes SPY to `universe` + `macro`.
2. **Soak**: first Saturday SF firing post-merge writes `universe.SPY` (full OHLCV + `atr_14_pct`); verify via a `universe` read. ≥1 week parallel.
3. **predictor** follow-up: retire the `macro.SPY` freshness-gate read once `universe.SPY` is proven.
4. **executor** follow-up: retire the `_MACRO_SYMBOLS` SPY special-cases (#185 ATR exclusion, #181 eod_reconcile dispatch) + their pin-tests. These stay correct-but-redundant during the soak (macro.SPY still written).

**Closes when** (ROADMAP): SPY readable from `universe` with a non-stale `atr_14_pct`; eod_reconcile + morning-planner run with the `_MACRO_SYMBOLS` SPY special-cases removed; predictor macro features still resolve; one clean weekday SF + EOD SF under the simplified path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)