### PR TITLE
fix(parity): relax WAVE4 epsilon 1e-6 → 1e-2 per Path B — close 5/23-SF P0 (m)

### DIFF
--- a/collectors/macro.py
+++ b/collectors/macro.py
@@ -80,8 +80,18 @@ def _load_breadth_prices(bucket: str) -> Optional[dict]:
     # every run. Grep ``WAVE4_PARITY_METRIC breadth`` over the observation
     # window before PR4 retires slim.
     if arctic_prices and slim_prices:
+        # L1718 / 5/23-SF P0 (m) — relax epsilon from default 1e-6 to 1e-2
+        # 2026-05-24 per operator decision Path B. ArcticDB universe writes
+        # auto-adjusted close (yfinance auto-adjust applied post-dividend);
+        # slim cache writes raw close. The 5.36 max_abs_value_delta on EQIX
+        # Close 2026-04-29 is dividend-scale, NOT float-precision — EQIX is
+        # a REIT with $5+ quarterly dividends. Slim cache is on the chopping
+        # block by design (L1718 PR4 deletes it); reconciling a doomed
+        # store to a policy already matched by universe is throwaway work.
+        # Once PR4 lands, this entire reconcile block becomes dead code.
         report = reconcile_frame_dicts(
-            slim_prices, arctic_prices, value_cols=("Close",)
+            slim_prices, arctic_prices, value_cols=("Close",),
+            epsilon=1e-2,
         )
         logger.info("breadth slim<->arctic %s", report.summary())
         logger.info(

--- a/features/compute.py
+++ b/features/compute.py
@@ -405,9 +405,16 @@ def _load_price_source(s3, bucket: str) -> dict | None:
         slim_data = None
 
     if combined and slim_data:
+        # L1718 / 5/23-SF P0 (m) — relax epsilon to 1e-2 per Path B
+        # (2026-05-24 operator decision). Dividend-adjustment-policy
+        # mismatch between universe (auto-adjusted) and slim (raw close);
+        # not float-precision. Slim is on the chopping block (L1718 PR4
+        # retires it); reconcile block becomes dead code post-PR4 merge.
+        # See collectors/macro.py for the full rationale block.
         report = reconcile_frame_dicts(
             slim_data, combined, value_cols=("Close",),
             require_ticker_match=False,
+            epsilon=1e-2,
         )
         log.info("compute slim<->arctic %s", report.summary())
         log.info(


### PR DESCRIPTION
## Summary

Close 5/23-SF P0 (m) per operator decision **Path B**: relax parity epsilon to cent-scale (1e-2) — slim cache is on the chopping block by design (L1718 PR4's terminal goal), so reconciling a doomed store to universe's adjustment policy is throwaway work.

Two caller sites updated:
- `collectors/macro.py` breadth parity
- `features/compute.py` compute parity

## Post-merge consequence
- WAVE4_PARITY_METRIC `passed: true` resumes Sat 5/30
- L1718 PR4 drafts (data #269 + backtester #227) become un-draftable
- Merging PR4 retires slim cache; this entire reconcile block becomes dead code

## Test plan
- [x] Full data suite 1471 pass
- [ ] Sat 5/30 DataPhase1: WAVE4_PARITY_METRIC fires `passed: true`
- [ ] Operator: un-draft + merge L1718 PR4 drafts

🤖 Generated with [Claude Code](https://claude.com/claude-code)