### PR TITLE
feat(sources): provider-agnostic price ingestion — PriceSourceAdapter port + canonical PriceBar (Phase 1a)

### DIFF
--- a/sources/SCHEMA.md
+++ b/sources/SCHEMA.md
@@ -1,0 +1,98 @@
+# Market-data source adapters — canonical price contract
+
+**Authoritative reference for the provider-agnostic price record (`PriceBar`)
+that every upstream vendor is normalized into, and the `PriceSourceAdapter`
+port each vendor plugs into.**
+
+`alpha-engine-data` is the SOLE market-data producer for the whole Nous Ergon
+system; all other modules (Metron, predictor, research, backtester) are pure S3
+consumers. Isolating the vendor behind this contract makes swapping or adding a
+provider (yfinance / Polygon / FRED today; **Databento** / Twelve Data next) a
+one-adapter change with zero downstream impact.
+
+Status: stable. The companion test `tests/test_price_source_contract.py`
+cross-checks the `PriceBar` dataclass against this file (§2) — a PR that adds or
+renames a canonical field without updating SCHEMA.md fails CI. Mirrors the
+feature-store contract (`features/SCHEMA.md`).
+
+See alpha-engine-config#1082 for the design + rollout phases.
+
+---
+
+## 1. The contract, in one breath
+
+- An **adapter** (`sources/<vendor>.py`) owns everything provider-specific: HTTP/SDK
+  calls, response parsing, symbol-quirk mapping (`map_symbol`), rate-limit and error
+  handling, and a declared `SourceCapabilities`.
+- Every adapter's `fetch_ohlcv(...)` returns a list of **`PriceBar`** — the
+  API-neutral record below. That is the ONLY shape the rest of the pipeline and all
+  consumers ever see.
+- The orchestration core (chain selection, source-priority coalescing, validation,
+  S3 + ArcticDB writes) is provider-agnostic and unchanged.
+
+**Naming/units discipline** (inherited from `features/SCHEMA.md`): any NEW field
+added to the canonical record that could be misread by a consumer MUST carry an
+explicit units suffix (`_raw` / `_ratio` / `_pct` / `_zscore` / `_log_return`) or be
+documented in §2 with its units. The OHLCV fields below are grandfathered with the
+units stated.
+
+---
+
+## 2. `PriceBar` — canonical field catalog (authoritative)
+
+| Field | Type / units | Notes |
+|---|---|---|
+| `ticker` | str | Canonical store-key (dash form for US class shares, e.g. `BRK-B`), caret-stripped. The persisted record always keeps this key regardless of the vendor's symbol convention. |
+| `date` | str `YYYY-MM-DD` | Trading day of the bar. |
+| `open` | float (price, `currency`) | Persisted column `Open`. |
+| `high` | float (price, `currency`) | Persisted column `High`. |
+| `low` | float (price, `currency`) | Persisted column `Low`. |
+| `close` | float (price, `currency`) | Persisted column `Close`. |
+| `adj_close` | float (price, `currency`) | Persisted column `Adj_Close`. Split/dividend-adjusted close where the source provides one (yfinance); equals `close` where it does not (Polygon, FRED). |
+| `volume` | int (raw shares) | `0` when the source carries no volume (FRED single-value closes). |
+| `source` | str | Provenance — the producing adapter's `name` (`polygon` / `fred` / `yfinance` / …). |
+| `currency` | str (ISO-4217) | Native currency of the listing. Defaults `USD`. **Carried in-memory only in Phase 1a** — see §4. |
+| `vwap` | float \| None (price) | True volume-weighted price. `None` when the source can't provide it — never a `(H+L+C)/3` proxy (2026-04-17 VWAP-centralization decision). Only Polygon supplies real VWAP today. |
+
+`to_record()` / `from_record()` bridge `PriceBar` ↔ the legacy persisted dict
+(`RECORD_KEYS` in `sources/contract.py`): keys
+`ticker, date, Open, High, Low, Close, Adj_Close, Volume, VWAP, source`.
+
+---
+
+## 3. Adapters & capabilities (today)
+
+| Adapter | `vwap` | `adjusted_close` | `intraday` | `regions` | `asset_classes` |
+|---|---|---|---|---|---|
+| `polygon` | ✓ | ✗ | ✓ | US | equity, etf |
+| `fred` | ✗ | ✗ | ✗ | US | index, macro |
+| `yfinance` | ✗ | ✓ | ✗ | global | equity, etf, index |
+| `databento` *(planned)* | — | — | — | US | equity, etf |
+
+`SourceCapabilities` lets the orchestrator route by need (e.g. only `vwap=True`
+adapters are asked for true VWAP; international listings route to an adapter whose
+`regions` cover the market).
+
+---
+
+## 4. `currency` materialization (deferred, by design)
+
+Decision 2026-06-15: `currency` belongs in the canonical model now so that adding
+international coverage later is an adapter/config change, not a schema migration.
+But Phase 1a is strictly **additive** — it does NOT change the persisted
+`staging/daily_closes/{date}.parquet` / ArcticDB schema. So `PriceBar` carries
+`currency` in-memory, while `to_record()` omits it. Materializing `currency` to the
+persisted artifact (additive column, default `USD`) rides the phase that introduces
+non-USD listings or rewires `collect()` (Phase 1b+).
+
+---
+
+## 5. PR checklist
+
+- **Adding a vendor:** implement `PriceSourceAdapter` in `sources/<vendor>.py`
+  (own its HTTP/symbol-map/errors, declare `SourceCapabilities`, emit `PriceBar`),
+  `register()` it, add it to the §3 table, and add a golden test (mock the vendor
+  boundary → assert canonical `PriceBar` output).
+- **Adding/renaming a canonical field:** update the `PriceBar` dataclass AND §2
+  here (the contract test enforces parity) AND `to_record()`/`from_record()`; carry
+  a units suffix per §1.

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -1,0 +1,38 @@
+"""Pluggable market-data **source adapters** — the provider-agnostic ingestion seam.
+
+``alpha-engine-data`` is the sole market-data producer for the whole system;
+this package isolates the upstream VENDOR behind a stable contract
+(:class:`~sources.contract.PriceBar` + :class:`~sources.contract.PriceSourceAdapter`)
+so swapping or adding a provider (yfinance / Polygon / FRED today; Databento /
+Twelve Data next) is "implement one adapter + register it", with zero change to
+the persisted artifacts or any downstream consumer.
+
+See ``sources/SCHEMA.md`` and alpha-engine-config#1082.
+"""
+
+from __future__ import annotations
+
+from .contract import (
+    PRICEBAR_FIELDS,
+    RECORD_KEYS,
+    PriceBar,
+    PriceSourceAdapter,
+    SourceCapabilities,
+)
+from .registry import available, get_adapter, register
+
+# Importing the adapter modules self-registers their instances.
+from . import fred as _fred  # noqa: E402,F401
+from . import polygon as _polygon  # noqa: E402,F401
+from . import yfinance as _yfinance  # noqa: E402,F401
+
+__all__ = [
+    "PriceBar",
+    "PriceSourceAdapter",
+    "SourceCapabilities",
+    "RECORD_KEYS",
+    "PRICEBAR_FIELDS",
+    "register",
+    "get_adapter",
+    "available",
+]

