### PR TITLE
fix(preflight): resolve API-key secrets via get_secret(), not stale env-var check (Sat SF DataPhase1 P0, facet 2)

### DIFF
--- a/preflight.py
+++ b/preflight.py
@@ -73,11 +73,21 @@ class DataPreflight(BasePreflight):
         # 2. S3 bucket (~ms, IAM)
         # 3. mode-specific HTTP probes (~200ms each)
         # 4. ArcticDB checks (~100ms list_libraries; ~seconds for read)
+        # AWS_REGION is a plain env var (boto3 region) — not a secret —
+        # so it stays an os.environ check. The API keys below moved to
+        # SSM via get_secret() in the .env-deprecation arc (#241/#242):
+        # every collector + the reachability probes in this file resolve
+        # them via get_secret(), so an os.environ assertion here is stale
+        # and fails spuriously on the SSM-backed spot (no .env present).
+        # Origin: 2026-05-16 Saturday SF DataPhase1 — phase1 preflight
+        # aborted "required env vars missing: ['FRED_API_KEY',
+        # 'POLYGON_API_KEY']" even though MorningEnrich (same collectors)
+        # had just fetched polygon + FRED fine via get_secret().
         self.check_env_vars("AWS_REGION")
         if self.mode == "phase1":
-            self.check_env_vars("FRED_API_KEY", "POLYGON_API_KEY")
+            self._check_secrets("FRED_API_KEY", "POLYGON_API_KEY")
         elif self.mode == "phase2":
-            self.check_env_vars("FMP_API_KEY", "FINNHUB_API_KEY", "EDGAR_IDENTITY")
+            self._check_secrets("FMP_API_KEY", "FINNHUB_API_KEY", "EDGAR_IDENTITY")
 
         self.check_s3_bucket()
 
@@ -109,6 +119,29 @@ class DataPreflight(BasePreflight):
             # Both libraries must be present — same gate as phase1 for
             # operator-clarity on partial-deploy scenarios.
             self._check_arcticdb_libraries_present(("universe", "macro"))
+
+    # ── Secret presence ──────────────────────────────────────────────────
+
+    def _check_secrets(self, *names: str) -> None:
+        """SSM-aware equivalent of ``check_env_vars`` for API-key secrets.
+
+        Post the .env-deprecation arc (#241/#242) the API keys live in
+        SSM, fetched lazily via ``get_secret()`` deeper in the run. This
+        keeps the fail-fast intent of the old ``check_env_vars`` gate —
+        abort in <1s, not 30min in — but resolves from SSM (with env
+        fallback, which ``get_secret`` handles) instead of asserting
+        ``os.environ`` directly. Raises the same RuntimeError shape so
+        operator-facing failure text is unchanged.
+        """
+        missing = [
+            n
+            for n in names
+            if not (get_secret(n, required=False, default="") or "").strip()
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Pre-flight: required secrets missing: {missing}"
+            )
 
     # ── Mode-specific primitives ─────────────────────────────────────────
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -208,25 +208,38 @@ class TestRunEndToEnd:
         mock_arctic = MagicMock()
         mock_arctic.list_libraries.return_value = ["universe", "macro"]
 
+        _secrets = {"POLYGON_API_KEY": "k1", "FRED_API_KEY": "k2"}
         with patch.dict(
-            "os.environ",
-            {"AWS_REGION": "us-east-1", "POLYGON_API_KEY": "k1", "FRED_API_KEY": "k2"},
-            clear=False,
+            "os.environ", {"AWS_REGION": "us-east-1"}, clear=False
+        ), patch(
+            "preflight.get_secret",
+            side_effect=lambda n, **kw: _secrets.get(n, kw.get("default", "")),
         ), patch("boto3.client", return_value=mock_s3), patch(
             "arcticdb.Arctic", return_value=mock_arctic
         ), patch("requests.get") as mock_http:
             mock_http.return_value = MagicMock(status_code=200, text='{"ok": true}')
             pf.run()
 
-    def test_phase1_missing_polygon_key_short_circuits(self):
-        """env var failure raises before HTTP/S3/ArcticDB are touched."""
+    def test_phase1_missing_polygon_secret_short_circuits(self):
+        """Missing API-key SECRET raises before HTTP/S3/ArcticDB are touched.
+
+        Post #241/#242 the keys resolve via get_secret() (SSM), not
+        os.environ — but the fail-fast short-circuit before the
+        reachability probes must still hold. Regression for the
+        2026-05-16 Saturday SF DataPhase1 phase1-preflight failure.
+        """
         pf = _make("phase1")
