### PR TITLE
feat(signal-returns): canonical 21d returns + log-alpha on score_performance

### DIFF
--- a/collectors/signal_returns.py
+++ b/collectors/signal_returns.py
@@ -408,14 +408,17 @@ def _backfill_score_context(
 
 
 def _backfill_score_returns(db_path: str, dry_run: bool) -> dict:
-    """Backfill 5d/10d/30d returns in score_performance by JOINing universe_returns."""
+    """Backfill 5d/10d/21d/30d returns in score_performance by JOINing
+    universe_returns, plus the canonical 21d log-domain market-relative
+    alpha (log_alpha_21d) — the same target the predictor trains on.
+    """
     try:
         conn = sqlite3.connect(db_path)
         _ensure_score_performance_schema(conn)
 
         updated = 0
-        for horizon in ("5d", "10d", "30d"):
-            bdays = {"5d": 5, "10d": 10, "30d": 30}[horizon]
+        for horizon in ("5d", "10d", "21d", "30d"):
+            bdays = {"5d": 5, "10d": 10, "21d": 21, "30d": 30}[horizon]
 
             # Find score_performance rows missing this horizon's return
             pending = pd.read_sql_query(
@@ -459,8 +462,54 @@ def _backfill_score_returns(db_path: str, dry_run: bool) -> dict:
                     )
                 updated += 1
 
+        # Backfill canonical 21d log-domain market-relative alpha
+        # (log_alpha_21d) — the same target the predictor trains on
+        # (actual_log_alpha). Separate block from the arithmetic loop
+        # because it sources the LOG columns, not the arithmetic ones:
+        #   log_alpha = log_return_21d - log_spy_return_21d
+        # Mirrors _backfill_predictor_returns (lines ~629-631) so the
+        # judge outcome-IC correlates against an identically-defined
+        # alpha. No clipping / sector-neutralization — raw log diff, per
+        # the canonical-alpha framework (cutover 2026-05-09).
+        ur_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(universe_returns)").fetchall()
+        }
+        if {"log_return_21d", "log_spy_return_21d"} <= ur_cols:
+            pending_alpha = pd.read_sql_query(
+                "SELECT symbol, score_date FROM score_performance WHERE log_alpha_21d IS NULL",
+                conn,
+            )
+            for _, row in pending_alpha.iterrows():
+                ticker = row["symbol"]
+                score_date = row["score_date"]
+                ur = conn.execute(
+                    "SELECT log_return_21d, log_spy_return_21d "
+                    "FROM universe_returns WHERE ticker = ? AND eval_date = ?",
+                    (ticker, score_date),
+                ).fetchone()
+                if ur is None or ur[0] is None:
+                    continue
+                log_alpha = ur[0] - (ur[1] if ur[1] is not None else 0.0)
+                if not dry_run:
+                    conn.execute(
+                        "UPDATE score_performance SET log_alpha_21d=? "
+                        "WHERE symbol=? AND score_date=? AND log_alpha_21d IS NULL",
+                        (round(log_alpha, 6), ticker, score_date),
+                    )
+                updated += 1
+        else:
+            # Carve-out per ~/Development/CLAUDE.md no-silent-fails: (a) failure
+            # mode = legacy universe_returns lacking 21d log columns (pre-#197);
+            # (b) primary deliverable (5/10/21/30d arithmetic returns above)
+            # survives; (c) recording surface = this WARN. Post-#197 DBs always
+            # have these, so a sustained WARN means a migration regressed.
+            logger.warning(
+                "score_performance: universe_returns lacks log_return_21d/"
+                "log_spy_return_21d — skipping canonical log_alpha_21d backfill"
+            )
+
         # Repair: fix beat_spy columns where return exists but beat_spy is NULL
-        for horizon in ("5d", "10d", "30d"):
+        for horizon in ("5d", "10d", "21d", "30d"):
             repaired = conn.execute(
                 f"UPDATE score_performance SET beat_spy_{horizon} = CASE WHEN return_{horizon} > spy_{horizon}_return THEN 1 ELSE 0 END WHERE return_{horizon} IS NOT NULL AND spy_{horizon}_return IS NOT NULL AND beat_spy_{horizon} IS NULL",
             ).rowcount
@@ -712,6 +761,15 @@ def _ensure_score_performance_schema(conn) -> None:
         ("beat_spy_5d", "INTEGER"), ("eval_date_5d", "TEXT"),
         ("price_10d", "REAL"), ("return_10d", "REAL"), ("spy_10d_return", "REAL"),
         ("beat_spy_10d", "INTEGER"), ("eval_date_10d", "TEXT"),
