### PR TITLE
fix(data): transient-API resilience + FRED window batching + key-scrub (L4492/L4494/L4495/L4496)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -52,18 +52,24 @@ from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
-_FRED_API_KEY_RE = re.compile(r"api_key=[^&\s]+")
+# Matches BOTH FRED's ``api_key=`` (snake) and polygon's ``apiKey=`` (camel)
+# querystring fragments. L4495: polygon error strings embed ``apiKey=<live>``
+# (confirmed 2026-06-03 from a grouped-daily 500 WARNING) and the original
+# FRED-only pattern let the polygon key through.
+_API_KEY_RE = re.compile(r"(?:api_key|apiKey)=[^&\s]+")
+# Back-compat alias — referenced by name in some tests.
+_FRED_API_KEY_RE = _API_KEY_RE
 
 
 def _scrub_api_key(msg: object) -> str:
-    """Mask the FRED ``api_key=...`` querystring fragment in any error string.
+    """Mask the ``api_key=...`` / ``apiKey=...`` querystring in any string.
 
-    ``requests.exceptions.HTTPError`` embeds the full request URL — including
-    the ``api_key`` querystring — in its ``str()`` representation. Logging
-    that to CloudWatch leaks the credential. Always pass FRED-fetch
-    exceptions through this scrubber before logging.
+    ``requests.exceptions.HTTPError`` (FRED and polygon) embeds the full
+    request URL — including the key querystring — in its ``str()``
+    representation. Logging that to CloudWatch leaks the credential. Always
+    pass FRED/polygon-fetch exceptions through this scrubber before logging.
     """
-    return _FRED_API_KEY_RE.sub("api_key=***", str(msg))
+    return _API_KEY_RE.sub(lambda m: m.group(0).split("=", 1)[0] + "=***", str(msg))
 
 _NYSE_TZ = ZoneInfo("America/New_York")
 
@@ -347,6 +353,7 @@ def collect(
     source: str = "auto",
     window_days: int = 1,
     skip_if_canonical: bool = False,
+    fred_window_cache: dict[str, list[tuple[str, float]]] | None = None,
 ) -> dict:
     """
     Fetch OHLCV for all tickers and write to S3.
@@ -624,7 +631,12 @@ def collect(
     ]
     fred_count = 0
     if fred_missing:
-        fred_count = _fetch_fred_closes(fred_missing, run_date, records)
+        # L4492: in window mode the caller prefetches the whole window's FRED
+        # series in one ranged call each and passes the cache down; per-date
+        # emit then reads from it (no per-date FRED I/O). None → legacy path.
+        fred_count = _fetch_fred_closes(
+            fred_missing, run_date, records, window_cache=fred_window_cache,
+        )
 
     # ── Step 3: yfinance ─────────────────────────────────────────────────────
     # polygon_only refuses yfinance fallback for the EQUITY universe per
