### PR TITLE
PR1a: macro breadth → ArcticDB (slim fallback + parity-observed)

### DIFF
--- a/collectors/macro.py
+++ b/collectors/macro.py
@@ -27,6 +27,8 @@ import requests
 import yfinance as yf
 
 from store.parquet_loader import load_slim_cache
+from alpha_engine_lib.arcticdb import load_universe_ohlcv
+from alpha_engine_lib.reconcile import reconcile_frame_dicts
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +45,58 @@ _FRED_SERIES = {
     "initial_claims": "ICSA",
     "hy_credit_spread_oas": "BAMLH0A0HYM2",
 }
+
+
+def _load_breadth_prices(bucket: str) -> Optional[dict]:
+    """Load the ~900-ticker price set for breadth — ArcticDB primary,
+    slim-cache fallback, parity-observed.
+
+    Wave 4 of the predictor/price_cache_slim deletion arc. ArcticDB (via the
+    lib ``load_universe_ohlcv`` slim-equivalent reader) is the single source
+    of truth; the legacy ``predictor/price_cache_slim/`` parquet read is kept
+    as a fallback so breadth cannot break if ArcticDB is unavailable. While
+    both sources still exist we dual-read and emit a ``reconcile`` ParityReport
+    so the eventual slim deletion (PR4) is a data-driven cutover, not an
+    eyeballed one. The slim side — and this dual-read — are removed in PR4.
+
+    Returns ``None`` only if BOTH sources fail (caller then omits the breadth
+    key, preserving the existing no-null contract).
+    """
+    arctic_prices = None
+    try:
+        arctic_prices = load_universe_ohlcv(bucket)
+    except Exception as exc:  # noqa: BLE001 - fall back, don't break breadth
+        logger.warning("ArcticDB universe read for breadth failed: %s", exc)
+
+    slim_prices = None
+    try:
+        slim_prices = load_slim_cache(boto3.client("s3"), bucket)
+    except Exception as exc:  # noqa: BLE001 - parity/fallback only
+        logger.warning(
+            "Slim cache read for breadth (parity/fallback) failed: %s", exc
+        )
+
+    # SOTA observation: while both exist, emit the quantitative parity metric
+    # every run. Grep ``WAVE4_PARITY_METRIC breadth`` over the observation
+    # window before PR4 retires slim.
+    if arctic_prices and slim_prices:
+        report = reconcile_frame_dicts(
+            slim_prices, arctic_prices, value_cols=("Close",)
+        )
+        logger.info("breadth slim<->arctic %s", report.summary())
+        logger.info(
+            "WAVE4_PARITY_METRIC breadth %s", json.dumps(report.as_metrics())
+        )
+
+    if arctic_prices:
+        return arctic_prices
+    if slim_prices:
+        logger.warning(
+            "breadth falling back to slim cache — ArcticDB universe "
+            "unavailable (Wave-4 migration fallback path)"
+        )
+        return slim_prices
+    return None
 
 
 def collect(
@@ -73,18 +127,14 @@ def collect(
     macro.update(market)
 
     # Compute breadth. If the caller did not pass in price_data, load the
-    # slim cache that Phase 1 just wrote to S3 so downstream Research still
-    # gets a real breadth reading. If that load fails for any reason, we
-    # OMIT the "breadth" key entirely rather than writing null — Research
-    # has its own fallback and macro_agent reads macro_data.get("breadth", {}),
-    # which only honors the default when the key is missing.
+    # ~900-ticker price set (ArcticDB primary, slim-cache fallback — see
+    # _load_breadth_prices) so downstream Research still gets a real breadth
+    # reading. If both sources fail we OMIT the "breadth" key entirely rather
+    # than writing null — Research has its own fallback and macro_agent reads
+    # macro_data.get("breadth", {}), which only honors the default when the
+    # key is missing.
     if price_data is None:
-        try:
-            s3_read = boto3.client("s3")
-            price_data = load_slim_cache(s3_read, bucket)
-        except Exception as exc:
-            logger.warning("Failed to load slim cache for breadth: %s", exc)
-            price_data = None
+        price_data = _load_breadth_prices(bucket)
 
     if price_data:
         macro["breadth"] = _compute_market_breadth(price_data)

--- a/tests/test_macro_breadth.py
+++ b/tests/test_macro_breadth.py
@@ -76,7 +76,8 @@ def test_breadth_key_omitted_when_no_price_data_and_slim_cache_empty(monkeypatch
     """The critical regression: breadth must NEVER be serialized as null."""
     _stub_fetchers(monkeypatch)
 
-    # slim cache load returns empty dict (no parquets in S3)
+    # Both sources empty (no ArcticDB symbols, no slim parquets in S3)
+    monkeypatch.setattr(macro, "load_universe_ohlcv", lambda *a, **k: {})
     monkeypatch.setattr(macro, "load_slim_cache", lambda s3, bucket: {})
 
     written = {}
@@ -105,6 +106,10 @@ def test_breadth_key_omitted_when_slim_cache_load_raises(monkeypatch):
     def _boom(s3, bucket):
         raise RuntimeError("S3 unreachable")
 
+    def _arctic_boom(*a, **k):
+        raise RuntimeError("ArcticDB unreachable")
+
+    monkeypatch.setattr(macro, "load_universe_ohlcv", _arctic_boom)
     monkeypatch.setattr(macro, "load_slim_cache", _boom)
 
     written = {}
@@ -120,3 +125,75 @@ def test_breadth_key_omitted_when_slim_cache_load_raises(monkeypatch):
     import json
     body = json.loads(written["Body"])
     assert "breadth" not in body
+
+
+# ── Wave-4 migration: ArcticDB primary / slim fallback / parity emit ─────────
+
+
+def _universe(n=220):
+    return {
+        "AAA": _synthetic_price_frame(n, 100.0),
+        "BBB": _synthetic_price_frame(n, 250.0),
+    }
+
+
+def _collect_body(monkeypatch):
+    written = {}
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            written.update(kwargs)
+
+    monkeypatch.setattr(macro.boto3, "client", lambda service: _FakeS3())
+    result = macro.collect(bucket="test-bucket", run_date="2026-04-11")
+    assert result["status"] == "ok"
+    import json
+    return json.loads(written["Body"])
+
+
+def test_breadth_uses_arcticdb_when_available(monkeypatch):
+    """ArcticDB is primary — breadth computed from it even if slim is empty."""
+    _stub_fetchers(monkeypatch)
+    monkeypatch.setattr(macro, "load_universe_ohlcv", lambda *a, **k: _universe())
+    monkeypatch.setattr(macro, "load_slim_cache", lambda s3, bucket: {})
+
+    body = _collect_body(monkeypatch)
+    assert isinstance(body["breadth"], dict)
+    assert body["breadth"]["n_stocks"] == 2
+
+
+def test_breadth_falls_back_to_slim_when_arcticdb_unavailable(monkeypatch, caplog):
+    """ArcticDB read fails -> slim fallback keeps breadth working."""
+    _stub_fetchers(monkeypatch)
+
+    def _arctic_boom(*a, **k):
+        raise RuntimeError("ArcticDB unreachable")
+
+    monkeypatch.setattr(macro, "load_universe_ohlcv", _arctic_boom)
+    monkeypatch.setattr(macro, "load_slim_cache", lambda s3, bucket: _universe())
+
+    with caplog.at_level("WARNING"):
+        body = _collect_body(monkeypatch)
+    assert isinstance(body["breadth"], dict)
+    assert any("falling back to slim cache" in r.message for r in caplog.records)
+
+
+def test_parity_metric_emitted_when_both_sources_present(monkeypatch, caplog):
+    """SOTA observation: dual-read emits a JSON ParityReport every run."""
+    _stub_fetchers(monkeypatch)
+    monkeypatch.setattr(macro, "load_universe_ohlcv", lambda *a, **k: _universe())
+    monkeypatch.setattr(macro, "load_slim_cache", lambda s3, bucket: _universe())
+
+    with caplog.at_level("INFO"):
+        body = _collect_body(monkeypatch)
+
+    assert isinstance(body["breadth"], dict)
+    metric_lines = [
+        r.message for r in caplog.records
+        if "WAVE4_PARITY_METRIC breadth" in r.message
+    ]
+    assert len(metric_lines) == 1
+    import json
+    payload = json.loads(metric_lines[0].split("WAVE4_PARITY_METRIC breadth ", 1)[1])
+    assert payload["passed"] is True  # identical fixtures -> parity holds
+    assert payload["max_abs_value_delta"] == 0.0


### PR DESCRIPTION
Third PR of the **Wave 4** arc (`predictor/price_cache_slim/` deletion → ArcticDB single-source-of-truth). First **production consumer** migrated — the low-risk, ROADMAP-known one. Builds on PR0a (lib `v0.19.0`, merged) + PR0b ([#266](https://github.com/cipher813/alpha-engine-data/pull/266), merged: parity harness + consumer-set lock).

## Change
`collectors/macro._compute_market_breadth`'s price source moves from `load_slim_cache` → lib `load_universe_ohlcv`, via a new `_load_breadth_prices()` helper:

- **ArcticDB primary** (single source of truth).
- **Slim-cache retained as fallback** — contract-safe consumer-first-with-fallback. Breadth cannot break if ArcticDB is unavailable. Preserves the existing **no-null-breadth contract**: returns `None` (→ breadth key omitted, never `null`) only if *both* sources fail.
- **SOTA observation principle**: while both sources exist, every run dual-reads and emits `reconcile_frame_dicts(...).as_metrics()` as a JSON log line — grep **`WAVE4_PARITY_METRIC breadth`** over the observation window. PR4's slim deletion becomes a data-driven cutover, not eyeballed. The dual-read + slim side are removed in PR4.

## Runtime / safety
- **No Dockerfile change needed** (precise audit, not blanket): `macro.collect` runs *only* in `weekly_collector` Phase 1 on **EC2 spot**, whose `requirements.txt` already carries `[arcticdb,flow_doctor,rag]`. It is not Lambda-packaged → the lib `[flow_doctor]`-only Lambda image is unaffected. (The `[arcticdb]`-extra concern stays flagged for PR1b/PR2 if those touch a Lambda path.)
- No S3 path/schema change; `macro.json` shape unchanged (consumer-side only).
- `730d` default `load_universe_ohlcv` window covers the 200d-MA breadth need and matches the slim 2y tail → parity window aligns.
- `test_macro_breadth`: omit-on-empty / omit-on-raise tests updated to stub both sources; **+3 tests** (ArcticDB-primary, slim-fallback, parity-metric emission). **Full data suite 1375 passing**; Wave-4 anti-drift consumer-set guard still holds (`macro.py` stays in `WAVE4_INVENTORY.data_read_consumers` — slim fallback retained until PR4).

## Sequence
Next: **PR1b** — `features/compute.py::_load_prices_and_macro` (the ROADMAP-missed feature-pipeline price base; riskier, its own PR + own parity observation, per your split decision). Then PR2 (backtester), PR3 (dashboard retire), PR4 (delete writer+prefix, gated on one clean Saturday-SF zero-diff `ParityReport`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)