### PR TITLE
fix(eventbridge): CFN-canonical cron rules + target-uniqueness chokepoint (closes 2026-05-26 dup-target incident)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -125,6 +125,16 @@ Resources:
       ScheduleExpression: 'cron(0 9 ? * SAT *)'
       State: ENABLED
       Targets:
+        # SINGLE TARGET PER RULE. EventBridge dispatches the cron event
+        # to every target on a rule; a duplicate target ID fans the
+        # trigger to two parallel SF executions. The Tuesday 5/26
+        # weekday-pipeline failure (321 E_NON_INCREASING_INDEX_VERSION
+        # ArcticDB races during MorningEnrich) was caused by exactly
+        # that — PR #317 added a parallel target via the deploy script
+        # alongside this CFN target. The substrate gate is the
+        # TestCFNTargetUniqueness chokepoint, which fails CI if any
+        # cron rule grows a second target. SoT for this rule is THIS
+        # FILE; the deploy scripts no longer touch EventBridge.
         - Id: saturday-pipeline
           Arn: !Ref SaturdayPipeline
           RoleArn: !Ref EventBridgeSfnRoleArn
@@ -135,10 +145,21 @@ Resources:
           # Ad-hoc operator launches MUST set their own pipeline_role
           # (smoke / recovery / backfill / operator-replay) per the
           # taxonomy in pipeline-reporting-revamp-260524.md §6.
+          #
+          # enable_standalone_scanner=true activates the L1995 Phase 2
+          # Scanner SF state (alpha-engine-research-scanner Lambda
+          # writes candidates.json in parallel-observe mode). Set true
+          # from 2026-05-25 onward (originally in deploy_step_function.sh
+          # via PR #313; migrated here 2026-05-26 in the EB-target
+          # single-SoT PR — keeping the flag on the SCRIPT meant
+          # re-deploying CFN silently flipped it off). Revert by
+          # flipping to false here in the same PR that updates
+          # ``tests/test_deploy_step_function_eventbridge_input.py``.
           Input: !Sub |
             {
               "ec2_instance_id": ["${MicroInstanceId}"],
               "sns_topic_arn": "${AlertsTopic}",
+              "enable_standalone_scanner": true,
               "pipeline_role": "weekly"
             }
 
@@ -181,6 +202,8 @@ Resources:
       ScheduleExpression: 'cron(45 20 ? * FRI *)'
       State: DISABLED
       Targets:
+        # SINGLE TARGET PER RULE. See the SaturdayTrigger Targets
+        # comment for the 2026-05-26 duplicate-target incident.
         - Id: friday-shell-run
           Arn: !Ref SaturdayPipeline
           RoleArn: !Ref EventBridgeSfnRoleArn
@@ -218,6 +241,10 @@ Resources:
       ScheduleExpression: 'cron(45 12 ? * MON-FRI *)'
       State: ENABLED
       Targets:
+        # SINGLE TARGET PER RULE. See the SaturdayTrigger Targets
+        # comment for the 2026-05-26 duplicate-target incident that
+        # codified this invariant. SoT for this rule is THIS FILE;
+        # the deploy scripts no longer touch EventBridge.
         - Id: weekday-pipeline
           Arn: !Ref WeekdayPipeline
           RoleArn: !Ref EventBridgeSfnRoleArn

--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -149,25 +149,50 @@ else
 fi
 echo "  State machine ARN: $SM_ARN"
 
