### PR TITLE
feat(freshness-monitor): wire cycle_completion rollup into the monitor (L249)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -40,6 +40,17 @@
         "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*",
         "arn:aws:s3:::alpha-engine-research/_alerts/_dedup/*"
       ]
+    },
+    {
+      "Sid": "CloudWatchCycleCompletionMetric",
+      "Effect": "Allow",
+      "Action": ["cloudwatch:PutMetricData"],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "cloudwatch:namespace": "AlphaEngine/Substrate"
+        }
+      }
     }
   ]
 }

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -47,6 +47,7 @@ import json
 import logging
 import os
 import time
+from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
@@ -58,6 +59,8 @@ from alpha_engine_lib.artifact_freshness import (
     ArtifactSpec,
     CheckResult,
     check_freshness,
+    cycle_completion,
+    resolve_current_cycle,
     resolve_dedup_key,
 )
 from alpha_engine_lib.trading_calendar import previous_trading_day
@@ -75,6 +78,12 @@ REGISTRY_KEY = os.environ.get(
 HEARTBEAT_KEY = "_freshness_monitor/heartbeat.json"
 CHECK_RESULTS_KEY = "_freshness_monitor/check_results.json"
 HISTORY_KEY = "_freshness_monitor/history.json"
+CYCLE_VERDICT_KEY = "_freshness_monitor/cycle_verdict.json"
+
+# CloudWatch namespace for the per-cycle completion rollup metric. Shares
+# the substrate-health namespace so cycle-completion + substrate-row health
+# graph together. Dimensioned by Cadence only (low-cardinality, alarm-able).
+CW_NAMESPACE = "AlphaEngine/Substrate"
 
 # Historical-mode lookback depth per cadence. Tunable via event payload
 # (event["lookback"] = {"saturday_sf": 12, ...}). Defaults sized for ~3
@@ -254,6 +263,78 @@ def _put_json(s3_client: Any, bucket: str, key: str, payload: dict) -> None:
         Body=body,
         ContentType="application/json",
     )
+
+
+# ── Per-cycle completion rollup (L249 consumer) ─────────────────────────────
+
+
+def _serialize_cycle_verdicts(
+    pairs: list[tuple[ArtifactSpec, CheckResult]], now: datetime
+) -> dict[str, Any]:
+    """Roll the per-artifact probe results up into one completion verdict
+    per execution cycle, via :func:`cycle_completion`.
+
+    The registry walk covers EVERY cadence in a single 15-min pass, so the
+    grouping by ``(cadence, cycle_label)`` is mandatory — a single rollup
+    over the mixed-cadence ``pairs`` would conflate the Saturday, weekday,
+    EOD and continuous cycles into one meaningless verdict. ``weekday_sf``
+    and ``eod_sf`` share a date-shaped label, so the cadence is part of the
+    group key to keep them distinct.
+
+    ``cycle_completion`` itself filters to ``severity="critical"`` rows; a
+    group whose cadence has no critical artifacts rolls up vacuously
+    complete (``n_required=0``).
+    """
+    groups: dict[tuple[str, str], list[tuple[ArtifactSpec, CheckResult]]] = (
+        defaultdict(list)
+    )
+    for spec, result in pairs:
+        _, label = resolve_current_cycle(spec, now)
+        groups[(spec.cadence, label)].append((spec, result))
+
+    verdicts = []
+    for (cadence, label), grp in sorted(groups.items()):
+        v = cycle_completion(grp, cycle_label=label)
+        verdicts.append(
+            {
+                "cadence": cadence,
+                "cycle_label": label,
+                "state": v.state,
+                "complete": v.complete,
+                "n_required": v.n_required,
+                "n_satisfied": v.n_satisfied,
+                "missing": v.missing,
+                "stale": v.stale,
+                "probe_failed": v.probe_failed,
+                "grace_period": v.grace_period,
+                "reason": v.reason,
+            }
+        )
+    return {"run_at": now.isoformat(), "verdicts": verdicts}
+
+
+def _emit_cycle_metrics(cw_client: Any, verdict_payload: dict[str, Any]) -> None:
+    """Emit one ``ArtifactFreshnessCycleComplete`` datapoint per cadence
+    (1.0 complete / 0.0 not), in :data:`CW_NAMESPACE`.
+
+    Dimensioned by ``Cadence`` ONLY — a stable, low-cardinality set
+    (``{saturday_sf, weekday_sf, eod_sf, continuous}``) that a CW alarm can
+    bind to. The per-cycle ``cycle_label`` is recorded in the S3 artifact,
+    NOT a metric dimension: a label is high-cardinality (a new value every
+    week/day) and would make the metric both unalarmable and costly.
+    """
+    metric_data = [
+        {
+            "MetricName": "ArtifactFreshnessCycleComplete",
+            "Dimensions": [{"Name": "Cadence", "Value": v["cadence"]}],
+            "Value": 1.0 if v["complete"] else 0.0,
+            "Unit": "Count",
+        }
+        for v in verdict_payload["verdicts"]
+    ]
+    if metric_data:
+        # Cadence set is ≤4 → one call, well under CW's 1000-metric cap.
+        cw_client.put_metric_data(Namespace=CW_NAMESPACE, MetricData=metric_data)
 
 
 # ── Alerting (gated on ALERTS_ENABLED) ──────────────────────────────────────
