### PR TITLE
fix(quality-gates): one aggregated Flow Doctor alert per run, not one per ticker

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -63,6 +63,7 @@ from builders._price_cache_writeboth import (
 )
 from validators.price_validator import (
     ALL_ANOMALY_TYPES,
+    ANOMALY_INTRABAR_INCONSISTENT,
     DEFAULT_BLOCK_ANOMALY_TYPES,
     validate_today_row,
 )
@@ -279,10 +280,10 @@ def _emit_quality_gate_metrics(
     """Emit ``AlphaEngine/Data/daily_append_quality_*`` gauges.
 
     Best-effort: CloudWatch errors WARN but don't fail the pipeline — the
-    per-anomaly logger.error calls above are the load-bearing Flow Doctor
-    surface; the metric catches slow drift so a chronic 1-2-ticker-per-day
-    anomaly stream surfaces before it cumulates into a regression.
-    Mirrors ``_emit_missing_from_closes_metric``.
+    aggregated run-level quality-gate record (one per run, after the chunk
+    loop) is the load-bearing Flow Doctor surface; the metric catches slow
+    drift so a chronic 1-2-ticker-per-day anomaly stream surfaces before
+    it cumulates into a regression. Mirrors ``_emit_missing_from_closes_metric``.
     """
     if not counts_by_type and n_blocked == 0 and n_warned == 0:
         return
@@ -311,8 +312,8 @@ def _emit_quality_gate_metrics(
     except Exception as exc:
         log.warning(
             "CloudWatch daily_append_quality_* metric failed: %s. "
-            "Not blocking daily_append — the per-anomaly logger.error calls "
-            "above are the load-bearing Flow Doctor surface.",
+            "Not blocking daily_append — the aggregated run-level "
+            "quality-gate record is the load-bearing Flow Doctor surface.",
             exc,
         )
 
@@ -1034,6 +1035,7 @@ def _daily_append_impl(
     n_quality_blocked = 0  # rows refused by validate_today_row (block severity)
     n_quality_warned = 0   # rows written but flagged by validate_today_row (warn)
     quality_counts_by_type: dict[str, int] = {}
+    quality_blocked_details: list[tuple[str, str]] = []  # (ticker, anomaly_type)
 
     # Read DAILY_APPEND_BLOCK_ANOMALY_TYPES once per run (raises on malformed
     # JSON / unknown types — fail fast before the chunked pass begins).
@@ -1321,27 +1323,30 @@ def _daily_append_impl(
                 # Runs after today_row is fully shaped (OHLCV + features +
                 # provenance + dtypes aligned) but before the row is queued
                 # for batch write. Two outcomes: block (skip queue + log
-                # error so Flow Doctor surfaces) or warn (queue write +
-                # log warning + count). DEFAULT_BLOCK_ANOMALY_TYPES
-                # blocks only definitely-bad rows (High<Low, Close<=0);
-                # operators can upgrade types via the
-                # DAILY_APPEND_BLOCK_ANOMALY_TYPES env var.
+                # + count) or warn (queue write + log warning + count).
+                # DEFAULT_BLOCK_ANOMALY_TYPES blocks only definitely-bad
+                # rows (High<Low, Close<=0); operators can upgrade types
+                # via the DAILY_APPEND_BLOCK_ANOMALY_TYPES env var.
+                #
+                # Per-ticker block lines log at WARNING; the load-bearing
+                # Flow Doctor surface is the single aggregated run-level
+                # record emitted after the chunk loop (one systemic event
+                # → one alert, not one per ticker — see the 2026-06-11
+                # EOD storm note there).
                 qg = validate_today_row(today_row, hist, ticker)
                 blocking_anomalies = [
                     a for a in qg["anomalies"] if a["type"] in block_anomaly_types
                 ]
                 if blocking_anomalies:
                     for a in blocking_anomalies:
-                        # logger.error so the FlowDoctorHandler picks this
-                        # up — return-dicts are invisible to it per
-                        # feedback_collector_return_dict_invisible_to_flow_doctor.
-                        log.error(
+                        log.warning(
                             "Quality gate BLOCK %s.%s: %s",
                             ticker, a["type"], a["detail"],
                         )
                         quality_counts_by_type[a["type"]] = (
                             quality_counts_by_type.get(a["type"], 0) + 1
                         )
+                        quality_blocked_details.append((ticker, a["type"]))
                     n_quality_blocked += 1
                     continue  # do not queue this row for write
                 if qg["anomalies"]:
@@ -1477,6 +1482,46 @@ def _daily_append_impl(
         del hists_by_ticker, write_tasks, update_payloads, write_payloads
         gc.collect()
 
+    # ── Aggregated quality-gate alert (one per run, not one per ticker) ──
+    # 2026-06-11: the EOD run blocked 10 tickers' unsettled bars and fanned
+    # out 10 Flow Doctor alert emails + auto-filed issues (hitting
+    # max_alerts_per_day) for ONE systemic provider-settlement event. The
+    # per-ticker BLOCK lines above stay at WARNING for log forensics; this
+    # single record is what crosses the logging boundary into Flow Doctor
+    # (only ERROR-level records do, per
+    # feedback_collector_return_dict_invisible_to_flow_doctor).
+    #
+    # EOD severity carve-out: on the post-market path (skip_if_exists=True,
+    # minutes after the close) an intrabar_inconsistent block is the
+    # EXPECTED provider artifact — the closing-auction print lands in Close
+    # before the High/Low aggregates settle (NVR/ADC/HPE/… daily, all
+    # sub-1% gaps). The heal is structural: next morning's MorningEnrich
+    # overwrites with settled polygon data, and the universe-freshness scan
+    # hard-raises at >3 trading days as backstop. So an all-intrabar EOD
+    # block set logs the summary at WARNING (recorded surface: per-ticker
+    # WARN lines + CW quality metrics + result counters — no alert). Any
+    # other anomaly type, or ANY block on the settled MorningEnrich path,
+    # is a real data-quality event → single ERROR → one alert.
+    if n_quality_blocked:
+        blocked_types = {atype for _, atype in quality_blocked_details}
+        detail_list = ", ".join(
+            f"{tkr}.{atype}" for tkr, atype in quality_blocked_details[:20]
+        )
+        if len(quality_blocked_details) > 20:
+            detail_list += f", … +{len(quality_blocked_details) - 20} more"
+        if skip_if_exists and blocked_types == {ANOMALY_INTRABAR_INCONSISTENT}:
+            log.warning(
+                "Quality gate blocked %d row(s) this run — expected EOD "
+                "unsettled-bar artifact (close-auction print ahead of "
+                "High/Low settlement); rows heal via next MorningEnrich "
+                "overwrite: %s",
+                n_quality_blocked, detail_list,
+            )
+        else:
+            log.error(
+                "Quality gate blocked %d row(s) this run (types=%s): %s",
+                n_quality_blocked, sorted(blocked_types), detail_list,
+            )
 
     t_total = time.time() - t0
 

--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -202,8 +202,8 @@ def _emit_quality_gate_metrics(
     except Exception as exc:
         logger.warning(
             "CloudWatch alternative_quality_* metric failed: %s. Not "
-            "blocking — the per-anomaly logger.error calls are the "
-            "load-bearing Flow Doctor surface.",
+            "blocking — the aggregated run-level quality-gate logger.error "
+            "is the load-bearing Flow Doctor surface.",
             exc,
         )
 
@@ -566,6 +566,7 @@ def collect(
     n_quality_blocked = 0
     n_quality_warned = 0
     quality_counts_by_type: dict[str, int] = {}
+    quality_blocked_details: list[str] = []  # "TICKER.source.type" per block
     # Per-source populated counts. Increment only when the source for
     # this ticker carried real (non-default) data — see _HAS_DATA_PREDICATES
     # commentary above for the silent-fail surface this protects against.
@@ -592,13 +593,18 @@ def collect(
             )
             if blocking:
                 for a in blocking:
-                    # logger.error so FlowDoctorHandler picks it up.
-                    logger.error(
+                    # WARNING per ticker; the single aggregated run-level
+                    # logger.error below is the Flow Doctor surface (one
+                    # systemic event → one alert, not one per ticker).
+                    logger.warning(
                         "Alternative quality gate BLOCK %s.%s.%s: %s",
                         ticker, a["source"], a["type"], a["detail"],
                     )
                     quality_counts_by_type[a["type"]] = (
                         quality_counts_by_type.get(a["type"], 0) + 1
+                    )
+                    quality_blocked_details.append(
+                        f"{ticker}.{a['source']}.{a['type']}"
                     )
                 n_quality_blocked += 1
                 failed += 1
@@ -641,7 +647,20 @@ def collect(
             errors.append({"ticker": ticker, "error": scrubbed})
             logger.warning("Alternative data failed for %s: %s", ticker, scrubbed)
 
-    if n_quality_blocked or n_quality_warned:
+    if n_quality_blocked:
+        # Single aggregated ERROR per run — the Flow Doctor surface for the
+        # block path (per-ticker lines above are WARNING-only; one systemic
+        # event must produce one alert, not one per ticker — see the
+        # 2026-06-11 daily_append EOD storm note).
+        detail_list = ", ".join(quality_blocked_details[:20])
+        if len(quality_blocked_details) > 20:
+            detail_list += f", … +{len(quality_blocked_details) - 20} more"
+        logger.error(
+            "Alternative quality gate blocked %d ticker(s) this run "
+            "(counts=%s): %s",
+            n_quality_blocked, quality_counts_by_type, detail_list,
+        )
+    elif n_quality_warned:
         logger.info(
             "Alternative quality gate: %d blocked, %d warned, counts=%s",
             n_quality_blocked, n_quality_warned, quality_counts_by_type,

--- a/collectors/fundamentals.py
+++ b/collectors/fundamentals.py
@@ -141,7 +141,7 @@ def _emit_quality_gate_metrics(
     """Emit ``AlphaEngine/Data/fundamentals_quality_*`` gauges.
 
     Best-effort: CloudWatch errors WARN but don't fail the collector — the
-    per-anomaly logger.error calls on the block path are the load-bearing
+    aggregated run-level quality-gate logger.error is the load-bearing
     Flow Doctor surface; the metric catches slow drift. Mirrors
     ``builders.daily_append._emit_quality_gate_metrics``.
     """
@@ -174,8 +174,8 @@ def _emit_quality_gate_metrics(
     except Exception as exc:
         logger.warning(
             "CloudWatch fundamentals_quality_* metric failed: %s. Not "
-            "blocking — the per-anomaly logger.error calls are the "
-            "load-bearing Flow Doctor surface.",
+            "blocking — the aggregated run-level quality-gate logger.error "
+            "is the load-bearing Flow Doctor surface.",
             exc,
         )
 
@@ -390,6 +390,7 @@ def collect(
     n_quality_blocked = 0  # records replaced with NEUTRAL (block severity)
     n_quality_warned = 0   # records kept but flagged (warn severity)
     quality_counts_by_type: dict[str, int] = {}
+    quality_blocked_details: list[str] = []  # "TICKER.type" per block
 
     for ticker in tickers:
         try:
@@ -397,9 +398,10 @@ def collect(
             # ── Write-time value-range gate ─────────────────────────────
             # Runs on the fully-shaped (clipped) per-ticker dict before it
             # is queued for the S3 snapshot. block → drop the corrupt row
-            # to NEUTRAL + logger.error so Flow Doctor surfaces it (a
-            # NaN/inf or negative margin would otherwise poison the
-            # predictor feature store). warn → keep + log + count.
+            # to NEUTRAL + count (a NaN/inf or negative margin would
+            # otherwise poison the predictor feature store); the aggregated
+            # run-level logger.error below surfaces blocks to Flow Doctor.
+            # warn → keep + log + count.
             qg = validate_feature_record(
                 data, _FUNDAMENTALS_FIELD_SPECS, ticker
             )
@@ -409,15 +411,17 @@ def collect(
             ]
             if blocking:
                 for a in blocking:
-                    # logger.error so FlowDoctorHandler picks it up —
-                    # return-dicts are invisible to it.
-                    logger.error(
+                    # WARNING per ticker; the single aggregated run-level
+                    # logger.error below is the Flow Doctor surface (one
+                    # systemic event → one alert, not one per ticker).
+                    logger.warning(
                         "Fundamentals quality gate BLOCK %s.%s: %s",
                         ticker, a["type"], a["detail"],
                     )
                     quality_counts_by_type[a["type"]] = (
                         quality_counts_by_type.get(a["type"], 0) + 1
                     )
+                    quality_blocked_details.append(f"{ticker}.{a['type']}")
                 n_quality_blocked += 1
                 # Refuse the corrupt row; NEUTRAL is the existing
                 # no-data sentinel the ok_ratio gate already accounts for.
@@ -448,7 +452,20 @@ def collect(
         "Fundamentals fetched in %.1fs: %d populated, %d errors, %d total (ok_ratio=%.1f%%)",
         elapsed, n_ok, n_err, len(results), ok_ratio * 100,
     )
-    if n_quality_blocked or n_quality_warned:
+    if n_quality_blocked:
+        # Single aggregated ERROR per run — the Flow Doctor surface for the
+        # block path (per-ticker lines above are WARNING-only; one systemic
+        # event must produce one alert, not one per ticker — see the
+        # 2026-06-11 daily_append EOD storm note).
+        detail_list = ", ".join(quality_blocked_details[:20])
+        if len(quality_blocked_details) > 20:
+            detail_list += f", … +{len(quality_blocked_details) - 20} more"
+        logger.error(
+            "Fundamentals quality gate blocked %d ticker(s) this run "
+            "(counts=%s): %s",
+            n_quality_blocked, quality_counts_by_type, detail_list,
+        )
+    elif n_quality_warned:
         logger.info(
             "Fundamentals quality gate: %d blocked, %d warned, counts=%s",
             n_quality_blocked, n_quality_warned, quality_counts_by_type,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,16 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+# Hard-disable flow-doctor for the whole pytest session. The lib's
+# PYTEST_CURRENT_TEST guard does not cover handler attachment at module
+# IMPORT time (several tests import weekly_collector, whose module-top
+# setup_logging runs during collection, before PYTEST_CURRENT_TEST is
+# set) — on 2026-06-11 a local test run leaked REAL alert emails + GitHub
+# issues + S3 changelog entries for synthetic fixture tickers (T0/T1/BAD).
+# Must be set before any test module import, hence module level here, not
+# a fixture.
+os.environ.setdefault("FLOW_DOCTOR_DISABLED", "1")
+
 
 @pytest.fixture(autouse=True)
 def _isolate_secrets_from_ssm(monkeypatch):

--- a/tests/test_daily_append_quality_gates.py
+++ b/tests/test_daily_append_quality_gates.py
@@ -11,9 +11,10 @@ downstream feature compute + predictor training.
 
 This wave wires ``validate_today_row`` into the per-symbol write_tasks
 loop with per-anomaly-type severity semantics: ``block`` definitely-bad
-rows by default (refuse the queue + log error so Flow Doctor surfaces),
-``warn`` legitimately-rare-but-possible signals (queue write + log
-warning + emit metric). Operators upgrade types to block via
+rows by default (refuse the queue + per-ticker WARNING + ONE aggregated
+run-level record for Flow Doctor), ``warn``
+legitimately-rare-but-possible signals (queue write + log warning +
+emit metric). Operators upgrade types to block via
 ``DAILY_APPEND_BLOCK_ANOMALY_TYPES``.
 
 Source-text invariants pin the wiring shape; functional cases through
@@ -78,17 +79,39 @@ def test_validate_today_row_called_before_write_queue():
     )
 
 
-def test_block_path_uses_logger_error_not_warning():
-    """Blocking anomalies must emit logger.error so the FlowDoctorHandler
-    picks them up — per feedback_collector_return_dict_invisible_to_flow_doctor,
-    only logger.error / logger.critical cross the logging boundary."""
+def test_block_path_per_ticker_logs_warning_not_error():
+    """Per-ticker block lines must log at WARNING, not ERROR — one systemic
+    event (e.g. the 2026-06-11 EOD unsettled-bar storm, 10 tickers) must not
+    fan out into one Flow Doctor alert per ticker. The aggregated run-level
+    record below is the alert surface."""
     src = _source()
-    # The block branch must use log.error
-    assert 'log.error(\n                            "Quality gate BLOCK %s.%s: %s"' in src or \
-        'log.error(\n                            "Quality gate BLOCK' in src, (
-            "Block path must call log.error so Flow Doctor surfaces the "
-            "anomaly via SNS / GitHub issue."
-        )
+    assert 'log.warning(\n                            "Quality gate BLOCK' in src, (
+        "Per-ticker block lines must be log.warning — the aggregated "
+        "run-level record is the Flow Doctor surface."
+    )
+    assert 'log.error(\n                            "Quality gate BLOCK' not in src, (
+        "Per-ticker log.error block lines reintroduce the alert storm "
+        "(one email per blocked ticker)."
+    )
+
+
+def test_aggregated_block_summary_is_flow_doctor_surface():
+    """Exactly one run-level record crosses into Flow Doctor when rows were
+    blocked — ERROR for real data-quality events, WARNING for the expected
+    EOD unsettled-bar artifact (skip_if_exists + all-intrabar_inconsistent),
+    which heals via the next MorningEnrich overwrite."""
+    src = _source()
+    assert "if n_quality_blocked:" in src
+    # The expected-EOD carve-out must key on BOTH the post-market path flag
+    # and the anomaly-type set — a settled-path (MorningEnrich) intrabar
+    # block, or any other anomaly type, must stay ERROR.
+    assert (
+        "skip_if_exists and blocked_types == {ANOMALY_INTRABAR_INCONSISTENT}"
+        in src
+    )
+    assert '"Quality gate blocked %d row(s) this run (types=%s): %s"' in src
+    # Per-ticker (ticker, type) details must be accumulated for the summary.
+    assert "quality_blocked_details.append((ticker, a[\"type\"]))" in src
 
 
 def test_block_path_skips_write_via_continue():

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -40,6 +40,10 @@ def stub_flow_doctor_env(monkeypatch):
     but breaks tests that don't intend to fire the network call. Same
     knob applies to S3Notifier's bucket head-check in 0.4.0+.
     """
+    # conftest.py hard-sets FLOW_DOCTOR_DISABLED=1 for the whole session
+    # (kill switch outranks ENABLED=1) — clear it for tests that exercise
+    # activation deliberately with fully-stubbed notifiers.
+    monkeypatch.delenv("FLOW_DOCTOR_DISABLED", raising=False)
     monkeypatch.setenv("FLOW_DOCTOR_ENABLED", "1")
     monkeypatch.setenv("FLOW_DOCTOR_SKIP_PREFLIGHT", "1")
     monkeypatch.setenv("EMAIL_SENDER", "test@example.com")


### PR DESCRIPTION
## Problem

The 2026-06-11 EOD `daily_append` run blocked 10 tickers (`intrabar_inconsistent`, all sub-1% close-vs-high gaps — the closing-auction print lands in Close minutes before the provider High/Low aggregates settle) and fanned out **10 Flow Doctor alert emails + auto-filed GitHub issues**, hitting `max_alerts_per_day` — for ONE systemic provider-settlement event. The identical storm fired 2026-06-10. Dedup cannot collapse them: each ticker symbol + float detail is a unique signature.

Separately, a pytest run that morning leaked REAL alerts + issues + S3 changelog entries for synthetic fixture tickers (`T0`/`T1`/`BAD`): the lib PYTEST_CURRENT_TEST guard misses handler attachment at module-import/collection time (tests import `weekly_collector`, whose module-top `setup_logging` runs during collection).

## Fix

Across the three quality-gate fan-out sites (`builders/daily_append.py`, `collectors/alternative.py`, `collectors/fundamentals.py`):

- Per-ticker BLOCK lines demoted ERROR → WARNING (message text unchanged for log forensics; counters + CW metrics unchanged).
- **ONE aggregated run-level record** after the loop is now the sole Flow Doctor surface (only ERROR records cross the logging boundary).
- `daily_append` EOD carve-out: on the post-market path (`skip_if_exists=True`) an all-`intrabar_inconsistent` block set is the EXPECTED unsettled-bar artifact → summary at WARNING (no alert). **Fail-loud rationale (per the no-silent-swallows rule):** (a) swallowed failure mode = expected EOD provider-settlement artifact only; (b) the primary deliverable survives — the row is still refused, and the heal is structural (next MorningEnrich overwrites with settled polygon data; universe-freshness scan hard-raises at >3 trading days); (c) recording surfaces = per-ticker WARN lines + `daily_append_quality_*` CW metrics + result counters. Any other anomaly type, or ANY block on the settled MorningEnrich path, stays a single ERROR → one alert.
- `tests/conftest.py`: hard-set `FLOW_DOCTOR_DISABLED=1` for the whole pytest session (kills the import-time leak class); `test_flow_doctor_wiring`'s opt-in fixture clears the kill switch for deliberate stubbed activation tests.

Companion lib PR hardens the activation guard with a `sys.modules` pytest check (fleet-wide chokepoint).

## Tests

Full suite: **1951 passed, 2 skipped**. `test_daily_append_quality_gates.py` source-pins inverted: per-ticker WARNING asserted, per-ticker `log.error` asserted ABSENT, aggregated summary + EOD carve-out condition asserted present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)