### PR TITLE
feat(constituents): shared run_date-aware loader chokepoint — close L1397

### DIFF
--- a/builders/_constituents_loader.py
+++ b/builders/_constituents_loader.py
@@ -1,0 +1,101 @@
+"""Shared constituents.json reader — single chokepoint for both
+``builders/backfill.py`` and ``builders/prune_delisted_tickers.py``.
+
+Lifted 2026-05-24 to close ROADMAP L1397 + 5/23-SF P0 sweep follow-on
+per [[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]:
+the same ``latest_weekly.json`` pointer-vs-direct-read TOCTOU defect class
+that bit ``backfill()`` (data #294) also lives in
+``prune_delisted_tickers._load_latest_constituents``. Both consumers
+live in the same repo, so the institutional move is an in-repo helper
+chokepoint — not cross-repo lib lift. (A third reader in a different
+repo would justify the cross-repo lift; until then, in-repo helper is
+right-sized scope per ``~/Development/CLAUDE.md`` SOTA rule.)
+
+Failure mode the helper closes (verbatim from 2026-05-23 SF L1316):
+
+  - Constituents collector writes ``weekly/2026-05-23/constituents.json``
+    at T0 (903 tickers including BNY/P/SN).
+  - ``_write_manifest`` advances ``latest_weekly.json`` pointer to
+    2026-05-23 at T0 + N min (end of Phase 1).
+  - Any reader running between T0 and T0+N reading the pointer sees the
+    PRIOR weekly's constituents — BNY/P/SN missing on the way IN to
+    ArcticDB writes (backfill); BK/FLO/PSTG still pruning-protected on
+    the way OUT (prune). Both sides have the same root cause.
+
+Fix: callers that know their ``run_date`` (the Phase-1 work date)
+read directly from ``weekly/{run_date}/constituents.json``. Callers
+that don't (CLI, ad-hoc recovery) fall back to the pointer — which
+is then safely advanced after the work completes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def load_constituents_for_run_date(
+    s3,
+    bucket: str,
+    run_date: str | None = None,
+) -> tuple[set[str], str]:
+    """Load the current S&P 500 + 400 constituents set.
+
+    When ``run_date`` is provided (Phase-1 happy path), reads directly
+    from ``market_data/weekly/{run_date}/constituents.json`` — the file
+    the constituents collector wrote earlier in this same Phase-1
+    invocation. Otherwise falls back to ``market_data/latest_weekly.json``
+    for ad-hoc callers (per-ticker recovery, dry-runs, post-Phase-1
+    intraday recovery scripts).
+
+    Parameters
+    ----------
+    s3
+        boto3 S3 client.
+    bucket
+        S3 bucket holding the weekly constituents partitions.
+    run_date
+        ``YYYY-MM-DD`` of the current Phase-1 work date, OR ``None`` to
+        follow the pointer.
+
+    Returns
+    -------
+    tuple
+        ``(tickers_set, weekly_date_str)`` — ``tickers_set`` is the set
+        of constituent symbols; ``weekly_date_str`` is the resolved
+        weekly partition's date (the value of ``run_date`` when passed,
+        or the pointer's ``date`` field when not).
+
+    Raises
+    ------
+    RuntimeError
+        If ``constituents.json`` is reachable but missing/empty the
+        ``tickers`` field. Filtering against an empty set would write
+        zero tickers to ArcticDB OR delete every symbol on the prune
+        path — both are catastrophic. Fail-loud per
+        ``[[feedback_no_silent_fails]]``.
+    """
+    if run_date:
+        key = f"market_data/weekly/{run_date}/constituents.json"
+        weekly_date = run_date
+        source = f"run_date={run_date} (direct)"
+    else:
+        pointer_obj = s3.get_object(Bucket=bucket, Key="market_data/latest_weekly.json")
+        pointer = json.loads(pointer_obj["Body"].read())
+        weekly_date = pointer["date"]
+        prefix = pointer["s3_prefix"].rstrip("/")
+        key = f"{prefix}/constituents.json"
+        source = f"pointer→{weekly_date}"
+    cons_obj = s3.get_object(Bucket=bucket, Key=key)
+    payload = json.loads(cons_obj["Body"].read())
+    tickers = payload.get("tickers")
+    if not tickers:
+        raise RuntimeError(
+            f"constituents.json at s3://{bucket}/{key} ({source}) has no "
+            f"`tickers` field — refusing to operate against an empty "
+            f"constituents set (would either write zero tickers to arctic "
+            f"universe OR delete every symbol on the prune path)."
+        )
+    return set(tickers), weekly_date

--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -61,6 +61,7 @@ from builders._price_cache_writeboth import (
     PRICE_CACHE_LEGACY_PREFIX,
     list_price_cache_keys,
 )
+from builders._constituents_loader import load_constituents_for_run_date
 from builders.daily_append import _scan_universe_and_emit_freshness_receipt
 
 log = logging.getLogger(__name__)
@@ -81,39 +82,19 @@ PROVENANCE_COL = _CANONICAL_PROVENANCE_COL
 def _load_current_constituents(s3, bucket: str, run_date: str | None = None) -> set[str]:
     """Load the current S&P 500 / 400 constituents set.
 
