### PR TITLE
feat(macro): emit historical macro time series (macro_history.parquet)

### DIFF
--- a/collectors/macro.py
+++ b/collectors/macro.py
@@ -12,6 +12,7 @@ Writes macro.json to S3 with:
 
 from __future__ import annotations
 
+import io
 import json
 import logging
 import time
@@ -43,6 +44,34 @@ _FRED_SERIES = {
     "initial_claims": "ICSA",
     "hy_credit_spread_oas": "BAMLH0A0HYM2",
 }
+
+# ── Historical macro time series ──────────────────────────────────────────────
+# A standalone, dashboard-facing artifact (NOT the per-ticker feature store):
+# full FRED observation history per series, refreshed weekly and OVERWRITTEN each
+# run (FRED returns the entire series, so the artifact is idempotent + self-
+# healing — no week-by-week accumulation). Consumed by robodashboard's Macro page
+# via market_data/macro_history.parquet. See ARTIFACT_REGISTRY.yaml.
+_MACRO_HISTORY_KEY = "macro_history.parquet"
+_MACRO_HISTORY_START = "2000-01-01"  # ~25y of history is plenty for a dashboard
+
+# series_id → (label, units, frequency). Mirrors _FRED_SERIES plus the native
+# 10Y-2Y spread series and the raw CPI index (CPI YoY is derived below).
+_FRED_HISTORY_SERIES = {
+    "FEDFUNDS": ("Fed Funds Rate", "percent", "monthly"),
+    "DGS2": ("2Y Treasury", "percent", "daily"),
+    "DGS10": ("10Y Treasury", "percent", "daily"),
+    "T10Y2Y": ("Yield Curve Slope (10Y-2Y)", "percent", "daily"),
+    "VIXCLS": ("VIX", "index", "daily"),
+    "UNRATE": ("Unemployment Rate", "percent", "monthly"),
+    "UMCSENT": ("Consumer Sentiment", "index", "monthly"),
+    "ICSA": ("Initial Jobless Claims", "count", "weekly"),
+    "BAMLH0A0HYM2": ("High-Yield Credit Spread (OAS)", "percent", "daily"),
+    "CPIAUCSL": ("CPI (Index)", "index", "monthly"),
+}
+
+# Derived series (computed from a raw series above), appended to the artifact so
+# the dashboard consumes them directly rather than re-deriving.
+_CPI_YOY = ("CPI_YOY", "Inflation (CPI YoY)", "percent", "monthly")
 
 
 def _load_breadth_prices(bucket: str) -> Optional[dict]:
@@ -129,7 +158,19 @@ def collect(
     )
     logger.info("Wrote macro.json to s3://%s/%s", bucket, key)
 
-    return {"status": "ok", "fields": len(macro)}
+    # Historical macro time series — a SECONDARY, dashboard-only artifact hung off
+    # the primary macro.json write. Guarded so a FRED-history failure (the swallowed
+    # mode) cannot mask the macro.json success that the trading pipeline depends on
+    # (why primary survives); the failure is recorded in the WARN log + the returned
+    # ``macro_history`` status field (the recording surfaces). Not raised here.
+    history_status: dict = {"status": "skipped_empty", "rows": 0}
+    try:
+        history_status = write_macro_history(bucket=bucket, s3_prefix=s3_prefix, dry_run=dry_run)
+    except Exception as e:  # noqa: BLE001 - secondary artifact; never fail macro.json
+        logger.warning("macro_history write failed (macro.json unaffected): %s", e)
+        history_status = {"status": "error", "error": str(e)}
+
+    return {"status": "ok", "fields": len(macro), "macro_history": history_status}
 
 
 def _fetch_fred() -> dict:
@@ -209,6 +250,128 @@ def _fred_cpi_yoy(api_key: str) -> Optional[float]:
     except Exception as e:
         logger.warning("CPI YoY computation failed: %s", e)
         return None
