### PR TITLE
fix(data): bridge class-share dash↔polygon-dot symbols (fixes weekday SF timeout)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -122,6 +122,44 @@ _POLYGON_MIN_COVERAGE = 0.95    # below this, polygon_only mode hard-fails
 _DISCREPANCY_WARN_PCT = 0.01    # |polygon_close - yfinance_close| / yfinance_close
 _DISCREPANCY_ERROR_PCT = 0.05
 
+# Share-class symbol convention bridge (Yahoo/our-universe dash → polygon dot).
+#
+# Our universe + ArcticDB key class shares with a dash + single class
+# letter (BRK-B, BF-B, MOG-A — the Yahoo convention). Polygon serves the
+# *same security* under the dot convention (BRK.B, BF.B, MOG.A). This is
+# a pure symbol-format mismatch, NOT a data gap or a delay: polygon's
+# grouped-daily bulk call we already make every morning ALREADY contains
+# these rows under the dot key (live-verified 2026-05-19 for 2026-05-18:
+# BRK.B/BF.B/MOG.A all present same-day; BRK-B/BF-B/MOG-A all absent).
+#
+# Before this bridge, `grouped.get("BRK-B")` missed, then the rate-limited
+# (5 calls/min) per-ticker fallback re-queried "BRK-B" and also missed
+# (recovered 0/N) on every one of the 14 window dates — ~12 min of pure
+# wasted retries that pushed weekday MorningEnrich past its 30-min SSM
+# timeout (2026-05-19 SIGKILL/137 → whole weekday pipeline FAILED).
+#
+# The pattern is anchored to exactly the US class-share convention — a
+# 1–5 char root, one hyphen, one uppercase class letter. It cannot
+# misfire on a normal ticker, an index/^ ticker, a sector ETF, or a
+# FRED-mapped symbol (none match `^[A-Z]{1,5}-[A-Z]$`). Future S&P
+# class shares are handled automatically — no per-ticker config upkeep
+# and no new chronic-gap entries.
+_SHARE_CLASS_RE = re.compile(r"^[A-Z]{1,5}-[A-Z]$")
+
+
+def _polygon_symbol(store_ticker: str) -> str:
+    """Map our dash store-key to polygon's symbol for query/lookup.
+
+    Returns the dot form for class-share tickers (``BRK-B`` → ``BRK.B``),
+    else the input unchanged. The return value is ONLY ever used to talk
+    to polygon (grouped-daily key lookup + the per-ticker endpoint path);
+    the stored record always keeps the original dash ``store_ticker`` so
+    ArcticDB / universe / downstream keys are unaffected.
+    """
+    if _SHARE_CLASS_RE.match(store_ticker):
+        return store_ticker.replace("-", ".")
+    return store_ticker
+
 
 def _previous_business_days(run_date: str, n: int) -> list[str]:
     """Return ``n`` business days ending on ``run_date`` (inclusive),
@@ -705,7 +743,9 @@ def _fetch_polygon_closes(
     polygon_count = 0
     for ticker in tickers:
         store_ticker = ticker.lstrip("^")
-        g = grouped.get(store_ticker)
+        # Look up by polygon's symbol (dot form for class shares), but
+        # keep ``store_ticker`` (dash) as the persisted record key.
+        g = grouped.get(_polygon_symbol(store_ticker))
         if g:
             records.append({
                 "ticker": store_ticker,
@@ -758,7 +798,11 @@ def _fetch_polygon_closes_per_ticker(
     Each ticker is one rate-limited polygon call. With the default 5
     calls/min and ~10-15 misses on a typical bulk-endpoint flake, this
     adds 2-3 minutes to MorningEnrich runtime — well under the SF's
-    DataPhase1 budget.
+    DataPhase1 budget. Class-share tickers are now recovered for free
+    by the grouped-daily dot-key lookup (see ``_polygon_symbol``) so
+    they no longer reach this fallback; ``_polygon_symbol`` is still
+    applied here for the rare case a class share is genuinely dropped
+    by the bulk endpoint on a given date.
     """
     from polygon_client import polygon_client
 