+        # Canonical 21d horizon (alpha-engine-research migration #18,
+        # 2026-05-29). Arithmetic parity columns + the canonical
+        # log-domain market-relative alpha (log_alpha_21d) the predictor
+        # trains on (actual_log_alpha). Sourced from universe_returns'
+        # return_21d / log_return_21d columns (alpha-engine-data #197).
+        # Powers the judge outcome-IC validation (ROADMAP L480 re-scope).
+        ("price_21d", "REAL"), ("return_21d", "REAL"), ("spy_21d_return", "REAL"),
+        ("beat_spy_21d", "INTEGER"), ("eval_date_21d", "TEXT"),
+        ("log_alpha_21d", "REAL"),
         ("price_30d", "REAL"), ("return_30d", "REAL"), ("spy_30d_return", "REAL"),
         ("beat_spy_30d", "INTEGER"), ("eval_date_30d", "TEXT"),
         # Calibrator-v1 context (alpha-engine-research migration #12)

--- a/tests/test_signal_returns_score_context.py
+++ b/tests/test_signal_returns_score_context.py
@@ -651,3 +651,144 @@ class TestEnsureScorePerformanceSchemaIncludesStance:
             _ensure_score_performance_schema(conn)
             cols = {r[1] for r in conn.execute("PRAGMA table_info(score_performance)").fetchall()}
         assert "stance" in cols
+
+
+# ── Canonical 21d returns + log-alpha backfill (ROADMAP L480, 2026-05-29) ──
+#
+# The judge outcome-IC validation correlates judge quality scores against
+# realized canonical 21d log-domain market-relative alpha. These tests pin
+# that _backfill_score_returns now populates the 21d arithmetic parity
+# columns AND log_alpha_21d (= log_return_21d - log_spy_return_21d, the
+# same definition the predictor's actual_log_alpha uses).
+
+
+from collectors.signal_returns import _backfill_score_returns
+
+
+def _make_21d_db(
+    path,
+    *,
+    ticker="AAPL",
+    score_date="2026-05-01",
+    entry_price=100.0,
+    include_log_cols=True,
+    log_21d=0.0488,
+    log_spy_21d=0.00995,
+):
+    """score_performance with one seeded row + a universe_returns carrying
+    the full horizon column set (only 21d populated)."""
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE score_performance ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, symbol TEXT NOT NULL, "
+            "score_date TEXT NOT NULL, score REAL, price_on_date REAL, "
+            "UNIQUE(symbol, score_date))"
+        )
+        conn.execute(
+            "INSERT INTO score_performance (symbol, score_date, score, price_on_date) "
+            "VALUES (?, ?, ?, ?)",
+            (ticker, score_date, 78.0, entry_price),
+        )
+        log_cols = (
+            ", log_return_21d REAL, log_spy_return_21d REAL"
+            if include_log_cols else ""
+        )
+        conn.execute(
+            "CREATE TABLE universe_returns ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, ticker TEXT NOT NULL, "
+            "eval_date TEXT NOT NULL, "
+            "return_5d REAL, spy_return_5d REAL, beat_spy_5d INTEGER, "
+            "return_10d REAL, spy_return_10d REAL, beat_spy_10d INTEGER, "
+            "return_21d REAL, spy_return_21d REAL, beat_spy_21d INTEGER, "
+            "return_30d REAL, spy_return_30d REAL, beat_spy_30d INTEGER"
+            f"{log_cols}, UNIQUE(ticker, eval_date))"
+        )
+        if include_log_cols:
+            conn.execute(
+                "INSERT INTO universe_returns "
+                "(ticker, eval_date, return_21d, spy_return_21d, beat_spy_21d, "
+                "log_return_21d, log_spy_return_21d) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (ticker, score_date, 0.05, 0.01, 1, log_21d, log_spy_21d),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO universe_returns "
+                "(ticker, eval_date, return_21d, spy_return_21d, beat_spy_21d) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (ticker, score_date, 0.05, 0.01, 1),
+            )
+        conn.commit()
+
+
+class TestBackfillScoreReturns21d:
+    def test_populates_21d_arithmetic_and_canonical_log_alpha(self, tmp_path):
+        db = str(tmp_path / "research.db")
+        _make_21d_db(db, log_21d=0.0488, log_spy_21d=0.00995)
+
+        out = _backfill_score_returns(db, dry_run=False)
+        assert out["status"] == "ok"
+
+        with sqlite3.connect(db) as conn:
+            row = conn.execute(
+                "SELECT price_21d, return_21d, spy_21d_return, beat_spy_21d, "
+                "log_alpha_21d FROM score_performance WHERE symbol='AAPL'"
+            ).fetchone()
+        price_21d, return_21d, spy_21d_return, beat_spy_21d, log_alpha_21d = row
+        assert price_21d == pytest.approx(105.0)         # 100 * (1 + 0.05)
+        assert return_21d == pytest.approx(5.0)          # stored as percent
+        assert spy_21d_return == pytest.approx(1.0)
+        assert beat_spy_21d == 1
+        # Canonical: log_alpha = log_return_21d - log_spy_return_21d
+        assert log_alpha_21d == pytest.approx(0.0488 - 0.00995, abs=1e-6)
+
+    def test_missing_log_columns_warns_but_arithmetic_survives(self, tmp_path, caplog):
+        import logging
+
+        db = str(tmp_path / "research.db")
+        _make_21d_db(db, include_log_cols=False)
+
+        with caplog.at_level(logging.WARNING, logger="collectors.signal_returns"):
+            out = _backfill_score_returns(db, dry_run=False)
+        assert out["status"] == "ok"
+
+        with sqlite3.connect(db) as conn:
+            row = conn.execute(
+                "SELECT return_21d, log_alpha_21d FROM score_performance WHERE symbol='AAPL'"
+            ).fetchone()
+        # Primary deliverable (arithmetic 21d) survives; canonical alpha NULL.
+        assert row[0] == pytest.approx(5.0)
+        assert row[1] is None
+        assert any(
+            "log_alpha_21d" in r.getMessage() for r in caplog.records
+            if r.levelno == logging.WARNING
+        ), "no-silent-fails: missing log columns must emit a WARN"
+
+    def test_dry_run_does_not_write_21d(self, tmp_path):
+        db = str(tmp_path / "research.db")
+        _make_21d_db(db)
+
+        _backfill_score_returns(db, dry_run=True)
+
+        with sqlite3.connect(db) as conn:
+            row = conn.execute(
+                "SELECT return_21d, log_alpha_21d FROM score_performance WHERE symbol='AAPL'"
+            ).fetchone()
+        assert row == (None, None)
+
+    def test_rerun_is_noop_once_populated(self, tmp_path):
+        db = str(tmp_path / "research.db")
+        _make_21d_db(db)
+        _backfill_score_returns(db, dry_run=False)
+        out = _backfill_score_returns(db, dry_run=False)
+        # Second pass finds nothing NULL → 0 further writes.
+        assert out["rows_written"] == 0
+
+    def test_schema_ensure_adds_21d_columns(self, tmp_db):
+        with sqlite3.connect(tmp_db) as conn:
+            _ensure_score_performance_schema(conn)
+            cols = {r[1] for r in conn.execute(
+                "PRAGMA table_info(score_performance)"
+            ).fetchall()}
+        for col in ("price_21d", "return_21d", "spy_21d_return",
+                    "beat_spy_21d", "eval_date_21d", "log_alpha_21d"):
+            assert col in cols, f"missing {col}"


