### PR TITLE
feat(sf): enable_standalone_scanner=true by default (L1995 Phase 3 activation)

### DIFF
--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -187,11 +187,23 @@ aws iam create-role \
 
 EB_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${EB_ROLE_NAME}"
 
-# The EventBridge target passes the execution input with EC2 instance ID and SNS topic
+# The EventBridge target passes the execution input with EC2 instance ID and SNS topic.
+#
+# enable_standalone_scanner=true activates the L1995 Phase 2 Scanner SF state
+# (alpha-engine-research-scanner Lambda writes candidates.json in
+# parallel-observe mode). Set true from 2026-05-25 onward — the SF chain is
+# byte-identical to pre-Phase-2 except the new state writes an additional
+# S3 artifact at s3://alpha-engine-research/candidates/{run_date}/candidates.json.
+# Catch posture: scanner Lambda failure is non-blocking (routes to
+# CheckSkipRAGIngestion); the artifact is observe-only with no consumer
+# until L1995 Phase 4 wires RAGIngestion to read it. First soak cycle: Sat
+# 2026-05-30. Revert by flipping to false here + re-running this script,
+# OR by ad-hoc `aws events put-targets` with a fresh Input.
 INPUT_JSON=$(cat <<EOF
 {
   "ec2_instance_id": ["$EC2_INSTANCE_ID"],
-  "sns_topic_arn": "$SNS_TOPIC_ARN"
+  "sns_topic_arn": "$SNS_TOPIC_ARN",
+  "enable_standalone_scanner": true
 }
 EOF
 )

--- a/tests/test_deploy_step_function_eventbridge_input.py
+++ b/tests/test_deploy_step_function_eventbridge_input.py
@@ -1,0 +1,81 @@
+"""Pins the EventBridge Input contract in ``deploy_step_function.sh``.
+
+The Saturday SF cron-fired execution gets its input from the
+EventBridge rule's ``Input`` field, which is constructed in
+``infrastructure/deploy_step_function.sh`` (see the ``INPUT_JSON``
+heredoc + ``aws events put-targets`` invocation). The Saturday SF's
+behavior on cron firing is therefore controlled by THIS file, not by
+the SF JSON alone.
+
+ROADMAP L1995 Phase 3 — `enable_standalone_scanner: true` must be in
+the EventBridge Input or the new Scanner SF state (Phase 2) takes the
+default-off path and parallel-observe mode does NOT run. This test
+pins the flag's presence so a future deploy_step_function.sh edit
+can't silently revert Phase 3 by dropping the flag.
+
+If the operator deliberately wants to revert Phase 3 (e.g. divergence
+audit failed on Sat 5/30 and the substrate needs a fix-and-rerun
+cycle), this test should be updated in the same PR that flips the
+flag back to false.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEPLOY_PATH = _REPO_ROOT / "infrastructure" / "deploy_step_function.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _DEPLOY_PATH.read_text()
+
+
+@pytest.fixture(scope="module")
+def input_json_block(script_text: str) -> str:
+    """Extract the EventBridge target Input heredoc body."""
+    # Match the INPUT_JSON=$(cat <<EOF ... EOF) heredoc.
+    m = re.search(
+        r"INPUT_JSON=\$\(cat <<EOF\n(.+?)\nEOF\n\)",
+        script_text,
+        re.DOTALL,
+    )
+    assert m is not None, "INPUT_JSON heredoc not found in deploy_step_function.sh"
+    return m.group(1)
+
+
+class TestEventBridgeInput:
+    def test_ec2_instance_id_present(self, input_json_block):
+        # Baseline — the rule was always supposed to thread the
+        # MicroInstance ID through to the SF execution.
+        assert "ec2_instance_id" in input_json_block
+
+    def test_sns_topic_arn_present(self, input_json_block):
+        # Baseline — same.
+        assert "sns_topic_arn" in input_json_block
+
+    def test_enable_standalone_scanner_flag_set_true(self, input_json_block):
+        # L1995 Phase 3 — the new Scanner SF state (Phase 2) gates on
+        # this flag. Without it the parallel-observe mode does NOT run
+        # and Phase 3 soak does not happen. Revert deliberately by
+        # flipping to false here in the same PR that updates this test.
+        assert "enable_standalone_scanner" in input_json_block, (
+            "deploy_step_function.sh::INPUT_JSON dropped the "
+            "enable_standalone_scanner field; this silently reverts "
+            "L1995 Phase 3 + freezes the arc. If the revert is "
+            "intentional, update both this test and the SCRIPT in the "
+            "same PR."
+        )
+        # Pin the value too — present-but-false also reverts Phase 3.
+        assert re.search(
+            r'"enable_standalone_scanner"\s*:\s*true',
+            input_json_block,
+        ), (
+            "enable_standalone_scanner is present but not set to true. "
+            "Phase 3 requires the flag value to be true."
+        )


### PR DESCRIPTION
## Summary
Activates the Scanner SF state (L1995 Phase 2, data #312 MERGED) for Saturday SF cron-fired executions starting **2026-05-30** (Sat 09:00 UTC = Sat 2 AM PT).

The Saturday SF cron-fired execution gets its input from the EventBridge rule's `Input` field, constructed by `deploy_step_function.sh`'s `INPUT_JSON` heredoc. The new Scanner SF state is gated on `$.enable_standalone_scanner`; the default-off Phase 2 contract means the cron-fired SF takes the byte-identical-to-pre-Phase-2 default path unless this flag is true.

## Why default-on now (vs 1-cycle ad-hoc soak)
- **Phase 2 Catch posture**: scanner Lambda failure routes to `CheckSkipRAGIngestion` — non-blocking, pipeline continues even on Lambda failure
- **Artifact is observe-only** — no consumer reads `candidates.json` until Phase 4 wires RAGIngestion
- **Phase 4 (alpha-bearing payoff) requires the flag to stay on** — a 1-cycle ad-hoc soak just delays the same flip by a week
- **Revert is single-file flip + redeploy** if Sat 5/30 divergence audit fails (which is exactly what Phase 3 is for)

Per `[[feedback_no_bandaids_go_big_or_home]]` — option (a) "flip default-on, lean on Phase 2 Catch posture" over option (b) "1-cycle ad-hoc soak then re-flip."

## Operator runbook for Sat 5/30
1. **Run `bash infrastructure/deploy_step_function.sh`** on main to push the updated EventBridge Input. (No SF JSON change — the SF state is already deployed from data #312.)
2. After Sat 5/30 09:00 UTC cron fires, verify:
   - `s3://alpha-engine-research/candidates/2026-05-30/candidates.json` landed
   - `scanner_tickers` in the artifact match `signals/2026-05-30/signals.json::universe` minus `population` (Research's internal scanner output)
3. **Zero divergence** = Phase 3 → Phase 4 transition signal; open Phase 4 PR (RAG read switch)
4. **Divergence found** = revert this flag + fix `data/scanner_orchestrator.py` + repeat

## Tests
New `test_deploy_step_function_eventbridge_input.py` (3 tests) pins the flag's presence + value so a future `deploy_step_function.sh` edit can't silently revert Phase 3.

Suite: **1518 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)