### PR TITLE
feat(iam): grant SSM SendCommand on dashboard instance for auto-deploy

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -250,6 +250,26 @@
           ]
         }
       }
+    },
+    {
+      "Sid": "DashboardDeployViaSSM",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand"
+      ],
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:instance/i-09b539c844515d549",
+        "arn:aws:ssm:us-east-1::document/AWS-RunShellScript"
+      ]
+    },
+    {
+      "Sid": "DashboardDeployPollCommand",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetCommandInvocation",
+        "ssm:ListCommandInvocations"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Extends `github-actions-lambda-deploy` (the cross-cutting OIDC role assumed by every alpha-engine-* GHA deploy workflow) with `ssm:SendCommand` scoped to the dashboard instance (i-09b539c844515d549) + the AWS-RunShellScript document, plus `ssm:GetCommandInvocation` for polling.

Unblocks alpha-engine-dashboard PR auto-deploy (separate PR opens once this merges). Pattern mirrors the existing lambda deploys: PR merge → GHA workflow → SSM → instance pulls + restarts streamlit services → health check.

## Why this role, not a new one

`github-actions-lambda-deploy` is already cross-cutting by design (per `infrastructure/iam/README.md`), already includes infra-deploy actions (CloudFormation, SNS, scheduler, etc.) despite the name, and its OIDC trust already permits `cipher813/alpha-engine-dashboard:main`. Single role is the lower-ceremony choice for a 1-dev project. If the dashboard deploy ever needs blast-radius isolation, splitting is mechanical.

## Apply.sh ran pre-merge

Per the add-grant discipline ([[feedback_apply_sh_iam_drift_check_inverts_timing]]) — codified must match live before the drift-check CI can pass on this PR:

```
$ bash infrastructure/iam/apply.sh github-actions-lambda-deploy
Applying github-actions-lambda-deploy.json -> role=github-actions-lambda-deploy policy=github-actions-lambda-deploy-policy
  OK
$ python3 infrastructure/iam/check-drift.py
OK: no IAM drift for alpha-engine-eventbridge-sfn-role, alpha-engine-step-functions-role, github-actions-lambda-deploy
```

## Test plan

- [x] apply.sh executed cleanly
- [x] check-drift.py reports no drift
- [ ] CI drift-check workflow passes on this PR
- [ ] Post-merge: open alpha-engine-dashboard PR with the new deploy workflow + verify the workflow assumes the role successfully on a workflow_dispatch test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)