### PR TITLE
feat(eod-success-friday-shell-trigger): event-driven weekly shell-run

### DIFF
--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/README.md
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/README.md
@@ -1,0 +1,125 @@
+# eod-success-friday-shell-trigger
+
+Subscribes to EventBridge `Step Functions Execution Status Change` events
+for `alpha-engine-eod-pipeline` SUCCEEDED transitions and, when the
+underlying trading_day is a Friday, starts the Saturday Step Function in
+shell-run mode (`shell_run: true`).
+
+**Replaces** the prior fixed-time cron rule `alpha-engine-friday-shell-run`
+(`cron(45 20 ? * FRI *)` = 13:45 PT Friday). Disable the cron AFTER this
+Lambda's first successful Friday event-driven invocation:
+
+```bash
+aws events disable-rule --name alpha-engine-friday-shell-run --region us-east-1
+```
+
+## Why event-driven over cron
+
+The cron fires unconditionally at a fixed time. It has three known failure
+modes the event-driven design eliminates:
+
+1. **Races `StopTradingInstance`.** The cron fires at 13:45 PT Friday, but
+   the EOD SF often runs past that window. The cron would try to boot the
+   trading EC2 while EOD's `StopTradingInstance` was still in flight.
+2. **Fires even when Friday EOD fails.** A broken upstream EOD does not
+   mean we should still preflight the Saturday SF; the shell run depends
+   on EOD-produced data substrate being healthy. The cron has no signal
+   to check this.
+3. **No way to handle late re-runs.** If Friday's EOD is fixed and
+   re-triggered later that day, the cron is already gone. The
+   event-driven path naturally fires whenever EOD reaches SUCCEEDED.
+
+## trading_day binding (not wall-clock)
+
+The handler derives `trading_day` via the canonical
+`alpha_engine_lib.trading_calendar.last_closed_trading_day` helper,
+passing `event.detail.stopDate` (epoch ms, UTC) as a tz-aware UTC
+datetime. The lib converts to NYSE local time and walks back to the most
+recent closed session.
+
+This handles the UTC ↔ ET ↔ PT rollover failure mode that a naive
+`datetime.utcnow().weekday()` check would have:
+
+| Scenario | stopDate (UTC) | wall-clock day (UTC) | trading_day (lib) | Fires? |
+| --- | --- | --- | --- | --- |
+| Normal Fri 13:25 PT EOD success | Fri 20:25 UTC | Fri | Fri | ✅ |
+| Fri 18:00 PT fix-and-rerun | Sat 01:00 UTC | Sat ❌ | Fri ✅ | ✅ |
+| Sat 10:00 PT fix-and-rerun for Fri's data | Sat 17:00 UTC | Sat ❌ | Fri ✅ | ✅ |
+| Normal Wed 13:25 PT EOD success | Wed 20:25 UTC | Wed | Wed | ❌ |
+
+## Fail-loud semantics
+
+Per the `feedback_wire_orphaned_producer_must_fail_loud` discipline,
+every failure surface in this Lambda raises:
+
+- Missing `detail.stopDate` on a SUCCEEDED event → `RuntimeError`
+  (upstream EventBridge contract violation).
+- `last_closed_trading_day` lookup failure → propagates (lib bug).
+- `states:StartExecution` boto3 failure → propagates (EventBridge will
+  retry; CW Lambda-error alarms page if persistent).
+
+Non-Friday trading_day is the intended skip path and returns
+`{"fired": False, "reason": "not_friday", ...}` with a structured log —
+this is NOT a swallow.
+
+## Architecture
+
+```
+EOD SF reaches SUCCEEDED
+       │
+       ▼
+EventBridge default bus
+   (aws.states / Step Functions Execution Status Change,
+    filtered to alpha-engine-eod-pipeline + SUCCEEDED only)
+       │
+       ▼
+alpha-engine-eod-success-friday-shell-trigger
+       │
+       ├──► last_closed_trading_day(stopDate UTC) → trading_day
+       │
+       └──► if trading_day.weekday() == FRI:
+                states:StartExecution on alpha-engine-saturday-pipeline
+                with input { ec2_instance_id, sns_topic_arn, shell_run: true }
+```
+
+## Deploy
+
+```bash
+# First-time bootstrap — creates IAM role, Lambda, EventBridge rule, permission
+bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --bootstrap
+
+# Code-only update (default)
+bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+
+# Dry-run (validate + package, do not apply)
+bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --dry-run
+
+# Smoke-test — WARNING: triggers a REAL saturday-pipeline shell run
+bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --smoke
+```
+
+Auth: uses active AWS CLI creds. Personal IAM user has enough perms;
+deliberately not wired into CI to keep the OIDC role's blast radius narrow,
+matching the sf-telegram-notifier / spot-orphan-reaper /
+changelog-cloudwatch-mirror convention.
+
+## IAM (inline policy)
+
+- `logs:CreateLogGroup/Stream + PutLogEvents` on the Lambda's own log group
+- `states:StartExecution` on
+  `arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline`
+  (single-target scope — cannot start any other SF)
+
+## Cutover plan
+
+1. Merge this PR.
+2. `bash deploy.sh --bootstrap` to create the Lambda + EventBridge rule.
+   The new rule starts firing on the next EOD SUCCEEDED transition.
+3. Leave the old cron rule `alpha-engine-friday-shell-run` ENABLED through
+   one successful Friday event-driven invocation (belt + suspenders for
+   the first Friday).
+4. After the first Friday confirms the event-driven path fired and the
+   shell run completed:
+   `aws events disable-rule --name alpha-engine-friday-shell-run`.
+5. Drop the cron rule entirely in a follow-up commit once a second Friday
+   confirms the event-driven path is the canonical trigger.

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-eod-success-friday-shell-trigger
+# Lambda and wire its EventBridge EOD-SUCCEEDED trigger.
+#
+# This Lambda subscribes to `aws.states` / "Step Functions Execution Status
+# Change" events for `alpha-engine-eod-pipeline` SUCCEEDED transitions only.
+# On every EOD success it derives trading_day via the canonical
+# `alpha_engine_lib.trading_calendar.last_closed_trading_day` (handles UTC
+# rollover) and, if trading_day.weekday()==4 (Friday), invokes the Saturday
+# Step Function with `shell_run: true`.
+#
+# Replaces the prior fixed-time cron rule `alpha-engine-friday-shell-run`
+# (cron(45 20 ? * FRI *) = 13:45 PT Friday). Disable the cron AFTER this
+# Lambda's first successful Friday event-driven invocation:
+#   aws events disable-rule --name alpha-engine-friday-shell-run --region us-east-1
+#
+# Managed outside CloudFormation — same rationale as sf-telegram-notifier +
+# spot-orphan-reaper + changelog-cloudwatch-mirror (keeps the
+# github-actions-lambda-deploy OIDC role's blast radius narrow;
+# operator-deployed only).
+#
+# Usage:
+#   bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh             # update code only
+#   bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --bootstrap # first-time create + wire EventBridge
+#   bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --smoke     # invoke once with a synthetic Fri-SUCCEEDED event
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-eod-success-friday-shell-trigger"
+ROLE_NAME="alpha-engine-eod-success-friday-shell-trigger-role"
+POLICY_NAME="alpha-engine-eod-success-friday-shell-trigger-policy"
+RULE_NAME="alpha-engine-eod-success-friday-shell-trigger"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 30 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge rule: Step Functions Execution Status Change for EOD SF SUCCEEDED only
+  echo "  Creating EventBridge rule: ${RULE_NAME}"
+  EVENT_PATTERN=$(cat <<EOF
+{
+  "source": ["aws.states"],
+  "detail-type": ["Step Functions Execution Status Change"],
+  "detail": {
+    "stateMachineArn": [
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+    ],
+    "status": ["SUCCEEDED"]
+  }
+}
+EOF
+)
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --event-pattern "${EVENT_PATTERN}" \
+    --description "Trigger Saturday SF shell-run on Friday EOD SUCCEEDED (Lambda day-of-week-guards)" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (synthetic Friday-SUCCEEDED event) --------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (synthetic Friday-EOD SUCCEEDED event)..."
+  RESP=$(mktemp)
+  # 2026-05-22 (Friday) 20:25 UTC = 13:25 PT — normal Friday EOD success window
+  PAYLOAD=$(cat <<'EOF'
+{
+  "source": "aws.states",
+  "detail-type": "Step Functions Execution Status Change",
+  "detail": {
+    "status": "SUCCEEDED",
+    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline",
+    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:smoke-test",
+    "name": "smoke-test",
+    "startDate": 1779827700000,
+    "stopDate": 1779828300000
+  }
+}
+EOF
+)
+  echo "WARNING: --smoke will START a real saturday-pipeline shell run if the embedded date is a Friday."
+  echo "         Confirm before proceeding or omit --smoke and rely on unit tests + first live event."
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload "${PAYLOAD}" \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/iam-policy.json
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/iam-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-eod-success-friday-shell-trigger:*"
+    },
+    {
+      "Sid": "StartSaturdayShellRun",
+      "Effect": "Allow",
+      "Action": ["states:StartExecution"],
+      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
+    }
+  ]
+}

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
@@ -1,0 +1,158 @@
+"""alpha-engine-eod-success-friday-shell-trigger — kick the weekly shell-run.
+
+Subscribes to EventBridge ``Step Functions Execution Status Change`` events,
+filtered to ``alpha-engine-eod-pipeline`` + ``SUCCEEDED``. On every EOD-SF
+success the handler computes the trading_day this execution closed against
+and, if that trading_day is a Friday, starts the Saturday Step Function in
+shell-run mode (``shell_run: true``) so the spot instances boot for real
+while the workload paths short-circuit.
+
+Replaces the prior fixed-time EventBridge cron (``alpha-engine-friday-shell-run``,
+cron(45 20 ? * FRI *) = 13:45 PT Friday), which fired unconditionally and
+raced the EOD SF's ``StopTradingInstance`` state when EOD ran long. The
+event-driven design has three guarantees the cron lacked:
+
+  1. **No fire on Friday-EOD failure.** If Friday's EOD never reaches
+     SUCCEEDED, this Lambda never invokes, so the shell-run does not chase
+     a broken upstream.
+  2. **Late re-runs work for free.** If Friday's EOD is fixed and re-run
+     later that day (or Saturday morning processing Friday's data), the
+     handler still sees a SUCCEEDED transition and trading_day is still
+     Friday — the shell-run starts at the fix-time, not on a stale clock.
+  3. **trading_day-bound, not wall-clock.** trading_day is derived via
+     ``alpha_engine_lib.trading_calendar.last_closed_trading_day`` from
+     ``detail.stopDate`` (epoch ms UTC), so a Friday EOD re-run that
+     succeeds at 02:00 UTC Saturday (= Friday evening PT) correctly stamps
+     trading_day=Fri and fires. Pure ``datetime.now()`` would have read
+     Saturday and skipped.
+
+Fail-loud semantics (per the ``feedback_wire_orphaned_producer_must_fail_loud``
+discipline — this Lambda is a new producer of shell-run starts):
+
+  * Missing ``detail.stopDate`` → raises. SUCCEEDED events without a stop
+    timestamp are an upstream contract violation, not a silent skip.
+  * trading_calendar lookup failure → raises (lib bug surfaces fast).
+  * boto3 ``states:StartExecution`` failure → raises (do not silently
+    fail to launch the shell run; the EventBridge → Lambda retry policy
+    will retry, and CW alarms on Lambda errors will page).
+
+Non-Friday trading_day is the intended skip path and returns ``{"fired": False}``
+with a structured log line; this is NOT a swallow.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import boto3
+
+from alpha_engine_lib.trading_calendar import last_closed_trading_day
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
+
+SATURDAY_SF_ARN = (
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
+)
+EOD_SF_NAME = "alpha-engine-eod-pipeline"
+
+TRADING_EC2_INSTANCE_ID = os.environ.get(
+    "TRADING_EC2_INSTANCE_ID", "i-09b539c844515d549"
+)
+SNS_TOPIC_ARN = os.environ.get(
+    "SNS_TOPIC_ARN",
+    f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts",
+)
+
+FRIDAY_WEEKDAY = 4  # date.weekday(): Mon=0, Fri=4
+
+
+def _derive_trading_day_utc_ms(stop_date_ms: int):
+    """trading_day = NYSE last-closed session at the EventBridge stopDate moment.
+
+    Accepts epoch milliseconds (UTC) from ``event.detail.stopDate`` and hands
+    a tz-aware UTC datetime to the lib helper. The helper itself converts to
+    NYSE local time before walking back to the most recent closed session,
+    so callers do not have to reason about UTC ↔ ET rollover.
+    """
+    dt_utc = datetime.fromtimestamp(int(stop_date_ms) / 1000, tz=timezone.utc)
+    return last_closed_trading_day(dt_utc)
+
+
+def _build_shell_run_input() -> str:
+    return json.dumps(
+        {
+            "ec2_instance_id": [TRADING_EC2_INSTANCE_ID],
+            "sns_topic_arn": SNS_TOPIC_ARN,
+            "shell_run": True,
+        }
+    )
+
+
+def _start_saturday_shell_run(execution_name: str) -> str:
+    client = boto3.client("stepfunctions", region_name=REGION)
+    resp = client.start_execution(
+        stateMachineArn=SATURDAY_SF_ARN,
+        name=execution_name,
+        input=_build_shell_run_input(),
+    )
+    return resp["executionArn"]
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    detail = event.get("detail") or {}
+
+    sm_arn = detail.get("stateMachineArn", "")
+    sm_name = sm_arn.rsplit(":", 1)[-1]
+    status = detail.get("status", "")
+    if sm_name != EOD_SF_NAME or status != "SUCCEEDED":
+        # EventBridge rule is filtered, but defend against accidental
+        # invocations (manual test fires, rule drift). Not a fail-loud case
+        # — this is a "wrong audience" log, not a contract violation.
+        logger.info(
+            "ignored event: sm_name=%s status=%s (expected %s/SUCCEEDED)",
+            sm_name,
+            status,
+            EOD_SF_NAME,
+        )
+        return {"fired": False, "reason": "wrong_event"}
+
+    stop_date_ms = detail.get("stopDate")
+    if stop_date_ms is None:
+        raise RuntimeError(
+            "EOD SUCCEEDED event missing detail.stopDate — upstream contract violation"
+        )
+
+    trading_day = _derive_trading_day_utc_ms(stop_date_ms)
+    if trading_day.weekday() != FRIDAY_WEEKDAY:
+        logger.info(
+            "EOD SUCCEEDED trading_day=%s (weekday=%d) — not Friday, no shell run",
+            trading_day.isoformat(),
+            trading_day.weekday(),
+        )
+        return {
+            "fired": False,
+            "reason": "not_friday",
+            "trading_day": trading_day.isoformat(),
+        }
+
+    eod_name = detail.get("name", "unknown")
+    sat_name = f"friday-shell-{trading_day.isoformat()}-{eod_name}"[:80]
+    sat_arn = _start_saturday_shell_run(sat_name)
+    logger.info(
+        "Friday EOD SUCCEEDED (trading_day=%s) → started saturday shell run: %s",
+        trading_day.isoformat(),
+        sat_arn,
+    )
+    return {
+        "fired": True,
+        "trading_day": trading_day.isoformat(),
+        "saturday_execution_arn": sat_arn,
+        "saturday_execution_name": sat_name,
+    }

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,0 +1,4 @@
+# Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
+# the same alpha-engine-data lib substrate; keeping the pin coherent across
+# sibling Lambdas avoids divergence on lib-side date helpers.
+alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/test_handler.py
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/test_handler.py
@@ -1,0 +1,222 @@
+"""Unit tests for eod-success-friday-shell-trigger index.handler.
+
+Stubs ``alpha_engine_lib.trading_calendar.last_closed_trading_day`` and
+``boto3.client`` so tests do not hit AWS or the lib. Each test asserts the
+handler's invoke-or-skip decision plus the input shape passed to
+``states:StartExecution``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import date, datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub `alpha_engine_lib.trading_calendar` before importing the handler so
+# test environments without the lib installed (CI runners pre-pip-install)
+# still pass. The handler depends only on this one import path from the lib.
+_lib_pkg = types.ModuleType("alpha_engine_lib")
+_tc_mod = types.ModuleType("alpha_engine_lib.trading_calendar")
+_tc_mod.last_closed_trading_day = MagicMock()
+_lib_pkg.trading_calendar = _tc_mod
+sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
+sys.modules.setdefault("alpha_engine_lib.trading_calendar", _tc_mod)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+
+EOD_ARN = (
+    "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+)
+SATURDAY_ARN = (
+    "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
+)
+
+
+def _epoch_ms(year: int, month: int, day: int, hour: int = 20, minute: int = 25) -> int:
+    """UTC epoch ms for a wall-clock UTC datetime."""
+    return int(
+        datetime(year, month, day, hour, minute, tzinfo=timezone.utc).timestamp() * 1000
+    )
+
+
+def _event(
+    status: str = "SUCCEEDED",
+    sm_arn: str = EOD_ARN,
+    stop_date_ms: int | None = None,
+    **detail_overrides,
+) -> dict:
+    detail: dict = {
+        "status": status,
+        "stateMachineArn": sm_arn,
+        "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:exec-001",
+        "name": "exec-001",
+        "startDate": _epoch_ms(2026, 5, 22, 20, 15),
+        "stopDate": stop_date_ms
+        if stop_date_ms is not None
+        else _epoch_ms(2026, 5, 22, 20, 25),
+    }
+    detail.update(detail_overrides)
+    return {"detail": detail}
+
+
+@pytest.fixture(autouse=True)
+def reset_mocks():
+    _tc_mod.last_closed_trading_day.reset_mock()
+    _tc_mod.last_closed_trading_day.side_effect = None
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)  # Friday
+    yield
+
+
+def _patch_sfn(start_execution_return: dict | None = None, side_effect=None):
+    fake_client = MagicMock()
+    if side_effect is not None:
+        fake_client.start_execution.side_effect = side_effect
+    else:
+        fake_client.start_execution.return_value = (
+            start_execution_return
+            or {
+                "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:friday-shell-test",
+                "startDate": datetime(2026, 5, 22, 20, 25, tzinfo=timezone.utc),
+            }
+        )
+    return patch("index.boto3.client", return_value=fake_client), fake_client
+
+
+def test_friday_eod_success_fires_saturday_sf_with_shell_run_input():
+    """Friday EOD SUCCEEDED → StartExecution on saturday SF with shell_run:true."""
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)  # Friday
+    sfn_patch, fake_client = _patch_sfn()
+    with sfn_patch:
+        result = index.handler(_event(), None)
+
+    fake_client.start_execution.assert_called_once()
+    call_kwargs = fake_client.start_execution.call_args.kwargs
+    assert call_kwargs["stateMachineArn"] == SATURDAY_ARN
+    assert call_kwargs["name"].startswith("friday-shell-2026-05-22-")
+
+    import json as _json
+
+    input_dict = _json.loads(call_kwargs["input"])
+    assert input_dict["shell_run"] is True
+    assert input_dict["ec2_instance_id"] == [index.TRADING_EC2_INSTANCE_ID]
+    assert input_dict["sns_topic_arn"] == index.SNS_TOPIC_ARN
+
+    assert result["fired"] is True
+    assert result["trading_day"] == "2026-05-22"
+    assert result["saturday_execution_arn"].endswith(":friday-shell-test")
+
+
+@pytest.mark.parametrize(
+    "trading_day,weekday_label",
+    [
+        (date(2026, 5, 18), "Mon"),
+        (date(2026, 5, 19), "Tue"),
+        (date(2026, 5, 20), "Wed"),
+        (date(2026, 5, 21), "Thu"),
+    ],
+)
+def test_non_friday_eod_success_does_not_fire(trading_day, weekday_label):
+    _tc_mod.last_closed_trading_day.return_value = trading_day
+    sfn_patch, fake_client = _patch_sfn()
+    with sfn_patch:
+        result = index.handler(_event(), None)
+
+    fake_client.start_execution.assert_not_called()
+    assert result["fired"] is False
+    assert result["reason"] == "not_friday"
+    assert result["trading_day"] == trading_day.isoformat()
+
+
+def test_saturday_morning_eod_rerun_for_friday_trading_day_fires():
+    """A late re-run that succeeds Sat AM still binds to Fri trading_day."""
+    # stopDate at Sat 10:00 PT = Sat 17:00 UTC. The lib's
+    # last_closed_trading_day correctly returns Fri (the last closed
+    # session) — and the handler trusts the lib's answer.
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)  # Friday
+    sfn_patch, fake_client = _patch_sfn()
+    with sfn_patch:
+        result = index.handler(
+            _event(stop_date_ms=_epoch_ms(2026, 5, 23, 17, 0)), None
+        )
+
+    fake_client.start_execution.assert_called_once()
+    assert result["fired"] is True
+    assert result["trading_day"] == "2026-05-22"
+
+
+def test_missing_stop_date_raises_fail_loud():
+    """SUCCEEDED without detail.stopDate is an upstream contract violation."""
+    sfn_patch, fake_client = _patch_sfn()
+    with sfn_patch, pytest.raises(RuntimeError, match="missing detail.stopDate"):
+        index.handler(_event(stop_date_ms=None, stopDate=None), None)
+    fake_client.start_execution.assert_not_called()
+
+
+def test_wrong_state_machine_arn_logs_and_returns_without_firing():
+    """Defensive: rule filter mismatch should NOT raise but also not fire."""
+    sfn_patch, fake_client = _patch_sfn()
+    weekday_arn = (
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+    )
+    with sfn_patch:
+        result = index.handler(_event(sm_arn=weekday_arn), None)
+    fake_client.start_execution.assert_not_called()
+    assert result["fired"] is False
+    assert result["reason"] == "wrong_event"
+
+
+def test_non_succeeded_status_does_not_fire():
+    """FAILED / TIMED_OUT / RUNNING never trigger the shell run."""
+    sfn_patch, fake_client = _patch_sfn()
+    for bad_status in ("RUNNING", "FAILED", "TIMED_OUT", "ABORTED"):
+        with sfn_patch:
+            result = index.handler(_event(status=bad_status), None)
+        assert result["fired"] is False
+        assert result["reason"] == "wrong_event"
+    fake_client.start_execution.assert_not_called()
+
+
+def test_trading_calendar_lookup_failure_raises():
+    """Lib-side error must surface, not be swallowed."""
+    _tc_mod.last_closed_trading_day.side_effect = RuntimeError("calendar unavailable")
+    sfn_patch, fake_client = _patch_sfn()
+    with sfn_patch, pytest.raises(RuntimeError, match="calendar unavailable"):
+        index.handler(_event(), None)
+    fake_client.start_execution.assert_not_called()
+
+
+def test_start_execution_failure_raises():
+    """boto3 StartExecution failure is a fail-loud — never silent fall-through."""
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)  # Friday
+    sfn_patch, fake_client = _patch_sfn(
+        side_effect=RuntimeError("StateMachineDoesNotExist")
+    )
+    with sfn_patch, pytest.raises(RuntimeError, match="StateMachineDoesNotExist"):
+        index.handler(_event(), None)
+
+
+def test_execution_name_truncates_to_80_chars():
+    """SF execution name max is 80 chars; build truncates safely."""
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)
+    sfn_patch, fake_client = _patch_sfn()
+    long_name = "x" * 200
+    with sfn_patch:
+        index.handler(_event(name=long_name), None)
+    assert len(fake_client.start_execution.call_args.kwargs["name"]) <= 80
+
+
+def test_derive_trading_day_passes_tz_aware_utc_to_lib():
+    """The lib receives a tz-aware UTC datetime, not naive."""
+    stop_ms = _epoch_ms(2026, 5, 22, 20, 25)
+    index._derive_trading_day_utc_ms(stop_ms)
+    _tc_mod.last_closed_trading_day.assert_called_once()
+    arg = _tc_mod.last_closed_trading_day.call_args.args[0]
+    assert isinstance(arg, datetime)
+    assert arg.tzinfo is not None
+    assert arg.tzinfo.utcoffset(arg).total_seconds() == 0  # UTC


