### PR TITLE
feat(metron): restore history + add sectors/earnings reference producer

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -41,9 +41,36 @@ DEFAULT_BUCKET = "alpha-engine-research"
 HOLDINGS_UNIVERSE_KEY = "metron/holdings_universe.json"
 CLOSES_PREFIX = "market_data/eod_closes/"
 FX_PREFIX = "market_data/fx/"
+# History artifacts (per-symbol / per-currency) — power Metron's Performance NAV
+# reconstruction (close series) + as-of-date realized/dividend FX conversion.
+CLOSE_HISTORY_PREFIX = "market_data/close_history/"
+FX_HISTORY_PREFIX = "market_data/fx_history/"
+# Reference data — GICS sector per held symbol + SPY's sector weights (Brinson
+# attribution), and each held symbol's next earnings date (Calendar page). Moves
+# Metron's last yfinance fetches to the spine so Metron reads ALL external data here.
+SECTORS_PREFIX = "market_data/sectors/"
+EARNINGS_PREFIX = "market_data/earnings/"
 CLOSES_SCHEMA_VERSION = 1
 FX_SCHEMA_VERSION = 1
+CLOSE_HISTORY_SCHEMA_VERSION = 1
+FX_HISTORY_SCHEMA_VERSION = 1
+SECTORS_SCHEMA_VERSION = 1
+EARNINGS_SCHEMA_VERSION = 1
 BASE_CURRENCY = "USD"
+DEFAULT_HISTORY_PERIOD = "10y"  # mirrors the predictor price_cache 10y convention
+BENCHMARK = "SPY"  # the attribution benchmark whose GICS sector weights we publish
+
+# yfinance ``funds_data.sector_weightings`` snake_case keys → canonical GICS label
+# (the Title-Case labels ``Ticker.info['sector']`` returns). Stable GICS reference;
+# mirrored from metron portfolio_analytics/sectors.
+_FUNDS_SECTOR_KEY = {
+    "technology": "Technology", "financial_services": "Financial Services",
+    "healthcare": "Healthcare", "consumer_cyclical": "Consumer Cyclical",
+    "consumer_defensive": "Consumer Defensive", "energy": "Energy",
+    "industrials": "Industrials", "basic_materials": "Basic Materials",
+    "utilities": "Utilities", "realestate": "Real Estate",
+    "communication_services": "Communication Services",
+}
 
 _YFINANCE_BATCH_SIZE = 100
 _YFINANCE_BATCH_DELAY = 2  # seconds between batches (rate-limit courtesy)
@@ -53,6 +80,14 @@ _YFINANCE_BATCH_DELAY = 2  # seconds between batches (rate-limit courtesy)
 CloseSource = Callable[[list[str]], dict[str, tuple[float, str]]]
 # An FX source maps currencies → {currency: rate} (base per 1 unit of currency).
 FxSource = Callable[[list[str]], dict[str, float]]
+# History sources map symbols/currencies → {key: [(date_iso, value), …]} ascending.
+CloseHistorySource = Callable[[list[str]], dict[str, list[tuple[str, float]]]]
+FxHistorySource = Callable[[list[str]], dict[str, list[tuple[str, float]]]]
+# Reference sources: sectors maps yf_symbols → {yf_symbol: gics}; benchmark weights is a
+# 0-arg → {sector: weight}; earnings maps yf_symbols → {yf_symbol: date_iso}.
+SectorSource = Callable[[list[str]], dict[str, str]]
+BenchmarkWeightsSource = Callable[[], dict[str, float]]
+EarningsSource = Callable[[list[str]], dict[str, str]]
 
 
 # ── Universe read ───────────────────────────────────────────────────────────
