### PR TITLE
feat(daily-news): persist raw per-article records for human-readable feed

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -49,6 +49,7 @@ from collectors.nlp.loughran_mcdonald import (
 logger = logging.getLogger(__name__)
 
 DAILY_PREFIX = "data/news_aggregates_daily"
+ARTICLES_PREFIX = "data/news_articles_daily"
 HOLDINGS_UNIVERSE_KEY = "robodashboard/holdings_universe.json"
 DEFAULT_LOOKBACK_HOURS = 24
 DEFAULT_BUCKET = "alpha-engine-research"
@@ -226,12 +227,59 @@ def collect(
         prefix=DAILY_PREFIX,
     )
     logger.info("[daily_news] wrote %d rows to s3://%s/%s", len(df), bucket, key)
+
+    # ── Additive raw-article companion (human-readable feed substrate) ────────
+    # The aggregate above is the PRIMARY artifact (consumers + ARTIFACT_REGISTRY
+    # gate on it). This second write preserves the underlying deduped articles
+    # (headline/url/source/excerpt/per-article sentiment) for the dashboard
+    # "Daily News" page — built from the SAME already-fetched data, so no extra
+    # API calls and no LLM spend.
+    #
+    # FAIL-SOFT, deliberately (per [[feedback_no_silent_fails]] — acceptable
+    # category: secondary artifact hung off a path whose PRIMARY deliverable
+    # already succeeded). (a) Failure mode swallowed: the raw-article parquet/
+    # sidecar write fails (S3 hiccup, schema bug). (b) Primary survives: the
+    # aggregate already landed above; consumers are unaffected. (c) Recording
+    # surface: a WARN log here AND the ``articles_status`` field on the returned
+    # status dict (which the SF/logs capture). It must never abort the weekday
+    # SF — the whole daily_news producer is already secondary/fail-soft.
+    articles_status = "ok"
+    articles_key = None
+    articles_rows = 0
+    try:
+        from data.derived.news_articles import articles_build_and_write
+
+        articles_key, articles_df = articles_build_and_write(
+            articles=articles,
+            nlp_output=nlp_output,
+            aggregate_date=agg_date,
+            aggregator=aggregator,
+            s3_client=s3_client,
+            bucket=bucket,
+            prefix=ARTICLES_PREFIX,
+        )
+        articles_rows = int(len(articles_df))
+        logger.info(
+            "[daily_news] wrote %d article rows to s3://%s/%s",
+            articles_rows, bucket, articles_key,
+        )
+    except Exception as e:  # noqa: BLE001 — fail-soft secondary artifact (see above)
+        articles_status = "error"
+        logger.warning(
+            "[daily_news] raw-article companion write FAILED (%s: %s) — "
+            "aggregate artifact already landed, continuing",
+            type(e).__name__, e,
+        )
+
     return {
         "status": "ok",
         "tickers": len(universe),
         "articles": len(articles),
         "rows": int(len(df)),
         "key": key,
+        "articles_status": articles_status,
+        "articles_key": articles_key,
+        "articles_rows": articles_rows,
     }
 
 

--- a/data/derived/news_articles.py
+++ b/data/derived/news_articles.py
@@ -1,0 +1,384 @@
+"""Raw per-article daily news records — the human-readable companion to
+``news_aggregates`` (the per-(ticker, date) rollup).
+
+Where ``news_aggregates.py`` collapses a day's articles into one
+sentiment/event row per ticker (the machine-readable feature substrate an
+LLM brief or the agents read), this module preserves the underlying
+deduped articles themselves — one row per canonical story — so a
+human-facing surface (the dashboard "Daily News" console page) can render
+a reverse-chronological feed of linked headlines, sources, and excerpts.
+
+Both artifacts are written from the SAME already-fetched + already-parsed
+article set in ``collectors.daily_news.collect`` — the raw-article write
+is purely additive (one extra S3 PUT) and adds NO API calls and NO LLM
+spend (the producer stays deterministic). The aggregate remains the
+primary artifact; this is a secondary, richer-grained companion.
+
+Schema design mirrors ``news_aggregates``:
+
+- ``schema_version`` column on every row for consumer shimming.
+- list-valued fields (``tickers``, ``sources``, ``tags``, ``authors``)
+  are JSON-serialized strings — portable across the parquet round-trip
+  without pyarrow struct/list fiddliness, and trivially ``json.loads``-ed
+  by the dashboard before exploding per-ticker.
+- One row per canonical (deduped) story, NOT per (story, ticker): a
+  multi-ticker piece stays a single row carrying its full ticker tuple;
+  the consumer explodes when it wants a per-ticker view.
+
+Eval-artifacts shape (flat layout + YYMMDDHHMM run_id + ``latest.json``
+sidecar) is identical to the aggregate so the dashboard reuses the same
+listing/read conventions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import date as Date
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Any, Iterable, Sequence
+
+import pandas as pd
+
+from collectors.news_aggregator import AggregatedNewsArticle, NewsAggregator
+from collectors.nlp.pipeline import NewsNLPOutput
+from collectors.nlp.protocols import EventFlag, SentimentScore
+
+# Reuse the aggregate module's trust-weight resolution so the two
+# artifacts agree on "which source is most trusted" for a given story.
+from data.derived.news_aggregates import _make_trust_weight_fn
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = 1
+"""Bump on any breaking change to the per-article row schema. Additive
+columns bump this comment's minor note but not the lock; consumers gate
+on the ``schema_version`` column."""
+
+
+# ── Row shape ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class NewsArticleRecord:
+    """One row in the raw-article parquet — a single canonical story.
+
+    - ``tickers_json``: JSON list of every ticker this story concerns
+      (union across deduped source variants).
+    - ``primary_source`` / ``sources_json``: the highest-trust source
+      slug + the sorted set of all source slugs that carried the story.
+    - ``body_excerpt``: lead paragraph / summary from the highest-trust
+      variant (full body lives only in the RAG corpus, not here).
+    - ``lm_sentiment``: Loughran-McDonald composite in [-1, +1] for THIS
+      story (mean across LM scores for its fingerprint; 0.0 if unscored).
+    - ``top_event_description``: highest-severity rule-based event
+      description for the story ("" when no event flagged).
+    """
+
+    article_fingerprint: str
+    aggregate_date: Date
+    schema_version: int
+    title: str
+    url: str
+    tickers_json: str
+    n_tickers: int
+    primary_source: str
+    sources_json: str
+    n_sources: int
+    trust_weight_max: float
+    published_at: str
+    body_excerpt: str
+    authors_json: str
+    tags_json: str
+    lm_sentiment: float
+    lm_positive_words: int
+    lm_negative_words: int
+    lm_uncertainty_words: int
+    event_count: int
+    event_severity_max: float
+    event_categories: str
+    top_event_description: str
+
+
+# ── Builder ────────────────────────────────────────────────────────────
+
+
+def build_news_articles_df(
+    articles: Sequence[AggregatedNewsArticle],
+    nlp_output: NewsNLPOutput,
+    *,
+    aggregate_date: Date,
+    aggregator: NewsAggregator | None = None,
+    trust_weights: dict[str, float] | None = None,
+) -> pd.DataFrame:
+    """Produce a DataFrame with one row per canonical (deduped) article.
+
+    ``trust_weights`` (or ``aggregator.trust_weights`` if provided) drive
+    the ``primary_source`` / ``trust_weight_max`` selection. Falls back to
+    a flat-1.0 weighting if neither is passed (ties broken by sort order).
+    """
+    weight_fn = _make_trust_weight_fn(aggregator, trust_weights)
+
+    # Index NLP streams by article fingerprint for O(1) per-article lookup.
+    sentiment_by_fp: dict[str, list[SentimentScore]] = {}
+    for s in nlp_output.sentiment_scores:
+        sentiment_by_fp.setdefault(s.article_fingerprint, []).append(s)
+
+    events_by_fp: dict[str, list[EventFlag]] = {}
+    for e in nlp_output.event_flags:
+        events_by_fp.setdefault(e.article_fingerprint, []).append(e)
+
+    rows: list[NewsArticleRecord] = []
+    for article in articles:
+        rows.append(_build_article_row(
+            article=article,
+            sentiment_by_fp=sentiment_by_fp,
+            events_by_fp=events_by_fp,
+            aggregate_date=aggregate_date,
+            weight_fn=weight_fn,
+        ))
+
+    if not rows:
+        return _empty_df()
+    # Newest first — the parquet is already in feed order for consumers.
+    df = pd.DataFrame([r.__dict__ for r in rows])
+    return df.sort_values("published_at", ascending=False).reset_index(drop=True)
+
+
+def _build_article_row(
+    *,
+    article: AggregatedNewsArticle,
+    sentiment_by_fp: dict[str, list[SentimentScore]],
+    events_by_fp: dict[str, list[EventFlag]],
+    aggregate_date: Date,
+    weight_fn,
+) -> NewsArticleRecord:
+    fp = article.canonical_fingerprint
+    variants = list(article.variants)
+
+    # Source provenance — sorted unique slugs + the most-trusted variant.
+    sources = sorted({v.source for v in variants})
+    primary_variant = max(
+        variants,
+        key=lambda v: weight_fn(v.source),
+        default=None,
+    )
+    primary_source = primary_variant.source if primary_variant else ""
+    trust_weight_max = max((weight_fn(v.source) for v in variants), default=0.0)
+
+    # Body excerpt: prefer the highest-trust variant; fall back to the
+    # first non-empty excerpt across variants (some feeds are headline-only).
+    body_excerpt = ""
+    if primary_variant and (primary_variant.body_excerpt or "").strip():
+        body_excerpt = primary_variant.body_excerpt
+    else:
+        for v in variants:
+            if (v.body_excerpt or "").strip():
+                body_excerpt = v.body_excerpt
+                break
+
+    # Authors from the primary variant (wire feeds often expose none).
+    authors = list(primary_variant.headline_authors) if (
+        primary_variant and primary_variant.headline_authors
+    ) else []
+
+    # Vendor tags unioned across variants.
+    tags: set[str] = set()
+    for v in variants:
+        tags.update(v.tags or ())
+
+    # Sentiment — LM composite mean for this fingerprint.
+    lm_scores: list[float] = []
+    pos = neg = unc = 0
+    for s in sentiment_by_fp.get(fp, []):
+        if s.scorer != "loughran_mcdonald":
+            continue
+        lm_scores.append(s.composite)
+        pos += s.positive_word_count or 0
+        neg += s.negative_word_count or 0
+        unc += s.uncertainty_word_count or 0
+    lm_sentiment = sum(lm_scores) / len(lm_scores) if lm_scores else 0.0
+
+    # Events for this story.
+    events = events_by_fp.get(fp, [])
+    if events:
+        event_count = len(events)
+        severities = [e.severity for e in events]
+        event_severity_max = max(severities)
+        categories_str = ",".join(sorted({e.category for e in events}))
+        top = max(events, key=lambda e: e.severity)
+        top_event_description = top.description
+    else:
+        event_count = 0
+        event_severity_max = 0.0
+        categories_str = ""
+        top_event_description = ""
+
+    return NewsArticleRecord(
+        article_fingerprint=fp,
+        aggregate_date=aggregate_date,
+        schema_version=SCHEMA_VERSION,
+        title=article.canonical_title,
+        url=article.canonical_url,
+        tickers_json=json.dumps(list(article.tickers), separators=(",", ":")),
+        n_tickers=len(article.tickers),
+        primary_source=primary_source,
+        sources_json=json.dumps(sources, separators=(",", ":")),
+        n_sources=len(sources),
+        trust_weight_max=round(trust_weight_max, 4),
+        published_at=_iso(article.earliest_published_at),
+        body_excerpt=body_excerpt,
+        authors_json=json.dumps(authors, separators=(",", ":")),
+        tags_json=json.dumps(sorted(tags), separators=(",", ":")),
+        lm_sentiment=round(lm_sentiment, 6),
+        lm_positive_words=pos,
+        lm_negative_words=neg,
+        lm_uncertainty_words=unc,
+        event_count=event_count,
+        event_severity_max=round(event_severity_max, 4),
+        event_categories=categories_str,
+        top_event_description=top_event_description,
+    )
+
+
+def _iso(dt: datetime) -> str:
+    """UTC ISO-8601 with a trailing ``Z`` (consistent with the sidecar)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _empty_df() -> pd.DataFrame:
+    """Empty DataFrame with the canonical column order so consumers
+    reading an empty-day parquet don't crash on missing columns."""
+    cols = list(NewsArticleRecord.__dataclass_fields__.keys())
+    return pd.DataFrame(columns=cols)
+
+
+# ── S3 parquet writer ──────────────────────────────────────────────────
+
+
+DEFAULT_S3_BUCKET = "alpha-engine-research"
+DEFAULT_S3_PREFIX = "data/news_articles_daily"
+
+
+def write_news_articles_parquet(
+    df: pd.DataFrame,
+    *,
+    aggregate_date: Date,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+    run_id: str | None = None,
+) -> str:
+    """Write the per-article DataFrame to S3 as parquet using the canonical
+    ``alpha_engine_lib.eval_artifacts`` shape: flat layout + YYMMDDHHMM
+    run_id + ``latest.json`` sidecar. Returns the artifact S3 key.
+
+    Mirrors ``news_aggregates.write_news_aggregates_parquet`` so the
+    dashboard reuses the same sidecar→artifact resolution.
+    """
+    from alpha_engine_lib.eval_artifacts import (
+        eval_artifact_key,
+        eval_latest_key,
+        new_eval_run_id,
+    )
+
+    run_id = run_id or new_eval_run_id()
+    artifact_key = eval_artifact_key(prefix, run_id, basename="articles.parquet")
+    latest_key = eval_latest_key(prefix)
+
+    buf = BytesIO()
+    df.to_parquet(buf, engine="pyarrow", index=False)
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=artifact_key,
+        Body=buf.getvalue(),
+        ContentType="application/octet-stream",
+    )
+    latest_payload = {
+        "run_id": run_id,
+        "artifact_key": artifact_key,
+        "aggregate_date": aggregate_date.isoformat(),
+        "schema_version": SCHEMA_VERSION,
+        "row_count": int(len(df)),
+        "written_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=latest_key,
+        Body=json.dumps(latest_payload).encode("utf-8"),
+        ContentType="application/json",
+    )
+    logger.info(
+        "[news_articles] wrote %d rows to s3://%s/%s (latest=%s)",
+        len(df), bucket, artifact_key, latest_key,
+    )
+    return artifact_key
+
+
+def read_news_articles_parquet(
+    *,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> pd.DataFrame:
+    """Consumer-side read. Resolves the canonical artifact via the
+    ``latest.json`` sidecar. Returns an empty canonical-schema DataFrame
+    when no artifact exists."""
+    from alpha_engine_lib.eval_artifacts import eval_latest_key
+
+    latest_key = eval_latest_key(prefix)
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=latest_key)
+        sidecar = json.loads(obj["Body"].read())
+        artifact_key = sidecar.get("artifact_key")
+        if artifact_key:
+            body = s3_client.get_object(Bucket=bucket, Key=artifact_key)
+            return pd.read_parquet(BytesIO(body["Body"].read()), engine="pyarrow")
+    except Exception as e:
+        logger.info(
+            "[news_articles] canonical sidecar read failed for %s (%s)",
+            latest_key, type(e).__name__,
+        )
+    return _empty_df()
+
+
+# ── Orchestrator-friendly helper ──────────────────────────────────────
+
+
+def articles_build_and_write(
+    articles: Iterable[AggregatedNewsArticle],
+    nlp_output: NewsNLPOutput,
+    *,
+    aggregate_date: Date | datetime,
+    aggregator: NewsAggregator | None,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> tuple[str, pd.DataFrame]:
+    """End-to-end: build the per-article DataFrame + write it to S3.
+
+    Returns ``(s3_key, dataframe)``. The DataFrame is returned for
+    immediate downstream use (logging row counts, status dict) so the
+    caller doesn't re-read from S3.
+    """
+    if isinstance(aggregate_date, datetime):
+        aggregate_date = aggregate_date.date()
+    df = build_news_articles_df(
+        articles=list(articles),
+        nlp_output=nlp_output,
+        aggregate_date=aggregate_date,
+        aggregator=aggregator,
+    )
+    key = write_news_articles_parquet(
+        df,
+        aggregate_date=aggregate_date,
+        s3_client=s3_client,
+        bucket=bucket,
+        prefix=prefix,
+    )
+    return key, df

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -82,6 +82,7 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "data/cache.py": 1,
     "data/derived/analyst_revisions.py": 2,
     "data/derived/news_aggregates.py": 2,
+    "data/derived/news_articles.py": 2,  # raw-article parquet + latest.json sidecar
     "data/snapshotter/analyst_daily.py": 2,
     "features/compute.py": 1,
     "features/registry.py": 1,

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -127,3 +127,59 @@ def test_collect_fails_loud_when_lm_dict_unavailable(
     assert out["reason"] == "lm_dict_unavailable"
     mock_write.assert_not_called()  # no degraded artifact written
     mock_agg.assert_not_called()  # failed fast, before the ~17-min news pull
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_collect_writes_raw_article_companion(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_ensure
+):
+    """The additive raw-article companion is written to the articles prefix
+    alongside the aggregate, surfacing its key/rows on the status dict."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock()
+    agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("data/news_aggregates_daily/run/result.parquet", agg_df)
+    art_df = MagicMock()
+    art_df.__len__ = lambda self: 12
+    mock_articles.return_value = (
+        "data/news_articles_daily/run/articles.parquet", art_df,
+    )
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3)
+
+    assert out["status"] == "ok"
+    assert mock_articles.call_args.kwargs["prefix"] == daily_news.ARTICLES_PREFIX
+    assert out["articles_status"] == "ok"
+    assert out["articles_rows"] == 12
+    assert out["articles_key"] == "data/news_articles_daily/run/articles.parquet"
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_collect_article_companion_failure_is_fail_soft(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_ensure
+):
+    """A failure writing the raw-article companion must NOT fail the run —
+    the aggregate (primary) already landed; status stays ok with the failure
+    recorded on articles_status (per the fail-soft secondary-artifact rule)."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock()
+    agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("data/news_aggregates_daily/run/result.parquet", agg_df)
+    mock_articles.side_effect = RuntimeError("S3 hiccup")
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3)
+
+    assert out["status"] == "ok"            # primary deliverable survived
+    assert out["rows"] == 7
+    assert out["articles_status"] == "error"  # failure recorded, not silent
+    assert out["articles_key"] is None

--- a/tests/test_news_articles.py
+++ b/tests/test_news_articles.py
@@ -1,0 +1,345 @@
+"""Tests for the raw per-article daily news writer (companion to the
+per-(ticker, date) aggregate).
+
+Covers:
+  - One row per canonical (deduped) story
+  - Multi-ticker story stays a single row carrying its full ticker tuple
+  - Primary source = highest-trust variant; sources/tags unioned
+  - Per-article LM sentiment + event rollup (top description by severity)
+  - body_excerpt falls back across variants
+  - Newest-first ordering
+  - Empty input → well-formed empty DataFrame
+  - S3 parquet write + read round-trip + missing-key empty schema
+  - Schema version pinned to column
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from io import BytesIO
+
+import pytest
+
+from alpha_engine_lib.sources import NewsArticle
+
+from collectors.news_aggregator import (
+    AggregatedNewsArticle,
+    DEFAULT_TRUST_WEIGHTS,
+    NewsAggregator,
+)
+from collectors.nlp.pipeline import NewsNLPOutput
+from collectors.nlp.protocols import EventFlag, SentimentScore
+
+from data.derived.news_articles import (
+    SCHEMA_VERSION,
+    NewsArticleRecord,
+    articles_build_and_write,
+    build_news_articles_df,
+    read_news_articles_parquet,
+    write_news_articles_parquet,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_variant(
+    source: str,
+    *,
+    title: str = "t",
+    url: str = "https://x/1",
+    body: str = "body",
+    published_at: datetime | None = None,
+    tags: tuple[str, ...] = (),
+    authors: tuple[str, ...] | None = None,
+) -> NewsArticle:
+    return NewsArticle(
+        tickers=("AAPL",),
+        title=title,
+        body_excerpt=body,
+        url=url,
+        published_at=published_at or _now(),
+        source=source,
+        fetched_at=_now(),
+        headline_authors=authors,
+        tags=tags,
+    )
+
+
+def _make_aggregated(
+    *,
+    fingerprint: str,
+    tickers: tuple[str, ...] = ("AAPL",),
+    sources: tuple[str, ...] = ("polygon",),
+    title: str = "Story",
+    url: str = "https://x.com/a",
+    published_at: datetime | None = None,
+    variant_kwargs: dict | None = None,
+) -> AggregatedNewsArticle:
+    vk = variant_kwargs or {}
+    variants = tuple(_make_variant(s, title=title, **vk) for s in sources)
+    return AggregatedNewsArticle(
+        canonical_title=title,
+        canonical_url=url,
+        tickers=tickers,
+        earliest_published_at=published_at or _now(),
+        variants=variants,
+        canonical_fingerprint=fingerprint,
+    )
+
+
+def _lm_score(fp: str, *, composite: float, pos: int = 0, neg: int = 0, total: int = 10) -> SentimentScore:
+    return SentimentScore(
+        scorer="loughran_mcdonald",
+        article_fingerprint=fp,
+        composite=composite,
+        positive_word_count=pos,
+        negative_word_count=neg,
+        uncertainty_word_count=0,
+        total_token_count=total,
+    )
+
+
+def _event(fp: str, *, category="earnings_release", description="Q4 results.", severity=0.5) -> EventFlag:
+    return EventFlag(
+        extractor="rule_based",
+        article_fingerprint=fp,
+        category=category,
+        description=description,
+        tickers=(),
+        severity=severity,
+        extracted_at=_now(),
+    )
+
+
+class TestBuildNewsArticlesDf:
+    def test_one_story_one_row(self):
+        articles = [_make_aggregated(fingerprint="fp1", tickers=("AAPL",))]
+        out = NewsNLPOutput(
+            sentiment_scores=[_lm_score("fp1", composite=0.5, pos=3)],
+            event_flags=[_event("fp1", severity=0.7, description="Big news.")],
+        )
+        df = build_news_articles_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["title"] == "Story"
+        assert row["url"] == "https://x.com/a"
+        assert row["aggregate_date"] == date(2026, 5, 13)
+        assert row["schema_version"] == SCHEMA_VERSION
+        assert json.loads(row["tickers_json"]) == ["AAPL"]
+        assert row["n_tickers"] == 1
+        assert row["lm_sentiment"] == pytest.approx(0.5)
+        assert row["lm_positive_words"] == 3
+        assert row["event_count"] == 1
+        assert row["event_severity_max"] == 0.7
+        assert row["top_event_description"] == "Big news."
+
+    def test_multi_ticker_story_is_single_row(self):
+        articles = [_make_aggregated(
+            fingerprint="fp1", tickers=("AAPL", "MSFT", "GOOGL"),
+        )]
+        df = build_news_articles_df(
+            articles=articles, nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        assert len(df) == 1
+        assert json.loads(df.iloc[0]["tickers_json"]) == ["AAPL", "MSFT", "GOOGL"]
+        assert df.iloc[0]["n_tickers"] == 3
+
+    def test_primary_source_is_highest_trust(self):
+        # polygon (0.9) outranks yahoo_rss (0.5)
+        articles = [_make_aggregated(
+            fingerprint="a", sources=("yahoo_rss", "polygon"),
+        )]
+        agg = NewsAggregator(sources=[])
+        df = build_news_articles_df(
+            articles=articles, nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13), aggregator=agg,
+        )
+        row = df.iloc[0]
+        assert row["primary_source"] == "polygon"
+        assert json.loads(row["sources_json"]) == ["polygon", "yahoo_rss"]
+        assert row["n_sources"] == 2
+        assert row["trust_weight_max"] == pytest.approx(DEFAULT_TRUST_WEIGHTS["polygon"])
+
+    def test_tags_unioned_sorted(self):
+        articles = [_make_aggregated(
+            fingerprint="a", sources=("polygon", "gdelt"),
+            variant_kwargs={"tags": ("earnings", "guidance")},
+        )]
+        df = build_news_articles_df(
+            articles=articles, nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        assert json.loads(df.iloc[0]["tags_json"]) == ["earnings", "guidance"]
+
+    def test_body_excerpt_falls_back_to_nonempty_variant(self):
+        # Highest-trust variant has empty body; lower-trust has text.
+        v_hi = _make_variant("polygon", body="   ")
+        v_lo = _make_variant("yahoo_rss", body="real summary text")
+        art = AggregatedNewsArticle(
+            canonical_title="t", canonical_url="https://x/1",
+            tickers=("AAPL",), earliest_published_at=_now(),
+            variants=(v_hi, v_lo), canonical_fingerprint="a",
+        )
+        agg = NewsAggregator(sources=[])
+        df = build_news_articles_df(
+            articles=[art], nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13), aggregator=agg,
+        )
+        assert df.iloc[0]["body_excerpt"] == "real summary text"
+
+    def test_top_event_description_is_highest_severity(self):
+        articles = [_make_aggregated(fingerprint="a")]
+        out = NewsNLPOutput(event_flags=[
+            _event("a", description="minor", severity=0.2),
+            _event("a", description="major", severity=0.9),
+        ])
+        df = build_news_articles_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        row = df.iloc[0]
+        assert row["event_count"] == 2
+        assert row["top_event_description"] == "major"
+        assert row["event_severity_max"] == 0.9
+
+    def test_newest_first_ordering(self):
+        old = _make_aggregated(
+            fingerprint="old", title="old",
+            published_at=datetime(2026, 5, 13, 9, 0, tzinfo=timezone.utc),
+        )
+        new = _make_aggregated(
+            fingerprint="new", title="new",
+            published_at=datetime(2026, 5, 13, 15, 0, tzinfo=timezone.utc),
+        )
+        df = build_news_articles_df(
+            articles=[old, new], nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        assert df.iloc[0]["title"] == "new"
+        assert df.iloc[1]["title"] == "old"
+
+    def test_published_at_is_iso_z(self):
+        art = _make_aggregated(
+            fingerprint="a",
+            published_at=datetime(2026, 5, 13, 15, 30, tzinfo=timezone.utc),
+        )
+        df = build_news_articles_df(
+            articles=[art], nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        assert df.iloc[0]["published_at"] == "2026-05-13T15:30:00Z"
+
+    def test_no_sentiment_defaults_zero(self):
+        df = build_news_articles_df(
+            articles=[_make_aggregated(fingerprint="a")],
+            nlp_output=NewsNLPOutput(), aggregate_date=date(2026, 5, 13),
+        )
+        assert df.iloc[0]["lm_sentiment"] == 0.0
+        assert df.iloc[0]["event_count"] == 0
+        assert df.iloc[0]["top_event_description"] == ""
+
+    def test_empty_articles_produces_empty_df_with_schema(self):
+        df = build_news_articles_df(
+            articles=[], nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13),
+        )
+        assert len(df) == 0
+        for col in NewsArticleRecord.__dataclass_fields__:
+            assert col in df.columns
+
+
+# ── S3 round-trip (in-memory mock; no moto dep) ────────────────────────
+
+
+class _InMemoryS3:
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self._store[(Bucket, Key)] = Body
+        return {"ETag": "stub"}
+
+    def get_object(self, *, Bucket, Key):
+        if (Bucket, Key) not in self._store:
+            raise KeyError(f"NoSuchKey: {Bucket}/{Key}")
+        return {"Body": BytesIO(self._store[(Bucket, Key)])}
+
+
+class TestS3ParquetRoundTrip:
+    def test_write_then_read_preserves_rows(self):
+        s3 = _InMemoryS3()
+        articles = [_make_aggregated(fingerprint="a", tickers=("AAPL", "MSFT"))]
+        out = NewsNLPOutput(sentiment_scores=[_lm_score("a", composite=0.42)])
+        df_in = build_news_articles_df(
+            articles=articles, nlp_output=out, aggregate_date=date(2026, 5, 13),
+        )
+        key = write_news_articles_parquet(
+            df_in, aggregate_date=date(2026, 5, 13), s3_client=s3,
+            run_id="2605131934",
+        )
+        assert key == "data/news_articles_daily/2605131934_articles.parquet"
+        assert ("alpha-engine-research", "data/news_articles_daily/latest.json") in s3._store
+
+        df_out = read_news_articles_parquet(s3_client=s3)
+        assert len(df_out) == 1
+        assert json.loads(df_out.iloc[0]["tickers_json"]) == ["AAPL", "MSFT"]
+        assert df_out.iloc[0]["lm_sentiment"] == pytest.approx(0.42)
+
+    def test_missing_parquet_returns_empty_schema_df(self):
+        s3 = _InMemoryS3()
+        df = read_news_articles_parquet(s3_client=s3)
+        assert len(df) == 0
+        for col in NewsArticleRecord.__dataclass_fields__:
+            assert col in df.columns
+
+    def test_sidecar_payload_shape(self):
+        s3 = _InMemoryS3()
+        df_in = build_news_articles_df(
+            articles=[_make_aggregated(fingerprint="a")],
+            nlp_output=NewsNLPOutput(), aggregate_date=date(2026, 5, 13),
+        )
+        write_news_articles_parquet(
+            df_in, aggregate_date=date(2026, 5, 13), s3_client=s3,
+            run_id="2605131934",
+        )
+        sidecar = json.loads(
+            s3._store[("alpha-engine-research", "data/news_articles_daily/latest.json")]
+        )
+        assert sidecar["run_id"] == "2605131934"
+        assert sidecar["artifact_key"] == "data/news_articles_daily/2605131934_articles.parquet"
+        assert sidecar["aggregate_date"] == "2026-05-13"
+        assert sidecar["schema_version"] == SCHEMA_VERSION
+        assert sidecar["row_count"] == 1
+
+
+class TestArticlesBuildAndWrite:
+    def test_end_to_end_returns_key_and_df(self):
+        s3 = _InMemoryS3()
+        articles = [_make_aggregated(fingerprint="a")]
+        agg = NewsAggregator(sources=[])
+        key, df = articles_build_and_write(
+            articles=articles, nlp_output=NewsNLPOutput(),
+            aggregate_date=date(2026, 5, 13), aggregator=agg, s3_client=s3,
+        )
+        assert key.startswith("data/news_articles_daily/")
+        assert key.endswith("_articles.parquet")
+        assert len(df) == 1
+
+    def test_accepts_datetime_for_aggregate_date(self):
+        s3 = _InMemoryS3()
+        key, _ = articles_build_and_write(
+            articles=[], nlp_output=NewsNLPOutput(),
+            aggregate_date=datetime(2026, 5, 13, 12, tzinfo=timezone.utc),
+            aggregator=None, s3_client=s3,
+        )
+        assert key.startswith("data/news_articles_daily/")
+
+
+def test_schema_version_pinned():
+    assert isinstance(SCHEMA_VERSION, int)
+    assert SCHEMA_VERSION == 1


### PR DESCRIPTION
## What

Adds a **raw per-article** daily-news artifact so we can build a human-readable news surface (and give a future LLM brief richer grounding). Today the weekday `daily_news` producer fetches articles from free sources (Polygon/GDELT/Yahoo RSS), rolls them up into a per-(ticker, date) **aggregate**, and **discards the articles**. This PR additively persists the underlying deduped stories.

## How

- **`data/derived/news_articles.py`** — `NewsArticleRecord` (versioned schema) + `build_news_articles_df` / `write_news_articles_parquet` / `read_news_articles_parquet` / `articles_build_and_write`. One row per canonical (deduped) story: title, url, tickers, sources, primary_source, published_at, body_excerpt, tags, authors, per-article LM sentiment, event count/severity/category/top-description. Mirrors `news_aggregates`' eval-artifacts shape (`{run_id}_articles.parquet` + `latest.json` sidecar) → new prefix `data/news_articles_daily/`.
- **`collectors/daily_news.py`** — after the aggregate write, additively write the raw-article companion from the **same** in-memory article set. **No new API calls, no LLM spend** (producer stays deterministic).
- **Fail-soft, by design** — the aggregate stays the PRIMARY artifact; if the companion write fails it logs WARN + records `articles_status="error"` on the returned status dict and continues (never aborts the weekday SF). This is the secondary-artifact carve-out of the no-silent-fails rule (primary already landed; failure has a named recording surface) — documented inline.

## Tests

- `tests/test_news_articles.py` — builder (one-row-per-story, multi-ticker single row, primary-source/trust, tag union, body fallback, top-event-by-severity, newest-first, ISO-Z) + S3 round-trip + sidecar shape + schema pin.
- `tests/test_daily_news.py` — companion write to the articles prefix + fail-soft on companion failure.
- `tests/test_artifact_registry_coverage.py` — pin the new 2-PUT producer file.

**Full suite: 1999 passed, 2 skipped locally.**

## Companion PRs / follow-ups

- **alpha-engine-config**: `ARTIFACT_REGISTRY.yaml` row for `data/news_articles_daily/latest.json` (freshness registry).
- **alpha-engine-dashboard**: the "Daily News" console page that consumes this artifact.
- The Metron/robodashboard morning brief (L4574) can now read raw articles for richer grounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)