### PR TITLE
feat(data): spot_data_weekly.sh --preflight-only (Friday shell-run dry path)

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -23,8 +23,25 @@
 # Usage:
 #   ./infrastructure/spot_data_weekly.sh                   # phase1 + rag
 #   ./infrastructure/spot_data_weekly.sh --smoke-only      # quick validation, then terminate
+#   ./infrastructure/spot_data_weekly.sh --preflight-only  # boot + DataPhase1/MorningEnrich preflight, exit 0 (NO fetch/write)
+#   ./infrastructure/spot_data_weekly.sh --rag-only --preflight-only  # boot + RAG-path preflight, exit 0 (NO fetch/write)
 #   ./infrastructure/spot_data_weekly.sh --instance-type c5.xlarge   # override size
 #   ./infrastructure/spot_data_weekly.sh --branch my-branch          # override branch
+#
+# --preflight-only (Friday shell-run dry path, ROADMAP "Friday shell-run —
+# per-module dry-path activation" owed-item #1): boots the spot for real,
+# installs deps, runs the EXISTING preflight (env/secret resolution via
+# get_secret, AWS/SSM reachability, ArcticDB connect + libraries-present
+# read, S3 HEAD), then exits 0 BEFORE any collector fetch or any
+# S3/ArcticDB/config write. Hard invariant: ZERO external API data fetches
+# (the preflight's polygon/FRED *reachability probes* are sub-second
+# auth/HEAD-class calls that fetch no collector data) and ZERO
+# S3/ArcticDB/config/email/SNS mutations under this flag. The point is to
+# catch bootstrap-class breakage (lib-pin drift, sys.path collision, stale
+# ArcticDB symbol, SSM timeout, Dockerfile/image gap) ~12h before the real
+# Saturday run. Composes with --rag-only: `--rag-only --preflight-only`
+# runs ONLY the RAG-path preflight (rag.preflight: env-vars + S3 HEAD);
+# `--preflight-only` alone runs ONLY the DataPhase1/MorningEnrich preflight.
 #
 # Prerequisites on the launching host (ae-dashboard when invoked by the
 # Saturday Step Function):
@@ -84,6 +101,15 @@ IAM_PROFILE="alpha-engine-executor-profile"
 # preflight-bearing action as its own SF task: a phase1 failure no longer
 # re-pays the ~28-min morning-enrich. data-only stays for manual reruns.
 RUN_MODE="full"
+# PREFLIGHT_ONLY is a MODIFIER, orthogonal to RUN_MODE — it composes with
+# the data path (default / --data-only / --phase1-only / --morning-enrich-only)
+# AND with --rag-only. When set, every workload invocation is replaced by
+# its existing preflight + an early `exit 0`; no collector fetch or
+# S3/ArcticDB/config write code path is reachable. The preflight-task-split
+# (2026-05-16) modes still select WHICH preflight (phase1 vs morning_enrich
+# vs RAG) runs; --preflight-only only swaps "preflight + work" for
+# "preflight + exit 0".
+PREFLIGHT_ONLY=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --smoke-only) RUN_MODE="smoke-only"; shift ;;
@@ -92,6 +118,7 @@ while [[ $# -gt 0 ]]; do
         --data-only) RUN_MODE="data-only"; shift ;;
         --morning-enrich-only) RUN_MODE="morning-enrich-only"; shift ;;
         --phase1-only) RUN_MODE="phase1-only"; shift ;;
+        --preflight-only) PREFLIGHT_ONLY=1; shift ;;
         --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
         --branch) BRANCH="$2"; shift 2 ;;
         *) echo "Unknown flag: $1"; exit 1 ;;
@@ -106,6 +133,7 @@ echo "  AMI           : $AMI_ID"
 echo "  Region        : $AWS_REGION"
 echo "  Branch        : $BRANCH"
 echo "  Run mode      : $RUN_MODE"
+echo "  Preflight-only: $PREFLIGHT_ONLY  (1 = boot + preflight + exit 0, NO fetch/write)"
 echo "  S3 bucket     : $S3_BUCKET"
 echo ""
 