@@ -162,6 +197,113 @@ def _yfinance_fx(currencies: list[str], base: str = BASE_CURRENCY) -> dict[str, 
     return out
 
 
+def _yf_history(symbols: list[str], period: str, *, is_fx: bool = False, base: str = BASE_CURRENCY) -> dict[str, list[tuple[str, float]]]:
+    """Daily close series per symbol via yfinance over ``period`` →
+    ``{key: [(bar_date, close), …]}`` ascending. ``is_fx`` maps a currency to the
+    ``{CCY}{BASE}=X`` pair and keys the result by the bare currency. Empty series omitted."""
+    try:
+        import pandas as pd
+        import yfinance as yf
+    except ImportError:  # pragma: no cover
+        logger.warning("[metron_market_data] yfinance/pandas unavailable for history")
+        return {}
+
+    targets = {f"{c}{base}=X": c for c in symbols if c and c != base} if is_fx else {s: s for s in symbols if s}
+    if not targets:
+        return {}
+    out: dict[str, list[tuple[str, float]]] = {}
+    keys = list(targets)
+    batches = [keys[i:i + _YFINANCE_BATCH_SIZE] for i in range(0, len(keys), _YFINANCE_BATCH_SIZE)]
+    for i, batch in enumerate(batches):
+        if i > 0:
+            time.sleep(_YFINANCE_BATCH_DELAY)
+        try:
+            raw = yf.download(tickers=batch[0] if len(batch) == 1 else batch, period=period,
+                              interval="1d", auto_adjust=False, progress=False, group_by="ticker", threads=True)
+            is_multi = isinstance(raw.columns, pd.MultiIndex)
+            for key in batch:
+                try:
+                    df = (raw[key] if is_multi else raw).copy()
+                    df.index = pd.to_datetime(df.index)
+                    df = df.dropna(subset=["Close"])
+                    if df.empty:
+                        continue
+                    out[targets[key]] = [(d.date().isoformat(), round(float(c), 6)) for d, c in df["Close"].items()]
+                except Exception as e:
+                    logger.warning("[metron_market_data] history extract failed for %s: %s", key, e)
+        except Exception as e:
+            logger.warning("[metron_market_data] yfinance history batch failed: %s", e)
+    logger.info("[metron_market_data] history: %d/%d series captured", len(out), len(targets))
+    return out
+
+
+def _yfinance_close_history(yf_symbols: list[str], period: str = DEFAULT_HISTORY_PERIOD) -> dict[str, list[tuple[str, float]]]:
+    return _yf_history(yf_symbols, period, is_fx=False)
+
+
+def _yfinance_fx_history(currencies: list[str], period: str = DEFAULT_HISTORY_PERIOD) -> dict[str, list[tuple[str, float]]]:
+    return _yf_history(currencies, period, is_fx=True)
+
+
+def _yfinance_sectors(yf_symbols: list[str]) -> dict[str, str]:
+    """Canonical GICS sector per held symbol via ``yf.Ticker(sym).info['sector']``.
+    Fail-soft: an unclassifiable symbol is omitted (Metron shows a coverage gap)."""
+    try:
+        import yfinance as yf
+    except ImportError:  # pragma: no cover
+        return {}
+    out: dict[str, str] = {}
+    for sym in yf_symbols:
+        try:
+            sector = (yf.Ticker(sym).info or {}).get("sector")
+            if sector:
+                out[sym] = str(sector)
+        except Exception as e:
+            logger.warning("[metron_market_data] sector fetch failed for %s: %s", sym, e)
+    logger.info("[metron_market_data] sectors: %d/%d classified", len(out), len(yf_symbols))
+    return out
+
+
+def _yfinance_spy_weights() -> dict[str, float]:
+    """SPY's live GICS sector weights (canonical label → fraction) via
+    ``funds_data.sector_weightings`` (snake_case → canonical). ``{}`` on failure."""
+    try:
+        import yfinance as yf
+    except ImportError:  # pragma: no cover
+        return {}
+    try:
+        raw = yf.Ticker(BENCHMARK).funds_data.sector_weightings or {}
+    except Exception as e:
+        logger.warning("[metron_market_data] SPY sector weights fetch failed: %s", e)
+        return {}
+    return {_FUNDS_SECTOR_KEY[k]: float(v) for k, v in raw.items() if k in _FUNDS_SECTOR_KEY}
+
+
+def _yfinance_earnings(yf_symbols: list[str]) -> dict[str, str]:
+    """Next (earliest upcoming) earnings date per held symbol via yfinance →
+    ``{yf_symbol: date_iso}``. Fail-soft: no resolvable date → omitted."""
+    try:
+        import pandas as pd
+        import yfinance as yf
+    except ImportError:  # pragma: no cover
+        return {}
+    out: dict[str, str] = {}
+    for sym in yf_symbols:
+        try:
+            df = yf.Ticker(sym).get_earnings_dates(limit=8)
+            if df is None or df.empty:
+                continue
+            idx = pd.to_datetime(df.index)
+            today = pd.Timestamp.utcnow().tz_localize(None)
+            future = sorted(d for d in idx.tz_localize(None) if d >= today)
+            if future:
+                out[sym] = future[0].date().isoformat()
+        except Exception as e:
+            logger.warning("[metron_market_data] earnings fetch failed for %s: %s", sym, e)
+    logger.info("[metron_market_data] earnings: %d/%d dated", len(out), len(yf_symbols))
+    return out
+
+
 # ── S3 write (the single put-object site for this file) ──────────────────────
 
 
@@ -246,16 +388,110 @@ def collect(
     }
 
 
+def collect_history(
+    *, bucket: str = DEFAULT_BUCKET, dry_run: bool = False, s3_client: Any = None,
+    period: str = DEFAULT_HISTORY_PERIOD,
+    close_history_source: CloseHistorySource | None = None,
+    fx_history_source: FxHistorySource | None = None,
+) -> dict:
+    """Write per-symbol close-history + per-currency FX-history artifacts for Metron's
+    held universe (Performance NAV reconstruction + as-of-date realized/dividend FX):
+
+        market_data/close_history/{yf_symbol}.json  {schema_version, yf_symbol, currency, closes: [[date, close], …]}
+        market_data/fx_history/{CCY}.json           {schema_version, currency, base, rates: [[date, rate], …]}
+
+    Idempotent (full-series overwrite each run). Injectable sources/S3 for tests."""
+    if s3_client is None:
+        import boto3
+        s3_client = boto3.client("s3")
+    holdings, currencies = load_metron_universe(bucket, s3_client)
+    if not holdings:
+        return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
+    ccy_by_yf = {h["yf_symbol"]: h["currency"] for h in holdings}
+    closes = (close_history_source or _yfinance_close_history)(sorted(ccy_by_yf))
+    fx = (fx_history_source or _yfinance_fx_history)(currencies)
+    if dry_run:
+        logger.info("[metron_market_data] DRY-RUN history: %d close series, %d fx series", len(closes), len(fx))
+        return {"status": "ok_dry_run", "close_series": len(closes), "fx_series": len(fx)}
+    try:
+        for yf_sym, series in sorted(closes.items()):
+            _write_json(s3_client, bucket, f"{CLOSE_HISTORY_PREFIX}{yf_sym}.json", {
+                "schema_version": CLOSE_HISTORY_SCHEMA_VERSION, "yf_symbol": yf_sym,
+                "currency": ccy_by_yf.get(yf_sym, "USD"), "closes": [list(p) for p in series]})
+        for ccy, series in sorted(fx.items()):
+            _write_json(s3_client, bucket, f"{FX_HISTORY_PREFIX}{ccy}.json", {
+                "schema_version": FX_HISTORY_SCHEMA_VERSION, "currency": ccy,
+                "base": BASE_CURRENCY, "rates": [list(p) for p in series]})
+    except Exception as e:  # fail loud to the phase registry
+        logger.error("[metron_market_data] history write failed: %s", e)
+        return {"status": "error", "error": str(e)}
+    logger.info("[metron_market_data] wrote %d close-history + %d fx-history series", len(closes), len(fx))
+    return {"status": "ok", "close_series": len(closes), "fx_series": len(fx)}
+
+
+def collect_reference(
+    *, bucket: str = DEFAULT_BUCKET, run_date: str | None = None, dry_run: bool = False,
+    s3_client: Any = None, sector_source: SectorSource | None = None,
+    benchmark_source: BenchmarkWeightsSource | None = None, earnings_source: EarningsSource | None = None,
+) -> dict:
+    """Write the GICS-sectors + earnings reference artifacts for Metron's held universe —
+    moving Metron's last external (yfinance) fetches to the spine:
+
+        market_data/sectors/latest.json   {schema_version, as_of, sectors: {yf_symbol: gics}, spy_sector_weights: {sector: weight}}
+        market_data/earnings/latest.json   {schema_version, as_of, earnings: {yf_symbol: date_iso}}
+
+    Keyed by yf_symbol (consistent with the closes artifact). Injectable sources/S3."""
+    run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if s3_client is None:
+        import boto3
+        s3_client = boto3.client("s3")
+    holdings, _ = load_metron_universe(bucket, s3_client)
+    if not holdings:
+        return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
+    yf_symbols = sorted({h["yf_symbol"] for h in holdings})
+    sectors = (sector_source or _yfinance_sectors)(yf_symbols)
+    spy_weights = (benchmark_source or _yfinance_spy_weights)()
+    earnings = (earnings_source or _yfinance_earnings)(yf_symbols)
+    sectors_artifact = {"schema_version": SECTORS_SCHEMA_VERSION, "as_of": run_date,
+                        "sectors": dict(sorted(sectors.items())), "spy_sector_weights": dict(sorted(spy_weights.items()))}
+    earnings_artifact = {"schema_version": EARNINGS_SCHEMA_VERSION, "as_of": run_date,
+                         "earnings": dict(sorted(earnings.items()))}
+    if dry_run:
+        logger.info("[metron_market_data] DRY-RUN reference: %d sectors, %d spy-weights, %d earnings",
+                    len(sectors), len(spy_weights), len(earnings))
+        return {"status": "ok_dry_run", "sectors": len(sectors), "earnings": len(earnings)}
+    try:
+        _write_json(s3_client, bucket, f"{SECTORS_PREFIX}latest.json", sectors_artifact)
+        _write_json(s3_client, bucket, f"{EARNINGS_PREFIX}latest.json", earnings_artifact)
+    except Exception as e:  # fail loud
+        logger.error("[metron_market_data] reference write failed: %s", e)
+        return {"status": "error", "error": str(e)}
+    logger.info("[metron_market_data] wrote %d sectors + %d spy-weights + %d earnings",
+                len(sectors), len(spy_weights), len(earnings))
+    return {"status": "ok", "sectors": len(sectors), "spy_weights": len(spy_weights), "earnings": len(earnings)}
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="python -m collectors.metron_market_data", description=__doc__)
     parser.add_argument("--bucket", default=DEFAULT_BUCKET)
     parser.add_argument("--date", default=None, help="run date YYYY-MM-DD (default: today UTC)")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--history", action="store_true", help="also write close/FX history artifacts")
