### PR TITLE
fix(data): institutional EDGAR cache → /tmp (Lambda read-only $HOME) + scrub API keys in alt-data logs

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 import threading
 from datetime import date, datetime, timedelta, timezone
@@ -205,6 +206,63 @@ def _emit_quality_gate_metrics(
             "load-bearing Flow Doctor surface.",
             exc,
         )
+
+
+# ── EDGAR local data dir → /tmp (Lambda read-only $HOME) ───────────────────
+#
+# edgartools (the ``edgar`` package, used by _fetch_institutional for 13F
+# data) writes its local data + HTTP response cache under a root directory
+# that defaults to ``~/.edgar`` (and ``~/.edgar/_tcache`` for the httpx
+# cache). In the DataPhase2 Lambda sandbox ``$HOME`` (``/home/sbx_user1051``)
+# is a read-only filesystem — only ``/tmp`` is writable — so every edgar
+# call raised ``[Errno 30] Read-only file system`` on 2026-05-17, leaving
+# the institutional source 0/33 populated and breaching the per-source
+# populated-ratio gate (``institutional`` threshold 0.20) → DataPhase2
+# returned ``{"status": "ERROR"}``.
+#
+# edgartools resolves ``EDGAR_LOCAL_DATA_DIR`` at *call time* (verified
+# against installed edgartools 5.28.2: edgar.paths.get_data_directory ->
+# os.getenv(ENV_EDGAR_DATA_DIR); edgar.httpclient.get_cache_directory ->
+# get_edgar_data_directory()/"_tcache"). Setting it before any
+# ``from edgar import ...`` / ``Company(...)`` runs is therefore effective,
+# and the env var alone redirects both the data dir and the _tcache HTTP
+# cache (the path that failed) — no ``$HOME`` override is required. We only
+# set it if unset so an operator-provided value still wins.
+_EDGAR_TMP_DATA_DIR = "/tmp/edgar"
+if not os.environ.get("EDGAR_LOCAL_DATA_DIR"):
+    try:
+        os.makedirs(_EDGAR_TMP_DATA_DIR, exist_ok=True)
+        os.environ["EDGAR_LOCAL_DATA_DIR"] = _EDGAR_TMP_DATA_DIR
+    except OSError as _e:  # pragma: no cover - /tmp is writable on Lambda
+        logger.warning("Could not prepare EDGAR_LOCAL_DATA_DIR: %s", _e)
+
+
+# ── Generic URL-credential scrubber ────────────────────────────────────────
+#
+# requests.exceptions.HTTPError embeds the full request URL — including any
+# ``apikey=``/``api_key=``/``token=`` querystring credential — in its
+# ``str()`` representation. The FMP-backed warnings (e.g. "EPS estimate
+# failed for AFL: 402 ... ?apikey=<KEY>&...") and Finnhub-backed warnings
+# (``token=<KEY>``) would leak the live credential to CloudWatch. Every
+# exception-logging site in this file that can carry an HTTP fetch URL
+# routes the exception through this scrubber before logging. It is a no-op
+# on strings without a matching querystring fragment (idempotent).
+#
+# Mirrors collectors/daily_closes._scrub_api_key (FRED-specific, masks only
+# ``api_key=``); kept local here because that helper is too narrow for the
+# FMP ``apikey=`` / Finnhub ``token=`` shapes and importing it would couple
+# two unrelated collectors.
+_URL_CRED_RE = re.compile(r"(?i)(api_?key|apikey|token)=[^&\s'\"]+")
+
+
+def _scrub_url_creds(msg: object) -> str:
+    """Mask ``apikey=``/``api_key=``/``token=`` querystring secrets.
+
+    Accepts an exception object or any value; stringifies then masks.
+    No-op (returns the input string unchanged) when no credential
+    fragment is present, and idempotent on already-scrubbed strings.
+    """
+    return _URL_CRED_RE.sub(lambda m: f"{m.group(1)}=***", str(msg))
 
 
 # ── Per-source populated-ratio gate ──────────────────────────────────────────
