### PR TITLE
feat(data): spot_drift_detection.sh --preflight-only (Friday shell-run dry path — closes DriftDetection skip-exception)

### DIFF
--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -21,8 +21,29 @@
 # Usage:
 #   ./infrastructure/spot_drift_detection.sh
 #   ./infrastructure/spot_drift_detection.sh --smoke-only
+#   ./infrastructure/spot_drift_detection.sh --preflight-only  # boot + read-only preflight, exit 0 (NO scan/fetch/write)
 #   ./infrastructure/spot_drift_detection.sh --instance-type c5.xlarge
 #   ./infrastructure/spot_drift_detection.sh --branch my-branch
+#
+# --preflight-only (Friday shell-run dry path, ROADMAP "Friday shell-run —
+# per-module dry-path activation" — closes the DriftDetection skip-exception):
+# boots the spot for real, clones both repos, installs deps, then runs ONLY a
+# read-only preflight and `exit 0` BEFORE `monitoring.drift_detector` is ever
+# invoked. Catches bootstrap-class breakage (lib-pin drift, sys.path / sibling-
+# clone collision, missing dep, SSM/region env gap) ~12h before the real
+# Saturday run, while doing ZERO drift scan, ZERO external API data fetch, and
+# ZERO S3/CloudWatch/SNS/config writes.
+#
+# Substrate: the drift workload binary (`monitoring.drift_detector`) lives in
+# alpha-engine-predictor, not this repo, and has no --preflight-only flag of
+# its own; this repo's `preflight.py` DataPreflight modes are data-collection
+# scoped (daily / morning_enrich / phase1 / phase2) — none maps to drift. So
+# per the canonical-lib fallback the preflight here composes the canonical
+# `alpha_engine_lib.preflight.BasePreflight` directly (env-vars + S3-bucket
+# HEAD — both strictly read-only) plus an import-only smoke of the drift
+# module under the same PYTHONPATH the real run uses. No bespoke preflight
+# scaffolding is duplicated. PREFLIGHT_ONLY is a MODIFIER, orthogonal to
+# RUN_MODE — it only swaps "preflight + drift scan" for "preflight + exit 0".
 
 set -euo pipefail
 
@@ -53,9 +74,18 @@ IAM_PROFILE="alpha-engine-executor-profile"
 MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-1800}"
 
 RUN_MODE="full"
+# PREFLIGHT_ONLY is a MODIFIER, orthogonal to RUN_MODE (mirrors the
+# spot_data_weekly.sh #259 / predictor #175 / backtester #224 pattern).
+# When set, the drift scan + heartbeat are replaced by a read-only
+# preflight + early `exit 0`; no monitoring.drift_detector code path
+# (which is the SOLE function doing any S3 read/put_object, SNS publish,
+# or CloudWatch emit) is reachable. Initialised before the parse loop
+# for `set -u` safety.
+PREFLIGHT_ONLY=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --smoke-only) RUN_MODE="smoke-only"; shift ;;
+        --preflight-only) PREFLIGHT_ONLY=1; shift ;;
         --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
         --branch) BRANCH="$2"; shift 2 ;;
         *) echo "Unknown flag: $1"; exit 1 ;;
@@ -67,6 +97,7 @@ echo "  DriftDetection Spot Run — $(date +%Y-%m-%d)"
 echo "═══════════════════════════════════════════════════════════════"
 echo "  Instance type : $INSTANCE_TYPE"
 echo "  Run mode      : $RUN_MODE"
+echo "  Preflight-only: $PREFLIGHT_ONLY  (1 = boot + read-only preflight + exit 0, NO scan/fetch/write)"
 echo ""
 
 # ── Preflight ───────────────────────────────────────────────────────────────
@@ -212,6 +243,87 @@ $REMOTE_PYTHON -m monitoring.drift_detector --help 2>&1 | head -20
 SMOKE
 
     echo "==> Smoke complete — instance will be terminated."