@@ -766,7 +810,9 @@ def _fetch_polygon_closes_per_ticker(
     for ticker in tickers:
         store_ticker = ticker.lstrip("^")
         try:
-            bar = polygon_client().get_single_day_bar(store_ticker, run_date)
+            bar = polygon_client().get_single_day_bar(
+                _polygon_symbol(store_ticker), run_date
+            )
         except Exception as exc:
             logger.warning(
                 "Polygon per-ticker fallback failed for %s @ %s: %s",

--- a/tests/test_polygon_shareclass_symbol.py
+++ b/tests/test_polygon_shareclass_symbol.py
@@ -1,0 +1,153 @@
+"""Share-class symbol bridge: Yahoo/our-universe dash ↔ polygon dot.
+
+Regression lock for the 2026-05-19 weekday-pipeline FAILURE.
+
+Root cause: our universe keys class shares with a dash + class letter
+(BRK-B, BF-B, MOG-A); polygon serves the same securities under the dot
+convention (BRK.B, BF.B, MOG.A). ``grouped.get("BRK-B")`` missed the
+row that polygon's bulk grouped-daily call ALREADY contained under
+"BRK.B", so the rate-limited (5/min) per-ticker fallback re-queried the
+dash form and also missed — recovered 0/N on every one of the 14 window
+dates, ~12 min of pure wasted retries that pushed weekday MorningEnrich
+past its 30-min SSM timeout (SIGKILL/137 → whole pipeline FAILED).
+
+These tests pin three invariants:
+
+1. ``_polygon_symbol`` maps class shares to the dot form and leaves
+   every other ticker shape (normal, index/^-stripped, ETF, no-hyphen)
+   untouched — the anchored pattern cannot misfire.
+2. ``_fetch_polygon_closes`` recovers a class share straight from the
+   grouped-daily dot key, stores it under the DASH key, and does NOT
+   reach the per-ticker fallback (the cost-quiet path that fixes the
+   timeout).
+3. ``_fetch_polygon_closes_per_ticker`` queries polygon with the dot
+   form for a class share but persists the dash record key.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collectors.daily_closes import (
+    _fetch_polygon_closes,
+    _fetch_polygon_closes_per_ticker,
+    _polygon_symbol,
+)
+
+
+# ── _polygon_symbol unit ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "store_ticker,expected",
+    [
+        ("BRK-B", "BRK.B"),
+        ("BF-B", "BF.B"),
+        ("MOG-A", "MOG.A"),
+        ("A-B", "A.B"),          # 1-char root still a valid class share
+        ("ABCDE-A", "ABCDE.A"),  # 5-char root boundary
+    ],
+)
+def test_class_share_maps_dash_to_dot(store_ticker, expected):
+    assert _polygon_symbol(store_ticker) == expected
+
+
+@pytest.mark.parametrize(
+    "store_ticker",
+    [
+        "AAPL",      # normal common stock
+        "PSTG",      # genuine chronic gap — no hyphen, must stay as-is
+        "VIX",       # ^-stripped index symbol
+        "VIX3M",
+        "XLB",       # sector ETF
+        "ABCDEF-A",  # 6-char root — outside the anchored {1,5} bound
+        "ABC-AB",    # two-letter class segment — not the convention
+        "ABC-1",     # digit segment — not a class share
+        "BRK.B",     # already dot form — idempotent, unchanged
+    ],
+)
+def test_non_class_share_unchanged(store_ticker):
+    assert _polygon_symbol(store_ticker) == store_ticker
+
+
+# ── _fetch_polygon_closes integration — the core regression + cost win ────────
+
+
+def test_class_share_recovered_from_grouped_dot_key_no_fallback():
+    """Polygon's grouped-daily returns BRK.B (dot). The collector must
+    recover it via the dot-key lookup, persist it under the DASH key
+    (BRK-B) for ArcticDB/universe consistency, and NOT spend a
+    rate-limited per-ticker call — this is the ~12-min saving that pulls
+    MorningEnrich back under its 30-min SSM ceiling."""
+    records: list[dict] = []
+    fake_client = MagicMock()
+    fake_client.get_grouped_daily.return_value = {
+        "AAPL": {"open": 99.0, "high": 101.0, "low": 98.0, "close": 100.0,
+                 "volume": 5_000_000, "vwap": 99.5},
+        "BRK.B": {"open": 487.0, "high": 490.0, "low": 486.0, "close": 488.38,
+                  "volume": 3_000_000, "vwap": 488.0},
+    }
+
+    with patch("polygon_client.polygon_client", return_value=fake_client):
+        polygon_count = _fetch_polygon_closes(
+            ["AAPL", "BRK-B"], "2026-05-18", records, source="polygon_only",
+        )
+
+    assert polygon_count == 2
+    # Stored under the DASH key, not the dot key polygon used.
+    assert {r["ticker"] for r in records} == {"AAPL", "BRK-B"}
+    brk = next(r for r in records if r["ticker"] == "BRK-B")
+    assert brk["Close"] == 488.38
+    assert brk["source"] == "polygon"
+    # The cost-quiet invariant: no per-ticker fallback was needed.
+    fake_client.get_single_day_bar.assert_not_called()
+
+
+def test_class_share_genuine_grouped_drop_uses_dot_per_ticker():
+    """If the bulk endpoint genuinely drops a class share on some date,
+    the per-ticker fallback must query polygon with the DOT form and
+    still persist the DASH record key."""
+    records: list[dict] = []
+    fake_client = MagicMock()
+    fake_client.get_grouped_daily.return_value = {
+        "AAPL": {"open": 99.0, "high": 101.0, "low": 98.0, "close": 100.0,
+                 "volume": 5_000_000, "vwap": 99.5},
+    }
+    fake_client.get_single_day_bar.return_value = {
+        "open": 487.0, "high": 490.0, "low": 486.0, "close": 488.38,
+        "volume": 3_000_000, "vwap": 488.0,
+    }
+
+    with patch("polygon_client.polygon_client", return_value=fake_client):
+        polygon_count = _fetch_polygon_closes(
+            ["AAPL", "BRK-B"], "2026-05-18", records, source="polygon_only",
+        )
+
+    assert polygon_count == 2
+    # polygon was asked for the DOT form…
+    fake_client.get_single_day_bar.assert_called_once_with("BRK.B", "2026-05-18")
+    # …but the record key stays DASH.
+    assert {r["ticker"] for r in records} == {"AAPL", "BRK-B"}
+
+
+def test_per_ticker_fallback_class_share_dot_query_dash_store():
+    """Direct ``_fetch_polygon_closes_per_ticker`` unit: dot query,
+    dash persisted key."""
+    records: list[dict] = []
+    fake_client = MagicMock()
+    fake_client.get_single_day_bar.return_value = {
+        "open": 305.0, "high": 308.0, "low": 304.0, "close": 306.2,
+        "volume": 120_000, "vwap": 306.0,
+    }
+
+    with patch("polygon_client.polygon_client", return_value=fake_client):
+        recovered = _fetch_polygon_closes_per_ticker(
+            ["MOG-A"], "2026-05-18", records
+        )
+
+    assert recovered == 1
+    fake_client.get_single_day_bar.assert_called_once_with("MOG.A", "2026-05-18")
+    assert records[0]["ticker"] == "MOG-A"
+    assert records[0]["Close"] == 306.2


### PR DESCRIPTION
## Root cause (2026-05-19 weekday pipeline FAILURE)

`alpha-engine-weekday-pipeline` FAILED at `MorningEnrich` — the SSM command was SIGKILLed at exactly 30:00 (`ResponseCode 137`, `ExecutionElapsedTime PT30M0.006S`), hitting the step's `executionTimeout: 1800`.

Our universe/ArcticDB keys class shares with a **dash + class letter** (`BRK-B`, `BF-B`, `MOG-A` — the Yahoo convention). Polygon serves the **same securities** under the **dot** convention (`BRK.B`, `BF.B`, `MOG.A`). So `grouped.get("BRK-B")` missed rows the bulk grouped-daily call **already contained** under `BRK.B`; the rate-limited (5/min) per-ticker fallback then re-queried the dash form and **also missed** — `recovered 0/N` on every one of the 14 `window_days` dates ≈ **~12 min of pure wasted retries**, pushing MorningEnrich past its 30-min ceiling.

Live-verified 2026-05-19 against polygon for 2026-05-18: `BRK.B`/`BF.B`/`MOG.A` all present **same-day**; `BRK-B`/`BF-B`/`MOG-A` all absent. **Not a delay, not a gap — a pure symbol-format mismatch.**

## Fix

`_polygon_symbol`: an anchored `^[A-Z]{1,5}-[A-Z]$` bridge mapping class shares to polygon's dot form **for query/lookup only**. The persisted record key stays the dash `store_ticker`, so ArcticDB / universe / downstream keys are unaffected. Applied at the grouped-daily lookup and the per-ticker fallback.

- Class shares now recovered authoritatively from the bulk call we already make — **zero extra API calls**, `source=polygon`, no yfinance degradation.
- They no longer reach the rate-limited per-ticker fallback → removes the ~12-min waste that caused the timeout.
- Pattern cannot misfire on normal/index(^-stripped)/ETF/FRED symbols.

## Companion change

alpha-engine-config: removes `BF-B`/`BRK-B`/`MOG-A` from `chronic_polygon_gaps` (no longer gaps; they now hard-fail correctly like any healthy ticker if genuinely missing). `PSTG` stays (genuine gap, no dot variant).

## Tests

`+14` in `tests/test_polygon_shareclass_symbol.py` (unit + integration: dot-key recovery, dash persistence, no-fallback cost-quiet invariant, no-misfire). Full suite: **1368 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)