### PR TITLE
fix(alternative): edgartools API drift — close 5/23-SF P0 L1308

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -228,6 +228,60 @@ def _emit_quality_gate_metrics(
 # and the env var alone redirects both the data dir and the _tcache HTTP
 # cache (the path that failed) — no ``$HOME`` override is required. We only
 # set it if unset so an operator-provided value still wins.
+def _holdings_to_value_dict(holdings) -> dict:
+    """Map an edgartools `ThirteenF.holdings` (or `previous.holdings`) result
+    to ``{cusip: value}`` regardless of whether the underlying API returns
+    a `pd.DataFrame` (edgartools 5.x — current) or a list-of-objects
+    (legacy edgartools 4.x — pre-2026-04-25).
+
+    Closes 5/23-SF P0 sweep L1308 (edgartools API drift). The drift happens
+    silently because edgartools changes the `holdings` return-shape across
+    minor versions without a breaking-change banner. Wrapping in a helper
+    + supporting both forms keeps the institutional data layer resilient
+    to future drift in the same direction.
+
+    Returns an empty dict if ``holdings`` is None or empty. Per-row
+    failures (missing Cusip / non-numeric Value) are logged at DEBUG and
+    skipped — single-row corruption shouldn't blank the whole report.
+    """
+    if holdings is None:
+        return {}
+    # Try DataFrame path first (edgartools 5.x). Column names per the
+    # holdings() docstring: Cusip (PascalCase), Value.
+    try:
+        import pandas as pd
+        if isinstance(holdings, pd.DataFrame):
+            if holdings.empty:
+                return {}
+            # Tolerate column-case variations (Cusip / cusip / CUSIP).
+            cusip_col = next(
+                (c for c in ("Cusip", "cusip", "CUSIP") if c in holdings.columns),
+                None,
+            )
+            value_col = next(
+                (c for c in ("Value", "value", "VALUE") if c in holdings.columns),
+                None,
+            )
+            if cusip_col is None or value_col is None:
+                logger.warning(
+                    "13F holdings DataFrame missing Cusip/Value columns "
+                    "(got %s) — empty result",
+                    list(holdings.columns),
+                )
+                return {}
+            return dict(zip(holdings[cusip_col], holdings[value_col]))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("13F DataFrame path failed: %s", exc)
+    # Legacy list-of-objects fallback (edgartools 4.x).
+    try:
+        return {h.cusip: h.value for h in holdings}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "13F holdings legacy iteration failed: %s — empty result", exc,
+        )
+        return {}
+
+
 _EDGAR_TMP_DATA_DIR = "/tmp/edgar"
 if not os.environ.get("EDGAR_LOCAL_DATA_DIR"):
     try:
@@ -1313,12 +1367,22 @@ def _fetch_institutional(ticker: str) -> dict:
             if hasattr(thirteen_f, 'previous_holding_report'):
                 prev = thirteen_f.previous_holding_report()
                 if prev is not None:
-                    current_holdings = {
-                        h.cusip: h.value for h in thirteen_f.holdings
-                    } if hasattr(thirteen_f, 'holdings') else {}
-                    prev_holdings = {
-                        h.cusip: h.value for h in prev.holdings
-                    } if hasattr(prev, 'holdings') else {}
+                    # edgartools API drift fix (L1308 / 5/23-SF P0 sweep):
+                    # `thirteen_f.holdings` now returns a `pd.DataFrame`
+                    # (aggregated holdings by security, columns include
+                    # `Cusip` + `Value` per the edgartools 5.x docstring).
+                    # The pre-fix code iterated the frame, yielding column
+                    # name strings, hence the `'str' object has no
+                    # attribute 'cusip'` AttributeError that silenced
+                    # institutional data for 29 days (2026-04-25 →
+                    # 2026-05-24 audit). Use `.itertuples()` to materialize
+                    # row records; column names are PascalCase post-drift.
+                    current_holdings = _holdings_to_value_dict(
+                        getattr(thirteen_f, 'holdings', None)
+                    )
+                    prev_holdings = _holdings_to_value_dict(
+                        getattr(prev, 'holdings', None)
+                    )
 
                     for cusip, current_value in current_holdings.items():
                         prev_value = prev_holdings.get(cusip, 0)

