### PR TITLE
W2.3 factor-momentum integration: second-pass builder + register factor_momentum_ratio (L4469)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -36,6 +36,7 @@ from features.feature_engineer import (
     MIN_ROWS_FOR_FEATURES,
     compute_features,
 )
+from features.factor_momentum import materialize_factor_momentum
 from features.compute import (
     DEFAULT_BUCKET,
     SOURCE_CATEGORIES,
@@ -733,6 +734,25 @@ def backfill(
                     sector_df = pd.DataFrame({"Close": macro[key]}, index=macro[key].index)
                     sector_df.index.name = "date"
                     macro_lib.write(key, to_arctic_safe(sector_df))
+
+    # ── 5b. Factor-momentum second pass (W2.3, L4469) ────────────────────────
+    # ``factor_momentum_ratio`` is a cross-sectional-time-series feature: date
+    # t's value ranks the WHOLE cross-section and builds factor-return
+    # portfolios, so it can't be produced inside the per-ticker compute_features
+    # loop above. Run it as a second pass over the just-written universe lib,
+    # reading back the slim (close + loadings) panel and writing the column
+    # back per ticker (canonical projection keeps it in its FEATURES position).
+    # Full-universe only — a ``--ticker X`` patch can't reconstruct the
+    # cross-section, so the column is left to the next full backfill / the
+    # daily go-forward path. Runs BEFORE the snapshot so the snapshot is
+    # complete.
+    if not dry_run and ticker_filter is None:
+        fm_result = materialize_factor_momentum(
+            universe_lib,
+            universe_tickers,
+            canonical_fn=to_arctic_canonical,
+        )
+        log.info("Factor-momentum second pass: %s", json.dumps(fm_result, default=str))
 
     # ── 6. Snapshot ──────────────────────────────────────────────────────────
     if not dry_run:

--- a/features/SCHEMA.md
+++ b/features/SCHEMA.md
@@ -115,6 +115,7 @@ parity.
 | `residual_momentum_ratio` | information ratio (dimensionless) | `sum(residual_returns)[t-252,t-21] / (std(residual_returns).rolling(20) * sqrt(231))` — reuses the beta-residualized log-return (same series as idio_vol_60d) | predictor (W2 residual-momentum L1, observe-gated) |
 | `mom_12_1_pct` | decimal return | `close.shift(21) / close.shift(252) - 1` (12-1 skip-month momentum) | predictor (W2) |
 | `sector_mom_pct` | decimal return | sector-ETF `close.shift(21) / close.shift(252) - 1` (absolute industry momentum) | predictor (W2) |
+| `factor_momentum_ratio` | dimensionless projection | `Σ_f zscore(loading_{i,f,t}) × factor_momentum_{f,t}` (Gupta-Kelly factor momentum) — **second-pass** column materialized over the full universe panel by `factor_momentum.materialize_factor_momentum` (not per-ticker `compute_features`); backward-only | predictor (W2.3, observe) |
 
 ### Macro (one row per date — `per_ticker=False`)
 

--- a/features/factor_momentum.py
+++ b/features/factor_momentum.py
@@ -28,8 +28,12 @@ sectional-time-series construction needs the whole panel, not a per-ticker slice
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pandas as pd
+
+log = logging.getLogger(__name__)
 
 # The factor-loading columns this signal tilts across. These are the raw
 # per-ticker loadings the feature store already computes; the cross-sectional
@@ -163,3 +167,122 @@ def compute_factor_momentum_feature(
     ssum = np.where(finite, prod, 0.0).sum(axis=1)
     signal = np.where(count > 0, ssum / np.maximum(count, 1), np.nan)
     return pd.Series(signal, index=panel.index, name="factor_momentum_ratio")
+
+
+def materialize_factor_momentum(
+    universe_lib,
+    tickers,
+    *,
+    loading_cols: list[str] | None = None,
+    window: int = 252,
+    skip: int = 21,
+    quantile: float = 0.3,
+    min_names: int = 20,
+    write: bool = True,
+    canonical_fn=None,
+) -> dict:
+    """Second-pass library builder: materialize ``factor_momentum_ratio`` over
+    the FULL universe-library history (W2.3, L4469).
+
+    Factor momentum is a cross-sectional-time-series construction — date t's
+    value needs EVERY ticker's (close + loadings) history at once (to rank the
+    cross-section and build factor-return portfolios). The streaming per-ticker
+    writes in ``builders/backfill.py`` / ``builders/daily_append.py`` never hold
+    the whole panel in memory, so this runs as a SEPARATE pass AFTER those
+    writes:
+
+      * Pass 1 — read back the slim ``(close + loadings)`` panel per ticker
+        (the full feature frame is ~630 MB universe-wide; the slim slice is a
+        fraction of that), assemble the long panel, and call
+        ``compute_factor_momentum_feature`` once over the whole thing.
+      * Pass 2 — read-modify-write ``factor_momentum_ratio`` into each ticker's
+        stored frame (one frame in memory at a time). ``canonical_fn`` (pass
+        ``store.arctic_store.to_arctic_canonical``) re-projects to the
+        OHLCV+source+FEATURES column contract so the new column lands in its
+        canonical position; ``factor_momentum_ratio`` must be in ``FEATURES`` or
+        the canonical projection would drop it.
+
+    Tickers that fail to read/write are skipped with a WARN (the signal is
+    OBSERVE-mode and best-effort); an all-NaN ``factor_momentum_ratio`` count is
+    logged LOUD so a silently-empty materialization can't pass for success.
+    Returns a summary dict.
+    """
+    cols = list(loading_cols) if loading_cols is not None else list(DEFAULT_FACTOR_LOADINGS)
+
+    # ── Pass 1: assemble the slim long panel (close + loadings) ──────────────
+    frames: list[pd.DataFrame] = []
+    read_fail = 0
+    for t in tickers:
+        try:
+            df = universe_lib.read(t).data
+        except Exception as exc:
+            log.warning("factor-momentum: read failed for %s (skipped): %s", t, exc)
+            read_fail += 1
+            continue
+        if df is None or df.empty or "Close" not in df.columns:
+            continue
+        sub = pd.DataFrame({"close": df["Close"].astype(float)})
+        for c in cols:
+            if c in df.columns:
+                sub[c] = df[c].astype(float)
+        sub["ticker"] = t
+        sub["date"] = df.index
+        frames.append(sub.reset_index(drop=True))
+
+    if not frames:
+        log.warning(
+            "factor-momentum: no readable tickers (read_fail=%d) — nothing materialized",
+            read_fail,
+        )
+        return {"status": "empty", "tickers_written": 0, "read_fail": read_fail}
+
+    panel = pd.concat(frames, ignore_index=True)
+    fm = compute_factor_momentum_feature(
+        panel, loading_cols=cols, window=window, skip=skip,
+        quantile=quantile, min_names=min_names,
+    )
+    panel["factor_momentum_ratio"] = fm.to_numpy()
+
+    # ── Pass 2: read-modify-write the column per ticker ──────────────────────
+    n_written = 0
+    n_all_nan = 0
+    write_fail = 0
+    n_tickers = panel["ticker"].nunique()
+    for t, grp in panel.groupby("ticker", sort=False):
+        col = grp.set_index("date")["factor_momentum_ratio"].astype(float)
+        if not np.isfinite(col.to_numpy()).any():
+            n_all_nan += 1
+        if not write:
+            continue
+        try:
+            df = universe_lib.read(t).data
+            df["factor_momentum_ratio"] = col.reindex(df.index).astype("float32")
+            out = canonical_fn(df) if canonical_fn is not None else df
+            universe_lib.write(t, out)
+            n_written += 1
+        except Exception as exc:
+            log.warning("factor-momentum: write failed for %s (skipped): %s", t, exc)
+            write_fail += 1
+
+    if n_all_nan:
+        # LOUD per [[feedback_no_silent_fails]]: an all-NaN signal is the
+        # short-history / no-finite-loadings tail, not a failure — but a HIGH
+        # count would mean the panel/loadings were wrong, so surface it.
+        log.warning(
+            "factor-momentum: %d/%d tickers have an all-NaN factor_momentum_ratio "
+            "(short history or no finite loadings → neutral downstream, NOT a "
+            "silent zero).",
+            n_all_nan, n_tickers,
+        )
+    log.info(
+        "factor-momentum materialized: %d written, %d all-NaN, %d read-fail, "
+        "%d write-fail (of %d panel tickers)",
+        n_written, n_all_nan, read_fail, write_fail, n_tickers,
+    )
+    return {
+        "status": "ok",
+        "tickers_written": n_written,
+        "tickers_all_nan": n_all_nan,
+        "read_fail": read_fail,
+        "write_fail": write_fail,
+    }

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -170,6 +170,14 @@ FEATURES = [
     "residual_momentum_ratio",
     "mom_12_1_pct",
     "sector_mom_pct",
+    # W2.3 (L4469) — factor momentum ("Factor Momentum Everywhere", Gupta-Kelly).
+    # A cross-sectional-time-series projection, so (like the C.1 z-scores below)
+    # it is NOT produced by per-ticker compute_features — it is materialized in a
+    # SECOND PASS over the universe library by features.factor_momentum.
+    # materialize_factor_momentum, called at the end of builders/backfill.py
+    # (full 10y) and the daily go-forward path. Predictor-consumed (W2.3);
+    # observe-only.
+    "factor_momentum_ratio",
     # C.1 (optimizer-sota-upgrades-260526.md §C.1) — factor-loading z-scores
     # for the executor's Σ = B·F·Bᵀ + D risk decomposition (C.3). Computed
     # POST-assembly in features/compute.py via features.cross_sectional.

--- a/features/registry.py
+++ b/features/registry.py
@@ -106,6 +106,12 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("residual_momentum_ratio", "technical", "Vol-scaled cumulative residual (idiosyncratic) log-return over the 12-1 skip-month window: ∑resid_ret[t-252,t-21] / (σ_resid·√231) — an information ratio (Blitz/Hanauer residual momentum)", source="yfinance", refresh="daily"),
     FeatureEntry("mom_12_1_pct", "technical", "12-1 skip-month raw price momentum: close.shift(21)/close.shift(252) - 1 (classic momentum factor, skips the recent-month reversal)", source="yfinance", refresh="daily"),
     FeatureEntry("sector_mom_pct", "technical", "The ticker's sector-ETF own 12-1 skip-month momentum (GKX industry momentum — absolute, distinct from sector_vs_spy_* relative features)", source="yfinance", refresh="daily"),
+    # W2.3 (L4469) — factor momentum (Gupta-Kelly "Factor Momentum Everywhere").
+    # Cross-sectional-time-series projection: Σ_f zscore(loading_{i,f,t}) ×
+    # factor_momentum_{f,t}. NOT produced by per-ticker compute_features —
+    # materialized in a second pass over the universe lib (factor_momentum.
+    # materialize_factor_momentum). Mirrors the post-assembly *_zscore loadings.
+    FeatureEntry("factor_momentum_ratio", "technical", "Factor-momentum tilt (Gupta-Kelly): per date, dot the ticker's cross-sectionally z-scored factor loadings with each factor's trailing 12-1 long-short return momentum — Σ_f zscore(loading) × factor_mom. Dimensionless projection; backward-only (loadings at t × factor momentum through t-skip)", source="derived", refresh="daily"),
 
     # ── Fundamental (13) — quarterly financials ───────────────────────────────
     FeatureEntry("pe_ratio", "fundamental", "Trailing P/E ratio, normalized (PE / 30)", source="fmp", refresh="quarterly"),

--- a/tests/test_factor_momentum.py
+++ b/tests/test_factor_momentum.py
@@ -18,6 +18,7 @@ from features.factor_momentum import (
     compute_daily_factor_returns,
     compute_factor_momentum_feature,
     compute_factor_momentum_series,
+    materialize_factor_momentum,
 )
 
 
@@ -111,3 +112,99 @@ class TestRobustness:
         out = compute_factor_momentum_feature(panel, ["f1"], window=252, skip=21)
         assert len(out) == len(panel)
         assert out.isna().all()
+
+
+class _MockLib:
+    """Minimal in-memory stand-in for an ArcticDB Library — supports the
+    ``read(sym).data`` / ``write(sym, df)`` surface materialize_factor_momentum
+    uses, storing per-ticker frames keyed by symbol."""
+
+    class _Item:
+        def __init__(self, data):
+            self.data = data
+
+    def __init__(self, frames: dict):
+        self._store = dict(frames)
+
+    def read(self, sym):
+        return self._Item(self._store[sym].copy())
+
+    def write(self, sym, df):
+        self._store[sym] = df.copy()
+
+    def list_symbols(self):
+        return list(self._store)
+
+
+def _panel_to_universe_frames(panel: pd.DataFrame) -> dict:
+    """Reshape the long persistent-factor panel into per-ticker date-indexed
+    frames with a ``Close`` column + the ``f1`` loading (mirrors the universe
+    library's per-symbol storage)."""
+    frames = {}
+    for t, grp in panel.groupby("ticker", sort=False):
+        g = grp.sort_values("date").set_index("date")
+        frames[t] = pd.DataFrame({"Close": g["close"].astype(float), "f1": g["f1"].astype(float)})
+    return frames
+
+
+class TestMaterializeSecondPass:
+    def test_writes_factor_momentum_column_consistent_with_pure_fn(self):
+        panel, tickers, loading = _persistent_factor_panel(seed=7)
+        lib = _MockLib(_panel_to_universe_frames(panel))
+
+        result = materialize_factor_momentum(lib, tickers, loading_cols=["f1"])
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == len(tickers)
+
+        # Every ticker's stored frame now carries the column.
+        for t in tickers:
+            df = lib.read(t).data
+            assert "factor_momentum_ratio" in df.columns
+
+        # High-loading name's latest value is positive and exceeds the low one —
+        # same property the pure-function test asserts, now end-to-end.
+        hi = max(loading, key=loading.get)
+        lo = min(loading, key=loading.get)
+        s_hi = lib.read(hi).data["factor_momentum_ratio"].iloc[-1]
+        s_lo = lib.read(lo).data["factor_momentum_ratio"].iloc[-1]
+        assert np.isfinite(s_hi) and s_hi > 0
+        assert s_hi > s_lo
+
+    def test_write_false_computes_but_does_not_mutate_store(self):
+        panel, tickers, _ = _persistent_factor_panel(seed=8)
+        lib = _MockLib(_panel_to_universe_frames(panel))
+        result = materialize_factor_momentum(lib, tickers, loading_cols=["f1"], write=False)
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == 0
+        for t in tickers:
+            assert "factor_momentum_ratio" not in lib.read(t).data.columns
+
+    def test_canonical_fn_applied_on_write(self):
+        panel, tickers, _ = _persistent_factor_panel(seed=9)
+        lib = _MockLib(_panel_to_universe_frames(panel))
+        seen = {}
+
+        def _canon(df):
+            seen["called"] = True
+            return df
+
+        materialize_factor_momentum(lib, tickers, loading_cols=["f1"], canonical_fn=_canon)
+        assert seen.get("called") is True
+
+    def test_unreadable_tickers_are_skipped_loudly_not_fatal(self):
+        panel, tickers, _ = _persistent_factor_panel(seed=10)
+        frames = _panel_to_universe_frames(panel)
+        lib = _MockLib(frames)
+        # A ticker named in the list but absent from the store → read raises.
+        result = materialize_factor_momentum(
+            lib, tickers + ["MISSING"], loading_cols=["f1"],
+        )
+        assert result["status"] == "ok"
+        assert result["read_fail"] == 1
+        assert result["tickers_written"] == len(tickers)
+
+    def test_empty_universe_returns_empty_status(self):
+        lib = _MockLib({})
+        result = materialize_factor_momentum(lib, [], loading_cols=["f1"])
+        assert result["status"] == "empty"
+        assert result["tickers_written"] == 0


### PR DESCRIPTION
## What

Wires the factor-momentum core (#358) into the materialization path and registers the `factor_momentum_ratio` feature-store column, so the predictor can read it for the **Tuesday 6/2 off-cycle observe firing** (L4469 P0). OBSERVE-mode — gates nothing.

## Why

`factor_momentum_ratio` (Gupta-Kelly "Factor Momentum Everywhere") is a **cross-sectional-time-series** projection: at each date it ranks the whole cross-section by factor loadings, builds long-short factor-return portfolios, and tilts each name by its loadings × each factor's trailing 12-1 momentum. That construction needs the **whole universe panel at once** — it cannot be produced inside the per-ticker `compute_features` loop. So this lands as a **second pass** over the just-written universe library.

## Changes

- **`features/factor_momentum.py`** — `materialize_factor_momentum(universe_lib, tickers, ...)`:
  - Pass 1: read the slim `(close + loadings)` panel back per ticker (full feature panel is ~630 MB universe-wide; the slim slice is a fraction), assemble the long panel, compute once.
  - Pass 2: read-modify-write `factor_momentum_ratio` into each ticker's frame (one frame in memory at a time) via `to_arctic_canonical` so it lands in its canonical FEATURES position.
  - All-NaN ticker count logged **LOUD** (short-history / no-finite-loadings tail → neutral downstream, not a silent zero), per `[[feedback_no_silent_fails]]`.
- **`builders/backfill.py`** — call it at the end of `backfill()` (§5b), **full-universe only** (a `--ticker X` patch can't reconstruct the cross-section), before the snapshot so the snapshot is complete.
- **Register** `factor_momentum_ratio` (suffix `_ratio`, dimensionless projection): `feature_engineer.FEATURES` (a post-pass column — mirrors the existing C.1 `*_zscore` precedent, also post-assembly), `registry.CATALOG`, `SCHEMA.md` §3.
- **Tests** — 5 builder integration tests (mock universe lib): column written, end-to-end consistency with the pure fn (high-loading name → positive tilt, monotone), `write=False` no-op, `canonical_fn` applied, unreadable tickers skipped loudly, empty universe.

## Out of scope (tracked fast-follow, before Sat 6/6)

The **daily go-forward** path (Saturday DataPhase1 / the universe-lib daily update) — wiring the SAME `compute_factor_momentum_feature` over a trailing ~273d cross-sectional panel. Until it lands, weekday `daily_append` NaN-fills the column via `_align_schema_for_update` (the established additive-FEATURES pattern, same as the 2026-05-09 provenance `source` column — **not** a break; NaN is the correct "not-yet-computed" sentinel, masked to neutral downstream). No DataPhase1 run occurs between Tuesday's backfill and the fast-follow.

## Test plan

- `pytest tests/test_schema_contract.py tests/test_factor_momentum.py tests/test_schema_roundtrip.py` ✅
- Full suite: **1766 passed, 1 skipped** ✅
- Tuesday: full `builders.backfill` writes `factor_momentum_ratio` over 10y → PredictorTraining reads it (predictor PR follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)