+    exit 0
+fi
+
+# ── Preflight-only (Friday shell-run dry path) ──────────────────────────────
+# Closes the DriftDetection skip-exception in ROADMAP "Friday shell-run —
+# per-module dry-path activation". Runs ONLY a read-only preflight then
+# `exit 0` strictly BEFORE the `run_remote bash -s <<DRIFT` block below —
+# `monitoring.drift_detector` (the SOLE code that does ANY S3 get_object/
+# put_object of the drift report, SNS publish on alert, and which this
+# launcher's CloudWatch put-metric-data heartbeat trails) is therefore
+# statically unreachable here. No scan, no external API data fetch, no
+# S3/CW/SNS/config mutation — a passed preflight is a healthy outcome, so
+# the early exit is 0 (SSM/SF report Success).
+#
+# The preflight composes the canonical lib substrate directly — NO bespoke
+# scaffolding (Brian standing canonical-lib rule):
+#   * alpha_engine_lib.preflight.BasePreflight.check_env_vars("AWS_REGION")
+#     — the same fail-fast gate the data path uses; AWS_REGION/.._DEFAULT_REGION
+#     are exported via ${ENV_SOURCE} below (the #241 .env-deprecation re-export).
+#   * BasePreflight.check_s3_bucket() — a HEAD-bucket probe ONLY (read-only;
+#     proves the spot's IAM profile + region reach the drift bucket the real
+#     run reads predictor weights / slim cache / metrics from).
+#   * an import-only smoke of `monitoring.drift_detector` under the exact
+#     PYTHONPATH (sibling alpha-engine-predictor clone) the real run uses —
+#     this is what actually catches the bootstrap-class breakage a Friday
+#     dry path exists for (lib-pin drift, sys.path / sibling-clone collision,
+#     a missing/renamed dep). Importing the module runs no scan: the boto3
+#     client + drift checks live behind `def main()` / `check_drift()`, gated
+#     by `if __name__ == "__main__"`, none of which import triggers.
+# DEFAULT_BUCKET in monitoring.drift_detector is "alpha-engine-research"; the
+# preflight HEADs that same bucket so a bucket/region/IAM regression fails
+# here ~12h early instead of mid-Saturday.
+if [ "$PREFLIGHT_ONLY" = "1" ]; then
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  PREFLIGHT-ONLY: DriftDetection"
+    echo "  (boot + read-only preflight + exit 0 — NO scan, NO fetch, NO write)"
+    echo "═══════════════════════════════════════════════════════════════"
+    run_remote bash -s <<PREFLIGHT_ONLY_BLOCK
+set -euo pipefail
+cd /home/ec2-user/alpha-engine-data
+${ENV_SOURCE}
+
+echo "Starting read-only preflight at \$(date)"
+if ! $REMOTE_PYTHON - <<'PYEOF'
+import sys
+
+from alpha_engine_lib.preflight import BasePreflight
+
+# Read-only canonical preflight: env-vars fail-fast + S3 bucket HEAD.
+# "alpha-engine-research" mirrors monitoring.drift_detector.DEFAULT_BUCKET.
+pf = BasePreflight("alpha-engine-research")
+pf.check_env_vars("AWS_REGION")
+pf.check_s3_bucket()
+print("preflight: BasePreflight env-vars + S3 HEAD OK (read-only)")
+
+# Import-only smoke of the drift workload under the real PYTHONPATH. This
+# imports the module (catching lib-pin / sys.path / missing-dep breakage)
+# WITHOUT invoking it: boto3 clients + scan live behind def main() /
+# check_drift(), gated by __main__, which an import does not trigger.
+import importlib
+
+mod = importlib.import_module("monitoring.drift_detector")
+assert hasattr(mod, "main") and hasattr(mod, "check_drift"), (
+    "monitoring.drift_detector missing expected entrypoints — "
+    "stale clone or API drift"
+)
+print("preflight: monitoring.drift_detector import OK (no scan invoked)")
+sys.exit(0)
+PYEOF
+then
+    echo "ERROR: DriftDetection preflight failed (bootstrap-class breakage caught ~12h before Saturday)." >&2
+    exit 1
+fi
+echo "DriftDetection preflight-only OK at \$(date) — NO scan, NO fetch, NO write."
+PREFLIGHT_ONLY_BLOCK
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  Preflight-only complete (NO scan/fetch/write). Instance will be terminated."
+    echo "═══════════════════════════════════════════════════════════════"
     exit 0
 fi
 

