### PR TITLE
iam: grant github-actions-lambda-deploy access to the evaluator (auto-deploy)

### DIFF
--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -73,11 +73,27 @@ regression class.
 
 ## Trust policies + role creation
 
-Out of scope for this directory. Trust policies + initial role creation
-are handled inline in the deploy scripts that need them
-(`infrastructure/deploy_step_function.sh` for the SF + EB-SFN roles).
-This directory only manages the **inline policy documents** on roles
-that already exist.
+Initial role creation is out of scope (handled inline in the deploy
+scripts that need them — `infrastructure/deploy_step_function.sh` for the
+SF + EB-SFN roles). `apply.sh` only manages the **inline permission
+documents** on roles that already exist.
+
+**Exception — `github-actions-lambda-deploy.trust.json` (reference copy).**
+The OIDC trust policy for the shared `github-actions-lambda-deploy` role
+(which repos may assume it from GitHub Actions) was historically manual /
+uncodified. The `*.trust.json` file is a version-tracked snapshot of that
+trust policy so additions are reviewable. `apply.sh` does NOT apply it
+(it's an assume-role-policy, not an inline policy). Apply a trust-policy
+change explicitly:
+
+```
+aws iam update-assume-role-policy --role-name github-actions-lambda-deploy --policy-document file://infrastructure/iam/github-actions-lambda-deploy.trust.json
+```
+
+When a new repo needs to auto-deploy, add its
+`repo:cipher813/<repo>:ref:refs/heads/main` (+ `:pull_request`) entry to
+the trust JSON AND add its resource ARNs to the permission JSON, then
+apply both.
 
 ## Drift detection
 

--- a/infrastructure/iam/apply.sh
+++ b/infrastructure/iam/apply.sh
@@ -87,6 +87,13 @@ else
     exit 0
   fi
   for file in "${files[@]}"; do
+    # *.trust.json are version-tracked snapshots of assume-role (trust)
+    # policies, NOT inline permission documents — they are applied with
+    # `aws iam update-assume-role-policy`, never put-role-policy. Skip them
+    # in the bulk pass (see README "Trust policies + role creation").
+    case "$file" in
+      *.trust.json) echo "Skipping trust snapshot $file (apply with update-assume-role-policy)"; continue ;;
+    esac
     apply_one "$file"
   done
 fi

--- a/infrastructure/iam/check-drift.py
+++ b/infrastructure/iam/check-drift.py
@@ -101,7 +101,12 @@ def main() -> int:
             sys.stderr.write(f"ERROR: {role_files[0]} not found\n")
             return 2
     else:
-        role_files = sorted(SCRIPT_DIR.glob("*.json"))
+        # *.trust.json are assume-role (trust) policy snapshots, not inline
+        # permission documents — they have no `{stem}-policy` inline policy to
+        # diff, so exclude them from the drift sweep (mirrors apply.sh).
+        role_files = sorted(
+            f for f in SCRIPT_DIR.glob("*.json") if not f.name.endswith(".trust.json")
+        )
 
     if not role_files:
         print(f"No codified role files found under {SCRIPT_DIR} — nothing to check.")

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -25,7 +25,8 @@
         "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-research-alerts",
         "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-predictor",
         "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-data-collector",
-        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-health-check"
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-health-check",
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-evaluator"
       ]
     },
     {
@@ -58,7 +59,9 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check"
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director"
       ]
     },
     {
@@ -101,7 +104,11 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check:*"
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director:*"
       ]
     },
     {

--- a/infrastructure/iam/github-actions-lambda-deploy.trust.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.trust.json
@@ -1,0 +1,46 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::711398986525:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:cipher813/alpha-engine-research:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-research:pull_request",
+            "repo:cipher813/alpha-engine-predictor:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-predictor:pull_request",
+            "repo:cipher813/alpha-engine-data:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-data:pull_request",
+            "repo:cipher813/alpha-engine-dashboard:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-dashboard:pull_request",
+            "repo:cipher813/alpha-engine:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine:pull_request",
+            "repo:cipher813/alpha-engine-backtester:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-backtester:pull_request",
+            "repo:cipher813/alpha-engine-lib:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-lib:pull_request",
+            "repo:cipher813/alpha-engine-config:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-config:pull_request",
+            "repo:cipher813/alpha-engine-docs:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-docs:pull_request",
+            "repo:cipher813/mnemon:ref:refs/heads/main",
+            "repo:cipher813/mnemon:pull_request",
+            "repo:cipher813/flow-doctor:ref:refs/heads/main",
+            "repo:cipher813/flow-doctor:pull_request",
+            "repo:cipher813/robodashboard:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-evaluator:ref:refs/heads/main",
+            "repo:cipher813/alpha-engine-evaluator:pull_request"
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Companion to **alpha-engine-evaluator #24** (the auto-deploy workflow). The shared `github-actions-lambda-deploy` role is an **explicit-ARN allowlist** (not an `alpha-engine-*` wildcard for the core deploy actions), so the evaluator must be added before its workflow can assume the role + push + update the Lambdas.

## Permission policy (`github-actions-lambda-deploy.json`)
Add the evaluator to three statements:
- **ECRPush** → `alpha-engine-evaluator` ECR repo
- **LambdaUpdate** → `alpha-engine-evaluator` + `alpha-engine-evaluator-director` function ARNs
- **LambdaInvokeCanary** → both functions + their `:*` (deploy.sh canary-invokes each)

## Trust policy (newly codified)
The OIDC trust policy was historically **uncodified** (manual). This adds a version-tracked snapshot `github-actions-lambda-deploy.trust.json` with the two evaluator subs (`:ref:refs/heads/main` + `:pull_request`) added to the existing 23 — so future additions are reviewable. `apply.sh` now skips `*.trust.json` in its bulk pass (trust policies apply via `update-assume-role-policy`, not `put-role-policy`); the README documents the command.

## Apply (operator — AWS writes on the shared deploy role)
```
./infrastructure/iam/apply.sh github-actions-lambda-deploy
aws iam update-assume-role-policy --role-name github-actions-lambda-deploy --policy-document file://infrastructure/iam/github-actions-lambda-deploy.trust.json
```
I did **not** apply these live — widening the shared prod deploy role is an explicit-authorization / operator action (the auto-mode classifier also gated it). Both are purely additive; the trust snapshot was generated by read-modify-write off the live policy with all 23 existing subs verified intact.

`test_sf_iam_lambda_grants.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)