### PR TITLE
L4472: split Saturday Backtester SF state into 3 (simulate / predictor / optimizer)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1593,7 +1593,7 @@
     },
     "Backtester": {
       "Type": "Task",
-      "Comment": "Backtest (10y simulate + param sweep, ~121 min) on spot instance, after predictor training. The parity stage was split into a separate Parity SF state by the preflight-task-split (2026-05-16, plan alpha-engine-docs/private/preflight-task-split-260516.md): backtest and parity are independent preflight-bearing actions, so a parity failure must never re-run the ~121-min backtest. Post-2026-05-07 the evaluator stage was already its own state (plan: alpha-engine-docs/private/evaluator-split-260507.md). spot_backtest.sh is invoked with --skip-stages=parity,evaluator so this state runs ONLY the backtest stage; the Parity state runs --skip-stages=backtest,evaluator and the Evaluator state runs --skip-stages=backtest,parity, all against the same backtest/{date}/ S3 prefix. State name kept as Backtester (lower-churn vs renaming to Backtest \u2014 preserves DriftDetection's Next/Catch edges and all inbound wiring). If this state fails, Parity is NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).",
+      "Comment": "Backtest SIMULATION-ONLY stage (10y simulate + param sweep) on spot instance, after predictor training. L4472 phase-split (2026-05-31, ROADMAP L4472): the monolithic Backtester state ran simulate+param_sweep+predictor-backtest+Phase4+optimizer/cov/gamma in ONE SSM command whose SUMMED runtime exceeded the SSM execution timeout on a fresh date (L4470). This state now runs ONLY the simulation pipeline via --mode=param-sweep; the predictor-backtest+Phase4 block runs in the new PredictorBacktest state and the optimizer/cov/gamma block in PortfolioOptimizerBacktest, each with its own SSM timeout + independent redrive. --no-pit-parity here so pit_parity runs exactly once (in PredictorBacktest, where it belongs). State name kept as Backtester (lower-churn \u2014 preserves DriftDetection's Next/Catch edges + skip_backtester gate semantics; skip_backtester still skips the whole backtest-family by routing past CheckSkipParity to CheckSkipEvaluator). Mirrors the 2026-05-07/05-16 simulate/parity/evaluator split precedent (plans evaluator-split-260507.md + preflight-task-split-260516.md). All states key off the same backtest/{date}/ S3 prefix. If this state fails, PredictorBacktest is NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -1602,7 +1602,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -1668,7 +1668,7 @@
         {
           "Variable": "$.backtester_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipParity"
+          "Next": "PredictorBacktest"
         },
         {
           "Variable": "$.backtester_poll.Status",
@@ -1687,6 +1687,200 @@
       "Type": "Wait",
       "Seconds": 60,
       "Next": "WaitForBacktester"
+    },
+    "PredictorBacktest": {
+      "Type": "Task",
+      "Comment": "Predictor-backtest + Phase 4a/b/c stage on a fresh spot SSM command, after the simulation-only Backtester state. L4472 phase-split (2026-05-31): runs spot_backtest.sh --mode=predictor-backtest, which executes the predictor_pipeline (GBM inference + 10y ArcticDB read + predictor param sweep) and Phase 4a/b/c — the block that, bundled with simulate + the optimizer sweeps in the old single Backtester state, summed past the SSM execution timeout on a fresh date (L4470). pit_parity runs HERE (default ON; Backtester + PortfolioOptimizerBacktest pass --no-pit-parity) so the observational walk-forward parity fires exactly once. Reads the backtest/{date}/ artifacts the Backtester state just wrote and writes its own predictor_sweep_df.parquet + predictor_stats.json to the same prefix. Per the L4472 executor-apply fix (backtester backtest.py::_run_predictor_pipeline gated on mode==all), this --mode=predictor-backtest run does NOT write the from_executor_optimizer.json recommendation artifact — the Backtester (param-sweep) state is its sole writer, so the assembler sees sim-based executor params (monolithic semantics preserved). If this state fails, PortfolioOptimizerBacktest is NOT entered (anti-auto-promote-garbage).",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.ec2_instance_id",
+        "Parameters": {
+          "executionTimeout": [
+            "7200"
+          ],
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator{}',$.preflight_args))"
+        },
+        "TimeoutSeconds": 7200
+      },
+      "TimeoutSeconds": 7260,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.TaskFailed",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 180,
+          "BackoffRate": 2.0,
+          "Comment": "Retry on failure/timeout — handles spot interruption (new instance on retry). Mirrors Backtester retry posture."
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.predictor_backtest_result",
+      "Next": "WaitForPredictorBacktest"
+    },
+    "WaitForPredictorBacktest": {
+      "Type": "Task",
+      "Comment": "Poll SSM command until predictor-backtest complete",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.predictor_backtest_result.Command.CommandId",
+        "InstanceId.$": "$.ec2_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.predictor_backtest_poll",
+      "Next": "CheckPredictorBacktestStatus"
+    },
+    "CheckPredictorBacktestStatus": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.predictor_backtest_poll.Status",
+          "StringEquals": "Success",
+          "Next": "PortfolioOptimizerBacktest"
+        },
+        {
+          "Variable": "$.predictor_backtest_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "PredictorBacktestWait"
+        },
+        {
+          "Variable": "$.predictor_backtest_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "PredictorBacktestWait"
+        }
+      ],
+      "Default": "ExtractPredictorBacktestError"
+    },
+    "PredictorBacktestWait": {
+      "Type": "Wait",
+      "Seconds": 60,
+      "Next": "WaitForPredictorBacktest"
+    },
+    "PortfolioOptimizerBacktest": {
+      "Type": "Task",
+      "Comment": "Portfolio-optimizer block (portfolio_optimizer_gate + cov_estimator_sweep + gamma_sweep) on a fresh spot SSM command, after PredictorBacktest. L4472 phase-split (2026-05-31): runs spot_backtest.sh --mode=portfolio-optimizer-backtest. Each of these three phases re-runs the predictor pipeline (GBM inference + 10y ArcticDB read) internally; bundled with simulate + predictor-backtest in the old single state their summed runtime blew the SSM execution timeout on a fresh date (L4470). --no-pit-parity (pit_parity already ran in PredictorBacktest). Reads/writes the same backtest/{date}/ prefix. On Success routes to CheckSkipParity so the downstream Parity -> Evaluator chain is unchanged. If this state fails, Parity is NOT entered (anti-auto-promote-garbage).",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.ec2_instance_id",
+        "Parameters": {
+          "executionTimeout": [
+            "7200"
+          ],
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
+        },
+        "TimeoutSeconds": 7200
+      },
+      "TimeoutSeconds": 7260,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.TaskFailed",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 180,
+          "BackoffRate": 2.0,
+          "Comment": "Retry on failure/timeout — handles spot interruption (new instance on retry). Mirrors Backtester retry posture."
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.portfolio_optimizer_result",
+      "Next": "WaitForPortfolioOptimizerBacktest"
+    },
+    "WaitForPortfolioOptimizerBacktest": {
+      "Type": "Task",
+      "Comment": "Poll SSM command until portfolio-optimizer block complete",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.portfolio_optimizer_result.Command.CommandId",
+        "InstanceId.$": "$.ec2_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.portfolio_optimizer_poll",
+      "Next": "CheckPortfolioOptimizerBacktestStatus"
+    },
+    "CheckPortfolioOptimizerBacktestStatus": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.portfolio_optimizer_poll.Status",
+          "StringEquals": "Success",
+          "Next": "CheckSkipParity"
+        },
+        {
+          "Variable": "$.portfolio_optimizer_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "PortfolioOptimizerBacktestWait"
+        },
+        {
+          "Variable": "$.portfolio_optimizer_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "PortfolioOptimizerBacktestWait"
+        }
+      ],
+      "Default": "ExtractPortfolioOptimizerBacktestError"
+    },
+    "PortfolioOptimizerBacktestWait": {
+      "Type": "Wait",
+      "Seconds": 60,
+      "Next": "WaitForPortfolioOptimizerBacktest"
     },
     "CheckSkipParity": {
       "Type": "Choice",
@@ -2155,6 +2349,28 @@
         "phase": "Parity",
         "source": "CheckParityStatus.Default",
         "poll.$": "$.parity_poll"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "ExtractPredictorBacktestError": {
+      "Type": "Pass",
+      "Comment": "Normalize PredictorBacktest SSM non-Success poll into $.error. Mirrors ExtractBacktesterError \u2014 the soft-failure path from CheckPredictorBacktestStatus.Default does not populate $.error, only Task Catch blocks do. Added by the L4472 phase-split.",
+      "Parameters": {
+        "phase": "PredictorBacktest",
+        "source": "CheckPredictorBacktestStatus.Default",
+        "poll.$": "$.predictor_backtest_poll"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "ExtractPortfolioOptimizerBacktestError": {
+      "Type": "Pass",
+      "Comment": "Normalize PortfolioOptimizerBacktest SSM non-Success poll into $.error. Mirrors ExtractBacktesterError \u2014 the soft-failure path from CheckPortfolioOptimizerBacktestStatus.Default does not populate $.error, only Task Catch blocks do. Added by the L4472 phase-split.",
+      "Parameters": {
+        "phase": "PortfolioOptimizerBacktest",
+        "source": "CheckPortfolioOptimizerBacktestStatus.Default",
+        "poll.$": "$.portfolio_optimizer_poll"
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -1,73 +1,91 @@
 {
-  "Backtester": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-    "cd /home/ec2-user/alpha-engine-backtester",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator"
-  ],
-  "DataPhase1": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
-    "cd /home/ec2-user/alpha-engine-data",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
-  ],
-  "DriftDetection": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-    "cd /home/ec2-user/alpha-engine-data",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh"
-  ],
-  "Evaluator": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-    "cd /home/ec2-user/alpha-engine-backtester",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
-  ],
-  "MorningEnrich": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
-    "cd /home/ec2-user/alpha-engine-data",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
-  ],
-  "Parity": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-    "cd /home/ec2-user/alpha-engine-backtester",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator"
-  ],
-  "PredictorTraining": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
-    "sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml",
-    "cd /home/ec2-user/alpha-engine-predictor",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
-  ],
-  "RAGIngestion": [
-    "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-    "cd /home/ec2-user/alpha-engine-data",
-    "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
-  ]
+ "Backtester": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-backtester",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "export RUN_DATE='2026-05-18'",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator"
+ ],
+ "DataPhase1": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-data",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
+ ],
+ "DriftDetection": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-data",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh"
+ ],
+ "Evaluator": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-backtester",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "export RUN_DATE='2026-05-18'",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
+ ],
+ "MorningEnrich": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-data",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
+ ],
+ "Parity": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-backtester",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "export RUN_DATE='2026-05-18'",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator"
+ ],
+ "PortfolioOptimizerBacktest": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-backtester",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "export RUN_DATE='2026-05-18'",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator"
+ ],
+ "PredictorBacktest": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-backtester",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "export RUN_DATE='2026-05-18'",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator"
+ ],
+ "PredictorTraining": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+  "sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml",
+  "cd /home/ec2-user/alpha-engine-predictor",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
+ ],
+ "RAGIngestion": [
+  "set -eo pipefail",
+  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+  "cd /home/ec2-user/alpha-engine-data",
+  "export HOME=/home/ec2-user",
+  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
+ ]
 }

