### PR TITLE
feat: intraday producer v2 — exchange-calendar gate, Metron demand gate, 5-min cadence, suspect flag

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -9,7 +9,7 @@ Metron makes NO direct market-data API calls of its own:
     market_data/eod_closes/{date}.json   + market_data/eod_closes/latest.json
     market_data/fx/{date}.json           + market_data/fx/latest.json
     market_data/fundamentals/latest.json   (daily — tearsheet multiples/ratios)
-    market_data/intraday/latest.json       (every 15 min during US RTH — Today view)
+    market_data/intraday/latest.json       (every 5 min while NYSE open AND Metron in use)
 
 Closes cover the held union — including foreign listings (``1299.HK``, ``RMS.PA``), OTC
 (``GTBIF``), and funds (``FNILX``) that the ~903-name SP1500 constituent cache refuses.
@@ -33,7 +33,7 @@ import argparse
 import json
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
@@ -701,23 +701,76 @@ def collect_fundamentals(
     return {"status": "ok", "universe": len(holdings), "fundamentals": len(fundamentals)}
 
 
-# US regular trading hours in UTC, with margin: 13:25 (pre-13:30 open) → 20:10
-# (post-20:00 close). EDT-based; in EST (winter) the 14:30–21:00 session shifts an
-# hour later, so the window below is widened to cover BOTH offsets — the cost is a
-# few harmless extra runs, never a missed session segment.
-_RTH_UTC_START = (13, 25)
-_RTH_UTC_END = (21, 10)
+# NYSE early-close days (1:00 PM ET close): day after Thanksgiving, and Christmas
+# Eve / July 3 when they fall on a weekday. Source: nyse.com/markets/hours-calendars.
+# Holidays themselves come from alpha_engine_lib.trading_calendar.NYSE_HOLIDAYS (the
+# fleet-canonical set, maintained through 2030). Lift this early-close set into
+# alpha_engine_lib.trading_calendar on second adoption per the
+# lift-invariants-after-second-recurrence rule.
+NYSE_EARLY_CLOSES: set = {
+    # 2026
+    date(2026, 11, 27),  # day after Thanksgiving
+    date(2026, 12, 24),  # Christmas Eve (Thursday)
+    # 2027
+    date(2027, 11, 26),  # day after Thanksgiving
+    date(2027, 12, 23),  # day before observed Christmas (Dec 24 = observed holiday)
+    # 2028
+    date(2028, 7, 3),    # day before Independence Day (Monday)
+    date(2028, 11, 24),  # day after Thanksgiving
+    # 2029
+    date(2029, 7, 3),    # day before Independence Day (Tuesday)
+    date(2029, 11, 23),  # day after Thanksgiving
+    date(2029, 12, 24),  # Christmas Eve (Monday)
+    # 2030
+    date(2030, 7, 3),    # day before Independence Day (Wednesday)
+    date(2030, 11, 29),  # day after Thanksgiving
+    date(2030, 12, 24),  # Christmas Eve (Tuesday)
+}
+_SESSION_MARGIN_MIN = 5  # minutes of slack either side of the official session
 
 
 def in_us_market_window(now: datetime | None = None) -> bool:
-    """True on a weekday inside the (DST-widened) US RTH UTC window. NYSE holidays
-    are NOT checked here — on a holiday the trading box is the scheduler and the
-    quotes are simply unchanged; the artifact's ``session_date`` keeps it honest."""
+    """True inside the actual NYSE session (±5 min margin), in exchange time.
+
+    Exchange-calendar gating: weekends and NYSE holidays via the fleet-canonical
+    ``alpha_engine_lib.trading_calendar.is_trading_day``; the session is 9:30 ET →
+    16:00 ET (13:00 ET on ``NYSE_EARLY_CLOSES`` half-days), evaluated in
+    America/New_York so DST is handled exactly — no widened-UTC heuristic."""
+    from zoneinfo import ZoneInfo
+
+    from alpha_engine_lib.trading_calendar import is_trading_day
+
     now = now or datetime.now(timezone.utc)
-    if now.weekday() >= 5:
+    et = now.astimezone(ZoneInfo("America/New_York"))
+    if not is_trading_day(et.date()):
         return False
-    hm = (now.hour, now.minute)
-    return _RTH_UTC_START <= hm <= _RTH_UTC_END
+    close_hm = (13, 0) if et.date() in NYSE_EARLY_CLOSES else (16, 0)
+    open_min = 9 * 60 + 30 - _SESSION_MARGIN_MIN
+    close_min = close_hm[0] * 60 + close_hm[1] + _SESSION_MARGIN_MIN
+    return open_min <= et.hour * 60 + et.minute <= close_min
+
+
+# The demand gate: Metron's web layer touches this key while the app is actively
+# being used (throttled heartbeat — see metron api/services/data_spine.py). The
+# intraday producer fetches ONLY while the heartbeat is fresh, so a closed app
+# costs zero quote fetches. Missing key = app never opened → skip.
+UI_HEARTBEAT_KEY = "metron/ui_heartbeat.json"
+HEARTBEAT_FRESH_SECONDS = 600  # 10 min — two missed 5-min ticks ends the session
+
+
+def metron_app_active(bucket: str, s3_client: Any, now: datetime | None = None) -> bool:
+    """True when Metron's UI heartbeat exists and is fresh (see ``UI_HEARTBEAT_KEY``).
+    Fail-soft on read errors → inactive (the artifact just goes stale; the consumer
+    shows staleness honestly via ``as_of_utc``)."""
+    now = now or datetime.now(timezone.utc)
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=UI_HEARTBEAT_KEY)
+        ts = json.loads(obj["Body"].read()).get("ts", "")
+        beat = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        return (now - beat).total_seconds() <= HEARTBEAT_FRESH_SECONDS
+    except Exception as e:  # missing key, parse error, no creds — all mean "not active"
+        logger.info("[metron_market_data] no fresh UI heartbeat (%s) — app inactive", e)
+        return False
 
 
 def collect_intraday(
@@ -732,23 +785,39 @@ def collect_intraday(
             {schema_version, as_of_utc, source: "yfinance_delayed",
              quotes: {yf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}}}
 
-    ``last`` is ~15-min delayed. Runs every 15 min during US RTH via a systemd timer
-    on the trading box (infrastructure/systemd/metron-intraday.timer); outside the
-    market window it returns ``skipped`` without fetching (``force`` overrides, for
-    manual runs). Single ``latest.json`` key — consumers see staleness via
-    ``as_of_utc``. Injectable source/S3 for tests."""
+    ``last`` is ~15-min delayed. Runs every 5 min via a systemd timer on the trading
+    box (infrastructure/systemd/metron-intraday.timer), double-gated: the NYSE
+    session window (exchange calendar incl. half-days) AND the Metron UI heartbeat
+    (``metron_app_active``) — quotes are fetched only while the market is open AND
+    the app is actually being used. Outside either gate it returns ``skipped``
+    without fetching (``force`` overrides both, for manual runs). A quote moving
+    >40% vs prior close carries ``suspect: true`` (flagged, never dropped). Single
+    ``latest.json`` key — consumers see staleness via ``as_of_utc``. Injectable
+    source/S3 for tests."""
     if not force and not in_us_market_window(now):
         return {"status": "skipped", "reason": "outside US market window"}
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")
+    if not force and not metron_app_active(bucket, s3_client, now):
+        return {"status": "skipped", "reason": "metron app inactive (no fresh UI heartbeat)"}
     holdings, _ = load_metron_universe(bucket, s3_client)
     if not holdings:
         return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
     ccy_by_yf = {h["yf_symbol"]: h["currency"] for h in holdings}
     quotes = (intraday_source or _yfinance_intraday)(sorted(ccy_by_yf))
+    n_suspect = 0
     for sym, q in quotes.items():
         q["currency"] = ccy_by_yf.get(sym, "USD")
+        # Sanity flag — a >40% jump vs prior close is almost always a bad scrape or
+        # an unadjusted corporate action, not a real move. Flag, never drop/clamp
+        # (no fabrication): the consumer renders a warning instead of a wild P&L leg.
+        prev = q.get("prev_close") or 0.0
+        if prev and abs(q.get("last", prev) / prev - 1.0) > 0.40:
+            q["suspect"] = True
+            n_suspect += 1
+    if n_suspect:
+        logger.warning("[metron_market_data] %d intraday quote(s) flagged suspect (>40%% vs prev close)", n_suspect)
     artifact = {
         "schema_version": INTRADAY_SCHEMA_VERSION,
         "as_of_utc": (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -777,9 +846,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--macro", action="store_true", help="also write the macro-indicators artifact")
     parser.add_argument("--fundamentals", action="store_true", help="also write the tearsheet-fundamentals artifact")
     parser.add_argument("--only-intraday", action="store_true",
-                        help="write ONLY the intraday-quotes artifact (the 15-min timer entry; "
-                             "no-op outside the US market window unless --force)")
-    parser.add_argument("--force", action="store_true", help="bypass the market-window gate for --only-intraday")
+                        help="write ONLY the intraday-quotes artifact (the 5-min timer entry; "
+                             "no-op outside the NYSE session or without a fresh Metron UI heartbeat, unless --force)")
+    parser.add_argument("--force", action="store_true",
+                        help="bypass the market-window AND app-heartbeat gates for --only-intraday")
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
     if args.only_intraday:

--- a/infrastructure/systemd/metron-intraday.service
+++ b/infrastructure/systemd/metron-intraday.service
@@ -1,7 +1,7 @@
 # Metron intraday-quotes producer (config#1023) — one shot per timer tick.
 # Writes market_data/intraday/latest.json (last / open / prior close per held
 # symbol, ~15-min delayed) for Metron's Today view. The collector itself gates
-# on the US market window, so off-hours ticks exit "skipped" without fetching.
+# on the US market window AND the Metron UI heartbeat, so off-gate ticks exit "skipped" without fetching.
 # Installed on the trading box by infrastructure/install-metron-intraday.sh;
 # S3 write rides the instance role (executor-role already has market_data/*).
 [Unit]

--- a/infrastructure/systemd/metron-intraday.timer
+++ b/infrastructure/systemd/metron-intraday.timer
@@ -1,12 +1,13 @@
-# Every 15 minutes while the trading box is up. The box's own lifecycle is the
-# session gate (weekday SF starts it pre-open ~12:45 UTC, EOD SF stops it after
-# close ~21:15 UTC), and the collector additionally no-ops outside the US market
-# window — so this never needs a market calendar of its own.
+# Every 5 minutes while the trading box is up. The box's lifecycle bounds the
+# day; the collector itself double-gates each tick on the NYSE session calendar
+# (holidays + half-days via alpha_engine_lib.trading_calendar) AND the Metron UI
+# heartbeat — quotes are fetched only while the market is open and the app is
+# actually in use, so off-gate ticks cost one S3 GET and exit.
 [Unit]
-Description=Metron intraday quotes every 15 min (market-window gated in-process)
+Description=Metron intraday quotes every 5 min (session + app-heartbeat gated in-process)
 
 [Timer]
-OnCalendar=*-*-* *:00/15:00
+OnCalendar=*-*-* *:00/5:00
 AccuracySec=30
 Persistent=false
 

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -9,20 +9,32 @@ the dry-run no-write path, and the fail-soft empty-universe skip.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 from collectors import metron_market_data as mmd
 
 
-def _universe_s3(universe: dict | None) -> MagicMock:
-    """A MagicMock S3 whose get_object returns ``universe`` JSON (or raises if None)."""
+def _universe_s3(universe: dict | None, heartbeat_ts: str | None = None) -> MagicMock:
+    """A MagicMock S3 whose get_object dispatches per key: the Metron universe JSON
+    (raises if None) and, when ``heartbeat_ts`` is given, a fresh UI-heartbeat object
+    (the intraday demand gate); any other key raises NoSuchKey."""
     s3 = MagicMock()
-    if universe is None:
-        s3.get_object.side_effect = Exception("NoSuchKey")
-    else:
-        body = MagicMock()
-        body.read.return_value = json.dumps(universe).encode()
-        s3.get_object.return_value = {"Body": body}
+
+    def _get(Bucket, Key):
+        def _body(obj):
+            body = MagicMock()
+            body.read.return_value = json.dumps(obj).encode()
+            return {"Body": body}
+        if Key == "metron/ui_heartbeat.json":
+            if heartbeat_ts is None:
+                raise Exception("NoSuchKey")
+            return _body({"ts": heartbeat_ts})
+        if universe is None:
+            raise Exception("NoSuchKey")
+        return _body(universe)
+
+    s3.get_object.side_effect = _get
     return s3
 
 
@@ -230,13 +242,21 @@ class TestIntraday:
                     "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
     }
 
-    def test_writes_quotes_with_currency_inside_market_window(self):
-        from datetime import datetime, timezone
+    # Friday 2026-06-12 15:00 UTC = 11:00 ET — mid-session (EDT).
+    _RTH = datetime(2026, 6, 12, 15, 0, tzinfo=timezone.utc)
 
-        s3 = _universe_s3(_UNIVERSE)
-        rth = datetime(2026, 6, 12, 15, 0, tzinfo=timezone.utc)  # Friday 15:00 UTC
+    def _s3(self, *, heartbeat_offset_s: int | None = 60, universe: dict | None = _UNIVERSE):
+        """Fake S3 with a heartbeat ``offset_s`` seconds BEFORE the test's RTH now."""
+        ts = None
+        if heartbeat_offset_s is not None:
+            ts = (self._RTH - timedelta(seconds=heartbeat_offset_s)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return _universe_s3(universe, heartbeat_ts=ts)
+
+    def test_writes_quotes_with_currency_when_open_and_app_active(self):
+        s3 = self._s3()
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=lambda s: dict(self._QUOTES), now=rth
+            bucket="b", s3_client=s3, intraday_source=lambda s: {k: dict(v) for k, v in self._QUOTES.items()},
+            now=self._RTH,
         )
         assert result["status"] == "ok" and result["quotes"] == 2
         puts = _puts(s3)
@@ -247,47 +267,81 @@ class TestIntraday:
         assert art["as_of_utc"] == "2026-06-12T15:00:00Z"
         # Currency joined from the universe (the consumer FX-converts the P&L legs).
         assert art["quotes"]["1299.HK"]["currency"] == "HKD"
-        assert art["quotes"]["AAPL"]["prev_close"] == 201.5
+        # Normal moves carry no suspect flag.
+        assert "suspect" not in art["quotes"]["AAPL"]
 
-    def test_skips_outside_market_window_without_fetching(self):
-        from datetime import datetime, timezone
+    def test_suspect_flag_on_extreme_move_never_dropped(self):
+        s3 = self._s3()
+        quotes = {"AAPL": {"last": 350.0, "open": 200.5, "prev_close": 201.5,
+                           "session_date": "2026-06-12", "prev_session_date": "2026-06-11"}}
+        result = mmd.collect_intraday(
+            bucket="b", s3_client=s3, intraday_source=lambda s: quotes, now=self._RTH
+        )
+        assert result["status"] == "ok"
+        art = _puts(s3)["market_data/intraday/latest.json"]
+        q = art["quotes"]["AAPL"]
+        assert q["suspect"] is True
+        assert q["last"] == 350.0  # flagged, never clamped/dropped — no fabrication
 
-        s3 = _universe_s3(_UNIVERSE)
+    def test_skips_without_fresh_heartbeat(self):
+        """The demand gate: Metron closed (no/stale heartbeat) → zero quote fetches."""
         calls = []
         source = lambda s: calls.append(1) or {}
-        # Friday 22:00 UTC — after the (DST-widened) close window.
-        late = datetime(2026, 6, 12, 22, 0, tzinfo=timezone.utc)
-        result = mmd.collect_intraday(bucket="b", s3_client=s3, intraday_source=source, now=late)
-        assert result["status"] == "skipped" and "market window" in result["reason"]
-        assert not calls and not s3.put_object.called
-        # Saturday inside the hour window — still skipped (weekend).
-        sat = datetime(2026, 6, 13, 15, 0, tzinfo=timezone.utc)
-        assert mmd.collect_intraday(bucket="b", s3_client=s3, intraday_source=source, now=sat)["status"] == "skipped"
-        # force=True bypasses the gate (manual backfill/debug runs).
+        # No heartbeat key at all.
+        absent = self._s3(heartbeat_offset_s=None)
+        r1 = mmd.collect_intraday(bucket="b", s3_client=absent, intraday_source=source, now=self._RTH)
+        assert r1["status"] == "skipped" and "heartbeat" in r1["reason"]
+        # Stale heartbeat (older than HEARTBEAT_FRESH_SECONDS).
+        stale = self._s3(heartbeat_offset_s=mmd.HEARTBEAT_FRESH_SECONDS + 60)
+        r2 = mmd.collect_intraday(bucket="b", s3_client=stale, intraday_source=source, now=self._RTH)
+        assert r2["status"] == "skipped" and "heartbeat" in r2["reason"]
+        assert not calls and not absent.put_object.called and not stale.put_object.called
+        # force bypasses BOTH gates (manual/debug runs).
         forced = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=lambda s: dict(self._QUOTES), now=late, force=True
+            bucket="b", s3_client=self._s3(heartbeat_offset_s=None),
+            intraday_source=lambda s: {k: dict(v) for k, v in self._QUOTES.items()},
+            now=self._RTH, force=True,
         )
         assert forced["status"] == "ok"
 
