### PR TITLE
feat(data): per-collector value-range validation (ROADMAP L1243 / extends #215)

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -57,7 +57,154 @@ import boto3
 from alpha_engine_lib.secrets import get_secret
 import requests
 
+from validators.price_validator import (
+    ALL_FEATURE_ANOMALY_TYPES,
+    DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES,
+    validate_feature_record,
+)
+
 logger = logging.getLogger(__name__)
+
+
+# ── Write-time value-range gate (ROADMAP L1243, extends #215) ──────────────
+# alternative.collect writes one feature-source JSON per ticker to S3 that
+# bypasses builders/daily_append.py's validate_today_row gate entirely. A
+# corrupt numeric sub-field (a NaN put/call ratio from a 0/0 open-interest
+# divide, a negative analyst price target from a malformed yfinance .info,
+# a negative fund-increasing count) silently degrades the research qual
+# sub-score with no pipeline failure. The per-source ok_ratio gate above
+# only checks *presence* of data, not whether the present values are
+# sane — this gate closes the value-range half.
+#
+# Specs are declared per (source, field). Only numeric, semantically
+# value-constrained fields are listed; free-form / categorical fields
+# (rating string, news article lists) are out of scope for value-range
+# validation. lo/hi bands are deliberately generous — the goal is to
+# catch gross corruption, not to second-guess a legitimately extreme but
+# real metric (gross_outlier warns, never blocks by default).
+_ALT_FIELD_SPECS: dict[str, dict[str, dict]] = {
+    "analyst_consensus": {
+        "target_price": {"nonneg": True, "lo": 0.0, "hi": 1_000_000.0},
+        "num_analysts": {"nonneg": True, "lo": 0.0, "hi": 200.0},
+    },
+    "eps_revision": {
+        # EPS can legitimately be negative (loss-making firms); only flag
+        # absurd magnitudes as a gross outlier.
+        "current_estimate": {"lo": -10_000.0, "hi": 10_000.0},
+        "revision_4w": {"lo": -100_000.0, "hi": 100_000.0},
+    },
+    "options_flow": {
+        "put_call_ratio": {"nonneg": True, "lo": 0.0, "hi": 1_000.0},
+        "iv_rank": {"nonneg": True, "lo": 0.0, "hi": 100.0},
+        "expected_move_pct": {"nonneg": True, "lo": 0.0, "hi": 1_000.0},
+    },
+    "insider_activity": {
+        "net_shares_30d": {"lo": -1e12, "hi": 1e12},
+    },
+    "institutional": {
+        "funds_increasing": {"nonneg": True, "lo": 0.0, "hi": 100_000.0},
+        "funds_decreasing": {"nonneg": True, "lo": 0.0, "hi": 100_000.0},
+    },
+}
+
+
+def _load_alt_block_anomaly_types() -> frozenset[str]:
+    """Read ``ALT_BLOCK_ANOMALY_TYPES`` env var or fall back to defaults.
+
+    Format + validation mirror ``fundamentals._load_fundamentals_block_anomaly_types``
+    and ``daily_append._load_block_anomaly_types``: a JSON list of
+    feature-anomaly type strings; unknown types raise (NoSilentFails).
+    """
+    raw = os.environ.get("ALT_BLOCK_ANOMALY_TYPES", "").strip()
+    if not raw:
+        return DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"ALT_BLOCK_ANOMALY_TYPES is not valid JSON: {exc}. "
+            f"Expected a JSON list of feature-anomaly type strings."
+        ) from exc
+    if not isinstance(parsed, list) or not all(isinstance(x, str) for x in parsed):
+        raise RuntimeError(
+            f"ALT_BLOCK_ANOMALY_TYPES must be a JSON list of strings, "
+            f"got {parsed!r}"
+        )
+    unknown = set(parsed) - ALL_FEATURE_ANOMALY_TYPES
+    if unknown:
+        raise RuntimeError(
+            f"ALT_BLOCK_ANOMALY_TYPES contains unknown anomaly types: "
+            f"{sorted(unknown)}. Known types: "
+            f"{sorted(ALL_FEATURE_ANOMALY_TYPES)}"
+        )
+    return frozenset(parsed)
+
+
+def _validate_alt_payload(
+    payload: dict, ticker: str, block_anomaly_types: frozenset[str]
+) -> tuple[list[dict], list[dict]]:
+    """Run validate_feature_record over each spec'd sub-section of an
+    alternative-data payload.
+
+    Returns ``(blocking, warning)`` anomaly lists (each anomaly dict gains
+    a ``source`` key so the caller can log which sub-section failed).
+    """
+    blocking: list[dict] = []
+    warning: list[dict] = []
+    for source, specs in _ALT_FIELD_SPECS.items():
+        section = payload.get(source)
+        if not isinstance(section, dict):
+            continue
+        qg = validate_feature_record(section, specs, ticker)
+        for a in qg["anomalies"]:
+            a = {**a, "source": source}
+            if a["type"] in block_anomaly_types:
+                blocking.append(a)
+            else:
+                warning.append(a)
+    return blocking, warning
+
+
+def _emit_quality_gate_metrics(
+    counts_by_type: dict[str, int], n_blocked: int, n_warned: int
+) -> None:
+    """Emit ``AlphaEngine/Data/alternative_quality_*`` gauges.
+
+    Best-effort: CloudWatch errors WARN but don't fail the collector.
+    Mirrors ``builders.daily_append._emit_quality_gate_metrics`` and
+    ``fundamentals._emit_quality_gate_metrics``.
+    """
+    if not counts_by_type and n_blocked == 0 and n_warned == 0:
+        return
+    try:
+        cw = boto3.client("cloudwatch")
+        metric_data: list[dict] = [
+            {
+                "MetricName": "alternative_quality_blocked_count",
+                "Value": float(n_blocked),
+                "Unit": "Count",
+            },
+            {
+                "MetricName": "alternative_quality_warned_count",
+                "Value": float(n_warned),
+                "Unit": "Count",
+            },
+        ]
+        for atype, count in counts_by_type.items():
+            metric_data.append({
+                "MetricName": "alternative_quality_anomaly_count",
+                "Dimensions": [{"Name": "anomaly_type", "Value": atype}],
+                "Value": float(count),
+                "Unit": "Count",
+            })
+        cw.put_metric_data(Namespace="AlphaEngine/Data", MetricData=metric_data)
+    except Exception as exc:
+        logger.warning(
+            "CloudWatch alternative_quality_* metric failed: %s. Not "
+            "blocking — the per-anomaly logger.error calls are the "
+            "load-bearing Flow Doctor surface.",
+            exc,
+        )
 
 
 # ── Per-source populated-ratio gate ──────────────────────────────────────────
@@ -295,9 +442,18 @@ def collect(
             "ticker_list": tickers[:10],
         }
 
+    # Read ALT_BLOCK_ANOMALY_TYPES once per run (raises on malformed env —
+    # fail fast before fetching).
+    block_anomaly_types = _load_alt_block_anomaly_types()
+
     succeeded = 0
     failed = 0
     errors = []
+    # Write-time value-range gate accounting (parallels daily_append +
+    # fundamentals).
+    n_quality_blocked = 0
+    n_quality_warned = 0
+    quality_counts_by_type: dict[str, int] = {}
     # Per-source populated counts. Increment only when the source for
     # this ticker carried real (non-default) data — see _HAS_DATA_PREDICATES
     # commentary above for the silent-fail surface this protects against.
