### PR TITLE
fix(weekly_collector,backfill): chronic-gap constituents-drift gate + backfill ticker_filter error split

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -485,8 +485,62 @@ def backfill(
 
     if ticker_filter:
         if ticker_filter not in universe_tickers:
-            log.error("Ticker %s not found in universe (no data or in skip list)", ticker_filter)
-            return {"status": "error", "error": f"ticker_not_found: {ticker_filter}"}
+            # Split the three reasons so operators / CW alarms can distinguish
+            # transient data absence from configuration drift. The single
+            # "no data or in skip list" string previously here masked the
+            # 2026-05-27 PSTG case (ticker dropped from constituents but
+            # still in chronic_polygon_gaps allowlist) by collapsing it into
+            # a "no data" framing.
+            if (
+                ticker_filter in _SKIP_TICKERS
+                and ticker_filter not in _UNIVERSE_EXTRA
+            ):
+                log.error(
+                    "Ticker %s is in _SKIP_TICKERS and not promoted via "
+                    "_UNIVERSE_EXTRA — not eligible for universe write.",
+                    ticker_filter,
+                )
+                return {
+                    "status": "error",
+                    "error": f"ticker_in_skip_list: {ticker_filter}",
+                }
+            if _is_sector_etf(ticker_filter):
+                log.error(
+                    "Ticker %s is a sector ETF (prefix in _SECTOR_ETF_PREFIXES) "
+                    "— not eligible for universe write.",
+                    ticker_filter,
+                )
+                return {
+                    "status": "error",
+                    "error": f"ticker_is_sector_etf: {ticker_filter}",
+                }
+            if (
+                price_data.get(ticker_filter) is None
+                or ticker_filter not in price_data
+            ):
+                log.error(
+                    "Ticker %s has no parquet rows in the price_cache read "
+                    "prefix chain — backfill cannot proceed.",
+                    ticker_filter,
+                )
+                return {
+                    "status": "error",
+                    "error": f"ticker_no_data: {ticker_filter}",
+                }
+            # Last reason: not in current constituents (the 2026-05-27 PSTG
+            # case). All other gates passed, parquet was read, ticker just
+            # isn't a constituent — usually means the caller's allowlist /
+            # config has drifted past a recent S&P remove.
+            log.error(
+                "Ticker %s has price_cache data but is not in current "
+                "constituents (run_date=%s) — drop the upstream allowlist "
+                "entry (e.g. chronic_polygon_gaps) and retry.",
+                ticker_filter, run_date,
+            )
+            return {
+                "status": "error",
+                "error": f"ticker_not_in_constituents: {ticker_filter}",
+            }
         universe_tickers = [ticker_filter]
         n_short_history_in_scope = (
             1 if len(price_data[ticker_filter]) < MIN_ROWS_FOR_FEATURES else 0

--- a/tests/test_backfill_ticker_filter_error_split.py
+++ b/tests/test_backfill_ticker_filter_error_split.py
@@ -1,0 +1,173 @@
+"""Regression tests for `builders.backfill.backfill` ticker_filter error split.
+
+The single "no data or in skip list" error message previously emitted by
+the ticker_filter sad path masked the 2026-05-27 PSTG case (ticker
+dropped from constituents but still in chronic_polygon_gaps allowlist)
+by collapsing it into a "no data" framing. The flow-doctor alert
+``Ticker PSTG not found in universe (no data or in skip list)`` led to
+~15 minutes of investigation before the constituents-drift root cause
+surfaced.
+
+After the split, each disqualification reason returns its own ``error``
+code so an operator (or future CW alarm) can tell at a glance whether
+the failure is:
+  - ``ticker_in_skip_list``  — config issue (ticker is in _SKIP_TICKERS)
+  - ``ticker_is_sector_etf`` — config issue (ticker matches a sector
+                               ETF prefix)
+  - ``ticker_no_data``       — transient (parquet missing or empty)
+  - ``ticker_not_in_constituents`` — config drift (chronic_polygon_gaps
+                               or other allowlist lags an S&P remove)
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+
+def _ohlcv(start: str, n: int = 5) -> pd.DataFrame:
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.DataFrame(
+        {"Open": 100.0, "High": 101.0, "Low": 99.0, "Close": 100.0, "Volume": 1_000_000},
+        index=idx,
+    )
+
+
+def _stub_backfill_deps(price_data: dict, constituents_set: set):
+    """Build the patch context all four tests need: stub the four loader
+    helpers + the daily-delta merge + the S3 client. The ticker_filter
+    error path returns BEFORE any ArcticDB write, so get_universe_lib /
+    get_macro_lib don't need to be stubbed.
+    """
+    from builders import backfill as _bf
+
+    patches = [
+        patch.object(_bf, "_load_full_cache", return_value=price_data),
+        patch.object(
+            _bf, "_apply_daily_delta",
+            return_value=(price_data, []),
+        ),
+        patch.object(_bf, "_extract_macro_series", return_value={}),
+        patch.object(_bf, "_load_sector_map", return_value={}),
+        patch.object(_bf, "_load_cached_fundamentals", return_value={}),
+        patch.object(_bf, "_load_cached_alternative", return_value={}),
+        patch.object(
+            _bf, "_load_current_constituents",
+            return_value=set(constituents_set),
+        ),
+        patch.object(_bf, "boto3", MagicMock()),
+    ]
+    return patches
+
+
+def _enter_all(patches):
+    """Enter every patch and return the list of mock objects in order."""
+    return [p.__enter__() for p in patches]
+
+
+def _exit_all(patches):
+    for p in reversed(patches):
+        p.__exit__(None, None, None)
+
+
+def test_ticker_filter_returns_in_skip_list_error_for_skip_ticker():
+    """A ticker in _SKIP_TICKERS (and not promoted via _UNIVERSE_EXTRA)
+    is rejected as a config error, not silently as 'no data'. VIX is
+    in _SKIP_TICKERS but not _UNIVERSE_EXTRA."""
+    from builders.backfill import backfill
+
+    price_data = {"AAPL": _ohlcv("2026-04-01"), "VIX": _ohlcv("2026-04-01")}
+    patches = _stub_backfill_deps(
+        price_data=price_data,
+        constituents_set={"AAPL", "VIX"},  # even if "in constituents", skip wins
+    )
+    _enter_all(patches)
+    try:
+        result = backfill(
+            bucket="test-bucket",
+            ticker_filter="VIX",
+            dry_run=False,
+        )
+    finally:
+        _exit_all(patches)
+
+    assert result["status"] == "error"
+    assert result["error"] == "ticker_in_skip_list: VIX"
+
+
+def test_ticker_filter_returns_sector_etf_error_for_sector_etf():
+    """A ticker matching the _SECTOR_ETF_PREFIXES (XL*) is rejected with
+    its own dedicated error code."""
+    from builders.backfill import backfill
+
+    price_data = {"AAPL": _ohlcv("2026-04-01"), "XLF": _ohlcv("2026-04-01")}
+    patches = _stub_backfill_deps(
+        price_data=price_data,
+        constituents_set={"AAPL", "XLF"},
+    )
+    _enter_all(patches)
+    try:
+        result = backfill(
+            bucket="test-bucket",
+            ticker_filter="XLF",
+            dry_run=False,
+        )
+    finally:
+        _exit_all(patches)
+
+    assert result["status"] == "error"
+    assert result["error"] == "ticker_is_sector_etf: XLF"
+
+
+def test_ticker_filter_returns_no_data_error_when_parquet_missing():
+    """A ticker that has no row in price_data (parquet absent / empty)
+    returns ticker_no_data — distinguishes a transient S3/data fault
+    from a config-drift fault."""
+    from builders.backfill import backfill
+
+    price_data = {"AAPL": _ohlcv("2026-04-01")}  # NVDA missing
+    patches = _stub_backfill_deps(
+        price_data=price_data,
+        constituents_set={"AAPL", "NVDA"},
+    )
+    _enter_all(patches)
+    try:
+        result = backfill(
+            bucket="test-bucket",
+            ticker_filter="NVDA",
+            dry_run=False,
+        )
+    finally:
+        _exit_all(patches)
+
+    assert result["status"] == "error"
+    assert result["error"] == "ticker_no_data: NVDA"
+
+
+def test_ticker_filter_returns_not_in_constituents_error_for_pstg_case():
+    """The 2026-05-27 PSTG case verbatim: PSTG has parquet data (the
+    chronic-gap self-heal JUST wrote it) but PSTG is no longer in the
+    current constituents set. New ticker_not_in_constituents code names
+    the config-drift cause so an operator sees it directly."""
+    from builders.backfill import backfill
+
+    price_data = {
+        "AAPL": _ohlcv("2026-04-01"),
+        "PSTG": _ohlcv("2026-04-01"),
+    }
+    patches = _stub_backfill_deps(
+        price_data=price_data,
+        constituents_set={"AAPL"},  # PSTG NOT in constituents — the bug case
+    )
+    _enter_all(patches)
+    try:
+        result = backfill(
+            bucket="test-bucket",
+            ticker_filter="PSTG",
+            dry_run=False,
+        )
+    finally:
+        _exit_all(patches)
+
+    assert result["status"] == "error"
+    assert result["error"] == "ticker_not_in_constituents: PSTG"

--- a/tests/test_chronic_gap_constituents_drift.py
+++ b/tests/test_chronic_gap_constituents_drift.py
@@ -1,0 +1,193 @@
+"""Regression tests for `weekly_collector._detect_chronic_gap_constituents_drift`.
+
+Mirrors `_detect_chronic_gap_polygon_recovery` on the inverse axis. The
+polygon-recovery detector catches "polygon now serves this — remove from
+allowlist"; this detector catches "ticker no longer a constituent —
+remove from allowlist".
+
+Origin: 2026-05-27 flow-doctor ERROR "Ticker PSTG not found in universe".
+PSTG dropped from S&P 500/400 constituents between the 5/16 and 5/23
+weekly partitions but stayed in the chronic_polygon_gaps allowlist;
+MorningEnrich's chronic-gap self-heal yfinance-backfilled PSTG.parquet
+then called ``backfill(ticker_filter='PSTG')``, which hard-erred
+against the constituents filter at ``builders/backfill.py``. This
+detector is the GATE that closes the loop so a config that lags a
+constituents change becomes a WARN + skip instead of a hard ERROR.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _patch_constituents_loader(constituents_set, weekly_date="2026-05-23"):
+    """Patch the shared constituents loader to return the given set + date."""
+    return patch(
+        "builders._constituents_loader.load_constituents_for_run_date",
+        return_value=(set(constituents_set), weekly_date),
+    )
+
+
+def test_constituents_drift_no_drop_returns_full_list():
+    """Steady-state happy path: every chronic ticker is still a
+    constituent; nothing dropped, CW metric emits 0."""
+    from weekly_collector import _detect_chronic_gap_constituents_drift
+
+    cw = MagicMock()
+    s3 = MagicMock()
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        with _patch_constituents_loader(
+            constituents_set={"AAPL", "MSFT", "BF-B", "PSTG"},
+            weekly_date="2026-05-16",
+        ):
+            result = _detect_chronic_gap_constituents_drift(
+                bucket="test-bucket",
+                chronic_tickers=["BF-B", "PSTG"],
+            )
+
+    assert result["status"] == "ok"
+    assert result["chronic_tickers_checked"] == 2
+    assert sorted(result["still_constituents"]) == ["BF-B", "PSTG"]
+    assert result["dropped_non_constituent"] == []
+    assert result["weekly_date"] == "2026-05-16"
+    cw.put_metric_data.assert_called_once()
+    metric = cw.put_metric_data.call_args.kwargs["MetricData"][0]
+    assert metric["MetricName"] == "chronic_gap_non_constituent_count"
+    assert metric["Value"] == 0.0
+
+
+def test_constituents_drift_drops_non_constituent_pstg():
+    """The 2026-05-27 PSTG case verbatim: PSTG no longer in constituents
+    set (5/23 partition); detector drops it; remaining chronic ticker
+    proceeds; CW metric emits 1."""
+    from weekly_collector import _detect_chronic_gap_constituents_drift
+
+    cw = MagicMock()
+    s3 = MagicMock()
+    # 5/23 constituents: AAPL/MSFT/BF-B in, PSTG OUT
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        with _patch_constituents_loader(
+            constituents_set={"AAPL", "MSFT", "BF-B"},
+            weekly_date="2026-05-23",
+        ):
+            result = _detect_chronic_gap_constituents_drift(
+                bucket="test-bucket",
+                chronic_tickers=["BF-B", "PSTG"],
+            )
+
+    assert result["status"] == "ok"
+    assert result["still_constituents"] == ["BF-B"]
+    assert result["dropped_non_constituent"] == ["PSTG"]
+    assert result["weekly_date"] == "2026-05-23"
+    metric = cw.put_metric_data.call_args.kwargs["MetricData"][0]
+    assert metric["MetricName"] == "chronic_gap_non_constituent_count"
+    assert metric["Value"] == 1.0
+
+
+def test_constituents_drift_drops_all_chronic_tickers():
+    """Pathological case: every chronic ticker has dropped. Returned
+    still_constituents list is empty; caller's self-heal then becomes
+    a no-op (no yfinance fetch, no backfill call)."""
+    from weekly_collector import _detect_chronic_gap_constituents_drift
+
+    cw = MagicMock()
+    s3 = MagicMock()
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        with _patch_constituents_loader(
+            constituents_set={"AAPL", "MSFT"},
+            weekly_date="2026-05-30",
+        ):
+            result = _detect_chronic_gap_constituents_drift(
+                bucket="test-bucket",
+                chronic_tickers=["BF-B", "PSTG"],
+            )
+
+    assert result["status"] == "ok"
+    assert result["still_constituents"] == []
+    assert sorted(result["dropped_non_constituent"]) == ["BF-B", "PSTG"]
+    metric_value = cw.put_metric_data.call_args.kwargs["MetricData"][0]["Value"]
+    assert metric_value == 2.0
+
+
+def test_constituents_drift_empty_chronic_list_is_noop():
+    """No chronic tickers configured → no S3 read, no metric emit."""
+    from weekly_collector import _detect_chronic_gap_constituents_drift
+
+    cw = MagicMock()
+    s3 = MagicMock()
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        result = _detect_chronic_gap_constituents_drift(
+            bucket="test-bucket",
+            chronic_tickers=[],
+        )
+
+    assert result["status"] == "ok"
+    assert result["chronic_tickers_checked"] == 0
+    assert result["still_constituents"] == []
+    assert result["dropped_non_constituent"] == []
+    cw.put_metric_data.assert_not_called()
+
+
+def test_constituents_drift_falls_through_on_read_failure():
+    """Best-effort: a constituents read failure logs a WARN and returns
+    status='skipped' with the FULL chronic list as still_constituents.
+    The caller's self-heal proceeds with the original list and the
+    existing backfill-side hard-err remains the load-bearing surface."""
+    from weekly_collector import _detect_chronic_gap_constituents_drift
+
+    cw = MagicMock()
+    s3 = MagicMock()
+
+    def _raise_on_load(*_args, **_kwargs):
+        raise RuntimeError("simulated S3 read failure")
+
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        with patch(
+            "builders._constituents_loader.load_constituents_for_run_date",
+            side_effect=_raise_on_load,
+        ):
+            result = _detect_chronic_gap_constituents_drift(
+                bucket="test-bucket",
+                chronic_tickers=["BF-B", "PSTG"],
+            )
+
+    assert result["status"] == "skipped"
+    # Crucial: still_constituents preserves the FULL list on failure so
+    # the caller falls back to the pre-drift-detection behavior.
+    assert sorted(result["still_constituents"]) == ["BF-B", "PSTG"]
+    assert result["dropped_non_constituent"] == []
+    assert len(result["errors"]) == 1
+    # No CW emit on the skipped path — it's an observability metric;
+    # missing-data is the right CW shape for an upstream substrate fault.
+    cw.put_metric_data.assert_not_called()
+
+
+def test_constituents_drift_metric_emit_failure_does_not_raise():
+    """Best-effort metric emit: if CW put_metric_data fails, the
+    detector still returns the filter result without raising. The
+    drift filter result is the primary deliverable; CW emit is
+    observability hung off it."""
+    from weekly_collector import _detect_chronic_gap_constituents_drift
+
+    cw = MagicMock()
+    cw.put_metric_data.side_effect = RuntimeError("CW emit failed")
+    s3 = MagicMock()
+    with patch("weekly_collector.boto3.client",
+               side_effect=lambda svc: s3 if svc == "s3" else cw):
+        with _patch_constituents_loader(
+            constituents_set={"AAPL", "BF-B"},
+            weekly_date="2026-05-23",
+        ):
+            result = _detect_chronic_gap_constituents_drift(
+                bucket="test-bucket",
+                chronic_tickers=["BF-B", "PSTG"],
+            )
+
+    # Filter logic still landed despite CW failure.
+    assert result["status"] == "ok"
+    assert result["still_constituents"] == ["BF-B"]
+    assert result["dropped_non_constituent"] == ["PSTG"]

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -621,6 +621,127 @@ def _detect_chronic_gap_polygon_recovery(
     return summary
 
 
+def _detect_chronic_gap_constituents_drift(
+    bucket: str,
+    chronic_tickers: list[str],
+) -> dict:
+    """Drift alarm: detect when a chronic_polygon_gaps allowlist ticker has
+    dropped out of the current S&P 500/400 constituents set.
+
+    Pairs with ``_self_heal_chronic_polygon_gaps`` and serves as the GATE
+    on its inputs — non-constituent tickers are filtered out before any
+    yfinance fetch or ``backfill(ticker_filter=...)`` call so the heal
+    path never hands a non-constituent ticker to the constituents-filtered
+    backfill writer (which hard-errs per ``builders/backfill.py``).
+
+    Mirrors :func:`_detect_chronic_gap_polygon_recovery` on the inverse
+    axis. The polygon-recovery detector catches the "polygon now serves
+    this — remove from allowlist" direction; this detector catches the
+    "ticker no longer a constituent — remove from allowlist" direction.
+
+    Origin: 2026-05-27 flow-doctor ERROR "Ticker PSTG not found in
+    universe" — PSTG dropped from S&P 500/400 constituents between the
+    5/16 and 5/23 weekly partitions (REMOVED cohort = {BK, FLO, PSTG};
+    see config private-docs/ROADMAP.md L1772) but stayed in the
+    chronic_polygon_gaps allowlist. MorningEnrich yfinance-backfilled
+    PSTG.parquet then called ``backfill(ticker_filter='PSTG')``, which
+    hard-erred against the constituents filter. The polygon-recovery
+    drift detector was the existing axis; this is the missing inverse
+    axis.
+
+    Reads the current constituents via the shared chokepoint
+    :func:`builders._constituents_loader.load_constituents_for_run_date`
+    (no ``run_date`` argument → pointer-following ad-hoc read, which is
+    the correct read for a MorningEnrich-time check between Saturday SFs).
+
+    Emits a CloudWatch gauge
+    ``AlphaEngine/Data/chronic_gap_non_constituent_count`` for alarming.
+
+    Best-effort: a constituents read failure logs a WARN and returns
+    ``status='skipped'`` with the full chronic list as ``still_constituents``
+    so the caller falls through to the existing behavior (the original
+    hard-err at backfill is then the load-bearing surface). Never raises.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"|"skipped", "chronic_tickers_checked": int,
+           "still_constituents": list[str], "dropped_non_constituent": list[str],
+           "weekly_date": str|None, "errors": list[dict]}``
+    """
+    summary: dict = {
+        "status": "ok",
+        "chronic_tickers_checked": len(chronic_tickers),
+        "still_constituents": list(chronic_tickers),
+        "dropped_non_constituent": [],
+        "weekly_date": None,
+        "errors": [],
+    }
+    if not chronic_tickers:
+        return summary
+
+    try:
+        from builders._constituents_loader import load_constituents_for_run_date
+        s3 = boto3.client("s3")
+        constituents_set, weekly_date = load_constituents_for_run_date(s3, bucket)
+        summary["weekly_date"] = weekly_date
+    except Exception as exc:
+        logger.warning(
+            "chronic-gap constituents-drift check: could not load current "
+            "constituents — drift gate skipped this cycle, all %d chronic "
+            "ticker(s) will proceed to self-heal. %s",
+            len(chronic_tickers), exc,
+        )
+        summary["status"] = "skipped"
+        summary["errors"].append({"reason": str(exc)})
+        return summary
+
+    still: list[str] = []
+    dropped: list[str] = []
+    for ticker in chronic_tickers:
+        if ticker in constituents_set:
+            still.append(ticker)
+        else:
+            dropped.append(ticker)
+
+    summary["still_constituents"] = still
+    summary["dropped_non_constituent"] = dropped
+
+    if dropped:
+        logger.warning(
+            "chronic-gap constituents drift detected: %d chronic_polygon_gaps "
+            "ticker(s) no longer in current constituents (%s, weekly=%s): %s. "
+            "These will be SKIPPED by self-heal — prune from "
+            "alpha-engine-config/data/config.yaml chronic_polygon_gaps.tickers "
+            "to silence this WARN.",
+            len(dropped), bucket, weekly_date, dropped,
+        )
+    else:
+        logger.info(
+            "chronic-gap constituents drift: %d of %d chronic tickers still "
+            "in current constituents (weekly=%s) — allowlist coherent.",
+            len(still), len(chronic_tickers), weekly_date,
+        )
+
+    try:
+        cw = boto3.client("cloudwatch")
+        cw.put_metric_data(
+            Namespace="AlphaEngine/Data",
+            MetricData=[{
+                "MetricName": "chronic_gap_non_constituent_count",
+                "Value": float(len(dropped)),
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:
+        logger.warning(
+            "chronic_gap_non_constituent_count metric emit failed: %s — "
+            "drift alarm cadence may degrade until next cycle.", exc,
+        )
+
+    return summary
+
+
 def _self_heal_chronic_polygon_gaps(
     bucket: str,
     target_date: str,
@@ -1030,6 +1151,29 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
         except Exception as e:
             logger.warning("Chronic-gap drift detection failed (non-blocking): %s", e)
             results["collectors"]["chronic_gap_drift_detection"] = {
+                "status": "skipped",
+                "error": str(e),
+            }
+
+        # Drift GATE: filter out chronic tickers that have dropped out of
+        # the current constituents set. The heal path ends in
+        # ``backfill(ticker_filter=...)``, which hard-errs against the
+        # constituents filter for non-constituents (2026-05-27 PSTG
+        # flow-doctor alert origin). Filtering here closes the loop so a
+        # config that lags a constituents change becomes a WARN + skip
+        # instead of a hard ERROR. Best-effort — a read failure falls
+        # through with the original list and the existing backfill-side
+        # error remains the load-bearing surface.
+        try:
+            cdrift_result = _detect_chronic_gap_constituents_drift(
+                bucket=bucket,
+                chronic_tickers=chronic_tickers,
+            )
+            results["collectors"]["chronic_gap_constituents_drift"] = cdrift_result
+            chronic_tickers = cdrift_result["still_constituents"]
+        except Exception as e:
+            logger.warning("Chronic-gap constituents drift check failed (non-blocking): %s", e)
+            results["collectors"]["chronic_gap_constituents_drift"] = {
                 "status": "skipped",
                 "error": str(e),
             }


### PR DESCRIPTION
## Summary

Pairs with alpha-engine-config PR #330 (drop PSTG from chronic_polygon_gaps). Closes the substrate gap that surfaced the **2026-05-27** flow-doctor ERROR:

```
Severity: ERROR
Time: 2026-05-27T13:09:31.343795
Source: data-collector
Message: Ticker PSTG not found in universe (no data or in skip list)
```

Root cause: PSTG dropped from S&P 500/400 constituents between the 5/16 and 5/23 weekly partitions (`REMOVED = {BK, FLO, PSTG}`; alpha-engine-config private-docs/ROADMAP.md L1772) but stayed in the `chronic_polygon_gaps.tickers` allowlist. `_self_heal_chronic_polygon_gaps` yfinance-backfilled `predictor/price_cache/PSTG.parquet`, then called `backfill(ticker_filter='PSTG')`, which hard-erred against the constituents filter at `builders/backfill.py:488`.

The existing `_detect_chronic_gap_polygon_recovery` already covers the "polygon now serves this — remove from allowlist" axis. The inverse axis ("ticker no longer a constituent — remove from allowlist") was the gap.

## Changes

### 1. `_detect_chronic_gap_constituents_drift` (new) — `weekly_collector.py`

GATE on `chronic_polygon_gaps` inputs:

- Reads current constituents via the shared `builders._constituents_loader.load_constituents_for_run_date` chokepoint (no `run_date` arg → pointer-following ad-hoc read; correct shape for MorningEnrich-time between Saturday SFs).
- Returns `{still_constituents, dropped_non_constituent, weekly_date}`.
- WARNs + emits CW gauge `AlphaEngine/Data/chronic_gap_non_constituent_count` for any non-constituent so an alarm can fire if `> 0` across consecutive cycles.
- Wired into `_run_morning_enrich` **before** the self-heal — non-constituent chronic tickers are dropped from the heal list, so no yfinance fetch + no `backfill(ticker_filter=...)` call + no hard ERROR.
- Best-effort: a constituents read failure logs a WARN and falls through with the **full** chronic list as `still_constituents`. The pre-fix backfill-side hard-err then remains the load-bearing surface — observability does not weaken safety.
- Mirrors `_detect_chronic_gap_polygon_recovery` (same function shape, sibling-named on the inverse axis).

### 2. `backfill.py:486–543` — ticker_filter error split

Split the previously single ``\"no data or in skip list\"`` error into four named error codes so an operator (or future CW alarm) can distinguish a **config-drift** fault from a **transient data** fault:

| Code | Cause |
|---|---|
| `ticker_in_skip_list` | Ticker in `_SKIP_TICKERS`, not promoted via `_UNIVERSE_EXTRA` (config issue) |
| `ticker_is_sector_etf` | Ticker matches `_SECTOR_ETF_PREFIXES` (config issue) |
| `ticker_no_data` | Parquet missing or empty (transient — likely upstream collector fault) |
| `ticker_not_in_constituents` | Ticker has data but is not in current constituents (**the 2026-05-27 PSTG case**) |

## Tests

10 new tests (all pass):

- `tests/test_chronic_gap_constituents_drift.py` (6) — no-drop happy path, PSTG drop case, all-drop case, empty-list noop, S3-read-failure fall-through, CW-emit-failure tolerance.
- `tests/test_backfill_ticker_filter_error_split.py` (4) — one per error code with the PSTG case named verbatim.

Full suite: **1567 passed, 1 skipped** (no regressions).

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Chronic ticker still a constituent | self-heal yfinance + backfill | unchanged |
| Chronic ticker dropped from constituents | yfinance fetch + parquet write + backfill HARD-ERR + alert | WARN + CW gauge + skip self-heal entirely |
| `backfill(ticker_filter=X)` X in skip list | `ticker_not_found: X` | `ticker_in_skip_list: X` |
| `backfill(ticker_filter=X)` X is sector ETF | `ticker_not_found: X` | `ticker_is_sector_etf: X` |
| `backfill(ticker_filter=X)` no parquet | `ticker_not_found: X` | `ticker_no_data: X` |
| `backfill(ticker_filter=X)` X not in constituents | `ticker_not_found: X` | `ticker_not_in_constituents: X` |

## Composes with

- [[feedback_no_silent_fails]] — named recording surfaces + diagnostic error codes per ``~/Development/CLAUDE.md`` rule.
- [[feedback_lift_invariants_to_chokepoint_after_second_recurrence]] — current scope keeps the drift gate in-repo; if a second consumer of `chronic_polygon_gaps` (or any other allowlist) needs the same constituents-drift check, lift to `alpha_engine_lib`.
- Existing `_constituents_loader` chokepoint (data #294, #302) — this PR is the first new consumer of the lifted reader.
- alpha-engine-config PR #330 — companion drop of PSTG from the allowlist; this PR closes the substrate gap so a future similar config lag becomes a WARN, not an ERROR.

## Test plan

- [x] 10 new tests pass
- [x] Full data suite 1567 passed / 1 skipped
- [x] No silent-fail violations: every new error path WARNs + records to summary + emits CW metric where applicable
- [ ] First MorningEnrich firing post-merge (against the merged alpha-engine-config #330 + the empty `tickers: {}` allowlist): expect `chronic_gap_constituents_drift.chronic_tickers_checked: 0` (no-op)
- [ ] If a future S&P partition removes a chronic_polygon_gaps ticker before the allowlist update: verify `chronic_gap_non_constituent_count` CW gauge fires and the heal becomes a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)