### PR TITLE
fix(watchdog): trading-day-aware EOD window (close 2026-05-26 false-positive Telegram alert)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -24,8 +24,17 @@ plan doc §3.5.
 
   - **EOD SF** (``alpha-engine-eod-pipeline``)
       Watch-day: same condition as Weekday — EOD fires after the trading
-      day's daemon shutdown, which only happens on trading days. Alert if
-      0 executions started in the last 24h.
+      day's daemon shutdown, which only happens on trading days. Window
+      is TRADING-DAY-AWARE, NOT a fixed 24h calendar window: today's EOD
+      fires ~20:00 UTC (post market close at 13:00 PT + daemon shutdown),
+      which is AFTER the watchdog's 14:00 UTC cron firing — so the most
+      recent EXPECTED EOD execution is the PREVIOUS trading day's. The
+      window starts at ``previous_trading_day(today) @ 20:00 UTC`` +
+      slack. After a holiday weekend (Fri close → Mon holiday → Tue
+      watchdog) the gap is ~66h, not 24h. Alert if 0 executions started
+      in that window. See ``_eod_window_seconds`` for the derivation and
+      the 2026-05-26 morning false-positive Telegram alert that drove
+      this fix.
 
   - **Saturday SF** (``alpha-engine-saturday-pipeline``)
       Watch-day: TODAY is Sunday (weekday 6) — Saturday SF fires at 09:00
@@ -75,7 +84,10 @@ from typing import Optional
 import boto3
 
 from alpha_engine_lib import alerts
-from alpha_engine_lib.trading_calendar import last_closed_trading_day
+from alpha_engine_lib.trading_calendar import (
+    last_closed_trading_day,
+    previous_trading_day,
+)
 
 
 logger = logging.getLogger()
@@ -104,9 +116,80 @@ WATCHDOG_SNS_TOPIC_ARN = os.environ.get(
     f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-watchdog-alerts",
 )
 
