### PR TITLE
fix(signal-returns): WARN + counter on non-binary direction skip (fail-loud)

### DIFF
--- a/collectors/signal_returns.py
+++ b/collectors/signal_returns.py
@@ -607,6 +607,7 @@ def _backfill_predictor_returns(
             return {"status": "ok", "rows_written": 0}
 
         resolved = 0
+        non_binary_skipped: dict[str, int] = {}
         for _, row in pending.iterrows():
             ticker = row["symbol"]
             pred_date = row["prediction_date"]
@@ -635,11 +636,20 @@ def _backfill_predictor_returns(
             elif direction == "DOWN":
                 correct = 1 if log_alpha < 0 else 0
             else:
-                # Predictor emits binary UP/DOWN only since alpha-engine-predictor
-                # #143 collapsed the 3-class FLAT scaffolding at calibrator level.
-                # Legacy rows with predicted_direction="FLAT" (or any non-binary
-                # value) fall through unresolved — finite legacy set, not load-
-                # bearing on any consumer.
+                # Per ~/Development/CLAUDE.md fail-loud-and-fast rule: a silent
+                # skip in a backfill loop is forbidden by default. Carve-out
+                # here is "finite legacy set" — the predictor has emitted
+                # binary UP/DOWN only since alpha-engine-predictor #143
+                # collapsed the 3-class FLAT scaffolding at calibrator level.
+                # Carve-out conditions: (a) failure mode = non-binary direction
+                # value (legacy FLAT or unexpected new label); (c) recording
+                # surface = WARN log + grouped counter below + the rows stay
+                # NULL-resolved so a future SELECT on `actual_log_alpha IS NULL`
+                # still surfaces them. If the counter starts growing, the
+                # predictor has regressed past the binary contract and needs
+                # a new branch added here.
+                key = str(direction) if direction is not None else "NULL"
+                non_binary_skipped[key] = non_binary_skipped.get(key, 0) + 1
                 continue
 
             if not dry_run:
@@ -661,7 +671,20 @@ def _backfill_predictor_returns(
                 "(log-domain canonical) via universe_returns JOIN",
                 resolved, h,
             )
-        return {"status": "ok", "rows_written": resolved}
+        if non_binary_skipped:
+            logger.warning(
+                "[signal_returns] skipped %d predictor_outcomes rows with "
+                "non-binary predicted_direction (legacy FLAT or unexpected "
+                "label, by value: %s). Expected post-#143: binary UP/DOWN "
+                "only. If this count grows over time, audit the predictor's "
+                "calibrator output contract.",
+                sum(non_binary_skipped.values()), non_binary_skipped,
+            )
+        return {
+            "status": "ok",
+            "rows_written": resolved,
+            "non_binary_skipped": non_binary_skipped,
+        }
 
     except Exception as e:
         logger.error("backfill_predictor_returns failed: %s", e)

--- a/tests/test_signal_returns_log_canonical.py
+++ b/tests/test_signal_returns_log_canonical.py
@@ -293,15 +293,21 @@ class TestForwardWindowUnclosedSkipped:
 # -- Binary UP/DOWN contract (post-#143 calibrator) ---------------------------
 
 
-def test_legacy_flat_direction_falls_through_unresolved():
+def test_legacy_flat_direction_falls_through_unresolved(caplog):
     """Predictor #143 collapsed FLAT at the calibrator level. Legacy rows
-    with predicted_direction='FLAT' should fall through the else-branch
-    (correct=NULL, actual_log_alpha=NULL), not be silently scored.
+    with predicted_direction='FLAT' fall through the else-branch (correct
+    + actual_log_alpha stay NULL), AND the skip MUST surface via a WARN
+    log + grouped counter per the ~/Development/CLAUDE.md fail-loud-and-
+    fast rule.
 
-    The branch was removed 2026-05-21 per ROADMAP L2009. This test pins
-    the binary-only contract so a future re-introduction of a FLAT scoring
-    branch surfaces in code review rather than silent calibrator drift.
+    If this test goes silent (no WARN, no counter), the backfill loop has
+    reverted to true silent-skip and the rule is violated. The PR that
+    removed the FLAT scoring branch (2026-05-21 per ROADMAP L2009) added
+    the WARN+counter in the same commit as a defense against a future
+    calibrator regression producing non-binary directions invisibly.
     """
+    import logging
+
     with tempfile.TemporaryDirectory() as tmp:
         db = str(Path(tmp) / "data.db")
         _seed_universe_returns(db, "JPM", "2026-03-02", log_stock=0.005, log_spy=0.005)
@@ -309,10 +315,18 @@ def test_legacy_flat_direction_falls_through_unresolved():
         with sqlite3.connect(db) as conn:
             _ensure_predictor_outcomes_schema(conn)
 
-        result = _backfill_predictor_returns(db, dry_run=False, forward_days=21)
+        with caplog.at_level(logging.WARNING, logger="collectors.signal_returns"):
+            result = _backfill_predictor_returns(db, dry_run=False, forward_days=21)
         assert result["status"] == "ok"
         # 0 rows scored — FLAT falls through
         assert result["rows_written"] == 0
+        # Counter pins the per-value skip count
+        assert result["non_binary_skipped"] == {"FLAT": 1}
+        # WARN log mentions the surface so ops triage is possible
+        warn_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("non-binary predicted_direction" in r.getMessage() for r in warn_records), (
+            "fail-loud rule: non-binary direction skip must emit a WARN log"
+        )
 
         with sqlite3.connect(db) as conn:
             row = conn.execute(
@@ -320,7 +334,9 @@ def test_legacy_flat_direction_falls_through_unresolved():
                 "WHERE symbol='JPM' AND prediction_date='2026-03-02'"
             ).fetchone()
         # Unresolved — by design (legacy FLAT rows are a finite set, not
-        # load-bearing on any consumer per ROADMAP L2009).
+        # load-bearing on any consumer per ROADMAP L2009). Future SELECT
+        # on `actual_log_alpha IS NULL` still surfaces them; counter +
+        # WARN above replace the silent-skip path.
         assert row[0] is None
         assert row[1] is None
 
@@ -351,3 +367,5 @@ def test_binary_directions_still_score_correctly():
             }
         assert rows["AAPL"][2] == 1  # UP + positive alpha = correct
         assert rows["XOM"][2] == 1   # DOWN + negative alpha = correct
+        # Counter empty on clean binary runs — non-empty is a regression signal
+        assert result["non_binary_skipped"] == {}


### PR DESCRIPTION
## Summary

Follow-up to merged #280 (L2009) — tightens the else-branch that #280 added per the new \`~/Development/CLAUDE.md\` **\"Fail loud and fast on errors\"** standing rule (added 2026-05-21 as item 4 of \"Things to do\").

## Why this PR

#280 removed the dead 3-class FLAT branch and let legacy \`predicted_direction='FLAT'\` rows fall through \`else: continue\` unresolved. The PR rationale named the population as \"finite legacy set, not load-bearing on any consumer\" — fine on its own.

But the new fail-loud rule explicitly flags **\"silent skip in a backfill loop without a counter + WARN\"** as a NOT-acceptable rationale. A future calibrator regression that begins producing non-binary directions invisibly would be undetectable today.

## What changes

- \`collectors/signal_returns.py\` — else-branch now (a) groups counts by the unexpected direction value into a \`non_binary_skipped\` dict and (b) emits a single end-of-loop WARN summarising the count + per-value breakdown. Counter exposed via the result dict so downstream callers can alarm on growth. Inline comment names the carve-out conditions per the new rule: (a) failure mode, (c) recording surface.
- \`tests/test_signal_returns_log_canonical.py\` — \`test_legacy_flat_direction_falls_through_unresolved\` updated to pin BOTH the unresolved-row contract AND the WARN+counter contract. If a future change reverts to true silent-skip, the test goes red. \`test_binary_directions_still_score_correctly\` updated to pin the empty-counter side so consumers can confidently treat a non-empty counter as a regression signal.

## Test plan

- [x] \`pytest tests/test_signal_returns_log_canonical.py\` — 12 passed
- [x] Full unit suite: 1394 passed, 1 skipped (no change in count; existing tests tightened rather than added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)