-# ── 4. EventBridge Rule ────────────────────────────────────────────────────
+# ── 4. EventBridge Rule + Targets — CFN-CANONICAL ──────────────────────────
+#
+# This script no longer writes the EventBridge rule or its targets;
+# both are codified in
+# infrastructure/cloudformation/alpha-engine-orchestration.yaml as the
+# single source of truth.
+#
+# WHY (2026-05-26): PR #317 added a put-targets call here AND left the
+# CFN ``Targets:`` block intact, so the alpha-engine-saturday rule
+# (and its weekday sibling) carried TWO targets — Id="1" from this
+# script + Id="saturday-pipeline" from CFN. EventBridge dispatched
+# every weekday cron firing to BOTH targets, fanning the cron into two
+# parallel SF executions on the same trading instance. Both ran
+# MorningEnrich → both connected ArcticDB → 321 unique-symbol
+# E_NON_INCREASING_INDEX_VERSION races → the 5%-threshold daily_append
+# gate hard-failed both runs at 35.6% error rate (905 tickers,
+# n_err=322). Trading didn't happen on 5/26.
+#
+# The substrate gate that prevents recurrence is
+# ``tests/test_deploy_step_function_eventbridge_input.py``::
+#   - ``TestDeployScriptsHaveNoEventBridgeWrites`` (this script must
+#     not contain ``aws events put-rule`` or ``aws events put-targets``)
+#   - ``TestCFNTargetUniqueness`` (each cron rule has exactly 1 target
+#     in the CFN template)
+#
+# Operators applying EventBridge changes:
+#
+#   aws cloudformation deploy \
+#     --template-file infrastructure/cloudformation/alpha-engine-orchestration.yaml \
+#     --stack-name alpha-engine-orchestration \
+#     --parameter-overrides ...
+#
+# This script's remaining responsibility is the SF state machine JSON
+# (upload to S3 + update-state-machine), plus the bootstrap IAM role
+# the CFN template's EventBridgeSfnRoleArn parameter references
+# (kept here so a fresh region/account can still be bootstrapped via
+# this script alone; idempotent ``|| true`` on re-runs).
+#
+# IAM bootstrap: trust policy + role creation only. The role's INLINE
+# policy is codified in the alpha-engine repo's
+# infrastructure/iam/ directory and applied via that repo's apply.sh —
+# do NOT add inline-policy writes here (per the dual-writer incident
+# 2026-04-21/05-04/05-06 documented above the IAM block historically).
 
-echo "Creating EventBridge rule: $EVENTBRIDGE_RULE..."
-
-aws events put-rule \
-  --name "$EVENTBRIDGE_RULE" \
-  --schedule-expression "cron(0 9 ? * SAT *)" \
-  --state ENABLED \
-  --description "Saturday 09:00 UTC (02:00 AM PT Sat) — triggers full Alpha Engine pipeline. Schedule chosen so polygon's Friday daily aggregate has settled (T+1 lag) before MorningEnrich + DataPhase1 fetch it." \
-  --region "$REGION"
-
-# EventBridge needs a role to start Step Functions executions.
-# Trust policy + role creation kept here (one-time bootstrap); inline
-# policy is codified in this repo's infrastructure/iam/ directory
-# (alpha-engine-eventbridge-sfn-role.json). Apply via apply.sh, not
-# here. Prior inline block listed only the saturday SFN ARN — every
-# saturday deploy clobbered the weekday ARN that the daily script had
-# granted, breaking the next weekday auto-fire (recurred 2026-04-21,
-# 2026-05-04, 2026-05-06).
 EB_ROLE_NAME="alpha-engine-eventbridge-sfn-role"
 EB_TRUST='{
   "Version": "2012-10-17",
@@ -185,41 +210,8 @@ aws iam create-role \
   --assume-role-policy-document "$EB_TRUST" \
   --region "$REGION" 2>/dev/null || true
 
-EB_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${EB_ROLE_NAME}"
-
-# The EventBridge target passes the execution input with EC2 instance ID and SNS topic.
-#
-# enable_standalone_scanner=true activates the L1995 Phase 2 Scanner SF state
-# (alpha-engine-research-scanner Lambda writes candidates.json in
-# parallel-observe mode). Set true from 2026-05-25 onward — the SF chain is
-# byte-identical to pre-Phase-2 except the new state writes an additional
-# S3 artifact at s3://alpha-engine-research/candidates/{run_date}/candidates.json.
-# Catch posture: scanner Lambda failure is non-blocking (routes to
-# CheckSkipRAGIngestion); the artifact is observe-only with no consumer
-# until L1995 Phase 4 wires RAGIngestion to read it. First soak cycle: Sat
-# 2026-05-30. Revert by flipping to false here + re-running this script,
-# OR by ad-hoc `aws events put-targets` with a fresh Input.
-INPUT_JSON=$(cat <<EOF
-{
-  "ec2_instance_id": ["$EC2_INSTANCE_ID"],
-  "sns_topic_arn": "$SNS_TOPIC_ARN",
-  "enable_standalone_scanner": true,
-  "pipeline_role": "weekly"
-}
-EOF
-)
-
-aws events put-targets \
-  --rule "$EVENTBRIDGE_RULE" \
-  --targets '[{
-    "Id": "1",
-    "Arn": "'"$SM_ARN"'",
-    "RoleArn": "'"$EB_ROLE_ARN"'",
-    "Input": '"$(echo "$INPUT_JSON" | python3 -c "import sys,json; print(json.dumps(json.dumps(json.load(sys.stdin))))")"'
-  }]' \
-  --region "$REGION"
-
-echo "  EventBridge rule: cron(0 9 ? * SAT *) -> $STATE_MACHINE_NAME"
+echo "  EventBridge rule + targets: managed by CFN orchestration template"
+echo "  EventBridge IAM role bootstrap: $EB_ROLE_NAME (idempotent)"
 
 # ── 5. Disable old crons (optional) ────────────────────────────────────────
 

