### PR TITLE
feat(collector): record barrier_win_prob into predictor_outcomes (L239)

### DIFF
--- a/collectors/signal_returns.py
+++ b/collectors/signal_returns.py
@@ -542,6 +542,11 @@ def _seed_predictor_outcomes(s3, bucket: str, db_path: str, dry_run: bool) -> di
             return {"status": "ok", "rows_written": 0, "note": "no prediction files in S3"}
 
         conn = sqlite3.connect(db_path)
+        # Ensure horizon-agnostic + barrier_win_prob columns exist BEFORE the
+        # seed INSERT (Step 3) — the backfill (Step 4) also calls this but runs
+        # later, so the INSERT below would reference a missing column on first
+        # run without this. Idempotent: Step 4's call becomes a no-op.
+        _ensure_predictor_outcomes_schema(conn)
         existing = {
             (r[0], r[1]) for r in
             conn.execute("SELECT symbol, prediction_date FROM predictor_outcomes").fetchall()
@@ -559,8 +564,8 @@ def _seed_predictor_outcomes(s3, bucket: str, db_path: str, dry_run: bool) -> di
                         continue
                     if not dry_run:
                         conn.execute(
-                            "INSERT INTO predictor_outcomes (symbol, prediction_date, predicted_direction, prediction_confidence, p_up, p_flat, p_down, score_modifier_applied) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                            (ticker, pred_date, p.get("predicted_direction"), p.get("prediction_confidence"), p.get("p_up"), p.get("p_flat"), p.get("p_down"), 0.0),
+                            "INSERT INTO predictor_outcomes (symbol, prediction_date, predicted_direction, prediction_confidence, p_up, p_flat, p_down, score_modifier_applied, barrier_win_prob) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            (ticker, pred_date, p.get("predicted_direction"), p.get("prediction_confidence"), p.get("p_up"), p.get("p_flat"), p.get("p_down"), 0.0, p.get("barrier_win_prob")),
                         )
                     existing.add((ticker, pred_date))
                     inserted += 1
@@ -804,6 +809,12 @@ def _ensure_predictor_outcomes_schema(conn) -> None:
         ("actual_log_alpha", "REAL"),
         ("horizon_days", "INTEGER"),
         ("correct", "INTEGER"),
+        # Observe-only López-de-Prado meta-label: P(upper/profit barrier touched
+        # before lower/stop barrier), emitted by alpha-engine-predictor #211 into
+        # predictions.json. Nullable — null when the meta-label classifier isn't
+        # loaded/fitted for a cycle. Recording it here unblocks the backtester's
+        # barrier_sizing_optimizer IC gate (was returning barrier_win_prob_column_absent).
+        ("barrier_win_prob", "REAL"),
     ]:
         if col not in cols:
             conn.execute(f"ALTER TABLE predictor_outcomes ADD COLUMN {col} {col_type}")

