### PR TITLE
feat(sf): wire AggregateCosts Lambda at end of Branch A (L1146.B)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1035,7 +1035,7 @@
                       "BooleanEquals": true
                     }
                   ],
-                  "Next": "BranchAComplete"
+                  "Next": "CheckSkipAggregateCosts"
                 }
               ],
               "Default": "Counterfactual"
@@ -1070,12 +1070,68 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Eval observability layer \u2014 counterfactual failure must NOT halt the pipeline. Same Catch pattern as the rest of the agent-justification triple. Routes to CheckSkipPredictorTraining (post-2026-05-07 reorder).",
-                  "Next": "BranchAComplete",
+                  "Comment": "Eval observability layer \u2014 counterfactual failure must NOT halt the pipeline. Same Catch pattern as the rest of the agent-justification triple. Routes to CheckSkipAggregateCosts so the cost-telemetry aggregation step still runs even when counterfactual fails (the JSONLs the aggregator reads were written by Research / eval-judge / rationale-clustering / replay-concordance / counterfactual independently; a counterfactual failure doesn't invalidate the upstream cost rows).",
+                  "Next": "CheckSkipAggregateCosts",
                   "ResultPath": "$.counterfactual_error"
                 }
               ],
               "ResultPath": "$.counterfactual_result",
