### PR TITLE
fix(daily_closes): coalesce-arc hardening — polygon-transient / FRED-backoff / weekday-pull / restatement-severity (L4482/L4480/L4483/L4486)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import io
 import logging
+import random
 import re
 import time
 from datetime import datetime, time as dtime, timedelta, timezone
@@ -71,6 +72,67 @@ _YFINANCE_BATCH_DELAY = 2  # seconds between batches
 
 _FRED_BASE = "https://api.stlouisfed.org/fred/series/observations"
 _FRED_TIMEOUT = 15
+# L4480: bounded retry with exponential backoff + full jitter for FRED.
+# The windowed reconciliation fires ~N×(window) FRED calls in a tight burst;
+# without spacing FRED returns 429 storms (the 2026-06-01 TNX failure). #354
+# made us resilient to a missed value; this stops the storm at the source.
+# Honors a server `Retry-After` when present, else exponential backoff + jitter.
+_FRED_MAX_ATTEMPTS = 3
+_FRED_BACKOFF_BASE = 1.0   # seconds; wait ≈ base * 2**attempt + U(0, base)
+_FRED_BACKOFF_CAP = 30.0   # seconds; never wait longer than this between tries
+
+
+def _fred_get_with_retry(params: dict) -> requests.Response:
+    """GET a FRED observation with bounded backoff + jitter on transient errors.
+
+    Retries on 429 / 5xx / timeout / connection error (the recoverable class);
+    a 4xx other than 429 (e.g. a malformed series_id) raises immediately — no
+    point retrying a deterministic client error. Raises the last exception (or
+    an HTTPError via ``raise_for_status``) after ``_FRED_MAX_ATTEMPTS``.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(_FRED_MAX_ATTEMPTS):
+        try:
+            resp = requests.get(_FRED_BASE, params=params, timeout=_FRED_TIMEOUT)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after is not None:
+                    try:
+                        wait = float(retry_after)
+                    except ValueError:
+                        wait = _FRED_BACKOFF_BASE * (2 ** attempt)
+                else:
+                    wait = _FRED_BACKOFF_BASE * (2 ** attempt)
+                wait = min(wait + random.uniform(0, _FRED_BACKOFF_BASE), _FRED_BACKOFF_CAP)
+                if attempt < _FRED_MAX_ATTEMPTS - 1:
+                    logger.warning(
+                        "FRED %s — backing off %.1fs (attempt %d/%d)",
+                        resp.status_code, wait, attempt + 1, _FRED_MAX_ATTEMPTS,
+                    )
+                    time.sleep(wait)
+                    continue
+            resp.raise_for_status()
+            return resp
+        except (requests.Timeout, requests.ConnectionError) as exc:
+            last_exc = exc
+            if attempt < _FRED_MAX_ATTEMPTS - 1:
+                wait = min(
+                    _FRED_BACKOFF_BASE * (2 ** attempt)
+                    + random.uniform(0, _FRED_BACKOFF_BASE),
+                    _FRED_BACKOFF_CAP,
+                )
+                logger.warning(
+                    "FRED transient %s — backing off %.1fs (attempt %d/%d)",
+                    type(exc).__name__, wait, attempt + 1, _FRED_MAX_ATTEMPTS,
+                )
+                time.sleep(wait)
+                continue
+            raise
+    if last_exc is not None:
+        raise last_exc
+    # All attempts were 429/5xx that fell through the loop — surface the last.
+    resp.raise_for_status()
+    return resp
 
 # Map our ArcticDB ticker key (after stripping ^) to FRED series id.
 # Both yfinance (^VIX, ^TNX, ...) and FRED (VIXCLS, DGS10, ...) publish
@@ -516,9 +578,39 @@ def collect(
     # ── Step 1: polygon.io grouped-daily ─────────────────────────────────────
     # Skipped in yfinance_only mode (free tier returns 403 same-day; deferring
     # to the morning polygon_only enrichment is the canonical path).
+    #
+    # L4482: a TRANSIENT polygon NETWORK failure (read-timeout / connection
+    # error / rate-limit-exhausted) must NOT abort the whole date — the
+    # FRED-index macro tickers (^TNX/^VIX/^IRX/^VIX3M) and their yfinance
+    # backstop NEVER come from polygon, yet a raise here skips Steps 2 & 3 and
+    # leaves the critical macro keys unfilled (the exact gap that failed
+    # recovery re-run #1 on 2026-06-01 despite #354 — a polygon read-timeout).
+    # So in polygon_only mode we catch ONLY the transient network class, log
+    # loudly, and fall through to FRED + the macro backstop. A REAL polygon
+    # outage is still surfaced: zero equity records → the equity coverage gate
+    # below hard-fails, so the catch cannot mask an equity-data failure.
+    # NARROW BY DESIGN: `PolygonForbiddenError` (structural 403) and
+    # `_fetch_polygon_closes`'s deliberate "0 tickers" empty-data RuntimeError
+    # still propagate with their own clear messages — only network transients
+    # are downgraded to "continue to the macro backstop".
+    from polygon_client import PolygonRateLimitError
     polygon_count = 0
     if source != "yfinance_only":
-        polygon_count = _fetch_polygon_closes(tickers, run_date, records, source=source)
+        try:
+            polygon_count = _fetch_polygon_closes(
+                tickers, run_date, records, source=source
+            )
+        except (requests.Timeout, requests.ConnectionError,
+                PolygonRateLimitError) as exc:
+            if source != "polygon_only":
+                raise  # auto mode already owns its fallback inside the fetch
+            logger.warning(
+                "L4482: polygon grouped-daily failed transiently for %s (%s: %s) "
+                "— proceeding to FRED (Step 2) + macro yfinance backstop (Step 3) "
+                "so the FRED-index macro keys still fill. A real equity outage is "
+                "caught by the coverage gate (0 equity records → hard-fail).",
+                run_date, type(exc).__name__, exc,
+            )
 
     # ── Step 2: FRED for the 4 indices polygon never serves ──────────────────
     # VIX/VIX3M/TNX/IRX are not on polygon free tier (and won't be on paid either
@@ -990,10 +1082,23 @@ def _log_close_discrepancies(
     consolidated tape coverage variance. Larger drifts (>1% WARN, >5% ERROR)
     typically indicate corporate-action timing differences or one-source data
     quality issues worth a human eyeball.
+
+    L4486: the >5% ERROR band is for genuine cross-source EQUITY drift (polygon
+    overwriting a different-source equity close — a data-quality flag). The
+    FRED-index macro tickers (^TNX/^VIX/^IRX/^VIX3M, …) are a different class:
+    the windowed reconciliation predictably RESTATES them toward the
+    authoritative FRED value — healing a cell clobbered by a transient 429 (the
+    5/14 VIX case) or correcting a stale T-1 edge cell (the reconciliation runs
+    before FRED publishes the prior session's value). Those self-heals jump >5%
+    on volatile-VIX days but are DESIRABLE, not anomalies, so they log at WARN
+    (`fred_restatement`) and are excluded from the flow-doctor ERROR filter. The
+    recording surface stays (per feedback_no_silent_fails) — just at the right
+    severity. Pattern observed twice (2026-05-12, 2026-06-02).
     """
     n_compared = 0
     n_warn = 0
     n_error = 0
