### PR TITLE
feat(weekday-sf): split ArcticDB daily_append into its own skip-gated state (L4608)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -248,7 +248,7 @@
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/morning-enrich.log \"s3://alpha-engine-research/_ssm_logs/morning-enrich/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/morning-enrich.log",
-            "python weekly_collector.py --morning-enrich --skip-chronic-heal 2>&1 | tee -a /var/log/morning-enrich.log"
+            "python weekly_collector.py --morning-enrich --skip-chronic-heal --skip-arctic-append 2>&1 | tee -a /var/log/morning-enrich.log"
           ],
           "executionTimeout": ["1800"]
         },
@@ -302,7 +302,7 @@
         {
           "Variable": "$.morning_enrich_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipChronicGapHeal"
+          "Next": "CheckSkipMorningArcticAppend"
         },
         {
           "Variable": "$.morning_enrich_poll.Status",
@@ -990,17 +990,127 @@
 
     "CheckSkipMorningEnrich": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4606). Input {\"skip_morning_enrich\": true} routes past MorningEnrich to the next gate (CheckSkipChronicGapHeal); missing flag = run as normal. Mirrors the Saturday SF CheckSkip<State> structure so the weekday pipeline is rerunnable task-by-task — an operator recovery rerun resumes at the first incomplete task instead of re-running completed upstream work. The 2026-06-11 chronic-gap rerun had to re-run the already-completed MorningEnrich daily_append (~20 min) because this gate did not exist. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_morning_enrich\": true} routes past MorningEnrich (fetch: constituents + prune + polygon daily_closes) to the next gate (CheckSkipMorningArcticAppend); missing flag = run as normal. Mirrors the Saturday SF CheckSkip<State> structure so the weekday pipeline is rerunnable task-by-task — an operator recovery rerun resumes at the first incomplete task instead of re-running completed upstream work. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_morning_enrich", "IsPresent": true},
             {"Variable": "$.skip_morning_enrich", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipChronicGapHeal"
+          "Next": "CheckSkipMorningArcticAppend"
         }
       ],
       "Default": "MorningEnrich"
