### PR TITLE
feat(sf): immediate SNS alert on parallel-branch failure (close visibility gap)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1084,7 +1084,27 @@
                 "payload.$": "$.research_result.Payload"
               },
               "ResultPath": "$.error",
-              "Next": "BranchAFailed"
+              "Next": "PublishResearchFailureImmediate"
+            },
+            "PublishResearchFailureImmediate": {
+              "Type": "Task",
+              "Comment": "Fire an immediate SNS failure alert when the Research branch fails, BEFORE the sibling PredictorTraining branch completes its full ~12-min train + the parent SF's parallel-join aggregation. Closes the 2026-05-24 operator-confusion gap where a mid-parallel failure surfaced only after the sibling branch's work completed (the salvage-at-join design is correct; the visibility lag was the actual problem). Branch terminus is still BranchAFailed (Pass) so the salvage semantics are preserved: SF still fails at the join via CheckBranchOutcomes; the sibling branch's completed work still persists for the next redrive's skip-set. SNS publish failure is caught and routed forward — best-effort alert must NEVER prevent the branch from properly terminating.",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — Research FAILED (early signal — SF will fail at join)', $.pipeline_label)",
+                "Message.$": "States.Format('Research branch hard-failed inside ResearchPredictorParallel. The sibling PredictorTraining branch is still running and will complete its own work; the SF will fail at the parallel-join aggregation via CheckBranchOutcomes once both branches terminate. This is an EARLY-SIGNAL alert so you do not have to wait for the join. Error: {}', States.JsonToString($.error))"
+              },
+              "ResultPath": null,
+              "Next": "BranchAFailed",
+              "Catch": [
+                {
+                  "ErrorEquals": ["States.ALL"],
+                  "Comment": "Best-effort: a failed SNS publish must not prevent the branch from terminating cleanly. The branch still routes to BranchAFailed and the SF still fails at the join.",
+                  "ResultPath": null,
+                  "Next": "BranchAFailed"
+                }
+              ]
             },
             "BranchAComplete": {
               "Type": "Pass",
@@ -1235,7 +1255,27 @@
                 "poll.$": "$.predictor_poll"
               },
               "ResultPath": "$.error",
