### PR TITLE
fix(iam): grant gha-lambda-deploy OIDC role on alpha-engine-sf-execution-mutex (L274 hotfix)

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -302,6 +302,24 @@
           ]
         }
       }
+    },
+    {
+      "Sid": "InfraDeployMutexTable",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:UpdateTable",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource",
+        "dynamodb:ListTagsOfResource",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:UpdateContinuousBackups",
+        "dynamodb:DescribeTimeToLive",
+        "dynamodb:UpdateTimeToLive"
+      ],
+      "Resource": "arn:aws:dynamodb:us-east-1:711398986525:table/alpha-engine-sf-execution-mutex"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Hotfix for the post-merge `Deploy Infrastructure` failure on PR #332. The CFN stack rolled back at `CREATE_FAILED` on `ExecutionMutexTable` because the `github-actions-lambda-deploy` OIDC role used by CI lacks `dynamodb:DescribeTable` (+ siblings) needed to manage the new DynamoDB resource.

Root cause: CFN-managed DynamoDB tables are a first for this stack — every prior resource the OIDC role manages is in CFN, SNS, EventBridge, CloudWatch, Lambda, or Scheduler, all already covered by the existing Statements.

## Live state right after the rollback (mitigated by L274's fail-open design)

`deploy-infrastructure.sh` runs `aws stepfunctions update-state-machine` BEFORE the CFN deploy step, so the 3 cadence SF JSONs are live with the `CheckMutexRole` → `AcquireMutex` → `MutexConflict` chain pointing at a table that doesn't exist. The L274 `States.ALL` Catch (per `[[feedback_no_silent_fails]]` secondary-observability carve-out) routes around this — cadence runs still proceed via the fail-open path to the former first state, with the error captured in `$.mutex_error` for forensic review.

Net: trading runs aren't blocked; the noise is CW-only (an extra Catch entry in execution history) and only fires on the next cadence cron. After this PR merges + deploy-infrastructure retriggers cleanly, AcquireMutex acquires properly and `$.mutex_result` carries the DDB PutItem response on the happy path.

## Changes

New `InfraDeployMutexTable` Statement on `infrastructure/iam/github-actions-lambda-deploy.json` scoped to `arn:aws:dynamodb:us-east-1:711398986525:table/alpha-engine-sf-execution-mutex` with 11 actions covering CFN's create/update/describe/tag/continuous-backups/TTL-probe paths:

- `dynamodb:CreateTable`, `DescribeTable`, `DeleteTable`, `UpdateTable`
- `dynamodb:TagResource`, `UntagResource`, `ListTagsOfResource`
- `dynamodb:DescribeContinuousBackups`, `UpdateContinuousBackups`
- `dynamodb:DescribeTimeToLive`, `UpdateTimeToLive` (CFN probes these even when not configured)

Live-applied via `bash infrastructure/iam/apply.sh github-actions-lambda-deploy` (Brian-authorized); `check-drift.py` clean across all 3 codified roles.

## Test plan

- [x] `check-drift.py` clean on all roles (live AWS matches codified).
- [x] Codified JSON parses + Statement count incremented by 1.
- [ ] PR merge retriggers Deploy Infrastructure; CFN stack converges (UPDATE_COMPLETE); `aws dynamodb describe-table --table-name alpha-engine-sf-execution-mutex` returns the table.
- [ ] First cadence SF firing post-merge acquires mutex cleanly (`$.mutex_result` populated, NOT `$.mutex_error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)