@@ -371,6 +399,57 @@ fi
 # secrets from SSM, runs the real (non-dry-run) RAG ingestion, emits only the
 # rag-ingestion heartbeat so CloudWatch state accurately reflects what ran.
 if [ "$RUN_MODE" = "rag-only" ]; then
+    if [ "$PREFLIGHT_ONLY" = "1" ]; then
+        echo ""
+        echo "═══════════════════════════════════════════════════════════════"
+        echo "  RAG-ONLY PREFLIGHT-ONLY (boot + RAG preflight, NO fetch/write)"
+        echo "═══════════════════════════════════════════════════════════════"
+        # Friday shell-run dry path. Fetch the 4 RAG secrets from SSM (so
+        # rag.preflight's check_env_vars sees them) then run ONLY step 0
+        # (rag.preflight: check_env_vars + check_s3_bucket HEAD — read-only,
+        # no fetch, no write) and exit 0 BEFORE any ingest pipeline. The
+        # run_weekly_ingestion.sh --preflight-only path exits 0 right
+        # after `python -m rag.preflight` and before Step 1
+        # (ingest_sec_filings) — proof that no ingest_*/embedding/Postgres
+        # write code path is reachable. Heartbeat is deliberately NOT
+        # emitted (a preflight is not a completed ingestion).
+        run_remote bash -s <<RAG_ONLY_PREFLIGHT
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+${ENV_SOURCE}
+
+echo "──────────────────────────────────────────────────────────────"
+echo "Fetching RAG secrets from SSM at \$(date)"
+echo "──────────────────────────────────────────────────────────────"
+for name in VOYAGE_API_KEY FINNHUB_API_KEY EDGAR_IDENTITY RAG_DATABASE_URL; do
+    val=\$(aws ssm get-parameter --name /alpha-engine/\$name --with-decryption --query 'Parameter.Value' --output text --region "\${AWS_REGION:-us-east-1}" 2>/dev/null || echo "")
+    if [ -z "\$val" ]; then
+        echo "ERROR: could not fetch /alpha-engine/\$name from SSM — required for RAG preflight" >&2
+        exit 1
+    fi
+    export \$name="\$val"
+    unset val
+done
+echo "RAG secrets fetched: VOYAGE_API_KEY, FINNHUB_API_KEY, EDGAR_IDENTITY, RAG_DATABASE_URL"
+
+echo ""
+echo "──────────────────────────────────────────────────────────────"
+echo "Starting rag/pipelines/run_weekly_ingestion.sh --preflight-only at \$(date)"
+echo "──────────────────────────────────────────────────────────────"
+if ! bash rag/pipelines/run_weekly_ingestion.sh --preflight-only 2>&1; then
+    echo "ERROR: RAG preflight failed (bootstrap-class breakage caught ~12h before Saturday)." >&2
+    exit 1
+fi
+echo "RAG preflight-only OK at \$(date)"
+RAG_ONLY_PREFLIGHT
+
+        echo ""
+        echo "═══════════════════════════════════════════════════════════════"
+        echo "  RAG preflight-only complete (NO fetch/write). Instance will be terminated."
+        echo "═══════════════════════════════════════════════════════════════"
+        exit 0
+    fi
+
     echo ""
     echo "═══════════════════════════════════════════════════════════════"
     echo "  RAG-ONLY RUN (skipping DataPhase1)"
@@ -452,6 +531,74 @@ case "$RUN_MODE" in
         DO_MORNING_ENRICH=1; DO_PHASE1=1; SKIP_RAG_BLOCK=0
         MODE_LABEL="data-phase1" ;;
 esac
