### PR TITLE
chore(signal-returns): drop dead 3-class FLAT branch from backfill scorer (L2009)

### DIFF
--- a/collectors/signal_returns.py
+++ b/collectors/signal_returns.py
@@ -634,11 +634,12 @@ def _backfill_predictor_returns(
                 correct = 1 if log_alpha > 0 else 0
             elif direction == "DOWN":
                 correct = 1 if log_alpha < 0 else 0
-            elif direction == "FLAT":
-                # FLAT correctness band: |log_alpha| < 0.01 log-units
-                # (≈1% arithmetic at small magnitudes via log(1+r) ≈ r).
-                correct = 1 if abs(log_alpha) < 0.01 else 0
             else:
+                # Predictor emits binary UP/DOWN only since alpha-engine-predictor
+                # #143 collapsed the 3-class FLAT scaffolding at calibrator level.
+                # Legacy rows with predicted_direction="FLAT" (or any non-binary
+                # value) fall through unresolved — finite legacy set, not load-
+                # bearing on any consumer.
                 continue
 
             if not dry_run:

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -99,8 +99,10 @@ def synthetic_predictions():
                 "veto": False,
             },
             "JPM": {
-                "direction": "FLAT",
-                "confidence": 0.52,
+                # Binary UP/DOWN only since alpha-engine-predictor #143
+                # collapsed the FLAT class at calibrator level.
+                "direction": "DOWN",
+                "confidence": 0.04,
                 "predicted_alpha": 0.001,
                 "veto": False,
             },
@@ -196,7 +198,8 @@ class TestPredictionsContract:
         for ticker, pred in synthetic_predictions["predictions"].items():
             assert "direction" in pred
             assert "confidence" in pred
-            assert pred["direction"] in ("UP", "FLAT", "DOWN")
+            # Predictor emits binary UP/DOWN since alpha-engine-predictor #143.
+            assert pred["direction"] in ("UP", "DOWN")
             assert 0 <= pred["confidence"] <= 1
 
 

--- a/tests/test_signal_returns_log_canonical.py
+++ b/tests/test_signal_returns_log_canonical.py
@@ -288,3 +288,66 @@ class TestForwardWindowUnclosedSkipped:
                     "WHERE symbol='AAPL' AND prediction_date='2026-03-02'"
                 ).fetchone()
             assert row[0] is None
+
+
+# -- Binary UP/DOWN contract (post-#143 calibrator) ---------------------------
+
+
+def test_legacy_flat_direction_falls_through_unresolved():
+    """Predictor #143 collapsed FLAT at the calibrator level. Legacy rows
+    with predicted_direction='FLAT' should fall through the else-branch
+    (correct=NULL, actual_log_alpha=NULL), not be silently scored.
+
+    The branch was removed 2026-05-21 per ROADMAP L2009. This test pins
+    the binary-only contract so a future re-introduction of a FLAT scoring
+    branch surfaces in code review rather than silent calibrator drift.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "data.db")
+        _seed_universe_returns(db, "JPM", "2026-03-02", log_stock=0.005, log_spy=0.005)
+        _seed_predictor_outcomes(db, "JPM", "2026-03-02", "FLAT")
+        with sqlite3.connect(db) as conn:
+            _ensure_predictor_outcomes_schema(conn)
+
+        result = _backfill_predictor_returns(db, dry_run=False, forward_days=21)
+        assert result["status"] == "ok"
+        # 0 rows scored — FLAT falls through
+        assert result["rows_written"] == 0
+
+        with sqlite3.connect(db) as conn:
+            row = conn.execute(
+                "SELECT actual_log_alpha, correct FROM predictor_outcomes "
+                "WHERE symbol='JPM' AND prediction_date='2026-03-02'"
+            ).fetchone()
+        # Unresolved — by design (legacy FLAT rows are a finite set, not
+        # load-bearing on any consumer per ROADMAP L2009).
+        assert row[0] is None
+        assert row[1] is None
+
+
+def test_binary_directions_still_score_correctly():
+    """UP/DOWN paths must remain intact post-FLAT-branch removal."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "data.db")
+        # UP, log_alpha > 0 → correct=1
+        _seed_universe_returns(db, "AAPL", "2026-03-02", log_stock=0.05, log_spy=0.01)
+        _seed_predictor_outcomes(db, "AAPL", "2026-03-02", "UP")
+        # DOWN, log_alpha < 0 → correct=1
+        _seed_universe_returns(db, "XOM", "2026-03-02", log_stock=-0.03, log_spy=0.01)
+        _seed_predictor_outcomes(db, "XOM", "2026-03-02", "DOWN")
+        with sqlite3.connect(db) as conn:
+            _ensure_predictor_outcomes_schema(conn)
+
+        result = _backfill_predictor_returns(db, dry_run=False, forward_days=21)
+        assert result["status"] == "ok"
+        assert result["rows_written"] == 2
+
+        with sqlite3.connect(db) as conn:
+            rows = {
+                r[0]: r for r in conn.execute(
+                    "SELECT symbol, actual_log_alpha, correct FROM predictor_outcomes "
+                    "WHERE prediction_date='2026-03-02'"
+                ).fetchall()
+            }
+        assert rows["AAPL"][2] == 1  # UP + positive alpha = correct
+        assert rows["XOM"][2] == 1   # DOWN + negative alpha = correct


### PR DESCRIPTION
## Summary

Closes ROADMAP L2009. alpha-engine-predictor #143 collapsed FLAT at the calibrator level (\`direction = \"UP\" if p_up >= 0.5 else \"DOWN\"\`, \`p_flat=0.0\` hardcoded). The FLAT correctness band (\`|log_alpha| < 0.01\`) in \`_backfill_predictor_returns\` was scoring a class no fresh predictor row reaches.

## Changes

- \`collectors/signal_returns.py:637\` — drop the FLAT branch; legacy rows with \`predicted_direction='FLAT'\` (a finite legacy set, not load-bearing on any consumer per the ROADMAP entry) fall through the existing else-branch unresolved.
- \`tests/integration/test_pipeline_e2e.py\` — fixture + assertion updated to reflect the binary UP/DOWN contract.
- \`tests/test_signal_returns_log_canonical.py\` +2 regression tests pinning the binary-only contract.

## Out of scope (deliberate)

- \`p_flat\` column on \`predictor_outcomes\` + INSERT statement preserved — schema migration is out-of-scope (no named consumer, would need schema_version bump + dashboard coordination). Predictor continues to emit \`p_flat=0.0\` as a backward-compat sidecar.

## Test plan

- [x] \`pytest tests/test_signal_returns_log_canonical.py\` — 12 passed (was 10)
- [x] \`pytest tests/integration/test_pipeline_e2e.py\` — 13 passed
- [x] Full unit suite: 1394 passed, 1 skipped (was 1392 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)