+    },
+
+    "CheckSkipMorningArcticAppend": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4608). Input {\"skip_morning_arctic_append\": true} routes past MorningArcticAppend to the next gate (CheckSkipChronicGapHeal); missing flag = run as normal. The slow ArcticDB daily_append was split out of MorningEnrich 2026-06-11 — it ran ~20-38 min and a same-morning rerun exceeded MorningEnrich's 1800s SSM timeout and SIGKILLed it. As its own state it gets a longer timeout decoupled from the fast fetch, and a recovery rerun can skip whichever half already completed. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_morning_arctic_append", "IsPresent": true},
+            {"Variable": "$.skip_morning_arctic_append", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipChronicGapHeal"
+        }
+      ],
+      "Default": "MorningArcticAppend"
+    },
+
+    "MorningArcticAppend": {
+      "Type": "Task",
+      "Comment": "LOAD-BEARING: ArcticDB universe daily_append for the prior trading day — writes the polygon-corrected OHLCV row + recomputed features that predictor inference reads next. Split out of MorningEnrich (L4608, 2026-06-11): the append is the slow part (~20-38 min on the t3.small) and on 2026-06-11 a same-morning rerun's append exceeded MorningEnrich's 1800s executionTimeout and SIGKILLed the whole command. Own longer timeout (2400s) decoupled from the fast fetch; reads the constituents MorningEnrich just refreshed to S3. Failure → HandleFailure (predictor must not run on a stale ArcticDB).",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+            "cd /home/ec2-user/alpha-engine-data",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/morning-arctic-append.log \"s3://alpha-engine-research/_ssm_logs/morning-arctic-append/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
+            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/morning-arctic-append.log",
+            "python weekly_collector.py --morning-arctic-append 2>&1 | tee -a /var/log/morning-arctic-append.log"
+          ],
+          "executionTimeout": ["2400"]
+        },
+        "TimeoutSeconds": 2400
+      },
+      "TimeoutSeconds": 2460,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.arctic_append_result",
+      "Next": "WaitForMorningArcticAppend"
+    },
+
+    "WaitForMorningArcticAppend": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.arctic_append_result.Command.CommandId",
+        "InstanceId.$": "$.trading_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.arctic_append_poll",
+      "Next": "CheckMorningArcticAppendStatus"
+    },
+
+    "CheckMorningArcticAppendStatus": {
+      "Type": "Choice",
+      "Comment": "LOAD-BEARING like CheckMorningEnrichStatus: only Success proceeds (to the chronic-gap heal gate, then PredictorInference); any other terminal SSM status → HandleFailure (predictor must not run on a stale ArcticDB universe). Only InProgress/Pending keep polling.",
+      "Choices": [
+        {
+          "Variable": "$.arctic_append_poll.Status",
+          "StringEquals": "Success",
+          "Next": "CheckSkipChronicGapHeal"
+        },
+        {
+          "Variable": "$.arctic_append_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "MorningArcticAppendWait"
+        },
+        {
+          "Variable": "$.arctic_append_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "MorningArcticAppendWait"
+        }
+      ],
+      "Default": "HandleFailure"
+    },
+
+    "MorningArcticAppendWait": {
+      "Type": "Wait",
+      "Seconds": 20,
+      "Next": "WaitForMorningArcticAppend"
     },
 
     "CheckSkipChronicGapHeal": {

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -63,22 +63,26 @@ class TestChainOrdering:
     """CheckMorningEnrichStatus(Success) → ChronicGapSelfHeal →
     WaitForChronicGap → CheckChronicGapStatus(terminal) → PredictorInference."""
 
-    def test_morning_enrich_success_routes_to_heal(self, states):
-        # Since L4606 the heal sits behind the CheckSkipChronicGapHeal rerun
-        # gate, whose Default runs the heal. MorningEnrich success → that gate
-        # → (no skip flag) ChronicGapSelfHeal. The heal still runs AFTER a
-        # completed (load-bearing) MorningEnrich.
+    def test_heal_runs_after_morning_enrich_and_append(self, states):
+        # Since L4608 the load-bearing daily_append (CheckSkipMorningArcticAppend
+        # → MorningArcticAppend) sits between MorningEnrich and the heal. The
+        # heal still runs (behind its skip-gate) AFTER both, before predictions.
         success = [
             c["Next"]
             for c in states["CheckMorningEnrichStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == ["CheckSkipChronicGapHeal"], (
-            "MorningEnrich success must hand off to the chronic-gap skip-gate"
+        assert success == ["CheckSkipMorningArcticAppend"], (
+            "MorningEnrich success must hand off to the arctic-append gate"
         )
-        assert states["CheckSkipChronicGapHeal"]["Default"] == _HEAL, (
-            "the skip-gate's Default must run ChronicGapSelfHeal"
-        )
+        # Append success → the chronic-gap skip-gate → (no flag) the heal.
+        append_success = [
+            c["Next"]
+            for c in states["CheckMorningArcticAppendStatus"]["Choices"]
+            if c.get("StringEquals") == "Success"
+        ]
+        assert append_success == ["CheckSkipChronicGapHeal"]
+        assert states["CheckSkipChronicGapHeal"]["Default"] == _HEAL
 
     def test_heal_routes_to_poll(self, states):
         assert states[_HEAL]["Next"] == _POLL

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -31,7 +31,8 @@ _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
 
 # (gate, task, skip_flag, next_gate) in pipeline order.
 _CHAIN = [
-    ("CheckSkipMorningEnrich", "MorningEnrich", "skip_morning_enrich", "CheckSkipChronicGapHeal"),
+    ("CheckSkipMorningEnrich", "MorningEnrich", "skip_morning_enrich", "CheckSkipMorningArcticAppend"),
+    ("CheckSkipMorningArcticAppend", "MorningArcticAppend", "skip_morning_arctic_append", "CheckSkipChronicGapHeal"),
     ("CheckSkipChronicGapHeal", "ChronicGapSelfHeal", "skip_chronic_gap_heal", "CheckSkipPredictorInference"),
     ("CheckSkipPredictorInference", "PredictorInference", "skip_predictor_inference", "CheckSkipMorningPlanner"),
     ("CheckSkipMorningPlanner", "RunMorningPlanner", "skip_morning_planner", "CheckSkipRunDaemon"),
@@ -85,10 +86,31 @@ class TestEntryEdgesRouteThroughGates:
     def test_trading_day_check_failed_enters_morning_enrich_gate(self, states):
         assert states["TradingDayCheckFailed"]["Next"] == "CheckSkipMorningEnrich"
 
-    def test_morning_enrich_success_enters_heal_gate(self, states):
+    def test_morning_enrich_success_enters_append_gate(self, states):
+        # L4608: the slow daily_append is now its own load-bearing state behind
+        # CheckSkipMorningArcticAppend, after the fast MorningEnrich fetch.
         success = [c["Next"] for c in states["CheckMorningEnrichStatus"]["Choices"]
                    if c.get("StringEquals") == "Success"]
+        assert success == ["CheckSkipMorningArcticAppend"]
+
+    def test_arctic_append_success_enters_heal_gate(self, states):
+        success = [c["Next"] for c in states["CheckMorningArcticAppendStatus"]["Choices"]
+                   if c.get("StringEquals") == "Success"]
         assert success == ["CheckSkipChronicGapHeal"]
+
+    def test_arctic_append_is_load_bearing(self, states):
+        # Unlike the fail-soft heal, daily_append must halt the pipeline on
+        # failure — predictor reads the ArcticDB universe right after.
+        assert states["CheckMorningArcticAppendStatus"]["Default"] == "HandleFailure"
+        assert states["MorningArcticAppend"]["Catch"][0]["Next"] == "HandleFailure"
+        assert states["WaitForMorningArcticAppend"]["Catch"][0]["Next"] == "HandleFailure"
+        # Its SSM command runs the standalone append entrypoint, with a longer
+        # timeout than MorningEnrich's 1800s.
+        from tests.sf_command_utils import extract_commands
+        cmds = "\n".join(extract_commands(states["MorningArcticAppend"]))
+        assert "weekly_collector.py --morning-arctic-append" in cmds
+        et = states["MorningArcticAppend"]["Parameters"]["Parameters"]["executionTimeout"]
+        assert int(et[0] if isinstance(et, list) else et) > 1800
 
     def test_chronic_gap_terminal_enters_predictor_gate(self, states):
         # CheckChronicGapStatus Default + both heal Catches.
@@ -146,9 +168,20 @@ class TestPaths:
             assert task not in order, f"{task} ran despite its skip flag"
         assert order == ["PipelineComplete"]
 
-    def test_skip_morning_enrich_only_resumes_at_heal(self, states):
-        """The exact 6/11 case: MorningEnrich already done → skip it, run the rest."""
+    def test_skip_fetch_only_resumes_at_append(self, states):
+        """MorningEnrich fetch already done → skip it, run the append onward."""
         order = self._walk(states, "CheckSkipMorningEnrich", skip_flags={"skip_morning_enrich"})
         assert "MorningEnrich" not in order
+        assert order[0] == "MorningArcticAppend"
+        assert "PredictorInference" in order and order[-1] == "PipelineComplete"
+
+    def test_skip_fetch_and_append_resumes_at_heal(self, states):
+        """The exact 6/11 recovery case: fetch + append both done → skip both,
+        resume at the heal → predictions."""
+        order = self._walk(
+            states, "CheckSkipMorningEnrich",
+            skip_flags={"skip_morning_enrich", "skip_morning_arctic_append"},
+        )
+        assert "MorningEnrich" not in order and "MorningArcticAppend" not in order
         assert order[0] == "ChronicGapSelfHeal"
         assert "PredictorInference" in order and order[-1] == "PipelineComplete"

--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -768,3 +768,64 @@ def test_run_chronic_gap_heal_never_raises_on_load_failure():
     assert out["status"] == "ok"
     assert out["mode"] == "chronic_gap_heal"
     assert out["collectors"]["chronic_gap_heal_wrapper"]["status"] == "error"
+
+
+# ── arctic-append split (L4608) ─────────────────────────────────────────────
+
+
+def test_arctic_append_routes_via_run_weekly():
+    """run_weekly must dispatch --morning-arctic-append to _run_morning_arctic_append."""
+    args = SimpleNamespace(
+        morning_enrich=False, morning_arctic_append=True, chronic_gap_heal=False, daily=False,
+    )
+    with patch("weekly_collector._run_morning_arctic_append",
+               return_value={"status": "ok", "mode": "morning_arctic_append"}) as ap:
+        out = weekly_collector.run_weekly({"bucket": "b"}, args)
+    ap.assert_called_once()
+    assert out["mode"] == "morning_arctic_append"
+
+
+def test_morning_enrich_skip_arctic_append_does_not_append():
+    """--skip-arctic-append (weekday SF) suppresses the inline daily_append —
+    the separate MorningArcticAppend SF state runs it instead."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(
+        date="2026-04-22", dry_run=True, morning_enrich=True,
+        skip_chronic_heal=True, skip_arctic_append=True,
+    )
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+    append_calls = []
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok_dry_run", "polygon": 1, "fred": 0,
+                             "yfinance": 0, "tickers_captured": 1, "source": "polygon_only"}), \
+         patch("builders.daily_append.daily_append",
+               side_effect=lambda **k: append_calls.append(k) or {"status": "ok"}):
+        result = weekly_collector._run_morning_enrich(config, args)
+    assert append_calls == [], "daily_append must not run when --skip-arctic-append"
+    assert "arcticdb" not in result["collectors"]
+
+
+def test_arctic_append_runs_daily_append_and_is_load_bearing():
+    """_run_morning_arctic_append runs daily_append for the target date and
+    returns failed (load-bearing) when the append errors."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-04-22", dry_run=False)
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL", "MSFT"]}
+
+    # happy path
+    calls = []
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.daily_append.daily_append",
+               side_effect=lambda **k: calls.append(k) or {"status": "ok"}):
+        ok = weekly_collector._run_morning_arctic_append(config, args)
+    assert ok["status"] == "ok" and ok["mode"] == "morning_arctic_append"
+    assert calls and calls[0]["date_str"] == "2026-04-22"
+
+    # load-bearing: append raises → failed
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.daily_append.daily_append", side_effect=RuntimeError("boom")):
+        bad = weekly_collector._run_morning_arctic_append(config, args)
+    assert bad["status"] == "failed"

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -220,6 +220,9 @@ def run_weekly(config: dict, args: argparse.Namespace) -> dict:
     if getattr(args, "morning_enrich", False):
         return _run_morning_enrich(config, args)
 
+    if getattr(args, "morning_arctic_append", False):
+        return _run_morning_arctic_append(config, args)
+
     if getattr(args, "chronic_gap_heal", False):
         return _run_chronic_gap_heal(config, args)
 
@@ -1204,22 +1207,34 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
     # ── Re-append to ArcticDB so the polygon-overwritten row replaces the
     # yfinance row written at EOD. universe_lib.update() is idempotent for
     # same-date overwrites (see daily_append.py:232-242 for the design intent).
-    logger.info("=" * 60)
-    logger.info("APPENDING: ArcticDB universe (morning enrich, %s)", target_date)
-    logger.info("=" * 60)
-    try:
-        from builders.daily_append import daily_append
-        with _maybe_phase(reg, "morning_arcticdb"):
-            arctic_result = daily_append(
-                date_str=target_date,
-                bucket=bucket,
-                dry_run=dry_run,
-                expected_tickers=tickers,
-            )
-        results["collectors"]["arcticdb"] = arctic_result
-    except Exception as e:
-        logger.exception("ArcticDB daily_append (morning enrich) failed for %s", target_date)
-        results["collectors"]["arcticdb"] = {"status": "error", "error": str(e)}
+    #
+    # daily_append is the SLOW part of MorningEnrich (~20-38 min on the
+    # t3.small). 2026-06-11: a same-morning rerun's append exceeded the 1800s
+    # SSM executionTimeout and SIGKILLed MorningEnrich (L4608). ``--skip-arctic-append``
+    # decouples it on the WEEKDAY pipeline, where it runs as its OWN skip-gated,
+    # load-bearing SF state (``MorningArcticAppend``, via ``_run_morning_arctic_append``)
+    # with a longer timeout AFTER the fast fetch — so (a) the append's duration
+    # can no longer time out the fetch, and (b) a recovery rerun can skip the
+    # completed fetch and re-run only the append (or vice-versa). The SATURDAY
+    # pipeline still runs it INLINE here (no skip flag): the append must precede
+    # DataPhase1's postflight, same rationale as the inline chronic-gap heal.
+    if not getattr(args, "skip_arctic_append", False):
+        logger.info("=" * 60)
+        logger.info("APPENDING: ArcticDB universe (morning enrich, %s)", target_date)
+        logger.info("=" * 60)
+        try:
+            from builders.daily_append import daily_append
+            with _maybe_phase(reg, "morning_arcticdb"):
+                arctic_result = daily_append(
+                    date_str=target_date,
+                    bucket=bucket,
+                    dry_run=dry_run,
+                    expected_tickers=tickers,
+                )
+            results["collectors"]["arcticdb"] = arctic_result
+        except Exception as e:
+            logger.exception("ArcticDB daily_append (morning enrich) failed for %s", target_date)
+            results["collectors"]["arcticdb"] = {"status": "error", "error": str(e)}
 
     # ── Chronic-polygon-gap self-heal ────────────────────────────────────────
     # The chronic-gap drift-detection + yfinance self-heal logic lives in
@@ -1312,6 +1327,103 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
         ", ".join(f"{k}={v.get('status', '?')}" for k, v in results["collectors"].items()),
         duration,
     )
+    return results
+
+
+def _run_morning_arctic_append(config: dict, args: argparse.Namespace) -> dict:
+    """Standalone ArcticDB universe append for the prior trading day (L4608).
+
+    Split out of :func:`_run_morning_enrich` (2026-06-11) into its own weekday-SF
+    state (``MorningArcticAppend``). MorningEnrich now does only the fast fetch
+    (constituents refresh + prune + polygon daily_closes overwrite, via
+    ``--skip-arctic-append``); this runs the SLOW ``daily_append`` that writes
+    the polygon-corrected row + recomputed features into the ArcticDB universe
+    library.
+
+    Why split: ``daily_append`` ran ~20-38 min on the t3.small and on 2026-06-11
+    a same-morning rerun exceeded MorningEnrich's 1800s SSM ``executionTimeout``
+    and SIGKILLed it. As its own state the append gets a longer timeout decoupled
+    from the fetch, and a recovery rerun can skip whichever half already
+    completed (``skip_morning_enrich`` / ``skip_morning_arctic_append``) instead
+    of re-paying both.
+
+    LOAD-BEARING: predictor inference reads the ArcticDB universe right after
+    this, so an append failure returns ``status="failed"`` → ``main()`` exits 1
+    → the SF's ``CheckMorningArcticAppendStatus`` routes to HandleFailure. Reads
+    the constituents MorningEnrich just refreshed to S3 (so the expected-ticker
+    scope matches the post-prune universe).
+    """
+    bucket = config["bucket"]
+    started_at = datetime.now(timezone.utc).isoformat()
+
+    # Same PT-aware target-date resolution as MorningEnrich, so the append
+    # targets the prior trading day MorningEnrich just fetched.
+    if args.date is None:
+        from zoneinfo import ZoneInfo
+        target_date = _previous_trading_day(
+            reference=datetime.now(ZoneInfo("America/Los_Angeles"))
+        )
+    else:
+        target_date = args.date
+
+    dry_run = args.dry_run
+    results: dict = {
+        "mode": "morning_arctic_append",
+        "date": target_date,
+        "started_at": started_at,
+        "collectors": {},
+    }
+
+    # Load the constituents MorningEnrich just refreshed to S3 (post-prune
+    # universe scope for daily_append's expected-ticker check). S3 → Wikipedia
+    # fallback, mirroring _run_daily.
+    tickers: list[str] = []
+    market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
+    try:
+        existing = constituents.load_from_s3(bucket, market_prefix)
+        if existing:
+            tickers = existing.get("tickers", [])
+            logger.info("Loaded %d tickers from S3 constituents", len(tickers))
+    except Exception as exc:
+        logger.warning("S3 constituents load failed — will try Wikipedia fallback: %s", exc)
+    if not tickers:
+        try:
+            tickers, _, _, _, _ = constituents._fetch_constituents()
+            logger.info("Loaded %d tickers from Wikipedia (S3 fallback)", len(tickers))
+        except Exception as exc:
+            logger.error("Wikipedia constituents fallback failed: %s", exc)
+
+    if not tickers:
+        logger.error("No tickers available for ArcticDB append")
+        results["status"] = "failed"
+        results["completed_at"] = datetime.now(timezone.utc).isoformat()
+        return results
+
+    logger.info("=" * 60)
+    logger.info("APPENDING: ArcticDB universe (arctic-append state, %s)", target_date)
+    logger.info("=" * 60)
+    reg = _build_registry(config, args, target_date)
+    try:
+        from builders.daily_append import daily_append
+        with _maybe_phase(reg, "morning_arcticdb"):
+            arctic_result = daily_append(
+                date_str=target_date,
+                bucket=bucket,
+                dry_run=dry_run,
+                expected_tickers=tickers,
+            )
+        results["collectors"]["arcticdb"] = arctic_result
+        # daily_append returns its own status; surface it as the load-bearing
+        # verdict so a write failure halts the pipeline (predictor reads next).
+        _status = arctic_result.get("status", "unknown")
+        results["status"] = "ok" if _status in ("ok", "ok_dry_run") else "failed"
+    except Exception as e:
+        logger.exception("ArcticDB daily_append (arctic-append state) failed for %s", target_date)
+        results["collectors"]["arcticdb"] = {"status": "error", "error": str(e)}
+        results["status"] = "failed"
+
+    results["completed_at"] = datetime.now(timezone.utc).isoformat()
+    logger.info("ArcticDB append %s for %s", results["status"].upper(), target_date)
     return results
 
 
@@ -1900,6 +2012,19 @@ def _parse_args() -> argparse.Namespace:
              "(the weekday SF runs it as a separate fail-soft ChronicGapSelfHeal "
              "state instead). The Saturday SF omits this flag so the heal still "
              "runs inline before DataPhase1's postflight.",
+    )
+    parser.add_argument(
+        "--skip-arctic-append", dest="skip_arctic_append", action="store_true",
+        help="With --morning-enrich: skip the inline ArcticDB daily_append "
+             "(the weekday SF runs it as a separate load-bearing MorningArcticAppend "
+             "state with a longer timeout). The Saturday SF omits this flag so the "
+             "append still runs inline before DataPhase1's postflight.",
+    )
+    parser.add_argument(
+        "--morning-arctic-append", dest="morning_arctic_append", action="store_true",
+        help="Standalone ArcticDB universe append for the prior trading day "
+             "(the slow daily_append split out of --morning-enrich, L4608). "
+             "Load-bearing: exits 1 on append failure. --date overrides target day.",
     )
     parser.add_argument(
         "--phase", type=int, choices=[1, 2], default=None,


### PR DESCRIPTION
Splits the slow ArcticDB daily_append out of MorningEnrich into its own load-bearing, skip-gated SF state (MorningArcticAppend, 2400s timeout). Fixes L4608: on 2026-06-11 a same-morning recovery rerun's append exceeded MorningEnrich's 1800s SSM timeout and SIGKILLed it. MorningEnrich now runs fetch-only (--morning-enrich --skip-chronic-heal --skip-arctic-append); a recovery rerun can skip the completed fetch OR append independently (skip_morning_enrich / skip_morning_arctic_append). Saturday keeps it inline. New --morning-arctic-append mode (load-bearing, exits 1 on failure). Full suite green (1929 passed, 1 skipped). Auto-deploys on merge.