### PR TITLE
feat(news): daily news producer for the held + tracked universe

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -1,0 +1,247 @@
+"""Daily news producer — weekday news pull for the held + tracked universe.
+
+Mirrors the Saturday ``run_news_pipeline`` chain (``NewsAggregator`` →
+``NewsNLPPipeline`` → ``aggregate_and_write``) but on a WEEKDAY cadence over a
+small, high-value universe:
+
+    robodashboard holdings  ∪  alpha-engine signals universe (tracked + recs)
+
+and writes to a SEPARATE eval-artifact prefix (``data/news_aggregates_daily/``)
+with a ``latest.json`` sidecar, so the robodashboard morning brief gets a stable
+pointer to the freshest pull without knowing the trading day. The Saturday
+``data/news_aggregates/`` artifact (full signals universe, 168h, RAG-ingested)
+is untouched — this is an additive daily companion.
+
+Deterministic: APIs (Polygon/GDELT/Yahoo) + dictionary NLP (Loughran-McDonald +
+rule-based events). No LLM, no API spend — honors
+``[[preference_llm_calls_confined_to_research_module]]``.
+
+Why a small universe (vs. all ~900 constituents): the only daily consumers are
+robodashboard's brief (the held names) and AE's own tracked set — and Polygon's
+free tier is 5 req/min, so a per-ticker pull over 900 names is infeasible in any
+morning window. The full universe stays on the weekly Saturday cadence.
+
+NOTE on scheduling: a per-ticker pull over ~50-70 names at 5 req/min is ~10-14
+min. That is too long to bolt onto the latency-sensitive daily SSM step (the
+1200s ceiling — see ``weekly_collector.py`` daily-append comment). Run this as
+its own decoupled weekday step / invocation (``python -m collectors.daily_news``),
+not inside ``_run_daily``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import date as Date
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DAILY_PREFIX = "data/news_aggregates_daily"
+HOLDINGS_UNIVERSE_KEY = "robodashboard/holdings_universe.json"
+DEFAULT_LOOKBACK_HOURS = 24
+DEFAULT_BUCKET = "alpha-engine-research"
+
+
+def _load_holdings_universe(bucket: str, s3_client: Any) -> list[str]:
+    """Read robodashboard's published held-ticker symbols (fail-soft → [])."""
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=HOLDINGS_UNIVERSE_KEY)
+        data = json.loads(obj["Body"].read())
+        tickers = [
+            str(t).strip().upper() for t in data.get("tickers", []) if str(t).strip()
+        ]
+        logger.info("[daily_news] loaded %d robodashboard holdings tickers", len(tickers))
+        return tickers
+    except Exception as e:  # missing object, no creds, parse error, etc.
+        logger.warning(
+            "[daily_news] holdings_universe unavailable (%s) — proceeding with AE universe only",
+            e,
+        )
+        return []
+
+
+def assemble_universe(bucket: str, s3_client: Any) -> list[str]:
+    """Union robodashboard holdings ∪ AE signals universe (tracked + recs).
+
+    Each slice is fail-soft: a missing holdings file or signals.json degrades
+    to whatever is available rather than aborting the pull.
+    """
+    from rag.pipelines._signals_universe import load_signals_tickers
+
+    holdings = _load_holdings_universe(bucket, s3_client)
+    try:
+        ae = load_signals_tickers(bucket=bucket, s3_client=s3_client)
+    except Exception as e:
+        logger.warning("[daily_news] signals universe unavailable (%s)", e)
+        ae = []
+    universe = sorted(set(holdings) | set(ae))
+    logger.info(
+        "[daily_news] universe = %d holdings ∪ %d AE-signals = %d unique",
+        len(holdings),
+        len(ae),
+        len(universe),
+    )
+    return universe
+
+
+def _build_aggregator():
+    """Construct the default multi-source aggregator (mirrors run_news_pipeline).
+
+    Isolated as a seam so the daily orchestrator can be unit-tested without the
+    adapter constructors or the SEC company-name fetch touching the network.
+    """
+    from collectors.news_aggregator import NewsAggregator
+    from collectors.news_sources.gdelt import GdeltNewsAdapter
+    from collectors.news_sources.polygon import PolygonNewsAdapter
+    from collectors.news_sources.yahoo_rss import YahooRssNewsAdapter
+    from rag.pipelines.run_news_pipeline import _load_ticker_name_map
+
+    return NewsAggregator(
+        sources=[
+            PolygonNewsAdapter(),
+            GdeltNewsAdapter(ticker_name_map=_load_ticker_name_map()),
+            YahooRssNewsAdapter(),
+        ]
+    )
+
+
+def _build_nlp_pipeline():
+    """Construct the default rule-based NLP pipeline (no LLM)."""
+    from collectors.nlp.loughran_mcdonald import LoughranMcDonaldScorer
+    from collectors.nlp.pipeline import NewsNLPPipeline
+    from collectors.nlp.rule_based_event_extraction import RuleBasedEventExtractor
+
+    return NewsNLPPipeline(
+        sentiment_scorers=[LoughranMcDonaldScorer()],
+        event_extractors=[RuleBasedEventExtractor()],
+    )
+
+
+def collect(
+    bucket: str = DEFAULT_BUCKET,
+    *,
+    run_date: str | None = None,
+    hours: int = DEFAULT_LOOKBACK_HOURS,
+    dry_run: bool = False,
+    s3_client: Any = None,
+) -> dict:
+    """Pull daily news for the held + tracked universe and write the daily
+    aggregates parquet (``data/news_aggregates_daily/``).
+
+    Returns a status dict. This is a SECONDARY artifact — callers should treat
+    a non-``ok`` status as a soft degrade (no news that day), never a hard
+    failure of any primary pipeline.
+    """
+    if s3_client is None:
+        import boto3
+
+        s3_client = boto3.client("s3")
+
+    agg_date = (
+        Date.fromisoformat(run_date)
+        if run_date
+        else datetime.now(timezone.utc).date()
+    )
+
+    universe = assemble_universe(bucket, s3_client)
+    if not universe:
+        logger.warning("[daily_news] empty universe — skipping news pull")
+        return {"status": "skipped", "reason": "empty_universe", "tickers": 0}
+
+    # ── Fetch (mirrors run_news_pipeline; deterministic multi-source) ────────
+    aggregator = _build_aggregator()
+    articles = aggregator.fetch(universe, hours=hours)
+    logger.info(
+        "[daily_news] fetched %d aggregated articles for %d tickers",
+        len(articles),
+        len(universe),
+    )
+
+    # ── NLP (rule-based; no LLM) ─────────────────────────────────────────────
+    nlp_output = _build_nlp_pipeline().process(articles)
+
+    if dry_run:
+        logger.info(
+            "[daily_news] dry-run — skipping parquet write (%d articles, %d tickers)",
+            len(articles),
+            len(universe),
+        )
+        return {
+            "status": "ok_dry_run",
+            "tickers": len(universe),
+            "articles": len(articles),
+        }
+
+    # ── Write to the DAILY prefix (separate from Saturday's) ─────────────────
+    from data.derived.news_aggregates import aggregate_and_write
+
+    key, df = aggregate_and_write(
+        articles=articles,
+        nlp_output=nlp_output,
+        aggregate_date=agg_date,
+        aggregator=aggregator,
+        s3_client=s3_client,
+        bucket=bucket,
+        prefix=DAILY_PREFIX,
+    )
+    logger.info("[daily_news] wrote %d rows to s3://%s/%s", len(df), bucket, key)
+    return {
+        "status": "ok",
+        "tickers": len(universe),
+        "articles": len(articles),
+        "rows": int(len(df)),
+        "key": key,
+    }
+
+
+def read_daily_news(*, bucket: str = DEFAULT_BUCKET, s3_client: Any = None):
+    """Consumer-side read of the latest daily news aggregates (via the
+    ``latest.json`` sidecar). Returns an empty canonical-schema DataFrame when
+    no daily artifact exists yet."""
+    from data.derived.news_aggregates import read_news_aggregates_parquet
+
+    if s3_client is None:
+        import boto3
+
+        s3_client = boto3.client("s3")
+    return read_news_aggregates_parquet(
+        s3_client=s3_client, bucket=bucket, prefix=DAILY_PREFIX
+    )
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", type=str, default=DEFAULT_BUCKET)
+    parser.add_argument(
+        "--hours",
+        type=int,
+        default=DEFAULT_LOOKBACK_HOURS,
+        help="Lookback window in hours (default 24 = overnight + pre-market).",
+    )
+    parser.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="Aggregate date stamp (default: today UTC).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch + NLP but don't write the parquet.",
+    )
+    args = parser.parse_args()
+    result = collect(
+        args.bucket, run_date=args.date, hours=args.hours, dry_run=args.dry_run
+    )
+    logger.info("[daily_news] complete: %s", result)
+    return 0 if result.get("status", "").startswith("ok") or result["status"] == "skipped" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -791,7 +791,96 @@
         }
       ],
       "ResultPath": "$.daemon_result",
