### PR TITLE
feat(eventbridge): Option-D pipeline_role tags on all 3 SF cron rules

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -128,10 +128,18 @@ Resources:
         - Id: saturday-pipeline
           Arn: !Ref SaturdayPipeline
           RoleArn: !Ref EventBridgeSfnRoleArn
+          # pipeline_role tag (Option-D 2026-05-25): identifies this as the
+          # canonical Saturday weekly cadence run. Page 25 filters to
+          # role="weekly" by default so smoke / recovery / operator-replay
+          # executions don't displace the real weekly run as "most recent".
+          # Ad-hoc operator launches MUST set their own pipeline_role
+          # (smoke / recovery / backfill / operator-replay) per the
+          # taxonomy in pipeline-reporting-revamp-260524.md §6.
           Input: !Sub |
             {
               "ec2_instance_id": ["${MicroInstanceId}"],
-              "sns_topic_arn": "${AlertsTopic}"
+              "sns_topic_arn": "${AlertsTopic}",
+              "pipeline_role": "weekly"
             }
 
   # Friday-PM "shell run" — automated full-fidelity dry preflight of the
@@ -176,11 +184,18 @@ Resources:
         - Id: friday-shell-run
           Arn: !Ref SaturdayPipeline
           RoleArn: !Ref EventBridgeSfnRoleArn
+          # pipeline_role="shell-run" (Option-D 2026-05-25): tags this
+          # execution so page 25's role filter distinguishes Friday-PM
+          # dry-pass from the canonical Saturday weekly run. shell_run=true
+          # remains the load-bearing input field consumed by
+          # InitializeInput/CheckShellRun; pipeline_role is the surface
+          # contract that dashboard / Slack / CLI consumers filter on.
           Input: !Sub |
             {
               "ec2_instance_id": ["${MicroInstanceId}"],
               "sns_topic_arn": "${AlertsTopic}",
-              "shell_run": true
+              "shell_run": true,
+              "pipeline_role": "shell-run"
             }
 
   WeekdayTrigger:
@@ -206,11 +221,15 @@ Resources:
         - Id: weekday-pipeline
           Arn: !Ref WeekdayPipeline
           RoleArn: !Ref EventBridgeSfnRoleArn
+          # pipeline_role="daily" (Option-D 2026-05-25): identifies this as
+          # the canonical weekday trading-cadence run. Page 25 filters to
+          # role="daily" by default for the Weekday section.
           Input: !Sub |
             {
               "ec2_instance_id": ["${MicroInstanceId}"],
               "trading_instance_id": ["${TradingInstanceId}"],
-              "sns_topic_arn": "${AlertsTopic}"
+              "sns_topic_arn": "${AlertsTopic}",
+              "pipeline_role": "daily"
             }
 
   # --------------------------------------------------------------------------

--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -203,7 +203,8 @@ INPUT_JSON=$(cat <<EOF
 {
   "ec2_instance_id": ["$EC2_INSTANCE_ID"],
   "sns_topic_arn": "$SNS_TOPIC_ARN",
-  "enable_standalone_scanner": true
+  "enable_standalone_scanner": true,
+  "pipeline_role": "weekly"
 }
 EOF
 )

--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -126,7 +126,8 @@ EB_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-eventbridge-sfn-role"
 INPUT_JSON=$(cat <<EOF
 {
   "trading_instance_id": ["$TRADING_INSTANCE"],
-  "sns_topic_arn": "$SNS_TOPIC_ARN"
+  "sns_topic_arn": "$SNS_TOPIC_ARN",
+  "pipeline_role": "daily"
 }
 EOF
 )

--- a/tests/test_deploy_step_function_eventbridge_input.py
+++ b/tests/test_deploy_step_function_eventbridge_input.py
@@ -79,3 +79,132 @@ class TestEventBridgeInput:
             "enable_standalone_scanner is present but not set to true. "
             "Phase 3 requires the flag value to be true."
         )
