### PR TITLE
docs+test: Wave 2 — pin feature-store prefix to top-level features/

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -55,7 +55,7 @@ Centralized data collection — price universe, macro, alternative data, feature
 | 10y OHLCV universe | `s3://alpha-engine-research/arcticdb/universe/` |
 | 2y inference slim cache | `s3://alpha-engine-research/arcticdb/universe_slim/` |
 | Daily OHLCV staging (7-day lifecycle) | `s3://alpha-engine-research/staging/daily_closes/{date}.parquet` |
-| Engineered features | `s3://alpha-engine-research/predictor/feature_store/{date}/` |
+| Engineered features | `s3://alpha-engine-research/features/{date}/` |
 | Weekly market data bundle | `s3://alpha-engine-research/market_data/weekly/{date}/` |
 | Phase 1 completion marker | `s3://alpha-engine-research/health/data_phase1.json` |
 | Universe returns table | `s3://alpha-engine-research/research.db` (`universe_returns`) |

--- a/tests/test_feature_store_prefix_invariant.py
+++ b/tests/test_feature_store_prefix_invariant.py
@@ -1,0 +1,46 @@
+"""Wave 2 regression — pin the feature-store S3 prefix invariant.
+
+ROADMAP "predictor/ S3 namespace rationalization — Wave 2" audited the
+`predictor/feature_store/` prefix and found it RESOLVED: that prefix never
+existed in current production. The data module's feature snapshots are
+written to the top-level `features/` prefix (which carries its own
+90d-IA / 365d-expiration lifecycle rule applied in Wave 1 PR #113),
+NOT under the `predictor/` junk-drawer prefix.
+
+These source-text invariants mirror the Wave 1 discipline (6 regression
+tests pinning the migrated prefix) so a future refactor cannot silently
+re-introduce a `predictor/feature_store/` write path and re-create the
+2026-04-29 cross-repo consumer-audit surprise.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from features.compute import FEATURE_STORE_PREFIX
+from features.writer import DEFAULT_PREFIX
+
+
+def test_compute_feature_store_prefix_is_top_level():
+    """features/compute.py must write to top-level `features/`."""
+    assert FEATURE_STORE_PREFIX == "features/"
+
+
+def test_writer_default_prefix_is_top_level():
+    """features/writer.py's default prefix must be top-level `features/`."""
+    assert DEFAULT_PREFIX == "features/"
+
+
+def test_no_predictor_feature_store_prefix_anywhere():
+    """No live writer/reader may target the retired `predictor/feature_store/`.
+
+    `predictor/feature_store/` was an early-consumer-bound name that was
+    never actually used by current production (the prefix has 0 objects in
+    S3). Guard against any source-text re-introduction outside of historical
+    lineage docstrings.
+    """
+    assert not FEATURE_STORE_PREFIX.startswith("predictor/")
+    assert not DEFAULT_PREFIX.startswith("predictor/")
+    assert "feature_store" not in FEATURE_STORE_PREFIX


### PR DESCRIPTION
## ROADMAP: \`predictor/\` S3 namespace rationalization — Wave 2

**Audit conclusion: Wave 2 is RESOLVED / ALREADY DONE.** No migration needed.

### Evidence
- \`aws s3 ls s3://alpha-engine-research/predictor/feature_store/\` → **0 objects**. The prefix the ROADMAP named never existed in current production.
- Live feature snapshots are written to **top-level \`features/\`** (275 objects, last written 2026-05-16 Saturday SF):
  - \`features/compute.py:48\` — \`FEATURE_STORE_PREFIX = "features/"\`
  - \`features/writer.py:22\` — \`DEFAULT_PREFIX = "features/"\`
- \`features/\` already carries its intended lifecycle rule (\`feature-store-retention\`: 90d→STANDARD_IA, 365d expiration) applied in **Wave 1 PR alpha-engine-data #113**.
- The only remaining \`predictor/feature_store\` strings were (a) docstring lineage comments and (b) two stale \`OVERVIEW.md\` S3-layout rows (this repo + predictor). Cross-repo grep found **zero live writers/readers** of \`predictor/feature_store/\`.

### Changes
- Fix stale \`OVERVIEW.md\` row → \`features/{date}/\` (the real path; misleading docs caused the 2026-04-29 daily_closes consumer-audit surprise).
- New \`tests/test_feature_store_prefix_invariant.py\` — 3 source-text invariants mirroring the Wave 1 regression discipline; guards against silent re-introduction of \`predictor/feature_store/\`.

### Safety
- No production or S3 behavior change. Doc + new test only.
- Full suite: **1222 passed, 1 skipped** (pre-existing unrelated FutureWarning).

### Cross-repo
- Companion doc-only PR in **alpha-engine-predictor** (\`chore/wave2-feature-store-doc-fix\`) fixes the same stale OVERVIEW row there. **No merge-order dependency** — both are independent doc fixes.
- ROADMAP/SYSTEM_STATE Wave 2 checkbox closure handled separately by the config sweep (not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)