### PR TITLE
feat(schema): signals.schema.json market_regime to 3-class — Phase 1C

### DIFF
--- a/contracts/signals.schema.json
+++ b/contracts/signals.schema.json
@@ -20,8 +20,8 @@
     },
     "market_regime": {
       "type": "string",
-      "enum": ["bull", "neutral", "caution", "bear"],
-      "description": "Current market regime assessment"
+      "enum": ["bull", "neutral", "bear"],
+      "description": "Current market regime assessment. 3-class Ang-Bekaert taxonomy (v0.42.0 / 2026-05-28). Legacy 4-class 'caution' retired per caution-regime-retirement-260528.md — its driving signals (VIX, HY OAS, SPY 30d return) are weighted continuously into regime_intensity_z (predictor META_FEATURE 13) rather than discretized into a 4th category. Portfolio-protective hysteresis is a separate axis on the predictor drawdown leg (risk_on/caution/risk_off). Historical signals.json artifacts with 'caution' in market_regime are grandfathered — consumers tolerant of legacy enum on read."
     },
     "sector_ratings": {
       "type": "object",

--- a/tests/integration/test_data_contract_validation.py
+++ b/tests/integration/test_data_contract_validation.py
@@ -69,6 +69,41 @@ class TestSignalsContract:
         with pytest.raises(ValidationError):
             validate(instance=bad_signals, schema=schema)
 
+    def test_market_regime_enum_is_3class(self):
+        # 3-class Ang-Bekaert taxonomy (v0.42.0 / 2026-05-28).
+        # Legacy 4-class "caution" retired per
+        # caution-regime-retirement-260528.md.
+        schema = _load_schema("signals.schema.json")
+        regime_field = schema["properties"]["market_regime"]
+        assert regime_field["enum"] == ["bull", "neutral", "bear"]
+
+    def test_market_regime_caution_rejected(self):
+        schema = _load_schema("signals.schema.json")
+        bad_signals = {
+            "date": "2026-04-03",
+            "run_time": "00:30:00",
+            "market_regime": "caution",
+            "sector_ratings": {},
+            "universe": [],
+            "buy_candidates": [],
+        }
+        with pytest.raises(ValidationError):
+            validate(instance=bad_signals, schema=schema)
+
+    def test_each_3class_regime_accepted(self):
+        schema = _load_schema("signals.schema.json")
+        for regime in ("bull", "neutral", "bear"):
+            signals = {
+                "date": "2026-04-03",
+                "run_time": "00:30:00",
+                "market_regime": regime,
+                "sector_ratings": {},
+                "universe": [],
+                "buy_candidates": [],
+            }
+            # Should not raise
+            validate(instance=signals, schema=schema)
+
 
 class TestPredictionsContract:
     def test_valid_predictions_pass(self):


### PR DESCRIPTION
## Summary

Caution-regime retirement Phase 1C — data contract trim. Plan doc: `alpha-engine-docs/private/caution-regime-retirement-260528.md`.

- `market_regime` enum: `["bull","neutral","caution","bear"]` → `["bull","neutral","bear"]` (3-class Ang-Bekaert).
- Schema description names the SOTA framing + grandfather treatment.
- 3 new tests pin enum invariant + caution-rejected + 3-class accept-all.

## Why

Stress signals (VIX, HY OAS, SPY 30d return) flow through the continuous `regime_intensity_z` META_FEATURE (predictor L2 Ridge input) rather than discretizing into a 4th regime category. Portfolio-protective hysteresis is a separate axis on the predictor drawdown leg (`risk_on/caution/risk_off`); Phase 2 separates the type system so the leg's vocabulary stops aliasing into the macro regime vocabulary.

Historical `signals.json` artifacts in S3 with `market_regime: "caution"` are grandfathered — consumers tolerant of legacy enum on read, no S3 migration.

## Test plan

- [x] `test_market_regime_enum_is_3class` — pins the enum literal
- [x] `test_market_regime_caution_rejected` — pins jsonschema rejection
- [x] `test_each_3class_regime_accepted` — forward-compat smoke
- [x] Full suite 1675 → 1678 passing

## Phasing

- alpha-engine-lib #86 (Phase 1A — MERGED, v0.42.0 published)
- alpha-engine-research #250 (Phase 1B — research macro_agent retirement, OPEN)
- THIS PR (Phase 1C)
- alpha-engine-config Phase 1D — universe.yaml + ROADMAP
- Phase 2A-D + Phase 3 follow per plan doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)