--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -103,46 +103,27 @@ fi
 echo "  State machine ARN: $SM_ARN"
 
 # ── EventBridge Rule ────────────────────────────────────────────────────────
+#
+# RULE + TARGETS ARE CFN-CANONICAL.
+#
+# This script no longer writes the EventBridge rule or its targets;
+# both are codified in
+# infrastructure/cloudformation/alpha-engine-orchestration.yaml as
+# the single source of truth. See the matching comment block in
+# infrastructure/deploy_step_function.sh for the 2026-05-26
+# duplicate-target incident that drove this consolidation, and for
+# the test chokepoints
+# (``TestDeployScriptsHaveNoEventBridgeWrites``,
+# ``TestCFNTargetUniqueness``) that fail CI on regression.
+#
+# Operators applying EventBridge changes run:
+#
+#   aws cloudformation deploy \
+#     --template-file infrastructure/cloudformation/alpha-engine-orchestration.yaml \
+#     --stack-name alpha-engine-orchestration \
+#     --parameter-overrides ...
 
-echo "Creating EventBridge rule: $EVENTBRIDGE_RULE..."
-
-# 13:00 UTC = 6:00 AM PT (Mon-Fri)
-aws events put-rule \
-  --name "$EVENTBRIDGE_RULE" \
-  --schedule-expression "cron(0 13 ? * MON-FRI *)" \
-  --state ENABLED \
-  --description "Weekday 13:00 UTC (6:00 AM PT) — daily data + predictor + executor start" \
-  --region "$REGION"
-
-# Reuse EventBridge role from Saturday pipeline.
-# IAM policy on this role is codified in alpha-engine/infrastructure/iam/
-# (alpha-engine-eventbridge-sfn-role/) — apply via `apply.sh` from that
-# repo, not inline here. The previous inline block on this script + the
-# saturday script wrote the same role policy with different ARN sets and
-# clobbered each other; the saturday-only write hit prod three times
-# (2026-04-21, 2026-05-04, 2026-05-06) before the role was codified.
-EB_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-eventbridge-sfn-role"
-
-INPUT_JSON=$(cat <<EOF
-{
-  "trading_instance_id": ["$TRADING_INSTANCE"],
-  "sns_topic_arn": "$SNS_TOPIC_ARN",
-  "pipeline_role": "daily"
-}
-EOF
-)
-
-aws events put-targets \
-  --rule "$EVENTBRIDGE_RULE" \
-  --targets '[{
-    "Id": "1",
-    "Arn": "'"$SM_ARN"'",
-    "RoleArn": "'"$EB_ROLE_ARN"'",
-    "Input": '"$(echo "$INPUT_JSON" | python3 -c "import sys,json; print(json.dumps(json.dumps(json.load(sys.stdin))))")"'
-  }]' \
-  --region "$REGION"
-
-echo "  EventBridge rule: cron(0 13 ? * MON-FRI *) -> $STATE_MACHINE_NAME"
+echo "  EventBridge rule: managed by CFN orchestration template (see comment above)"
 
 # ── Disable old rules (optional) ───────────────────────────────────────────
 

--- a/tests/test_deploy_step_function_eventbridge_input.py
+++ b/tests/test_deploy_step_function_eventbridge_input.py
@@ -1,22 +1,40 @@
-"""Pins the EventBridge Input contract in ``deploy_step_function.sh``.
+"""Pins the EventBridge cron-rule contract.
 
-The Saturday SF cron-fired execution gets its input from the
-EventBridge rule's ``Input`` field, which is constructed in
-``infrastructure/deploy_step_function.sh`` (see the ``INPUT_JSON``
-heredoc + ``aws events put-targets`` invocation). The Saturday SF's
-behavior on cron firing is therefore controlled by THIS file, not by
-the SF JSON alone.
+Two source-of-truth invariants are enforced here:
 
