### PR TITLE
fix(daily_closes): target-driven window status — non-target backfill miss is non-fatal (P0 MorningEnrich exit-1)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -222,11 +222,18 @@ def collect(
         ``tickers_captured``, ``polygon``/``fred``/``yfinance`` counts,
         ``source``.
 
-        Window mode (``window_days > 1``): dict with ``status``
-        (``"ok"`` if every date succeeded, ``"partial"`` if any date
-        errored), aggregated ``tickers_captured`` / ``polygon`` /
-        ``fred`` / ``yfinance`` counters across the window, ``source``,
-        ``window_days``, ``per_date`` (date → per-date result dict),
+        Window mode (``window_days > 1``): dict with **target-driven**
+        ``status`` — ``"ok"`` iff the TARGET date (``target_date``, the
+        newest date in the window = the date downstream reads)
+        succeeded, regardless of non-target *historical backfill* date
+        failures; ``"error"`` only if the target date itself failed
+        (caller escalates that to a hard stop). Non-target backfill
+        failures are recorded in ``per_date`` and listed in
+        ``backfill_failed_dates`` (best-effort, NON-fatal — surfaced via
+        a WARNING for the surveillance channel, never halts the
+        pipeline). Also: aggregated ``tickers_captured`` / ``polygon`` /
+        ``fred`` / ``yfinance`` counters, ``source``, ``window_days``,
+        ``target_date``, ``per_date`` (date → per-date result dict),
         ``skipped_dates`` (post-close already-written dates).
 
     Raises:
@@ -547,16 +554,39 @@ def _collect_window(
     return-shape section for the schema.
     """
     window_dates = _previous_business_days(run_date, n=window_days)
+    # The newest date in the window is the TARGET date — the one
+    # downstream (predictor inference / eod_reconcile) actually reads.
+    # The older dates are best-effort *historical backfill*: a per-date
+    # polygon/coverage hiccup on them (same-day-403, polygon free-tier
+    # quota/rate-limit exhaustion, a transient non-overlapping
+    # grouped-daily) must NOT hard-fail the run — that would block the
+    # whole weekly/EOD pipeline on a recoverable backfill miss while the
+    # target date is perfectly good. Same best-effort discipline as the
+    # chronic-gap self-heal step in weekly_collector.py. Fatality is
+    # decided AFTER the loop, from the TARGET date only.
+    #
+    # 2026-05-15 incident: a non-target backfill date failed on a
+    # same-day recovery re-run; the old "any per-date error → aggregate
+    # 'partial'" → strict caller roll-up (weekly_collector.py:1076,
+    # `not in ("ok","ok_dry_run")` ⇒ "failed") escalated it to
+    # SystemExit(1), halting an otherwise-healthy MorningEnrich. The
+    # static "point-in-time coverage-gate" theory was falsified by a
+    # dry-run repro (coverage held ~99%); the real defect is this
+    # best-effort-vs-strict-rollup contradiction. See plan doc
+    # morningenrich-coverage-gate-260515.md §8/§9.
+    target_date = window_dates[0]
     aggregate: dict = {
         "status": "ok",
         "source": source,
         "window_days": window_days,
+        "target_date": target_date,
         "per_date": {},
         "tickers_captured": 0,
         "polygon": 0,
         "fred": 0,
         "yfinance": 0,
         "skipped_dates": [],
+        "backfill_failed_dates": [],
     }
     # Iterate oldest → newest so the most recent date's parquet is the
     # last one written. Matches the operator mental model "the latest
@@ -574,10 +604,9 @@ def _collect_window(
                 skip_if_canonical=skip_if_canonical,
             )
         except Exception as exc:
-            # Per-date failures don't kill the rest of the window; record
-            # the failure and continue. This matches the existing single-
-            # date semantics where a coverage-gate / API failure on one
-            # day doesn't block subsequent days when re-run.
+            # Record + continue. Fatality is target-driven (decided
+            # after the loop) — a non-target backfill miss is recoverable
+            # and must not halt the pipeline.
             logger.warning(
                 "[daily_closes window] date=%s source=%s failed: %s — "
                 "recording and continuing window",
@@ -588,16 +617,44 @@ def _collect_window(
                 "error": str(exc),
                 "source": source,
             }
-            aggregate["status"] = "partial"
             continue
         aggregate["per_date"][d] = result
         for k in ("tickers_captured", "polygon", "fred", "yfinance"):
             if k in result and isinstance(result[k], int):
                 aggregate[k] += result[k]
-        if result.get("status") == "error":
-            aggregate["status"] = "partial"
         if result.get("skipped"):
             aggregate["skipped_dates"].append(d)
+
+    # ── Fatality is TARGET-driven, not "any per-date error" ─────────────
+    _target = aggregate["per_date"].get(target_date)
+    _target_ok = _target is not None and _target.get("status") in (
+        "ok", "ok_dry_run",
+    )
+    aggregate["backfill_failed_dates"] = sorted(
+        d for d, r in aggregate["per_date"].items()
+        if r.get("status") == "error" and d != target_date
+    )
+    if not _target_ok:
+        # Target date itself failed (or produced no result) — FATAL. The
+        # caller's strict roll-up escalates this to SystemExit(1), which
+        # is correct: downstream must not read a bad/absent target row.
+        aggregate["status"] = "error"
+        aggregate["error"] = (
+            f"target date {target_date} failed: "
+            f"{(_target or {}).get('error', 'no result produced')}"
+        )
+    else:
+        # Target good. Non-target backfill misses (if any) are surfaced
+        # loudly for the surveillance / Flow-Doctor channel but are
+        # non-fatal (mirrors chronic-gap self-heal best-effort policy).
+        if aggregate["backfill_failed_dates"]:
+            logger.warning(
+                "[daily_closes window] target %s OK; %d non-target "
+                "backfill date(s) failed — best-effort, NON-FATAL: %s",
+                target_date, len(aggregate["backfill_failed_dates"]),
+                ", ".join(aggregate["backfill_failed_dates"]),
+            )
+        aggregate["status"] = "ok"
     return aggregate
 
 

--- a/tests/test_daily_closes_window_days.py
+++ b/tests/test_daily_closes_window_days.py
@@ -15,9 +15,12 @@ These tests pin:
    once per date (the free-tier rate-limit contract).
 3. The per-date result dicts aggregate into a stable window-mode
    return shape with ``per_date`` keyed by ISO date.
-4. Per-date failures don't take down the rest of the window — the
-   aggregate's ``status`` flips to ``"partial"`` but every other date
-   completes.
+4. Fatality is TARGET-driven: a non-target *historical backfill* date
+   failing is best-effort (recorded in ``backfill_failed_dates``,
+   aggregate stays ``"ok"`` so the caller's strict roll-up does not
+   SystemExit); only the target date (newest = downstream-read)
+   failing yields aggregate ``"error"``. (Regression guard for the
+   2026-05-15 MorningEnrich exit-1 incident.)
 5. ``_previous_business_days`` skips weekends and respects ``n``.
 6. Invalid ``window_days`` (< 1) raises ``ValueError`` early.
 """
@@ -319,18 +322,13 @@ class TestWindowOrchestration:
         # fan-out works).
         assert len(captured) == 2
 
-    def test_per_date_failure_does_not_block_window(self):
-        """If one date errors (e.g. a coverage-gate trip on a non-trading
-        day), the rest of the window completes. Aggregate status flips
-        to ``partial``."""
-        captured = []
-        s3 = _no_existing_parquet_s3()
-
+    @staticmethod
+    def _yf_side_factory(captured, fail_dates):
         def _yf_side(missing, run_date, records):
             captured.append(run_date)
-            if run_date == "2026-05-07":
-                # Simulate yfinance returning nothing on this date — the
-                # coverage gate should fire and the date's call raises.
+            if run_date in fail_dates:
+                # yfinance returns nothing on this date — the coverage
+                # gate fires and the per-date call raises.
                 return 0
             for t in missing:
                 records.append({
@@ -340,25 +338,71 @@ class TestWindowOrchestration:
                     "Volume": 1000, "VWAP": None, "source": "yfinance",
                 })
             return len(missing)
+        return _yf_side
 
+    def _run_window(self, run_date, window_days, fail_dates):
+        captured = []
+        s3 = _no_existing_parquet_s3()
         with patch("collectors.daily_closes.boto3.client", return_value=s3):
             with patch.object(
                 daily_closes, "_fetch_polygon_closes", return_value=0
             ), patch.object(
-                daily_closes, "_fetch_yfinance_closes", side_effect=_yf_side,
+                daily_closes, "_fetch_yfinance_closes",
+                side_effect=self._yf_side_factory(captured, fail_dates),
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
             ):
                 result = daily_closes.collect(
-                    bucket="b", tickers=["AAPL"], run_date="2026-05-08",
-                    source="yfinance_only", window_days=3,
+                    bucket="b", tickers=["AAPL"], run_date=run_date,
+                    source="yfinance_only", window_days=window_days,
                 )
-        # All 3 dates were attempted.
-        assert sorted(captured) == ["2026-05-06", "2026-05-07", "2026-05-08"]
-        # Aggregate flagged partial because 5/7 hit the coverage gate.
-        assert result["status"] == "partial"
-        assert "2026-05-07" in result["per_date"]
+        return result, sorted(captured)
+
+    def test_non_target_backfill_failure_is_non_fatal(self):
+        """2026-05-15 regression: a NON-target historical backfill date
+        failing must NOT fail the window — aggregate stays ``"ok"`` (so
+        the caller's strict roll-up does not SystemExit(1)); the miss is
+        recorded in ``backfill_failed_dates`` for the alert channel."""
+        # window = [5/06, 5/07, 5/08]; target = newest = 5/08. 5/07 fails.
+        result, captured = self._run_window(
+            "2026-05-08", window_days=3, fail_dates={"2026-05-07"},
+        )
+        assert captured == ["2026-05-06", "2026-05-07", "2026-05-08"]
+        assert result["target_date"] == "2026-05-08"
+        # Target good ⇒ aggregate OK ⇒ caller roll-up treats as success.
+        assert result["status"] == "ok"
+        assert result["status"] in ("ok", "ok_dry_run")  # caller contract
+        # Non-target miss recorded but non-fatal.
+        assert result["backfill_failed_dates"] == ["2026-05-07"]
         assert result["per_date"]["2026-05-07"]["status"] == "error"
-        # Other dates still succeeded.
         assert result["per_date"]["2026-05-06"]["status"] == "ok"
         assert result["per_date"]["2026-05-08"]["status"] == "ok"
+
+    def test_target_date_failure_is_fatal(self):
+        """The safety property: if the TARGET (newest) date fails, the
+        aggregate is ``"error"`` so the caller halts — downstream must
+        never read a bad/absent target row."""
+        # window = [5/06, 5/07, 5/08]; target = 5/08 — make it fail.
+        result, captured = self._run_window(
+            "2026-05-08", window_days=3, fail_dates={"2026-05-08"},
+        )
+        assert captured == ["2026-05-06", "2026-05-07", "2026-05-08"]
+        assert result["target_date"] == "2026-05-08"
+        assert result["status"] == "error"
+        assert result["status"] not in ("ok", "ok_dry_run")  # caller halts
+        assert "2026-05-08" in result["error"]
+        # Backfill list excludes the target even though it errored.
+        assert result["backfill_failed_dates"] == []
+        assert result["per_date"]["2026-05-08"]["status"] == "error"
+        # Earlier dates still completed.
+        assert result["per_date"]["2026-05-06"]["status"] == "ok"
+        assert result["per_date"]["2026-05-07"]["status"] == "ok"
+
+    def test_target_ok_and_no_backfill_failures_is_ok(self):
+        """All-good window: status ok, empty backfill_failed_dates."""
+        result, captured = self._run_window(
+            "2026-05-08", window_days=3, fail_dates=set(),
+        )
+        assert captured == ["2026-05-06", "2026-05-07", "2026-05-08"]
+        assert result["status"] == "ok"
+        assert result["backfill_failed_dates"] == []


### PR DESCRIPTION
## P0 — MorningEnrich multi-date-backfill exit-1 on re-run

### What this fixes
The 5/15 full-SF recovery re-run's MorningEnrich exited 1 even though the target date was healthy. Diagnostic capture (#244) is live; this is the Part-2 fix.

### Root cause (corrected — earlier static theory was falsified)
My initial static diagnosis ("survivorship-biased point-in-time coverage-gate") was **falsified by a controlled dry-run reproduction**: coverage held at **913/921 ≈ 99.1%** for every historical window date — an order of magnitude above the 5% gate. (Plan doc `alpha-engine-docs/private/morningenrich-coverage-gate-260515.md` §8/§9.)

The **real defect**: `_collect_window` is best-effort per-date by design, but set aggregate `status="partial"` on *any* per-date error — including a **non-target historical backfill date** (same-day-403 / polygon free-tier quota-rate-limit / transient non-overlapping grouped-daily). The caller's strict roll-up (`weekly_collector.py:1076`, `status not in ("ok","ok_dry_run") ⇒ "failed"`) then escalated that recoverable backfill miss into `SystemExit(1)`, halting an otherwise-healthy run. Most plausible 5/15 trigger: polygon free-tier quota exhaustion by the time of the same-day recovery re-run (28.5-min runtime ⇒ heavy throttling).

### Fix (narrow — Layer-3 only)
Aggregate `status` is now **target-driven**: the newest window date (`target_date` = what downstream actually reads) decides fatality.
- Target OK ⇒ aggregate `ok`; non-target misses recorded in the new additive `backfill_failed_dates` + a WARNING for the surveillance channel. **Non-fatal.**
- Target failed ⇒ aggregate `error` (caller halts — safety property preserved; downstream must not read a bad target row).

Correct **regardless of which transient** (403/429/quota) triggered it — they all funnel through this same escalation defect. Mirrors the established chronic-gap-self-heal best-effort precedent (`weekly_collector.py:1051-1060`). Fixes the EOD `--daily` window path identically (same roll-up). Layers 1 (market-breadth gate) & 2 (PIT completeness) **dropped from this P0** — the repro proved coverage is healthy; they'd fix a non-problem (logged separately, non-gating).

### Tests
Rewrote `test_per_date_failure_does_not_block_window` → `test_non_target_backfill_failure_is_non_fatal` (the exact 5/15 scenario) + added `test_target_date_failure_is_fatal` (safety property) + `test_target_ok_and_no_backfill_failures_is_ok`. Schema additive-only per S3 Contract Safety. **Full suite: 1048 passed, 1 skipped.**

### Follow-up (not blocking)
Next real captured `_ssm_logs/morning-enrich` failure log will disambiguate same-day-403 vs quota-exhaustion vs transient and inform whether a secondary same-day/quota-aware refinement is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)