-    def test_market_window_boundaries(self):
-        from datetime import datetime, timezone
+    def test_skips_outside_session_before_heartbeat_read(self):
+        calls = []
+        source = lambda s: calls.append(1) or {}
+        s3 = self._s3()
+        # Friday 22:00 UTC = 18:00 ET — after close.
+        late = datetime(2026, 6, 12, 22, 0, tzinfo=timezone.utc)
+        assert mmd.collect_intraday(bucket="b", s3_client=s3, intraday_source=source, now=late)["status"] == "skipped"
+        # Saturday mid-window-hours — weekend.
+        sat = datetime(2026, 6, 13, 15, 0, tzinfo=timezone.utc)
+        assert mmd.collect_intraday(bucket="b", s3_client=s3, intraday_source=source, now=sat)["status"] == "skipped"
+        assert not calls
 
-        mk = lambda h, m: datetime(2026, 6, 12, h, m, tzinfo=timezone.utc)  # a Friday
-        assert not mmd.in_us_market_window(mk(13, 24))   # pre-open margin edge
-        assert mmd.in_us_market_window(mk(13, 25))       # EDT open margin
-        assert mmd.in_us_market_window(mk(20, 0))        # EDT close
-        assert mmd.in_us_market_window(mk(21, 10))       # EST close margin
-        assert not mmd.in_us_market_window(mk(21, 11))
+    def test_market_window_exchange_calendar(self):
+        mk = lambda y, mo, d, h, mi: datetime(y, mo, d, h, mi, tzinfo=timezone.utc)
+        # EDT regular day (2026-06-12): session 13:30–20:00 UTC, ±5 min margin.
+        assert not mmd.in_us_market_window(mk(2026, 6, 12, 13, 24))
+        assert mmd.in_us_market_window(mk(2026, 6, 12, 13, 25))
+        assert mmd.in_us_market_window(mk(2026, 6, 12, 20, 5))
+        assert not mmd.in_us_market_window(mk(2026, 6, 12, 20, 6))
+        # EST regular day (2026-12-15): session 14:30–21:00 UTC — the old widened-UTC
+        # heuristic would have opened an hour early; the ET evaluation does not.
+        assert not mmd.in_us_market_window(mk(2026, 12, 15, 13, 30))
+        assert mmd.in_us_market_window(mk(2026, 12, 15, 14, 25))
+        assert mmd.in_us_market_window(mk(2026, 12, 15, 21, 5))
+        # NYSE holiday (Thanksgiving 2026-11-26) — closed all day.
+        assert not mmd.in_us_market_window(mk(2026, 11, 26, 15, 0))
+        # Half-day (day after Thanksgiving, EST): closes 13:00 ET = 18:00 UTC.
+        assert mmd.in_us_market_window(mk(2026, 11, 27, 17, 0))
+        assert mmd.in_us_market_window(mk(2026, 11, 27, 18, 5))
+        assert not mmd.in_us_market_window(mk(2026, 11, 27, 19, 0))  # old heuristic said open
 
     def test_intraday_dry_run_and_empty_universe(self):
