### PR TITLE
chore(deps): bump alpha-engine-lib pin v0.24.0 → v0.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.24.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.25.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
 # psycopg2-binary + pgvector now come via [rag] (added in lib v0.3.0,
 # direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.24.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.25.0


### PR DESCRIPTION
## Summary

Bumps `alpha-engine-lib` pin from v0.24.0 to v0.25.0 in `requirements.txt` and `Dockerfile`. Picks up `alpha_engine_lib.ssm_log_capture` — the Python CLI chokepoint that replaces the inline-bash `trap 'aws s3 cp ...' EXIT` + `tee` pattern across all SSM-RunShellScript states.

## Blocks on

[alpha-engine-lib PR #57](https://github.com/cipher813/alpha-engine-lib/pull/57) — merges auto-tag v0.25.0; until then this PR's pip install will fail.

## Required for

Follow-up alpha-engine-data PR: "convert 8 SF states to `python -m alpha_engine_lib.ssm_log_capture`" (unblocks the broken Saturday-SF spot states caught by the 2026-05-22 Friday-PM dry-pass).

## Test plan

- [ ] alpha-engine-lib PR #57 merged + v0.25.0 tag exists
- [ ] CI passes (lib install succeeds against new tag)
- [ ] No new transitive deps introduced (lib v0.25.0 adds only `ssm_log_capture` — boto3 already in deps tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)