@@ -653,6 +734,29 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     _put_json(s3, REGISTRY_BUCKET, CHECK_RESULTS_KEY, check_results)
     _put_json(s3, REGISTRY_BUCKET, HEARTBEAT_KEY, heartbeat)
 
+    # ── Per-cycle completion rollup (L249 consumer) ─────────────────────
+    # Secondary observability hung off the primary probe pass. The artifact
+    # write comes first (S3 PutObject is already granted); the CW emit is
+    # last (it needs the cloudwatch:PutMetricData grant added in iam-policy.json,
+    # which only takes effect on the next deploy). The whole block is wrapped
+    # so a failure here can NEVER take down the monitor's primary deliverables
+    # (check_results + heartbeat + alerts), already persisted above.
+    #   (a) swallowed failure: cycle-verdict compute / S3 write / CW put error.
+    #   (c) recording surface: the WARN log below (CW Logs) + the staleness of
+    #       cycle_verdict.json (itself a monitorable artifact).
+    # Per CLAUDE.md no-silent-fails secondary-observability carve-out.
+    cycle_verdicts: dict[str, str] = {}
+    try:
+        verdict_payload = _serialize_cycle_verdicts(pairs, now)
+        _put_json(s3, REGISTRY_BUCKET, CYCLE_VERDICT_KEY, verdict_payload)
+        _emit_cycle_metrics(boto3.client("cloudwatch"), verdict_payload)
+        cycle_verdicts = {
+            v["cadence"]: v["state"] for v in verdict_payload["verdicts"]
+        }
+        logger.info("cycle verdicts: %s", cycle_verdicts)
+    except Exception as exc:  # noqa: BLE001 — secondary observability, must not sink the monitor
+        logger.warning("cycle-completion rollup failed (non-fatal): %s", exc)
+
     logger.info(
         "freshness-monitor complete: %s checked, %s alerted, %s per-spec exceptions, "
         "duration=%.2fs",
@@ -667,4 +771,5 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "alerted": alerted,
         "per_spec_exceptions": per_spec_exceptions,
         "duration_seconds": heartbeat["duration_seconds"],
+        "cycle_verdicts": cycle_verdicts,
     }

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -660,3 +660,132 @@ def test_resolve_axis_dates_holiday_skips_via_lib():
     # Don't pin a specific value here — just assert it's NOT Mon 5/25.
     assert dates[0] != _date(2026, 5, 25)
     assert dates[0] < _date(2026, 5, 26)
