### PR TITLE
fix(daily-news): self-heal LM dict from S3 + fail loud (no silent zero-sentiment) — L4575

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -41,6 +41,11 @@ from datetime import date as Date
 from datetime import datetime, timezone
 from typing import Any
 
+from collectors.nlp.loughran_mcdonald import (
+    LmDictUnavailable,
+    ensure_lm_master_dict,
+)
+
 logger = logging.getLogger(__name__)
 
 DAILY_PREFIX = "data/news_aggregates_daily"
@@ -157,6 +162,25 @@ def collect(
     if not universe:
         logger.warning("[daily_news] empty universe — skipping news pull")
         return {"status": "skipped", "reason": "empty_universe", "tickers": 0}
+
+    # ── Ensure the LM sentiment dict is present (self-heal from S3) ──────────
+    # A missing dict makes the scorer silently return all-zero sentiment; rather
+    # than write that degraded artifact, fail loud here (L4575 /
+    # [[feedback_no_silent_fails]]). Checked BEFORE the ~17-min news pull so a
+    # dict outage fails fast. ensure_lm_master_dict self-heals any host that
+    # never ran the install script by fetching the canonical CSV from S3.
+    try:
+        ensure_lm_master_dict(s3_client=s3_client)
+    except LmDictUnavailable as e:
+        logger.error(
+            "[daily_news] %s — refusing to write an all-zero-sentiment artifact",
+            e,
+        )
+        return {
+            "status": "error",
+            "reason": "lm_dict_unavailable",
+            "tickers": len(universe),
+        }
 
     # ── Fetch (concurrent multi-source fan-in; deterministic) ────────────────
     # AsyncNewsAggregator.fetch is a coroutine — drive it from this sync entry

--- a/collectors/nlp/loughran_mcdonald.py
+++ b/collectors/nlp/loughran_mcdonald.py
@@ -48,12 +48,66 @@ from collectors.nlp.protocols import SentimentScore
 logger = logging.getLogger(__name__)
 
 
+class LmDictUnavailable(RuntimeError):
+    """The Loughran-McDonald master dictionary could not be made present
+    (missing locally AND the S3 fallback fetch failed). Producers should
+    treat this as a HARD failure rather than silently scoring all-zero
+    sentiment — see ``ensure_lm_master_dict`` + [[feedback_no_silent_fails]]."""
+
+
 # ── Lexicon I/O ────────────────────────────────────────────────────────
 
 
 _DEFAULT_LM_PATH = (
     Path(__file__).parent / "data" / "lm_master_dict.csv"
 )
+
+# Durable fallback source for the dict (the upstream Notre Dame Google-Drive
+# URL rotates and 404s — see L4575). We mirror the canonical CSV into our own
+# private S3 so any news-producing host can self-heal a missing local copy.
+_S3_DICT_BUCKET = "alpha-engine-research"
+_S3_DICT_KEY = "reference/nlp/lm_master_dict.csv"
+
+
+def ensure_lm_master_dict(
+    path: Path | None = None,
+    *,
+    s3_client=None,
+    bucket: str = _S3_DICT_BUCKET,
+    key: str = _S3_DICT_KEY,
+) -> Path:
+    """Ensure the LM master dict exists locally, fetching from S3 if missing.
+
+    Returns the resolved path on success. Raises :class:`LmDictUnavailable`
+    when the dict is absent locally AND the S3 fallback fetch fails — the
+    caller (a producer) must then fail loud rather than score all-zero
+    sentiment. Self-heals any host (trading box, Saturday spot) that never
+    ran the install script.
+    """
+    path = path or _DEFAULT_LM_PATH
+    if path.exists() and path.stat().st_size > 0:
+        return path
+    try:
+        if s3_client is None:
+            import boto3
+
+            s3_client = boto3.client("s3")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        s3_client.download_file(bucket, key, str(path))
+    except Exception as e:  # noqa: BLE001 — re-raise as the named hard failure
+        raise LmDictUnavailable(
+            f"LM master dict missing at {path} and S3 fallback fetch "
+            f"failed (s3://{bucket}/{key}): {e}"
+        ) from e
+    if not (path.exists() and path.stat().st_size > 0):
+        raise LmDictUnavailable(
+            f"LM master dict still absent/empty after S3 fetch to {path}"
+        )
+    logger.info(
+        "[loughran_mcdonald] fetched master dict from s3://%s/%s → %s",
+        bucket, key, path,
+    )
+    return path
 
 
 def load_lm_master_dict(

--- a/scripts/download_lm_dict.py
+++ b/scripts/download_lm_dict.py
@@ -31,13 +31,16 @@ from pathlib import Path
 
 
 # Update this URL when Bill McDonald rotates the dict version. As of
-# 2026-05-13 the latest stable release is the 2022 Master Dictionary.
-# The redirect-friendly URL pattern is preferred over the direct
-# Dropbox link which has changed multiple times.
+# 2026-06-09 the latest stable release is the 1993-2025 Master Dictionary
+# (updated March 2026). NOTE: this upstream Google-Drive id rotates and has
+# 404'd before (L4575) — production hosts self-heal from our own S3 mirror
+# (s3://alpha-engine-research/reference/nlp/lm_master_dict.csv) via
+# collectors.nlp.loughran_mcdonald.ensure_lm_master_dict, NOT this script.
+# This script is the operator path for (re)seeding that S3 mirror.
 LM_DICT_URL = (
     "https://drive.google.com/uc?export=download&id="
-    "17CmUZM9hGUdGUkXKZpaSPMUNVxlgnVfP"
-    # ^ 2022 Master Dictionary; if this 404s, fetch the latest URL from
+    "1iq2RUf8qGFEAk1g8wQntP3habOnR3fXF"
+    # ^ 1993-2025 Master Dictionary; if this 404s, fetch the latest URL from
     #   https://sraf.nd.edu/loughranmcdonald-master-dictionary/
 )
 

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -76,9 +76,10 @@ def test_build_aggregator_is_async_concurrent_fanin():
     assert set(agg.source_names) == {"polygon", "gdelt", "yahoo_rss"}
 
 
+@patch("collectors.daily_news.ensure_lm_master_dict")
 @patch("collectors.daily_news._build_nlp_pipeline")
 @patch("collectors.daily_news._build_aggregator")
-def test_collect_dry_run_does_not_write(mock_agg, mock_nlp):
+def test_collect_dry_run_does_not_write(mock_agg, mock_nlp, mock_ensure):
     mock_agg.return_value = _fake_aggregator()
     s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
     out = daily_news.collect("b", s3_client=s3, dry_run=True)
@@ -86,10 +87,11 @@ def test_collect_dry_run_does_not_write(mock_agg, mock_nlp):
     assert out["tickers"] == 2
 
 
+@patch("collectors.daily_news.ensure_lm_master_dict")
 @patch("data.derived.news_aggregates.aggregate_and_write")
 @patch("collectors.daily_news._build_nlp_pipeline")
 @patch("collectors.daily_news._build_aggregator")
-def test_collect_writes_to_daily_prefix(mock_agg, mock_nlp, mock_write):
+def test_collect_writes_to_daily_prefix(mock_agg, mock_nlp, mock_write, mock_ensure):
     mock_agg.return_value = _fake_aggregator()
     fake_df = MagicMock()
     fake_df.__len__ = lambda self: 7
@@ -102,3 +104,26 @@ def test_collect_writes_to_daily_prefix(mock_agg, mock_nlp, mock_write):
     # Wrote to the DAILY prefix, NOT the Saturday data/news_aggregates prefix.
     assert mock_write.call_args.kwargs["prefix"] == daily_news.DAILY_PREFIX
     assert out["rows"] == 7
+
+
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+@patch("collectors.daily_news.ensure_lm_master_dict")
+def test_collect_fails_loud_when_lm_dict_unavailable(
+    mock_ensure, mock_agg, mock_nlp, mock_write
+):
+    """A missing LM dict must NOT write an all-zero-sentiment artifact — the
+    producer returns an error status and never reaches the writer (L4575)."""
+    from collectors.nlp.loughran_mcdonald import LmDictUnavailable
+
+    mock_ensure.side_effect = LmDictUnavailable("missing + S3 fetch failed")
+    mock_agg.return_value = _fake_aggregator()
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+
+    out = daily_news.collect("b", s3_client=s3)
+
+    assert out["status"] == "error"
+    assert out["reason"] == "lm_dict_unavailable"
+    mock_write.assert_not_called()  # no degraded artifact written
+    mock_agg.assert_not_called()  # failed fast, before the ~17-min news pull

--- a/tests/test_nlp_pipeline.py
+++ b/tests/test_nlp_pipeline.py
@@ -27,9 +27,11 @@ from collectors.nlp.rule_based_event_extraction import (
     RuleBasedEventExtractor,
 )
 from collectors.nlp.loughran_mcdonald import (
+    LmDictUnavailable,
     LoughranMcDonaldScorer,
     _tokenize,
     _truthy,
+    ensure_lm_master_dict,
     load_lm_master_dict,
 )
 from collectors.nlp.pipeline import NewsNLPPipeline, NewsNLPOutput
@@ -277,6 +279,43 @@ class TestLoadLmMasterDict:
         out = load_lm_master_dict(csv)
         assert "good" in out
         assert "" not in out
+
+
+class TestEnsureLmMasterDict:
+    """ensure_lm_master_dict self-heals a missing dict from S3, else fails loud
+    (L4575 — no silent all-zero sentiment)."""
+
+    def test_present_returns_path_without_fetch(self, tmp_path: Path):
+        p = tmp_path / "lm.csv"
+        p.write_text("Word,Negative,Positive\ngood,0,2009\n")
+        s3 = MagicMock()
+        assert ensure_lm_master_dict(p, s3_client=s3) == p
+        s3.download_file.assert_not_called()
+
+    def test_missing_fetches_from_s3(self, tmp_path: Path):
+        p = tmp_path / "nested" / "lm.csv"
+        s3 = MagicMock()
+
+        def _dl(bucket, key, dest):  # emulate a successful S3 download
+            Path(dest).write_text("Word,Negative,Positive\ngood,0,2009\n")
+
+        s3.download_file.side_effect = _dl
+        out = ensure_lm_master_dict(p, s3_client=s3)
+        assert out == p and p.exists()
+        s3.download_file.assert_called_once()
+
+    def test_missing_and_s3_fails_raises(self, tmp_path: Path):
+        p = tmp_path / "lm.csv"
+        s3 = MagicMock()
+        s3.download_file.side_effect = RuntimeError("no such key")
+        with pytest.raises(LmDictUnavailable):
+            ensure_lm_master_dict(p, s3_client=s3)
+
+    def test_empty_after_fetch_raises(self, tmp_path: Path):
+        p = tmp_path / "lm.csv"
+        s3 = MagicMock()  # download_file is a no-op → file never created
+        with pytest.raises(LmDictUnavailable):
+            ensure_lm_master_dict(p, s3_client=s3)
 
 
 # ── Anthropic event extractor ──────────────────────────────────────────


### PR DESCRIPTION
## Problem
The L4573 async-fanin fix let `daily_news` reach the NLP step for the first time — unmasking that it emits **all-zero sentiment**. The Loughran-McDonald dict is a download-at-install file (upstream Google-Drive URL that **404s/rotates** — confirmed today), the trading box never had it, and `LoughranMcDonaldScorer` silently falls back to an empty dict → every `lm_sentiment_*` value is 0. Artifact lands `ok`, content is degraded.

## Fix (no-silent-fails)
- **`ensure_lm_master_dict()`** (new): fetch the dict from our **private S3 mirror** (`s3://alpha-engine-research/reference/nlp/lm_master_dict.csv`) when the local copy is missing — self-heals any host. Raises **`LmDictUnavailable`** if it still can't load.
- **`daily_news.collect()`**: ensure the dict **before** the ~17-min news pull (fail fast); on `LmDictUnavailable`, log ERROR + return `status=error` and **do not write a degraded artifact** (freshness monitor catches the absence instead of a silent zeros file).
- **`download_lm_dict.py`**: bump the stale 2022 URL → 1993-2025 dict; document the S3 mirror as the production self-heal path.

## Validated on-box (today)
Dict fetched from S3 (9.1 MB), producer re-ran clean: `status: ok`, 88 tickers, **sentiment now non-zero on 163/169 tickers** (`lm_sentiment_mean` ∈ [−0.066, +0.10]). S3 mirror staged. 57 daily_news + nlp_pipeline tests green.

## Follow-up (L4575, not this PR)
Verify the **Saturday** weekly `news_aggregates` sentiment isn't also zero (same dict dependency, different host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)