### PR TITLE
feat(weekday-sf): per-task CheckSkip<State> rerun gates (L4606)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -223,7 +223,7 @@
               "StringMatches": "*TRADING DAY*"
             }
           ],
-          "Next": "MorningEnrich"
+          "Next": "CheckSkipMorningEnrich"
         }
       ],
       "Default": "TradingDayCheckFailed"
@@ -302,7 +302,7 @@
         {
           "Variable": "$.morning_enrich_poll.Status",
           "StringEquals": "Success",
-          "Next": "ChronicGapSelfHeal"
+          "Next": "CheckSkipChronicGapHeal"
         },
         {
           "Variable": "$.morning_enrich_poll.Status",
@@ -358,7 +358,7 @@
             "States.ALL"
           ],
           "Comment": "Fail-soft — a chronic-gap heal failure (incl. the SSM-timeout SIGKILL it used to cause) must never block predictions. Proceed to PredictorInference.",
-          "Next": "PredictorInference",
+          "Next": "CheckSkipPredictorInference",
           "ResultPath": "$.chronic_gap_error"
         }
       ],
@@ -390,7 +390,7 @@
             "States.ALL"
           ],
           "Comment": "Fail-soft — a poll failure proceeds to PredictorInference, no heal that day.",
-          "Next": "PredictorInference",
+          "Next": "CheckSkipPredictorInference",
           "ResultPath": "$.chronic_gap_error"
         }
       ],
@@ -413,7 +413,7 @@
           "Next": "ChronicGapWait"
         }
       ],
-      "Default": "PredictorInference"
+      "Default": "CheckSkipPredictorInference"
     },
 
     "ChronicGapWait": {
@@ -438,7 +438,7 @@
         "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. State: {}', States.JsonToString($))"
       },
       "ResultPath": "$.trading_day_error_notify",
-      "Next": "MorningEnrich"
+      "Next": "CheckSkipMorningEnrich"
     },
 
     "StopExecutorOnHoliday": {
@@ -757,12 +757,12 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Predictor health check is non-blocking — continue to morning planner. Executor's own upstream-health gate catches real data-freshness problems before placing orders.",
-          "Next": "RunMorningPlanner",
+          "Next": "CheckSkipMorningPlanner",
           "ResultPath": "$.predictor_health_error"
         }
       ],
       "ResultPath": "$.predictor_health_result",
-      "Next": "RunMorningPlanner"
+      "Next": "CheckSkipMorningPlanner"
     },
 
     "RunMorningPlanner": {
@@ -843,7 +843,7 @@
         {
           "Variable": "$.planner_poll.Status",
           "StringEquals": "Success",
-          "Next": "RunDaemon"
+          "Next": "CheckSkipRunDaemon"
         },
         {
           "Variable": "$.planner_poll.Status",
@@ -894,7 +894,7 @@
         }
       ],
       "ResultPath": "$.daemon_result",
