### PR TITLE
fix(finnhub): bounded transient-error retry to close the analyst_consensus gap (#399)

### DIFF
--- a/collectors/finnhub_client.py
+++ b/collectors/finnhub_client.py
@@ -11,6 +11,24 @@ DataPhase1 orchestrator runs them sequentially in the same process.
 Free-tier rate limit: 60 calls/min. Conservative ``_MIN_INTERVAL = 1.1s``
 gives ~54 calls/min — leaves headroom for clock skew and HTTP latency.
 
+Resilience (2026-06-11): each call now retries the transient class
+(429 + 5xx + network errors) with bounded exponential backoff + full
+jitter via ``alpha_engine_lib.http_retry.request_with_retry`` (the
+L4499 chokepoint). Previously this was a single attempt — a one-off 429
+or 5xx returned ``[]`` / raised immediately, so a Saturday rate-limit
+burst silently nulled whole alt-data sources. That is what zeroed the
+``analyst_consensus`` source (Finnhub supplies its rating / num_analysts
+/ earnings) and breached DataPhase2's per-source populated-ratio gate
+(alpha-engine-data #397 / #399: analyst_consensus dipped to 0/10 then
+recovered to 7/10 within ~40 min — the signature of intermittent
+throttling, not a dead key).
+
+Auth is sent via the ``X-Finnhub-Token`` header rather than a ``token=``
+query param: the http-retry api-key scrubber masks ``api_key=`` /
+``apiKey=`` but NOT ``token=``, and ``request_with_retry`` embeds the
+effective URL in its backoff logs / ``HttpRetryError``. Keeping the
+secret out of the URL means there is nothing to leak.
+
 Usage::
 
     from collectors.finnhub_client import finnhub_get
@@ -20,10 +38,12 @@ Usage::
         metrics = payload.get("metric", {})
 
 Returns ``[]`` (or empty dict if upstream expects ``dict``) when the API
-key is missing or the call hit a 429 — callers must handle the empty
-response. Other errors (5xx, timeouts) propagate via
-``requests.HTTPError``; callers decide whether to retry, fall through,
-or hard-fail per their no-silent-fails policy.
+key is missing or the call hit a 429 that survived all retries — callers
+must handle the empty response. Other non-2xx responses (4xx, or a 5xx
+that survived retries) propagate via ``requests.HTTPError``; an exhausted
+network error raises ``alpha_engine_lib.http_retry.HttpRetryError``.
+Callers decide whether to fall through or hard-fail per their
+no-silent-fails policy.
 """
 
 from __future__ import annotations
@@ -34,6 +54,7 @@ import time
 
 import requests
 
+from alpha_engine_lib.http_retry import request_with_retry
 from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
@@ -45,19 +66,26 @@ _finnhub_lock = threading.Lock()
 _finnhub_last_call = 0.0
 _FINNHUB_MIN_INTERVAL = 1.1  # seconds; ~54 calls/min, under 60/min free-tier ceiling
 
+# Bounded retry on the transient class (429 + 5xx + network). 3 attempts with
+# full-jitter exponential backoff — enough to ride out an intermittent throttle
+# without unbounded blocking inside the rate-limited Saturday collection.
+_FINNHUB_MAX_ATTEMPTS = 3
+
 _TIMEOUT = 10
 
 
 def finnhub_get(endpoint: str, params: dict | None = None) -> dict | list:
-    """Rate-limited Finnhub GET.
+    """Rate-limited Finnhub GET with bounded transient-error retry.
 
     Returns the parsed JSON response (dict for object-shaped endpoints,
     list for array-shaped endpoints), or ``[]`` if:
       * ``FINNHUB_API_KEY`` is not set
-      * Finnhub returned a 429 rate-limit response
+      * Finnhub returned a 429 that survived all ``_FINNHUB_MAX_ATTEMPTS``
+        retries (still throttled).
 
-    Raises ``requests.HTTPError`` on other non-2xx responses (5xx,
-    timeouts). Caller decides retry / fall-through / hard-fail.
+    Retries 429 / 5xx / network errors with bounded backoff first. Raises
+    ``requests.HTTPError`` on other non-2xx responses, or ``HttpRetryError``
+    on an exhausted network error. Caller decides fall-through / hard-fail.
     """
     global _finnhub_last_call
     api_key = get_secret("FINNHUB_API_KEY", required=False, default="")
@@ -65,10 +93,15 @@ def finnhub_get(endpoint: str, params: dict | None = None) -> dict | list:
         return []
 
     url = f"{_FINNHUB_BASE}/{endpoint}"
-    p = {"token": api_key}
-    if params:
-        p.update(params)
 
+    # Auth via header (NOT a token= query param) so the secret never reaches the
+    # URL that request_with_retry logs / embeds in HttpRetryError. See module doc.
+    session = requests.Session()
+    session.headers["X-Finnhub-Token"] = api_key
+
+    # Shared free-tier throttle: serialize callers in-process and hold the
+    # min-interval since the last call. Retries inside request_with_retry add
+    # their own (>= 1s) backoff, which keeps them comfortably under the ceiling.
     with _finnhub_lock:
         now = time.monotonic()
         wait = _FINNHUB_MIN_INTERVAL - (now - _finnhub_last_call)
@@ -76,9 +109,29 @@ def finnhub_get(endpoint: str, params: dict | None = None) -> dict | list:
             time.sleep(wait)
         _finnhub_last_call = time.monotonic()
 
-    resp = requests.get(url, params=p, timeout=_TIMEOUT)
+    try:
+        resp = request_with_retry(
+            url,
+            params=params or {},
+            session=session,
+            timeout=_TIMEOUT,
+            max_attempts=_FINNHUB_MAX_ATTEMPTS,
+            label=f"finnhub:{endpoint}",
+            logger=logger,
+        )
+    finally:
+        session.close()
+
     if resp.status_code == 429:
-        logger.warning("Finnhub 429 rate-limited on %s", endpoint)
+        # Still throttled after every retry. Existing contract: return empty so
+        # the caller treats it as no-data. WARN (not silent) so the throttle is
+        # visible — the upstream per-source populated-ratio gate still hard-fails
+        # if enough tickers come back empty, so this never hides a systemic gap.
+        logger.warning(
+            "Finnhub 429 rate-limited on %s after %d attempts",
+            endpoint,
+            _FINNHUB_MAX_ATTEMPTS,
+        )
         return []
     resp.raise_for_status()
     return resp.json()

--- a/tests/test_finnhub_client.py
+++ b/tests/test_finnhub_client.py
@@ -1,0 +1,117 @@
+"""Tests for the shared Finnhub HTTP client.
+
+Focus: the resilience + secret-hygiene wiring added 2026-06-11 to close the
+analyst_consensus gap (#397 / #399). The bounded-backoff retry math itself
+lives in (and is tested by) ``alpha_engine_lib.http_retry`` — here we assert
+that ``finnhub_get`` *uses* that primitive correctly and handles its outputs:
+
+  * missing key short-circuits to [] (no HTTP),
+  * auth rides the ``X-Finnhub-Token`` header, never a ``token=`` query param
+    (so the secret can't leak into retry logs / HttpRetryError),
+  * the request is routed through ``request_with_retry`` with a bounded
+    ``max_attempts`` and a scrub-safe label,
+  * a 429 that survives retries returns [] (no raise),
+  * a non-2xx that survives retries raises ``requests.HTTPError``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from collectors import finnhub_client
+
+
+def _fake_response(status_code: int, payload=None) -> MagicMock:
+    """A stand-in for the requests.Response that request_with_retry returns."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.json.return_value = payload if payload is not None else {}
+
+    def _raise_for_status():
+        if status_code >= 400:
+            raise requests.HTTPError(f"{status_code} Error")
+
+    resp.raise_for_status.side_effect = _raise_for_status
+    return resp
+
+
+@pytest.fixture
+def _set_key(monkeypatch):
+    monkeypatch.setattr(finnhub_client, "get_secret", lambda *a, **k: "SECRET_KEY")
+
+
+def test_missing_key_returns_empty_without_http(monkeypatch):
+    monkeypatch.setattr(finnhub_client, "get_secret", lambda *a, **k: "")
+    called = MagicMock()
+    monkeypatch.setattr(finnhub_client, "request_with_retry", called)
+
+    assert finnhub_client.finnhub_get("stock/recommendation", {"symbol": "AAPL"}) == []
+    called.assert_not_called()
+
+
+def test_auth_via_header_not_query_param(_set_key, monkeypatch):
+    """The token must travel in the X-Finnhub-Token header, never in params/URL."""
+    captured = {}
+
+    def _fake_rwr(url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params")
+        captured["session"] = kwargs.get("session")
+        captured["max_attempts"] = kwargs.get("max_attempts")
+        captured["label"] = kwargs.get("label")
+        return _fake_response(200, {"ok": True})
+
+    monkeypatch.setattr(finnhub_client, "request_with_retry", _fake_rwr)
+
+    out = finnhub_client.finnhub_get("stock/recommendation", {"symbol": "AAPL"})
+
+    assert out == {"ok": True}
+    # Secret is in the session header, not the query params or the URL.
+    assert captured["session"].headers["X-Finnhub-Token"] == "SECRET_KEY"
+    assert "token" not in (captured["params"] or {})
+    assert "SECRET_KEY" not in captured["url"]
+    assert captured["params"] == {"symbol": "AAPL"}
+    # Routed through the bounded-retry primitive with a scrub-safe label.
+    assert captured["max_attempts"] == finnhub_client._FINNHUB_MAX_ATTEMPTS
+    assert captured["label"] == "finnhub:stock/recommendation"
+
+
+def test_persistent_429_returns_empty(_set_key, monkeypatch):
+    monkeypatch.setattr(
+        finnhub_client, "request_with_retry",
+        lambda url, **kw: _fake_response(429),
+    )
+    # No raise — a throttled-out call is no-data, not a hard error.
+    assert finnhub_client.finnhub_get("stock/earnings", {"symbol": "AAPL"}) == []
+
+
+def test_success_returns_parsed_json(_set_key, monkeypatch):
+    payload = [{"strongBuy": 5, "buy": 3, "hold": 1, "sell": 0, "strongSell": 0}]
+    monkeypatch.setattr(
+        finnhub_client, "request_with_retry",
+        lambda url, **kw: _fake_response(200, payload),
+    )
+    assert finnhub_client.finnhub_get("stock/recommendation", {"symbol": "AAPL"}) == payload
+
+
+def test_non_2xx_survivor_raises(_set_key, monkeypatch):
+    """A 5xx that survives retries is returned by the primitive; we raise on it."""
+    monkeypatch.setattr(
+        finnhub_client, "request_with_retry",
+        lambda url, **kw: _fake_response(500),
+    )
+    with pytest.raises(requests.HTTPError):
+        finnhub_client.finnhub_get("stock/metric", {"symbol": "AAPL", "metric": "all"})
+
+
+def test_no_params_call_routes_empty_params(_set_key, monkeypatch):
+    captured = {}
+
+    def _fake_rwr(url, **kwargs):
+        captured["params"] = kwargs.get("params")
+        return _fake_response(200, {"ok": 1})
+
+    monkeypatch.setattr(finnhub_client, "request_with_retry", _fake_rwr)
+    finnhub_client.finnhub_get("stock/recommendation")
+    assert captured["params"] == {}


### PR DESCRIPTION
## Root cause
`analyst_consensus` breached DataPhase2's per-source populated-ratio gate twice today:

| Issue | Time | analyst_consensus |
|---|---|---|
| [#397](https://github.com/cipher813/alpha-engine-data/issues/397) (EXTERNAL) | 13:49 | **0/10** |
| [#399](https://github.com/cipher813/alpha-engine-data/issues/399) (DATA) | 14:30 | **7/10** |

Recovering 0% → 70% in ~40 min rules out a dead key (that would stay 0%) — it's **intermittent Finnhub throttling sitting right at the 80% gate**. And `finnhub_get` made a **single attempt**: a one-off 429 or 5xx returned `[]`/raised immediately with **zero retry**, so a Saturday rate-limit burst silently nulled the source that supplies analyst rating / num_analysts / earnings.

> Note: the source is **Finnhub + yfinance**, *not* FMP/SEC — flow-doctor's "FMP 402 / SEC rate-limit" hypotheses and its `affected_files` (`daily_news.py`) were both off. The real path is `finnhub_client.py` + `alternative.py::_fetch_analyst`.

## Fix
Migrate `finnhub_get` onto **`alpha_engine_lib.http_retry.request_with_retry`** — the L4499 bounded-backoff chokepoint that consolidated four data-repo sites but never picked up `finnhub_client.py` (which is *why* it had no retry). Now: 3 attempts, full-jitter exponential backoff, `Retry-After` honored, on the transient class (429 + 5xx + network).

Contract preserved:
- missing key → `[]`
- persistent 429 (survives retries) → `[]` + **WARN** (not silent — the populated-ratio gate still hard-fails a systemic gap, so this never hides a real outage)
- non-2xx survivor → `requests.HTTPError` as before

## Secret hygiene
Auth moves from a `token=` query param to the **`X-Finnhub-Token` header**. The http-retry scrubber masks `api_key=`/`apiKey=` but **not** `token=`, and `request_with_retry` embeds the effective URL in its backoff logs / `HttpRetryError` — header auth keeps the secret out of the URL entirely, so there's nothing to leak.

## Tests
New `tests/test_finnhub_client.py`: missing-key short-circuit, header-not-query auth (token absent from params + URL), persistent-429 → `[]`, success, non-2xx raise, empty-params routing. Full suite green locally: **1925 passed, 1 skipped**.

## Deferred (written rationale)
`yfinance Ticker.info` (the sole price-target source) is also retry-less, but it is **not** the gating field — `analyst_consensus` is satisfied by Finnhub's rating/num_analysts/earnings alone — and a per-ticker yfinance retry loop risks blowing the collection runtime. Better as a separate P2 than bundled here.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)