### PR TITLE
lib v0.56.0 + flow-doctor 0.6.0rc2 soak (auto-issue + auto-fix-PR, Haiku, $0.50/day)

### DIFF
--- a/.github/workflows/flow-doctor-fix.yml
+++ b/.github/workflows/flow-doctor-fix.yml
@@ -1,0 +1,61 @@
+name: Flow Doctor Fix
+
+# Fires when flow-doctor (or a human) applies the `flow-doctor:fix` label to
+# an issue. During the 0.6.0rc2 soak, flow-doctor's auto_fix_pr toggle applies
+# that label automatically on each filed issue, so this generates a fix PR with
+# no human step. Cost is bounded upstream: flow-doctor.yaml caps issues at
+# max_issues_per_day: 3 (-> <=3 label events -> <=3 runs/day), the fix model is
+# Haiku, and diagnosis has a $0.50/day hard cap. Generated PRs are proposals
+# (scope-guarded + test-gated) and are NEVER auto-merged.
+
+on:
+  issues:
+    types: [labeled]
+
+# The default GITHUB_TOKEN needs write scope to open the fix PR + comment.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  generate-fix:
+    if: github.event.label.name == 'flow-doctor:fix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        # requirements.txt pins alpha-engine-lib@v0.56.0, which installs
+        # flow-doctor[diagnosis,s3]==0.6.0rc2 (the soak version + the fix CLI).
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Generate fix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python -m flow_doctor.fix.cli generate-fix \
+            --issue-number ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --token $GITHUB_TOKEN \
+            --config flow-doctor.yaml
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: '⚠️ Flow Doctor fix generation failed. See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            })

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.39.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.56.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -11,6 +11,12 @@ notify:
   - type: github
     repo: cipher813/alpha-engine-data
     token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+    # 0.6.0rc2 soak: file an issue on failure (default) AND auto-apply the
+    # flow-doctor:fix label so the flow-doctor-fix workflow generates a fix
+    # PR with no human step. Both bounded by max_issues_per_day below.
+    auto_create_issue: true
+    auto_fix_pr: true
+    fix_label: flow-doctor:fix
   # System-wide changelog corpus — every flow-doctor report lands as a
   # schema-1.0.0 entry at s3://alpha-engine-research/changelog/entries/
   # alongside CI deploy entries + SNS-mirrored alarm entries. Closes
@@ -25,5 +31,48 @@ store:
 dedup_cooldown_minutes: 60
 rate_limits:
   max_alerts_per_day: 10
-  max_issues_per_day: 3
-  max_diagnosed_per_day: 3
+  max_issues_per_day: 3       # caps issues -> labels -> fix-PR generations
+  max_diagnosed_per_day: 3    # caps diagnosis LLM calls
+
+# Top-level GitHub config consumed by the fix CLI (flow_doctor.fix.cli).
+github:
+  token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+  labels: [flow-doctor]
+
+# LLM root-cause diagnosis. Required for fix-PR generation (the fix CLI
+# reads the diagnosis metadata embedded in the issue body). Haiku for the
+# soak — cheap; the hard daily dollar cap is the cost backstop.
+diagnosis:
+  enabled: true
+  model: claude-haiku-4-5
+  api_key: ${ANTHROPIC_API_KEY}
+  max_daily_cost_usd: 0.50
+
+# Auto-fix-PR generation (runs in the flow-doctor-fix GitHub Actions
+# workflow when an issue gets the fix label). Haiku, scoped to source
+# dirs, test-gated. dry_run: false so a PR actually opens for the soak —
+# PRs are proposals (human-reviewed), never auto-merged.
+auto_fix:
+  enabled: true
+  model: claude-haiku-4-5
+  confidence_threshold: 0.90
+  dry_run: false
+  test_command: "pytest tests/ -x -q"
+  scope:
+    allow:
+      - collectors/
+      - features/
+      - validators/
+      - builders/
+      - store/
+      - contracts/
+      - data/
+      - rag/
+    deny:
+      - "*.yaml"
+      - "*.yml"
+      - .github/
+      - infrastructure/
+      - tests/
+      - scripts/
+      - lambda/

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.39.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.56.0

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -46,6 +46,11 @@ def stub_flow_doctor_env(monkeypatch):
     monkeypatch.setenv("EMAIL_RECIPIENTS", "test@example.com")
     monkeypatch.setenv("GMAIL_APP_PASSWORD", "stub-password")
     monkeypatch.setenv("FLOW_DOCTOR_GITHUB_TOKEN", "stub-token")
+    # 0.6.0rc2 soak: flow-doctor.yaml now enables Haiku diagnosis with
+    # api_key: ${ANTHROPIC_API_KEY}. flow-doctor fails loud on an unresolved
+    # ${VAR}, so the wiring tests must seed it (mirrors the runtime, where the
+    # box resolves it from SSM /alpha-engine/ANTHROPIC_API_KEY).
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "stub-anthropic-key")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Begins the **flow-doctor 0.6.0rc2 soak** on alpha-engine-data (the fleet's noisiest flow-doctor consumer). Two parts:

1. **lib pin `v0.39.0 → v0.56.0`** — moves data's flow-doctor from 0.4.x → 0.6.0rc2 (carries the `from_config` shim + the cap-lift). lib `v0.56.0` is published.
2. **flow-doctor.yaml: enable both toggles** for the soak —
   - `auto_create_issue: true` + `auto_fix_pr: true` (auto-applies `flow-doctor:fix` → fix-PR workflow, no human step)
   - **Haiku** diagnosis, `max_daily_cost_usd: 0.50` hard cap
   - scoped + test-gated `auto_fix` (Haiku, source dirs only, config/CI/tests denied)
   - new `.github/workflows/flow-doctor-fix.yml`

## Cost bound

`max_issues_per_day: 3` → ≤3 fix-PR generations/day; Haiku on diagnosis + fix; $0.50/day diagnosis dollar cap. PRs are proposals — scope-guarded, test-gated, never auto-merged.

## Drift-gate + config validation

- Drift-gate safe: data isn't in the `backtester==predictor` co-install parity pair, and `v0.56.0` > the `v0.39.0` floor.
- Validated locally: `0.6.0rc2 + [diagnosis,s3]` builds data's real `flow-doctor.yaml` clean (diagnosis on, Haiku, $0.50 cap, `auto_fix_pr` true).

## Operator prerequisites

- ✅ `ANTHROPIC_API_KEY` GitHub Actions secret set (fix workflow).
- Runtime: diagnosis runs in-process on the data box and seeds `${ANTHROPIC_API_KEY}` from SSM `/alpha-engine/ANTHROPIC_API_KEY` via lib's secret seeding (same path as the existing `${GMAIL_APP_PASSWORD}` etc.).

On merge, data picks up rc2 on its next run; soak begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)