### PR TITLE
deps(lib): bump alpha-engine-lib v0.27.0 → v0.31.0 (cost-telemetry Phase 0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.31.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.32.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.27.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.31.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ arcticdb>=6.11
 # news-article event-extraction LLM calls into the cost-telemetry stream
 # (highest-volume untracked site at ~100–300 Haiku calls/wk during
 # RAGIngestion). All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.31.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,11 @@ arcticdb>=6.11
 # flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
 # psycopg2-binary + pgvector now come via [rag] (added in lib v0.3.0,
 # direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.27.0
+# v0.30.0 + v0.31.0 add the cost-telemetry SDK adapter
+# (``metadata_from_anthropic_message``) + server-tool fee tracking
+# (``ToolFee`` / ``ToolFeeTable``) — required by Phase 0 of the cost-
+# optimization workstream to wire ``collectors/nlp/event_extraction.py``'s
+# news-article event-extraction LLM calls into the cost-telemetry stream
+# (highest-volume untracked site at ~100–300 Haiku calls/wk during
+# RAGIngestion). All additive surface — existing imports unchanged.
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.31.0


### PR DESCRIPTION
## Summary

Tri-state lockstep bump (requirements.txt + Dockerfile) to v0.31.0, unlocking the cost-telemetry SDK adapter (v0.30.0) and server-tool fee tracking (v0.31.0).

Required by Phase 0 of the cost-optimization workstream — `collectors/nlp/event_extraction.py:170` (the news-article event-extraction LLM call invoked during the Saturday SF RAGIngestion state) currently fires with **zero cost-telemetry attribution** and is estimated at **$20–60/mo** — the largest single untracked LLM call site in Alpha Engine.

## Why lockstep matters

`tests/test_lib_pin_lockstep.py` enforces that `requirements.txt` and `Dockerfile` pin the same lib version. Same-class drift bit the 2026-05-12 data Lambda canary (`ModuleNotFoundError: alpha_engine_lib.secrets`). Both files moved here.

Auxiliary Lambda subdirectories (`eod-success-friday-shell-trigger`, `sf-telegram-notifier`) intentionally remain on their pre-existing pins (v0.20.0); they're not load-bearing for Phase 0.

## Test plan

- [x] All existing imports (secrets/dates/logging/preflight/sources/trading_calendar/collector_results) resolve at v0.31.0
- [x] Full test suite: 1480 passed, 1 skipped (including `test_lib_pin_lockstep`)
- [x] New `cost.*` imports available
- [ ] Follow-up PR on this branch (or successor): wire `event_extraction.py:170` into cost-telemetry stream

## Workstream context

Investigation doc: `~/Development/alpha-engine-docs/private/prompt-caching-investigation-260525.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)