@@ -525,8 +583,9 @@ def collect(
             logger.info("Alternative data: %s -> s3://%s/%s", ticker, bucket, key)
         except Exception as e:
             failed += 1
-            errors.append({"ticker": ticker, "error": str(e)})
-            logger.warning("Alternative data failed for %s: %s", ticker, e)
+            scrubbed = _scrub_url_creds(e)
+            errors.append({"ticker": ticker, "error": scrubbed})
+            logger.warning("Alternative data failed for %s: %s", ticker, scrubbed)
 
     if n_quality_blocked or n_quality_warned:
         logger.info(
@@ -854,7 +913,7 @@ def _fetch_analyst(ticker: str) -> dict:
                     result["rating"] = "Hold"
                 result["num_analysts"] = total
     except Exception as e:
-        logger.warning("Finnhub recommendation failed for %s: %s", ticker, e)
+        logger.warning("Finnhub recommendation failed for %s: %s", ticker, _scrub_url_creds(e))
 
     # Finnhub historical earnings surprises: list of {actual, estimate,
     # surprise, surprisePercent, period, quarter, symbol, year}, most
@@ -878,7 +937,7 @@ def _fetch_analyst(ticker: str) -> dict:
                 })
             result["earnings_surprises"] = surprises
     except Exception as e:
-        logger.warning("Finnhub earnings failed for %s: %s", ticker, e)
+        logger.warning("Finnhub earnings failed for %s: %s", ticker, _scrub_url_creds(e))
 
     # yfinance Ticker.info: ``targetMeanPrice`` is the consensus price target;
     # ``numberOfAnalystOpinions`` is the count of analysts covering the name
@@ -898,7 +957,7 @@ def _fetch_analyst(ticker: str) -> dict:
             if n is not None:
                 result["num_analysts"] = int(n)
     except Exception as e:
-        logger.warning("yfinance target_price failed for %s: %s", ticker, e)
+        logger.warning("yfinance target_price failed for %s: %s", ticker, _scrub_url_creds(e))
 
     return result
 
@@ -926,7 +985,7 @@ def _fetch_revisions(ticker: str, bucket: str, run_date: str) -> dict:
                 or data[0].get("estimatedEpsAvg")
             )
     except Exception as e:
-        logger.warning("EPS estimate failed for %s: %s", ticker, e)
+        logger.warning("EPS estimate failed for %s: %s", ticker, _scrub_url_creds(e))
 
     # Load prior snapshot for revision comparison
     try:
@@ -1051,7 +1110,7 @@ def _fetch_options(ticker: str, run_date: str) -> dict:
     except ImportError:
         logger.debug("yfinance/numpy not available for options data")
     except Exception as e:
-        logger.warning("Options fetch failed for %s: %s", ticker, e)
+        logger.warning("Options fetch failed for %s: %s", ticker, _scrub_url_creds(e))
 
     return result
 
@@ -1187,7 +1246,7 @@ def _fetch_institutional(ticker: str) -> dict:
                             elif current_value < prev_value:
                                 n_decreasing += 1
         except Exception as e:
-            logger.warning("13F comparison failed for %s: %s", ticker, e)
+            logger.warning("13F comparison failed for %s: %s", ticker, _scrub_url_creds(e))
 
         result["funds_increasing"] = n_accumulating
         result["funds_decreasing"] = n_decreasing
@@ -1196,7 +1255,7 @@ def _fetch_institutional(ticker: str) -> dict:
     except ImportError:
         logger.debug("edgartools not available for 13F data")
     except Exception as e:
-        logger.warning("Institutional fetch failed for %s: %s", ticker, e)
+        logger.warning("Institutional fetch failed for %s: %s", ticker, _scrub_url_creds(e))
 
     return result
 
