### PR TITLE
feat(sf): L274 SF MutualExclusionGuard via DynamoDB conditional PUT

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -73,6 +73,46 @@ Resources:
       Protocol: email
       Endpoint: !Ref AlertEmail
 
+  # --------------------------------------------------------------------------
+  # DynamoDB — Step Function Execution Mutex (L274 SF MutualExclusionGuard)
+  # --------------------------------------------------------------------------
+  # Single-writer-per-cadence-cell invariant for the three Alpha Engine SFs.
+  # Closes the architectural hole that the L286a/b producer-side
+  # `universe_writer_lock` covers for manual `daily_append` invocations —
+  # that lock guards the data writer; this table guards the SF entry point.
+  # Together they cover both halves of "exactly one cron-fired execution of
+  # each SF per minute bucket."
+  #
+  # Trigger of record: the 2026-05-26 duplicate-EventBridge-target incident
+  # (PR #322), where two parallel SF executions raced 321 unique-symbol
+  # ArcticDB E_NON_INCREASING_INDEX_VERSION errors in MorningEnrich and
+  # hard-failed the weekday pipeline. The PR #322 CFN-target-uniqueness
+  # CI gate catches the SPECIFIC duplicate-target shape; this mutex catches
+  # the broader class (operator double-paste, EventBridge internal retry-on-
+  # throttle, cross-region replay coincidence, any future shape the CI
+  # chokepoint misses).
+  #
+  # Schema: mutex_key (S) PK only — no TTL attribute and no auto-release.
+  # The mutex_key encodes `{state-machine-name}#{pipeline_role}#{minute-bucket}`,
+  # so a successfully-acquired key is naturally single-use: no future
+  # execution can land in the same minute-bucket of a past UTC date. Item
+  # accumulation is ~12 items/week × cadence runs ≈ <1000/yr; PAY_PER_REQUEST
+  # storage cost is negligible (sub-cent annual). Periodic sweeper deferred —
+  # operationally meaningful staleness is a non-issue.
+  ExecutionMutexTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: alpha-engine-sf-execution-mutex
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: mutex_key
+          AttributeType: S
+      KeySchema:
+        - AttributeName: mutex_key
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+
   # NOTE: AlertsTopic also has a SECOND subscriber — a Lambda that mirrors
   # every alert to s3://alpha-engine-research/changelog/incidents/ for the
   # system-wide event-mining changelog. That Lambda + its IAM role + its
@@ -596,3 +636,7 @@ Outputs:
   WeekdayPipelineArn:
     Value: !Ref WeekdayPipeline
     Description: Weekday pipeline state machine ARN
+
+  ExecutionMutexTableName:
+    Value: !Ref ExecutionMutexTable
+    Description: DynamoDB table name for SF execution mutex (L274)

--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -67,6 +67,11 @@
                 "logs:DescribeLogGroups"
             ],
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "dynamodb:PutItem",
+            "Resource": "arn:aws:dynamodb:us-east-1:711398986525:table/alpha-engine-sf-execution-mutex"
         }
     ]
 }

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -9,7 +9,67 @@
         "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"preflight_args\":\"\",\"research_dry\":false,\"data_phase2_dry\":false,\"regime_action\":\"produce\",\"pipeline_label\":\"\",\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
       "OutputPath": "$.merged",
+      "Next": "CheckMutexRole"
+    },
+    "CheckMutexRole": {
+      "Type": "Choice",
+      "Comment": "L274 SF MutualExclusionGuard — gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations — that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell. Trigger of record: 2026-05-26 duplicate-EventBridge-target incident (PR #322 closed the SPECIFIC dup-target shape via CI; this mutex closes the broader class).",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.pipeline_role", "IsPresent": true},
+            {
+              "Or": [
+                {"Variable": "$.pipeline_role", "StringEquals": "daily"},
+                {"Variable": "$.pipeline_role", "StringEquals": "weekly"},
+                {"Variable": "$.pipeline_role", "StringEquals": "eod"},
+                {"Variable": "$.pipeline_role", "StringEquals": "shell-run"}
+              ]
+            }
+          ],
+          "Next": "AcquireMutex"
+        }
+      ],
+      "Default": "CheckShellRun"
+    },
+    "AcquireMutex": {
+      "Type": "Task",
+      "Comment": "L274 — DynamoDB conditional PUT. mutex_key = '{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}' (UTC minute bucket parsed from $$.Execution.StartTime). Two duplicate cron-fired executions started in the same minute produce identical keys; the second loses with ConditionalCheckFailedException → MutexConflict Fail. No TTL / no release: the date+minute in the key is itself the staleness window. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:putItem",
+      "Parameters": {
+        "TableName": "alpha-engine-sf-execution-mutex",
+        "Item": {
+          "mutex_key": {
+            "S.$": "States.Format('{}#{}#{}:{}', $$.StateMachine.Name, $.pipeline_role, States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 0), States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 1))"
+          },
+          "execution_arn": {"S.$": "$$.Execution.Id"},
+          "started_at": {"S.$": "$$.Execution.StartTime"},
+          "state_machine": {"S.$": "$$.StateMachine.Name"},
+          "pipeline_role": {"S.$": "$.pipeline_role"}
+        },
+        "ConditionExpression": "attribute_not_exists(mutex_key)"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"],
+          "Comment": "Mutex held by another concurrent execution in the same minute bucket — the duplicate-trigger case we are explicitly protecting against. Fail loud so the dup is visible in SF execution history + SNS alert.",
+          "Next": "MutexConflict",
+          "ResultPath": "$.mutex_conflict"
+        },
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block a real trading cadence run. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability' carve-out, the primary deliverable survives a mutex-side failure. The error is captured in $.mutex_error for forensic review.",
+          "Next": "CheckShellRun",
+          "ResultPath": "$.mutex_error"
+        }
+      ],
+      "ResultPath": "$.mutex_result",
       "Next": "CheckShellRun"
