### PR TITLE
fix(watchdog): add s3:ListBucket on _alerts/_dedup prefix (L295)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
+++ b/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
@@ -41,6 +41,20 @@
       "Effect": "Allow",
       "Action": ["s3:GetObject", "s3:PutObject"],
       "Resource": "arn:aws:s3:::alpha-engine-research/_alerts/_dedup/*"
+    },
+    {
+      "Sid": "DedupMarkerListBucket",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "_alerts/_dedup",
+            "_alerts/_dedup/*"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

\`alpha_engine_lib.alerts.publish\`'s S3-backed dedup uses HeadObject + conditional PUT semantics that require \`s3:ListBucket\` on the bucket itself (scoped via \`s3:prefix\` condition). The watchdog role previously had only \`s3:GetObject\` + \`s3:PutObject\` on the dedup-marker prefix; the missing ListBucket caused dedup probes to error with AccessDenied, and the lib's fail-safe-to-publish path correctly fired the alert anyway — but with dedup non-functional, every cron firing during a persistent outage re-paged the operator instead of collapsing under the 12h dedup window.

## Scoping

The grant is scoped by an \`s3:prefix\` Condition to \`_alerts/_dedup\` + \`_alerts/_dedup/*\` so the watchdog can't enumerate other prefixes on the bucket. Mirrors the alpha-engine-data [#327](https://github.com/cipher813/alpha-engine-data/pull/327) (L258) precedent where \`ArcticDBSmokeListBucket\` added the same Condition-scoped grant.

## Live state

Already applied via \`aws iam put-role-policy\` against \`alpha-engine-pipeline-watchdog-role\` — verified live. The deploy.sh re-applies the policy on every run, so the codified JSON is in lockstep with AWS.

## Test plan

- [x] IAM JSON validates as well-formed JSON
- [x] Live policy applied + verified (\`DedupMarkerListBucket\` Sid present with correct prefix Condition)
- [x] IAM drift check will pass on next run
- [ ] First post-merge watchdog cron firing's CW logs should NOT show \`dedup marker check errored\`
- [ ] Subsequent firings on a persistent simulated outage should dedup correctly (no re-pages within the 12h window)

ROADMAP L295 (P2, 2026-05-26 PM audit finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)