### PR TITLE
feat(data): migrate eps_revision FMP→yfinance (analyst-estimates 402 paid-tier; clears Phase-2 gate)

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -965,48 +965,130 @@ def _fetch_analyst(ticker: str) -> dict:
 # ---- 2. EPS revisions ----
 
 def _fetch_revisions(ticker: str, bucket: str, run_date: str) -> dict:
-    """Fetch current EPS estimate and compute revision vs prior week."""
+    """Fetch current EPS estimate and compute the ~4-week estimate revision.
+
+    Source: yfinance ``Ticker.eps_trend`` (migrated 2026-05-18 off the FMP
+    ``analyst-estimates`` endpoint, which began returning 402 Payment Required
+    on the free tier ~2026-05-17 — paid-tier only — collapsing this source to
+    ~15%% populated and breaching DataPhase2's per-source populated-ratio gate
+    (``eps_revision`` floor 0.50). yfinance is already the integrated provider
+    for ``target_price``/``options_flow`` in this module, so the
+    auth/availability/idiom precedent is established).
+
+    ``eps_trend`` is itself a revision series: a DataFrame indexed by period
+    (``0q``/``+1q``/``0y``/``+1y``) with columns ``current``, ``7daysAgo``,
+    ``30daysAgo``, ``60daysAgo``, ``90daysAgo`` (consensus-mean EPS estimate
+    snapshots taken at those lookbacks).
+
+    Return contract (UNCHANGED — ``_has_revision_data`` and all downstream
+    consumers key off ``current_estimate``):
+
+    * ``current_estimate`` — the ``0y`` (current fiscal year) row's
+      ``current`` column. The annual row mirrors the prior FMP
+      ``period="annual"`` choice so the field's semantics are unchanged.
+    * ``revision_4w`` — percent change of the consensus annual EPS estimate
+      over the trailing ~4 weeks, i.e.
+      ``(current - 30daysAgo) / abs(30daysAgo) * 100`` on the ``0y`` row
+      (same semantic as the prior FMP path's "estimate now vs ~30d ago",
+      but sourced from yfinance's own 30-day-ago snapshot instead of a
+      week-old S3 archive — which removes the prior dependency on a
+      ``archive/revisions/{date}.json`` snapshot that is never written
+      anywhere in this codebase, so the old path was effectively dead).
+    * ``streak`` — count of consecutive non-negative steps in the ``0y``
+      annual estimate walking newest→oldest across
+      ``current → 7daysAgo → 30daysAgo → 60daysAgo → 90daysAgo`` (i.e. a
+      "consecutive weeks the estimate did not get cut" run length, max 4).
+      The prior FMP implementation hardcoded ``streak`` to 0 (it had no
+      multi-snapshot series to derive a streak from); this is a strictly
+      more faithful derivation of the field's intended meaning, computed
+      from the now-available snapshot series. The field/key is preserved.
+
+    ``bucket``/``run_date`` are retained in the signature (callers and the
+    legacy S3-snapshot fallback below are unaffected); they are no longer
+    required for the primary path since yfinance carries the 30-day-ago
+    snapshot inline.
+    """
     result = {
         "current_estimate": None,
         "revision_4w": None,
         "streak": 0,
     }
 
-    # /stable requires period=annual on free tier; quarter is 402 paid.
+    # ── Primary: yfinance eps_trend (free, already integrated) ──────────────
     try:
-        data = _fmp_get(
-            "analyst-estimates",
-            params={"symbol": ticker, "period": "annual", "limit": 1},
-        )
-        if isinstance(data, list) and data:
-            # /stable renames the field vs v3 — accept either shape.
-            result["current_estimate"] = (
-                data[0].get("epsAvg")
-                or data[0].get("estimatedEpsAvg")
-            )
-    except Exception as e:
-        logger.warning("EPS estimate failed for %s: %s", ticker, _scrub_url_creds(e))
+        import yfinance as yf
 
