### PR TITLE
fix(infra): SF deploy 'Argument list too long' — pass definition via file:// (P0: live SFs stale)

### DIFF
--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -101,10 +101,19 @@ echo "==> Updating Step Function definitions..."
 SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
 DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-weekday-pipeline"
 
-aws stepfunctions update-state-machine --state-machine-arn "$SAT_ARN" --definition "$(cat "$SAT_STAMPED")" --query "updateDate" --output text
+# Pass the definition via file:// — NOT inline "$(cat ...)". The Saturday ASL is
+# ~131 KB and growing (one state per pipeline step); combined with the AWS
+# session-token env on the CI runner, an inline arg blows past the effective
+# ARG_MAX and the runner aborts with "aws: Argument list too long" (exit 126),
+# which silently leaves the live SF stamp behind origin/main HEAD and trips the
+# deploy-drift preflight on the next pipeline run. file:// reads from disk, so
+# the definition size is bounded only by the SF service limit (1 MB), not ARG_MAX.
+# Regression: 2026-06-04 — the Director SF state pushed the Saturday ASL over the
+# line and broke this deploy.
+aws stepfunctions update-state-machine --state-machine-arn "$SAT_ARN" --definition "file://$SAT_STAMPED" --query "updateDate" --output text
 echo "  Saturday pipeline updated."
 
-aws stepfunctions update-state-machine --state-machine-arn "$DAILY_ARN" --definition "$(cat "$DAILY_STAMPED")" --query "updateDate" --output text
+aws stepfunctions update-state-machine --state-machine-arn "$DAILY_ARN" --definition "file://$DAILY_STAMPED" --query "updateDate" --output text
 echo "  Weekday pipeline updated."
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────


### PR DESCRIPTION
## P0 — main is in a half-deployed state; merging this self-heals it

The Director SF state (data #370) pushed the Saturday ASL to ~131 KB. The `deploy-infrastructure.yml` auto-deploy on the #370 merge (sha `220094c`) **failed** at `update-state-machine` with:

```
infrastructure/deploy-infrastructure.sh: line 104: /usr/local/bin/aws: Argument list too long
##[error]Process completed with exit code 126.
```

`--definition "$(cat …)"` passes the whole ASL inline; combined with the AWS session-token env on the runner it blew past the effective `ARG_MAX`. Because the script aborted there (before the weekday update + CFN), **both live state machines are still stamped at the previous main HEAD (`956e7c6`) while `origin/main` is `220094c`** — the deploy-drift preflight contract (live stamp == origin/main HEAD) is broken, so the **next weekday/Saturday pipeline run could halt** on `DeployDriftCheck`, and the Director state isn't live yet.

## Fix
`--definition "file://$STAMPED"` for both the Saturday + weekday updates. `file://` reads from disk → bounded by the SF service limit (1 MB), not `ARG_MAX`. No other behavior change.

## Merging this self-heals
On merge, `deploy-infrastructure.yml` re-runs the **fixed** script: it restamps both live SFs to the new main HEAD, applies the Director state, and updates the CFN git-sha tag — closing the drift window. **Please merge before the next weekday pipeline run (Fri 6 AM PT / 13:00 UTC)** so `DeployDriftCheck` doesn't halt trading.

(I did not hand-apply `update-state-machine` from this branch — per the merge-auto-deploy + drift-contract convention, the live SF must be stamped with a *merged* main SHA, not a branch SHA.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)