### PR TITLE
fix(daily_closes): source-priority coalesce — never regress a cell to a less-informative value

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -105,6 +105,75 @@ _FRED_INDEX_MAP = {
 }
 
 
+def _coalesce_by_source_priority(
+    new_records: list[dict],
+    existing_rows: list[dict],
+    run_date: str,
+) -> tuple[list[dict], dict]:
+    """Merge this-run records with the prior parquet by source priority.
+
+    Institutional source-of-record waterfall (see ``_SOURCE_PRIORITY``). For
+    each ticker, keep the row from the highest-priority source across {prior
+    parquet, this run}:
+
+    * **retain-on-empty** — a ticker the live pass could not refresh this run
+      (absent from ``new_records``) keeps its prior row instead of being
+      dropped. A populated cell can never regress to absent. This is the bug
+      that halted the 2026-06-01 weekday pipeline: a transient FRED 429 on
+      ``TNX`` let a wholesale overwrite blank a value the prior parquet held.
+    * **restatement wins** — a ticker present from the SAME-or-higher priority
+      source this run overwrites the prior value (ties resolve to the fresh
+      row), so polygon's corporate-action-adjusted close still lands.
+    * **no source-downgrade** — a strictly lower-priority fresh value (e.g. a
+      yfinance backstop) cannot clobber a higher-priority existing value (e.g.
+      a prior polygon close + true VWAP), preventing the 2026-04-17
+      ``VWAP=None`` contamination class.
+
+    A row whose ``Close`` is null/NaN is treated as missing (priority below any
+    real value) so it neither wins a merge nor gets written as an empty cell.
+
+    Returns ``(merged_records, stats)`` — stats counts retained / overwritten /
+    new_only / downgrade_blocked tickers for loud observability.
+    """
+    def _prio(row: dict | None) -> int:
+        if row is None:
+            return -1
+        close = row.get("Close")
+        if close is None or pd.isna(close):
+            return 0
+        return _SOURCE_PRIORITY.get(row.get("source"), _UNKNOWN_SOURCE_PRIORITY)
+
+    new_by_ticker = {r["ticker"]: r for r in new_records}
+    existing_by_ticker = {r["ticker"]: r for r in existing_rows}
+
+    merged: dict[str, dict] = {}
+    stats = {"overwritten": 0, "retained": 0, "new_only": 0, "downgrade_blocked": 0}
+
+    for ticker in set(new_by_ticker) | set(existing_by_ticker):
+        new_row = new_by_ticker.get(ticker)
+        old_row = existing_by_ticker.get(ticker)
+        new_p, old_p = _prio(new_row), _prio(old_row)
+
+        # Nothing usable from either side — drop (don't write a null cell).
+        if max(new_p, old_p) <= 0:
+            continue
+
+        if old_row is None:
+            merged[ticker] = new_row
+            stats["new_only"] += 1
+        elif new_p < 0:  # ticker absent from this run → retain prior
+            merged[ticker] = old_row
+            stats["retained"] += 1
+        elif new_p >= old_p:  # equal-or-higher source wins (tie → restatement)
+            merged[ticker] = new_row
+            stats["overwritten"] += 1
+        else:  # fresh value is strictly lower-quality — keep the better existing
+            merged[ticker] = old_row
+            stats["downgrade_blocked"] += 1
+
+    return list(merged.values()), stats
+
+
 def _is_post_close_write(last_modified: datetime, run_date: str) -> bool:
     """Return True if ``last_modified`` is at or after the NYSE close for ``run_date``.
 
@@ -121,6 +190,21 @@ _YFINANCE_MIN_COVERAGE = 0.95   # below this, yfinance_only mode hard-fails
 _POLYGON_MIN_COVERAGE = 0.95    # below this, polygon_only mode hard-fails
 _DISCREPANCY_WARN_PCT = 0.01    # |polygon_close - yfinance_close| / yfinance_close
 _DISCREPANCY_ERROR_PCT = 0.05
+
+# Source-of-record priority for the coalescing merge (institutional waterfall).
+# A cell is replaced only by an equal-or-higher-priority source; a lower-priority
+# or *missing* value never clobbers a higher-quality existing value. This is the
+# structural form of Brian's 2026-05-10 decision ("a cell is only updated if the
+# data exists in [the authoritative source], else the prior datapoint is
+# retained") — generalized so data can never regress to a less-informative value.
+# polygon (adjusted close + true VWAP) and fred (sole source for its index
+# series) are co-primary over DISJOINT ticker domains (equities vs ^indices), so
+# they never compete for the same cell; yfinance is the backstop tier.
+_SOURCE_PRIORITY = {"polygon": 3, "fred": 3, "yfinance": 1}
+# Prior parquet rows written before the `source` column existed: treat as
+# backstop-tier so a fresh polygon/fred value wins but a missing fresh value
+# still retains them (never blanked).
+_UNKNOWN_SOURCE_PRIORITY = 1
 
 # Share-class symbol convention bridge (Yahoo/our-universe dash → polygon dot).
 #
@@ -310,6 +394,10 @@ def collect(
     # Skip-on-exists short-circuit (yfinance_only + auto only) returns inside
     # the live branch since dry_run by definition isn't going to write.
     existing_close_for_discrepancy: dict[str, float] | None = None
+    # Full prior-parquet rows (with ``source``), used by the polygon_only
+    # source-priority coalesce so a transient live-fetch gap retains the prior
+    # value instead of blanking it. Empty unless an existing parquet is read.
+    existing_rows_for_merge: list[dict] = []
     # When skip_if_canonical=True, ``canonical_existing_rows`` carries
     # the records dicts for tickers in the existing parquet that already
     # have an authoritative source (yfinance / polygon) and a non-null
@@ -333,9 +421,13 @@ def collect(
     if head is not None:
         last_modified = head["LastModified"]
         if source == "polygon_only":
-            # Read existing rows so we can log Close-discrepancy after the
-            # polygon overwrite. Failures here are non-fatal — discrepancy
-            # logging is observability, not a write blocker.
+            # Read existing rows for (a) Close-discrepancy logging and (b) the
+            # source-priority coalesce merge before write — so a cell the live
+            # pass can't refresh this run is RETAINED, never blanked. Failures
+            # here are non-fatal for discrepancy logging, but losing the prior
+            # rows means we fall back to the legacy destructive overwrite, so
+            # warn loudly. The coverage gate still runs on the FRESH fetch, so
+            # a real polygon outage is not masked by retained rows.
             try:
                 obj = s3.get_object(Bucket=bucket, Key=key)
                 existing_df = pd.read_parquet(io.BytesIO(obj["Body"].read()), engine="pyarrow")
@@ -344,15 +436,19 @@ def collect(
                     for t in existing_df.index
                     if pd.notna(existing_df.loc[t, "Close"])
                 }
+                for t in existing_df.index:
+                    row = {"ticker": str(t)}
+                    row.update(existing_df.loc[t].to_dict())
+                    existing_rows_for_merge.append(row)
                 logger.info(
                     "polygon_only: found existing parquet (last_modified=%s, %d tickers) — "
-                    "will overwrite and log Close discrepancies",
+                    "will coalesce (retain-on-empty, priority-ranked) and log Close discrepancies",
                     last_modified.isoformat(), len(existing_close_for_discrepancy),
                 )
             except Exception as exc:
                 logger.warning(
-                    "polygon_only: failed to read existing parquet for discrepancy logging "
-                    "(%s) — proceeding with overwrite without discrepancy comparison",
+                    "polygon_only: failed to read existing parquet for coalesce/discrepancy "
+                    "(%s) — proceeding with destructive overwrite (no retain-on-empty this run)",
                     exc,
                 )
         elif skip_if_canonical:
@@ -438,10 +534,16 @@ def collect(
     if fred_missing:
         fred_count = _fetch_fred_closes(fred_missing, run_date, records)
 
-    # ── Step 3: yfinance — only in auto + yfinance_only modes ────────────────
-    # polygon_only refuses yfinance fallback per feedback_no_silent_fails: a
-    # silent yfinance fill would hide polygon outages and re-introduce the
-    # 2026-04-17 → 2026-04-23 VWAP=None contamination.
+    # ── Step 3: yfinance ─────────────────────────────────────────────────────
+    # polygon_only refuses yfinance fallback for the EQUITY universe per
+    # feedback_no_silent_fails: a silent yfinance fill would hide a polygon
+    # outage and re-introduce the 2026-04-17 → 2026-04-23 VWAP=None
+    # contamination. That refusal is equity-specific — it does NOT apply to the
+    # FRED-index macro tickers (^TNX/^VIX/^IRX/^VIX3M), which polygon never
+    # serves and which carry no VWAP. For those, FRED → yfinance is the
+    # legitimate primary chain, so a FRED 429 (the 2026-06-01 TNX failure)
+    # falls through to yfinance LOUDLY rather than leaving a critical macro key
+    # absent. Equities still refuse yfinance in polygon_only.
     captured_tickers = {r["ticker"] for r in records}
     missing = [t for t in tickers if t.lstrip("^") not in captured_tickers]
     # When skip_if_canonical=True (yfinance_only / auto window mode), drop
@@ -457,8 +559,21 @@ def collect(
             run_date, before, len(missing), before - len(missing),
         )
     yfinance_count = 0
-    if missing and source != "polygon_only":
-        yfinance_count = _fetch_yfinance_closes(missing, run_date, records)
+    if missing:
+        if source == "polygon_only":
+            # Equity universe stays refused; macro FRED-index tickers get the
+            # loud yfinance backstop.
+            macro_missing = [t for t in missing if t.lstrip("^") in _FRED_INDEX_MAP]
+            if macro_missing:
+                logger.warning(
+                    "polygon_only: FRED did not supply macro ticker(s) %s for %s — "
+                    "falling back to yfinance (loud backstop; FRED likely rate-limited). "
+                    "Equity universe still refuses yfinance per feedback_no_silent_fails.",
+                    macro_missing, run_date,
+                )
+                yfinance_count = _fetch_yfinance_closes(macro_missing, run_date, records)
+        else:
+            yfinance_count = _fetch_yfinance_closes(missing, run_date, records)
 
     # Merge preserved canonical rows from the existing parquet into the
     # records list. These are tickers we deliberately skipped fetching
@@ -505,6 +620,33 @@ def collect(
     if not records:
         logger.warning("No closes captured for %s (source=%s)", run_date, source)
         return {"status": "error", "error": "no data fetched", "tickers_captured": 0, "source": source}
+
+    # ── Source-priority coalesce (polygon_only) ──────────────────────────────
+    # Merge the fresh fetch with the prior parquet so a cell the live pass could
+    # not refresh this run RETAINS its prior value instead of being blanked,
+    # while polygon restatements still win and a lower-tier fresh value can't
+    # downgrade a higher-tier existing cell. Runs AFTER the coverage gate, so a
+    # genuine polygon outage still hard-fails on the FRESH fetch before any
+    # retained rows could mask it. (yfinance_only / auto preserve prior state
+    # via ``canonical_existing_rows`` above, so the coalesce is polygon_only.)
+    if source == "polygon_only" and existing_rows_for_merge:
+        records, merge_stats = _coalesce_by_source_priority(
+            records, existing_rows_for_merge, run_date,
+        )
+        if merge_stats["retained"] or merge_stats["downgrade_blocked"]:
+            logger.warning(
+                "polygon_only coalesce for %s: retained %d prior cell(s) the live pass "
+                "could not refresh, blocked %d source-downgrade(s); overwrote %d, new %d "
+                "(total %d).",
+                run_date, merge_stats["retained"], merge_stats["downgrade_blocked"],
+                merge_stats["overwritten"], merge_stats["new_only"], len(records),
+            )
+        else:
+            logger.info(
+                "polygon_only coalesce for %s: overwrote %d, new %d, total %d "
+                "(no retain/downgrade events).",
+                run_date, merge_stats["overwritten"], merge_stats["new_only"], len(records),
+            )
 
     closes_df = pd.DataFrame(records).set_index("ticker")
     logger.info(

--- a/tests/test_daily_closes_source_modes.py
+++ b/tests/test_daily_closes_source_modes.py
@@ -137,8 +137,11 @@ def test_polygon_only_propagates_polygon_forbidden():
     yf_spy.assert_not_called()
 
 
-def test_polygon_only_does_not_call_yfinance():
-    """polygon_only must never call yfinance — even when polygon coverage is partial."""
+def test_polygon_only_does_not_call_yfinance_for_equities():
+    """polygon_only must never call yfinance for the EQUITY universe — even when
+    polygon coverage is partial. (The FRED-index macro tickers have their own
+    loud yfinance backstop, exercised by
+    ``test_polygon_only_calls_yfinance_backstop_for_missing_macro``.)"""
     s3 = _no_existing_parquet_s3()
 
     mock_pg_client = MagicMock()
@@ -207,8 +210,69 @@ def test_polygon_only_writes_vwap_from_polygon():
 # ── overwrite + discrepancy logging ─────────────────────────────────────────
 
 
+def test_polygon_only_calls_yfinance_backstop_for_missing_macro():
+    """When FRED fails to supply a macro index ticker (the 2026-06-01 TNX 429),
+    polygon_only must fall through to yfinance for that ticker ONLY — never for
+    equities."""
+    s3 = _no_existing_parquet_s3()
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.return_value = {
+        "AAPL": {"open": 100, "high": 105, "low": 99, "close": 103, "volume": 1_000_000, "vwap": 102.5},
+    }
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client), \
+         patch("collectors.daily_closes._fetch_fred_closes", return_value=0), \
+         patch("collectors.daily_closes._fetch_yfinance_closes", return_value=0) as yf_spy:
+        daily_closes.collect(
+            bucket="b", tickers=["AAPL", "^TNX"], run_date="2026-04-23",
+            source="polygon_only", dry_run=True,
+        )
+
+    yf_spy.assert_called_once()
+    backstop_tickers = yf_spy.call_args.args[0]
+    assert backstop_tickers == ["^TNX"], "only the macro ticker may hit the yfinance backstop"
+    assert "AAPL" not in backstop_tickers, "equities must never reach the yfinance backstop"
+
+
+def test_polygon_only_retains_prior_macro_cell_on_live_gap():
+    """2026-06-01 regression: a macro ticker the live pass cannot refresh (polygon
+    never serves it, FRED 429, yfinance down) must RETAIN its prior parquet value
+    rather than being blanked by the overwrite."""
+    s3 = _existing_parquet_s3(
+        {"AAPL": 103.0, "TNX": 4.5},
+        last_modified=datetime(2026, 4, 22, 21, 0, 0, tzinfo=timezone.utc),  # post-close
+    )
+    mock_pg_client = MagicMock()
+    mock_pg_client.get_grouped_daily.return_value = {  # polygon serves AAPL only
+        "AAPL": {"open": 100, "high": 105, "low": 99, "close": 103.5, "volume": 1_000_000, "vwap": 102.5},
+    }
+
+    captured = {}
+    s3.put_object.side_effect = lambda **kw: captured.update(kw) or {}
+
+    with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+         patch("polygon_client.polygon_client", return_value=mock_pg_client), \
+         patch("collectors.daily_closes._fetch_fred_closes", return_value=0), \
+         patch("collectors.daily_closes._fetch_yfinance_closes", return_value=0):
+        result = daily_closes.collect(
+            bucket="b", tickers=["AAPL", "^TNX"], run_date="2026-04-22",
+            source="polygon_only",
+        )
+
+    assert result["status"] == "ok"
+    import io
+    df = pd.read_parquet(io.BytesIO(captured["Body"]), engine="pyarrow")
+    assert "TNX" in df.index, "TNX must be retained, not blanked by the overwrite"
+    assert df.loc["TNX", "Close"] == 4.5
+    assert df.loc["AAPL", "Close"] == 103.5, "AAPL still overwritten with fresh polygon close"
+
+
 def test_polygon_only_always_overwrites_existing_parquet():
-    """polygon_only must NEVER skip on existing parquet — overwrite is the design."""
+    """polygon_only must NEVER skip on existing parquet — it re-fetches and
+    overwrites every ticker the live pass *can* refresh (no skip-on-exists).
+    Tickers the live pass cannot refresh are retained, not dropped — see
+    ``test_polygon_only_retains_prior_macro_cell_on_live_gap``."""
     s3 = _existing_parquet_s3(
         {"AAPL": 103.0, "MSFT": 206.0},
         last_modified=datetime(2026, 4, 22, 21, 0, 0, tzinfo=timezone.utc),  # post-close

--- a/tests/test_daily_closes_source_priority_merge.py
+++ b/tests/test_daily_closes_source_priority_merge.py
@@ -1,0 +1,182 @@
+"""Tests for the source-priority coalesce merge on
+``collectors.daily_closes._coalesce_by_source_priority`` and its wiring into
+``collect(source="polygon_only")``.
+
+Background (incident 2026-06-01):
+
+The Monday weekday pipeline halted at MorningEnrich. A FRED 429 rate-limit
+storm meant ``TNX`` (DGS10, the 10Y yield) was never collected for the 5/29
+target date. ``polygon_only`` mode then OVERWROTE the existing 5/29 parquet
+wholesale — and because polygon never serves ``^TNX`` and yfinance was refused,
+the rewrite BLANKED the ``TNX`` value the prior (Friday EOD) parquet already
+held. ``daily_append`` correctly hard-failed on the missing critical macro key,
+halting the pipeline.
+
+Root cause: the ``polygon_only`` overwrite was not coverage-aware — it let a
+transient live-fetch gap regress a populated cell to absent, violating the
+2026-05-10 decision ("a cell is only updated if the data exists in the
+authoritative source, else the prior datapoint is retained").
+
+The fix is an institutional source-of-record waterfall (``_SOURCE_PRIORITY``):
+a cell is replaced only by an equal-or-higher-priority source; lower or missing
+never clobbers higher-quality existing data. These tests lock the contract.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from collectors.daily_closes import _coalesce_by_source_priority
+
+
+def _row(ticker, close, source, vwap=None):
+    return {
+        "ticker": ticker,
+        "date": "2026-05-29",
+        "Open": close,
+        "High": close,
+        "Low": close,
+        "Close": close,
+        "Adj_Close": close,
+        "Volume": 0,
+        "VWAP": vwap,
+        "source": source,
+    }
+
+
+def _by_ticker(records):
+    return {r["ticker"]: r for r in records}
+
+
+def test_retain_on_empty_keeps_prior_macro_cell():
+    """The 2026-06-01 bug: TNX absent from this run must retain the prior value,
+    not be dropped/blanked."""
+    existing = [_row("TNX", 4.51, "fred")]
+    new = [_row("AAPL", 200.0, "polygon", vwap=199.8)]  # live run, no TNX
+
+    merged, stats = _coalesce_by_source_priority(new, existing, "2026-05-29")
+    m = _by_ticker(merged)
+
+    assert "TNX" in m, "TNX must be retained, not blanked"
+    assert m["TNX"]["Close"] == 4.51
+    assert m["TNX"]["source"] == "fred"
+    assert stats["retained"] == 1
+    assert m["AAPL"]["Close"] == 200.0
+
+
+def test_restatement_same_source_overwrites():
+    """Polygon re-emitting a corporate-action-adjusted close (tie on priority)
+    must win — restatement absorption is the whole point of the morning pass."""
+    existing = [_row("AAPL", 100.0, "polygon", vwap=99.5)]
+    new = [_row("AAPL", 105.0, "polygon", vwap=104.5)]  # split-adjusted
+
+    merged, stats = _coalesce_by_source_priority(new, existing, "2026-05-29")
+    m = _by_ticker(merged)
+
+    assert m["AAPL"]["Close"] == 105.0
+    assert m["AAPL"]["VWAP"] == 104.5
+    assert stats["overwritten"] == 1
+
+
+def test_fresh_polygon_overwrites_prior_yfinance():
+    """Morning polygon (adjusted + true VWAP) must replace the prior EOD
+    yfinance row — higher priority wins."""
+    existing = [_row("AAPL", 100.0, "yfinance", vwap=None)]
+    new = [_row("AAPL", 100.2, "polygon", vwap=100.1)]
+
+    merged, stats = _coalesce_by_source_priority(new, existing, "2026-05-29")
+    m = _by_ticker(merged)
+
+    assert m["AAPL"]["source"] == "polygon"
+    assert m["AAPL"]["VWAP"] == 100.1
+    assert stats["overwritten"] == 1
+
+
+def test_lower_tier_cannot_downgrade_higher_tier():
+    """A yfinance backstop value must NOT clobber an existing polygon cell —
+    prevents the 2026-04-17 VWAP=None contamination class."""
+    existing = [_row("AAPL", 100.0, "polygon", vwap=99.9)]
+    new = [_row("AAPL", 100.0, "yfinance", vwap=None)]
+
+    merged, stats = _coalesce_by_source_priority(new, existing, "2026-05-29")
+    m = _by_ticker(merged)
+
+    assert m["AAPL"]["source"] == "polygon", "must keep the higher-quality source"
+    assert m["AAPL"]["VWAP"] == 99.9, "polygon VWAP must survive"
+    assert stats["downgrade_blocked"] == 1
+
+
+def test_null_close_fresh_does_not_win():
+    """A fresh row with a null Close is treated as missing — the prior real
+    value is kept."""
+    existing = [_row("TNX", 4.5, "fred")]
+    new = [_row("TNX", float("nan"), "fred")]
+
+    merged, _ = _coalesce_by_source_priority(new, existing, "2026-05-29")
+    m = _by_ticker(merged)
+
+    assert m["TNX"]["Close"] == 4.5
+
+
+def test_both_empty_ticker_dropped():
+    """No usable value anywhere → ticker is not written as a null cell."""
+    new = [_row("ZZZ", float("nan"), "polygon")]
+    merged, _ = _coalesce_by_source_priority(new, [], "2026-05-29")
+    assert all(r["ticker"] != "ZZZ" for r in merged)
+
+
+def test_new_only_passthrough():
+    """A brand-new ticker with no prior row passes straight through."""
+    new = [_row("MSFT", 400.0, "polygon", vwap=399.0)]
+    merged, stats = _coalesce_by_source_priority(new, [], "2026-05-29")
+    m = _by_ticker(merged)
+
+    assert m["MSFT"]["Close"] == 400.0
+    assert stats["new_only"] == 1
+
+
+def test_unknown_prior_source_retained_but_overwritten_by_fresh_primary():
+    """A prior row with no ``source`` (legacy parquet) is backstop-tier: a fresh
+    polygon value wins, but a missing fresh value still retains it."""
+    existing_no_source = [{"ticker": "AAPL", "Close": 100.0, "VWAP": None, "date": "2026-05-29"}]
+
+    # Fresh polygon overwrites the unknown-source prior.
+    merged, _ = _coalesce_by_source_priority(
+        [_row("AAPL", 101.0, "polygon", vwap=100.5)], existing_no_source, "2026-05-29"
+    )
+    assert _by_ticker(merged)["AAPL"]["source"] == "polygon"
+
+    # No fresh AAPL → unknown-source prior is retained, not blanked.
+    merged2, stats2 = _coalesce_by_source_priority([], existing_no_source, "2026-05-29")
+    assert _by_ticker(merged2)["AAPL"]["Close"] == 100.0
+    assert stats2["retained"] == 1
+
+
+def test_mixed_scenario_stats():
+    """End-to-end stats across all four outcomes in one merge."""
+    existing = [
+        _row("TNX", 4.5, "fred"),            # absent this run -> retained
+        _row("AAPL", 100.0, "polygon", 99.9),  # downgraded attempt -> blocked
+        _row("MSFT", 400.0, "yfinance"),     # fresh polygon -> overwritten
+    ]
+    new = [
+        _row("AAPL", 100.0, "yfinance"),     # lower tier, blocked
+        _row("MSFT", 401.0, "polygon", 400.5),  # higher tier, overwrites
+        _row("NVDA", 900.0, "polygon", 899.0),  # brand new
+    ]
+
+    merged, stats = _coalesce_by_source_priority(new, existing, "2026-05-29")
+    m = _by_ticker(merged)
+
+    assert m["TNX"]["Close"] == 4.5            # retained
+    assert m["AAPL"]["source"] == "polygon"    # downgrade blocked
+    assert m["MSFT"]["source"] == "polygon"    # overwritten
+    assert m["NVDA"]["Close"] == 900.0         # new
+    assert stats == {
+        "retained": 1,
+        "downgrade_blocked": 1,
+        "overwritten": 1,
+        "new_only": 1,
+    }


### PR DESCRIPTION
## Why

The **2026-06-01 weekday Step Function failed** at MorningEnrich. Root cause:

- A **FRED 429 rate-limit storm** meant `TNX` (DGS10, the 10Y yield) was never collected for the 5/29 target date.
- `polygon_only` mode **overwrote the existing daily-closes parquet wholesale** (`canonical_existing_rows` empty by construction). Polygon never serves `^TNX` and yfinance was refused, so the rewrite **blanked the `TNX` value the prior (Friday EOD) parquet already held**.
- `daily_append` correctly hard-failed on the missing critical macro key → pipeline halt.

This violated the **2026-05-10 decision** ("a cell is only updated if the data exists in the authoritative source, else the prior datapoint is retained"). The retain mechanism existed (`canonical_existing_rows`) but was gated to `yfinance_only`/`auto`; `polygon_only` opted out and did a destructive overwrite.

## SOTA / institutional alignment

This implements the **source-of-record waterfall** that institutional market-data masters use (provenance per cell + priority-ranked COALESCE upsert + bitemporal revisions-not-blanking + loud degradation events). Verified against that pattern before implementing.

## What changed (`collectors/daily_closes.py`)

- **`_coalesce_by_source_priority`** — for each ticker, keep the row from the highest-priority source across {prior parquet, this run}. `_SOURCE_PRIORITY = {polygon:3, fred:3, yfinance:1}` (polygon/fred are co-primary over disjoint domains — equities vs `^`indices). Subsumes:
  - **retain-on-empty** — a ticker the live pass can't refresh keeps its prior row (fixes the TNX blank).
  - **restatement wins** — same-or-higher source overwrites (ties → fresh), so polygon's corporate-action-adjusted closes still land.
  - **no source-downgrade** — a yfinance backstop can't clobber a prior polygon close + true VWAP (prevents the 2026-04-17 `VWAP=None` contamination class).
  - null/NaN `Close` treated as missing (never wins, never written as an empty cell).
- **`polygon_only` now coalesces before write** instead of destructive overwrite. Runs **after** the coverage gate (computed on the **fresh** fetch), so a genuine polygon outage still hard-fails and is **not** masked by retained rows.
- **Macro yfinance backstop** — the equity-specific no-silent-fails refusal no longer blanket-blocks the FRED-index macro tickers (`^TNX/^VIX/^IRX/^VIX3M`). Polygon never serves them and they carry no VWAP, so FRED → yfinance is their legitimate chain. **Loud WARN** on fallback (records the FRED degradation; satisfies `feedback_no_silent_fails`). **Equities still refuse yfinance.**

### `no_silent_fails` deviation rationale (per CLAUDE.md)
The macro yfinance backstop is a *loud* fallback, not a silent one: (a) failure mode = FRED rate-limit/outage on a FRED-only macro ticker; (b) primary deliverable (the parquet + macro keys) survives via the documented FRED→yfinance chain; (c) recording surface = explicit `WARN` log naming the ticker(s) + the `polygon_only coalesce` WARN counting retained/downgrade-blocked cells. Equity universe semantics are unchanged.

## Tests
- New `tests/test_daily_closes_source_priority_merge.py` — 9 tests on the coalesce invariant (retain-on-empty, restatement, downgrade-block, null handling, unknown-source prior, mixed-scenario stats).
- `tests/test_daily_closes_source_modes.py` — added macro-backstop wiring test + end-to-end TNX-retain regression; tightened 2 docstrings that over-claimed the old destructive-overwrite contract.
- **Full suite: 1742 passed, 1 skipped.**

## Out-of-scope follow-ups (filing to ROADMAP)
1. **FRED rate-limit hardening** — this PR makes the system *resilient* to FRED 429s but does not stop them. The windowed backfill fires ~N×2 FRED calls in a tight burst with no backoff/jitter. A FRED retry/backoff-with-jitter (SOTA retry primitive) is separate hardening.
2. **Waterfall consolidation (P3)** — `polygon_only` (coalesce) and `yfinance_only`/`auto` (`canonical_existing_rows`) are parallel preservation mechanisms; consider unifying on the priority-waterfall primitive.
3. **Operator note** — today's 6/1 weekday SF did not trade (halted pre-MorningEnrich-completion); no recovery re-run fired (pre-open window had closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)