+        # FRED present, POLYGON absent — at the SSM layer, not env.
+        _secrets = {"AWS_REGION": "us-east-1", "FRED_API_KEY": "k2"}
         with patch.dict(
-            "os.environ", {"AWS_REGION": "us-east-1", "FRED_API_KEY": "k2"}, clear=True
-        ), patch("requests.get") as mock_http, patch("boto3.client") as mock_boto, patch(
-            "arcticdb.Arctic"
-        ) as mock_arctic:
-            with pytest.raises(RuntimeError, match="POLYGON_API_KEY"):
+            "os.environ", {"AWS_REGION": "us-east-1"}, clear=True
+        ), patch(
+            "preflight.get_secret",
+            side_effect=lambda n, **kw: _secrets.get(n, kw.get("default", "")),
+        ), patch("requests.get") as mock_http, patch(
+            "boto3.client"
+        ) as mock_boto, patch("arcticdb.Arctic") as mock_arctic:
+            with pytest.raises(RuntimeError, match="secrets missing.*POLYGON_API_KEY"):
                 pf.run()
             mock_http.assert_not_called()
             mock_boto.assert_not_called()
@@ -262,15 +275,16 @@ class TestRunEndToEnd:
         mock_s3 = MagicMock()
         mock_s3.head_bucket.return_value = {}
 
+        _secrets = {
+            "FMP_API_KEY": "x",
+            "FINNHUB_API_KEY": "y",
+            "EDGAR_IDENTITY": "Tester test@example.com",
+        }
         with patch.dict(
-            "os.environ",
-            {
-                "AWS_REGION": "us-east-1",
-                "FMP_API_KEY": "x",
-                "FINNHUB_API_KEY": "y",
-                "EDGAR_IDENTITY": "Tester test@example.com",
-            },
-            clear=False,
+            "os.environ", {"AWS_REGION": "us-east-1"}, clear=False
+        ), patch(
+            "preflight.get_secret",
+            side_effect=lambda n, **kw: _secrets.get(n, kw.get("default", "")),
         ), patch("boto3.client", return_value=mock_s3), patch("requests.get") as mock_http:
             mock_http.return_value = MagicMock(
                 status_code=200, text='[{"symbol":"AAPL"}]', json=lambda: [{"symbol": "AAPL"}]


### PR DESCRIPTION
## Context — second facet of the #241/#242 .env-deprecation regression

Surfaced during the 2026-05-16 Saturday SF recovery. **#247 (AWS_REGION) worked**: DataPhase1 cleared preflight and **MorningEnrich completed end-to-end** (`Morning enrichment OK for 2026-05-15 ... in 1675s`; polygon 913/921 + FRED 4/4 fetched fine via `get_secret()`) — so Friday's polygon-authoritative `daily_closes` are now collected and the original stale-data P0 is resolved.

But `weekly_collector.py --phase 1` then aborted at preflight:

```
RuntimeError: Pre-flight: required env vars missing: ['FRED_API_KEY', 'POLYGON_API_KEY']
```

## Root cause (reproduced, not speculative)

Every collector **and both reachability probes in `preflight.py` itself** already resolve these keys via `get_secret()` (SSM) — empirically proven by MorningEnrich succeeding with no env vars set. The only stale code is `DataPreflight.run()`:

```python
if self.mode == "phase1":
    self.check_env_vars("FRED_API_KEY", "POLYGON_API_KEY")      # stale os.environ assertion
elif self.mode == "phase2":
    self.check_env_vars("FMP_API_KEY", "FINNHUB_API_KEY", "EDGAR_IDENTITY")  # same latent bug
```

The env-deprecation arc migrated every *consumer* to `get_secret()` but missed this gate. MorningEnrich slipped through because its preflight only checks `AWS_REGION`; phase1/phase2 hard-fail on the stale gate. **phase2 would have been the next failure.**

## Fix

- `AWS_REGION` stays an env-var check (plain boto3 region, not a secret — supplied by #247's `ENV_SOURCE`).
- API keys go through a new `_check_secrets()` helper using `get_secret(required=False)` — identical <1s fail-fast intent and `RuntimeError` shape, sourced from SSM (with `get_secret`'s env fallback) instead of `os.environ`.
- phase2 fixed in the same change (identical latent bug).

## Test

Updated the two end-to-end tests that encoded the old env-var assumption to patch `preflight.get_secret` instead; added a renamed regression test (`test_phase1_missing_polygon_secret_short_circuits`) asserting the SSM-layer short-circuit still fires before HTTP/S3/ArcticDB. **Full suite: 1050 passed, 1 skipped.**

## Recovery

After merge, re-trigger the Saturday SF. MorningEnrich's Friday fill from the recovery run is already persisted (ArcticDB + S3), so the re-run is safe; phase1 will now pass preflight and proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)