### PR TITLE
docs: renumber ROADMAP ref L4567→L4573 in daily-news comments

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -29,7 +29,7 @@ Run this as its own decoupled weekday SSM step (``python -m collectors.daily_new
 not inside ``_run_daily``; the ``RunDailyNews`` SF step's ``executionTimeout`` is
 sized with headroom over that floor. (Before 2026-06-09 this used the *sync*
 aggregator, which summed the sources sequentially and ``TimedOut`` every weekday
-at the 1200s ceiling, silently producing nothing — see ROADMAP L4567.)
+at the 1200s ceiling, silently producing nothing — see ROADMAP L4573.)
 """
 
 from __future__ import annotations
@@ -96,7 +96,7 @@ def _build_aggregator():
 
     Uses :class:`AsyncNewsAggregator` (concurrent fan-in + per-vendor rate
     limits + tenacity retry) so the three sources overlap instead of summing
-    sequentially — the fix for the 1200s SSM timeout (ROADMAP L4567). Isolated
+    sequentially — the fix for the 1200s SSM timeout (ROADMAP L4573). Isolated
     as a seam so the daily orchestrator can be unit-tested without the adapter
     constructors or the SEC company-name fetch touching the network.
     """
@@ -161,7 +161,7 @@ def collect(
     # ── Fetch (concurrent multi-source fan-in; deterministic) ────────────────
     # AsyncNewsAggregator.fetch is a coroutine — drive it from this sync entry
     # point with anyio.run so the three vendors overlap (≈ Polygon-bound wall
-    # time) instead of summing sequentially past the SSM timeout (L4567).
+    # time) instead of summing sequentially past the SSM timeout (L4573).
     import functools
 
     import anyio

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -796,7 +796,7 @@
 
     "RunDailyNews": {
       "Type": "Task",
-      "Comment": "Secondary daily news pull for the held + tracked universe (robodashboard holdings ∪ AE signals universe). Writes data/news_aggregates_daily/ for the robodashboard morning brief + AE consumers. Runs AFTER RunDaemon so it never delays the trading path. FAIL-SOFT: news must never fail the weekday SF — the Catch here, the WaitForDailyNews Catch, and the CheckDailyNewsStatus Default all route to PipelineComplete. ~50-70-ticker pull, concurrent fan-in via AsyncNewsAggregator (sources overlap), Polygon-bound at 5 req/min ≈ 12-14 min; executionTimeout 1800s gives headroom over that floor (bumped from 1200s 2026-06-09 — the sync aggregator summed sources sequentially and TimedOut every weekday, silently producing nothing; ROADMAP L4567).",
+      "Comment": "Secondary daily news pull for the held + tracked universe (robodashboard holdings ∪ AE signals universe). Writes data/news_aggregates_daily/ for the robodashboard morning brief + AE consumers. Runs AFTER RunDaemon so it never delays the trading path. FAIL-SOFT: news must never fail the weekday SF — the Catch here, the WaitForDailyNews Catch, and the CheckDailyNewsStatus Default all route to PipelineComplete. ~50-70-ticker pull, concurrent fan-in via AsyncNewsAggregator (sources overlap), Polygon-bound at 5 req/min ≈ 12-14 min; executionTimeout 1800s gives headroom over that floor (bumped from 1200s 2026-06-09 — the sync aggregator summed sources sequentially and TimedOut every weekday, silently producing nothing; ROADMAP L4573).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",


### PR DESCRIPTION
Follow-up to #382. The `L4567` id used in #382's code comments + SF `Comment` collided with a pre-existing ROADMAP entry; the canonical finding was renumbered to **L4573** (ae-config #577). Comment-only, no behavior change. SF JSON re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)