+    parser.add_argument("--reference", action="store_true", help="also write sectors/earnings artifacts")
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
     result = collect(bucket=args.bucket, run_date=args.date, dry_run=args.dry_run)
-    logger.info("[metron_market_data] done: %s", result)
-    return 0 if result.get("status") in ("ok", "ok_dry_run", "skipped") else 1
+    logger.info("[metron_market_data] latest done: %s", result)
+    ok = result.get("status") in ("ok", "ok_dry_run", "skipped")
+    if args.history:
+        hist = collect_history(bucket=args.bucket, dry_run=args.dry_run)
+        logger.info("[metron_market_data] history done: %s", hist)
+        ok = ok and hist.get("status") in ("ok", "ok_dry_run", "skipped")
+    if args.reference:
+        ref = collect_reference(bucket=args.bucket, run_date=args.date, dry_run=args.dry_run)
+        logger.info("[metron_market_data] reference done: %s", ref)
+        ok = ok and ref.get("status") in ("ok", "ok_dry_run", "skipped")
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -114,3 +114,55 @@ def test_load_universe_parses_holdings_and_currencies():
     holdings, currencies = mmd.load_metron_universe("b", s3)
     assert {h["yf_symbol"] for h in holdings} == {"AAPL", "1299.HK"}
     assert currencies == ["HKD"]