-    When ``run_date`` is provided (DataPhase1 happy path), reads directly from
-    ``market_data/weekly/{run_date}/constituents.json`` — the file the
-    constituents collector wrote earlier in this same Phase 1 invocation.
-    Otherwise falls back to ``market_data/latest_weekly.json`` for ad-hoc
-    callers (per-ticker recovery backfills, dry-runs, tests).
+    Thin wrapper around :func:`load_constituents_for_run_date` —
+    preserved for backwards compatibility with backfill's caller sites
+    that consume just the ticker set (not the weekly_date tuple). New
+    code should call :func:`load_constituents_for_run_date` directly.
 
-    The pointer-based fallback exists because ``_write_manifest`` only advances
-    ``latest_weekly.json`` at the *end* of Phase 1, while ``backfill`` runs in
-    the middle. Using the pointer here previously caused new constituents
-    (added to Wikipedia between Saturdays) to be excluded from the ArcticDB
-    write — the very tickers Research then asks for at preflight time,
-    tripping the 5% per-ticker error threshold (see 2026-05-23 SF failure).
+    Lifted 2026-05-24 (ROADMAP L1397): the run_date-aware constituents
+    read is now a single chokepoint at
+    :func:`builders._constituents_loader.load_constituents_for_run_date`,
+    shared with ``prune_delisted_tickers``. See module docstring there
+    for the TOCTOU defect class this closes (see 2026-05-23 SF failure).
     """
-    if run_date:
-        key = f"market_data/weekly/{run_date}/constituents.json"
-        source = f"run_date={run_date} (direct)"
-    else:
-        pointer_obj = s3.get_object(Bucket=bucket, Key="market_data/latest_weekly.json")
-        pointer = json.loads(pointer_obj["Body"].read())
-        weekly_date = pointer["date"]
-        prefix = pointer["s3_prefix"].rstrip("/")
-        key = f"{prefix}/constituents.json"
-        source = f"pointer→{weekly_date}"
-    cons_obj = s3.get_object(Bucket=bucket, Key=key)
-    payload = json.loads(cons_obj["Body"].read())
-    tickers = payload.get("tickers")
-    if not tickers:
-        raise RuntimeError(
-            f"constituents.json at s3://{bucket}/{key} ({source}) has no "
-            f"`tickers` field — refusing to filter against an empty "
-            f"constituents set (would write zero tickers to arctic universe)."
-        )
-    return set(tickers)
+    tickers, _ = load_constituents_for_run_date(s3, bucket, run_date=run_date)
+    return tickers
 
 
 def _load_full_cache(s3, bucket: str, prefix: str = PRICE_CACHE_LEGACY_PREFIX) -> dict[str, pd.DataFrame]:

--- a/builders/prune_delisted_tickers.py
+++ b/builders/prune_delisted_tickers.py
@@ -42,6 +42,7 @@ from datetime import datetime, timedelta, timezone
 import boto3
 import pandas as pd
 
+from builders._constituents_loader import load_constituents_for_run_date
 from features.compute import DEFAULT_BUCKET, _SKIP_TICKERS, _is_sector_etf
 from store.arctic_store import get_universe_lib
 
@@ -51,25 +52,29 @@ DEFAULT_ABSENT_DAYS = 14
 AUDIT_PREFIX = "builders/prune_audit/"
 
 
-def _load_latest_constituents(s3, bucket: str) -> tuple[set[str], str]:
-    """Return (tickers_set, weekly_date_str) from the latest constituents.json."""
-    pointer_key = "market_data/latest_weekly.json"
-    obj = s3.get_object(Bucket=bucket, Key=pointer_key)
-    pointer = json.loads(obj["Body"].read())
-    weekly_date = pointer["date"]
-    prefix = pointer["s3_prefix"].rstrip("/")
-    constituents_key = f"{prefix}/constituents.json"
+def _load_latest_constituents(
+    s3, bucket: str, run_date: str | None = None,
+) -> tuple[set[str], str]:
+    """Return ``(tickers_set, weekly_date_str)`` from the current
+    constituents.json.
 