+              "Next": "CheckSkipAggregateCosts"
+            },
+            "CheckSkipAggregateCosts": {
+              "Type": "Choice",
+              "Comment": "Skip-gate. {\"skip_aggregate_costs\": true} bypasses the daily cost-telemetry aggregation Lambda (used for ad-hoc reruns where the cost parquet for the date is already current, or when iterating on the aggregator script). Standalone invocation of the Lambda is always available via the deploy.sh aggregate_costs target. Independent of skip_rationale_clustering / skip_replay_concordance / skip_counterfactual \u2014 the four are independent observability paths.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.skip_aggregate_costs",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.skip_aggregate_costs",
+                      "BooleanEquals": true
+                    }
+                  ],
+                  "Next": "BranchAComplete"
+                }
+              ],
+              "Default": "AggregateCosts"
+            },
+            "AggregateCosts": {
+              "Type": "Task",
+              "Comment": "Daily cost-telemetry aggregation Lambda (ROADMAP L1146 \u2014 SF-wire scripts/aggregate_costs.py CLI). Reads decision_artifacts/_cost_raw/{run_date}/*.jsonl (written by Research / eval-judge / rationale-clustering / replay-concordance / counterfactual during the upstream chain), writes the daily parquet at decision_artifacts/_cost/{run_date}/cost.parquet, emits per-agent CW metrics under AlphaEngine/Cost. Placed at end of Branch A so all LLM-emitting upstream states have written their cost JSONL rows by the time the aggregator runs. Failure is non-blocking (Catch routes to BranchAComplete) \u2014 cost telemetry is observability, NOT a primary deliverable; aggregator failure does NOT regress the alpha pipeline. Status contract OK / SKIPPED / ERROR mirrors data #295 + L3277 audit \u2014 SKIPPED on no _cost_raw partitions for the date is a legitimate upstream no-op and treated as success.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-aggregate-costs:live",
+                "Payload": {
+                  "date.$": "$.run_date",
+                  "dry_run_llm.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 600,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Cost-telemetry aggregation is observability \u2014 failure must NOT halt the pipeline. The next Saturday SF will retry over a fresh _cost_raw partition; the prior week's parquet (or the manual-trigger fallback via scripts/aggregate_costs.py) remains available.",
+                  "Next": "BranchAComplete",
+                  "ResultPath": "$.aggregate_costs_error"
+                }
+              ],
+              "ResultPath": "$.aggregate_costs_result",
               "Next": "BranchAComplete"
             },
             "ExtractResearchError": {

--- a/tests/test_sf_aggregate_costs_wiring.py
+++ b/tests/test_sf_aggregate_costs_wiring.py
@@ -1,0 +1,225 @@
+"""Pins the AggregateCosts Lambda wiring in the Saturday Step Functions JSON.
+
+ROADMAP L1146 — SF-wire ``scripts/aggregate_costs.py`` CLI. The
+companion alpha-engine-research PR adds the
+``alpha-engine-research-aggregate-costs:live`` Lambda; this test only
+asserts the SF wiring.
+
+Pin the chain end of Branch A:
+
+    ... Counterfactual → CheckSkipAggregateCosts → AggregateCosts
+                                                 → BranchAComplete
+
+The aggregator must sit AFTER the entire LLM chain (Research /
+eval-judge / rationale-clustering / replay-concordance / counterfactual)
+so every upstream LLM-emitting state has finished writing its
+``_cost_raw/{date}/*.jsonl`` rows by the time the aggregator runs.
+Catches regressions like: a future SF refactor that drops the new
+state, or reroutes Counterfactual back to BranchAComplete bypassing
+the aggregator.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    """Flattened state view: top-level states UNION every Parallel
+    branch's states. Mirrors the helper in test_sf_eval_judge_wiring.py.
+    """
+    flat: dict = dict(sf["States"])
+    for st in sf["States"].values():
+        if st.get("Type") == "Parallel":
+            for branch in st["Branches"]:
+                flat.update(branch["States"])
+    return flat
+
+
+# ── State presence ────────────────────────────────────────────────────────
+
+
+class TestStatesPresent:
+    def test_aggregate_costs_states_exist(self, states):
+        assert "CheckSkipAggregateCosts" in states
+        assert "AggregateCosts" in states
+
+    def test_aggregate_costs_is_a_task(self, states):
+        assert states["AggregateCosts"]["Type"] == "Task"
+
+    def test_aggregate_costs_check_skip_is_a_choice(self, states):
+        assert states["CheckSkipAggregateCosts"]["Type"] == "Choice"
+
+
+# ── Lambda target + payload ───────────────────────────────────────────────
+
+
+class TestLambdaTarget:
+    def test_lambda_function_arn(self, states):
+        params = states["AggregateCosts"]["Parameters"]
+        assert (
+            params["FunctionName"]
+            == "alpha-engine-research-aggregate-costs:live"
+        )
+        assert states["AggregateCosts"]["Resource"] == (
+            "arn:aws:states:::lambda:invoke"
+        )
+
+    def test_payload_threads_run_date(self, states):
+        # The handler hard-requires event["date"] — must be threaded
+        # from $.run_date (seeded by InitializeInput from
+        # $$.Execution.StartTime).
+        payload = states["AggregateCosts"]["Parameters"]["Payload"]
+        assert payload["date.$"] == "$.run_date"
+
+    def test_payload_threads_shell_run_dry_flag(self, states):
+        # dry_run_llm threading mirrors the rationale_clustering /
+        # eval-judge chain — Friday-Preflight shell runs short-circuit
+        # the S3 read + parquet write.
+        payload = states["AggregateCosts"]["Parameters"]["Payload"]
+        assert payload["dry_run_llm.$"] == "$.research_dry"
+
+
+# ── Failure isolation ─────────────────────────────────────────────────────
+
+
+class TestFailureIsolation:
+    def test_catch_routes_to_branch_a_complete(self, states):
+        # Cost telemetry is observability — aggregator failure must NOT
+        # halt the pipeline. Mirrors the rationale-clustering Catch.
+        catches = states["AggregateCosts"]["Catch"]
+        assert len(catches) >= 1
+        assert any(
+            c["Next"] == "BranchAComplete"
+            and "States.ALL" in c["ErrorEquals"]
+            for c in catches
+        )
+
+    def test_retry_only_on_lambda_service_errors(self, states):
+        # Same shape as rationale-clustering — service-level retries
+        # (Lambda.ServiceException, TooManyRequestsException) but NO
+        # retry on application-level errors (which would mask
+        # aggregator bugs).
+        retries = states["AggregateCosts"]["Retry"]
+        assert any(
+            "Lambda.ServiceException" in r["ErrorEquals"]
+            and "Lambda.TooManyRequestsException" in r["ErrorEquals"]
+            for r in retries
+        )
+
+
+# ── Wiring: edges into and out of AggregateCosts ──────────────────────────
+
+
+class TestEdges:
+    def test_counterfactual_routes_to_check_skip_aggregate_costs(self, states):
+        # Default path (success) — Counterfactual's Next must hit the
+        # new skip-gate, NOT BranchAComplete directly.
+        cf = states["Counterfactual"]
+        assert cf["Next"] == "CheckSkipAggregateCosts"
+
+    def test_counterfactual_catch_routes_to_check_skip_aggregate_costs(self, states):
+        # Counterfactual failure must STILL run the aggregator —
+        # upstream LLM cost rows are independent of counterfactual's
+        # success. (The aggregator's own Catch routes to
+        # BranchAComplete so a downstream failure-of-failure can't
+        # ladder back into the failed counterfactual error path.)
+        cf = states["Counterfactual"]
+        catches = cf["Catch"]
+        assert any(
+            c["Next"] == "CheckSkipAggregateCosts"
+            for c in catches
+        )
+
+    def test_check_skip_counterfactual_default_unchanged(self, states):
+        # CheckSkipCounterfactual's Default → Counterfactual stays
+        # unchanged; only the SKIP branch is rerouted to the new
+        # CheckSkipAggregateCosts.
+        skip = states["CheckSkipCounterfactual"]
+        assert skip["Default"] == "Counterfactual"
+
+    def test_check_skip_counterfactual_skip_routes_to_aggregate_costs_gate(
+        self, states,
+    ):
+        # When operator skips counterfactual, the flow MUST still hit
+        # the aggregator gate (an operator skipping counterfactual is
+        # NOT also skipping cost-telemetry — those are independent
+        # skip flags per the comment on CheckSkipAggregateCosts).
+        skip = states["CheckSkipCounterfactual"]
+        skip_choices = skip["Choices"]
+        assert len(skip_choices) == 1
+        assert skip_choices[0]["Next"] == "CheckSkipAggregateCosts"
+
+    def test_aggregate_costs_success_routes_to_branch_a_complete(self, states):
+        assert states["AggregateCosts"]["Next"] == "BranchAComplete"
+
+    def test_check_skip_aggregate_costs_skip_routes_to_branch_a_complete(
+        self, states,
+    ):
+        skip = states["CheckSkipAggregateCosts"]
+        skip_choices = skip["Choices"]
+        assert len(skip_choices) == 1
+        assert skip_choices[0]["Next"] == "BranchAComplete"
+
+    def test_check_skip_aggregate_costs_default_is_aggregate_costs(self, states):
+        assert states["CheckSkipAggregateCosts"]["Default"] == "AggregateCosts"
+
+
+# ── Skip-flag semantics ───────────────────────────────────────────────────
+
+
+class TestSkipFlagSemantics:
+    def test_skip_flag_named_skip_aggregate_costs(self, states):
+        skip = states["CheckSkipAggregateCosts"]
+        # Each choice's conjunction names the variable being inspected.
+        choice = skip["Choices"][0]
+        # Mirror the pattern used by the other observability skip
+        # gates: IsPresent + BooleanEquals true.
+        variables = [c["Variable"] for c in choice["And"]]
+        assert all(v == "$.skip_aggregate_costs" for v in variables)
+        assert any(c.get("BooleanEquals") is True for c in choice["And"])
+
+
+# ── Result paths (state-merge contract) ───────────────────────────────────
+
+
+class TestResultPaths:
+    def test_success_result_lands_under_aggregate_costs_result(self, states):
+        # Mirrors rationale_clustering_result / counterfactual_result —
+        # each observability Lambda result is namespaced under its own
+        # ResultPath so the parent state doesn't get clobbered.
+        assert (
+            states["AggregateCosts"]["ResultPath"]
+            == "$.aggregate_costs_result"
+        )
+
+    def test_failure_result_lands_under_aggregate_costs_error(self, states):
+        catches = states["AggregateCosts"]["Catch"]
+        catch_all = next(
+            c for c in catches if "States.ALL" in c["ErrorEquals"]
+        )
+        assert catch_all["ResultPath"] == "$.aggregate_costs_error"
+
+
+# ── Timeout ───────────────────────────────────────────────────────────────
+
+
+class TestTimeout:
+    def test_timeout_is_bounded(self, states):
+        # The handler's expected wallclock is ~minutes for thousands
+        # of small S3 reads + one parquet write. 600s (10 min) gives
+        # generous headroom while still tripping a hung run.
+        assert states["AggregateCosts"]["TimeoutSeconds"] == 600

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -640,16 +640,20 @@ class TestReplayConcordance:
 
 
 class TestSkipCounterfactual:
-    def test_skip_flag_bypasses_to_branch_a_terminal(self, states):
-        """Skipping Counterfactual is the Branch-A chain-exit path. Post
-        the 2026-05-16 Research || PredictorTraining SF Parallel
-        restructure, the eval/agent-justification chain is Branch A; its
-        exit is the branch-local terminal BranchAComplete (End:true) — a
-        branch must SUCCEED, never throw, so SF Parallel's
-        cancel-siblings-on-error default can never abandon an in-flight
-        (or completed+S3-promoted) PredictorTraining branch.
-        CheckSkipPredictorTraining now lives in the SIBLING Branch B; the
-        post-join CheckBranchOutcomes is the new sync point."""
+    def test_skip_flag_bypasses_to_aggregate_costs_gate(self, states):
+        """Skipping Counterfactual now lands on the AggregateCosts
+        skip-gate (ROADMAP L1146 — SF-wired daily cost aggregator
+        added 2026-05-25), not directly on BranchAComplete. The cost
+        aggregator reads cost JSONLs written by upstream LLM states
+        (Research / eval-judge / rationale-clustering / replay-
+        concordance / counterfactual); a counterfactual skip does NOT
+        invalidate those upstream rows, so the aggregator MUST still
+        run. The four observability skip flags (skip_counterfactual /
+        skip_rationale_clustering / skip_replay_concordance /
+        skip_aggregate_costs) are independent. Pre-L1146 this assertion
+        pinned ``BranchAComplete``; the L1146 wire-up reroutes through
+        ``CheckSkipAggregateCosts`` which transitively reaches the
+        Branch-A terminal."""
         skip = states["CheckSkipCounterfactual"]
         choice = skip["Choices"][0]
         and_clauses = choice["And"]
@@ -658,7 +662,7 @@ class TestSkipCounterfactual:
             and c.get("BooleanEquals") is True
             for c in and_clauses
         )
-        assert choice["Next"] == "BranchAComplete"
+        assert choice["Next"] == "CheckSkipAggregateCosts"
 
     def test_default_runs_counterfactual(self, states):
         assert states["CheckSkipCounterfactual"]["Default"] == "Counterfactual"
@@ -686,24 +690,30 @@ class TestCounterfactual:
         # across 8 weeks of corpus).
         assert states["Counterfactual"]["TimeoutSeconds"] == 600
 
-    def test_success_exits_to_branch_a_terminal(self, states):
-        # Post the 2026-05-16 SF Parallel restructure: Counterfactual is
-        # the last state in Branch A (the eval/agent-justification
-        # chain); success exits to the branch-local terminal
-        # BranchAComplete (End:true). Its persisted S3 artifacts are
-        # still available to the downstream Evaluator, which now runs
-        # AFTER the Parallel join.
-        assert states["Counterfactual"]["Next"] == "BranchAComplete"
+    def test_success_exits_to_aggregate_costs_gate(self, states):
+        # Counterfactual is now the SECOND-to-last load-bearing state in
+        # Branch A — the L1146 wire-up (2026-05-25) inserted the
+        # AggregateCosts cost-telemetry aggregator after it. Success now
+        # exits to CheckSkipAggregateCosts, which transitively reaches
+        # BranchAComplete (End:true). Persisted S3 artifacts are still
+        # available to the downstream Evaluator, which runs AFTER the
+        # Parallel join. Pre-L1146: Counterfactual.Next == BranchAComplete.
+        assert states["Counterfactual"]["Next"] == "CheckSkipAggregateCosts"
 
-    def test_catch_routes_to_branch_a_terminal_not_failure(self, states):
+    def test_catch_routes_to_aggregate_costs_gate_not_failure(self, states):
         # Same Catch posture as the rest of the agent-justification
         # triple — Counterfactual is observability, not load-bearing, so
-        # failures fall through to the Branch-A success terminal rather
-        # than halting the pipeline (and crucially NOT to HandleFailure,
-        # which would abort the sibling PredictorTraining branch).
+        # failures fall through to the next observability step (the cost
+        # aggregator) rather than halting the pipeline (and crucially
+        # NOT to HandleFailure, which would abort the sibling
+        # PredictorTraining branch). Pre-L1146 this routed directly to
+        # BranchAComplete; the cost aggregator inserted between
+        # Counterfactual and the branch terminal is itself a separate
+        # observability layer with its own Catch routing to
+        # BranchAComplete.
         catch = states["Counterfactual"]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
-        assert catch["Next"] == "BranchAComplete"
+        assert catch["Next"] == "CheckSkipAggregateCosts"
         assert catch["Next"] != "HandleFailure"
 
     def test_retries_on_transient_lambda_errors(self, states):
@@ -749,25 +759,28 @@ class TestJudgeChainBeforePredictor:
             == "CheckSkipEvalJudge"
         )
 
-    def test_counterfactual_exits_to_branch_a_terminal(self, states):
-        """Counterfactual is the last state in Branch A (the eval/
-        agent-justification chain); post the 2026-05-16 SF Parallel
-        restructure its Next + Catch + the skip-gate above it all
-        converge to the branch-local success terminal BranchAComplete
-        (End:true). The Evaluator-sees-judge-artifacts ordering invariant
-        is still satisfied because Evaluator runs AFTER the Parallel
-        join, by which point Branch A has completed and its S3 artifacts
-        are landed. Pre-2026-05-07 this was SaturdayHealthCheck;
-        2026-05-07→2026-05-16 it was CheckSkipPredictorTraining;
-        post-2026-05-16 it is BranchAComplete."""
-        assert states["Counterfactual"]["Next"] == "BranchAComplete"
+    def test_counterfactual_exits_to_aggregate_costs_gate(self, states):
+        """Counterfactual's three exit edges (Next + Catch + the
+        skip-gate above it) all converge on the AggregateCosts skip-gate
+        added by ROADMAP L1146 (2026-05-25). The Evaluator-sees-judge-
+        artifacts ordering invariant is still satisfied because
+        Evaluator runs AFTER the Parallel join, by which point Branch A
+        (including the inserted cost-aggregator step) has completed and
+        its S3 artifacts are landed. Edge target history:
+        pre-2026-05-07 SaturdayHealthCheck → 2026-05-07→05-16
+        CheckSkipPredictorTraining → 2026-05-16→05-25 BranchAComplete →
+        post-L1146 CheckSkipAggregateCosts. The transitive reach to
+        BranchAComplete is preserved (CheckSkipAggregateCosts.Default →
+        AggregateCosts.Next → BranchAComplete; CheckSkipAggregateCosts's
+        skip-branch → BranchAComplete directly)."""
+        assert states["Counterfactual"]["Next"] == "CheckSkipAggregateCosts"
         assert (
             states["Counterfactual"]["Catch"][0]["Next"]
-            == "BranchAComplete"
+            == "CheckSkipAggregateCosts"
         )
         assert (
             states["CheckSkipCounterfactual"]["Choices"][0]["Next"]
-            == "BranchAComplete"
+            == "CheckSkipAggregateCosts"
         )
 
     def test_evaluator_exits_directly_to_health_check(self, states):

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -91,6 +91,10 @@ _EXPECTED_SKIPS = {
     "skip_rationale_clustering",
     "skip_replay_concordance",
     "skip_counterfactual",
+    # Added 2026-05-25 (ROADMAP L1146 — SF-wire aggregate_costs.py CLI).
+    # Observability skip; independent of the three above per the
+    # CheckSkipAggregateCosts comment.
+    "skip_aggregate_costs",
     "skip_predictor_training",
     "skip_drift_detection",
     "skip_backtester",


### PR DESCRIPTION
## Summary
Companion to **alpha-engine-research #234** which adds the `alpha-engine-research-aggregate-costs` Lambda. This PR adds the Saturday SF state that invokes it at the end of Branch A — after all upstream LLM-emitting states (Research, DataPhase2, eval-judge chain, rationale-clustering, replay-concordance, counterfactual) have written their `_cost_raw/{date}/` JSONL rows.

ROADMAP L1146 — option (a) institutional path: dedicated Lambda + dedicated SF state, NOT the spot-coupling bandaid (option b).

## New chain end of Branch A
```
... Counterfactual → CheckSkipAggregateCosts → AggregateCosts → BranchAComplete
                                            ↘ (skip)         ↗
```

## Wiring shape
Mirrors `RationaleClustering` (observability layer):
- **Lambda**: `alpha-engine-research-aggregate-costs:live`
- **Payload**: `{ "date.$": "$.run_date", "dry_run_llm.$": "$.research_dry" }`. `run_date` is seeded by `InitializeInput` from `$$.Execution.StartTime`; `research_dry` threads the Friday-Preflight shell-run dry signal so the canary boots + imports without S3 read.
- **Catch routes to `BranchAComplete`** — failure is non-blocking because cost telemetry is observability, NOT a primary deliverable. Same posture as the rest of the agent-justification triple.
- **`skip_aggregate_costs`** operator flag for ad-hoc reruns; independent of `skip_rationale_clustering` / `skip_replay_concordance` / `skip_counterfactual`.
- **Counterfactual's success AND catch paths both reroute** to `CheckSkipAggregateCosts` — a counterfactual failure does NOT skip the aggregator (upstream LLM cost rows are independent of counterfactual's success).

## Tests
- **New**: 19 in `test_sf_aggregate_costs_wiring.py` — state presence, Lambda target ARN, payload field threading, retry/catch shape, edge wiring (Counterfactual's three exit edges all converge), skip-flag semantics, ResultPath isolation, timeout bounded at 600s.
- **Updated**: 3 in `test_sf_eval_judge_wiring.py` — Counterfactual's `Next` / Catch / skip-gate now reach `CheckSkipAggregateCosts` (was `BranchAComplete`); transitive reach to `BranchAComplete` is preserved.
- **Updated**: 1 in `test_sf_friday_shell_run_wiring.py` — `skip_aggregate_costs` added to `_EXPECTED_SKIPS` set per the #258 keystone's "no skip flag deleted/added without coordinated update" guard.

Full data suite: **1498 passed**.

## Dependency
- This PR depends on alpha-engine-research #234 deploying the Lambda. SF deployment without the Lambda live will produce a `Lambda.FunctionNotFound` from `arn:...alpha-engine-research-aggregate-costs:live` — caught by SF Catch, routes to `BranchAComplete` (non-blocking), but should be avoided. Suggested merge order: research #234 first (`Deploy aggregate-costs Lambda` step creates the function on first push to main), then this PR.

## Test plan
- [ ] CI green
- [ ] research #234 merges + `Deploy aggregate-costs Lambda` workflow step succeeds (Lambda auto-created on first run)
- [ ] This PR merges + `deploy_step_function.sh` updates the live SF definition
- [ ] Next Saturday SF firing produces `decision_artifacts/_cost/{date}/cost.parquet` via Lambda invocation (no manual `python -m scripts.aggregate_costs --date X` needed)
- [ ] alpha-engine-config ROADMAP L1146 flips to `[x]` (companion C PR holds until both A + B merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)