-ROADMAP L1995 Phase 3 — `enable_standalone_scanner: true` must be in
-the EventBridge Input or the new Scanner SF state (Phase 2) takes the
-default-off path and parallel-observe mode does NOT run. This test
-pins the flag's presence so a future deploy_step_function.sh edit
-can't silently revert Phase 3 by dropping the flag.
+1. **CFN is canonical** for EventBridge rules + targets. The deploy
+   scripts (``infrastructure/deploy_step_function{,_daily}.sh``) MUST
+   NOT contain ``aws events put-rule`` or ``aws events put-targets``.
+   Both rules + their targets are defined in
+   ``infrastructure/cloudformation/alpha-engine-orchestration.yaml``.
 
-If the operator deliberately wants to revert Phase 3 (e.g. divergence
-audit failed on Sat 5/30 and the substrate needs a fix-and-rerun
-cycle), this test should be updated in the same PR that flips the
-flag back to false.
+2. **Each cron rule has exactly ONE target.** EventBridge dispatches
+   a rule's trigger event to every target, so a duplicate target
+   silently fans the cron into N parallel SF executions.
+
+Why these chokepoints (2026-05-26 incident):
+
+PR #317 (33c3753, 2026-05-25 evening) added ``pipeline_role`` tagging
+to all three SF cron triggers and stamped the change in BOTH
+source-of-truth paths — the CFN template AND the deploy scripts —
+with DIFFERENT target IDs (``Id="1"`` from the scripts, ``Id="...-
+pipeline"`` from CFN). EventBridge couldn't dedupe (different IDs =
+different targets), so every weekday cron firing fanned to TWO
+parallel SF executions. Both spawned MorningEnrich on the same
+trading instance via SSM SendCommand, both connected ArcticDB, and
+both reached ``daily_append``'s ``update_batch`` / ``write_batch``
+phase, where the ArcticDB C++ engine emitted 321 unique-symbol
+``E_NON_INCREASING_INDEX_VERSION`` (code 5090) races
+("This is most likely due to parallel writes to the same symbol").
+The 5%-threshold daily_append gate hard-failed both runs at 35.6%
+error rate (905 tickers, n_err=322). Trading didn't happen on 5/26.
+
+PR #317's existing chokepoint tests validated target *input
+contents* (``pipeline_role`` value, ``enable_standalone_scanner``
+value) but not target *uniqueness* — so CI passed. The new
+``TestCFNTargetUniqueness`` + ``TestDeployScriptsHaveNoEventBridgeWrites``
+classes below close that gap so the next duplicate-target attempt
+fails at PR time.
 """
 
 from __future__ import annotations
@@ -28,128 +46,23 @@ import pytest
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_DEPLOY_PATH = _REPO_ROOT / "infrastructure" / "deploy_step_function.sh"
+_INFRA = _REPO_ROOT / "infrastructure"
+_CFN_ORCHESTRATION_PATH = _INFRA / "cloudformation" / "alpha-engine-orchestration.yaml"
 
-
-@pytest.fixture(scope="module")
-def script_text() -> str:
-    return _DEPLOY_PATH.read_text()
-
-
-@pytest.fixture(scope="module")
-def input_json_block(script_text: str) -> str:
-    """Extract the EventBridge target Input heredoc body."""
-    # Match the INPUT_JSON=$(cat <<EOF ... EOF) heredoc.
-    m = re.search(
-        r"INPUT_JSON=\$\(cat <<EOF\n(.+?)\nEOF\n\)",
-        script_text,
-        re.DOTALL,
-    )
-    assert m is not None, "INPUT_JSON heredoc not found in deploy_step_function.sh"
-    return m.group(1)
-
-
-class TestEventBridgeInput:
-    def test_ec2_instance_id_present(self, input_json_block):
-        # Baseline — the rule was always supposed to thread the
-        # MicroInstance ID through to the SF execution.
-        assert "ec2_instance_id" in input_json_block
-
-    def test_sns_topic_arn_present(self, input_json_block):
-        # Baseline — same.
-        assert "sns_topic_arn" in input_json_block
-
-    def test_enable_standalone_scanner_flag_set_true(self, input_json_block):
-        # L1995 Phase 3 — the new Scanner SF state (Phase 2) gates on
-        # this flag. Without it the parallel-observe mode does NOT run
-        # and Phase 3 soak does not happen. Revert deliberately by
-        # flipping to false here in the same PR that updates this test.
-        assert "enable_standalone_scanner" in input_json_block, (
-            "deploy_step_function.sh::INPUT_JSON dropped the "
-            "enable_standalone_scanner field; this silently reverts "
-            "L1995 Phase 3 + freezes the arc. If the revert is "
-            "intentional, update both this test and the SCRIPT in the "
-            "same PR."
-        )
-        # Pin the value too — present-but-false also reverts Phase 3.
-        assert re.search(
-            r'"enable_standalone_scanner"\s*:\s*true',
-            input_json_block,
-        ), (
-            "enable_standalone_scanner is present but not set to true. "
-            "Phase 3 requires the flag value to be true."
-        )
-
-    def test_pipeline_role_set_to_weekly(self, input_json_block):
-        """Option-D 2026-05-25: every cron-triggered execution carries a
-        ``pipeline_role`` tag so page 25 / Slack / CLI consumers can filter
-        out smoke / recovery / operator-replay executions from the
-        canonical cadence run. Saturday cron = ``"weekly"``.
-
-        Dropping this field silently reverts page 25 to the pre-Option-D
-        "smoke runs displace the real weekly" behavior — operator opens
-        page 25 expecting last weekly run, sees a smoke retry instead.
-        """
-        assert re.search(
-            r'"pipeline_role"\s*:\s*"weekly"',
-            input_json_block,
-        ), (
-            "deploy_step_function.sh::INPUT_JSON must set "
-            "pipeline_role=\"weekly\" on the Saturday cron rule. If you "
-            "are intentionally changing the role taxonomy, update both "
-            "this test AND the SCRIPT in the same PR — and remember to "
-            "update the dashboard's page-25 role_filter set to match."
-        )
-
-
-# ── Daily (Weekday) cron rule ─────────────────────────────────────────────
-
-
-_DAILY_DEPLOY_PATH = _REPO_ROOT / "infrastructure" / "deploy_step_function_daily.sh"
-
-
-@pytest.fixture(scope="module")
-def daily_script_text() -> str:
-    return _DAILY_DEPLOY_PATH.read_text()
-
-
-@pytest.fixture(scope="module")
-def daily_input_json_block(daily_script_text: str) -> str:
-    m = re.search(
-        r"INPUT_JSON=\$\(cat <<EOF\n(.+?)\nEOF\n\)",
-        daily_script_text,
-        re.DOTALL,
-    )
-    assert m is not None, (
-        "INPUT_JSON heredoc not found in deploy_step_function_daily.sh"
-    )
-    return m.group(1)
-
-
-class TestWeekdayEventBridgeInput:
-    def test_pipeline_role_set_to_daily(self, daily_input_json_block):
-        """Option-D 2026-05-25 — Weekday cron rule must tag executions
-        with ``pipeline_role="daily"`` so page 25's Weekday section
-        filters past operator-replay / smoke executions to land on the
-        canonical 5:45 AM PT trading-cadence run."""
-        assert re.search(
-            r'"pipeline_role"\s*:\s*"daily"',
-            daily_input_json_block,
-        ), (
-            "deploy_step_function_daily.sh::INPUT_JSON must set "
-            "pipeline_role=\"daily\" on the Weekday cron rule."
-        )
-
-
-# ── CFN orchestration template chokepoint ─────────────────────────────────
-
-
-_CFN_ORCHESTRATION_PATH = (
-    _REPO_ROOT
-    / "infrastructure"
-    / "cloudformation"
-    / "alpha-engine-orchestration.yaml"
+_DEPLOY_SCRIPTS = (
+    "deploy_step_function.sh",
+    "deploy_step_function_daily.sh",
 )
+
+# Each cron-rule CFN block runs from its name marker to the next
+# top-level name marker. Pairing each rule with its known successor
+# lets us slice the block deterministically without a YAML parser
+# (CFN's ``!Sub`` / ``!Ref`` tags require a custom loader).
+_TRIGGER_SUCCESSORS = {
+    "SaturdayTrigger": "FridayShellRunTrigger",
+    "FridayShellRunTrigger": "WeekdayTrigger",
+    "WeekdayTrigger": "ResearchAlerts",
+}
 
 
 @pytest.fixture(scope="module")
@@ -157,54 +70,172 @@ def orchestration_text() -> str:
     return _CFN_ORCHESTRATION_PATH.read_text()
 
 
-class TestOrchestrationCFNPipelineRoles:
-    """The CFN template is a parallel source-of-truth to the deploy
-    scripts. When CFN is re-applied (or when a fresh region/account is
-    bootstrapped) the cron rules' Input fields come from the YAML, not
-    the .sh scripts. Both must carry pipeline_role to prevent drift
-    between the two paths.
+def _trigger_block(text: str, name: str) -> str:
+    """Extract a single ``AWS::Events::Rule`` block from the CFN text."""
+    head = text.split(f"{name}:", 1)
+    assert len(head) == 2, f"{name} block not found in orchestration CFN"
+    successor = _TRIGGER_SUCCESSORS[name]
+    return head[1].split(f"{successor}:", 1)[0]
+
+
+# ── Substrate gate 1: scripts must not touch EventBridge ──────────────────
+
+
+class TestDeployScriptsHaveNoEventBridgeWrites:
+    """Single source of truth: CFN owns EventBridge rules + targets;
+    deploy scripts only update the SF state machine JSON.
+
+    Codified 2026-05-26 after PR #317's dual-write pattern caused the
+    duplicate-target incident (see module docstring). The script side
+    of the dual write is what created the second target; removing it
+    here prevents recurrence.
     """
 