-# Per-SF expected-window seconds. EOD + Weekday fire daily, Saturday weekly.
-WINDOW_SECONDS_DAILY = 24 * 3600  # 86_400
-WINDOW_SECONDS_WEEKLY = 7 * 24 * 3600  # 604_800
+# Per-SF expected-window seconds. Weekday cron fires at 12:45 UTC, which
+# is BEFORE the watchdog's 14:00 UTC cron firing, so a 24h calendar window
+# correctly captures today's expected weekday execution. Saturday cron
+# fires at 09:00 UTC Sat, watchdog runs Sundays at 14:00 UTC → 7d calendar
+# window correctly captures that Saturday firing.
+#
+# EOD SF is the exception — it fires AFTER market close (~20:00 UTC)
+# which is AFTER the watchdog's 14:00 UTC firing today, so the most
+# recent EXPECTED EOD execution at watchdog time is the PREVIOUS
+# trading day's EOD. After a holiday weekend (Fri close → Mon holiday →
+# Tue 14:00 UTC watchdog), that gap is ~66h, not 24h. EOD uses
+# ``_eod_window_seconds`` instead of a constant.
+WINDOW_SECONDS_DAILY = 24 * 3600  # 86_400 — Weekday SF
+WINDOW_SECONDS_WEEKLY = 7 * 24 * 3600  # 604_800 — Saturday SF
+
+# EOD window slack — added to the gap-to-previous-trading-day-EOD so a
+# late EOD firing (daemon shut down slightly later than the nominal time)
+# or clock skew between watchdog + SF control plane doesn't false-positive
+# on the boundary.
+EOD_WINDOW_SLACK_SECONDS = 3600  # 1 hour
+
+# Nominal expected EOD firing time in UTC. Daemon shuts down ~13:15 PT
+# after the 13:00 PT (US market close), which is ~20:15 UTC during PDT.
+# A wider window via SLACK above absorbs the ~30 min spread.
+EOD_EXPECTED_UTC_HOUR = 20
+
+
+def _eod_window_seconds(now_utc: datetime) -> int:
+    """EOD SF runs after the trading day's market close (~20:00 UTC). At
+    the watchdog's 14:00 UTC firing time the most recent EXPECTED EOD
+    execution is the PREVIOUS trading day's EOD (today's hasn't fired
+    yet — it will fire ~6h after the watchdog runs).
+
+    Window start = previous_trading_day(today) @ ``EOD_EXPECTED_UTC_HOUR``.
+    Window seconds = ``now - window_start + slack``.
+
+    Examples:
+      - Wed 14:00 UTC, post-normal-Tue:
+          prev_td = Tue, prev_eod_expected = Tue 20:00 UTC,
+          gap = 18h, window = 18h + 1h slack = 19h.
+      - Tue 14:00 UTC, post-Memorial-Mon-holiday:
+          prev_td = Fri (because Mon was holiday), prev_eod_expected =
+          Fri 20:00 UTC, gap = 4 days × 24h − 6h = 90h, window = 90h +
+          1h slack = 91h.
+      - Mon 14:00 UTC after normal weekend:
+          prev_td = Fri, prev_eod_expected = Fri 20:00 UTC, gap = 3
+          days × 24h − 6h = 66h, window = 67h. (No false alert on
+          Monday morning post-weekend.)
+
+    Why this is the right cutover rather than "always use a 24h window
+    that we extend on holidays": the watchdog's purpose is to detect a
+    missing EXPECTED firing. The expectation is set by NYSE's session
+    calendar, not by clock arithmetic. A 24h window encodes "we expect a
+    daily firing" but the firing isn't daily on weekends and holidays.
+    Pulling the window start from ``previous_trading_day`` makes the
+    encoded expectation match the actual schedule — which is exactly
+    what ``feedback_dual_source_audit_must_assess_every_downstream_consumer``
+    + ``feedback_no_silent_fails`` argue for at substrate level.
+    """
+    prev_td = previous_trading_day(now_utc.date())
+    # Construct the previous-trading-day EOD-expected timestamp via
+    # ``now_utc.replace`` + ``timedelta`` (avoids ``datetime.combine``,
+    # which the existing test pattern's ``patch("index.datetime")`` mock
+    # doesn't proxy through to the real classmethod).
+    days_back = (now_utc.date() - prev_td).days
+    prev_eod_expected = now_utc.replace(
+        hour=EOD_EXPECTED_UTC_HOUR, minute=0, second=0, microsecond=0
+    ) - timedelta(days=days_back)
+    gap_seconds = int((now_utc - prev_eod_expected).total_seconds())
+    # Defensive: if the gap somehow goes negative (e.g., a future test
+    # passing a now_utc earlier than prev_eod_expected), clamp to the slack
+    # so the window is at least non-zero and we don't ListExecutions with
+    # a negative timedelta.
+    return max(gap_seconds, 0) + EOD_WINDOW_SLACK_SECONDS
 
 # Status filter for "real" executions — anything that actually started.
 # FAILED / TIMED_OUT / ABORTED executions still START the SF — what