@@ -826,6 +838,22 @@ def _collect_window(
     return-shape section for the schema.
     """
     window_dates = _previous_business_days(run_date, n=window_days)
+    # ── L4492: prefetch FRED once per series over the whole window ──────────
+    # Each per-date ``collect`` below previously re-fetched all FRED index
+    # series for its date (window_days × len(series) calls → 429 storm + the
+    # 2026-06-03 30-min timeout). Fetch each series once over the window range
+    # (padded a few calendar days so the oldest date's on-or-before lookup
+    # resolves) and hand the cache to every per-date call. Only prefetch when
+    # the universe actually contains FRED-index tickers — keeps non-macro
+    # window callers (and tests) on a zero-FRED-I/O path.
+    fred_tickers = [t for t in tickers if t.lstrip("^") in _FRED_INDEX_MAP]
+    fred_window_cache: dict[str, list[tuple[str, float]]] | None = None
+    if fred_tickers:
+        _oldest = window_dates[-1]  # _previous_business_days returns newest-first
+        _start = (
+            datetime.strptime(_oldest, "%Y-%m-%d") - timedelta(days=10)
+        ).strftime("%Y-%m-%d")
+        fred_window_cache = _fetch_fred_window(fred_tickers, _start, window_dates[0])
     # The newest date in the window is the TARGET date — the one
     # downstream (predictor inference / eod_reconcile) actually reads.
     # The older dates are best-effort *historical backfill*: a per-date
@@ -874,6 +902,7 @@ def _collect_window(
                 source=source,
                 window_days=1,
                 skip_if_canonical=skip_if_canonical,
+                fred_window_cache=fred_window_cache,  # L4492: 1 ranged call/series
             )
         except Exception as exc:
             # Record + continue. Fatality is target-driven (decided
@@ -882,11 +911,11 @@ def _collect_window(
             logger.warning(
                 "[daily_closes window] date=%s source=%s failed: %s — "
                 "recording and continuing window",
-                d, source, exc,
+                d, source, _scrub_api_key(exc),  # L4495: exc may carry polygon apiKey
             )
             aggregate["per_date"][d] = {
                 "status": "error",
-                "error": str(exc),
+                "error": _scrub_api_key(exc),  # L4495: never persist the key to S3 logs
                 "source": source,
             }
             continue
@@ -962,7 +991,10 @@ def _fetch_polygon_closes(
     except Exception as e:
         if source == "polygon_only":
             raise
-        logger.warning("Polygon grouped-daily failed in auto mode: %s — falling back", e)
+        logger.warning(
+            "Polygon grouped-daily failed in auto mode: %s — falling back",
+            _scrub_api_key(e),  # L4495: exc may carry polygon apiKey
+        )
         return 0
 
     if not grouped:
@@ -1050,7 +1082,7 @@ def _fetch_polygon_closes_per_ticker(
         except Exception as exc:
             logger.warning(
                 "Polygon per-ticker fallback failed for %s @ %s: %s",
-                store_ticker, run_date, exc,
+                store_ticker, run_date, _scrub_api_key(exc),  # L4495
             )
             continue
         if not bar:
@@ -1140,10 +1172,121 @@ def _log_close_discrepancies(
     )
 
 
+def _fred_record(store_ticker: str, date_str: str, close: float) -> dict:
+    """Build a FRED daily-close record (OHLC all = close; no volume/VWAP).
+
+    VWAP only meaningful from polygon grouped-daily (volume-weighted across
+    trades). FRED single-value closes give us no distribution to VWAP, so
+    None rather than passing Close off as VWAP.
+    """
+    return {
+        "ticker": store_ticker,
+        "date": date_str,
+        "Open": round(close, 4),
+        "High": round(close, 4),
+        "Low": round(close, 4),
+        "Close": round(close, 4),
+        "Adj_Close": round(close, 4),
+        "Volume": 0,
+        "VWAP": None,
+        "source": "fred",
+    }
+
+
+def _fred_value_on_or_before(
+    series: list[tuple[str, float]], date_str: str,
+) -> float | None:
+    """Value of the most-recent observation dated on-or-before ``date_str``.
+
+    ``series`` is ascending-sorted ``(date, value)``. Mirrors the per-date
+    API semantics (``observation_end=date_str``, newest non-missing) against
+    the prefetched window cache (L4492) — a future-dated value is never
+    returned, matching the legacy path's defensive ``obs_date > date_str``
+    guard.
+    """
+    candidate: float | None = None
+    for d, v in series:
+        if d <= date_str:
+            candidate = v
+        else:
+            break
+    return candidate
+
+
+def _fetch_fred_window(
+    tickers: list[str],
+    start_date: str,
+    end_date: str,
+) -> dict[str, list[tuple[str, float]]]:
+    """Fetch each FRED index series ONCE over ``[start_date, end_date]`` (L4492).
+
+    The windowed-reconciliation loop previously hit FRED once PER DATE per
+    series (``window_days × len(series)`` calls — 56 at window=14), firing a
+    self-inflicted 429 storm and burning most of MorningEnrich's runtime (the
+    2026-06-03 30-min SSM timeout). The FRED ``observations`` endpoint takes
+    ``observation_start``/``observation_end``, so the whole window's values
+    for a series come back in ONE ranged call; the per-date emit then indexes
+    this cache via :func:`_fred_value_on_or_before` (no further I/O). This
+    *supersedes* L4480's backoff-on-429 (which only tolerated the storm
+    slowly) by removing the storm at the source.
+
+    Returns ``{store_ticker: [(obs_date, value), ...]}`` ascending by date,
+    non-missing only. A series whose fetch fails is simply absent — the
+    per-date caller skips it and the loud yfinance macro backstop fills the
+    gap (same degradation as a per-date FRED miss). ``start_date`` should be
+    padded a few calendar days before the oldest window date so the oldest
+    date's on-or-before lookup can resolve to a prior observation (FRED daily
+    series skip weekends/holidays).
+    """
+    api_key = get_secret("FRED_API_KEY", required=False, default="")
+    if not api_key:
+        logger.warning(
+            "FRED_API_KEY not set — skipping FRED window prefetch for %d tickers",
+            len(tickers),
+        )
+        return {}
+
+    cache: dict[str, list[tuple[str, float]]] = {}
+    for ticker in tickers:
+        store_ticker = ticker.lstrip("^")
+        series_id = _FRED_INDEX_MAP.get(store_ticker)
+        if not series_id:
+            continue
+        try:
+            params = {
+                "series_id": series_id,
+                "api_key": api_key,
+                "file_type": "json",
+                "observation_start": start_date,
+                "observation_end": end_date,
+                "sort_order": "asc",
+            }
+            resp = _fred_get_with_retry(params)  # L4480: backoff + jitter
+            obs = resp.json().get("observations", [])
+            series = [
+                (o["date"], float(o["value"]))
+                for o in obs
+                if o.get("value", ".") != "." and o.get("date")
+            ]
+            cache[store_ticker] = series
+            logger.info(
+                "FRED window %s → %s: %d obs over [%s, %s] (1 ranged call)",
+                store_ticker, series_id, len(series), start_date, end_date,
+            )
+        except Exception as e:
+            logger.warning(
+                "FRED window fetch failed for %s (%s): %s — per-date emit will "
+                "skip it (yfinance macro backstop fills the gap)",
+                store_ticker, series_id, _scrub_api_key(e),
+            )
+    return cache
+
+
 def _fetch_fred_closes(
     tickers: list[str],
     date_str: str,
     records: list[dict],
+    window_cache: dict[str, list[tuple[str, float]]] | None = None,
 ) -> int:
     """Fetch FRED close on-or-before ``date_str`` for index tickers.
 
