### PR TITLE
feat(cost-telemetry): wire news event extraction + lib v0.32→v0.33 (Phase 0.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.32.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.33.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/rag/pipelines/_cost_telemetry.py
+++ b/rag/pipelines/_cost_telemetry.py
@@ -1,0 +1,236 @@
+"""Cost-telemetry sink for the news-pipeline LLM call site.
+
+Wraps an Anthropic SDK client so every ``messages.create()`` response
+is buffered as a priced JSONL row, flushed to S3 in a single
+``PutObject`` at end-of-pipeline. Closes the largest previously-untracked
+LLM cost slice in the system (~$20–60/mo per the Phase 0 telemetry
+audit at ``alpha-engine-docs/private/prompt-caching-investigation-260525.md``
+§1.1).
+
+**Sink contract:**
+
+- One JSONL object per run at
+  ``s3://alpha-engine-research/decision_artifacts/_cost_raw/{date}/{date}/data-news-event-extraction.jsonl``.
+- Path mirrors the research-side cost-raw partition so the existing
+  daily aggregator (``alpha-engine-research/scripts/aggregate_costs.py``)
+  picks up data's rows alongside research's — single chokepoint, single
+  parquet output, dashboard shows everyone in one panel.
+- Per-row fields delegated to :func:`alpha_engine_lib.cost.record_anthropic_call`
+  (the v0.33.0 chokepoint). Adds ``run_id`` + ``agent_id`` extras for
+  the aggregator's drilldown columns.
+
+Buffered + flushed once at pipeline exit rather than per-call to keep
+S3 PutObject volume sane: a single RAGIngestion run can fire 100–300
+Haiku calls; per-call writes would be 100–300 PutObjects vs 1.
+
+Per ``[[feedback_no_silent_fails]]`` the flush is hard-fail on S3
+error — a silent miss on the dominant cost slice would defeat the
+whole Phase 0 visibility goal.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date as date_type
+from typing import Any
+
+from alpha_engine_lib.cost import record_anthropic_call
+
+logger = logging.getLogger(__name__)
+
+
+_COST_BUCKET = "alpha-engine-research"
+_COST_PREFIX = "decision_artifacts/_cost_raw"
+
+
+class CostBufferFlushError(RuntimeError):
+    """Raised when the S3 PutObject for the buffered cost rows fails.
+
+    Per ``[[feedback_no_silent_fails]]`` — a silent S3 failure on the
+    cost-telemetry sink would defeat the workstream's visibility goal,
+    so the pipeline surfaces it loud rather than swallowing.
+    """
+
+
+class S3CostBuffer:
+    """In-memory buffer of priced cost records; flushes once to S3.
+
+    The wrapped client (see :func:`wrap_client_for_cost_telemetry`)
+    appends one record per ``messages.create()`` response into
+    ``self._rows`` via :meth:`record`. The pipeline calls
+    :meth:`flush` at end-of-run to write the accumulated rows as a
+    single JSONL object.
+    """
+
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        agent_id: str,
+        bucket: str = _COST_BUCKET,
+        s3_client: Any | None = None,
+    ) -> None:
+        self._run_id = run_id
+        self._agent_id = agent_id
+        self._bucket = bucket
+        self._s3 = s3_client
+        self._rows: list[dict] = []
+
+    def record(self, msg: Any) -> float:
+        """Price ``msg``, append to buffer, return the row's USD cost.
+
+        Pure delegation to :func:`alpha_engine_lib.cost.record_anthropic_call`
+        with the buffer's ``run_id`` + ``agent_id`` stamped onto the
+        record's extra_fields so the daily aggregator's by-agent_id
+        breakdown surfaces this site's spend.
+        """
+        record = record_anthropic_call(
+            msg,
+            extra_fields={
+                "run_id": self._run_id,
+                "agent_id": self._agent_id,
+            },
+        )
+        self._rows.append(record)
+        return float(record["cost_usd"])
+
+    @property
+    def row_count(self) -> int:
+        return len(self._rows)
+
+    def flush(self) -> str | None:
+        """Write the buffered rows as a single JSONL object to S3.
+
+        Returns the S3 key written, or ``None`` if the buffer is empty
+        (no LLM calls fired this run — no sink object created so the
+        partition stays clean of empty files).
+
+        Raises :exc:`CostBufferFlushError` on any S3 error per
+        ``[[feedback_no_silent_fails]]``.
+        """
+        if not self._rows:
+            logger.info(
+                "[cost_telemetry] no rows to flush for run_id=%s agent_id=%s",
+                self._run_id, self._agent_id,
+            )
+            return None
+
+        key = (
+            f"{_COST_PREFIX}/{self._run_id}/{self._run_id}/"
+            f"{self._agent_id}.jsonl"
+        )
+        body = "\n".join(
+            json.dumps(row, default=str) for row in self._rows
+        ).encode("utf-8")
+
+        try:
+            client = self._s3
+            if client is None:
+                import boto3
+                client = boto3.client("s3")
+            client.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=body,
+                ContentType="application/x-ndjson",
+            )
+        except Exception as exc:
+            raise CostBufferFlushError(
+                f"Failed to flush {len(self._rows)} cost rows to "
+                f"s3://{self._bucket}/{key}: {exc}"
+            ) from exc
+
+        logger.info(
+            "[cost_telemetry] flushed %d rows to s3://%s/%s "
+            "(total cost=$%.4f)",
+            len(self._rows), self._bucket, key,
+            sum(float(r.get("cost_usd", 0)) for r in self._rows),
+        )
+        return key
+
+
+class _CostTrackingMessages:
+    """Proxy for ``anthropic.Anthropic().messages`` that records every
+    ``create()`` response into the wrapped buffer."""
+
+    def __init__(self, wrapped: Any, buffer: S3CostBuffer) -> None:
+        self._wrapped = wrapped
+        self._buffer = buffer
+
+    def create(self, *args, **kwargs):
+        response = self._wrapped.create(*args, **kwargs)
+        try:
+            self._buffer.record(response)
+        except Exception as exc:
+            # Cost-telemetry failure must NOT bring down the producer
+            # (event extraction is the primary deliverable). Log loud +
+            # keep going. The flush step at pipeline exit still raises
+            # on S3 error per the no-silent-fails rule for the artifact
+            # write itself — per-call recording failures show up at flush
+            # time as a partial row count.
+            logger.warning(
+                "[cost_telemetry] per-call recording failed: %s "
+                "(token counts NOT captured for this call; pipeline "
+                "continues)", exc,
+            )
+        return response
+
+
+class _CostTrackingClient:
+    """Proxy around an Anthropic SDK client. Forwards every attribute
+    EXCEPT ``messages``, which is replaced by a ``_CostTrackingMessages``
+    proxy that records cost telemetry per call.
+
+    Used by :func:`wrap_client_for_cost_telemetry` so callers can pass
+    the wrapped client to any consumer (e.g.,
+    ``AnthropicEventExtractor(client=wrapped)``) with zero change to
+    the consumer.
+    """
+
+    def __init__(self, wrapped: Any, buffer: S3CostBuffer) -> None:
+        self._wrapped = wrapped
+        self._buffer = buffer
+
+    @property
+    def messages(self):
+        return _CostTrackingMessages(self._wrapped.messages, self._buffer)
+
+    def __getattr__(self, name: str) -> Any:
+        # Forward any other SDK surface (e.g., .beta) verbatim.
+        return getattr(self._wrapped, name)
+
+
+def wrap_client_for_cost_telemetry(
+    client: Any,
+    buffer: S3CostBuffer,
+) -> Any:
+    """Wrap an Anthropic SDK client so every ``messages.create()``
+    response is recorded into ``buffer``.
+
+    Zero-coupling pattern: the wrapped client is API-compatible with
+    the raw SDK client, so consumers (e.g.,
+    ``AnthropicEventExtractor(client=...)``) need no change. The
+    pipeline composes telemetry at the client-construction layer.
+    """
+    return _CostTrackingClient(client, buffer)
+
+
+def build_news_cost_buffer(
+    *,
+    run_date: date_type,
+    s3_client: Any | None = None,
+) -> S3CostBuffer:
+    """Factory for the news-pipeline cost buffer.
+
+    Standardizes the ``run_id`` + ``agent_id`` naming so the dashboard
+    cost panel can pivot on a stable per-site identifier. ``run_id``
+    matches the news-pipeline's ``aggregate_date`` (the natural date
+    partition for the run) so cost rows align with the data artifact
+    they accompany.
+    """
+    return S3CostBuffer(
+        run_id=run_date.isoformat(),
+        agent_id="data:news_event_extraction",
+        s3_client=s3_client,
+    )

--- a/rag/pipelines/run_news_pipeline.py
+++ b/rag/pipelines/run_news_pipeline.py
@@ -124,18 +124,31 @@ def main() -> int:
         logger.info("[run_news_pipeline] step 2/4 — SKIPPED (--skip-nlp)")
         from collectors.nlp.pipeline import NewsNLPOutput
         nlp_output = NewsNLPOutput()
+        cost_buffer = None
     else:
         logger.info("[run_news_pipeline] step 2/4 — NLP pipeline")
-        nlp_output = _run_nlp(articles)
+        from rag.pipelines._cost_telemetry import build_news_cost_buffer
+        cost_buffer = build_news_cost_buffer(run_date=agg_date)
+        nlp_output = _run_nlp(articles, cost_buffer=cost_buffer)
         logger.info(
             "[run_news_pipeline] step 2 — sentiment_scores=%d "
-            "event_flags=%d entity_mentions=%d (%d/%d articles processed)",
+            "event_flags=%d entity_mentions=%d (%d/%d articles processed); "
+            "cost rows buffered=%d",
             len(nlp_output.sentiment_scores),
             len(nlp_output.event_flags),
             len(nlp_output.entity_mentions),
             nlp_output.n_articles_processed,
             nlp_output.n_articles_processed + nlp_output.n_articles_failed,
+            cost_buffer.row_count,
         )
+
+    # Flush cost-telemetry rows to S3. Per [[feedback_no_silent_fails]]
+    # the flush is hard-fail — a silent miss on the previously-dominant
+    # untracked cost slice would defeat the Phase 0 visibility goal.
+    # Pipeline-side dry-run + skip-nlp skip the flush by construction
+    # (buffer is None / empty).
+    if cost_buffer is not None and not args.dry_run:
+        cost_buffer.flush()
 
     # ── Step 3: structured aggregates parquet ────────────────────
     if args.dry_run:
@@ -181,9 +194,16 @@ def main() -> int:
     return 0
 
 
-def _run_nlp(articles):
+def _run_nlp(articles, *, cost_buffer=None):
     """Instantiate the default NLP pipeline (LM sentiment + Anthropic
-    event extraction) and run over the article set."""
+    event extraction) and run over the article set.
+
+    When ``cost_buffer`` is provided, the Anthropic SDK client is
+    wrapped via :func:`wrap_client_for_cost_telemetry` so every
+    ``messages.create()`` response is buffered for the per-run cost-
+    telemetry flush at end of pipeline. Pure compose at construction;
+    no change required to ``AnthropicEventExtractor``.
+    """
     from collectors.nlp.event_extraction import AnthropicEventExtractor
     from collectors.nlp.loughran_mcdonald import LoughranMcDonaldScorer
     from collectors.nlp.pipeline import NewsNLPPipeline
