### PR TITLE
docs: reposition README tagline to the harness framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alpha-engine-data
 
-> Part of [**Nous Ergon**](https://nousergon.ai) — Autonomous Multi-Agent Trading System. Repo and S3 names use the underlying project name `alpha-engine`.
+> Part of [**Nous Ergon**](https://nousergon.ai) — a harness for rigorous AI/ML experiments in finance: an equity research-and-trading system instrumented end-to-end. Repo and S3 names use the underlying project name `alpha-engine`.
 
 [![Part of Nous Ergon](https://img.shields.io/badge/Part_of-Nous_Ergon-1a73e8?style=flat-square)](https://nousergon.ai)
 [![Python](https://img.shields.io/badge/python-3.13+-blue?style=flat-square)](https://www.python.org/)


### PR DESCRIPTION
Reposition the README tagline from the retired "Autonomous Multi-Agent Trading System" framing to the current harness-of-experiments positioning that nousergon.ai already carries ("A harness for rigorous AI/ML experiments in finance").

Drops the "autonomous" identity claim per the public-copy claims-discipline rule; eval-led, finance-specific positioning. Tagline-only change (one line). Part of propagating the website repositioning to all public surfaces (ROADMAP L4570).

🤖 Generated with [Claude Code](https://claude.com/claude-code)