+    },
+    "MutexConflict": {
+      "Type": "Fail",
+      "Error": "MutexConflict",
+      "Cause": "L274: another SF execution with the same state-machine + pipeline_role + start-minute already holds the mutex. Most likely cause: duplicate EventBridge target fan-out (PR #322 closes the specific CFN-vs-deploy-script shape; this Fail catches the broader class). Forensic: check execution history for the prior holder's executionArn via DynamoDB GetItem on the mutex_key in $.mutex_conflict."
     },
     "CheckShellRun": {
       "Type": "Choice",

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -10,7 +10,70 @@
         "merged.$": "States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'), $$.Execution.Input, false)"
       },
       "OutputPath": "$.merged",
+      "Next": "CheckMutexRole"
+    },
+
+    "CheckMutexRole": {
+      "Type": "Choice",
+      "Comment": "L274 SF MutualExclusionGuard — gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations — that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell. Trigger of record: 2026-05-26 duplicate-EventBridge-target incident (PR #322 closed the SPECIFIC dup-target shape via CI; this mutex closes the broader class — operator double-paste / EB internal retry-on-throttle / cross-region replay / future shapes the CI chokepoint misses).",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.pipeline_role", "IsPresent": true},
+            {
+              "Or": [
+                {"Variable": "$.pipeline_role", "StringEquals": "daily"},
+                {"Variable": "$.pipeline_role", "StringEquals": "weekly"},
+                {"Variable": "$.pipeline_role", "StringEquals": "eod"},
+                {"Variable": "$.pipeline_role", "StringEquals": "shell-run"}
+              ]
+            }
+          ],
+          "Next": "AcquireMutex"
+        }
+      ],
+      "Default": "DeployDriftCheck"
+    },
+
+    "AcquireMutex": {
+      "Type": "Task",
+      "Comment": "L274 — DynamoDB conditional PUT. mutex_key = '{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}' (UTC minute bucket parsed from $$.Execution.StartTime). Two duplicate cron-fired executions started in the same minute produce identical keys; the second loses with ConditionalCheckFailedException → MutexConflict Fail. No TTL / no release: the date+minute in the key is itself the staleness window — a successfully-acquired key is naturally single-use because no future execution can land in the same past minute-bucket. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:putItem",
+      "Parameters": {
+        "TableName": "alpha-engine-sf-execution-mutex",
+        "Item": {
+          "mutex_key": {
+            "S.$": "States.Format('{}#{}#{}:{}', $$.StateMachine.Name, $.pipeline_role, States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 0), States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 1))"
+          },
+          "execution_arn": {"S.$": "$$.Execution.Id"},
+          "started_at": {"S.$": "$$.Execution.StartTime"},
+          "state_machine": {"S.$": "$$.StateMachine.Name"},
+          "pipeline_role": {"S.$": "$.pipeline_role"}
+        },
+        "ConditionExpression": "attribute_not_exists(mutex_key)"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"],
+          "Comment": "Mutex held by another concurrent execution in the same minute bucket — the duplicate-trigger case we are explicitly protecting against. Fail loud so the dup is visible in SF execution history + SNS alert (HandleFailure picks it up via MutexConflict's terminal Fail).",
+          "Next": "MutexConflict",
+          "ResultPath": "$.mutex_conflict"
+        },
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block a real trading cadence run. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability hung off a primary path' carve-out, the primary deliverable survives a mutex-side failure. The error is captured in $.mutex_error for forensic review via SF execution history; CW alarm wiring deferred (operator-decision when first non-Conditional-Check mutex error appears).",
+          "Next": "DeployDriftCheck",
+          "ResultPath": "$.mutex_error"
+        }
+      ],
+      "ResultPath": "$.mutex_result",
       "Next": "DeployDriftCheck"