@@ -197,6 +217,11 @@ def _run_nlp(articles):
         api_key = get_secret("ANTHROPIC_API_KEY", required=False, default="")
         if api_key:
             client = anthropic.Anthropic(api_key=api_key)
+            if cost_buffer is not None:
+                from rag.pipelines._cost_telemetry import (
+                    wrap_client_for_cost_telemetry,
+                )
+                client = wrap_client_for_cost_telemetry(client, cost_buffer)
             event_extractor = AnthropicEventExtractor(client)
             extractors = [event_extractor]
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,11 @@ arcticdb>=6.11
 # direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
 # v0.30.0 + v0.31.0 add the cost-telemetry SDK adapter
 # (``metadata_from_anthropic_message``) + server-tool fee tracking
-# (``ToolFee`` / ``ToolFeeTable``) — required by Phase 0 of the cost-
-# optimization workstream to wire ``collectors/nlp/event_extraction.py``'s
-# news-article event-extraction LLM calls into the cost-telemetry stream
-# (highest-volume untracked site at ~100–300 Haiku calls/wk during
-# RAGIngestion). All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.32.0
+# (``ToolFee`` / ``ToolFeeTable``). v0.33.0 adds the
+# ``record_anthropic_call`` capture chokepoint used by
+# ``rag/pipelines/_cost_telemetry.py`` to wire
+# ``collectors/nlp/event_extraction.py``'s news-article event-extraction
+# LLM calls into the cost-telemetry stream (highest-volume previously-
+# untracked site at ~100–300 Haiku calls/wk during RAGIngestion).
+# All additive surface — existing imports unchanged.
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.33.0