@@ -1234,7 +1293,7 @@ def _fetch_news(ticker: str) -> dict:
     except ImportError:
         logger.debug("feedparser not available for news")
     except Exception as e:
-        logger.warning("Yahoo RSS failed for %s: %s", ticker, e)
+        logger.warning("Yahoo RSS failed for %s: %s", ticker, _scrub_url_creds(e))
 
     # EDGAR 8-K
     try:
@@ -1256,6 +1315,6 @@ def _fetch_news(ticker: str) -> dict:
                 "form_type": src.get("form_type", "8-K"),
             })
     except Exception as e:
-        logger.warning("EDGAR 8-K failed for %s: %s", ticker, e)
+        logger.warning("EDGAR 8-K failed for %s: %s", ticker, _scrub_url_creds(e))
 
     return result

--- a/tests/test_alternative_key_scrub_and_edgar_tmp.py
+++ b/tests/test_alternative_key_scrub_and_edgar_tmp.py
@@ -1,0 +1,169 @@
+"""Regression tests for two production fixes in ``collectors/alternative.py``.
+
+1. EDGAR local data dir → /tmp (Lambda read-only $HOME)
+   --------------------------------------------------------
+   edgartools (``edgar`` package, used by ``_fetch_institutional`` for 13F
+   data) writes its local data + httpx response cache under ``~/.edgar`` /
+   ``~/.edgar/_tcache``. In the DataPhase2 Lambda sandbox ``$HOME`` is a
+   read-only filesystem (only ``/tmp`` is writable), so on 2026-05-17 every
+   edgar call raised ``[Errno 30] Read-only file system`` → institutional
+   source 0/33 populated → per-source populated-ratio gate (``institutional``
+   floor 0.20) breached → DataPhase2 returned ``{"status": "ERROR"}``.
+
+   The module sets ``EDGAR_LOCAL_DATA_DIR`` to a writable ``/tmp`` path at
+   import time *only if unset* (an operator-provided value must win).
+
+2. API-key leak in alt-data exception logs
+   ----------------------------------------
+   FMP-backed warnings ("EPS estimate failed for AFL: 402 ... ?apikey=<KEY>")
+   and Finnhub-backed warnings (``token=<KEY>``) embed the live credential in
+   the request URL inside ``HTTPError.str()``. ``_scrub_url_creds`` masks
+   ``apikey=``/``api_key=``/``token=`` querystring secrets before logging.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+
+# ── _scrub_url_creds ───────────────────────────────────────────────────────
+
+
+def test_scrub_masks_fmp_apikey_in_402_url():
+    from collectors import alternative
+
+    msg = (
+        "402 Client Error: Payment Required for url: "
+        "https://financialmodelingprep.com/stable/analyst-estimates"
+        "?apikey=4509846484a78c3ee667a118d5179de7&symbol=AFL&period=annual"
+    )
+    scrubbed = alternative._scrub_url_creds(msg)
+    assert "4509846484a78c3ee667a118d5179de7" not in scrubbed
+    assert "apikey=***" in scrubbed
+    # querystring after the key must survive (regex stops at ``&``).
+    assert "symbol=AFL" in scrubbed and "period=annual" in scrubbed
+
+
+def test_scrub_masks_api_key_underscore_variant():
+    from collectors import alternative
+
+    msg = "url: https://x/?api_key=SECRETVALUEXYZ&file_type=json"
+    scrubbed = alternative._scrub_url_creds(msg)
+    assert "SECRETVALUEXYZ" not in scrubbed
+    assert "api_key=***" in scrubbed
+    assert scrubbed == "url: https://x/?api_key=***&file_type=json"
+
+
+def test_scrub_masks_token_variant():
+    from collectors import alternative
+
+    msg = "https://finnhub.io/api/v1/stock/recommendation?token=LIVEFINNHUB&symbol=AFL"
+    scrubbed = alternative._scrub_url_creds(msg)
+    assert "LIVEFINNHUB" not in scrubbed
+    assert "token=***" in scrubbed
+
+
+def test_scrub_accepts_exception_object_directly():
+    """The helper is invoked at ``logger.warning("... %s", _scrub(e))``
+    sites — it must accept an exception object, not just a str."""
+    import requests
+
+    try:
+        resp = requests.Response()
+        resp.status_code = 402
+        resp.url = (
+            "https://financialmodelingprep.com/stable/analyst-estimates"
+            "?apikey=EXC_OBJ_SECRET&symbol=AFL"
+        )
+        resp.reason = "Payment Required"
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        from collectors import alternative
+
+        scrubbed = alternative._scrub_url_creds(e)
+
+    assert "EXC_OBJ_SECRET" not in scrubbed
+    assert "apikey=***" in scrubbed
+
+
+def test_scrub_is_noop_on_clean_string():
+    from collectors import alternative
+
+    msg = "Finnhub recommendation failed for AFL: connection timed out"
+    assert alternative._scrub_url_creds(msg) == msg
+
+
+def test_scrub_is_idempotent():
+    from collectors import alternative
+
+    msg = "url: https://fmp/x?apikey=SECRET&symbol=AFL"
+    once = alternative._scrub_url_creds(msg)
+    twice = alternative._scrub_url_creds(once)
+    assert once == twice
+    assert "SECRET" not in twice
+
+
+def test_scrub_case_insensitive():
+    from collectors import alternative
+
+    msg = "https://x/?APIKEY=MIXEDCASE&a=1"
+    scrubbed = alternative._scrub_url_creds(msg)
+    assert "MIXEDCASE" not in scrubbed
+    assert "APIKEY=***" in scrubbed
+
+
+# ── EDGAR_LOCAL_DATA_DIR redirect ──────────────────────────────────────────
+
+
+def test_edgar_local_data_dir_set_to_tmp_when_unset(monkeypatch):
+    """Simulate the Lambda env (no preset var): after the institutional
+    module is (re)imported, ``EDGAR_LOCAL_DATA_DIR`` points at a writable
+    ``/tmp`` path and the directory exists."""
+    monkeypatch.delenv("EDGAR_LOCAL_DATA_DIR", raising=False)
+
+    from collectors import alternative
+
+    importlib.reload(alternative)
+
+    val = os.environ.get("EDGAR_LOCAL_DATA_DIR")
+    assert val is not None
+    assert val.startswith("/tmp/"), f"expected /tmp path, got {val!r}"
+    assert os.path.isdir(val)
+
+
+def test_edgar_local_data_dir_respects_operator_preset(monkeypatch, tmp_path):
+    """An operator-provided ``EDGAR_LOCAL_DATA_DIR`` must NOT be overridden
+    (e.g. a future EFS mount or a tuned /tmp subdir)."""
+    preset = str(tmp_path / "operator-edgar")
+    monkeypatch.setenv("EDGAR_LOCAL_DATA_DIR", preset)
+
+    from collectors import alternative
+
+    importlib.reload(alternative)
+
+    assert os.environ.get("EDGAR_LOCAL_DATA_DIR") == preset
+
+
+def test_edgar_redirect_is_effective_for_installed_edgartools():
+    """End-to-end: with the env var set by the module, the installed
+    edgartools resolves BOTH its data dir and its httpx ``_tcache`` cache
+    (the path that raised the read-only-FS error) under the redirected
+    root — proving the env var alone is sufficient (no $HOME override)."""
+    edgar = pytest.importorskip("edgar")
+
+    from collectors import alternative  # noqa: F401  (sets the env var)
+
+    root = os.environ["EDGAR_LOCAL_DATA_DIR"]
+    resolved_root = os.path.realpath(root)
+
+    from edgar.core import get_edgar_data_directory
+    from edgar.httpclient import get_cache_directory
+
+    data_dir = os.path.realpath(str(get_edgar_data_directory()))
+    http_cache = os.path.realpath(str(get_cache_directory()))
+
+    assert data_dir.startswith(resolved_root), (data_dir, resolved_root)
+    assert http_cache.startswith(resolved_root), (http_cache, resolved_root)


### PR DESCRIPTION
## Root causes (from the 2026-05-17 DataPhase2 Lambda logs)

### Issue 1 — institutional 0/33 → Phase 2 gate breach (deterministic)
`_fetch_institutional` uses edgartools (the `edgar` package). edgartools writes its local data + httpx response cache under `~/.edgar` / `~/.edgar/_tcache`. In the DataPhase2 Lambda sandbox `$HOME` (`/home/sbx_user1051`) is a **read-only filesystem** — only `/tmp` is writable — so every edgar call raised `[Errno 30] Read-only file system`. Institutional ended up **0% populated for every ticker**, breaching the per-source populated-ratio gate (`institutional` floor `0.20`), so DataPhase2 returned `{"status":"ERROR"}`.

### Issue 2 — API key leak class (security)
FMP-backed warnings (`EPS estimate failed for AFL: 402 ... for url: https://financialmodelingprep.com/stable/analyst-estimates?apikey=<KEY>&...`) and Finnhub-backed warnings (`token=<KEY>`) embed the live credential in the request URL inside `HTTPError.str()`, leaking it to CloudWatch.

## Fixes

**Issue 1:** At module import (before any `from edgar import ...` / `Company(...)`), set `EDGAR_LOCAL_DATA_DIR=/tmp/edgar` (`os.makedirs(exist_ok=True)`) **only if unset** so an operator-provided value still wins. Verified against installed **edgartools 5.28.2**: `edgar.paths.get_data_directory` reads `os.getenv(EDGAR_LOCAL_DATA_DIR)` at **call time**, and `edgar.httpclient.get_cache_directory` derives `_tcache` from `get_edgar_data_directory()` — so the env var **alone** redirects both the data dir and the `_tcache` HTTP cache (the exact path that failed). No `$HOME` override was required.

**Issue 2:** Added `_scrub_url_creds` (regex `(?i)(api_?key|apikey|token)=[^&\s'"]+` → `key=***`; no-op + idempotent on clean strings), mirroring the FRED-specific `collectors/daily_closes._scrub_api_key` (kept local — that helper masks only `api_key=`, too narrow for the FMP `apikey=` / Finnhub `token=` shapes). Routed **every** exception-logging site in `alternative.py` that can carry an HTTP fetch URL through it: the per-ticker catch-all (incl. its `errors[]` payload), plus the Finnhub recommendation / Finnhub earnings / yfinance target_price / FMP EPS estimate / options / 13F comparison / institutional fetch / Yahoo RSS / EDGAR 8-K provider warnings. Control flow unchanged — only logged strings sanitized.

## Deliberately out of scope
The `eps_revision` 402 (FMP `analyst-estimates` paid-tier entitlement) is a **pending operator decision**. `_REQUIRED_POPULATED_RATIOS` / `_fetch_revisions` control flow is **untouched** (its log line is still scrubbed per Issue 2 — sanitizing a leak is not a control-flow change).

## Tests
New `tests/test_alternative_key_scrub_and_edgar_tmp.py` (mirrors `test_fred_api_key_scrub.py` style): scrubber masks `apikey=`/`api_key=`/`token=` in a representative FMP 402 URL (+ exception object, case-insensitive), is idempotent and a no-op on clean strings; `EDGAR_LOCAL_DATA_DIR` set to a `/tmp` path when unset and respected when operator-preset; end-to-end assertion that installed edgartools resolves both its data dir and `_tcache` under the redirected root.

**Suite: 1229 passed, 1 skipped (pre-existing), 5 warnings (pre-existing, unrelated).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)