### PR TITLE
feat(eod-sf): per-task CheckSkip<State> rerun gates (L4607)

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -21,7 +21,7 @@
           "Next": "AcquireMutex"
         }
       ],
-      "Default": "PostMarketData"
+      "Default": "CheckSkipPostMarketData"
     },
     "AcquireMutex": {
       "Type": "Task",
@@ -50,12 +50,12 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block the EOD reconcile + instance-stop path. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability' carve-out, the primary deliverable (reconcile + stop trading EC2) survives a mutex-side failure. The error is captured in $.mutex_error for forensic review.",
-          "Next": "PostMarketData",
+          "Next": "CheckSkipPostMarketData",
           "ResultPath": "$.mutex_error"
         }
       ],
       "ResultPath": "$.mutex_result",
-      "Next": "PostMarketData"
+      "Next": "CheckSkipPostMarketData"
     },
     "MutexConflict": {
       "Type": "Fail",
@@ -134,7 +134,7 @@
       "Type": "Choice",
       "Comment": "Default routes to HandleFailure so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed.",
       "Choices": [
-        { "Variable": "$.postmarket_poll.Status", "StringEquals": "Success", "Next": "CaptureSnapshot" },
+        { "Variable": "$.postmarket_poll.Status", "StringEquals": "Success", "Next": "CheckSkipCaptureSnapshot" },
         { "Variable": "$.postmarket_poll.Status", "StringEquals": "InProgress", "Next": "PostMarketWait" },
         { "Variable": "$.postmarket_poll.Status", "StringEquals": "Pending", "Next": "PostMarketWait" },
         { "Variable": "$.postmarket_poll.Status", "StringEquals": "Delayed", "Next": "PostMarketWait" }
@@ -232,7 +232,7 @@
       "Type": "Choice",
       "Comment": "Default routes to HandleFailure so any unexpected SSM status is surfaced, not silently swallowed.",
       "Choices": [
-        { "Variable": "$.snapshot_poll.Status", "StringEquals": "Success", "Next": "EODReconcile" },
+        { "Variable": "$.snapshot_poll.Status", "StringEquals": "Success", "Next": "CheckSkipEODReconcile" },
         { "Variable": "$.snapshot_poll.Status", "StringEquals": "InProgress", "Next": "SnapshotWait" },
         { "Variable": "$.snapshot_poll.Status", "StringEquals": "Pending", "Next": "SnapshotWait" },
         { "Variable": "$.snapshot_poll.Status", "StringEquals": "Delayed", "Next": "SnapshotWait" }
@@ -329,7 +329,7 @@
       "Type": "Choice",
       "Comment": "Default routes to HandleFailure so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed.",
       "Choices": [
-        { "Variable": "$.eod_poll.Status", "StringEquals": "Success", "Next": "DailySubstrateHealthCheck" },
+        { "Variable": "$.eod_poll.Status", "StringEquals": "Success", "Next": "CheckSkipDailySubstrateHealthCheck" },
         { "Variable": "$.eod_poll.Status", "StringEquals": "InProgress", "Next": "EODWait" },
         { "Variable": "$.eod_poll.Status", "StringEquals": "Pending", "Next": "EODWait" },
         { "Variable": "$.eod_poll.Status", "StringEquals": "Delayed", "Next": "EODWait" }
@@ -416,6 +416,62 @@
       ],
       "ResultPath": "$.substrate_check_poll",
       "Next": "StopTradingInstance"
+    },
+    "CheckSkipPostMarketData": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4607). Input {\"skip_post_market_data\": true} routes past PostMarketData to the next gate (CheckSkipCaptureSnapshot); missing flag = run as normal. Mirrors the Saturday SF CheckSkip<State> structure so the EOD pipeline is rerunnable task-by-task — an operator recovery rerun resumes at the first incomplete task instead of re-running completed upstream work (e.g. an EODReconcile failure rerun should not re-run PostMarketData + CaptureSnapshot). Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_post_market_data", "IsPresent": true},
+            {"Variable": "$.skip_post_market_data", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipCaptureSnapshot"
+        }
+      ],
+      "Default": "PostMarketData"
+    },
+    "CheckSkipCaptureSnapshot": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4607). Input {\"skip_capture_snapshot\": true} routes past CaptureSnapshot to the next gate (CheckSkipEODReconcile); missing flag = run as normal. Skip only when the snapshot trades/snapshots/{run_date}.json already exists from a prior run. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_capture_snapshot", "IsPresent": true},
+            {"Variable": "$.skip_capture_snapshot", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipEODReconcile"
+        }
+      ],
+      "Default": "CaptureSnapshot"
+    },
+    "CheckSkipEODReconcile": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4607). Input {\"skip_eod_reconcile\": true} routes past EODReconcile to the next gate (CheckSkipDailySubstrateHealthCheck); missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_eod_reconcile", "IsPresent": true},
+            {"Variable": "$.skip_eod_reconcile", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipDailySubstrateHealthCheck"
+        }
+      ],
+      "Default": "EODReconcile"
+    },
+    "CheckSkipDailySubstrateHealthCheck": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4607). Input {\"skip_daily_substrate_health_check\": true} routes past DailySubstrateHealthCheck directly to StopTradingInstance (the always-run cost-guard cleanup); missing flag = run as normal. The substrate check is already non-blocking. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_daily_substrate_health_check", "IsPresent": true},
+            {"Variable": "$.skip_daily_substrate_health_check", "BooleanEquals": true}
+          ],
+          "Next": "StopTradingInstance"
+        }
+      ],
+      "Default": "DailySubstrateHealthCheck"
     },
     "StopTradingInstance": {
       "Type": "Task",

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -1,0 +1,114 @@
+"""Pins the per-task `CheckSkip<State>` rerun gates on the EOD SF (L4607).
+
+Directive (Brian, 2026-06-11): *"the saturday weekly sf can be rerun task by
+task, i expect morning and eod to adopt the same structure."* The EOD SF had
+zero skip-gates, so an EODReconcile-failure rerun re-ran PostMarketData +
+CaptureSnapshot from scratch. This adds a skip-gate before each EOD work task
+so an operator rerun passing `{"skip_<task>": true}` resumes at the first
+incomplete task. Mirrors the weekday SF gates (L4606) and the Saturday SF.
+
+The final cost-guard `StopTradingInstance` is intentionally NOT skip-gated — it
+must always run to release the trading EC2.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_eod.json"
+
+# (gate, task, skip_flag, next_after_skip) in pipeline order.
+_CHAIN = [
+    ("CheckSkipPostMarketData", "PostMarketData", "skip_post_market_data", "CheckSkipCaptureSnapshot"),
+    ("CheckSkipCaptureSnapshot", "CaptureSnapshot", "skip_capture_snapshot", "CheckSkipEODReconcile"),
+    ("CheckSkipEODReconcile", "EODReconcile", "skip_eod_reconcile", "CheckSkipDailySubstrateHealthCheck"),
+    ("CheckSkipDailySubstrateHealthCheck", "DailySubstrateHealthCheck", "skip_daily_substrate_health_check", "StopTradingInstance"),
+]
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+class TestGatePresenceAndShape:
+    @pytest.mark.parametrize("gate,task,flag,nxt", _CHAIN)
+    def test_gate_exists_and_shaped(self, states, gate, task, flag, nxt):
+        assert gate in states and states[gate]["Type"] == "Choice"
+        c = states[gate]["Choices"][0]
+        assert {cond["Variable"] for cond in c["And"]} == {f"$.{flag}"}
+        assert any(cond.get("IsPresent") is True for cond in c["And"])
+        assert any(cond.get("BooleanEquals") is True for cond in c["And"])
+        assert c["Next"] == nxt
+        assert states[gate]["Default"] == task
+
+
+class TestEntryEdgesRouteThroughGates:
+    def test_mutex_paths_enter_post_market_gate(self, states):
+        # All three entries to PostMarketData now go through the gate.
+        assert states["CheckMutexRole"]["Default"] == "CheckSkipPostMarketData"
+        assert states["AcquireMutex"]["Next"] == "CheckSkipPostMarketData"
+        failopen = [c["Next"] for c in states["AcquireMutex"]["Catch"]
+                    if "States.ALL" in c["ErrorEquals"]]
+        assert failopen == ["CheckSkipPostMarketData"]
+
+    def test_post_market_success_enters_snapshot_gate(self, states):
+        succ = [c["Next"] for c in states["CheckPostMarketStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["CheckSkipCaptureSnapshot"]
+
+    def test_snapshot_success_enters_reconcile_gate(self, states):
+        succ = [c["Next"] for c in states["CheckSnapshotStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["CheckSkipEODReconcile"]
+
+    def test_eod_success_enters_substrate_gate(self, states):
+        succ = [c["Next"] for c in states["CheckEODStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["CheckSkipDailySubstrateHealthCheck"]
+
+
+class TestPaths:
+    def _walk(self, states, skip_flags):
+        gates = {c[0] for c in _CHAIN}
+        order, seen, cur = [], set(), "CheckSkipPostMarketData"
+        while cur and cur in states and cur not in seen:
+            seen.add(cur)
+            st = states[cur]
+            if cur in gates:
+                flag = next(c[2] for c in _CHAIN if c[0] == cur)
+                cur = st["Choices"][0]["Next"] if flag in skip_flags else st["Default"]
+                continue
+            order.append(cur)
+            if st.get("End") or st["Type"] in ("Succeed", "Fail"):
+                break
+            if st["Type"] == "Choice":
+                succ = [c["Next"] for c in st.get("Choices", []) if c.get("StringEquals") == "Success"]
+                cur = succ[0] if succ else st.get("Default")
+            else:
+                cur = st.get("Next")
+        return order
+
+    def test_happy_path_runs_every_task_then_stops_instance(self, states):
+        order = self._walk(states, skip_flags=set())
+        tasks = [c[1] for c in _CHAIN]
+        idxs = [order.index(t) for t in tasks]
+        assert idxs == sorted(idxs), order
+        assert order[-1] == "StopTradingInstance"
+
+    def test_full_skip_still_stops_the_instance(self, states):
+        order = self._walk(states, skip_flags={c[2] for c in _CHAIN})
+        for task in (c[1] for c in _CHAIN):
+            assert task not in order, f"{task} ran despite skip flag"
+        # Cost-guard cleanup must ALWAYS run.
+        assert order == ["StopTradingInstance"]
+
+    def test_skip_post_market_resumes_at_snapshot(self, states):
+        order = self._walk(states, skip_flags={"skip_post_market_data"})
+        assert "PostMarketData" not in order
+        assert order[0] == "CaptureSnapshot"
+        assert order[-1] == "StopTradingInstance"

--- a/tests/test_sf_eod_substrate_check_wiring.py
+++ b/tests/test_sf_eod_substrate_check_wiring.py
@@ -68,10 +68,16 @@ class TestChainOrdering:
             (c for c in choices if c.get("StringEquals") == "Success"), None
         )
         assert success_choice is not None, "CheckEODStatus must have a Success branch"
-        assert success_choice["Next"] == "DailySubstrateHealthCheck", (
-            "CheckEODStatus Success must hand off to the substrate check, "
-            "not skip directly to StopTradingInstance."
+        # Since L4607 the substrate check sits behind the
+        # CheckSkipDailySubstrateHealthCheck rerun gate, whose Default runs it.
+        # CheckEODStatus Success → that gate → (no skip flag) the substrate
+        # check — it still runs after EODReconcile, not skipped to stop.
+        assert success_choice["Next"] == "CheckSkipDailySubstrateHealthCheck", (
+            "CheckEODStatus Success must hand off to the substrate skip-gate."
         )
+        assert states["CheckSkipDailySubstrateHealthCheck"]["Default"] == (
+            "DailySubstrateHealthCheck"
+        ), "the skip-gate's Default must run the substrate check"
 
     def test_substrate_check_routes_to_wait_state(self, states):
         assert states["DailySubstrateHealthCheck"]["Next"] == (

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -77,7 +77,11 @@ CADENCE_ROLES = {"daily", "weekly", "eod", "shell-run"}
 FORMER_FIRST_STATE_BY_SF = {
     "saturday": ("step_function.json", "CheckShellRun"),
     "weekday": ("step_function_daily.json", "DeployDriftCheck"),
-    "eod": ("step_function_eod.json", "PostMarketData"),
+    # L4607: the EOD SF's first post-mutex state is now the per-task rerun
+    # gate CheckSkipPostMarketData (whose Default runs PostMarketData), not
+    # PostMarketData directly. The mutex still routes to the pipeline's first
+    # work state — that state is just the skip-gate now.
+    "eod": ("step_function_eod.json", "CheckSkipPostMarketData"),
 }
 
 

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -418,6 +418,13 @@ class TestEODSFTopLevelFieldsClosed:
             "mutex_error",
             "mutex_result",
             "pipeline_role",
+            # L4607 per-task rerun gates — each CheckSkip<State> reads an
+            # optional boolean skip flag from the execution input so an
+            # operator recovery rerun can resume at the first incomplete task.
+            "skip_post_market_data",
+            "skip_capture_snapshot",
+            "skip_eod_reconcile",
+            "skip_daily_substrate_health_check",
         }
     )
 


### PR DESCRIPTION
## Why

Per Brian's directive (2026-06-11): *"the saturday weekly sf can be rerun task by task, i expect morning and eod to adopt the same structure."* Companion to #401 (weekday, L4606). The EOD SF had **zero** skip-gates — an `EODReconcile` failure rerun re-ran `PostMarketData` + `CaptureSnapshot` from scratch.

## What

Adds a `CheckSkip<State>` Choice before each EOD work task:

| Gate | Task | Skip flag |
|---|---|---|
| `CheckSkipPostMarketData` | PostMarketData | `skip_post_market_data` |
| `CheckSkipCaptureSnapshot` | CaptureSnapshot | `skip_capture_snapshot` |
| `CheckSkipEODReconcile` | EODReconcile | `skip_eod_reconcile` |
| `CheckSkipDailySubstrateHealthCheck` | DailySubstrateHealthCheck | `skip_daily_substrate_health_check` |

Each gate: `{"skip_<task>": true}` → next gate; missing flag → run the task. All three entries into `PostMarketData` (mutex bypass + acquire + fail-open catch) now route through the first gate.

**`StopTradingInstance` is intentionally NOT gated** — the cost-guard cleanup must always run to release the trading EC2. The full-skip path goes straight to it; a wiring test pins that.

So an `EODReconcile`-failure rerun can skip the completed upstream:
```
aws stepfunctions start-execution --input '{..., "skip_post_market_data": true, "skip_capture_snapshot": true}'
```

## Tests

- New `tests/test_sf_eod_skipgate_wiring.py` — gate presence/shape, entry-edge rerouting, happy path runs every task then stops the instance, **full-skip still stops the instance**, skip-post-market resumes at snapshot.
- Updated `test_sf_eod_substrate_check_wiring.py` (gate-mediated routing), `test_sf_mutex_wiring.py` (EOD first-post-mutex state is now the gate), `test_sf_payload_uniqueness.py` (register the 4 skip flags).
- **Full suite green: 1891 passed, 1 skipped.**

## Deploy ⚠️ MANUAL

Unlike the Saturday + weekday SFs, the EOD SF is **not** in `deploy-infrastructure.yml` auto-deploy. After merge:
```
cd ~/Development/alpha-engine-data && ./infrastructure/update_eod_pipeline_sf.sh
```
(Surfacing this gap — the EOD SF arguably should be folded into the auto-deploy for consistency; noting it rather than expanding this PR's scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)