+
+    def test_pipeline_role_set_to_weekly(self, input_json_block):
+        """Option-D 2026-05-25: every cron-triggered execution carries a
+        ``pipeline_role`` tag so page 25 / Slack / CLI consumers can filter
+        out smoke / recovery / operator-replay executions from the
+        canonical cadence run. Saturday cron = ``"weekly"``.
+
+        Dropping this field silently reverts page 25 to the pre-Option-D
+        "smoke runs displace the real weekly" behavior — operator opens
+        page 25 expecting last weekly run, sees a smoke retry instead.
+        """
+        assert re.search(
+            r'"pipeline_role"\s*:\s*"weekly"',
+            input_json_block,
+        ), (
+            "deploy_step_function.sh::INPUT_JSON must set "
+            "pipeline_role=\"weekly\" on the Saturday cron rule. If you "
+            "are intentionally changing the role taxonomy, update both "
+            "this test AND the SCRIPT in the same PR — and remember to "
+            "update the dashboard's page-25 role_filter set to match."
+        )
+
+
+# ── Daily (Weekday) cron rule ─────────────────────────────────────────────
+
+
+_DAILY_DEPLOY_PATH = _REPO_ROOT / "infrastructure" / "deploy_step_function_daily.sh"
+
+
+@pytest.fixture(scope="module")
+def daily_script_text() -> str:
+    return _DAILY_DEPLOY_PATH.read_text()
+
+
+@pytest.fixture(scope="module")
+def daily_input_json_block(daily_script_text: str) -> str:
+    m = re.search(
+        r"INPUT_JSON=\$\(cat <<EOF\n(.+?)\nEOF\n\)",
+        daily_script_text,
+        re.DOTALL,
+    )
+    assert m is not None, (
+        "INPUT_JSON heredoc not found in deploy_step_function_daily.sh"
+    )
+    return m.group(1)
+
+
+class TestWeekdayEventBridgeInput:
+    def test_pipeline_role_set_to_daily(self, daily_input_json_block):
+        """Option-D 2026-05-25 — Weekday cron rule must tag executions
+        with ``pipeline_role="daily"`` so page 25's Weekday section
+        filters past operator-replay / smoke executions to land on the
+        canonical 5:45 AM PT trading-cadence run."""
+        assert re.search(
+            r'"pipeline_role"\s*:\s*"daily"',
+            daily_input_json_block,
+        ), (
+            "deploy_step_function_daily.sh::INPUT_JSON must set "
+            "pipeline_role=\"daily\" on the Weekday cron rule."
+        )
+
+
+# ── CFN orchestration template chokepoint ─────────────────────────────────
+
+
+_CFN_ORCHESTRATION_PATH = (
+    _REPO_ROOT
+    / "infrastructure"
+    / "cloudformation"
+    / "alpha-engine-orchestration.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def orchestration_text() -> str:
+    return _CFN_ORCHESTRATION_PATH.read_text()
+
+
+class TestOrchestrationCFNPipelineRoles:
+    """The CFN template is a parallel source-of-truth to the deploy
+    scripts. When CFN is re-applied (or when a fresh region/account is
+    bootstrapped) the cron rules' Input fields come from the YAML, not
+    the .sh scripts. Both must carry pipeline_role to prevent drift
+    between the two paths.
+    """
+
+    def _trigger_block(self, text: str, name: str) -> str:
+        """Extract a single Rule block from the CFN text."""
+        # Crude but stable: split on rule names that appear at the same
+        # indent level. Each trigger block begins with the rule name +
+        # ``:`` on a leading-whitespace line and ends before the next
+        # such name. We pin against a known successor name per rule.
+        markers = {
+            "SaturdayTrigger": "FridayShellRunTrigger",
+            "FridayShellRunTrigger": "WeekdayTrigger",
+            "WeekdayTrigger": "ResearchAlerts",
+        }
+        head = text.split(f"{name}:", 1)
+        assert len(head) == 2, f"{name} block not found in orchestration CFN"
+        successor = markers[name]
+        block = head[1].split(f"{successor}:", 1)[0]
+        return block
+
+    def test_saturday_trigger_has_weekly_role(self, orchestration_text):
+        block = self._trigger_block(orchestration_text, "SaturdayTrigger")
+        assert re.search(
+            r'"pipeline_role"\s*:\s*"weekly"',
+            block,
+        ), (
+            "SaturdayTrigger Input must carry pipeline_role=\"weekly\"."
+        )
+
+    def test_friday_shell_run_trigger_has_shell_run_role(self, orchestration_text):
+        block = self._trigger_block(orchestration_text, "FridayShellRunTrigger")
+        assert re.search(
+            r'"pipeline_role"\s*:\s*"shell-run"',
+            block,
+        ), (
+            "FridayShellRunTrigger Input must carry "
+            "pipeline_role=\"shell-run\" — distinguishes the dry-pass "
+            "from the canonical weekly run on page 25."
+        )
+
+    def test_weekday_trigger_has_daily_role(self, orchestration_text):
+        block = self._trigger_block(orchestration_text, "WeekdayTrigger")
+        assert re.search(
+            r'"pipeline_role"\s*:\s*"daily"',
+            block,
+        ), "WeekdayTrigger Input must carry pipeline_role=\"daily\"."


### PR DESCRIPTION
## Summary

Tags every cron-triggered SF execution with a `pipeline_role` input field per the Option-D execution-picker plan (Brian-approved 2026-05-25 evening; lib substrate in [alpha-engine-lib#75](https://github.com/cipher813/alpha-engine-lib/pull/75); daemon companion in [alpha-engine#214](https://github.com/cipher813/alpha-engine/pull/214)). Page 25 / Slack / CLI consumers filter by role so smoke / recovery / operator-replay executions never displace the canonical cadence run as "most recent."

- `SaturdayTrigger` (cron 09:00 UTC SAT) → `pipeline_role="weekly"`
- `FridayShellRunTrigger` (cron 20:45 UTC FRI, shipped DISABLED) → `pipeline_role="shell-run"`
- `WeekdayTrigger` (cron 12:45 UTC MON-FRI) → `pipeline_role="daily"`

## Dual source-of-truth coverage

Edits land in BOTH the CFN orchestration template AND the live-EventBridge-applied deploy scripts so neither path goes stale:

| Source | Saturday | Weekday | Friday shell-run |
|--------|----------|---------|------------------|
| `infrastructure/cloudformation/alpha-engine-orchestration.yaml` | ✓ | ✓ | ✓ |
| `infrastructure/deploy_step_function.sh` | ✓ | — | — |
| `infrastructure/deploy_step_function_daily.sh` | — | ✓ | — |

## Naming convention

| `pipeline_role` | Triggered by | Page 25 default |
|---|---|---|
| `\"weekly\"` | SaturdayTrigger EventBridge cron | shown |
| `\"daily\"` | WeekdayTrigger EventBridge cron | shown |
| `\"eod\"` | `daemon._trigger_eod_pipeline` | shown |
| `\"shell-run\"` | FridayShellRunTrigger (DISABLED) | hidden by default |
| `\"smoke\"` | operator smoke / debug | hidden by default |
| `\"recovery\"` | operator fix-and-rerun | hidden by default |
| `\"backfill\"` | operator historical backfill | hidden by default |
| `\"operator-replay\"` | operator ad-hoc replay (catch-all) | hidden by default |

## Test plan

- [x] 5 new chokepoint tests in `test_deploy_step_function_eventbridge_input.py` — assert the right `pipeline_role` on each trigger across all three sources of truth. Drift in either the CFN OR a deploy script fails CI loudly with a named remediation path.
- [x] Full data suite: `1532 passed, 1 skipped, 7 warnings in 8.15s`
- [x] Verified SF JSON `InitializeInput` uses `States.JsonMerge` — the new `pipeline_role` field is preserved through to all downstream states without breaking any JSONPath reference.
- [ ] After all three merge: run `infrastructure/deploy_step_function.sh` + `infrastructure/deploy_step_function_daily.sh` to update the live EventBridge rules. Verify via `aws events list-targets-by-rule --rule alpha-engine-saturday --region us-east-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)