### PR TITLE
fix(daily-news): concurrent fan-in to stop the silent SSM timeout (L4567)

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -1,6 +1,6 @@
 """Daily news producer — weekday news pull for the held + tracked universe.
 
-Mirrors the Saturday ``run_news_pipeline`` chain (``NewsAggregator`` →
+Mirrors the Saturday ``run_news_pipeline`` chain (news aggregator →
 ``NewsNLPPipeline`` → ``aggregate_and_write``) but on a WEEKDAY cadence over a
 small, high-value universe:
 
@@ -21,11 +21,15 @@ robodashboard's brief (the held names) and AE's own tracked set — and Polygon'
 free tier is 5 req/min, so a per-ticker pull over 900 names is infeasible in any
 morning window. The full universe stays on the weekly Saturday cadence.
 
-NOTE on scheduling: a per-ticker pull over ~50-70 names at 5 req/min is ~10-14
-min. That is too long to bolt onto the latency-sensitive daily SSM step (the
-1200s ceiling — see ``weekly_collector.py`` daily-append comment). Run this as
-its own decoupled weekday step / invocation (``python -m collectors.daily_news``),
-not inside ``_run_daily``.
+NOTE on scheduling: a per-ticker pull over ~50-70 names is bounded by Polygon's
+free-tier 5 req/min (~12-14 min). We fan the three sources in CONCURRENTLY via
+:class:`AsyncNewsAggregator` (per-vendor rate limits + tenacity retry), so wall
+time ≈ the Polygon-bound ~12-14 min rather than the SUM of the three sources.
+Run this as its own decoupled weekday SSM step (``python -m collectors.daily_news``),
+not inside ``_run_daily``; the ``RunDailyNews`` SF step's ``executionTimeout`` is
+sized with headroom over that floor. (Before 2026-06-09 this used the *sync*
+aggregator, which summed the sources sequentially and ``TimedOut`` every weekday
+at the 1200s ceiling, silently producing nothing — see ROADMAP L4567.)
 """
 
 from __future__ import annotations
@@ -88,18 +92,21 @@ def assemble_universe(bucket: str, s3_client: Any) -> list[str]:
 
 
 def _build_aggregator():
-    """Construct the default multi-source aggregator (mirrors run_news_pipeline).
+    """Construct the default multi-source ASYNC aggregator.
 