+
+
+class TestHistory:
+    def test_writes_per_symbol_close_history_and_per_currency_fx_history(self):
+        s3 = _universe_s3(_UNIVERSE)
+        close_hist = lambda syms: {"AAPL": [("2026-06-10", 200.0), ("2026-06-11", 201.5)], "1299.HK": [("2026-06-11", 64.2)]}
+        fx_hist = lambda ccys: {"HKD": [("2026-06-10", 0.128), ("2026-06-11", 0.1282)]}
+        result = mmd.collect_history(bucket="b", s3_client=s3, close_history_source=close_hist, fx_history_source=fx_hist)
+        assert result["status"] == "ok" and result["close_series"] == 2 and result["fx_series"] == 1
+        puts = _puts(s3)
+        assert set(puts) == {"market_data/close_history/AAPL.json", "market_data/close_history/1299.HK.json",
+                             "market_data/fx_history/HKD.json"}
+        aapl = puts["market_data/close_history/AAPL.json"]
+        assert aapl["yf_symbol"] == "AAPL" and aapl["currency"] == "USD"
+        assert aapl["closes"] == [["2026-06-10", 200.0], ["2026-06-11", 201.5]]
+        assert puts["market_data/fx_history/HKD.json"]["rates"][-1] == ["2026-06-11", 0.1282]
+
+    def test_history_dry_run_and_empty_universe(self):
+        s3 = _universe_s3(_UNIVERSE)
+        r = mmd.collect_history(bucket="b", dry_run=True, s3_client=s3, close_history_source=lambda s: {"AAPL": [("2026-06-11", 201.5)]}, fx_history_source=lambda c: {})
+        assert r["status"] == "ok_dry_run"
+        s3.put_object.assert_not_called()
+        s3b = _universe_s3({"holdings": [], "currencies": []})
+        assert mmd.collect_history(bucket="b", s3_client=s3b, close_history_source=lambda s: {}, fx_history_source=lambda c: {})["status"] == "skipped"
+
+
+class TestReference:
+    def test_writes_sectors_and_earnings_keyed_by_yf_symbol(self):
+        s3 = _universe_s3(_UNIVERSE)
+        result = mmd.collect_reference(
+            bucket="b", run_date="2026-06-11", s3_client=s3,
+            sector_source=lambda syms: {"AAPL": "Technology", "1299.HK": "Financial Services"},
+            benchmark_source=lambda: {"Technology": 0.30, "Financial Services": 0.13},
+            earnings_source=lambda syms: {"AAPL": "2026-07-30"},
+        )
+        assert result["status"] == "ok" and result["sectors"] == 2 and result["earnings"] == 1
+        puts = _puts(s3)
+        assert set(puts) == {"market_data/sectors/latest.json", "market_data/earnings/latest.json"}
+        sec = puts["market_data/sectors/latest.json"]
+        assert sec["schema_version"] == mmd.SECTORS_SCHEMA_VERSION
+        assert sec["sectors"] == {"1299.HK": "Financial Services", "AAPL": "Technology"}
+        assert sec["spy_sector_weights"]["Technology"] == 0.30
+        assert puts["market_data/earnings/latest.json"]["earnings"] == {"AAPL": "2026-07-30"}
+
+    def test_reference_dry_run_and_empty_universe(self):
+        s3 = _universe_s3(_UNIVERSE)
+        r = mmd.collect_reference(bucket="b", run_date="2026-06-11", dry_run=True, s3_client=s3,
+                                  sector_source=lambda s: {"AAPL": "Technology"}, benchmark_source=lambda: {}, earnings_source=lambda s: {})
+        assert r["status"] == "ok_dry_run"
+        s3.put_object.assert_not_called()
+        s3b = _universe_s3({"holdings": [], "currencies": []})
+        assert mmd.collect_reference(bucket="b", s3_client=s3b, sector_source=lambda s: {}, benchmark_source=lambda: {}, earnings_source=lambda s: {})["status"] == "skipped"

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -1736,6 +1736,21 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
         lambda: metron_market_data.collect(bucket=bucket, run_date=run_date, dry_run=dry_run),
         artifact_key=f"{metron_market_data.CLOSES_PREFIX}{run_date}.json",
     )