+
+# ── Data-path preflight-only (Friday shell-run dry path) ────────────────────
+# Reuses the DO_MORNING_ENRICH / DO_PHASE1 gates above to decide WHICH
+# weekly_collector preflight to run, then runs ONLY the preflight via the
+# new `weekly_collector.py ... --preflight-only` flag. That flag executes
+# DataPreflight(mode).run() (env/secret get_secret resolution, S3 HEAD,
+# polygon/FRED auth-reachability probes, ArcticDB connect + libraries-present
+# read) then sys.exit(0) BEFORE run_weekly() — run_weekly() is the sole
+# function in weekly_collector that does ANY collector fetch or any
+# S3/ArcticDB/parquet/config write, so it is statically unreachable here.
+# No prune (builders.prune_delisted_tickers writes the prune-audit JSON),
+# no RAG, no CloudWatch heartbeat, no S3 log upload — a preflight is not a
+# completed workload. Zero external API DATA fetch and zero mutation.
+#
+# Note on universe-freshness tolerance (ROADMAP owed-item #5): the Friday
+# shell-run uses the phase1 / morning_enrich preflight modes. Per
+# preflight.py::DataPreflight.run, NEITHER mode runs check_arcticdb_fresh
+# — they only do _check_arcticdb_libraries_present (a presence read, not a
+# freshness gate). morning_enrich deliberately omits a freshness check
+# (it is part of what *makes* ArcticDB fresh); phase1 *populates* ArcticDB.
+# So a Friday run that predates Friday's settled polygon aggregate does
+# NOT spuriously fail on a Thursday-last-bar: the only freshness gate
+# (check_arcticdb_fresh, macro/SPY, 4d) lives in the "daily" mode, which
+# the Saturday/Friday data path never selects. No --preflight-only-scoped
+# tolerance code is required for the data path; documented here so a
+# future mode-mapping change re-audits this invariant.
+if [ "$PREFLIGHT_ONLY" = "1" ]; then
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  PREFLIGHT-ONLY: $HEADER_LABEL"
+    echo "  (boot + preflight + exit 0 — NO collector fetch, NO write)"
+    echo "═══════════════════════════════════════════════════════════════"
+    run_remote bash -s <<PREFLIGHT_WORKLOADS
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+${ENV_SOURCE}
+
+if [ "${DO_MORNING_ENRICH}" = "1" ]; then
+    echo "──────────────────────────────────────────────────────────────"
+    echo "weekly_collector.py --morning-enrich --preflight-only at \$(date)"
+    echo "──────────────────────────────────────────────────────────────"
+    if ! $REMOTE_PYTHON weekly_collector.py --morning-enrich --preflight-only 2>&1; then
+        echo "ERROR: morning-enrich preflight failed (bootstrap-class breakage caught ~12h before Saturday)." >&2
+        exit 1
+    fi
+fi
+
+if [ "${DO_PHASE1}" = "1" ]; then
+    echo ""
+    echo "──────────────────────────────────────────────────────────────"
+    echo "weekly_collector.py --phase 1 --preflight-only at \$(date)"
+    echo "──────────────────────────────────────────────────────────────"
+    if ! $REMOTE_PYTHON weekly_collector.py --phase 1 --preflight-only 2>&1; then
+        echo "ERROR: phase1 preflight failed (bootstrap-class breakage caught ~12h before Saturday)." >&2
+        exit 1
+    fi
+fi
+
+echo ""
+echo "Data-path preflight-only OK at \$(date) — NO fetch, NO write."
+PREFLIGHT_WORKLOADS
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  Preflight-only complete (NO fetch/write). Instance will be terminated."
+    echo "═══════════════════════════════════════════════════════════════"
+    exit 0
+fi
 
 echo ""
 echo "═══════════════════════════════════════════════════════════════"

--- a/rag/pipelines/run_weekly_ingestion.sh
+++ b/rag/pipelines/run_weekly_ingestion.sh
@@ -22,8 +22,16 @@
 # fires flow-doctor.
 #
 # Usage:
