### PR TITLE
fix(weekday-sf): split chronic-gap self-heal into its own fail-soft state (2026-06-11 SIGKILL)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -248,7 +248,7 @@
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/morning-enrich.log \"s3://alpha-engine-research/_ssm_logs/morning-enrich/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/morning-enrich.log",
-            "python weekly_collector.py --morning-enrich 2>&1 | tee -a /var/log/morning-enrich.log"
+            "python weekly_collector.py --morning-enrich --skip-chronic-heal 2>&1 | tee -a /var/log/morning-enrich.log"
           ],
           "executionTimeout": ["1800"]
         },
@@ -297,12 +297,12 @@
 
     "CheckMorningEnrichStatus": {
       "Type": "Choice",
-      "Comment": "Block predictor inference until polygon enrichment confirms the prior trading day's row is overwritten with authoritative VWAP. SSM Failed → HandleFailure (must not proceed to inference on uncorrected data per feedback_no_silent_fails).",
+      "Comment": "Block predictor inference until polygon enrichment confirms the prior trading day's row is overwritten with authoritative VWAP. SSM Failed → HandleFailure (must not proceed to inference on uncorrected data per feedback_no_silent_fails). Success → ChronicGapSelfHeal (best-effort, fail-soft) → PredictorInference; the chronic-gap heal was split out of MorningEnrich 2026-06-11 so a yfinance hang in it can never SIGKILL the load-bearing enrich.",
       "Choices": [
         {
           "Variable": "$.morning_enrich_poll.Status",
           "StringEquals": "Success",
-          "Next": "PredictorInference"
+          "Next": "ChronicGapSelfHeal"
         },
         {
           "Variable": "$.morning_enrich_poll.Status",
@@ -322,6 +322,104 @@
       "Type": "Wait",
       "Seconds": 15,
       "Next": "WaitForMorningEnrich"
+    },
+
+    "ChronicGapSelfHeal": {
+      "Type": "Task",
+      "Comment": "Best-effort chronic-polygon-gap yfinance self-heal (BF-B/BRK-B/MOG-A/PSTG — polygon doesn't reliably serve them) + polygon-recovery / constituents-drift alarms. SPLIT OUT of MorningEnrich 2026-06-11: inline, an unbounded yf.download hang ran out MorningEnrich's SSM executionTimeout and SIGKILLed the whole command, discarding ~20 min of completed daily_append and failing the weekday pipeline (no predictions that day). Per the standing rule (a best-effort downstream step must never force re-running a completed upstream task — same rule that split MorningEnrich out of DataPhase1), this runs as its OWN FAIL-SOFT state: short executionTimeout, and the Catch + CheckChronicGapStatus Default both route to PredictorInference so a heal failure/hang can never block the trading path. Runs before PredictorInference so the healed chronic rows are fresh for inference; postflight remains the load-bearing freshness gate.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-data",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/chronic-gap-heal.log \"s3://alpha-engine-research/_ssm_logs/chronic-gap-heal/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
+            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/chronic-gap-heal.log",
+            "python weekly_collector.py --chronic-gap-heal 2>&1 | tee -a /var/log/chronic-gap-heal.log"
+          ],
+          "executionTimeout": [
+            "300"
+          ]
+        },
+        "TimeoutSeconds": 300
+      },
+      "TimeoutSeconds": 360,
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-soft — a chronic-gap heal failure (incl. the SSM-timeout SIGKILL it used to cause) must never block predictions. Proceed to PredictorInference.",
+          "Next": "PredictorInference",
+          "ResultPath": "$.chronic_gap_error"
+        }
+      ],
+      "ResultPath": "$.chronic_gap_result",
+      "Next": "WaitForChronicGap"
+    },
+
+    "WaitForChronicGap": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.chronic_gap_result.Command.CommandId",
+        "InstanceId.$": "$.trading_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-soft — a poll failure proceeds to PredictorInference, no heal that day.",
+          "Next": "PredictorInference",
+          "ResultPath": "$.chronic_gap_error"
+        }
+      ],
+      "ResultPath": "$.chronic_gap_poll",
+      "Next": "CheckChronicGapStatus"
+    },
+
+    "CheckChronicGapStatus": {
+      "Type": "Choice",
+      "Comment": "Chronic-gap heal is fail-soft: any TERMINAL status (Success OR failure OR timeout) proceeds to PredictorInference; only keep polling while InProgress/Pending. This is the inverse of CheckMorningEnrichStatus (which HandleFailures on non-success) — MorningEnrich is load-bearing, this best-effort heal is not.",
+      "Choices": [
+        {
+          "Variable": "$.chronic_gap_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "ChronicGapWait"
+        },
+        {
+          "Variable": "$.chronic_gap_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "ChronicGapWait"
+        }
+      ],
+      "Default": "PredictorInference"
+    },
+
+    "ChronicGapWait": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "WaitForChronicGap"
     },
 
     "TradingDayCheckWait": {

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -1,0 +1,198 @@
+"""Pins the ChronicGapSelfHeal fail-soft split in the WEEKDAY SF.
+
+Origin: 2026-06-11 — the weekday pipeline FAILED. The chronic-polygon-gap
+self-heal ran INLINE at the tail of MorningEnrich (``weekly_collector.py
+--morning-enrich``). It is best-effort by design, but inline it could not
+honour that: an unbounded ``yf.download`` hang ran out MorningEnrich's SSM
+``executionTimeout`` and SIGKILLed (137) the whole command — AFTER the
+load-bearing ``daily_append`` had already completed (~20 min of work). The
+SF saw MorningEnrich ``Failed`` → ``HandleFailure`` → the weekday pipeline
+failed with no predictions / planner / daemon that day.
+
+The fix (per the standing rule — a best-effort downstream step must never
+force re-running a completed upstream task; the same rule that split
+MorningEnrich out of DataPhase1) moves the heal into its OWN fail-soft SF
+state, ``ChronicGapSelfHeal``, that runs AFTER MorningEnrich and routes to
+PredictorInference on EVERY terminal outcome (success, failure, timeout).
+
+This test catches regressions like:
+- Someone reroutes CheckMorningEnrichStatus(Success) straight back to
+  PredictorInference, dropping the ChronicGapSelfHeal state.
+- Someone makes ChronicGapSelfHeal (or its poll) fatal by routing a
+  failure to HandleFailure instead of PredictorInference.
+- Someone drops ``--skip-chronic-heal`` from the weekday MorningEnrich
+  command, re-introducing the inline (un-isolated) heal.
+- Someone points the heal state at the wrong entrypoint.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.sf_command_utils import extract_commands
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
+
+_HEAL = "ChronicGapSelfHeal"
+_POLL = "WaitForChronicGap"
+_CHECK = "CheckChronicGapStatus"
+_WAIT = "ChronicGapWait"
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    return sf["States"]
+
+
+class TestStatePresence:
+    @pytest.mark.parametrize("name", [_HEAL, _POLL, _CHECK, _WAIT])
+    def test_state_exists(self, states, name):
+        assert name in states, f"{name} missing from weekday SF States"
+
+
+class TestChainOrdering:
+    """CheckMorningEnrichStatus(Success) → ChronicGapSelfHeal →
+    WaitForChronicGap → CheckChronicGapStatus(terminal) → PredictorInference."""
+
+    def test_morning_enrich_success_routes_to_heal(self, states):
+        success = [
+            c["Next"]
+            for c in states["CheckMorningEnrichStatus"]["Choices"]
+            if c.get("StringEquals") == "Success"
+        ]
+        assert success == [_HEAL], (
+            "MorningEnrich success must hand off to ChronicGapSelfHeal — the "
+            "heal runs AFTER a completed (load-bearing) MorningEnrich."
+        )
+
+    def test_heal_routes_to_poll(self, states):
+        assert states[_HEAL]["Next"] == _POLL
+
+    def test_poll_routes_to_status_check(self, states):
+        assert states[_POLL]["Next"] == _CHECK
+
+    def test_status_inprogress_and_pending_loop_via_wait(self, states):
+        nexts = {
+            c["StringEquals"]: c["Next"]
+            for c in states[_CHECK]["Choices"]
+        }
+        assert nexts["InProgress"] == _WAIT
+        assert nexts["Pending"] == _WAIT
+        assert states[_WAIT]["Next"] == _POLL
+
+    def test_heal_precedes_predictor_inference(self, sf, states):
+        """Walk the happy path from MorningEnrich success and assert
+        ChronicGapSelfHeal is visited strictly before PredictorInference."""
+        order: list[str] = []
+        seen: set[str] = set()
+        cur = _HEAL
+        while cur and cur in states and cur not in seen:
+            seen.add(cur)
+            order.append(cur)
+            st = states[cur]
+            if st.get("Type") == "Choice":
+                # Status check: only InProgress/Pending loop; the terminal
+                # path is the Default (= proceed to PredictorInference).
+                cur = st.get("Default")
+            else:
+                cur = st.get("Next")
+            if cur == "PredictorInference":
+                order.append(cur)
+                break
+        assert _HEAL in order, order
+        assert "PredictorInference" in order, order
+        assert order.index(_HEAL) < order.index("PredictorInference"), order
+
+
+class TestFailSoft:
+    """A heal failure / hang / timeout must NEVER fail the pipeline — every
+    terminal edge routes to PredictorInference, never HandleFailure."""
+
+    def test_check_default_is_predictor_inference_not_handlefailure(self, states):
+        # Inverse of CheckMorningEnrichStatus, whose Default is HandleFailure.
+        assert states[_CHECK]["Default"] == "PredictorInference", (
+            "Chronic-gap heal is best-effort: any terminal status (incl. "
+            "failure) must proceed to PredictorInference, not HandleFailure."
+        )
+
+    def test_heal_catch_routes_to_predictor_inference(self, states):
+        catches = states[_HEAL].get("Catch", [])
+        assert catches, f"{_HEAL} must have a fail-soft Catch"
+        for c in catches:
+            assert c["Next"] == "PredictorInference", (
+                f"{_HEAL} Catch must route to PredictorInference (fail-soft), "
+                f"got {c['Next']}"
+            )
+
+    def test_poll_catch_routes_to_predictor_inference(self, states):
+        catches = states[_POLL].get("Catch", [])
+        assert catches, f"{_POLL} must have a fail-soft Catch"
+        for c in catches:
+            assert c["Next"] == "PredictorInference"
+
+    def test_no_heal_state_routes_to_handlefailure(self, states):
+        """No Next/Default/Catch target across the heal quartet may be
+        HandleFailure (checks routing edges, not comment text)."""
+        def _targets(o):
+            out = []
+            if isinstance(o, dict):
+                for k, v in o.items():
+                    if k in ("Next", "Default") and isinstance(v, str):
+                        out.append(v)
+                    else:
+                        out.extend(_targets(v))
+            elif isinstance(o, list):
+                for x in o:
+                    out.extend(_targets(x))
+            return out
+
+        for name in (_HEAL, _POLL, _CHECK, _WAIT):
+            targets = _targets(states[name])
+            assert "HandleFailure" not in targets, (
+                f"{name} routes to HandleFailure {targets} — the heal is fail-soft."
+            )
+
+
+class TestSsmCommandShape:
+    def test_heal_invokes_chronic_gap_heal_entrypoint(self, states):
+        cmds = extract_commands(states[_HEAL])
+        joined = "\n".join(cmds)
+        assert "weekly_collector.py --chronic-gap-heal" in joined, (
+            "ChronicGapSelfHeal must invoke the standalone --chronic-gap-heal "
+            f"entrypoint. Commands:\n{joined}"
+        )
+
+    def test_heal_has_pipefail_and_deployed_exports(self, states):
+        cmds = extract_commands(states[_HEAL])
+        assert cmds[0] == "set -eo pipefail"
+        joined = "\n".join(cmds)
+        assert "export FLOW_DOCTOR_ENABLED=1" in joined
+        assert "export ALPHA_ENGINE_DEPLOYED=1" in joined
+
+    def test_heal_has_bounded_execution_timeout(self, states):
+        et = states[_HEAL]["Parameters"]["Parameters"]["executionTimeout"]
+        # SSM executionTimeout is a single-element string list.
+        secs = int(et[0]) if isinstance(et, list) else int(et)
+        assert 0 < secs <= 600, (
+            "The heal state must carry a short, bounded SSM executionTimeout so "
+            "a hang is capped in its OWN state (not MorningEnrich's). "
+            f"got {secs}s"
+        )
+
+    def test_weekday_morning_enrich_skips_inline_heal(self, states):
+        cmds = extract_commands(states["MorningEnrich"])
+        joined = "\n".join(cmds)
+        assert "--morning-enrich --skip-chronic-heal" in joined, (
+            "The weekday MorningEnrich must pass --skip-chronic-heal so the "
+            "inline heal is not double-run alongside the ChronicGapSelfHeal "
+            "state (and MorningEnrich stays fully isolated from the heal)."
+        )

--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -692,3 +692,79 @@ def test_morning_enrich_dry_run_skips_preflight_writes():
 
     fake_constituents.collect.assert_not_called()
     assert prune_called == []
+
+
+# ── chronic-gap heal split (2026-06-11) ─────────────────────────────────────
+
+
+def test_chronic_gap_heal_routes_via_run_weekly():
+    """run_weekly must dispatch --chronic-gap-heal to _run_chronic_gap_heal."""
+    args = SimpleNamespace(
+        morning_enrich=False, chronic_gap_heal=True, daily=False,
+    )
+    with patch("weekly_collector._run_chronic_gap_heal",
+               return_value={"status": "ok", "mode": "chronic_gap_heal"}) as heal:
+        out = weekly_collector.run_weekly({"bucket": "b"}, args)
+    heal.assert_called_once()
+    assert out["mode"] == "chronic_gap_heal"
+
+
+def test_morning_enrich_skip_chronic_heal_does_not_run_inline_heal():
+    """--skip-chronic-heal (the weekday SF path) suppresses the inline heal —
+    the separate ChronicGapSelfHeal SF state runs it instead."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(
+        date="2026-04-22", dry_run=True, morning_enrich=True,
+        skip_chronic_heal=True,
+    )
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok_dry_run", "polygon": 1, "fred": 0,
+                             "yfinance": 0, "tickers_captured": 1,
+                             "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append", return_value={"status": "ok"}), \
+         patch("weekly_collector._run_chronic_gap_heal") as heal:
+        result = weekly_collector._run_morning_enrich(config, args)
+
+    heal.assert_not_called()
+    assert result["status"] == "ok"
+
+
+def test_morning_enrich_runs_inline_heal_without_skip_flag():
+    """Without --skip-chronic-heal (the Saturday SF path), the inline heal
+    still runs before DataPhase1's postflight."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(
+        date="2026-04-22", dry_run=True, morning_enrich=True,
+        skip_chronic_heal=False,
+    )
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok_dry_run", "polygon": 1, "fred": 0,
+                             "yfinance": 0, "tickers_captured": 1,
+                             "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append", return_value={"status": "ok"}), \
+         patch("weekly_collector._run_chronic_gap_heal",
+               return_value={"status": "ok", "collectors": {}}) as heal:
+        weekly_collector._run_morning_enrich(config, args)
+
+    heal.assert_called_once()
+
+
+def test_run_chronic_gap_heal_never_raises_on_load_failure():
+    """The standalone heal must return status=ok (best-effort) even when an
+    inner call raises — it must exit 0 so the SF state is non-fatal."""
+    config = {"bucket": "test-bucket"}
+    args = SimpleNamespace(date="2026-04-22", dry_run=True)
+    with patch("weekly_collector._load_chronic_polygon_gaps",
+               side_effect=RuntimeError("boom")):
+        out = weekly_collector._run_chronic_gap_heal(config, args)
+    assert out["status"] == "ok"
+    assert out["mode"] == "chronic_gap_heal"
+    assert out["collectors"]["chronic_gap_heal_wrapper"]["status"] == "error"

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -220,6 +220,9 @@ def run_weekly(config: dict, args: argparse.Namespace) -> dict:
     if getattr(args, "morning_enrich", False):
         return _run_morning_enrich(config, args)
 
+    if getattr(args, "chronic_gap_heal", False):
+        return _run_chronic_gap_heal(config, args)
+
     if args.daily:
         return _run_daily(config, args)
 
@@ -916,6 +919,12 @@ def _self_heal_chronic_polygon_gaps(
                 end=end_excl.strftime("%Y-%m-%d"),
                 progress=False,
                 auto_adjust=True,
+                # Bound the network call so a hung yfinance fetch can't stall
+                # the heal indefinitely. The 2026-06-11 incident was an
+                # unbounded yf.download here; the SF state isolation is the
+                # primary fix, this is defence-in-depth so a single ticker's
+                # stall is capped rather than eating the whole state timeout.
+                timeout=30,
             )
             if isinstance(yf_df.columns, _pd.MultiIndex):
                 yf_df.columns = yf_df.columns.get_level_values(0)
@@ -1213,98 +1222,29 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
         results["collectors"]["arcticdb"] = {"status": "error", "error": str(e)}
 
     # ── Chronic-polygon-gap self-heal ────────────────────────────────────────
-    # Yfinance-backfills any ArcticDB universe row gap for the chronic-gap
-    # tickers (BF-B/BRK-B/MOG-A/PSTG by default — see config). Polygon does
-    # not reliably serve these, so the polygon_only daily_append above leaves
-    # them at whatever the prior EOD yfinance pass landed; on days when EOD
-    # also dropped them, the row gap compounds and postflight catches them
-    # as stale. This step closes that loop without weakening polygon_only's
-    # "no silent fails" stance for the other ~900 tickers.
+    # The chronic-gap drift-detection + yfinance self-heal logic lives in
+    # ``_run_chronic_gap_heal`` (shared). It heals BF-B/BRK-B/MOG-A/PSTG row
+    # gaps (polygon doesn't reliably serve them) before downstream consumers
+    # read ArcticDB.
     #
-    # Best-effort: a yfinance hiccup on one chronic ticker logs + records in
-    # the result but does not halt the morning enrich. Postflight remains
-    # the load-bearing gate on freshness — if a chronic ticker is still
-    # stale after this step, postflight surfaces it.
-    chronic_tickers = _load_chronic_polygon_gaps(config)
-    if chronic_tickers:
-        # Drift alarm: detect polygon recovery for chronic tickers (BEFORE
-        # self-heal so the signal is a clean read of what polygon shipped
-        # today, not contaminated by our yfinance backfill). Best-effort,
-        # observability only — never raises.
-        try:
-            drift_result = _detect_chronic_gap_polygon_recovery(
-                bucket=bucket,
-                target_date=target_date,
-                chronic_tickers=chronic_tickers,
-                daily_closes_prefix=daily_cfg.get("s3_prefix", "staging/daily_closes/"),
-            )
-            results["collectors"]["chronic_gap_drift_detection"] = drift_result
-        except Exception as e:
-            logger.warning("Chronic-gap drift detection failed (non-blocking): %s", e)
-            results["collectors"]["chronic_gap_drift_detection"] = {
-                "status": "skipped",
-                "error": str(e),
-            }
-
-        # Drift GATE: filter out chronic tickers that have dropped out of
-        # the current constituents set. The heal path ends in
-        # ``backfill(ticker_filter=...)``, which hard-errs against the
-        # constituents filter for non-constituents (2026-05-27 PSTG
-        # flow-doctor alert origin). Filtering here closes the loop so a
-        # config that lags a constituents change becomes a WARN + skip
-        # instead of a hard ERROR. Best-effort — a read failure falls
-        # through with the original list and the existing backfill-side
-        # error remains the load-bearing surface.
-        try:
-            cdrift_result = _detect_chronic_gap_constituents_drift(
-                bucket=bucket,
-                chronic_tickers=chronic_tickers,
-            )
-            results["collectors"]["chronic_gap_constituents_drift"] = cdrift_result
-            chronic_tickers = cdrift_result["still_constituents"]
-        except Exception as e:
-            logger.warning("Chronic-gap constituents drift check failed (non-blocking): %s", e)
-            results["collectors"]["chronic_gap_constituents_drift"] = {
-                "status": "skipped",
-                "error": str(e),
-            }
-
-        logger.info("=" * 60)
-        logger.info(
-            "SELF-HEAL: chronic polygon coverage gaps (%d ticker(s): %s)",
-            len(chronic_tickers), ", ".join(chronic_tickers),
-        )
-        logger.info("=" * 60)
-        try:
-            with _maybe_phase(reg, "morning_self_heal"):
-                heal_result = _self_heal_chronic_polygon_gaps(
-                    bucket=bucket,
-                    target_date=target_date,
-                    chronic_tickers=chronic_tickers,
-                    dry_run=dry_run,
-                )
-            # Always "ok" by design — chronic-gap self-heal is best-effort.
-            # Postflight is the load-bearing gate; if a chronic ticker is
-            # still stale after this step, postflight raises. Marking it
-            # "partial" on per-ticker yfinance failures would halt
-            # MorningEnrich on a transient yfinance hiccup, which would
-            # block the entire weekly pipeline for ~5 ms of yfinance flake.
-            results["collectors"]["chronic_gap_self_heal"] = {
-                "status": "ok",
-                **heal_result,
-            }
-            logger.info(
-                "chronic-gap self-heal: %d healed, %d already-fresh, %d errors",
-                len(heal_result["healed"]),
-                len(heal_result["skipped_already_fresh"]),
-                len(heal_result["errors"]),
-            )
-        except Exception as e:
-            logger.exception("Chronic-gap self-heal step failed for %s", target_date)
-            results["collectors"]["chronic_gap_self_heal"] = {
-                "status": "error",
-                "error": str(e),
-            }
+    # ``--skip-chronic-heal`` decouples it from MorningEnrich on the WEEKDAY
+    # pipeline, where it runs as its own fail-soft SF state (``ChronicGapSelfHeal``)
+    # AFTER MorningEnrich. Origin: 2026-06-11 — an unbounded ``yf.download`` hang
+    # in the inline heal ran out MorningEnrich's SSM ``executionTimeout`` and
+    # SIGKILLed the whole command, discarding ~20 min of completed daily_append
+    # and failing the weekday pipeline. Splitting it (per the standing rule: a
+    # best-effort downstream step must never force re-running a completed
+    # upstream task) means a heal hang can no longer touch the load-bearing
+    # data write.
+    #
+    # The SATURDAY pipeline still runs the heal INLINE here (no skip flag): it
+    # must precede DataPhase1's postflight, whose freshness gate is the heal's
+    # origin (2026-05-09 stale-PSTG failure). The ``yf.download(timeout=30)``
+    # bound now caps the hang that the inline path can't otherwise isolate;
+    # splitting Saturday's heal into its own state too is a tracked follow-up.
+    if not getattr(args, "skip_chronic_heal", False):
+        heal = _run_chronic_gap_heal(config, args)
+        results["collectors"].update(heal.get("collectors", {}))
 
     results["completed_at"] = datetime.now(timezone.utc).isoformat()
     statuses = [r.get("status", "unknown") for r in results["collectors"].values()]
@@ -1372,6 +1312,149 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
         ", ".join(f"{k}={v.get('status', '?')}" for k, v in results["collectors"].items()),
         duration,
     )
+    return results
+
+
+def _run_chronic_gap_heal(config: dict, args: argparse.Namespace) -> dict:
+    """Best-effort chronic-polygon-gap drift detection + yfinance self-heal.
+
+    Split out of :func:`_run_morning_enrich` (2026-06-11) into its own
+    weekday-SF state (``ChronicGapSelfHeal``). Yfinance-backfills any ArcticDB
+    universe row gap for the chronic-gap tickers (BF-B/BRK-B/MOG-A/PSTG by
+    default — see config; polygon does not reliably serve them) and emits the
+    polygon-recovery + constituents-drift alarms.
+
+    Runs AFTER MorningEnrich's load-bearing daily_append, as a fail-soft SF
+    state, so an unbounded ``yf.download`` hang here (the 2026-06-11 SIGKILL
+    incident) can never run out MorningEnrich's SSM ``executionTimeout`` and
+    throw away completed daily_append work. The standing rule: a best-effort
+    downstream step must never force re-running a completed upstream task.
+
+    NEVER raises — the whole body is wrapped so that any unexpected failure
+    returns ``status="error"`` rather than propagating a non-zero exit that
+    the SF would (correctly, but pointlessly here) treat as a state failure.
+    The SF Catch makes a failed state non-fatal regardless; this is
+    defence-in-depth so the SSM command itself exits 0. Postflight remains the
+    load-bearing freshness gate — a still-stale chronic ticker surfaces there.
+    """
+    bucket = config["bucket"]
+    started_at = datetime.now(timezone.utc).isoformat()
+
+    # Mirror _run_morning_enrich's PT-aware target-date resolution so the heal
+    # targets the same trading day the enrich just wrote.
+    if args.date is None:
+        from zoneinfo import ZoneInfo
+        target_date = _previous_trading_day(
+            reference=datetime.now(ZoneInfo("America/Los_Angeles"))
+        )
+    else:
+        target_date = args.date
+
+    dry_run = args.dry_run
+    daily_cfg = config.get("daily_closes", {})
+    results: dict = {
+        "mode": "chronic_gap_heal",
+        "date": target_date,
+        "started_at": started_at,
+        "collectors": {},
+    }
+
+    try:
+        chronic_tickers = _load_chronic_polygon_gaps(config)
+        if not chronic_tickers:
+            logger.info("chronic-gap heal: no chronic_polygon_gaps configured — nothing to do.")
+            results["status"] = "ok"
+            results["completed_at"] = datetime.now(timezone.utc).isoformat()
+            return results
+
+        # Drift alarm: detect polygon recovery for chronic tickers (BEFORE
+        # self-heal so the signal is a clean read of what polygon shipped
+        # today, not contaminated by our yfinance backfill). Best-effort,
+        # observability only — never raises.
+        try:
+            drift_result = _detect_chronic_gap_polygon_recovery(
+                bucket=bucket,
+                target_date=target_date,
+                chronic_tickers=chronic_tickers,
+                daily_closes_prefix=daily_cfg.get("s3_prefix", "staging/daily_closes/"),
+            )
+            results["collectors"]["chronic_gap_drift_detection"] = drift_result
+        except Exception as e:
+            logger.warning("Chronic-gap drift detection failed (non-blocking): %s", e)
+            results["collectors"]["chronic_gap_drift_detection"] = {
+                "status": "skipped",
+                "error": str(e),
+            }
+
+        # Drift GATE: filter out chronic tickers that have dropped out of
+        # the current constituents set. The heal path ends in
+        # ``backfill(ticker_filter=...)``, which hard-errs against the
+        # constituents filter for non-constituents (2026-05-27 PSTG
+        # flow-doctor alert origin). Filtering here closes the loop so a
+        # config that lags a constituents change becomes a WARN + skip
+        # instead of a hard ERROR. Best-effort — a read failure falls
+        # through with the original list and the existing backfill-side
+        # error remains the load-bearing surface.
+        try:
+            cdrift_result = _detect_chronic_gap_constituents_drift(
+                bucket=bucket,
+                chronic_tickers=chronic_tickers,
+            )
+            results["collectors"]["chronic_gap_constituents_drift"] = cdrift_result
+            chronic_tickers = cdrift_result["still_constituents"]
+        except Exception as e:
+            logger.warning("Chronic-gap constituents drift check failed (non-blocking): %s", e)
+            results["collectors"]["chronic_gap_constituents_drift"] = {
+                "status": "skipped",
+                "error": str(e),
+            }
+
+        logger.info("=" * 60)
+        logger.info(
+            "SELF-HEAL: chronic polygon coverage gaps (%d ticker(s): %s)",
+            len(chronic_tickers), ", ".join(chronic_tickers),
+        )
+        logger.info("=" * 60)
+        try:
+            heal_result = _self_heal_chronic_polygon_gaps(
+                bucket=bucket,
+                target_date=target_date,
+                chronic_tickers=chronic_tickers,
+                dry_run=dry_run,
+            )
+            # Always "ok" by design — chronic-gap self-heal is best-effort.
+            results["collectors"]["chronic_gap_self_heal"] = {
+                "status": "ok",
+                **heal_result,
+            }
+            logger.info(
+                "chronic-gap self-heal: %d healed, %d already-fresh, %d errors",
+                len(heal_result["healed"]),
+                len(heal_result["skipped_already_fresh"]),
+                len(heal_result["errors"]),
+            )
+        except Exception as e:
+            logger.exception("Chronic-gap self-heal step failed for %s", target_date)
+            results["collectors"]["chronic_gap_self_heal"] = {
+                "status": "error",
+                "error": str(e),
+            }
+    except Exception as e:  # defence-in-depth — this state must exit 0
+        logger.exception("Chronic-gap heal wrapper failed for %s", target_date)
+        results["collectors"]["chronic_gap_heal_wrapper"] = {
+            "status": "error",
+            "error": str(e),
+        }
+
+    results["completed_at"] = datetime.now(timezone.utc).isoformat()
+    # Best-effort step: report ok unless the whole thing fell over. Per-ticker /
+    # per-substep failures are recorded in collectors but do not flip the state
+    # to failed (the SF Catch makes it non-fatal either way).
+    results["status"] = "ok"
+    statuses = {
+        k: v.get("status", "?") for k, v in results["collectors"].items()
+    }
+    logger.info("Chronic-gap heal complete for %s: %s", target_date, statuses)
     return results
 
 
@@ -1802,6 +1885,21 @@ def _parse_args() -> argparse.Namespace:
         help="Morning polygon enrichment: overwrite the prior trading day's parquet + ArcticDB row "
              "with polygon's authoritative OHLCV+VWAP. Hard-fails on polygon failure (no yfinance "
              "fallback). --date overrides which trading day to enrich (default: previous trading day).",
+    )
+    parser.add_argument(
+        "--chronic-gap-heal", dest="chronic_gap_heal", action="store_true",
+        help="Best-effort: yfinance-backfill ArcticDB row gaps for the chronic-polygon-gap "
+             "tickers (polygon doesn't reliably serve them) + emit the polygon-recovery / "
+             "constituents-drift alarms. Split out of --morning-enrich (2026-06-11) so a "
+             "yfinance hang in this best-effort step can never SIGKILL the load-bearing "
+             "MorningEnrich. Never raises — returns a status dict. --date overrides target day.",
+    )
+    parser.add_argument(
+        "--skip-chronic-heal", dest="skip_chronic_heal", action="store_true",
+        help="With --morning-enrich: skip the inline chronic-gap self-heal "
+             "(the weekday SF runs it as a separate fail-soft ChronicGapSelfHeal "
+             "state instead). The Saturday SF omits this flag so the heal still "
+             "runs inline before DataPhase1's postflight.",
     )
     parser.add_argument(
         "--phase", type=int, choices=[1, 2], default=None,


### PR DESCRIPTION
## What broke

The **2026-06-11 weekday pipeline FAILED** at `MorningEnrich` — `ResponseCode: 137` (SIGKILL) after 36.5 min. No predictions, planner, or daemon ran that day.

**Root cause:** `daily_append` (the load-bearing ArcticDB write) ran for ~20 min and **succeeded** at 13:07:43. Then the **chronic-polygon-gap self-heal** — which runs *inline* at the tail of `weekly_collector.py --morning-enrich` and is best-effort by design (its own docstring: *"a yfinance hiccup must not halt the morning enrich"*) — hung on an **unbounded `yf.download`** for ~15 min. That blew MorningEnrich's SSM `executionTimeout: 1800` → SIGKILL of the whole command → SF saw `Failed` → `HandleFailure` → pipeline failed, **discarding the 20 min of completed `daily_append` work**.

A best-effort step halted the pipeline and forced re-running completed upstream work — exactly the failure mode the standing preflight-isolation rule forbids (the same rule that split `MorningEnrich` out of `DataPhase1`).

## Fix

- **New `ChronicGapSelfHeal` weekday-SF state** (fail-soft): runs between `MorningEnrich(Success)` and `PredictorInference`, with a short `executionTimeout: 300`. Its `Catch` **and** `CheckChronicGapStatus` Default both route to `PredictorInference` — a heal hang/failure/timeout can **never** fail `MorningEnrich` or block predictions again.
- **New `--chronic-gap-heal` standalone entrypoint** (`_run_chronic_gap_heal`): best-effort, never raises (returns a status dict so the SSM command exits 0).
- Weekday `MorningEnrich` now passes **`--skip-chronic-heal`** so the inline heal is not double-run.
- **Saturday SF unchanged:** `_run_morning_enrich` still runs the heal inline (no skip flag) because there it must precede `DataPhase1`'s postflight — the heal's origin (2026-05-09 stale-PSTG postflight failure). Splitting Saturday's heal into its own state too is the tracked follow-up below.
- **`yf.download(timeout=30)`** bounds the actual hang on both paths (root-cause defence-in-depth; the SF-state isolation is the structural fix).

## Why not also split the Saturday SF in this PR

The Saturday SF's `MorningEnrich` is materially more complex (ssm_log_capture wrapper, `States.Array`/`States.Format` run_date threading, spot EC2). The `yf.download` timeout removes the actual 6/11 hang on the Saturday path too, so the residual risk there is small. A symmetric Saturday split is filed as a **P2 follow-up** (alpha-engine-config L4605) rather than bundled into the hotfix.

## Tests

- New `tests/test_sf_chronic_gap_heal_wiring.py` — state presence, chain ordering, **fail-soft routing** (never `HandleFailure`), SSM command shape (`--chronic-gap-heal`, bounded timeout, weekday passes `--skip-chronic-heal`).
- 4 new unit tests in `test_weekly_collector_morning_enrich.py` — CLI routing, skip-flag suppresses inline heal, inline heal still runs without the flag, standalone heal never raises.
- **Full suite green: 1880 passed, 1 skipped.**

## Deploy

**Automatic on merge** — `.github/workflows/deploy-infrastructure.yml` runs `deploy-infrastructure.sh` on every push to `main` (no path filter), which stamps `[git:<sha>]` and `update-state-machine`s both the Saturday and weekday SFs. **No manual deploy step.** The box auto-pulls `weekly_collector.py` on the next run's `git pull`. No 6/11 backfill needed — that day's data already landed; per the session decision, today's trading was skipped and the next scheduled run is the first clean one.

## Follow-up

Filed as alpha-engine-config **L4605 (P2)** — mirror the `ChronicGapSelfHeal` split into the Saturday SF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)