### PR TITLE
fix(sf): run pit_parity once in the Parity state (L4486) — companion to backtester PR

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1699,7 +1699,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -1913,7 +1913,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -1,91 +1,91 @@
 {
- "Backtester": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-backtester",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "export RUN_DATE='2026-05-18'",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator"
- ],
- "DataPhase1": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-data",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
- ],
- "DriftDetection": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-data",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh"
- ],
- "Evaluator": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-backtester",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "export RUN_DATE='2026-05-18'",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
- ],
- "MorningEnrich": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-data",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
- ],
- "Parity": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-backtester",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "export RUN_DATE='2026-05-18'",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator"
- ],
- "PortfolioOptimizerBacktest": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-backtester",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "export RUN_DATE='2026-05-18'",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator"
- ],
- "PredictorBacktest": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-backtester",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "export RUN_DATE='2026-05-18'",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator"
- ],
- "PredictorTraining": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
-  "sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml",
-  "cd /home/ec2-user/alpha-engine-predictor",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
- ],
- "RAGIngestion": [
-  "set -eo pipefail",
-  "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-  "cd /home/ec2-user/alpha-engine-data",
-  "export HOME=/home/ec2-user",
-  "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-  "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
- ]
+  "Backtester": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-backtester",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "export RUN_DATE='2026-05-18'",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator"
+  ],
+  "DataPhase1": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-data",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
+  ],
+  "DriftDetection": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-data",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh"
+  ],
+  "Evaluator": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-backtester",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "export RUN_DATE='2026-05-18'",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
+  ],
+  "MorningEnrich": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-data",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
+  ],
+  "Parity": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-backtester",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "export RUN_DATE='2026-05-18'",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator"
+  ],
+  "PortfolioOptimizerBacktest": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-backtester",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "export RUN_DATE='2026-05-18'",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator"
+  ],
+  "PredictorBacktest": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-backtester",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "export RUN_DATE='2026-05-18'",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator"
+  ],
+  "PredictorTraining": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+    "sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml",
+    "cd /home/ec2-user/alpha-engine-predictor",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
+  ],
+  "RAGIngestion": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-data",
+    "export HOME=/home/ec2-user",
+    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
+  ]
 }

--- a/tests/test_sf_backtest_parity_split_wiring.py
+++ b/tests/test_sf_backtest_parity_split_wiring.py
@@ -27,15 +27,19 @@ timeout on a fresh date (L4470). The backtest stage is now decomposed by
 --mode into THREE sequential SF states, each with its own SSM timeout +
 independent redrive:
   Backtester               --mode=param-sweep --no-pit-parity   (simulate+sweep)
-  PredictorBacktest        --mode=predictor-backtest            (predictor+Phase4, pit_parity HERE)
+  PredictorBacktest        --mode=predictor-backtest --no-pit-parity  (predictor+Phase4)
   PortfolioOptimizerBacktest --mode=portfolio-optimizer-backtest --no-pit-parity
+  Parity                   --skip-stages=backtest,evaluator     (parity + pit_parity HERE, L4486)
 The happy path is now:
   CheckSkipBacktester → Backtester → PredictorBacktest →
   PortfolioOptimizerBacktest → CheckSkipParity → Parity →
   CheckSkipEvaluator → Evaluator.
 skip_backtester still skips the whole backtest-family (routes past
-CheckSkipParity to CheckSkipEvaluator). pit_parity fires exactly once
-(default-ON in PredictorBacktest; the other two pass --no-pit-parity).
+CheckSkipParity to CheckSkipEvaluator). L4486 (2026-06-05): pit_parity fires
+exactly once, RELOCATED to the standalone Parity state (fresh process, ≥8 GB
+floor) — the other three states pass --no-pit-parity. It used to run stacked in
+PredictorBacktest, OOM-guard-failing on the 8 GB box (2nd predictor_pipeline
+after the main one held ~3.5 GB).
 
 This test catches regressions like:
 - Someone reverts Backtester's SSM command back to --skip-stages=evaluator
@@ -295,7 +299,7 @@ class TestSsmCommandShape:
 
     def test_parity_invokes_parity_stage_only(self, states):
         joined = " ".join(self._commands(states, "Parity"))
-        assert "spot_backtest.sh --skip-stages=backtest,evaluator" in joined, (
+        assert "spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator" in joined, (
             "Parity must run ONLY the parity stage."
         )
         assert "--skip-stages=evaluator" not in joined
@@ -333,7 +337,7 @@ class TestSsmCommandShape:
         )
         assert "--slug parity" in work
         assert "--log /var/log/parity.log" in work
