### PR TITLE
feat(sf): preventive lib-pin drift gate as the Saturday SF's first state (L4517 PR B)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -9,7 +9,68 @@
         "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"preflight_args\":\"\",\"research_dry\":false,\"data_phase2_dry\":false,\"regime_action\":\"produce\",\"pipeline_label\":\"\",\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
       "OutputPath": "$.merged",
-      "Next": "CheckMutexRole"
+      "Next": "CheckSkipLibPinDriftCheck"
+    },
+    "CheckSkipLibPinDriftCheck": {
+      "Type": "Choice",
+      "Comment": "Skip-gate (L4517). {\"skip_lib_pin_drift_check\": true} bypasses the preventive cross-repo lib-pin drift check — e.g. an operator rerun where pins are known-good.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_lib_pin_drift_check", "IsPresent": true},
+            {"Variable": "$.skip_lib_pin_drift_check", "BooleanEquals": true}
+          ],
+          "Next": "CheckMutexRole"
+        }
+      ],
+      "Default": "LibPinDriftCheck"
+    },
+    "LibPinDriftCheck": {
+      "Type": "Task",
+      "Comment": "Preventive cross-repo alpha-engine-lib pin-drift gate (L4517). Runs BEFORE any spot launch: asserts backtester-pin == predictor-pin (co-install parity — the only multi-repo co-install site, the 2026-05-12 silent-downgrade incident) AND every Saturday-SF repo's pin >= MIN_LIB_VERSION (v0.39.0 floor = data's lowest INTENTIONAL pin). has_drift=true halts in seconds with a named offender instead of a co-install break ~12 min into a spot. FAIL-OPEN: a GitHub-fetch/parse miss sets has_drift=false (the probe's own degraded mode), and the Catch routes any Lambda failure (incl. an unknown action before predictor PR A deploys) straight to the pipeline — so the checker NEVER false-halts the weekly run.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_lib_pin_drift"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-open — the probe's own failure must not halt the weekly run; proceed to the pipeline.",
+          "Next": "CheckMutexRole",
+          "ResultPath": "$.libpin_drift_error"
+        }
+      ],
+      "ResultPath": "$.libpin_drift_result",
+      "Next": "LibPinDriftGate"
+    },
+    "LibPinDriftGate": {
+      "Type": "Choice",
+      "Comment": "Hard-fail when the lib-pin probe reports has_drift=true (a confirmed co-install parity break or below-floor regression). Surfaces cross-repo pin drift loudly before the SF spends on any spot launch.",
+      "Choices": [
+        {
+          "Variable": "$.libpin_drift_result.Payload.has_drift",
+          "BooleanEquals": true,
+          "Next": "HandleFailure"
+        }
+      ],
+      "Default": "CheckMutexRole"
     },
     "CheckMutexRole": {
       "Type": "Choice",

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -80,6 +80,9 @@ _CFN_PATH = (
 # targeted operator skips) — this constant + test_skip_gates_still_intact
 # enforce that none were deleted.
 _EXPECTED_SKIPS = {
+    # Added 2026-06-08 (L4517 — preventive cross-repo lib-pin drift gate,
+    # the first state after InitializeInput).
+    "skip_lib_pin_drift_check",
     "skip_morning_enrich",
     "skip_data_phase1",
     "skip_rag_ingestion",
@@ -388,7 +391,10 @@ class TestStrictSuperset:
         # CheckShellRun (the cadence-role acquire path lands at the same
         # downstream state). See tests/test_sf_mutex_wiring.py for the full
         # mutex-chain contract.
-        assert states["InitializeInput"]["Next"] == "CheckMutexRole"
+        # 2026-06-08 (L4517): the lib-pin drift gate precedes the mutex; its
+        # paths converge on CheckMutexRole (see test_sf_lib_pin_drift_wiring.py),
+        # so the mutex→CheckShellRun superset property below is unchanged.
+        assert states["InitializeInput"]["Next"] == "CheckSkipLibPinDriftCheck"
         assert states["CheckMutexRole"]["Default"] == "CheckShellRun", (
             "Mutex bypass path must route to CheckShellRun so the shell-run "
             "chain remains a strict superset for non-cadence inputs"
@@ -947,8 +953,15 @@ class TestHappyPathTraversal:
         assert "ApplyShellRunDefaults" not in order
         assert "NotifyShellRunComplete" not in order
         assert not skipped, "nothing skipped when shell_run absent"
+        # 2026-06-08 (L4517): the lib-pin drift gate is now the first hop after
+        # InitializeInput; with no skip flag + no drift, its skip/check/gate
+        # Defaults converge on CheckMutexRole — same downstream chain, three
+        # extra states in the visited order.
         assert order[: order.index("CheckSkipMorningEnrich") + 2] == [
             "InitializeInput",
+            "CheckSkipLibPinDriftCheck",
+            "LibPinDriftCheck",
+            "LibPinDriftGate",
             "CheckMutexRole",
             "CheckShellRun",
             "CheckSkipMorningEnrich",

--- a/tests/test_sf_lib_pin_drift_wiring.py
+++ b/tests/test_sf_lib_pin_drift_wiring.py
@@ -1,0 +1,108 @@
+"""Pins the preventive lib-pin drift gate in the Saturday SF (L4517).
+
+The gate (`LibPinDriftCheck` → `LibPinDriftGate`) MUST run before any spot
+launch and hard-fail the SF on a CONFIRMED cross-repo `alpha-engine-lib` pin
+drift (backtester != predictor co-install parity, or a below-floor pin),
+while failing OPEN on the probe's own error. These tests catch regressions
+like: someone reorders it after a spot launch (defeating "fail before spend"),
+drops the fail-open Catch (probe fragility false-halts the weekly run), or
+inverts the gate's halt condition.
+
+Pairs with alpha-engine-predictor `inference/lib_pin_drift.py` (the
+`action=check_lib_pin_drift` Lambda handler).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def sf():
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf):
+    return sf["States"]
+
+
+@pytest.mark.parametrize(
+    "name", ["CheckSkipLibPinDriftCheck", "LibPinDriftCheck", "LibPinDriftGate"]
+)
+def test_gate_states_exist(states, name):
+    assert name in states, f"{name} missing from Saturday SF States"
+
+
+def test_runs_first_off_initialize_input(sf, states):
+    # The gate is the very first thing after InitializeInput — before any state.
+    assert sf["StartAt"] == "InitializeInput"
+    assert states["InitializeInput"]["Next"] == "CheckSkipLibPinDriftCheck"
+
+
+def test_skip_gate_default_runs_check_and_skip_bypasses(states):
+    skip = states["CheckSkipLibPinDriftCheck"]
+    assert skip["Default"] == "LibPinDriftCheck"
+    c = skip["Choices"][0]
+    # skip_lib_pin_drift_check == true bypasses straight into the pipeline
+    assert c["Next"] == "CheckMutexRole"
+    variables = {x["Variable"] for x in c["And"]}
+    assert variables == {"$.skip_lib_pin_drift_check"}
+
+
+def test_check_invokes_predictor_lambda_with_action(states):
+    chk = states["LibPinDriftCheck"]
+    assert chk["Type"] == "Task"
+    assert chk["Resource"] == "arn:aws:states:::lambda:invoke"
+    assert chk["Parameters"]["FunctionName"] == "alpha-engine-predictor-inference:live"
+    assert chk["Parameters"]["Payload"]["action"] == "check_lib_pin_drift"
+    assert chk["ResultPath"] == "$.libpin_drift_result"
+    assert chk["Next"] == "LibPinDriftGate"
+
+
+def test_check_fails_open_via_catch(states):
+    # The probe's own failure (incl. an unknown action pre-PR-A-deploy) must
+    # proceed into the pipeline, NOT halt the weekly run.
+    catch = states["LibPinDriftCheck"]["Catch"][0]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "CheckMutexRole"  # the pipeline, not HandleFailure
+
+
+def test_gate_halts_only_on_confirmed_drift(states):
+    gate = states["LibPinDriftGate"]
+    assert gate["Type"] == "Choice"
+    c = gate["Choices"][0]
+    assert c["Variable"] == "$.libpin_drift_result.Payload.has_drift"
+    assert c["BooleanEquals"] is True
+    assert c["Next"] == "HandleFailure"
+    # No drift → proceed into the pipeline.
+    assert gate["Default"] == "CheckMutexRole"
+
+
+def test_gate_runs_before_any_spot_launch(sf, states):
+    """Walk the happy path (Next / Choice-Default) from StartAt and assert
+    LibPinDriftGate is reached BEFORE the first ssm:sendCommand spot launch —
+    the whole point of L4517 is to fail before any spot spend."""
+    seen_gate = False
+    cur = sf["StartAt"]
+    for _ in range(40):  # bounded walk
+        st = states[cur]
+        res = st.get("Resource", "")
+        if "ssm:sendCommand" in res:
+            assert seen_gate, (
+                f"spot launch {cur} reached before LibPinDriftGate — the gate "
+                f"must precede all spot spend"
+            )
+            return
+        if cur == "LibPinDriftGate":
+            seen_gate = True
+        nxt = st.get("Next") or st.get("Default")
+        if nxt is None:
+            break
+        cur = nxt
+    assert seen_gate, "walk never reached LibPinDriftGate"

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -76,9 +76,12 @@ class TestChainOrdering:
         # acquires the mutex; or any non-cadence role that bypasses) still
         # reaches the MorningEnrich skip-gate first — MorningEnrich still
         # precedes DataPhase1.
-        assert states["InitializeInput"]["Next"] == "CheckMutexRole", (
-            "InitializeInput now hands off to the L274 mutex gate; see "
-            "tests/test_sf_mutex_wiring.py for the mutex-chain contract"
+        # 2026-06-08: L4517 inserted the lib-pin drift gate as the new first
+        # state; its skip/check/gate Defaults converge on CheckMutexRole, so the
+        # downstream mutex→CheckShellRun→CheckSkipMorningEnrich chain is unchanged.
+        assert states["InitializeInput"]["Next"] == "CheckSkipLibPinDriftCheck", (
+            "InitializeInput now hands off to the L4517 lib-pin drift gate; see "
+            "tests/test_sf_lib_pin_drift_wiring.py for the gate→mutex chain"
         )
         assert states["CheckMutexRole"]["Default"] == "CheckShellRun", (
             "Mutex bypass must route to CheckShellRun so the pre-mutex "

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -162,7 +162,12 @@ class TestMutexWiring:
     and the bypass path (operator/missing role)."""
 
     def test_saturday_initialize_input_routes_to_check_mutex_role(self, saturday_sf):
-        assert saturday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"
+        # 2026-06-08 (L4517): the preventive lib-pin drift gate is now the first
+        # state after InitializeInput; its skip-default + gate-default converge
+        # on CheckMutexRole — the mutex still sits between entry and the
+        # former-first-state, one gate further down.
+        assert saturday_sf["States"]["InitializeInput"]["Next"] == "CheckSkipLibPinDriftCheck"
+        assert saturday_sf["States"]["LibPinDriftGate"]["Default"] == "CheckMutexRole"
 
     def test_weekday_initialize_input_routes_to_check_mutex_role(self, weekday_sf):
         assert weekday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -71,6 +71,8 @@ def _flatten_states(sf_doc: dict) -> dict:
 #
 # Saturday SF — alpha-engine-research + alpha-engine-data Lambdas
 _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
+    # L4517: preventive cross-repo lib-pin drift gate (predictor-inference Lambda).
+    "LibPinDriftCheck": frozenset({"action"}),
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),
     "RegimeSubstrate": frozenset({"action.$"}),
     "RegimeRetrospectiveEval": frozenset({"action.$"}),


### PR DESCRIPTION
## What

Adds the **preventive cross-repo lib-pin drift gate** to the Saturday SF as the **very first state** after `InitializeInput` — before any spot launch. Pairs with [alpha-engine-predictor #242](https://github.com/cipher813/alpha-engine-predictor/pull/242) (the `check_lib_pin_drift` Lambda action).

## Why

`spot_backtest.sh` co-installs backtester + predictor into one venv; a pin drift silently downgrades the lib and breaks the run (2026-05-12). The existing guard is **reactive** (fires ~12 min into the spot). This is the **preventive** layer — fail in *seconds*, before any spend.

## States (mirror `DeployDriftCheck`/`DeployDriftGate`)

```
InitializeInput → CheckSkipLibPinDriftCheck → LibPinDriftCheck → LibPinDriftGate → CheckMutexRole → …
```
- `CheckSkipLibPinDriftCheck` — `{"skip_lib_pin_drift_check": true}` bypass (operator rerun).
- `LibPinDriftCheck` — Task → `alpha-engine-predictor-inference:live` `{action: check_lib_pin_drift}`, `TimeoutSeconds:60`, Retry on Lambda.ServiceException. **Catch `States.ALL` → `CheckMutexRole`** (fail-open).
- `LibPinDriftGate` — Choice: `$.libpin_drift_result.Payload.has_drift == true` → `HandleFailure` (→ SNS `alpha-engine-alerts` → `FailExecution`); Default → `CheckMutexRole`.

**Fail-open** is load-bearing: the Catch + the probe's own degraded mode mean any checker failure — including an **unknown action before PR A deploys** — proceeds into the pipeline, never halting the weekly run. Halts **only** on a confirmed parity break or below-floor pin.

## Tests

`test_sf_lib_pin_drift_wiring.py` (9): states exist; runs first off `InitializeInput`; invokes the right Lambda+action; fails open via Catch; halts **only** on `has_drift=true`; and a happy-path walk asserts the gate **precedes the first `ssm:sendCommand`** spot launch. Updated 4 entry-point/traversal/payload-registry tests for the new first hop (mirrors the 2026-05-27 `CheckMutexRole`-insertion precedent). **Full suite 1836 passed.**

## Deploy

`infrastructure/deploy_step_function.sh`. **Deploy AFTER predictor #242** (preferred, not load-bearing — the fail-open Catch makes a pre-A invocation a no-op proceed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)