-    obj = s3.get_object(Bucket=bucket, Key=constituents_key)
-    payload = json.loads(obj["Body"].read())
-    tickers = payload.get("tickers")
-    if not tickers:
-        raise RuntimeError(
-            f"constituents.json at s3://{bucket}/{constituents_key} has no "
-            f"`tickers` field — refusing to prune against an empty universe "
-            f"(would delete every symbol)."
-        )
-    return set(tickers), weekly_date
+    Thin wrapper around
+    :func:`builders._constituents_loader.load_constituents_for_run_date`.
+    When ``run_date`` is provided (Phase-1 happy path), reads directly
+    from ``market_data/weekly/{run_date}/constituents.json``; otherwise
+    falls back to the ``latest_weekly.json`` pointer.
+
+    Lifted 2026-05-24 (ROADMAP L1397). The pre-lift implementation
+    always followed the pointer — which, during Phase-1, points at the
+    PRIOR week's partition (the constituents collector writes the new
+    weekly file first; ``_write_manifest`` advances the pointer at
+    end-of-Phase-1). Calling prune mid-Phase-1 with the stale pointer
+    pruned tickers REMOVED last week instead of this week (BK/FLO/PSTG
+    for the 5/23 cycle would have stayed in arctic for one extra week
+    before the next prune run cleared them). Same defect class as the
+    L1316 backfill TOCTOU.
+    """
+    return load_constituents_for_run_date(s3, bucket, run_date=run_date)
 
 
 def _read_last_date(universe_lib, ticker: str) -> pd.Timestamp | None:
@@ -100,6 +105,7 @@ def prune_delisted_tickers(
     apply: bool = False,
     tickers_override: list[str] | None = None,
     constituents_override: "set[str] | list[str] | None" = None,
+    run_date: str | None = None,
     today: pd.Timestamp | None = None,
 ) -> dict:
     """Prune ArcticDB universe symbols that are confirmed delistings.
