### PR TITLE
feat(sf): Friday-PM shell_run dry-pass of the Saturday pipeline (spine; rule shipped disabled)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -134,6 +134,55 @@ Resources:
               "sns_topic_arn": "${AlertsTopic}"
             }
 
+  # Friday-PM "shell run" — automated full-fidelity dry preflight of the
+  # Saturday SF (ROADMAP "Scheduled Friday-PM shell run", P1; spine in
+  # step_function.json's CheckShellRun/ApplyShellRunDefaults gate). Fires the
+  # SAME alpha-engine-saturday-pipeline SF (NOT a parallel SF) with
+  # shell_run=true, which the InitializeInput→CheckShellRun gate fans into
+  # every skip_* flag so the whole workload no-ops while the SF/health
+  # bootstrap chain is still exercised ~11.5 h before the real Sat 02:00 PT
+  # firing — surfacing a Saturday-fatal break inside an operator-awake
+  # Friday-evening fix window.
+  #
+  # SHIPPED DISABLED (State: DISABLED) — zero-risk to merge. This is
+  # additive observability, NOT a backstop (the system's "fail loud,
+  # no backstop" design decision stands). Brian enables it deliberately:
+  #   aws events enable-rule --name alpha-engine-friday-shell-run --region us-east-1
+  # (and, if the spine's per-module dry paths are still scoped follow-ons,
+  # the shell run is a pure-skip no-op pass until those land — still a
+  # valid SF/IAM/EventBridge/health-check bootstrap smoke test).
+  #
+  # Cron: 21:30 UTC Fri = 14:30 PT (PDT, the dominant season) / 13:30 PT
+  # (PST). Chosen AFTER the Friday EOD SF (~1:25 PT) completes so the
+  # shell run never collides with PostMarketData / EODReconcile /
+  # StopTradingInstance on the trading instance, and ~11.5 h BEFORE the
+  # real Saturday 09:00 UTC firing — a red shell-run report Friday
+  # evening leaves a full operator fix window before the real run
+  # consumes its weekly research/training/backtest cycle. shell_run mode
+  # makes nothing fetch, so the Saturday "polygon T+1 must have settled"
+  # timing constraint is moot here (no API calls in a shell run).
+  FridayShellRunTrigger:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: alpha-engine-friday-shell-run
+      Description: >-
+        Friday 21:30 UTC (14:30 PT PDT / 13:30 PT PST) — DISABLED by default —
+        fires the Saturday SF with shell_run=true (full dry preflight, no API
+        calls / no S3-config-email-SNS writes) ~11.5h before the real Sat run.
+        Enable via: aws events enable-rule --name alpha-engine-friday-shell-run
+      ScheduleExpression: 'cron(30 21 ? * FRI *)'
+      State: DISABLED
+      Targets:
+        - Id: friday-shell-run
+          Arn: !Ref SaturdayPipeline
+          RoleArn: !Ref EventBridgeSfnRoleArn
+          Input: !Sub |
+            {
+              "ec2_instance_id": ["${MicroInstanceId}"],
+              "sns_topic_arn": "${AlertsTopic}",
+              "shell_run": true
+            }
+
   WeekdayTrigger:
     Type: AWS::Events::Rule
     Properties:

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -9,6 +9,35 @@
         "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
       "OutputPath": "$.merged",
