### PR TITLE
chore: drop single-developer/solo framing from public surfaces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Nous Ergon / Alpha Engine is a single-developer portfolio project running paper-account trading. No customer funds, no production user data.
+Nous Ergon / Alpha Engine runs paper-account trading. No customer funds, no production user data.
 
 ## Reporting a vulnerability
 

--- a/WAVE4_SLIM_DELETION_RUNBOOK.md
+++ b/WAVE4_SLIM_DELETION_RUNBOOK.md
@@ -37,7 +37,7 @@ run by CI or any pipeline).
    the backtester PR4. Re-confirm no new consumer via the terminal guard
    `tests/test_wave4_slim_arctic_parity.py`.
 
-## Procedure (single-dev, paper-trading; bounded-reversible)
+## Procedure (paper-trading; bounded-reversible)
 
 ```
 # 1. Pre-deletion byte-equal backup (Wave-5 precedent).
@@ -68,7 +68,7 @@ aws s3 ls s3://alpha-engine-research/predictor/price_cache_slim/ \
 
 `git revert` the Wave-4 PR(s) + `aws s3 cp --recursive` the backup prefix
 back to `predictor/price_cache_slim/`. The slim writer resumes on the next
-weekly SF. Worst case from a missed divergence in this single-dev
+weekly SF. Worst case from a missed divergence in this
 paper-trading context: degraded features for ~one week until noticed — no
 capital or data-loss risk (per the CLAUDE.md severity posture).
 


### PR DESCRIPTION
Brian directive 2026-06-11: stop referring to Nous Ergon as a sole/solo-dev project on public surfaces. SECURITY.md reworded fleet-wide (keeps the defensible facts: paper trading, no customer funds, no production user data — drops the positioning). Additional surfaces for this repo, if any, in the diff. These surfaces still say Nous Ergon / Alpha Engine — the Crucible rename rides config#904 separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)