### PR TITLE
feat(sf): retime Friday shell-run rule to 1:45 PM PT (operator request)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -152,10 +152,10 @@ Resources:
   # the shell run is a pure-skip no-op pass until those land — still a
   # valid SF/IAM/EventBridge/health-check bootstrap smoke test).
   #
-  # Cron: 21:30 UTC Fri = 14:30 PT (PDT, the dominant season) / 13:30 PT
-  # (PST). Chosen AFTER the Friday EOD SF (~1:25 PT) completes so the
+  # Cron: 20:45 UTC Fri = 1:45 PM PT (PDT, the dominant season) /
+  # 12:45 PM PT (PST). Chosen AFTER the Friday EOD SF (~1:25 PT) so the
   # shell run never collides with PostMarketData / EODReconcile /
-  # StopTradingInstance on the trading instance, and ~11.5 h BEFORE the
+  # StopTradingInstance on the trading instance, and ~12 h BEFORE the
   # real Saturday 09:00 UTC firing — a red shell-run report Friday
   # evening leaves a full operator fix window before the real run
   # consumes its weekly research/training/backtest cycle. shell_run mode
@@ -166,11 +166,11 @@ Resources:
     Properties:
       Name: alpha-engine-friday-shell-run
       Description: >-
-        Friday 21:30 UTC (14:30 PT PDT / 13:30 PT PST) — DISABLED by default —
+        Friday 20:45 UTC (1:45 PM PT PDT / 12:45 PM PT PST) — DISABLED by default —
         fires the Saturday SF with shell_run=true (full dry preflight, no API
-        calls / no S3-config-email-SNS writes) ~11.5h before the real Sat run.
+        calls / no S3-config-email-SNS writes) ~12h before the real Sat run.
         Enable via: aws events enable-rule --name alpha-engine-friday-shell-run
-      ScheduleExpression: 'cron(30 21 ? * FRI *)'
+      ScheduleExpression: 'cron(45 20 ? * FRI *)'
       State: DISABLED
       Targets:
         - Id: friday-shell-run

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -731,6 +731,7 @@ class TestFridayEventBridgeRule:
         block = cfn_text.split("FridayShellRunTrigger:", 1)[1].split(
             "WeekdayTrigger:", 1
         )[0]
-        # 21:30 UTC Fri = 14:30 PT (PDT) — after Friday EOD SF (~1:25 PT),
-        # ~11.5h before the real Sat 09:00 UTC firing.
-        assert "cron(30 21 ? * FRI *)" in block
+        # 20:45 UTC Fri = 1:45 PM PT (PDT) — after Friday EOD SF (~1:25 PT),
+        # ~12h before the real Sat 09:00 UTC firing. (Retimed from 21:30 UTC
+        # per operator request 2026-05-18.)
+        assert "cron(45 20 ? * FRI *)" in block


### PR DESCRIPTION
Retimes the existing `alpha-engine-friday-shell-run` EventBridge rule (shipped by #258) from `cron(30 21 ? * FRI *)` (14:30 PT PDT) → **`cron(45 20 ? * FRI *)` = 20:45 UTC = 1:45 PM PT PDT / 12:45 PM PT PST**, per operator request.

- **One rule retimed, not a second rule** — per the no-redundant-scheduled-infra principle; the #258 rule already *is* the dedicated Friday shell trigger, just at the wrong time.
- Still **after** the Friday EOD SF (~1:25 PT — no trading-instance collision) and ~12h before the real Sat 09:00 UTC firing (operator fix window preserved).
- Rule **stays `State: DISABLED`** — enable deliberately via `aws events enable-rule --name alpha-engine-friday-shell-run --region us-east-1` (per the fail-loud/no-backstop posture).
- DST note: EventBridge cron is fixed UTC; anchored to PDT (the dominant season) exactly as #258 did — seasonal ±1h drift is immaterial for a preflight that just needs to land Friday-PM before Sat 02:00.
- Comments + the wiring test's pinned cron/timing assertion updated. Full data suite 1337 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)