### PR TITLE
feat(freshness-monitor): Phase 3 Lambda — every-15min absence-driven artifact probe

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-freshness-monitor Lambda,
+# wire its EventBridge cron, and upload the artifact registry from the
+# local alpha-engine-config clone to S3.
+#
+# Phase 3 of the artifact-freshness-monitor arc (plan doc at
+# ~/Development/alpha-engine-docs/private/artifact-freshness-monitor-260527.md).
+# Loads `private-docs/ARTIFACT_REGISTRY.yaml` from the operator's local
+# clone of cipher813/alpha-engine-config and uploads it to
+# s3://alpha-engine-research/_freshness_monitor/ARTIFACT_REGISTRY.yaml.
+# Validates the registry locally before upload — a malformed registry
+# never reaches S3.
+#
+# Managed outside CloudFormation — same rationale as sf-telegram-notifier /
+# spot-orphan-reaper / changelog-cloudwatch-mirror (keeps the
+# github-actions-lambda-deploy OIDC role's blast radius narrow;
+# operator-deployed only). Phase 6 cutover flips
+# MNEMON_FRESHNESS_MONITOR_ENABLED via
+# `aws lambda update-function-configuration` without redeploying.
+#
+# Usage:
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh             # update code + registry
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh --bootstrap # first-time create + wire EventBridge
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh --smoke     # invoke once after deploy
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-freshness-monitor"
+ROLE_NAME="alpha-engine-freshness-monitor-role"
+POLICY_NAME="alpha-engine-freshness-monitor-policy"
+RULE_NAME="alpha-engine-freshness-monitor-cron"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+# Registry SoT. The validator lives next to the YAML in alpha-engine-config;
+# we sanity-check the file parses + matches the lib's expected schema
+# before uploading.
+CONFIG_REPO="${CONFIG_REPO:-${HOME}/Development/alpha-engine-config}"
+REGISTRY_LOCAL="${CONFIG_REPO}/private-docs/ARTIFACT_REGISTRY.yaml"
+REGISTRY_VALIDATOR="${CONFIG_REPO}/scripts/validate_artifact_registry.py"
+REGISTRY_BUCKET="alpha-engine-research"
+REGISTRY_S3_KEY="_freshness_monitor/ARTIFACT_REGISTRY.yaml"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler syntax + run unit tests --------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 0b. Validate registry locally before upload --------------------------
+
+if [[ ! -f "${REGISTRY_LOCAL}" ]]; then
+  echo "❌ Registry not found at ${REGISTRY_LOCAL}"
+  echo "   Clone cipher813/alpha-engine-config into ~/Development/ or set CONFIG_REPO"
+  exit 1
+fi
+
+if [[ ! -f "${REGISTRY_VALIDATOR}" ]]; then
+  echo "❌ Validator not found at ${REGISTRY_VALIDATOR}"
+  echo "   alpha-engine-config must be at the post-PR-#344 commit (artifact-registry-bootstrap merged)"
+  exit 1
+fi
+
+echo "Validating registry locally before upload..."
+python3 "${REGISTRY_VALIDATOR}" --registry "${REGISTRY_LOCAL}"
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    # OBSERVE-mode default: MNEMON_FRESHNESS_MONITOR_ENABLED=false.
+    # Phase 6 cutover flips via update-function-configuration without
+    # redeploying. ≥2 weekly soak cycles before flip.
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 120 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,MNEMON_FRESHNESS_MONITOR_ENABLED=false}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge cron: every 15 minutes. Sub-15min granularity isn't
+  # load-bearing (alerts dedup by cadence window) — this is the floor
+  # for "operator-perceived" probe cadence.
+  echo "  Creating EventBridge cron: ${RULE_NAME}"
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --schedule-expression "cron(*/15 * * * ? *)" \
+    --description "Every 15min probe of the artifact freshness registry" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Upload registry to S3 ---------------------------------------------
+
+echo "Uploading registry: ${REGISTRY_LOCAL} → s3://${REGISTRY_BUCKET}/${REGISTRY_S3_KEY}"
+run aws s3 cp \
+  "${REGISTRY_LOCAL}" \
+  "s3://${REGISTRY_BUCKET}/${REGISTRY_S3_KEY}" \
+  --region "${REGION}"
+
+echo "✓ Registry uploaded."
+
+# ----- 5. Smoke (direct invoke) ---------------------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke..."
+  RESP=$(mktemp)
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{}' \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  echo "Lambda response:"
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -1,0 +1,45 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-freshness-monitor:*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    },
+    {
+      "Sid": "SnsPublishAlerts",
+      "Effect": "Allow",
+      "Action": ["sns:Publish"],
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    },
+    {
+      "Sid": "S3HeadAndReadProbe",
+      "Effect": "Allow",
+      "Action": ["s3:HeadObject", "s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/*"
+    },
+    {
+      "Sid": "S3WriteMonitorArtifacts",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*",
+        "arn:aws:s3:::alpha-engine-research/_alerts/_dedup/*"
+      ]
+    }
+  ]
+}

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -1,0 +1,365 @@
+"""alpha-engine-freshness-monitor — absence-driven S3 artifact monitor.
+
+Phase 3 of the artifact-freshness-monitor arc (plan doc at
+``~/Development/alpha-engine-docs/private/artifact-freshness-monitor-260527.md``).
+Closes the silent absence-of-artifact bug class — the 2026-05-17→27
+``pit_parity.json`` incident (load-bearing artifact silently absent
+for 11 days), the 2026-05-18 factor-profiles orphan, and the
+2026-05-23 missing-``signals.json`` incident are the sibling triggers.
+SF Catch / flow-doctor / substrate-health-check are all *event-driven*
+(failure → alert); this Lambda is the *absence-driven* complement
+(silence → alert).
+
+**Architecture.** EventBridge fires this Lambda every 15min. Per
+invocation:
+
+  1. Load the registry from S3
+     (``s3://{REGISTRY_BUCKET}/{REGISTRY_KEY}``, YAML).
+  2. Walk every spec. For each, call
+     :func:`alpha_engine_lib.artifact_freshness.check_freshness`
+     against the current ``now`` (UTC).
+  3. Aggregate results into a single ``check_results.json`` artifact
+     under ``_freshness_monitor/`` (the dashboard surface reads this).
+  4. Emit a self-heartbeat at ``_freshness_monitor/heartbeat.json``
+     — the monitor monitors itself; substrate-health-check daily
+     watches the heartbeat.
+  5. For misses past SLA (``state ∈ {missing, stale, probe_failed}``),
+     route to :func:`alpha_engine_lib.alerts.publish` with
+     ``dedup_key=resolve_dedup_key(spec, now)`` — dedup collapses
+     4×/hour retries to one alert per cycle per artifact.
+  6. **OBSERVE-mode gate**: when env
+     ``MNEMON_FRESHNESS_MONITOR_ENABLED`` is anything other than
+     ``"true"`` (case-insensitive), alerts are suppressed but the
+     check results and heartbeat are still emitted. Phase 6 cutover
+     flips the env var via ``aws lambda update-function-configuration``
+     without redeploying — mirrors the mnemon 0.7.0rc4 pattern.
+
+**Never raises.** Lambda failures cannot be silent (this monitor IS
+the silent-failure trap). The handler catches per-spec exceptions
+and records them in ``check_results.json`` so a bad registry entry
+doesn't take down the whole probe pass. The handler's own outer
+exception path is a CW Logs-level surface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import date, datetime, timezone
+from typing import Any
+
+import boto3
+import yaml
+
+from alpha_engine_lib.alerts import publish
+from alpha_engine_lib.artifact_freshness import (
+    ArtifactSpec,
+    CheckResult,
+    check_freshness,
+    resolve_dedup_key,
+)
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+
+# ── Configuration (env-driven so Phase 6 cutover is a single CLI flip) ──────
+
+REGISTRY_BUCKET = os.environ.get("REGISTRY_BUCKET", "alpha-engine-research")
+REGISTRY_KEY = os.environ.get(
+    "REGISTRY_KEY", "_freshness_monitor/ARTIFACT_REGISTRY.yaml"
+)
+HEARTBEAT_KEY = "_freshness_monitor/heartbeat.json"
+CHECK_RESULTS_KEY = "_freshness_monitor/check_results.json"
+
+# OBSERVE-mode gate. Plan §3 invariant 10 + §4 Phase 6 default. Anything
+# other than literal "true" (case-insensitive) suppresses alerts. Check
+# results + heartbeat are emitted regardless.
+ALERTS_ENABLED = (
+    os.environ.get("MNEMON_FRESHNESS_MONITOR_ENABLED", "false").lower() == "true"
+)
+
+# ArtifactSpec field set — used to strip extra YAML keys (e.g., the
+# top-level `defaults` shape carries `s3_bucket` which we want, but a
+# future schema extension would otherwise pollute the constructor).
+_SPEC_FIELDS = frozenset(
+    {
+        "artifact_id",
+        "s3_bucket",
+        "s3_key_template",
+        "cadence",
+        "sla_minutes_after_cron",
+        "severity",
+        "owner_repo",
+        "created_at",
+        "grace_period_cycles",
+        "recovery_key_template",
+        "calendar_aware",
+        "interval_minutes",
+    }
+)
+
+
+# ── Registry loader ─────────────────────────────────────────────────────────
+
+
+def _coerce_date(value: Any) -> date:
+    """YAML ``safe_load`` already returns ``datetime.date`` for ISO date
+    scalars; this is a defensive coercion for string inputs (e.g.,
+    when the registry is hand-built in a test fixture)."""
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+    raise TypeError(f"created_at must be date or ISO-string, got {type(value).__name__}")
+
+
+def load_registry(s3_client: Any, bucket: str, key: str) -> list[ArtifactSpec]:
+    """Fetch the registry from S3 and parse into :class:`ArtifactSpec`
+    instances. The YAML ``defaults`` block is merged into every entry
+    (per-entry keys override defaults).
+
+    Raises on YAML parse error or schema violation — the Lambda's outer
+    handler logs + re-raises so the failure surfaces in CW Logs +
+    Lambda error metrics (which Brian's existing CW alarms cover).
+    The registry's PR-time validator (alpha-engine-config
+    ``scripts/validate_artifact_registry.py``) is the prevent-it-at-PR
+    chokepoint; this is the runtime defense.
+    """
+    obj = s3_client.get_object(Bucket=bucket, Key=key)
+    body = obj["Body"].read()
+    data = yaml.safe_load(body)
+    if not isinstance(data, dict) or not data.get("artifacts"):
+        raise ValueError(f"registry at s3://{bucket}/{key} missing 'artifacts'")
+
+    defaults = data.get("defaults", {}) or {}
+    specs: list[ArtifactSpec] = []
+    for entry in data["artifacts"]:
+        merged = {**defaults, **entry}
+        merged["created_at"] = _coerce_date(merged["created_at"])
+        # Strip any extension fields (forward-compat with future schema).
+        spec_kwargs = {k: v for k, v in merged.items() if k in _SPEC_FIELDS}
+        specs.append(ArtifactSpec(**spec_kwargs))
+    return specs
+
+
+# ── Per-spec probe (catches per-spec errors so one bad row doesn't sink the pass) ─
+
+
+def _check_one(
+    s3_client: Any, spec: ArtifactSpec, now: datetime
+) -> tuple[CheckResult, Exception | None]:
+    """Wrap :func:`check_freshness` with a per-spec exception trap.
+
+    Returns ``(result, None)`` on success or
+    ``(synthesized_probe_failed_result, exc)`` on a per-spec error
+    (e.g., a malformed key template that fails ``str.format``,
+    a transient network blip the substrate didn't classify).
+    """
+    try:
+        return check_freshness(s3_client, spec, now), None
+    except Exception as exc:  # noqa: BLE001 — per-spec resilience
+        result = CheckResult(
+            state="probe_failed",
+            reason=f"per-spec exception: {type(exc).__name__}: {exc}",
+            canonical_key=spec.s3_key_template,
+        )
+        return result, exc
+
+
+# ── Aggregation + S3 emission ───────────────────────────────────────────────
+
+
+def _serialize_check_results(
+    pairs: list[tuple[ArtifactSpec, CheckResult]], now: datetime
+) -> dict[str, Any]:
+    """Build the ``check_results.json`` payload — one row per spec for
+    the dashboard surface (Phase 5)."""
+    rows = []
+    for spec, result in pairs:
+        rows.append(
+            {
+                "artifact_id": spec.artifact_id,
+                "owner_repo": spec.owner_repo,
+                "severity": spec.severity,
+                "cadence": spec.cadence,
+                "canonical_key": result.canonical_key,
+                "state": result.state,
+                "reason": result.reason,
+                "last_modified": (
+                    result.last_modified.isoformat()
+                    if result.last_modified is not None
+                    else None
+                ),
+                "sla_violated_by_minutes": result.sla_violated_by_minutes,
+                "recovery_substituted": result.recovery_substituted,
+            }
+        )
+    return {
+        "run_at": now.isoformat(),
+        "alerts_enabled": ALERTS_ENABLED,
+        "n_entries": len(rows),
+        "results": rows,
+    }
+
+
+def _serialize_heartbeat(
+    pairs: list[tuple[ArtifactSpec, CheckResult]],
+    now: datetime,
+    started_at_epoch: float,
+) -> dict[str, Any]:
+    """Build the ``heartbeat.json`` payload. Plan §3 invariant 9: the
+    monitor monitors itself; substrate-health-check daily SSM watches
+    this artifact's freshness. Self-registered in
+    ``ARTIFACT_REGISTRY.yaml`` as ``freshness_monitor_heartbeat``."""
+    counts: dict[str, int] = {
+        "fresh": 0,
+        "stale": 0,
+        "missing": 0,
+        "probe_failed": 0,
+        "grace_period": 0,
+    }
+    for _spec, result in pairs:
+        counts[result.state] = counts.get(result.state, 0) + 1
+
+    return {
+        "last_run": now.isoformat(),
+        "alerts_enabled": ALERTS_ENABLED,
+        "duration_seconds": round(time.time() - started_at_epoch, 3),
+        "n_entries_checked": len(pairs),
+        "counts": counts,
+    }
+
+
+def _put_json(s3_client: Any, bucket: str, key: str, payload: dict) -> None:
+    body = json.dumps(payload, indent=2, default=str).encode("utf-8")
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType="application/json",
+    )
+
+
+# ── Alerting (gated on ALERTS_ENABLED) ──────────────────────────────────────
+
+
+_ALERTING_STATES = frozenset({"missing", "stale", "probe_failed"})
+
+
+def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime) -> bool:
+    """Route an alert for a non-fresh probe result. Returns True if
+    publish was attempted (OBSERVE-mode short-circuit returns False).
+
+    Only fires when:
+      - ``result.state ∈ {missing, stale, probe_failed}``
+      - ``result.sla_violated_by_minutes > 0`` for missing/stale (give
+        the SLA grace window), OR ``probe_failed`` (no grace for
+        broken probes — operator needs to know immediately)
+      - :data:`ALERTS_ENABLED` is True
+
+    Dedup-key resolution via
+    :func:`alpha_engine_lib.artifact_freshness.resolve_dedup_key` ⇒
+    at most one alert per (artifact, cadence-window) regardless of
+    how many 15min probes have already fired in this window.
+    """
+    if result.state not in _ALERTING_STATES:
+        return False
+
+    # Substrate already filters fresh/grace; the SLA-grace filter
+    # mirrors the substrate's clip-at-zero arithmetic for
+    # missing/stale. probe_failed has no SLA — fire immediately.
+    if result.state in ("missing", "stale") and result.sla_violated_by_minutes == 0:
+        return False
+
+    if not ALERTS_ENABLED:
+        logger.info(
+            "OBSERVE-mode: would alert on %s state=%s reason=%r",
+            spec.artifact_id, result.state, result.reason,
+        )
+        return False
+
+    # Compose the alert body.
+    body = (
+        f"artifact_id={spec.artifact_id} "
+        f"owner_repo={spec.owner_repo} "
+        f"state={result.state} "
+        f"key={result.canonical_key} "
+        f"sla_violated_by_minutes={result.sla_violated_by_minutes} "
+        f"reason={result.reason}"
+    )
+    dedup_key = resolve_dedup_key(spec, now)
+
+    # Probe failures route to critical (the monitor itself is broken);
+    # missing/stale respect the spec's severity. Plan §3 invariant 6.
+    severity = "critical" if result.state == "probe_failed" else spec.severity
+
+    publish(
+        body,
+        severity=severity,
+        source="freshness-monitor",
+        dedup_key=dedup_key,
+        dedup_window_min=None,  # one alert per cadence window — substrate handles cycle bucketing
+    )
+    return True
+
+
+# ── Handler ─────────────────────────────────────────────────────────────────
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """EventBridge cron handler — every 15min walk the registry,
+    emit heartbeat + check_results, alert on misses past SLA."""
+    started_at = time.time()
+    now = datetime.now(timezone.utc)
+    s3 = boto3.client("s3")
+
+    logger.info(
+        "freshness-monitor invoked at %s (alerts_enabled=%s)",
+        now.isoformat(), ALERTS_ENABLED,
+    )
+
+    # Load registry. If THIS fails, we want the Lambda to error out
+    # so the CW alarm fires — a broken registry must not be silent.
+    specs = load_registry(s3, REGISTRY_BUCKET, REGISTRY_KEY)
+    logger.info("loaded %d specs from registry", len(specs))
+
+    # Walk and probe.
+    pairs: list[tuple[ArtifactSpec, CheckResult]] = []
+    alerted = 0
+    per_spec_exceptions = 0
+    for spec in specs:
+        result, exc = _check_one(s3, spec, now)
+        if exc is not None:
+            per_spec_exceptions += 1
+            logger.warning(
+                "per-spec exception for %s: %s", spec.artifact_id, exc,
+            )
+        pairs.append((spec, result))
+        if _maybe_alert(spec, result, now):
+            alerted += 1
+
+    # Emit dashboard surface + self-heartbeat.
+    check_results = _serialize_check_results(pairs, now)
+    heartbeat = _serialize_heartbeat(pairs, now, started_at)
+
+    _put_json(s3, REGISTRY_BUCKET, CHECK_RESULTS_KEY, check_results)
+    _put_json(s3, REGISTRY_BUCKET, HEARTBEAT_KEY, heartbeat)
+
+    logger.info(
+        "freshness-monitor complete: %s checked, %s alerted, %s per-spec exceptions, "
+        "duration=%.2fs",
+        heartbeat["n_entries_checked"], alerted, per_spec_exceptions,
+        heartbeat["duration_seconds"],
+    )
+
+    return {
+        "n_entries_checked": heartbeat["n_entries_checked"],
+        "counts": heartbeat["counts"],
+        "alerts_enabled": ALERTS_ENABLED,
+        "alerted": alerted,
+        "per_spec_exceptions": per_spec_exceptions,
+        "duration_seconds": heartbeat["duration_seconds"],
+    }

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,0 +1,5 @@
+# Pinned to alpha-engine-lib v0.40.0 (the artifact_freshness substrate
+# was introduced here). Bumping this is a substrate-change PR — not
+# something to do absent-mindedly during a code-only refresh.
+alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.40.0
+pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -1,0 +1,478 @@
+"""
+Unit tests for the freshness-monitor Lambda (``index.py``).
+
+Phase 3 of the artifact-freshness-monitor arc. Pins the Lambda-level
+contract: registry loading, per-spec exception isolation, heartbeat
++ check_results emission, OBSERVE-mode alert suppression, dedup-key
+threading, severity routing for probe_failed.
+
+Tests mock both ``boto3.client`` AND ``alpha_engine_lib.alerts.publish``
+so no live AWS or Telegram calls fire. The lib substrate
+(``check_freshness`` itself) is exercised through real code — only
+the S3 client is mocked, mirroring the substrate's own test pattern.
+
+See also: ``alpha-engine-lib/tests/test_artifact_freshness.py`` (the
+substrate's exhaustive 37-test suite) — this file does not duplicate
+those branches; it covers the Lambda-orchestration layer on top.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Make the Lambda handler importable.
+sys.path.insert(0, str(Path(__file__).parent))
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def yaml_registry_body() -> bytes:
+    """A small but representative registry — three rows covering the
+    canonical-fresh path, the missing path, and a continuous-cadence
+    heartbeat. created_at=2025-01-01 puts every row well past the
+    grace period."""
+    return b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+  grace_period_cycles: 2
+  calendar_aware: true
+  severity: warning
+artifacts:
+  - artifact_id: probe_fresh
+    s3_key_template: "path/{date}/fresh.json"
+    cadence: saturday_sf
+    sla_minutes_after_cron: 60
+    severity: warning
+    owner_repo: alpha-engine-test
+    created_at: 2025-01-01
+  - artifact_id: probe_missing
+    s3_key_template: "path/{date}/missing.json"
+    cadence: saturday_sf
+    sla_minutes_after_cron: 60
+    severity: critical
+    owner_repo: alpha-engine-test
+    created_at: 2025-01-01
+  - artifact_id: probe_heartbeat
+    s3_key_template: "_freshness_monitor/heartbeat.json"
+    cadence: continuous
+    interval_minutes: 15
+    sla_minutes_after_cron: 15
+    severity: critical
+    owner_repo: alpha-engine-data
+    calendar_aware: false
+    created_at: 2025-01-01
+"""
+
+
+@pytest.fixture
+def fake_s3():
+    """Fake boto3 S3 client tracking put_object payloads and routing
+    head_object via a per-key dispatch table."""
+    client = mock.Mock()
+    client._put_calls: list[tuple[str, str, bytes]] = []
+    client._head_returns: dict[str, dict] = {}
+
+    def _head(*, Bucket, Key):
+        if Key in client._head_returns:
+            return client._head_returns[Key]
+        err = _ClientError404()
+        raise err
+
+    def _put(*, Bucket, Key, Body, **kwargs):
+        client._put_calls.append((Bucket, Key, Body))
+        return {"ETag": '"deadbeef"'}
+
+    def _get(*, Bucket, Key):
+        return {"Body": io.BytesIO(client._registry_body)}
+
+    client.head_object.side_effect = _head
+    client.put_object.side_effect = _put
+    client.get_object.side_effect = _get
+    return client
+
+
+class _ClientError404(Exception):
+    def __init__(self):
+        super().__init__("Not Found")
+        self.response = {
+            "Error": {"Code": "404"},
+            "ResponseMetadata": {"HTTPStatusCode": 404},
+        }
+
+
+@pytest.fixture
+def fixed_now():
+    """Pin ``datetime.now`` to a Saturday 18:00 UTC inside W22 so the
+    saturday_sf cycle is 2026-05-30 and all SLA arithmetic is
+    deterministic."""
+    return datetime(2026, 5, 30, 18, 0, tzinfo=timezone.utc)
+
+
+# ── load_registry ───────────────────────────────────────────────────────────
+
+
+def test_load_registry_parses_and_merges_defaults(yaml_registry_body, fake_s3):
+    """Defaults block must merge into each entry; per-entry keys override."""
+    fake_s3._registry_body = yaml_registry_body
+    import index
+    specs = index.load_registry(fake_s3, "buck", "key")
+    assert len(specs) == 3
+    by_id = {s.artifact_id: s for s in specs}
+    assert by_id["probe_fresh"].s3_bucket == "alpha-engine-research"  # from defaults
+    assert by_id["probe_fresh"].grace_period_cycles == 2              # from defaults
+    assert by_id["probe_missing"].severity == "critical"              # per-entry override
+    assert by_id["probe_heartbeat"].calendar_aware is False           # per-entry override
+
+
+def test_load_registry_raises_on_missing_artifacts_key(fake_s3):
+    fake_s3._registry_body = b"schema_version: 1\nartifacts: null\n"
+    import index
+    with pytest.raises(ValueError, match="missing 'artifacts'"):
+        index.load_registry(fake_s3, "buck", "key")
+
+
+def test_load_registry_coerces_iso_date_string(fake_s3):
+    """YAML safe_load returns date for ISO scalars; defensive coercion
+    handles fixtures that quote the date as a string."""
+    fake_s3._registry_body = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+artifacts:
+  - artifact_id: probe_x
+    s3_key_template: "path/{date}/x.json"
+    cadence: saturday_sf
+    sla_minutes_after_cron: 60
+    severity: warning
+    owner_repo: ae-test
+    created_at: "2025-01-01"
+"""
+    import index
+    specs = index.load_registry(fake_s3, "buck", "key")
+    assert specs[0].created_at == date(2025, 1, 1)
+
+
+# ── handler — alerts disabled (OBSERVE mode) ────────────────────────────────
+
+
+def _patch_now(monkeypatch, fixed):
+    import index
+    real_dt = index.datetime
+
+    class _FixedDT(real_dt):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed if tz is None else fixed.astimezone(tz)
+
+    monkeypatch.setattr(index, "datetime", _FixedDT)
+
+
+def test_handler_observe_mode_does_not_alert(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """OBSERVE mode (MNEMON_FRESHNESS_MONITOR_ENABLED unset) writes
+    heartbeat + check_results but suppresses alerts.publish."""
+    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    fake_s3._registry_body = yaml_registry_body
+
+    # Mark probe_fresh as actually fresh (HEAD returns within cycle).
+    cycle_tick = datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)
+    fake_s3._head_returns["path/2026-05-30/fresh.json"] = {
+        "LastModified": cycle_tick.replace(hour=12),
+    }
+    # probe_missing 404s by default.
+    # probe_heartbeat 404s by default (will be classified missing).
+
+    import importlib
+    import index
+    importlib.reload(index)  # pick up env state
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+
+    result = index.handler({}, None)
+
+    assert result["alerts_enabled"] is False
+    assert result["n_entries_checked"] == 3
+    assert publish_mock.call_count == 0  # OBSERVE mode
+
+    # heartbeat + check_results both emitted regardless of OBSERVE mode.
+    put_keys = [k for (_, k, _) in fake_s3._put_calls]
+    assert "_freshness_monitor/heartbeat.json" in put_keys
+    assert "_freshness_monitor/check_results.json" in put_keys
+
+    # heartbeat counts reflect the three states.
+    heartbeat_body = next(
+        body for (_, k, body) in fake_s3._put_calls
+        if k == "_freshness_monitor/heartbeat.json"
+    )
+    heartbeat = json.loads(heartbeat_body)
+    assert heartbeat["counts"]["fresh"] == 1
+    assert heartbeat["counts"]["missing"] == 2  # probe_missing + probe_heartbeat
+    assert heartbeat["alerts_enabled"] is False
+
+
+def test_handler_alerts_enabled_fires_with_dedup_key(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """Production mode (MNEMON_FRESHNESS_MONITOR_ENABLED=true) routes
+    misses past SLA to alerts.publish with the resolved dedup key."""
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = yaml_registry_body
+
+    cycle_tick = datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)
+    fake_s3._head_returns["path/2026-05-30/fresh.json"] = {
+        "LastModified": cycle_tick.replace(hour=12),
+    }
+    # probe_missing 404s (past SLA — Sat 18:00 - (09:00 + 60min) = 8hr breach)
+    # probe_heartbeat 404s
+
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+
+    result = index.handler({}, None)
+
+    assert result["alerts_enabled"] is True
+    assert publish_mock.called
+
+    # Inspect the publish calls — dedup keys should be unique per-artifact
+    # and reflect the cycle window.
+    dedup_keys = [c.kwargs["dedup_key"] for c in publish_mock.call_args_list]
+    # probe_missing is saturday_sf in W22 → "freshness_probe_missing_2026-W22"
+    assert "freshness_probe_missing_2026-W22" in dedup_keys
+
+
+def test_handler_probe_failed_routes_to_critical(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """probe_failed (e.g., 403) routes to critical regardless of the
+    spec's severity — the monitor itself is broken; operator must know.
+    Plan §3 invariant 6."""
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = yaml_registry_body
+
+    class _ClientError403(Exception):
+        def __init__(self):
+            super().__init__("Access Denied")
+            self.response = {
+                "Error": {"Code": "AccessDenied"},
+                "ResponseMetadata": {"HTTPStatusCode": 403},
+            }
+
+    def _head(*, Bucket, Key):
+        if Key == "path/2026-05-30/fresh.json":
+            raise _ClientError403()
+        raise _ClientError404()
+    fake_s3.head_object.side_effect = _head
+
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+
+    index.handler({}, None)
+
+    # Find the probe_fresh call (which now probe_failed) — severity should be critical
+    # NOT the spec's warning.
+    fresh_calls = [
+        c for c in publish_mock.call_args_list
+        if "probe_fresh" in c.args[0]
+    ]
+    assert len(fresh_calls) == 1
+    assert fresh_calls[0].kwargs["severity"] == "critical"
+
+
+def test_handler_per_spec_exception_does_not_sink_pass(
+    monkeypatch, fake_s3, fixed_now
+):
+    """A malformed spec (e.g., key template requiring an unsupported
+    placeholder) should result in probe_failed for that spec, not a
+    handler-level raise. The other specs in the registry still get
+    probed."""
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    # `{ticker}` is NOT a supported placeholder in the substrate's
+    # _format_key — str.format will raise KeyError.
+    fake_s3._registry_body = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+artifacts:
+  - artifact_id: probe_bad_template
+    s3_key_template: "path/{ticker}/x.json"
+    cadence: saturday_sf
+    sla_minutes_after_cron: 60
+    severity: warning
+    owner_repo: ae-test
+    created_at: 2025-01-01
+  - artifact_id: probe_ok
+    s3_key_template: "path/{date}/x.json"
+    cadence: saturday_sf
+    sla_minutes_after_cron: 60
+    severity: warning
+    owner_repo: ae-test
+    created_at: 2025-01-01
+"""
+
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+
+    result = index.handler({}, None)
+
+    assert result["n_entries_checked"] == 2
+    assert result["per_spec_exceptions"] == 1
+    # Both specs landed in the heartbeat counts.
+    assert sum(result["counts"].values()) == 2
+
+
+def test_handler_observe_to_production_cutover_via_env_flip(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """Mirrors the mnemon 0.7.0rc4 pattern from 2026-05-24 — flipping
+    the env var should change alert behavior without code redeploy.
+    Tested via two reloads under different env state."""
+    fake_s3._registry_body = yaml_registry_body
+
+    # Pass 1: OBSERVE mode.
+    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+    r1 = index.handler({}, None)
+    assert r1["alerts_enabled"] is False
+    assert publish_mock.call_count == 0
+
+    # Pass 2: env flipped to true, reload, re-invoke.
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._put_calls.clear()
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    publish_mock2 = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock2)
+    r2 = index.handler({}, None)
+    assert r2["alerts_enabled"] is True
+    assert publish_mock2.call_count >= 1
+
+
+# ── _maybe_alert direct unit coverage ───────────────────────────────────────
+
+
+def test_maybe_alert_skips_fresh_state(monkeypatch, fixed_now):
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+
+    from alpha_engine_lib.artifact_freshness import ArtifactSpec, CheckResult
+
+    spec = ArtifactSpec(
+        artifact_id="x", s3_bucket="b", s3_key_template="k/{date}",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity="warning", owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(state="fresh")
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+    assert index._maybe_alert(spec, result, fixed_now) is False
+    assert publish_mock.call_count == 0
+
+
+def test_maybe_alert_skips_missing_within_sla_grace(monkeypatch, fixed_now):
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+
+    from alpha_engine_lib.artifact_freshness import ArtifactSpec, CheckResult
+
+    spec = ArtifactSpec(
+        artifact_id="x", s3_bucket="b", s3_key_template="k/{date}",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity="warning", owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    # missing but sla_violated_by_minutes=0 ⇒ still within grace; no alert.
+    result = CheckResult(state="missing", sla_violated_by_minutes=0)
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+    assert index._maybe_alert(spec, result, fixed_now) is False
+    assert publish_mock.call_count == 0
+
+
+def test_maybe_alert_fires_missing_past_sla(monkeypatch, fixed_now):
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+
+    from alpha_engine_lib.artifact_freshness import ArtifactSpec, CheckResult
+
+    spec = ArtifactSpec(
+        artifact_id="x", s3_bucket="b", s3_key_template="k/{date}",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity="warning", owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(
+        state="missing", sla_violated_by_minutes=120,
+        canonical_key="k/2026-05-30", reason="absent",
+    )
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+    assert index._maybe_alert(spec, result, fixed_now) is True
+    publish_mock.assert_called_once()
+    call = publish_mock.call_args
+    assert "artifact_id=x" in call.args[0]
+    assert call.kwargs["severity"] == "warning"  # spec severity, not bumped
+    assert call.kwargs["dedup_key"] == "freshness_x_2026-W22"
+
+
+def test_maybe_alert_probe_failed_uses_critical_severity(monkeypatch, fixed_now):
+    """probe_failed always escalates to critical regardless of spec."""
+    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+
+    from alpha_engine_lib.artifact_freshness import ArtifactSpec, CheckResult
+
+    spec = ArtifactSpec(
+        artifact_id="x", s3_bucket="b", s3_key_template="k/{date}",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity="warning", owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(state="probe_failed", reason="403")
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+    assert index._maybe_alert(spec, result, fixed_now) is True
+    publish_mock.assert_called_once()
+    assert publish_mock.call_args.kwargs["severity"] == "critical"


### PR DESCRIPTION
## Summary

Phase 3 of the **artifact-freshness-monitor arc** (plan doc at `~/Development/alpha-engine-docs/private/artifact-freshness-monitor-260527.md`; ROADMAP P1 entry in [alpha-engine-config #342](https://github.com/cipher813/alpha-engine-config/pull/342) + status update in #344). The **absence-driven** complement to flow-doctor / SF Catch / substrate-health-check (all event-driven). Closes the silent absence-of-artifact bug class — the 2026-05-17→27 `pit_parity.json` (load-bearing artifact silently absent for 11 days) + the sibling factor-profiles orphan + missing-`signals.json` incidents.

Depends on:
- [alpha-engine-lib #83](https://github.com/cipher813/alpha-engine-lib/pull/83) (merged, v0.40.0 tag cut) — the `artifact_freshness` substrate
- [alpha-engine-config #344](https://github.com/cipher813/alpha-engine-config/pull/344) (merged) — the `ARTIFACT_REGISTRY.yaml` SoT + PR-time validator

## Changes

`infrastructure/lambdas/freshness-monitor/` (new Lambda):

- **`index.py`** — EventBridge cron handler (every 15min):
  1. `load_registry(s3, REGISTRY_BUCKET, REGISTRY_KEY)` — fetches `_freshness_monitor/ARTIFACT_REGISTRY.yaml` from S3, merges `defaults` block into each entry, instantiates `ArtifactSpec`.
  2. Walks every spec, calls `alpha_engine_lib.artifact_freshness.check_freshness` per row, isolates per-spec exceptions (`_check_one` wraps with a probe_failed fallback so a bad row doesn't sink the pass).
  3. Emits `_freshness_monitor/check_results.json` (dashboard surface in Phase 5) + `_freshness_monitor/heartbeat.json` (self-heartbeat per plan §3 invariant 9 — the monitor monitors itself).
  4. For misses past SLA (`state ∈ {missing, stale, probe_failed}`), routes to `alpha_engine_lib.alerts.publish` with `dedup_key=resolve_dedup_key(spec, now)` — collapses 4×/hour retries to one alert per cycle per artifact.
  5. `probe_failed` always escalates to `severity=critical` regardless of spec — the monitor itself is broken; operator must know (plan §3 invariant 6).
  6. **OBSERVE-mode gate**: `MNEMON_FRESHNESS_MONITOR_ENABLED` env var (default unset = `false`) suppresses alerts but emits results. Phase 6 cutover flips via `aws lambda update-function-configuration` without redeploying — mirrors mnemon 0.7.0rc4 pattern from 2026-05-24.

- **`requirements.txt`** — pinned to `alpha-engine-lib@v0.40.0` + `pyyaml`.

- **`iam-policy.json`** — Logs + Telegram SSM params + `alpha-engine-alerts` SNS publish + S3 HeadObject/GetObject on `alpha-engine-research` + S3 PutObject scoped to `_freshness_monitor/` + `_alerts/_dedup/`.

- **`deploy.sh`** — `--bootstrap` (IAM role + Lambda + EventBridge cron `cron(*/15 * * * ? *)` + cron permission), code-update path, registry upload from local `alpha-engine-config` clone to S3. **Validates registry locally** via `alpha-engine-config/scripts/validate_artifact_registry.py` BEFORE upload — malformed YAML never reaches S3. Mirrors the `sf-telegram-notifier` deploy.sh shape; managed outside CFN per the existing operator-deployed-only Lambda pattern.

- **`test_handler.py`** — 12 unit tests covering:
  - `load_registry` (defaults merge, per-entry override, ISO-string date coercion, missing-artifacts raise)
  - Handler OBSERVE-mode does not alert but emits heartbeat
  - Handler alerts-enabled fires alerts with resolved dedup_key
  - probe_failed routes to critical severity regardless of spec
  - Per-spec exception (e.g., unsupported placeholder) classified as probe_failed without sinking the rest of the pass
  - Env-flip cutover (OBSERVE → production) without code change
  - `_maybe_alert` per-state coverage (fresh skip, within-SLA-grace skip, missing-past-SLA fires, probe_failed bumps severity)

## Deploy plan (post-merge, operator-driven)

```bash
# First-time bootstrap (creates IAM role + Lambda + EventBridge cron + uploads registry)
bash infrastructure/lambdas/freshness-monitor/deploy.sh --bootstrap

# Subsequent code or registry updates
bash infrastructure/lambdas/freshness-monitor/deploy.sh
```

Bootstrap default state: `MNEMON_FRESHNESS_MONITOR_ENABLED=false` (OBSERVE). Cutover (Phase 6) flips via:

```bash
aws lambda update-function-configuration \
  --function-name alpha-engine-freshness-monitor \
  --environment 'Variables={LOG_LEVEL=INFO,MNEMON_FRESHNESS_MONITOR_ENABLED=true}'
```

## Soak plan (Phase 6)

≥2 weekly cycles in OBSERVE mode. Earliest cutover ~2026-06-13 if this PR lands before Sat 5/30 (so the next 5/30 + 6/6 Saturday SFs exercise the probe under realistic load); more realistically ~2026-06-20.

During soak: dashboard surface (Phase 5) populates with real check_results; operator validates alert payloads against known-good Saturday firings (no false alarms on holidays, recovery-SF substitution working, dedup window collapsing retry storms correctly).

## Acceptance (plan §7)

- [x] `pytest test_handler.py` — 12 passing
- [ ] Post-deploy: first cron firing within 15min emits `_freshness_monitor/heartbeat.json` to S3
- [ ] Post-deploy: simulated `pit_parity`-class silent failure (mock: rename the expected S3 key) fires Telegram with correct dedup key within ~15min
- [ ] Post-deploy: NYSE-holiday Monday (next is 2026-06-19 Juneteenth) produces zero alerts for weekday_sf artifacts despite cron firing
- [ ] Phase 5 dashboard PR consumes `check_results.json`

## Test plan

- [x] `pytest infrastructure/lambdas/freshness-monitor/test_handler.py -v` — 12 passing
- [ ] Local smoke: `bash infrastructure/lambdas/freshness-monitor/deploy.sh --dry-run` (after merge of #344 is in operator's local checkout)
- [ ] Post-deploy smoke: `--smoke` flag invokes once and confirms heartbeat lands

## Composes with

- [alpha-engine-lib #83](https://github.com/cipher813/alpha-engine-lib/pull/83) — the `artifact_freshness` substrate (`ArtifactSpec`, `check_freshness`, `resolve_dedup_key`)
- [alpha-engine-config #344](https://github.com/cipher813/alpha-engine-config/pull/344) — the registry SoT
- `[[feedback_no_silent_fails]]` — operationalizes the rule for the absence-of-artifact case
- `[[feedback_sota_institutional_default_no_shortcuts]]` — registry-as-config (Google SRE Ch. 4 SLI/SLO pattern) + S3-loaded substrate over hardcoded specs
- `[[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]` — Phase 4 CI-guard cascade ships next, mirroring the `test_schema_contract.py` chokepoint pattern across the 4 producing repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)