### PR TITLE
fix(sf): start weekday pipeline 05:45 PT so daemon is ready before 06:30 open

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -187,8 +187,20 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: alpha-engine-weekday
-      Description: Weekday 13:00 UTC (6:00 AM PT) — daily data + predictor + executor
-      ScheduleExpression: 'cron(0 13 ? * MON-FRI *)'
+      # 2026-05-19: moved 06:00 → 05:45 PT (13:00 → 12:45 UTC). At the old
+      # 06:00 start the daemon was ready ~31–32 min later (06:31–06:32 PT)
+      # even on SUCCESSFUL runs — i.e. the order book/daemon was ~1–2 min
+      # LATE for the 06:30 PT open every single day. Combined with the
+      # alpha-engine-data#264 MorningEnrich speedup (~−12 min, no longer
+      # flirting with the 30-min SSM timeout), a 05:45 start gives ~22 min
+      # expected / ~32 min P99 to daemon-ready → ready ≤ 06:17 PT at the
+      # 99th percentile, comfortably before the 06:30 open with margin.
+      # NOTE (pre-existing, unchanged here): the UTC expression assumes
+      # PDT (UTC−7); during PST the effective PT start shifts an hour.
+      # That DST caveat predates this change and is intentionally left
+      # as-is — out of scope for the start-time fix.
+      Description: Weekday 12:45 UTC (5:45 AM PT, PDT) — daily data + predictor + executor; daemon ready before 06:30 PT open
+      ScheduleExpression: 'cron(45 12 ? * MON-FRI *)'
       State: ENABLED
       Targets:
         - Id: weekday-pipeline


### PR DESCRIPTION
## Why

Per-state timing of recent **successful** weekday runs (start 06:00:03 PT):

| Date | Order book ready | Daemon ready | Pipeline end (PT) |
|---|---|---|---|
| 2026-05-18 | +30.5m | +31.0m | 06:31:04 |
| 2026-05-14 | +31.4m | +32.2m | 06:32:14 |
| 2026-05-13 | +30.6m | +31.9m | 06:31:57 |

Even with **nothing failing**, the daemon was ready ~31–32 min after start = **06:31–06:32 PT — already 1–2 min after the 06:30 open, every single day.** Your "ready by 06:30, not a single second later" requirement surfaces this latent miss.

## Change

`WeekdayTrigger` `cron(0 13 …)` → `cron(45 12 …)` — i.e. **06:00 → 05:45 PT** (13:00 → 12:45 UTC).

Sized against the data + the **alpha-engine-data#264** MorningEnrich speedup (≈ −12 min, and no longer flirting with the 30-min SSM timeout that caused today's FAIL):
- post-#264 daemon-ready ≈ **~22 min expected**, **~32 min P99** (bad polygon-latency / ArcticDB day).
- 05:45 + 32 min P99 = **06:17 PT** → ~13 min slack before the 06:30 open ⇒ ≥99% on time, without being wastefully early.
- #264 is the companion change. An earlier start **alone** would only shift *when* the MorningEnrich SIGKILL happens — both are required.

## Notes

- **DST**: the UTC expression assumes PDT (UTC−7); during PST the effective PT start shifts an hour. This caveat **predates** this change and is intentionally left as-is (out of scope for the start-time fix) — flagging it explicitly.
- Auto-deploys on merge (`deploy-infrastructure.yml`, `push:main` → CFN stack update; rule is CFN-managed by `alpha-engine-orchestration`, so the template is the correct edit point — not `aws events put-rule`, which would create drift). `aws cloudformation validate-template` passes.
- Cost: instance runs ~15 min longer/day (negligible). No EOD impact (EOD is independently triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)