-        from datetime import datetime, timezone
-
-        rth = datetime(2026, 6, 12, 15, 0, tzinfo=timezone.utc)
-        s3 = _universe_s3(_UNIVERSE)
+        s3 = self._s3()
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, dry_run=True, intraday_source=lambda s: dict(self._QUOTES), now=rth
+            bucket="b", s3_client=s3, dry_run=True,
+            intraday_source=lambda s: {k: dict(v) for k, v in self._QUOTES.items()}, now=self._RTH,
         )
         assert result["status"] == "ok_dry_run"
         assert not s3.put_object.called
-        empty = _universe_s3({"holdings": [], "currencies": []})
-        assert mmd.collect_intraday(bucket="b", s3_client=empty, now=rth)["status"] == "skipped"
+        empty = self._s3(universe={"holdings": [], "currencies": []})
+        assert mmd.collect_intraday(bucket="b", s3_client=empty, now=self._RTH)["status"] == "skipped"


### PR DESCRIPTION
Implements config#1025 (all three items) **plus the demand gate** (Brian 2026-06-12: the feed should only update while Metron is open).

## The four changes
1. **Exchange-calendar session gate** — `in_us_market_window` now evaluates in `America/New_York` against the fleet-canonical `alpha_engine_lib.trading_calendar.is_trading_day` (holidays + weekends; no new dependency) plus a local `NYSE_EARLY_CLOSES` set (1:00 PM ET half-days through 2030, lift-to-lib note for second adoption). Kills the DST-widened UTC heuristic: no hour-early winter opens, no post-half-day junk ticks, holidays fully skipped.
2. **Demand gate** — the producer additionally requires a fresh `metron/ui_heartbeat.json` (<600s old), written by metron-api while the app is actively used (companion PR metron#43). Closed app → `skipped` with zero yfinance calls; an off-gate tick costs one S3 GET. `--force` bypasses both gates.
3. **5-min cadence** — timer tightened from 15 → 5 min; worst-case end-to-end staleness ~35 → ~25 min (the yfinance ~15-min delay dominates). Cost unchanged in any meaningful sense: ~$0.01/month worst case, $0 marginal compute.
4. **Suspect-quote flag** — a quote moving >40% vs prior close carries `suspect: true` (flagged, never dropped/clamped — no fabrication) + WARN log; the Today view renders a warning instead of a wild P&L leg.

## Verification
Intraday test class rewritten for the double gate: heartbeat fresh/stale/absent + force bypass, EDT vs EST session boundaries, Thanksgiving holiday, day-after-Thanksgiving half-day (the old heuristic would call 19:00 UTC open; the calendar says closed). Full suite **1961 passed**.

## Post-merge operator steps
1. Re-run `sudo bash infrastructure/install-metron-intraday.sh` on the trading box (unit-file change needs daemon-reload) — I'll do it via SSM on merge.
2. Merge metron#43 (heartbeat writer) — until it's live, the intraday feed pauses by design (nothing consumes it yet).
3. Registry row update rides a fresh config PR (demand-gated freshness semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)