+
+
+def _fred_history(series_id: str, api_key: str, start: str = _MACRO_HISTORY_START) -> list[tuple[str, float]]:
+    """Fetch the full observation history for a FRED series (with retry).
+
+    Returns ``[(date, value), ...]`` ascending by date, missing values ('.')
+    dropped. Returns ``[]`` on persistent failure (the caller omits the series
+    rather than writing partial/None rows).
+    """
+    for attempt in range(1, 3):
+        try:
+            params = {
+                "series_id": series_id,
+                "api_key": api_key,
+                "file_type": "json",
+                "observation_start": start,
+                "sort_order": "asc",
+            }
+            resp = requests.get(_FRED_BASE, params=params, timeout=_FRED_TIMEOUT)
+            resp.raise_for_status()
+            obs = resp.json().get("observations", [])
+            out: list[tuple[str, float]] = []
+            for o in obs:
+                val = o.get("value", ".")
+                if val != ".":
+                    out.append((o["date"], float(val)))
+            return out
+        except requests.exceptions.RequestException as e:
+            if attempt < 2:
+                logger.warning("FRED history %s attempt %d failed: %s — retrying", series_id, attempt, e)
+                time.sleep(3)
+            else:
+                logger.warning("FRED history %s failed after 2 attempts: %s", series_id, e)
+        except Exception as e:
+            logger.warning("FRED history %s failed: %s", series_id, e)
+            return []
+    return []
+
+
+def _cpi_yoy_rows(cpi_obs: list[tuple[str, float]]) -> list[tuple[str, float]]:
+    """Derive CPI YoY% from the raw monthly CPI index history.
+
+    For each month with an observation 12 entries prior, YoY = (v / v_12mo − 1) * 100.
+    ``cpi_obs`` must be ascending by date (as ``_fred_history`` returns).
+    """
+    rows: list[tuple[str, float]] = []
+    for i in range(12, len(cpi_obs)):
+        prior = cpi_obs[i - 12][1]
+        if prior:
+            rows.append((cpi_obs[i][0], round((cpi_obs[i][1] / prior - 1) * 100, 2)))
+    return rows
+
+
+def build_macro_history(api_key: str | None = None) -> pd.DataFrame:
+    """Build the long-format macro history DataFrame.
+
+    Columns: ``date, series_id, label, value, units, frequency``. One row per
+    (series, date). Includes the raw FRED series in ``_FRED_HISTORY_SERIES`` plus
+    the derived CPI YoY series. Returns an empty frame (correct columns) when no
+    FRED key is configured, so callers can skip the write cleanly.
+    """
+    cols = ["date", "series_id", "label", "value", "units", "frequency"]
+    if api_key is None:
+        api_key = get_secret("FRED_API_KEY", required=False, default="")
+    if not api_key:
+        logger.warning("FRED_API_KEY not set — skipping macro history")
+        return pd.DataFrame(columns=cols)
+
+    records: list[dict] = []
+    cpi_obs: list[tuple[str, float]] = []
+    for series_id, (label, units, frequency) in _FRED_HISTORY_SERIES.items():
+        obs = _fred_history(series_id, api_key)
+        if series_id == "CPIAUCSL":
+            cpi_obs = obs
+        for date, value in obs:
+            records.append(
+                {"date": date, "series_id": series_id, "label": label,
+                 "value": value, "units": units, "frequency": frequency}
+            )
+
+    # Derived: CPI YoY (inflation) from the raw CPI index.
+    yoy_id, yoy_label, yoy_units, yoy_freq = _CPI_YOY
+    for date, value in _cpi_yoy_rows(cpi_obs):
+        records.append(
+            {"date": date, "series_id": yoy_id, "label": yoy_label,
+             "value": value, "units": yoy_units, "frequency": yoy_freq}
+        )
+
+    df = pd.DataFrame(records, columns=cols)
+    logger.info("Built macro history: %d rows across %d series", len(df), df["series_id"].nunique() if not df.empty else 0)
+    return df
+
+
+def write_macro_history(bucket: str, s3_prefix: str = "market_data/", dry_run: bool = False) -> dict:
+    """Build + write the macro history parquet to ``market_data/macro_history.parquet``.
+
+    OVERWRITES the single fixed key each run (idempotent — FRED returns full
+    history). Returns a status dict; raises on the S3 write failure so a hard
+    producer fault surfaces, but an empty build (no FRED key / all fetches failed)
+    is a no-op rather than writing an empty artifact over a good one.
+    """
+    df = build_macro_history()
+    if df.empty:
+        logger.warning("macro history empty — skipping write (no FRED key or all series failed)")
+        return {"status": "skipped_empty", "rows": 0}
+
+    if dry_run:
+        logger.info("[dry-run] macro_history: %d rows across %d series", len(df), df["series_id"].nunique())
+        return {"status": "ok_dry_run", "rows": len(df), "series": int(df["series_id"].nunique())}
+
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy", index=False)
+    buf.seek(0)
+    key = f"{s3_prefix}{_MACRO_HISTORY_KEY}"
+    boto3.client("s3").put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=buf.getvalue(),
+        ContentType="application/octet-stream",
+    )
+    logger.info("Wrote macro history to s3://%s/%s (%d rows)", bucket, key, len(df))
+    return {"status": "ok", "rows": len(df), "series": int(df["series_id"].nunique())}
 
 
 def _fetch_market_prices() -> dict:

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -73,7 +73,7 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "collectors/daily_closes_fred_repair.py": 1,
     "collectors/fred_history.py": 1,
     "collectors/fundamentals.py": 1,