-    def _trigger_block(self, text: str, name: str) -> str:
-        """Extract a single Rule block from the CFN text."""
-        # Crude but stable: split on rule names that appear at the same
-        # indent level. Each trigger block begins with the rule name +
-        # ``:`` on a leading-whitespace line and ends before the next
-        # such name. We pin against a known successor name per rule.
-        markers = {
-            "SaturdayTrigger": "FridayShellRunTrigger",
-            "FridayShellRunTrigger": "WeekdayTrigger",
-            "WeekdayTrigger": "ResearchAlerts",
-        }
-        head = text.split(f"{name}:", 1)
-        assert len(head) == 2, f"{name} block not found in orchestration CFN"
-        successor = markers[name]
-        block = head[1].split(f"{successor}:", 1)[0]
-        return block
+    @staticmethod
+    def _executable_lines(text: str) -> str:
+        """Return the script with comment + blank lines stripped so the
+        substring scan below only looks at executable statements. Bash
+        comments start with ``#`` after any leading whitespace.
+        Documentation blocks describing the prohibited commands stay in
+        place (they're informative), but don't trigger the test."""
+        kept = []
+        for line in text.splitlines():
+            stripped = line.lstrip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            kept.append(line)
+        return "\n".join(kept)
+
+    @pytest.mark.parametrize("script", _DEPLOY_SCRIPTS)
+    def test_no_put_targets(self, script):
+        text = self._executable_lines((_INFRA / script).read_text())
+        assert "aws events put-targets" not in text, (
+            f"infrastructure/{script} contains an executable "
+            f"`aws events put-targets` call. EventBridge rules + targets "
+            f"are CFN-canonical "
+            f"(infrastructure/cloudformation/alpha-engine-orchestration.yaml). "
+            f"If you need to change a target, edit the CFN template and run "
+            f"`aws cloudformation deploy --template-file "
+            f"infrastructure/cloudformation/alpha-engine-orchestration.yaml ...`. "
+            f"Calling put-targets from the deploy script created the "
+            f"2026-05-26 duplicate-target incident."
+        )
+
+    @pytest.mark.parametrize("script", _DEPLOY_SCRIPTS)
+    def test_no_put_rule(self, script):
+        text = self._executable_lines((_INFRA / script).read_text())
+        assert "aws events put-rule" not in text, (
+            f"infrastructure/{script} contains an executable "
+            f"`aws events put-rule` call. EventBridge rules are "
+            f"CFN-canonical "
+            f"(infrastructure/cloudformation/alpha-engine-orchestration.yaml). "
+            f"Edit the CFN ``AWS::Events::Rule`` resource and re-deploy "
+            f"the stack."
+        )
+
+
+# ── Substrate gate 2: each cron rule has exactly ONE target ───────────────
+
+
+class TestCFNTargetUniqueness:
+    """EventBridge dispatches a rule's trigger event to every target.
+    A duplicate target silently fans the cron into N parallel SF
+    executions, which then race at any shared downstream resource
+    (the 2026-05-26 ArcticDB race; see module docstring).
+
+    Constraint: every cron-triggered ``AWS::Events::Rule`` in the
+    orchestration CFN template has EXACTLY ONE entry under
+    ``Targets:``. If you have a legitimate reason to fan one rule to
+    multiple targets, document the rationale + update this test in
+    the same PR.
+    """
+
+    @pytest.mark.parametrize("trigger", list(_TRIGGER_SUCCESSORS.keys()))
+    def test_exactly_one_target_per_trigger(self, orchestration_text, trigger):
+        block = _trigger_block(orchestration_text, trigger)
+        # ``Targets:`` is followed by one or more ``- Id: ...`` entries
+        # at the same indent. Count the ``- Id:`` markers between
+        # ``Targets:`` and the end of the block.
+        targets_split = block.split("Targets:", 1)
+        assert len(targets_split) == 2, (
+            f"{trigger} block missing ``Targets:`` section"
+        )
+        targets_body = targets_split[1]
+        id_count = len(re.findall(r"^\s*- Id:\s*\S+", targets_body, re.MULTILINE))
+        assert id_count == 1, (
+            f"{trigger} declares {id_count} targets; must be exactly 1. "
+            f"EventBridge fans triggers to every target — a second target "
+            f"on this rule will spawn parallel SF executions on every "
+            f"firing (see the 2026-05-26 duplicate-target incident in the "
+            f"module docstring). If multi-target is intentional here, "
+            f"update this test in the same PR with the rationale."
+        )
+
+
+# ── Content checks: pipeline_role + scanner activation (CFN side) ─────────
+
+
+class TestOrchestrationCFNPipelineRoles:
+    """The cron rules' Input fields come from the CFN template (now
+    the sole source of truth — see ``TestDeployScriptsHaveNoEvent``-
+    ``BridgeWrites``). Both cron rules must carry their canonical
+    ``pipeline_role`` tag so page 25 / Slack / CLI consumers filter
+    smoke / recovery / operator-replay executions out of the cadence
+    section.
+    """
 
     def test_saturday_trigger_has_weekly_role(self, orchestration_text):