-    Isolated as a seam so the daily orchestrator can be unit-tested without the
-    adapter constructors or the SEC company-name fetch touching the network.
+    Uses :class:`AsyncNewsAggregator` (concurrent fan-in + per-vendor rate
+    limits + tenacity retry) so the three sources overlap instead of summing
+    sequentially — the fix for the 1200s SSM timeout (ROADMAP L4567). Isolated
+    as a seam so the daily orchestrator can be unit-tested without the adapter
+    constructors or the SEC company-name fetch touching the network.
     """
-    from collectors.news_aggregator import NewsAggregator
+    from collectors.news_aggregator_async import AsyncNewsAggregator
     from collectors.news_sources.gdelt import GdeltNewsAdapter
     from collectors.news_sources.polygon import PolygonNewsAdapter
     from collectors.news_sources.yahoo_rss import YahooRssNewsAdapter
     from rag.pipelines.run_news_pipeline import _load_ticker_name_map
 
-    return NewsAggregator(
+    return AsyncNewsAggregator(
         sources=[
             PolygonNewsAdapter(),
             GdeltNewsAdapter(ticker_name_map=_load_ticker_name_map()),
@@ -151,9 +158,16 @@ def collect(
         logger.warning("[daily_news] empty universe — skipping news pull")
         return {"status": "skipped", "reason": "empty_universe", "tickers": 0}
 
-    # ── Fetch (mirrors run_news_pipeline; deterministic multi-source) ────────
+    # ── Fetch (concurrent multi-source fan-in; deterministic) ────────────────
+    # AsyncNewsAggregator.fetch is a coroutine — drive it from this sync entry
+    # point with anyio.run so the three vendors overlap (≈ Polygon-bound wall
+    # time) instead of summing sequentially past the SSM timeout (L4567).
+    import functools
+
+    import anyio
+
     aggregator = _build_aggregator()
-    articles = aggregator.fetch(universe, hours=hours)
+    articles = anyio.run(functools.partial(aggregator.fetch, universe, hours=hours))
     logger.info(
         "[daily_news] fetched %d aggregated articles for %d tickers",
         len(articles),

--- a/collectors/news_aggregator_async.py
+++ b/collectors/news_aggregator_async.py
@@ -159,6 +159,15 @@ class AsyncNewsAggregator:
     def source_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self._sources)
 
+    def trust_weight(self, source_name: str) -> float:
+        """Per-source trust weight — delegates to the wrapped sync aggregator.
+
+        Makes this class a drop-in for ``aggregate_and_write(aggregator=...)``
+        (which looks up per-source trust weights when building the aggregates
+        DataFrame). Same weights, same 0.5 fallback + warning as the sync path.
+        """
+        return self._sync_aggregator.trust_weight(source_name)
+
     def _semaphore_for(self, vendor: str) -> anyio.Semaphore:
         if vendor not in self._semaphores:
             limit = self._concurrency.get(vendor, 2)

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -796,7 +796,7 @@
 
     "RunDailyNews": {
       "Type": "Task",
-      "Comment": "Secondary daily news pull for the held + tracked universe (robodashboard holdings ∪ AE signals universe). Writes data/news_aggregates_daily/ for the robodashboard morning brief + AE consumers. Runs AFTER RunDaemon so it never delays the trading path. FAIL-SOFT: news must never fail the weekday SF — the Catch here, the WaitForDailyNews Catch, and the CheckDailyNewsStatus Default all route to PipelineComplete. ~50-70-ticker per-ticker Polygon pull at 5 req/min ≈ 12 min; executionTimeout 1200s absorbs it well under the SSM ceiling.",
+      "Comment": "Secondary daily news pull for the held + tracked universe (robodashboard holdings ∪ AE signals universe). Writes data/news_aggregates_daily/ for the robodashboard morning brief + AE consumers. Runs AFTER RunDaemon so it never delays the trading path. FAIL-SOFT: news must never fail the weekday SF — the Catch here, the WaitForDailyNews Catch, and the CheckDailyNewsStatus Default all route to PipelineComplete. ~50-70-ticker pull, concurrent fan-in via AsyncNewsAggregator (sources overlap), Polygon-bound at 5 req/min ≈ 12-14 min; executionTimeout 1800s gives headroom over that floor (bumped from 1200s 2026-06-09 — the sync aggregator summed sources sequentially and TimedOut every weekday, silently producing nothing; ROADMAP L4567).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -813,10 +813,10 @@
             "trap 'aws s3 cp /var/log/daily-news.log \"s3://alpha-engine-research/_ssm_logs/daily-news/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python -m collectors.daily_news 2>&1 | tee -a /var/log/daily-news.log"
           ],
-          "executionTimeout": ["1200"]
+          "executionTimeout": ["1800"]
         }
       },
-      "TimeoutSeconds": 1260,
+      "TimeoutSeconds": 1860,
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from collectors import daily_news
 
@@ -55,9 +55,25 @@ def test_collect_skips_on_empty_universe():
 
 
 def _fake_aggregator():
+    # AsyncNewsAggregator.fetch is a coroutine — collect() drives it via
+    # anyio.run, so the fetch seam must be awaitable.
     agg = MagicMock()
-    agg.fetch.return_value = []
+    agg.fetch = AsyncMock(return_value=[])
     return agg
+
+
+def test_build_aggregator_is_async_concurrent_fanin():
+    """The producer must use the concurrent AsyncNewsAggregator (3 sources
+    overlapping), not the sequential sync aggregator — the L4567 timeout fix.
+    """
+    from collectors.news_aggregator_async import AsyncNewsAggregator
+
+    with patch(
+        "rag.pipelines.run_news_pipeline._load_ticker_name_map", return_value={}
+    ):
+        agg = daily_news._build_aggregator()
+    assert isinstance(agg, AsyncNewsAggregator)
+    assert set(agg.source_names) == {"polygon", "gdelt", "yahoo_rss"}
 
 
 @patch("collectors.daily_news._build_nlp_pipeline")


### PR DESCRIPTION
## Problem
The weekday `daily_news` producer has **`TimedOut` every run since merge (6/05)** — `s3://alpha-engine-research/data/news_aggregates_daily/` is **empty**, and `_ssm_logs/daily-news/` never received a log (the EXIT trap doesn't fire on SSM force-kill). Confirmed live: the 6/08 + 6/09 `RunDailyNews` SSM commands both ended `TimedOut`.

**Root cause:** `collectors/daily_news.py` used the **sync** `NewsAggregator`, which runs Polygon/GDELT/Yahoo **sequentially** over ~50–70 tickers. Polygon's free tier (5 req/min) is a ~12–14 min floor on its own; GDELT (1s/ticker + `429`s) and Yahoo stack on top, so the run exceeds the **1200s** SSM `executionTimeout` and is killed before `aggregate_and_write` runs. The `RunDailyNews` SF state is fail-soft (3 catches → `PipelineComplete`), so the weekday SF reported **SUCCEEDED** every day and nothing paged — a silent total failure for ~4 days.

## Fix (institutional, not a timeout band-aid)
Adopt the already-built + tested `AsyncNewsAggregator` (the planned "PR D" concurrent fan-in — per-vendor rate limits + tenacity retry + optional cache). The three sources now **overlap**, so wall time ≈ the Polygon-bound ~12–14 min instead of the sequential sum.

- `collectors/daily_news.py` — `_build_aggregator` → `AsyncNewsAggregator`; `collect()` drives the coroutine via `anyio.run(functools.partial(aggregator.fetch, …))`. Docstring scheduling note corrected.
- `collectors/news_aggregator_async.py` — add `trust_weight()` delegation so the async class is a true drop-in for `aggregate_and_write(aggregator=…)`.
- `infrastructure/step_function_daily.json` — `executionTimeout` 1200→**1800s**, `TimeoutSeconds` 1260→**1860s** (headroom over Polygon's hard floor); `Comment` updated.
- `tests/test_daily_news.py` — `AsyncMock` the fetch seam + a regression test asserting the producer uses `AsyncNewsAggregator` over all 3 sources.

66 news tests green (`test_daily_news` + `test_async_and_cache` + `test_news_sources_and_aggregator`).

## Deploy notes
- **SF JSON needs an operator deploy** (`deploy_step_function_daily.sh`, drift-gated) for the timeout bump to take effect.
- The **code** change auto-applies on the next `RunDailyNews` run (the SSM step `git pull --ff-only origin main` first), once merged.
- After deploy, verify `news_aggregates_daily/latest.json` lands on the next weekday run + freshness monitor reads green — that's the gate that unblocks the robodashboard Phase 2 brief (ROADMAP L4568).

Finding tracked: alpha-engine-config L4567 (PR cipher813/alpha-engine-config#575).

🤖 Generated with [Claude Code](https://claude.com/claude-code)