### PR TITLE
L4484: factor_momentum_ratio daily go-forward path + static-schema break-fix

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -35,6 +35,7 @@ from features.feature_engineer import (
     MIN_ROWS_FOR_FEATURES,
     compute_features,
 )
+from features.factor_momentum import update_factor_momentum_latest
 from features.compute import (
     DEFAULT_BUCKET,
     _SKIP_TICKERS,
@@ -1263,6 +1264,23 @@ def _daily_append_impl(
                 # passthrough behaviour.
                 today_row[PROVENANCE_COL] = new_row.iloc[0][PROVENANCE_COL]
 
+                # ── L4484: align today_row to the stored schema ──────────────
+                # The universe lib is STATIC-schema, so update_batch's descriptor
+                # must match the stored symbol's column SET. A FEATURES column
+                # the stored series carries but ``compute_features`` does NOT emit
+                # — ``factor_momentum_ratio``, a cross-sectional SECOND-PASS
+                # column written by features.factor_momentum over the full panel
+                # (it cannot be produced per-ticker here) — would otherwise be
+                # absent from today_row, tripping StreamDescriptorMismatch on the
+                # first daily_append after a backfill that added it. Add any such
+                # column as NaN so the descriptor matches; its real go-forward
+                # value is filled by the factor-momentum second pass after the
+                # write loop. Generalizes _align_schema_for_update (single-row
+                # path) to the batch path. Per [[feedback_no_silent_fails]].
+                for _stored_col in hist.columns:
+                    if _stored_col in FEATURES and _stored_col not in today_row.columns:
+                        today_row[_stored_col] = np.nan
+
                 # Column order is enforced by ``to_arctic_canonical`` at
                 # the queue site below — no per-site reorder required.
 
@@ -1514,6 +1532,24 @@ def _daily_append_impl(
                 f"ArcticDB daily_append error rate {err_rate:.1%} exceeds 5% threshold "
                 f"(n_ok={n_ok} n_err={n_err} of {len(stock_tickers)}) — treating as pipeline failure"
             )
+
+        # ── L4484: factor-momentum daily go-forward second pass ──────────────
+        # factor_momentum_ratio is a cross-sectional-time-series feature that
+        # can't be produced per-ticker in the loop above (it ranks the WHOLE
+        # cross-section + builds factor-return portfolios). Now that today's
+        # OHLCV+loadings rows are written, recompute the latest date's value
+        # over a slim trailing panel and update it in place. Best-effort +
+        # OBSERVE: the function never raises; gate off via the env var if it
+        # ever misbehaves. Skipped on dry_run (no writes happened).
+        if os.environ.get("FACTOR_MOMENTUM_DAILY_ENABLED", "true").lower() != "false":
+            try:
+                fm_result = update_factor_momentum_latest(
+                    universe_lib, stock_tickers, today_ts,
+                    canonical_fn=to_arctic_canonical,
+                )
+                log.info("Factor-momentum daily update: %s", json.dumps(fm_result, default=str))
+            except Exception as exc:  # belt-and-suspenders — never fail the daily pipeline
+                log.warning("Factor-momentum daily update FAILED (OBSERVE, non-fatal): %s", exc)
 
         # Producer-side post-write validation. Catches the partial-write
         # class (2026-04-21 ASGN/MOH) that the per-ticker error-rate gate

--- a/features/factor_momentum.py
+++ b/features/factor_momentum.py
@@ -286,3 +286,152 @@ def materialize_factor_momentum(
         "read_fail": read_fail,
         "write_fail": write_fail,
     }
+
+
+def update_factor_momentum_latest(
+    universe_lib,
+    tickers,
+    as_of_ts,
+    *,
+    loading_cols: list[str] | None = None,
+    window: int = 252,
+    skip: int = 21,
+    quantile: float = 0.3,
+    min_names: int = 20,
+    trailing_days: int | None = None,
+    write: bool = True,
+    canonical_fn=None,
+) -> dict:
+    """Daily go-forward update of ``factor_momentum_ratio`` (W2.3 / L4484).
+
+    The go-forward sibling of ``materialize_factor_momentum``: instead of a full
+    10y rewrite, read only the TRAILING (close + loadings) slice per ticker
+    (factor momentum at ``as_of_ts`` needs ~``window+skip`` days of
+    cross-sectional factor returns), compute the full-panel signal, and write
+    ONLY ``as_of_ts``'s ``factor_momentum_ratio`` per ticker — so the daily
+    universe-append keeps the column fresh without the cost of a 10y rebuild.
+
+    Runs as a SECOND PASS after ``builders/daily_append`` has written the day's
+    OHLCV+features rows (so ``as_of_ts``'s close + loadings are in the lib).
+    Uses ``read_batch`` (slim trailing read + today's full rows) + ``update_batch``
+    for ArcticDB-native parallelism — mirrors daily_append's own I/O pattern.
+    Best-effort + OBSERVE: read/write failures are logged and skipped, all-NaN
+    counts logged LOUD (per [[feedback_no_silent_fails]]); never raises into the
+    daily pipeline.
+    """
+    import pandas as _pd
+    from arcticdb.version_store.library import ReadRequest, UpdatePayload
+    from arcticdb_ext.exceptions import ArcticException  # noqa: F401  (parity w/ daily_append err handling)
+
+    cols = list(loading_cols) if loading_cols is not None else list(DEFAULT_FACTOR_LOADINGS)
+    if trailing_days is None:
+        trailing_days = int(window) + int(skip) + 40  # factor-return warmup buffer
+    as_of_ts = _pd.Timestamp(as_of_ts)
+    # Calendar span covering ~trailing_days trading days (×1.6 for weekends/holidays).
+    start_ts = as_of_ts - _pd.Timedelta(days=int(trailing_days * 1.6) + 5)
+
+    tickers = list(tickers)
+    slim_cols = ["Close", *cols]
+
+    # ── Pass 1: slim trailing (close + loadings) panel via read_batch ────────
+    try:
+        slim_reqs = [
+            ReadRequest(symbol=t, date_range=(start_ts, as_of_ts), columns=slim_cols)
+            for t in tickers
+        ]
+        slim_results = universe_lib.read_batch(slim_reqs)
+    except Exception as exc:
+        log.warning("factor-momentum daily: slim read_batch failed (skipped): %s", exc)
+        return {"status": "read_error", "error": str(exc), "tickers_written": 0}
+
+    frames: list[pd.DataFrame] = []
+    read_fail = 0
+    for t, res in zip(tickers, slim_results):
+        data = getattr(res, "data", None)
+        if data is None:  # DataError / missing symbol
+            read_fail += 1
+            continue
+        if data.empty or "Close" not in data.columns:
+            continue
+        sub = pd.DataFrame({"close": data["Close"].astype(float)})
+        for c in cols:
+            if c in data.columns:
+                sub[c] = data[c].astype(float)
+        sub["ticker"] = t
+        sub["date"] = data.index
+        frames.append(sub.reset_index(drop=True))
+
+    if not frames:
+        log.warning("factor-momentum daily: no readable tickers (read_fail=%d)", read_fail)
+        return {"status": "empty", "tickers_written": 0, "read_fail": read_fail}
+
+    panel = pd.concat(frames, ignore_index=True)
+    fm = compute_factor_momentum_feature(
+        panel, loading_cols=cols, window=window, skip=skip,
+        quantile=quantile, min_names=min_names,
+    )
+    panel["factor_momentum_ratio"] = fm.to_numpy()
+
+    # Latest value per ticker AT as_of_ts (the go-forward date just appended).
+    latest = panel[panel["date"] == panel["date"].max()]
+    fm_by_ticker = {
+        t: float(g["factor_momentum_ratio"].iloc[-1]) for t, g in latest.groupby("ticker", sort=False)
+    }
+    n_all_nan = sum(1 for v in fm_by_ticker.values() if not np.isfinite(v))
+    if not write:
+        return {"status": "ok", "tickers_written": 0, "tickers_all_nan": n_all_nan,
+                "read_fail": read_fail, "n_computed": len(fm_by_ticker)}
+
+    # ── Pass 2: read today's FULL rows, set factor_momentum_ratio, update ────
+    # A full-row update is required because the lib is static-schema (no
+    # column-wise update); today's row already carries factor_momentum_ratio as
+    # NaN from daily_append's schema-align, so the descriptor matches.
+    write_tickers = list(fm_by_ticker)
+    try:
+        today_results = universe_lib.read_batch(
+            [ReadRequest(symbol=t, date_range=(as_of_ts, as_of_ts)) for t in write_tickers]
+        )
+    except Exception as exc:
+        log.warning("factor-momentum daily: today read_batch failed (skipped): %s", exc)
+        return {"status": "read_error", "error": str(exc), "tickers_written": 0,
+                "read_fail": read_fail}
+
+    payloads = []
+    for t, res in zip(write_tickers, today_results):
+        data = getattr(res, "data", None)
+        if data is None or data.empty or as_of_ts not in data.index:
+            continue
+        row = data.copy()
+        row.loc[as_of_ts, "factor_momentum_ratio"] = np.float32(fm_by_ticker[t])
+        out = canonical_fn(row) if canonical_fn is not None else row
+        payloads.append(UpdatePayload(symbol=t, data=out))
+
+    n_written = 0
+    write_fail = 0
+    if payloads:
+        try:
+            universe_lib.update_batch(payloads)
+            n_written = len(payloads)
+        except Exception as exc:
+            log.warning("factor-momentum daily: update_batch failed (skipped): %s", exc)
+            write_fail = len(payloads)
+
+    if n_all_nan:
+        log.warning(
+            "factor-momentum daily: %d/%d tickers have an all-NaN latest value "
+            "(short history / no finite loadings → neutral downstream, not a "
+            "silent zero).", n_all_nan, len(fm_by_ticker),
+        )
+    log.info(
+        "factor-momentum daily update @ %s: %d written, %d all-NaN, %d read-fail, "
+        "%d write-fail (of %d computed)",
+        as_of_ts.date(), n_written, n_all_nan, read_fail, write_fail, len(fm_by_ticker),
+    )
+    return {
+        "status": "ok",
+        "tickers_written": n_written,
+        "tickers_all_nan": n_all_nan,
+        "read_fail": read_fail,
+        "write_fail": write_fail,
+        "n_computed": len(fm_by_ticker),
+    }

--- a/tests/test_daily_append_factor_momentum.py
+++ b/tests/test_daily_append_factor_momentum.py
@@ -1,0 +1,43 @@
+"""L4484: daily_append factor-momentum integration invariants.
+
+Two structural guarantees (source-inspection, mirroring
+test_daily_append_read_batch.py's style — full daily_append e2e needs live
+ArcticDB + closes + macro mocks):
+
+  1. **Schema-align break-fix.** A FEATURES column the stored series carries but
+     compute_features doesn't emit (factor_momentum_ratio — a cross-sectional
+     SECOND-PASS column) must be NaN-filled into today_row BEFORE the canonical
+     write, or the static-schema update_batch StreamDescriptorMismatches on the
+     first daily_append after a backfill that added it.
+  2. **Daily go-forward second pass.** update_factor_momentum_latest must run
+     AFTER the per-ticker write loop (so today's close+loadings are in the lib),
+     best-effort (never fails the daily pipeline).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
+
+
+def _source() -> str:
+    return _DAILY_APPEND.read_text()
+
+
+def test_today_row_aligned_to_stored_schema():
+    """The break-fix loop must NaN-fill stored FEATURES columns missing from
+    today_row (the factor_momentum_ratio static-schema descriptor case)."""
+    src = _source()
+    assert "for _stored_col in hist.columns:" in src
+    assert "_stored_col in FEATURES and _stored_col not in today_row.columns" in src
+
+
+def test_factor_momentum_daily_update_invoked_after_write_loop():
+    """update_factor_momentum_latest is imported + called with today_ts and the
+    canonical writer, gated by the FACTOR_MOMENTUM_DAILY_ENABLED env var."""
+    src = _source()
+    assert "from features.factor_momentum import update_factor_momentum_latest" in src
+    assert "update_factor_momentum_latest(" in src
+    assert "FACTOR_MOMENTUM_DAILY_ENABLED" in src
+    # Best-effort: wrapped so it never fails the daily pipeline.
+    assert "Factor-momentum daily update FAILED" in src

--- a/tests/test_daily_append_skip_if_exists.py
+++ b/tests/test_daily_append_skip_if_exists.py
@@ -44,6 +44,15 @@ _DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
 _WEEKLY_COLLECTOR = Path(__file__).parent.parent / "weekly_collector.py"
 
 
+@pytest.fixture(autouse=True)
+def _disable_factor_momentum_daily(monkeypatch):
+    # L4484: isolate these tests from the daily factor-momentum second pass —
+    # its extra read_batch/update_batch calls would perturb the skip/call-count
+    # assertions here. The pass has its own tests (test_factor_momentum.py +
+    # test_daily_append_factor_momentum.py).
+    monkeypatch.setenv("FACTOR_MOMENTUM_DAILY_ENABLED", "false")
+
+
 def _stub_closes(tickers: list[str]) -> dict:
     """Minimal daily_closes shape: per-ticker {Open,High,Low,Close,Volume,VWAP}."""
     return {

--- a/tests/test_daily_append_universe_chunking.py
+++ b/tests/test_daily_append_universe_chunking.py
@@ -31,8 +31,17 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from tests.test_daily_append_skip_if_exists import _patch_targets
+
+
+@pytest.fixture(autouse=True)
+def _disable_factor_momentum_daily(monkeypatch):
+    # L4484: isolate the chunk-count assertions from the daily factor-momentum
+    # second pass (its extra read_batch/update_batch calls would inflate the
+    # per-chunk call counts pinned here). The pass has its own tests.
+    monkeypatch.setenv("FACTOR_MOMENTUM_DAILY_ENABLED", "false")
 
 
 def test_universe_pass_chunks_read_batch_calls(monkeypatch):

--- a/tests/test_factor_momentum.py
+++ b/tests/test_factor_momentum.py
@@ -19,6 +19,7 @@ from features.factor_momentum import (
     compute_factor_momentum_feature,
     compute_factor_momentum_series,
     materialize_factor_momentum,
+    update_factor_momentum_latest,
 )
 
 
@@ -206,5 +207,109 @@ class TestMaterializeSecondPass:
     def test_empty_universe_returns_empty_status(self):
         lib = _MockLib({})
         result = materialize_factor_momentum(lib, [], loading_cols=["f1"])
+        assert result["status"] == "empty"
+        assert result["tickers_written"] == 0
+
+
+class _BatchResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _BatchLib:
+    """Mock supporting the read_batch(ReadRequest)/update_batch(UpdatePayload)
+    surface update_factor_momentum_latest uses, with date_range + columns
+    slicing. Missing symbols return a result whose ``.data`` is None
+    (DataError-like)."""
+
+    def __init__(self, frames: dict):
+        self._store = {t: df.copy() for t, df in frames.items()}
+
+    def read_batch(self, reqs):
+        out = []
+        for req in reqs:
+            sym = req.symbol
+            if sym not in self._store:
+                out.append(_BatchResult(None))
+                continue
+            df = self._store[sym]
+            dr = getattr(req, "date_range", None)
+            if dr is not None:
+                lo, hi = dr
+                if lo is not None:
+                    df = df.loc[df.index >= lo]
+                if hi is not None:
+                    df = df.loc[df.index <= hi]
+            cols = getattr(req, "columns", None)
+            if cols:
+                df = df[[c for c in cols if c in df.columns]]
+            out.append(_BatchResult(df.copy()))
+        return out
+
+    def update_batch(self, payloads):
+        for p in payloads:
+            cur = self._store.get(p.symbol)
+            if cur is None:
+                self._store[p.symbol] = p.data.copy()
+                continue
+            cur = cur.copy()
+            for idx in p.data.index:
+                for c in p.data.columns:
+                    cur.loc[idx, c] = p.data.loc[idx, c]
+            self._store[p.symbol] = cur
+
+
+def _panel_to_full_frames(panel: pd.DataFrame) -> dict:
+    """Per-ticker date-indexed frames with Close + the f1 loading."""
+    frames = {}
+    for t, grp in panel.groupby("ticker", sort=False):
+        g = grp.sort_values("date").set_index("date")
+        frames[t] = pd.DataFrame({"Close": g["close"].astype(float), "f1": g["f1"].astype(float)})
+    return frames
+
+
+class TestUpdateLatestDaily:
+    def test_writes_latest_value_consistent_with_pure_fn(self):
+        panel, tickers, loading = _persistent_factor_panel(seed=11)
+        frames = _panel_to_full_frames(panel)
+        lib = _BatchLib(frames)
+        as_of = max(df.index.max() for df in frames.values())
+
+        result = update_factor_momentum_latest(lib, tickers, as_of, loading_cols=["f1"])
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == len(tickers)
+
+        hi = max(loading, key=loading.get)
+        lo = min(loading, key=loading.get)
+        v_hi = lib._store[hi].loc[as_of, "factor_momentum_ratio"]
+        v_lo = lib._store[lo].loc[as_of, "factor_momentum_ratio"]
+        assert np.isfinite(v_hi) and v_hi > 0
+        assert v_hi > v_lo
+        # Only the latest row is updated — earlier rows have no fm column.
+        assert "factor_momentum_ratio" not in frames[hi].columns
+
+    def test_write_false_computes_but_does_not_write(self):
+        panel, tickers, _ = _persistent_factor_panel(seed=12)
+        lib = _BatchLib(_panel_to_full_frames(panel))
+        as_of = max(df.index.max() for df in lib._store.values())
+        result = update_factor_momentum_latest(lib, tickers, as_of, loading_cols=["f1"], write=False)
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == 0
+        assert result["n_computed"] == len(tickers)
+        for t in tickers:
+            assert "factor_momentum_ratio" not in lib._store[t].columns
+
+    def test_missing_symbols_counted_read_fail_not_fatal(self):
+        panel, tickers, _ = _persistent_factor_panel(seed=13)
+        lib = _BatchLib(_panel_to_full_frames(panel))
+        as_of = max(df.index.max() for df in lib._store.values())
+        result = update_factor_momentum_latest(lib, tickers + ["GHOST"], as_of, loading_cols=["f1"])
+        assert result["status"] == "ok"
+        assert result["read_fail"] == 1
+        assert result["tickers_written"] == len(tickers)
+
+    def test_empty_store_returns_empty_status(self):
+        lib = _BatchLib({})
+        result = update_factor_momentum_latest(lib, ["A", "B"], pd.Timestamp("2020-06-01"), loading_cols=["f1"])
         assert result["status"] == "empty"
         assert result["tickers_written"] == 0


### PR DESCRIPTION
## What

Closes **L4484** — the daily go-forward path for `factor_momentum_ratio` — **and fixes a latent production break** the W2.3 backfill (#359) would otherwise arm.

## The break (and a correction)

When I deferred this in the W2.3 plan I claimed weekday `daily_append` would NaN-fill the column "via `_align_schema_for_update`." **That was wrong** — `_align_schema_for_update` is only in the single-row path; production uses the **batch** path, which doesn't align. The universe lib is **static-schema**, and `factor_momentum_ratio` is the one FEATURES column `compute_features` doesn't emit (it's the cross-sectional second-pass column). So once the backfill writes it into the lib, the **first `daily_append` after would `StreamDescriptorMismatch`** (today_row lacks the column the stored series now has) and fail for every ticker.

## Changes

- **Break-fix (`builders/daily_append.py`):** before the canonical write, NaN-fill any FEATURES column the stored series carries but `compute_features` didn't emit — aligns today_row to the stored descriptor (generalizes `_align_schema_for_update` to the batch path). Prevents the mismatch for `factor_momentum_ratio` *and* any future second-pass column.
- **Daily go-forward (`features/factor_momentum.update_factor_momentum_latest`):** after the write loop, recompute `factor_momentum_ratio` for the new date over a **slim trailing cross-sectional panel** (`read_batch` close+loadings) and update today's value in place (`read_batch` today's full rows → set → `update_batch`). Cross-sectional + chunked-loop + static-schema ⇒ a **decoupled post-write second pass** (not the per-ticker loop). Best-effort + OBSERVE, gated by `FACTOR_MOMENTUM_DAILY_ENABLED` (default on); never raises into the pipeline.

## Sequencing (important)

The break arms the moment a backfill writes `factor_momentum_ratio` (i.e. the Tuesday backfill). **This must merge + deploy to the dispatcher before the Tuesday backfill runs** (or before the next `daily_append` after it). Recommend: deploy this, *then* run the Tuesday backfill.

## Test plan

- `update_factor_momentum_latest` (batch-lib mock): latest-only write, consistency with the pure fn (high-loading > low-loading, positive), `write=False` computes-not-writes, missing-symbol/empty status.
- daily_append integration invariants (align loop present; second pass invoked, gated, best-effort).
- Isolated two daily_append test files from the new pass (`FACTOR_MOMENTUM_DAILY_ENABLED=false`) so their chunk/skip call-count assertions stay focused.
- Full suite: **1772 passed, 1 skipped** (was 1766).

Per [[feedback_no_silent_fails]] + [[feedback_sota_institutional_default_no_shortcuts]].

🤖 Generated with [Claude Code](https://claude.com/claude-code)