-        assert "-- bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator" in work
+        assert "-- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator" in work
         assert not any(c.startswith("trap ") for c in cmds), (
             "Inline trap must not coexist with the lib CLI — the CLI "
             "internalizes the trap."
@@ -453,27 +457,42 @@ class TestL4472PhaseSplit:
 
     def test_predictor_backtest_invokes_predictor_mode(self, states):
         joined = " ".join(self._commands(states, "PredictorBacktest"))
-        assert "spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator" in joined
-        # pit_parity runs HERE (no --no-pit-parity on this state)
-        assert "--no-pit-parity" not in joined
+        assert "spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator" in joined
+        # L4486: pit_parity NO LONGER runs here (it was stacked after the main
+        # predictor_pipeline → 8 GB OOM-guard fail). Relocated to the Parity state.
+        assert "--no-pit-parity" in joined
 
     def test_optimizer_invokes_optimizer_mode_no_pit(self, states):
         joined = " ".join(self._commands(states, "PortfolioOptimizerBacktest"))
         assert "spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator" in joined
 
-    def test_pit_parity_runs_exactly_once(self, sf):
-        """--no-pit-parity must appear on Backtester + PortfolioOptimizer but
-        NOT PredictorBacktest, so the observational pit_parity pass fires
-        exactly once across the three split states."""
-        blob = json.dumps(sf)
-        # PredictorBacktest is the only backtest-family state without --no-pit-parity
+    def test_pit_parity_runs_exactly_once_in_parity_state(self, sf):
+        """L4486: pit_parity fires EXACTLY ONCE, in the standalone Parity state
+        (fresh process, ≥8 GB floor via --mode=all). A state runs pit_parity iff
+        it neither passes --no-pit-parity NOR skips the `pit_parity` stage token.
+        Backtester / PredictorBacktest / PortfolioOptimizerBacktest all pass
+        --no-pit-parity; Parity does not, and its --skip-stages=backtest,evaluator
+        does not contain pit_parity."""
+        import re
         from tests.sf_command_utils import extract_commands
         states = sf["States"]
-        def has_no_pit(name):
-            return "--no-pit-parity" in " ".join(extract_commands(states[name]))
-        assert has_no_pit("Backtester")
-        assert has_no_pit("PortfolioOptimizerBacktest")
-        assert not has_no_pit("PredictorBacktest")
+
+        def runs_pit_parity(name):
+            cmd = " ".join(extract_commands(states[name]))
+            # isolate the spot_backtest.sh invocation flags
+            m = re.search(r"spot_backtest\.sh ([^']*)", cmd)
+            flags = m.group(1) if m else ""
+            if "--no-pit-parity" in flags:
+                return False
+            skip = re.search(r"--skip-stages=(\S+)", flags)
+            skipped = skip.group(1).split(",") if skip else []
+            return "pit_parity" not in skipped
+
+        family = ["Backtester", "PredictorBacktest", "PortfolioOptimizerBacktest", "Parity"]
+        runners = [n for n in family if runs_pit_parity(n)]
+        assert runners == ["Parity"], (
+            f"pit_parity must fire exactly once, in Parity; got runners={runners}"
+        )
 
     @pytest.mark.parametrize(
         "name",

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -134,7 +134,7 @@ _SPOT_STATES = {
         "/var/log/backtester.log",
     ),
     "PredictorBacktest": (
-        "bash infrastructure/spot_backtest.sh --mode=predictor-backtest --skip-stages=parity,evaluator",
+        "bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator",
         "/var/log/predictor-backtest.log",
     ),
     "PortfolioOptimizerBacktest": (
@@ -142,7 +142,7 @@ _SPOT_STATES = {
         "/var/log/portfolio-optimizer.log",
     ),
     "Parity": (
-        "bash infrastructure/spot_backtest.sh --skip-stages=backtest,evaluator",
+        "bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator",
         "/var/log/parity.log",
     ),
     "Evaluator": (


### PR DESCRIPTION
Companion SF change to alpha-engine-backtester #282 (pit_parity stage-token gate).

## Change
- **PredictorBacktest**: add `--no-pit-parity` — stop the stacked pit_parity run that OOM-guard-failed (2nd `predictor_pipeline` after the main one held ~3.5 GB → only ~4.5 GB free < 6 GB guard on the 8 GB box).
- **Parity**: add `--pit-parity-enabled=1` (explicit) — pit_parity now runs here, in a **fresh process with full RAM headroom**, already on the ≥8 GB floor (`--mode=all`).

pit_parity fires **exactly once**, in Parity. `test_sf_backtest_parity_split_wiring` updated to pin the new location (`test_pit_parity_runs_exactly_once_in_parity_state`). 61 SF tests pass.

## ⚠️ Co-deploy with backtester #282
The backtester PR changes the gate token (`backtest` → `pit_parity`). With only ONE of the two PRs deployed, pit_parity could fire twice or not at all. Merge + deploy both in the same window before the 2026-06-06 Saturday cron, then validate via a scoped SF run (skip Evaluator): confirm exactly one of the four spot logs shows `stage=pit_parity START` and `backtest/{date}/pit_parity.json` lands with `status != failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)