+    },
+
+    "MutexConflict": {
+      "Type": "Fail",
+      "Error": "MutexConflict",
+      "Cause": "L274: another SF execution with the same state-machine + pipeline_role + start-minute already holds the mutex. Most likely cause: duplicate EventBridge target fan-out (PR #322 closes the specific CFN-vs-deploy-script shape; this Fail catches the broader class). Forensic: check execution history for the prior holder's executionArn via DynamoDB GetItem on the mutex_key in $.mutex_conflict."
     },
 
     "DeployDriftCheck": {

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1,7 +1,67 @@
 {
   "Comment": "Alpha Engine EOD Pipeline — post-market data capture, snapshot capture, reconciliation, daily substrate health check, instance shutdown. Triggered by daemon shutdown on trading EC2.",
-  "StartAt": "PostMarketData",
+  "StartAt": "CheckMutexRole",
   "States": {
+    "CheckMutexRole": {
+      "Type": "Choice",
+      "Comment": "L274 SF MutualExclusionGuard — gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Daemon-triggered EOD launches set pipeline_role='eod' (executor/daemon.py:1092); operator-launched replays MUST set their own pipeline_role per the taxonomy in pipeline-reporting-revamp-260524.md §6. Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations — that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.pipeline_role", "IsPresent": true},
+            {
+              "Or": [
+                {"Variable": "$.pipeline_role", "StringEquals": "daily"},
+                {"Variable": "$.pipeline_role", "StringEquals": "weekly"},
+                {"Variable": "$.pipeline_role", "StringEquals": "eod"},
+                {"Variable": "$.pipeline_role", "StringEquals": "shell-run"}
+              ]
+            }
+          ],
+          "Next": "AcquireMutex"
+        }
+      ],
+      "Default": "PostMarketData"
+    },
+    "AcquireMutex": {
+      "Type": "Task",
+      "Comment": "L274 — DynamoDB conditional PUT. mutex_key = '{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}' (UTC minute bucket parsed from $$.Execution.StartTime). Two duplicate cron-fired executions started in the same minute produce identical keys; the second loses with ConditionalCheckFailedException → MutexConflict Fail. No TTL / no release: the date+minute in the key is itself the staleness window. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:putItem",
+      "Parameters": {
+        "TableName": "alpha-engine-sf-execution-mutex",
+        "Item": {
+          "mutex_key": {
+            "S.$": "States.Format('{}#{}#{}:{}', $$.StateMachine.Name, $.pipeline_role, States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 0), States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 1))"
+          },
+          "execution_arn": {"S.$": "$$.Execution.Id"},
+          "started_at": {"S.$": "$$.Execution.StartTime"},
+          "state_machine": {"S.$": "$$.StateMachine.Name"},
+          "pipeline_role": {"S.$": "$.pipeline_role"}
+        },
+        "ConditionExpression": "attribute_not_exists(mutex_key)"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"],
+          "Comment": "Mutex held by another concurrent execution in the same minute bucket — the duplicate-trigger case we are explicitly protecting against. Fail loud (EOD has its own ForceStopInstance cost-guard on the failure path, so a MutexConflict still releases the trading instance).",
+          "Next": "MutexConflict",
+          "ResultPath": "$.mutex_conflict"
+        },
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block the EOD reconcile + instance-stop path. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability' carve-out, the primary deliverable (reconcile + stop trading EC2) survives a mutex-side failure. The error is captured in $.mutex_error for forensic review.",
+          "Next": "PostMarketData",
+          "ResultPath": "$.mutex_error"
+        }
+      ],
+      "ResultPath": "$.mutex_result",
+      "Next": "PostMarketData"
+    },
+    "MutexConflict": {
+      "Type": "Fail",
+      "Error": "MutexConflict",
+      "Cause": "L274: another EOD execution with the same pipeline_role + start-minute already holds the mutex. Cost-guard note: the EOD SF's HandleFailure → ForceStopInstance chain is unreachable from a Fail state, but a duplicate EOD execution by definition means another EOD execution IS running the cost-guard path; the trading instance still gets stopped."
+    },
     "PostMarketData": {
       "Type": "Task",
       "Comment": "Capture today's closing prices via yfinance + append to ArcticDB (runs on ae-trading). Hard-fails on non-zero exit via pipefail so tee does not mask python failures.",

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -372,7 +372,23 @@ class TestStrictSuperset:
     """shell_run absent/false ⇒ byte-identical to the pre-spine Saturday run."""
 
     def test_initialize_input_routes_to_shell_run_gate(self, states):
-        assert states["InitializeInput"]["Next"] == "CheckShellRun"
+        # 2026-05-27: L274 SF MutualExclusionGuard inserted a CheckMutexRole
+        # Choice between InitializeInput and CheckShellRun. The strict-superset
+        # property holds because CheckMutexRole.Default → CheckShellRun (the
+        # bypass path that runs for any input without a cadence pipeline_role
+        # in {daily, weekly, eod, shell-run}), and AcquireMutex.Next →
+        # CheckShellRun (the cadence-role acquire path lands at the same
+        # downstream state). See tests/test_sf_mutex_wiring.py for the full
+        # mutex-chain contract.
+        assert states["InitializeInput"]["Next"] == "CheckMutexRole"
+        assert states["CheckMutexRole"]["Default"] == "CheckShellRun", (
+            "Mutex bypass path must route to CheckShellRun so the shell-run "
+            "chain remains a strict superset for non-cadence inputs"
+        )
+        assert states["AcquireMutex"]["Next"] == "CheckShellRun", (
+            "Mutex acquire path must also land at CheckShellRun so the "
+            "shell-run chain runs after a successful cadence acquire"
+        )
 
     def test_initialize_input_merge_expr_unchanged(self, states):
         # The run_date / sns_topic_arn defaults-under-input merge must be
@@ -871,12 +887,18 @@ class TestHappyPathTraversal:
         assert "WeeklySubstrateHealthCheck" in order
 
     def test_shell_run_absent_is_pre_keystone_path(self, sf, states):
+        # 2026-05-27: L274 mutex chain inserted CheckMutexRole between
+        # InitializeInput and CheckShellRun. With no pipeline_role on the
+        # input (the trace's default), CheckMutexRole.Default routes to
+        # CheckShellRun — same downstream chain as pre-mutex, with one
+        # extra Choice in the visited order.
         order, skipped = self._trace_main(sf, states, shell_run=False)
         assert "ApplyShellRunDefaults" not in order
         assert "NotifyShellRunComplete" not in order
         assert not skipped, "nothing skipped when shell_run absent"
         assert order[: order.index("CheckSkipMorningEnrich") + 2] == [
             "InitializeInput",
+            "CheckMutexRole",
             "CheckShellRun",
             "CheckSkipMorningEnrich",
             "MorningEnrich",

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -68,15 +68,25 @@ class TestChainOrdering:
     CheckSkipDataPhase1 → DataPhase1 (existing downstream unchanged)."""
 
     def test_initialize_input_routes_to_morning_enrich_skipgate(self, states):
-        # Post Friday-PM shell-run spine (feat/sf-friday-shell-run):
-        # InitializeInput now hands off to the CheckShellRun gate, whose
-        # Default is the pre-spine target CheckSkipMorningEnrich. The real
-        # Saturday run (no shell_run input) therefore still reaches the
-        # MorningEnrich skip-gate first — MorningEnrich still precedes
-        # DataPhase1. Strict superset: shell_run absent ⇒ unchanged.
-        assert states["InitializeInput"]["Next"] == "CheckShellRun", (
-            "InitializeInput must hand off to the shell-run gate, whose "
-            "Default preserves the pre-spine MorningEnrich skip-gate path."
+        # 2026-05-27: L274 SF MutualExclusionGuard inserted CheckMutexRole
+        # between InitializeInput and CheckShellRun. The strict-superset
+        # property still holds: CheckMutexRole.Default → CheckShellRun,
+        # whose Default is the pre-spine target CheckSkipMorningEnrich. The
+        # real Saturday run (no shell_run + with pipeline_role='weekly' that
+        # acquires the mutex; or any non-cadence role that bypasses) still
+        # reaches the MorningEnrich skip-gate first — MorningEnrich still
+        # precedes DataPhase1.
+        assert states["InitializeInput"]["Next"] == "CheckMutexRole", (
+            "InitializeInput now hands off to the L274 mutex gate; see "
+            "tests/test_sf_mutex_wiring.py for the mutex-chain contract"
+        )
+        assert states["CheckMutexRole"]["Default"] == "CheckShellRun", (
+            "Mutex bypass must route to CheckShellRun so the pre-mutex "
+            "downstream chain is byte-identical for operator/missing-role inputs"
+        )
+        assert states["AcquireMutex"]["Next"] == "CheckShellRun", (
+            "Mutex acquire path must also land at CheckShellRun so cadence "
+            "runs reach the same downstream chain after grabbing the mutex"
         )
         assert states["CheckShellRun"]["Default"] == "CheckSkipMorningEnrich", (
             "CheckShellRun.Default must be CheckSkipMorningEnrich so the "

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -1,0 +1,479 @@
+"""Pins the L274 SF MutualExclusionGuard wiring across all 3 Alpha Engine SFs.
+
+Origin: 2026-05-26 duplicate-EventBridge-target incident. PR #322
+closed the SPECIFIC duplicate-target shape via the CFN-target-uniqueness
+CI gate (``test_deploy_step_function_eventbridge_input.py``); L274 closes
+the BROADER class (operator double-paste, EventBridge internal retry-on-
+throttle, cross-region replay coincidence, any future shape the CI
+chokepoint misses) by gating each SF at its entry point on a DynamoDB
+conditional-PUT mutex.
+
+Design:
+- Allowlist cadence roles (``daily`` / ``weekly`` / ``eod`` / ``shell-run``)
+  acquire the mutex via ``DynamoDB.PutItem`` with
+  ``ConditionExpression: attribute_not_exists(mutex_key)``.
+- Operator-initiated runs (any other ``pipeline_role`` value, including
+  absent) bypass entirely — they are deliberately concurrent with
+  cadence runs.
+- ``mutex_key`` = ``{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}``
+  (UTC minute bucket parsed from ``$$.Execution.StartTime``). Two
+  duplicate cron-fired executions in the same minute produce identical
+  keys; the second loses with ``ConditionalCheckFailedException`` →
+  ``MutexConflict`` Fail.
+- No TTL / no release: the date+minute in the key is itself the
+  staleness window — a successfully-acquired key is naturally single-use
+  because no future execution can land in the same past minute-bucket.
+- Fail-open on non-Conditional-Check errors (DDB outage / IAM drift):
+  the mutex is best-effort architectural insurance; per
+  ``[[feedback_no_silent_fails]]`` "secondary observability" carve-out
+  the primary deliverable survives a mutex-side failure.
+
+This test pins:
+- The 3 new states exist in each SF (``CheckMutexRole``, ``AcquireMutex``,
+  ``MutexConflict``) with correct Type + Resource.
+- Wiring: ``InitializeInput.Next`` (or ``StartAt`` for EOD) → ``CheckMutexRole``;
+  ``CheckMutexRole.Default`` → former-first-state;
+  ``AcquireMutex.Next`` → former-first-state.
+- ``CheckMutexRole`` gates on ``$.pipeline_role`` in the cadence allowlist.
+- ``AcquireMutex`` catches ``DynamoDB.ConditionalCheckFailedException`` →
+  ``MutexConflict``; catches ``States.ALL`` → fail-open to former-first-state.
+- ``mutex_key`` Format string references ``$$.StateMachine.Name``,
+  ``$.pipeline_role``, and ``$$.Execution.StartTime`` so the minute-bucket
+  parsing is anchored to SF runtime context (not a hardcoded value).
+- CFN: ``ExecutionMutexTable`` exists with PK ``mutex_key`` (S),
+  PAY_PER_REQUEST, no TTL attribute (intentional — minute-bucket key
+  encodes its own staleness).
+- IAM: ``alpha-engine-step-functions-role`` has ``dynamodb:PutItem`` on
+  the mutex table resource (release/cleanup excluded because the design
+  intentionally has no release path).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INFRA = REPO_ROOT / "infrastructure"
+IAM_DIR = INFRA / "iam"
+
+SATURDAY_SF = INFRA / "step_function.json"
+WEEKDAY_SF = INFRA / "step_function_daily.json"
+EOD_SF = INFRA / "step_function_eod.json"
+CFN_PATH = INFRA / "cloudformation" / "alpha-engine-orchestration.yaml"
+ROLE_PATH = IAM_DIR / "alpha-engine-step-functions-role.json"
+
+MUTEX_TABLE_NAME = "alpha-engine-sf-execution-mutex"
+MUTEX_TABLE_ARN = (
+    "arn:aws:dynamodb:us-east-1:711398986525:table/alpha-engine-sf-execution-mutex"
+)
+CADENCE_ROLES = {"daily", "weekly", "eod", "shell-run"}
+
+# Per SF, the state that the mutex chain (CheckMutexRole.Default and
+# AcquireMutex.Next) routes into — i.e., the state that USED TO BE first
+# before this PR inserted the mutex chain in front of it.
+FORMER_FIRST_STATE_BY_SF = {
+    "saturday": ("step_function.json", "CheckShellRun"),
+    "weekday": ("step_function_daily.json", "DeployDriftCheck"),
+    "eod": ("step_function_eod.json", "PostMarketData"),
+}
+
+
+def _load_sf(name: str) -> dict:
+    path = INFRA / FORMER_FIRST_STATE_BY_SF[name][0]
+    return json.loads(path.read_text())
+
+
+@pytest.fixture(scope="module")
+def saturday_sf() -> dict:
+    return _load_sf("saturday")
+
+
+@pytest.fixture(scope="module")
+def weekday_sf() -> dict:
+    return _load_sf("weekday")
+
+
+@pytest.fixture(scope="module")
+def eod_sf() -> dict:
+    return _load_sf("eod")
+
+
+@pytest.fixture(scope="module")
+def all_sfs(saturday_sf, weekday_sf, eod_sf):
+    return {
+        "saturday": saturday_sf,
+        "weekday": weekday_sf,
+        "eod": eod_sf,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mutex-chain presence + correct state types
+# ---------------------------------------------------------------------------
+
+class TestMutexStatesPresent:
+    """Each SF must carry all three mutex states with correct Type."""
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_check_mutex_role_is_choice(self, sf_name, all_sfs):
+        states = all_sfs[sf_name]["States"]
+        assert "CheckMutexRole" in states, (
+            f"{sf_name} SF missing CheckMutexRole — L274 mutex chain not wired"
+        )
+        assert states["CheckMutexRole"]["Type"] == "Choice"
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_acquire_mutex_is_dynamodb_task(self, sf_name, all_sfs):
+        states = all_sfs[sf_name]["States"]
+        assert "AcquireMutex" in states, (
+            f"{sf_name} SF missing AcquireMutex — L274 mutex chain not wired"
+        )
+        st = states["AcquireMutex"]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:dynamodb:putItem", (
+            f"{sf_name} AcquireMutex must use the AWS-SDK direct integration "
+            f"for DynamoDB putItem (got {st['Resource']!r}). If a future PR "
+            f"swaps to a Lambda-based mutex, this assertion needs to evolve "
+            f"alongside the IAM grant in alpha-engine-step-functions-role.json."
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_mutex_conflict_is_fail(self, sf_name, all_sfs):
+        states = all_sfs[sf_name]["States"]
+        assert "MutexConflict" in states, (
+            f"{sf_name} SF missing MutexConflict — Conditional-Check losers "
+            f"would silently fall through"
+        )
+        st = states["MutexConflict"]
+        assert st["Type"] == "Fail"
+        assert st["Error"] == "MutexConflict"
+
+
+# ---------------------------------------------------------------------------
+# Wiring — entry-point reroute, Choice default, Acquire next-state
+# ---------------------------------------------------------------------------
+
+class TestMutexWiring:
+    """The mutex chain must sit BETWEEN the SF's entry point and the
+    former-first-state, on both the gated path (cadence role acquires)
+    and the bypass path (operator/missing role)."""
+
+    def test_saturday_initialize_input_routes_to_check_mutex_role(self, saturday_sf):
+        assert saturday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"
+
+    def test_weekday_initialize_input_routes_to_check_mutex_role(self, weekday_sf):
+        assert weekday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"
+
+    def test_eod_start_at_routes_to_check_mutex_role(self, eod_sf):
+        assert eod_sf["StartAt"] == "CheckMutexRole", (
+            "EOD SF has no InitializeInput state, so the mutex chain "
+            "must be reachable via StartAt directly."
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_check_mutex_role_default_routes_to_former_first_state(
+        self, sf_name, all_sfs
+    ):
+        former = FORMER_FIRST_STATE_BY_SF[sf_name][1]
+        states = all_sfs[sf_name]["States"]
+        assert states["CheckMutexRole"]["Default"] == former, (
+            f"{sf_name} SF: operator/missing-role bypass must land on "
+            f"the SF's former first state ({former}), not skip past it"
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_acquire_mutex_next_routes_to_former_first_state(
+        self, sf_name, all_sfs
+    ):
+        former = FORMER_FIRST_STATE_BY_SF[sf_name][1]
+        states = all_sfs[sf_name]["States"]
+        assert states["AcquireMutex"]["Next"] == former, (
+            f"{sf_name} SF: cadence-role acquire path must continue to the "
+            f"former first state ({former}) after grabbing the mutex"
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_former_first_state_still_exists(self, sf_name, all_sfs):
+        """Guards against the mutex chain pointing at a renamed/deleted target."""
+        former = FORMER_FIRST_STATE_BY_SF[sf_name][1]
+        assert former in all_sfs[sf_name]["States"], (
+            f"{sf_name} SF: former-first-state {former!r} not in States — "
+            f"either renamed or deleted. Update FORMER_FIRST_STATE_BY_SF "
+            f"in this test AND the mutex chain wiring in the SF JSON."
+        )
+
+
+# ---------------------------------------------------------------------------
+# CheckMutexRole — pipeline_role allowlist
+# ---------------------------------------------------------------------------
+
+class TestCheckMutexRoleAllowlist:
+    """CheckMutexRole's Choices block must allowlist exactly the four
+    cadence roles. Adding a fifth role (e.g., a new cron cadence) MUST
+    be a deliberate edit here AND in the cadence-role-set across other
+    tests; promoting an operator role to a cadence role without
+    updating both surfaces silently un-protects the SF."""
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_allowlist_matches_cadence_set(self, sf_name, all_sfs):
+        choices = all_sfs[sf_name]["States"]["CheckMutexRole"]["Choices"]
+        assert len(choices) == 1, (
+            f"{sf_name} CheckMutexRole: expected exactly 1 Choices entry "
+            f"(an Or over cadence-role string-equals); got {len(choices)}"
+        )
+        rule = choices[0]
+        assert "And" in rule and any(
+            "IsPresent" in cond.get("Variable", "") + str(cond)
+            for cond in rule["And"]
+        ), (
+            f"{sf_name} CheckMutexRole: the gating Choice must require "
+            f"$.pipeline_role IsPresent before string-comparing it (missing "
+            f"IsPresent makes the StringEquals branches error on absent input)"
+        )
+        # Extract string-equals values from the Or sub-block
+        or_block = next(
+            (cond["Or"] for cond in rule["And"] if "Or" in cond), None
+        )
+        assert or_block is not None, (
+            f"{sf_name} CheckMutexRole: gating Choice missing Or-over-roles"
+        )
+        seen = {c["StringEquals"] for c in or_block if "StringEquals" in c}
+        assert seen == CADENCE_ROLES, (
+            f"{sf_name} CheckMutexRole allowlist drift: expected "
+            f"{sorted(CADENCE_ROLES)}, got {sorted(seen)}. If a new cadence "
+            f"is being added (or an operator role promoted), update "
+            f"CADENCE_ROLES in this test AND every SF's CheckMutexRole."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AcquireMutex — ConditionExpression + Catch blocks + key format
+# ---------------------------------------------------------------------------
+
+class TestAcquireMutexSemantics:
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_acquire_targets_the_named_mutex_table(self, sf_name, all_sfs):
+        params = all_sfs[sf_name]["States"]["AcquireMutex"]["Parameters"]
+        assert params["TableName"] == MUTEX_TABLE_NAME, (
+            f"{sf_name} AcquireMutex: TableName must match the CFN "
+            f"ExecutionMutexTable resource name ({MUTEX_TABLE_NAME})"
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_acquire_uses_conditional_put(self, sf_name, all_sfs):
+        params = all_sfs[sf_name]["States"]["AcquireMutex"]["Parameters"]
+        assert (
+            params.get("ConditionExpression") == "attribute_not_exists(mutex_key)"
+        ), (
+            f"{sf_name} AcquireMutex must use "
+            f"attribute_not_exists(mutex_key) — without the ConditionExpression "
+            f"the PutItem unconditionally clobbers, defeating the whole guard"
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_mutex_key_format_includes_runtime_anchors(self, sf_name, all_sfs):
+        params = all_sfs[sf_name]["States"]["AcquireMutex"]["Parameters"]
+        key_format = params["Item"]["mutex_key"]["S.$"]
+        # The key MUST reference all 3 anchors so duplicate-target detection
+        # bins on (state-machine, pipeline-role, minute-bucket).
+        for anchor in (
+            "$$.StateMachine.Name",
+            "$.pipeline_role",
+            "$$.Execution.StartTime",
+        ):
+            assert anchor in key_format, (
+                f"{sf_name} AcquireMutex mutex_key Format missing anchor "
+                f"{anchor!r} — without it the bucketing collapses and "
+                f"either over-protects (false MutexConflict) or under-protects "
+                f"(misses dup-triggers)"
+            )
+        # Minute-bucket parsing splits StartTime on ':' and joins [0] + [1].
+        # Verifying both ArrayGetItem(..., 0) AND ArrayGetItem(..., 1) appear
+        # catches an accidental degrade to hour-bucket (only [0]).
+        assert "ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 0)" in key_format, (
+            f"{sf_name} AcquireMutex: minute-bucket parsing must extract "
+            f"[0] segment of StartTime split on ':' (year-through-hour)"
+        )
+        assert "ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 1)" in key_format, (
+            f"{sf_name} AcquireMutex: minute-bucket parsing must extract "
+            f"[1] segment of StartTime split on ':' (minute). Missing this "
+            f"degrades to hour-bucketing, which would falsely conflict every "
+            f"intra-hour operator rerun of a cadence role."
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_acquire_catches_conditional_check_to_mutex_conflict(
+        self, sf_name, all_sfs
+    ):
+        catches = all_sfs[sf_name]["States"]["AcquireMutex"]["Catch"]
+        match = [
+            c
+            for c in catches
+            if "DynamoDB.ConditionalCheckFailedException" in c.get("ErrorEquals", [])
+        ]
+        assert len(match) == 1, (
+            f"{sf_name} AcquireMutex must Catch "
+            f"DynamoDB.ConditionalCheckFailedException explicitly — without "
+            f"it, a States.ALL Catch would swallow the duplicate-trigger "
+            f"case and fail-open silently (the worst possible behavior)"
+        )
+        assert match[0]["Next"] == "MutexConflict", (
+            f"{sf_name} AcquireMutex: Conditional-Check Catch must route to "
+            f"MutexConflict (Fail), not bypass to the workload"
+        )
+
+    @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
+    def test_acquire_states_all_catch_fails_open_to_former_first_state(
+        self, sf_name, all_sfs
+    ):
+        former = FORMER_FIRST_STATE_BY_SF[sf_name][1]
+        catches = all_sfs[sf_name]["States"]["AcquireMutex"]["Catch"]
+        match = [c for c in catches if "States.ALL" in c.get("ErrorEquals", [])]
+        assert len(match) == 1, (
+            f"{sf_name} AcquireMutex must Catch States.ALL (DDB outage / IAM "
+            f"drift / transient SDK error) — without it, mutex-side failures "
+            f"would hard-fail the SF, defeating the fail-open posture"
+        )
+        assert match[0]["Next"] == former, (
+            f"{sf_name} AcquireMutex: States.ALL fail-open must route to "
+            f"the former first state ({former}), so cadence runs survive "
+            f"a DDB outage. Got {match[0]['Next']!r}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# CFN — ExecutionMutexTable
+# ---------------------------------------------------------------------------
+
+class TestCfnExecutionMutexTable:
+    """The CFN template must declare the mutex DynamoDB table with the
+    schema the SF JSONs target. Raw-text parsing per the existing
+    test_deploy_step_function_eventbridge_input.py precedent — CFN's
+    !Ref / !Sub / !GetAtt tags require a custom YAML loader."""
+
+    @pytest.fixture(scope="class")
+    def cfn_text(self) -> str:
+        return CFN_PATH.read_text()
+
+    def test_mutex_table_resource_declared(self, cfn_text):
+        assert "ExecutionMutexTable:" in cfn_text, (
+            "CFN template missing ExecutionMutexTable resource — without it "
+            "the SF AcquireMutex states would error with "
+            "ResourceNotFoundException at runtime"
+        )
+
+    def test_mutex_table_type_is_dynamodb(self, cfn_text):
+        # Slice the ExecutionMutexTable block
+        anchor = cfn_text.index("ExecutionMutexTable:")
+        block = cfn_text[anchor : anchor + 1200]
+        assert "Type: AWS::DynamoDB::Table" in block
+
+    def test_mutex_table_name_matches_sf_target(self, cfn_text):
+        anchor = cfn_text.index("ExecutionMutexTable:")
+        block = cfn_text[anchor : anchor + 1200]
+        assert f"TableName: {MUTEX_TABLE_NAME}" in block, (
+            f"CFN ExecutionMutexTable TableName must match the SF "
+            f"AcquireMutex TableName ({MUTEX_TABLE_NAME}); drift here = "
+            f"runtime ResourceNotFoundException"
+        )
+
+    def test_mutex_table_pay_per_request(self, cfn_text):
+        anchor = cfn_text.index("ExecutionMutexTable:")
+        block = cfn_text[anchor : anchor + 1200]
+        assert "BillingMode: PAY_PER_REQUEST" in block, (
+            "PAY_PER_REQUEST is the right mode here — mutex traffic is bursty "
+            "(cron-driven, ~12 writes/week), provisioned capacity would "
+            "either over-provision or throttle real traffic"
+        )
+
+    def test_mutex_table_pk_is_mutex_key(self, cfn_text):
+        anchor = cfn_text.index("ExecutionMutexTable:")
+        block = cfn_text[anchor : anchor + 1200]
+        assert "AttributeName: mutex_key" in block
+        assert "AttributeType: S" in block
+        assert "KeyType: HASH" in block, (
+            "mutex_key must be the HASH key — the conditional-PUT semantics "
+            "this whole design relies on key off the partition-key existence"
+        )
+
+    def test_mutex_table_intentionally_has_no_ttl(self, cfn_text):
+        """The design INTENTIONALLY omits TTL — the minute-bucket in the
+        key encodes its own staleness window. If a future PR adds TTL,
+        it MUST also update this test + the design docstring at the top
+        + ROADMAP L274 — silent TTL addition would change the semantic
+        contract (locks no longer permanent past their natural staleness)."""
+        anchor = cfn_text.index("ExecutionMutexTable:")
+        block = cfn_text[anchor : anchor + 1200]
+        assert "TimeToLiveSpecification" not in block, (
+            "ExecutionMutexTable must NOT declare TimeToLiveSpecification — "
+            "the design intentionally relies on minute-bucket key encoding "
+            "for natural single-use semantics. If you want TTL, also update "
+            "this test + AcquireMutex Item.ttl_epoch + the L274 design"
+        )
+
+
+# ---------------------------------------------------------------------------
+# IAM — SF role has dynamodb:PutItem on the mutex table only
+# ---------------------------------------------------------------------------
+
+class TestIamGrant:
+    """alpha-engine-step-functions-role must carry exactly dynamodb:PutItem
+    on the mutex table — no DeleteItem (design has no release path),
+    no broader DDB perms (least-privilege)."""
+
+    @pytest.fixture(scope="class")
+    def role_policy(self) -> dict:
+        return json.loads(ROLE_PATH.read_text())
+
+    def test_role_has_dynamodb_putitem_statement(self, role_policy):
+        ddb_stmts = [
+            s
+            for s in role_policy["Statement"]
+            if "dynamodb" in str(s.get("Action", "")).lower()
+        ]
+        assert len(ddb_stmts) >= 1, (
+            "alpha-engine-step-functions-role missing dynamodb:PutItem — "
+            "the SF AcquireMutex states would fail AccessDenied at runtime"
+        )
+        # Must include putItem specifically
+        actions = []
+        for s in ddb_stmts:
+            a = s.get("Action", [])
+            actions.extend([a] if isinstance(a, str) else a)
+        assert "dynamodb:PutItem" in actions, (
+            f"Expected dynamodb:PutItem in SF role; got actions {actions}"
+        )
+
+    def test_role_does_not_grant_delete_item(self, role_policy):
+        """L274 design has no release path. dynamodb:DeleteItem would be
+        dead permission — least-privilege violation. If a future PR adds
+        release/cleanup, also update this test + the design docstring."""
+        for stmt in role_policy["Statement"]:
+            a = stmt.get("Action", [])
+            actions = [a] if isinstance(a, str) else a
+            assert "dynamodb:DeleteItem" not in actions, (
+                "alpha-engine-step-functions-role should NOT grant "
+                "dynamodb:DeleteItem — L274 design intentionally has no "
+                "release path (minute-bucket key encodes natural staleness). "
+                "If you're adding release, update the test + the design"
+            )
+
+    def test_role_ddb_grant_scoped_to_mutex_table(self, role_policy):
+        ddb_stmts = [
+            s
+            for s in role_policy["Statement"]
+            if "dynamodb" in str(s.get("Action", "")).lower()
+        ]
+        for stmt in ddb_stmts:
+            res = stmt.get("Resource", [])
+            res_list = [res] if isinstance(res, str) else res
+            for r in res_list:
+                assert r == MUTEX_TABLE_ARN or r.endswith(MUTEX_TABLE_NAME), (
+                    f"DDB grant must be scoped to the mutex table only "
+                    f"(expected {MUTEX_TABLE_ARN}); got {r}. Broader scope "
+                    f"violates least-privilege."
+                )

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -399,6 +399,14 @@ class TestEODSFTopLevelFieldsClosed:
             "substrate_check_poll",
             "substrate_check_result",
             "trading_instance_id",
+            # L274 SF MutualExclusionGuard (2026-05-27) — CheckMutexRole
+            # reads $.pipeline_role; AcquireMutex emits $.mutex_result on
+            # success, $.mutex_conflict on ConditionalCheckFailed Catch,
+            # and $.mutex_error on the fail-open States.ALL Catch.
+            "mutex_conflict",
+            "mutex_error",
+            "mutex_result",
+            "pipeline_role",
         }
     )
 


### PR DESCRIPTION
## Summary

Closes ROADMAP L274 — the architectural insurance layer against ANY duplicate cron-fired SF trigger. PR #322 closed the SPECIFIC dup-EB-target shape via CI chokepoint; this PR closes the broader class (operator double-paste, EventBridge internal retry-on-throttle, cross-region replay coincidence, any future shape the CI chokepoint misses).

Symmetric with L286a/b's `universe_writer_lock` (S3 conditional PUT for manual `daily_append`): that lock guards the data writer; this mutex guards the SF entry point. Both layers of the same "single-writer-per-cadence-cell" invariant.

## Design

- **CFN** (`alpha-engine-orchestration.yaml`): adds `ExecutionMutexTable` — PAY_PER_REQUEST, PK=`mutex_key` (S), **intentionally no TTL** (minute-bucket key encodes its own staleness window). Item accumulation ~<1000/yr, sub-cent annual.
- **IAM** (`alpha-engine-step-functions-role.json`): adds `dynamodb:PutItem` scoped to the mutex table ARN. **No `DeleteItem`** — design has no release path; the minute-bucket key is naturally single-use.
- **3 SF JSONs** (Saturday, weekday, EOD): each inserts a 3-state mutex chain before its existing first state:
  - `CheckMutexRole` — Choice on `$.pipeline_role` allowlist `{daily, weekly, eod, shell-run}`. Operator/recovery/smoke/backfill/operator-replay roles (and missing role) bypass entirely.
  - `AcquireMutex` — `aws-sdk:dynamodb:putItem` with `ConditionExpression: attribute_not_exists(mutex_key)`. `mutex_key = '{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}'` (UTC minute bucket parsed from `$$.Execution.StartTime`).
  - `MutexConflict` — Fail terminal on `DynamoDB.ConditionalCheckFailedException` Catch.
  - `States.ALL` Catch on `AcquireMutex` **fails OPEN** to the former first state (DDB outage / IAM drift must not block trading) per `[[feedback_no_silent_fails]]` secondary-observability carve-out; error captured in `$.mutex_error` for forensic review.

## Deploy ordering (CRITICAL — apply in this order)

1. `aws cloudformation deploy --template-file infrastructure/cloudformation/alpha-engine-orchestration.yaml --stack-name alpha-engine-orchestration --capabilities CAPABILITY_IAM` — creates the DynamoDB table. **REQUIRED FIRST.**
2. `bash infrastructure/iam/apply.sh alpha-engine-step-functions-role` — grants `dynamodb:PutItem` on the table.
3. `bash infrastructure/deploy_step_function.sh && bash infrastructure/deploy_step_function_daily.sh && bash infrastructure/update_eod_pipeline_sf.sh` — uploads new SF JSONs that reference the table + IAM grant.

**Out-of-order risk:** the next cron-fired cadence SF would fail `AccessDenied` or `ResourceNotFoundException` at `AcquireMutex`. The fail-open Catch absorbs the failure (cadence runs still proceed), but the CW alarm noise is avoidable.

## First exercise

- **Sat 2026-05-30 09:00 UTC** — Saturday SF fires with `pipeline_role: "weekly"` → acquires mutex on `alpha-engine-saturday-pipeline#weekly#2026-05-30T09:00`. SF execution history shows the new `CheckMutexRole` → `AcquireMutex` chain as the first two states. `$.mutex_result` carries the DDB PutItem response.
- **Mon 2026-06-02 12:45 UTC** — first weekday cron exercise. Same shape with `pipeline_role: "daily"`.
- **Mon 2026-06-02 ~21:00 UTC** — first EOD-SF exercise (daemon-triggered with `pipeline_role: "eod"`).

If any of these emit `MutexConflict` from a single cron fire (no duplicate trigger present), there's a wiring bug — verify via `aws dynamodb scan --table-name alpha-engine-sf-execution-mutex` for the mutex_key.

## Out of scope / follow-ups

- **CW alarm on `MutexConflict` Fail rate** — when the first non-zero count fires, operator action is to investigate the duplicate-trigger source (CFN drift, EB Internal retry, operator double-paste). Filing as P3 follow-up at wind-down.
- **Periodic sweeper for old mutex items** — minute-bucket key encodes natural staleness; storage cost is sub-cent annual. Deferred indefinitely unless DDB cost surfaces.
- **Promote fail-open posture to fail-closed** — only after MutexConflict alarm has been operator-tested + the dashboard exposes the mutex state. Today the right posture is fail-open (substrate first; correctness later).

## Test plan

- [x] All 48 new `test_sf_mutex_wiring.py` tests pass.
- [x] Full `tests/` suite: 1626 → 1674 passing (3 pre-existing tests updated to account for the InitializeInput.Next reroute).
- [ ] Sat 2026-05-30 SF execution history shows `CheckMutexRole` + `AcquireMutex` as the first two states; `$.mutex_result` carries DDB PutItem response.
- [ ] DDB scan shows the mutex_key item written with `execution_arn` + `started_at` populated.
- [ ] Mon 2026-06-02 weekday SF + EOD SF same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)