### PR TITLE
feat: flow-doctor default-on roll (lib v0.58.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.56.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -130,6 +130,7 @@
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
             "cd /home/ec2-user/alpha-engine",
             "source .venv/bin/activate",
             "python -m alpha_engine_lib.trading_calendar"
@@ -239,6 +240,7 @@
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
@@ -675,6 +677,7 @@
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
             "cd /home/ec2-user/alpha-engine",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
@@ -774,6 +777,7 @@
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
             "sudo systemctl restart alpha-engine-daemon.service",
             "echo 'Daemon restarted'"
           ],
@@ -805,6 +809,7 @@
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -26,7 +26,7 @@ import traceback
 # where Dockerfile COPYs flow-doctor.yaml) takes precedence; falls back
 # to two-dirs-up from this file for local dev (lambda/handler.py →
 # repo root). Mirrors alpha-engine-research/lambda/handler.py.
-from alpha_engine_lib.logging import setup_logging
+from alpha_engine_lib.logging import setup_logging, monitor_handler
 _FLOW_DOCTOR_EXCLUDE_PATTERNS: list[str] = []
 _FLOW_DOCTOR_YAML = os.path.join(
     os.environ.get(
@@ -44,6 +44,7 @@ setup_logging(
 logger = logging.getLogger(__name__)
 
 
+@monitor_handler
 def handler(event, context):
     """
     AWS Lambda handler for Phase 2 alternative data collection.

--- a/rag/preflight.py
+++ b/rag/preflight.py
@@ -17,7 +17,7 @@ import logging
 import os
 import sys
 
-from alpha_engine_lib.logging import setup_logging
+from alpha_engine_lib.logging import setup_logging, guard_entrypoint
 from alpha_engine_lib.preflight import BasePreflight
 
 # Structured logging + flow-doctor singleton via alpha-engine-lib (shared
@@ -78,4 +78,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Capture an uncaught crash via flow-doctor before re-raising
+    # (no-ops when flow-doctor is inactive).
+    with guard_entrypoint():
+        sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.56.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.0

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -64,7 +64,7 @@ _load_dotenv()
 # pattern across all 5 entrypoints; see executor/main.py for reference).
 # Module-top so import-time errors in the collectors block below are also
 # captured by flow-doctor's ERROR handler.
-from alpha_engine_lib.logging import setup_logging
+from alpha_engine_lib.logging import setup_logging, guard_entrypoint
 _FLOW_DOCTOR_EXCLUDE_PATTERNS: list[str] = []
 _FLOW_DOCTOR_YAML = str(Path(__file__).parent / "flow-doctor.yaml")
 setup_logging(
@@ -1802,4 +1802,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    # Capture an uncaught crash via flow-doctor before re-raising
+    # (no-ops when flow-doctor is inactive).
+    with guard_entrypoint():
+        main()


### PR DESCRIPTION
## Why
Work stream 3 (data, the flow-doctor soak host) of the "make flow-doctor actually kick in" arc. Advances the soak from `0.6.0rc2 → 0.6.0rc3` and adds crash-capture.

## What
- **Pin** `alpha-engine-lib@v0.56.0 → v0.58.0` (`requirements.txt` + `Dockerfile`): default-on flow-doctor + flow-doctor `0.6.0rc3` (decision-trace, heartbeat, telegram-on-fix-PR).
- **Crash capture:** `@monitor_handler` on `lambda/handler.py`; `guard_entrypoint()` on `weekly_collector.py` + `rag/preflight.py` `__main__` — an uncaught `raise` now reaches flow-doctor. No-ops when inactive.
- **`ALPHA_ENGINE_DEPLOYED=1`** added alongside each `FLOW_DOCTOR_ENABLED=1` in `step_function_daily.json` (5 SSM steps) — fail-loud marker.

**telegram-on-issue deferred:** the data Lambda runtime's `TELEGRAM_*` availability isn't confirmed, so I defer it with the other repos (fast-follow) rather than risk a strict `ConfigError` on the soak host.

## Validation
**1842 tests pass**; SF JSON re-validated. flow-doctor stays inactive under pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)