### PR TITLE
feat(store): lift canonical column-order enforcement into to_arctic_canonical chokepoint (closes L1483)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -49,7 +49,14 @@ from features.compute import (
     _load_cached_alternative,
     make_source_series,
 )
-from store.arctic_store import get_universe_lib, get_macro_lib, to_arctic_safe
+from store.arctic_store import (
+    OHLCV_COLS as _CANONICAL_OHLCV_COLS,
+    PROVENANCE_COL as _CANONICAL_PROVENANCE_COL,
+    get_universe_lib,
+    get_macro_lib,
+    to_arctic_canonical,
+    to_arctic_safe,
+)
 from builders._price_cache_writeboth import (
     PRICE_CACHE_LEGACY_PREFIX,
     list_price_cache_keys,
@@ -57,25 +64,17 @@ from builders._price_cache_writeboth import (
 
 log = logging.getLogger(__name__)
 
-# OHLCV columns to keep alongside features in ArcticDB.
-# VWAP added 2026-04-17 (Phase 7 VWAP centralization). Backfill source
-# (``predictor/price_cache/*.parquet``) is OHLCV only and predates polygon
-# adoption, so historical rows have no source for true volume-weighted VWAP.
-# Per the 2026-04-17 decision, we do NOT synthesize a ``(H+L+C)/3`` proxy —
-# that misrepresents arithmetic typical price as VWAP. Historical rows get
-# NaN VWAP; the column becomes populated from the first daily_append run
-# against a polygon-sourced daily_closes parquet. See ROADMAP "VWAP
-# centralization" for the full rationale.
-OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
-
-# Per-row data-provenance column (mirrors builders/daily_append.py).
-# Backfill sources rows from ``predictor/price_cache/*.parquet`` (10y
-# yfinance-sourced) plus the daily_closes delta (mixed polygon / yfinance
-# / fred per row). Pre-delta rows default to ``"yfinance"``; delta rows
-# get whatever source the daily_closes parquet recorded. Closes the
-# audit trail of "where did this row's value come from" at row
-# granularity even after a full backfill rewrite.
-PROVENANCE_COL = "source"
+# Canonical universe-library schema — single source of truth in
+# ``store.arctic_store``. Re-exported here for the local float32-cast
+# loop + partial-features observability log, both of which iterate
+# FEATURES / OHLCV_COLS directly. VWAP centralization rationale
+# (2026-04-17 Phase 7): historical price_cache parquets predate polygon,
+# carry no source for true volume-weighted VWAP, and we do NOT
+# synthesize a ``(H+L+C)/3`` proxy — historical rows get NaN VWAP and
+# the column populates from the first daily_append run against a
+# polygon-sourced daily_closes parquet.
+OHLCV_COLS = _CANONICAL_OHLCV_COLS
+PROVENANCE_COL = _CANONICAL_PROVENANCE_COL
 
 
 def _load_current_constituents(s3, bucket: str) -> set[str]:
@@ -584,12 +583,11 @@ def backfill(
                     ["yfinance"] * len(featured_df), index=featured_df.index,
                 )
 
-            keep_cols = (
-                [c for c in OHLCV_COLS if c in featured_df.columns]
-                + [PROVENANCE_COL]
-                + [f for f in FEATURES if f in featured_df.columns]
-            )
-            symbol_df = featured_df[keep_cols].copy()
+            # Column-order projection + drop-non-canonical happens at the
+            # write boundary via ``to_arctic_canonical``. The local copy
+            # is still needed so the float32-cast below doesn't mutate
+            # the in-memory price cache shared across the run.
+            symbol_df = featured_df.copy()
 
             for f in FEATURES:
                 if f in symbol_df.columns:
@@ -612,9 +610,13 @@ def backfill(
                 )
 
             if not dry_run:
-                # to_arctic_safe strips the Categorical ``source`` dtype
-                # (PR #211) before write — ArcticDB rejects categoricals.
-                universe_lib.write(ticker, to_arctic_safe(symbol_df))
+                # ``to_arctic_canonical`` re-projects to
+                # ``OHLCV + source + FEATURES`` order, drops non-canonical
+                # cols, and strips Categorical dtypes — single chokepoint
+                # for the universe library's column-order + dtype
+                # contract (closes the 2026-05-14 + 2026-05-21 EOD
+                # column-order recurrence class).
+                universe_lib.write(ticker, to_arctic_canonical(symbol_df))
 
             n_ok += 1
 

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -47,7 +47,14 @@ from features.compute import (
 from arcticdb.version_store.library import ReadRequest, UpdatePayload, WritePayload
 from arcticdb_ext.version_store import DataError
 
-from store.arctic_store import get_universe_lib, get_macro_lib, to_arctic_safe
+from store.arctic_store import (
+    OHLCV_COLS as _CANONICAL_OHLCV_COLS,
+    PROVENANCE_COL as _CANONICAL_PROVENANCE_COL,
+    get_universe_lib,
+    get_macro_lib,
+    to_arctic_canonical,
+    to_arctic_safe,
+)
 from store.parquet_loader import load_parquet_from_s3
 from builders._price_cache_writeboth import (
     PRICE_CACHE_LEGACY_PREFIX,
@@ -61,17 +68,17 @@ from validators.price_validator import (
 
 log = logging.getLogger(__name__)
 
-OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
-
-# Per-row data-provenance column. Set by ``daily_closes.collect`` from the
-# source-mode (`polygon` / `yfinance` / `fred`) per row in the staging
-# parquet, surfaced into ``_load_daily_closes`` records, written into
-# ArcticDB universe rows alongside OHLCV. Closes the audit trail of
-# "where did this row's value come from" at row granularity. Carried as
-# a separate column from OHLCV_COLS because it's a string metadata field,
-# not a numeric one — keeping OHLCV_COLS pure simplifies the rolling-stat
-# and feature-compute call sites that iterate it expecting numerics.
-PROVENANCE_COL = "source"
+# OHLCV_COLS + PROVENANCE_COL are the canonical universe-library schema —
+# re-exported from store.arctic_store so the chokepoint
+# (``to_arctic_canonical``) and these per-site usages share a single
+# source of truth. Pre-2026-05-22 both were defined here AND in
+# ``store/arctic_store.py``; consolidating them removes the per-site
+# discipline that the 2026-05-14 + 2026-05-21 column-order incidents
+# both relied on. Existing operator scripts that
+# ``from builders.daily_append import OHLCV_COLS, PROVENANCE_COL``
+# continue to work via these re-exports.
+OHLCV_COLS = _CANONICAL_OHLCV_COLS
+PROVENANCE_COL = _CANONICAL_PROVENANCE_COL
 # Legacy single-prefix constant retained for backward-compat with any caller
 # that imports it (audited 2026-05-19: only the local ``_load_parquet_warmup``,
 # which now goes through ``price_cache_read_prefixes``). Wave-3 PR4 cutover
@@ -1164,25 +1171,8 @@ def daily_append(
                 # passthrough behaviour.
                 today_row[PROVENANCE_COL] = new_row.iloc[0][PROVENANCE_COL]
 
-                # Match the persisted ArcticDB column order so update_batch
-                # passes its strict descriptor-equality check. Existing
-                # universe symbols were laid down with `source` between
-                # VWAP and the first feature (idx 7 in the storage layout)
-                # via `_write_row_backfill_safe` + earlier per-ticker
-                # write paths. The bare `today_row[PROVENANCE_COL] = ...`
-                # assignment above appends `source` at the END of the
-                # frame, which is fine for write_batch (full rewrite) but
-                # ArcticDB's update_batch raises StreamDescriptorMismatch
-                # when the incoming column order differs from the existing
-                # version — observed 2026-05-14 EOD: 99.9% error rate
-                # (903 / 904 tickers) with `existing` showing source idx=7
-                # and `new_val` showing source idx=71.
-                ordered_cols = (
-                    [c for c in OHLCV_COLS if c in today_row.columns]
-                    + ([PROVENANCE_COL] if PROVENANCE_COL in today_row.columns else [])
-                    + [f for f in FEATURES if f in today_row.columns]
-                )
-                today_row = today_row[ordered_cols]
+                # Column order is enforced by ``to_arctic_canonical`` at
+                # the queue site below — no per-site reorder required.
 
                 # Per-ticker coverage observability: count NaN features now
                 # so the eventual log + counter reflects exactly what's
@@ -1297,39 +1287,28 @@ def daily_append(
                 # Append at head — fast path. update_batch with upsert=True
                 # also handles the rare "symbol doesn't exist yet" case
                 # (replaces _write_row_backfill_safe's lib.write fallback).
-                # to_arctic_safe strips Categorical ``source`` dtype (PR #211)
-                # which ArcticDB's update_batch rejects.
+                # ``to_arctic_canonical`` enforces the
+                # ``OHLCV + source + FEATURES`` column order AND strips
+                # Categorical ``source`` dtype (PR #211) — single
+                # chokepoint for both descriptor-match invariants.
                 update_payloads.append(
-                    UpdatePayload(symbol=ticker, data=to_arctic_safe(today_row))
+                    UpdatePayload(symbol=ticker, data=to_arctic_canonical(today_row))
                 )
             else:
                 # Backfill — splice into existing series, full rewrite. Same
                 # logic as _write_row_backfill_safe's backfill branch.
                 #
-                # Re-project combined to canonical OHLCV+source+FEATURES order
-                # BEFORE the write. pd.concat's default outer-join preserves
-                # ``hist``'s column order and appends any new columns from
-                # ``today_row`` at the end — which produces a layout that
-                # differs from ``today_row``'s canonical order. A subsequent
-                # same-or-later-date UpdatePayload (with cols in canonical
-                # order) then trips ArcticDB's StreamDescriptorMismatch.
-                # Observed 2026-05-21: PR #279 widened FEATURES with 5 new
-                # pillar fields in the middle of the list; that morning's
-                # MorningEnrich rewrote 891/904 symbols via this WRITE path
-                # (pd.concat appended the 5 new cols at the end, layout
-                # diverged from canonical); the same-day EOD's UPDATE then
-                # failed 905/905 with pillars-at-end vs pillars-in-middle.
-                # Same defect class as the today_row reorder one layer up.
+                # ``pd.concat``'s default outer-join preserves ``hist``'s
+                # column order and appends any new columns from
+                # ``today_row`` at the end. ``to_arctic_canonical`` below
+                # re-projects to ``OHLCV + source + FEATURES`` before the
+                # write so the persisted descriptor stays canonical and a
+                # subsequent same-or-later-date UpdatePayload doesn't trip
+                # ArcticDB's StreamDescriptorMismatch (2026-05-21 EOD).
                 combined = pd.concat([hist, today_row])
                 combined = combined[~combined.index.duplicated(keep="last")].sort_index()
-                combined_ordered_cols = (
-                    [c for c in OHLCV_COLS if c in combined.columns]
-                    + ([PROVENANCE_COL] if PROVENANCE_COL in combined.columns else [])
-                    + [f for f in FEATURES if f in combined.columns]
-                )
-                combined = combined[combined_ordered_cols]
                 write_payloads.append(
-                    WritePayload(symbol=ticker, data=to_arctic_safe(combined))
+                    WritePayload(symbol=ticker, data=to_arctic_canonical(combined))
                 )
 
         if update_payloads or write_payloads:

--- a/store/arctic_store.py
+++ b/store/arctic_store.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Sequence
 
 import arcticdb as adb
 import pandas as pd
@@ -27,6 +28,17 @@ log = logging.getLogger(__name__)
 
 DEFAULT_BUCKET = "alpha-engine-research"
 ARCTIC_PREFIX = "arcticdb"
+
+# Canonical universe-library schema. Persisted layout is
+# ``OHLCV_COLS + [PROVENANCE_COL] + FEATURES`` — any write that lays
+# columns down in a different order trips ArcticDB's
+# ``StreamDescriptorMismatch`` on the next update_batch (observed
+# 2026-05-14 EOD, 2026-05-21 EOD). These constants are the single
+# source of truth; ``builders/daily_append.py`` re-exports them for
+# backwards-compat with operator scripts that already import from
+# there.
+OHLCV_COLS: list[str] = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
+PROVENANCE_COL: str = "source"
 
 _arctic_instance: adb.Arctic | None = None
 
@@ -90,3 +102,67 @@ def to_arctic_safe(df: pd.DataFrame) -> pd.DataFrame:
     for col in cat_cols:
         df[col] = df[col].astype(object)
     return df
+
+
+def to_arctic_canonical(
+    df: pd.DataFrame,
+    *,
+    features: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Project a universe-shaped DataFrame to canonical
+    ``OHLCV_COLS + [PROVENANCE_COL] + FEATURES`` order, then strip
+    Categorical dtypes.
+
+    This is the chokepoint enforcing the universe library's column-order
+    contract — every WritePayload / UpdatePayload / ``lib.write`` call
+    site that writes universe symbols must go through this helper, so
+    no new caller can lay down columns in a non-canonical order and
+    silently corrupt the persisted descriptor.
+
+    Why a centralized chokepoint:
+        Per-site discipline failed twice in one week
+        (2026-05-14 UPDATE-path, 2026-05-21 WRITE-path) when FEATURES
+        widened mid-list and one of three call sites missed the
+        accompanying reorder. Both incidents required emergency operator
+        recovery — instance start + SSM migration + EOD redrive.
+        Centralizing here removes the per-call-site discipline so
+        future FEATURES widenings become safe additive changes with
+        no companion column-ordering audit.
+
+    Behaviour:
+        - Intersect-then-reorder. Columns outside
+          ``OHLCV_COLS + [PROVENANCE_COL] + features`` are DROPPED
+          (matches the prior per-site recipe).
+        - Empty frames pass through unchanged (no copy).
+        - Frames already in canonical order and free of categoricals
+          pass through unchanged (no copy).
+        - ``features`` defaults to ``features.feature_engineer.FEATURES``
+          (lazy-imported to keep ``store`` free of a top-level
+          ``features`` dependency). Pass an explicit ``features``
+          when the caller has its own contract (e.g. tests).
+
+    Call exactly once, immediately before every universe
+    ``update_batch`` / ``write_batch`` / ``write`` invocation. Macro
+    writes have a different schema and continue to use
+    ``to_arctic_safe`` directly.
+    """
+    if df.empty:
+        return df
+
+    if features is None:
+        # Lazy import — keeps the dependency direction
+        # ``builders → features`` + ``builders → store`` without
+        # forcing ``store → features`` at module load.
+        from features.feature_engineer import FEATURES as _FEATURES
+        features = _FEATURES
+
+    canonical: list[str] = (
+        [c for c in OHLCV_COLS if c in df.columns]
+        + ([PROVENANCE_COL] if PROVENANCE_COL in df.columns else [])
+        + [f for f in features if f in df.columns]
+    )
+
+    if list(df.columns) != canonical:
+        df = df[canonical]
+
+    return to_arctic_safe(df)

--- a/tests/test_arctic_write_contract.py
+++ b/tests/test_arctic_write_contract.py
@@ -28,7 +28,12 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from store.arctic_store import to_arctic_safe
+from store.arctic_store import (
+    OHLCV_COLS,
+    PROVENANCE_COL,
+    to_arctic_canonical,
+    to_arctic_safe,
+)
 
 
 _REPO_ROOT = Path(__file__).parent.parent
@@ -176,77 +181,209 @@ _BACKFILL_SRC = (_REPO_ROOT / "builders" / "backfill.py").read_text()
 
 
 def test_daily_append_wraps_update_batch_payload():
-    """update_batch payload must go through to_arctic_safe — this is the
-    exact site that failed 2026-05-12 on BRK-B.
+    """update_batch payload must go through ``to_arctic_canonical`` —
+    the chokepoint enforces BOTH the column order
+    (2026-05-14 incident class) AND the Categorical-strip
+    (2026-05-12 BRK-B incident class).
     """
-    assert "UpdatePayload(symbol=ticker, data=to_arctic_safe(today_row))" in _DAILY_APPEND_SRC, (
+    assert "UpdatePayload(symbol=ticker, data=to_arctic_canonical(today_row))" in _DAILY_APPEND_SRC, (
         "daily_append.py's UpdatePayload data must be wrapped in "
-        "to_arctic_safe — bare today_row carries Categorical 'source' "
-        "(PR #211) which ArcticDB update_batch rejects."
+        "to_arctic_canonical — projects to OHLCV+source+FEATURES and "
+        "strips Categorical 'source' (PR #211) which ArcticDB "
+        "update_batch rejects on both descriptor + dtype mismatches."
     )
 
 
 def test_daily_append_wraps_write_batch_payload():
-    """The backfill-branch WritePayload also concatenates today_row's
-    Categorical source into a combined frame — same wrap required.
+    """The backfill-branch WritePayload concatenates ``today_row``'s
+    Categorical source into a combined frame whose
+    ``pd.concat`` outer-join may have appended novel columns at the
+    end (2026-05-21 EOD: PR #279 widened FEATURES, write-path
+    rewrote 891/904 symbols with pillars-at-end, the same-day
+    EOD UPDATE then failed 905/905). The chokepoint re-projects
+    to canonical here.
     """
-    assert "WritePayload(symbol=ticker, data=to_arctic_safe(combined))" in _DAILY_APPEND_SRC, (
+    assert "WritePayload(symbol=ticker, data=to_arctic_canonical(combined))" in _DAILY_APPEND_SRC, (
         "daily_append.py's WritePayload (backfill branch) must wrap "
-        "combined in to_arctic_safe."
+        "combined in to_arctic_canonical — re-projects to OHLCV+source"
+        "+FEATURES so the persisted descriptor stays canonical."
     )
 
 
 def test_backfill_wraps_universe_write():
-    """Saturday SF backfill writes per-ticker symbol_df with the same
-    Categorical 'source' (PR #211). Must wrap before lib.write.
+    """Saturday SF backfill writes per-ticker symbol_df via the
+    chokepoint. Single source of truth for column order + dtype.
     """
-    assert "universe_lib.write(ticker, to_arctic_safe(symbol_df))" in _BACKFILL_SRC, (
+    assert "universe_lib.write(ticker, to_arctic_canonical(symbol_df))" in _BACKFILL_SRC, (
         "backfill.py's universe_lib.write must wrap symbol_df in "
-        "to_arctic_safe — PR #211's Categorical source column flows "
-        "through here on Saturday SF."
+        "to_arctic_canonical — column-order enforcement + Categorical "
+        "strip both happen at this single boundary."
     )
 
 
 def test_backfill_wraps_macro_writes():
-    """Macro writes never use Categorical today, but uniform wrapping
-    keeps the contract single-source — and defends against a future
-    writer that adds one. Cheap because the helper short-circuits on
-    no-categorical frames.
+    """Macro writes use a different schema from universe (no FEATURES
+    column block) so they continue to use ``to_arctic_safe`` directly
+    for the Categorical strip. Uniform wrapping keeps the contract
+    single-source — and defends against a future writer that adds one.
     """
     assert "macro_lib.write(\"features\", to_arctic_safe(macro_df))" in _BACKFILL_SRC
     assert "macro_lib.write(key, to_arctic_safe(macro_series_df))" in _BACKFILL_SRC
     assert "macro_lib.write(key, to_arctic_safe(sector_df))" in _BACKFILL_SRC
 
 
-def test_daily_append_today_row_column_order_matches_storage():
-    """Pin the today_row column order to [OHLCV, source, FEATURES].
+# ── to_arctic_canonical chokepoint contract ──────────────────────────────────
+# Round-trip + drop-non-canonical + features-default behaviour. Pins the
+# institutional invariant lifted at the 2026-05-22 chokepoint PR: every
+# universe write boundary projects to ``OHLCV + source + FEATURES`` before
+# the bytes hit ArcticDB, so no caller can violate column order by accident.
 
-    2026-05-14 EOD failure: 99.9% (903 / 904) of update_batch calls failed
-    with ``StreamDescriptorMismatch`` because today_row was being built as
-    [OHLCV, FEATURES, source] (source appended at the end via the bare
-    ``today_row[PROVENANCE_COL] = …`` assignment) while every persisted
-    universe symbol carries source at idx 7 (between VWAP and the first
-    feature). ArcticDB's update_batch enforces strict column-order match
-    against the existing version's descriptor; the backfill-branch
-    write_batch path masks this because full rewrite ignores prior
-    descriptor.
 
-    The fix re-projects today_row via an explicit column order before the
-    write queue. If a future PR removes that re-projection, this test
-    fails — preventing a silent re-introduction of the same EOD outage.
+def test_to_arctic_canonical_reorders_scrambled_input():
+    """If a caller builds a frame with FEATURES inserted mid-column-list
+    in the WRONG order (the exact 2026-05-21 EOD failure shape — pillars
+    appended at the end via ``pd.concat`` outer-join), the chokepoint
+    must re-project to canonical order before the write.
     """
-    assert (
-        "ordered_cols = (\n"
-        "                    [c for c in OHLCV_COLS if c in today_row.columns]\n"
-        "                    + ([PROVENANCE_COL] if PROVENANCE_COL in today_row.columns else [])\n"
-        "                    + [f for f in FEATURES if f in today_row.columns]\n"
-        "                )\n"
-        "                today_row = today_row[ordered_cols]"
-    ) in _DAILY_APPEND_SRC, (
-        "daily_append.py must re-project today_row to "
-        "[OHLCV, source, FEATURES] before queuing the UpdatePayload — "
-        "matches the persisted ArcticDB descriptor (source at idx 7). "
-        "The bare `today_row[PROVENANCE_COL] = …` assignment alone "
-        "appends source at the end, which trips StreamDescriptorMismatch "
-        "on update_batch (2026-05-14 EOD)."
+    idx = pd.date_range("2026-05-08", periods=3, freq="B", name="date")
+    # Build in a scrambled order to mimic pd.concat([hist, today_row])
+    # when today_row carries 2 novel features absent from hist.
+    df = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0, 102.0],
+            "Close": [100.5, 101.5, 102.5],
+            "novel_feat_a": [0.1, 0.2, 0.3],  # appended at end
+            "Volume": [1_000_000] * 3,
+            "novel_feat_b": [0.4, 0.5, 0.6],  # appended at end
+            "source": ["yfinance"] * 3,
+            "High": [101.0, 102.0, 103.0],
+            "Low": [99.0, 100.0, 101.0],
+            "VWAP": [100.4, 101.4, 102.4],
+        },
+        index=idx,
+    )
+
+    out = to_arctic_canonical(df, features=["novel_feat_a", "novel_feat_b"])
+
+    expected = ["Open", "High", "Low", "Close", "Volume", "VWAP", "source",
+                "novel_feat_a", "novel_feat_b"]
+    assert list(out.columns) == expected, (
+        "to_arctic_canonical must re-project to OHLCV+source+FEATURES "
+        f"order; got {list(out.columns)!r}"
+    )
+
+
+def test_to_arctic_canonical_drops_unknown_columns():
+    """Columns outside OHLCV + PROVENANCE + features are silently
+    dropped (matches the pre-chokepoint per-site recipe). Defends
+    against an accidental leakage of intermediate columns into
+    persisted storage.
+    """
+    idx = pd.date_range("2026-05-08", periods=2, freq="B", name="date")
+    df = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0],
+            "Close": [100.5, 101.5],
+            "Volume": [1_000_000, 1_000_000],
+            "_internal_debug_col": ["x", "y"],
+            "source": ["polygon", "polygon"],
+        },
+        index=idx,
+    )
+
+    out = to_arctic_canonical(df, features=[])
+
+    assert "_internal_debug_col" not in out.columns
+    assert list(out.columns) == ["Open", "Close", "Volume", "source"]
+
+
+def test_to_arctic_canonical_preserves_values_and_index():
+    """Reorder is a pure projection — row values, the index, and the
+    Categorical-strip semantics survive untouched.
+    """
+    idx = pd.date_range("2026-05-08", periods=3, freq="B", name="date")
+    df = pd.DataFrame(
+        {
+            "Close": [100.0, 101.0, 102.0],
+            "source": pd.Categorical(
+                ["yfinance", "polygon", "yfinance"],
+                categories=("polygon", "yfinance", "fred", "unknown"),
+            ),
+            "Open": [99.5, 100.5, 101.5],
+        },
+        index=idx,
+    )
+
+    out = to_arctic_canonical(df, features=[])
+
+    assert list(out.columns) == ["Open", "Close", "source"]
+    assert list(out.index) == list(idx)
+    assert list(out["source"]) == ["yfinance", "polygon", "yfinance"]
+    assert out["source"].dtype == object, (
+        "to_arctic_canonical must run the Categorical-strip via "
+        "to_arctic_safe — single chokepoint for both invariants."
+    )
+
+
+def test_to_arctic_canonical_empty_passthrough():
+    """Empty frames return unchanged (no copy, no reorder)."""
+    df = pd.DataFrame()
+    out = to_arctic_canonical(df, features=[])
+    assert out is df
+    assert out.empty
+
+
+def test_to_arctic_canonical_features_default_resolves_to_feature_engineer():
+    """When ``features`` is omitted, the helper resolves the default
+    from ``features.feature_engineer.FEATURES`` — the same constant
+    every steady-state caller imports. Pins the lazy-import default
+    contract so the chokepoint is correct without per-call kwargs.
+    """
+    from features.feature_engineer import FEATURES as _CANONICAL_FEATURES
+
+    idx = pd.date_range("2026-05-08", periods=2, freq="B", name="date")
+    # Build with one real FEATURE + one bogus column. The default lookup
+    # should preserve the real FEATURE and drop the bogus column.
+    real_feat = _CANONICAL_FEATURES[0]
+    df = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0],
+            real_feat: [0.5, 0.6],
+            "_bogus_not_a_feature": [1, 2],
+        },
+        index=idx,
+    )
+
+    out = to_arctic_canonical(df)  # no features kwarg → default lookup
+
+    assert real_feat in out.columns
+    assert "_bogus_not_a_feature" not in out.columns
+    assert list(out.columns)[0] == "Open"  # OHLCV head ordering preserved
+
+
+def test_to_arctic_canonical_no_reorder_when_already_canonical():
+    """Fast-path: a frame already in canonical order and free of
+    categoricals passes through unchanged. Keeps the helper cheap
+    enough to apply uniformly at every universe write site.
+    """
+    idx = pd.date_range("2026-05-08", periods=2, freq="B", name="date")
+    df = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0],
+            "High": [101.0, 102.0],
+            "Low": [99.0, 100.0],
+            "Close": [100.5, 101.5],
+            "Volume": [1_000_000, 1_000_000],
+            "VWAP": [100.4, 101.4],
+            "source": ["polygon", "polygon"],
+            "feat_x": [0.1, 0.2],
+        },
+        index=idx,
+    )
+
+    out = to_arctic_canonical(df, features=["feat_x"])
+
+    assert out is df, (
+        "Already-canonical frames must pass through without a copy "
+        "(no reorder, no Categorical strip needed)."
     )

