### PR TITLE
fix(sf): stamp run_date once at InitializeInput, thread to spot stages

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -4,9 +4,9 @@
   "States": {
     "InitializeInput": {
       "Type": "Pass",
-      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + ec2_instance_id explicitly; manual runs for partial-execution testing often omit sns_topic_arn, which previously caused HandleFailure/NotifyComplete to error on missing JSONPath. States.JsonMerge with user-input as the second arg lets explicit values win.",
+      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + ec2_instance_id explicitly; manual runs for partial-execution testing often omit sns_topic_arn, which previously caused HandleFailure/NotifyComplete to error on missing JSONPath. States.JsonMerge with user-input as the second arg lets explicit values win. | 2026-05-17: also stamps run_date = date($$.Execution.StartTime) so every spot stage of one execution keys backtest/{date}/ off ONE date (fixes the Backtester=05-17 vs Evaluator=05-18 UTC-midnight split). User-passed run_date still wins.",
       "Parameters": {
-        "merged.$": "States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'), $$.Execution.Input, false)"
+        "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
       "OutputPath": "$.merged",
       "Next": "CheckSkipMorningEnrich"
@@ -1408,18 +1408,10 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-backtester",
-            "export HOME=/home/ec2-user",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "trap 'aws s3 cp /var/log/backtester.log \"s3://alpha-engine-research/_ssm_logs/backtester/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator 2>&1 | tee /var/log/backtester.log"
-          ],
           "executionTimeout": [
             "7200"
-          ]
+          ],
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/backtester.log \"s3://alpha-engine-research/_ssm_logs/backtester/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),'bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator 2>&1 | tee /var/log/backtester.log')"
         },
         "TimeoutSeconds": 7200
       },
@@ -1532,18 +1524,10 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-backtester",
-            "export HOME=/home/ec2-user",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "trap 'aws s3 cp /var/log/parity.log \"s3://alpha-engine-research/_ssm_logs/parity/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator 2>&1 | tee /var/log/parity.log"
-          ],
           "executionTimeout": [
             "7200"
-          ]
+          ],
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/parity.log \"s3://alpha-engine-research/_ssm_logs/parity/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),'bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator 2>&1 | tee /var/log/parity.log')"
         },
         "TimeoutSeconds": 7200
       },
@@ -1656,18 +1640,10 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-backtester",
-            "export HOME=/home/ec2-user",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "trap 'aws s3 cp /var/log/evaluator.log \"s3://alpha-engine-research/_ssm_logs/evaluator/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity 2>&1 | tee /var/log/evaluator.log"
-          ],
           "executionTimeout": [
             "3600"
-          ]
+          ],
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/evaluator.log \"s3://alpha-engine-research/_ssm_logs/evaluator/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),'bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity 2>&1 | tee /var/log/evaluator.log')"
         },
         "TimeoutSeconds": 3600
       },

--- a/tests/sf_command_utils.py
+++ b/tests/sf_command_utils.py
@@ -1,0 +1,92 @@
+"""Shared helper: extract an SSM state's shell commands whether they are
+stored as a static ``commands`` list or as a ``commands.$`` ASL intrinsic.
+
+The run_date-at-SF-start fix (fix/sf-stamp-run-date) rebuilt the
+Backtester / Parity / Evaluator command arrays via ``States.Array(...)``
+so an ``export RUN_DATE='<$.run_date>'`` element (a ``States.Format``)
+can be injected before the ``spot_backtest.sh`` launch. The wiring
+tests assert on command *content/order*, which is unchanged — they just
+need to read through the intrinsic. This parser renders literals
+(unescaping ASL ``\\'`` ``\\\\`` ``\\{`` ``\\}``) and a ``States.Format``
+element as its template string, which is sufficient for the substring /
+ordering assertions.
+"""
+
+from __future__ import annotations
+
+
+def _split_top_level(s: str) -> list[str]:
+    """Split on commas not inside an ASL single-quoted string or parens."""
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    in_str = False
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if in_str:
+            buf.append(ch)
+            if ch == "\\" and i + 1 < len(s):
+                buf.append(s[i + 1])
+                i += 2
+                continue
+            if ch == "'":
+                in_str = False
+        else:
+            if ch == "'":
+                in_str = True
+                buf.append(ch)
+            elif ch == "(":
+                depth += 1
+                buf.append(ch)
+            elif ch == ")":
+                depth -= 1
+                buf.append(ch)
+            elif ch == "," and depth == 0:
+                parts.append("".join(buf))
+                buf = []
+            else:
+                buf.append(ch)
+        i += 1
+    if buf:
+        parts.append("".join(buf))
+    return parts
+
+
+def _unescape_asl(s: str) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(s):
+        if s[i] == "\\" and i + 1 < len(s):
+            out.append(s[i + 1])
+            i += 2
+        else:
+            out.append(s[i])
+            i += 1
+    return "".join(out)
+
+
+def extract_commands(state: dict) -> list[str]:
+    """Return the ordered shell-command strings for an SSM Task state."""
+    params = state["Parameters"]["Parameters"]
+    if "commands" in params:
+        return list(params["commands"])
+    expr = params["commands.$"]
+    assert expr.startswith("States.Array("), f"unexpected commands.$: {expr[:60]}"
+    inner = expr[expr.index("(") + 1 : expr.rindex(")")]
+    out: list[str] = []
+    for raw in _split_top_level(inner):
+        a = raw.strip()
+        if a.startswith("'") and a.endswith("'"):
+            out.append(_unescape_asl(a[1:-1]))
+        elif a.startswith("States.Format("):
+            fmt_inner = a[a.index("(") + 1 : a.rindex(")")]
+            first = _split_top_level(fmt_inner)[0].strip()
+            out.append(
+                _unescape_asl(first[1:-1])
+                if first.startswith("'") and first.endswith("'")
+                else first
+            )
+        else:
+            out.append(a)
+    return out