-        block = self._trigger_block(orchestration_text, "SaturdayTrigger")
+        block = _trigger_block(orchestration_text, "SaturdayTrigger")
         assert re.search(
             r'"pipeline_role"\s*:\s*"weekly"',
             block,
-        ), (
-            "SaturdayTrigger Input must carry pipeline_role=\"weekly\"."
-        )
+        ), 'SaturdayTrigger Input must carry pipeline_role="weekly".'
 
     def test_friday_shell_run_trigger_has_shell_run_role(self, orchestration_text):
-        block = self._trigger_block(orchestration_text, "FridayShellRunTrigger")
+        block = _trigger_block(orchestration_text, "FridayShellRunTrigger")
         assert re.search(
             r'"pipeline_role"\s*:\s*"shell-run"',
             block,
         ), (
-            "FridayShellRunTrigger Input must carry "
-            "pipeline_role=\"shell-run\" — distinguishes the dry-pass "
+            'FridayShellRunTrigger Input must carry '
+            'pipeline_role="shell-run" — distinguishes the dry-pass '
             "from the canonical weekly run on page 25."
         )
 
     def test_weekday_trigger_has_daily_role(self, orchestration_text):
-        block = self._trigger_block(orchestration_text, "WeekdayTrigger")
+        block = _trigger_block(orchestration_text, "WeekdayTrigger")
         assert re.search(
             r'"pipeline_role"\s*:\s*"daily"',
             block,
-        ), "WeekdayTrigger Input must carry pipeline_role=\"daily\"."
+        ), 'WeekdayTrigger Input must carry pipeline_role="daily".'
+
+
+class TestSaturdayCFNTargetActivatesScanner:
+    """ROADMAP L1995 Phase 3 — ``enable_standalone_scanner: true`` is
+    what activates the Scanner SF state (Phase 2) in parallel-observe
+    mode. Originally lived in ``deploy_step_function.sh``'s INPUT_JSON
+    (PR #313); migrated to CFN here on 2026-05-26 as part of the
+    EB-target single-SoT consolidation. Keeping the flag on the
+    SCRIPT meant that re-deploying CFN would silently revert Phase 3
+    by overwriting the live target with a CFN-form input that lacks
+    the flag — a footgun the SoT consolidation removes.
+
+    Revert by flipping to ``false`` in the CFN template in the same
+    PR that updates this test.
+    """
+
+    def test_enable_standalone_scanner_present_and_true(self, orchestration_text):
+        block = _trigger_block(orchestration_text, "SaturdayTrigger")
+        assert "enable_standalone_scanner" in block, (
+            "SaturdayTrigger Input dropped enable_standalone_scanner. "
+            "This silently reverts ROADMAP L1995 Phase 3 (Scanner SF "
+            "state runs default-off). If the revert is intentional, "
+            "update both this test and the CFN template in the same PR."
+        )
+        assert re.search(
+            r'"enable_standalone_scanner"\s*:\s*true',
+            block,
+        ), (
+            "enable_standalone_scanner is present but not set to true. "
+            "Phase 3 requires the flag value to be true."
+        )