+    # Per-symbol close-history + per-currency FX-history for Metron's NAV reconstruction +
+    # as-of-date realized/dividend FX. Per-symbol keys (no single stable artifact) →
+    # markers + watchdog only, no auto-skip.
+    results["collectors"]["metron_market_data_history"] = _phase_collect(
+        reg, "metron_market_data_history",
+        lambda: metron_market_data.collect_history(bucket=bucket, dry_run=dry_run),
+        supports_auto_skip=False,
+    )
+    # GICS sectors + SPY weights + earnings dates — Metron's last external fetches, now
+    # on the spine so Metron reads ALL market/reference data from `data`.
+    results["collectors"]["metron_reference_data"] = _phase_collect(
+        reg, "metron_reference_data",
+        lambda: metron_market_data.collect_reference(bucket=bucket, run_date=run_date, dry_run=dry_run),
+        artifact_key=f"{metron_market_data.SECTORS_PREFIX}latest.json",
+    )
 
     # Module health stamp for daily_data — scoped to daily_closes only. The
     # executor gate at alpha-engine/executor/main.py reads this key to decide


### PR DESCRIPTION
## Completes the Metron producer — restores history + adds sectors/earnings

Per your directive (2026-06-11): *anything Metron fetches that the producer doesn't yet produce moves to the producer; Metron references only.* Two parts:

