### PR TITLE
fix(changelog): classify SNS-mirror entries (stop mislabeling SUCCESS/OK as incidents)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v
 
+      # Changelog mirror Lambdas live outside tests/ (pytest testpaths) and each
+      # stubs boto3 in sys.modules, so they can't share a pytest process. Run
+      # each in its own interpreter. Guards the deterministic SNS classifier
+      # (classify.py) against a mislabeling regression.
+      - name: Run changelog lambda tests
+        run: |
+          python3 infrastructure/lambdas/_shared/test_vocab.py
+          python3 infrastructure/lambdas/_shared/test_classify.py
+          python3 infrastructure/lambdas/changelog-incident-mirror/test_handler.py
+          python3 infrastructure/lambdas/changelog-cloudwatch-mirror/test_handler.py
+
       - name: Security audit
         run: |
           pip install pip-audit

--- a/infrastructure/lambdas/_shared/classify.py
+++ b/infrastructure/lambdas/_shared/classify.py
@@ -1,0 +1,141 @@
+"""Deterministic (no-LLM) classifier for SNS-mirror changelog entries.
+
+Maps an alert's subject + message to ``(event_type, severity, subsystem,
+root_cause_category)`` drawn from the controlled vocab in ``vocab.py``. Pure
+and rule-based — reused by both:
+
+  - ``changelog-incident-mirror/index.py``  (go-forward, every SNS message)
+  - ``reclassify_history.py``               (one-time backfill of the corpus)
+
+so the two never drift apart.
+
+**Why this exists.** The SNS topic ``alpha-engine-alerts`` carries a MIX:
+real failures (``ALARM:`` / ``— FAILED`` / ``[ERROR]``), warnings
+(``[WARN]``), recoveries (``OK:`` alarm-clears), and success notifications
+(``— SUCCESS`` / ``PASSED`` / ``Skipped``). The original Lambda hard-coded
+**every** message to ``incident`` / ``high`` / ``infrastructure_failure``, so
+SUCCESS + OK entries flooded the incident corpus and made the retro-candidate
+feed meaningless. This classifier sorts each message to its true type so the
+console Retros page can mine real incidents deterministically — no LLM.
+
+**Fail-loud default.** An unrecognized subject is classified as a real
+``incident`` (``high``) so a new, unanticipated alert shape surfaces LOUDLY in
+the incident corpus rather than being silently downgraded to noise. (Per the
+"fail loud and fast" rule — a producer must not silently swallow.)
+"""
+
+from __future__ import annotations
+
+# Real-failure markers (substring, case-insensitive). FAILED is checked before
+# SUCCESS so a "PredictorTraining FAILED" never matches a success rule.
+_FAIL_MARKERS = ("FAILED", "FAILURE", "CRASHED", "TIMED OUT", "TIMEOUT", "EXCEPTION")
+# Success / benign-completion markers.
+_SUCCESS_MARKERS = ("SUCCESS", "SUCCEEDED", "PASSED", "SKIPPED")
+
+# Subsystem inference — first token match wins. Keys are uppercase substrings
+# tested against the subject; values are vocab SUBSYSTEMS members.
+_SUBSYSTEM_TOKENS = (
+    ("BACKTESTER", "backtester"),
+    ("PREDICTOR", "predictor"),
+    ("RESEARCH", "research"),
+    ("EXECUTOR", "executor"),
+    ("DASHBOARD", "dashboard"),
+    ("RAG", "retrieval"),
+    ("RETRIEVAL", "retrieval"),
+    ("PROMPT", "prompts"),
+    ("EVAL", "eval"),
+    ("DATAPHASE", "data_pipeline"),
+    ("DATA STALENESS", "data_pipeline"),
+    ("DATA-PIPELINE", "data_pipeline"),
+)
+
+
+def _scan_text(subject: str, message: str) -> str:
+    """The text the rules inspect: the subject, or — when the subject is empty
+    (some raw SNS publishes carry only a body) — the first line of the
+    message. Mirrors the handler's own summary fallback."""
+    text = (subject or "").strip()
+    if not text and message:
+        lines = message.strip().splitlines()
+        text = lines[0] if lines else ""
+    return text
+
+
+def infer_subsystem(subject: str, message: str = "") -> str:
+    """Best-effort subsystem from the subject/message; defaults to
+    ``infrastructure``.
+
+    Most SNS alerts are SF/Lambda/box-health failures (infrastructure); the
+    token table promotes the ones that name a specific module so the retro
+    page can group by subsystem.
+    """
+    su = _scan_text(subject, message).upper()
+    for token, subsystem in _SUBSYSTEM_TOKENS:
+        if token in su:
+            return subsystem
+    return "infrastructure"
+
+
+def classify_sns(subject: str, message: str = "") -> tuple[str, str, str, str | None]:
+    """Return ``(event_type, severity, subsystem, root_cause_category)``.
+
+    Precedence (first match wins):
+      1. CloudWatch alarm state transitions — subject prefix ``OK:`` /
+         ``ALARM:`` / ``INSUFFICIENT_DATA``.
+      2. Explicit ``alpha_engine_lib.alerts`` severity tags —
+         ``[CRITICAL]`` / ``[ERROR]`` / ``[WARN]`` / ``[WARNING]`` / ``[INFO]``.
+      3. Pipeline/job result suffixes — ``FAILED`` (real) vs ``SUCCESS`` /
+         ``PASSED`` / ``SKIPPED`` (benign).
+      4. Default — unrecognized alert → ``incident`` / ``high`` (fail loud).
+
+    ``root_cause_category`` is ``infrastructure_failure`` for incidents (an
+    auto-default the operator refines via ``changelog-log``) and ``None`` for
+    non-incident (recovery / change) entries.
+    """
+    su = _scan_text(subject, message).upper()
+    subsystem = infer_subsystem(subject, message)
+
+    def incident(sev: str):
+        return ("incident", sev, subsystem, "infrastructure_failure")
+
+    def non_incident(event_type: str, sev: str):
+        return (event_type, sev, subsystem, None)
+
+    # 1. CloudWatch alarm state transitions (subject is canonical).
+    if su.startswith("OK:"):
+        return non_incident("recovery", "informational")
+    if su.startswith("ALARM:"):
+        return incident("high")
+    if su.startswith("INSUFFICIENT_DATA"):
+        return incident("low")
+
+    # 2. Explicit severity tags from alpha_engine_lib.alerts.
+    if "[CRITICAL]" in su:
+        return incident("critical")
+    if "[ERROR]" in su:
+        return incident("high")
+    if "[WARN]" in su or "[WARNING]" in su:
+        return incident("medium")
+    if "[INFO]" in su:
+        return non_incident("change", "informational")
+
+    # 3. Pipeline / job result notifications. FAILED before SUCCESS.
+    if any(m in su for m in _FAIL_MARKERS):
+        return incident("critical" if "CRITICAL" in su else "high")
+    if any(m in su for m in _SUCCESS_MARKERS):
+        return non_incident("change", "informational")
+
+    # 4. Unrecognized → treat as a real incident (fail loud).
+    return incident("high")
+
+
+def derive_fields(subject: str, message: str = "") -> dict[str, str | None]:
+    """Convenience wrapper returning the classified fields as a dict, for
+    merging into a structured changelog entry."""
+    event_type, severity, subsystem, rcc = classify_sns(subject, message)
+    return {
+        "event_type": event_type,
+        "severity": severity,
+        "subsystem": subsystem,
+        "root_cause_category": rcc,
+    }

