### PR TITLE
fix(spot): re-export AWS_REGION into spot shell — close #241 .env-removal regression (Sat SF DataPhase1 P0)

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -247,7 +247,16 @@ REMOTE_PYTHON=$(run_remote "command -v python3.12 || command -v python3")
 # bootstrapped. AL2023 spots install python3.12 but have no bare `python`
 # symlink — the RAG script's `python -m ...` fails without this. Origin:
 # 2026-04-17 Saturday Step Function failure in RAG step-0 preflight.
-ENV_SOURCE="export XDG_CACHE_HOME=/tmp; export PYTHON_BIN=$REMOTE_PYTHON;"
+#
+# AWS_REGION/AWS_DEFAULT_REGION: the spot shell no longer sources a .env
+# (PR 9f / #241 removed `.env` sourcing in favor of runtime get_secret()
+# SSM lookups), but AWS_REGION is a plain env var — not a secret — that
+# alpha_engine_lib.preflight.check_env_vars hard-requires, and boto3 needs
+# a default region with no .env present. Re-export it explicitly from the
+# dispatcher-side $AWS_REGION (set above with us-east-1 fallback). Origin:
+# 2026-05-16 Saturday SF DataPhase1 failure — weekly_collector --morning-enrich
+# aborted at preflight with "required env vars missing: ['AWS_REGION']".
+ENV_SOURCE="export XDG_CACHE_HOME=/tmp; export PYTHON_BIN=$REMOTE_PYTHON; export AWS_REGION=$AWS_REGION; export AWS_DEFAULT_REGION=$AWS_REGION;"
 
 # ── Smoke-only: imports + --phase 1 --dry-run ────────────────────────────────
 if [ "$RUN_MODE" = "smoke-only" ]; then

--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -190,7 +190,11 @@ echo "Dependencies installed."
 DEPS
 
 REMOTE_PYTHON=$(run_remote "command -v python3.12 || command -v python3")
-ENV_SOURCE='export XDG_CACHE_HOME=/tmp; export PYTHONPATH=/home/ec2-user/alpha-engine-predictor;'
+# AWS_REGION/AWS_DEFAULT_REGION re-export: same #241 regression as
+# spot_data_weekly.sh — the spot shell no longer sources a .env, so the
+# region env vars boto3 + lib preflight depend on must be set explicitly
+# from the dispatcher-side $AWS_REGION (set above with us-east-1 fallback).
+ENV_SOURCE="export XDG_CACHE_HOME=/tmp; export PYTHONPATH=/home/ec2-user/alpha-engine-predictor; export AWS_REGION=$AWS_REGION; export AWS_DEFAULT_REGION=$AWS_REGION;"
 
 # ── Smoke-only: imports + --help ─────────────────────────────────────────────
 if [ "$RUN_MODE" = "smoke-only" ]; then

--- a/tests/test_spot_env_source_aws_region.py
+++ b/tests/test_spot_env_source_aws_region.py
@@ -1,0 +1,47 @@
+"""Pins the spot dispatcher scripts to export AWS_REGION into the spot shell.
+
+PR 9f (#241) removed the `.env` sourcing from the spot bootstrap in favor
+of runtime get_secret() SSM lookups. That correctly handled *secrets*, but
+the same `.env` was also the only thing exporting AWS_REGION — a plain env
+var (not a secret) that:
+
+  - alpha_engine_lib.preflight.check_env_vars() hard-requires, and
+  - boto3 needs as a default region with no .env / ~/.aws/config present.
+
+Result: 2026-05-16 Saturday SF DataPhase1 aborted at preflight with
+"required env vars missing: ['AWS_REGION']". This test catches that
+shim-deletion launch-mechanism regression class: any future edit to the
+ENV_SOURCE injected into the remote heredocs must keep the region exports.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = [
+    _REPO_ROOT / "infrastructure" / "spot_data_weekly.sh",
+    _REPO_ROOT / "infrastructure" / "spot_drift_detection.sh",
+]
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.name)
+def test_env_source_exports_region(script: Path):
+    text = script.read_text()
+    # The single ENV_SOURCE assignment that gets interpolated into every
+    # remote `run_remote bash -s <<HEREDOC` workload.
+    m = re.search(r'^ENV_SOURCE=.*$', text, re.MULTILINE)
+    assert m, f"{script.name}: no ENV_SOURCE assignment found"
+    env_source = m.group(0)
+    assert "export AWS_REGION=" in env_source, (
+        f"{script.name}: ENV_SOURCE must export AWS_REGION — without it the "
+        "spot shell has no region (no .env post-#241) and lib preflight / "
+        "boto3 fail. See 2026-05-16 DataPhase1 failure."
+    )
+    assert "export AWS_DEFAULT_REGION=" in env_source, (
+        f"{script.name}: ENV_SOURCE must also export AWS_DEFAULT_REGION for "
+        "boto3 clients that read the default-region var."
+    )


### PR DESCRIPTION
## Root cause (P0 — 2026-05-16 Saturday SF DataPhase1 failure)

Saturday pipeline aborted ~1m52s into `DataPhase1` at `weekly_collector.py --morning-enrich` preflight:

```
RuntimeError: Pre-flight: required env vars missing: ['AWS_REGION']
```

PR 9f (#241, `61253df`) removed the spot-side `.env` sourcing in favor of runtime `get_secret()` SSM lookups. Diff line 118→119:

- **before:** `ENV_SOURCE="set -a; ... source .../.env; set +a; export XDG_CACHE_HOME=/tmp; ..."`
- **after:** `ENV_SOURCE="export XDG_CACHE_HOME=/tmp; export PYTHON_BIN=$REMOTE_PYTHON;"`

The audit correctly migrated **secrets** to `get_secret()`, but the same `.env` was also the only thing exporting **`AWS_REGION`** — a plain env var (not a secret) that `alpha_engine_lib.preflight.check_env_vars()` hard-requires and boto3 needs as a default region. This is the [shim-deletion / launch-mechanism] regression class.

No stale-data risk: failure happened at preflight, before any S3/ArcticDB write; spot self-terminated.

## Fix

`ENV_SOURCE` (interpolated into every `run_remote bash -s <<HEREDOC` workload) now also exports `AWS_REGION` + `AWS_DEFAULT_REGION` from the dispatcher-side `$AWS_REGION` (already defaulted to `us-east-1`). Applied to **both** `spot_data_weekly.sh` and `spot_drift_detection.sh` — the identical #241 regression also affects the Saturday `DriftDetection` state.

## Test

`tests/test_spot_env_source_aws_region.py` pins both scripts' `ENV_SOURCE` region exports so a future edit can't silently drop them. Subset run: **278 passed, 1 skipped**.

## Recovery

After merge, re-trigger the Saturday SF (dispatcher git-pulls `main` before running the spot script). DataPhase1 must clear before downstream Research/Predictor/Backtester.

🤖 Generated with [Claude Code](https://claude.com/claude-code)