### PR TITLE
feat(spot): capacity-resilient launch via alpha_engine_lib.ec2_spot + lib pin v0.25.0 → v0.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.25.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.26.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -69,7 +69,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 AWS_REGION="${AWS_REGION:-us-east-1}"
 S3_BUCKET="${S3_BUCKET:-alpha-engine-research}"
 BRANCH="${BRANCH:-main}"
-INSTANCE_TYPE="c5.large"            # 2 vCPU, 4 GB RAM — DataPhase1 is memory-bound, not CPU-bound
+# Capacity-resilient instance-type fallback set (2026-05-22 incident:
+# Evaluator's launch hit InsufficientInstanceCapacity for c5.large in
+# us-east-1f). All 2 vCPU / 4-8 GB RAM — equivalent for our workloads.
+# Order = preference; the lib CLI tries each in turn until one launches.
+INSTANCE_TYPES="${INSTANCE_TYPES:-c5.large,m5.large,c6i.large,c5a.large}"
+# Backward-compat: --instance-type X collapses the list to a single type.
+INSTANCE_TYPE=""
 AMI_ID="ami-0c421724a94bba6d6"      # Amazon Linux 2023 x86_64
 # Spot-side watchdog budget: DataPhase1 historically runs 25-35 min;
 # RAG ingestion adds another 20-45 min. 90 min with headroom covers both
@@ -79,8 +85,19 @@ MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-5400}"
 KEY_NAME="alpha-engine-key"
 KEY_FILE="$HOME/.ssh/alpha-engine-key.pem"
 SECURITY_GROUP="sg-03cd3c4bd91e610b0"
-SUBNET_ID="subnet-e07166ec"
+# All 6 default-VPC subnets across us-east-1{a,b,c,d,e,f}. The lib CLI
+# (alpha_engine_lib.ec2_spot) rotates across this list on capacity
+# error. Verified 2026-05-22 — all 6 are public-IP-on-launch, all in
+# vpc-566f002e, all with ~4091 free IPs. If the VPC topology changes,
+# update via `aws ec2 describe-subnets --filters Name=vpc-id,Values=vpc-566f002e`.
+SUBNETS="${SUBNETS:-subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,subnet-c670118d,subnet-7cff7c43,subnet-e07166ec}"
 IAM_PROFILE="alpha-engine-executor-profile"
+# Lib CLI path: ae-dashboard is the SSM target instance ($MicroInstanceId)
+# for all 8 Saturday-SF spot states; the dispatcher's .venv has
+# alpha-engine-lib installed (see deploy-on-merge.sh in the dashboard
+# repo). Bare `python3` resolves to system python which does NOT carry
+# the lib — use the full venv path.
+LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
 
 # ── Parse flags ──────────────────────────────────────────────────────────────
 # RUN_MODE values:
@@ -119,7 +136,7 @@ while [[ $# -gt 0 ]]; do
         --morning-enrich-only) RUN_MODE="morning-enrich-only"; shift ;;
         --phase1-only) RUN_MODE="phase1-only"; shift ;;
         --preflight-only) PREFLIGHT_ONLY=1; shift ;;
-        --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
+        --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;  # legacy: collapses INSTANCE_TYPES to single value
         --branch) BRANCH="$2"; shift 2 ;;
         *) echo "Unknown flag: $1"; exit 1 ;;
     esac
@@ -128,7 +145,14 @@ done
 echo "═══════════════════════════════════════════════════════════════"
 echo "  Weekly Data Spot Run (Phase1 + RAG) — $(date +%Y-%m-%d)"
 echo "═══════════════════════════════════════════════════════════════"
-echo "  Instance type : $INSTANCE_TYPE"
+# --instance-type collapses the rotation list to a single value (legacy
+# behavior). Otherwise the lib CLI rotates across INSTANCE_TYPES on
+# capacity error.
+if [ -n "$INSTANCE_TYPE" ]; then
+    INSTANCE_TYPES="$INSTANCE_TYPE"
+fi
+echo "  Instance types: $INSTANCE_TYPES"
+echo "  Subnets       : $SUBNETS"
 echo "  AMI           : $AMI_ID"
 echo "  Region        : $AWS_REGION"
 echo "  Branch        : $BRANCH"
@@ -147,22 +171,32 @@ fi
 # script fetched a PAT from /alpha-engine/lib-token via SSM — no longer needed.
 
 # ── Launch spot ──────────────────────────────────────────────────────────────