@@ -202,7 +285,13 @@ def _count_executions_in_window(
                 start = exec_row.get("startDate")
                 if start is None:
                     continue
-                if not isinstance(start, datetime):
+                # Duck-type: ListExecutions returns boto3 datetime objects
+                # with tzinfo+astimezone. Skip anything that's not datetime-
+                # shaped (defensive against missing-field edge cases). Use
+                # ``hasattr`` rather than ``isinstance(start, datetime)`` so
+                # tests can patch ``index.datetime`` without false-tripping
+                # the typecheck (MagicMock isn't a type).
+                if not hasattr(start, "astimezone"):
                     continue
                 start_utc = (
                     start.astimezone(timezone.utc)
@@ -330,7 +419,16 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
             "today is not a NYSE trading day (weekend / holiday) per "
             "alpha_engine_lib.trading_calendar"
         ),
-        window_seconds=WINDOW_SECONDS_DAILY,
+        # Trading-day-aware: previous_trading_day-based, NOT a 24h calendar
+        # window. Today's EOD fires ~20:00 UTC (after market close + daemon
+        # shutdown); watchdog runs 14:00 UTC, so the most recent EXPECTED
+        # EOD is the PREVIOUS trading day's. After a holiday weekend (Fri
+        # close → Mon holiday → Tue 14:00 UTC watchdog) the gap is ~66h,
+        # not 24h — see ``_eod_window_seconds`` for derivation. Closes the
+        # 2026-05-26 morning false-positive Telegram alert ("EOD SF has
+        # not executed in the last 24 hours") on the first trading day
+        # after Memorial Day.
+        window_seconds=_eod_window_seconds(now_utc),
     )
     saturday = _check_sf(
         sf_label="Saturday SF",

--- a/infrastructure/lambdas/pipeline-watchdog/test_handler.py
+++ b/infrastructure/lambdas/pipeline-watchdog/test_handler.py
@@ -23,6 +23,7 @@ import pytest
 _lib_pkg = types.ModuleType("alpha_engine_lib")
 _tc_mod = types.ModuleType("alpha_engine_lib.trading_calendar")
 _tc_mod.last_closed_trading_day = MagicMock()
+_tc_mod.previous_trading_day = MagicMock()
 _alerts_mod = types.ModuleType("alpha_engine_lib.alerts")
 _alerts_mod.publish = MagicMock()
 _lib_pkg.trading_calendar = _tc_mod
@@ -49,6 +50,8 @@ def _reset_lib_mocks():
     side_effects don't leak."""
     _tc_mod.last_closed_trading_day.reset_mock()
     _tc_mod.last_closed_trading_day.side_effect = None
+    _tc_mod.previous_trading_day.reset_mock()
+    _tc_mod.previous_trading_day.side_effect = None
     _alerts_mod.publish.reset_mock()
     _alerts_mod.publish.side_effect = None
     _alerts_mod.publish.return_value = _make_publish_result(sns_ok=True, telegram_ok=True)
@@ -276,6 +279,8 @@ def test_handler_on_trading_day_checks_weekday_and_eod_skips_saturday():
         date(2026, 5, 26),  # pre-open call at now
         date(2026, 5, 27),  # synthetic 22:00 UTC call → returns today
     ]
+    # EOD window calc: previous_trading_day(2026-05-27) → 2026-05-26 (Tue)
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 26)
     now = _frozen_now(2026, 5, 27, 14, 0)
 
     # Mock boto3.client to return our fake client (no executions = alerts)
@@ -363,6 +368,7 @@ def test_handler_propagates_listexecutions_error_for_lambda_retry():
         date(2026, 5, 26),
         date(2026, 5, 27),
     ]
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 26)
     now = _frozen_now(2026, 5, 27, 14, 0)
 
     failing_client = MagicMock()
@@ -376,3 +382,141 @@ def test_handler_propagates_listexecutions_error_for_lambda_retry():
 
         with pytest.raises(RuntimeError, match="IAM denied"):
             index.handler({}, None)
