### PR TITLE
fix(deploy): L221 dedup_key on canary-rollback alert + lib pin v0.21→v0.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.21.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.24.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -199,11 +199,15 @@ if [ "$CANARY_STATUS" != "OK" ] && [ "$CANARY_STATUS" != "SKIPPED" ]; then
   # Independent-channel surveillance per ROADMAP L221 — this exact
   # rollback chain fired silently 10 consecutive times across 2 days
   # (alpha-engine-data #274 retrospective) before Brian noticed the
-  # GitHub Actions red-icon. Best-effort; trailing || true never
+  # GitHub Actions red-icon. ``dedup_key`` collapses an image-wide
+  # rebuild that breaks N Lambdas' canaries within the hour into one
+  # alert per (Lambda, version) — lib v0.24.0 substrate (L221
+  # retrofit 2026-05-22). Best-effort; trailing || true never
   # overrides the deploy's exit 1.
   python3 -m alpha_engine_lib.alerts publish \
     --severity error \
     --source "alpha-engine-data/infrastructure/deploy.sh" \
+    --dedup-key "canary-fail-${FUNCTION_NAME}-v${VERSION}" \
     --message "Canary rolled back: ${FUNCTION_NAME} canary returned status='${CANARY_STATUS}', live alias reverted v${VERSION}→v${PREV_VERSION}. See CloudWatch /aws/lambda/${FUNCTION_NAME} for payload." \
     || true
   exit 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
 # psycopg2-binary + pgvector now come via [rag] (added in lib v0.3.0,
 # direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.21.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.24.0


### PR DESCRIPTION
## Summary

- Adds \`--dedup-key "canary-fail-\${FUNCTION_NAME}-v\${VERSION}"\` to the canary-rollback alert publish in \`infrastructure/deploy.sh\`.
- Lib pin v0.21.0 → v0.24.0 across requirements.txt + Dockerfile.
- Closes L221 dedup retrofit slice for data repo (consumer migration #6, completes the 4-repo retrofit).

## Why

The 2-day silent rollback chain that motivated L221 (10 consecutive rollbacks before operator notice) would have produced 10 alerts; now collapses to one alert per (Lambda, version) within the lib v0.24.0 60-min default window.

Originally filed as P1 owed BEFORE the 4 L221 canary PRs merged; those merged 5/21 23:42-23:51Z so this is a post-merge retrofit per the ROADMAP downgrade rule.

## Test plan

- [x] Full suite — 1425 passed, 1 skipped
- [ ] First production exercise: next failing canary on a data deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)