### PR TITLE
fix(sf): convert 8 broken Saturday spot states to alpha_engine_lib.ssm_log_capture CLI

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -68,7 +68,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/morning-enrich.log \"s3://alpha-engine-research/_ssm_logs/morning-enrich/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('bash infrastructure/spot_data_weekly.sh --morning-enrich-only{} 2>&1 | tee /var/log/morning-enrich.log',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only{}',$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -182,7 +182,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/data-weekly.log \"s3://alpha-engine-research/_ssm_logs/data-weekly/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('bash infrastructure/spot_data_weekly.sh --phase1-only{} 2>&1 | tee /var/log/data-weekly.log',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only{}',$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -296,7 +296,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/rag-ingestion.log \"s3://alpha-engine-research/_ssm_logs/rag-ingestion/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('bash infrastructure/spot_data_weekly.sh --rag-only{} 2>&1 | tee /var/log/rag-ingestion.log',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$.preflight_args))",
           "executionTimeout": [
             "3600"
           ]
@@ -1138,7 +1138,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/predictor-training.log \"s3://alpha-engine-research/_ssm_logs/predictor-training/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('bash infrastructure/spot_train.sh --full-only{} 2>&1 | tee /var/log/predictor-training.log',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only{}',$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -1353,7 +1353,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/drift-detection.log \"s3://alpha-engine-research/_ssm_logs/drift-detection/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('bash infrastructure/spot_drift_detection.sh{} 2>&1 | tee /var/log/drift-detection.log',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh{}',$.preflight_args))",
           "executionTimeout": [
             "1200"
           ]
@@ -1405,7 +1405,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/backtester.log \"s3://alpha-engine-research/_ssm_logs/backtester/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator{} 2>&1 | tee /var/log/backtester.log',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -1521,7 +1521,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/parity.log \"s3://alpha-engine-research/_ssm_logs/parity/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator{} 2>&1 | tee /var/log/parity.log',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -1637,7 +1637,7 @@
           "executionTimeout": [
             "3600"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','trap \\'aws s3 cp /var/log/evaluator.log \"s3://alpha-engine-research/_ssm_logs/evaluator/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity{} 2>&1 | tee /var/log/evaluator.log',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity{}',$.preflight_args))"
         },
         "TimeoutSeconds": 3600
       },

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -5,9 +5,8 @@
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/backtester.log \"s3://alpha-engine-research/_ssm_logs/backtester/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
     "export RUN_DATE='2026-05-18'",
-    "bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator 2>&1 | tee /var/log/backtester.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator"
   ],
   "DataPhase1": [
     "set -eo pipefail",
@@ -16,8 +15,7 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/data-weekly.log \"s3://alpha-engine-research/_ssm_logs/data-weekly/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-    "bash infrastructure/spot_data_weekly.sh --phase1-only 2>&1 | tee /var/log/data-weekly.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
   ],
   "DriftDetection": [
     "set -eo pipefail",
@@ -25,8 +23,7 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/drift-detection.log \"s3://alpha-engine-research/_ssm_logs/drift-detection/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-    "bash infrastructure/spot_drift_detection.sh 2>&1 | tee /var/log/drift-detection.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh"
   ],
   "Evaluator": [
     "set -eo pipefail",
@@ -34,9 +31,8 @@
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/evaluator.log \"s3://alpha-engine-research/_ssm_logs/evaluator/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
     "export RUN_DATE='2026-05-18'",
-    "bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity 2>&1 | tee /var/log/evaluator.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
   ],
   "MorningEnrich": [
     "set -eo pipefail",
@@ -45,8 +41,7 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/morning-enrich.log \"s3://alpha-engine-research/_ssm_logs/morning-enrich/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-    "bash infrastructure/spot_data_weekly.sh --morning-enrich-only 2>&1 | tee /var/log/morning-enrich.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
   ],
   "Parity": [
     "set -eo pipefail",
@@ -54,9 +49,8 @@
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/parity.log \"s3://alpha-engine-research/_ssm_logs/parity/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
     "export RUN_DATE='2026-05-18'",
-    "bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator 2>&1 | tee /var/log/parity.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator"
   ],
   "PredictorTraining": [
     "set -eo pipefail",
@@ -66,8 +60,7 @@
     "cd /home/ec2-user/alpha-engine-predictor",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/predictor-training.log \"s3://alpha-engine-research/_ssm_logs/predictor-training/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-    "bash infrastructure/spot_train.sh --full-only 2>&1 | tee /var/log/predictor-training.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
   ],
   "RAGIngestion": [
     "set -eo pipefail",
@@ -75,7 +68,6 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "trap 'aws s3 cp /var/log/rag-ingestion.log \"s3://alpha-engine-research/_ssm_logs/rag-ingestion/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-    "bash infrastructure/spot_data_weekly.sh --rag-only 2>&1 | tee /var/log/rag-ingestion.log"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
   ]
 }