--- a/tests/test_daily_append_read_batch.py
+++ b/tests/test_daily_append_read_batch.py
@@ -163,8 +163,7 @@ def test_writes_use_arcticdb_batch_api():
 def test_write_path_reorders_combined_before_write_payload():
     """The WRITE branch (``combined = pd.concat([hist, today_row])``) must
     re-project ``combined`` to canonical OHLCV+source+FEATURES order before
-    handing it to WritePayload — same defensive reorder the UPDATE branch's
-    today_row already does.
+    handing it to WritePayload.
 
     2026-05-21 EOD regression: PR #279 inserted five pillar fields in the
     middle of ``FEATURES``; that morning's MorningEnrich ran daily_append
@@ -176,25 +175,25 @@ def test_write_path_reorders_combined_before_write_payload():
     canonical pillars-in-middle order) tripped ArcticDB's
     StreamDescriptorMismatch on 905/905 symbols, halting EOD Reconcile.
 
-    A source-grep test rather than a functional one because the batch path
-    is glued together with read_batch / update_batch / write_batch APIs that
-    aren't usefully mockable at unit-test scope — the actual defect class is
-    a missing reorder pair, easy to spot lexically.
+    2026-05-22 chokepoint lift: the canonical column-order projection
+    moved from a per-site reorder block into ``to_arctic_canonical`` —
+    a single helper called at every universe write boundary. This test
+    now pins the chokepoint at the WRITE-branch payload site.
+    Functional round-trip coverage of the projection lives in
+    ``test_arctic_write_contract.test_to_arctic_canonical_*``.
     """
     src = _source()
     write_block_anchor = "combined = pd.concat([hist, today_row])"
     assert write_block_anchor in src, (
-        "Expected the backfill splice anchor to remain — fixed by relocating "
-        "the reorder, not by deleting the concat."
+        "Expected the backfill splice anchor to remain — chokepoint applies "
+        "at the WritePayload boundary, not by removing the concat."
     )