-#   bash rag/pipelines/run_weekly_ingestion.sh              # full run
-#   bash rag/pipelines/run_weekly_ingestion.sh --dry-run    # preview only
+#   bash rag/pipelines/run_weekly_ingestion.sh                 # full run
+#   bash rag/pipelines/run_weekly_ingestion.sh --dry-run       # preview only
+#   bash rag/pipelines/run_weekly_ingestion.sh --preflight-only # step 0 only, exit 0
+#
+# --preflight-only (Friday shell-run dry path, ROADMAP "Friday shell-run —
+# per-module dry-path activation" #1): runs ONLY Step 0 (python -m
+# rag.preflight: check_env_vars + check_s3_bucket HEAD — both read-only,
+# zero external API fetch, zero write) then exits 0 BEFORE Step 1
+# (ingest_sec_filings). No ingest_* pipeline, no Voyage embedding call,
+# no Postgres/pgvector write, no manifest emit is reachable under it.
 #
 # Prerequisites (verified by step 0):
 #   - .env with RAG_DATABASE_URL, VOYAGE_API_KEY, FINNHUB_API_KEY, EDGAR_IDENTITY
@@ -37,9 +45,11 @@ cd "$REPO_ROOT"
 
 # Parse flags
 DRY_RUN=""
+PREFLIGHT_ONLY=0
 for arg in "$@"; do
     case "$arg" in
         --dry-run) DRY_RUN="--dry-run" ;;
+        --preflight-only) PREFLIGHT_ONLY=1 ;;
     esac
 done
 
@@ -80,6 +90,20 @@ echo "========================================"
 echo ""
 echo "==> Step 0/9: Preflight checks..."
 $PYTHON_BIN -m rag.preflight
+
+# Friday shell-run dry path: stop HERE, immediately after the existing
+# rag.preflight passed and strictly BEFORE Step 1 (the first ingest
+# pipeline). Every fetch (SEC/Finnhub/yfinance), every Voyage embedding
+# call, and every Postgres/pgvector + parquet write lives in Steps 1-9
+# below — all statically unreachable once we exit here. rag.preflight
+# itself only does check_env_vars + check_s3_bucket (S3 HEAD): read-only,
+# zero external API fetch, zero mutation.
+if [ "$PREFLIGHT_ONLY" = "1" ]; then
+    echo ""
+    echo "==> --preflight-only: rag.preflight passed — exiting 0 before Step 1"
+    echo "    (NO ingest, NO embedding, NO Postgres/parquet write)."
+    exit 0
+fi
 
 # ── Step 1: SEC filings (10-K/10-Q) ─────────────────────────────────────────
 echo ""

