### PR TITLE
chore(orchestration): align StopTradingSchedule CFN with live 10 PM PT backstop

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -236,16 +236,26 @@ Resources:
       SourceArn: !GetAtt ResearchAlerts.Arn
 
   # --------------------------------------------------------------------------
-  # EventBridge Scheduler — Stop Trading Instance
+  # EventBridge Scheduler — Stop Trading Instance (10 PM PT backstop)
   # --------------------------------------------------------------------------
   # Note: EventBridge Scheduler uses a different API than EventBridge Rules.
   # CloudFormation support for Scheduler is via AWS::Scheduler::Schedule.
+  #
+  # Role: late-night cost-guard backstop. The EOD SF's
+  # ``StopTradingInstance`` + ``ForceStopInstance`` states are the
+  # authoritative stoppers right after market close (success or failure
+  # path). This scheduler only fires if both of those paths missed —
+  # e.g. EOD SF never started, daemon never triggered the SF, or AWS
+  # SDK call failures left the instance running past expected stop.
+  # 10:00 PM PT places it ~8 h after market close, well outside any
+  # legitimate same-day workflow.
   StopTradingSchedule:
     Type: AWS::Scheduler::Schedule
     Properties:
       Name: alpha-engine-stop-trading
-      Description: Stop trading EC2 after market close (1:30 PM PT / 20:30 UTC)
-      ScheduleExpression: 'cron(30 13 ? * MON-FRI *)'
+      Description: Cost-guard backstop — stop trading EC2 at 10 PM PT if EOD SF didn't
+      ScheduleExpression: 'cron(0 22 ? * MON-FRI *)'
+      ScheduleExpressionTimezone: 'America/Los_Angeles'
       FlexibleTimeWindow:
         Mode: 'OFF'
       State: ENABLED


### PR DESCRIPTION
## Summary

CFN drift: ``StopTradingSchedule`` source said 1:30 PM PT ENABLED, live was 10 PM PT DISABLED. Re-enabled live as part of 2026-05-21 EOD post-mortem; this PR aligns the CFN source so the next stack apply doesn't revert.

- Schedule: ``cron(30 13 ? * MON-FRI *)`` → ``cron(0 22 ? * MON-FRI *)``
- Adds ``ScheduleExpressionTimezone: 'America/Los_Angeles'`` (was missing — only worked because cron was UTC-equivalent of 1:30 PM PT)
- Description updated to reflect new role as cost-guard backstop
- Code comment explains EOD SF (``StopTradingInstance`` + ``ForceStopInstance``) is the authoritative same-day stopper; this scheduler is the late-night safety net for the no-EOD-SF-ran case

Sibling PR in ``alpha-engine`` aligns the parallel ``infrastructure/setup-eventbridge.sh`` provisioner.

## Why

2026-05-21 EOD failed at PostMarketData (schema mismatch — see alpha-engine-data PR #283). The EOD SF's ``ForceStopInstance`` state stopped the trading instance at 13:25 PT as designed (cost-guard on failure). That kept costs sane. But Brian's mental model assumed a 10 PM PT scheduler was active as backstop — when I checked, both stop schedules were disabled, leaving no cost-guard if the EOD SF itself never starts (daemon doesn't trigger, SF API call fails, etc.). Re-enabled the 10 PM scheduler live, source-fixing here so it survives the next apply.

Per the live-disable-without-source-fix antipattern: live ENABLED, CFN ENABLED, both match.

## Test plan

- [x] CFN syntax: ``ScheduleExpressionTimezone`` is a valid property on ``AWS::Scheduler::Schedule``
- [ ] Operator: next ``cfn deploy`` (or drift-detection run) confirms no drift between source and live
- [ ] 2026-05-22 22:00 PT: scheduler fires no-op (instance already stopped by EOD SF) — observable in CloudTrail
- [ ] Smoke validation that the EOD SF behavior is unchanged — ``ForceStopInstance`` still fires on failure (it should, since this PR only touches the AWS Scheduler resource)

🤖 Generated with [Claude Code](https://claude.com/claude-code)