-    after_anchor = src.split(write_block_anchor, 1)[1]
-    write_payload_idx = after_anchor.index("WritePayload(symbol=ticker")
-    pre_write_payload = after_anchor[:write_payload_idx]
-    assert "combined_ordered_cols" in pre_write_payload and "combined[combined_ordered_cols]" in pre_write_payload, (
-        "WRITE-path must re-project combined to canonical OHLCV+source+FEATURES "
-        "order before WritePayload — otherwise pd.concat's default column "
-        "ordering (hist-first, new-cols-appended) silently scrambles the "
-        "schema, breaking subsequent UPDATE calls (2026-05-21 EOD regression)."
+    assert (
+        "WritePayload(symbol=ticker, data=to_arctic_canonical(combined))"
+        in src
+    ), (
+        "WRITE-path must wrap ``combined`` in ``to_arctic_canonical`` before "
+        "WritePayload — the chokepoint projects to OHLCV+source+FEATURES "
+        "regardless of ``pd.concat``'s default hist-first-new-cols-appended "
+        "ordering (2026-05-21 EOD regression class)."
     )
-    assert "for c in OHLCV_COLS" in pre_write_payload
-    assert "for f in FEATURES" in pre_write_payload


### PR DESCRIPTION
## Summary

- Adds `to_arctic_canonical(df, *, features=None)` to `store.arctic_store` — single chokepoint enforcing `OHLCV + source + FEATURES` order + Categorical-strip at every universe write boundary.
- Deletes the per-site reorder blocks added by PR #238 (UPDATE-path, 2026-05-14) and PR #283 (WRITE-path, 2026-05-21) — both replaced by the centralized helper.
- Closes ROADMAP L1483 (filed at 2026-05-21 wind-down after the EOD blackout).

## Why

Same defect class recurred twice in eight days:
- **2026-05-14 EOD**: 903/904 `update_batch` failures (`StreamDescriptorMismatch`) — `source` appended at end of `today_row` via bare `today_row[PROVENANCE_COL] = …`. Fixed PR #238 with per-site reorder.
- **2026-05-21 EOD**: 891/904 symbols persisted via WRITE-path with pillars-at-end after `pd.concat([hist, today_row])` outer-joined novel columns. Same-day EOD UPDATE then failed 905/905. Fixed PR #283 with second per-site reorder + one-off migration.

Both required emergency operator recovery. The third recurrence is just one missed reorder away — every new universe write site needs to remember the projection, every FEATURES widening needs to think about column ordering. Lifting the invariant into a chokepoint removes that per-call-site discipline.

Composes with [[feedback_lift_invariants_to_chokepoint_after_second_recurrence]] + [[feedback_sota_institutional_default_no_shortcuts]] — centralized chokepoint IS the institutional pattern over per-site discipline.

## Scope

- `store/arctic_store.py` — add `OHLCV_COLS` + `PROVENANCE_COL` constants + `to_arctic_canonical`. `FEATURES` resolves lazily from `features.feature_engineer` so `store` stays free of a top-level `features` dep.
- `builders/daily_append.py` — re-export the constants for BC; delete the two manual reorder blocks; swap `to_arctic_safe → to_arctic_canonical` at both UpdatePayload + WritePayload sites.
- `builders/backfill.py` — remove the `keep_cols` projection (drop+reorder now at chokepoint); swap to `to_arctic_canonical` at `universe.write` site. Macro writes stay on `to_arctic_safe` (different schema).
- Migration scripts (`migrate_universe_feature_order`, `migrate_universe_vwap`, `promote_ohlcv_only_schema`) keep their explicit logic — one-off operator scripts with deliberate tail-column preservation that the steady-state chokepoint doesn't replicate.

## Tests

- 6 new `test_to_arctic_canonical_*` round-trip tests in `tests/test_arctic_write_contract.py` (scrambled input → canonical output, unknown-col drop, value/index preservation, empty passthrough, features-default lookup, no-op fast path).
- Existing `test_*_wraps_*` source-grep regressions repointed at `to_arctic_canonical`.
- `test_write_path_reorders_combined_before_write_payload` rewritten to pin the chokepoint at the payload site.

**Full suite: 1430 passed, 1 skipped.**

## Test plan

- [x] `pytest tests/test_arctic_write_contract.py` — 16 passed
- [x] `pytest tests/ -k "daily_append or backfill or arctic or universe or provenance"` — 266 passed
- [x] Full suite — 1430 passed, 1 skipped
- [ ] Saturday SF 2026-05-23 — first production exercise of the chokepoint at backfill + Saturday daily_append write paths
- [ ] Weekday SF 2026-05-26+ — daily MorningEnrich (UPDATE branch) + EOD via the chokepoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)