### PR TITLE
feat(l658): consolidated Friday shell-run report Lambda

### DIFF
--- a/infrastructure/lambdas/friday-shell-run-report/README.md
+++ b/infrastructure/lambdas/friday-shell-run-report/README.md
@@ -1,0 +1,49 @@
+# alpha-engine-friday-shell-run-report
+
+Consolidated pass/fail report for the **Friday shell-run** (the Friday-PM dry
+preflight of the Saturday Step Function). Closes ROADMAP **L658** design point 5
+— the scoped follow-on the shell-run SF spine deferred (see
+`CheckShellRunNotify`'s comment in `infrastructure/step_function.json`).
+
+## What it does
+
+Subscribes (EventBridge) to `alpha-engine-saturday-pipeline` **terminal**
+execution-status transitions (`SUCCEEDED` / `FAILED` / `TIMED_OUT` / `ABORTED`).
+For executions that ran in **shell-run mode** (`shell_run: true` /
+`pipeline_role: "shell-run"` — started by the sibling
+`eod-success-friday-shell-trigger` Lambda), it:
+
+1. reads the execution history (`states:GetExecutionHistory`),
+2. reduces it to a per-state `{name, status: PASS|FAIL, duration_s}` summary (a
+   state entered-but-never-exited = the failure point),
+3. computes a readiness verdict — `GO_SATURDAY` (all states passed) or
+   `HOLD_INVESTIGATE`,
+4. writes `s3://alpha-engine-research/friday-shell-run/{trading_day}/report.json`,
+5. publishes a structured per-state SNS summary to `alpha-engine-alerts`.
+
+Real Saturday runs (no `shell_run`) are the intended **no-op** path
+(`{"reported": false}`). The report is the Lambda's deliverable, so
+GetExecutionHistory / S3 / SNS failures **raise** (EventBridge retry + the
+CloudWatch Lambda-error alarm surface them).
+
+This is the consolidated-report half of L658; the shell-run orchestration
+(the `CheckShellRun` SF spine + the Friday trigger Lambda) shipped ~2026-05-29.
+
+## Why event-driven (not an SF state)
+
+Wiring the report as a new terminal SF state would need surgery on both the
+success and failure paths. An EventBridge rule on the execution status-change
+covers **both** terminal outcomes with zero SF-JSON change, mirroring the
+sibling `eod-success-friday-shell-trigger` pattern.
+
+## Deploy (operator-managed, outside CloudFormation)
+
+```
+bash infrastructure/lambdas/friday-shell-run-report/deploy.sh --bootstrap  # first-time: role + rule + lambda
+bash infrastructure/lambdas/friday-shell-run-report/deploy.sh              # code-only update
+bash infrastructure/lambdas/friday-shell-run-report/deploy.sh --dry-run    # show actions
+```
+
+`trading_day` is parsed from the execution name (`friday-shell-{YYYY-MM-DD}-…`),
+falling back to `alpha_engine_lib.trading_calendar.last_closed_trading_day` on
+`detail.stopDate`.

--- a/infrastructure/lambdas/friday-shell-run-report/deploy.sh
+++ b/infrastructure/lambdas/friday-shell-run-report/deploy.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-friday-shell-run-report Lambda
+# and wire its EventBridge trigger.
+#
+# Subscribes to `aws.states` / "Step Functions Execution Status Change" events
+# for `alpha-engine-saturday-pipeline` terminal transitions (SUCCEEDED / FAILED
+# / TIMED_OUT / ABORTED). The handler no-ops on real Saturday runs and, for
+# shell-run executions (shell_run=true), reads the execution history and writes
+# the consolidated report to s3://alpha-engine-research/friday-shell-run/{date}/
+# report.json + a structured SNS summary (ROADMAP L658 design point 5).
+#
+# Managed outside CloudFormation — same rationale as the sibling
+# eod-success-friday-shell-trigger (keeps the github-actions-lambda-deploy OIDC
+# role's blast radius narrow; operator-deployed only).
+#
+# Usage:
+#   bash infrastructure/lambdas/friday-shell-run-report/deploy.sh             # update code only
+#   bash infrastructure/lambdas/friday-shell-run-report/deploy.sh --bootstrap # first-time create + wire EventBridge
+#   bash infrastructure/lambdas/friday-shell-run-report/deploy.sh --dry-run   # show actions, do not apply
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-friday-shell-run-report"
+ROLE_NAME="alpha-engine-friday-shell-run-report-role"
+POLICY_NAME="alpha-engine-friday-shell-run-report-policy"
+RULE_NAME="alpha-engine-friday-shell-run-report"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
+      --zip-file "fileb://${ZIP}" --timeout 60 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,S3_BUCKET=alpha-engine-research}' \
+      --region "${REGION}" --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge rule: Saturday SF terminal transitions (SUCCEEDED/FAILED/TIMED_OUT/ABORTED).
+  # The handler no-ops on non-shell-run executions, so no input-content filter is needed.
+  echo "  Creating EventBridge rule: ${RULE_NAME}"
+  EVENT_PATTERN=$(cat <<EOF
+{
+  "source": ["aws.states"],
+  "detail-type": ["Step Functions Execution Status Change"],
+  "detail": {
+    "stateMachineArn": ["arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"],
+    "status": ["SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"]
+  }
+}
+EOF
+)
+  run aws events put-rule --name "${RULE_NAME}" --event-pattern "${EVENT_PATTERN}" \
+    --description "Consolidated Friday shell-run report on Saturday SF terminal (Lambda shell-run-guards)" \
+    --region "${REGION}" --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" --action lambda:InvokeFunction \
+    --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "✓ Code deployed."