+    n_restatement = 0
     biggest: tuple[str, float] = ("", 0.0)
     for ticker in new_df.index:
         prior = prior_close.get(str(ticker))
@@ -1001,8 +1106,18 @@ def _log_close_discrepancies(
         if prior is None or pd.isna(new_close) or prior == 0:
             continue
         n_compared += 1
+        is_fred_index = str(ticker).lstrip("^") in _FRED_INDEX_MAP
         pct_diff = abs(float(new_close) - prior) / prior
-        if pct_diff > _DISCREPANCY_ERROR_PCT:
+        if pct_diff > _DISCREPANCY_ERROR_PCT and is_fred_index:
+            # FRED-index restatement toward the authoritative value — expected
+            # self-heal, NOT an equity data-quality anomaly. WARN, not ERROR.
+            logger.warning(
+                "fred_restatement %s @ %s: Close %.4f → %.4f (%.2f%% diff vs prior parquet) — "
+                "windowed reconciliation healed toward authoritative FRED (expected)",
+                ticker, run_date, prior, float(new_close), pct_diff * 100,
+            )
+            n_restatement += 1
+        elif pct_diff > _DISCREPANCY_ERROR_PCT:
             logger.error(
                 "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f (%.2f%% diff vs prior parquet) — "
                 "investigate before downstream consumers re-read",
@@ -1019,8 +1134,9 @@ def _log_close_discrepancies(
             biggest = (str(ticker), pct_diff)
     logger.info(
         "polygon_only discrepancy summary for %s: compared=%d warn(>1%%)=%d error(>5%%)=%d "
-        "biggest=%s@%.2f%%",
-        run_date, n_compared, n_warn, n_error, biggest[0] or "n/a", biggest[1] * 100,
+        "fred_restatement(>5%%)=%d biggest=%s@%.2f%%",
+        run_date, n_compared, n_warn, n_error, n_restatement,
+        biggest[0] or "n/a", biggest[1] * 100,
     )
 
 
@@ -1069,8 +1185,7 @@ def _fetch_fred_closes(
                 "sort_order": "desc",
                 "limit": 5,
             }
-            resp = requests.get(_FRED_BASE, params=params, timeout=_FRED_TIMEOUT)
-            resp.raise_for_status()
+            resp = _fred_get_with_retry(params)  # L4480: backoff + jitter
             obs = resp.json().get("observations", [])
             latest = next((o for o in obs if o.get("value", ".") != "."), None)
             if latest is None:

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -239,6 +239,8 @@
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",

--- a/tests/test_daily_closes_coalesce_hardening.py
+++ b/tests/test_daily_closes_coalesce_hardening.py
@@ -1,0 +1,152 @@
+"""Coalesce-arc hardening tests (L4480 / L4482 / L4486).
+
+Follow-ups to the 2026-06-01 FRED-429 / polygon-timeout incident:
+
+  * L4480 — `_fred_get_with_retry`: bounded exponential backoff + jitter on the
+    transient class (429 / 5xx / timeout), immediate raise on a deterministic
+    4xx, surface failure after the attempt budget.
+  * L4482 — a TRANSIENT polygon network failure in ``polygon_only`` mode must
+    not abort the date; FRED + the macro yfinance backstop still run.
+  * L4486 — a FRED-index restatement toward the authoritative value logs at
+    WARN (`fred_restatement`), not the ERROR band reserved for equity drift.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+import requests
+from botocore.exceptions import ClientError
+
+from collectors import daily_closes
+
+
+def _resp(status_code: int, *, observations=None, headers=None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.json.return_value = {"observations": observations or []}
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = requests.HTTPError(f"{status_code}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _no_existing_parquet_s3():
+    s3 = MagicMock()
+    s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject",
+    )
+    return s3
+
+
+# ── L4480: FRED backoff + jitter ─────────────────────────────────────────────
+
+class TestFredRetry:
+    def test_retries_429_then_succeeds(self):
+        ok = _resp(200, observations=[{"date": "2026-06-01", "value": "16.0"}])
+        seq = [_resp(429), ok]
+        with patch.object(daily_closes.requests, "get", side_effect=seq) as g, \
+                patch.object(daily_closes.time, "sleep") as sleep:
+            out = daily_closes._fred_get_with_retry({"series_id": "VIXCLS"})
+        assert out is ok
+        assert g.call_count == 2          # one 429, one success
+        assert sleep.call_count == 1      # backed off once
+
+    def test_persistent_429_raises_after_budget(self):
+        with patch.object(daily_closes.requests, "get", return_value=_resp(429)), \
+                patch.object(daily_closes.time, "sleep"):
+            with pytest.raises(requests.HTTPError):
+                daily_closes._fred_get_with_retry({"series_id": "VIXCLS"})
+
+    def test_deterministic_4xx_not_retried(self):
+        # A 404 is not in the transient class — raise immediately, no backoff.
+        with patch.object(daily_closes.requests, "get", return_value=_resp(404)) as g, \
+                patch.object(daily_closes.time, "sleep") as sleep:
+            with pytest.raises(requests.HTTPError):
+                daily_closes._fred_get_with_retry({"series_id": "BOGUS"})
+        assert g.call_count == 1
+        assert sleep.call_count == 0
+
+    def test_timeout_retried_then_reraised(self):
+        with patch.object(daily_closes.requests, "get",
+                          side_effect=requests.Timeout("read timeout")), \
+                patch.object(daily_closes.time, "sleep") as sleep:
+            with pytest.raises(requests.Timeout):
+                daily_closes._fred_get_with_retry({"series_id": "VIXCLS"})
+        # Budget-1 backoffs before the final reraise.
+        assert sleep.call_count == daily_closes._FRED_MAX_ATTEMPTS - 1
+
+
+# ── L4482: transient polygon failure is non-fatal to the macro backstop ──────
+
+class TestPolygonTransientNonFatal:
+    def test_polygon_timeout_still_fills_macro_via_fred(self):
+        s3 = _no_existing_parquet_s3()
+
+        def _fred_side_effect(tickers, date_str, records):
+            for t in tickers:
+                records.append({
+                    "ticker": t.lstrip("^"), "date": date_str,
+                    "Open": 16.0, "High": 16.0, "Low": 16.0, "Close": 16.0,
+                    "Adj_Close": 16.0, "Volume": 0, "VWAP": None, "source": "fred",
+                })
+            return len(tickers)
+
+        with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+                patch("collectors.daily_closes._fetch_polygon_closes",
+                      side_effect=requests.Timeout("read timeout")), \
+                patch("collectors.daily_closes._fetch_fred_closes",
+                      side_effect=_fred_side_effect):
+            # Macro-only ticker list → no equity-coverage gate to satisfy.
+            result = daily_closes.collect(
+                bucket="b", tickers=["^VIX"], run_date="2026-06-01",
+                source="polygon_only", dry_run=True,
+            )
+        # Did NOT raise on the polygon timeout; the macro key filled from FRED.
+        assert result.get("status") != "error", result
+
+    def test_polygon_forbidden_still_propagates(self):
+        # The structural 403 is NOT transient — it must still raise loudly.
+        s3 = _no_existing_parquet_s3()
+        from polygon_client import PolygonForbiddenError
+        with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+                patch("collectors.daily_closes._fetch_polygon_closes",
+                      side_effect=PolygonForbiddenError("403")):
+            with pytest.raises(PolygonForbiddenError):
+                daily_closes.collect(
+                    bucket="b", tickers=["AAPL"], run_date="2026-06-01",
+                    source="polygon_only", dry_run=True,
+                )
+
+
+# ── L4486: FRED-index restatement → WARN, equity drift → ERROR ───────────────
+
+class TestRestatementSeverity:
+    def _df(self, ticker: str, close: float) -> pd.DataFrame:
+        return pd.DataFrame(
+            [{"Close": close}], index=pd.Index([ticker], name="ticker"),
+        )
+
+    def test_fred_index_large_jump_is_warn_not_error(self, caplog):
+        # VIX 16.01 → 17.26 (~7.8%, >5%) — an expected reconciliation self-heal.
+        with caplog.at_level(logging.WARNING):
+            daily_closes._log_close_discrepancies(
+                self._df("VIX", 17.26), {"VIX": 16.01}, "2026-06-02",
+            )
+        assert any(r.levelno == logging.WARNING and "fred_restatement" in r.message
+                   for r in caplog.records)
+        assert not any(r.levelno == logging.ERROR for r in caplog.records)
+
+    def test_equity_large_jump_stays_error(self, caplog):
+        # AAPL 100 → 120 (20%, >5%) — genuine cross-source drift, still ERROR.
+        with caplog.at_level(logging.WARNING):
+            daily_closes._log_close_discrepancies(
+                self._df("AAPL", 120.0), {"AAPL": 100.0}, "2026-06-02",
+            )
+        assert any(r.levelno == logging.ERROR for r in caplog.records)
+        assert not any("fred_restatement" in r.message for r in caplog.records)

--- a/tests/test_daily_closes_fred_per_date.py
+++ b/tests/test_daily_closes_fred_per_date.py
@@ -36,6 +36,7 @@ from collectors import daily_closes
 def _fred_response(observations: list[dict]) -> MagicMock:
     """Build a mock ``requests.get`` response with the given observations."""
     resp = MagicMock()
+    resp.status_code = 200  # L4480: _fred_get_with_retry inspects status_code
     resp.raise_for_status.return_value = None
     resp.json.return_value = {"observations": observations}
     return resp

--- a/tests/test_fred_api_key_scrub.py
+++ b/tests/test_fred_api_key_scrub.py
@@ -92,6 +92,9 @@ def test_fetch_fred_closes_scrubs_api_key_on_http_error(
     monkeypatch.setenv("FRED_API_KEY", "live-test-key-1234567890")
 
     class _ExplodingResponse:
+        status_code = 200  # L4480: _fred_get_with_retry reads status_code first
+        headers: dict = {}
+
         def raise_for_status(self):
             err_msg = (
                 "500 Server Error: Internal Server Error for url: "


### PR DESCRIPTION
## What

Four follow-ups to the **2026-06-01 FRED-429 / polygon-timeout incident**. #354 made the system resilient to a missed value; these close the surrounding gaps the incident exposed. All in `collectors/daily_closes.py` + the weekday Step Function.

### L4482 (P1) — macro backstop survives a transient polygon-fetch exception
`collect()` Step 1 now catches the **transient network class** (`requests.Timeout` / `ConnectionError` / `PolygonRateLimitError`) in `polygon_only` mode, logs loudly, and falls through to FRED (Step 2) + the macro yfinance backstop (Step 3). This is the exact gap that **failed recovery re-run #1** — a polygon read-timeout aborted `collect()` before the FRED-index macro keys (`^TNX/^VIX/^IRX/^VIX3M`, which never come from polygon) could fill.
**Narrow by design:** `PolygonForbiddenError` (403) and the deliberate `"0 tickers"` empty-data `RuntimeError` still propagate with their own clear messages; a real equity outage still hard-fails at the coverage gate (0 equity records → <95%), so the catch **cannot mask** equity data loss.

### L4480 (P1) — FRED backoff + jitter
New `_fred_get_with_retry`: bounded exponential backoff + full jitter on the transient class (429 / 5xx / timeout / connection), honors a server `Retry-After` when present, **raises immediately on a deterministic 4xx** (no point retrying a bad `series_id`). Stops the 429 *storm at the source* rather than only tolerating a missed value. Mirrors the in-repo `polygon_client` retry idiom; no new dependency.

### L4483 (P2) — weekday SF MorningEnrich now git-pulls
`infrastructure/step_function_daily.json` MorningEnrich adds the same `git -C … pull --ff-only origin main` for `alpha-engine-data` + `alpha-engine-config` that the **Saturday** SF already runs. A same-day recovery re-run on a still-running instance no longer executes stale code (this incident cost a manual SSM `git pull` to deploy #354).

### L4486 (P2) — discrepancy ERROR severity scoped
`_log_close_discrepancies` now emits **FRED-index restatements** toward the authoritative value at **WARN** (`fred_restatement`, excluded from the flow-doctor ERROR filter) while keeping **ERROR** for genuine cross-source **equity** drift. The reconciliation predictably restates VIX/TNX >5% when healing a 429-clobbered cell (5/14 VIX) or a stale T-1 edge cell (6/2) — desirable self-heals, not anomalies. Recording surface stays (per `feedback_no_silent_fails`) at the right level. Pattern observed twice (5/12, 6/2).

## Tests
- New `tests/test_daily_closes_coalesce_hardening.py` (8): retry class (429→success, persistent-429 raises, 4xx not retried, timeout reraised), transient-non-fatal control flow + 403-still-propagates, restatement-vs-equity severity.
- Fixed two affected fixtures to set `status_code` (the helper now inspects it before `raise_for_status`).
- **Full suite: 1785 passed, 1 skipped.**

## Deploy note
**L4483 changes the weekday Step Function** — needs the SF definition re-applied (CFN/Terraform/`aws stepfunctions update-state-machine`) for the git-pull to take effect; the daily_closes code changes deploy via the new MorningEnrich pull (or boot-pull). No S3 schema/path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)