--- a/infrastructure/lambdas/_shared/test_classify.py
+++ b/infrastructure/lambdas/_shared/test_classify.py
@@ -1,0 +1,121 @@
+"""Unit tests for the deterministic SNS classifier.
+
+Run from the repo root:
+
+  python3 infrastructure/lambdas/_shared/test_classify.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import vocab as _vocab  # noqa: E402
+from classify import classify_sns, derive_fields, infer_subsystem  # noqa: E402
+
+
+class ClassifyTests(unittest.TestCase):
+    def _ev(self, subject, message=""):
+        return classify_sns(subject, message)
+
+    # ---- CloudWatch alarm state transitions --------------------------------
+    def test_alarm_is_incident_high(self):
+        et, sev, _sub, rcc = self._ev('ALARM: "alpha-engine-saturday-sf-failed" in US East')
+        self.assertEqual((et, sev, rcc), ("incident", "high", "infrastructure_failure"))
+
+    def test_ok_is_recovery_informational_no_rcc(self):
+        et, sev, _sub, rcc = self._ev('OK: "alpha-engine-research-runner-timeout" in US East')
+        self.assertEqual((et, sev, rcc), ("recovery", "informational", None))
+
+    def test_insufficient_data_is_low_incident(self):
+        et, sev, _sub, _rcc = self._ev('INSUFFICIENT_DATA: "some-alarm"')
+        self.assertEqual((et, sev), ("incident", "low"))
+
+    # ---- alpha_engine_lib.alerts severity tags -----------------------------
+    def test_error_tag_is_incident_high(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine alert [ERROR] — alpha-engine-backtester/analysis")
+        self.assertEqual((et, sev), ("incident", "high"))
+
+    def test_warn_tag_is_incident_medium(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine alert [WARN] — research:score_aggregator")
+        self.assertEqual((et, sev), ("incident", "medium"))
+
+    def test_warning_tag_is_incident_medium(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine alert [WARNING] — box-health")
+        self.assertEqual((et, sev), ("incident", "medium"))
+
+    def test_critical_tag_is_incident_critical(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine alert [CRITICAL] — executor")
+        self.assertEqual((et, sev), ("incident", "critical"))
+
+    def test_info_tag_is_change_informational(self):
+        et, sev, _sub, rcc = self._ev("Alpha Engine alert [INFO] — box-health")
+        self.assertEqual((et, sev, rcc), ("change", "informational", None))
+
+    # ---- pipeline result suffixes ------------------------------------------
+    def test_pipeline_failed_is_incident(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine Saturday Pipeline — FAILED")
+        self.assertEqual((et, sev), ("incident", "high"))
+
+    def test_pipeline_success_is_change_informational(self):
+        et, sev, _sub, rcc = self._ev("Alpha Engine Saturday Pipeline — SUCCESS")
+        self.assertEqual((et, sev, rcc), ("change", "informational", None))
+
+    def test_shell_run_passed_is_change(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine Saturday Pipeline — SHELL RUN PASSED (Friday dry run)")
+        self.assertEqual((et, sev), ("change", "informational"))
+
+    def test_market_holiday_skip_is_change(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine Weekday Pipeline — Skipped (Market Holiday)")
+        self.assertEqual((et, sev), ("change", "informational"))
+
+    def test_failed_beats_nothing_in_predictor_training(self):
+        et, sev, sub, _rcc = self._ev("Alpha Engine Saturday Pipeline — PredictorTraining FAILED (early)")
+        self.assertEqual((et, sev), ("incident", "high"))
+        self.assertEqual(sub, "predictor")
+
+    # ---- default fail-loud --------------------------------------------------
+    def test_unrecognized_defaults_to_incident_high(self):
+        et, sev, _sub, _rcc = self._ev("Alpha Engine — Data Staleness Alert")
+        self.assertEqual((et, sev), ("incident", "high"))
+
+    def test_empty_subject_falls_back_to_message(self):
+        et, sev, _sub, _rcc = self._ev("", "DeployDriftCheck timed out after 60s")
+        self.assertEqual((et, sev), ("incident", "high"))
+
+    # ---- subsystem inference ------------------------------------------------
+    def test_subsystem_backtester(self):
+        self.assertEqual(infer_subsystem("[ERROR] — alpha-engine-backtester/analysis"), "backtester")
+
+    def test_subsystem_research(self):
+        self.assertEqual(infer_subsystem("[WARN] — research:score_aggregator"), "research")
+
+    def test_subsystem_default_infrastructure(self):
+        self.assertEqual(infer_subsystem("Alpha Engine Saturday Pipeline — FAILED"), "infrastructure")
+
+    # ---- output always vocab-valid -----------------------------------------
+    def test_every_classification_is_vocab_valid(self):
+        subjects = [
+            'ALARM: "x"', 'OK: "x"', 'INSUFFICIENT_DATA: "x"',
+            "[ERROR] — y", "[WARN] — y", "[WARNING] — y", "[CRITICAL] — y", "[INFO] — y",
+            "Saturday Pipeline — FAILED", "Saturday Pipeline — SUCCESS",
+            "Weekday Pipeline — Skipped (Market Holiday)", "Some unknown alert",
+        ]
+        for subj in subjects:
+            fields = derive_fields(subj)
+            # Build a minimal entry and validate vocab membership.
+            entry = {
+                "schema_version": _vocab.SCHEMA_VERSION,
+                "event_id": "x", "ts_utc": "2026-06-07T00:00:00Z",
+                "summary": "s", "resolution_type": None,
+                **fields,
+            }
+            errors = _vocab.validate_entry(entry)
+            self.assertEqual(errors, [], f"{subj!r} -> {fields} produced {errors}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -56,13 +56,14 @@ fi
 # --dry-run.
 ENV_PAYLOAD='Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_PREFIX=changelog/incidents,CHANGELOG_STRUCTURED_PREFIX=changelog/entries,CHANGELOG_QUARANTINE_PREFIX=changelog/quarantine}'
 
-# Package the handler + vendored vocab into a zip in /tmp.
+# Package the handler + vendored vocab + classifier into a zip in /tmp.
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 cp "${SCRIPT_DIR}/../_shared/vocab.py" "${PKG}/vocab.py"
+cp "${SCRIPT_DIR}/../_shared/classify.py" "${PKG}/classify.py"
 ZIP="${PKG}/function.zip"
-(cd "${PKG}" && zip -q "function.zip" index.py vocab.py)
+(cd "${PKG}" && zip -q "function.zip" index.py vocab.py classify.py)
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
 
 if $DRY_RUN; then

--- a/infrastructure/lambdas/changelog-incident-mirror/index.py
+++ b/infrastructure/lambdas/changelog-incident-mirror/index.py
@@ -45,9 +45,10 @@ from hashlib import sha1
 
 import boto3
 
-# Vendored at deploy time (deploy.sh copies _shared/vocab.py alongside
-# index.py so the import works in the Lambda runtime).
+# Vendored at deploy time (deploy.sh copies _shared/vocab.py + classify.py
+# alongside index.py so the imports work in the Lambda runtime).
 import vocab as _vocab
+from classify import classify_sns
 
 _S3 = boto3.client("s3")
 _BUCKET = os.environ["CHANGELOG_BUCKET"]
@@ -97,14 +98,22 @@ def handler(event, context):
         actor_safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in topic_name)
         event_id = f"{ts_id}_{actor_safe}_{event_hash}"
 
+        # Deterministic (no-LLM) classification of the alert. The SNS topic
+        # carries a MIX of real failures, warnings, recoveries (OK alarm-clears)
+        # and success notifications; classify_sns sorts each to its true type so
+        # the incident corpus + retro-candidate feed are not polluted by
+        # SUCCESS/OK entries. Unrecognized subjects default to incident/high
+        # (fail loud). See _shared/classify.py.
+        event_type, severity, subsystem, root_cause_category = classify_sns(subject, message)
+
         structured_entry = {
             "schema_version": SCHEMA_VERSION,
             "event_id": event_id,
             "ts_utc": ts_utc,
-            "event_type": "incident",
-            "severity": "high",
-            "subsystem": "infrastructure",
-            "root_cause_category": "infrastructure_failure",
+            "event_type": event_type,
+            "severity": severity,
+            "subsystem": subsystem,
+            "root_cause_category": root_cause_category,
             "resolution_type": None,
             "started_at": None,
             "detected_at": ts_utc,

--- a/infrastructure/lambdas/changelog-incident-mirror/reclassify_history.py
+++ b/infrastructure/lambdas/changelog-incident-mirror/reclassify_history.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""One-time backfill: re-classify historical SNS-mirror changelog entries.
+
+The ``changelog-incident-mirror`` Lambda used to hard-code every SNS message to
+``incident`` / ``high`` / ``infrastructure_failure``. The go-forward fix routes
+new messages through ``_shared/classify.py``; this script applies the SAME
+classifier to the entries already written to S3 so the corpus (and the console
+Retros page that mines it) reflects the corrected types instead of carrying
+months of mislabeled SUCCESS/OK noise.
+
+Scope: only entries with ``source == "sns-mirror"`` are touched — CI-deploy,
+cloudwatch-mirror (errors by construction), manual, and changelog-log entries
+are left exactly as-is. An entry is rewritten only if at least one of
+``event_type`` / ``severity`` / ``subsystem`` / ``root_cause_category`` changes;
+unchanged entries are skipped (idempotent — safe to re-run). Each rewrite stamps
+``reclassified_at`` + ``reclassified_from`` for provenance.
+
+Safe by default: DRY-RUN unless ``--apply`` is passed. Self-contained on stdlib
++ the ``aws`` CLI (no boto3), matching the aggregator scripts.
+
+  python3 reclassify_history.py                 # preview (dry-run)
+  python3 reclassify_history.py --apply         # rewrite changed entries
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from classify import classify_sns  # noqa: E402
+
+DEFAULT_BUCKET = "alpha-engine-research"
+ENTRIES_PREFIX = "changelog/entries"
+_CLASSIFIED_FIELDS = ("event_type", "severity", "subsystem", "root_cause_category")
+
+
+def _aws_sync_down(bucket: str, prefix: str, dest: Path) -> None:
+    proc = subprocess.run(
+        ["aws", "s3", "sync", f"s3://{bucket}/{prefix}/", str(dest), "--quiet"],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(f"ERROR: aws s3 sync failed (exit {proc.returncode})")
+
+
+def _aws_put(bucket: str, key: str, body: bytes) -> None:
+    proc = subprocess.run(
+        ["aws", "s3", "cp", "-", f"s3://{bucket}/{key}", "--content-type", "application/json"],
+        input=body, capture_output=True, check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr.decode("utf-8", errors="replace"))
+        raise SystemExit(f"ERROR: aws s3 cp (write) failed for {key}")
+
+
+def _subject_of(entry: dict) -> str:
+    """The text the original Lambda classified from: the SNS subject, falling
+    back to the entry summary (which itself fell back to the message)."""
+    return (entry.get("sns") or {}).get("subject") or entry.get("summary") or ""
+
+
+def reclassify_entry(entry: dict) -> dict | None:
+    """Return an updated copy if classification changes, else None."""
+    subject = _subject_of(entry)
+    message = entry.get("description") or ""
+    event_type, severity, subsystem, rcc = classify_sns(subject, message)
+    new = {
+        "event_type": event_type,
+        "severity": severity,
+        "subsystem": subsystem,
+        "root_cause_category": rcc,
+    }
+    if all(entry.get(k) == new[k] for k in _CLASSIFIED_FIELDS):
+        return None
+    updated = dict(entry)
+    updated["reclassified_from"] = {k: entry.get(k) for k in _CLASSIFIED_FIELDS}
+    updated["reclassified_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    updated.update(new)
+    return updated
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--prefix", default=ENTRIES_PREFIX)
+    parser.add_argument("--apply", action="store_true",
+                        help="Write changes back to S3 (default: dry-run preview).")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Cap entries written (0 = no cap). Dry-run still scans all.")
+    args = parser.parse_args(argv)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        corpus = Path(tmp)
+        _aws_sync_down(args.bucket, args.prefix, corpus)
+
+        scanned = sns = changed = written = 0
+        transitions: Counter = Counter()
+        for path in sorted(corpus.glob("**/*.json")):
+            scanned += 1
+            try:
+                entry = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            if entry.get("source") != "sns-mirror":
+                continue
+            sns += 1
+            updated = reclassify_entry(entry)
+            if updated is None:
+                continue
+            changed += 1
+            old = (entry.get("event_type"), entry.get("severity"))
+            new = (updated["event_type"], updated["severity"])
+            transitions[f"{old} -> {new}"] += 1
+            if args.apply and (args.limit == 0 or written < args.limit):
+                # Reconstruct the S3 key from the local path (relative to corpus).
+                key = f"{args.prefix}/{path.relative_to(corpus).as_posix()}"
+                _aws_put(args.bucket, key, json.dumps(updated).encode("utf-8"))
+                written += 1
+
+        print(f"Scanned {scanned} entries; {sns} sns-mirror; {changed} need reclassification.")
+        print("Transitions (old (type,sev) -> new):")
+        for k, n in transitions.most_common():
+            print(f"  {n:4d}  {k}")
+        if args.apply:
+            print(f"APPLIED: rewrote {written} entries to s3://{args.bucket}/{args.prefix}/")
+        else:
+            print("DRY-RUN: no writes. Re-run with --apply to rewrite.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/lambdas/changelog-incident-mirror/test_handler.py
+++ b/infrastructure/lambdas/changelog-incident-mirror/test_handler.py
@@ -173,5 +173,56 @@ class QuarantineTests(unittest.TestCase):
         self.assertEqual(body["validation_errors"], ["err-a", "err-b"])
 
 
+class ClassificationTests(unittest.TestCase):
+    """End-to-end: the handler applies classify_sns so SUCCESS/OK messages are
+    no longer mislabeled as high-severity incidents (the bug this fixes)."""
+
+    def setUp(self):
+        self.index, self.s3 = _import_handler()
+
+    def _emit(self, subject, message="body"):
+        ev = _sample_event()
+        ev["Records"][0]["Sns"]["Subject"] = subject
+        ev["Records"][0]["Sns"]["Message"] = message
+        self.index.handler(ev, context=None)
+        call = next(c for c in self.s3.put_object.call_args_list if "entries/" in c.kwargs["Key"])
+        return json.loads(call.kwargs["Body"].decode())
+
+    def test_success_pipeline_is_change_not_incident(self):
+        body = self._emit("Alpha Engine Saturday Pipeline — SUCCESS")
+        self.assertEqual(body["event_type"], "change")
+        self.assertEqual(body["severity"], "informational")
+        self.assertIsNone(body["root_cause_category"])
+
+    def test_alarm_ok_is_recovery(self):
+        body = self._emit('OK: "alpha-engine-research-runner-timeout" in US East')
+        self.assertEqual(body["event_type"], "recovery")
+        self.assertEqual(body["severity"], "informational")
+
+    def test_alarm_fired_is_incident(self):
+        body = self._emit('ALARM: "alpha-engine-saturday-sf-failed" in US East')
+        self.assertEqual(body["event_type"], "incident")
+        self.assertEqual(body["severity"], "high")
+        self.assertEqual(body["root_cause_category"], "infrastructure_failure")
+
+    def test_warn_is_medium_incident_with_subsystem(self):
+        body = self._emit("Alpha Engine alert [WARN] — research:score_aggregator")
+        self.assertEqual(body["event_type"], "incident")
+        self.assertEqual(body["severity"], "medium")
+        self.assertEqual(body["subsystem"], "research")
+
+    def test_non_incident_entries_pass_validation_and_land_in_entries(self):
+        # change/recovery entries must not be quarantined.
+        for subj in ("Alpha Engine Saturday Pipeline — SUCCESS",
+                     'OK: "x" in US East'):
+            self.s3.reset_mock()
+            ev = _sample_event()
+            ev["Records"][0]["Sns"]["Subject"] = subj
+            self.index.handler(ev, context=None)
+            keys = [c.kwargs["Key"] for c in self.s3.put_object.call_args_list]
+            self.assertTrue(all(k.startswith("changelog/entries/") for k in keys),
+                            f"{subj!r} should not quarantine: {keys}")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

The `changelog-incident-mirror` Lambda hard-coded `event_type=incident`, `severity=high`, `root_cause_category=infrastructure_failure` for **every** SNS message on `alpha-engine-alerts`. So pipeline `SUCCESS` notifications and CloudWatch `OK:` (alarm-clear) transitions were stored as high-severity incidents.

Empirically: of 291 `sns-mirror` entries in the corpus, **all** were `incident/high` — including 18 "Saturday Pipeline — SUCCESS" and 16 "OK: alarm cleared". This makes the incident corpus and the (planned) console **Retros** retro-candidate feed meaningless.

## Fix — deterministic, no-LLM classifier

New `_shared/classify.py` (`classify_sns`) maps subject/message → vocab fields, reused by the Lambda (go-forward) **and** the history backfill so they never drift:

| Subject pattern | event_type | severity |
|---|---|---|
| `ALARM:` / `— FAILED` / `[ERROR]` | incident | high |
| `[WARN]` / `[WARNING]` | incident | medium |
| `[CRITICAL]` | incident | critical |
| `OK:` (alarm clear) | recovery | informational |
| `SUCCESS` / `PASSED` / `Skipped` / `[INFO]` | change | informational |
| _unrecognized_ | incident | high (**fail loud**) |

Also infers `subsystem` from the subject (backtester/research/predictor/…). Non-incident entries get `root_cause_category=null`.

`cloudwatch-mirror` is **unchanged** — it only captures ERROR log lines (subscription filter), so `incident/high` is correct by construction.

## History backfill

`reclassify_history.py` applies the same classifier to existing `sns-mirror` entries. **DRY-RUN by default**; `--apply` rewrites with `reclassified_from`/`reclassified_at` provenance. Idempotent. Dry-run preview:

```
Scanned 2363 entries; 291 sns-mirror; 130 need reclassification.
   48  ('incident','high') -> ('incident','medium')
   43  ('incident','high') -> ('incident','high')      # subsystem-only change
   23  ('incident','high') -> ('change','informational')
   16  ('incident','high') -> ('recovery','informational')
```

⚠️ **Not yet applied** — rewriting the corpus is a prod-S3 mutation; awaiting operator go-ahead to run `--apply`.

## CI

Changelog lambda tests were outside `tests/` (pytest `testpaths`) and each stubs `boto3` in `sys.modules`, so they can't share a pytest process. Added a CI step running each in its own interpreter — guards the classifier against a mislabeling regression.

## Tests
`_shared/test_classify.py` (19) + 5 new handler classification cases; full changelog lambda set **66 passing**.

## Deploy
`changelog-incident-mirror` is managed **outside CloudFormation** — needs a manual `deploy.sh` run to take effect (now also vendors `classify.py`). No auto-deploy on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)