### 1. ⚠️ Restores the close/FX history producer (lost in #408's squash)
#408 was squash-merged with only its first commit — the **history producer second commit didn't make it into the squash**, so merged `main` produced no `close_history/*` or `fx_history/*`. But the merged Metron consumer ([#32](https://github.com/cipher813/metron/pull/32)) **already reads** those for Performance NAV reconstruction + as-of-date realized/dividend FX. This restores `collect_history()`:
```
market_data/close_history/{yf_symbol}.json   {schema_version, yf_symbol, currency, closes: [[date, close], …]}
market_data/fx_history/{CCY}.json            {schema_version, currency, base, rates: [[date, rate], …]}
```

### 2. Adds the sectors + earnings reference producer (Metron's last yfinance fetches)
`collect_reference()` — GICS sector per held symbol (`Ticker.info['sector']`), SPY's sector weights (`funds_data.sector_weightings` → canonical), next earnings date:
```
market_data/sectors/latest.json    {schema_version, as_of, sectors: {yf_symbol: gics}, spy_sector_weights: {sector: weight}}
market_data/earnings/latest.json   {schema_version, as_of, earnings: {yf_symbol: date_iso}}
```
Keyed by `yf_symbol` (consistent with the closes artifact). Unclassifiable / undated symbols omitted, never fabricated.

### Wiring / tests
Both added as daily phases in `weekly_collector._run_daily` (`metron_market_data_history`, `metron_reference_data`). Still **one `_write_json` put-site** → registry-coverage count unchanged. Injectable sources/S3 for tests. **7 tests added; full data suite 1950 passed.**

### Next
The Metron consumer PR swaps `sectors/` + `calendar/` to spine sources reading these artifacts and **removes the yfinance dependency from Metron entirely** (prices/FX already cut over in #32). After that, Metron's only remaining external fetch is FRED (Macro page) — the producer already produces macro, so that's a separate consumer-side cutover.

### Deploy
Hangs off the weekday daily data run; inert until Metron publishes its universe (`MARKET_DATA_SYNC_ENABLED=true`). Register the new artifacts in `ARTIFACT_REGISTRY.yaml` once the producer is live.
