### PR TITLE
feat(sf): ModelZooRotation best-effort branch after PredictorTraining — L4544

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1401,7 +1401,7 @@
                 {
                   "Variable": "$.predictor_poll.Status",
                   "StringEquals": "Success",
-                  "Next": "BranchBComplete"
+                  "Next": "ModelZooRotation"
                 },
                 {
                   "Variable": "$.predictor_poll.Status",
@@ -1452,9 +1452,104 @@
                 }
               ]
             },
+            "ModelZooRotation": {
+              "Type": "Task",
+              "Comment": "L4544: after the champion retrain SUCCEEDS, train the weekly model-zoo rotation (challenger variants) + immediate leak-free-CPCV selection on the SAME spot instance, off the live-trading path. Observe-first: writes predictor/model_zoo/leaderboard/{date}.json and only PROMOTES if MODEL_ZOO_AUTO_PROMOTE_WINNER is set. BEST-EFFORT: every failure path routes to BranchBComplete (the champion already trained+promoted; a rotation failure must NEVER fail the Saturday SF). Budget=1 challenger/week (predictor.yaml model_zoo_weekly_budget) round-robins the 3 specs; each is ~one full train, so this extends Branch B by ~one champion-train.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+              "Parameters": {
+                "DocumentName": "AWS-RunShellScript",
+                "InstanceIds.$": "$.ec2_instance_id",
+                "Parameters": {
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp /home/ec2-user/alpha-engine-config/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-model-zoo --log /var/log/predictor-model-zoo.log -- bash infrastructure/spot_train.sh --model-zoo-weekly{}',$.preflight_args))",
+                  "executionTimeout": [
+                    "5400"
+                  ]
+                },
+                "TimeoutSeconds": 5400
+              },
+              "TimeoutSeconds": 5460,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "States.TaskFailed",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 180,
+                  "BackoffRate": 2.0,
+                  "Comment": "Single best-effort retry (e.g. spot interruption); the rotation is non-critical so we do not over-retry."
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: a rotation failure must NEVER fail the branch. The champion already trained+promoted.",
+                  "Next": "BranchBComplete",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultPath": "$.model_zoo_result",
+              "Next": "WaitForModelZoo"
+            },
+            "WaitForModelZoo": {
+              "Type": "Task",
+              "Comment": "Poll the model-zoo rotation SSM command until complete.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+              "Parameters": {
+                "CommandId.$": "$.model_zoo_result.Command.CommandId",
+                "InstanceId.$": "$.ec2_instance_id[0]"
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Ssm.InvocationDoesNotExistException",
+                    "Ssm.InvocationDoesNotExist"
+                  ],
+                  "MaxAttempts": 10,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: poll failure must not fail the branch.",
+                  "Next": "BranchBComplete",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultPath": "$.model_zoo_poll",
+              "Next": "CheckModelZooStatus"
+            },
+            "CheckModelZooStatus": {
+              "Type": "Choice",
+              "Comment": "Any non-success routes to BranchBComplete — the rotation is best-effort and its failure is logged on the box (predictor-model-zoo.log); the champion is already live.",
+              "Choices": [
+                {
+                  "Variable": "$.model_zoo_poll.Status",
+                  "StringEquals": "InProgress",
+                  "Next": "ModelZooWait"
+                },
+                {
+                  "Variable": "$.model_zoo_poll.Status",
+                  "StringEquals": "Pending",
+                  "Next": "ModelZooWait"
+                }
+              ],
+              "Default": "BranchBComplete"
+            },
+            "ModelZooWait": {
+              "Type": "Wait",
+              "Seconds": 60,
+              "Next": "WaitForModelZoo"
+            },
             "BranchBComplete": {
               "Type": "Pass",
-              "Comment": "Branch B (PredictorTraining quartet) completed (training success OR skipped via skip_predictor_training). Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch.",
+              "Comment": "Branch B (PredictorTraining quartet) completed (training success OR skipped via skip_predictor_training; the L4544 model-zoo rotation, if it ran, is best-effort and converges here regardless of outcome). Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch.",
               "Result": {
                 "branch_b_status": "OK"
               },

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -455,7 +455,10 @@ class TestEODSFTopLevelFieldsClosed:
 # was split into Backtester (simulate) + PredictorBacktest +
 # PortfolioOptimizerBacktest so no single SSM command carries the summed
 # 60-100 min post-sweep runtime that blew the timeout (L4470).
-_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 10
+# 10 → 11 on 2026-06-08 (ROADMAP L4544): ModelZooRotation — the best-effort
+# model-zoo weekly rotation + CPCV selection, sequential after PredictorTraining
+# success in Branch B (same spot instance, off the live-trading path).
+_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 11
 
 
 def _saturday_spot_states() -> list[str]:

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -275,13 +275,45 @@ class TestBranchBContents:
             "WaitForPredictorTraining"
         )
 
