### PR TITLE
feat(sf): Scanner runs unconditionally — remove CheckEnableStandaloneScanner Choice gate

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -185,21 +185,10 @@ Resources:
           # Ad-hoc operator launches MUST set their own pipeline_role
           # (smoke / recovery / backfill / operator-replay) per the
           # taxonomy in pipeline-reporting-revamp-260524.md §6.
-          #
-          # enable_standalone_scanner=true activates the L1995 Phase 2
-          # Scanner SF state (alpha-engine-research-scanner Lambda
-          # writes candidates.json in parallel-observe mode). Set true
-          # from 2026-05-25 onward (originally in deploy_step_function.sh
-          # via PR #313; migrated here 2026-05-26 in the EB-target
-          # single-SoT PR — keeping the flag on the SCRIPT meant
-          # re-deploying CFN silently flipped it off). Revert by
-          # flipping to false here in the same PR that updates
-          # ``tests/test_deploy_step_function_eventbridge_input.py``.
           Input: !Sub |
             {
               "ec2_instance_id": ["${MicroInstanceId}"],
               "sns_topic_arn": "${AlertsTopic}",
-              "enable_standalone_scanner": true,
               "pipeline_role": "weekly"
             }
 

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -230,7 +230,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckEnableStandaloneScanner"
+          "Next": "Scanner"
         }
       ],
       "Default": "DataPhase1"
@@ -310,7 +310,7 @@
         {
           "Variable": "$.data_phase1_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckEnableStandaloneScanner"
+          "Next": "Scanner"
         },
         {
           "Variable": "$.data_phase1_poll.Status",
@@ -330,29 +330,9 @@
       "Seconds": 30,
       "Next": "WaitForDataPhase1"
     },
-    "CheckEnableStandaloneScanner": {
-      "Type": "Choice",
-      "Comment": "L1995 Phase 2 gate — default-off. {\"enable_standalone_scanner\": true} routes through the new Scanner Lambda (alpha-engine-research-scanner, ROADMAP L1995 Phase 1 / research #235), which writes s3://alpha-engine-research/candidates/{run_date}/candidates.json in parallel-observe mode (Research Lambda still runs its own internal scanner — Phase 5 will cut Research over to read the artifact). Default (flag absent or false) routes straight to CheckSkipRAGIngestion — byte-identical to the pre-Phase-2 chain. Operator flips the flag for the Phase 3 soak; first scheduled flip-on Saturday is 2026-05-30 if operator opts in.",
-      "Choices": [
-        {
-          "And": [
-            {
-              "Variable": "$.enable_standalone_scanner",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.enable_standalone_scanner",
-              "BooleanEquals": true
-            }
-          ],
-          "Next": "Scanner"
-        }
-      ],
-      "Default": "CheckSkipRAGIngestion"
-    },
     "Scanner": {
       "Type": "Task",
-      "Comment": "Standalone scanner Lambda (ROADMAP L1995 Phase 1 — alpha-engine-research #235). Reads constituents.json + feature store, runs the same run_quant_filter as Research Lambda's internal scanner, writes the candidates.json artifact for THIS run_date. Phase 2 posture: observe-only — gated by enable_standalone_scanner flag; failure is NON-BLOCKING (Catch routes to CheckSkipRAGIngestion). The artifact is parallel-observe only; no consumer reads it yet (Phase 4 will switch RAG to read it, Phase 5 will switch Research). Status contract OK / ERROR — no SKIPPED today (constituents.json + feature store are hard preconditions). dry_run_llm threads the Friday-Preflight shell-run signal so the Lambda boots+imports without S3 read on $.research_dry=true. Includes a 5/30 soak: Brian flips enable_standalone_scanner=true on the 5/30 SF input and compares candidates.json::scanner_tickers against research's signals.json::universe (minus population). Zero divergence is the Phase 3 → Phase 4 transition signal.",
+      "Comment": "Standalone scanner Lambda (ROADMAP L1995 Phase 1 — alpha-engine-research #235). Reads constituents.json + feature store, runs the same run_quant_filter as Research Lambda's internal scanner, writes the candidates.json artifact for THIS run_date. Phase 2 posture: observe-only — runs UNCONDITIONALLY on every Saturday SF firing (the prior CheckEnableStandaloneScanner Choice gate was removed 2026-05-28 per feedback_observe_mode_unconditional_gates_govern_cutover — observation must not be flag-gated; absence-of-artifact is itself the failure mode the soak is meant to detect). Failure is NON-BLOCKING (Catch routes to CheckSkipRAGIngestion). The artifact is parallel-observe only; no consumer reads it yet (Phase 4 will switch RAG to read it, Phase 5 will switch Research) — the Phase 4/5 consumer-cutover flag belongs at the consumer side. Status contract OK / ERROR — no SKIPPED today (constituents.json + feature store are hard preconditions). dry_run_llm threads the Friday-Preflight shell-run signal so the Lambda boots+imports without S3 read on $.research_dry=true. First post-fix Saturday SF (2026-05-30) lands candidates.json structurally; compare candidates.json::scanner_tickers against signals.json::universe (minus population). Zero divergence is the Phase 3 → Phase 4 transition signal.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-research-scanner:live",

--- a/tests/test_deploy_step_function_eventbridge_input.py
+++ b/tests/test_deploy_step_function_eventbridge_input.py
@@ -210,32 +210,24 @@ class TestOrchestrationCFNPipelineRoles:
         ), 'WeekdayTrigger Input must carry pipeline_role="daily".'
 
 