+      "Next": "CheckShellRun"
+    },
+    "CheckShellRun": {
+      "Type": "Choice",
+      "Comment": "Friday-PM 'shell run' gate (ROADMAP 'Scheduled Friday-PM shell run', spine landed feat/sf-friday-shell-run). Input {\"shell_run\": true} (supplied by the DISABLED-by-default Friday EventBridge rule alpha-engine-friday-shell-run) routes to ApplyShellRunDefaults, which layers every skip_* flag = true UNDER the user input so the entire Saturday workload is no-op'd via the EXISTING Choice-gated skip mechanism (zero new dry paths added in the spine). shell_run absent OR false routes straight to CheckSkipMorningEnrich — BYTE-IDENTICAL to the pre-spine Saturday run (this is a strict superset; the real Sat 02:00 PT firing passes no shell_run, so this Choice always takes Default for it). Per-module --preflight-only/--dry-run paths (so spots boot + smoke instead of skip) are scoped follow-on PRs per the ROADMAP owed-work — NOT in this spine.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.shell_run",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.shell_run",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "ApplyShellRunDefaults"
+        }
+      ],
+      "Default": "CheckSkipMorningEnrich"
+    },
+    "ApplyShellRunDefaults": {
+      "Type": "Pass",
+      "Comment": "shell_run=true ONLY. Merges every skip_* flag = true UNDER the current state (States.JsonMerge(shellDefaults, $, false) — second arg wins) so an explicit per-flag override in the execution input still takes effect (e.g. {\"shell_run\": true, \"skip_research\": false} still runs Research). Mirrors InitializeInput's defaults-under-input JsonMerge pattern exactly. Every workload state in the Saturday SF already has a Choice-gated skip_* (verified: morning_enrich, data_phase1, rag_ingestion, regime_substrate, regime_retrospective_eval, research, data_phase2, eval_judge, rationale_clustering, replay_concordance, counterfactual, predictor_training, drift_detection, backtester, parity, evaluator) so with all 16 true the SF traverses InitializeInput → (skip every workload) → SaturdayHealthCheck → WeeklySubstrateHealthCheck → Notify. The two health-check states have NO skip gate by design — they are read-only input-freshness / substrate scans and are exactly the kind of bootstrap/transport check the shell run wants exercised Friday PM (their shell_run-aware missing-Friday-bar tolerance is ROADMAP owed-work item 5, a scoped follow-on).",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"skip_morning_enrich\":true,\"skip_data_phase1\":true,\"skip_rag_ingestion\":true,\"skip_regime_substrate\":true,\"skip_regime_retrospective_eval\":true,\"skip_research\":true,\"skip_data_phase2\":true,\"skip_eval_judge\":true,\"skip_rationale_clustering\":true,\"skip_replay_concordance\":true,\"skip_counterfactual\":true,\"skip_predictor_training\":true,\"skip_drift_detection\":true,\"skip_backtester\":true,\"skip_parity\":true,\"skip_evaluator\":true}'),$,false)"
+      },
+      "OutputPath": "$.merged",
       "Next": "CheckSkipMorningEnrich"
     },
     "CheckSkipMorningEnrich": {
@@ -1859,7 +1888,39 @@
         }
       ],
       "ResultPath": "$.substrate_check_poll",
