### PR TITLE
fix(sf): auto-heal venv<->lib-pin drift in daily box entrypoints (2026-06-10 MorningEnrich fail)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -247,6 +247,7 @@
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/morning-enrich.log \"s3://alpha-engine-research/_ssm_logs/morning-enrich/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
+            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/morning-enrich.log",
             "python weekly_collector.py --morning-enrich 2>&1 | tee -a /var/log/morning-enrich.log"
           ],
           "executionTimeout": ["1800"]
@@ -816,6 +817,7 @@
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/daily-news.log \"s3://alpha-engine-research/_ssm_logs/daily-news/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
+            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/daily-news.log",
             "python -m collectors.daily_news 2>&1 | tee -a /var/log/daily-news.log"
           ],
           "executionTimeout": ["1800"]

--- a/scripts/ensure_lib_pin.sh
+++ b/scripts/ensure_lib_pin.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Self-heal venv <-> requirements `alpha-engine-lib` pin drift before an
+# entrypoint runs.
+#
+# Closes the code-vs-installed-lib deploy-skew bug class (the 2026-06-10
+# weekday-SF MorningEnrich failure): an SSM entrypoint `git pull`s new code that
+# imports a NEW lib symbol AND bumps the pin in the SAME commit (data #385 added
+# `from alpha_engine_lib.logging import guard_entrypoint` + bumped the pin to
+# v0.58.0), but the box venv is never reinstalled between the pull and the run --
+# so the new symbol resolves against the STALE installed lib -> ImportError ->
+# hard pipeline fail. The box auto-pulls code on a different cadence than it
+# reinstalls the lib, and nothing closed that window.
+#
+# This is the reconcile step that belongs BETWEEN `git pull` and the entrypoint.
+# It is deliberately a REPO script, NOT an `alpha_engine_lib` CLI like
+# `ssm_log_capture`: the whole failure mode is "the installed lib is stale," so
+# the heal mechanism must not live in the lib -- a lib-resident form would be
+# absent on the very box it needs to fix (a venv old enough to lack the new
+# symbol is also old enough to lack the heal module). A repo script arrives with
+# the same `git pull` that brings the new pin, so it is never stale. (This is the
+# documented deviation from the CLAUDE.md "lift cross-repo primitives into
+# alpha-engine-lib" sub-rule: lib-residence has a bootstrapping hole here.)
+#
+# Idempotent: a cheap version compare on every run; pip only on the rare
+# post-bump run. Fail-loud: exits non-zero if it cannot reconcile (better than
+# silently running against a broken lib -- per the no-silent-fails rule).
+#
+# Usage:  ensure_lib_pin.sh <repo_dir> [requirements_file]
+#   Call AFTER `source .venv/bin/activate` so `python`/`pip` resolve to the venv.
+set -euo pipefail
+
+repo_dir="${1:?ensure_lib_pin: <repo_dir> required}"
+req_file="${2:-${repo_dir}/requirements.txt}"
+
+if [ ! -f "$req_file" ]; then
+  echo "ensure_lib_pin: $req_file not found -- skipping" >&2
+  exit 0
+fi
+
+libspec="$(grep -E '^alpha-engine-lib' "$req_file" | head -1 || true)"
+if [ -z "$libspec" ]; then
+  echo "ensure_lib_pin: no alpha-engine-lib pin in $req_file -- skipping" >&2
+  exit 0
+fi
+
+pinned="$(printf '%s' "$libspec" | grep -oE '@v[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^@v//')"
+if [ -z "$pinned" ]; then
+  # `@main` and other non-version refs are forbidden by TestLibVersionPin; if we
+  # somehow cannot parse a vX.Y.Z pin, do not block the run -- just warn.
+  echo "ensure_lib_pin: could not parse a vX.Y.Z pin from '$libspec' -- skipping" >&2
+  exit 0
+fi
+
+installed="$(python -c 'import alpha_engine_lib as _l; print(_l.__version__)' 2>/dev/null || echo none)"
+
+if [ "$installed" = "$pinned" ]; then
+  echo "ensure_lib_pin: in sync (alpha-engine-lib v$installed)"
+  exit 0
+fi
+
+echo "ensure_lib_pin: drift -- installed=$installed pinned=v$pinned -- reinstalling '$libspec'"
+pip install --quiet "$libspec"
+
+healed="$(python -c 'import alpha_engine_lib as _l; print(_l.__version__)' 2>/dev/null || echo none)"
+if [ "$healed" != "$pinned" ]; then
+  echo "ensure_lib_pin: FAILED to reconcile -- installed=$healed still != pinned=v$pinned" >&2
+  exit 1
+fi
+echo "ensure_lib_pin: healed -> alpha-engine-lib v$healed"