### PR DESCRIPTION
## Summary

- **Root cause** of the 2026-05-26 weekday-pipeline failure: PR #317 added `pipeline_role` tagging in BOTH the CFN template AND the deploy scripts with different target IDs. EventBridge couldn't dedupe → `alpha-engine-weekday` shipped with TWO targets pointing to the same SF → every weekday cron fanned to 2 parallel SF executions → both spawned MorningEnrich on the same trading instance → 321 unique-symbol `E_NON_INCREASING_INDEX_VERSION` (5090) races in `daily_append`'s `update_batch`/`write_batch` → 5%-threshold gate hard-failed both at 35.6% (`n_err=322/905`). `alpha-engine-saturday` had the identical defect (first exposure Sat 5/30).
- **Fix**: EB rules + targets are now CFN-canonical (deploy scripts no longer call `put-rule` / `put-targets`). `enable_standalone_scanner=true` migrated from script to CFN saturday target (was script-only — re-deploying CFN would have silently reverted L1995 Phase 3).
- **Substrate gates** (the chokepoint PR #317 lacked):
  - `TestDeployScriptsHaveNoEventBridgeWrites`: both deploy scripts must not contain executable `aws events put-rule` / `put-targets` lines
  - `TestCFNTargetUniqueness`: each cron-triggered `AWS::Events::Rule` has exactly 1 entry under `Targets:`

## Operational state at PR-open time

- Duplicate live targets removed manually via `aws events remove-targets` (Id=`weekday-pipeline` + Id=`saturday-pipeline`) — Wed 5/27 + Sat 5/30 will fire correctly without waiting for this PR to merge.
- Today's failed weekday SF redriven via operator-launched execution (`pipeline_role=recovery`).
- EB IAM role bootstrap (trust policy + `create-role`) kept in the saturday deploy script so a fresh region/account can still bootstrap via that script alone. Inline policy remains codified in `alpha-engine` repo's `infrastructure/iam/`.

## Follow-up (filed at session wind-down)

- **P1**: SF-side `MutualExclusionGuard` (DynamoDB conditional PUT) so any future duplicate trigger (operator double-paste, EB bug, cross-region replay) hard-fails before any SSM `SendCommand`.
- **P1**: `alpha-engine-lib` producer-side universe-writer lock (S3 conditional PUT) — covers manual `python -m builders.daily_append` runs that don't go through SF.
- **P0 retrospective**: PR #317 audit — the existing `TestEventBridgeInput` chokepoint validated target *input contents* but not *target count uniqueness*. Pattern to watch: when tests pin SoT-A content, also pin SoT-A uniqueness.

## Test plan

- [x] `pytest tests/test_deploy_step_function_eventbridge_input.py` (11 passed)
- [x] Full suite: 1539 passed, 1 skipped
- [x] Live EB state confirmed single-target on both `alpha-engine-weekday` and `alpha-engine-saturday`
- [x] Today's recovery SF in flight (started 12:29 UTC, monitoring) — confirms duplicate-target removal unblocks the path
- [ ] After merge, operator runs `aws cloudformation deploy --template-file infrastructure/cloudformation/alpha-engine-orchestration.yaml ...` to re-converge the CFN-managed state with the live state (idempotent — current live Id="1" gets renamed to "weekday-pipeline"/"saturday-pipeline" per the CFN template; behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)