-              "Next": "BranchBFailed"
+              "Next": "PublishPredictorFailureImmediate"
+            },
+            "PublishPredictorFailureImmediate": {
+              "Type": "Task",
+              "Comment": "Fire an immediate SNS failure alert when PredictorTraining fails, BEFORE the sibling Research branch finishes its eval-judge / RollingMean / Counterfactual chain + the parent SF's parallel-join aggregation. Closes the 2026-05-24 operator-confusion gap where the predictor OOM surfaced only after the Research-eval chain completed (~10 min of misleading 'progress' visible while the run was already known-doomed). Branch terminus is still BranchBFailed (Pass) so the salvage semantics are preserved: SF still fails at the join via CheckBranchOutcomes; Research's eval-judge work still persists for the next redrive's skip-set. SNS publish failure is caught and routed forward — best-effort alert must NEVER prevent the branch from properly terminating.",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — PredictorTraining FAILED (early signal — SF will fail at join)', $.pipeline_label)",
+                "Message.$": "States.Format('PredictorTraining branch failed inside ResearchPredictorParallel. The sibling Research branch is still running and will complete its eval-judge / RollingMean / Counterfactual work independently; the SF will fail at the parallel-join aggregation via CheckBranchOutcomes once both branches terminate. This is an EARLY-SIGNAL alert so you do not have to wait for the join. Error: {}', States.JsonToString($.error))"
+              },
+              "ResultPath": null,
+              "Next": "BranchBFailed",
+              "Catch": [
+                {
+                  "ErrorEquals": ["States.ALL"],
+                  "Comment": "Best-effort: a failed SNS publish must not prevent the branch from terminating cleanly. The branch still routes to BranchBFailed and the SF still fails at the join.",
+                  "ResultPath": null,
+                  "Next": "BranchBFailed"
+                }
+              ]
             },
             "BranchBComplete": {
               "Type": "Pass",

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -62,12 +62,14 @@ _BRANCH_A_STATES = {
     "CheckSkipRationaleClustering", "RationaleClustering",
     "CheckSkipReplayConcordance", "ReplayConcordance",
     "CheckSkipCounterfactual", "Counterfactual", "ExtractResearchError",
+    "PublishResearchFailureImmediate",
     "BranchAComplete", "BranchAFailed",
 }
 _BRANCH_B_STATES = {
     "CheckSkipPredictorTraining", "PredictorTraining",
     "WaitForPredictorTraining", "CheckPredictorStatus", "PredictorWait",
-    "ExtractPredictorError", "BranchBComplete", "BranchBFailed",
+    "ExtractPredictorError", "PublishPredictorFailureImmediate",
+    "BranchBComplete", "BranchBFailed",
 }
 
 
@@ -357,12 +359,26 @@ class TestPerBranchErrorIsolation:
 
     def test_research_hardfail_routes_to_branch_a_failed(self, branch_a):
         """strict-Research hard-fail (Task Catch) + the soft-fail status
-        path (ExtractResearchError) must record FAILED, not halt the SF."""
+        path (ExtractResearchError → PublishResearchFailureImmediate) must
+        record FAILED, not halt the SF. The PublishResearchFailureImmediate
+        intermediate is the fast-SNS-alert state added 2026-05-24; both
+        success and failure paths through it terminate at BranchAFailed."""
         catch_targets = [
             c["Next"] for c in branch_a["Research"]["Catch"]
         ]
         assert catch_targets == ["BranchAFailed"]
-        assert branch_a["ExtractResearchError"]["Next"] == "BranchAFailed"
+        # ExtractError → PublishImmediate → BranchAFailed
+        assert (
+            branch_a["ExtractResearchError"]["Next"]
+            == "PublishResearchFailureImmediate"
+        )
+        publish = branch_a["PublishResearchFailureImmediate"]
+        assert publish["Type"] == "Task"
+        assert publish["Resource"] == "arn:aws:states:::sns:publish"
+        assert publish["Next"] == "BranchAFailed"
+        # SNS-publish-fails escape hatch also lands at BranchAFailed
+        for c in publish.get("Catch", []):
+            assert c["Next"] == "BranchAFailed"
         # CheckResearchStatus non-OK/SKIPPED → ExtractResearchError
         assert (
             branch_a["CheckResearchStatus"]["Default"]
@@ -375,6 +391,11 @@ class TestPerBranchErrorIsolation:
         ]
 
     def test_predictor_failure_routes_to_branch_b_failed(self, branch_b):
+        """PredictorTraining failures (Task Catch + WaitForPredictorTraining
+        Catch + CheckPredictorStatus default) route through
+        ExtractPredictorError → PublishPredictorFailureImmediate (fast SNS
+        alert added 2026-05-24) → BranchBFailed. Salvage semantics
+        preserved: SF still fails at the join via CheckBranchOutcomes."""
         assert [
             c["Next"] for c in branch_b["PredictorTraining"]["Catch"]
         ] == ["BranchBFailed"]
@@ -382,7 +403,16 @@ class TestPerBranchErrorIsolation:
             c["Next"]
             for c in branch_b["WaitForPredictorTraining"]["Catch"]
         ] == ["BranchBFailed"]
-        assert branch_b["ExtractPredictorError"]["Next"] == "BranchBFailed"
+        assert (
+            branch_b["ExtractPredictorError"]["Next"]
+            == "PublishPredictorFailureImmediate"
+        )
+        publish = branch_b["PublishPredictorFailureImmediate"]
+        assert publish["Type"] == "Task"
+        assert publish["Resource"] == "arn:aws:states:::sns:publish"
+        assert publish["Next"] == "BranchBFailed"
+        for c in publish.get("Catch", []):
+            assert c["Next"] == "BranchBFailed"
         assert (
             branch_b["CheckPredictorStatus"]["Default"]
             == "ExtractPredictorError"


### PR DESCRIPTION
## Summary

Closes the 2026-05-24 operator-confusion gap where PredictorTraining OOMed mid-`ResearchPredictorParallel` but the failure surfaced only after the sibling Research branch's eval-judge chain completed (~10 min of misleading 'progress' visible while the run was already known-doomed). Operator's question was 'did predictor succeed?' because eval emails were still firing.

Per Brian's directive: keep salvage-at-join semantics (the design comment is right — completed branch's work has independent value for the next redrive's skip-set), but add fast visibility so the operator sees failure immediately.

## What changes

Two new SNS-publish states inserted between the existing failure-extractors and branch terminuses:

| Path | Before | After |
|---|---|---|
| Research failure | `ExtractResearchError → BranchAFailed` | `ExtractResearchError → PublishResearchFailureImmediate → BranchAFailed` |
| Predictor failure | `ExtractPredictorError → BranchBFailed` | `ExtractPredictorError → PublishPredictorFailureImmediate → BranchBFailed` |

Each publish state fires an SNS alert to `$.sns_topic_arn` with subject 'Alpha Engine Saturday{} Pipeline — Research/PredictorTraining FAILED (early signal — SF will fail at join)' the moment its branch fails. Best-effort: the publish state has its own Catch that routes SNS-failure forward to BranchXFailed so a transient SNS hiccup never prevents the branch from terminating cleanly.

## Salvage semantics preserved

- BranchAFailed / BranchBFailed remain **Pass states** (NOT Fail states)
- SF still fails at the join via `CheckBranchOutcomes → ExtractParallelBranchError → HandleFailure`
- Sibling branch's completed work still persists for the next redrive's skip-set
- The final HandleFailure SNS at the join is still the canonical 'pipeline FAILED' message; the new early-signal alerts are additive

## Test plan

- [x] `_BRANCH_A_STATES` / `_BRANCH_B_STATES` extended; structural wiring tests assert the new states exist and chain correctly
- [x] `test_research_hardfail_routes_to_branch_a_failed` + `test_predictor_failure_routes_to_branch_b_failed` updated to assert the full chain through the new publish states + the SNS-failure escape hatch
- [x] Suite **1444 passing**, no regressions
- [ ] Post-merge: deploy SF via `update_step_function.sh` (control-plane only, no execution rerun); next branch failure produces an immediate SNS email + the existing pipeline-failure email at the join

## Composes with

- alpha-engine-predictor [#193](https://github.com/cipher813/alpha-engine-predictor/pull/193) — memory profiling + 3-vol-variant OOM fix (the actual root cause of today's incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)