--- a/tests/test_sf_lib_pin_self_heal_wiring.py
+++ b/tests/test_sf_lib_pin_self_heal_wiring.py
@@ -1,0 +1,77 @@
+"""Pin: every daily-SF SSM entrypoint that `git pull`s alpha-engine-data and
+then runs python from its venv MUST self-heal the venv<->requirements
+`alpha-engine-lib` pin (scripts/ensure_lib_pin.sh) BETWEEN the pull and the
+work line.
+
+Closes the 2026-06-10 weekday-SF failure: data #385 bumped the alpha-engine-lib
+pin AND imported a new symbol (`guard_entrypoint`) in one commit; MorningEnrich
+`git pull`ed the new code but the box venv was never reinstalled, so the import
+resolved against the stale installed lib -> ImportError -> pipeline FAILED.
+
+In-scope states are detected structurally (pull-data-repo + run-from-data-dir),
+not hard-coded, so a future data-repo entrypoint added without the heal is
+caught here. `test_known_data_entrypoints_in_scope` pins the currently-known
+set so a refactor that accidentally drops detection is also caught.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from tests.sf_command_utils import extract_commands
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DAILY_SF = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
+
+_DATA_PULL = "git -C /home/ec2-user/alpha-engine-data pull"
+_DATA_CD = "cd /home/ec2-user/alpha-engine-data"
+_VENV_ACTIVATE = "source .venv/bin/activate"
+_HEAL = "scripts/ensure_lib_pin.sh"
+
+
+def _data_repo_entrypoints() -> dict[str, list[str]]:
+    sf = json.loads(_DAILY_SF.read_text())
+    out: dict[str, list[str]] = {}
+    for name, state in sf["States"].items():
+        if not state.get("Resource", "").endswith("ssm:sendCommand"):
+            continue
+        cmds = extract_commands(state)
+        joined = "\n".join(cmds)
+        # In scope: pulls the data repo AND runs from the data-repo venv.
+        if _DATA_PULL in joined and _DATA_CD in joined:
+            out[name] = cmds
+    return out
+
+
+def test_known_data_entrypoints_in_scope():
+    eps = set(_data_repo_entrypoints())
+    assert {"MorningEnrich", "RunDailyNews"} <= eps, sorted(eps)
+
+
+@pytest.mark.parametrize("name", sorted(_data_repo_entrypoints()))
+def test_entrypoint_self_heals_lib_pin_after_pull_before_run(name):
+    cmds = _data_repo_entrypoints()[name]
+
+    heal_idx = next((i for i, c in enumerate(cmds) if _HEAL in c), None)
+    assert heal_idx is not None, f"{name}: missing {_HEAL} self-heal step"
+
+    pull_idx = next(i for i, c in enumerate(cmds) if _DATA_PULL in c)
+    activate_idx = next(i for i, c in enumerate(cmds) if _VENV_ACTIVATE in c)
+    work_idx = next(
+        i for i, c in enumerate(cmds) if c.strip().startswith("python ")
+    )
+
+    assert pull_idx < heal_idx, f"{name}: heal must run AFTER the git pull"
+    assert activate_idx < heal_idx, f"{name}: heal must run AFTER venv activate"
+    assert heal_idx < work_idx, f"{name}: heal must run BEFORE the python work line"
+
+
+def test_heal_script_exists_and_executable():
+    p = _REPO_ROOT / "scripts" / "ensure_lib_pin.sh"
+    assert p.exists(), "scripts/ensure_lib_pin.sh missing"
+    assert os.stat(p).st_mode & stat.S_IXUSR, "ensure_lib_pin.sh must be executable"


### PR DESCRIPTION
## Why

The weekday SF **failed this morning (2026-06-10)** — no trading. `MorningEnrich` crashed on:

```
ImportError: cannot import name 'guard_entrypoint' from 'alpha_engine_lib.logging'
```

PR #385 (flow-doctor default-on roll) added `from alpha_engine_lib.logging import ... guard_entrypoint` **and** bumped the lib pin to `v0.58.0` in the same commit. The box `git pull`ed the new code but its venv was never reinstalled between the pull and the run, so the new symbol resolved against the **stale installed lib** → ImportError → hard fail.

Root cause is structural: on the EC2 box, code (git pull) and the lib (pip install) deploy on **different cadences**, and nothing closed the window. The Saturday SF got a `LibPinDriftCheck` first-state for exactly this class; the daily SF had no equivalent.

## What

The two daily-SF SSM entrypoints that `git pull` `alpha-engine-data` and then run from its venv — **`MorningEnrich`** and **`RunDailyNews`** — now run `scripts/ensure_lib_pin.sh` **between the pull and the work line**:

- Compares installed `alpha_engine_lib.__version__` to the `requirements.txt` pin.
- **In sync → no-op** (a cheap version compare, the common case).
- **Drift → reinstalls** the exact pinned spec (extras preserved), verifies, and proceeds → the run **self-heals** instead of failing.
- **Cannot reconcile → exits non-zero** (fail-loud per the no-silent-fails rule — better than running against a broken lib).

`RunMorningPlanner`/`RunDaemon` don't `git pull` in-line (boot-pull cadence) and `CheckTradingDay` runs from the executor venv, so they're out of scope here.

### Why a repo script, not an `alpha_engine_lib` CLI
The failure mode *is* "the installed lib is stale," so the heal must not live in the lib — a lib-resident form would be absent on the very box it needs to fix. A repo script arrives with the same `git pull` that brings the new pin, so it's never stale. (Documented deviation from the CLAUDE.md lift-to-lib sub-rule.)

## Tests
- New `tests/test_sf_lib_pin_self_heal_wiring.py` — detects in-scope entrypoints **structurally** (pull-data-repo + run-from-data-dir) so a future data-repo entrypoint added without the heal is caught; asserts heal ordering (after pull + activate, before the python work line) + script exists/executable.
- Behavior-verified the script across **in-sync / drift-heals / cannot-reconcile** (stubbed python/pip).
- `587 passed, 1 skipped` across the SF-wiring + morning-enrich + daily-news + lib-pin suites.

## Deploy note
The live daily Step Function ASL updates via `infrastructure/deploy_step_function_daily.sh` (manual — the SF JSON is **not** auto-deployed on merge). The heal takes effect after that deploy runs; **today is already healed** (box venv is at 0.58.0), so there's no urgency, but the deploy should land before the next lib-pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)