### PR TITLE
fix(data): [PR4a] additively mirror options to predictor-expected S3 key (write-both)

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -32,6 +32,14 @@ query-string tickers. On /stable, these endpoints are paid-tier (HTTP
 
 Output: one JSON file per ticker at market_data/weekly/{date}/alternative/{TICKER}.json
 plus a manifest at market_data/weekly/{date}/alternative/manifest.json.
+
+Additionally (write-both, additive) writes a flat single-file options
+projection at archive/options/{date}.json — the legacy-shaped key that
+alpha-engine-predictor's data/options_fetcher.py::load_historical_options
+reads. Producer/consumer key + shape differ (verified read-only against
+predictor origin/main 2026-05-16); this mirror starts the ≥1-week soak that
+gates the separate, later predictor-side consumer swap (yfinance
+centralization plan PR 4b). The canonical per-ticker files are untouched.
 """
 
 from __future__ import annotations
@@ -182,6 +190,67 @@ _HAS_DATA_PREDICATES = {
 }
 
 
+# ── Predictor-options mirror (write-both, additive) ──────────────────────────
+#
+# The canonical alternative-data layout is one JSON per ticker at
+# ``market_data/weekly/{date}/alternative/{TICKER}.json`` (options nested
+# under the ``options_flow`` sub-dict). That is the format research consumes
+# and is left untouched.
+#
+# alpha-engine-predictor's ``data/options_fetcher.py::load_historical_options``
+# reads a DIFFERENT, legacy-shaped key: a single flat file at
+# ``archive/options/{date}.json`` mapping ``{ticker: {put_call_ratio, iv_rank,
+# atm_iv}}``. Verified read-only against predictor origin/main 2026-05-16:
+# the consumer takes ``put_call_ratio`` raw then ``np.log()``-transforms it,
+# divides ``iv_rank`` by 100, and defaults ``atm_iv`` to 0.0 on miss. The
+# producer's ``options_flow`` already emits ``put_call_ratio`` as a raw ratio
+# and ``iv_rank`` on a 0-100 scale — exactly the units the consumer expects
+# to log/÷100. ``atm_iv`` is not surfaced by ``_fetch_options`` (it is
+# computed locally as a variable but never stored); the consumer's 0.0
+# default handles its absence gracefully.
+#
+# Per the S3-contract rule (additive only, never rename/remove, write-both
+# for ≥1 week before any consumer relies on it), the collector ADDITIVELY
+# also writes the predictor-expected key/shape alongside the canonical
+# per-ticker files. This starts the soak that gates the SEPARATE, LATER
+# predictor-side consumer swap (yfinance-centralization plan PR 4b — NOT in
+# this PR).
+
+# Predictor-expected single-file mirror key (no s3_prefix — predictor reads
+# the bucket root, matching its hardcoded ``archive/options/{date}.json``).
+_PREDICTOR_OPTIONS_MIRROR_KEY_FMT = "archive/options/{run_date}.json"
+
+
+def _build_predictor_options_mirror(
+    per_ticker_alt: dict[str, dict],
+) -> dict[str, dict]:
+    """Project the canonical per-ticker alt-data payloads down to the flat
+    ``{ticker: {put_call_ratio, iv_rank, atm_iv}}`` shape that
+    alpha-engine-predictor's ``load_historical_options`` expects.
+
+    Only tickers whose ``options_flow`` carried real data are included
+    (predictor neutral-fills missing tickers on its side, matching the
+    canonical per-ticker file's own _has_options_data gate). ``atm_iv`` is
+    emitted as 0.0 since ``_fetch_options`` does not store it — the consumer
+    defaults the same value on a missing key, so this is semantically inert
+    and forward-compatible if a future PR surfaces a real ATM IV.
+    """
+    mirror: dict[str, dict] = {}
+    for ticker, payload in per_ticker_alt.items():
+        opts = (payload or {}).get("options_flow", {}) or {}
+        if not _has_options_data(opts):
+            continue
+        mirror[ticker] = {
+            # Raw ratio — predictor log-transforms on read.
+            "put_call_ratio": opts.get("put_call_ratio"),
+            # 0-100 scale — predictor divides by 100 on read.
+            "iv_rank": opts.get("iv_rank"),
+            # Not produced by _fetch_options; predictor defaults 0.0 on miss.
+            "atm_iv": opts.get("atm_iv", 0.0),
+        }
+    return mirror
+
+
 def collect(
     bucket: str,
     s3_prefix: str,
@@ -233,6 +302,11 @@ def collect(
     # this ticker carried real (non-default) data — see _HAS_DATA_PREDICATES
     # commentary above for the silent-fail surface this protects against.
     source_ok_counts: dict[str, int] = {k: 0 for k in _HAS_DATA_PREDICATES}
+    # Accumulate successful per-ticker payloads so we can additively write
+    # the predictor-expected flat single-file mirror (write-both; see
+    # _build_predictor_options_mirror commentary). Canonical per-ticker
+    # files above are the source of truth and are left untouched.
+    per_ticker_alt: dict[str, dict] = {}
 
     for ticker in tickers:
         try:
@@ -244,6 +318,7 @@ def collect(
                 Body=json.dumps(data, indent=2, default=str),
                 ContentType="application/json",
             )
+            per_ticker_alt[ticker] = data
             succeeded += 1
             for source_name, predicate in _HAS_DATA_PREDICATES.items():
                 if predicate(data.get(source_name, {}) or {}):
@@ -272,6 +347,30 @@ def collect(
         for source in _HAS_DATA_PREDICATES
         if source_ratios[source] < min_ok_ratios[source]
     ]
+
+    # ── Predictor-options mirror (additive, write-both) ─────────────────────
+    # Project the canonical per-ticker options data down to the flat
+    # single-file shape alpha-engine-predictor's load_historical_options
+    # reads (archive/options/{date}.json). Written BEFORE the gate raises
+    # for the same reason as the manifest: the soak that gates predictor
+    # PR 4b should proceed on every run that produced options data, not
+    # only clean ones. This is a pure producer-side ADD — the canonical
+    # per-ticker files (research's consumers) are unaffected, nothing is
+    # renamed or removed.
+    predictor_options_mirror = _build_predictor_options_mirror(per_ticker_alt)
+    predictor_mirror_key = _PREDICTOR_OPTIONS_MIRROR_KEY_FMT.format(
+        run_date=run_date
+    )
+    s3.put_object(
+        Bucket=bucket,
+        Key=predictor_mirror_key,
+        Body=json.dumps(predictor_options_mirror, indent=2, default=str),
+        ContentType="application/json",
+    )
+    logger.info(
+        "Predictor options mirror: %d tickers -> s3://%s/%s (write-both)",
+        len(predictor_options_mirror), bucket, predictor_mirror_key,
+    )
 
     # Write manifest BEFORE the gate raises — operators triaging a
     # gate breach need the manifest's per-source counts to identify

--- a/tests/test_alternative_predictor_options_mirror.py
+++ b/tests/test_alternative_predictor_options_mirror.py
@@ -1,0 +1,233 @@
+"""Tests for the predictor-options write-both mirror in ``collectors/alternative.py``.
+
+Background (yfinance-centralization plan PR 4a):
+The canonical alternative-data layout is one JSON per ticker at
+``market_data/weekly/{date}/alternative/{TICKER}.json`` (options nested
+under ``options_flow``). alpha-engine-predictor's
+``data/options_fetcher.py::load_historical_options`` reads a DIFFERENT,
+legacy-shaped key — a single flat file at ``archive/options/{date}.json``
+mapping ``{ticker: {put_call_ratio, iv_rank, atm_iv}}``.
+
+Per the S3-contract rule (additive only; write-both ≥1 week before any
+consumer relies on the new key), the collector now ADDITIVELY also writes
+the predictor-expected key/shape alongside the canonical per-ticker files.
+These tests lock that contract: both keys land, the mirror carries the
+same option payloads as the per-ticker files, units are preserved, and
+the canonical files are untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from collectors import alternative
+
+
+def _alt_payload(ticker: str, *, pc, iv, with_options: bool = True) -> dict:
+    """A `_fetch_all_alternative`-shaped return; options_flow populated
+    unless ``with_options`` is False (provider dark)."""
+    return {
+        "ticker": ticker,
+        "fetched_at": "2026-05-16T20:00:00+00:00",
+        "analyst_consensus": {
+            "rating": "Buy", "target_price": 200.0,
+            "num_analysts": 25, "earnings_surprises": [{"date": "Q1"}],
+        },
+        "eps_revision": {"current_estimate": 6.5, "revision_4w": 1.2, "streak": 2},
+        "options_flow": (
+            {"put_call_ratio": pc, "iv_rank": iv, "expected_move_pct": 4.5}
+            if with_options
+            else {"put_call_ratio": None, "iv_rank": None, "expected_move_pct": None}
+        ),
+        "insider_activity": {
+            "cluster_buying": True, "net_shares_30d": 5000,
+            "transactions": [{"insider": "CEO", "shares": 5000}],
+        },
+        "institutional": {
+            "accumulation": True, "funds_increasing": 7, "funds_decreasing": 2,
+        },
+        "news": {"articles": [{"headline": "X"}], "sec_filings_8k": [{"title": "8-K"}]},
+    }
+
+
+def _patch_collect(monkeypatch, *, fetch_returns: list[dict]):
+    s3 = MagicMock()
+    monkeypatch.setattr(alternative, "boto3", MagicMock(client=lambda *a, **k: s3))
+    monkeypatch.setattr(
+        alternative, "_load_promoted_tickers",
+        lambda *a, **k: [d["ticker"] for d in fetch_returns],
+    )
+    fetch_iter = iter(fetch_returns)
+    monkeypatch.setattr(
+        alternative, "_fetch_all_alternative",
+        lambda ticker, run_date, bucket: next(fetch_iter),
+    )
+    return s3
+
+
+def _puts_by_key(s3) -> dict[str, dict]:
+    """Map every put_object Key → parsed JSON body."""
+    out: dict[str, dict] = {}
+    for c in s3.put_object.call_args_list:
+        out[c.kwargs["Key"]] = json.loads(c.kwargs["Body"])
+    return out
+
+
+# ── A. _build_predictor_options_mirror (pure projection) ─────────────────────
+
+
+def test_mirror_projects_options_flow_to_flat_predictor_shape():
+    per_ticker = {
+        "AAPL": _alt_payload("AAPL", pc=0.72, iv=35),
+        "MSFT": _alt_payload("MSFT", pc=1.10, iv=60),
+    }
+    mirror = alternative._build_predictor_options_mirror(per_ticker)
+
+    assert set(mirror) == {"AAPL", "MSFT"}
+    # Flat shape exactly matches what load_historical_options reads.
+    assert set(mirror["AAPL"]) == {"put_call_ratio", "iv_rank", "atm_iv"}
+    # put_call_ratio carried RAW (predictor log-transforms on read).
+    assert mirror["AAPL"]["put_call_ratio"] == 0.72
+    # iv_rank carried on the 0-100 scale (predictor ÷100 on read).
+    assert mirror["MSFT"]["iv_rank"] == 60
+    # atm_iv not surfaced by _fetch_options → 0.0 (predictor defaults same).
+    assert mirror["AAPL"]["atm_iv"] == 0.0
+
+
+def test_mirror_excludes_tickers_with_no_options_data():
+    per_ticker = {
+        "AAPL": _alt_payload("AAPL", pc=0.72, iv=35),
+        "NVDA": _alt_payload("NVDA", pc=None, iv=None, with_options=False),
+    }
+    mirror = alternative._build_predictor_options_mirror(per_ticker)
+    assert "AAPL" in mirror
+    assert "NVDA" not in mirror, (
+        "tickers whose options_flow went dark must be omitted — "
+        "predictor neutral-fills missing tickers on its side"
+    )
+
+
+def test_mirror_carries_real_atm_iv_if_ever_surfaced():
+    """Forward-compatible: if a future PR stores atm_iv in options_flow,
+    the mirror must carry it instead of the 0.0 default."""
+    per_ticker = {
+        "AAPL": {
+            **_alt_payload("AAPL", pc=0.8, iv=40),
+            "options_flow": {
+                "put_call_ratio": 0.8, "iv_rank": 40,
+                "expected_move_pct": 3.1, "atm_iv": 0.27,
+            },
+        }
+    }
+    mirror = alternative._build_predictor_options_mirror(per_ticker)
+    assert mirror["AAPL"]["atm_iv"] == 0.27
+
+
+# ── B. collect() writes BOTH keys ────────────────────────────────────────────
+
+
+def test_collect_writes_canonical_and_predictor_mirror_keys(monkeypatch):
+    payloads = [
+        _alt_payload("AAPL", pc=0.72, iv=35),
+        _alt_payload("MSFT", pc=1.10, iv=60),
+    ]
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="alpha-engine-research",
+        s3_prefix="market_data/",
+        run_date="2026-05-16",
+        tickers=["AAPL", "MSFT"],
+    )
+    assert result["status"] == "ok"
+
+    by_key = _puts_by_key(s3)
+
+    # Canonical per-ticker files (research consumers) — untouched/present.
+    assert "market_data/weekly/2026-05-16/alternative/AAPL.json" in by_key
+    assert "market_data/weekly/2026-05-16/alternative/MSFT.json" in by_key
+    # Canonical manifest still written.
+    assert "market_data/weekly/2026-05-16/alternative/manifest.json" in by_key
+    # NEW: predictor-expected flat single-file mirror at the legacy key
+    # (bucket-root, no market_data/ prefix — matches predictor's hardcoded
+    # archive/options/{date}.json read).
+    assert "archive/options/2026-05-16.json" in by_key
+
+
+def test_mirror_payload_matches_canonical_options_flow(monkeypatch):
+    """The mirror must carry the SAME option values as the canonical
+    per-ticker files — no divergence between the two written keys."""
+    payloads = [
+        _alt_payload("AAPL", pc=0.72, iv=35),
+        _alt_payload("MSFT", pc=1.10, iv=60),
+    ]
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    alternative.collect(
+        bucket="alpha-engine-research",
+        s3_prefix="market_data/",
+        run_date="2026-05-16",
+        tickers=["AAPL", "MSFT"],
+    )
+    by_key = _puts_by_key(s3)
+
+    mirror = by_key["archive/options/2026-05-16.json"]
+    for tkr in ("AAPL", "MSFT"):
+        canonical = by_key[
+            f"market_data/weekly/2026-05-16/alternative/{tkr}.json"
+        ]["options_flow"]
+        assert mirror[tkr]["put_call_ratio"] == canonical["put_call_ratio"]
+        assert mirror[tkr]["iv_rank"] == canonical["iv_rank"]
+
+
+def test_mirror_written_even_on_gate_breach(monkeypatch):
+    """Like the manifest, the mirror lands even when the per-source gate
+    breaches — the ≥1wk soak that gates predictor PR 4b should proceed on
+    every run that produced options data, not only clean ones."""
+    # analyst_consensus dark for all 10 → gate breach, but options_flow
+    # is still populated.
+    payloads = []
+    for i in range(10):
+        p = _alt_payload(f"TKR{i}", pc=0.9, iv=20)
+        p["analyst_consensus"] = {
+            "rating": None, "target_price": None,
+            "num_analysts": None, "earnings_surprises": [],
+        }
+        payloads.append(p)
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = alternative.collect(
+        bucket="alpha-engine-research",
+        s3_prefix="market_data/",
+        run_date="2026-05-16",
+        tickers=[f"TKR{i}" for i in range(10)],
+    )
+    assert result["status"] == "error"  # gate breached
+    by_key = _puts_by_key(s3)
+    assert "archive/options/2026-05-16.json" in by_key
+    mirror = by_key["archive/options/2026-05-16.json"]
+    assert len(mirror) == 10
+    assert mirror["TKR0"]["put_call_ratio"] == 0.9
+
+
+def test_dry_run_writes_no_mirror(monkeypatch):
+    """Dry-run short-circuits before any fetch/write — no mirror key."""
+    s3 = MagicMock()
+    monkeypatch.setattr(
+        alternative, "boto3", MagicMock(client=lambda *a, **k: s3),
+    )
+    monkeypatch.setattr(
+        alternative, "_load_promoted_tickers", lambda *a, **k: ["AAPL"],
+    )
+    result = alternative.collect(
+        bucket="alpha-engine-research",
+        s3_prefix="market_data/",
+        run_date="2026-05-16",
+        tickers=["AAPL"],
+        dry_run=True,
+    )
+    assert result["status"] == "ok_dry_run"
+    s3.put_object.assert_not_called()


### PR DESCRIPTION
## Summary

Producer-side **additive write-both** so alpha-engine-data also writes the options S3 key/shape that alpha-engine-predictor expects. Part of the yfinance-centralization arc (`yfinance-centralization-260516.md`, PR 4a / replacement-mapping row "P2/R4 options").

## Verified producer-vs-consumer mismatch (read-only audit vs `origin/main`, 2026-05-16)

| | key | shape |
|---|---|---|
| **Producer** (`collectors/alternative.py`) | `market_data/weekly/{date}/alternative/{TICKER}.json` (one file **per ticker**) | options nested under `options_flow` sub-dict: `put_call_ratio` (raw ratio), `iv_rank` (0–100), `expected_move_pct` |
| **Consumer** (`alpha-engine-predictor` `data/options_fetcher.py::load_historical_options`) | `archive/options/{date}.json` (a **single flat file**, no `market_data/` prefix) | `{ticker: {put_call_ratio, iv_rank, atm_iv}}` — reads `put_call_ratio` raw then `np.log()`s it, `iv_rank ÷ 100`, `atm_iv` default `0.0` on miss |

**Both the key AND the JSON shape differ — they do not align.** A mirror is genuinely required (this was the "only real unknown" called out in the plan's risk notes; resolved: they differ).

## Change (pure producer-side ADD)

`collect()` now additively also writes `archive/options/{run_date}.json`, projected from the same per-ticker `options_flow` payloads via the new pure helper `_build_predictor_options_mirror()`:

- Units preserved: `put_call_ratio` carried raw (predictor log-transforms on read), `iv_rank` on 0–100 scale (predictor ÷100 on read).
- `atm_iv` emitted as `0.0` — `_fetch_options` computes it locally as a variable but never stores it; the consumer defaults the same `0.0` on a missing key, so this is semantically inert **and** forward-compatible (helper carries a real `atm_iv` if a future PR ever surfaces one).
- Tickers whose `options_flow` went dark are omitted (predictor neutral-fills its side, matching the canonical file's own `_has_options_data` gate).
- Mirror is written **before** the per-source gate raises — same rationale as the existing manifest write: the soak that gates predictor PR 4b should proceed on every run that produced options data, not only clean ones.
- **Canonical per-ticker files + manifest are untouched** — research's existing consumers are unaffected; nothing renamed or removed. Dry-run still writes nothing.

## Soak

This starts the **≥1-week write-both soak** that gates the **separate, later** predictor-side consumer swap (plan **PR 4b** — *not* in this PR, *not* in scope here).

## Testing

Full suite: **1214 passed, 1 pre-existing skip, 0 failures**. New `tests/test_alternative_predictor_options_mirror.py` (8 tests) locks: both keys written, mirror payload == canonical `options_flow`, units preserved, dark tickers excluded, `atm_iv` forward-compat, mirror lands even on gate breach, dry-run writes nothing.

## Deploy

**DEPLOY HELD** — user reviews + merges. No `gh workflow run` / SF / Lambda triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
