### PR TITLE
feat(sources): route collect() through the source registry (Phase 1b)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -354,6 +354,9 @@ def collect(
     window_days: int = 1,
     skip_if_canonical: bool = False,
     fred_window_cache: dict[str, list[tuple[str, float]]] | None = None,
+    equities_source: str = "polygon",
+    index_source: str = "fred",
+    fallback_source: str = "yfinance",
 ) -> dict:
     """
     Fetch OHLCV for all tickers and write to S3.
@@ -451,6 +454,9 @@ def collect(
             source=source,
             window_days=window_days,
             skip_if_canonical=skip_if_canonical,
+            equities_source=equities_source,
+            index_source=index_source,
+            fallback_source=fallback_source,
         )
 
     s3 = boto3.client("s3")
@@ -601,11 +607,16 @@ def collect(
     # still propagate with their own clear messages — only network transients
     # are downgraded to "continue to the macro backstop".
     from polygon_client import PolygonRateLimitError
+    # Lazy import: ``sources`` adapters import ``collectors.daily_closes`` at
+    # module load, so importing it here (at call time, when this module is fully
+    # initialized) avoids a circular import. The registry makes the source per
+    # role config-/param-selectable — swapping polygon→databento is one param.
+    from sources import get_adapter
     polygon_count = 0
     if source != "yfinance_only":
         try:
-            polygon_count = _fetch_polygon_closes(
-                tickers, run_date, records, source=source
+            polygon_count = get_adapter(equities_source).fetch_into(
+                records, tickers, run_date, strict=(source == "polygon_only"),
             )
         except (requests.Timeout, requests.ConnectionError,
                 PolygonRateLimitError) as exc:
@@ -634,8 +645,8 @@ def collect(
         # L4492: in window mode the caller prefetches the whole window's FRED
         # series in one ranged call each and passes the cache down; per-date
         # emit then reads from it (no per-date FRED I/O). None → legacy path.
-        fred_count = _fetch_fred_closes(
-            fred_missing, run_date, records, window_cache=fred_window_cache,
+        fred_count = get_adapter(index_source).fetch_into(
+            records, fred_missing, run_date, window_cache=fred_window_cache,
         )
 
     # ── Step 3: yfinance ─────────────────────────────────────────────────────
@@ -675,9 +686,13 @@ def collect(
                     "Equity universe still refuses yfinance per feedback_no_silent_fails.",
                     macro_missing, run_date,
                 )
-                yfinance_count = _fetch_yfinance_closes(macro_missing, run_date, records)
+                yfinance_count = get_adapter(fallback_source).fetch_into(
+                    records, macro_missing, run_date,
+                )
         else:
-            yfinance_count = _fetch_yfinance_closes(missing, run_date, records)
+            yfinance_count = get_adapter(fallback_source).fetch_into(
+                records, missing, run_date,
+            )
 
     # Merge preserved canonical rows from the existing parquet into the
     # records list. These are tickers we deliberately skipped fetching
@@ -814,6 +829,9 @@ def _collect_window(
     source: str,
     window_days: int,
     skip_if_canonical: bool = False,
+    equities_source: str = "polygon",
+    index_source: str = "fred",
+    fallback_source: str = "yfinance",
 ) -> dict:
     """Iterate ``collect`` over a backward-looking business-day window.
 
@@ -903,6 +921,9 @@ def _collect_window(
                 window_days=1,
                 skip_if_canonical=skip_if_canonical,
                 fred_window_cache=fred_window_cache,  # L4492: 1 ranged call/series
+                equities_source=equities_source,
+                index_source=index_source,
+                fallback_source=fallback_source,
             )
         except Exception as exc:
             # Record + continue. Fatality is target-driven (decided

--- a/sources/SCHEMA.md
+++ b/sources/SCHEMA.md
@@ -24,9 +24,15 @@ See alpha-engine-config#1082 for the design + rollout phases.
 - An **adapter** (`sources/<vendor>.py`) owns everything provider-specific: HTTP/SDK
   calls, response parsing, symbol-quirk mapping (`map_symbol`), rate-limit and error
   handling, and a declared `SourceCapabilities`.
-- Every adapter's `fetch_ohlcv(...)` returns a list of **`PriceBar`** — the
-  API-neutral record below. That is the ONLY shape the rest of the pipeline and all
-  consumers ever see.
+- Every adapter exposes two fetch methods over the same logic: **`fetch_ohlcv(...)`**
+  returns a clean list of **`PriceBar`** (the API-neutral record below); **`fetch_into(records, ...)`**
+  is the pipeline-facing form that appends legacy record dicts to a passed list in
+  place (preserving partial-on-error + `window_cache` semantics) and returns a count.
+- **`collectors.daily_closes.collect()` dispatches its fetches through the registry**
+  via `fetch_into`, selecting the adapter per role from injectable params
+  (`equities_source` / `index_source` / `fallback_source`, defaults `polygon` / `fred`
+  / `yfinance`). Swapping polygon→**databento** is one param + the new adapter — no
+  change to `collect()`, the persisted artifacts, or any consumer.
 - The orchestration core (chain selection, source-priority coalescing, validation,
   S3 + ArcticDB writes) is provider-agnostic and unchanged.
 