-    "collectors/macro.py": 1,
+    "collectors/macro.py": 2,  # weekly/<date>/macro.json + macro_history.parquet
     "collectors/prices.py": 1,
     "collectors/short_interest.py": 1,
     "collectors/signal_returns.py": 1,

--- a/tests/test_macro_breadth.py
+++ b/tests/test_macro_breadth.py
@@ -38,6 +38,10 @@ def _stub_fetchers(monkeypatch):
         "_fetch_market_prices",
         lambda: {"sp500_close": 650.0, "sp500_30d_return": 2.0},
     )
+    # Macro history is a secondary write off collect(); stub it empty so these
+    # breadth tests stay offline and macro.json remains the single captured PUT.
+    _HISTORY_COLS = ["date", "series_id", "label", "value", "units", "frequency"]
+    monkeypatch.setattr(macro, "build_macro_history", lambda *a, **k: pd.DataFrame(columns=_HISTORY_COLS))
 
 
 def test_breadth_computed_when_price_data_supplied(monkeypatch):

--- a/tests/test_macro_history.py
+++ b/tests/test_macro_history.py
@@ -1,0 +1,109 @@
+"""Tests for the macro history artifact (collectors.macro.build_macro_history etc.).
+
+The macro history parquet (market_data/macro_history.parquet) is a standalone,
+dashboard-facing artifact: full FRED observation history per series in long
+format, overwritten weekly. Consumed by robodashboard's Macro page. These tests
+keep the FRED fetch + S3 write offline via monkeypatch.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pandas as pd
+
+from collectors import macro
+
+_HISTORY_COLS = ["date", "series_id", "label", "value", "units", "frequency"]
+
+
+def test_cpi_yoy_rows_derives_year_over_year():
+    """YoY% = (value / value_12_months_prior − 1) * 100, aligned to the later month."""
+    # 14 monthly points; index rising 1%/mo from 100 → only entries with a
+    # 12-prior partner produce a YoY value (entries 12 and 13).
+    obs = [(f"2020-{m:02d}-01", 100.0 + i) for i, m in enumerate(range(1, 13))]
+    obs += [("2021-01-01", 112.0), ("2021-02-01", 113.0)]
+    rows = macro._cpi_yoy_rows(obs)
+    assert [d for d, _ in rows] == ["2021-01-01", "2021-02-01"]
+    # 112 / 100 - 1 = 12.0%
+    assert rows[0][1] == 12.0
+    # 113 / 101 - 1 = 11.88%
+    assert rows[1][1] == 11.88
+
+
+def test_build_macro_history_long_format_and_derived_cpi(monkeypatch):
+    """build_macro_history returns long-format rows for each series + derived CPI YoY."""
+
+    def _fake_history(series_id, api_key, start=macro._MACRO_HISTORY_START):
+        if series_id == "CPIAUCSL":
+            # 13 months so exactly one YoY row is derivable.
+            return [(f"2020-{m:02d}-01", 100.0 + m) for m in range(1, 13)] + [("2021-01-01", 113.0)]
+        return [("2020-01-01", 1.0), ("2020-02-01", 2.0)]
+
+    monkeypatch.setattr(macro, "_fred_history", _fake_history)
+
+    df = macro.build_macro_history(api_key="fake-key")
+    assert list(df.columns) == _HISTORY_COLS
+    # Every configured raw series is present...
+    for series_id in macro._FRED_HISTORY_SERIES:
+        assert series_id in df["series_id"].values
+    # ...plus the derived inflation series.
+    assert "CPI_YOY" in df["series_id"].values
+    cpi_yoy = df[df["series_id"] == "CPI_YOY"]
+    assert len(cpi_yoy) == 1
+    assert cpi_yoy.iloc[0]["units"] == "percent"
+    assert cpi_yoy.iloc[0]["label"] == "Inflation (CPI YoY)"
+    # 113 / 101 - 1 = 11.88%
+    assert cpi_yoy.iloc[0]["value"] == round((113.0 / 101.0 - 1) * 100, 2)
+
+
+def test_build_macro_history_empty_without_key(monkeypatch):
+    """No FRED key → empty frame with the right columns (caller skips the write)."""
+    monkeypatch.setattr(macro, "get_secret", lambda *a, **k: "")
+    df = macro.build_macro_history()
+    assert df.empty
+    assert list(df.columns) == _HISTORY_COLS
+
+
+def test_write_macro_history_puts_parquet(monkeypatch):
+    """A non-empty build writes one parquet PUT to market_data/macro_history.parquet."""
+    df = pd.DataFrame(
+        [{"date": "2020-01-01", "series_id": "FEDFUNDS", "label": "Fed Funds Rate",
+          "value": 1.5, "units": "percent", "frequency": "monthly"}],
+        columns=_HISTORY_COLS,
+    )
+    monkeypatch.setattr(macro, "build_macro_history", lambda *a, **k: df)
+
+    captured = {}
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(macro.boto3, "client", lambda service: _FakeS3())
+
+    result = macro.write_macro_history(bucket="test-bucket")
+    assert result["status"] == "ok"
+    assert result["rows"] == 1
+    assert captured["Key"] == "market_data/macro_history.parquet"
+    # Body is a real parquet round-tripping to the same frame.
+    back = pd.read_parquet(io.BytesIO(captured["Body"]), engine="pyarrow")
+    assert list(back.columns) == _HISTORY_COLS
+    assert back.iloc[0]["series_id"] == "FEDFUNDS"
+
+
+def test_write_macro_history_skips_empty(monkeypatch):
+    """An empty build is a no-op — never overwrite a good artifact with nothing."""
+    monkeypatch.setattr(macro, "build_macro_history", lambda *a, **k: pd.DataFrame(columns=_HISTORY_COLS))
+
+    calls = []
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr(macro.boto3, "client", lambda service: _FakeS3())
+
+    result = macro.write_macro_history(bucket="test-bucket")
+    assert result["status"] == "skipped_empty"
+    assert calls == []


### PR DESCRIPTION
## What

Add a standalone, dashboard-facing macro **history** artifact: `s3://alpha-engine-research/market_data/macro_history.parquet`. Full FRED observation history per series in long/tidy format, refreshed weekly and **overwritten** each run.

## Why

robodashboard is gaining a **Macro** page (fed funds, inflation/CPI, unemployment, rates, VIX, credit spread, etc. — latest, trend, historical graphs). The AE feature store only retains the *latest* macro snapshot (`macro.json`), no history. Rather than duplicate the FRED integration + key into the dashboard, AE — which already has the FRED key, series mapping, and weekly cadence — becomes the canonical producer; robodashboard stays a pure S3 consumer (mirrors how it already reads signals/predictions).

FRED's observations endpoint returns the **entire series**, so each Saturday we pull full history and overwrite the artifact — idempotent + self-healing, full history available immediately (no week-by-week accumulation).

## Schema (long format)

`date, series_id, label, value, units, frequency` — one row per (series, date). Long format handles the mixed FRED frequencies (fed funds monthly, treasuries daily, claims weekly) without a NaN-riddled wide frame.

**Series:** FEDFUNDS, DGS2, DGS10, T10Y2Y (native 10Y-2Y slope), VIXCLS, UNRATE, UMCSENT, ICSA, BAMLH0A0HYM2 (HY OAS), CPIAUCSL — plus **derived CPI_YOY** (inflation), computed from the raw CPI index so the dashboard consumes it directly.

## Changes

- `collectors/macro.py`: `_fred_history` (full observations w/ retry), `_cpi_yoy_rows` (derived YoY), `build_macro_history` (long frame), `write_macro_history` (parquet → S3).
- Wired into `collect()` as a **secondary** write, guarded so a FRED-history failure can never mask the primary `macro.json` success the trading pipeline depends on — failure recorded in the WARN log + the returned `macro_history` status field (per the no-silent-fails rule; the swallow is documented inline with its recording surface).
- Empty build (no FRED key / all fetches failed) is a **no-op** — never overwrites a good artifact with nothing.
- Bumped the `collectors/macro.py` PUT-count pin 1 → 2 (per the per-file-count guard).
- Tests: CPI-YoY derivation, long-format build + derived series, empty-without-key, parquet PUT, skip-empty. Existing breadth tests stubbed to stay offline.

## Test

- `pytest`: **1806 passed**, 1 skipped (pre-existing).

## Cross-repo

- **alpha-engine-config**: ARTIFACT_REGISTRY.yaml row (low severity — dashboard-only) — separate PR.
- **robodashboard**: Macro page consuming this parquet — separate PR. Artifact will be **manually seeded** post-merge so the page renders before the next Saturday run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)