+
+
+# ── _eod_window_seconds — trading-day-aware EOD window ──────────────────
+#
+# Codified after the 2026-05-26 morning false-positive Telegram alert:
+# the watchdog fires at 14:00 UTC, but today's EOD SF doesn't fire until
+# ~20:00 UTC (after market close at 13:00 PT + daemon shutdown). So the
+# most recent EXPECTED EOD at watchdog firing time is the PREVIOUS trading
+# day's, NOT the previous 24h of calendar time. After a holiday weekend
+# (Fri close → Mon holiday → Tue 14:00 UTC watchdog), the gap is ~66h,
+# not 24h. ``_eod_window_seconds`` returns the correct trading-day-aware
+# window so EOD's Tuesday-post-Memorial-Day check correctly captures
+# Friday's EOD execution.
+
+
+def test_eod_window_seconds_normal_wed_after_tue():
+    """Wed 14:00 UTC, prev_trading_day=Tue. Gap from Tue 20:00 UTC to
+    Wed 14:00 UTC = 18h. Window = 18h + 1h slack = 19h."""
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 26)  # Tue
+    now = datetime(2026, 5, 27, 14, 0, tzinfo=timezone.utc)  # Wed
+    seconds = index._eod_window_seconds(now)
+    assert seconds == 18 * 3600 + 3600  # 19h
+
+
+def test_eod_window_seconds_tue_post_memorial_day_holiday():
+    """Tue 2026-05-26 14:00 UTC. Memorial Day (Mon 5/25) was a holiday;
+    prev_trading_day = Fri 5/22. Gap from Fri 20:00 UTC to Tue 14:00 UTC
+    = (4 calendar days * 24h) - 6h = 90h. Window = 90h + 1h slack = 91h.
+    **This is the 2026-05-26 morning incident** — the false-positive
+    Telegram alert was caused by the prior hardcoded 24h calendar window
+    failing to include Fri's EOD execution."""
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 22)  # Fri (Mon was holiday)
+    now = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)  # Tue post-holiday
+    seconds = index._eod_window_seconds(now)
+    assert seconds == 90 * 3600 + 3600  # 91h
+
+
+def test_eod_window_seconds_mon_after_normal_weekend():
+    """Mon 14:00 UTC after a normal weekend. prev_trading_day = Fri.
+    Gap from Fri 20:00 UTC to Mon 14:00 UTC = (3 days * 24h) - 6h = 66h.
+    Window = 67h. Catches Fri's EOD."""
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 29)  # Fri
+    now = datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc)  # Mon
+    seconds = index._eod_window_seconds(now)
+    assert seconds == 66 * 3600 + 3600  # 67h
+
+
+def test_eod_window_seconds_clamps_negative_gap_to_slack():
+    """Defensive: if prev_eod_expected somehow lands after now_utc
+    (synthetic test input), window collapses to slack only — never goes
+    negative."""
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 27)  # Wed (same as now)
+    now = datetime(2026, 5, 27, 10, 0, tzinfo=timezone.utc)  # Wed 10:00 UTC, prev_eod is "today" 20:00 UTC
+    # Gap = 10:00 - 20:00 = -10h → clamped to 0, window = 0 + 1h slack = 3600s
+    seconds = index._eod_window_seconds(now)
+    assert seconds == 3600
+
+
+# ── handler integration: post-holiday EOD captures previous Fri's EOD ──
+
+
+def test_handler_post_holiday_eod_does_not_false_alert():
+    """Tue 2026-05-26 14:00 UTC after Memorial Day Mon 5/25. EOD SF's
+    last expected firing was Fri 5/22 ~20:00 UTC (~66h ago). With the
+    trading-day-aware window, the watchdog should NOT alert when Friday's
+    EOD execution is visible in the 67h window. Regression guard for the
+    2026-05-26 morning false-positive Telegram alert."""
+    # is_trading_day_now: today (Tue 5/26) IS a trading day
+    _tc_mod.last_closed_trading_day.side_effect = [
+        date(2026, 5, 22),  # at 14:00 UTC pre-open, last close was Fri (Mon was holiday)
+        date(2026, 5, 26),  # synthetic 22:00 UTC post-close, today is the session
+    ]
+    # EOD prev_trading_day → Fri 5/22
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 22)
+    now = _frozen_now(2026, 5, 26, 14, 0)
+
+    # Fri 5/22 20:30 UTC EOD execution exists in S3 — i.e., in our mock
+    fri_eod_start = datetime(2026, 5, 22, 20, 30, tzinfo=timezone.utc)
+    # Weekday SF: today's 12:45 UTC execution (so weekday check also clears)
+    today_weekday_start = datetime(2026, 5, 26, 12, 45, tzinfo=timezone.utc)
+    fake_client = _make_sfn_client({
+        EOD_ARN: [{"startDate": fri_eod_start}],
+        WKD_ARN: [{"startDate": today_weekday_start}],
+    })
+
+    with patch("index.datetime") as mock_dt, patch("index.boto3") as mock_boto3:
+        mock_dt.now.return_value = now
+        mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        mock_dt.fromtimestamp = datetime.fromtimestamp
+        mock_boto3.client.return_value = fake_client
+
+        summary = index.handler({}, None)
+
+    by_label = {c["sf_label"]: c for c in summary["checks"]}
+    # EOD should be CLEAR (>=1 execution in 67h window catches Fri's EOD)
+    assert by_label["EOD SF"]["checked"] is True
+    assert by_label["EOD SF"]["alert_emitted"] is False, (
+        f"EOD watchdog should not false-alert on Tue post-Memorial-Day "
+        f"when Fri's EOD is visible in the trading-day-aware window. "
+        f"Got: {by_label['EOD SF']}"
+    )
+    # Weekday should also be clear (today's 12:45 UTC execution visible in 24h window)
+    assert by_label["Weekday SF"]["alert_emitted"] is False
+
+
+def test_handler_post_holiday_eod_alerts_when_friday_eod_missing():
+    """Same Tue post-Memorial-Day setup, but Fri's EOD did NOT execute
+    (genuine outage). With 0 executions in the 67h window, watchdog
+    correctly fires. Trading-day-aware window doesn't HIDE genuine
+    outages — it just stops the false-positives."""
+    _tc_mod.last_closed_trading_day.side_effect = [
+        date(2026, 5, 22),
+        date(2026, 5, 26),
+    ]
+    _tc_mod.previous_trading_day.return_value = date(2026, 5, 22)
+    now = _frozen_now(2026, 5, 26, 14, 0)
+
+    # NO EOD execution; Weekday execution exists so only EOD alerts
+    today_weekday_start = datetime(2026, 5, 26, 12, 45, tzinfo=timezone.utc)
+    fake_client = _make_sfn_client({
+        EOD_ARN: [],  # genuine outage
+        WKD_ARN: [{"startDate": today_weekday_start}],
+    })
+
+    with patch("index.datetime") as mock_dt, patch("index.boto3") as mock_boto3:
+        mock_dt.now.return_value = now
+        mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        mock_dt.fromtimestamp = datetime.fromtimestamp
+        mock_boto3.client.return_value = fake_client
+
+        summary = index.handler({}, None)
+
+    by_label = {c["sf_label"]: c for c in summary["checks"]}
+    assert by_label["EOD SF"]["alert_emitted"] is True, (
+        "EOD watchdog must still alert on a GENUINE missed firing — "
+        "the trading-day-aware window must not paper over real outages."
+    )
+    assert by_label["Weekday SF"]["alert_emitted"] is False