--- a/tests/test_signal_returns_barrier_win_prob.py
+++ b/tests/test_signal_returns_barrier_win_prob.py
@@ -1,0 +1,155 @@
+"""Tests for recording `barrier_win_prob` into predictor_outcomes.
+
+Covers ROADMAP L239: the predictor (alpha-engine-predictor #211) emits an
+observe-only López-de-Prado meta-label `barrier_win_prob` — P(upper/profit
+barrier touched before lower/stop barrier) — into predictions.json. The
+backtester's `barrier_sizing_optimizer` IC gate returns
+`barrier_win_prob_column_absent` until alpha-engine-data's predictor-outcomes
+seeder ALSO records this field into the `predictor_outcomes` table, mirroring
+the existing `p_up` write path.
+
+These tests pin two contracts:
+  - `_ensure_predictor_outcomes_schema` adds the nullable `barrier_win_prob`
+    column (idempotent ALTER).
+  - `_seed_predictor_outcomes` reads `barrier_win_prob` from each prediction
+    dict and writes it on the initial INSERT, recording NULL when the
+    predictor omitted the field (meta-label classifier not loaded that cycle).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from collectors.signal_returns import (
+    _ensure_predictor_outcomes_schema,
+    _seed_predictor_outcomes,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path) -> str:
+    """An empty predictor_outcomes table — pre-barrier_win_prob schema.
+
+    Mirrors the legacy shape research.db carries before this collector's
+    schema-ensure runs (the table is created by the research Lambda; the
+    seeder only ALTERs missing columns + inserts rows).
+    """
+    db = tmp_path / "research.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE predictor_outcomes (
+                id INTEGER PRIMARY KEY,
+                symbol TEXT NOT NULL,
+                prediction_date TEXT NOT NULL,
+                predicted_direction TEXT,
+                prediction_confidence REAL,
+                p_up REAL, p_flat REAL, p_down REAL,
+                score_modifier_applied REAL DEFAULT 0.0,
+                actual_5d_return REAL,
+                correct_5d INTEGER,
+                UNIQUE(symbol, prediction_date)
+            )
+            """
+        )
+        conn.commit()
+    return str(db)
+
+
+def _predictions_payload() -> dict:
+    """A predictions.json with one ticker carrying barrier_win_prob and one
+    omitting it (the meta-label classifier rides as null when not fitted)."""
+    return {
+        "date": "2026-05-29",
+        "predictions": [
+            {
+                "ticker": "AAPL",
+                "predicted_direction": "UP",
+                "prediction_confidence": 0.81,
+                "p_up": 0.62, "p_flat": 0.28, "p_down": 0.10,
+                "barrier_win_prob": 0.72,
+            },
+            {
+                # Older/observe-gap prediction — classifier not loaded, field absent.
+                "ticker": "MSFT",
+                "predicted_direction": "FLAT",
+                "prediction_confidence": 0.55,
+                "p_up": 0.34, "p_flat": 0.40, "p_down": 0.26,
+            },
+        ],
+    }
+
+
+def _mock_s3_for(payload: dict, *, key: str = "predictor/predictions/2026-05-29.json") -> MagicMock:
+    body = MagicMock()
+    body.read.return_value = json.dumps(payload).encode()
+    s3 = MagicMock()
+    s3.list_objects_v2.return_value = {"Contents": [{"Key": key}]}
+    s3.get_object.return_value = {"Body": body}
+    return s3
+
+
+# ── Schema bridge ──────────────────────────────────────────────────────────────
+
+
+def test_schema_ensure_adds_barrier_win_prob_column(tmp_db):
+    with sqlite3.connect(tmp_db) as conn:
+        _ensure_predictor_outcomes_schema(conn)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(predictor_outcomes)").fetchall()}
+    assert "barrier_win_prob" in cols
+
+
+# ── Seed: records barrier_win_prob from predictions.json ────────────────────────
+
+
+class TestSeedRecordsBarrierWinProb:
+
+    def test_records_value_when_present(self, tmp_db):
+        s3 = _mock_s3_for(_predictions_payload())
+        out = _seed_predictor_outcomes(s3, "bucket", tmp_db, dry_run=False)
+        assert out["status"] == "ok"
+        assert out["rows_written"] == 2
+
+        with sqlite3.connect(tmp_db) as conn:
+            row = conn.execute(
+                "SELECT barrier_win_prob FROM predictor_outcomes "
+                "WHERE symbol='AAPL' AND prediction_date='2026-05-29'"
+            ).fetchone()
+        assert row[0] == pytest.approx(0.72)
+
+    def test_records_null_when_field_absent(self, tmp_db):
+        s3 = _mock_s3_for(_predictions_payload())
+        _seed_predictor_outcomes(s3, "bucket", tmp_db, dry_run=False)
+
+        with sqlite3.connect(tmp_db) as conn:
+            row = conn.execute(
+                "SELECT barrier_win_prob FROM predictor_outcomes "
+                "WHERE symbol='MSFT' AND prediction_date='2026-05-29'"
+            ).fetchone()
+        assert row[0] is None
+
+    def test_seed_auto_creates_column_on_legacy_db(self, tmp_db):
+        """The seeder runs schema-ensure before its INSERT, so a research.db
+        whose predictor_outcomes predates barrier_win_prob still records it
+        without a separate migration step."""
+        s3 = _mock_s3_for(_predictions_payload())
+        _seed_predictor_outcomes(s3, "bucket", tmp_db, dry_run=False)
+        with sqlite3.connect(tmp_db) as conn:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(predictor_outcomes)").fetchall()}
+        assert "barrier_win_prob" in cols
+
+    def test_dry_run_writes_nothing(self, tmp_db):
+        s3 = _mock_s3_for(_predictions_payload())
+        out = _seed_predictor_outcomes(s3, "bucket", tmp_db, dry_run=True)
+        # rows_written counts intended inserts; dry_run skips the execute.
+        assert out["rows_written"] == 2
+        with sqlite3.connect(tmp_db) as conn:
+            n = conn.execute("SELECT COUNT(*) FROM predictor_outcomes").fetchone()[0]
+        assert n == 0


### PR DESCRIPTION
## What

Records the predictor's observe-only López-de-Prado meta-label `barrier_win_prob` into the `predictor_outcomes` table, mirroring the existing `p_up` write path.

`barrier_win_prob` = P(upper/profit barrier touched before lower/stop barrier), emitted into `predictions.json` by [alpha-engine-predictor #211](https://github.com/cipher813/alpha-engine-predictor/pull/211). It is nullable — the predictor rides it as `null` when the meta-label classifier isn't loaded/fitted for a cycle.

## Why

The backtester's `barrier_sizing_optimizer` IC gate returns `barrier_win_prob_column_absent` until this field is joined into `predictor_outcomes`. Until then the **B2 sizing flip** (`barrier_win_prob_sizing_enabled` in `executor_params.json`) can never be data-justified. This is the **activation prerequisite** for the Task B meta-labeling-for-sizing arc (ROADMAP L239).

## Changes

- `_ensure_predictor_outcomes_schema`: add nullable `barrier_win_prob REAL` (idempotent ALTER).
- `_seed_predictor_outcomes`: call schema-ensure **before** the seed INSERT (Step 3) so the column exists at insert time — the backfill (Step 4) also calls it but runs later, so its call is now a no-op. Read `p.get("barrier_win_prob")` and write it on insert.
- 5 new tests: schema-ensure adds the column; value recorded when present; NULL recorded when the predictor omits it; legacy DB auto-creates the column via the seed path; dry-run writes nothing.

## Verification

- New tests + sibling collector tests: 48 passed.
- Full suite: **1688 passed, 1 skipped** (warnings pre-existing, unrelated).

## Activation path (post-merge, soak-gated — not this PR)

Once ≥30 resolved rows accumulate with `barrier_win_prob` + ≥1 Saturday cycle, the B3 analyzer (`alpha-engine-backtester/optimizer/barrier_sizing_optimizer.py`) produces an IC verdict that gates flipping `barrier_win_prob_sizing_enabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)