### PR TITLE
feat(features): avg_volume_20d_raw + schema-contract substrate (Option E P1)

### DIFF
--- a/features/SCHEMA.md
+++ b/features/SCHEMA.md
@@ -1,0 +1,194 @@
+# Feature store — schema contract
+
+**Authoritative reference for every column emitted by
+`features/feature_engineer.py::compute_features` and persisted to the
+ArcticDB universe library + S3 feature store parquet.**
+
+Status: stable. Updated whenever a feature is added or its semantic
+changes. The companion test
+`tests/test_schema_contract.py` cross-checks this file against
+`features/registry.py::CATALOG` and `features/feature_engineer.FEATURES`
+— PRs that add or rename a column without updating SCHEMA.md fail CI.
+
+---
+
+## 1. Naming-convention rule (STANDING DIRECTIVE for new fields)
+
+Every new feature column **MUST** carry an explicit units suffix when
+its name alone could be misread by a downstream consumer. Allowed
+suffixes:
+
+| Suffix | Units / shape | Examples |
+|---|---|---|
+| `_raw` | Absolute units (shares, dollars, count). Consumer reads native scale. | `avg_volume_20d_raw` |
+| `_ratio` | Dimensionless ratio (typical range 0.5–2.0 or similar bounded band). | `rel_volume_ratio`, `vol_ratio_10_60` |
+| `_pct` | Decimal percentage (−1.0 to 1.0 typical). | `atr_14_pct` |
+| `_zscore` | Standardized z-score (mean 0, std 1 cross-sectionally). | (none today) |
+| `_log_return` | Natural-log return. | (none today) |
+
+**Bare-named fields** (no suffix) inherit one of these semantics by
+historical convention — every such field MUST appear in §3 below with
+its actual units explicitly documented. The bare-name == normalized /
+ratio convention is grandfathered; new bare-named fields are NOT
+permitted.
+
+**Rationale.** A column named `avg_volume_20d` was emitted as a
+ratio (`rolling_20d / per-ticker global mean`) for predictor input,
+while `alpha-engine-research/data/scanner.py` consumed it as raw
+shares (compared against `MIN_AVG_VOLUME = 500_000`). The result was
+**901/903 feature-store-covered tickers silently failing the Research
+scanner liquidity gate** for months, surfaced only when L1995 Phase 1
+shipped a standalone scanner Lambda that wrote operator-visible
+`candidates.json::scanner_tickers=[]`. The audit recovery, the additive
+`avg_volume_20d_raw` emit, and this contract substrate are the
+institutional fix.
+
+See `~/Development/alpha-engine-docs/private/feature-store-schema-audit-260525.md`
+for the full design doc.
+
+---
+
+## 2. Consumer contract
+
+Two repositories read from the feature store today:
+
+| Consumer | Repo | Read path | Units expected |
+|---|---|---|---|
+| **Predictor** (training + inference) | alpha-engine-predictor | ArcticDB universe library → `model/meta_model.py` META_FEATURES | All bare-named fields treated as predictor input. Normalized / ratio shape per §3. |
+| **Research scanner** | alpha-engine-research | `fetch_data_node` (graph) + `scanner_orchestrator._build_technical_scores_from_feature_store` | `_raw` suffix required for ABSOLUTE-quantity gates (avg_volume_20d_raw for the liquidity gate). Returns / ratios / pcts consumed at native shape. |
+
+A third consumer (executor for trade features? backtester for parity
+features?) appearing in the future triggers a per-`[[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]`
+lift of this contract from alpha-engine-data into
+`alpha_engine_lib`. Filed as P3 follow-up.
+
+---
+
+## 3. Field catalog — units, compute, consumers
+
+Sorted by group, matching `features/registry.py::CATALOG`. Every entry
+must be unique with the registry; the schema-contract test enforces
+parity.
+
+### Technical (per-ticker, daily refresh)
+
+| Field | Units | Compute | Consumers |
+|---|---|---|---|
+| `rsi_14` | 0–100 score (bare-named = normalized) | Wilder's RSI(14) via EWM(com=13) | predictor + scanner |
+| `macd_cross` | tri-state (+1 bull / −1 bear / 0 none) | Sign of MACD line crossing 0 within last 3 days | predictor + scanner |
+| `macd_above_zero` | binary (0/1) | `(macd_line > 0).astype(float)` | predictor + scanner |
+| `macd_line_last` | absolute (price units) | `EMA_fast(close) - EMA_slow(close)` | predictor |
+| `price_vs_ma50` | decimal pct (bare-named convention) | `(close - SMA50) / SMA50` | predictor + scanner (gate at −0.05) |
+| `price_vs_ma200` | decimal pct (bare-named convention) | `(close - SMA200) / SMA200` | predictor + scanner |
+| `momentum_20d` | decimal return (bare-named convention) | `close / close.shift(20) - 1` | predictor + scanner |
+| `avg_volume_20d` | ratio (rolling_20d / per-ticker global mean), ~1.0 typical | `avg_vol_20d / volume.mean()` | **predictor only** — relative liquidity feature |
+| `avg_volume_20d_raw` | **raw shares** | `volume.rolling(20).mean()` | **scanner only** — absolute liquidity gate vs `MIN_AVG_VOLUME=500_000` |
+| `dist_from_52w_high` | decimal pct (bare-named convention) | `(close - rolling_max_252) / rolling_max_252` | predictor + scanner |
+| `momentum_5d` | decimal return (bare-named convention) | `close / close.shift(5) - 1` | predictor + scanner |
+| `rel_volume_ratio` | ratio (today / rolling_20d) | `volume / volume.rolling(20).mean()` | predictor |
+| `return_vs_spy_5d` | decimal return (bare-named convention) | `momentum_5d - SPY_5d_return` | predictor |
+| `dist_from_52w_low` | decimal pct (bare-named convention) | `(close - rolling_min_252) / rolling_min_252` | predictor |
+| `vol_ratio_10_60` | ratio | `realized_vol_10d / realized_vol_60d` | predictor |
+| `bollinger_pct` | 0–1 channel position (bare-named convention) | `(close - lower_bb) / (upper_bb - lower_bb)` | predictor |
+| `sector_vs_spy_5d` | decimal return (bare-named convention) | `sector_etf_5d - SPY_5d` | predictor |
+| `sector_vs_spy_10d` | decimal return (bare-named convention) | `sector_etf_10d - SPY_10d` | predictor |
+| `sector_vs_spy_20d` | decimal return (bare-named convention) | `sector_etf_20d - SPY_20d` | predictor |
+| `price_accel` | decimal (5d return − 20d return) | `momentum_5d - momentum_20d` | predictor |
+| `ema_cross_8_21` | ratio (bare-named convention, `EMA8/EMA21 - 1`) | `EMA(8) / EMA(21) - 1` | predictor |
+| `atr_14_pct` | decimal pct (`_pct` suffix) | `ATR(14) / close` | predictor + scanner (consumer ×100 to display %) |
+| `realized_vol_20d` | annualized vol (decimal) | `std(daily_returns).rolling(20) * sqrt(252)` | predictor |
+| `realized_vol_63d` | annualized vol (decimal) | `std(daily_returns).rolling(63) * sqrt(252)` | predictor |
+| `volume_trend` | ratio (5d / 20d avg volume) | `vol_5 / vol_20` | predictor |
+| `obv_slope_10d` | normalized slope (bare-named convention) | `(OBV_fast - OBV_slow) / vol_20` | predictor |
+| `rsi_slope_5d` | bare-named (RSI delta / 5) | `(rsi - rsi.shift(5)) / 5` | predictor |
+| `volume_price_div` | tri-state (sign × sign) | `sign(volume_trend - 1) * sign(momentum_5d)` | predictor |
+| `return_60d` | decimal return (bare-named convention) | `close / close.shift(60) - 1` | predictor |
+| `return_120d` | decimal return (bare-named convention) | `close / close.shift(120) - 1` | predictor |
+| `overnight_return_5d` | decimal sum-of-overnight (bare-named convention) | `Σ (open_t / close_{t-1} - 1)` over 5d | predictor |
+| `intraday_return_5d` | decimal sum-of-intraday (bare-named convention) | `Σ (close_t / open_t - 1)` over 5d | predictor |
+| `dist_from_5d_high` | decimal pct (bare-named convention) | `(close - rolling_max_5) / rolling_max_5` | predictor |
+| `dist_from_20d_high` | decimal pct (bare-named convention) | `(close - rolling_max_20) / rolling_max_20` | predictor |
+| `beta_60d` | dimensionless slope (bare-named convention) | `rolling_60d cov(stock, spy) / var(spy)` (log returns) | predictor |
+| `idio_vol_60d` | annualized vol (decimal) | `std(residual_returns).rolling(60) * sqrt(252)` after beta removal | predictor |
+| `vol_of_vol_30d` | stdev of vol | `realized_vol_20d.rolling(30).std()` | predictor |
+| `max_drawdown_60d` | non-positive decimal pct (bare-named convention) | min of `(close / rolling_max_60 - 1)` over 60d | predictor |
+
+### Macro (one row per date — `per_ticker=False`)
+
+| Field | Units | Compute | Consumers |
+|---|---|---|---|
+| `vix_level` | normalized (VIX / 20) | `vix / vix_baseline` | predictor |
+| `yield_10y` | normalized (TNX / 10) | `tnx / tnx_normalizer` | predictor |
+| `yield_curve_slope` | normalized | `(tnx - irx) / tnx_normalizer` | predictor |
+| `gold_mom_5d` | decimal return | `gld / gld.shift(5) - 1` | predictor |
+| `oil_mom_5d` | decimal return | `uso / uso.shift(5) - 1` | predictor |
+| `vix_term_slope` | normalized | `(vix - vix3m) / vix_baseline` | predictor |
+| `xsect_dispersion` | stdev of universe returns | precomputed series | predictor |
+
+### Regime interactions (per-ticker × macro)
+
+| Field | Units | Compute | Consumers |
+|---|---|---|---|
+| `mom5d_x_vix` | bare-named (return × regime) | `momentum_5d * (vix_level - 1)` | predictor |
+| `rsi_x_vix` | bare-named (centered RSI × regime) | `(rsi - 50) / 50 * (vix_level - 1)` | predictor |
+| `sector_x_trend` | bare-named (sector-rel × SPY-trend) | `sector_vs_spy_5d * spy_20d_return` | predictor |
+| `atr_x_vix` | decimal pct × regime | `atr_14_pct * (vix_level - 1)` | predictor |
+| `vol_trend_x_vix` | ratio × regime | `(volume_trend - 1) * (vix_level - 1)` | predictor |
+
+### Alternative data (weekly refresh)
+
+| Field | Units | Compute | Consumers |
+|---|---|---|---|
+| `earnings_surprise_pct` | decimal pct (`_pct` suffix) | FMP earnings surprise % | predictor |
+| `days_since_earnings` | 0–1 normalized (days / 90) | `days / 90.0` | predictor |
+| `eps_revision_4w` | decimal pct (bare-named convention) | FMP 4-week EPS revision % | predictor |
+| `revision_streak` | count (bare-named convention — integer count) | Consecutive same-direction-revision weeks | predictor |
+| `put_call_ratio` | log-transformed ratio | `log(put_oi / call_oi)` | predictor |
+| `iv_rank` | 0–1 percentile rank | IV percentile over 1y window | predictor |
+| `iv_vs_rv` | ratio | `atm_iv / realized_vol_20d` | predictor |
+
+### Fundamental (quarterly refresh)
+
+| Field | Units | Compute | Consumers |
+|---|---|---|---|
+| `pe_ratio` | normalized (PE / 30) | trailing P/E normalized | predictor |
+| `pb_ratio` | normalized (PB / 5) | price-to-book normalized | predictor |
+| `debt_to_equity` | normalized (D/E / 2) | total debt / total equity normalized | predictor |
+| `revenue_growth_yoy` | decimal pct (bare-named convention) | year-over-year revenue growth | predictor |
+| `fcf_yield` | decimal pct (bare-named convention) | FCF / market cap | predictor |
+| `gross_margin` | 0–1 fraction (bare-named convention) | gross profit / revenue | predictor |
+| `roe` | decimal pct (bare-named convention) | return on equity | predictor |
+| `current_ratio` | normalized (CR / 3) | current assets / current liabilities normalized | predictor |
+| `revenue_growth_3y` | decimal pct CAGR (bare-named convention) | 3y revenue CAGR | predictor |
+| `eps_growth_3y` | decimal pct CAGR (bare-named convention) | 3y EPS CAGR | predictor |
+| `payout_ratio` | 0–2 clipped ratio | TTM dividends / net income | predictor |
+| `dividend_yield` | decimal pct (bare-named convention) | indicated annual dividend yield | predictor |
+| `capex_growth_5y` | decimal pct (bare-named convention) | 5y CAPEX growth | predictor |
+
+---
+
+## 4. PR checklist for new features
+
+Before opening a PR that adds a column to `compute_features`:
+
+1. Pick a name with an explicit units suffix from §1, OR justify a
+   bare-named exception in the PR body (the test will fail otherwise).
+2. Add a `FeatureEntry(...)` to `features/registry.py::CATALOG` with a
+   description that names units explicitly. Description must not say
+   "20-day avg X" without also stating the units (shares, dollars, %).
+3. Add the field to `features/feature_engineer.py::FEATURES` in the
+   correct group.
+4. Add a row to §3 of this file.
+5. If the field has a NEW consumer (e.g., backtester reads it for
+   parity), add the consumer to §2 AND add a consumer-contract test in
+   the consuming repo that pins the expected units.
+6. `pytest tests/test_schema_contract.py` must pass.
+
+---
+
+## 5. Historical reference
+
+| Date | Event |
+|---|---|
+| 2026-05-25 | L1995 Phase 1 standalone scanner Lambda surfaces `scanner_tickers=[]`; audit reveals `avg_volume_20d` units mismatch with Research scanner consumer; Option E selected as SOTA fix. |
+| 2026-05-25 | This SCHEMA.md + additive `avg_volume_20d_raw` + naming-convention rule shipped as the institutional substrate (alpha-engine-data Phase 1). |

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -71,6 +71,7 @@ FEATURES = [
     "price_vs_ma200",
     "momentum_20d",
     "avg_volume_20d",
+    "avg_volume_20d_raw",
     # v1.1 additions
     "dist_from_52w_high",
     "momentum_5d",
@@ -303,12 +304,18 @@ def compute_features(
     _mom_long = _FC["momentum_long"]
     df["momentum_20d"] = (close / close.shift(_mom_long)) - 1.0
 
-    # ── Average volume (normalized) ───────────────────────────────────────────
+    # ── Average volume (raw + normalized) ─────────────────────────────────────
+    # Two consumers, two units. See features/SCHEMA.md for the suffix rule.
+    #   avg_volume_20d_raw : raw shares — Research scanner absolute-liquidity
+    #                       gate (compares to MIN_AVG_VOLUME=500_000).
+    #   avg_volume_20d     : ratio (rolling_20d / per-ticker global mean) —
+    #                       Predictor relative-liquidity input, ~1.0 typical.
     _vol_slow = _FC["volume_slow"]
+    avg_vol_20d_raw = volume.rolling(window=_vol_slow, min_periods=_vol_slow).mean()
+    df["avg_volume_20d_raw"] = avg_vol_20d_raw
     volume_global_mean = volume.mean()
     if volume_global_mean > 0:
-        avg_vol_20d = volume.rolling(window=_vol_slow, min_periods=_vol_slow).mean()
-        df["avg_volume_20d"] = avg_vol_20d / volume_global_mean
+        df["avg_volume_20d"] = avg_vol_20d_raw / volume_global_mean
     else:
         df["avg_volume_20d"] = 1.0
 

--- a/features/registry.py
+++ b/features/registry.py
@@ -40,7 +40,8 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("price_vs_ma50", "technical", "Close / SMA(50) ratio", source="yfinance", refresh="daily"),
     FeatureEntry("price_vs_ma200", "technical", "Close / SMA(200) ratio", source="yfinance", refresh="daily"),
     FeatureEntry("momentum_20d", "technical", "20-day price return", source="yfinance", refresh="daily"),
-    FeatureEntry("avg_volume_20d", "technical", "20-day avg volume / global mean volume", source="yfinance", refresh="daily"),
+    FeatureEntry("avg_volume_20d", "technical", "Predictor input: 20-day avg volume / per-ticker global mean (relative liquidity ratio, ~1.0 typical). See features/SCHEMA.md for the bare-name == normalized convention.", source="yfinance", refresh="daily"),
+    FeatureEntry("avg_volume_20d_raw", "technical", "Research scanner input: 20-day avg volume in raw shares. Absolute-liquidity gate consumer (MIN_AVG_VOLUME=500_000). The _raw suffix encodes units per features/SCHEMA.md.", source="yfinance", refresh="daily"),
     FeatureEntry("dist_from_52w_high", "technical", "(Close - 52w high) / 52w high", source="yfinance", refresh="daily"),
     FeatureEntry("momentum_5d", "technical", "5-day price return", source="yfinance", refresh="daily"),
     FeatureEntry("rel_volume_ratio", "technical", "Today volume / 20-day avg volume", source="yfinance", refresh="daily"),
@@ -55,6 +56,7 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("ema_cross_8_21", "technical", "EMA(8) / EMA(21) ratio", source="yfinance", refresh="daily"),
     FeatureEntry("atr_14_pct", "technical", "ATR(14) / Close, normalized volatility", source="yfinance", refresh="daily"),
     FeatureEntry("realized_vol_20d", "technical", "20-day annualized return std dev", source="yfinance", refresh="daily"),
+    FeatureEntry("realized_vol_63d", "technical", "63-day (3-month) annualized return std dev — slower vol regime than 20d, pairs as vol-term-structure", source="yfinance", refresh="daily"),
     FeatureEntry("volume_trend", "technical", "5-day avg volume / 20-day avg volume", source="yfinance", refresh="daily"),
     FeatureEntry("obv_slope_10d", "technical", "OBV linear regression slope over 10 days", source="yfinance", refresh="daily"),
     FeatureEntry("rsi_slope_5d", "technical", "5-day RSI slope", source="yfinance", refresh="daily"),
@@ -92,6 +94,12 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("intraday_return_5d", "technical", "5d sum of intraday returns (Close_t vs Open_t)", source="yfinance", refresh="daily"),
     FeatureEntry("dist_from_5d_high", "technical", "(Close - 5d rolling max High) / 5d rolling max High", source="yfinance", refresh="daily"),
     FeatureEntry("dist_from_20d_high", "technical", "(Close - 20d rolling max High) / 20d rolling max High", source="yfinance", refresh="daily"),
+
+    # ── v3.2 per-ticker risk features (Stage 2 of regime-conditioning rebuild) ──
+    FeatureEntry("beta_60d", "technical", "60d rolling regression slope of stock log-returns vs SPY log-returns (systematic market exposure)", source="yfinance", refresh="daily"),
+    FeatureEntry("idio_vol_60d", "technical", "60d residual vol after removing beta exposure; std × sqrt(252) (idiosyncratic risk)", source="yfinance", refresh="daily"),
+    FeatureEntry("vol_of_vol_30d", "technical", "30d rolling stdev of realized_vol_20d (stability of vol regime)", source="yfinance", refresh="daily"),
+    FeatureEntry("max_drawdown_60d", "technical", "Worst peak-to-trough drawdown within trailing 60d window (non-positive decimal pct)", source="yfinance", refresh="daily"),
 
     # ── Fundamental (13) — quarterly financials ───────────────────────────────
     FeatureEntry("pe_ratio", "fundamental", "Trailing P/E ratio, normalized (PE / 30)", source="fmp", refresh="quarterly"),

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -1,0 +1,302 @@
+"""Feature-store schema contract test.
+
+Enforces parity across three sources of truth for the feature catalog:
+
+  1. ``features/feature_engineer.FEATURES``           — runtime emit list
+  2. ``features/registry.CATALOG``                    — S3 registry.json source
+  3. ``features/SCHEMA.md``                           — declarative spec for
+                                                       cross-repo consumers
+
+Every column in the feature engineer's output MUST appear in all three.
+Adding a column without updating SCHEMA.md is a PR-time failure.
+
+Background: see ``features/SCHEMA.md`` and the
+``feature-store-schema-audit-260525.md`` plan doc. The driver was a
+silent units mismatch on ``avg_volume_20d`` (predictor ratio vs. scanner
+raw shares) that hid for months. The contract layer codifies the
+``_raw / _ratio / _zscore / _pct / _log_return`` naming convention and
+catches future misnamed columns at PR time.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from features.feature_engineer import FEATURES, compute_features
+from features.registry import CATALOG
+
+
+_FEATURES_DIR = Path(__file__).resolve().parents[1] / "features"
+_SCHEMA_MD = _FEATURES_DIR / "SCHEMA.md"
+
+
+# ── SCHEMA.md parser ─────────────────────────────────────────────────────────
+
+# Match `field_name` at the start of a markdown table row, e.g.
+# ``| `avg_volume_20d_raw` | raw shares | ... |``
+_FIELD_ROW_RE = re.compile(r"^\|\s*`([a-zA-Z0-9_]+)`\s*\|")
+
+# §3 ("Field catalog") is the authoritative per-column section. The
+# §1 ("Naming-convention rule") table also contains backticked tokens
+# (the suffix list — `_raw`, `_ratio`, etc.) which are NOT field names.
+# Parse only between the §3 header and the next top-level section.
+_SECTION_3_HEADER = "## 3. Field catalog"
+_SECTION_4_HEADER = "## 4. PR checklist"
+
+
+def _parse_schema_md_fields() -> set[str]:
+    text = _SCHEMA_MD.read_text(encoding="utf-8")
+    in_section = False
+    fields: set[str] = set()
+    for line in text.splitlines():
+        if line.startswith(_SECTION_3_HEADER):
+            in_section = True
+            continue
+        if in_section and line.startswith(_SECTION_4_HEADER):
+            break
+        if not in_section:
+            continue
+        m = _FIELD_ROW_RE.match(line)
+        if m:
+            fields.add(m.group(1))
+    return fields
+
+
+# ── Parity tests ─────────────────────────────────────────────────────────────
+
+
+def test_features_and_catalog_are_in_sync():
+    """``FEATURES`` (emit list) and ``CATALOG`` (registry) must agree."""
+    catalog_names = {f.name for f in CATALOG}
+    features = set(FEATURES)
+
+    missing_from_catalog = features - catalog_names
+    missing_from_features = catalog_names - features
+
+    assert not missing_from_catalog, (
+        f"Columns in FEATURES but missing from registry.CATALOG "
+        f"(add a FeatureEntry to features/registry.py): {sorted(missing_from_catalog)}"
+    )
+    assert not missing_from_features, (
+        f"Columns in registry.CATALOG but missing from FEATURES "
+        f"(remove from CATALOG or add to feature_engineer.FEATURES): "
+        f"{sorted(missing_from_features)}"
+    )
+
+
+def test_schema_md_documents_every_catalog_field():
+    """Every registry CATALOG entry must appear in SCHEMA.md §3."""
+    schema_fields = _parse_schema_md_fields()
+    catalog_names = {f.name for f in CATALOG}
+
+    missing = catalog_names - schema_fields
+    assert not missing, (
+        "Columns in registry.CATALOG but missing from features/SCHEMA.md §3. "
+        "Add a row documenting units + compute + consumers: "
+        f"{sorted(missing)}"
+    )
+
+
+def test_schema_md_has_no_orphan_fields():
+    """Reverse direction — SCHEMA.md must not mention deleted features."""
+    schema_fields = _parse_schema_md_fields()
+    catalog_names = {f.name for f in CATALOG}
+
+    orphans = schema_fields - catalog_names
+    assert not orphans, (
+        "Columns documented in SCHEMA.md but not in registry.CATALOG "
+        "(stale doc — remove the SCHEMA.md row or restore the CATALOG entry): "
+        f"{sorted(orphans)}"
+    )
+
+
+# ── Naming-convention sniff tests ────────────────────────────────────────────
+
+
+_ALLOWED_SUFFIXES = ("_raw", "_ratio", "_pct", "_zscore", "_log_return")
+
+# Bare-named fields are grandfathered (see SCHEMA.md §1). New bare-named
+# fields are NOT permitted — the test below enforces it. Adding a new
+# bare-named field requires updating this set AND justifying it in the PR
+# body.
+_GRANDFATHERED_BARE_FIELDS: frozenset[str] = frozenset({
+    # Technical
+    "rsi_14", "macd_cross", "macd_above_zero", "macd_line_last",
+    "price_vs_ma50", "price_vs_ma200", "momentum_20d", "avg_volume_20d",
+    "dist_from_52w_high", "momentum_5d", "rel_volume_ratio",
+    "return_vs_spy_5d", "dist_from_52w_low", "vol_ratio_10_60",
+    "bollinger_pct", "sector_vs_spy_5d", "sector_vs_spy_10d",
+    "sector_vs_spy_20d", "price_accel", "ema_cross_8_21", "atr_14_pct",
+    "realized_vol_20d", "realized_vol_63d", "volume_trend",
+    "obv_slope_10d", "rsi_slope_5d", "volume_price_div",
+    "return_60d", "return_120d", "overnight_return_5d",
+    "intraday_return_5d", "dist_from_5d_high", "dist_from_20d_high",
+    "beta_60d", "idio_vol_60d", "vol_of_vol_30d", "max_drawdown_60d",
+    # Macro
+    "vix_level", "yield_10y", "yield_curve_slope", "gold_mom_5d",
+    "oil_mom_5d", "vix_term_slope", "xsect_dispersion",
+    # Interaction
+    "mom5d_x_vix", "rsi_x_vix", "sector_x_trend", "atr_x_vix",
+    "vol_trend_x_vix",
+    # Alternative
+    "earnings_surprise_pct", "days_since_earnings", "eps_revision_4w",
+    "revision_streak", "put_call_ratio", "iv_rank", "iv_vs_rv",
+    # Fundamental
+    "pe_ratio", "pb_ratio", "debt_to_equity", "revenue_growth_yoy",
+    "fcf_yield", "gross_margin", "roe", "current_ratio",
+    "revenue_growth_3y", "eps_growth_3y", "payout_ratio",
+    "dividend_yield", "capex_growth_5y",
+})
+
+
+def test_new_fields_must_carry_units_suffix():
+    """New fields (not grandfathered) MUST end in an allowed suffix.
+
+    The grandfathered set is frozen as of 2026-05-25 (the avg_volume_20d
+    audit). Any future addition that lacks a recognized suffix and is
+    not in the grandfathered set fails here — by intent. The PR author
+    must either rename the field (preferred) or update the grandfathered
+    set with a written rationale.
+    """
+    catalog_names = {f.name for f in CATALOG}
+    new_bare_names: list[str] = []
+    for name in catalog_names:
+        if name in _GRANDFATHERED_BARE_FIELDS:
+            continue
+        if not any(name.endswith(suf) for suf in _ALLOWED_SUFFIXES):
+            new_bare_names.append(name)
+    assert not new_bare_names, (
+        "New feature columns lack an explicit units suffix "
+        f"(allowed: {_ALLOWED_SUFFIXES}). Either rename to add a suffix "
+        "or add to _GRANDFATHERED_BARE_FIELDS with a PR-body rationale: "
+        f"{sorted(new_bare_names)}"
+    )
+
+
+def test_grandfathered_set_matches_documented_bare_names():
+    """The grandfathered set must be a subset of CATALOG.
+
+    Catches drift if a grandfathered field is renamed or removed without
+    updating this list.
+    """
+    catalog_names = {f.name for f in CATALOG}
+    stale = _GRANDFATHERED_BARE_FIELDS - catalog_names
+    assert not stale, (
+        "_GRANDFATHERED_BARE_FIELDS references columns not in CATALOG. "
+        "Either restore the column or remove it from the grandfathered "
+        f"set: {sorted(stale)}"
+    )
+
+
+# ── Units sniff test ─────────────────────────────────────────────────────────
+
+
+def _synthetic_ohlcv(n: int = 400, seed: int = 0) -> pd.DataFrame:
+    """Minimal OHLCV frame sufficient for compute_features warmup."""
+    rng = np.random.default_rng(seed)
+    daily_returns = rng.normal(0.0005, 0.012, n)
+    close = 100.0 * np.exp(np.cumsum(daily_returns))
+    high = close * (1 + np.abs(rng.normal(0, 0.005, n)))
+    low = close * (1 - np.abs(rng.normal(0, 0.005, n)))
+    open_ = close * (1 + rng.normal(0, 0.003, n))
+    # Realistic raw share volume — well above the 500k MIN_AVG_VOLUME gate.
+    volume = rng.integers(1_000_000, 10_000_000, n).astype(float)
+    idx = pd.date_range("2024-01-01", periods=n, freq="B")
+    return pd.DataFrame(
+        {"Open": open_, "High": high, "Low": low, "Close": close, "Volume": volume},
+        index=idx,
+    )
+
+
+def test_avg_volume_20d_raw_is_in_raw_share_units():
+    """The raw column must produce values >> 1.0 (raw shares scale).
+
+    Sniff-test: if a future refactor accidentally normalizes
+    ``avg_volume_20d_raw`` (e.g., copies the divisor from the
+    normalized field), values will drop to ~1.0 and this test fails
+    loudly. Mirrors the institutional check the Research scanner now
+    relies on.
+    """
+    df = _synthetic_ohlcv()
+    out = compute_features(df)
+    # Drop rolling-window warmup rows.
+    raw = out["avg_volume_20d_raw"].dropna()
+    assert len(raw) > 0, "Insufficient warmup — synthetic frame too short."
+
+    median_raw = float(raw.median())
+    # Synthetic volume in [1M, 10M] — median rolling-20d-avg must be
+    # solidly within that band. The Research scanner's MIN_AVG_VOLUME
+    # gate is 500_000; we want to be at least an order of magnitude above
+    # the gate threshold so the sniff has real teeth.
+    assert median_raw >= 1_000_000, (
+        f"avg_volume_20d_raw median is {median_raw:,.0f} but should be "
+        ">= 1,000,000 (raw shares scale). Likely re-normalized — check "
+        "feature_engineer.py."
+    )
+
+
+def test_avg_volume_20d_is_normalized_ratio():
+    """The bare-named column must be ~1.0 (per-ticker normalization)."""
+    df = _synthetic_ohlcv()
+    out = compute_features(df)
+    ratio = out["avg_volume_20d"].dropna()
+    assert len(ratio) > 0
+    median_ratio = float(ratio.median())
+    # Ratio = rolling_20d / global_mean; close to 1.0 by construction.
+    assert 0.5 <= median_ratio <= 2.0, (
+        f"avg_volume_20d median ratio is {median_ratio:.4f} — expected "
+        "~1.0. Predictor consumes this as a normalized relative-liquidity "
+        "feature."
+    )
+
+
+def test_avg_volume_20d_raw_is_orders_of_magnitude_above_ratio():
+    """Cross-check the two columns are clearly distinct in scale.
+
+    The original bug class was confusing one for the other. This test
+    pins the assertion that they MUST live on different scales: the raw
+    one should be at least 1e5x larger than the ratio one.
+    """
+    df = _synthetic_ohlcv()
+    out = compute_features(df)
+    raw_med = float(out["avg_volume_20d_raw"].dropna().median())
+    ratio_med = float(out["avg_volume_20d"].dropna().median())
+    assert raw_med / max(ratio_med, 1e-12) > 1e5, (
+        "avg_volume_20d_raw and avg_volume_20d are on similar scales — "
+        f"raw={raw_med:.2e}, ratio={ratio_med:.4f}. The whole point of "
+        "the two-column emit is that they are on different scales."
+    )
+
+
+# ── Description quality ─────────────────────────────────────────────────────
+
+
+def test_avg_volume_descriptions_disambiguate_units():
+    """Registry descriptions for the two columns must explicitly name units.
+
+    Avoids the original "20-day avg volume / global mean volume" wording
+    that was ambiguous about units.
+    """
+    by_name = {f.name: f for f in CATALOG}
+    raw_desc = by_name["avg_volume_20d_raw"].description.lower()
+    ratio_desc = by_name["avg_volume_20d"].description.lower()
+
+    assert "raw shares" in raw_desc, (
+        "avg_volume_20d_raw description must include 'raw shares' to "
+        f"disambiguate units: {raw_desc!r}"
+    )
+    # Ratio description should reference the per-ticker normalization
+    # so consumers can't misread it as raw.
+    assert "ratio" in ratio_desc or "normalized" in ratio_desc or "/" in ratio_desc, (
+        "avg_volume_20d description must explicitly flag it as a "
+        f"ratio / normalized field: {ratio_desc!r}"
+    )


### PR DESCRIPTION
## Summary

Phase 1 of the **Option E SOTA fix** for the feature-store schema mismatch that silently failed 901/903 tickers' Research scanner liquidity gate. Plan doc: `~/Development/alpha-engine-docs/private/feature-store-schema-audit-260525.md`.

The bug: `avg_volume_20d` was emitted as a **normalized ratio** (rolling_20d / per-ticker global mean) for predictor input, but `alpha-engine-research/data/scanner.py` consumed it as **raw shares** vs `MIN_AVG_VOLUME = 500_000`. Result: every feature-store-covered ticker silently failed the scanner liquidity gate. The 1–3 weekly picks came from the OHLCV fallback path. Surfaced by L1995 Phase 1's standalone scanner Lambda which made the empty `scanner_tickers` list operator-visible for the first time.

The fix is the **bug-class fix**, not just the one-bug fix:

- **Additive `avg_volume_20d_raw` column** (raw shares) alongside the existing normalized `avg_volume_20d`. Predictor reads unchanged — **no retrain**.
- **`features/SCHEMA.md`** — declarative schema contract: units / compute / consumers per column. Codifies the `_raw / _ratio / _pct / _zscore / _log_return` suffix rule as a **STANDING DIRECTIVE** for all future feature additions. Grandfathered set of existing bare-named fields is frozen.
- **`features/registry.py`** — disambiguated descriptions; added the raw entry; also fixed pre-existing CATALOG drift (5 v3.2 risk features that were in `FEATURES` but missing from `CATALOG`) that the new contract test caught.
- **`tests/test_schema_contract.py`** — 9 tests enforcing FEATURES ↔ CATALOG ↔ SCHEMA.md parity, raw-units sniff (median > 1M shares), new-field-must-have-suffix rule. Future PRs that add a column without SCHEMA.md update fail CI.

## Why Option E over Option A (raw emit only)

Per `[[feedback_no_bandaids_go_big_or_home]]` and `[[feedback_sota_institutional_default_no_shortcuts]]`. Option A solves THIS bug; Option E solves the BUG CLASS. The marginal cost is ~1-2 hours of substrate work (SCHEMA.md + contract test + naming convention). The benefit is every future feature-store field addition follows the same chokepoint.

## Audit findings filed for follow-up

Per `[[feedback_audit_findings_become_roadmap_followups]]`:

- **CATALOG drift discovered:** v3.2 risk features (`beta_60d`, `idio_vol_60d`, `vol_of_vol_30d`, `max_drawdown_60d`, `realized_vol_63d`) were in `FEATURES` but missing from `registry.CATALOG`. Fixed in this PR — no behavior change since CATALOG only generates the S3 `registry.json` for cross-repo consumers; the bug was the registry under-reporting the column set. Filing as a wind-down ROADMAP note.

## Out of scope (will be filed at wind-down)

- **Phase 5+ full SOTA refactor** — move all normalization out of the feature store, persist only raw features, normalize inline at predictor training. Largest architectural shift, requires predictor retrain.
- **Predictor weight sensitivity audit** — confirm `avg_volume_20d` weight is materially nonzero in meta-Ridge L2.
- **Cross-repo CI gate** that runs the consumer-contract test on data PRs.
- **Lift schema contract to `alpha-engine-lib`** — triggered on second feature-store adoption.

## Test plan

- [x] 9 new `test_schema_contract.py` tests pass
- [x] All existing feature-related tests pass (32 tests in 3 files)
- [x] Full data-repo unit suite: 1507 passed, 1 skipped
- [ ] Phase 2 (research repo consumer flip) merges
- [ ] First Saturday SF (6/06) after Phase 2 merge produces `scanner_tickers >= 50`
- [ ] Phase 3 (config CLAUDE.md naming convention + ROADMAP close-out) lands

## Composes with

- `[[feedback_audit_findings_become_roadmap_followups]]` · `[[feedback_no_silent_fails]]` · `[[feedback_sota_institutional_default_no_shortcuts]]` · `[[feedback_no_bandaids_go_big_or_home]]` · `[[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)