--- a/sources/contract.py
+++ b/sources/contract.py
@@ -1,0 +1,148 @@
+"""
+sources/contract.py — the canonical, provider-agnostic market-data contract.
+
+``alpha-engine-data`` is the SOLE market-data producer for the whole Nous Ergon
+system; every other module (Metron, predictor, research, backtester) is a pure
+S3 consumer. This module defines the API-neutral price record (:class:`PriceBar`)
+that every upstream vendor is normalized INTO, and the
+:class:`PriceSourceAdapter` port that each vendor (yfinance, Polygon, FRED, and —
+post-beta — Databento / Twelve Data) plugs into. Swapping or adding a vendor is
+then "implement one adapter + register it", with zero change to the persisted
+artifacts or any downstream consumer.
+
+**Phase 1a (this landing):** the contract + port + a registry of the three
+existing sources, additively, WITHOUT yet rewiring
+``collectors.daily_closes.collect``. The adapters faithfully wrap today's
+``_fetch_*_closes`` implementations so output is byte-identical to the live
+pipeline. Phase 1b moves the implementations in and makes ``collect()`` dispatch
+through the registry / config-driven routing.
+
+See ``sources/SCHEMA.md`` and alpha-engine-config#1082.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Optional, Protocol, runtime_checkable
+
+
+# The exact persisted record keys — the existing ``staging/daily_closes/{date}.parquet``
+# columns (capitalized OHLCV) + provenance. ``PriceBar.to_record()`` reproduces
+# THIS dict precisely, so an adapter-driven ``collect()`` (Phase 1b) is
+# byte-identical to today. ``currency`` is intentionally NOT a persisted key yet
+# (see SCHEMA.md §4).
+RECORD_KEYS: tuple[str, ...] = (
+    "ticker", "date", "Open", "High", "Low", "Close",
+    "Adj_Close", "Volume", "VWAP", "source",
+)
+
+
+@dataclass(frozen=True)
+class PriceBar:
+    """One ticker's OHLCV bar for one trading day — normalized, provider-neutral.
+
+    The capitalized-OHLCV persisted columns map to these lowercase fields;
+    ``to_record()`` / ``from_record()`` bridge to the legacy dict. ``currency``
+    (ISO-4217) is carried in-memory now for international readiness (decision
+    2026-06-15) and materialized to the persisted artifact in a later phase.
+    See ``sources/SCHEMA.md``.
+    """
+
+    ticker: str                    # canonical store-key (dash form: BRK-B), caret-stripped
+    date: str                      # YYYY-MM-DD trading day of the bar
+    open: float
+    high: float
+    low: float
+    close: float
+    adj_close: float
+    volume: int                    # raw shares (0 when the source carries no volume, e.g. FRED)
+    source: str                    # provenance — the producing adapter's name
+    currency: str = "USD"          # ISO-4217 native currency of the listing
+    vwap: Optional[float] = None   # true volume-weighted price; None when the source can't provide it
+
+    def to_record(self) -> dict:
+        """Reproduce the EXACT legacy pipeline record dict.
+
+        ``currency`` is omitted — it is not (yet) a persisted column; the
+        persisted schema is unchanged in Phase 1a. See SCHEMA.md §4.
+        """
+        return {
+            "ticker": self.ticker,
+            "date": self.date,
+            "Open": self.open,
+            "High": self.high,
+            "Low": self.low,
+            "Close": self.close,
+            "Adj_Close": self.adj_close,
+            "Volume": self.volume,
+            "VWAP": self.vwap,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_record(cls, r: dict, *, currency: str = "USD") -> "PriceBar":
+        """Build a PriceBar from a legacy pipeline record dict."""
+        return cls(
+            ticker=r["ticker"],
+            date=r["date"],
+            open=r["Open"],
+            high=r["High"],
+            low=r["Low"],
+            close=r["Close"],
+            adj_close=r["Adj_Close"],
+            volume=r["Volume"],
+            vwap=r["VWAP"],
+            source=r["source"],
+            currency=currency,
+        )
+
+
+# Canonical PriceBar field names — the authoritative set the schema-contract test
+# cross-checks against ``sources/SCHEMA.md``.
+PRICEBAR_FIELDS: tuple[str, ...] = tuple(f.name for f in fields(PriceBar))
+
+
+@dataclass(frozen=True)
+class SourceCapabilities:
+    """What a provider adapter can supply — lets the orchestrator route by need.
+
+    e.g. only adapters with ``vwap=True`` are asked for true VWAP; international
+    holdings route to an adapter whose ``regions`` include the listing's market.
+    """
+
+    vwap: bool                       # provides true volume-weighted VWAP
+    adjusted_close: bool             # provides a split/dividend-adjusted close distinct from close
+    intraday: bool                   # can supply intraday / real-time (vs EOD only)
+    regions: tuple[str, ...]         # coverage, e.g. ("US",) or ("US", "EU", "HK")
+    asset_classes: tuple[str, ...]   # e.g. ("equity", "etf", "index")
+
+
+@runtime_checkable
+class PriceSourceAdapter(Protocol):
+    """The provider-agnostic ingestion port. One implementation per vendor.
+
+    Implementations: ``PolygonAdapter``, ``FredAdapter``, ``YfinanceAdapter``
+    today; ``DatabentoAdapter`` / ``TwelveDataAdapter`` are a drop-in away.
+    """
+
+    name: str
+    capabilities: SourceCapabilities
+
+    def map_symbol(self, ticker: str) -> str:
+        """Translate a canonical store-key to this vendor's symbol convention.
+
+        (e.g. ``BRK-B`` → ``BRK.B`` for Polygon.) The persisted record always
+        keeps the canonical store-key; this mapping is only for talking to the
+        vendor.
+        """
+        ...
+
+    def fetch_ohlcv(
+        self, tickers: list[str], run_date: str, *, strict: bool = False
+    ) -> list[PriceBar]:
+        """Fetch one trading day's bars for ``tickers``, normalized to PriceBar.
+
+        ``strict=True`` asks the adapter to RAISE on source failure / empty
+        result (mirrors today's ``*_only`` modes) rather than degrade silently.
+        """
+        ...

--- a/sources/fred.py
+++ b/sources/fred.py
@@ -1,0 +1,42 @@
+"""FRED (Federal Reserve Economic Data) price-source adapter.
+
+Serves the index/macro symbols not on polygon's free tier (VIX, VIX3M, TNX, IRX,
+TWO, HYOAS, BAA10Y) as daily closes (OHLC all = close; no volume/VWAP).
+
+Phase 1a: faithfully wraps ``collectors.daily_closes._fetch_fred_closes``.
+"""
+
+from __future__ import annotations
+
+from collectors import daily_closes as _dc
+
+from .contract import PriceBar, SourceCapabilities
+from .registry import register
+
+
+class FredAdapter:
+    """FRED daily index/macro closes (single-value; no OHLC spread, no volume)."""
+
+    name = "fred"
+    capabilities = SourceCapabilities(
+        vwap=False,
+        adjusted_close=False,
+        intraday=False,
+        regions=("US",),
+        asset_classes=("index", "macro"),
+    )
+
+    def map_symbol(self, ticker: str) -> str:
+        # FRED series mapping is internal (``_FRED_INDEX_MAP``); the store-key is
+        # carried through unchanged.
+        return ticker
+
+    def fetch_ohlcv(
+        self, tickers: list[str], run_date: str, *, strict: bool = False
+    ) -> list[PriceBar]:
+        records: list[dict] = []
+        _dc._fetch_fred_closes(tickers, run_date, records)
+        return [PriceBar.from_record(r) for r in records]
+
+
+register(FredAdapter())

--- a/sources/polygon.py
+++ b/sources/polygon.py
@@ -1,0 +1,44 @@
+"""Polygon grouped-daily price-source adapter.
+
+Phase 1a: faithfully wraps ``collectors.daily_closes._fetch_polygon_closes`` so
+output is byte-identical to the live pipeline. Phase 1b moves the implementation
+here and inverts the dependency (``collect()`` calls the adapter, not vice-versa).
+"""
+
+from __future__ import annotations
+
+from collectors import daily_closes as _dc
+
+from .contract import PriceBar, SourceCapabilities
+from .registry import register
+
+
+class PolygonAdapter:
+    """Polygon.io grouped-daily OHLCV + true VWAP (US equities/ETFs)."""
+
+    name = "polygon"
+    capabilities = SourceCapabilities(
+        vwap=True,            # polygon grouped-daily carries volume-weighted VWAP
+        adjusted_close=False,  # Adj_Close == Close (no separate adjustment series)
+        intraday=True,         # polygon can supply intraday/real-time (EOD used here)
+        regions=("US",),
+        asset_classes=("equity", "etf"),
+    )
+
+    def map_symbol(self, ticker: str) -> str:
+        # Dash store-key → polygon's dot form for class shares (BRK-B → BRK.B).
+        return _dc._polygon_symbol(ticker.lstrip("^"))
+
+    def fetch_ohlcv(
+        self, tickers: list[str], run_date: str, *, strict: bool = False
+    ) -> list[PriceBar]:
+        records: list[dict] = []
+        # ``polygon_only`` raises on 403 / empty grouped-daily; ``auto`` degrades.
+        _dc._fetch_polygon_closes(
+            tickers, run_date, records,
+            source="polygon_only" if strict else "auto",
+        )
+        return [PriceBar.from_record(r) for r in records]
+
+
+register(PolygonAdapter())

--- a/sources/registry.py
+++ b/sources/registry.py
@@ -1,0 +1,32 @@
+"""sources/registry.py — registry of available price-source adapters.
+
+Config-driven routing (Phase 1b) resolves source names → adapters through this
+registry. Adding a vendor = implement :class:`~sources.contract.PriceSourceAdapter`
+and ``register()`` it (the adapter modules self-register on import).
+"""
+
+from __future__ import annotations
+
+from .contract import PriceSourceAdapter
+
+_ADAPTERS: dict[str, PriceSourceAdapter] = {}
+
+
+def register(adapter: PriceSourceAdapter) -> None:
+    """Register an adapter under its ``name`` (idempotent — last wins)."""
+    _ADAPTERS[adapter.name] = adapter
+
+
+def get_adapter(name: str) -> PriceSourceAdapter:
+    """Return the registered adapter for ``name`` or raise ValueError."""
+    try:
+        return _ADAPTERS[name]
+    except KeyError:
+        raise ValueError(
+            f"unknown price source {name!r}; registered: {sorted(_ADAPTERS)}"
+        ) from None
+
+
+def available() -> list[str]:
+    """Sorted list of registered adapter names."""
+    return sorted(_ADAPTERS)

--- a/sources/yfinance.py
+++ b/sources/yfinance.py
@@ -1,0 +1,44 @@
+"""yfinance price-source adapter.
+
+Same-day OHLCV fallback (and the EOD pass source). Provides a true adjusted
+close but NO true VWAP (None is written — never a (H+L+C)/3 proxy, per the
+2026-04-17 VWAP-centralization decision).
+
+Phase 1a: faithfully wraps ``collectors.daily_closes._fetch_yfinance_closes``.
+"""
+
+from __future__ import annotations
+
+from collectors import daily_closes as _dc
+
+from .contract import PriceBar, SourceCapabilities
+from .registry import register
+
+
+class YfinanceAdapter:
+    """yfinance daily OHLCV (broad but uneven international coverage)."""
+
+    name = "yfinance"
+    capabilities = SourceCapabilities(
+        vwap=False,            # no true volume-weighted VWAP
+        adjusted_close=True,   # provides a split/dividend-adjusted close
+        intraday=False,        # EOD daily bars here
+        regions=("global",),   # broad-but-uneven global coverage
+        asset_classes=("equity", "etf", "index"),
+    )
+
+    def map_symbol(self, ticker: str) -> str:
+        # The legacy fetch strips the caret internally; store-key passes through.
+        return ticker
+
+    def fetch_ohlcv(
+        self, tickers: list[str], run_date: str, *, strict: bool = False
+    ) -> list[PriceBar]:
+        # yfinance has no strict mode (it logs + returns a partial count); the
+        # ``strict`` flag is accepted for port-uniformity and ignored.
+        records: list[dict] = []
+        _dc._fetch_yfinance_closes(tickers, run_date, records)
+        return [PriceBar.from_record(r) for r in records]
+
+
+register(YfinanceAdapter())

--- a/tests/test_price_source_contract.py
+++ b/tests/test_price_source_contract.py
@@ -1,0 +1,186 @@
+"""Price-source adapter contract + golden tests.
+
+Pins three things for the provider-agnostic ingestion seam (alpha-engine-config#1082):
+
+  1. **Schema parity** — the ``PriceBar`` dataclass fields match the authoritative
+     field catalog in ``sources/SCHEMA.md`` §2 (mirrors ``test_schema_contract.py``).
+  2. **Port conformance** — every registered adapter satisfies the
+     ``PriceSourceAdapter`` Protocol, declares capabilities, and round-trips a record.
+  3. **Golden fidelity** — for a mocked VENDOR response, each adapter emits the same
+     canonical ``PriceBar`` records the live pipeline produces (Phase 1a wraps the
+     legacy ``_fetch_*`` faithfully, so output is byte-identical).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from collectors import daily_closes as dc  # noqa: E402
+import sources  # noqa: E402
+from sources import available, get_adapter  # noqa: E402
+from sources.contract import (  # noqa: E402
+    PRICEBAR_FIELDS,
+    RECORD_KEYS,
+    PriceBar,
+    PriceSourceAdapter,
+    SourceCapabilities,
+)
+
+_SCHEMA_MD = Path(__file__).resolve().parents[1] / "sources" / "SCHEMA.md"
+
+# Match `field` at the start of a §2 markdown table row: ``| `ticker` | ... |``
+_FIELD_ROW_RE = re.compile(r"^\|\s*`([a-zA-Z0-9_]+)`\s*\|")
+_SECTION_2 = "## 2. `PriceBar` — canonical field catalog"
+_NEXT_SECTION = "## 3."
+
+
+def _schema_md_fields() -> set[str]:
+    """Field names from the SCHEMA.md §2 catalog table."""
+    text = _SCHEMA_MD.read_text()
+    start = text.index(_SECTION_2)
+    end = text.index(_NEXT_SECTION, start)
+    out: set[str] = set()
+    for line in text[start:end].splitlines():
+        m = _FIELD_ROW_RE.match(line)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+# ── 1. Schema parity ─────────────────────────────────────────────────────────
+
+def test_pricebar_fields_match_schema_md():
+    """PriceBar dataclass fields == SCHEMA.md §2 catalog (drift fails CI)."""
+    assert _schema_md_fields() == set(PRICEBAR_FIELDS)
+
+
+def test_to_record_keys_are_the_legacy_contract():
+    """to_record() reproduces exactly the persisted record keys (no currency)."""
+    bar = PriceBar(
+        ticker="AAPL", date="2026-06-12", open=1.0, high=2.0, low=0.5,
+        close=1.5, adj_close=1.5, volume=1000, source="polygon", vwap=1.4,
+    )
+    assert tuple(bar.to_record().keys()) == RECORD_KEYS
+    assert "currency" not in bar.to_record()
+
+
+def test_record_roundtrip_lossless():
+    """from_record(...).to_record() == original legacy record, for each flavor."""
+    samples = [
+        {"ticker": "AAPL", "date": "2026-06-12", "Open": 1.0, "High": 2.0,
+         "Low": 0.5, "Close": 1.5, "Adj_Close": 1.5, "Volume": 1000,
+         "VWAP": 1.4, "source": "polygon"},
+        {"ticker": "VIX", "date": "2026-06-12", "Open": 17.0, "High": 17.0,
+         "Low": 17.0, "Close": 17.0, "Adj_Close": 17.0, "Volume": 0,
+         "VWAP": None, "source": "fred"},
+        {"ticker": "MSFT", "date": "2026-06-12", "Open": 10.0, "High": 11.0,
+         "Low": 9.0, "Close": 10.5, "Adj_Close": 10.4, "Volume": 50,
+         "VWAP": None, "source": "yfinance"},
+    ]
+    for r in samples:
+        assert PriceBar.from_record(r).to_record() == r
+
+
+# ── 2. Port conformance ──────────────────────────────────────────────────────
+
+def test_three_sources_registered():
+    assert set(available()) == {"polygon", "fred", "yfinance"}
+
+
+@pytest.mark.parametrize("name", ["polygon", "fred", "yfinance"])
+def test_adapter_satisfies_port(name):
+    adapter = get_adapter(name)
+    assert isinstance(adapter, PriceSourceAdapter)
+    assert adapter.name == name
+    assert isinstance(adapter.capabilities, SourceCapabilities)
+    # map_symbol is total + string-returning.
+    assert isinstance(adapter.map_symbol("AAPL"), str)
+
+
+def test_get_adapter_unknown_raises():
+    with pytest.raises(ValueError):
+        get_adapter("databento")  # not registered yet
+
+
+def test_polygon_symbol_mapping():
+    assert get_adapter("polygon").map_symbol("BRK-B") == "BRK.B"
+    assert get_adapter("polygon").map_symbol("AAPL") == "AAPL"
+
+
+# ── 3. Golden fidelity (mock the vendor boundary, run the real legacy path) ───
+
+class _FakeGroupedClient:
+    def get_grouped_daily(self, run_date):
+        return {
+            "AAPL": {"open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5,
+                     "volume": 1000, "vwap": 1.4},
+            "BRK.B": {"open": 10.0, "high": 11.0, "low": 9.0, "close": 10.5,
+                      "volume": 50, "vwap": 10.2},
+        }
+
+
+def test_polygon_adapter_golden(monkeypatch):
+    """Mocked polygon grouped-daily → canonical PriceBars (dash store-key kept)."""
+    monkeypatch.setattr("polygon_client.polygon_client", lambda: _FakeGroupedClient())
+    bars = get_adapter("polygon").fetch_ohlcv(["AAPL", "BRK-B"], "2026-06-12")
+    by_ticker = {b.ticker: b for b in bars}
+    assert set(by_ticker) == {"AAPL", "BRK-B"}
+    brk = by_ticker["BRK-B"]
+    assert brk.ticker == "BRK-B"          # stored dash key, looked up via BRK.B
+    assert brk.close == 10.5
+    assert brk.vwap == 10.2
+    assert brk.volume == 50
+    assert brk.source == "polygon"
+    assert brk.currency == "USD"
+    # to_record() reproduces the legacy persisted shape.
+    assert by_ticker["AAPL"].to_record() == {
+        "ticker": "AAPL", "date": "2026-06-12", "Open": 1.0, "High": 2.0,
+        "Low": 0.5, "Close": 1.5, "Adj_Close": 1.5, "Volume": 1000,
+        "VWAP": 1.4, "source": "polygon",
+    }
+
+
+def test_yfinance_adapter_golden(monkeypatch):
+    """Mocked yf.download → canonical PriceBar (adjusted close, VWAP None)."""
+    pytest.importorskip("yfinance")
+    df = pd.DataFrame(
+        {"Open": [10.0], "High": [11.0], "Low": [9.0], "Close": [10.5],
+         "Adj Close": [10.4], "Volume": [50]},
+        index=pd.to_datetime(["2026-06-12"]),
+    )
+    monkeypatch.setattr("yfinance.download", lambda **kw: df)
+    bars = get_adapter("yfinance").fetch_ohlcv(["MSFT"], "2026-06-12")
+    assert len(bars) == 1
+    bar = bars[0]
+    assert bar.ticker == "MSFT"
+    assert bar.close == 10.5
+    assert bar.adj_close == 10.4   # yfinance supplies a distinct adjusted close
+    assert bar.vwap is None        # never a proxy
+    assert bar.source == "yfinance"
+
+
+def test_fred_adapter_golden(monkeypatch):
+    """FRED HTTP correctness is covered by test_daily_closes_fred_*; here we pin
+    the adapter's conversion contract: whatever record the legacy fetch produces
+    is losslessly normalized to a PriceBar."""
+    def _fake_fetch(tickers, date_str, records, window_cache=None):
+        records.append(dc._fred_record("VIX", date_str, 17.25))
+        return 1
+
+    monkeypatch.setattr(dc, "_fetch_fred_closes", _fake_fetch)
+    bars = get_adapter("fred").fetch_ohlcv(["VIX"], "2026-06-12")
+    assert len(bars) == 1
+    bar = bars[0]
+    assert bar.ticker == "VIX"
+    assert bar.close == 17.25
+    assert bar.volume == 0
+    assert bar.vwap is None
+    assert bar.source == "fred"


### PR DESCRIPTION
## Phase 1a — provider-agnostic price ingestion seam (alpha-engine-config#1082)

`alpha-engine-data` is the sole market-data producer; this lands the **provider-agnostic ingestion seam** so swapping/adding a vendor (Databento, Twelve Data) becomes **one adapter + one config line**, with zero change to persisted artifacts or downstream consumers (Metron, predictor, research, backtester).

**Strictly additive — does NOT touch `collect()` or the live pipeline.** The adapters faithfully WRAP today's `_fetch_*_closes`, so output is byte-identical.

- `sources/contract.py` — canonical **`PriceBar`** (API-neutral record; `currency` carried in-memory for intl-readiness), `SourceCapabilities`, `PriceSourceAdapter` Protocol, `RECORD_KEYS`.
- `sources/{polygon,fred,yfinance}.py` — adapters wrapping the legacy fetches; declare capabilities + `map_symbol`; self-register.
- `sources/registry.py` — name → adapter registry.
- `sources/SCHEMA.md` — canonical price contract (mirrors `features/SCHEMA.md`), pinned by the contract test.
- `tests/test_price_source_contract.py` — schema parity + port conformance + vendor-boundary golden fidelity (12 tests).

**Tests:** full suite **2011 passed, 2 skipped** locally (the 12 new tests included); zero existing files modified.

**Next (separate PRs):** Phase 1b rewires `collect()` to dispatch through the registry (config-driven routing) + moves implementations into the adapters; then the **Databento** adapter is a drop-in (post-beta, per metron-ops#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)