### PR TITLE
refactor(arcticdb): delegate to lib chokepoint (L2771 part 3/5)

### DIFF
--- a/sf_preflight.py
+++ b/sf_preflight.py
@@ -172,11 +172,8 @@ def check_arctic_connectivity(ctx: PreflightContext) -> CheckResult:
     t0 = time.time()
     try:
         import arcticdb as adb
-        uri = (
-            f"s3s://s3.us-east-1.amazonaws.com:{ctx.bucket}"
-            "?path_prefix=arcticdb&aws_auth=true"
-        )
-        arctic = adb.Arctic(uri)
+        from alpha_engine_lib.arcticdb import open_arctic
+        arctic = open_arctic(ctx.bucket, region="us-east-1")
         libs = set(arctic.list_libraries())
         if "universe" not in libs or "macro" not in libs:
             return CheckResult(

--- a/validators/postflight.py
+++ b/validators/postflight.py
@@ -119,19 +119,12 @@ class DataPostflight:
 
     def _open_arctic_libs(self) -> "tuple[Any, Any]":
         if self._universe_lib is None or self._macro_lib is None:
-            import arcticdb as adb
-            uri = (
-                f"s3s://s3.{self.region}.amazonaws.com:{self.bucket}"
-                "?path_prefix=arcticdb&aws_auth=true"
-            )
+            from alpha_engine_lib.arcticdb import open_universe_lib, open_macro_lib
             try:
-                arctic = adb.Arctic(uri)
-                self._universe_lib = arctic.get_library("universe")
-                self._macro_lib = arctic.get_library("macro")
+                self._universe_lib = open_universe_lib(self.bucket, region=self.region)
+                self._macro_lib = open_macro_lib(self.bucket, region=self.region)
             except Exception as exc:
-                raise PostflightError(
-                    f"ArcticDB unreachable at {uri}: {exc}"
-                ) from exc
+                raise PostflightError(str(exc)) from exc
         return self._universe_lib, self._macro_lib
 
     # ── Checks ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two ae-data sites migrated to `alpha_engine_lib.arcticdb`:
- `sf_preflight.py::_check_arctic_connectivity` — uses `open_arctic` (specialized shape: inspects both libs before opening).
- `validators/postflight.py::_open_arctic_libs` — uses `open_universe_lib` + `open_macro_lib`. `PostflightError` preserved.

**Not migrated:** `store/arctic_store.py:64` is a writer-side `get_library(..., create_if_missing=True)` call — the lib chokepoint is reader-only. Out of scope.

ROADMAP: **L2771 part 3 of 5** (parts 1+2 = alpha-engine #225, alpha-engine-research #247).

## Test plan
- [x] Full suite green: 1675 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)