### PR TITLE
chore(deps): drop redundant psycopg2-binary + pgvector direct pins (via alpha-engine-lib[rag])

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,10 @@ feedparser>=6.0
 beautifulsoup4>=4.12
 lxml>=5.0
 edgartools>=2.0
-psycopg2-binary>=2.9
-pgvector>=0.2
 voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
-# [rag] (added in lib v0.3.0) consolidates psycopg2-binary + pgvector + numpy
-# previously listed above as direct deps; kept those direct lines for now to
-# avoid breaking pinning during the migration. Drop the duplicate direct
-# pgvector/psycopg2-binary pins once the migration soaks.
+# psycopg2-binary + pgvector now come via [rag] (added in lib v0.3.0,
+# direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
 alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0


### PR DESCRIPTION
## Summary

Drops the duplicate direct pins on \`psycopg2-binary>=2.9\` and \`pgvector>=0.2\` in \`requirements.txt\` — both are now supplied by the \`alpha-engine-lib[rag]\` extra (added in lib v0.3.0, now pinned at v0.20.0). The direct pins were the explicit "kept for now to avoid breaking pinning during the migration" carve-out that the L615 ROADMAP entry tracked; gate cleared with >2 weeks of soak.

## Verification

- \`alpha-engine-lib[rag]\` extra at \`pyproject.toml:27-29\` declares the same lower bounds (\`psycopg2-binary>=2.9\` / \`pgvector>=0.2\`).
- \`python -c "import psycopg2; import pgvector"\` succeeds after the drop (psycopg2 resolves to 2.9.11 via the lib extra).
- Full suite: **1401 passed / 1 skipped** — no regression.

Closes the L615 P3 → P2 promotion from the 2026-05-20 P3 curation pass.

## Test plan

- [x] Suite green locally (1401 / 1 skipped)
- [ ] Next Saturday SF (5/23) DataPhase1 + DataPhase2 spot launches with the slim image and \`psycopg2-binary\` / \`pgvector\` still resolve via the lib extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)