### PR TITLE
Fix near-term release dates missing from the macro calendar (weekly limit)

### DIFF
--- a/collectors/macro.py
+++ b/collectors/macro.py
@@ -451,6 +451,12 @@ def _fred_release_dates(release_id: int, api_key: str) -> list[str]:
     ``include_release_dates_with_no_data=true`` makes FRED include FUTURE
     scheduled dates (which have no data yet). Returns ``[]`` on failure; the
     caller filters to the forward horizon.
+
+    ``sort_order=desc`` returns the furthest-future scheduled dates first, so the
+    limit must exceed the count of ALL future-scheduled dates or the NEAREST ones
+    get truncated off the bottom — that silently dropped near-term weekly claims
+    (a ~7-week gap) at limit=24. 130 comfortably covers a year-plus of any
+    cadence (weekly ≈ 52/yr) while the caller still trims to the 180d horizon.
     """
     try:
         params = {
@@ -459,7 +465,7 @@ def _fred_release_dates(release_id: int, api_key: str) -> list[str]:
             "file_type": "json",
             "include_release_dates_with_no_data": "true",
             "sort_order": "desc",
-            "limit": 24,
+            "limit": 130,
         }
         resp = requests.get(_FRED_RELEASE_DATES_BASE, params=params, timeout=_FRED_TIMEOUT)
         resp.raise_for_status()

--- a/tests/test_release_calendar.py
+++ b/tests/test_release_calendar.py
@@ -96,6 +96,33 @@ def test_build_release_calendar_empty_without_key(monkeypatch):
     assert list(df.columns) == _CAL_COLS
 
 
+def test_fred_release_dates_requests_enough_future_dates(monkeypatch):
+    """Regression: the FRED query must request enough desc dates to reach the
+    NEAREST future ones. sort_order=desc returns furthest-future first, so a
+    small limit truncated near-term weekly claims (the ~7-week ICSA gap). Pin a
+    floor on the limit + the future-dates flag so a shrink re-surfaces visibly.
+    """
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"release_dates": [{"date": "2026-06-11"}]}
+
+    def _fake_get(url, params=None, timeout=None):
+        captured.update(params or {})
+        return _Resp()
+
+    monkeypatch.setattr(macro.requests, "get", _fake_get)
+    out = macro._fred_release_dates(10, "fake-key")
+    assert out == ["2026-06-11"]
+    assert captured["include_release_dates_with_no_data"] == "true"
+    assert captured["sort_order"] == "desc"
+    assert captured["limit"] >= 120  # must cover a year-plus of weekly cadence
+
+
 def test_write_release_calendar_puts_parquet(monkeypatch):
     df = pd.DataFrame(
         [{"date": "2026-06-11", "kind": "release", "series_id": "CPIAUCSL",


### PR DESCRIPTION
## The bug
The seeded `macro_release_calendar.parquet` was **missing ~7 weeks of near-term Initial Claims (ICSA) dates** — it started at 7/23 instead of 6/5. Monthly series (CPI/unemployment/sentiment) were fine.

## Cause
`_fred_release_dates` queried FRED with `sort_order=desc` + `limit=24`. Desc returns the **furthest**-future scheduled dates first, so for a weekly series (which has ~52 future scheduled dates) the top-24 are all far-future and the **nearest** ones fall off the bottom of the limit.

## Fix
Bump the limit to **130** — comfortably covers a year-plus of any cadence (weekly ≈ 52/yr) so the desc window always reaches today; the caller still trims to the 180-day horizon. Added a regression test pinning `limit >= 120` + the `include_release_dates_with_no_data` / `sort_order` params (the existing tests mock `_fred_release_dates` wholesale, so they can't catch the query params).

## Verification
- 17 macro/registry tests pass.
- **Re-seeded the live artifact**: ICSA now 26 weekly dates from 2026-06-04; 49 events total (was 42 with the gap). Earliest events: 6/4 (claims), 6/5 (jobs), 6/10 (CPI).

Follows the merged #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)