--- a/tests/test_sf_backtest_parity_split_wiring.py
+++ b/tests/test_sf_backtest_parity_split_wiring.py
@@ -20,12 +20,30 @@ This is SF-wiring-only: spot_backtest.sh's --skip-stages already supports
 backtest/parity/evaluator independently (validated stage vocabulary
 _KNOWN_STAGES="backtest parity evaluator") — no backtester-repo change.
 
+L4472 phase-split (2026-05-31, ROADMAP L4472): the single `Backtester`
+state ran simulate+param_sweep+predictor-backtest+Phase4+optimizer/cov/
+gamma in ONE SSM command whose SUMMED runtime exceeded the SSM execution
+timeout on a fresh date (L4470). The backtest stage is now decomposed by
+--mode into THREE sequential SF states, each with its own SSM timeout +
+independent redrive:
+  Backtester               --mode=param-sweep --no-pit-parity   (simulate+sweep)
+  PredictorBacktest        --mode=predictor-backtest            (predictor+Phase4, pit_parity HERE)
+  PortfolioOptimizerBacktest --mode=portfolio-optimizer-backtest --no-pit-parity
+The happy path is now:
+  CheckSkipBacktester → Backtester → PredictorBacktest →
+  PortfolioOptimizerBacktest → CheckSkipParity → Parity →
+  CheckSkipEvaluator → Evaluator.
+skip_backtester still skips the whole backtest-family (routes past
+CheckSkipParity to CheckSkipEvaluator). pit_parity fires exactly once
+(default-ON in PredictorBacktest; the other two pass --no-pit-parity).
+
 This test catches regressions like:
 - Someone reverts Backtester's SSM command back to --skip-stages=evaluator