@@ -311,6 +467,49 @@ def collect(
     for ticker in tickers:
         try:
             data = _fetch_all_alternative(ticker, run_date, bucket)
+            # ── Write-time value-range gate ─────────────────────────────
+            # Runs on the assembled per-ticker payload before the S3
+            # write. A block-severity anomaly (NaN/inf or
+            # negative-where-impossible in a numeric feature sub-field)
+            # refuses the whole ticker write — a corrupt sub-section would
+            # otherwise silently degrade the research qual sub-score. The
+            # ticker is then accounted exactly like a fetch failure so the
+            # existing failed/errors + ok_ratio machinery surfaces it.
+            blocking, warning = _validate_alt_payload(
+                data, ticker, block_anomaly_types
+            )
+            if blocking:
+                for a in blocking:
+                    # logger.error so FlowDoctorHandler picks it up.
+                    logger.error(
+                        "Alternative quality gate BLOCK %s.%s.%s: %s",
+                        ticker, a["source"], a["type"], a["detail"],
+                    )
+                    quality_counts_by_type[a["type"]] = (
+                        quality_counts_by_type.get(a["type"], 0) + 1
+                    )
+                n_quality_blocked += 1
+                failed += 1
+                errors.append({
+                    "ticker": ticker,
+                    "error": (
+                        "value-range gate blocked: "
+                        + "; ".join(
+                            f"{a['source']}.{a['type']}" for a in blocking
+                        )
+                    ),
+                })
+                continue
+            if warning:
+                for a in warning:
+                    logger.warning(
+                        "Alternative quality gate WARN %s.%s.%s: %s",
+                        ticker, a["source"], a["type"], a["detail"],
+                    )
+                    quality_counts_by_type[a["type"]] = (
+                        quality_counts_by_type.get(a["type"], 0) + 1
+                    )
+                n_quality_warned += 1
             key = f"{s3_prefix}weekly/{run_date}/alternative/{ticker}.json"
             s3.put_object(
                 Bucket=bucket,
@@ -328,6 +527,21 @@ def collect(
             failed += 1
             errors.append({"ticker": ticker, "error": str(e)})
             logger.warning("Alternative data failed for %s: %s", ticker, e)
+
+    if n_quality_blocked or n_quality_warned:
+        logger.info(
+            "Alternative quality gate: %d blocked, %d warned, counts=%s",
+            n_quality_blocked, n_quality_warned, quality_counts_by_type,
+        )
+    _emit_quality_gate_metrics(
+        quality_counts_by_type, n_quality_blocked, n_quality_warned
+    )
+    _quality_fields = {
+        "tickers_quality_blocked": n_quality_blocked,
+        "tickers_quality_warned": n_quality_warned,
+        "quality_anomaly_counts": quality_counts_by_type,
+        "quality_block_anomaly_types": sorted(block_anomaly_types),
+    }
 
     # ── Per-source ok_ratio gate ────────────────────────────────────────────
     # Mirrors `fundamentals.py::_MIN_OK_RATIO` and
@@ -385,6 +599,7 @@ def collect(
         "source_ok_ratios": {k: round(v, 4) for k, v in source_ratios.items()},
         "source_min_ok_ratios": min_ok_ratios,
         "errors": errors[:20],
+        **_quality_fields,
     }
     manifest_key = f"{s3_prefix}weekly/{run_date}/alternative/manifest.json"
     s3.put_object(
@@ -420,6 +635,7 @@ def collect(
             "source_min_ok_ratios": min_ok_ratios,
             "breached_sources": [src for src, _, _ in breached],
             "errors": errors[:20],
+            **_quality_fields,
         }
 
     status = "ok" if failed == 0 else "partial"
@@ -436,6 +652,7 @@ def collect(
         "source_ok_ratios": {k: round(v, 4) for k, v in source_ratios.items()},
         "source_min_ok_ratios": min_ok_ratios,
         "errors": errors[:20],
+        **_quality_fields,
     }
 
 

--- a/collectors/fundamentals.py
+++ b/collectors/fundamentals.py
@@ -62,13 +62,122 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 
 from alpha_engine_lib.secrets import get_secret
 
+from validators.price_validator import (
+    ALL_FEATURE_ANOMALY_TYPES,
+    DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES,
+    validate_feature_record,
+)
+
 from .finnhub_client import finnhub_get
 
 logger = logging.getLogger(__name__)
+
+# ── Write-time value-range gate (ROADMAP L1243, extends #215) ──────────────
+# fundamentals.py writes a feature-source snapshot to S3 that bypasses
+# builders/daily_append.py's validate_today_row gate entirely. A single
+# corrupt field (NaN from a divide-by-near-zero FCF computation, or a
+# negative gross_margin from a malformed Finnhub payload) silently poisons
+# the predictor feature store + research scoring with no pipeline failure —
+# the exact FMP-zero'd-fundamentals class that already burned ~2 weeks of
+# alpha. Field specs declare the value-range invariant per output field.
+# Clipping (_clip) already bounds the *range*, so the load-bearing residual
+# this gate catches is NaN/inf (clip of NaN propagates NaN) + the
+# structural non-negativity of margin/ratio fields. lo/hi mirror the clip
+# bands so a gross outlier surfaces if a future refactor drops a _clip.
+_FUNDAMENTALS_FIELD_SPECS: dict[str, dict] = {
+    "pe_ratio":           {"lo": -3.0, "hi": 3.0},
+    "pb_ratio":           {"lo": -3.0, "hi": 3.0},
+    "debt_to_equity":     {"lo": -3.0, "hi": 3.0},
+    "revenue_growth_yoy": {"lo": -1.0, "hi": 2.0},
+    "fcf_yield":          {"lo": -0.5, "hi": 0.5},
+    "gross_margin":       {"nonneg": True, "lo": 0.0, "hi": 1.0},
+    "roe":                {"lo": -1.0, "hi": 1.0},
+    "current_ratio":      {"nonneg": True, "lo": 0.0, "hi": 3.0},
+}
+
+
+def _load_fundamentals_block_anomaly_types() -> frozenset[str]:
+    """Read ``FUNDAMENTALS_BLOCK_ANOMALY_TYPES`` env var or fall back.
+
+    Format + validation mirror ``daily_append._load_block_anomaly_types``:
+    a JSON list of feature-anomaly type strings; unknown types raise (a
+    silent typo would let corrupt rows through — NoSilentFails). Empty /
+    unset uses the conservative default (NaN/inf + negative-where-nonneg
+    block; gross_outlier warns).
+    """
+    raw = os.environ.get("FUNDAMENTALS_BLOCK_ANOMALY_TYPES", "").strip()
+    if not raw:
+        return DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"FUNDAMENTALS_BLOCK_ANOMALY_TYPES is not valid JSON: {exc}. "
+            f"Expected a JSON list of feature-anomaly type strings."
+        ) from exc
+    if not isinstance(parsed, list) or not all(isinstance(x, str) for x in parsed):
+        raise RuntimeError(
+            f"FUNDAMENTALS_BLOCK_ANOMALY_TYPES must be a JSON list of strings, "
+            f"got {parsed!r}"
+        )
+    unknown = set(parsed) - ALL_FEATURE_ANOMALY_TYPES
+    if unknown:
+        raise RuntimeError(
+            f"FUNDAMENTALS_BLOCK_ANOMALY_TYPES contains unknown anomaly "
+            f"types: {sorted(unknown)}. Known types: "
+            f"{sorted(ALL_FEATURE_ANOMALY_TYPES)}"
+        )
+    return frozenset(parsed)
+
+
+def _emit_quality_gate_metrics(
+    counts_by_type: dict[str, int], n_blocked: int, n_warned: int
+) -> None:
+    """Emit ``AlphaEngine/Data/fundamentals_quality_*`` gauges.
+
+    Best-effort: CloudWatch errors WARN but don't fail the collector — the
+    per-anomaly logger.error calls on the block path are the load-bearing
+    Flow Doctor surface; the metric catches slow drift. Mirrors
+    ``builders.daily_append._emit_quality_gate_metrics``.
+    """
+    if not counts_by_type and n_blocked == 0 and n_warned == 0:
+        return
+    try:
+        import boto3
+
+        cw = boto3.client("cloudwatch")
+        metric_data: list[dict] = [
+            {
+                "MetricName": "fundamentals_quality_blocked_count",
+                "Value": float(n_blocked),
+                "Unit": "Count",
+            },
+            {
+                "MetricName": "fundamentals_quality_warned_count",
+                "Value": float(n_warned),
+                "Unit": "Count",
+            },
+        ]
+        for atype, count in counts_by_type.items():
+            metric_data.append({
+                "MetricName": "fundamentals_quality_anomaly_count",
+                "Dimensions": [{"Name": "anomaly_type", "Value": atype}],
+                "Value": float(count),
+                "Unit": "Count",
+            })
+        cw.put_metric_data(Namespace="AlphaEngine/Data", MetricData=metric_data)
+    except Exception as exc:
+        logger.warning(
+            "CloudWatch fundamentals_quality_* metric failed: %s. Not "
+            "blocking — the per-anomaly logger.error calls are the "
+            "load-bearing Flow Doctor surface.",
+            exc,
+        )
 
 # Minimum fraction of requested tickers that must produce real fundamentals
 # (at least one non-zero field) for the run to be considered OK. Below
@@ -221,13 +330,61 @@ def collect(
     )
     t0 = time.time()
 
+    # Read FUNDAMENTALS_BLOCK_ANOMALY_TYPES once per run (raises on
+    # malformed env — fail fast before fetching).
+    block_anomaly_types = _load_fundamentals_block_anomaly_types()
+
     results: dict[str, dict] = {}
     n_ok = 0
     n_err = 0
+    # Write-time value-range gate accounting (parallels daily_append).
+    n_quality_blocked = 0  # records replaced with NEUTRAL (block severity)
+    n_quality_warned = 0   # records kept but flagged (warn severity)
+    quality_counts_by_type: dict[str, int] = {}
 
     for ticker in tickers:
         try:
             data = _fetch_single_ticker(ticker)
+            # ── Write-time value-range gate ─────────────────────────────
+            # Runs on the fully-shaped (clipped) per-ticker dict before it
+            # is queued for the S3 snapshot. block → drop the corrupt row
+            # to NEUTRAL + logger.error so Flow Doctor surfaces it (a
+            # NaN/inf or negative margin would otherwise poison the
+            # predictor feature store). warn → keep + log + count.
+            qg = validate_feature_record(
+                data, _FUNDAMENTALS_FIELD_SPECS, ticker
+            )
+            blocking = [
+                a for a in qg["anomalies"]
+                if a["type"] in block_anomaly_types
+            ]
+            if blocking:
+                for a in blocking:
+                    # logger.error so FlowDoctorHandler picks it up —
+                    # return-dicts are invisible to it.
+                    logger.error(
+                        "Fundamentals quality gate BLOCK %s.%s: %s",
+                        ticker, a["type"], a["detail"],
+                    )
+                    quality_counts_by_type[a["type"]] = (
+                        quality_counts_by_type.get(a["type"], 0) + 1
+                    )
+                n_quality_blocked += 1
+                # Refuse the corrupt row; NEUTRAL is the existing
+                # no-data sentinel the ok_ratio gate already accounts for.
+                results[ticker] = NEUTRAL.copy()
+                n_err += 1
+                continue
+            if qg["anomalies"]:
+                for a in qg["anomalies"]:
+                    logger.warning(
+                        "Fundamentals quality gate WARN %s.%s: %s",
+                        ticker, a["type"], a["detail"],
+                    )
+                    quality_counts_by_type[a["type"]] = (
+                        quality_counts_by_type.get(a["type"], 0) + 1
+                    )
+                n_quality_warned += 1
             results[ticker] = data
             if data != NEUTRAL:
                 n_ok += 1
@@ -242,6 +399,20 @@ def collect(
         "Fundamentals fetched in %.1fs: %d populated, %d errors, %d total (ok_ratio=%.1f%%)",
         elapsed, n_ok, n_err, len(results), ok_ratio * 100,
     )
+    if n_quality_blocked or n_quality_warned:
+        logger.info(
+            "Fundamentals quality gate: %d blocked, %d warned, counts=%s",
+            n_quality_blocked, n_quality_warned, quality_counts_by_type,
+        )
+    _emit_quality_gate_metrics(
+        quality_counts_by_type, n_quality_blocked, n_quality_warned
+    )
+    _quality_fields = {
+        "tickers_quality_blocked": n_quality_blocked,
+        "tickers_quality_warned": n_quality_warned,
+        "quality_anomaly_counts": quality_counts_by_type,
+        "quality_block_anomaly_types": sorted(block_anomaly_types),
+    }
 
     if ok_ratio < _MIN_OK_RATIO:
         msg = (
@@ -259,6 +430,7 @@ def collect(
             "n_ok": n_ok,
             "n_errors": n_err,
             "elapsed_seconds": round(elapsed, 1),
+            **_quality_fields,
         }
 
     if dry_run:
@@ -270,6 +442,7 @@ def collect(
             "n_errors": n_err,
             "elapsed_seconds": round(elapsed, 1),
             "dry_run": True,
+            **_quality_fields,
         }
 
     # Write to S3
@@ -290,4 +463,5 @@ def collect(
         "n_errors": n_err,
         "elapsed_seconds": round(elapsed, 1),
         "s3_key": key,
+        **_quality_fields,
     }

--- a/tests/test_alternative_value_range_gate.py
+++ b/tests/test_alternative_value_range_gate.py
@@ -1,0 +1,238 @@
+"""Tests for the write-time value-range gate in ``collectors/alternative.py``.
+
+Background (ROADMAP L1243, extends alpha-engine-data #215):
+``alternative.collect`` writes one feature-source JSON per ticker to S3
+that bypasses ``builders/daily_append.py``'s ``validate_today_row`` gate
+entirely. The pre-existing per-source ok_ratio gate only checks data
+*presence*; a corrupt-but-present numeric sub-field (NaN put/call ratio
+from a 0/0 open-interest divide, negative analyst price target from a
+malformed yfinance ``.info``, negative fund counts) flowed straight into
+the research qual sub-score with no pipeline failure.
+
+This gate runs ``validators.price_validator.validate_feature_record``
+over each spec'd sub-section of the assembled per-ticker payload before
+the S3 write. A block-severity anomaly (NaN/inf or negative-where-
+impossible) refuses the whole ticker write — accounted exactly like a
+fetch failure so the existing failed/errors + ok_ratio machinery
+surfaces it. A gross outlier warns. Mirrors #215's definitely-bad-blocks
+/ rare-but-possible-warns split + the env-tunable block-set loader.
+
+These tests lock the gate's contract so a future "simplify away the
+value-range gate" revert reintroduces the silent-corruption surface.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collectors import alternative
+
+
+def _populated_alt_payload(ticker: str) -> dict:
+    """A `_fetch_all_alternative` return where every source has real,
+    in-range data."""
+    return {
+        "ticker": ticker,
+        "fetched_at": "2026-05-18T20:00:00+00:00",
+        "analyst_consensus": {
+            "rating": "Buy",
+            "target_price": 200.0,
+            "num_analysts": 25,
+            "earnings_surprises": [{"date": "2026-Q1", "surprise_pct": 5.2}],
+        },
+        "eps_revision": {"current_estimate": 6.50, "revision_4w": 1.2, "streak": 2},
+        "options_flow": {"put_call_ratio": 0.7, "iv_rank": 35, "expected_move_pct": 4.5},
+        "insider_activity": {
+            "cluster_buying": True, "net_shares_30d": 50000,
+            "transactions": [{"insider": "CEO", "shares": 50000}],
+        },
+        "institutional": {
+            "accumulation": True, "funds_increasing": 7, "funds_decreasing": 2,
+        },
+        "news": {
+            "articles": [{"headline": "X", "source": "Yahoo"}],
+            "sec_filings_8k": [{"title": "Item 2.02", "date": "2026-05-15"}],
+        },
+    }
+
+
+def _patch_collect(monkeypatch, *, fetch_returns: list[dict]):
+    s3 = MagicMock()
+    monkeypatch.setattr(alternative, "boto3", MagicMock(client=lambda *a, **k: s3))
+    monkeypatch.setattr(
+        alternative, "_load_promoted_tickers",
+        lambda *a, **k: [d["ticker"] for d in fetch_returns],
+    )
+    fetch_iter = iter(fetch_returns)
+    monkeypatch.setattr(
+        alternative, "_fetch_all_alternative",
+        lambda ticker, run_date, bucket: next(fetch_iter),
+    )
+    return s3
+
+
+def _collect(tickers):
+    return alternative.collect(
+        bucket="test-bucket",
+        s3_prefix="market_data/",
+        run_date="2026-05-18",
+        tickers=tickers,
+    )
+
+
+# ── Block path ───────────────────────────────────────────────────────────────
+
+
+def test_nan_put_call_ratio_blocks_ticker(monkeypatch):
+    payloads = [_populated_alt_payload(f"T{i}") for i in range(10)]
+    payloads[0]["options_flow"]["put_call_ratio"] = float("nan")
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect([f"T{i}" for i in range(10)])
+
+    assert result["tickers_quality_blocked"] == 1
+    assert result["quality_anomaly_counts"].get("nan_or_inf") == 1
+    # Blocked ticker is NOT written to S3 (9 ticker writes + mirror +
+    # manifest); accounted as a failure.
+    assert result["tickers_failed"] == 1
+    assert result["tickers_processed"] == 9
+
+
+def test_negative_target_price_blocks_ticker(monkeypatch):
+    payloads = [_populated_alt_payload(f"T{i}") for i in range(10)]
+    payloads[3]["analyst_consensus"]["target_price"] = -12.0
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect([f"T{i}" for i in range(10)])
+
+    assert result["tickers_quality_blocked"] == 1
+    assert result["quality_anomaly_counts"].get("negative_where_nonneg") == 1
+
+
+def test_negative_fund_count_blocks_ticker(monkeypatch):
+    payloads = [_populated_alt_payload(f"T{i}") for i in range(10)]
+    payloads[1]["institutional"]["funds_increasing"] = -3
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect([f"T{i}" for i in range(10)])
+
+    assert result["tickers_quality_blocked"] == 1
+    assert result["quality_anomaly_counts"].get("negative_where_nonneg") == 1
+
+
+def test_blocked_ticker_not_written_to_s3(monkeypatch):
+    payloads = [_populated_alt_payload("GOOD"), _populated_alt_payload("BAD")]
+    payloads[1]["options_flow"]["iv_rank"] = float("inf")
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    _collect(["GOOD", "BAD"])
+
+    written_keys = [
+        c.kwargs.get("Key", "")
+        for c in s3.put_object.call_args_list
+    ]
+    assert any("GOOD.json" in k for k in written_keys)
+    assert not any("BAD.json" in k for k in written_keys)
+
+
+# ── Warn path ────────────────────────────────────────────────────────────────
+
+
+def test_gross_outlier_warns_not_blocks(monkeypatch):
+    payloads = [_populated_alt_payload(f"T{i}") for i in range(10)]
+    # iv_rank hi band is 100; 9999 is a defeated upstream clamp.
+    payloads[0]["options_flow"]["iv_rank"] = 9999.0
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect([f"T{i}" for i in range(10)])
+
+    assert result["tickers_quality_blocked"] == 0
+    assert result["tickers_quality_warned"] == 1
+    assert result["quality_anomaly_counts"].get("gross_outlier") == 1
+    assert result["tickers_processed"] == 10  # still written
+
+
+# ── Clean path + return contract ─────────────────────────────────────────────
+
+
+def test_clean_run_no_quality_anomalies(monkeypatch):
+    payloads = [_populated_alt_payload(f"T{i}") for i in range(5)]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect([f"T{i}" for i in range(5)])
+
+    assert result["tickers_quality_blocked"] == 0
+    assert result["tickers_quality_warned"] == 0
+    assert result["quality_anomaly_counts"] == {}
+
+
+def test_quality_fields_in_manifest_and_return(monkeypatch):
+    payloads = [_populated_alt_payload("AAPL")]
+    s3 = _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect(["AAPL"])
+
+    for k in (
+        "tickers_quality_blocked", "tickers_quality_warned",
+        "quality_anomaly_counts", "quality_block_anomaly_types",
+    ):
+        assert k in result
+
+    import json
+    manifest_call = next(
+        c for c in s3.put_object.call_args_list
+        if "manifest.json" in c.kwargs.get("Key", "")
+    )
+    manifest = json.loads(manifest_call.kwargs["Body"])
+    assert "tickers_quality_blocked" in manifest
+    assert "quality_anomaly_counts" in manifest
+
+
+# ── Env-tunable block set ────────────────────────────────────────────────────
+
+
+def test_malformed_block_env_raises(monkeypatch):
+    monkeypatch.setenv("ALT_BLOCK_ANOMALY_TYPES", "not-json")
+    payloads = [_populated_alt_payload("AAPL")]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        _collect(["AAPL"])
+
+
+def test_unknown_block_type_in_env_raises(monkeypatch):
+    monkeypatch.setenv("ALT_BLOCK_ANOMALY_TYPES", '["made_up"]')
+    payloads = [_populated_alt_payload("AAPL")]
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+    with pytest.raises(RuntimeError, match="unknown anomaly types"):
+        _collect(["AAPL"])
+
+
+def test_env_can_promote_gross_outlier_to_block(monkeypatch):
+    monkeypatch.setenv(
+        "ALT_BLOCK_ANOMALY_TYPES",
+        '["nan_or_inf", "negative_where_nonneg", "gross_outlier"]',
+    )
+    payloads = [_populated_alt_payload(f"T{i}") for i in range(10)]
+    payloads[0]["options_flow"]["iv_rank"] = 9999.0
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect([f"T{i}" for i in range(10)])
+
+    assert result["tickers_quality_blocked"] == 1
+    assert result["quality_anomaly_counts"].get("gross_outlier") == 1
+
+
+def test_env_empty_list_is_pure_observation_mode(monkeypatch):
+    # "[]" → nothing blocks; even a NaN only warns (observability).
+    monkeypatch.setenv("ALT_BLOCK_ANOMALY_TYPES", "[]")
+    payloads = [_populated_alt_payload(f"T{i}") for i in range(10)]
+    payloads[0]["options_flow"]["put_call_ratio"] = float("nan")
+    _patch_collect(monkeypatch, fetch_returns=payloads)
+
+    result = _collect([f"T{i}" for i in range(10)])
+
+    assert result["tickers_quality_blocked"] == 0
+    assert result["tickers_quality_warned"] == 1
+    assert result["quality_anomaly_counts"].get("nan_or_inf") == 1

--- a/tests/test_fundamentals_finnhub.py
+++ b/tests/test_fundamentals_finnhub.py
@@ -253,3 +253,120 @@ class TestCollect:
         assert result["status"] == "ok"
         assert result["n_ok"] == 9
         assert result["n_errors"] == 1
+
+
+# ── Write-time value-range gate (ROADMAP L1243, extends #215) ────────────────
+
+
+class TestFundamentalsValueRangeGate:
+    """fundamentals.py writes a feature-source snapshot bypassing
+    builders/daily_append.py's validate_today_row. This gate runs
+    validate_feature_record over each per-ticker dict before the S3
+    write. NaN/inf + negative-where-nonneg block (→ NEUTRAL); a gross
+    outlier (defeated _clip) warns. Mirrors #215's split + env loader."""
+
+    def _good(self):
+        return {"pe_ratio": 1.0, **{k: NEUTRAL[k] for k in NEUTRAL if k != "pe_ratio"}}
+
+    def test_nan_field_is_blocked_and_neutralized(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        bad = dict(self._good())
+        bad["roe"] = float("nan")
+        side_effect = [bad] + [self._good() for _ in range(9)]
+        with patch.object(fundamentals, "_fetch_single_ticker", side_effect=side_effect):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(10)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        assert result["tickers_quality_blocked"] == 1
+        assert result["quality_anomaly_counts"].get("nan_or_inf") == 1
+        # Blocked ticker counted as an error (NEUTRAL'd, not written).
+        assert result["n_errors"] == 1
+
+    def test_negative_margin_is_blocked(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        bad = dict(self._good())
+        bad["gross_margin"] = -0.2  # declared non-negative
+        side_effect = [bad] + [self._good() for _ in range(9)]
+        with patch.object(fundamentals, "_fetch_single_ticker", side_effect=side_effect):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(10)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        assert result["tickers_quality_blocked"] == 1
+        assert result["quality_anomaly_counts"].get("negative_where_nonneg") == 1
+
+    def test_gross_outlier_warns_not_blocks(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        bad = dict(self._good())
+        bad["roe"] = 9.9  # well above the hi=1.0 band (a defeated _clip)
+        side_effect = [bad] + [self._good() for _ in range(9)]
+        with patch.object(fundamentals, "_fetch_single_ticker", side_effect=side_effect):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(10)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        assert result["tickers_quality_blocked"] == 0
+        assert result["tickers_quality_warned"] == 1
+        assert result["quality_anomaly_counts"].get("gross_outlier") == 1
+        assert result["status"] == "ok"
+
+    def test_clean_run_no_quality_anomalies(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        with patch.object(fundamentals, "_fetch_single_ticker", return_value=self._good()):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(5)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        assert result["tickers_quality_blocked"] == 0
+        assert result["tickers_quality_warned"] == 0
+        assert result["quality_anomaly_counts"] == {}
+
+    def test_quality_fields_present_in_all_return_paths(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        with patch.object(fundamentals, "_fetch_single_ticker", return_value=self._good()):
+            result = fundamentals.collect(
+                bucket="test", tickers=["AAPL"], run_date="2026-04-25", dry_run=True,
+            )
+        for k in (
+            "tickers_quality_blocked", "tickers_quality_warned",
+            "quality_anomaly_counts", "quality_block_anomaly_types",
+        ):
+            assert k in result
+
+    def test_malformed_block_env_raises(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        monkeypatch.setenv("FUNDAMENTALS_BLOCK_ANOMALY_TYPES", "not-json")
+        with patch.object(fundamentals, "_fetch_single_ticker", return_value=self._good()):
+            with pytest.raises(RuntimeError, match="not valid JSON"):
+                fundamentals.collect(
+                    bucket="test", tickers=["AAPL"],
+                    run_date="2026-04-25", dry_run=True,
+                )
+
+    def test_unknown_block_type_in_env_raises(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        monkeypatch.setenv("FUNDAMENTALS_BLOCK_ANOMALY_TYPES", '["bogus_type"]')
+        with patch.object(fundamentals, "_fetch_single_ticker", return_value=self._good()):
+            with pytest.raises(RuntimeError, match="unknown anomaly types"):
+                fundamentals.collect(
+                    bucket="test", tickers=["AAPL"],
+                    run_date="2026-04-25", dry_run=True,
+                )
+
+    def test_env_can_promote_gross_outlier_to_block(self, monkeypatch):
+        monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+        monkeypatch.setenv(
+            "FUNDAMENTALS_BLOCK_ANOMALY_TYPES",
+            '["nan_or_inf", "negative_where_nonneg", "gross_outlier"]',
+        )
+        bad = dict(self._good())
+        bad["roe"] = 9.9
+        side_effect = [bad] + [self._good() for _ in range(9)]
+        with patch.object(fundamentals, "_fetch_single_ticker", side_effect=side_effect):
+            result = fundamentals.collect(
+                bucket="test", tickers=[f"T{i}" for i in range(10)],
+                run_date="2026-04-25", dry_run=True,
+            )
+        assert result["tickers_quality_blocked"] == 1
+        assert result["quality_anomaly_counts"].get("gross_outlier") == 1

--- a/tests/test_price_validator.py
+++ b/tests/test_price_validator.py
@@ -6,10 +6,17 @@ import pytest
 from validators.price_validator import (
     ANOMALY_BAD_OHLC,
     ANOMALY_EXTREME_DAILY_MOVE,
+    ANOMALY_GROSS_OUTLIER,
+    ANOMALY_INTRABAR_INCONSISTENT,
+    ANOMALY_NAN_OR_INF,
     ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+    ANOMALY_NEGATIVE_VOLUME,
+    ANOMALY_NEGATIVE_WHERE_NONNEG,
     ANOMALY_VOLUME_SPIKE,
     ANOMALY_ZERO_VOLUME,
     DEFAULT_BLOCK_ANOMALY_TYPES,
+    DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES,
+    validate_feature_record,
     validate_parquet,
     validate_today_row,
 )
@@ -220,7 +227,179 @@ class TestValidateTodayRow:
         # docs should be able to trust that flipping the env to "[]" gives
         # them pure observability mode, while leaving it unset blocks
         # bad_ohlc + negative_or_zero_close.
+        # ROADMAP L1243 residual added the two intra-bar checks
+        # (intrabar_inconsistent + negative_volume) — both unambiguous
+        # corruption, so both block by default alongside the original two.
         assert DEFAULT_BLOCK_ANOMALY_TYPES == frozenset({
             ANOMALY_BAD_OHLC,
             ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+            ANOMALY_INTRABAR_INCONSISTENT,
+            ANOMALY_NEGATIVE_VOLUME,
+        })
+
+
+class TestValidateTodayRowIntrabarChecks:
+    """ROADMAP L1243 residual: the two intra-bar checks validate_today_row
+    did not previously cover — Close outside [Low, High] and negative
+    volume. Both default-block (unambiguous corruption)."""
+
+    def test_close_above_high_blocks(self):
+        hist = _make_ohlcv()
+        # H/L band itself sane (high>=low) but Close pokes above High.
+        today = _make_today_row(close=105.0, high=101.0, low=99.0)
+        result = validate_today_row(today, hist, "BADCLOSE")
+        anomaly = next(
+            a for a in result["anomalies"]
+            if a["type"] == ANOMALY_INTRABAR_INCONSISTENT
+        )
+        assert anomaly["severity"] == "block"
+
+    def test_close_below_low_blocks(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(close=90.0, high=101.0, low=99.0)
+        result = validate_today_row(today, hist, "BADCLOSE2")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_INTRABAR_INCONSISTENT in types
+
+    def test_close_within_band_clean(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(close=100.0, high=101.0, low=99.0)
+        result = validate_today_row(today, hist, "OK")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_INTRABAR_INCONSISTENT not in types
+
+    def test_intrabar_skipped_when_hl_band_already_bad(self):
+        # When High<Low the bad_ohlc check owns the failure; the intra-bar
+        # check is meaningless against an inverted band, so it should not
+        # also fire (avoids double-counting the same corrupt bar).
+        hist = _make_ohlcv()
+        today = _make_today_row(close=100.0, high=98.0, low=102.0)
+        result = validate_today_row(today, hist, "INVERTED")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_BAD_OHLC in types
+        assert ANOMALY_INTRABAR_INCONSISTENT not in types
+
+    def test_negative_volume_blocks(self):
+        hist = _make_ohlcv()
+        today = _make_today_row(volume=-500)
+        result = validate_today_row(today, hist, "NEGVOL")
+        anomaly = next(
+            a for a in result["anomalies"]
+            if a["type"] == ANOMALY_NEGATIVE_VOLUME
+        )
+        assert anomaly["severity"] == "block"
+
+    def test_zero_volume_still_warns_not_negative(self):
+        # Zero volume keeps its existing warn semantics — the new
+        # negative_volume block must not subsume the zero_volume warn.
+        hist = _make_ohlcv()
+        today = _make_today_row(volume=0)
+        result = validate_today_row(today, hist, "ZEROVOL")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_ZERO_VOLUME in types
+        assert ANOMALY_NEGATIVE_VOLUME not in types
+
+
+class TestValidateFeatureRecord:
+    """ROADMAP L1243 residual: write-time value-range gate for the
+    non-OHLCV feature collectors (fundamentals.py + alternative.py)."""
+
+    SPEC = {
+        "target_price": {"nonneg": True, "lo": 0.0, "hi": 1000.0},
+        "roe": {"lo": -1.0, "hi": 1.0},
+        "rating": {"nonneg": True},  # non-numeric values are skipped
+    }
+
+    def test_clean_record_no_anomalies(self):
+        rec = {"target_price": 150.0, "roe": 0.2, "rating": "Buy"}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        assert result["anomalies"] == []
+        assert result["ticker"] == "AAPL"
+
+    def test_nan_blocks(self):
+        rec = {"target_price": float("nan")}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        anomaly = next(
+            a for a in result["anomalies"] if a["type"] == ANOMALY_NAN_OR_INF
+        )
+        assert anomaly["severity"] == "block"
+
+    def test_inf_blocks(self):
+        rec = {"roe": float("inf")}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_NAN_OR_INF in types
+
+    def test_negative_where_nonneg_blocks(self):
+        rec = {"target_price": -5.0}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        anomaly = next(
+            a for a in result["anomalies"]
+            if a["type"] == ANOMALY_NEGATIVE_WHERE_NONNEG
+        )
+        assert anomaly["severity"] == "block"
+
+    def test_negative_allowed_when_not_declared_nonneg(self):
+        # roe legitimately goes negative — only a gross-outlier band
+        # violation should fire, never negative_where_nonneg.
+        rec = {"roe": -0.5}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        assert result["anomalies"] == []
+
+    def test_gross_outlier_warns(self):
+        rec = {"roe": 9.9}  # well above hi=1.0
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        anomaly = next(
+            a for a in result["anomalies"]
+            if a["type"] == ANOMALY_GROSS_OUTLIER
+        )
+        assert anomaly["severity"] == "warn"
+
+    def test_gross_outlier_below_lo_warns(self):
+        rec = {"roe": -9.9}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        types = {a["type"] for a in result["anomalies"]}
+        assert ANOMALY_GROSS_OUTLIER in types
+
+    def test_none_value_skipped(self):
+        # None is the collectors' legitimate "no data" sentinel — coverage
+        # is the ok_ratio gate's job, not value-range validation's.
+        rec = {"target_price": None, "roe": None}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        assert result["anomalies"] == []
+
+    def test_non_numeric_value_skipped(self):
+        rec = {"rating": "Buy"}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        assert result["anomalies"] == []
+
+    def test_field_absent_from_record_skipped(self):
+        result = validate_feature_record({}, self.SPEC, "AAPL")
+        assert result["anomalies"] == []
+
+    def test_field_absent_from_spec_skipped(self):
+        rec = {"unspecified_field": float("nan")}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        # nan_or_inf only checked for spec'd fields — an unspecified field
+        # is out of this validator's contract.
+        assert result["anomalies"] == []
+
+    def test_nan_skips_further_numeric_checks(self):
+        # A NaN on a nonneg field should produce exactly one anomaly
+        # (nan_or_inf), not also negative_where_nonneg / gross_outlier.
+        rec = {"target_price": float("nan")}
+        result = validate_feature_record(rec, self.SPEC, "AAPL")
+        assert len(result["anomalies"]) == 1
+        assert result["anomalies"][0]["type"] == ANOMALY_NAN_OR_INF
+
+    def test_empty_inputs_safe(self):
+        assert validate_feature_record({}, {}, "X")["anomalies"] == []
+        assert validate_feature_record(None, self.SPEC, "X")["anomalies"] == []
+
+    def test_feature_default_block_set_constants(self):
+        # NaN/inf + negative-where-nonneg block by default; gross_outlier
+        # warns (may be a legitimate extreme).
+        assert DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES == frozenset({
+            ANOMALY_NAN_OR_INF,
+            ANOMALY_NEGATIVE_WHERE_NONNEG,
         })

--- a/validators/price_validator.py
+++ b/validators/price_validator.py
@@ -11,11 +11,24 @@ Two surfaces:
   severity so the caller can hard-fail on definitely-bad rows (negative
   prices, High<Low) while only warning on legitimately-rare-but-possible
   signals (>50% moves on event days, single-day volume spikes).
+- ``validate_feature_record`` — write-time per-record gate for the
+  *non-OHLCV* feature collectors (``collectors/fundamentals.py`` +
+  ``collectors/alternative.py``) that bypass ``builders/daily_append.py``
+  entirely. Same structured-anomaly + per-type-severity contract as
+  ``validate_today_row``, but the field semantics are caller-supplied
+  (a fundamentals row has no High/Low, an analyst-target field has its
+  own non-negative invariant) so the caller passes a small spec rather
+  than the validator hard-coding OHLCV column names. Covers the generic
+  data-corruption surface that is field-agnostic: NaN / inf (always bad —
+  these poison ArcticDB + every downstream mean/zscore), negative values
+  where the field is semantically non-negative, and gross outliers
+  outside a caller-declared sane band.
 """
 
 from __future__ import annotations
 
 import logging
+import math
 from pathlib import Path
 
 import pandas as pd
@@ -36,10 +49,33 @@ ANOMALY_NEGATIVE_OR_ZERO_CLOSE = "negative_or_zero_close"  # default block
 ANOMALY_EXTREME_DAILY_MOVE = "extreme_daily_move"   # default warn
 ANOMALY_ZERO_VOLUME = "zero_volume"                 # default warn
 ANOMALY_VOLUME_SPIKE = "volume_spike"               # default warn
+# Added 2026-05-18 (ROADMAP L1243 residual): the two intra-bar checks
+# validate_today_row did not previously cover.
+ANOMALY_INTRABAR_INCONSISTENT = "intrabar_inconsistent"  # default block
+ANOMALY_NEGATIVE_VOLUME = "negative_volume"         # default block
+
+# ── Feature-collector anomaly catalog (non-OHLCV) ──────────────────────────
+# Used by validate_feature_record for fundamentals.py + alternative.py.
+ANOMALY_NAN_OR_INF = "nan_or_inf"                   # default block
+ANOMALY_NEGATIVE_WHERE_NONNEG = "negative_where_nonneg"  # default block
+ANOMALY_GROSS_OUTLIER = "gross_outlier"             # default warn
 
 DEFAULT_BLOCK_ANOMALY_TYPES: frozenset[str] = frozenset({
     ANOMALY_BAD_OHLC,
     ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
+    ANOMALY_INTRABAR_INCONSISTENT,
+    ANOMALY_NEGATIVE_VOLUME,
+})
+
+# Default block set for the feature collectors. NaN/inf and
+# negative-where-impossible are unambiguous corruption — they poison the
+# ArcticDB feature store + every downstream mean/zscore — so they block by
+# default; a gross outlier may be a legitimate extreme (e.g. a real -300%
+# ROE for a wiped-out firm) so it only warns, mirroring #215's
+# definitely-bad-blocks / rare-but-possible-warns split.
+DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES: frozenset[str] = frozenset({
+    ANOMALY_NAN_OR_INF,
+    ANOMALY_NEGATIVE_WHERE_NONNEG,
 })
 
 ALL_ANOMALY_TYPES: frozenset[str] = frozenset({
@@ -48,6 +84,14 @@ ALL_ANOMALY_TYPES: frozenset[str] = frozenset({
     ANOMALY_EXTREME_DAILY_MOVE,
     ANOMALY_ZERO_VOLUME,
     ANOMALY_VOLUME_SPIKE,
+    ANOMALY_INTRABAR_INCONSISTENT,
+    ANOMALY_NEGATIVE_VOLUME,
+})
+
+ALL_FEATURE_ANOMALY_TYPES: frozenset[str] = frozenset({
+    ANOMALY_NAN_OR_INF,
+    ANOMALY_NEGATIVE_WHERE_NONNEG,
+    ANOMALY_GROSS_OUTLIER,
 })
 
 
@@ -87,6 +131,33 @@ def validate_today_row(
                 "detail": f"High={high:.4f} < Low={low:.4f}",
             })
 
+    # ── 1b. Intra-bar consistency: Low <= Close <= High ───────────────────
+    # (intrabar_inconsistent — default block). bad_ohlc above only checks
+    # High vs Low; a split-day reporting lag or corp-action artifact can
+    # land a Close *outside* the [Low, High] band even when High >= Low,
+    # which poisons every return/vol feature derived from the bar. This is
+    # the first of the two intra-bar checks the ROADMAP L1243 residual
+    # called out as not-yet-covered by validate_today_row.
+    if all(c in today_row.columns for c in ("High", "Low", "Close")):
+        high = row.get("High")
+        low = row.get("Low")
+        close = row.get("Close")
+        if (
+            pd.notna(high)
+            and pd.notna(low)
+            and pd.notna(close)
+            and high >= low  # only meaningful when the H/L band is itself sane
+            and not (low <= close <= high)
+        ):
+            anomalies.append({
+                "type": ANOMALY_INTRABAR_INCONSISTENT,
+                "severity": "block",
+                "detail": (
+                    f"Close={close:.4f} outside [Low={low:.4f}, "
+                    f"High={high:.4f}]"
+                ),
+            })
+
     # ── 2. Zero or negative close (negative_or_zero_close — default block) ──
     if "Close" in today_row.columns:
         close = row.get("Close")
@@ -95,6 +166,20 @@ def validate_today_row(
                 "type": ANOMALY_NEGATIVE_OR_ZERO_CLOSE,
                 "severity": "block",
                 "detail": f"Close={close:.4f}",
+            })
+
+    # ── 2b. Negative volume (negative_volume — default block) ──────────────
+    # The second ROADMAP L1243 residual intra-bar check. The existing
+    # zero_volume check (#4 below) only catches Volume==0; a negative
+    # volume is unambiguously corrupt (no such thing as negative shares
+    # traded) and must hard-fail rather than merely warn.
+    if "Volume" in today_row.columns:
+        vol = row.get("Volume")
+        if pd.notna(vol) and vol < 0:
+            anomalies.append({
+                "type": ANOMALY_NEGATIVE_VOLUME,
+                "severity": "block",
+                "detail": f"Volume={vol:.0f} < 0",
             })
 
     # ── 3. Extreme daily return vs prior close (extreme_daily_move — warn) ──
@@ -150,6 +235,107 @@ def validate_today_row(
                         f"(ratio={ratio:.1f}x > {MAX_VOLUME_SPIKE:.0f}x)"
                     ),
                 })
+
+    return {"ticker": ticker, "anomalies": anomalies}
+
+
+# Field spec for validate_feature_record. ``nonneg`` = the field is
+# semantically non-negative (a negative value is corruption, not a
+# legitimate extreme — e.g. a price target or current ratio). ``lo``/``hi``
+# = the sane band; a value outside it is flagged as a gross outlier (warn
+# by default). ``nonneg``/``lo``/``hi`` are all optional — omit a bound to
+# skip that check for the field. NaN/inf is always checked regardless.
+class FeatureFieldSpec(dict):
+    """Thin dict subclass for self-documenting field specs.
+
+    A spec is just ``{"nonneg": bool, "lo": float, "hi": float}`` with
+    every key optional. Subclassing dict keeps it JSON/`**`-friendly while
+    giving the spec a name at call sites.
+    """
+
+
+def validate_feature_record(
+    record: dict,
+    field_specs: dict[str, dict],
+    ticker: str,
+) -> dict:
+    """Inspect a single non-OHLCV feature record against per-field specs.
+
+    Used by the feature collectors (``fundamentals.py`` +
+    ``alternative.py``) that write feature-source rows bypassing
+    ``builders/daily_append.py``'s ``validate_today_row`` gate. ``record``
+    is the about-to-be-written per-ticker dict (a flat fundamentals dict,
+    or one sub-section of an alternative-data payload). ``field_specs``
+    maps field name → ``{"nonneg": bool, "lo": float, "hi": float}`` (all
+    keys optional). Only keys present in *both* ``record`` and
+    ``field_specs`` are checked; ``None`` values are skipped (the
+    collectors use ``None``/NEUTRAL as a legitimate "no data" sentinel —
+    that's the ok_ratio gate's job, not this validator's).
+
+    Returns the same ``{"ticker", "anomalies": [{"type", "severity",
+    "detail"}, ...]}`` contract as ``validate_today_row`` so the callers
+    reuse the identical block-set / metric wiring.
+
+    Severities are *defaults*; the caller decides final block/warn by
+    consulting its configured block set (see
+    ``DEFAULT_FEATURE_BLOCK_ANOMALY_TYPES``).
+    """
+    anomalies: list[dict] = []
+
+    if not record or not field_specs:
+        return {"ticker": ticker, "anomalies": anomalies}
+
+    for field, spec in field_specs.items():
+        if field not in record:
+            continue
+        val = record[field]
+        if val is None:
+            # Legitimate "no data" sentinel — coverage is the ok_ratio
+            # gate's responsibility, not value-range validation's.
+            continue
+        # Coerce to float for numeric checks; non-numeric (e.g. a string
+        # "rating") is out of scope for value-range validation — skip it.
+        try:
+            num = float(val)
+        except (TypeError, ValueError):
+            continue
+
+        # ── 1. NaN / inf (nan_or_inf — default block) ──────────────────
+        # Unambiguous corruption: a single NaN/inf in ArcticDB poisons
+        # every cross-sectional mean / zscore that touches the column.
+        if math.isnan(num) or math.isinf(num):
+            anomalies.append({
+                "type": ANOMALY_NAN_OR_INF,
+                "severity": "block",
+                "detail": f"{field}={val!r} is NaN/inf",
+            })
+            continue  # further numeric checks on NaN/inf are meaningless
+
+        # ── 2. Negative where non-negative required ────────────────────
+        # (negative_where_nonneg — default block).
+        if spec.get("nonneg") and num < 0:
+            anomalies.append({
+                "type": ANOMALY_NEGATIVE_WHERE_NONNEG,
+                "severity": "block",
+                "detail": f"{field}={num:.6g} < 0 (field declared non-negative)",
+            })
+
+        # ── 3. Gross outlier outside the sane band ─────────────────────
+        # (gross_outlier — default warn; may be a real extreme).
+        lo = spec.get("lo")
+        hi = spec.get("hi")
+        if lo is not None and num < lo:
+            anomalies.append({
+                "type": ANOMALY_GROSS_OUTLIER,
+                "severity": "warn",
+                "detail": f"{field}={num:.6g} < lo={lo:.6g}",
+            })
+        elif hi is not None and num > hi:
+            anomalies.append({
+                "type": ANOMALY_GROSS_OUTLIER,
+                "severity": "warn",
+                "detail": f"{field}={num:.6g} > hi={hi:.6g}",
+            })
 
     return {"ticker": ticker, "anomalies": anomalies}
 


### PR DESCRIPTION
## Summary

Closes the residual scope of ROADMAP **L1243 — "Per-collector value-range validation"** (P1, promoted from P2 2026-05-16). L940 / #215 shipped the write-time quality gate on the OHLCV `builders/daily_append.py` path. This PR extends equivalent write-time value-range validation to the two feature collectors that **bypass `daily_append` entirely** and write feature-source rows straight to S3 (consumed by the predictor feature store + research scoring) — the exact FMP-zero'd-fundamentals class that already burned ~2 weeks of alpha.

## Scope

### `validators/price_validator.py`
- **Two intra-bar checks the ROADMAP residual called out as not-yet-covered by `validate_today_row`:**
  - `intrabar_inconsistent` — `Close` outside `[Low, High]` even when `High >= Low` (a split-day reporting lag / corp-action artifact that `bad_ohlc`'s High-vs-Low check misses). **Default block.** Skipped when `High < Low` so it doesn't double-count the same corrupt bar `bad_ohlc` already owns.
  - `negative_volume` — the existing `zero_volume` check only caught `Volume == 0`; a negative volume is unambiguously corrupt. **Default block.**
  - Both added to `DEFAULT_BLOCK_ANOMALY_TYPES`.
- **New `validate_feature_record(record, field_specs, ticker)`** — generic value-range gate for non-OHLCV records, same structured-anomaly + per-type-severity contract as `validate_today_row` so callers reuse identical block-set / metric wiring. Caller passes a per-field spec (`nonneg` / `lo` / `hi`, all optional). `None` values skipped (coverage is the ok_ratio gate's job).

### Checks added (field → severity)

| Surface | Check | Anomaly type | Default severity |
|---|---|---|---|
| `validate_today_row` (OHLCV) | `Close` outside `[Low, High]` | `intrabar_inconsistent` | **block** |
| `validate_today_row` (OHLCV) | `Volume < 0` | `negative_volume` | **block** |
| feature record (any spec'd field) | NaN / inf | `nan_or_inf` | **block** |
| feature record (field declared `nonneg`) | value `< 0` | `negative_where_nonneg` | **block** |
| feature record (field with `lo`/`hi`) | value outside band | `gross_outlier` | warn |

### `collectors/fundamentals.py`
Validates each fully-shaped (post-`_clip`) per-ticker dict before the S3 snapshot. The load-bearing residual `_clip` can't catch is **NaN/inf** (clip of NaN propagates NaN) + structural non-negativity of `gross_margin`/`current_ratio`; `lo`/`hi` mirror the clip bands so a gross outlier surfaces if a future refactor drops a `_clip`. Block → replace with `NEUTRAL` + `logger.error` (counted as an error so the existing ok_ratio gate accounts for it). Env-tunable block set via `FUNDAMENTALS_BLOCK_ANOMALY_TYPES`. CW metric `AlphaEngine/Data/fundamentals_quality_*`.

### `collectors/alternative.py`
Validates each spec'd numeric sub-section (`analyst_consensus`, `eps_revision`, `options_flow`, `insider_activity`, `institutional`) of the assembled per-ticker payload before the S3 write. The pre-existing per-source ok_ratio gate only checks data *presence*; this closes the value-range half. Block → refuse the whole ticker write, accounted exactly like a fetch failure (existing `failed`/`errors` + ok_ratio machinery surfaces it). Env-tunable block set via `ALT_BLOCK_ANOMALY_TYPES`. CW metric `AlphaEngine/Data/alternative_quality_*`. Quality counts threaded into the manifest + every return path.

## Severity defaults

Mirrors #215's split: definitely-corrupt conditions (NaN/inf, negative-where-impossible, intra-bar inconsistency, negative volume) **block by default**; rare-but-possibly-legitimate (gross outlier — e.g. a real -300% ROE for a wiped-out firm that defeated an upstream clamp) **warns**. Operators flip behavior per-collector via the env vars; unknown-type / malformed-JSON raises (NoSilentFails), matching `_load_block_anomaly_types`.

## Tests

**+39 tests (1220 → 1259); full suite 1258 passed, 1 skipped (pre-existing).** No new pip deps.

- `tests/test_price_validator.py`: `TestValidateTodayRowIntrabarChecks` (Close-out-of-band block, negative-volume block, zero-volume-still-warns, double-count avoidance) + `TestValidateFeatureRecord` (NaN/inf block, negative-where-nonneg block, gross-outlier warn, None/non-numeric/absent skip, NaN-short-circuits-further-checks). Updated the `DEFAULT_BLOCK_ANOMALY_TYPES` contract test for the two added intra-bar types.
- `tests/test_fundamentals_finnhub.py`: `TestFundamentalsValueRangeGate` (NaN block + NEUTRAL'd, negative-margin block, gross-outlier warn, return-path field presence, env-loader malformed/unknown/promote).
- `tests/test_alternative_value_range_gate.py` (new): block paths (NaN/negative target/negative fund count, blocked-ticker-not-written), warn path, clean path, manifest + return contract, env-tunable block set (malformed/unknown/promote/empty-list observation mode). Reuses the established `_patch_collect` stub pattern from `test_alternative_ok_ratio_gate.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)