@@ -126,6 +132,19 @@ def prune_delisted_tickers(
         (which has cross-module read fan-out — alternative/macro/
         features/compute all depend on it). Mutually exclusive with
         ``tickers_override``.
+    run_date
+        ``YYYY-MM-DD`` of the current Phase-1 work date. When set, the
+        constituents read goes directly to
+        ``market_data/weekly/{run_date}/constituents.json`` rather than
+        following the ``latest_weekly.json`` pointer — required for
+        in-Phase-1 callers (``weekly_collector._run_phase1``) because
+        the pointer isn't advanced until ``_write_manifest`` at end-of-
+        Phase-1. Without ``run_date``, a Phase-1 prune call sees LAST
+        week's constituents and fails to prune this-week's REMOVALS
+        (BK/FLO/PSTG for the 5/23 cycle). Mutually exclusive with
+        ``constituents_override``; ignored when ``tickers_override`` is
+        set. Closes ROADMAP L1397 (same TOCTOU defect class as L1316
+        ``backfill`` fix in data #294).
     today
         Override the staleness reference date for testing. Defaults to
         UTC midnight today.
@@ -168,10 +187,14 @@ def prune_delisted_tickers(
                 len(constituents),
             )
         else:
-            constituents, weekly_date = _load_latest_constituents(s3, bucket)
+            constituents, weekly_date = _load_latest_constituents(
+                s3, bucket, run_date=run_date,
+            )
             log.info(
-                "Latest constituents (date=%s): %d tickers",
-                weekly_date, len(constituents),
+                "Latest constituents (date=%s, source=%s): %d tickers",
+                weekly_date,
+                "run_date direct" if run_date else "latest_weekly pointer",
+                len(constituents),
             )
         # Only stocks can be pruned — never touch macro/index series or
         # sector ETFs (those aren't constituents-tracked but are still

--- a/tests/test_constituents_loader_shared.py
+++ b/tests/test_constituents_loader_shared.py
@@ -1,0 +1,183 @@
+"""Tests for the shared `load_constituents_for_run_date` helper.
+
+Closes ROADMAP L1397 + 5/23-SF P0 sweep follow-on per
+[[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]:
+the in-repo chokepoint consumed by BOTH `builders/backfill.py` and
+`builders/prune_delisted_tickers.py`.
+
+Pins:
+  1. With `run_date`, reads from `weekly/{run_date}/constituents.json`
+     directly (NO pointer read).
+  2. Without `run_date`, falls back to `latest_weekly.json` pointer.
+  3. Empty/missing `tickers` field raises RuntimeError (fail-loud).
+  4. Both wrappers (`backfill._load_current_constituents` +
+     `prune._load_latest_constituents`) delegate through the helper.
+"""
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from builders._constituents_loader import load_constituents_for_run_date
+
+
+def _mock_s3_with(get_object_side_effect):
+    s3 = MagicMock()
+    s3.get_object.side_effect = get_object_side_effect
+    return s3
+
+
+def _make_payload(tickers: list[str]) -> dict:
+    return {"Body": io.BytesIO(json.dumps({"tickers": tickers}).encode())}
+
+
+def test_run_date_provided_reads_direct_partition_no_pointer():
+    """When run_date is provided, the read goes directly to
+    `weekly/{run_date}/constituents.json` — pointer is NEVER touched."""
+    calls = []
+
+    def _get(Bucket, Key):
+        calls.append(Key)
+        assert Key == "market_data/weekly/2026-05-23/constituents.json", (
+            f"unexpected key {Key} — pointer should NOT be read when run_date is set"
+        )
+        return _make_payload(["AAPL", "BNY", "P", "SN"])
+
+    s3 = _mock_s3_with(_get)
+    tickers, weekly_date = load_constituents_for_run_date(
+        s3, "alpha-engine-research", run_date="2026-05-23",
+    )
+    assert tickers == {"AAPL", "BNY", "P", "SN"}
+    assert weekly_date == "2026-05-23"
+    # Exactly ONE call — the direct partition read.
+    assert len(calls) == 1
+    assert "latest_weekly.json" not in calls[0]
+
+
+def test_no_run_date_falls_back_to_pointer():
+    """When run_date is None, the pointer is read first, then the
+    constituents.json under the pointed-to prefix."""
+    calls = []
+
+    def _get(Bucket, Key):
+        calls.append(Key)
+        if Key == "market_data/latest_weekly.json":
+            return {"Body": io.BytesIO(json.dumps({
+                "date": "2026-05-16",
+                "s3_prefix": "market_data/weekly/2026-05-16/",
+            }).encode())}
+        if Key == "market_data/weekly/2026-05-16/constituents.json":
+            return _make_payload(["AAPL", "MSFT"])
+        raise AssertionError(f"unexpected key {Key}")
+
+    s3 = _mock_s3_with(_get)
+    tickers, weekly_date = load_constituents_for_run_date(s3, "alpha-engine-research")
+    assert tickers == {"AAPL", "MSFT"}
+    assert weekly_date == "2026-05-16"
+    assert calls == [
+        "market_data/latest_weekly.json",
+        "market_data/weekly/2026-05-16/constituents.json",
+    ]
+
+
+def test_empty_tickers_raises():
+    def _get(Bucket, Key):
+        if Key == "market_data/weekly/2026-05-23/constituents.json":
+            return {"Body": io.BytesIO(json.dumps({"tickers": []}).encode())}
+        raise AssertionError(f"unexpected key {Key}")
+
+    s3 = _mock_s3_with(_get)
+    with pytest.raises(RuntimeError, match="no `tickers` field"):
+        load_constituents_for_run_date(
+            s3, "alpha-engine-research", run_date="2026-05-23",
+        )
+
+
+def test_missing_tickers_field_raises():
+    def _get(Bucket, Key):
+        return {"Body": io.BytesIO(json.dumps({"date": "2026-05-23"}).encode())}
+
+    s3 = _mock_s3_with(_get)
+    with pytest.raises(RuntimeError, match="no `tickers` field"):
+        load_constituents_for_run_date(
+            s3, "alpha-engine-research", run_date="2026-05-23",
+        )
+
+
+def test_backfill_wrapper_delegates_to_shared_helper():
+    """`builders.backfill._load_current_constituents` is now a thin
+    wrapper — verify it returns just the ticker set (legacy contract)
+    and routes through the shared helper."""
+    from builders.backfill import _load_current_constituents
+
+    def _get(Bucket, Key):
+        assert Key == "market_data/weekly/2026-05-23/constituents.json"
+        return _make_payload(["AAPL", "BNY"])
+
+    s3 = _mock_s3_with(_get)
+    tickers = _load_current_constituents(s3, "alpha-engine-research", run_date="2026-05-23")
+    # Legacy return shape — set only (NOT tuple) so backfill callers
+    # don't need to change.
+    assert tickers == {"AAPL", "BNY"}
+
+
+def test_prune_wrapper_delegates_to_shared_helper_with_run_date():
+    """`builders.prune_delisted_tickers._load_latest_constituents` now
+    accepts run_date and routes through the shared helper."""
+    from builders.prune_delisted_tickers import _load_latest_constituents
+
+    def _get(Bucket, Key):
+        assert Key == "market_data/weekly/2026-05-23/constituents.json", (
+            "prune should use direct partition read when run_date is set, "
+            "NOT the latest_weekly.json pointer (TOCTOU defect class)"
+        )
+        return _make_payload(["AAPL", "BNY", "P", "SN"])
+
+    s3 = _mock_s3_with(_get)
+    tickers, weekly_date = _load_latest_constituents(
+        s3, "alpha-engine-research", run_date="2026-05-23",
+    )
+    assert tickers == {"AAPL", "BNY", "P", "SN"}
+    assert weekly_date == "2026-05-23"
+
+
+def test_prune_wrapper_falls_back_to_pointer_without_run_date():
+    """Without run_date (ad-hoc CLI invocation), prune falls back to
+    the pointer — same as the pre-lift behavior."""
+    from builders.prune_delisted_tickers import _load_latest_constituents
+
+    def _get(Bucket, Key):
+        if Key == "market_data/latest_weekly.json":
+            return {"Body": io.BytesIO(json.dumps({
+                "date": "2026-05-16",
+                "s3_prefix": "market_data/weekly/2026-05-16/",
+            }).encode())}
+        if Key == "market_data/weekly/2026-05-16/constituents.json":
+            return _make_payload(["AAPL"])
+        raise AssertionError(f"unexpected key {Key}")
+
+    s3 = _mock_s3_with(_get)
+    tickers, weekly_date = _load_latest_constituents(s3, "alpha-engine-research")
+    assert tickers == {"AAPL"}
+    assert weekly_date == "2026-05-16"
+
+
+def test_prune_function_threads_run_date_to_helper():
+    """The public `prune_delisted_tickers()` function now accepts a
+    `run_date` parameter and forwards it to the constituents read.
+    Regression-pin so a future refactor can't silently drop the
+    threading (the L1397 fix's load-bearing semantic)."""
+    import inspect
+    from builders.prune_delisted_tickers import prune_delisted_tickers
+    sig = inspect.signature(prune_delisted_tickers)
+    assert "run_date" in sig.parameters, (
+        "prune_delisted_tickers() must accept `run_date` parameter — "
+        "the L1397 threading fix"
+    )
+    # Also verify the body forwards run_date to _load_latest_constituents.
+    src = inspect.getsource(prune_delisted_tickers)
+    assert "_load_latest_constituents(" in src
+    assert "run_date=run_date" in src

--- a/tests/test_prune_delisted_tickers.py
+++ b/tests/test_prune_delisted_tickers.py
@@ -374,7 +374,10 @@ def test_empty_constituents_raises(monkeypatch):
     lib = _stub_universe_lib(symbols=["AAPL"], last_dates={"AAPL": "2026-04-25"})
     _patch_targets(monkeypatch, s3_mock=s3, universe_lib_mock=lib)
 
-    with pytest.raises(RuntimeError, match="empty universe"):
+    # Post-L1397 (lift-to-shared-helper): error message broadened from
+    # prune-specific "empty universe" to the shared helper's "empty
+    # constituents set" (serves both backfill and prune call sites).
+    with pytest.raises(RuntimeError, match="empty constituents set"):
         _mod.prune_delisted_tickers(
             absent_days=14, apply=True,
             today=pd.Timestamp("2026-04-28"),


### PR DESCRIPTION
## Summary

Close ROADMAP L1397 (5/23-SF P0 sweep follow-on, P1→P0 promotion).

- **First occurrence** (data #294, MERGED): `backfill()` had a pointer-vs-direct TOCTOU on `latest_weekly.json` — fixed by adding `run_date` to `_load_current_constituents`.
- **Second occurrence** (this PR): `prune_delisted_tickers._load_latest_constituents` had the same defect class.
- Per [[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]: both consumers live in the same repo → in-repo chokepoint helper. (Cross-repo lib lift would be the move on a THIRD reader in a DIFFERENT repo.)

## Implementation

- **New** `builders/_constituents_loader.py` owns `load_constituents_for_run_date(s3, bucket, run_date=None) -> (set, str)`. Reads `market_data/weekly/{run_date}/constituents.json` directly when `run_date` is set; falls back to pointer for ad-hoc callers.
- `backfill._load_current_constituents` reduced to thin wrapper preserving legacy `set`-only return.
- `prune._load_latest_constituents` reduced to thin wrapper, **now accepting `run_date`** (the L1397 fix).
- `prune_delisted_tickers()` public function gains `run_date` parameter, threaded through.
- Helper error message broadened from prune-specific "empty universe" to "empty constituents set".

## Test plan
- [x] 8 new tests in `test_constituents_loader_shared.py`: run_date direct / pointer fallback / empty raises / missing field raises / both wrappers delegate / signature regression-pin
- [x] `test_prune_delisted_tickers::test_empty_constituents_raises` regex updated for the broadened message
- [x] Full data suite 1457 pass / 1 skip
- [ ] Next Saturday SF: same-week prune of REMOVED tickers (BK/FLO/PSTG-class) executes correctly if any future Phase-1 caller invokes prune without `constituents_override`

## Out of scope (future P2 audit)
4 other `latest_weekly.json` readers (`collectors/{alternative,macro,constituents}`, `features/compute`, `sf_preflight`) — each needs contextual analysis for whether they run post-Phase-1 (pointer is correct) or during (TOCTOU possible). Filed as continuing audit.

## Composes with
- L1316 BNY/P/SN ArcticDB TOCTOU (data #294 — the first-occurrence fix this consolidates)
- L1320 same-cycle prune verification (now closeable when a Phase-1 prune call routes through `run_date`)
- `[[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]` — second-occurrence trigger fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)