### PR DESCRIPTION
## Summary

- **Root cause** of today's false-positive Telegram alert (\"EOD SF has not executed in the last 24 hours\"): watchdog fires at 14:00 UTC, EOD SF fires ~20:00 UTC (post market close + daemon shutdown). The check looks at the PREVIOUS EOD execution. Hardcoded 24h calendar window worked on normal trading days (Mon→Tue gap ≈ 18h) but FAILED after every NYSE holiday (Fri→Tue gap ≈ 90h after Memorial Day).
- **Fix**: replace `WINDOW_SECONDS_DAILY` for EOD with dynamic `_eod_window_seconds(now_utc)` using `previous_trading_day(today) @ 20:00 UTC + 1h slack`.
- **Tightens** `_count_executions_in_window` from `isinstance(start, datetime)` to `hasattr(start, \"astimezone\")` — duck typing, plays nicely with test mocks.

## Confirmed from today's CW logs

```
Weekday SF executions_seen=3  (no alert ✓)
EOD SF     executions_seen=0  (ALERT EMITTED ✗ ← false positive)
Saturday SF skipped (not Sunday ✓)
```

## Worked examples (in tests)

| Scenario | prev_td | gap | window |
|---|---|---|---|
| Wed 14:00 UTC, post-normal-Tue | Tue | 18h | 19h |
| Tue 14:00 UTC, post-Memorial-Mon-holiday | Fri | 90h | **91h** (today's case) |
| Mon 14:00 UTC, post-normal-weekend | Fri | 66h | 67h |

## Tests (6 new, 15 → 21 total in watchdog suite)

- `_eod_window_seconds`: normal Wed-after-Tue, post-Memorial Tue (load-bearing), post-normal-weekend Mon, defensive clamp on negative gap
- Handler integration: post-holiday Tue EOD does **NOT** false-alert when Friday's EOD is visible (regression guard for today's incident); post-holiday Tue EOD **DOES** alert on a genuine missed firing (trading-day-aware window must not paper over real outages)

## Test plan

- [x] `pytest infrastructure/lambdas/pipeline-watchdog/test_handler.py` — 21 pass
- [x] `pytest tests/` — 1539 pass, 1 skipped (no regression)
- [ ] After merge: operator runs `cd infrastructure/lambdas/pipeline-watchdog && ./deploy.sh` to push new code; next Wed 14:00 UTC firing should show EOD `executions_seen >= 1` with `alert_emitted=False`

## Operator follow-up unblocked

Today's CW logs also revealed a **separate** `s3:ListBucket` IAM denial on the watchdog role (\"alerts.publish: dedup marker check errored (fail-safe to publish)\"). Fail-safe IS to publish (so today's alert went through), but persistent IAM denial means dedup is non-functional and the operator would get re-paged on every cron firing of a persistent outage. P2 follow-up to be filed in ROADMAP — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)