### PR TITLE
feat(deploy): Telegram + SNS alert on canary rollback (L221 — 3/5)

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -196,6 +196,16 @@ if [ "$CANARY_STATUS" != "OK" ] && [ "$CANARY_STATUS" != "SKIPPED" ]; then
       --region "$REGION" 2>/dev/null || true
     echo "  Rolled back to version $PREV_VERSION"
   fi
+  # Independent-channel surveillance per ROADMAP L221 — this exact
+  # rollback chain fired silently 10 consecutive times across 2 days
+  # (alpha-engine-data #274 retrospective) before Brian noticed the
+  # GitHub Actions red-icon. Best-effort; trailing || true never
+  # overrides the deploy's exit 1.
+  python3 -m alpha_engine_lib.alerts publish \
+    --severity error \
+    --source "alpha-engine-data/infrastructure/deploy.sh" \
+    --message "Canary rolled back: ${FUNCTION_NAME} canary returned status='${CANARY_STATUS}', live alias reverted v${VERSION}→v${PREV_VERSION}. See CloudWatch /aws/lambda/${FUNCTION_NAME} for payload." \
+    || true
   exit 1
 fi
 echo "  Canary passed (status=$CANARY_STATUS)"


### PR DESCRIPTION
## Summary

3/5 of the L221 fleet pass. **The repo that originated the recurrence class.** \`infrastructure/deploy.sh\` is the script whose silent canary rollback fired 10 consecutive times across 2 days in the #274 retrospective. This PR adds the surveillance line that would have caught it at hit #1.

## Implementation

Single insert in the canary-failure rollback block (L185-200). \`python3 -m alpha_engine_lib.alerts publish --severity error --message "Canary rolled back: ..."\` before \`exit 1\`. Trailing \`|| true\` ensures the alert publish failure never overrides the deploy's intended exit code.

The message includes the function name, canary status, and the version transition (v→v-1) so the operator can match the alert to the rollback log.

## Sub-Lambda audit (negative)

The 4 sub-Lambda deploys don't have canary/rollback paths and stay unchanged:
- \`infrastructure/lambdas/spot-orphan-reaper/deploy.sh\`
- \`infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh\`
- \`infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh\`
- \`infrastructure/lambdas/sf-telegram-notifier/deploy.sh\`

The 5th sub-Lambda \`changelog-incident-mirror/deploy.sh\` already uses \`alpha_engine_lib.alerts\` (L143/L146 prior fleet pass, alpha-engine-data #277).

## Fleet pass scope

| repo | sites | status |
|---|---|---|
| alpha-engine-research | 1 | [#216](https://github.com/cipher813/alpha-engine-research/pull/216) |
| alpha-engine-predictor | 3 | [#184](https://github.com/cipher813/alpha-engine-predictor/pull/184) |
| **alpha-engine-data** | 1 (main) | **this PR** |
| alpha-engine-backtester | 3 (health / counterfactual / concordance) | TBD |
| alpha-engine-dashboard | n/a | n/a |

## Test plan

- [x] \`bash -n infrastructure/deploy.sh\` clean
- [x] Pre-commit hooks pass
- [ ] First production exercise on the next canary rollback (which by definition is the failure mode this surveillance is designed for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)