### PR TITLE
chore: bump alpha-engine-lib v0.58.1 → v0.58.2 (flow-doctor rc5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.1" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.2" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.1
+alpha-engine-lib[arcticdb,flow_doctor,rag] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.2


### PR DESCRIPTION
Final step closing the **#397 bug class** in CI. Bumps the lib pin to `v0.58.2`, which carries **flow-doctor 0.6.0rc5**.

## What this fixes
alpha-engine-data is the **only** repo that runs the fix CLI (`flow-doctor-fix.yml` → `generate-fix`), so it's the only place #397's symptom appears. rc5 makes the CLI three-state (`CREATED`/`SKIPPED`/`FAILED`):

- Before: an `EXTERNAL` provider-outage diagnosis (which flow-doctor correctly *cannot* patch) returned `exit 1` → red workflow run + a "⚠️ Flow Doctor fix generation failed" comment on top of the accurate "not auto-fixable" one.
- After: it returns `SKIPPED` → `exit 0`, green job, single ℹ️ "no auto-fix — this is expected, not an error" notification. The `failure()` step no longer fires.

## Chain
flow-doctor [#31](https://github.com/cipher813/flow-doctor/pull/31) (rc5, PyPI) → alpha-engine-lib [#110](https://github.com/cipher813/alpha-engine-lib/pull/110) (v0.58.2) → **this PR**.

One-line pin change; all lib surface is additive.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)