### PR TITLE
feat(sf): Scanner SF state gated default-off + IAM walker fix (L1995 Phase 2)

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -9,6 +9,8 @@
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-aggregate-costs*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-scanner*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -170,7 +170,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckSkipRAGIngestion"
+          "Next": "CheckEnableStandaloneScanner"
         }
       ],
       "Default": "DataPhase1"
@@ -250,7 +250,7 @@
         {
           "Variable": "$.data_phase1_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipRAGIngestion"
+          "Next": "CheckEnableStandaloneScanner"
         },
         {
           "Variable": "$.data_phase1_poll.Status",
@@ -269,6 +269,62 @@
       "Type": "Wait",
       "Seconds": 30,
       "Next": "WaitForDataPhase1"
+    },
+    "CheckEnableStandaloneScanner": {
+      "Type": "Choice",
+      "Comment": "L1995 Phase 2 gate — default-off. {\"enable_standalone_scanner\": true} routes through the new Scanner Lambda (alpha-engine-research-scanner, ROADMAP L1995 Phase 1 / research #235), which writes s3://alpha-engine-research/candidates/{run_date}/candidates.json in parallel-observe mode (Research Lambda still runs its own internal scanner — Phase 5 will cut Research over to read the artifact). Default (flag absent or false) routes straight to CheckSkipRAGIngestion — byte-identical to the pre-Phase-2 chain. Operator flips the flag for the Phase 3 soak; first scheduled flip-on Saturday is 2026-05-30 if operator opts in.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.enable_standalone_scanner",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.enable_standalone_scanner",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "Scanner"
+        }
+      ],
+      "Default": "CheckSkipRAGIngestion"
+    },
+    "Scanner": {
+      "Type": "Task",
+      "Comment": "Standalone scanner Lambda (ROADMAP L1995 Phase 1 — alpha-engine-research #235). Reads constituents.json + feature store, runs the same run_quant_filter as Research Lambda's internal scanner, writes the candidates.json artifact for THIS run_date. Phase 2 posture: observe-only — gated by enable_standalone_scanner flag; failure is NON-BLOCKING (Catch routes to CheckSkipRAGIngestion). The artifact is parallel-observe only; no consumer reads it yet (Phase 4 will switch RAG to read it, Phase 5 will switch Research). Status contract OK / ERROR — no SKIPPED today (constituents.json + feature store are hard preconditions). dry_run_llm threads the Friday-Preflight shell-run signal so the Lambda boots+imports without S3 read on $.research_dry=true. Includes a 5/30 soak: Brian flips enable_standalone_scanner=true on the 5/30 SF input and compares candidates.json::scanner_tickers against research's signals.json::universe (minus population). Zero divergence is the Phase 3 → Phase 4 transition signal.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-research-scanner:live",
+        "Payload": {
+          "run_date.$": "$.run_date",
+          "dry_run_llm.$": "$.research_dry"
+        }
+      },
+      "TimeoutSeconds": 600,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Phase 2 observe-only contract — scanner failure must NOT halt the pipeline. Research Lambda's internal scanner still runs in parallel and provides the load-bearing scanner output downstream; this artifact is parallel-observe and consumer-less today (Phase 4 will flip RAG to read it). Routes forward to CheckSkipRAGIngestion so the pipeline continues exactly as it would on flag=false.",
+          "Next": "CheckSkipRAGIngestion",
+          "ResultPath": "$.scanner_error"
+        }
+      ],
+      "ResultPath": "$.scanner_result",
+      "Next": "CheckSkipRAGIngestion"
     },
     "CheckSkipRAGIngestion": {
       "Type": "Choice",

--- a/tests/test_sf_iam_lambda_grants.py
+++ b/tests/test_sf_iam_lambda_grants.py
@@ -58,29 +58,49 @@ def _collect_invoked_lambda_arns(sf_doc: dict) -> set[str]:
 
     Returns the set of fully-qualified ARNs (or short names that we
     convert to ARNs assuming us-east-1 + the canonical account).
+
+    Recursively walks Parallel branches so Lambda invocations nested
+    inside a Parallel state (e.g. the ResearchPredictorParallel Branch
+    A chain: Research → DataPhase2 → eval-judge chain →
+    RationaleClustering → ReplayConcordance → Counterfactual →
+    AggregateCosts) are not silently skipped. Pre-2026-05-26 the walker
+    only iterated top-level States; the aggregate-costs Lambda was
+    added 2026-05-25 (L1146.B) inside Branch A and shipped without an
+    IAM grant because this walker missed it.
     """
     found: set[str] = set()
-    for state_name, state in sf_doc.get("States", {}).items():
-        if state.get("Type") != "Task":
-            continue
-        resource = state.get("Resource", "")
-        if "lambda:invoke" not in resource and "lambda:Invoke" not in resource:
-            continue
-        params = state.get("Parameters", {})
-        fn = params.get("FunctionName") or params.get("FunctionName.$")
-        if not fn or not isinstance(fn, str):
-            continue
-        if fn.startswith("arn:aws:lambda:"):
-            arn = fn.split(":")[6] if fn.count(":") >= 6 else fn  # function name part
-            # Normalize to full ARN minus alias suffix for prefix matching
-            base = ":".join(fn.split(":")[:7])  # arn:aws:lambda:region:acct:function:NAME
-            found.add(base)
-        else:
-            # Short name with optional ":alias" — assume canonical region/acct
-            short = fn.split(":")[0]
-            found.add(
-                f"arn:aws:lambda:us-east-1:711398986525:function:{short}"
-            )
+
+    def _walk(states: dict) -> None:
+        for state_name, state in states.items():
+            if state.get("Type") == "Parallel":
+                for branch in state.get("Branches", []):
+                    _walk(branch.get("States", {}))
+                continue
+            if state.get("Type") != "Task":
+                continue
+            resource = state.get("Resource", "")
+            if (
+                "lambda:invoke" not in resource
+                and "lambda:Invoke" not in resource
+            ):
+                continue
+            params = state.get("Parameters", {})
+            fn = params.get("FunctionName") or params.get("FunctionName.$")
+            if not fn or not isinstance(fn, str):
+                continue
+            if fn.startswith("arn:aws:lambda:"):
+                arn = fn.split(":")[6] if fn.count(":") >= 6 else fn
+                # Normalize to full ARN minus alias suffix for prefix matching
+                base = ":".join(fn.split(":")[:7])
+                found.add(base)
+            else:
+                # Short name with optional ":alias" — assume canonical region/acct
+                short = fn.split(":")[0]
+                found.add(
+                    f"arn:aws:lambda:us-east-1:711398986525:function:{short}"
+                )
+
+    _walk(sf_doc.get("States", {}))
     return found
 
 

--- a/tests/test_sf_scanner_wiring.py
+++ b/tests/test_sf_scanner_wiring.py
@@ -1,0 +1,219 @@
+"""Pins the Scanner Lambda wiring in the Saturday Step Functions JSON.
+
+ROADMAP L1995 Phase 2 — gated default-off via `enable_standalone_scanner`
+flag. The companion alpha-engine-research PR #235 adds the
+`alpha-engine-research-scanner:live` Lambda (Phase 1); this PR inserts
+the SF state that invokes it when the operator flips the flag (Phase 3
+soak), so RAGIngestion (Phase 4) can later read the new
+`candidates.json` artifact.
+
+Pin the chain between DataPhase1 and CheckSkipRAGIngestion:
+
+    DataPhase1 (skip path)    ──┐
+                                ├──→ CheckEnableStandaloneScanner ──→ Scanner ──→ CheckSkipRAGIngestion
+    CheckDataPhase1Status.Success┘                              └──(default)──→ CheckSkipRAGIngestion
+
+When the flag is false/absent (Phase 2 default), the path through
+CheckEnableStandaloneScanner is byte-identical to the pre-Phase-2 chain
+— Choice.Default goes directly to CheckSkipRAGIngestion, no Lambda
+invocation occurs. When the flag is true, the Lambda runs in
+parallel-observe mode and Catch ensures failure does NOT halt the
+pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    """Flattened state view: top-level states UNION every Parallel
+    branch's states. Mirrors the helper in test_sf_eval_judge_wiring.py.
+    """
+    flat: dict = dict(sf["States"])
+    for st in sf["States"].values():
+        if st.get("Type") == "Parallel":
+            for branch in st["Branches"]:
+                flat.update(branch["States"])
+    return flat
+
+
+# ── State presence ────────────────────────────────────────────────────────
+
+
+class TestStatesPresent:
+    def test_scanner_states_exist(self, states):
+        assert "CheckEnableStandaloneScanner" in states
+        assert "Scanner" in states
+
+    def test_scanner_is_a_task(self, states):
+        assert states["Scanner"]["Type"] == "Task"
+
+    def test_check_enable_is_a_choice(self, states):
+        assert states["CheckEnableStandaloneScanner"]["Type"] == "Choice"
+
+
+# ── Lambda target + payload ───────────────────────────────────────────────
+
+
+class TestLambdaTarget:
+    def test_lambda_function_arn(self, states):
+        params = states["Scanner"]["Parameters"]
+        assert (
+            params["FunctionName"]
+            == "alpha-engine-research-scanner:live"
+        )
+        assert states["Scanner"]["Resource"] == (
+            "arn:aws:states:::lambda:invoke"
+        )
+
+    def test_payload_threads_run_date(self, states):
+        # The handler hard-requires event["run_date"] — must be threaded
+        # from $.run_date (seeded by InitializeInput from
+        # $$.Execution.StartTime).
+        payload = states["Scanner"]["Parameters"]["Payload"]
+        assert payload["run_date.$"] == "$.run_date"
+
+    def test_payload_threads_shell_run_dry_flag(self, states):
+        # dry_run_llm threading mirrors the rationale_clustering /
+        # eval-judge / aggregate_costs chain — Friday-Preflight shell
+        # runs short-circuit the S3 read + Lambda S3 write.
+        payload = states["Scanner"]["Parameters"]["Payload"]
+        assert payload["dry_run_llm.$"] == "$.research_dry"
+
+
+# ── Failure isolation ─────────────────────────────────────────────────────
+
+
+class TestFailureIsolation:
+    def test_catch_routes_to_check_skip_rag(self, states):
+        # Phase 2 observe-only contract — scanner failure must NOT halt
+        # the pipeline. Research Lambda's internal scanner still runs
+        # in parallel and the artifact is consumer-less today.
+        catches = states["Scanner"]["Catch"]
+        assert len(catches) >= 1
+        assert any(
+            c["Next"] == "CheckSkipRAGIngestion"
+            and "States.ALL" in c["ErrorEquals"]
+            for c in catches
+        )
+
+    def test_retry_only_on_lambda_service_errors(self, states):
+        # Same shape as rationale-clustering / aggregate_costs —
+        # service-level retries but NO retry on application-level errors
+        # (which would mask scanner bugs during Phase 3 soak).
+        retries = states["Scanner"]["Retry"]
+        assert any(
+            "Lambda.ServiceException" in r["ErrorEquals"]
+            and "Lambda.TooManyRequestsException" in r["ErrorEquals"]
+            for r in retries
+        )
+
+
+# ── Gate semantics (default-off) ──────────────────────────────────────────
+
+
+class TestGateDefaultOff:
+    def test_default_path_is_check_skip_rag(self, states):
+        # Phase 2 ships gated default-off: when the flag is absent or
+        # false the chain is byte-identical to pre-Phase-2.
+        assert (
+            states["CheckEnableStandaloneScanner"]["Default"]
+            == "CheckSkipRAGIngestion"
+        )
+
+    def test_flag_true_routes_to_scanner(self, states):
+        gate = states["CheckEnableStandaloneScanner"]
+        choices = gate["Choices"]
+        assert len(choices) == 1
+        choice = choices[0]
+        assert choice["Next"] == "Scanner"
+        # Conjunction pins the variable + bool semantics (IsPresent AND
+        # BooleanEquals true).
+        variables = [c["Variable"] for c in choice["And"]]
+        assert all(v == "$.enable_standalone_scanner" for v in variables)
+        assert any(c.get("BooleanEquals") is True for c in choice["And"])
+
+
+# ── Wiring: edges into and out of the new states ──────────────────────────
+
+
+class TestEdges:
+    def test_data_phase1_skip_path_routes_to_scanner_gate(self, states):
+        # CheckSkipDataPhase1's skip branch (operator passes
+        # skip_data_phase1=true) previously went to CheckSkipRAGIngestion
+        # directly. Phase 2 re-routes it through the new gate so the
+        # Phase-2-enabled path is honored even on a phase1-skip rerun.
+        skip = states["CheckSkipDataPhase1"]
+        skip_choices = skip["Choices"]
+        assert any(
+            c["Next"] == "CheckEnableStandaloneScanner"
+            for c in skip_choices
+        )
+
+    def test_data_phase1_success_path_routes_to_scanner_gate(self, states):
+        # CheckDataPhase1Status.Success previously went to
+        # CheckSkipRAGIngestion directly; Phase 2 re-routes through the
+        # new gate.
+        status = states["CheckDataPhase1Status"]
+        success = next(
+            c for c in status["Choices"]
+            if c.get("StringEquals") == "Success"
+        )
+        assert success["Next"] == "CheckEnableStandaloneScanner"
+
+    def test_scanner_success_routes_to_check_skip_rag(self, states):
+        assert states["Scanner"]["Next"] == "CheckSkipRAGIngestion"
+
+    def test_default_path_byte_identical_to_pre_phase_2(self, states):
+        # The end of this chain MUST equal what the pre-Phase-2 chain
+        # had — CheckSkipRAGIngestion. Anyone changing the gate's
+        # Default without updating this assertion is silently breaking
+        # the observe-only Phase 2 contract.
+        assert (
+            states["CheckEnableStandaloneScanner"]["Default"]
+            == "CheckSkipRAGIngestion"
+        )
+
+
+# ── Result paths (state-merge contract) ───────────────────────────────────
+
+
+class TestResultPaths:
+    def test_success_result_lands_under_scanner_result(self, states):
+        # Mirrors rationale_clustering_result / counterfactual_result /
+        # aggregate_costs_result — each observability Lambda result is
+        # namespaced under its own ResultPath so the parent state
+        # doesn't get clobbered.
+        assert states["Scanner"]["ResultPath"] == "$.scanner_result"
+
+    def test_failure_result_lands_under_scanner_error(self, states):
+        catches = states["Scanner"]["Catch"]
+        catch_all = next(
+            c for c in catches if "States.ALL" in c["ErrorEquals"]
+        )
+        assert catch_all["ResultPath"] == "$.scanner_error"
+
+
+# ── Timeout ───────────────────────────────────────────────────────────────
+
+
+class TestTimeout:
+    def test_timeout_is_bounded(self, states):
+        # The handler's expected wallclock is ~minutes for the full
+        # ~903-ticker filter pass + small artifact write. 600s gives
+        # generous headroom while still tripping a hung run.
+        assert states["Scanner"]["TimeoutSeconds"] == 600


### PR DESCRIPTION
## Summary
Companion to **alpha-engine-research #235** (Phase 1 — Scanner Lambda observe-only, MERGED). This PR inserts the SF state that invokes it, **gated default-off** via `$.enable_standalone_scanner` so the chain stays byte-identical to pre-Phase-2 until the operator flips the flag for the Phase 3 soak.

ROADMAP L1995 Phase 2.

## New chain (between DataPhase1 and RAGIngestion)
```
DataPhase1 (skip path)    ──┐
                            ├──→ CheckEnableStandaloneScanner ──→ Scanner ──→ CheckSkipRAGIngestion
CheckDataPhase1Status.Success─┘                            ↘ (default)     ↗
```

## Wiring shape
Mirrors `RationaleClustering` (observability layer):
- **Lambda**: `alpha-engine-research-scanner:live`
- **Payload**: `{ "run_date.$": "$.run_date", "dry_run_llm.$": "$.research_dry" }`
- **Catch routes to `CheckSkipRAGIngestion`** — Phase 2 observe-only: scanner failure must NOT halt the pipeline. Research Lambda's internal scanner still runs in parallel and provides the load-bearing scanner output downstream.
- **Timeout 600s**, ResultPath isolation under `$.scanner_result` / `$.scanner_error`.

## Default-off contract
| Flag state | Path |
|---|---|
| Absent or `false` | Default → `CheckSkipRAGIngestion` (byte-identical to pre-Phase-2 chain) |
| `true` | Scanner Lambda invoked, then `CheckSkipRAGIngestion` |

First scheduled flip-on Saturday is **2026-05-30** if operator opts in (Phase 3 soak target).

## ⚠️ IAM walker bug fix — surfaces pre-existing gap

`tests/test_sf_iam_lambda_grants.py::_collect_invoked_lambda_arns` previously only walked TOP-LEVEL States, **silently skipping every Lambda invocation nested inside Parallel branches**.

The `aggregate-costs` Lambda was added 2026-05-25 (L1146.B) inside Branch A of `ResearchPredictorParallel` and **shipped WITHOUT an IAM grant** because this walker missed it. Same shape would have hit my Phase 2 work if I hadn't placed the Scanner state at top level.

This PR:
1. **Fixes the walker** to recursively traverse Parallel branches (load-bearing — catches the next recurrence of this class at PR time)
2. **Adds the missing aggregate-costs IAM grant** (pre-existing gap, surfaced + closed)
3. **Adds the new scanner IAM grant** (required for this PR)

Per `[[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]` — the walker IS the chokepoint that should have caught L1146.B's silent IAM regression.

## Tests
- **New**: 17 in `test_sf_scanner_wiring.py` — state presence, Lambda target ARN, payload field threading, failure isolation, gate default-off semantics, edge wiring (DataPhase1 skip path AND CheckDataPhase1Status.Success path both reroute correctly), ResultPath isolation, timeout bounded.
- **Updated**: `test_sf_iam_lambda_grants.py` walker now recursive.

Full data suite: **1515 passed**.

## Companion PRs
- alpha-engine-research [#235](https://github.com/cipher813/alpha-engine-research/pull/235) — Phase 1 (Scanner Lambda) **MERGED**
- alpha-engine-config — ROADMAP closure annotation in separate PR

## Test plan
- [ ] PR build green
- [ ] On merge, `deploy_step_function.sh` updates the live SF definition + `apply.sh` reapplies the IAM policy (operator step — IAM apply is not auto on merge)
- [ ] Pre-flip dry-run: trigger an ad-hoc Saturday SF execution with empty input — verify the chain takes the default path (Scanner state NOT invoked) and the cycle completes byte-identically to pre-Phase-2
- [ ] Operator flips `enable_standalone_scanner=true` on the 5/30 Saturday SF input for Phase 3 soak

🤖 Generated with [Claude Code](https://claude.com/claude-code)