-echo "==> Requesting spot instance ($INSTANCE_TYPE)..."
+# Capacity-resilient launch via alpha_engine_lib.ec2_spot (lib v0.26.0+).
+# The CLI iterates (instance_type × subnet) on InsufficientInstanceCapacity /
+# InsufficientHostCapacity / Unsupported / InvalidAvailabilityZone /
+# SpotMaxPriceTooLow, returning the InstanceId of the first successful
+# launch. Non-capacity errors (auth, AMI not found, quota) raise
+# immediately. Replaces the 2026-05-22 broken-by-design hardcoded
+# single-subnet + single-instance-type pattern that failed Evaluator's
+# launch when us-east-1f ran out of c5.large.
+echo "==> Requesting spot instance (lib CLI rotation: types=[$INSTANCE_TYPES], subnets=[$SUBNETS])..."
 
-INSTANCE_ID=$(aws ec2 run-instances \
+INSTANCE_ID=$("$LIB_PYTHON" -m alpha_engine_lib.ec2_spot launch \
+    --types "$INSTANCE_TYPES" \
+    --subnets "$SUBNETS" \
     --image-id "$AMI_ID" \
-    --instance-type "$INSTANCE_TYPE" \
     --key-name "$KEY_NAME" \
-    --security-group-ids "$SECURITY_GROUP" \
-    --subnet-id "$SUBNET_ID" \
-    --iam-instance-profile Name="$IAM_PROFILE" \
-    --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}' \
-    --instance-initiated-shutdown-behavior terminate \
-    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
-    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-data-weekly-$(date +%Y%m%d)}]" \
-    --region "$AWS_REGION" \
-    --query 'Instances[0].InstanceId' \
-    --output text)
+    --security-group "$SECURITY_GROUP" \
+    --iam-profile "$IAM_PROFILE" \
+    --name "alpha-engine-data-weekly-$(date +%Y%m%d)" \
+    --region "$AWS_REGION")
+ec2_spot_rc=$?
+if [ "$ec2_spot_rc" -ne 0 ] || [ -z "$INSTANCE_ID" ]; then
+    if [ "$ec2_spot_rc" -eq 64 ]; then
+        echo "ERROR: capacity exhausted across all instance_type × subnet combinations. Wait + retry, or expand the lists." >&2
+    fi
+    exit "${ec2_spot_rc:-1}"
+fi
 
 echo "  Instance ID: $INSTANCE_ID"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
 # psycopg2-binary + pgvector now come via [rag] (added in lib v0.3.0,
 # direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.25.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.26.0


### PR DESCRIPTION
## Summary

Closes the 2026-05-22 dry-pass failure where Evaluator's spot launch hit `InsufficientInstanceCapacity` for c5.large in us-east-1f (3rd break caught by the Friday-PM dry-pass safety net tonight — first: trap escape, second: keystone merge order, third: this single-AZ single-instance-type fragility).

Replaces the hardcoded single-subnet + single-instance-type pattern with the lib's `ec2_spot.launch` rotation primitive (lib v0.26.0, see [alpha-engine-lib PR #58](https://github.com/cipher813/alpha-engine-lib/pull/58)).

## Changes

**Pin bump** (lockstep across both files per `test_lib_pin_lockstep`):
- `requirements.txt`: v0.25.0 → v0.26.0
- `Dockerfile`: v0.25.0 → v0.26.0

**`infrastructure/spot_data_weekly.sh`:**
- Drop hardcoded `SUBNET_ID="subnet-e07166ec"` (us-east-1f only) + single `INSTANCE_TYPE="c5.large"`.
- Add `INSTANCE_TYPES` list (default `c5.large,m5.large,c6i.large,c5a.large` — all 2 vCPU / 4-8 GB RAM, capacity-resilient set).
- Add `SUBNETS` list (all 6 default-VPC subnets across us-east-1{a..f} — verified 2026-05-22, all public-IP-on-launch, all in `vpc-566f002e`, all with ~4091 free IPs).
- Replace `aws ec2 run-instances ...` block with `$LIB_PYTHON -m alpha_engine_lib.ec2_spot launch ...`.
- `LIB_PYTHON` defaults to `/home/ec2-user/alpha-engine-dashboard/.venv/bin/python` (ae-dashboard is the SSM target; bare `python3` resolves to system python which doesn't carry the lib).
- Legacy `--instance-type X` flag preserved: collapses `INSTANCE_TYPES` to a single value for ad-hoc operator runs.
- Echo block surfaces both rotation lists so failures are obvious from the SSM log capture.

## Blocks on

[alpha-engine-lib PR #58](https://github.com/cipher813/alpha-engine-lib/pull/58) — auto-tags v0.26.0.

## Test plan

- [x] Lockstep test passes locally (requirements + Dockerfile both at v0.26.0)
- [x] `bash -n` syntax check on the launcher passes
- [x] Full suite 1430 passed, 1 skipped
- [ ] Lib #58 merged + v0.26.0 tag exists
- [ ] Post-merge: Friday-PM dry-pass re-fire confirms DataPhase1/MorningEnrich/RAGIngestion/DriftDetection spot states clear with capacity rotation working

🤖 Generated with [Claude Code](https://claude.com/claude-code)