--- a/tests/test_spot_drift_detection_preflight_only.py
+++ b/tests/test_spot_drift_detection_preflight_only.py
@@ -1,0 +1,120 @@
+"""Pins the spot_drift_detection.sh --preflight-only Friday shell-run dry path.
+
+Origin: ROADMAP "Friday shell-run — per-module dry-path activation" — this
+closes the DriftDetection skip-exception (the one per-module SF step that
+was still SKIPPED rather than dry-run on the Friday shell_run). Under the
+Friday shell-run the DriftDetection spot must boot for real, run its
+read-only preflight, then exit 0 with ZERO drift scan, ZERO external API
+data fetch, and ZERO S3/CloudWatch/SNS/config writes — catching
+bootstrap-class breakage (lib-pin drift, sys.path / sibling-clone
+collision, missing dep, SSM/region env gap) ~12h before the real
+Saturday run.
+
+Static greps / source-position assertions, matching the convention of
+tests/test_preflight_only_dry_path.py: the spot scripts only run
+end-to-end on a real spot, so the assertions pin the load-bearing
+invariant — --preflight-only is an early `exit 0` AFTER a read-only
+preflight and strictly BEFORE the `monitoring.drift_detector` invocation
+(the sole S3/SNS/scan code path) and before the CloudWatch heartbeat, so
+no scan / fetch / write code path is reachable.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SPOT = _REPO_ROOT / "infrastructure" / "spot_drift_detection.sh"
+
+
+@pytest.fixture(scope="module")
+def spot_text() -> str:
+    return _SPOT.read_text()
+
+
+class TestSpotDriftDetectionPreflightOnly:
+    def test_flag_parsed_as_modifier(self, spot_text):
+        """--preflight-only sets PREFLIGHT_ONLY=1 (a modifier orthogonal
+        to RUN_MODE, mirroring the #259 pattern), and PREFLIGHT_ONLY is
+        initialised to 0 before the parse loop for `set -u` safety."""
+        assert re.search(
+            r'--preflight-only\)\s*PREFLIGHT_ONLY=1;\s*shift\s*;;',
+            spot_text,
+        ), "--preflight-only must set PREFLIGHT_ONLY=1 in the arg-parse loop"
+        assert "PREFLIGHT_ONLY=0" in spot_text
+
+    def test_preflight_only_block_precedes_drift_and_heartbeat(self, spot_text):
+        """The PREFLIGHT_ONLY guard must come strictly BEFORE the
+        "Full drift detection" section (the DRIFT heredoc) and the
+        CloudWatch put-metric-data heartbeat — otherwise the scan +
+        writes would already have happened, defeating the dry path.
+
+        Anchored on the unique "# ── Full drift detection ──" section
+        header rather than the `<<DRIFT` heredoc string, because that
+        heredoc string is also mentioned verbatim in the header comment
+        above the guard (which would yield a pre-guard match)."""
+        i_guard = spot_text.index('if [ "$PREFLIGHT_ONLY" = "1" ]; then')
+        i_drift = spot_text.index("# ── Full drift detection ────────────────────────────────────────────────────")
+        i_heartbeat = spot_text.index("aws cloudwatch put-metric-data")
+
+        assert i_guard < i_drift < i_heartbeat, (
+            "Ordering must be: PREFLIGHT_ONLY guard → DRIFT heredoc → "
+            f"CloudWatch heartbeat. Got guard={i_guard}, "
+            f"drift={i_drift}, heartbeat={i_heartbeat}."
+        )
+
+    def test_preflight_only_block_exits_zero_before_drift(self, spot_text):
+        """The PREFLIGHT_ONLY block must `exit 0` before the DRIFT
+        heredoc so the scan/write path is unreachable, and a passed
+        preflight is a clean (exit 0) outcome so SSM/SF report Success."""
+        i_guard = spot_text.index('if [ "$PREFLIGHT_ONLY" = "1" ]; then')
+        i_drift = spot_text.index("# ── Full drift detection ────────────────────────────────────────────────────")
+        block = spot_text[i_guard:i_drift]
+        assert "exit 0" in block, (
+            "the PREFLIGHT_ONLY block must `exit 0` before the DRIFT heredoc"
+        )
+
+    def test_no_scan_or_write_in_preflight_only_block(self, spot_text):
+        """Hard invariant: no drift scan, no S3/CW/SNS write, no real
+        workload invocation inside the PREFLIGHT_ONLY block."""
+        i_guard = spot_text.index('if [ "$PREFLIGHT_ONLY" = "1" ]; then')
+        i_drift = spot_text.index("# ── Full drift detection ────────────────────────────────────────────────────")
+        block = spot_text[i_guard:i_drift]
+
+        assert "drift_detector --alert" not in block, (
+            "the real drift scan (drift_detector --alert) must NOT run "
+            "under --preflight-only"
+        )
+        assert "put-metric-data" not in block, (
+            "CloudWatch heartbeat must NOT be emitted for a preflight"
+        )
+        assert "aws s3 cp" not in block, (
+            "no S3 log/object upload inside the preflight-only block"
+        )
+        assert "aws sns" not in block, (
+            "no SNS publish inside the preflight-only block"
+        )
+
+    def test_preflight_reuses_canonical_lib_base(self, spot_text):
+        """The preflight must compose the canonical
+        alpha_engine_lib.preflight.BasePreflight (env-vars + S3 HEAD,
+        both read-only) — NO duplicated preflight scaffolding — plus an
+        import-only smoke of the drift module (no scan invoked)."""
+        i_guard = spot_text.index('if [ "$PREFLIGHT_ONLY" = "1" ]; then')
+        i_drift = spot_text.index("# ── Full drift detection ────────────────────────────────────────────────────")
+        block = spot_text[i_guard:i_drift]
+
+        assert "from alpha_engine_lib.preflight import BasePreflight" in block, (
+            "must reuse the canonical lib BasePreflight, not bespoke scaffolding"
+        )
+        assert "pf.check_env_vars(" in block
+        assert "pf.check_s3_bucket()" in block
+        assert 'importlib.import_module("monitoring.drift_detector")' in block, (
+            "must import-smoke the drift module under the real PYTHONPATH"
+        )
+        # Import-only: the scan entrypoints must NOT be *called* in the block.
+        assert "mod.check_drift(" not in block
+        assert "mod.main(" not in block


### PR DESCRIPTION
Adds a `--preflight-only` modifier to `infrastructure/spot_drift_detection.sh`, mirroring the merged alpha-engine-data #259 (`spot_data_weekly.sh`) / predictor #175 / backtester #224 pattern. Closes the **DriftDetection skip-exception** in ROADMAP "Friday shell-run — per-module dry-path activation" — the one per-module SF step still SKIPPED rather than dry-run on the Friday `shell_run`.

## Insertion point
- `PREFLIGHT_ONLY=0` modifier var, initialised before the arg-parse loop (orthogonal to `RUN_MODE`, `set -u` safe).
- `--preflight-only) PREFLIGHT_ONLY=1; shift ;;` added to the case loop; echo line added to the run banner.
- Guard block inserted **after** the `smoke-only` block and **strictly before** the `# ── Full drift detection ──` section (the `run_remote bash -s <<DRIFT` heredoc) and before the trailing `aws cloudwatch put-metric-data` heartbeat.

## No-scan / no-write proof
`monitoring.drift_detector` (lives in alpha-engine-predictor, reached via the sibling-clone PYTHONPATH) is the **sole** code path doing any S3 `get_object`/`put_object` of the drift report or SNS publish on alert; the launcher's CloudWatch `put-metric-data` heartbeat trails it. The `PREFLIGHT_ONLY` guard `exit 0`s strictly before the `<<DRIFT` heredoc, so the drift scan, the SNS publish, the S3 `put_object`, and the CloudWatch emit are all **statically unreachable**. The preflight itself runs only `BasePreflight.check_env_vars` (env read) + `BasePreflight.check_s3_bucket` (bucket HEAD) + an `importlib.import_module` of the drift module (import-only — the boto3 clients + `check_drift()`/`main()` sit behind `if __name__ == "__main__"`, which an import does not trigger). Hard invariant holds: zero external API data fetch, zero S3/CW/SNS/config mutation; early exit `0` because a passed preflight is a healthy outcome (SSM/SF report Success).

## Preflight substrate reused
The drift workload binary lives in alpha-engine-predictor (no `--preflight-only` of its own; out of scope to modify here) and this repo's `preflight.py` `DataPreflight` modes (`daily`/`morning_enrich`/`phase1`/`phase2`) are data-collection scoped — none maps to drift. Per the canonical-lib fallback the preflight composes **`alpha_engine_lib.preflight.BasePreflight` directly** (env-vars + S3 HEAD, both read-only). **No bespoke preflight scaffolding duplicated.**

## Verbatim flag name
`--preflight-only`

## Tests
New `tests/test_spot_drift_detection_preflight_only.py` — 5 static grep / source-position assertions, mirroring `tests/test_preflight_only_dry_path.py`:
1. flag parses as a modifier (`PREFLIGHT_ONLY=1`) + `PREFLIGHT_ONLY=0` init present
2. guard precedes the DRIFT section and the CloudWatch heartbeat
3. guard block `exit 0`s before the DRIFT section
4. no drift scan / S3 / CW / SNS write inside the block
5. canonical `BasePreflight` reused (env-vars + S3 HEAD) + import-only drift smoke, no scaffolding

`bash -n infrastructure/spot_drift_detection.sh` clean. Full data suite: **1342 passed, 1 skipped** (pre-existing), 5 pre-existing warnings (unrelated `daily_append.py` pandas FutureWarning).

## Relationship to #260
Independent: #260 touches `spot_data_weekly.sh` + the Lambda `--dry-run` keystone (a different file). The Saturday/Friday SF rewire to route the DriftDetection state at this `--preflight-only` flag under the Friday `shell_run` is a **separate follow-on** — no `step_function.json` change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)