### PR TITLE
refactor(changelog-incident-mirror): smoke test migrates to alpha_engine_lib.alerts CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.21.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -102,15 +102,29 @@ aws lambda wait function-updated \
 echo "✓ Deployed."
 
 # Smoke test: publish a single SNS message and verify the entry lands.
+# Migrated 2026-05-20 (ROADMAP L146) from raw ``aws sns publish`` to the
+# canonical ``alpha_engine_lib.alerts`` primitive (v0.21.0, lib #52).
+# Skips Telegram on purpose: this is a deliberate deploy smoke test, not
+# a real failure event, and a per-deploy operator ping would be noise.
+# SNS path stays identical (same default topic `alpha-engine-alerts`),
+# so the changelog-incident-mirror Lambda still sees the message.
 SMOKE_ARG="${1:-}"
 if [[ "${SMOKE_ARG}" == "--smoke" ]]; then
-  echo "Smoke-testing via SNS publish..."
+  echo "Smoke-testing via alerts.publish (SNS-only, severity=info)..."
   TS=$(date -u +%s)
-  aws sns publish \
-    --topic-arn "arn:aws:sns:${REGION}:711398986525:alpha-engine-alerts" \
-    --subject "deploy.sh smoke test ${TS}" \
-    --message "Verifying changelog-incident-mirror after deploy ${TS}" \
-    --query 'MessageId' --output text >/dev/null
+  # Resolve Python with alpha_engine_lib installed — prefer repo-local
+  # .venv, fall back to system python3 (mirrors the alpha-engine
+  # health_checker.sh pattern).
+  _alert_python="python3"
+  if [ -x "$(dirname "$0")/../../../.venv/bin/python" ]; then
+    _alert_python="$(dirname "$0")/../../../.venv/bin/python"
+  fi
+  "$_alert_python" -m alpha_engine_lib.alerts publish \
+    --severity info \
+    --no-telegram \
+    --source alpha-engine-data/changelog-incident-mirror/deploy.sh \
+    --message "deploy.sh smoke test ${TS}: Verifying changelog-incident-mirror after deploy" \
+    > /dev/null
   echo "  → Published. Entry should land in s3://alpha-engine-research/changelog/entries/ within ~3s."
   echo "  → Check with: aws s3 ls s3://alpha-engine-research/changelog/entries/$(date -u +%Y-%m-%d)/ --recursive | tail"
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
 # psycopg2-binary + pgvector now come via [rag] (added in lib v0.3.0,
 # direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.21.0


### PR DESCRIPTION
## Summary
- **L146 (P2)** — alpha-engine-data half of the inline-alerts → lib.alerts migration. Sibling PR: alpha-engine #200 (health_checker.sh).
- `infrastructure/lambdas/changelog-incident-mirror/deploy.sh` smoke path: raw `aws sns publish` → `python -m alpha_engine_lib.alerts publish --severity info --no-telegram --source alpha-engine-data/changelog-incident-mirror/deploy.sh`. SNS target topic unchanged (default `alpha-engine-alerts` resolution); Lambda receives the message; smoke test still validates end-to-end.
- `--no-telegram` + `severity=info` keep the per-deploy smoke off the operator channel (this is a deliberate test injection, not a failure event).
- Lib pin v0.20.0 → v0.21.0 in BOTH `requirements.txt` AND `Dockerfile` (lockstep — the `test_lib_pin_lockstep` regression test enforces this). v0.21.0 is the alerts-module floor.

## Why
ROADMAP L146 / SOTA sub-sub-rule (lift-to-lib for ≥2 consumers). First consumer was alpha-engine-backtester #231; this and PR #200 complete the two-site pass.

## Test plan
- [x] Suite: 1401 passed (vs 1400 baseline; `test_lib_pin_lockstep` validates Dockerfile/requirements.txt agree).
- [x] Lib v0.21.0 installs cleanly in data venv; `alpha_engine_lib.alerts` imports.
- [x] CLI dry-run with `--no-sns --no-telegram` returns the expected status string.
- [ ] Operator validation: next `deploy.sh --smoke` lands a record in `s3://alpha-engine-research/changelog/entries/{date}/` within ~3s with no Telegram ping.
- [ ] Acceptance (post-merge fleet check): `grep -rE "aws sns publish.*alpha-engine-alerts|api.telegram.org/bot" infrastructure/ --include="*.sh"` across alpha-engine + alpha-engine-data returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)