### PR TITLE
fix(ci): unblock Flow Doctor fix workflow (strict ${VAR} resolution)

### DIFF
--- a/.github/workflows/flow-doctor-fix.yml
+++ b/.github/workflows/flow-doctor-fix.yml
@@ -41,6 +41,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # flow-doctor's load_config strictly resolves EVERY ${VAR} in
+          # flow-doctor.yaml at load time, including the email-notify block —
+          # which the fix CLI never uses (it comments via the --token arg and
+          # reads diagnosis.api_key/ANTHROPIC_API_KEY). On EC2 those vars come
+          # from the box env; in CI they're absent, so the run died with
+          # "ConfigError: Unresolved environment variable(s): EMAIL_SENDER".
+          # Empty values satisfy resolution (os.environ.get -> "" != None).
+          # BRIDGE: remove once flow-doctor rc3 (fix CLI loads config with
+          # allow_unresolved) propagates via the alpha-engine-lib re-pin.
+          FLOW_DOCTOR_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EMAIL_SENDER: ""
+          EMAIL_RECIPIENTS: ""
+          GMAIL_APP_PASSWORD: ""
         run: |
           python -m flow_doctor.fix.cli generate-fix \
             --issue-number ${{ github.event.issue.number }} \


### PR DESCRIPTION
## Why (the failure you flagged on #391)

The **Flow Doctor Fix** workflow has **never succeeded** — 6 failures / 0 successes since #381 armed the 0.6.0rc2 soak. Every run dies before doing any work:

```
flow_doctor.core.errors.ConfigError: Unresolved environment variable(s)
in flow-doctor config: EMAIL_SENDER.
```

`flow_doctor.fix.cli generate-fix` calls `load_config()`, which **strictly resolves every `${VAR}`** in `flow-doctor.yaml` at load time — including the `notify:` email block (`${EMAIL_SENDER}`, `${EMAIL_RECIPIENTS}`, `${GMAIL_APP_PASSWORD}`) and `${FLOW_DOCTOR_GITHUB_TOKEN}`. The fix CLI **never uses any of them** (it comments via the `--token` arg and reads `ANTHROPIC_API_KEY`). Those vars exist on the EC2 collector runtime (box env) but not in GitHub Actions, where the repo's only secret is `ANTHROPIC_API_KEY`.

## What

Provide the missing vars in the `Generate fix` step. Empty values satisfy resolution (`os.environ.get` returns `""`, not `None`), and `FLOW_DOCTOR_GITHUB_TOKEN` reuses the workflow `GITHUB_TOKEN`. This unblocks the soak immediately with the currently-pinned flow-doctor 0.6.0rc2.

Marked as a **BRIDGE** — to be removed once the proper upstream fix (flow-doctor: the fix CLI loads config with `allow_unresolved` so unused notifier vars don't block) lands and propagates via the `alpha-engine-lib` re-pin.

## Heads-up on what unblocking surfaces

The 3 issues this fires on (#391/#392/#393) are all `intrabar_inconsistent` (a Close printed outside its own bar's Low/High) — OHLC anomalies that are likely **vendor/data glitches**, not code bugs. Once unblocked, Haiku will open code-fix PR *proposals* (scope-guarded, test-gated, never auto-merged, ≤3/day, \$0.50/day cap) against `collectors/`/`validators/`. Worth a skim to judge whether auto-fix is useful for this issue class or whether it should be gated to code-bug categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)