--- a/tests/test_sf_backtest_parity_split_wiring.py
+++ b/tests/test_sf_backtest_parity_split_wiring.py
@@ -254,7 +254,8 @@ class TestSsmCommandShape:
     only). The old combined --skip-stages=evaluator must NOT appear."""
 
     def _commands(self, states, name):
-        return states[name]["Parameters"]["Parameters"]["commands"]
+        from tests.sf_command_utils import extract_commands
+        return extract_commands(states[name])
 
     def test_backtester_invokes_backtest_stage_only(self, states):
         joined = " ".join(self._commands(states, "Backtester"))

--- a/tests/test_sf_evaluator_wiring.py
+++ b/tests/test_sf_evaluator_wiring.py
@@ -122,14 +122,16 @@ class TestEvaluatorTask:
         # only evaluate.py runs. If a future operator drops --skip-stages
         # the spot will re-run the full 121-min backtest and the split
         # collapses silently.
-        cmds = states["Evaluator"]["Parameters"]["Parameters"]["commands"]
+        from tests.sf_command_utils import extract_commands
+        cmds = extract_commands(states["Evaluator"])
         spot_cmd = next(c for c in cmds if "spot_backtest.sh" in c)
         assert "--skip-stages=backtest,parity" in spot_cmd
 
     def test_writes_to_evaluator_log(self, states):
         # Tee output into /var/log/evaluator.log so it's distinguishable
         # from /var/log/backtester.log on the spot host.
-        cmds = states["Evaluator"]["Parameters"]["Parameters"]["commands"]
+        from tests.sf_command_utils import extract_commands
+        cmds = extract_commands(states["Evaluator"])
         spot_cmd = next(c for c in cmds if "spot_backtest.sh" in c)
         assert "/var/log/evaluator.log" in spot_cmd
 

--- a/tests/test_sf_run_date_threading.py
+++ b/tests/test_sf_run_date_threading.py
@@ -1,0 +1,65 @@
+"""Locks the run_date-at-SF-start fix (fix/sf-stamp-run-date).
+
+2026-05-17 Saturday SF failed at the Evaluator: backtest/{date}/ was
+keyed off a per-stage wall-clock date, so a ~2.5h run that straddled
+UTC midnight split (Backtester wrote backtest/2026-05-17/, Evaluator's
+post-midnight spot looked in backtest/2026-05-18/). Fix: stamp run_date
+ONCE at InitializeInput from $$.Execution.StartTime and thread
+`export RUN_DATE='<$.run_date>'` into every spot stage's SSM command.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.sf_command_utils import extract_commands
+
+_SF_PATH = Path(__file__).resolve().parents[1] / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+def test_initialize_input_stamps_run_date_from_execution_start(states):
+    """InitializeInput stamps run_date = date($$.Execution.StartTime).
+    Constant for the whole execution → every stage gets ONE date."""
+    expr = states["InitializeInput"]["Parameters"]["merged.$"]
+    assert "$$.Execution.StartTime" in expr
+    assert "run_date" in expr
+    # date portion via StringSplit on 'T' then ArrayGetItem(...,0)
+    assert "States.StringSplit($$.Execution.StartTime,'T')" in expr
+    assert "States.ArrayGetItem(" in expr
+
+
+def test_initialize_input_user_run_date_still_wins(states):
+    """$$.Execution.Input is merged LAST so a manually passed run_date
+    overrides the stamp (same user-input-wins semantics as sns default)."""
+    expr = states["InitializeInput"]["Parameters"]["merged.$"]
+    assert expr.rstrip().endswith("$$.Execution.Input,false)")
+
+
+@pytest.mark.parametrize("stage", ["Backtester", "Parity", "Evaluator"])
+def test_spot_stage_exports_run_date_before_launch(states, stage):
+    """Each spot stage injects `export RUN_DATE=<run_date>` immediately
+    before the spot_backtest.sh launch so spot_backtest.sh resolves the
+    SF-declared date from env instead of recomputing wall-clock."""
+    cmds = extract_commands(states[stage])
+    rd_idx = next(
+        i for i, c in enumerate(cmds)
+        if c.startswith("export RUN_DATE=")
+    )
+    spot_idx = next(
+        i for i, c in enumerate(cmds) if "spot_backtest.sh" in c
+    )
+    assert rd_idx < spot_idx, (
+        f"{stage}: export RUN_DATE must precede the spot_backtest.sh launch"
+    )
+    # value is threaded from the SF-stamped $.run_date (States.Format)
+    raw_expr = states[stage]["Parameters"]["Parameters"]["commands.$"]
+    assert "States.Format('export RUN_DATE=" in raw_expr
+    assert "$.run_date" in raw_expr


### PR DESCRIPTION
Producer side (consumer = alpha-engine-backtester#223). InitializeInput stamps `run_date = date($$.Execution.StartTime)` (manual run_date still wins); Backtester/Parity/Evaluator commands rebuilt via `States.Array` to `export RUN_DATE` before the spot launch. Propagates safely across the Parallel (ResultPath=$.parallel_result, root preserved — same as $.ec2_instance_id). `validate-state-machine-definition` → OK, 0 diagnostics. **Deploy: requires applying the SF def (see deploy note in thread) — not live on merge alone unless deploy-infrastructure auto-runs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)