### PR DESCRIPTION
## Summary

Replaces the fixed-time cron EventBridge rule `alpha-engine-friday-shell-run` (`cron(45 20 ? * FRI *)` = 13:45 PT Friday) with a new Lambda subscribed to EventBridge `Step Functions Execution Status Change` events for `alpha-engine-eod-pipeline` SUCCEEDED transitions. The Lambda derives `trading_day` via `alpha_engine_lib.trading_calendar.last_closed_trading_day` and, when `trading_day.weekday()==4` (Friday), starts the Saturday SF in shell-run mode (`shell_run: true`).

## Why event-driven over cron

The cron has three failure modes the event-driven design eliminates:

1. **Races `StopTradingInstance`** — cron fires at 13:45 PT Friday, but EOD SF can still be mid-shutdown. Event trigger only fires after EOD reaches SUCCEEDED.
2. **Fires when Friday EOD fails** — a broken upstream EOD means the data substrate for the shell-run is missing. Cron has no signal to check; the event trigger naturally skips.
3. **No way to handle late re-runs** — if Friday EOD is fixed and re-run later that day (or Saturday morning processing Friday's data), the cron is already gone. The event trigger fires whenever EOD reaches SUCCEEDED.

## trading_day binding (not wall-clock)

Per the prior session's exchange — wall-clock `datetime.utcnow().weekday()` is dangerous because of UTC ↔ ET ↔ PT rollover. The lib's `last_closed_trading_day(stopDate UTC)` returns the correct trading_day regardless of when the EOD SUCCEEDED event fires:

| Scenario | stopDate (UTC) | wall-clock day | trading_day (lib) | Fires? |
| --- | --- | --- | --- | --- |
| Normal Fri 13:25 PT EOD | Fri 20:25 UTC | Fri | Fri | ✅ |
| Fri 18:00 PT fix-rerun | Sat 01:00 UTC | Sat ❌ | Fri ✅ | ✅ |
| Sat 10 AM PT fix-rerun for Fri data | Sat 17:00 UTC | Sat ❌ | Fri ✅ | ✅ |
| Normal Wed 13:25 PT EOD | Wed 20:25 UTC | Wed | Wed | ❌ |

## Files

- `infrastructure/lambdas/eod-success-friday-shell-trigger/index.py` — handler (135 lines)
- `infrastructure/lambdas/eod-success-friday-shell-trigger/test_handler.py` — 13 unit tests, all green
- `infrastructure/lambdas/eod-success-friday-shell-trigger/iam-policy.json` — Logs + `states:StartExecution` on saturday-pipeline only
- `infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh` — mirrors sf-telegram-notifier deploy pattern
- `infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt` — `alpha-engine-lib@v0.20.0` (matches sf-telegram-notifier pin)
- `infrastructure/lambdas/eod-success-friday-shell-trigger/README.md` — architecture + cutover plan

## Fail-loud (per `feedback_wire_orphaned_producer_must_fail_loud`)

- Missing `detail.stopDate` on SUCCEEDED → `RuntimeError`
- `last_closed_trading_day` failure → propagates
- `states:StartExecution` failure → propagates (EventBridge retries; CW Lambda-error alarms page)
- Non-Friday is the intended skip path with a structured log, NOT a swallow

## SOTA notes

- Mirrors the existing `sf-telegram-notifier` Lambda pattern (EventBridge SF status-change → Lambda) per the SOTA "mirror patterns from sibling repos" sub-rule.
- Reuses canonical `alpha_engine_lib.trading_calendar` (lib v0.20.0) rather than recomputing trading-day logic per the SOTA "use lib primitives" sub-rule.
- Operator-deployed via `deploy.sh`, outside CFN, matching `sf-telegram-notifier` / `spot-orphan-reaper` / `changelog-cloudwatch-mirror` convention for narrow OIDC blast radius.

## Cutover plan

1. Merge this PR
2. `bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --bootstrap` to create the Lambda + EventBridge rule
3. Leave the old cron rule `alpha-engine-friday-shell-run` ENABLED through one successful Friday event-driven invocation (belt + suspenders for the first Friday)
4. After the first Friday confirms the event-driven path fired: `aws events disable-rule --name alpha-engine-friday-shell-run --region us-east-1`
5. Drop the cron rule entirely in a follow-up commit once a second Friday confirms

## Test plan

- [x] 13 unit tests green (Friday fires, Mon/Tue/Wed/Thu skip, late re-run binds correctly, missing fields raise, boto3 failures raise, 80-char name truncation)
- [x] Full alpha-engine-data suite: 1414 passed, 1 skipped (no regressions)
- [ ] First Friday event-driven fire validated against the existing cron belt-and-suspenders (2026-05-22 13:25 PT-ish EOD success)
- [ ] Disable cron rule after first Friday confirms

## Related

- Origin: prior session's exchange refining the design from cron → EOD-SUCCEEDED event with trading_day binding
- Replaces the cron enabled earlier this session per ROADMAP L3072–L3073
- Composes with [[feedback_wire_orphaned_producer_must_fail_loud]] + [[feedback_sota_institutional_default_no_shortcuts]] + [[reference_sf_status_change_telegram_notifier_pattern]] (the data #275 pattern this mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)