### PR TITLE
fix(freshness-deploy): use file:// for historical-cron put-targets

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -215,10 +215,26 @@ if $BOOTSTRAP; then
     --region "${REGION}" \
     --query 'RuleArn' --output text
 
+  # JSON Input (`{"mode":"historical"}`) doesn't fit the put-targets
+  # shorthand form (Id=,Arn=,Input= chokes on the embedded quotes +
+  # comma). Write a temp JSON file + pass via file:// to dodge the
+  # shell-quoting trap. Caught live 2026-05-28 when --bootstrap re-run
+  # tripped argparse on the shorthand.
+  HIST_TARGET_JSON=$(mktemp)
+  cat > "${HIST_TARGET_JSON}" <<EOF
+[
+  {
+    "Id": "1",
+    "Arn": "${FN_ARN}",
+    "Input": "{\"mode\":\"historical\"}"
+  }
+]
+EOF
   run aws events put-targets \
     --rule "${HISTORICAL_RULE_NAME}" \
-    --targets "Id=1,Arn=${FN_ARN},Input={\"mode\":\"historical\"}" \
+    --targets "file://${HIST_TARGET_JSON}" \
     --region "${REGION}"
+  rm -f "${HIST_TARGET_JSON}"
 
   HIST_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${HISTORICAL_RULE_NAME}"
   run aws lambda add-permission \


### PR DESCRIPTION
## Summary

`deploy.sh --bootstrap` was tripping on the `put-targets` shorthand when the Input contains JSON. From PR #339 the historical cron's target carries `Input={"mode":"historical"}`; the shorthand form `Id=N,Arn=...,Input={...}` confuses argparse on the embedded quotes + comma.

Caught live 2026-05-28 when `--bootstrap` re-run partial-fired:
```
ParamValidation: Error parsing parameter '--targets': Expected: '=', received: '"' for input
```

Switch to a temp-file JSON spec via `file://`.

## Live state

The historical EB cron IS wired live in AWS (target attached manually via direct CLI during this session with the same JSON). First daily firing at **04:00 UTC tomorrow**. This commit ensures the next operator who runs `--bootstrap` from main doesn't trip the same trap.

## Verification

```
aws events list-targets-by-rule --rule alpha-engine-freshness-monitor-historical-cron \
  --query 'Targets[].{Id:Id,Input:Input}'
[{"Id": "1", "Input": "{\"mode\":\"historical\"}"}]

bash deploy.sh --bootstrap --dry-run
DRY: aws events put-targets --rule alpha-engine-freshness-monitor-historical-cron \
     --targets file:///tmp/tmp.KUaF4o3som --region us-east-1
```

## Composes with

- PR #339 (historical-mode substrate + new EB cron)
- PR #341 (template-aware probe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)