--- a/tests/test_news_cost_telemetry.py
+++ b/tests/test_news_cost_telemetry.py
@@ -15,14 +15,12 @@ Lock down:
 
 from __future__ import annotations
 
-import io
 import json
 from datetime import date
+from io import BytesIO
 from unittest.mock import MagicMock
 
-import boto3
 import pytest
-from moto import mock_aws
 
 from rag.pipelines._cost_telemetry import (
     CostBufferFlushError,
@@ -63,12 +61,43 @@ class _FakeMessage:
         self.usage = usage
 
 
+# ── In-memory S3 mock (no moto dep, mirrors test_news_aggregates.py) ─────
+
+
+class _InMemoryS3:
+    """Minimal in-memory S3 mock supporting put_object + list/get.
+
+    Mirrors the convention from ``test_news_aggregates.py`` — keeps the
+    repo's "no moto dep" posture (CI installs only ``requirements.txt``
+    + ``pytest``).
+    """
+
+    class _NoSuchKey(Exception):
+        pass
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self._store[(Bucket, Key)] = Body
+        return {"ETag": "stub"}
+
+    def get_object(self, *, Bucket, Key):
+        if (Bucket, Key) not in self._store:
+            raise self._NoSuchKey(f"NoSuchKey: {Bucket}/{Key}")
+        return {"Body": BytesIO(self._store[(Bucket, Key)])}
+
+    def list_objects_v2(self, *, Bucket, Prefix=""):
+        contents = [
+            {"Key": k} for (b, k) in self._store.keys()
+            if b == Bucket and k.startswith(Prefix)
+        ]
+        return {"Contents": contents, "KeyCount": len(contents)}
+
+
 @pytest.fixture
 def mocked_s3():
-    with mock_aws():
-        s3 = boto3.client("s3", region_name="us-east-1")
-        s3.create_bucket(Bucket=_BUCKET)
-        yield s3
+    yield _InMemoryS3()
 
 
 class TestS3CostBuffer:

--- a/tests/test_news_cost_telemetry.py
+++ b/tests/test_news_cost_telemetry.py
@@ -1,0 +1,214 @@
+"""Tests for rag/pipelines/_cost_telemetry.py — the news-pipeline cost sink.
+
+Lock down:
+
+- The Anthropic client proxy records each ``messages.create()`` response
+  into the buffer without changing the response shape returned to the caller.
+- Buffer ``flush()`` writes the rows as a single JSONL S3 object at the
+  canonical ``decision_artifacts/_cost_raw/{date}/{date}/data-news-event-extraction.jsonl``
+  key, or skips when empty.
+- Per-call recording failures (e.g. malformed response) are logged but
+  do NOT propagate — the event extractor's primary deliverable must
+  survive a cost-telemetry hiccup.
+- Flush failures (S3 errors) DO raise per ``[[feedback_no_silent_fails]]``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import date
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from rag.pipelines._cost_telemetry import (
+    CostBufferFlushError,
+    S3CostBuffer,
+    build_news_cost_buffer,
+    wrap_client_for_cost_telemetry,
+)
+
+
+_BUCKET = "alpha-engine-research"
+
+
+# ── Fake Anthropic types (mirrors test_cost.py in alpha-engine-lib) ──────
+
+
+class _FakeServerToolUsage:
+    def __init__(self, *, web_search_requests=0, web_fetch_requests=0):
+        self.web_search_requests = web_search_requests
+        self.web_fetch_requests = web_fetch_requests
+
+
+class _FakeUsage:
+    def __init__(
+        self, *, input_tokens, output_tokens,
+        cache_read_input_tokens=None, cache_creation_input_tokens=None,
+        server_tool_use=None,
+    ):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cache_read_input_tokens = cache_read_input_tokens
+        self.cache_creation_input_tokens = cache_creation_input_tokens
+        self.server_tool_use = server_tool_use
+
+
+class _FakeMessage:
+    def __init__(self, *, model, usage):
+        self.model = model
+        self.usage = usage
+
+
+@pytest.fixture
+def mocked_s3():
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket=_BUCKET)
+        yield s3
+
+
+class TestS3CostBuffer:
+    def test_record_returns_cost_and_appends_row(self):
+        buf = S3CostBuffer(
+            run_id="2026-05-25", agent_id="data:news_event_extraction",
+        )
+        msg = _FakeMessage(
+            model="claude-haiku-4-5",
+            usage=_FakeUsage(input_tokens=1000, output_tokens=200),
+        )
+        cost = buf.record(msg)
+        # (1000 * 1.0 + 200 * 5.0) / 1M = 0.002
+        assert cost == pytest.approx(0.002, abs=1e-6)
+        assert buf.row_count == 1
+
+    def test_record_stamps_run_id_and_agent_id(self):
+        buf = S3CostBuffer(
+            run_id="2026-05-25", agent_id="data:news_event_extraction",
+        )
+        msg = _FakeMessage(
+            model="claude-haiku-4-5",
+            usage=_FakeUsage(input_tokens=10, output_tokens=5),
+        )
+        buf.record(msg)
+        row = buf._rows[0]
+        assert row["run_id"] == "2026-05-25"
+        assert row["agent_id"] == "data:news_event_extraction"
+
+    def test_flush_empty_buffer_returns_none_and_writes_nothing(self, mocked_s3):
+        buf = S3CostBuffer(
+            run_id="2026-05-25", agent_id="data:news_event_extraction",
+            s3_client=mocked_s3,
+        )
+        key = buf.flush()
+        assert key is None
+        listing = mocked_s3.list_objects_v2(Bucket=_BUCKET)
+        assert listing.get("KeyCount", 0) == 0
+
+    def test_flush_writes_single_jsonl_at_canonical_key(self, mocked_s3):
+        buf = S3CostBuffer(
+            run_id="2026-05-25", agent_id="data:news_event_extraction",
+            s3_client=mocked_s3,
+        )
+        for i in range(3):
+            buf.record(_FakeMessage(
+                model="claude-haiku-4-5",
+                usage=_FakeUsage(input_tokens=100 * (i + 1), output_tokens=50),
+            ))
+        key = buf.flush()
+        expected = (
+            "decision_artifacts/_cost_raw/2026-05-25/2026-05-25/"
+            "data:news_event_extraction.jsonl"
+        )
+        assert key == expected
+        obj = mocked_s3.get_object(Bucket=_BUCKET, Key=key)
+        body = obj["Body"].read().decode("utf-8")
+        lines = [ln for ln in body.splitlines() if ln.strip()]
+        assert len(lines) == 3
+        for ln in lines:
+            row = json.loads(ln)
+            assert row["run_id"] == "2026-05-25"
+            assert row["agent_id"] == "data:news_event_extraction"
+            assert "cost_usd" in row
+
+    def test_flush_failure_hard_fails(self):
+        """S3 PutObject failure raises CostBufferFlushError, NOT swallowed.
+
+        Per ``[[feedback_no_silent_fails]]`` — losing the rolled-up cost
+        record would defeat the Phase 0 visibility goal."""
+        stub = MagicMock()
+        stub.put_object.side_effect = RuntimeError("AccessDenied")
+        buf = S3CostBuffer(
+            run_id="2026-05-25", agent_id="data:news_event_extraction",
+            s3_client=stub,
+        )
+        buf.record(_FakeMessage(
+            model="claude-haiku-4-5",
+            usage=_FakeUsage(input_tokens=10, output_tokens=5),
+        ))
+        with pytest.raises(CostBufferFlushError, match="AccessDenied"):
+            buf.flush()
+
+
+class TestWrapClientForCostTelemetry:
+    def test_proxy_records_each_create_call(self):
+        buf = S3CostBuffer(
+            run_id="2026-05-25", agent_id="data:news_event_extraction",
+        )
+        underlying_response = _FakeMessage(
+            model="claude-haiku-4-5",
+            usage=_FakeUsage(input_tokens=100, output_tokens=50),
+        )
+        underlying_client = MagicMock()
+        underlying_client.messages.create.return_value = underlying_response
+
+        wrapped = wrap_client_for_cost_telemetry(underlying_client, buf)
+        result = wrapped.messages.create(
+            model="claude-haiku-4-5", max_tokens=1024,
+            messages=[{"role": "user", "content": "x"}],
+        )
+
+        # Response unchanged.
+        assert result is underlying_response
+        # Recorded into buffer.
+        assert buf.row_count == 1
+        # Underlying client was actually invoked with the passed kwargs.
+        underlying_client.messages.create.assert_called_once()
+
+    def test_per_call_recording_failure_is_logged_not_raised(self, caplog):
+        """If the recorder raises (e.g., malformed response), the
+        primary deliverable (event extraction) MUST continue. Flush-
+        time S3 failures still raise; per-call recording does not."""
+        buf = MagicMock()
+        buf.record.side_effect = RuntimeError("bad msg shape")
+        underlying_client = MagicMock()
+        underlying_response = MagicMock()
+        underlying_client.messages.create.return_value = underlying_response
+
+        wrapped = wrap_client_for_cost_telemetry(underlying_client, buf)
+        # Should NOT raise.
+        result = wrapped.messages.create(model="x", messages=[])
+        assert result is underlying_response
+        # Warn logged.
+        assert any(
+            "per-call recording failed" in r.message
+            for r in caplog.records
+        )
+
+    def test_non_messages_attributes_forward_to_wrapped(self):
+        """Sanity: the proxy must not break access to other SDK surfaces."""
+        underlying_client = MagicMock()
+        underlying_client.beta = "beta-namespace"
+        buf = S3CostBuffer(run_id="2026-05-25", agent_id="x")
+        wrapped = wrap_client_for_cost_telemetry(underlying_client, buf)
+        assert wrapped.beta == "beta-namespace"
+
+
+class TestBuildNewsCostBuffer:
+    def test_canonical_naming(self):
+        buf = build_news_cost_buffer(run_date=date(2026, 5, 25))
+        assert buf._run_id == "2026-05-25"
+        assert buf._agent_id == "data:news_event_extraction"


### PR DESCRIPTION
## Summary

Closes the largest previously-untracked LLM cost slice in the system (~\$20–60/mo, the dominant ~20–60% of monthly Anthropic spend per the [Phase 0 audit](../alpha-engine-docs/private/prompt-caching-investigation-260525.md) §1.1). News-article event extraction in \`collectors/nlp/event_extraction.py:167\` fires 100–300 Haiku calls per RAGIngestion run; this PR records every response into a per-run JSONL flushed once to S3.

## Zero-coupling pattern

New \`rag/pipelines/_cost_telemetry.py\` provides \`wrap_client_for_cost_telemetry(client, buffer)\` — proxy that records every \`messages.create()\` response into a buffer without changing the response shape. **\`AnthropicEventExtractor\` is UNCHANGED** — telemetry composes at the client-construction layer in \`_run_nlp\` rather than polluting the extractor.

## Single S3 chokepoint

Rows land at \`s3://alpha-engine-research/decision_artifacts/_cost_raw/{date}/{date}/data:news_event_extraction.jsonl\` — same partition the research-side \`aggregate_costs.py\` already scans. Data's rows show up in the daily parquet's \`by_agent_id\` breakdown alongside research's; the Phase 0.3 dashboard cost panel surfaces every site in one view.

## Buffered + flushed once

100–300 calls per run → **1 PutObject at end-of-pipeline**. Per-call PutObjects would be wasteful.

## Failure semantics

- **Flush failure** raises \`CostBufferFlushError\` and fails the pipeline (per \`[[feedback_no_silent_fails]]\` — silent miss on the dominant cost slice would defeat Phase 0 visibility)
- **Per-call recording failure** (malformed response) is logged but does NOT propagate (event extractor's primary deliverable must survive a telemetry hiccup)

## Lib pin

\`v0.32.0 → v0.33.0\` in requirements.txt + Dockerfile to consume the lifted \`alpha_engine_lib.cost.record_anthropic_call\` (alpha-engine-lib #69 — data is consumer #2 of the SOTA chokepoint after morning-signal originated the pattern).

## Test plan

- [x] \`pytest tests/test_news_cost_telemetry.py\` — 9 new tests (buffer record/flush/empty/error paths, proxy passthrough, per-call failure isolation, factory naming)
- [x] Full suite 1480 → 1489 passing, zero regressions
- [x] Lib v0.33.0 install resolved cleanly in local venv
- [ ] Sat 5/30 RAGIngestion fires + JSONL lands at the canonical key + \`aggregate_costs.py\` picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)