--- a/sources/contract.py
+++ b/sources/contract.py
@@ -144,5 +144,28 @@ class PriceSourceAdapter(Protocol):
 
         ``strict=True`` asks the adapter to RAISE on source failure / empty
         result (mirrors today's ``*_only`` modes) rather than degrade silently.
+        The clean, list-returning API — built on :meth:`fetch_into`.
+        """
+        ...
+
+    def fetch_into(
+        self,
+        records: list[dict],
+        tickers: list[str],
+        run_date: str,
+        *,
+        strict: bool = False,
+        window_cache: dict | None = None,
+    ) -> int:
+        """Pipeline-facing fetch: APPEND legacy record dicts to ``records`` in
+        place and return the count appended.
+
+        Mutates the passed list (not a fresh one) so partial results survive a
+        mid-fetch error exactly as the legacy ``_fetch_*`` functions do — the
+        property the orchestrator's coverage gates rely on. This is the method
+        ``collectors.daily_closes.collect`` dispatches through;
+        :meth:`fetch_ohlcv` is the clean wrapper over it. ``window_cache`` is
+        used only by sources that support windowed reconciliation (FRED); others
+        ignore it.
         """
         ...

--- a/sources/fred.py
+++ b/sources/fred.py
@@ -31,11 +31,25 @@ class FredAdapter:
         # carried through unchanged.
         return ticker
 
+    def fetch_into(
+        self,
+        records: list[dict],
+        tickers: list[str],
+        run_date: str,
+        *,
+        strict: bool = False,
+        window_cache: dict | None = None,
+    ) -> int:
+        # FRED supports windowed reconciliation — forward the prefetched cache.
+        return _dc._fetch_fred_closes(
+            tickers, run_date, records, window_cache=window_cache,
+        )
+
     def fetch_ohlcv(
         self, tickers: list[str], run_date: str, *, strict: bool = False
     ) -> list[PriceBar]:
         records: list[dict] = []
-        _dc._fetch_fred_closes(tickers, run_date, records)
+        self.fetch_into(records, tickers, run_date, strict=strict)
         return [PriceBar.from_record(r) for r in records]
 
 

--- a/sources/polygon.py
+++ b/sources/polygon.py
@@ -29,15 +29,27 @@ class PolygonAdapter:
         # Dash store-key → polygon's dot form for class shares (BRK-B → BRK.B).
         return _dc._polygon_symbol(ticker.lstrip("^"))
 
+    def fetch_into(
+        self,
+        records: list[dict],
+        tickers: list[str],
+        run_date: str,
+        *,
+        strict: bool = False,
+        window_cache: dict | None = None,
+    ) -> int:
+        # ``polygon_only`` raises on 403 / empty grouped-daily; ``auto`` degrades.
+        # Mutates ``records`` in place (partial appends survive a mid-fetch raise).
+        return _dc._fetch_polygon_closes(
+            tickers, run_date, records,
+            source="polygon_only" if strict else "auto",
+        )
+
     def fetch_ohlcv(
         self, tickers: list[str], run_date: str, *, strict: bool = False
     ) -> list[PriceBar]:
         records: list[dict] = []
-        # ``polygon_only`` raises on 403 / empty grouped-daily; ``auto`` degrades.
-        _dc._fetch_polygon_closes(
-            tickers, run_date, records,
-            source="polygon_only" if strict else "auto",
-        )
+        self.fetch_into(records, tickers, run_date, strict=strict)
         return [PriceBar.from_record(r) for r in records]
 
 

--- a/sources/yfinance.py
+++ b/sources/yfinance.py
@@ -31,13 +31,24 @@ class YfinanceAdapter:
         # The legacy fetch strips the caret internally; store-key passes through.
         return ticker
 
+    def fetch_into(
+        self,
+        records: list[dict],
+        tickers: list[str],
+        run_date: str,
+        *,
+        strict: bool = False,
+        window_cache: dict | None = None,
+    ) -> int:
+        # yfinance has no strict mode (it logs + returns a partial count); the
+        # ``strict`` flag is accepted for port-uniformity and ignored.
+        return _dc._fetch_yfinance_closes(tickers, run_date, records)
+
     def fetch_ohlcv(
         self, tickers: list[str], run_date: str, *, strict: bool = False
     ) -> list[PriceBar]:
-        # yfinance has no strict mode (it logs + returns a partial count); the
-        # ``strict`` flag is accepted for port-uniformity and ignored.
         records: list[dict] = []
-        _dc._fetch_yfinance_closes(tickers, run_date, records)
+        self.fetch_into(records, tickers, run_date, strict=strict)
         return [PriceBar.from_record(r) for r in records]
 
 

--- a/tests/test_collect_config_routing.py
+++ b/tests/test_collect_config_routing.py
@@ -1,0 +1,72 @@
+"""Phase 1b — collect() dispatches fetches through the source registry.
+
+Pins the two properties that make the rewire behavior-preserving:
+  1. ``fetch_into`` mutates the PASSED records list in place and returns the
+     count (so partial appends survive a mid-fetch error, exactly as the legacy
+     ``_fetch_*`` functions do — the property collect()'s coverage gates rely on).
+  2. ``collect()`` exposes the injectable per-role source params (defaults =
+     today's behavior), so swapping polygon→databento is one param.
+
+The end-to-end behavior-equivalence net is the existing ``test_daily_closes_*``
+suite, which exercises collect() with mocked vendors and must pass unchanged.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from collectors import daily_closes as dc  # noqa: E402
+from sources import get_adapter  # noqa: E402
+
+
+class _FakeGroupedClient:
+    def get_grouped_daily(self, run_date):
+        return {
+            "AAPL": {"open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5,
+                     "volume": 1000, "vwap": 1.4},
+            "BRK.B": {"open": 10.0, "high": 11.0, "low": 9.0, "close": 10.5,
+                      "volume": 50, "vwap": 10.2},
+        }
+
+
+def test_fetch_into_mutates_in_place_and_counts(monkeypatch):
+    monkeypatch.setattr("polygon_client.polygon_client", lambda: _FakeGroupedClient())
+    pre = {"ticker": "PRE", "date": "2026-06-12", "Open": 0.0, "High": 0.0,
+           "Low": 0.0, "Close": 0.0, "Adj_Close": 0.0, "Volume": 0,
+           "VWAP": None, "source": "prior"}
+    records = [pre]
+    n = get_adapter("polygon").fetch_into(records, ["AAPL", "BRK-B"], "2026-06-12")
+    assert n == 2                       # count == appended
+    assert records[0] is pre            # prior row preserved (mutate in place)
+    assert {r["ticker"] for r in records[1:]} == {"AAPL", "BRK-B"}
+    # The appended records are the canonical persisted shape (dash store-key kept).
+    brk = next(r for r in records if r["ticker"] == "BRK-B")
+    assert brk["Close"] == 10.5 and brk["VWAP"] == 10.2 and brk["source"] == "polygon"
+
+
+def test_fetch_into_matches_legacy_fetch(monkeypatch):
+    """fetch_into is a faithful pass-through of the legacy _fetch_polygon_closes."""
+    monkeypatch.setattr("polygon_client.polygon_client", lambda: _FakeGroupedClient())
+    via_adapter: list[dict] = []
+    get_adapter("polygon").fetch_into(via_adapter, ["AAPL", "BRK-B"], "2026-06-12")
+    via_legacy: list[dict] = []
+    dc._fetch_polygon_closes(["AAPL", "BRK-B"], "2026-06-12", via_legacy, source="auto")
+    assert via_adapter == via_legacy
+
+
+def test_collect_exposes_injectable_source_params():
+    params = inspect.signature(dc.collect).parameters
+    assert params["equities_source"].default == "polygon"
+    assert params["index_source"].default == "fred"
+    assert params["fallback_source"].default == "yfinance"
+
+
+def test_collect_window_forwards_source_params():
+    params = inspect.signature(dc._collect_window).parameters
+    assert params["equities_source"].default == "polygon"
+    assert params["index_source"].default == "fred"
+    assert params["fallback_source"].default == "yfinance"


### PR DESCRIPTION
## Phase 1b — `collect()` dispatches through the source registry (alpha-engine-config#1082)

Completes the provider-agnostic seam: `collectors.daily_closes.collect()` now routes its three fetches (equities / index / fallback) through the `PriceSourceAdapter` registry instead of hard-coded `_fetch_*` calls, selecting each adapter from **injectable params** (`equities_source`/`index_source`/`fallback_source`, defaults `polygon`/`fred`/`yfinance`).

**→ Swapping polygon→Databento (post-beta) is now one param + the new adapter** — zero change to `collect()`, the persisted artifacts, or any consumer.

**Behavior-preserving by construction:**
- New `fetch_into(records, ...)` port method mutates the **passed** list in place — preserving the legacy `_fetch_*`'s **partial-on-error retention** and **`window_cache`** semantics exactly. `fetch_ohlcv()` is the clean list wrapper over it.
- Lazy `from sources import get_adapter` inside `collect()` avoids the `sources`↔`daily_closes` import cycle.
- `_collect_window` forwards the new params so window mode honors overrides.

**Tests:** full suite **2015 passed, 2 skipped** — the entire `test_daily_closes_*` suite (source modes, coalesce, vwap, window, preclose, skip_if_canonical) passes unchanged, which is the behavior-equivalence proof. +4 new routing tests.

Next: Phase 2 — the Databento adapter as a drop-in (post-beta, per metron-ops#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)