+
+
+# ── Per-cycle completion rollup (L249 consumer) ─────────────────────────────
+
+
+def _run_handler(monkeypatch, fake_s3, fixed_now, *, registry_body):
+    """Invoke the handler in OBSERVE mode with boto3 routed to fake_s3
+    (which also serves boto3.client('cloudwatch') — put_metric_data lands
+    on the same recording mock)."""
+    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    fake_s3._registry_body = registry_body
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+    return index.handler({}, None)
+
+
+def _cycle_verdict_payload(fake_s3) -> dict:
+    body = next(
+        b for (_, k, b) in fake_s3._put_calls
+        if k == "_freshness_monitor/cycle_verdict.json"
+    )
+    return json.loads(body)
+
+
+def test_handler_emits_cycle_verdict_per_cadence(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """The registry walk is mixed-cadence; the rollup must produce ONE
+    verdict per (cadence, label), never a single conflated verdict. With
+    the fixture: saturday_sf critical (probe_missing) 404s → incomplete;
+    continuous critical (probe_heartbeat) 404s → incomplete. probe_fresh is
+    WARNING → excluded from the required set."""
+    # probe_fresh fresh; the two criticals 404 by default.
+    fake_s3._head_returns["path/2026-05-30/fresh.json"] = {
+        "LastModified": datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc),
+    }
+    result = _run_handler(monkeypatch, fake_s3, fixed_now, registry_body=yaml_registry_body)
+
+    payload = _cycle_verdict_payload(fake_s3)
+    by_cadence = {v["cadence"]: v for v in payload["verdicts"]}
+    assert set(by_cadence) == {"saturday_sf", "continuous"}
+
+    sat = by_cadence["saturday_sf"]
+    assert sat["state"] == "incomplete"
+    assert sat["n_required"] == 1          # only probe_missing (critical); probe_fresh excluded
+    assert sat["missing"] == ["probe_missing"]
+
+    cont = by_cadence["continuous"]
+    assert cont["state"] == "incomplete"
+    assert cont["missing"] == ["probe_heartbeat"]
+
+    assert result["cycle_verdicts"] == {
+        "saturday_sf": "incomplete",
+        "continuous": "incomplete",
+    }
+
+
+def test_handler_cycle_complete_when_criticals_fresh(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """All critical artifacts present+valid → every cadence complete."""
+    # Saturday cycle tick is 09:00 UTC, so 12:00 is fresh.
+    sat_lm = {"LastModified": datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc)}
+    fake_s3._head_returns["path/2026-05-30/fresh.json"] = sat_lm
+    fake_s3._head_returns["path/2026-05-30/missing.json"] = sat_lm
+    # Continuous cycle tick is the current 15-min bucket (== now, 18:00), so the
+    # heartbeat must be modified at/after now to count fresh.
+    fake_s3._head_returns["_freshness_monitor/heartbeat.json"] = {
+        "LastModified": datetime(2026, 5, 30, 18, 0, tzinfo=timezone.utc),
+    }
+
+    result = _run_handler(monkeypatch, fake_s3, fixed_now, registry_body=yaml_registry_body)
+    assert result["cycle_verdicts"] == {
+        "saturday_sf": "complete",
+        "continuous": "complete",
+    }
+
+
+def test_handler_emits_cycle_completion_cw_metric(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """One ArtifactFreshnessCycleComplete datapoint per cadence, dimensioned
+    by Cadence only, in the AlphaEngine/Substrate namespace."""
+    fake_s3._head_returns["path/2026-05-30/fresh.json"] = {
+        "LastModified": datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc),
+    }
+    _run_handler(monkeypatch, fake_s3, fixed_now, registry_body=yaml_registry_body)
+
+    assert fake_s3.put_metric_data.called
+    _, kwargs = fake_s3.put_metric_data.call_args
+    assert kwargs["Namespace"] == "AlphaEngine/Substrate"
+    md = kwargs["MetricData"]
+    assert {m["MetricName"] for m in md} == {"ArtifactFreshnessCycleComplete"}
+    dims = {m["Dimensions"][0]["Value"] for m in md}
+    assert dims == {"saturday_sf", "continuous"}
+    # Both cadences incomplete here → all values 0.0.
+    assert all(m["Value"] == 0.0 for m in md)
+
+
+def test_handler_cycle_rollup_failure_is_non_fatal(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """A failure in the cycle-rollup block must NOT sink the monitor — the
+    primary check_results + heartbeat are still written and the handler
+    returns with cycle_verdicts={}."""
+    fake_s3._registry_body = yaml_registry_body
+    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+    # Force the rollup to blow up.
+    def _boom(*a, **kw):
+        raise RuntimeError("rollup exploded")
+    monkeypatch.setattr(index, "_serialize_cycle_verdicts", _boom)
+
+    result = index.handler({}, None)
+
+    assert result["cycle_verdicts"] == {}
+    put_keys = [k for (_, k, _) in fake_s3._put_calls]
+    assert "_freshness_monitor/heartbeat.json" in put_keys
+    assert "_freshness_monitor/check_results.json" in put_keys
+    assert "_freshness_monitor/cycle_verdict.json" not in put_keys


### PR DESCRIPTION
## What

Wires the `cycle_completion()` rollup (shipped dormant in [alpha-engine-lib #88](https://github.com/cipher813/alpha-engine-lib/pull/88), v0.44.0) into the **freshness-monitor Lambda** — the consumer follow-up filed against ROADMAP L249. The rollup existed but nothing called it; the monitor already builds the `(ArtifactSpec, CheckResult)` pairs it needs, so this is the natural home.

## Why the freshness-monitor (not transparency)

The two substrate consumers are independent: `transparency` validates `transparency_inventory.yaml` rows; the freshness-monitor probes `ARTIFACT_REGISTRY.yaml` artifacts via `check_freshness`. `cycle_completion` aggregates `check_freshness` results over `severity:critical` rows — so it belongs here, where those results already exist.

## Changes

- **`_serialize_cycle_verdicts()`** — groups the probe results by `(cadence, cycle_label)` and rolls each group up. The registry walk covers **every cadence in one 15-min pass**, so per-cadence grouping is **mandatory** — a single rollup over the mixed-cadence pairs would conflate the Saturday / weekday / EOD / continuous cycles into one meaningless verdict. (`weekday_sf` and `eod_sf` share a date-shaped label, so `cadence` is part of the group key.)
- Writes **`_freshness_monitor/cycle_verdict.json`** — one verdict per cadence-cycle, with `missing`/`stale`/`probe_failed`/`grace_period` localization lists.
- Emits **CloudWatch `ArtifactFreshnessCycleComplete`** (1.0/0.0) per cadence in `AlphaEngine/Substrate`. **Dimensioned by `Cadence` only** — a stable, low-cardinality set ({saturday_sf, weekday_sf, eod_sf, continuous}) a CW alarm can bind to. The per-cycle `cycle_label` lives in the S3 artifact, **not** a metric dimension (a label is high-cardinality → unalarmable + costly).
- **`iam-policy.json`** — adds `cloudwatch:PutMetricData` scoped to the `AlphaEngine/Substrate` namespace via condition. The monitor emitted no CW metrics before; `deploy.sh:148` (`aws iam put-role-policy`) applies the grant on next deploy.

## Fail-loud posture

The whole rollup block is wrapped (`try/except` → WARN), ordered **after** the primary `check_results` + `heartbeat` writes. It is **secondary observability** hung off the primary probe pass — a CW throttle, the IAM grant not-yet-applied, or a cycle-resolution edge can **never** sink the monitor's primary deliverables. Recording surface = WARN log + staleness of `cycle_verdict.json`. Per the CLAUDE.md no-silent-fails secondary-observability carve-out (inline comment names the swallowed mode + recording surface).

This is **observational only** — no new alert fires (the monitor is still in OBSERVE soak, `MNEMON_FRESHNESS_MONITOR_ENABLED`). Alerting on cycle incompleteness is a future step gated on the monitor exiting OBSERVE.

## Verification

- 4 new tests: per-cadence verdict + WARNING-excluded; complete-when-criticals-fresh; CW metric shape (namespace + Cadence dimension + values); non-fatal rollup failure (primary artifacts still written, `cycle_verdicts={}`).
- freshness-monitor suite: **27 → 31 passed**.

## Deploy note

Needs a freshness-monitor Lambda redeploy (`deploy.sh`) for the IAM grant to take effect — until then the CW emit WARN-logs and `cycle_verdict.json` (S3, already permitted) still lands, so the degradation is graceful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)