-class TestSaturdayCFNTargetActivatesScanner:
-    """ROADMAP L1995 Phase 3 — ``enable_standalone_scanner: true`` is
-    what activates the Scanner SF state (Phase 2) in parallel-observe
-    mode. Originally lived in ``deploy_step_function.sh``'s INPUT_JSON
-    (PR #313); migrated to CFN here on 2026-05-26 as part of the
-    EB-target single-SoT consolidation. Keeping the flag on the
-    SCRIPT meant that re-deploying CFN would silently revert Phase 3
-    by overwriting the live target with a CFN-form input that lacks
-    the flag — a footgun the SoT consolidation removes.
-
-    Revert by flipping to ``false`` in the CFN template in the same
-    PR that updates this test.
+class TestSaturdayCFNTargetHasNoScannerGateFlag:
+    """The ``CheckEnableStandaloneScanner`` SF Choice gate was removed
+    2026-05-28 — Scanner runs unconditionally per
+    ``feedback_observe_mode_unconditional_gates_govern_cutover``. The
+    EB target Input MUST NOT carry ``enable_standalone_scanner``: the
+    flag is dead substrate, and re-introducing it primes a future
+    re-add of the Choice gate (the test that pinned its presence is
+    what kept the gate alive). The Phase 4/5 consumer-cutover flag
+    (Research / RAG reading ``candidates.json``) belongs at the
+    consumer side, not on the producer-side EB target.
     """
 
-    def test_enable_standalone_scanner_present_and_true(self, orchestration_text):
+    def test_no_enable_standalone_scanner_in_input(self, orchestration_text):
         block = _trigger_block(orchestration_text, "SaturdayTrigger")
-        assert "enable_standalone_scanner" in block, (
-            "SaturdayTrigger Input dropped enable_standalone_scanner. "
-            "This silently reverts ROADMAP L1995 Phase 3 (Scanner SF "
-            "state runs default-off). If the revert is intentional, "
-            "update both this test and the CFN template in the same PR."
-        )
-        assert re.search(
-            r'"enable_standalone_scanner"\s*:\s*true',
-            block,
-        ), (
-            "enable_standalone_scanner is present but not set to true. "
-            "Phase 3 requires the flag value to be true."
+        assert "enable_standalone_scanner" not in block, (
+            "SaturdayTrigger Input must NOT carry enable_standalone_scanner. "
+            "Scanner runs unconditionally as of 2026-05-28; the flag is "
+            "dead substrate. Re-introducing it primes a re-add of the "
+            "removed Choice gate. See "
+            "feedback_observe_mode_unconditional_gates_govern_cutover."
         )

--- a/tests/test_sf_scanner_wiring.py
+++ b/tests/test_sf_scanner_wiring.py
@@ -1,24 +1,25 @@
 """Pins the Scanner Lambda wiring in the Saturday Step Functions JSON.
 
-ROADMAP L1995 Phase 2 — gated default-off via `enable_standalone_scanner`
-flag. The companion alpha-engine-research PR #235 adds the
-`alpha-engine-research-scanner:live` Lambda (Phase 1); this PR inserts
-the SF state that invokes it when the operator flips the flag (Phase 3
-soak), so RAGIngestion (Phase 4) can later read the new
-`candidates.json` artifact.
+ROADMAP L1995 Phase 2 — Scanner runs UNCONDITIONALLY on every Saturday
+SF firing (parallel-observe mode, non-blocking Catch). The prior
+``CheckEnableStandaloneScanner`` Choice gate was removed 2026-05-28 per
+``feedback_observe_mode_unconditional_gates_govern_cutover`` — observe-
+mode producer code must never be flag-gated, since silent absence-of-
+artifact is itself the failure mode the soak is meant to detect. The
+Phase 4/5 consumer-cutover flag (Research / RAG reading
+``candidates.json`` load-bearingly) belongs at the consumer side, not
+the producer side.
 
 Pin the chain between DataPhase1 and CheckSkipRAGIngestion:
 
