### PR TITLE
feat(validators): Friday-Preflight Wikipedia drift check — close 5/23-SF P0 (g)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1851,10 +1851,13 @@
             "source .venv/bin/activate",
             "pip install --quiet --upgrade -r requirements.txt",
             "trap 'aws s3 cp /var/log/substrate-health-check.log \"s3://alpha-engine-research/_ssm_logs/substrate-health-check/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "python -m alpha_engine_lib.transparency --cadence weekly --alert 2>&1 | tee /var/log/substrate-health-check.log"
+            "python -m alpha_engine_lib.transparency --cadence weekly --alert 2>&1 | tee /var/log/substrate-health-check.log",
+            "echo '--- constituents drift check ---' | tee -a /var/log/substrate-health-check.log",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-data && /home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m validators.constituents_drift_check 2>&1 | tee -a /var/log/substrate-health-check.log || true"
           ],
           "executionTimeout": [
-            "180"
+            "240"
           ]
         },
         "TimeoutSeconds": 180

--- a/tests/test_constituents_drift_check.py
+++ b/tests/test_constituents_drift_check.py
@@ -1,0 +1,148 @@
+"""Tests for the Friday-Preflight Wikipedia-vs-ArcticDB constituents
+drift check (5/23-SF P0 (g))."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_check_drift_no_drift_returns_ok():
+    """When Wikipedia ⊆ ArcticDB universe (modulo skip-list), status=ok."""
+    from validators.constituents_drift_check import check_drift
+
+    # Wikipedia returns a small known set; ArcticDB has the same + extras.
+    fake_fetch = MagicMock(return_value=(
+        ["AAPL", "MSFT", "NVDA"],  # tickers
+        {}, {},                      # sector_map, sector_etf_map
+        2, 1,                        # sp500_count, sp400_count
+    ))
+    fake_lib = MagicMock()
+    fake_lib.list_symbols.return_value = ["AAPL", "MSFT", "NVDA", "GOOG"]
+
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               return_value=fake_lib):
+        result = check_drift(alert=False)
+    assert result["status"] == "ok"
+    assert result["missing_from_arctic"] == []
+
+
+def test_check_drift_missing_tickers_detected():
+    """The canonical 5/23 scenario: Wikipedia lists BNY/P/SN, ArcticDB
+    doesn't — drift_detected + missing list populated."""
+    from validators.constituents_drift_check import check_drift
+
+    fake_fetch = MagicMock(return_value=(
+        ["AAPL", "MSFT", "BNY", "P", "SN"],
+        {}, {},
+        3, 2,
+    ))
+    fake_lib = MagicMock()
+    fake_lib.list_symbols.return_value = ["AAPL", "MSFT"]
+
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               return_value=fake_lib):
+        result = check_drift(alert=False)
+    assert result["status"] == "drift_detected"
+    assert set(result["missing_from_arctic"]) == {"BNY", "P", "SN"}
+    assert result["within_threshold"] is False
+
+
+def test_check_drift_under_threshold_passes():
+    """max_stragglers tolerance: 1 missing with cap=2 → status=ok."""
+    from validators.constituents_drift_check import check_drift
+
+    fake_fetch = MagicMock(return_value=(["AAPL", "BNY"], {}, {}, 1, 1))
+    fake_lib = MagicMock()
+    fake_lib.list_symbols.return_value = ["AAPL"]
+
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               return_value=fake_lib):
+        result = check_drift(alert=False, max_stragglers=2)
+    assert result["status"] == "ok"
+    assert result["missing_from_arctic"] == ["BNY"]
+    assert result["within_threshold"] is True
+
+
+def test_check_drift_skip_list_excluded_from_diff():
+    """SPY (in _SKIP_TICKERS) doesn't fire drift even if Wikipedia
+    lists it but ArcticDB lacks the SKIP_TICKERS entry — _SKIP_TICKERS
+    is stripped from BOTH sides of the comparison."""
+    from validators.constituents_drift_check import check_drift
+
+    fake_fetch = MagicMock(return_value=(["AAPL", "SPY", "VIX"], {}, {}, 1, 0))
+    fake_lib = MagicMock()
+    fake_lib.list_symbols.return_value = ["AAPL"]
+
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               return_value=fake_lib):
+        result = check_drift(alert=False)
+    assert result["status"] == "ok"
+    assert result["missing_from_arctic"] == []
+
+
+def test_check_drift_sector_etf_excluded():
+    """XLK / XLF / XL* prefixes excluded from drift comparison."""
+    from validators.constituents_drift_check import check_drift
+
+    fake_fetch = MagicMock(return_value=(["AAPL", "XLK", "XLF"], {}, {}, 1, 0))
+    fake_lib = MagicMock()
+    fake_lib.list_symbols.return_value = ["AAPL"]
+
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               return_value=fake_lib):
+        result = check_drift(alert=False)
+    assert result["status"] == "ok"
+
+
+def test_check_drift_wikipedia_fetch_failure_returns_error():
+    from validators.constituents_drift_check import check_drift
+
+    fake_fetch = MagicMock(side_effect=Exception("Wikipedia 503"))
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch):
+        result = check_drift(alert=False)
+    assert result["status"] == "error"
+    assert result["stage"] == "wikipedia_fetch"
+
+
+def test_check_drift_arctic_failure_returns_error():
+    from validators.constituents_drift_check import check_drift
+
+    fake_fetch = MagicMock(return_value=(["AAPL"], {}, {}, 1, 0))
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               side_effect=Exception("ArcticDB unreachable")):
+        result = check_drift(alert=False)
+    assert result["status"] == "error"
+    assert result["stage"] == "arctic_list"
+
+
+def test_main_exit_code_ok():
+    from validators.constituents_drift_check import main
+
+    fake_fetch = MagicMock(return_value=(["AAPL"], {}, {}, 1, 0))
+    fake_lib = MagicMock()
+    fake_lib.list_symbols.return_value = ["AAPL"]
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               return_value=fake_lib):
+        rc = main(["--no-alert"])
+    assert rc == 0
+
+
+def test_main_exit_code_drift_detected():
+    from validators.constituents_drift_check import main
+
+    fake_fetch = MagicMock(return_value=(["AAPL", "BNY"], {}, {}, 1, 1))
+    fake_lib = MagicMock()
+    fake_lib.list_symbols.return_value = ["AAPL"]
+    with patch("validators.constituents_drift_check._fetch_constituents", fake_fetch), \
+         patch("validators.constituents_drift_check._open_universe_lib",
+               return_value=fake_lib):
+        rc = main(["--no-alert"])
+    assert rc == 1