--- a/tests/test_preflight_only_dry_path.py
+++ b/tests/test_preflight_only_dry_path.py
@@ -1,0 +1,220 @@
+"""Pins the --preflight-only Friday shell-run dry path.
+
+Origin: ROADMAP "Friday shell-run — per-module dry-path activation"
+owed-item #1. Under the Friday `shell_run`, the DataPhase1/MorningEnrich
++ RAGIngestion spot states must boot the spot for real, run their
+EXISTING preflight, then exit 0 with ZERO external API data fetch and
+ZERO S3/ArcticDB/config/email/SNS writes — catching bootstrap-class
+breakage (lib-pin drift, sys.path collision, stale ArcticDB symbol, SSM
+timeout, Dockerfile/image gap) ~12h before the real Saturday run.
+
+These are static greps / AST-source assertions, matching the convention
+of tests/test_spot_data_weekly_run_modes.py and
+tests/test_weekly_collector_preflight_mode_mapping.py: the spot scripts
+only run end-to-end on a real spot, and weekly_collector.main() reads
+argv via _parse_args() with no DI. The assertions pin the load-bearing
+invariant: --preflight-only is an early `exit 0` AFTER the existing
+preflight and strictly BEFORE the sole fetch/write function so no
+collector/embedding/write code path is reachable.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SPOT = _REPO_ROOT / "infrastructure" / "spot_data_weekly.sh"
+_RAG = _REPO_ROOT / "rag" / "pipelines" / "run_weekly_ingestion.sh"
+_COLLECTOR = _REPO_ROOT / "weekly_collector.py"
+
+
+@pytest.fixture(scope="module")
+def spot_text() -> str:
+    return _SPOT.read_text()
+
+
+@pytest.fixture(scope="module")
+def rag_text() -> str:
+    return _RAG.read_text()
+
+
+@pytest.fixture(scope="module")
+def collector_text() -> str:
+    return _COLLECTOR.read_text()
+
+
+def _main_source() -> str:
+    src = _COLLECTOR.read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return ast.get_source_segment(src, node)
+    raise AssertionError("weekly_collector.main() not found")
+
+
+# ── weekly_collector.py: flag exists + early-exit ordering ──────────────────
+
+
+class TestCollectorPreflightOnly:
+    def test_flag_parsed(self, collector_text):
+        """--preflight-only must be a real argparse flag bound to
+        dest=preflight_only."""
+        assert '"--preflight-only"' in collector_text
+        assert 'dest="preflight_only"' in collector_text
+
+    def test_exit_zero_after_preflight_before_run_weekly(self):
+        """The load-bearing invariant: main() must (1) run
+        DataPreflight(...).run(), then (2) early-exit 0 on
+        --preflight-only, then (3) only AFTER that call run_weekly().
+
+        If the exit landed after run_weekly(), every collector fetch +
+        every S3/ArcticDB/config write would already have happened —
+        defeating the entire dry-path purpose.
+        """
+        src = _main_source()
+        i_preflight = src.index("DataPreflight(")
+        i_exit_guard = src.index('getattr(args, "preflight_only", False)')
+        i_run_weekly = src.index("run_weekly(config, args)")
+
+        assert i_preflight < i_exit_guard < i_run_weekly, (
+            "main() ordering must be: DataPreflight().run() → "
+            "--preflight-only guard → run_weekly(). Got positions "
+            f"preflight={i_preflight}, guard={i_exit_guard}, "
+            f"run_weekly={i_run_weekly}."
+        )
+
+    def test_guard_raises_systemexit_zero(self):
+        """The guard must exit 0 (clean) so SSM/SF report Success — a
+        passed preflight is a healthy outcome, not a failure."""
+        src = _main_source()
+        marker = 'getattr(args, "preflight_only", False)'
+        body = src[src.index(marker):src.index("run_weekly(config, args)")]
+        assert "raise SystemExit(0)" in body, (
+            "The --preflight-only branch must `raise SystemExit(0)` before "
+            f"run_weekly(). Branch body:\n{body!r}"
+        )
+
+    def test_run_weekly_only_called_once_after_guard(self):
+        """run_weekly() (the sole fetch/write function) must be invoked
+        exactly once and only after the guard — no pre-guard call."""
+        src = _main_source()
+        guard_pos = src.index('getattr(args, "preflight_only", False)')
+        pre = src[:guard_pos]
+        assert "run_weekly(config, args)" not in pre, (
+            "run_weekly() must not be invoked before the --preflight-only "
+            "guard — that would fetch/write before the early exit."
+        )
+
+
+# ── spot_data_weekly.sh: modifier flag composes with RUN_MODE ───────────────
+
+
+class TestSpotScriptPreflightOnly:
+    def test_flag_parsed_as_modifier(self, spot_text):
+        """--preflight-only sets PREFLIGHT_ONLY=1 (a modifier orthogonal
+        to RUN_MODE so it composes with the data path AND --rag-only)."""
+        assert re.search(
+            r'--preflight-only\)\s*PREFLIGHT_ONLY=1;\s*shift\s*;;',
+            spot_text,
+        ), "--preflight-only must set PREFLIGHT_ONLY=1 in the arg-parse loop"
+        # PREFLIGHT_ONLY must be initialised (set -u safety) before parse.
+        assert "PREFLIGHT_ONLY=0" in spot_text
+
+    def test_data_path_swaps_work_for_preflight_only_invocation(self, spot_text):
+        """Under PREFLIGHT_ONLY the data path must invoke
+        weekly_collector.py with --preflight-only (not the real --phase 1
+        / --morning-enrich work invocations) and never reach prune/RAG.
+
+        Slice the data-path block: the LAST `if [ "$PREFLIGHT_ONLY" = "1"
+        ]; then` (the rag-only nested one is earlier in the file) up to
+        the real WORKLOADS heredoc.
+        """
+        i_block = spot_text.rindex('if [ "$PREFLIGHT_ONLY" = "1" ]; then')
+        i_workloads = spot_text.index("run_remote bash -s <<WORKLOADS")
+        block = spot_text[i_block:i_workloads]
+        assert "weekly_collector.py --morning-enrich --preflight-only" in block
+        assert "weekly_collector.py --phase 1 --preflight-only" in block
+        # Hard invariant: no real work / write code path inside the block.
+        assert "prune_delisted_tickers" not in block, (
+            "prune writes a prune-audit JSON — must NOT run under --preflight-only"
+        )
+        assert "run_weekly_ingestion.sh" not in block, (
+            "RAG ingestion must NOT run under the data-path --preflight-only block"
+        )
+        assert "put-metric-data" not in block, (
+            "CloudWatch heartbeat must NOT be emitted for a preflight"
+        )
+        assert "aws s3 cp" not in block, (
+            "no S3 log upload inside the preflight-only data block"
+        )
+
+    def test_preflight_only_data_block_exits_zero(self, spot_text):
+        """The data-path preflight-only block must `exit 0` before the
+        real WORKLOADS heredoc so the work path is unreachable."""
+        i_block = spot_text.index('if [ "$PREFLIGHT_ONLY" = "1" ]; then')
+        i_workloads = spot_text.index("run_remote bash -s <<WORKLOADS")
+        assert i_block < i_workloads, (
+            "the PREFLIGHT_ONLY data block must precede the WORKLOADS heredoc"
+        )
+        between = spot_text[i_block:i_workloads]
+        assert "exit 0" in between, (
+            "the PREFLIGHT_ONLY data block must `exit 0` before WORKLOADS"
+        )
+
+    def test_rag_only_preflight_only_runs_rag_preflight_only(self, spot_text):
+        """`--rag-only --preflight-only` must run the RAG-path preflight
+        ONLY: run_weekly_ingestion.sh --preflight-only, no real RAG run,
+        no rag-ingestion heartbeat."""
+        m = re.search(
+            r'if \[ "\$RUN_MODE" = "rag-only" \]; then\n'
+            r'    if \[ "\$PREFLIGHT_ONLY" = "1" \]; then(.*?)\n        exit 0\n    fi',
+            spot_text,
+            re.DOTALL,
+        )
+        assert m, (
+            "expected a nested `if PREFLIGHT_ONLY` block inside the rag-only arm"
+        )
+        block = m.group(1)
+        assert "run_weekly_ingestion.sh --preflight-only" in block, (
+            "rag-only + preflight-only must call the RAG script with "
+            "--preflight-only (step-0-only, exit 0)"
+        )
+        assert "put-metric-data" not in block, (
+            "no rag-ingestion heartbeat for a preflight (not a completed ingestion)"
+        )
+
+
+# ── run_weekly_ingestion.sh: step-0-only early exit ─────────────────────────
+
+
+class TestRagScriptPreflightOnly:
+    def test_flag_parsed(self, rag_text):
+        assert "PREFLIGHT_ONLY=0" in rag_text
+        assert re.search(
+            r'--preflight-only\)\s*PREFLIGHT_ONLY=1\s*;;',
+            rag_text,
+        ), "--preflight-only must set PREFLIGHT_ONLY=1 in the RAG script arg loop"
+
+    def test_exit_zero_after_step0_before_step1(self, rag_text):
+        """The RAG dry path must exit 0 after `python -m rag.preflight`
+        (step 0) and strictly BEFORE Step 1 (ingest_sec_filings) so no
+        ingest / Voyage-embedding / Postgres-write path is reachable."""
+        i_preflight = rag_text.index("$PYTHON_BIN -m rag.preflight")
+        i_guard = rag_text.index('if [ "$PREFLIGHT_ONLY" = "1" ]; then')
+        # Anchor on the actual Step-1 invocation, not the header-comment
+        # mention of ingest_sec_filings earlier in the file.
+        i_step1 = rag_text.index("rag.pipelines.ingest_sec_filings")
+
+        assert i_preflight < i_guard < i_step1, (
+            "RAG ordering must be: rag.preflight → --preflight-only guard "
+            f"→ Step 1. Got preflight={i_preflight}, guard={i_guard}, "
+            f"step1={i_step1}."
+        )
+        guard_block = rag_text[i_guard:i_step1]
+        assert "exit 0" in guard_block, (
+            "the RAG --preflight-only guard must `exit 0` before Step 1"
+        )

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -1551,6 +1551,15 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Alpha Engine Weekly Data Collector")
     parser.add_argument("--config", default="config.yaml", help="Path to config.yaml")
     parser.add_argument("--dry-run", action="store_true", help="Validate without writing to S3")
+    parser.add_argument(
+        "--preflight-only", dest="preflight_only", action="store_true",
+        help="Run ONLY the entry preflight (DataPreflight: env/secret resolution, "
+             "S3 HEAD, polygon/FRED auth-reachability probes, ArcticDB connect + "
+             "libraries-present read) then exit 0 BEFORE run_weekly(). No collector "
+             "fetch, no S3/ArcticDB/parquet/config write. Friday shell-run dry path "
+             "(ROADMAP 'Friday shell-run — per-module dry-path activation' #1) — "
+             "catches bootstrap-class breakage ~12h before the real Saturday run.",
+    )
     parser.add_argument("--date", default=None, help="Override run date (YYYY-MM-DD)")
     parser.add_argument(
         "--daily", action="store_true",
@@ -1603,6 +1612,28 @@ def main() -> None:
     else:
         mode = f"phase{args.phase or 1}"
     DataPreflight(config["bucket"], mode).run()
+
+    # Friday shell-run dry path (ROADMAP "Friday shell-run — per-module
+    # dry-path activation" owed-item #1). --preflight-only exits HERE,
+    # immediately after the existing DataPreflight has passed and strictly
+    # BEFORE run_weekly(). run_weekly() is the sole function in this module
+    # that performs ANY collector fetch (polygon/FMP/FRED/yfinance) or ANY
+    # S3 / ArcticDB / parquet / config / module-health write — gating in
+    # front of it makes every fetch/write code path statically unreachable
+    # under this flag. The preflight itself only does read-only / auth
+    # probes (S3 HEAD, polygon/FRED reference-data auth calls that fetch no
+    # collector data, ArcticDB list_libraries) plus an S3 PUT+DELETE
+    # sentinel under preflight/ — that sentinel is the preflight's own
+    # liveness probe, not a data write, and it self-cleans. No external
+    # API data is fetched and no production artifact is mutated.
+    if getattr(args, "preflight_only", False):
+        logger.info(
+            "Pre-flight passed; --preflight-only set — exiting 0 before "
+            "run_weekly() (NO collector fetch, NO S3/ArcticDB/config write). "
+            "Friday shell-run dry path: bootstrap-class breakage would have "
+            "surfaced above."
+        )
+        raise SystemExit(0)
 
     results = run_weekly(config, args)
 


### PR DESCRIPTION
ROADMAP "Friday shell-run — per-module dry-path activation" owed-item #1.

Under the Friday `shell_run`, the DataPhase1/MorningEnrich + RAGIngestion spot states now **boot the spot for real, run their EXISTING preflight + imports + AWS/SSM/ArcticDB connectivity checks, then exit 0** with ZERO external API data fetch and ZERO S3/ArcticDB/config/email/SNS writes — catching bootstrap-class breakage (lib-pin drift, sys.path collision, stale ArcticDB symbol, SSM timeout, Dockerfile/image gap) ~12h before the real Saturday run. Reuses the existing preflight substrate; no parallel preflight written.

## Where the gate sits + zero-fetch / zero-write proof

**`weekly_collector.py`** — new `--preflight-only` argparse flag. `main()` exits **immediately after the existing `DataPreflight(config["bucket"], mode).run()`** and **strictly before `run_weekly(config, args)`** via `raise SystemExit(0)`. `run_weekly()` is the **sole** function in the module that performs any collector fetch (polygon/FMP/FRED/yfinance) or any S3/ArcticDB/parquet/config/module-health write — gating in front of it makes every fetch/write code path **statically unreachable**. The preflight itself only does read-only/auth probes (S3 HEAD, polygon/FRED reference-data auth calls that fetch no collector data, ArcticDB `list_libraries`) plus a self-cleaning S3 PUT+DELETE sentinel under `preflight/` (the preflight's own liveness probe, not a data write). Ordering pinned by an AST-source test.

**`rag/pipelines/run_weekly_ingestion.sh`** — new `--preflight-only` flag. Exits 0 **after Step 0 (`python -m rag.preflight`: `check_env_vars` + `check_s3_bucket` HEAD — read-only)** and **strictly before Step 1 (`ingest_sec_filings`)**. Every `ingest_*` pipeline, Voyage embedding call, and Postgres/pgvector + parquet write lives in Steps 1-9 — all unreachable once the guard exits.

**`infrastructure/spot_data_weekly.sh`** — new `--preflight-only` flag sets `PREFLIGHT_ONLY=1`, a **modifier orthogonal to `RUN_MODE`** so it composes with the data path AND `--rag-only`. A dedicated data-path block runs `weekly_collector.py --morning-enrich --preflight-only` and/or `weekly_collector.py --phase 1 --preflight-only` (gated by the existing `DO_MORNING_ENRICH`/`DO_PHASE1` preflight-task-split) then `exit 0` before the real WORKLOADS heredoc — **no prune** (prune-audit JSON write), **no RAG**, **no CloudWatch heartbeat**, **no S3 log upload**.

## `--rag-only --preflight-only` behavior

Runs ONLY the RAG-path preflight: boot + SSM secret fetch (so `rag.preflight`'s `check_env_vars` sees the 4 RAG secrets) + `run_weekly_ingestion.sh --preflight-only` (step-0-only + exit 0). No real RAG ingestion, no rag-ingestion heartbeat. `--preflight-only` alone → ONLY the DataPhase1/MorningEnrich preflight.

## Universe-freshness tolerance note (ROADMAP owed-item #5)

The Friday shell-run uses the **phase1 / morning_enrich** preflight modes. Per `preflight.py::DataPreflight.run`, **neither** runs `check_arcticdb_fresh` — they only do `_check_arcticdb_libraries_present` (a presence read, not a freshness gate). `morning_enrich` deliberately omits freshness (it is part of what *makes* ArcticDB fresh); `phase1` *populates* ArcticDB. The only freshness gate (`check_arcticdb_fresh` macro/SPY 4d) lives in the **`daily`** mode, which the Saturday/Friday data path never selects. So a Friday run predating Friday's settled polygon aggregate does **not** spuriously fail on a Thursday-last-bar — **no `--preflight-only`-scoped tolerance code is required for the data path**. Documented inline so a future mode-mapping change re-audits this invariant.

## Tests

New `tests/test_preflight_only_dry_path.py` (10 tests, static greps + AST-source assertions, matching the existing `test_spot_data_weekly_run_modes.py` / `test_weekly_collector_preflight_mode_mapping.py` convention): flag parsing on all 3 files, the exit-0-after-preflight-before-fetch/write ordering invariant, `--rag-only --preflight-only` step-0-only behavior, and the no-prune/no-RAG/no-heartbeat/no-S3-upload hard invariant.

- Full suite: **1229 passed, 1 skipped** (pre-existing skip)
- `bash -n` clean on both shell scripts
- No new deps, no secrets

**Flag name (verbatim, for the SF keystone follow-on): `--preflight-only`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)