--- a/tests/test_sf_backtest_parity_split_wiring.py
+++ b/tests/test_sf_backtest_parity_split_wiring.py
@@ -293,20 +293,25 @@ class TestSsmCommandShape:
         cmds = self._commands(states, "Parity")
         assert cmds[0].startswith("set ") and "pipefail" in cmds[0]
 
-    def test_parity_has_s3_log_trap_before_work(self, states):
+    def test_parity_log_capture_via_lib_cli(self, states):
+        """Parity's log-capture is satisfied by the lib CLI form
+        (lib v0.25.0), not by an inline `trap 'aws s3 cp ...' EXIT`
+        line. 2026-05-22 lift: the inline-trap form broke under
+        `commands.$ States.Array(...)` ASL escape semantics (caught by
+        Friday-PM dry-pass). See alpha-engine-lib PR #57 + sibling
+        states in test_sf_morning_enrich_split_wiring.py.
+        """
         cmds = self._commands(states, "Parity")
-        trap_idx = next(
-            i
-            for i, c in enumerate(cmds)
-            if c.startswith("trap ")
-            and "_ssm_logs" in c
-            and "parity.log" in c
+        work = next(
+            c for c in cmds if "alpha_engine_lib.ssm_log_capture run" in c
         )
-        work_idx = next(
-            i for i, c in enumerate(cmds) if "| tee /var/log/parity.log" in c
+        assert "--slug parity" in work
+        assert "--log /var/log/parity.log" in work
+        assert "-- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator" in work
+        assert not any(c.startswith("trap ") for c in cmds), (
+            "Inline trap must not coexist with the lib CLI — the CLI "
+            "internalizes the trap."
         )
-        assert trap_idx < work_idx
-        assert "|| true" in cmds[trap_idx]
 
 
 class TestBudgetParity:

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -291,13 +291,26 @@ def _resolve_spot_commands(state: dict, preflight_args: str) -> list[str]:
 
 @pytest.fixture(scope="module")
 def orig_spot_cmds() -> dict:
-    """Frozen pre-keystone (#258 origin/main) RESOLVED spot command lists.
+    """Frozen baseline RESOLVED spot command lists for byte-identicality.
 
     Captured at commit time into a committed fixture so the byte-identical
     proof is HERMETIC. The prior implementation shelled out to
     `git show origin/main:infrastructure/step_function.json` at test time,
     which fails (exit 128) in CI's shallow PR checkout where `origin/main`
     is not a local ref — that was the keystone CI failure.
+
+    History:
+    - Originally captured pre-keystone (#258) to prove the Friday-PM
+      shell-run mechanism didn't change the real Saturday absent path.
+    - **Regenerated 2026-05-22** as part of the inline-trap-to-lib-CLI
+      lift (alpha-engine-lib PR #57). The pre-keystone form had a broken
+      `'trap \\'aws s3 cp ...\\' EXIT'` inside `commands.$ States.Array`
+      (ASL doesn't unescape `\\'` in arg strings — caught by the
+      Friday-PM dry-pass). The baseline now reflects the lib-CLI form:
+      `python -m alpha_engine_lib.ssm_log_capture run --slug X
+      --log Y -- bash <launcher>`. The keystone's byte-identicality
+      proof against the new baseline still holds (the absent path runs
+      the same lib-CLI invocation with `preflight_args=""`).
 
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
@@ -550,14 +563,35 @@ class TestByteIdenticalAbsentPath:
     def test_spot_command_carries_preflight_only_under_shell_run(
         self, sf, name
     ):
+        """Under shell_run (preflight_args=" --preflight-only"), the final
+        command line must propagate --preflight-only AFTER the launcher's
+        mode token (the {} sits immediately after, leading-space-bearing
+        var produces exactly one separating space).
+
+        2026-05-22 reshape: the final line moved from
+            ``{token} --preflight-only 2>&1 | tee {log}``
+        to
+            ``/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m
+              alpha_engine_lib.ssm_log_capture run --slug X --log Y --
+              {token} --preflight-only``
+        as part of the inline-trap-to-lib-CLI lift (alpha-engine-lib PR #57).
+        The lib CLI internalizes tee + S3-ship; --preflight-only still
+        sits immediately after the launcher's mode token so the
+        orthogonal-modifier shape is preserved.
+        """
         token, log = _SPOT_STATES[name]
+        slug = Path(log).stem
         cmds = _resolve_spot_commands(
             self._state(sf, name), preflight_args=" --preflight-only"
         )
         final = cmds[-1]
-        # {} sits immediately after the mode token (no literal space) so the
-        # leading-space-bearing var produces exactly one separating space.
-        assert final == f"{token} --preflight-only 2>&1 | tee {log}", final
+        expected = (
+            "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python "
+            "-m alpha_engine_lib.ssm_log_capture run "
+            f"--slug {slug} --log {log} -- "
+            f"{token} --preflight-only"
+        )
+        assert final == expected, final
         assert "  --preflight-only" not in final, "double space — bad join"
 
     @pytest.mark.parametrize(

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -194,20 +194,36 @@ class TestSsmCommandShape:
         cmds = self._commands(states, "MorningEnrich")
         assert cmds[0].startswith("set ") and "pipefail" in cmds[0]
 
-    def test_morning_enrich_has_s3_log_trap_before_work(self, states):
+    def test_morning_enrich_log_capture_via_lib_cli(self, states):
+        """The trap-and-log-ship invariant is now satisfied by the
+        alpha_engine_lib.ssm_log_capture Python CLI (lib v0.25.0), not
+        by an inline `trap 'aws s3 cp ...' EXIT` line. The 2026-05-22
+        Friday-PM dry-pass caught the prior inline-trap form failing
+        under ASL States.Array escape semantics (`\\'` not unescaped to
+        `'` inside arg strings) — so we lifted to a Python CLI invoked
+        as a single States.Format-rendered token list with no bash
+        quoting surface. See alpha-engine-lib PR #57 + this state's
+        sibling traps across the 7 other Saturday-SF spot states.
+        """
         cmds = self._commands(states, "MorningEnrich")
-        trap_idx = next(
+        work_idx = next(
             i
             for i, c in enumerate(cmds)
-            if c.startswith("trap ")
-            and "_ssm_logs" in c
-            and "morning-enrich.log" in c
+            if "alpha_engine_lib.ssm_log_capture run" in c
         )
-        work_idx = next(
-            i for i, c in enumerate(cmds) if "| tee /var/log/morning-enrich.log" in c
+        work = cmds[work_idx]
+        # Right slug and log path
+        assert "--slug morning-enrich" in work
+        assert "--log /var/log/morning-enrich.log" in work
+        # Inner command is the morning-enrich launcher
+        assert "-- bash infrastructure/spot_data_weekly.sh --morning-enrich-only" in work
+        # No inline trap survives anywhere in this state
+        assert not any(c.startswith("trap ") for c in cmds), (
+            "Inline `trap 'aws s3 cp ...' EXIT` line must not coexist "
+            "with the lib CLI — the CLI internalizes the trap. Two "
+            "competing log-ship paths can race on the same /var/log "
+            "file."
         )
-        assert trap_idx < work_idx
-        assert "|| true" in cmds[trap_idx]
 
 
 class TestCatchSemantics:

--- a/tests/test_sf_ssm_pipefail_wiring.py
+++ b/tests/test_sf_ssm_pipefail_wiring.py
@@ -15,15 +15,37 @@ Three rules pinned here:
    stdout — exactly the failure mode on 2026-05-11, where two ERROR
    logs from `weekly_collector` fired but flow-doctor never escalated.
 
-3. Every command block that pipes its work to `| tee /var/log/X.log`
-   must arm an EXIT trap that ships that log to S3 before the work line.
-   SSM's `StandardOutputContent` is capped at 24KB and `StandardOutputUrl`
-   is empty (no CloudWatchOutputConfig), so when a long step exits 1 on a
-   stopped/terminated instance the actual error is unrecoverable. This is
-   a recurring diagnostic gap (MorningEnrich 2026-05-15, DataPhase1
-   2026-05-03, backtester 2026-04-22). The trap must be `|| true` so it
-   never alters the script's real exit status (the SF Catch must still
-   see the true failure).
+3. Every long-running command block must ship its log to S3 before the
+   instance terminates. SSM's `StandardOutputContent` is capped at 24KB
+   and `StandardOutputUrl` is empty (no CloudWatchOutputConfig), so when
+   a long step exits 1 on a stopped/terminated instance the actual error
+   is otherwise unrecoverable. Recurring diagnostic gap: MorningEnrich
+   2026-05-15, DataPhase1 2026-05-03, backtester 2026-04-22.
+
+   Two equivalent forms satisfy this invariant:
+   (a) **Inline bash trap** — `trap 'aws s3 cp /var/log/X.log
+       "s3://..." --only-show-errors || true' EXIT` BEFORE a
+       `| tee /var/log/X.log` work line. Used by states whose
+       `commands` is a plain JSON array.
+   (b) **`alpha_engine_lib.ssm_log_capture` CLI** — a single
+       `python -m alpha_engine_lib.ssm_log_capture run --slug X
+       --log /var/log/X.log -- bash <launcher> ...` invocation that
+       internalizes both the trap and the tee. Used by states whose
+       `commands.$` is a `States.Array(...)` (the ASL escape surface
+       for inner single quotes is broken, so the inline-trap form
+       cannot live there — see alpha-engine-lib PR #57 / 2026-05-22
+       Friday-PM dry-pass break).
+
+   The lib CLI is the institutional chokepoint per the CLAUDE.md SOTA
+   sub-sub-rule ("Pure-Bash primitives can stay mirrored unless
+   re-expressible as a Python CLI entry callable from Bash"). The
+   inline-trap form is retained for plain `commands` arrays that have
+   never been broken by ASL escape behavior.
+
+   In either form: the log-capture step must not be able to override
+   the script's real exit status. Inline traps use `|| true`; the lib
+   CLI propagates the inner subprocess exit code verbatim and swallows
+   S3 errors at WARNING.
 """
 
 from __future__ import annotations
@@ -33,6 +55,8 @@ import re
 from pathlib import Path
 
 import pytest
+
+from tests.sf_command_utils import extract_commands
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -45,7 +69,20 @@ _SF_PATHS = [
 
 
 def _iter_ssm_command_blocks(sf_doc: dict):
-    """Yield (state_name, commands_list) for every SSM RunShellScript task."""
+    """Yield (state_name, commands_list) for every SSM RunShellScript task.
+
+    Resolves BOTH ``commands`` (plain JSON array) and ``commands.$``
+    (``States.Array(...)`` intrinsic) forms via the shared
+    :func:`tests.sf_command_utils.extract_commands` helper. This was a
+    silent test gap that masked the 2026-05-22 Friday-PM dry-pass break
+    — the original implementation only iterated ``commands``, so the
+    Saturday-SF states that PR #253 (2026-05-17) flipped to
+    ``commands.$`` form silently stopped being covered. The
+    inline-bash-trap regression that followed went undetected by this
+    file until the dry-pass actually fired in production. The
+    extraction now covers both forms; the broken-trap class cannot
+    silently slip past again.
+    """
     for state_name, state in sf_doc.get("States", {}).items():
         if state.get("Type") != "Task":
             continue
@@ -56,9 +93,10 @@ def _iter_ssm_command_blocks(sf_doc: dict):
         if params.get("DocumentName") != "AWS-RunShellScript":
             continue
         inner = params.get("Parameters", {})
-        cmds = inner.get("commands")
-        if isinstance(cmds, list):
-            yield state_name, cmds
+        if "commands" in inner and isinstance(inner["commands"], list):
+            yield state_name, list(inner["commands"])
+        elif "commands.$" in inner:
+            yield state_name, extract_commands(state)
 
 
 _DAILY_SF_PATH = _INFRA / "step_function_daily.json"
@@ -138,26 +176,59 @@ def test_weekday_sf_ssm_blocks_export_flow_doctor_enabled() -> None:
 
 
 _TEE_WORK_RE = re.compile(r"\| tee (?:-a )?(/var/log/[\w.-]+\.log)")
+_LIB_CLI_RE = re.compile(
+    r"alpha_engine_lib\.ssm_log_capture\s+run\s+.*?--slug\s+(\S+)\s+--log\s+(/var/log/[\w.-]+\.log)"
+)
 
 
 @pytest.mark.parametrize("sf_path", _SF_PATHS, ids=lambda p: p.name)
-def test_long_ssm_steps_ship_log_to_s3_before_work(sf_path: Path) -> None:
-    """Every `| tee /var/log/X.log` work line needs a preceding S3 EXIT trap.
+def test_long_ssm_steps_ship_log_to_s3(sf_path: Path) -> None:
+    """Every long SSM step must ship its log to S3 — via inline trap OR lib CLI.
 
     Regression target: the recurring "step exits 1 but the cause is past
     SSM's 24KB StandardOutputContent cap and the instance is gone" gap
     (MorningEnrich 2026-05-15, DataPhase1 2026-05-03, backtester
-    2026-04-22). The fix is an EXIT trap that `aws s3 cp`s the local
-    /var/log/X.log to s3://alpha-engine-research/_ssm_logs/... — armed
-    BEFORE the long work command so it fires whether the step succeeds or
-    fails, and `|| true` so it never overrides the script's real exit
-    status (the SF Catch must still see the true failure).
+    2026-04-22). Two satisfying shapes (see module docstring rule #3):
+
+    (a) **Inline bash trap** before `| tee /var/log/X.log` work line —
+        original form, plain `commands` JSON arrays only.
+    (b) **`alpha_engine_lib.ssm_log_capture` CLI** — single
+        `python -m alpha_engine_lib.ssm_log_capture run --slug X
+        --log /var/log/X.log -- bash <launcher>` line; internalizes the
+        trap. Required form for `commands.$ States.Array(...)` states
+        (ASL doesn't unescape `\\'` in arg strings; the inline-trap
+        form breaks there — caught by the 2026-05-22 Friday-PM
+        dry-pass).
     """
     sf_doc = json.loads(sf_path.read_text())
     offenders: list[str] = []
     for state_name, cmds in _iter_ssm_command_blocks(sf_doc):
+        # Form (b): lib CLI satisfies the invariant on its own — the
+        # tee + S3 ship + exit-code propagation are all internalized.
+        lib_idx = next(
+            (i for i, c in enumerate(cmds) if _LIB_CLI_RE.search(c)),
+            None,
+        )
+        if lib_idx is not None:
+            # Optional consistency check: slug-vs-logpath should match
+            # the canonical layout (slug == basename of logfile minus
+            # .log) — caller convention, not strictly required by the
+            # lib but it's what every state in the fleet uses today.
+            m = _LIB_CLI_RE.search(cmds[lib_idx])
+            slug, logfile = m.group(1), m.group(2)
+            log_basename = Path(logfile).stem
+            if slug != log_basename:
+                offenders.append(
+                    f"{state_name}: lib CLI slug={slug!r} doesn't match "
+                    f"log basename={log_basename!r}; S3 _ssm_logs/ tree "
+                    f"will land logs under unexpected key prefix"
+                )
+            continue
+
+        # Form (a): inline trap before `| tee` work line.
         work_idx = next(
-            (i for i, c in enumerate(cmds) if _TEE_WORK_RE.search(c)), None
+            (i for i, c in enumerate(cmds) if _TEE_WORK_RE.search(c)),
+            None,
         )
         if work_idx is None:
             continue  # short step, output fits in the 24KB cap
@@ -188,9 +259,13 @@ def test_long_ssm_steps_ship_log_to_s3_before_work(sf_path: Path) -> None:
             )
     assert not offenders, (
         f"{sf_path.name}: long SSM steps missing the S3 log-capture "
-        f"trap:\n  - " + "\n  - ".join(offenders) + "\n\n"
-        "Add `\"trap 'aws s3 cp /var/log/X.log "
+        f"surface:\n  - " + "\n  - ".join(offenders) + "\n\n"
+        "Either add `\"trap 'aws s3 cp /var/log/X.log "
         "\\\"s3://alpha-engine-research/_ssm_logs/<slug>/...\\\" "
         "--only-show-errors || true' EXIT\"` immediately before the "
-        "`| tee` work line. See 2026-05-15 MorningEnrich ROADMAP P0."
+        "`| tee` work line (only works in plain `commands` arrays), "
+        "OR switch the work line to `python -m alpha_engine_lib.ssm_log_capture "
+        "run --slug X --log /var/log/X.log -- bash <launcher>` (required "
+        "for `commands.$ States.Array(...)` states). See 2026-05-22 "
+        "Friday-PM dry-pass + alpha-engine-lib PR #57."
     )


### PR DESCRIPTION
## Summary

Closes the **2026-05-22 Friday-PM dry-pass failure** ("Alpha Engine Saturday Pipeline FAILED" at MorningEnrich, exit 127, `trap: s3: invalid signal specification`). Lifts the inline `trap 'aws s3 cp /var/log/X.log "s3://..." || true' EXIT` + `tee /var/log/X.log` pattern out of JSON and into the `alpha_engine_lib.ssm_log_capture` Python CLI (lib v0.25.0).

The Friday-PM shell-run dry-pass safety net (#258 + #260 + #263) caught a latent regression introduced by #253 ~12h before the Saturday 09:00 UTC firing. Exactly the failure class it was built to catch.

## Root cause

PR #253 (merged 2026-05-17) flipped 8 Saturday-SF spot states from plain `commands` JSON arrays to `commands.$ States.Array(...)` so they could splice `$.run_date` / `$.preflight_args` via `States.Format`. Inside `States.Array` arg strings, ASL's documented escape for an inner single quote is `\'` — but **the AWS ASL evaluator does NOT unescape `\'` to `'` in practice**; it passes the backslash through literally.

The trap line `'trap \'cmd\' EXIT'` therefore rendered into the SSM `_script.sh` as `trap \'cmd\' EXIT`. Bash interpreted `\'` outside quotes as a literal apostrophe stripped of its quoting power, then word-split the line and passed every token after `aws` to `trap` as a signal name. Exit 127, line 7. Same defect lurked in ALL 8 Saturday-SF spot states.

## Fix

Each affected state now invokes a single `States.Format`-rendered token list — no bash trap, no inner single quotes:

```
/home/ec2-user/alpha-engine-dashboard/.venv/bin/python \
  -m alpha_engine_lib.ssm_log_capture run \
  --slug X --log /var/log/X.log -- bash <launcher> ...
```

The lib CLI internalizes tee + S3 ship-on-exit + exit-code propagation. No ASL escape surface by construction.

| State | Slug | Launcher |
|---|---|---|
| MorningEnrich | morning-enrich | `spot_data_weekly.sh --morning-enrich-only` |
| DataPhase1 | data-weekly | `spot_data_weekly.sh --phase1-only` |
| RAGIngestion | rag-ingestion | `spot_data_weekly.sh --rag-only` |
| PredictorTraining | predictor-training | `spot_train.sh --full-only` |
| DriftDetection | drift-detection | `spot_drift_detection.sh` |
| Backtester | backtester | `spot_backtest.sh --skip-stages=parity,evaluator` |
| Parity | parity | `spot_backtest.sh --skip-stages=backtest,evaluator` |
| Evaluator | evaluator | `spot_backtest.sh --skip-stages=backtest,parity` |

`States.Format('export RUN_DATE=\'{}\'', $.run_date)` in Backtester/Parity/Evaluator stays as-is — `States.Format` template unescaping IS reliable (different ASL code path).

## Test gaps closed in the same PR

1. **`test_sf_ssm_pipefail_wiring._iter_ssm_command_blocks`** previously only iterated plain `commands` arrays — silently skipped every `commands.$ States.Array(...)` state. That's why the broken trap went undetected from 2026-05-17 → 2026-05-22 dry-pass fire. Now iterates both forms via the shared `extract_commands` helper.
2. **`test_long_ssm_steps_ship_log_to_s3`** accepts EITHER the inline bash trap (plain commands form) OR the lib CLI (commands.$ form) as satisfying the invariant.
3. **`sf_prekeystone_spot_commands.json`** fixture regenerated per its own docstring permission ("Regenerate ONLY on a deliberate, reviewed change to a spot state's absent-path command"). Pre-keystone form had the broken trap baked in.
4. Per-state tests in `test_sf_morning_enrich_split_wiring.py` and `test_sf_backtest_parity_split_wiring.py` rewritten to assert lib-CLI presence + no-inline-trap-coexistence.
5. `test_spot_command_carries_preflight_only_under_shell_run` updated for the new shell_run command shape.

## Dependency chain (merge in order)

1. [alpha-engine-lib #57](https://github.com/cipher813/alpha-engine-lib/pull/57) — adds `ssm_log_capture`, auto-tags v0.25.0
2. [alpha-engine-data #289](https://github.com/cipher813/alpha-engine-data/pull/289) — bumps lib pin v0.24.0 → v0.25.0 (spot side)
3. [alpha-engine-predictor #188](https://github.com/cipher813/alpha-engine-predictor/pull/188) — bumps lib pin (PredictorTraining spot)
4. [alpha-engine-backtester #243](https://github.com/cipher813/alpha-engine-backtester/pull/243) — bumps lib pin (Backtester/Parity/Evaluator spots)
5. [alpha-engine-dashboard #118](https://github.com/cipher813/alpha-engine-dashboard/pull/118) — bumps lib pin v0.16.0 → v0.25.0 (ae-dashboard = SSM target, hosts the `.venv` where the lib CLI runs)
6. **THIS PR** — converts SF JSON to invoke the lib CLI
7. Run `alpha-engine-data/infrastructure/deploy_step_function.sh`
8. Redrive the Friday-PM dry-pass; confirm 8/8 spot states green
9. Saturday 09:00 UTC firing runs cleanly

## Test plan

- [x] Suite green locally: 1430 passed, 1 skipped (FutureWarnings unrelated)
- [ ] Deps 1–5 merged in order; v0.25.0 tag exists
- [ ] Merge this PR
- [ ] Verify `/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture --help` on ae-dashboard returns the CLI usage
- [ ] Run `bash infrastructure/deploy_step_function.sh` to push updated SF to AWS
- [ ] Redrive the failed `alpha-engine-saturday-pipeline` execution (Saturday SF), or re-fire the Friday-PM `alpha-engine-friday-shell-run` rule
- [ ] Confirm 8/8 spot states reach Success (or `--preflight-only` clean-exit) without trap-related failures
- [ ] Spot-check S3 `_ssm_logs/<slug>/<date>/<host>-<time>.log` keys land under the canonical layout
- [ ] Saturday 09:00 UTC: real Saturday SF firing runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)