### PR TITLE
fix(freshness-monitor): deploy.sh preflight test step now sees runtime deps

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -63,7 +63,7 @@ run() {
   fi
 }
 
-# ----- 0. Validate handler syntax + run unit tests --------------------------
+# ----- 0a. Syntax-check handler (no imports — works on bare python) --------
 
 python3 -c "
 import ast
@@ -72,12 +72,7 @@ ast.parse(src)
 print('index.py syntax OK')
 "
 
-if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Running handler unit tests..."
-  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
-fi
-
-# ----- 0b. Validate registry locally before upload --------------------------
+# ----- 0b. Verify ae-config clone present (registry validation runs later) -
 
 if [[ ! -f "${REGISTRY_LOCAL}" ]]; then
   echo "❌ Registry not found at ${REGISTRY_LOCAL}"
@@ -91,20 +86,41 @@ if [[ ! -f "${REGISTRY_VALIDATOR}" ]]; then
   exit 1
 fi
 
-echo "Validating registry locally before upload..."
-python3 "${REGISTRY_VALIDATOR}" --registry "${REGISTRY_LOCAL}"
-
-# ----- 1. Package: pip install deps + zip handler ---------------------------
+# ----- 1. Package: pip install runtime deps into $PKG ----------------------
 
 PKG=$(mktemp -d)
-trap "rm -rf '$PKG'" EXIT
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 
-echo "Installing deps into ${PKG} (pip install -t)..."
+echo "Installing runtime deps into ${PKG} (pip install -t)..."
 python3 -m pip install \
   --quiet \
   --target "${PKG}" \
   --upgrade \
   -r "${SCRIPT_DIR}/requirements.txt"
+
+# ----- 1a. Validate registry locally before upload --------------------------
+# Runs AFTER step 1's pip install — the validator imports yaml which isn't
+# guaranteed in the caller's bare python. PYTHONPATH=$PKG resolves it.
+
+echo "Validating registry locally before upload..."
+PYTHONPATH="${PKG}" python3 "${REGISTRY_VALIDATOR}" --registry "${REGISTRY_LOCAL}"
+
+# ----- 1b. Preflight handler unit tests with runtime deps available --------
+# Runs AFTER step 1's pip install so the test's `import index` succeeds
+# (index imports yaml + boto3 + alpha_engine_lib.{alerts,artifact_freshness}
+# — none of which are guaranteed in the caller's bare python). pytest +
+# its deps install into $TEST_DEPS (separate from $PKG) so they don't
+# get bundled into the Lambda zip.
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Installing pytest into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
+  echo "Running handler unit tests (PYTHONPATH=${PKG}:${TEST_DEPS})..."
+  PYTHONPATH="${PKG}:${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1c. Copy handler + zip Lambda package -------------------------------
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 ZIP="${PKG}/function.zip"


### PR DESCRIPTION
## Summary

Fixes the `ModuleNotFoundError: No module named 'yaml'` failure when running `bash infrastructure/lambdas/freshness-monitor/deploy.sh` against a Python environment that doesn't have the Lambda's runtime deps pre-installed.

## Root cause

PR [#335](https://github.com/cipher813/alpha-engine-data/pull/335) placed the preflight test step (`python3 -m pytest test_handler.py`) BEFORE the pip-install step. The test imports `index.py` which imports `yaml` + `boto3` + `alpha_engine_lib.{alerts,artifact_freshness}` at module load — none of which are guaranteed in the caller's bare python. Same issue applied to the registry validator (also imports yaml).

The pattern was mirrored from `sf-telegram-notifier/deploy.sh`, but that Lambda's test_handler.py STUBS all its 3rd-party imports via `sys.modules` (only `pytest` is a real dep). The freshness-monitor's test exercises real lib substrate (`ArtifactSpec`, `CheckResult`, `check_freshness`) so stubbing those defeats the test's purpose — installing the deps is the right answer.

## Fix

Restructure step ordering so deps install before consumers run:

| Step | Before | After |
|---|---|---|
| 0a | syntax-check | syntax-check (unchanged) |
| 0b | registry validator (fails — no yaml) | path-check only |
| 0c | preflight tests (fails — no yaml) | — (moved) |
| 1 | pip install runtime deps → `$PKG` | pip install runtime deps → `$PKG` |
| 1a | — | registry validator with `PYTHONPATH=$PKG` |
| 1b | — | install `pytest` → `$TEST_DEPS`; run handler tests with `PYTHONPATH=$PKG:$TEST_DEPS` |
| 1c | zip Lambda | zip Lambda (unchanged) |

The `$TEST_DEPS` separate dir keeps `pytest` + its transitive deps out of the final Lambda zip — only `requirements.txt` deps end up in the deployable artifact. Both temp dirs cleaned via the existing `trap`.

## Verified

End-to-end dry-run on the operator machine (homebrew python3):

```
index.py syntax OK
Installing runtime deps into /var/folders/.../tmp.pkeQqBGGoA (pip install -t)...
Validating registry locally before upload...
✅ ARTIFACT_REGISTRY.yaml validated: 48 artifacts + 27 grandfathered paths
Installing pytest into /var/folders/.../tmp.wKKWUBNrc6...
Running handler unit tests (PYTHONPATH=...:...)...
............                                                             [100%]
12 passed in 0.08s
Packaged function.zip (22498727 bytes)
✓ Code deployed.
✓ Registry uploaded.
```

## Why this matters

`deploy.sh` is the only path operators have to ship this Lambda; if the preflight fails on Brian's machine the artifact-freshness-monitor arc's Phase 6 deploy is blocked. This is a one-character-deep bug class (`if [[ -f test_handler.py ]]; then python3 -m pytest` assumes deps available) that bit because PR #335 mirrored the sf-telegram-notifier deploy.sh pattern without noting the test-stubbing difference.

## Test plan

- [x] `bash infrastructure/lambdas/freshness-monitor/deploy.sh --dry-run` — clean end-to-end
- [x] `pytest infrastructure/lambdas/freshness-monitor/test_handler.py` (in lib venv) — 12 passing
- [ ] Post-merge: Brian re-runs `--bootstrap` and instantiates the Lambda

🤖 Generated with [Claude Code](https://claude.com/claude-code)