--- a/validators/constituents_drift_check.py
+++ b/validators/constituents_drift_check.py
@@ -1,0 +1,237 @@
+"""
+validators/constituents_drift_check.py — Friday-Preflight detection of
+Wikipedia-vs-ArcticDB constituents drift (close 5/23-SF P0 (g)).
+
+Background:
+
+  The 2026-05-23 SF FAILED at Research because BNY/P/SN were Wikipedia-
+  listed S&P members but missing from ArcticDB universe — the constituents
+  collector advanced the `latest_weekly.json` pointer AFTER the backfill
+  ran, so the backfill saw last-week's constituents and skipped the new
+  cohort. Friday-Preflight SF couldn't detect this directly because the
+  Saturday constituents collector hadn't run yet.
+
+  BUT: Wikipedia's S&P 500/400 lists are the SOURCE OF TRUTH the collector
+  pulls from. We can read Wikipedia DIRECTLY from any Friday-Preflight
+  Lambda + diff against ArcticDB universe, with zero dependency on the
+  Saturday collector cadence.
+
+Usage:
+
+  python -m validators.constituents_drift_check          # checks + alerts on diff
+  python -m validators.constituents_drift_check --no-alert  # diagnostic, no SNS/Telegram
+  python -m validators.constituents_drift_check --max-stragglers 20  # allow up to N
+                                                                      # Wikipedia tickers
+                                                                      # missing from
+                                                                      # arctic before
+                                                                      # firing alert
+
+Exit code 0 on clean diff (or under-threshold drift), 1 on alert-worthy
+drift. SF Catch on the WeeklySubstrateHealthCheck state turns exit-1 into
+an alert.
+
+Composes with [[feedback_no_silent_fails]]: Wikipedia is the upstream
+authority; if it lists a ticker that ArcticDB universe lacks, that's the
+exact failure surface that hit production on 5/23.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+from collectors.constituents import _fetch_constituents
+from features.compute import _SKIP_TICKERS, _is_sector_etf
+
+logger = logging.getLogger(__name__)
+
+
+def _open_universe_lib(bucket: str):
+    """Open the ArcticDB universe library for read-only symbol listing."""
+    from store.arctic_store import get_universe_lib
+    return get_universe_lib(bucket)
+
+
+def check_drift(
+    *,
+    bucket: str = "alpha-engine-research",
+    max_stragglers: int = 0,
+    alert: bool = True,
+    alert_severity: str = "error",
+) -> dict:
+    """Run the Wikipedia → ArcticDB constituents drift check.
+
+    Args:
+        bucket: S3 bucket holding the ArcticDB universe library.
+        max_stragglers: number of Wikipedia tickers allowed to be missing
+            from ArcticDB before firing the alert. Default 0 (strict — any
+            missing ticker fires). Set higher to tolerate known
+            churn-in delay (e.g. the 1-Saturday backfill lag).
+        alert: if True, fire an `alpha_engine_lib.alerts.publish` on drift.
+            If False, return the diff without alerting (diagnostic mode).
+        alert_severity: severity tag for the published alert.
+
+    Returns:
+        dict with keys: status (`ok` | `drift_detected` | `error`),
+        wikipedia_count, arctic_count, missing_from_arctic (list),
+        only_in_arctic (list), within_threshold (bool).
+    """
+    try:
+        tickers, _sector_map, _sector_etf_map, sp500_count, sp400_count = (
+            _fetch_constituents()
+        )
+    except Exception as exc:
+        logger.exception("Wikipedia constituents fetch failed")
+        return {
+            "status": "error",
+            "error": str(exc),
+            "stage": "wikipedia_fetch",
+        }
+
+    wikipedia_set = set(tickers)
+    logger.info(
+        "Wikipedia constituents: %d tickers (S&P 500=%d, S&P 400=%d)",
+        len(wikipedia_set), sp500_count, sp400_count,
+    )
+
+    try:
+        lib = _open_universe_lib(bucket)
+        arctic_set = set(lib.list_symbols())
+    except Exception as exc:
+        logger.exception("ArcticDB universe list failed")
+        return {
+            "status": "error",
+            "error": str(exc),
+            "stage": "arctic_list",
+        }
+
+    # Strip macro/sector members and known-non-stock tickers from the
+    # comparison surface — the universe-write set is
+    # `wikipedia ∩ ¬_SKIP_TICKERS ∩ ¬sector_etfs` per builders/backfill.py.
+    comparable_wiki = {
+        t for t in wikipedia_set
+        if t not in _SKIP_TICKERS and not _is_sector_etf(t)
+    }
+    comparable_arctic = {
+        t for t in arctic_set
+        if t not in _SKIP_TICKERS and not _is_sector_etf(t)
+    }
+
+    missing_from_arctic = sorted(comparable_wiki - comparable_arctic)
+    only_in_arctic = sorted(comparable_arctic - comparable_wiki)
+
+    logger.info(
+        "Drift summary: missing_from_arctic=%d (cap=%d), only_in_arctic=%d "
+        "(prune candidates)",
+        len(missing_from_arctic), max_stragglers, len(only_in_arctic),
+    )
+
+    within_threshold = len(missing_from_arctic) <= max_stragglers
+
+    result = {
+        "status": "ok" if within_threshold else "drift_detected",
+        "wikipedia_count": len(wikipedia_set),
+        "arctic_count": len(arctic_set),
+        "missing_from_arctic": missing_from_arctic,
+        "only_in_arctic": only_in_arctic,
+        "max_stragglers": max_stragglers,
+        "within_threshold": within_threshold,
+    }
+
+    if not within_threshold and alert:
+        try:
+            from alpha_engine_lib import alerts  # noqa: PLC0415
+        except ImportError as exc:
+            logger.warning(
+                "alerts publish skipped — alpha_engine_lib.alerts unavailable: %s",
+                exc,
+            )
+            return result
+        # Truncate the missing list at 20 for the alert message so we don't
+        # blow the SNS subject length on a worst-case 50-ticker drift.
+        preview = missing_from_arctic[:20]
+        suffix = (
+            f" ... +{len(missing_from_arctic) - 20} more"
+            if len(missing_from_arctic) > 20 else ""
+        )
+        message = (
+            f"Friday-Preflight constituents drift detected: "
+            f"{len(missing_from_arctic)} Wikipedia-listed S&P ticker(s) "
+            f"missing from ArcticDB universe "
+            f"(threshold={max_stragglers}). "
+            f"Missing: {', '.join(preview)}{suffix}. "
+            f"Saturday SF will likely fail at Research preflight unless "
+            f"backfill picks these up. Investigate constituents collector + "
+            f"backfill TOCTOU. See ROADMAP P0 (g) + L1316."
+        )
+        try:
+            publish_result = alerts.publish(
+                message,
+                severity=alert_severity,
+                source="alpha-engine-data/validators/constituents_drift_check.py",
+                dedup_key=f"constituents_drift_{len(missing_from_arctic)}",
+                dedup_window_min=720,  # 12h — one alert per dry-pass window
+            )
+            logger.info(
+                "Drift alert publish: sns_ok=%s telegram_ok=%s any_ok=%s",
+                publish_result.sns.ok,
+                publish_result.telegram.ok,
+                publish_result.any_ok,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Drift alert publish failed: %s", exc)
+
+    return result
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Friday-Preflight constituents drift check",
+    )
+    parser.add_argument("--bucket", default="alpha-engine-research")
+    parser.add_argument("--max-stragglers", type=int, default=0,
+                        help="Wikipedia tickers allowed missing from ArcticDB")
+    parser.add_argument("--no-alert", action="store_true",
+                        help="diagnostic mode — no SNS/Telegram alert on drift")
+    parser.add_argument(
+        "--alert-severity", default="error",
+        choices=["info", "warn", "warning", "error", "critical"],
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+
+    result = check_drift(
+        bucket=args.bucket,
+        max_stragglers=args.max_stragglers,
+        alert=not args.no_alert,
+        alert_severity=args.alert_severity,
+    )
+
+    if result["status"] == "error":
+        logger.error("Drift check failed at stage=%s: %s",
+                     result.get("stage"), result.get("error"))
+        return 2
+
+    if result["status"] == "drift_detected":
+        logger.error(
+            "DRIFT DETECTED: %d Wikipedia tickers missing from ArcticDB "
+            "(threshold=%d). Missing: %s",
+            len(result["missing_from_arctic"]),
+            result["max_stragglers"],
+            result["missing_from_arctic"][:20],
+        )
+        return 1
+
+    logger.info("Drift check OK: arctic covers all Wikipedia-listed tickers")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Close 5/23-SF P0 (g) per operator's pushback "why can't we detect during the Friday Preflight SF?" — YES we can. Wikipedia is the upstream authority; Friday Preflight reads it directly + diffs against current ArcticDB universe.

New `validators/constituents_drift_check.py` + CLI module. Wired into `WeeklySubstrateHealthCheck` SF state so it fires on both Friday dry-pass and Saturday production. Alert via `alpha_engine_lib.alerts.publish` with dedup_key on missing-count.

## Detection path
- Fri ~13:45 PT — Friday-PM dry-pass → WeeklySubstrateHealthCheck → drift_check fetches Wikipedia + reads ArcticDB
- If BNY/P/SN-class drift exists → SNS+Telegram alert fires
- Operator has ~12h before Sat 02:00 PT to investigate

## Test plan
- [x] 9 new tests: no-drift / drift-detected / threshold tolerance / SPY+sector-ETF exclusion / Wikipedia error / ArcticDB error / CLI exit codes
- [ ] Next Friday Preflight (5/29 ~13:45 PT): drift check fires + exits 0 (no current drift)
- [ ] Synthetic test: stage a Wikipedia-only ticker mid-week + verify Friday alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)