-  (re-bundles parity into the 121-min backtest task).
+  (re-bundles parity into the backtest task) or drops --mode=param-sweep
+  (re-bundles the heavy post-sweep phases back into one SSM command).
 - Someone wires Parity BEFORE Backtester, or drops the Parity state.
-- Someone reroutes CheckBacktesterStatus(success) past CheckSkipParity
-  straight to CheckSkipEvaluator (silently drops parity).
+- Someone reroutes the backtest-family chain so a phase is skipped or
+  re-ordered (e.g. predictor before sim).
 - Someone drops the HandleFailure Catch on the new states.
 - The old single combined-Backtester semantics (--skip-stages=evaluator)
   reappears anywhere.
@@ -116,16 +134,21 @@ class TestChainOrdering:
     def test_backtester_wait_routes_to_status_check(self, states):
         assert states["WaitForBacktester"]["Next"] == "CheckBacktesterStatus"
 
-    def test_backtester_success_routes_to_parity_skipgate(self, states):
+    def test_backtester_success_routes_to_predictor_backtest(self, states):
+        """L4472: Backtester (simulate-only) success hands off to the new
+        PredictorBacktest state, not directly to CheckSkipParity — the
+        predictor+Phase4 block now runs in its own SF state so its runtime
+        no longer sums into the simulate SSM command."""
         success = [
             c["Next"]
             for c in states["CheckBacktesterStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == ["CheckSkipParity"], (
-            "Backtester (backtest stage) success must hand off to "
-            "CheckSkipParity — Parity runs AFTER a completed backtest, and "
-            "must never re-run the 121-min backtest on its own failure."
+        assert success == ["PredictorBacktest"], (
+            "Backtester (simulate-only) success must hand off to "
+            "PredictorBacktest — the L4472 phase-split runs predictor+Phase4 "
+            "in its own state so a fresh simulate never carries the post-sweep "
+            "stack into one SSM execution timeout."
         )
 
     def test_backtester_status_loops_and_default(self, states):
@@ -257,12 +280,15 @@ class TestSsmCommandShape:
         from tests.sf_command_utils import extract_commands
         return extract_commands(states[name])
 
-    def test_backtester_invokes_backtest_stage_only(self, states):
+    def test_backtester_invokes_simulation_stage_only(self, states):
+        """L4472: Backtester runs ONLY the simulation pipeline via
+        --mode=param-sweep, with --no-pit-parity (pit_parity belongs to
+        PredictorBacktest). It must still skip the parity+evaluator stages."""
         joined = " ".join(self._commands(states, "Backtester"))
-        assert "spot_backtest.sh --skip-stages=parity,evaluator" in joined, (
-            "Backtester must run ONLY the backtest stage post-split — "
-            "--skip-stages=evaluator re-bundles parity into the 121-min "
-            "backtest task."
+        assert "spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator" in joined, (
+            "Backtester must run --mode=param-sweep (simulation only) with "
+            "--no-pit-parity post-L4472-split — dropping --mode re-bundles the "
+            "heavy predictor/optimizer phases back into one SSM command."
         )
         assert "--skip-stages=evaluator" not in joined
         assert "--skip-stages=backtest,evaluator" not in joined
@@ -382,3 +408,114 @@ class TestResultPathIsolation:
     def test_wait_reads_parity_command_id(self, states):
         cmd_id = states["WaitForParity"]["Parameters"]["CommandId.$"]
         assert "parity_result" in cmd_id
+
+
+class TestL4472PhaseSplit:
+    """Pins the L4472 three-way split of the backtest stage: Backtester
+    (simulate) → PredictorBacktest (predictor+Phase4) →
+    PortfolioOptimizerBacktest (optimizer/cov/gamma) → CheckSkipParity.
+    Each heavy block is its own SF state so no single SSM command carries
+    the SUMMED 60-100 min runtime that blew the timeout on a fresh date."""
+
+    def _commands(self, states, name):
+        from tests.sf_command_utils import extract_commands
+        return extract_commands(states[name])
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "PredictorBacktest",
+            "WaitForPredictorBacktest",
+            "CheckPredictorBacktestStatus",
+            "PredictorBacktestWait",
+            "ExtractPredictorBacktestError",
+            "PortfolioOptimizerBacktest",
+            "WaitForPortfolioOptimizerBacktest",
+            "CheckPortfolioOptimizerBacktestStatus",
+            "PortfolioOptimizerBacktestWait",
+            "ExtractPortfolioOptimizerBacktestError",
+        ],
+    )
+    def test_new_state_exists(self, states, name):
+        assert name in states, f"{name} missing — L4472 split incomplete"
+
+    def test_chain_backtester_predictor_optimizer_parity(self, states):
+        """Backtester → PredictorBacktest → PortfolioOptimizerBacktest →
+        CheckSkipParity, each via its status gate's Success edge."""
+        def success(check):
+            return [
+                c["Next"] for c in states[check]["Choices"]
+                if c.get("StringEquals") == "Success"
+            ]
+        assert success("CheckBacktesterStatus") == ["PredictorBacktest"]
+        assert success("CheckPredictorBacktestStatus") == ["PortfolioOptimizerBacktest"]
+        assert success("CheckPortfolioOptimizerBacktestStatus") == ["CheckSkipParity"]
+
+    def test_predictor_backtest_invokes_predictor_mode(self, states):
+        joined = " ".join(self._commands(states, "PredictorBacktest"))
+        assert "spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator" in joined
+        # pit_parity runs HERE (no --no-pit-parity on this state)
+        assert "--no-pit-parity" not in joined
+
+    def test_optimizer_invokes_optimizer_mode_no_pit(self, states):
+        joined = " ".join(self._commands(states, "PortfolioOptimizerBacktest"))
+        assert "spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator" in joined
+
+    def test_pit_parity_runs_exactly_once(self, sf):
+        """--no-pit-parity must appear on Backtester + PortfolioOptimizer but
+        NOT PredictorBacktest, so the observational pit_parity pass fires
+        exactly once across the three split states."""
+        blob = json.dumps(sf)
+        # PredictorBacktest is the only backtest-family state without --no-pit-parity
+        from tests.sf_command_utils import extract_commands
+        states = sf["States"]
+        def has_no_pit(name):
+            return "--no-pit-parity" in " ".join(extract_commands(states[name]))
+        assert has_no_pit("Backtester")
+        assert has_no_pit("PortfolioOptimizerBacktest")
+        assert not has_no_pit("PredictorBacktest")
+
+    @pytest.mark.parametrize(
+        "name",
+        ["PredictorBacktest", "PortfolioOptimizerBacktest"],
+    )
+    def test_new_task_catches_handle_failure(self, states, name):
+        catches = states[name]["Catch"]
+        assert any(
+            c["ErrorEquals"] == ["States.ALL"]
+            and c["Next"] == "HandleFailure"
+            and c["ResultPath"] == "$.error"
+            for c in catches
+        )
+
+    def test_new_states_distinct_result_paths(self, states):
+        paths = {
+            states["Backtester"]["ResultPath"],
+            states["PredictorBacktest"]["ResultPath"],
+            states["PortfolioOptimizerBacktest"]["ResultPath"],
+        }
+        assert len(paths) == 3, f"result paths collide: {paths}"
+        assert states["PredictorBacktest"]["ResultPath"] == "$.predictor_backtest_result"
+        assert states["PortfolioOptimizerBacktest"]["ResultPath"] == "$.portfolio_optimizer_result"
+
+    @pytest.mark.parametrize(
+        "check,wait",
+        [
+            ("CheckPredictorBacktestStatus", "PredictorBacktestWait"),
+            ("CheckPortfolioOptimizerBacktestStatus", "PortfolioOptimizerBacktestWait"),
+        ],
+    )
+    def test_new_status_gates_loop_and_error_default(self, states, check, wait):
+        nexts = {c["StringEquals"]: c["Next"] for c in states[check]["Choices"]}
+        assert nexts["InProgress"] == wait
+        assert nexts["Pending"] == wait
+        assert states[check]["Default"].startswith("Extract")
+
+    def test_new_states_timeout_matches_backtester(self, states):
+        """Each split state gets its own full SSM execution timeout — the
+        point of the split is that none carries the summed runtime."""
+        bt_to = states["Backtester"]["TimeoutSeconds"]
+        bt_exec = states["Backtester"]["Parameters"]["Parameters"]["executionTimeout"]
+        for name in ("PredictorBacktest", "PortfolioOptimizerBacktest"):
+            assert states[name]["TimeoutSeconds"] == bt_to
+            assert states[name]["Parameters"]["Parameters"]["executionTimeout"] == bt_exec

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -108,18 +108,28 @@ class TestBacktesterTransition:
         #
         # Post-2026-05-16 preflight-task-split P1: the parity stage was
         # split out of the combined Backtester state into its own Parity
-        # quartet. Backtester (now the backtest stage only) success now
-        # routes to CheckSkipParity; CheckSkipEvaluator is reached
-        # transitively via the Parity quartet (CheckSkipParity → Parity →
-        # WaitForParity → CheckParityStatus(Success) → CheckSkipEvaluator)
-        # or the skip_parity short-circuit (CheckSkipParity →
-        # CheckSkipEvaluator). Either way the eval-judge chain stays
-        # reachable — pinned here by walking the forward path.
+        # quartet, reached via CheckSkipParity.
+        #
+        # Post-2026-05-31 L4472 phase-split: the backtest stage is further
+        # decomposed by --mode into Backtester (simulate) → PredictorBacktest
+        # → PortfolioOptimizerBacktest → CheckSkipParity. CheckSkipEvaluator
+        # (the eval-judge gate) stays reachable transitively through the whole
+        # chain; pinned here by walking each status gate's Success edge.
         bt = states["CheckBacktesterStatus"]
         success_choice = next(
             c for c in bt["Choices"] if c.get("StringEquals") == "Success"
         )
-        assert success_choice["Next"] == "CheckSkipParity"
+        assert success_choice["Next"] == "PredictorBacktest"
+
+        def _success(check):
+            return next(
+                c for c in states[check]["Choices"]
+                if c.get("StringEquals") == "Success"
+            )["Next"]
+
+        # Walk the L4472 split chain to the parity skip-gate.
+        assert _success("CheckPredictorBacktestStatus") == "PortfolioOptimizerBacktest"
+        assert _success("CheckPortfolioOptimizerBacktestStatus") == "CheckSkipParity"
 
         # skip_parity short-circuit reaches the Evaluator gate directly.
         skip_parity = states["CheckSkipParity"]

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -130,8 +130,16 @@ _SPOT_STATES = {
         "/var/log/predictor-training.log",
     ),
     "Backtester": (
-        "bash infrastructure/spot_backtest.sh --skip-stages=parity,evaluator",
+        "bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator",
         "/var/log/backtester.log",
+    ),
+    "PredictorBacktest": (
+        "bash infrastructure/spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator",
+        "/var/log/predictor-backtest.log",
+    ),
+    "PortfolioOptimizerBacktest": (
+        "bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator",
+        "/var/log/portfolio-optimizer.log",
     ),
     "Parity": (
         "bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator",
@@ -865,6 +873,8 @@ class TestHappyPathTraversal:
             "RAGIngestion",
             "DriftDetection",
             "Backtester",
+            "PredictorBacktest",
+            "PortfolioOptimizerBacktest",
             "Parity",
             "Evaluator",
             "RegimeSubstrate",

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -442,7 +442,11 @@ class TestEODSFTopLevelFieldsClosed:
 # `_SPOT_STATES` registry in test_sf_friday_shell_run_wiring.py:115. An
 # orphaned legacy state with a similar shape (e.g. ResearchML_old) would
 # fail this count.
-_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 8
+# 8 → 10 on 2026-05-31 (ROADMAP L4472): the single Backtester spot state
+# was split into Backtester (simulate) + PredictorBacktest +
+# PortfolioOptimizerBacktest so no single SSM command carries the summed
+# 60-100 min post-sweep runtime that blew the timeout (L4470).
+_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 10
 
 
 def _saturday_spot_states() -> list[str]:


### PR DESCRIPTION
## Context — ROADMAP L4472 (⏰ soft deadline: 2026-06-06 09:00 UTC Saturday SF)

The single Saturday `Backtester` state ran simulate+param_sweep+predictor-backtest+Phase4+optimizer/cov/gamma in **one** SSM command whose **summed** runtime exceeded the SSM execution timeout on a fresh date (L4470) → no backtester/parity/evaluator completion → config auto-apply froze (L4473). Each post-sweep phase re-runs the predictor pipeline (GBM inference + 10y ArcticDB read), so it was death-by-sum-of-runtime with **no single per-phase cap tripped**. The 06-06 run repeats this failure unless this lands first.

## The split

Decompose the backtest stage by `--mode` into **three** sequential SF states, each with its own SSM execution timeout + independent redrive (mirrors the 2026-05-07/05-16 simulate/parity/evaluator split precedent):

| State | Invocation | Runs |
|---|---|---|
| `Backtester` | `--mode=param-sweep --no-pit-parity` | simulate + param_sweep |
| `PredictorBacktest` *(new)* | `--mode=predictor-backtest` | predictor pipeline + Phase 4a/b/c; **pit_parity here** |
| `PortfolioOptimizerBacktest` *(new)* | `--mode=portfolio-optimizer-backtest --no-pit-parity` | optimizer_gate + cov_sweep + gamma_sweep |

**Happy path:** `CheckSkipBacktester → Backtester → PredictorBacktest → PortfolioOptimizerBacktest → CheckSkipParity → Parity → CheckSkipEvaluator → Evaluator`.

- `skip_backtester` still skips the whole backtest-family (routes past `CheckSkipParity` to `CheckSkipEvaluator`) — unchanged.
- `pit_parity` fires **exactly once** (default-ON in `PredictorBacktest`; the other two pass `--no-pit-parity`).
- Each new state mirrors `Backtester`'s Retry / Catch(`HandleFailure`) / Timeout posture, distinct ResultPaths; on failure the next state is **not** entered (anti-auto-promote-garbage). Decouples Backtester→Parity so `pit_parity.json` finally lands.
- **No backtester-repo logic change needed** for dispatch — `spot_backtest.sh` already threads `--mode`/`--no-pit-parity`/`--skip-stages`.

## Safety verified before wiring
- Each `--mode` is **self-contained** (re-reads from S3/ArcticDB; no in-memory handoff between phases) → 3 sequential processes == 1 `--mode=all` process for artifacts.
- The one semantic fork (executor-recommendation artifact collision) is closed by the companion **alpha-engine-backtester** PR (gate predictor's executor-apply on `mode=="all"`).

## Testing
- Updated SF pins: `test_sf_backtest_parity_split_wiring` (3-way split + new `TestL4472PhaseSplit`), `test_sf_eval_judge_wiring`, `test_sf_payload_uniqueness` (spot-state count 8→10), `test_sf_friday_shell_run_wiring` (`_SPOT_STATES` + main-thread trace).
- Regenerated `tests/fixtures/sf_prekeystone_spot_commands.json` (documented workflow for a deliberate spot-command change).
- SF graph validated (62→72 states, no dangling transitions). **Full data suite: 1731 passed, 1 skipped.**

## Deploy
SF deploy is a manual operator step (`infrastructure/deploy_step_function.sh` → `aws stepfunctions update-state-machine`). Must be deployed **before** the 06-06 09:00 UTC Saturday cron.

## Companion PRs
- `alpha-engine-backtester#269`: executor-apply mode-gate + simulation cap (correctness).
- `alpha-engine-config`: enable `assembler.cutover_enabled` + ROADMAP follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)