### PR TITLE
feat(daily_append): wire universe_writer_lock at top of daily_append (L286b)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.33.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.38.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -561,6 +561,36 @@ def _load_daily_closes(s3, bucket: str, date_str: str) -> dict[str, dict]:
     return records
 
 
+_LOCK_ENV_VAR = "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED"
+
+
+def _writer_lock_enabled(dry_run: bool) -> bool:
+    """True if the producer-side writer lock should fire for this call.
+
+    Default-OFF rollout: ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED`` must
+    be explicitly set to a truthy value. ``dry_run`` always bypasses the
+    lock because dry-run paths do not write to ArcticDB — locking them
+    would block legitimate concurrent dry-runs (e.g. operator inspection
+    while the Saturday SF is running).
+    """
+    if dry_run:
+        return False
+    return os.environ.get(_LOCK_ENV_VAR, "").lower() in ("1", "true", "yes")
+
+
+def _build_writer_id() -> str:
+    """Compose a process-identifying writer_id for the lock body.
+
+    Pattern: ``daily_append-{user}-pid{pid}``. The user and pid let the
+    operator recognize the holder when inspecting the lock object
+    (``aws s3 cp s3://alpha-engine-research/locks/universe-writer.lock -``)
+    or reading a ``LockHeldByAnotherWriterError`` from a failed
+    acquisition.
+    """
+    user = os.environ.get("USER", "unknown")
+    return f"daily_append-{user}-pid{os.getpid()}"
+
+
 def daily_append(
     date_str: str | None = None,
     bucket: str = DEFAULT_BUCKET,
@@ -576,6 +606,23 @@ def daily_append(
     2. Append today's OHLCV row
     3. Compute features for the combined series
     4. Extract the last row (today) and append to ArcticDB
+
+    **Producer-side write-coordination lock.** When
+    ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED=true`` is in the
+    environment, this function acquires the
+    :func:`alpha_engine_lib.locks.universe_writer_lock` at the top of
+    the call and releases it on exit. The lock closes the
+    manual-invocation half of the single-writer-per-resource invariant
+    (forensic / backfill / dev shells running ``python -m
+    builders.daily_append`` that bypass the SF entirely). The SF-entry
+    half lives in the L274 MutualExclusionGuard (DynamoDB-side).
+    Default-OFF for safe rollout — flip the env var to ``true`` after
+    one clean weekday + Saturday cycle. ``dry_run=True`` always bypasses
+    the lock (read-only path, no race surface).
+
+    On lock contention, :exc:`alpha_engine_lib.locks.LockHeldByAnotherWriterError`
+    propagates to the caller — fail-loud per
+    ``~/Development/CLAUDE.md``'s no-silent-fails rule.
 
     Parameters
     ----------
@@ -615,6 +662,42 @@ def daily_append(
         the expected set.
 
     Returns summary dict.
+    """
+    if _writer_lock_enabled(dry_run):
+        from alpha_engine_lib.locks import universe_writer_lock
+
+        with universe_writer_lock(writer_id=_build_writer_id()):
+            return _daily_append_impl(
+                date_str=date_str,
+                bucket=bucket,
+                dry_run=dry_run,
+                skip_if_exists=skip_if_exists,
+                expected_tickers=expected_tickers,
+            )
+    return _daily_append_impl(
+        date_str=date_str,
+        bucket=bucket,
+        dry_run=dry_run,
+        skip_if_exists=skip_if_exists,
+        expected_tickers=expected_tickers,
+    )
+
+
+def _daily_append_impl(
+    date_str: str | None = None,
+    bucket: str = DEFAULT_BUCKET,
+    dry_run: bool = False,
+    skip_if_exists: bool = False,
+    expected_tickers: list[str] | None = None,
+) -> dict:
+    """Inner implementation of :func:`daily_append`.
+
+    Single-writer-lock semantics are provided by the outer
+    :func:`daily_append` wrapper; this function performs the actual
+    OHLCV + features write to ArcticDB. Callers should invoke
+    :func:`daily_append`, not this. Exists separately so the lock
+    wrap is a tiny diff and the existing 800-line body stays
+    structurally unchanged.
     """
     s3 = boto3.client("s3")
     date_str = date_str or datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,10 @@ arcticdb>=6.11
 # ``collectors/nlp/event_extraction.py``'s news-article event-extraction
 # LLM calls into the cost-telemetry stream (highest-volume previously-
 # untracked site at ~100–300 Haiku calls/wk during RAGIngestion).
+# v0.38.0 adds the ``locks`` submodule
+# (``universe_writer_lock`` S3-conditional-PUT primitive) consumed by
+# ``builders/daily_append.py`` for the producer-side single-writer
+# invariant (ROADMAP L286). Gated default-OFF via
+# ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.33.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.38.0

--- a/tests/test_daily_append_writer_lock.py
+++ b/tests/test_daily_append_writer_lock.py
@@ -1,0 +1,291 @@
+"""Pin the universe_writer_lock wire-up in builders/daily_append.py.
+
+Origin: ROADMAP L286b — closes the producer-side half of the same
+single-writer-per-resource invariant the L274 SF MutualExclusionGuard
+(DynamoDB-side) covers at the SF entry point. Without this lock, an
+operator-launched manual ``python -m builders.daily_append`` run would
+race the SF-driven path at ArcticDB exactly like the 2026-05-26
+dup-EB-target incident (321 unique-symbol
+``E_NON_INCREASING_INDEX_VERSION`` races, 35.6% error rate, missed
+trading day).
+
+The lock is **default-OFF** via
+``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED`` for safe rollout — these
+tests pin both polarities:
+
+* env unset (default) → lock NOT acquired; ``_daily_append_impl``
+  called directly (existing behavior, byte-identical to v0.37 lib pin)
+* env truthy → lock IS acquired; impl called inside the ``with`` block
+* ``dry_run=True`` always bypasses the lock regardless of env
+
+Composes with the alpha-engine-lib v0.38.0 ``locks`` module's own unit
+tests (acquire / release / TTL recovery / contention). This file pins
+the integration shape: the wire-up calls the lib API correctly.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from builders import daily_append as daily_append_module
+
+
+@pytest.fixture
+def stub_impl():
+    """Replace ``_daily_append_impl`` with a MagicMock so the wrapper's
+    routing is observable without exercising the 800-line body."""
+    with patch.object(
+        daily_append_module, "_daily_append_impl", return_value={"ok": True}
+    ) as stub:
+        yield stub
+
+
+@pytest.fixture
+def clear_lock_env(monkeypatch):
+    """Ensure the env var is unset at the start of each test."""
+    monkeypatch.delenv(
+        "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED", raising=False
+    )
+
+
+# ── Default-OFF semantics ────────────────────────────────────────────────
+
+
+class TestDefaultOffRollout:
+    def test_env_unset_does_not_acquire_lock(self, stub_impl, clear_lock_env):
+        """No env var → existing behavior. Impl is called WITHOUT going
+        through ``universe_writer_lock``; no boto3 S3 client is built
+        for the lock."""
+        with patch(
+            "alpha_engine_lib.locks.universe_writer_lock"
+        ) as mock_lock:
+            result = daily_append_module.daily_append(date_str="2026-05-27")
+        assert result == {"ok": True}
+        mock_lock.assert_not_called()
+        stub_impl.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "falsy_value", ["", "false", "False", "0", "no", "off", "disabled"]
+    )
+    def test_env_falsy_value_does_not_acquire_lock(
+        self, stub_impl, monkeypatch, falsy_value
+    ):
+        monkeypatch.setenv(
+            "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED", falsy_value
+        )
+        with patch(
+            "alpha_engine_lib.locks.universe_writer_lock"
+        ) as mock_lock:
+            daily_append_module.daily_append(date_str="2026-05-27")
+        mock_lock.assert_not_called()
+
+
+# ── Lock acquisition when enabled ────────────────────────────────────────
+
+
+class TestLockAcquisitionWhenEnabled:
+    @pytest.mark.parametrize("truthy_value", ["1", "true", "True", "yes", "YES"])
+    def test_env_truthy_acquires_lock_with_writer_id(
+        self, stub_impl, monkeypatch, truthy_value
+    ):
+        """Env truthy → wire-up calls
+        ``universe_writer_lock(writer_id=...)`` exactly once. The writer_id
+        format is pinned so operators inspecting the live lock body
+        recognize the holder shape."""
+        monkeypatch.setenv(
+            "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED", truthy_value
+        )
+        monkeypatch.setenv("USER", "testop")
+        with patch(
+            "alpha_engine_lib.locks.universe_writer_lock"
+        ) as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            daily_append_module.daily_append(date_str="2026-05-27")
+        mock_lock.assert_called_once()
+        kwargs = mock_lock.call_args.kwargs
+        assert "writer_id" in kwargs
+        assert kwargs["writer_id"].startswith("daily_append-testop-pid")
+
+    def test_impl_called_inside_lock_context(
+        self, stub_impl, monkeypatch
+    ):
+        """The lock's ``__enter__`` must precede ``_daily_append_impl``'s
+        call; ``__exit__`` must follow. Pins the with-block ordering so
+        a future refactor that moves the impl call OUTSIDE the with
+        block fails loud."""
+        monkeypatch.setenv(
+            "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED", "true"
+        )
+        calls: list[str] = []
+        with patch(
+            "alpha_engine_lib.locks.universe_writer_lock"
+        ) as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock(
+                side_effect=lambda: calls.append("enter") or MagicMock()
+            )
+            mock_lock.return_value.__exit__ = MagicMock(
+                side_effect=lambda *a: calls.append("exit") or False
+            )
+            stub_impl.side_effect = lambda **k: (
+                calls.append("impl") or {"ok": True}
+            )
+            daily_append_module.daily_append(date_str="2026-05-27")
+        assert calls == ["enter", "impl", "exit"]
+
+
+# ── dry_run bypass ───────────────────────────────────────────────────────
+
+
+class TestDryRunBypassesLock:
+    def test_dry_run_skips_lock_even_when_env_enabled(
+        self, stub_impl, monkeypatch
+    ):
+        """dry_run paths are read-only and must NEVER take the lock —
+        otherwise operator inspection during a live Saturday SF would
+        block on the running writer's lease."""
+        monkeypatch.setenv(
+            "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED", "true"
+        )
+        with patch(
+            "alpha_engine_lib.locks.universe_writer_lock"
+        ) as mock_lock:
+            daily_append_module.daily_append(
+                date_str="2026-05-27", dry_run=True
+            )
+        mock_lock.assert_not_called()
+
+
+# ── Arg forwarding ───────────────────────────────────────────────────────
+
+
+class TestArgForwarding:
+    def test_all_kwargs_passed_through_lock_path(
+        self, stub_impl, monkeypatch
+    ):
+        """Every public parameter MUST forward unchanged across the
+        wrapper. A regression that drops a kwarg (or swaps positional
+        order) silently changes behavior on the LOCK path only."""
+        monkeypatch.setenv(
+            "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED", "true"
+        )
+        with patch(
+            "alpha_engine_lib.locks.universe_writer_lock"
+        ) as mock_lock:
+            mock_lock.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+            daily_append_module.daily_append(
+                date_str="2026-05-27",
+                bucket="custom-bucket",
+                dry_run=False,
+                skip_if_exists=True,
+                expected_tickers=["AAPL", "MSFT"],
+            )
+        stub_impl.assert_called_once_with(
+            date_str="2026-05-27",
+            bucket="custom-bucket",
+            dry_run=False,
+            skip_if_exists=True,
+            expected_tickers=["AAPL", "MSFT"],
+        )
+
+    def test_all_kwargs_passed_through_no_lock_path(
+        self, stub_impl, clear_lock_env
+    ):
+        """Same coverage for the default-OFF code path — drop-a-kwarg
+        regressions must surface regardless of env-var state."""
+        daily_append_module.daily_append(
+            date_str="2026-05-27",
+            bucket="custom-bucket",
+            dry_run=False,
+            skip_if_exists=True,
+            expected_tickers=["AAPL", "MSFT"],
+        )
+        stub_impl.assert_called_once_with(
+            date_str="2026-05-27",
+            bucket="custom-bucket",
+            dry_run=False,
+            skip_if_exists=True,
+            expected_tickers=["AAPL", "MSFT"],
+        )
+
+
+# ── Lock-held propagation ────────────────────────────────────────────────
+
+
+class TestLockHeldPropagates:
+    def test_lock_held_error_propagates_to_caller(
+        self, stub_impl, monkeypatch
+    ):
+        """If the lib's lock acquisition raises
+        ``LockHeldByAnotherWriterError``, that exception MUST propagate
+        unchanged — per ``~/Development/CLAUDE.md`` no-silent-fails
+        rule. The wrapper does not catch / convert the exception."""
+        from alpha_engine_lib.locks import LockHeldByAnotherWriterError, LockHolder
+
+        monkeypatch.setenv(
+            "ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED", "true"
+        )
+        holder = LockHolder(
+            writer_id="other-writer",
+            started_at="2026-05-27T12:00:00Z",
+            ttl_epoch=9_999_999_999,
+            hostname="other-host",
+            pid=999,
+        )
+        with patch(
+            "alpha_engine_lib.locks.universe_writer_lock"
+        ) as mock_lock:
+            mock_lock.side_effect = LockHeldByAnotherWriterError(
+                holder, "s3://alpha-engine-research/locks/universe-writer.lock"
+            )
+            with pytest.raises(LockHeldByAnotherWriterError) as excinfo:
+                daily_append_module.daily_append(date_str="2026-05-27")
+        assert excinfo.value.holder.writer_id == "other-writer"
+        stub_impl.assert_not_called()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_writer_lock_enabled_dry_run_bypass(self):
+        # dry_run trumps even a truthy env var
+        with patch.dict(
+            os.environ,
+            {"ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED": "true"},
+        ):
+            assert (
+                daily_append_module._writer_lock_enabled(dry_run=True)
+                is False
+            )
+            assert (
+                daily_append_module._writer_lock_enabled(dry_run=False)
+                is True
+            )
+
+    def test_writer_lock_enabled_env_unset(self, clear_lock_env):
+        assert (
+            daily_append_module._writer_lock_enabled(dry_run=False)
+            is False
+        )
+
+    def test_build_writer_id_shape(self, monkeypatch):
+        monkeypatch.setenv("USER", "alice")
+        wid = daily_append_module._build_writer_id()
+        assert wid.startswith("daily_append-alice-pid")
+        # pid is an int suffix
+        pid_str = wid.rsplit("pid", 1)[1]
+        assert pid_str.isdigit()
+
+    def test_build_writer_id_handles_missing_user(self, monkeypatch):
+        monkeypatch.delenv("USER", raising=False)
+        wid = daily_append_module._build_writer_id()
+        assert "daily_append-unknown-pid" in wid


### PR DESCRIPTION
## Summary

Closes the producer-side half of the single-writer-per-resource invariant — the manual-invocation path that bypasses the SF entirely. Pairs with [alpha-engine-lib #79](https://github.com/cipher813/alpha-engine-lib/pull/79) (\`locks.universe_writer_lock\` v0.38.0) and the in-flight L274 SF MutualExclusionGuard (DynamoDB-side, entry-point coverage).

**Failure mode this closes:** a forensic / backfill / dev shell running \`python -m builders.daily_append\` while the Saturday SF is running would race the SF-driven path at ArcticDB exactly like the 2026-05-26 dup-EB-target incident did (321 \`E_NON_INCREASING_INDEX_VERSION\` races, 35.6% error rate, missed trading day). The lock now refuses the manual run with \`LockHeldByAnotherWriterError\` carrying the live holder shape so the operator sees who owns the lease.

## Implementation

- \`daily_append()\` is now a thin wrapper that conditionally acquires the lock then dispatches to \`_daily_append_impl()\` with the existing 800-line body unchanged.
- Gated **default-OFF** via \`ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED\` env var for safe rollout. Flip to \`true\` after one clean weekday + Saturday cycle.
- \`dry_run=True\` always bypasses the lock (read-only path, no race surface — operator inspection during a live SF must not block).
- \`LockHeldByAnotherWriterError\` propagates unchanged to the caller per \`~/Development/CLAUDE.md\`'s no-silent-fails rule.
- Lib pin bumped \`v0.33.0 → v0.38.0\` in BOTH \`requirements.txt\` and \`Dockerfile\` (lockstep test pins). Intermediate releases (v0.34 / v0.35 / v0.36 / v0.37) are all additive surface unused by ae-data.

## Tests (22 new)

| Class | Cases | What it pins |
|---|---|---|
| \`TestDefaultOffRollout\` | 8 | env unset / 7 falsy values → impl called directly, no lock |
| \`TestLockAcquisitionWhenEnabled\` | 6 | 5 truthy values acquire lock with writer_id format; impl called inside \`with\` block ordering |
| \`TestDryRunBypassesLock\` | 1 | \`dry_run=True\` skips lock even when env truthy |
| \`TestArgForwarding\` | 2 | every kwarg threads through both lock + no-lock paths |
| \`TestLockHeldPropagates\` | 1 | \`LockHeldByAnotherWriterError\` propagates unchanged |
| \`TestHelpers\` | 4 | \`_writer_lock_enabled\` / \`_build_writer_id\` shape pins |

Suite: 1596 → 1618 (+22).

## Operator notes

- **PyPI v0.38.0 publish failed** (description over 512 chars — fix in [lib PR #80](https://github.com/cipher813/alpha-engine-lib/pull/80), ships as v0.38.1). The **git tag v0.38.0 exists cleanly**, so this PR's \`git+https://...@v0.38.0\` pin resolves correctly. Pin bump to v0.38.1 will follow as a routine tag-bump PR after #80 merges.
- Activation: \`flyctl ssm set ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED=true\` on the dispatcher EC2 + Saturday SF spot env source after one clean cycle. Until then this PR is byte-identical to v0.37 behavior.

## Test plan

- [x] 22 new wire-up tests pass locally
- [x] \`test_lib_pin_lockstep\` passes (requirements.txt + Dockerfile both v0.38.0)
- [x] Full suite passes (1618 passed, 1 skipped)
- [x] Function-extract preserves all 800 lines of original body unchanged (diff is wrapper + rename only)
- [ ] On merge: deploy.yml rebuilds Lambda image with new lib pin
- [ ] Future PR flips the env var to \`true\` after one clean weekday + Saturday cycle

Composes with [[reference-eventbridge-target-uniqueness-invariant]], ROADMAP L274 (SF MutualExclusionGuard, DynamoDB-side), and [[feedback_lift_invariants_to_chokepoint_after_second_recurrence]].

🤖 Generated with [Claude Code](https://claude.com/claude-code)