### PR TITLE
chore: re-pin alpha-engine-lib v0.58.1 + drop flow-doctor fix-workflow bridge

### DIFF
--- a/.github/workflows/flow-doctor-fix.yml
+++ b/.github/workflows/flow-doctor-fix.yml
@@ -41,19 +41,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # flow-doctor's load_config strictly resolves EVERY ${VAR} in
-          # flow-doctor.yaml at load time, including the email-notify block —
-          # which the fix CLI never uses (it comments via the --token arg and
-          # reads diagnosis.api_key/ANTHROPIC_API_KEY). On EC2 those vars come
-          # from the box env; in CI they're absent, so the run died with
-          # "ConfigError: Unresolved environment variable(s): EMAIL_SENDER".
-          # Empty values satisfy resolution (os.environ.get -> "" != None).
-          # BRIDGE: remove once flow-doctor rc3 (fix CLI loads config with
-          # allow_unresolved) propagates via the alpha-engine-lib re-pin.
-          FLOW_DOCTOR_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EMAIL_SENDER: ""
-          EMAIL_RECIPIENTS: ""
-          GMAIL_APP_PASSWORD: ""
         run: |
           python -m flow_doctor.fix.cli generate-fix \
             --issue-number ${{ github.event.issue.number }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.0" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.1" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.0
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.1


### PR DESCRIPTION
## What

- Re-pin `alpha-engine-lib@v0.58.0` → `@v0.58.1` (which pins flow-doctor **0.6.0rc4**).
- Remove the env-var **bridge** from `.github/workflows/flow-doctor-fix.yml` (the `EMAIL_SENDER`/`EMAIL_RECIPIENTS`/`GMAIL_APP_PASSWORD`/`FLOW_DOCTOR_GITHUB_TOKEN` block added in #394).

## Why

rc4's fix CLI loads config with `skip_sections=("notify","github")` (cipher813/flow-doctor#30), so the unused notifier `${VAR}`s no longer abort the run — the bridge that satisfied strict resolution on rc2 is no longer needed. The `Generate fix` step is back to just `GITHUB_TOKEN` + `ANTHROPIC_API_KEY`.

Completes the propagation chain → **closes #395**. (CI here installs the lib at `v0.58.1`, exercising rc4 transitively.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)