-      "Next": "RunDailyNews"
+      "Next": "CheckSkipRunDailyNews"
     },
 
     "RunDailyNews": {
@@ -986,6 +986,96 @@
       "Type": "Wait",
       "Seconds": 30,
       "Next": "WaitForDailyNews"
+    },
+
+    "CheckSkipMorningEnrich": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_morning_enrich\": true} routes past MorningEnrich to the next gate (CheckSkipChronicGapHeal); missing flag = run as normal. Mirrors the Saturday SF CheckSkip<State> structure so the weekday pipeline is rerunnable task-by-task — an operator recovery rerun resumes at the first incomplete task instead of re-running completed upstream work. The 2026-06-11 chronic-gap rerun had to re-run the already-completed MorningEnrich daily_append (~20 min) because this gate did not exist. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_morning_enrich", "IsPresent": true},
+            {"Variable": "$.skip_morning_enrich", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipChronicGapHeal"
+        }
+      ],
+      "Default": "MorningEnrich"
+    },
+
+    "CheckSkipChronicGapHeal": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_chronic_gap_heal\": true} routes past ChronicGapSelfHeal to the next gate (CheckSkipPredictorInference); missing flag = run as normal. The heal is already best-effort/fail-soft, so skipping it on a rerun is always safe. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_chronic_gap_heal", "IsPresent": true},
+            {"Variable": "$.skip_chronic_gap_heal", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipPredictorInference"
+        }
+      ],
+      "Default": "ChronicGapSelfHeal"
+    },
+
+    "CheckSkipPredictorInference": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_predictor_inference\": true} routes past PredictorInference (and its coverage/health sub-chain) to the next gate (CheckSkipMorningPlanner); missing flag = run as normal. Skip only when predictions/{date}.json already exists from a prior run. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_predictor_inference", "IsPresent": true},
+            {"Variable": "$.skip_predictor_inference", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipMorningPlanner"
+        }
+      ],
+      "Default": "PredictorInference"
+    },
+
+    "CheckSkipMorningPlanner": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_morning_planner\": true} routes past RunMorningPlanner to the next gate (CheckSkipRunDaemon); missing flag = run as normal. The planner writes the order book but places no orders, so re-running it is normally safe; skip is for reruns where the book is already current. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_morning_planner", "IsPresent": true},
+            {"Variable": "$.skip_morning_planner", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipRunDaemon"
+        }
+      ],
+      "Default": "RunMorningPlanner"
+    },
+
+    "CheckSkipRunDaemon": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daemon\": true} routes past RunDaemon (the daemon restart) to the next gate (CheckSkipRunDailyNews); missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_run_daemon", "IsPresent": true},
+            {"Variable": "$.skip_run_daemon", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipRunDailyNews"
+        }
+      ],
+      "Default": "RunDaemon"
+    },
+
+    "CheckSkipRunDailyNews": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daily_news\": true} routes past RunDailyNews directly to PipelineComplete; missing flag = run as normal. Daily news is already fail-soft. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_run_daily_news", "IsPresent": true},
+            {"Variable": "$.skip_run_daily_news", "BooleanEquals": true}
+          ],
+          "Next": "PipelineComplete"
+        }
+      ],
+      "Default": "RunDailyNews"
     },
 
     "PipelineComplete": {

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -64,14 +64,20 @@ class TestChainOrdering:
     WaitForChronicGap → CheckChronicGapStatus(terminal) → PredictorInference."""
 
     def test_morning_enrich_success_routes_to_heal(self, states):
+        # Since L4606 the heal sits behind the CheckSkipChronicGapHeal rerun
+        # gate, whose Default runs the heal. MorningEnrich success → that gate
+        # → (no skip flag) ChronicGapSelfHeal. The heal still runs AFTER a
+        # completed (load-bearing) MorningEnrich.
         success = [
             c["Next"]
             for c in states["CheckMorningEnrichStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == [_HEAL], (
-            "MorningEnrich success must hand off to ChronicGapSelfHeal — the "
-            "heal runs AFTER a completed (load-bearing) MorningEnrich."
+        assert success == ["CheckSkipChronicGapHeal"], (
+            "MorningEnrich success must hand off to the chronic-gap skip-gate"
+        )
+        assert states["CheckSkipChronicGapHeal"]["Default"] == _HEAL, (
+            "the skip-gate's Default must run ChronicGapSelfHeal"
         )
 
     def test_heal_routes_to_poll(self, states):
@@ -117,27 +123,35 @@ class TestFailSoft:
     """A heal failure / hang / timeout must NEVER fail the pipeline — every
     terminal edge routes to PredictorInference, never HandleFailure."""
 
-    def test_check_default_is_predictor_inference_not_handlefailure(self, states):
-        # Inverse of CheckMorningEnrichStatus, whose Default is HandleFailure.
-        assert states[_CHECK]["Default"] == "PredictorInference", (
-            "Chronic-gap heal is best-effort: any terminal status (incl. "
-            "failure) must proceed to PredictorInference, not HandleFailure."
-        )
+    # Since L4606 the forward target is the CheckSkipPredictorInference rerun
+    # gate (whose Default runs PredictorInference) rather than PredictorInference
+    # directly — still fail-soft: it proceeds toward predictions, never to
+    # HandleFailure.
+    _FWD = "CheckSkipPredictorInference"
 
-    def test_heal_catch_routes_to_predictor_inference(self, states):
+    def test_check_default_proceeds_toward_predictions_not_handlefailure(self, states):
+        # Inverse of CheckMorningEnrichStatus, whose Default is HandleFailure.
+        assert states[_CHECK]["Default"] == self._FWD, (
+            "Chronic-gap heal is best-effort: any terminal status (incl. "
+            "failure) must proceed toward PredictorInference, not HandleFailure."
+        )
+        # And the gate it hands to must actually run PredictorInference.
+        assert states[self._FWD]["Default"] == "PredictorInference"
+
+    def test_heal_catch_proceeds_toward_predictions(self, states):
         catches = states[_HEAL].get("Catch", [])
         assert catches, f"{_HEAL} must have a fail-soft Catch"
         for c in catches:
-            assert c["Next"] == "PredictorInference", (
-                f"{_HEAL} Catch must route to PredictorInference (fail-soft), "
-                f"got {c['Next']}"
+            assert c["Next"] == self._FWD, (
+                f"{_HEAL} Catch must proceed toward PredictorInference via "
+                f"{self._FWD} (fail-soft), got {c['Next']}"
             )
 
-    def test_poll_catch_routes_to_predictor_inference(self, states):
+    def test_poll_catch_proceeds_toward_predictions(self, states):
         catches = states[_POLL].get("Catch", [])
         assert catches, f"{_POLL} must have a fail-soft Catch"
         for c in catches:
-            assert c["Next"] == "PredictorInference"
+            assert c["Next"] == self._FWD
 
     def test_no_heal_state_routes_to_handlefailure(self, states):
         """No Next/Default/Catch target across the heal quartet may be

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -1,0 +1,154 @@
+"""Pins the per-task `CheckSkip<State>` rerun gates on the WEEKDAY SF (L4606).
+
+Directive (Brian, 2026-06-11): *"the saturday weekly sf can be rerun task by
+task, i expect morning and eod to adopt the same structure."* The Saturday SF
+has 10 `CheckSkip<State>` gates; the weekday SF had zero, so a recovery rerun
+re-ran every state from the top — the 2026-06-11 chronic-gap rerun had to
+re-run the already-completed MorningEnrich `daily_append` (~20 min) because no
+skip-gate existed.
+
+This adds a skip-gate before each weekday work task so an operator rerun
+passing `{"skip_<task>": true}` (or a future marker-based auto-skip) resumes at
+the first incomplete task. Mirrors `test_sf_morning_enrich_split_wiring.py`'s
+skip-gate assertions on the Saturday SF.
+
+Catches regressions like:
+- A skip-gate dropped, so an entry edge points straight at the task again.
+- A gate's skip edge pointing at the wrong next gate (breaks the resume chain).
+- A gate's Default not running its task (would skip the task unconditionally).
+- The happy path (no skip flags) no longer running every task in order.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
+
+# (gate, task, skip_flag, next_gate) in pipeline order.
+_CHAIN = [
+    ("CheckSkipMorningEnrich", "MorningEnrich", "skip_morning_enrich", "CheckSkipChronicGapHeal"),
+    ("CheckSkipChronicGapHeal", "ChronicGapSelfHeal", "skip_chronic_gap_heal", "CheckSkipPredictorInference"),
+    ("CheckSkipPredictorInference", "PredictorInference", "skip_predictor_inference", "CheckSkipMorningPlanner"),
+    ("CheckSkipMorningPlanner", "RunMorningPlanner", "skip_morning_planner", "CheckSkipRunDaemon"),
+    ("CheckSkipRunDaemon", "RunDaemon", "skip_run_daemon", "CheckSkipRunDailyNews"),
+    ("CheckSkipRunDailyNews", "RunDailyNews", "skip_run_daily_news", "PipelineComplete"),
+]
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+class TestGatePresence:
+    @pytest.mark.parametrize("gate", [c[0] for c in _CHAIN])
+    def test_gate_exists(self, states, gate):
+        assert gate in states, f"{gate} missing from weekday SF"
+        assert states[gate]["Type"] == "Choice"
+
+
+class TestGateShape:
+    @pytest.mark.parametrize("gate,task,flag,nxt", _CHAIN)
+    def test_skip_flag_routes_to_next_gate(self, states, gate, task, flag, nxt):
+        choices = states[gate]["Choices"]
+        assert len(choices) == 1, f"{gate} should have exactly one skip choice"
+        c = choices[0]
+        variables = {cond["Variable"] for cond in c["And"]}
+        assert variables == {f"$.{flag}"}, (
+            f"{gate} skip choice must gate on $.{flag}"
+        )
+        # And[ IsPresent, BooleanEquals true ] — same shape as the Saturday gates.
+        assert any(cond.get("IsPresent") is True for cond in c["And"])
+        assert any(cond.get("BooleanEquals") is True for cond in c["And"])
+        assert c["Next"] == nxt, f"{gate} skip must route to {nxt}"
+
+    @pytest.mark.parametrize("gate,task,flag,nxt", _CHAIN)
+    def test_default_runs_the_task(self, states, gate, task, flag, nxt):
+        assert states[gate]["Default"] == task, (
+            f"{gate} Default must run {task} (missing flag = run as normal)"
+        )
+
+
+class TestEntryEdgesRouteThroughGates:
+    """Every edge that used to enter a task now enters its skip-gate."""
+
+    def test_trading_day_success_enters_morning_enrich_gate(self, states):
+        nexts = [c["Next"] for c in states["CheckTradingDayResult"]["Choices"]]
+        assert "CheckSkipMorningEnrich" in nexts
+        assert "MorningEnrich" not in nexts
+
+    def test_trading_day_check_failed_enters_morning_enrich_gate(self, states):
+        assert states["TradingDayCheckFailed"]["Next"] == "CheckSkipMorningEnrich"
+
+    def test_morning_enrich_success_enters_heal_gate(self, states):
+        success = [c["Next"] for c in states["CheckMorningEnrichStatus"]["Choices"]
+                   if c.get("StringEquals") == "Success"]
+        assert success == ["CheckSkipChronicGapHeal"]
+
+    def test_chronic_gap_terminal_enters_predictor_gate(self, states):
+        # CheckChronicGapStatus Default + both heal Catches.
+        assert states["CheckChronicGapStatus"]["Default"] == "CheckSkipPredictorInference"
+        assert states["ChronicGapSelfHeal"]["Catch"][0]["Next"] == "CheckSkipPredictorInference"
+        assert states["WaitForChronicGap"]["Catch"][0]["Next"] == "CheckSkipPredictorInference"
+
+    def test_predictor_health_enters_planner_gate(self, states):
+        assert states["PredictorHealthCheck"]["Next"] == "CheckSkipMorningPlanner"
+        assert states["PredictorHealthCheck"]["Catch"][0]["Next"] == "CheckSkipMorningPlanner"
+
+    def test_planner_success_enters_daemon_gate(self, states):
+        success = [c["Next"] for c in states["CheckMorningPlannerStatus"]["Choices"]
+                   if c.get("StringEquals") == "Success"]
+        assert success == ["CheckSkipRunDaemon"]
+
+    def test_daemon_enters_daily_news_gate(self, states):
+        assert states["RunDaemon"]["Next"] == "CheckSkipRunDailyNews"
+
+
+class TestPaths:
+    def _walk(self, states, start, skip_flags):
+        """Walk from `start`, taking gate skip-edges for flags in `skip_flags`,
+        else running the task; for status-check Choices follow Success/terminal."""
+        order, seen, cur = [], set(), start
+        while cur and cur in states and cur not in seen:
+            seen.add(cur)
+            st = states[cur]
+            if cur in {c[0] for c in _CHAIN}:
+                flag = next(c[2] for c in _CHAIN if c[0] == cur)
+                cur = st["Choices"][0]["Next"] if flag in skip_flags else st["Default"]
+                continue
+            order.append(cur)
+            if st["Type"] == "Succeed":
+                break
+            if st["Type"] == "Choice":
+                succ = [c["Next"] for c in st.get("Choices", []) if c.get("StringEquals") == "Success"]
+                cur = succ[0] if succ else st.get("Default")
+            else:
+                cur = st.get("Next")
+        return order
+
+    def test_happy_path_runs_every_task_in_order(self, states):
+        order = self._walk(states, "CheckSkipMorningEnrich", skip_flags=set())
+        tasks_in_order = [c[1] for c in _CHAIN]
+        idxs = [order.index(t) for t in tasks_in_order]
+        assert all(t in order for t in tasks_in_order), order
+        assert idxs == sorted(idxs), f"tasks out of order: {order}"
+        assert order[-1] == "PipelineComplete"
+
+    def test_full_skip_reaches_complete_without_running_tasks(self, states):
+        all_flags = {c[2] for c in _CHAIN}
+        order = self._walk(states, "CheckSkipMorningEnrich", skip_flags=all_flags)
+        for task in (c[1] for c in _CHAIN):
+            assert task not in order, f"{task} ran despite its skip flag"
+        assert order == ["PipelineComplete"]
+
+    def test_skip_morning_enrich_only_resumes_at_heal(self, states):
+        """The exact 6/11 case: MorningEnrich already done → skip it, run the rest."""
+        order = self._walk(states, "CheckSkipMorningEnrich", skip_flags={"skip_morning_enrich"})
+        assert "MorningEnrich" not in order
+        assert order[0] == "ChronicGapSelfHeal"
+        assert "PredictorInference" in order and order[-1] == "PipelineComplete"


### PR DESCRIPTION
## Why

Per Brian's directive (2026-06-11): *"the saturday weekly sf can be rerun task by task, i expect morning and eod to adopt the same structure."*

The Saturday SF has 10 `CheckSkip<State>` gates → rerunnable task-by-task. The weekday SF had **zero** — a recovery rerun re-ran every state from the top. That's exactly why the 6/11 chronic-gap recovery rerun had to re-run the already-completed `MorningEnrich` `daily_append` (~20 min) instead of resuming at `PredictorInference`.

## What

Adds a `CheckSkip<State>` Choice before each weekday work task:

| Gate | Task | Skip flag |
|---|---|---|
| `CheckSkipMorningEnrich` | MorningEnrich | `skip_morning_enrich` |
| `CheckSkipChronicGapHeal` | ChronicGapSelfHeal | `skip_chronic_gap_heal` |
| `CheckSkipPredictorInference` | PredictorInference | `skip_predictor_inference` |
| `CheckSkipMorningPlanner` | RunMorningPlanner | `skip_morning_planner` |
| `CheckSkipRunDaemon` | RunDaemon | `skip_run_daemon` |
| `CheckSkipRunDailyNews` | RunDailyNews | `skip_run_daily_news` |

Each gate: `{"skip_<task>": true}` → next gate; missing flag → run the task (Default). Every edge that used to enter a task now enters its gate; each task's completion routes to the next gate. Same `And[IsPresent, BooleanEquals true]` shape as the Saturday gates. The pre-task infra (StartExecutorEC2 / SSM-ready / CheckTradingDay) is unchanged — those are cheap, idempotent preconditions that should always run.

So an operator recovery rerun can resume mid-pipeline, e.g. skip the completed MorningEnrich + heal and go straight to predictions:
```
aws stepfunctions start-execution --input '{..., "skip_morning_enrich": true, "skip_chronic_gap_heal": true}'
```

## Tests

- New `tests/test_sf_weekday_skipgate_wiring.py` — gate presence/shape, entry-edge rerouting, **happy path runs every task in order**, **full-skip reaches PipelineComplete without running any task**, and the exact 6/11 case (skip MorningEnrich only → resumes at the heal).
- Updated `test_sf_chronic_gap_heal_wiring.py` for the gate-mediated (still fail-soft) routing.
- **Full suite green: 1908 passed, 1 skipped.**

## Deploy

Automatic on merge via `deploy-infrastructure.yml`. No manual step.

## Follow-up

L4607 (P1) — EOD SF adopts the same structure (separate PR, next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)