-      "End": true
+      "Next": "RunDailyNews"
+    },
+
+    "RunDailyNews": {
+      "Type": "Task",
+      "Comment": "Secondary daily news pull for the held + tracked universe (robodashboard holdings ∪ AE signals universe). Writes data/news_aggregates_daily/ for the robodashboard morning brief + AE consumers. Runs AFTER RunDaemon so it never delays the trading path. FAIL-SOFT: news must never fail the weekday SF — the Catch here, the WaitForDailyNews Catch, and the CheckDailyNewsStatus Default all route to PipelineComplete. ~50-70-ticker per-ticker Polygon pull at 5 req/min ≈ 12 min; executionTimeout 1200s absorbs it well under the SSM ceiling.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-data",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/daily-news.log \"s3://alpha-engine-research/_ssm_logs/daily-news/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
+            "python -m collectors.daily_news 2>&1 | tee -a /var/log/daily-news.log"
+          ],
+          "executionTimeout": ["1200"]
+        }
+      },
+      "TimeoutSeconds": 1260,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Daily news is secondary — a send failure must not fail the SF.",
+          "Next": "PipelineComplete",
+          "ResultPath": "$.daily_news_error"
+        }
+      ],
+      "ResultPath": "$.daily_news_result",
+      "Next": "WaitForDailyNews"
+    },
+
+    "WaitForDailyNews": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.daily_news_result.Command.CommandId",
+        "InstanceId.$": "$.trading_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Fail-soft — a poll failure ends the SF cleanly, no news that day.",
+          "Next": "PipelineComplete",
+          "ResultPath": "$.daily_news_error"
+        }
+      ],
+      "ResultPath": "$.daily_news_poll",
+      "Next": "CheckDailyNewsStatus"
+    },
+
+    "CheckDailyNewsStatus": {
+      "Type": "Choice",
+      "Comment": "Daily news is fail-soft: any terminal status (Success OR failure) ends the SF via PipelineComplete; only keep polling while InProgress/Pending.",
+      "Choices": [
+        {
+          "Variable": "$.daily_news_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "DailyNewsWait"
+        },
+        {
+          "Variable": "$.daily_news_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "DailyNewsWait"
+        }
+      ],
+      "Default": "PipelineComplete"
+    },
+
+    "DailyNewsWait": {
+      "Type": "Wait",
+      "Seconds": 30,
+      "Next": "WaitForDailyNews"
     },
 
     "PipelineComplete": {

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -1,0 +1,88 @@
+"""Tests for collectors/daily_news.py — the weekday daily news producer.
+
+Heavier integration of NewsAggregator + NLP + parquet writer is covered in their
+own Wave 1 PRs; here we test the daily orchestrator shape: universe assembly
+(holdings ∪ signals, fail-soft) and the collect() control flow with the network
++ S3 layers mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from collectors import daily_news
+
+
+def _mock_s3(holdings=None, signals_universe=None):
+    """S3 mock serving the holdings_universe.json key and a signals.json."""
+    s3 = MagicMock()
+    s3.list_objects_v2.return_value = {
+        "CommonPrefixes": [{"Prefix": "signals/2026-06-05/"}],
+    }
+
+    def _get_object(Bucket, Key):
+        if Key == daily_news.HOLDINGS_UNIVERSE_KEY:
+            if holdings is None:
+                raise RuntimeError("NoSuchKey")
+            return {"Body": BytesIO(json.dumps({"tickers": holdings}).encode())}
+        if Key.endswith("signals.json"):
+            uni = [{"ticker": t} for t in (signals_universe or [])]
+            return {"Body": BytesIO(json.dumps({"universe": uni}).encode())}
+        raise RuntimeError(f"unexpected key {Key}")
+
+    s3.get_object.side_effect = _get_object
+    return s3
+
+
+def test_assemble_universe_unions_dedupes_sorts():
+    s3 = _mock_s3(holdings=["AAPL", "tsla"], signals_universe=["AAPL", "MSFT"])
+    assert daily_news.assemble_universe("b", s3) == ["AAPL", "MSFT", "TSLA"]
+
+
+def test_assemble_universe_fail_soft_no_holdings():
+    # Missing holdings_universe.json → AE signals universe only (not an error).
+    s3 = _mock_s3(holdings=None, signals_universe=["MSFT", "NVDA"])
+    assert daily_news.assemble_universe("b", s3) == ["MSFT", "NVDA"]
+
+
+def test_collect_skips_on_empty_universe():
+    s3 = _mock_s3(holdings=[], signals_universe=[])
+    out = daily_news.collect("b", s3_client=s3)
+    assert out["status"] == "skipped"
+    assert out["tickers"] == 0
+
+
+def _fake_aggregator():
+    agg = MagicMock()
+    agg.fetch.return_value = []
+    return agg
+
+
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_collect_dry_run_does_not_write(mock_agg, mock_nlp):
+    mock_agg.return_value = _fake_aggregator()
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3, dry_run=True)
+    assert out["status"] == "ok_dry_run"
+    assert out["tickers"] == 2
+
+
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_collect_writes_to_daily_prefix(mock_agg, mock_nlp, mock_write):
+    mock_agg.return_value = _fake_aggregator()
+    fake_df = MagicMock()
+    fake_df.__len__ = lambda self: 7
+    mock_write.return_value = ("data/news_aggregates_daily/run/result.parquet", fake_df)
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3)
+
+    assert out["status"] == "ok"
+    # Wrote to the DAILY prefix, NOT the Saturday data/news_aggregates prefix.
+    assert mock_write.call_args.kwargs["prefix"] == daily_news.DAILY_PREFIX
+    assert out["rows"] == 7


### PR DESCRIPTION
## What

**Phase 1 + 1d** of the news-aware Morning Brief arc: the daily news **producer** and its **weekday schedule**.

`collectors/daily_news.py` — a weekday news pull over a small, high-value universe so robodashboard's morning brief (and AE itself) get fresh, NLP-enriched news without a second pipeline.

**Universe** = robodashboard holdings (`robodashboard/holdings_universe.json`, from robodashboard #70) **∪** AE signals universe (`load_signals_tickers`). ~50–70 names — every name held or tracked, none of the speculative 900.

## Design

- **Reuses the Saturday chain**: `NewsAggregator` (Polygon/GDELT/Yahoo) → `NewsNLPPipeline` (Loughran-McDonald + rule-based events) → `aggregate_and_write`. No reinvention.
- Writes to a **separate prefix** `data/news_aggregates_daily/` with a `latest.json` sidecar (same eval-artifacts shape as the Saturday `data/news_aggregates/`, which is **untouched**). Consumers get a stable "latest" pointer without knowing the trading day.
- **Deterministic** — APIs + dictionary NLP, **no LLM / no API spend** (honors `[[preference_llm_calls_confined_to_research_module]]`).
- No new `s3.put_object` site (delegates to `aggregate_and_write`) → artifact-registry coverage guard stays green.

## Scheduling (1d) — dedicated weekday-SF step

`infrastructure/step_function_daily.json`: new `RunDailyNews` SSM step inserted **after `RunDaemon`**, so it never delays the trading path. Runs `python -m collectors.daily_news` on the already-booted trading instance (ae-data is checked out there for MorningEnrich). News lands ~9:30–9:45 ET.

**Fail-soft by construction**: `RunDailyNews` Catch + `WaitForDailyNews` Catch + `CheckDailyNewsStatus` Default all route to `PipelineComplete` — a news failure can never fail the weekday SF. Mirrors MorningEnrich's SSM hygiene (pipefail + `FLOW_DOCTOR_ENABLED=1` + S3 log-capture trap) and the dual-form `getCommandInvocation` retry. `executionTimeout` 1200s absorbs the ~12-min Polygon pull (kept off the latency-sensitive daily SSM step / its 1200s ceiling).

Deploy is operator-gated via `deploy_step_function_daily.sh` + the weekday-SF `DeployDriftCheck`.

## Tests

`tests/test_daily_news.py` (universe union/dedupe/fail-soft, skip, dry-run, daily-prefix write) + the full SF-wiring suite green (pipefail / invocation-retry / payload-uniqueness / mutex) — 538 passed.

## Sequencing

- robodashboard #70 publishes `holdings_universe.json` (fail-soft without it).
- ae-config registry entry (next PR) adds freshness monitoring for `data/news_aggregates_daily/latest.json`.
- robodashboard morning-brief consumer (Phase 2) lands after this soaks a few weekdays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)