### PR DESCRIPTION
**Prereq (1 of 2)** for the judge outcome-IC validation — the primary judge-validation piece from the 2026-05-29 L480 re-scope (config #372). Brian chose to anchor the IC on the **canonical 21d log-domain market-relative alpha**, not 10d/30d, so this adds that target to the research-pick outcome table.

## Change
`_backfill_score_returns` now also handles the **21d horizon**:
- Arithmetic parity columns: `price_21d` / `return_21d` / `spy_21d_return` / `beat_spy_21d` / `eval_date_21d` (same path as 5/10/30d)
- **`log_alpha_21d`** — canonical 21d log-domain market-relative alpha = `log_return_21d - log_spy_return_21d`, the *identical* definition the predictor's `actual_log_alpha` uses (mirrors `_backfill_predictor_returns`)

Sourced from `universe_returns`' existing 21d columns (alpha-engine-data #197). Pure-additive to `score_performance`; no consumer reads these columns yet.

## Robustness
Missing-log-column case (legacy pre-#197 DB) WARN-logs and degrades to arithmetic-only — primary deliverable survives, failure recorded, per the no-silent-fails rule.

## Pairs with
alpha-engine-research migration v18 (`feat/score-perf-21d-schema-v18-260529`) — the canonical schema migration mirroring these columns. The `_ensure_score_performance_schema` belt-and-suspenders ALTER here covers the case where the data Lambda fires before the research migration applies.

## Tests
5 new tests (21d arithmetic + canonical log-alpha, missing-log WARN+degrade, dry-run, rerun-noop, schema-ensure). Full data suite **1680 passed**.

## Backfill timeline
21d outcomes populate ~30 calendar days after each pick's `score_date`, on the first Saturday collector run after the window closes. Outcome-IC (backtester, separate PR) ships after this lands + a backfill cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)