--- a/infrastructure/lambdas/friday-shell-run-report/iam-policy.json
+++ b/infrastructure/lambdas/friday-shell-run-report/iam-policy.json
@@ -1,0 +1,33 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-friday-shell-run-report:*"
+    },
+    {
+      "Sid": "ReadSaturdayExecutionHistory",
+      "Effect": "Allow",
+      "Action": ["states:GetExecutionHistory"],
+      "Resource": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:*"
+    },
+    {
+      "Sid": "WriteShellRunReport",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/friday-shell-run/*"
+    },
+    {
+      "Sid": "PublishSummary",
+      "Effect": "Allow",
+      "Action": ["sns:Publish"],
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    }
+  ]
+}

--- a/infrastructure/lambdas/friday-shell-run-report/index.py
+++ b/infrastructure/lambdas/friday-shell-run-report/index.py
@@ -1,0 +1,203 @@
+"""alpha-engine-friday-shell-run-report — consolidate the Friday shell-run result.
+
+Subscribes to EventBridge ``Step Functions Execution Status Change`` events for
+the ``alpha-engine-saturday-pipeline`` state machine (terminal transitions:
+SUCCEEDED / FAILED / TIMED_OUT / ABORTED). For executions that ran in **shell-run
+mode** (``shell_run: true`` / ``pipeline_role: "shell-run"`` in the execution
+input — the Friday-PM dry preflight of the Saturday SF), the handler reads the
+execution history, reduces it to a per-state pass/fail summary, and writes a
+single consolidated report to
+``s3://{bucket}/friday-shell-run/{trading_day}/report.json`` plus a structured
+SNS summary — the "12 h before the real Saturday 02:00 PT firing" diagnostic
+artifact (ROADMAP L658 design point 5, the scoped follow-on the SF spine
+deferred).
+
+This is the consolidated-report half of L658; the shell-run orchestration
+(``CheckShellRun`` spine + the ``eod-success-friday-shell-trigger`` Lambda)
+already shipped ~2026-05-29. Real Saturday runs (no ``shell_run``) are the
+intended no-op path and return ``{"reported": False}``.
+
+Fail-loud semantics (the report IS this Lambda's deliverable, per
+``feedback_no_silent_fails``):
+  * ``states:GetExecutionHistory`` / ``s3:PutObject`` / ``sns:Publish`` failure
+    → raises (EventBridge→Lambda retry + CW Lambda-error alarm surface it).
+  * A non-shell-run execution, a non-Saturday state machine, or a non-terminal
+    status is an intended skip and returns a structured ``reported: False`` —
+    NOT a swallow.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+
+import boto3
+
+from alpha_engine_lib.trading_calendar import last_closed_trading_day
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
+SATURDAY_SF_NAME = "alpha-engine-saturday-pipeline"
+S3_BUCKET = os.environ.get("S3_BUCKET", "alpha-engine-research")
+SNS_TOPIC_ARN = os.environ.get(
+    "SNS_TOPIC_ARN", f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts"
+)
+REPORT_PREFIX = "friday-shell-run"
+_TERMINAL = {"SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"}
+# Shell-run executions are named `friday-shell-{YYYY-MM-DD}-{...}` by the
+# eod-success-friday-shell-trigger Lambda — primary trading_day source.
+_NAME_DATE_RE = re.compile(r"friday-shell-(\d{4}-\d{2}-\d{2})-")
+
+
+def _is_shell_run(execution_input: str, name: str) -> bool:
+    """True iff this execution ran the Friday-PM preflight. Load-bearing signal
+    is the input flag; the name prefix is the corroborating fallback."""
+    try:
+        payload = json.loads(execution_input or "{}")
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+    if payload.get("shell_run") is True or payload.get("pipeline_role") == "shell-run":
+        return True
+    return bool(_NAME_DATE_RE.match(name or ""))
+
+
+def _trading_day(name: str, stop_date_ms) -> str:
+    """trading_day the shell-run validated: parse from the execution name first
+    (authoritative — the trigger stamps it), else derive from the completion
+    timestamp via the canonical NYSE calendar helper."""
+    m = _NAME_DATE_RE.match(name or "")
+    if m:
+        return m.group(1)
+    if stop_date_ms is not None:
+        dt = datetime.fromtimestamp(int(stop_date_ms) / 1000, tz=timezone.utc)
+        return last_closed_trading_day(dt).isoformat()
+    raise RuntimeError(
+        "shell-run report: cannot resolve trading_day — execution name lacks the "
+        "friday-shell-{date} prefix AND detail.stopDate is absent"
+    )
+
+
+def _summarize_history(execution_arn: str) -> tuple[list[dict], dict | None]:
+    """Reduce the execution history to per-state {name, status, duration_s} and
+    the ExecutionFailed cause (if any). A state Entered-but-never-Exited is the
+    failure point (the execution died inside it)."""
+    sfn = boto3.client("stepfunctions", region_name=REGION)
+    entered: dict[str, datetime] = {}
+    exited: dict[str, datetime] = {}
+    order: list[str] = []
+    failure: dict | None = None
+
+    next_token = None
+    while True:
+        kwargs = {"executionArn": execution_arn, "maxResults": 1000,
+                  "includeExecutionData": False}
+        if next_token:
+            kwargs["nextToken"] = next_token
+        resp = sfn.get_execution_history(**kwargs)
+        for ev in resp.get("events", []):
+            etype = ev.get("type", "")
+            ts = ev.get("timestamp")
+            if etype.endswith("StateEntered"):
+                name = ev.get("stateEnteredEventDetails", {}).get("name")
+                if name:
+                    if name not in entered:
+                        order.append(name)
+                    entered[name] = ts
+            elif etype.endswith("StateExited"):
+                name = ev.get("stateExitedEventDetails", {}).get("name")
+                if name:
+                    exited[name] = ts
+            elif etype == "ExecutionFailed":
+                d = ev.get("executionFailedEventDetails", {})
+                failure = {"error": d.get("error"), "cause": d.get("cause")}
+        next_token = resp.get("nextToken")
+        if not next_token:
+            break
+
+    per_state = []
+    for name in order:
+        passed = name in exited
+        dur = None
+        if passed and entered.get(name) and exited.get(name):
+            dur = round((exited[name] - entered[name]).total_seconds(), 1)
+        per_state.append({
+            "name": name,
+            "status": "PASS" if passed else "FAIL",
+            "duration_s": dur,
+        })
+    return per_state, failure
+
+
+def _publish_summary(report: dict) -> None:
+    s = report["summary"]
+    failed = [p["name"] for p in report["per_state"] if p["status"] == "FAIL"]
+    lines = [
+        f"Friday shell-run preflight — {report['execution_status']}",
+        f"trading_day {report['trading_day']} | readiness {s['readiness']}",
+        f"states: {s['passed']} pass / {s['failed']} fail of {s['n_states']}",
+    ]
+    if failed:
+        lines.append("FAILED states: " + ", ".join(failed))
+    if report.get("failure"):
+        lines.append(f"cause: {report['failure'].get('error')}")
+    lines.append(f"report: s3://{S3_BUCKET}/{report['report_key']}")
+    boto3.client("sns", region_name=REGION).publish(
+        TopicArn=SNS_TOPIC_ARN,
+        Subject=f"Saturday Preflight Report — {s['readiness']} ({report['trading_day']})"[:100],
+        Message="\n".join(lines),
+    )
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    detail = event.get("detail") or {}
+    sm_name = detail.get("stateMachineArn", "").rsplit(":", 1)[-1]
+    status = detail.get("status", "")
+    if sm_name != SATURDAY_SF_NAME or status not in _TERMINAL:
+        logger.info("ignored event: sm=%s status=%s", sm_name, status)
+        return {"reported": False, "reason": "wrong_event"}
+
+    name = detail.get("name", "")
+    if not _is_shell_run(detail.get("input", ""), name):
+        logger.info("saturday execution %s is not a shell-run — no report", name)
+        return {"reported": False, "reason": "not_shell_run"}
+
+    execution_arn = detail["executionArn"]
+    trading_day = _trading_day(name, detail.get("stopDate"))
+    per_state, failure = _summarize_history(execution_arn)
+    n_pass = sum(1 for p in per_state if p["status"] == "PASS")
+    n_fail = sum(1 for p in per_state if p["status"] == "FAIL")
+    readiness = "GO_SATURDAY" if (status == "SUCCEEDED" and n_fail == 0) else "HOLD_INVESTIGATE"
+
+    report = {
+        "trading_day": trading_day,
+        "execution_arn": execution_arn,
+        "execution_name": name,
+        "execution_status": status,
+        "summary": {
+            "n_states": len(per_state),
+            "passed": n_pass,
+            "failed": n_fail,
+            "readiness": readiness,
+        },
+        "per_state": per_state,
+        "failure": failure,
+    }
+    report_key = f"{REPORT_PREFIX}/{trading_day}/report.json"
+    report["report_key"] = report_key
+
+    boto3.client("s3", region_name=REGION).put_object(
+        Bucket=S3_BUCKET, Key=report_key,
+        Body=json.dumps(report, indent=2).encode(), ContentType="application/json",
+    )
+    _publish_summary(report)
+    logger.info(
+        "shell-run report written: %s readiness=%s (%d/%d states pass)",
+        report_key, readiness, n_pass, len(per_state),
+    )
+    return {"reported": True, "report_key": report_key, "readiness": readiness}

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -1,0 +1,5 @@
+# Only alpha_engine_lib.trading_calendar.last_closed_trading_day is used (the
+# trading_day fallback when an execution name lacks the friday-shell-{date}
+# prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
+# so the two Friday-shell-run Lambdas share one lib-date substrate.
+alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0

--- a/infrastructure/lambdas/friday-shell-run-report/test_handler.py
+++ b/infrastructure/lambdas/friday-shell-run-report/test_handler.py
@@ -1,0 +1,132 @@
+"""Unit tests for the friday-shell-run-report handler.
+
+The lib (``alpha_engine_lib.trading_calendar``) and boto3 are stubbed so tests
+do not hit AWS or require the lib install. The handler resolves trading_day from
+the execution NAME in the happy path, so the lib stub is only the fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub alpha_engine_lib.trading_calendar before importing the handler.
+_ael = types.ModuleType("alpha_engine_lib")
+_tc = types.ModuleType("alpha_engine_lib.trading_calendar")
+_tc.last_closed_trading_day = lambda dt: dt.date()  # fallback only
+_ael.trading_calendar = _tc
+sys.modules.setdefault("alpha_engine_lib", _ael)
+sys.modules.setdefault("alpha_engine_lib.trading_calendar", _tc)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+SAT_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
+_EXEC_ARN = "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:friday-shell-2026-06-12-eodname"
+
+
+def _ts(sec: int) -> datetime:
+    return datetime(2026, 6, 12, 14, 30, sec, tzinfo=timezone.utc)
+
+
+def _entered(name, sec):
+    return {"type": "TaskStateEntered", "timestamp": _ts(sec),
+            "stateEnteredEventDetails": {"name": name}}
+
+
+def _exited(name, sec):
+    return {"type": "TaskStateExited", "timestamp": _ts(sec),
+            "stateExitedEventDetails": {"name": name}}
+
+
+def _event(status="SUCCEEDED", name="friday-shell-2026-06-12-eodname",
+           sm_arn=SAT_ARN, shell_run=True):
+    inp = json.dumps({"shell_run": True, "pipeline_role": "shell-run"}) if shell_run else "{}"
+    return {
+        "detail": {
+            "status": status, "stateMachineArn": sm_arn, "executionArn": _EXEC_ARN,
+            "name": name, "input": inp, "stopDate": 1781015400000,
+        }
+    }
+
+
+def _fake_clients(history_events):
+    """Return a boto3.client side_effect dispatching by service name."""
+    sfn = MagicMock()
+    sfn.get_execution_history.return_value = {"events": history_events}  # no nextToken
+    s3 = MagicMock()
+    sns = MagicMock()
+    clients = {"stepfunctions": sfn, "s3": s3, "sns": sns}
+    return lambda svc, **kw: clients[svc], s3, sns
+
+
+def test_successful_shell_run_writes_go_saturday_report():
+    history = [
+        _entered("MorningEnrich", 0), _exited("MorningEnrich", 5),
+        _entered("DataPhase1", 5), _exited("DataPhase1", 20),
+    ]
+    side, s3, sns = _fake_clients(history)
+    with patch("index.boto3.client", side_effect=side):
+        out = index.handler(_event("SUCCEEDED"), None)
+
+    assert out["reported"] is True
+    assert out["readiness"] == "GO_SATURDAY"
+    # report.json written to the trading_day-keyed prefix
+    put = s3.put_object.call_args.kwargs
+    assert put["Key"] == "friday-shell-run/2026-06-12/report.json"
+    body = json.loads(put["Body"])
+    assert body["summary"] == {"n_states": 2, "passed": 2, "failed": 0,
+                               "readiness": "GO_SATURDAY"}
+    assert {p["name"] for p in body["per_state"]} == {"MorningEnrich", "DataPhase1"}
+    assert all(p["status"] == "PASS" for p in body["per_state"])
+    sns.publish.assert_called_once()
+
+
+def test_failed_shell_run_flags_hold_and_names_failing_state():
+    # DataPhase1 entered but never exited → the failure point.
+    history = [
+        _entered("MorningEnrich", 0), _exited("MorningEnrich", 5),
+        _entered("DataPhase1", 5),
+        {"type": "ExecutionFailed", "timestamp": _ts(30),
+         "executionFailedEventDetails": {"error": "States.TaskFailed", "cause": "boom"}},
+    ]
+    side, s3, sns = _fake_clients(history)
+    with patch("index.boto3.client", side_effect=side):
+        out = index.handler(_event("FAILED"), None)
+
+    assert out["readiness"] == "HOLD_INVESTIGATE"
+    body = json.loads(s3.put_object.call_args.kwargs["Body"])
+    failing = [p["name"] for p in body["per_state"] if p["status"] == "FAIL"]
+    assert failing == ["DataPhase1"]
+    assert body["failure"]["error"] == "States.TaskFailed"
+
+
+def test_non_shell_run_is_a_noop():
+    side, s3, sns = _fake_clients([])
+    with patch("index.boto3.client", side_effect=side):
+        out = index.handler(_event("SUCCEEDED", name="weekly-run", shell_run=False), None)
+    assert out == {"reported": False, "reason": "not_shell_run"}
+    s3.put_object.assert_not_called()
+
+
+def test_wrong_state_machine_ignored():
+    side, s3, _ = _fake_clients([])
+    bad = _event("SUCCEEDED", sm_arn="arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline")
+    with patch("index.boto3.client", side_effect=side):
+        out = index.handler(bad, None)
+    assert out["reported"] is False and out["reason"] == "wrong_event"
+    s3.put_object.assert_not_called()
+
+
+def test_non_terminal_status_ignored():
+    side, s3, _ = _fake_clients([])
+    with patch("index.boto3.client", side_effect=side):
+        out = index.handler(_event("RUNNING"), None)
+    assert out["reported"] is False
+    s3.put_object.assert_not_called()


### PR DESCRIPTION
## What

Closes the **one remaining gap of L658** (Friday shell-run): the *consolidated per-state pass/fail report* the SF spine explicitly deferred — `CheckShellRunNotify`'s comment in `step_function.json` says *"the consolidated per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on."*

The shell-run orchestration itself — the `CheckShellRun` spine, the `eod-success-friday-shell-trigger` Lambda, all 8 spot `--preflight-only` + 10 Lambda dry-paths — **already shipped ~2026-05-29** (the ROADMAP entry calling it "PLANNED, not yet built" is stale and is reconciled in the config PR). Only the report artifact was missing.

## How

New `infrastructure/lambdas/friday-shell-run-report/` (mirrors the sibling `eod-success-friday-shell-trigger` package — `index.py` / `deploy.sh --bootstrap` / `iam-policy.json` / `test_handler.py` / `requirements.txt` / `README.md`):

- **EventBridge rule** on `alpha-engine-saturday-pipeline` **terminal** transitions (`SUCCEEDED`/`FAILED`/`TIMED_OUT`/`ABORTED`) — covers both outcomes with **zero SF-JSON surgery** (vs. wiring a new state into both success + failure paths).
- **Handler** no-ops on real Saturday runs; for shell-run executions (`shell_run: true` / `pipeline_role: "shell-run"`) it reads `states:GetExecutionHistory`, reduces to per-state `{name, PASS/FAIL, duration_s}` (a state entered-but-never-exited = the failure point), computes `GO_SATURDAY`/`HOLD_INVESTIGATE` readiness, writes `s3://alpha-engine-research/friday-shell-run/{trading_day}/report.json` + a structured per-state SNS summary.
- `trading_day` parsed from the execution name (`friday-shell-{date}-…`), `last_closed_trading_day` fallback.
- **Fail-loud**: GetExecutionHistory / S3 / SNS errors raise (the report IS the deliverable); non-shell-run / wrong-SM / non-terminal = structured skip.

## Notes
- **Additive** — new EventBridge rule + Lambda, operator-deployed outside CFN (same as the sibling, to keep the OIDC deploy role's blast radius narrow). No change to the shell-run spine.
- **Not** added to `ARTIFACT_REGISTRY.yaml` — shell-run artifacts are explicitly out of freshness-monitor scope.
- +5 handler tests; full data suite **1846 passed** (lambda dir isn't in `testpaths`, so its lib-stub can't pollute the main suite).
- Deploy after merge: `bash infrastructure/lambdas/friday-shell-run-report/deploy.sh --bootstrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)