-    # Load prior snapshot for revision comparison
-    try:
-        s3 = boto3.client("s3")
-        today = datetime.strptime(run_date, "%Y-%m-%d")
-        for days_ago in range(7, 15):
-            check_date = (today - timedelta(days=days_ago)).strftime("%Y-%m-%d")
-            try:
-                key = f"archive/revisions/{check_date}.json"
-                obj = s3.get_object(Bucket=bucket, Key=key)
-                prior = json.loads(obj["Body"].read())
-                prior_eps = prior.get(ticker, {}).get("eps_current", 0.0)
-                if prior_eps and result["current_estimate"]:
-                    result["revision_4w"] = round(
-                        (result["current_estimate"] - prior_eps) / abs(prior_eps) * 100, 2
-                    )
-                break
-            except Exception:
-                continue
-    except Exception:
-        pass
+        et = yf.Ticker(ticker).eps_trend
+        if et is not None and not et.empty and "0y" in et.index:
+            row = et.loc["0y"]
+
+            def _f(v):
+                try:
+                    if v is None:
+                        return None
+                    fv = float(v)
+                    return fv if fv == fv else None  # drop NaN
+                except (TypeError, ValueError):
+                    return None
+
+            cur = _f(row.get("current"))
+            d30 = _f(row.get("30daysAgo"))
+            if cur is not None:
+                result["current_estimate"] = round(cur, 4)
+            if cur is not None and d30 is not None and d30 != 0:
+                result["revision_4w"] = round((cur - d30) / abs(d30) * 100, 2)
+
+            # streak: consecutive non-negative steps newest→oldest
+            seq = [
+                _f(row.get(c))
+                for c in ("current", "7daysAgo", "30daysAgo", "60daysAgo", "90daysAgo")
+            ]
+            streak = 0
+            for newer, older in zip(seq, seq[1:]):
+                if newer is None or older is None:
+                    break
+                if newer - older >= 0:
+                    streak += 1
+                else:
+                    break
+            result["streak"] = streak
+    except Exception as e:
+        # yfinance exceptions do not embed API credentials (no keyed
+        # querystring) — mirror the module's existing yfinance warning idiom
+        # (_fetch_analyst's target_price block). The _scrub_url_creds helper
+        # added by PR #255 consolidates the FMP/keyed-fetch scrub surface; it
+        # is not needed on this unkeyed path. (TODO: once #255 merges, no
+        # change required here — kept for reviewer context.)
+        logger.warning("yfinance eps_trend failed for %s: %s", ticker, e)
+
+    # ── Legacy fallback: S3 prior snapshot for revision_4w only ────────────
+    # Retained for behavioural fidelity with the pre-migration function (and
+    # to keep the bucket/run_date params load-bearing). Note: no writer of
+    # ``archive/revisions/{date}.json`` exists in this codebase, so this
+    # loop is a no-op in practice — kept only as a non-regressing safety net
+    # in case yfinance supplied a current estimate but no 30-day-ago snapshot.
+    if result["current_estimate"] is not None and result["revision_4w"] is None:
+        try:
+            s3 = boto3.client("s3")
+            today = datetime.strptime(run_date, "%Y-%m-%d")
+            for days_ago in range(7, 15):
+                check_date = (today - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+                try:
+                    key = f"archive/revisions/{check_date}.json"
+                    obj = s3.get_object(Bucket=bucket, Key=key)
+                    prior = json.loads(obj["Body"].read())
+                    prior_eps = prior.get(ticker, {}).get("eps_current", 0.0)
+                    if prior_eps and result["current_estimate"]:
+                        result["revision_4w"] = round(
+                            (result["current_estimate"] - prior_eps)
+                            / abs(prior_eps) * 100,
+                            2,
+                        )
+                    break
+                except Exception:
+                    continue
+        except Exception:
+            pass
 
     return result
 

--- a/tests/test_alternative_revisions.py
+++ b/tests/test_alternative_revisions.py
@@ -1,0 +1,206 @@
+"""Tests for the EPS-revision sub-collector in ``collectors/alternative.py``.
+
+Contract as of 2026-05-18 (FMP→yfinance migration):
+
+  * Source is yfinance ``Ticker.eps_trend`` (the FMP ``analyst-estimates``
+    endpoint began 402-ing on the free tier ~2026-05-17 — paid-tier only).
+  * Return dict shape/keys are UNCHANGED:
+        {"current_estimate": <float|None>,
+         "revision_4w": <float|None>,
+         "streak": <int>}
+  * ``current_estimate`` ← ``eps_trend`` ``0y`` row, ``current`` column.
+  * ``revision_4w``      ← ``(current - 30daysAgo) / abs(30daysAgo) * 100``
+                            on the ``0y`` row, rounded to 2dp.
+  * ``streak``           ← count of consecutive non-negative steps walking
+                            newest→oldest across
+                            current → 7daysAgo → 30daysAgo → 60daysAgo →
+                            90daysAgo on the ``0y`` row (max 4).
+  * yfinance failures must degrade loudly (WARN) and never raise — the
+    function is called per-ticker and one provider outage must not poison
+    the whole Phase 2 batch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from collectors import alternative
+
+
+_EPS_TREND_COLS = ["current", "7daysAgo", "30daysAgo", "60daysAgo", "90daysAgo"]
+
+
+def _eps_trend_df(rows: dict[str, list]) -> pd.DataFrame:
+    """Build an eps_trend-shaped DataFrame (index = period rows)."""
+    df = pd.DataFrame.from_dict(rows, orient="index", columns=_EPS_TREND_COLS)
+    df.index.name = "period"
+    return df
+
+
+def _yf_with_trend(df) -> MagicMock:
+    mod = MagicMock()
+    mod.Ticker.return_value.eps_trend = df
+    return mod
+
+
+def _no_s3():
+    """Patch boto3 so the dead S3 fallback never touches the network."""
+    return patch.object(alternative, "boto3", MagicMock())
+
+
+def test_contract_keys_and_types_unchanged():
+    df = _eps_trend_df({
+        "0q":  [1.89, 1.89, 1.73, 1.73, 1.73],
+        "+1q": [2.01, 2.00, 1.97, 1.97, 1.98],
+        "0y":  [8.74, 8.76, 8.50, 8.50, 8.47],
+        "+1y": [9.63, 9.60, 9.33, 9.33, 9.30],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("AAPL", "bkt", "2026-05-18")
+
+    assert set(out.keys()) == {"current_estimate", "revision_4w", "streak"}
+    assert isinstance(out["current_estimate"], float)
+    assert isinstance(out["revision_4w"], float)
+    assert isinstance(out["streak"], int)
+    # current_estimate = 0y row "current"
+    assert out["current_estimate"] == 8.74
+
+
+def test_revision_4w_positive_delta_math():
+    # 0y: current 8.74 vs 30daysAgo 8.50 → +2.8235.. % → 2.82
+    df = _eps_trend_df({
+        "0y": [8.74, 8.76, 8.50, 8.49, 8.47],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("AAPL", "bkt", "2026-05-18")
+
+    assert out["revision_4w"] == round((8.74 - 8.50) / abs(8.50) * 100, 2)
+    assert out["revision_4w"] > 0
+
+
+def test_revision_4w_negative_delta_when_estimate_cut():
+    # estimate cut over the trailing 4w → negative revision_4w
+    df = _eps_trend_df({
+        "0y": [3.00, 3.10, 3.50, 3.50, 3.60],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("XYZ", "bkt", "2026-05-18")
+
+    assert out["revision_4w"] == round((3.00 - 3.50) / abs(3.50) * 100, 2)
+    assert out["revision_4w"] < 0
+
+
+def test_revision_4w_handles_negative_eps_estimates():
+    """Never-profitable names carry negative EPS — abs() denominator keeps
+    the sign of the numerator (estimate getting less negative = positive
+    revision)."""
+    df = _eps_trend_df({
+        "0y": [-1.50, -1.51, -1.64, -1.64, -1.61],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("RBLX", "bkt", "2026-05-18")
+
+    # (-1.50) - (-1.64) = +0.14 over abs(1.64) → positive (estimate improved)
+    assert out["revision_4w"] == round((-1.50 - -1.64) / abs(-1.64) * 100, 2)
+    assert out["revision_4w"] > 0
+
+
+def test_streak_counts_consecutive_non_negative_steps():
+    # newest→oldest: 9>8 ok, 8>7 ok, 7>6 ok, 6>5 ok → streak 4
+    df = _eps_trend_df({
+        "0y": [9.0, 8.0, 7.0, 6.0, 5.0],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("UP", "bkt", "2026-05-18")
+    assert out["streak"] == 4
+
+
+def test_streak_breaks_on_first_cut():
+    # current(8) vs 7d(9): 8-9 = -1 < 0 → streak breaks immediately → 0
+    df = _eps_trend_df({
+        "0y": [8.0, 9.0, 9.0, 9.0, 9.0],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("CUT", "bkt", "2026-05-18")
+    assert out["streak"] == 0
+
+
+def test_streak_partial_run():
+    # current(9)>=7d(8) ok; 7d(8) vs 30d(10) → -2 break → streak 1
+    df = _eps_trend_df({
+        "0y": [9.0, 8.0, 10.0, 10.0, 10.0],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("PART", "bkt", "2026-05-18")
+    assert out["streak"] == 1
+
+
+def test_missing_30days_ago_leaves_revision_none_but_estimate_populated():
+    """NaN in the 30daysAgo slot must null revision_4w without nulling the
+    estimate (so _has_revision_data still counts the ticker as populated)."""
+    df = _eps_trend_df({
+        "0y": [8.74, 8.76, float("nan"), 8.49, 8.47],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("AAPL", "bkt", "2026-05-18")
+
+    assert out["current_estimate"] == 8.74
+    assert out["revision_4w"] is None
+    assert alternative._has_revision_data(out) is True
+
+
+def test_empty_eps_trend_returns_none_safe_defaults():
+    """yfinance returning an empty DataFrame must not raise and must yield
+    the all-None/0 default contract."""
+    with _no_s3(), patch.dict(
+        "sys.modules", {"yfinance": _yf_with_trend(pd.DataFrame())}
+    ):
+        out = alternative._fetch_revisions("THIN", "bkt", "2026-05-18")
+
+    assert out == {"current_estimate": None, "revision_4w": None, "streak": 0}
+    assert alternative._has_revision_data(out) is False
+
+
+def test_eps_trend_none_returns_none_safe_defaults():
+    with _no_s3(), patch.dict(
+        "sys.modules", {"yfinance": _yf_with_trend(None)}
+    ):
+        out = alternative._fetch_revisions("THIN", "bkt", "2026-05-18")
+    assert out == {"current_estimate": None, "revision_4w": None, "streak": 0}
+
+
+def test_missing_0y_row_returns_defaults():
+    """Some names only expose quarterly rows — no 0y → defaults, no raise."""
+    df = _eps_trend_df({
+        "0q":  [1.0, 1.0, 1.0, 1.0, 1.0],
+        "+1q": [1.1, 1.1, 1.1, 1.1, 1.1],
+    })
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        out = alternative._fetch_revisions("QONLY", "bkt", "2026-05-18")
+    assert out == {"current_estimate": None, "revision_4w": None, "streak": 0}
+
+
+def test_yfinance_failure_degrades_loudly_without_raising():
+    """yfinance raising must not bubble up — degraded defaults returned."""
+    mod = MagicMock()
+    mod.Ticker.side_effect = RuntimeError("yfinance IP block")
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": mod}):
+        out = alternative._fetch_revisions("AAPL", "bkt", "2026-05-18")
+
+    assert out["current_estimate"] is None
+    assert out["revision_4w"] is None
+    assert out["streak"] == 0
+
+
+def test_signature_preserves_bucket_and_run_date_params():
+    """bucket/run_date must remain accepted positional params (callers and
+    the legacy S3 fallback are unaffected by the migration)."""
+    df = _eps_trend_df({"0y": [5.0, 5.0, 5.0, 5.0, 5.0]})
+    with _no_s3(), patch.dict("sys.modules", {"yfinance": _yf_with_trend(df)}):
+        # explicit kwargs must still work
+        out = alternative._fetch_revisions(
+            "AAPL", bucket="some-bucket", run_date="2026-05-18"
+        )
+    assert out["current_estimate"] == 5.0


### PR DESCRIPTION
## Root cause
FMP's `analyst-estimates` endpoint began returning **402 Payment Required** on the free tier (~2026-05-17 — paid-tier only). `_fetch_revisions` collapsed to ~15% populated, breaching DataPhase2's per-source populated-ratio gate (`_REQUIRED_POPULATED_RATIOS["eps_revision"] = 0.50`) → **DataPhase2 returned ERROR on every weekly run, incl. the 5/17 gate breach**. Operator (Brian) decided "swap source".

## Change
Swaps `collectors/alternative.py::_fetch_revisions` off FMP onto **yfinance `Ticker.eps_trend`**. yfinance is already the integrated provider for `target_price`/`options_flow` in this same module (auth/availability/idiom precedent established). No new pip dep.

`eps_trend` is itself a revision series — a DataFrame indexed by period (`0q`/`+1q`/`0y`/`+1y`) with columns `current`/`7daysAgo`/`30daysAgo`/`60daysAgo`/`90daysAgo` (consensus-mean EPS estimate snapshots at those lookbacks). The annual `0y` row is used, mirroring the prior FMP `period="annual"` choice.

### Field definitions
| Key | Definition |
|-----|-----------|
| `current_estimate` | `0y` row, `current` column (current FY consensus EPS estimate) |
| `revision_4w` | `(current - 30daysAgo) / abs(30daysAgo) * 100` on the `0y` row, 2dp. Same "now vs ~30d ago" semantic as the prior FMP path, but sourced from yfinance's own 30-day-ago snapshot. This **removes the dependency on `archive/revisions/{date}.json`** — a snapshot that is never written anywhere in this codebase, so the old revision path was effectively dead (always None). |
| `streak` | Count of consecutive non-negative steps in the `0y` estimate walking newest→oldest `current→7d→30d→60d→90d` (max 4). The prior FMP impl **hardcoded `streak=0`** (no multi-snapshot series available); this is a strictly more faithful derivation of the field's intended "weeks the estimate wasn't cut" meaning. Field/key preserved — not dropped. |

## Contract unchanged
Return dict keys/types `{current_estimate: float|None, revision_4w: float|None, streak: int}` are **identical**, so `_has_revision_data` and all downstream consumers are unaffected. `bucket`/`run_date` params retained; the read-only S3 prior-snapshot path is kept as a non-regressing fallback (no-op in practice — no writer exists).

## Verification (real yfinance calls, worktree code)
8 representative tickers incl. recent listing **ARM** (IPO 2023) and never-profitable **RBLX**:

```
AAPL current=8.739  rev4w=2.85  streak=0
MSFT current=16.845 rev4w=1.22  streak=2
NVDA current=8.381  rev4w=0.72  streak=4
ETSY current=3.525  rev4w=13.62 streak=4
ARM  current=2.162  rev4w=0.81  streak=3
RBLX current=-1.526 rev4w=7.24  streak=0
PLTR current=1.464  rev4w=10.77 streak=2
SOFI current=0.582  rev4w=-1.22 streak=0
```
**Observed populated ratio: 8/8 = 100%** — decisively clears the 0.50 gate.

## Scrub note
yfinance exceptions carry no API credentials (no keyed querystring), so the existing module yfinance warning idiom (`_fetch_analyst`'s `target_price` block) is mirrored. The `_scrub_url_creds` helper added by open **PR #255** consolidates the FMP/keyed-fetch scrub surface and is not needed on this unkeyed path.

## Merge order vs concurrent PRs
`collectors/alternative.py` is also touched by open **#254** (per-collector value-range validation) and **#255** (institutional /tmp + key scrub). Recommended order: **#255 → this → #254**. This branch is based off `origin/main`; expect a trivial rebase after #255 merges — no functional conflict (different functions).

## Tests
New `tests/test_alternative_revisions.py` (13 tests), mirrors `test_alternative_analyst.py` style — mocks yfinance via patched `sys.modules` + a DataFrame `eps_trend` fixture. Covers: contract keys/types unchanged, `revision_4w` sign/Δ math (positive, negative, negative-EPS `abs()` denominator), `streak` derivation (full/partial/broken runs), None-safety (empty/None df, missing `0y` row, NaN `30daysAgo`), loud-degrade on yfinance failure, signature param preservation.

**Full suite: 1232 passed, 1 skipped** (pre-existing skip, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)