--- a/tests/test_13f_holdings_dataframe_api.py
+++ b/tests/test_13f_holdings_dataframe_api.py
@@ -1,0 +1,102 @@
+"""Regression tests for L1308 edgartools API drift fix.
+
+Pre-fix: `{h.cusip: h.value for h in thirteen_f.holdings}` iterated over
+a DataFrame (edgartools 5.x return shape), yielding column-name strings
+that lack `.cusip` / `.value` attrs → AttributeError → 0/N institutional
+data populated → DataPhase2 status=error → health/data_phase2.json stale
+29 days (2026-04-25 → 2026-05-24 audit).
+
+Post-fix: `_holdings_to_value_dict` helper handles both API shapes
+(DataFrame from edgartools 5.x, list-of-objects from 4.x) and tolerates
+column-case variations.
+
+Pins:
+  1. DataFrame input (current edgartools 5.x) → correct cusip→value map.
+  2. List-of-objects input (legacy edgartools 4.x) → same shape.
+  3. None / empty → empty dict (no crash).
+  4. Missing column → empty dict + WARNING (not a crash).
+  5. Column-case variations (Cusip / cusip / CUSIP) tolerated.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from collectors.alternative import _holdings_to_value_dict
+
+
+def test_dataframe_input_pascalcase_columns():
+    """edgartools 5.x current API: PascalCase Cusip + Value columns."""
+    df = pd.DataFrame({
+        "Cusip": ["68389X105", "037833100", "594918104"],
+        "Value": [50_000_000, 75_000_000, 100_000_000],
+        "Issuer": ["ORCL", "AAPL", "MSFT"],
+    })
+    out = _holdings_to_value_dict(df)
+    assert out == {
+        "68389X105": 50_000_000,
+        "037833100": 75_000_000,
+        "594918104": 100_000_000,
+    }
+
+
+def test_dataframe_input_lowercase_columns():
+    """Tolerate lowercase variants (some edgartools versions diverge)."""
+    df = pd.DataFrame({
+        "cusip": ["AAA", "BBB"],
+        "value": [10, 20],
+    })
+    out = _holdings_to_value_dict(df)
+    assert out == {"AAA": 10, "BBB": 20}
+
+
+def test_dataframe_input_uppercase_columns():
+    """Tolerate ALL-CAPS variants (some edgartools versions)."""
+    df = pd.DataFrame({
+        "CUSIP": ["AAA"],
+        "VALUE": [10],
+    })
+    out = _holdings_to_value_dict(df)
+    assert out == {"AAA": 10}
+
+
+def test_dataframe_missing_columns_returns_empty():
+    """Defensive: a DataFrame without Cusip/Value columns must return
+    empty dict + WARN log (NOT a crash)."""
+    df = pd.DataFrame({"foo": [1, 2], "bar": [3, 4]})
+    out = _holdings_to_value_dict(df)
+    assert out == {}
+
+
+def test_empty_dataframe():
+    df = pd.DataFrame(columns=["Cusip", "Value"])
+    assert _holdings_to_value_dict(df) == {}
+
+
+def test_none_input():
+    assert _holdings_to_value_dict(None) == {}
+
+
+def test_legacy_list_of_objects_fallback():
+    """edgartools 4.x legacy: iterating holdings yielded objects with
+    .cusip + .value attrs. The fallback path must still work for any
+    consumer that pins the old version (or a future drift back)."""
+    class FakeHolding:
+        def __init__(self, cusip, value):
+            self.cusip = cusip
+            self.value = value
+    holdings = [
+        FakeHolding("AAA", 100),
+        FakeHolding("BBB", 200),
+    ]
+    out = _holdings_to_value_dict(holdings)
+    assert out == {"AAA": 100, "BBB": 200}
+
+
+def test_legacy_iteration_crash_returns_empty():
+    """If neither path works, return empty dict — never raise."""
+    # Iterating a non-iterable that's not DataFrame triggers TypeError.
+    out = _holdings_to_value_dict(42)
+    assert out == {}


### PR DESCRIPTION
## Summary

Close ROADMAP L1308 (5/23-SF P0 sweep). edgartools 5.x changed `ThirteenF.holdings` to return a `pd.DataFrame`; the pre-fix code iterated → column-name strings → `'str' object has no attribute 'cusip'` AttributeError → 0/N institutional data populated → DataPhase2 hard-fail → `health/data_phase2.json` stale 29 days.

Fix: new `_holdings_to_value_dict` helper handles both API shapes (5.x DataFrame, 4.x list-of-objects) + column-case variations. Never raises.

## Test plan
- [x] 8 new tests covering both API shapes + edge cases
- [ ] Next DataPhase2 invocation: `health/data_phase2.json` updates with fresh timestamp + institutional populated-ratio ≥20%

🤖 Generated with [Claude Code](https://claude.com/claude-code)