-      "Next": "NotifyComplete"
+      "Next": "CheckShellRunNotify"
+    },
+    "CheckShellRunNotify": {
+      "Type": "Choice",
+      "Comment": "Consolidated Friday-PM shell-run result notify. Reuses the EXISTING NotifyComplete SNS-publish substrate (same alpha-engine-alerts topic, same arn:aws:states:::sns:publish Resource) with a shell_run-tagged Subject/Message so the operator can tell a Friday dry-pass result apart from a real Saturday SUCCESS in their inbox. shell_run absent/false \u2192 NotifyComplete (BYTE-IDENTICAL to pre-spine). shell_run=true \u2192 NotifyShellRunComplete. No new SNS topic / Lambda / infra \u2014 the consolidated per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on; the spine delivers a single shell-run-tagged success signal by reusing NotifyComplete's pattern.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.shell_run",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.shell_run",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "NotifyShellRunComplete"
+        }
+      ],
+      "Default": "NotifyComplete"
+    },
+    "NotifyShellRunComplete": {
+      "Type": "Task",
+      "Comment": "Friday-PM shell-run success notification via SNS. Mirrors NotifyComplete exactly (same topic, Resource, ResultPath, End) with a SHELL RUN-tagged Subject so a green Friday dry-pass is distinguishable from a real Saturday SUCCESS. A FAILED shell run still routes through the unchanged HandleFailure (a 'FAILED' alert whose execution timestamp/ID is clearly the Friday run is still the actionable signal the operator needs inside the Friday fix window \u2014 re-pointing HandleFailure's 20 inbound edges to a shell-run variant was deliberately NOT done: high churn, zero added operator value, and it would perturb the real Saturday failure path's risk surface).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 SHELL RUN PASSED (Friday dry-pass)",
+        "Message": "Friday-PM shell run of the Saturday pipeline completed: all workload states no-op'd via shell_run, health/substrate checks ran. No Saturday-fatal bootstrap break detected for tomorrow's 02:00 PT real run. Check dashboard / execution history for per-state detail."
+      },
+      "ResultPath": "$.notify_result",
+      "End": true
     },
     "NotifyComplete": {
       "Type": "Task",

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -1,0 +1,366 @@
+"""Pins the Friday-PM `shell_run` spine in the Saturday SF.
+
+Origin: ROADMAP "Scheduled Friday-PM 'shell run' — automated full-fidelity
+preflight of the Saturday SF" (P1, added 2026-05-16). The *prevention* half
+of Saturday-SF reliability (the *containment* half — preflight-task-split —
+shipped 2026-05-16 in data #249/#250). Motivated by the recent multi-week
+Saturday-SF cascade history: a Saturday-fatal break is discovered only when
+the unattended 02:00 PT Sat run fails, wasting the week's
+research/training/backtest cycle.
+
+The spine is a STRICT SUPERSET of the pre-spine Saturday SF:
+- A `CheckShellRun` Choice after `InitializeInput`. `shell_run` absent OR
+  false → `CheckSkipMorningEnrich` (the pre-spine `InitializeInput.Next`),
+  BYTE-IDENTICAL behaviour to today's real Saturday run.
+- `shell_run=true` → `ApplyShellRunDefaults`, a Pass that merges every
+  `skip_*` flag = true UNDER the execution input (user per-flag overrides
+  still win), then → `CheckSkipMorningEnrich`. Every workload state already
+  has a Choice-gated `skip_*`, so the whole workload no-ops via the EXISTING
+  skip mechanism (no new dry paths added in the spine).
+- A `CheckShellRunNotify` Choice before the success notify. shell_run
+  absent/false → the unchanged `NotifyComplete`; shell_run=true →
+  `NotifyShellRunComplete` (shell-run-tagged Subject, same SNS substrate).
+
+This test catches regressions like:
+- Someone re-points `InitializeInput.Next` straight to
+  `CheckSkipMorningEnrich`, silently dropping the shell-run gate.
+- Someone makes `CheckShellRun.Default` anything other than
+  `CheckSkipMorningEnrich` (breaks the strict-superset / real-Saturday path).
+- The `ApplyShellRunDefaults` merge order flips so user overrides lose, or a
+  `skip_*` flag is dropped from the defaults blob (a workload state would
+  then RUN under shell_run — a side-effecting Saturday workload on a Friday).
+- `NotifyComplete` is mutated (the real Saturday SUCCESS email changes).
+- The Friday EventBridge rule is shipped ENABLED, or without shell_run=true,
+  or pointed at a different SF.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+_CFN_PATH = (
+    _REPO_ROOT / "infrastructure" / "cloudformation"
+    / "alpha-engine-orchestration.yaml"
+)
+
+# The complete set of Choice-gated skip flags in the Saturday SF. If a new
+# workload state is added with a new skip_* flag, it MUST be added to
+# ApplyShellRunDefaults too (else that state RUNS under shell_run) — this
+# constant + test_shell_defaults_cover_every_skip_gate enforce that.
+_EXPECTED_SKIPS = {
+    "skip_morning_enrich",
+    "skip_data_phase1",
+    "skip_rag_ingestion",
+    "skip_regime_substrate",
+    "skip_regime_retrospective_eval",
+    "skip_research",
+    "skip_data_phase2",
+    "skip_eval_judge",
+    "skip_rationale_clustering",
+    "skip_replay_concordance",
+    "skip_counterfactual",
+    "skip_predictor_training",
+    "skip_drift_detection",
+    "skip_backtester",
+    "skip_parity",
+    "skip_evaluator",
+}
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    return sf["States"]
+
+
+def _all_skip_gate_flags(states: dict) -> set[str]:
+    """Walk every Choice (incl. Parallel branches) and collect each
+    `$.skip_*` Variable it gates on."""
+    found: set[str] = set()
+
+    def walk(st: dict) -> None:
+        for v in st.values():
+            if v.get("Type") == "Choice":
+                for c in v.get("Choices", []):
+                    conds = c.get("And") or c.get("Or") or [c]
+                    for cc in conds:
+                        var = cc.get("Variable", "")
+                        if var.startswith("$.skip_"):
+                            found.add(var[2:])
+            if v.get("Type") == "Parallel":
+                for b in v["Branches"]:
+                    walk(b["States"])
+
+    walk(states)
+    return found
+
+
+class TestStatePresence:
+    @pytest.mark.parametrize(
+        "name",
+        ["CheckShellRun", "ApplyShellRunDefaults",
+         "CheckShellRunNotify", "NotifyShellRunComplete"],
+    )
+    def test_spine_state_exists(self, states, name):
+        assert name in states, f"{name} missing — shell-run spine incomplete"
+
+
+class TestStrictSuperset:
+    """shell_run absent/false ⇒ byte-identical to the pre-spine Saturday run."""
+
+    def test_initialize_input_routes_to_shell_run_gate(self, states):
+        assert states["InitializeInput"]["Next"] == "CheckShellRun"
+
+    def test_initialize_input_merge_expr_unchanged(self, states):
+        # The run_date / sns_topic_arn defaults-under-input merge must be
+        # untouched (a regression here would corrupt every real run).
+        expr = states["InitializeInput"]["Parameters"]["merged.$"]
+        assert expr.startswith("States.JsonMerge(States.JsonMerge(")
+        assert "run_date" in expr and "sns_topic_arn" in expr
+        assert expr.endswith(",$$.Execution.Input,false)")
+
+    def test_check_shell_run_default_is_pre_spine_target(self, states):
+        # Pre-spine InitializeInput.Next was CheckSkipMorningEnrich; the
+        # Default of the new gate MUST be exactly that → real Saturday run
+        # (no shell_run input) is unchanged.
+        assert states["CheckShellRun"]["Default"] == "CheckSkipMorningEnrich"
+
+    def test_check_shell_run_only_fires_on_true_present(self, states):
+        choices = states["CheckShellRun"]["Choices"]
+        assert len(choices) == 1
+        conds = choices[0]["And"]
+        kinds = {
+            (c["Variable"], "IsPresent" in c, c.get("BooleanEquals"))
+            for c in conds
+        }
+        assert ("$.shell_run", True, None) in kinds  # IsPresent: true
+        assert ("$.shell_run", False, True) in kinds  # BooleanEquals: true
+        assert choices[0]["Next"] == "ApplyShellRunDefaults"
+
+    def test_notify_complete_is_byte_identical(self, states):
+        """The real Saturday SUCCESS email must not change."""
+        nc = states["NotifyComplete"]
+        assert nc["Resource"] == "arn:aws:states:::sns:publish"
+        assert nc["Parameters"]["Subject"] == (
+            "Alpha Engine Saturday Pipeline — SUCCESS"
+        )
+        assert nc["Parameters"]["Message"] == (
+            "All steps completed successfully. Check dashboard for results."
+        )
+        assert nc["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"
+        assert nc["ResultPath"] == "$.notify_result"
+        assert nc["End"] is True
+
+    def test_success_notify_gate_default_is_notify_complete(self, states):
+        assert states["CheckShellRunNotify"]["Default"] == "NotifyComplete"
+
+
+class TestApplyShellRunDefaults:
+    """shell_run=true ⇒ every workload state is no-op'd via the EXISTING
+    skip mechanism, and user per-flag overrides still win."""
+
+    def _merge_expr(self, states) -> str:
+        return states["ApplyShellRunDefaults"]["Parameters"]["merged.$"]
+
+    def test_pass_state_routes_into_existing_skip_chain(self, states):
+        st = states["ApplyShellRunDefaults"]
+        assert st["Type"] == "Pass"
+        assert st["OutputPath"] == "$.merged"
+        assert st["Next"] == "CheckSkipMorningEnrich"
+
+    def test_user_input_wins_over_shell_defaults(self, states):
+        # States.JsonMerge(defaults, $, false) — $ (current state, carrying
+        # the user input) MUST be the 2nd arg so an explicit
+        # {"shell_run": true, "skip_research": false} still runs Research.
+        expr = self._merge_expr(states)
+        assert expr.startswith("States.JsonMerge(States.StringToJson(")
+        assert expr.endswith(",$,false)"), (
+            "user input ($) must be the 2nd JsonMerge arg so explicit "
+            "per-flag overrides win over the shell-run skip defaults"
+        )
+
+    def test_shell_defaults_blob_is_valid_json_all_true(self, states):
+        expr = self._merge_expr(states)
+        m = re.search(r"StringToJson\('(.+?)'\)", expr)
+        assert m, "could not extract the embedded skip-defaults JSON blob"
+        blob = json.loads(m.group(1))
+        assert set(blob) == _EXPECTED_SKIPS, set(blob) ^ _EXPECTED_SKIPS
+        assert all(v is True for v in blob.values()), blob
+
+    def test_shell_defaults_cover_every_skip_gate(self, states):
+        """Every Choice-gated skip_* in the SF must be force-true'd by
+        shell_run — otherwise that workload state RUNS on a Friday dry-pass
+        (a side-effecting Saturday workload firing on a Friday)."""
+        gated = _all_skip_gate_flags(states)
+        assert gated == _EXPECTED_SKIPS, (
+            "skip-gate flags drifted from the shell-run defaults blob: "
+            f"{gated ^ _EXPECTED_SKIPS}. Add the new flag to "
+            "ApplyShellRunDefaults (and _EXPECTED_SKIPS) so the new "
+            "workload state no-ops under shell_run."
+        )
+
+
+class TestConsolidatedNotify:
+    def test_substrate_check_routes_to_notify_gate(self, states):
+        assert (
+            states["WaitForWeeklySubstrateHealthCheck"]["Next"]
+            == "CheckShellRunNotify"
+        )
+
+    def test_shell_run_notify_reuses_sns_substrate(self, states):
+        st = states["NotifyShellRunComplete"]
+        assert st["Resource"] == "arn:aws:states:::sns:publish"
+        assert st["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"
+        assert "SHELL RUN" in st["Parameters"]["Subject"]
+        assert st["ResultPath"] == "$.notify_result"
+        assert st["End"] is True
+
+    def test_shell_run_notify_gate_fires_on_true(self, states):
+        choices = states["CheckShellRunNotify"]["Choices"]
+        assert len(choices) == 1
+        assert choices[0]["Next"] == "NotifyShellRunComplete"
+        conds = choices[0]["And"]
+        assert {c["Variable"] for c in conds} == {"$.shell_run"}
+
+
+class TestHappyPathTraversal:
+    """End-to-end: with shell_run=true the SF must reach
+    NotifyShellRunComplete having visited NO workload Task; with shell_run
+    absent it must be the pre-spine path (visits MorningEnrich etc.)."""
+
+    def _trace_main(self, sf, states, shell_run: bool) -> list[str]:
+        inp = {"shell_run": True} if shell_run else {}
+        # ApplyShellRunDefaults force-sets all skips when shell_run=true.
+        skips = set(_EXPECTED_SKIPS) if shell_run else set()
+        order: list[str] = []
+        seen: set[str] = set()
+        cur = sf["StartAt"]
+        while cur and cur in states and cur not in seen:
+            seen.add(cur)
+            order.append(cur)
+            st = states[cur]
+            t = st.get("Type")
+            if t == "Choice":
+                taken = None
+                for c in st.get("Choices", []):
+                    conds = c.get("And") or [c]
+                    vars_ = [
+                        cc.get("Variable", "").replace("$.", "")
+                        for cc in conds
+                        if "Variable" in cc
+                    ]
+                    # shell_run gate
+                    if vars_ == ["shell_run", "shell_run"] or vars_ == [
+                        "shell_run"
+                    ]:
+                        if inp.get("shell_run") is True:
+                            taken = c["Next"]
+                            break
+                        continue
+                    # skip_* gate
+                    if vars_ and all(v in _EXPECTED_SKIPS for v in vars_):
+                        if all(v in skips for v in vars_):
+                            taken = c["Next"]
+                            break
+                        continue
+                    # status checks (Success edge) — not exercised on the
+                    # all-skip happy path; fall through to Default
+                cur = taken if taken else st.get("Default")
+            elif t == "Parallel":
+                cur = st.get("Next")
+            elif t in ("Succeed", "Fail"):
+                break
+            else:
+                if st.get("End"):
+                    order.append("[END]")
+                    break
+                cur = st.get("Next")
+        return order
+
+    def test_shell_run_true_reaches_shell_notify_no_workload(
+        self, sf, states
+    ):
+        order = self._trace_main(sf, states, shell_run=True)
+        assert order[-1] == "[END]"
+        assert "NotifyShellRunComplete" in order
+        assert "NotifyComplete" not in order
+        # No side-effecting workload Task visited on the main thread.
+        for forbidden in (
+            "MorningEnrich",
+            "DataPhase1",
+            "RAGIngestion",
+            "RegimeSubstrate",
+            "Backtester",
+            "Parity",
+            "Evaluator",
+        ):
+            assert forbidden not in order, (
+                f"{forbidden} ran under shell_run — must be skipped"
+            )
+        # Health/substrate checks DO still run (the bootstrap smoke).
+        assert "SaturdayHealthCheck" in order
+        assert "WeeklySubstrateHealthCheck" in order
+
+    def test_shell_run_absent_is_pre_spine_path(self, sf, states):
+        order = self._trace_main(sf, states, shell_run=False)
+        # No shell_run ⇒ Default at CheckShellRun ⇒ run the real workload.
+        assert "ApplyShellRunDefaults" not in order
+        assert "NotifyShellRunComplete" not in order
+        assert order[: order.index("CheckSkipMorningEnrich") + 2] == [
+            "InitializeInput",
+            "CheckShellRun",
+            "CheckSkipMorningEnrich",
+            "MorningEnrich",
+        ]
+
+
+class TestFridayEventBridgeRule:
+    """The Friday rule must be shipped DISABLED, target the SAME Saturday
+    SF, and pass shell_run=true (additive observability, not a backstop)."""
+
+    @pytest.fixture(scope="class")
+    def cfn_text(self) -> str:
+        return _CFN_PATH.read_text()
+
+    def test_rule_block_present(self, cfn_text):
+        assert "FridayShellRunTrigger:" in cfn_text
+        assert "Name: alpha-engine-friday-shell-run" in cfn_text
+
+    def test_rule_shipped_disabled(self, cfn_text):
+        block = cfn_text.split("FridayShellRunTrigger:", 1)[1].split(
+            "WeekdayTrigger:", 1
+        )[0]
+        assert "State: DISABLED" in block, (
+            "Friday shell-run rule MUST ship DISABLED — zero-risk merge; "
+            "Brian enables it deliberately (fail-loud / no-backstop design)."
+        )
+        assert "State: ENABLED" not in block
+
+    def test_rule_targets_same_saturday_sf_with_shell_run(self, cfn_text):
+        block = cfn_text.split("FridayShellRunTrigger:", 1)[1].split(
+            "WeekdayTrigger:", 1
+        )[0]
+        assert "!Ref SaturdayPipeline" in block, (
+            "must reuse the existing Saturday SF — NOT a parallel SF"
+        )
+        assert "!Ref EventBridgeSfnRoleArn" in block  # same StartExecution grant
+        assert '"shell_run": true' in block
+
+    def test_friday_schedule_after_eod_before_saturday(self, cfn_text):
+        block = cfn_text.split("FridayShellRunTrigger:", 1)[1].split(
+            "WeekdayTrigger:", 1
+        )[0]
+        # 21:30 UTC Fri = 14:30 PT (PDT) — after Friday EOD SF (~1:25 PT),
+        # ~11.5h before the real Sat 09:00 UTC firing.
+        assert "cron(30 21 ? * FRI *)" in block

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -66,9 +66,19 @@ class TestChainOrdering:
     CheckSkipDataPhase1 → DataPhase1 (existing downstream unchanged)."""
 
     def test_initialize_input_routes_to_morning_enrich_skipgate(self, states):
-        assert states["InitializeInput"]["Next"] == "CheckSkipMorningEnrich", (
-            "InitializeInput must hand off to the MorningEnrich skip-gate "
-            "first — MorningEnrich precedes DataPhase1 post-split."
+        # Post Friday-PM shell-run spine (feat/sf-friday-shell-run):
+        # InitializeInput now hands off to the CheckShellRun gate, whose
+        # Default is the pre-spine target CheckSkipMorningEnrich. The real
+        # Saturday run (no shell_run input) therefore still reaches the
+        # MorningEnrich skip-gate first — MorningEnrich still precedes
+        # DataPhase1. Strict superset: shell_run absent ⇒ unchanged.
+        assert states["InitializeInput"]["Next"] == "CheckShellRun", (
+            "InitializeInput must hand off to the shell-run gate, whose "
+            "Default preserves the pre-spine MorningEnrich skip-gate path."
+        )
+        assert states["CheckShellRun"]["Default"] == "CheckSkipMorningEnrich", (
+            "CheckShellRun.Default must be CheckSkipMorningEnrich so the "
+            "real Saturday run is byte-identical pre-spine."
         )
 
     def test_skip_morning_enrich_default_runs_morning_enrich(self, states):

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -71,7 +71,16 @@ class TestChainOrdering:
         )
 
     def test_wait_for_substrate_routes_to_notify_complete(self, states):
-        assert states["WaitForWeeklySubstrateHealthCheck"]["Next"] == "NotifyComplete"
+        # Post Friday-PM shell-run spine (feat/sf-friday-shell-run): the
+        # success edge is gated through CheckShellRunNotify so a Friday
+        # dry-pass gets a shell-run-tagged email. The gate's Default is the
+        # unchanged NotifyComplete, so the REAL Saturday run (no shell_run
+        # input) still ends at NotifyComplete — strict superset preserved.
+        assert (
+            states["WaitForWeeklySubstrateHealthCheck"]["Next"]
+            == "CheckShellRunNotify"
+        )
+        assert states["CheckShellRunNotify"]["Default"] == "NotifyComplete"
 
 
 class TestCatchSemantics:


### PR DESCRIPTION
## Summary

Foundational **spine** of ROADMAP **"Scheduled Friday-PM 'shell run' — automated full-fidelity preflight of the Saturday SF"** (P1, added 2026-05-16). The *prevention* half of Saturday-SF reliability; the *containment* half (preflight-task-split) shipped 2026-05-16 in data #249/#250.

A scheduled Friday-PM dry/no-op pass of the entire Saturday SF turns a Saturday-fatal breakage from a Saturday-morning-after lost-week incident into a Friday-evening operator fix window (~11.5h before the real Sat 02:00 PT firing). Motivated by the recent multi-week Saturday-SF cascade history.

## Design

**Strict superset.** `shell_run` absent/false ⇒ **byte-identical** to today's real Saturday run. Mirrors the existing `skip_*` / `States.JsonMerge` precedent exactly — no new mechanism invented. Only two existing edges change, each routed through a new Choice whose `Default` is the pre-spine target:

| Edge | Pre-spine | Post-spine | Real Saturday run |
|---|---|---|---|
| `InitializeInput.Next` | `CheckSkipMorningEnrich` | `CheckShellRun` | `CheckShellRun.Default` → `CheckSkipMorningEnrich` (unchanged) |
| `WaitForWeeklySubstrateHealthCheck.Next` | `NotifyComplete` | `CheckShellRunNotify` | `CheckShellRunNotify.Default` → `NotifyComplete` (SUCCESS email untouched) |

`shell_run=true` → `ApplyShellRunDefaults` (Pass): `States.JsonMerge(<all 16 skip_*=true>, $, false)` layers every skip flag = true **under** the execution input, so an explicit per-flag override still wins (`{"shell_run":true,"skip_research":false}` still runs Research). Every workload state already has a Choice-gated `skip_*`, so the whole workload no-ops via the **existing** skip mechanism.

## Per-state dry-vs-skip inventory under `shell_run`

Spine = **pure-skip** (per-module "spots boot + smoke" dry paths are scoped follow-ons):

| State(s) | Under shell_run | Mechanism |
|---|---|---|
| MorningEnrich, DataPhase1, RAGIngestion, RegimeSubstrate, RegimeRetrospectiveEval, Research, DataPhase2, EvalJudge(+RollingMean), RationaleClustering, ReplayConcordance, Counterfactual, PredictorTraining, DriftDetection, Backtester, Parity, Evaluator (16) | **SKIPPED** | existing `skip_*` Choice gate, force-true'd by `ApplyShellRunDefaults` |
| SaturdayHealthCheck, WeeklySubstrateHealthCheck | **STILL RUNS** (read-only — exactly the bootstrap/transport smoke the shell run wants) | no skip gate by design; shell_run-aware missing-Friday-bar tolerance = ROADMAP owed-work item 5 (follow-on) |
| (success notify) | NotifyShellRunComplete | shell-run-tagged Subject, reuses the exact `NotifyComplete` SNS substrate |

## Friday cron + justification

`cron(30 21 ? * FRI *)` = **21:30 UTC Fri = 14:30 PT (PDT, dominant season) / 13:30 PT (PST)**. Chosen **after** the Friday EOD SF (~1:25 PT) so the shell run never collides with PostMarketData/EODReconcile/StopTradingInstance on the trading instance, and **~11.5h before** the real Sat 09:00 UTC firing — a red report Friday evening gives a full operator fix window. shell_run mode fetches nothing, so the Saturday "polygon T+1 must have settled" timing constraint is moot here.

## Operator enable step

The rule ships **`State: DISABLED`** — zero-risk merge. Additive observability, **not a backstop** (the "fail loud, no backstop" design decision stands). Brian enables deliberately:

```
aws events enable-rule --name alpha-engine-friday-shell-run --region us-east-1
```

It targets the **same** `alpha-engine-saturday-pipeline` SF (NOT a parallel SF) with `{"shell_run": true}`, same `EventBridgeSfnRoleArn`. The existing `states:StartExecution` grant is **SF-ARN-scoped** (`infrastructure/iam/alpha-engine-eventbridge-sfn-role.json`) so **no IAM change is needed**.

## Consolidated-notify decision

Shell-run SUCCESS reuses the existing `NotifyComplete` SNS pattern with a `SHELL RUN`-tagged Subject (**zero new infra**). A shell-run FAILURE reuses the unchanged `HandleFailure` — its 20 inbound error edges were deliberately **not** re-pointed (high churn, zero added operator value, would perturb the real Saturday failure path's risk surface; the FAILED alert's Friday execution timestamp/ID is the actionable signal). The richer per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on.

## Scoped per-module follow-on PRs (NOT in this spine)

Convert "skipped" → "spots boot + smoke":

| Repo | State | Dry mode needed |
|---|---|---|
| alpha-engine-data | DataPhase1 / MorningEnrich | `spot_data_weekly.sh --preflight-only` (preflight + universe-freshness scan, no polygon/FMP writes) |
| alpha-engine-data | RAGIngestion | `spot_data_weekly.sh --rag-only --preflight-only` (corpus reachability + secrets, no SEC/embedding writes) |
| alpha-engine-predictor | PredictorTraining | `spot_train.sh --preflight-only` (load + WF-gate-shape check, NO `predictor/weights/` promotion) |
| alpha-engine-backtester | Backtester / Parity / Evaluator | `spot_backtest.sh --mode=smoke` + simulate-dry, NO `config/*.json` auto-apply (freeze_evaluator pattern) |
| alpha-engine-data | SaturdayHealthCheck / WeeklySubstrateHealthCheck | shell_run-aware missing-Friday-bar tolerance (ROADMAP owed-work item 5) |

Research / predictor-inference / executor already have `--dry-run`/`--simulate`; wiring those into the SF states is part of the per-state follow-ons above.

## Tests

`tests/test_sf_friday_shell_run_wiring.py` — 23 cases: strict-superset edges, `JsonMerge` user-input-wins order, every skip-gate covered by the defaults blob (drift guard), full happy-path traversal for `shell_run` true vs absent, Friday rule DISABLED + same-SF + `shell_run=true` + cron. Updated two pre-spine wiring tests (`morning_enrich_split`, `substrate_check`) to assert through the new gates while pinning `Default == pre-spine target`. **Full suite: 1242 passed, 1 skipped** (pre-existing, unrelated). No new pip deps. No secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)