-    DataPhase1 (skip path)    ──┐
-                                ├──→ CheckEnableStandaloneScanner ──→ Scanner ──→ CheckSkipRAGIngestion
-    CheckDataPhase1Status.Success┘                              └──(default)──→ CheckSkipRAGIngestion
+    DataPhase1 (skip path)        ──┐
+                                    ├──→ Scanner ──→ CheckSkipRAGIngestion
+    CheckDataPhase1Status.Success ──┘    │
+                                         └─(Catch)──→ CheckSkipRAGIngestion
 
-When the flag is false/absent (Phase 2 default), the path through
-CheckEnableStandaloneScanner is byte-identical to the pre-Phase-2 chain
-— Choice.Default goes directly to CheckSkipRAGIngestion, no Lambda
-invocation occurs. When the flag is true, the Lambda runs in
-parallel-observe mode and Catch ensures failure does NOT halt the
-pipeline.
+Scanner failure must NOT halt the pipeline (Research Lambda's internal
+scanner still produces the load-bearing universe today; the standalone
+artifact is parallel-observe and consumer-less until Phase 4).
 """
 
 from __future__ import annotations
@@ -55,15 +56,22 @@ def states(sf) -> dict:
 
 
 class TestStatesPresent:
-    def test_scanner_states_exist(self, states):
-        assert "CheckEnableStandaloneScanner" in states
+    def test_scanner_state_exists(self, states):
         assert "Scanner" in states
 
     def test_scanner_is_a_task(self, states):
         assert states["Scanner"]["Type"] == "Task"
 
-    def test_check_enable_is_a_choice(self, states):
-        assert states["CheckEnableStandaloneScanner"]["Type"] == "Choice"
+    def test_no_enable_scanner_choice_gate(self, states):
+        # The Choice gate was removed 2026-05-28 — observe-mode must not
+        # be flag-gated. Re-introducing it silently disables observation
+        # any time the enable_standalone_scanner input is absent or false.
+        assert "CheckEnableStandaloneScanner" not in states, (
+            "CheckEnableStandaloneScanner Choice gate must not exist. "
+            "Per feedback_observe_mode_unconditional_gates_govern_cutover, "
+            "Scanner runs unconditionally — gates belong at the consumer "
+            "side (Phase 4/5), not the producer side."
+        )
 
 
 # ── Lambda target + payload ───────────────────────────────────────────────
@@ -123,70 +131,34 @@ class TestFailureIsolation:
         )
 
 
-# ── Gate semantics (default-off) ──────────────────────────────────────────
-
-
-class TestGateDefaultOff:
-    def test_default_path_is_check_skip_rag(self, states):
-        # Phase 2 ships gated default-off: when the flag is absent or
-        # false the chain is byte-identical to pre-Phase-2.
-        assert (
-            states["CheckEnableStandaloneScanner"]["Default"]
-            == "CheckSkipRAGIngestion"
-        )
-
-    def test_flag_true_routes_to_scanner(self, states):
-        gate = states["CheckEnableStandaloneScanner"]
-        choices = gate["Choices"]
-        assert len(choices) == 1
-        choice = choices[0]
-        assert choice["Next"] == "Scanner"
-        # Conjunction pins the variable + bool semantics (IsPresent AND
-        # BooleanEquals true).
-        variables = [c["Variable"] for c in choice["And"]]
-        assert all(v == "$.enable_standalone_scanner" for v in variables)
-        assert any(c.get("BooleanEquals") is True for c in choice["And"])
-
-
-# ── Wiring: edges into and out of the new states ──────────────────────────
+# ── Wiring: edges into and out of Scanner ─────────────────────────────────
 
 
 class TestEdges:
-    def test_data_phase1_skip_path_routes_to_scanner_gate(self, states):
+    def test_data_phase1_skip_path_routes_to_scanner(self, states):
         # CheckSkipDataPhase1's skip branch (operator passes
-        # skip_data_phase1=true) previously went to CheckSkipRAGIngestion
-        # directly. Phase 2 re-routes it through the new gate so the
-        # Phase-2-enabled path is honored even on a phase1-skip rerun.
+        # skip_data_phase1=true) routes through Scanner unconditionally,
+        # matching the success path. Anyone re-introducing a gate here
+        # silently disables observation on phase1-skip reruns.
         skip = states["CheckSkipDataPhase1"]
         skip_choices = skip["Choices"]
         assert any(
-            c["Next"] == "CheckEnableStandaloneScanner"
-            for c in skip_choices
-        )
+            c["Next"] == "Scanner" for c in skip_choices
+        ), "CheckSkipDataPhase1 skip branch must route directly to Scanner."
 
-    def test_data_phase1_success_path_routes_to_scanner_gate(self, states):
-        # CheckDataPhase1Status.Success previously went to
-        # CheckSkipRAGIngestion directly; Phase 2 re-routes through the
-        # new gate.
+    def test_data_phase1_success_path_routes_to_scanner(self, states):
         status = states["CheckDataPhase1Status"]
         success = next(
             c for c in status["Choices"]
             if c.get("StringEquals") == "Success"
         )
-        assert success["Next"] == "CheckEnableStandaloneScanner"
+        assert success["Next"] == "Scanner", (
+            "CheckDataPhase1Status Success branch must route directly "
+            "to Scanner — no intermediate gate."
+        )
 
     def test_scanner_success_routes_to_check_skip_rag(self, states):
         assert states["Scanner"]["Next"] == "CheckSkipRAGIngestion"
-
-    def test_default_path_byte_identical_to_pre_phase_2(self, states):
-        # The end of this chain MUST equal what the pre-Phase-2 chain
-        # had — CheckSkipRAGIngestion. Anyone changing the gate's
-        # Default without updating this assertion is silently breaking
-        # the observe-only Phase 2 contract.
-        assert (
-            states["CheckEnableStandaloneScanner"]["Default"]
-            == "CheckSkipRAGIngestion"
-        )
 
 
 # ── Result paths (state-merge contract) ───────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes the `CheckEnableStandaloneScanner` SF Choice state so the standalone Scanner Lambda runs unconditionally on every Saturday SF firing (parallel-observe mode, non-blocking Catch).
- Drops the dead `enable_standalone_scanner: true` flag from the EventBridge target Input in CFN.
- Rewrites the affected tests to pin the gate's ABSENCE and pin both DataPhase1-predecessor routes directly to `Scanner`.

## Why

Per `feedback_observe_mode_unconditional_gates_govern_cutover` (saved 2026-05-28): observe-mode producer code must run unconditionally on every scheduled firing. Silent absence-of-`candidates.json` is itself the failure mode the L1995 Phase 3 soak is meant to detect. Non-blocking Catch already handles producer-failure risk; one Lambda/week is rounding error.

PR #313 codified `enable_standalone_scanner=true` in the EB Input as a half-measure, but the Choice state itself remained a footgun — any future CFN deploy that re-rendered the target without the flag would silently disable observation. The Phase 4/5 consumer-cutover flag (Research / RAG reading `candidates.json` load-bearingly) belongs at the consumer side, not the producer side; conflating the two under one flag is the anti-pattern this PR removes.

## Changes

- `infrastructure/step_function.json`
  - `CheckSkipDataPhase1` skip branch + `CheckDataPhase1Status.Success` now `Next: Scanner` directly.
  - `CheckEnableStandaloneScanner` Choice state removed.
  - `Scanner` state Comment rewritten to document unconditional execution + cross-link to the feedback memory.
- `infrastructure/cloudformation/alpha-engine-orchestration.yaml`
  - SaturdayTrigger Input drops the `enable_standalone_scanner: true` line. Comment block referencing the flag also removed (its presence would trip the new negative-assertion test).
- `tests/test_sf_scanner_wiring.py`
  - `TestGateDefaultOff` deleted; replaced with `TestStatesPresent.test_no_enable_scanner_choice_gate` (negative assertion).
  - `TestEdges` rewritten to assert both DataPhase1 predecessors route directly to `Scanner`.
  - Module docstring updated.
- `tests/test_deploy_step_function_eventbridge_input.py`
  - `TestSaturdayCFNTargetActivatesScanner` (pinned flag presence) replaced with `TestSaturdayCFNTargetHasNoScannerGateFlag` (pins flag absence).

## Test plan

- [x] `pytest tests/test_sf_scanner_wiring.py tests/test_deploy_step_function_eventbridge_input.py -q` — 25 passed
- [x] `pytest tests/ -k "sf or eventbridge or scanner or saturday or step_function" -q` — 525 passed, 1 skipped
- [x] `pytest tests/ -q` — 1675 passed, 1 skipped (unchanged from main)
- [x] JSON validity of `step_function.json` (`python3 -c "import json; json.load(open(...))"`)

## Operator deploy steps

After merge:
1. `bash infrastructure/deploy_step_function.sh` — pushes the updated SF definition to AWS.
2. CFN stack update for the EB-target Input change.
3. First post-fix Saturday SF firing **2026-05-30 09:00 UTC** lands `candidates.json` structurally. Compare `candidates.json::scanner_tickers` against `signals.json::universe` minus `population` — zero divergence is the Phase 3 → Phase 4 transition signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)