@@ -1164,7 +1307,38 @@ def _fetch_fred_closes(
     returns the most-recent-on-or-before-today observation (typically T-1),
     so the legacy "today's parquet carries yesterday's FRED value" semantic
     is preserved for the current-day case.
+
+    ``window_cache`` (L4492): when provided (window mode), the per-date value
+    is read from the prefetched ranged-call cache (:func:`_fetch_fred_window`)
+    instead of hitting FRED — so the windowed-reconciliation loop makes
+    ``len(series)`` ranged calls total, not ``window_days × len(series)``
+    per-date calls. ``None`` (the default; single-date callers) preserves the
+    legacy per-date API path.
     """
+    if window_cache is not None:
+        count = 0
+        for ticker in tickers:
+            store_ticker = ticker.lstrip("^")
+            series = window_cache.get(store_ticker)
+            if not series:
+                # Series absent (not a FRED index, or its window fetch failed)
+                # — skip; the yfinance macro backstop handles the gap loudly.
+                continue
+            close = _fred_value_on_or_before(series, date_str)
+            if close is None:
+                logger.warning(
+                    "FRED %s: no cached observation on or before %s",
+                    store_ticker, date_str,
+                )
+                continue
+            records.append(_fred_record(store_ticker, date_str, close))
+            count += 1
+        logger.info(
+            "FRED window-cache: %d/%d index tickers captured for %s",
+            count, len(tickers), date_str,
+        )
+        return count
+
     api_key = get_secret("FRED_API_KEY", required=False, default="")
     if not api_key:
         logger.warning("FRED_API_KEY not set — skipping FRED fallback for %d tickers", len(tickers))
@@ -1205,21 +1379,7 @@ def _fetch_fred_closes(
                 )
                 continue
             close = float(latest["value"])
-            records.append({
-                "ticker": store_ticker,
-                "date": date_str,
-                "Open": round(close, 4),
-                "High": round(close, 4),
-                "Low": round(close, 4),
-                "Close": round(close, 4),
-                "Adj_Close": round(close, 4),
-                "Volume": 0,
-                # VWAP only meaningful from polygon grouped-daily (volume-weighted
-                # across trades). FRED single-value closes give us no distribution
-                # to VWAP, so None rather than passing Close off as VWAP.
-                "VWAP": None,
-                "source": "fred",
-            })
+            records.append(_fred_record(store_ticker, date_str, close))
             count += 1
         except Exception as e:
             logger.warning(

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -21,6 +21,8 @@ Usage:
 from __future__ import annotations
 
 import logging
+import random
+import re
 import time
 from collections import deque
 from datetime import date, datetime, timedelta
@@ -34,6 +36,31 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.polygon.io"
 _MAX_BARS_PER_REQUEST = 50_000  # polygon limit param max
+
+# L4495 (security): polygon authenticates via the ``apiKey`` querystring
+# (set on the session in ``__init__``), so ``requests.HTTPError`` /
+# ``RequestException`` ``str()`` representations — which embed the full
+# effective request URL — leak the live key into logs and operator
+# transcripts (confirmed 2026-06-03 from a grouped-daily 500 WARNING).
+# Mask ``apiKey=...`` AND ``api_key=...`` before any polygon error string
+# is raised or logged. Sibling of ``daily_closes._scrub_api_key``.
+_POLYGON_API_KEY_RE = re.compile(r"(?:apiKey|api_key)=[^&\s]+")
+
+
+def _scrub_api_key(msg: object) -> str:
+    """Mask the polygon ``apiKey=...`` (or ``api_key=...``) querystring."""
+    return _POLYGON_API_KEY_RE.sub(lambda m: m.group(0).split("=", 1)[0] + "=***", str(msg))
+
+
+# L4496: polygon 5xx + transient network errors on the grouped-daily TARGET
+# fetch were NOT in the retry class — a single transient server error (500/
+# 502/503) raised ``HTTPError`` via ``raise_for_status`` and hard-failed the
+# whole daily_closes run (4 reruns on 2026-06-03 AM). Bounded exponential
+# backoff + full jitter; honors a server ``Retry-After`` when present; fails
+# loud after the cap so a sustained outage still surfaces.
+_POLYGON_MAX_ATTEMPTS = 4
+_POLYGON_BACKOFF_BASE = 1.0   # seconds; wait ≈ base * 2**attempt + U(0, base)
+_POLYGON_BACKOFF_CAP = 30.0   # seconds; never wait longer than this between tries
 
 
 class PolygonRateLimitError(Exception):
@@ -89,11 +116,33 @@ class PolygonClient:
         self._call_times.append(time.monotonic())
 
     def _get(self, path: str, params: dict | None = None) -> dict:
-        """Make a rate-limited GET request. Handles 429 with retry."""
+        """Make a rate-limited GET request.
+
+        Retries the recoverable class — 429 rate-limit, 5xx server error
+        (L4496), and transient network errors (Timeout/ConnectionError) —
+        with bounded exponential backoff + full jitter, then fails loud.
+        403 (free-tier "before end of day" / bad key) raises immediately as
+        ``PolygonForbiddenError`` — never silently swallowed (the prior
+        behavior masked the 2026-04-17→23 VWAP outage). All error strings are
+        scrubbed of the ``apiKey`` querystring before raising (L4495).
+        """
         self._wait_for_slot()
         url = f"{_BASE_URL}{path}"
-        for attempt in range(3):
-            resp = self._session.get(url, params=params or {}, timeout=30)
+        for attempt in range(_POLYGON_MAX_ATTEMPTS):
+            last = attempt == _POLYGON_MAX_ATTEMPTS - 1
+            try:
+                resp = self._session.get(url, params=params or {}, timeout=30)
+            except (requests.Timeout, requests.ConnectionError) as exc:
+                # L4496: a transient network blip on the target fetch must not
+                # hard-fail the whole run on the first try — retry, then raise.
+                if last:
+                    raise requests.ConnectionError(
+                        _scrub_api_key(f"polygon transient error on {path} "
+                                       f"after {_POLYGON_MAX_ATTEMPTS} attempts: {exc}")
+                    ) from None
+                self._backoff(attempt, f"polygon transient {type(exc).__name__} on {path}")
+                continue
+
             if resp.status_code == 429:
                 retry_after = int(resp.headers.get("Retry-After", 15))
                 logger.warning("Rate limited (429), waiting %ds", retry_after)
@@ -113,11 +162,47 @@ class PolygonClient:
                 except (ValueError, KeyError):
                     msg = resp.text[:200] or "Not authorized"
                 raise PolygonForbiddenError(
-                    f"Polygon 403 on {path}: {msg}"
+                    _scrub_api_key(f"Polygon 403 on {path}: {msg}")
                 )
-            resp.raise_for_status()
+            if resp.status_code >= 500 and not last:
+                # L4496: transient polygon server error — back off + retry
+                # before the target-date hard-fail; a sustained 5xx still
+                # raises (scrubbed) once the attempts are exhausted.
+                retry_after = resp.headers.get("Retry-After")
+                self._backoff(
+                    attempt, f"polygon {resp.status_code} on {path}",
+                    retry_after=retry_after,
+                )
+                continue
+            try:
+                resp.raise_for_status()
+            except requests.HTTPError as exc:
+                # L4495: the HTTPError str embeds the effective URL incl.
+                # ``apiKey`` — re-raise with a scrubbed message.
+                raise requests.HTTPError(_scrub_api_key(exc), response=resp) from None
             return resp.json()
-        raise PolygonRateLimitError("Rate limited after 3 retries")
+        raise PolygonRateLimitError(
+            f"Rate limited after {_POLYGON_MAX_ATTEMPTS} retries"
+        )
+
+    def _backoff(self, attempt: int, reason: str, retry_after: str | None = None) -> None:
+        """Sleep ``base * 2**attempt + U(0, base)`` (capped), honoring a
+        server ``Retry-After`` header when present. Shared by the 5xx and
+        transient-network retry paths in :meth:`_get`."""
+        wait = None
+        if retry_after is not None:
+            try:
+                wait = float(retry_after)
+            except (TypeError, ValueError):
+                wait = None
+        if wait is None:
+            wait = _POLYGON_BACKOFF_BASE * (2 ** attempt)
+        wait = min(wait + random.uniform(0, _POLYGON_BACKOFF_BASE), _POLYGON_BACKOFF_CAP)
+        logger.warning(
+            "%s — backing off %.1fs (attempt %d/%d)",
+            reason, wait, attempt + 1, _POLYGON_MAX_ATTEMPTS,
+        )
+        time.sleep(wait)
 
     # -- Core endpoints ------------------------------------------------------
 

--- a/preflight.py
+++ b/preflight.py
@@ -16,6 +16,9 @@ the single source of truth. See alpha-engine-lib README for the
 from __future__ import annotations
 
 import logging
+import random
+import re
+import time
 import uuid
 from typing import Any
 
@@ -25,6 +28,27 @@ from alpha_engine_lib.secrets import get_secret
 log = logging.getLogger(__name__)
 
 _HTTP_TIMEOUT_SECS = 10.0
+
+# L4494: the polygon/FRED reachability probes had a hard 10s timeout and NO
+# retry, so a single transient ReadTimeout/ConnectionError aborted the whole
+# weekday pipeline at the gate (cost a rerun 2026-06-03). Wrap the probe GET in
+# bounded exponential backoff + full jitter; a sustained outage still fails
+# loud after the attempts. Mirrors the collect-side L4482 + polygon-client
+# L4496 retry idiom.
+_REACHABILITY_MAX_ATTEMPTS = 3
+_REACHABILITY_BACKOFF_BASE = 1.0   # seconds; wait ≈ base * 2**attempt + U(0, base)
+_REACHABILITY_BACKOFF_CAP = 8.0    # seconds; never wait longer than this between tries
+
+# Mask the api key querystring (FRED ``api_key=`` / polygon ``apiKey=``) before
+# a probe error string reaches a log or RuntimeError. Defensive — Timeout/
+# ConnectionError strings carry host:port not the full URL, but a broader
+# RequestException could embed the prepared URL. Sibling of
+# ``daily_closes._scrub_api_key``.
+_API_KEY_RE = re.compile(r"(?:api_key|apiKey)=[^&\s]+")
+
+
+def _scrub_api_key(msg: object) -> str:
+    return _API_KEY_RE.sub(lambda m: m.group(0).split("=", 1)[0] + "=***", str(msg))
 
 # FMP /stable probe: cheapest auth-gated call that distinguishes
 # (a) valid key on /stable from (b) a key that still works on the
@@ -218,6 +242,56 @@ class DataPreflight(BasePreflight):
 
     # ── Mode-specific primitives ─────────────────────────────────────────
 
+    def _reachability_get(self, label: str, url: str, params: dict) -> Any:
+        """GET a reachability probe with bounded backoff + jitter retry.
+
+        L4494: retries the transient network class (Timeout / ConnectionError)
+        a few times before declaring the endpoint unreachable, so one blip at
+        preflight doesn't abort the whole pipeline. A non-transient
+        ``RequestException`` (bad URL, too many redirects) raises immediately —
+        no point retrying a deterministic error. After the attempts are
+        exhausted a transient failure raises ``RuntimeError(... unreachable
+        ...)`` (the message all callers/tests match on). All error strings are
+        api-key-scrubbed.
+        """
+        import requests
+
+        last_exc: Exception | None = None
+        for attempt in range(_REACHABILITY_MAX_ATTEMPTS):
+            try:
+                return requests.get(url, params=params, timeout=_HTTP_TIMEOUT_SECS)
+            except (requests.Timeout, requests.ConnectionError) as exc:
+                last_exc = exc
+                if attempt < _REACHABILITY_MAX_ATTEMPTS - 1:
+                    wait = min(
+                        _REACHABILITY_BACKOFF_BASE * (2 ** attempt)
+                        + random.uniform(0, _REACHABILITY_BACKOFF_BASE),
+                        _REACHABILITY_BACKOFF_CAP,
+                    )
+                    log.warning(
+                        "preflight: %s transient %s — backing off %.1fs (attempt %d/%d)",
+                        label, type(exc).__name__, wait, attempt + 1,
+                        _REACHABILITY_MAX_ATTEMPTS,
+                    )
+                    time.sleep(wait)
+                    continue
+                raise RuntimeError(
+                    f"Pre-flight: {label} unreachable after "
+                    f"{_REACHABILITY_MAX_ATTEMPTS} attempts: {_scrub_api_key(exc)} — "
+                    f"sustained network outage or egress blocked."
+                ) from exc
+            except requests.RequestException as exc:
+                # Non-transient (bad URL / too many redirects) — fail fast.
+                raise RuntimeError(
+                    f"Pre-flight: {label} unreachable: {_scrub_api_key(exc)} — "
+                    f"network outage or egress blocked."
+                ) from exc
+        # Unreachable in practice (the loop returns or raises), but keeps the
+        # type-checker happy and surfaces the last exception defensively.
+        raise RuntimeError(
+            f"Pre-flight: {label} unreachable: {_scrub_api_key(last_exc)}"
+        )
+
     def _check_fmp_stable_reachable(self) -> None:
         """Validate FMP /stable auth + endpoint availability.
 
@@ -228,19 +302,12 @@ class DataPreflight(BasePreflight):
         before anyone noticed. A /stable probe at startup fails the
         Step Function in ~1s instead.
         """
-        import requests
-
         api_key = (get_secret("FMP_API_KEY", required=False, default="") or "").strip()
-        try:
-            resp = requests.get(
-                _FMP_STABLE_PROBE_URL,
-                params={"symbol": _FMP_STABLE_PROBE_SYMBOL, "apikey": api_key},
-                timeout=_HTTP_TIMEOUT_SECS,
-            )
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                f"Pre-flight: FMP /stable unreachable: {exc} — network outage or egress blocked."
-            ) from exc
+        resp = self._reachability_get(
+            "FMP /stable",
+            _FMP_STABLE_PROBE_URL,
+            {"symbol": _FMP_STABLE_PROBE_SYMBOL, "apikey": api_key},
+        )
 
         if resp.status_code in (401, 403):
             raise RuntimeError(
@@ -277,19 +344,10 @@ class DataPreflight(BasePreflight):
         catch rate-limit ceiling (next collector call will retry/fail
         loudly by design).
         """
-        import requests
-
         api_key = (get_secret("POLYGON_API_KEY", required=False, default="") or "").strip()
-        try:
-            resp = requests.get(
-                _POLYGON_PROBE_URL,
-                params={"apiKey": api_key},
-                timeout=_HTTP_TIMEOUT_SECS,
-            )
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                f"Pre-flight: polygon.io unreachable: {exc} — network outage or egress blocked."
-            ) from exc
+        resp = self._reachability_get(
+            "polygon.io", _POLYGON_PROBE_URL, {"apiKey": api_key},
+        )
 
         if resp.status_code in (401, 403):
             raise RuntimeError(
@@ -310,25 +368,18 @@ class DataPreflight(BasePreflight):
 
     def _check_fred_reachable(self) -> None:
         """Validate FRED network + auth via single-observation DFF call."""
-        import requests
-
         api_key = (get_secret("FRED_API_KEY", required=False, default="") or "").strip()
-        try:
-            resp = requests.get(
-                _FRED_PROBE_URL,
-                params={
-                    "series_id": _FRED_PROBE_SERIES,
-                    "api_key": api_key,
-                    "file_type": "json",
-                    "sort_order": "desc",
-                    "limit": 1,
-                },
-                timeout=_HTTP_TIMEOUT_SECS,
-            )
-        except requests.RequestException as exc:
-            raise RuntimeError(
-                f"Pre-flight: FRED unreachable: {exc} — network outage or egress blocked."
-            ) from exc
+        resp = self._reachability_get(
+            "FRED",
+            _FRED_PROBE_URL,
+            {
+                "series_id": _FRED_PROBE_SERIES,
+                "api_key": api_key,
+                "file_type": "json",
+                "sort_order": "desc",
+                "limit": 1,
+            },
+        )
 
         if resp.status_code == 400:
             # FRED returns 400 with body containing "api_key" on bad key

--- a/tests/test_api_resilience_L4492_L4496.py
+++ b/tests/test_api_resilience_L4492_L4496.py
@@ -1,0 +1,270 @@
+"""Transient external-API resilience + FRED window batching + key-scrub.
+
+Covers the 2026-06-03 weekday-SF hardening trio:
+
+  * L4492 — batch the FRED window fetch into ONE ranged call per series
+    (``observation_start``/``observation_end``) instead of one-per-date, so
+    the windowed reconciliation stops self-inflicting a 429 storm + the
+    30-min MorningEnrich timeout.
+  * L4495 (SECURITY) — polygon error strings embed ``apiKey=<live>`` via the
+    session querystring; they must be scrubbed before logging / raising.
+  * L4496 — polygon 5xx + transient network errors on the grouped-daily
+    fetch must retry (bounded backoff + jitter) before the target-date
+    hard-fail, then fail loud.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from collectors import daily_closes
+import polygon_client as pc
+from polygon_client import PolygonClient
+
+
+# ── L4492: FRED window batching ──────────────────────────────────────────────
+
+
+def test_fred_value_on_or_before_picks_latest_prior():
+    series = [("2026-05-28", 17.0), ("2026-05-29", 18.0), ("2026-06-01", 19.0)]
+    assert daily_closes._fred_value_on_or_before(series, "2026-05-30") == 18.0
+    assert daily_closes._fred_value_on_or_before(series, "2026-06-01") == 19.0
+    assert daily_closes._fred_value_on_or_before(series, "2026-06-05") == 19.0
+    # Nothing on-or-before the earliest obs → None (no future-dated leak).
+    assert daily_closes._fred_value_on_or_before(series, "2026-05-27") is None
+
+
+def test_fetch_fred_window_one_ranged_call_per_series(monkeypatch):
+    monkeypatch.setattr(daily_closes, "get_secret", lambda *a, **k: "fred-key")
+    captured: list[dict] = []
+
+    def fake_retry(params):
+        captured.append(params)
+        resp = MagicMock()
+        resp.json.return_value = {
+            "observations": [
+                {"date": "2026-05-28", "value": "17.0"},
+                {"date": "2026-05-29", "value": "."},   # missing → filtered out
+                {"date": "2026-06-01", "value": "19.0"},
+            ]
+        }
+        return resp
+
+    monkeypatch.setattr(daily_closes, "_fred_get_with_retry", fake_retry)
+    cache = daily_closes._fetch_fred_window(["^VIX"], "2026-05-20", "2026-06-01")
+
+    assert len(captured) == 1  # ONE ranged call for the series (not per-date)
+    assert captured[0]["observation_start"] == "2026-05-20"
+    assert captured[0]["observation_end"] == "2026-06-01"
+    assert captured[0]["sort_order"] == "asc"
+    assert "limit" not in captured[0]  # ranged, not last-5
+    assert cache["VIX"] == [("2026-05-28", 17.0), ("2026-06-01", 19.0)]
+
+
+def test_fetch_fred_window_no_key_returns_empty(monkeypatch):
+    monkeypatch.setattr(daily_closes, "get_secret", lambda *a, **k: "")
+    assert daily_closes._fetch_fred_window(["^VIX"], "2026-05-20", "2026-06-01") == {}
+
+
+def test_fetch_fred_window_failed_series_absent_from_cache(monkeypatch):
+    monkeypatch.setattr(daily_closes, "get_secret", lambda *a, **k: "fred-key")
+
+    def boom(params):
+        raise requests.HTTPError("500 for url ...?api_key=SECRET")
+
+    monkeypatch.setattr(daily_closes, "_fred_get_with_retry", boom)
+    cache = daily_closes._fetch_fred_window(["^VIX"], "2026-05-20", "2026-06-01")
+    assert cache == {}  # failed fetch → absent (per-date emit skips → yf backstop)
+
+
+def test_fetch_fred_closes_window_cache_no_api(monkeypatch):
+    """In window-cache mode the per-date emit must NOT hit the FRED API."""
+    def must_not_call(*a, **k):
+        raise AssertionError("FRED API must not be hit in window-cache mode")
+
+    monkeypatch.setattr(daily_closes, "_fred_get_with_retry", must_not_call)
+    cache = {"VIX": [("2026-05-28", 17.0), ("2026-06-01", 19.0)]}
+    records: list[dict] = []
+    n = daily_closes._fetch_fred_closes(["^VIX"], "2026-05-30", records, window_cache=cache)
+
+    assert n == 1
+    assert records[0] == daily_closes._fred_record("VIX", "2026-05-30", 17.0)
+
+
+def test_fetch_fred_closes_window_cache_no_prior_obs():
+    cache = {"VIX": [("2026-06-01", 19.0)]}
+    records: list[dict] = []
+    n = daily_closes._fetch_fred_closes(["^VIX"], "2026-05-28", records, window_cache=cache)
+    assert n == 0 and records == []
+
+
+def test_collect_window_prefetches_fred_once(monkeypatch):
+    calls = {"window": 0, "per_date_caches": []}
+
+    def fake_window(tickers, start, end):
+        calls["window"] += 1
+        assert tickers == ["^VIX"]
+        return {"VIX": [("2026-05-20", 17.0)]}
+
+    def fake_collect(**kwargs):
+        calls["per_date_caches"].append(kwargs.get("fred_window_cache"))
+        return {"status": "ok", "tickers_captured": 1, "polygon": 0, "fred": 1, "yfinance": 0}
+
+    monkeypatch.setattr(daily_closes, "_fetch_fred_window", fake_window)
+    monkeypatch.setattr(daily_closes, "collect", fake_collect)
+
+    result = daily_closes._collect_window(
+        bucket="b", tickers=["^VIX"], run_date="2026-06-01",
+        s3_prefix="p/", dry_run=True, source="polygon_only", window_days=3,
+    )
+
+    assert calls["window"] == 1                       # ONE prefetch for the window
+    assert len(calls["per_date_caches"]) == 3         # but 3 per-date collects
+    assert all(c == {"VIX": [("2026-05-20", 17.0)]} for c in calls["per_date_caches"])
+    assert result["status"] == "ok"
+
+
+def test_collect_window_no_fred_tickers_skips_prefetch(monkeypatch):
+    calls = {"window": 0, "caches": []}
+
+    def fake_window(*a, **k):
+        calls["window"] += 1
+        return {}
+
+    def fake_collect(**kwargs):
+        calls["caches"].append(kwargs.get("fred_window_cache"))
+        return {"status": "ok", "tickers_captured": 1, "polygon": 1, "fred": 0, "yfinance": 0}
+
+    monkeypatch.setattr(daily_closes, "_fetch_fred_window", fake_window)
+    monkeypatch.setattr(daily_closes, "collect", fake_collect)
+
+    daily_closes._collect_window(
+        bucket="b", tickers=["AAPL"], run_date="2026-06-01",
+        s3_prefix="p/", dry_run=True, source="polygon_only", window_days=2,
+    )
+
+    assert calls["window"] == 0                        # no FRED tickers → no prefetch
+    assert all(c is None for c in calls["caches"])
+
+
+# ── L4495: polygon apiKey scrub ──────────────────────────────────────────────
+
+
+def test_daily_closes_scrub_masks_both_styles():
+    assert daily_closes._scrub_api_key("x?apiKey=SECRET&y=1") == "x?apiKey=***&y=1"
+    assert daily_closes._scrub_api_key("x?api_key=SECRET&y=1") == "x?api_key=***&y=1"
+
+
+def test_polygon_client_scrub_masks_both_styles():
+    assert pc._scrub_api_key("x?apiKey=SECRET&y=1") == "x?apiKey=***&y=1"
+    assert pc._scrub_api_key("x?api_key=SECRET&y=1") == "x?api_key=***&y=1"
+
+
+def test_collect_window_warning_scrubs_polygon_apikey(monkeypatch, caplog):
+    """A per-date collect raising an HTTPError carrying ``apiKey`` must be
+    scrubbed in both the WARNING log AND the persisted per_date/aggregate
+    error (which lands in the S3 morning-enrich log)."""
+    leaked = "POLYLEAKED123"
+
+    def fake_collect(**kwargs):
+        raise requests.HTTPError(
+            "500 Server Error for url: https://api.polygon.io/v2/aggs/grouped/"
+            f"locale/us/market/stocks/2026-06-01?adjusted=true&apiKey={leaked}"
+        )
+
+    monkeypatch.setattr(daily_closes, "collect", fake_collect)
+
+    with caplog.at_level(logging.WARNING, logger="collectors.daily_closes"):
+        result = daily_closes._collect_window(
+            bucket="b", tickers=["AAPL"], run_date="2026-06-01",
+            s3_prefix="p/", dry_run=True, source="polygon_only", window_days=1,
+        )
+
+    combined = "\n".join(r.message for r in caplog.records)
+    assert leaked not in combined
+    assert "apiKey=***" in combined
+    # Persisted surfaces are scrubbed too.
+    assert leaked not in result["per_date"]["2026-06-01"]["error"]
+    assert leaked not in result.get("error", "")
+
+
+# ── L4496: polygon 5xx + transient retry ─────────────────────────────────────
+
+
+def _client() -> PolygonClient:
+    # High calls_per_min so the rate limiter never sleeps in tests.
+    return PolygonClient(api_key="test-key", calls_per_min=100_000)
+
+
+def _resp_500():
+    resp = MagicMock()
+    resp.status_code = 500
+    resp.headers = {}
+    resp.raise_for_status.side_effect = requests.HTTPError(
+        "500 Server Error for url: https://api.polygon.io/v2/aggs/grouped/"
+        "locale/us/market/stocks/2026-06-01?adjusted=true&apiKey=POLYLEAKED999"
+    )
+    return resp
+
+
+def _resp_200(parsed):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = parsed
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    monkeypatch.setattr(pc.time, "sleep", lambda *a, **k: None)
+
+
+def test_polygon_5xx_retries_then_succeeds():
+    client = _client()
+    parsed = {"results": [{"T": "AAPL", "o": 1, "h": 2, "l": 0.5, "c": 3, "v": 100, "vw": 1.5}]}
+    with patch.object(client._session, "get", side_effect=[_resp_500(), _resp_200(parsed)]) as m:
+        out = client.get_grouped_daily("2026-06-01")
+    assert m.call_count == 2
+    assert out["AAPL"]["close"] == 3
+
+
+def test_polygon_5xx_exhausted_raises_scrubbed():
+    client = _client()
+    resps = [_resp_500() for _ in range(pc._POLYGON_MAX_ATTEMPTS)]
+    with patch.object(client._session, "get", side_effect=resps):
+        with pytest.raises(requests.HTTPError) as ei:
+            client.get_grouped_daily("2026-06-01")
+    assert "POLYLEAKED999" not in str(ei.value)
+    assert "apiKey=***" in str(ei.value)
+
+
+def test_polygon_transient_timeout_retries_then_succeeds():
+    client = _client()
+    with patch.object(
+        client._session, "get",
+        side_effect=[requests.ReadTimeout("read timed out"), _resp_200({"results": []})],
+    ) as m:
+        out = client.get_grouped_daily("2026-06-01")
+    assert m.call_count == 2
+    assert out == {}
+
+
+def test_polygon_transient_exhausted_raises_scrubbed():
+    client = _client()
+    with patch.object(
+        client._session, "get",
+        side_effect=requests.ConnectionError("boom for url ...?apiKey=POLYLEAKED999"),
+    ):
+        with pytest.raises(requests.ConnectionError) as ei:
+            client.get_grouped_daily("2026-06-01")
+    assert "POLYLEAKED999" not in str(ei.value)

--- a/tests/test_daily_closes_coalesce_hardening.py
+++ b/tests/test_daily_closes_coalesce_hardening.py
@@ -88,7 +88,7 @@ class TestPolygonTransientNonFatal:
     def test_polygon_timeout_still_fills_macro_via_fred(self):
         s3 = _no_existing_parquet_s3()
 
-        def _fred_side_effect(tickers, date_str, records):
+        def _fred_side_effect(tickers, date_str, records, window_cache=None):
             for t in tickers:
                 records.append({
                     "ticker": t.lstrip("^"), "date": date_str,

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -77,11 +77,26 @@ class TestPolygonReachable:
                 pf._check_polygon_reachable()
 
     def test_network_error(self):
+        # L4494: a sustained ConnectionError now retries _REACHABILITY_MAX_ATTEMPTS
+        # times (backoff sleep patched out) before failing loud as "unreachable".
         pf = self._setup()
-        with patch("requests.get") as mock_get:
+        with patch("requests.get") as mock_get, patch("preflight.time.sleep"):
             mock_get.side_effect = requests.ConnectionError("DNS failure")
-            with pytest.raises(RuntimeError, match="unreachable"):
+            with pytest.raises(RuntimeError, match="unreachable after 3 attempts"):
                 pf._check_polygon_reachable()
+        assert mock_get.call_count == 3
+
+    def test_transient_then_success_recovers(self):
+        # L4494: a single transient blip must NOT abort — it retries and the
+        # next attempt's 200 passes the probe.
+        pf = self._setup()
+        with patch("requests.get") as mock_get, patch("preflight.time.sleep"):
+            mock_get.side_effect = [
+                requests.ReadTimeout("read timed out"),
+                MagicMock(status_code=200, text='{"results": []}'),
+            ]
+            pf._check_polygon_reachable()
+        assert mock_get.call_count == 2
 
 
 # ── FRED reachability ────────────────────────────────────────────────────────
@@ -120,11 +135,13 @@ class TestFredReachable:
                 pf._check_fred_reachable()
 
     def test_network_error(self):
+        # L4494: sustained Timeout retries then fails loud as "unreachable".
         pf = self._setup()
-        with patch("requests.get") as mock_get:
+        with patch("requests.get") as mock_get, patch("preflight.time.sleep"):
             mock_get.side_effect = requests.Timeout("timed out")
-            with pytest.raises(RuntimeError, match="unreachable"):
+            with pytest.raises(RuntimeError, match="unreachable after 3 attempts"):
                 pf._check_fred_reachable()
+        assert mock_get.call_count == 3
 
 
 # ── S3 writeable sentinel ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the **2026-06-03 weekday-SF hardening trio** surfaced by the stacked MorningEnrich failures (4 reruns: polygon preflight timeout → grouped-daily 500s → FRED 429 storm → 30-min SSM timeout). All four items are `alpha-engine-data`-local.

## L4492 (P0) — batch FRED window fetch into ONE ranged call per series
`_fetch_fred_window` fetches each FRED index series **once** over the window range (`observation_start`/`observation_end`, padded 10 calendar days so the oldest date's on-or-before lookup resolves). `_collect_window` prefetches it once and threads the cache through `collect` → `_fetch_fred_closes` (new `window_cache` arg); per-date emit indexes the cache via `_fred_value_on_or_before` with **zero further I/O**. Was `window_days × len(series)` calls (56 at window=14) → now `len(series)`. **Supersedes L4480**'s backoff-on-429 by removing the storm at the source. Single-date callers (`window_cache=None`) keep the legacy per-date path unchanged.

## L4495 (P1, SECURITY) — polygon error logs leaked the unredacted `apiKey`
Confirmed 2026-06-03: a grouped-daily 500 WARNING emitted `...?apiKey=<live>` to the S3 morning-enrich log + operator transcript. Extended `daily_closes._scrub_api_key` to mask **both** `api_key=` (FRED) and `apiKey=` (polygon); applied at the three polygon error-log sites (window-loop WARNING + persisted `per_date`/aggregate error, auto-mode fallback, per-ticker fallback). Added a sibling scrubber in `polygon_client` so `_get` re-raises HTTPError/transient errors with a **scrubbed message** — the key never leaves the client.
> **Operator action:** rotate polygon key `paRVBp…` when convenient (data-API key = cost-surface only per the public-repo security posture).

## L4496 (P1) — polygon 5xx / transient errors hard-failed the run
A 500/502/503 on the grouped-daily target raised `HTTPError` via `raise_for_status` and was **not** in the retry class. `_get` now retries `429 / 5xx / Timeout / ConnectionError` with bounded exponential backoff + full jitter (honors `Retry-After`), then fails loud after the cap.

## L4494 (P1) — preflight reachability had no retry
`preflight.py::_check_polygon_reachable`/`_check_fred_reachable` had a hard 10s timeout and no retry → one transient blip aborted the pipeline at the gate (cost a rerun this incident). New `_reachability_get` wraps the probe GET in the same bounded backoff+jitter retry (also applied to the FMP probe for free); a sustained outage still fails loud as `unreachable after N attempts`. Error strings api-key-scrubbed.

## Tests
- **+15 new** (`tests/test_api_resilience_L4492_L4496.py`): FRED batching (one ranged call/series, on-or-before semantics, cache-no-API, prefetch-once, skip-when-no-FRED-tickers), both scrub styles, polygon 5xx/transient retry + scrubbed raises.
- Preflight network-error tests updated to the new retry contract + a transient-then-recover case.
- **Full data suite: 1801 passed, 1 skipped.**

## Notes / follow-ups
- `daily_closes.window_days` is currently narrowed to **5** (the L4492 recovery config); can return to **~10** once this deploys (separate `alpha-engine-config` change — not in this PR).
- **L4483** (weekday-SF MorningEnrich git-pull parity, shipped in merged #363) still needs the **SF definition re-applied** to take effect — separate deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)