-    def test_predictor_success_routes_to_branch_complete(self, branch_b):
+    def test_predictor_success_routes_to_model_zoo_rotation(self, branch_b):
+        # L4544: champion-retrain success now flows into the best-effort model-zoo
+        # rotation before the branch completes (skip path still → BranchBComplete).
         success = [
             c["Next"]
             for c in branch_b["CheckPredictorStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == ["BranchBComplete"]
+        assert success == ["ModelZooRotation"]
+
+    def test_model_zoo_rotation_is_best_effort(self, branch_b):
+        """L4544: the rotation must NEVER fail Branch B — every terminal path
+        (task Catch, poll Catch, any non-success poll Status) converges to
+        BranchBComplete, since the champion already trained+promoted."""
+        zoo = branch_b["ModelZooRotation"]
+        # Task-level Catch routes failure to BranchBComplete (not BranchBFailed).
+        assert any(
+            c["Next"] == "BranchBComplete" and "States.ALL" in c["ErrorEquals"]
+            for c in zoo["Catch"]
+        )
+        assert zoo["Next"] == "WaitForModelZoo"
+        # Same shared instance as the champion retrain.
+        assert zoo["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
+        # The command invokes the rotation entrypoint, honoring shell-run preflight.
+        cmd = zoo["Parameters"]["Parameters"]["commands.$"]
+        assert "--model-zoo-weekly" in cmd
+        assert "$.preflight_args" in cmd
+        # Poll Catch is best-effort; the status Choice defaults to BranchBComplete.
+        wait = branch_b["WaitForModelZoo"]
+        assert any(
+            c["Next"] == "BranchBComplete" and "States.ALL" in c["ErrorEquals"]
+            for c in wait["Catch"]
+        )
+        check = branch_b["CheckModelZooStatus"]
+        assert check["Default"] == "BranchBComplete"
+        nexts = {c["StringEquals"]: c["Next"] for c in check["Choices"]}
+        assert nexts["InProgress"] == "ModelZooWait"
+        assert nexts["Pending"] == "ModelZooWait"
+        assert branch_b["ModelZooWait"]["Next"] == "WaitForModelZoo"
 
     def test_branch_b_ssm_can_resolve_instance_id(self, branch_b):
         """Branch B's SSM calls reference $.ec2_instance_id — which is


### PR DESCRIPTION
## What

Wires the model-zoo **weekly rotation + immediate CPCV selection** into the Saturday Step Function (L4544). After the champion retrain SUCCEEDS in Branch B of `ResearchPredictorParallel`, a new `ModelZooRotation` task runs `spot_train.sh --model-zoo-weekly` on the **same spot instance** (`$.ec2_instance_id`), training the stalest challenger spec and scoring the zoo.

## Design

- **Sequential after `PredictorTraining` success** (`CheckPredictorStatus: Success → ModelZooRotation`), so the champion is retrained+promoted first and the rotation sees it. The skip-predictor path is unchanged (→ `BranchBComplete`).
- **Task→Wait→Check→Wait** poll block mirroring `PredictorTraining` (same shared instance, SSM `sendCommand` + `getCommandInvocation`).
- **Best-effort — never fails the SF.** Every terminal path (task `Catch`, poll `Catch`, any non-success poll `Status`) converges to `BranchBComplete`, *not* `BranchBFailed`. The champion already trained+promoted; the zoo is bonus, and its failure is logged on the box (`/var/log/predictor-model-zoo.log`).
- **Off the live-trading path.** Weekday trading reads the already-promoted champion. This extends Branch B by ~one champion-train (budget = 1 challenger/week, `predictor.yaml model_zoo_weekly_budget`), delaying the post-join Backtester on Saturday — acceptable (no Saturday deadline).
- Honors `$.preflight_args` for the Friday shell-run dry path.

## Tests

- Rerouted `test_predictor_success_routes_to_*` to `ModelZooRotation`; added `test_model_zoo_rotation_is_best_effort` (all terminals → `BranchBComplete`, command invokes `--model-zoo-weekly`, shared instance, preflight-aware).
- Bumped `_EXPECTED_SATURDAY_SPOT_STATE_COUNT` 10 → 11 (deliberate spot-state addition).
- **Full suite: 1826 passed.** SF JSON validates.

## Companion PRs (this session)
- **alpha-engine-predictor #241** — the `--model-zoo-weekly` entrypoint + `run_rotation_and_select` core (observe-first).
- **alpha-engine-config** — `predictor.yaml` flags/budget + ROADMAP L4544 / OBSERVATION_REGISTRY / SYSTEM_STATE.

**Sequencing:** merge predictor #241 first (the box needs `spot_train.sh --model-zoo-weekly` before this SF state invokes it). Observe-first ⇒ no live-capital change on merge — the rotation writes a leaderboard; nothing promotes until the config flag flips post-soak.

Leaving for your review — not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)