### PR TITLE
feat(sf): defer PredictorTraining email to the model-zoo digest (PREDICTOR_DEFER_TRAINING_EMAIL)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1393,7 +1393,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only{}',$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -1546,8 +1546,8 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Best-effort: a rotation failure must NEVER fail the branch. The champion already trained+promoted.",
-                  "Next": "BranchBComplete",
+                  "Comment": "Best-effort: a rotation failure must NEVER fail the branch. The champion already trained+promoted. BUT it must NOT be SILENT: with PREDICTOR_DEFER_TRAINING_EMAIL=1 the base retrain deferred its email to the zoo digest, so a zoo failure here would otherwise produce zero email for the whole run. Route via PublishModelZooFailureImmediate (SNS alert) before converging to BranchBComplete.",
+                  "Next": "PublishModelZooFailureImmediate",
                   "ResultPath": "$.model_zoo_error"
                 }
               ],
@@ -1578,8 +1578,8 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Best-effort: poll failure must not fail the branch.",
-                  "Next": "BranchBComplete",
+                  "Comment": "Best-effort: poll failure must not fail the branch — but must not be SILENT either (the base retrain deferred its email to the zoo digest). Alert via PublishModelZooFailureImmediate, then converge to BranchBComplete.",
+                  "Next": "PublishModelZooFailureImmediate",
                   "ResultPath": "$.model_zoo_error"
                 }
               ],
@@ -1588,7 +1588,7 @@
             },
             "CheckModelZooStatus": {
               "Type": "Choice",
-              "Comment": "Any non-success routes to BranchBComplete — the rotation is best-effort and its failure is logged on the box (predictor-model-zoo.log); the champion is already live.",
+              "Comment": "Any non-success routes to PublishModelZooFailureImmediate (SNS alert) then BranchBComplete — the rotation is best-effort and its failure is logged on the box (predictor-model-zoo.log); the champion is already live. The alert is required because PREDICTOR_DEFER_TRAINING_EMAIL=1 deferred the base retrain's email to the zoo digest, so a silent zoo failure would otherwise mean zero email for the run.",
               "Choices": [
                 {
                   "Variable": "$.model_zoo_poll.Status",
@@ -1599,9 +1599,34 @@
                   "Variable": "$.model_zoo_poll.Status",
                   "StringEquals": "Pending",
                   "Next": "ModelZooWait"
+                },
+                {
+                  "Variable": "$.model_zoo_poll.Status",
+                  "StringEquals": "Success",
+                  "Next": "BranchBComplete"
                 }
               ],
-              "Default": "BranchBComplete"
+              "Default": "PublishModelZooFailureImmediate"
+            },
+            "PublishModelZooFailureImmediate": {
+              "Type": "Task",
+              "Comment": "Fire an SNS failure alert when the model-zoo rotation fails/times-out. REQUIRED for fallback safety: PredictorTraining now exports PREDICTOR_DEFER_TRAINING_EMAIL=1, so the base champion-arch retrain DEFERS its per-run training email to the consolidated zoo digest (sent at the end of run_rotation_and_select). If the zoo then fails, NEITHER email goes out — without this alert the run would be SILENT. Best-effort like the predictor early-signal alert: an SNS publish failure is caught and still routes to BranchBComplete (the champion already trained+promoted; the rotation is non-critical, so a zoo failure must NEVER fail the branch).",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — ModelZooRotation FAILED (zoo digest email may be missing)', $.pipeline_label)",
+                "Message.$": "States.Format('The model-zoo rotation failed or timed out. The base champion-arch retrain already trained+promoted and DEFERRED its training email to the zoo digest (PREDICTOR_DEFER_TRAINING_EMAIL=1), so the consolidated digest email may NOT have been sent for this run — review predictor-model-zoo.log on the spot and predictor/model_zoo/leaderboard/. The branch will still complete (the champion is live); the rotation is best-effort. Error: {}', States.JsonToString($.model_zoo_error))"
+              },
+              "ResultPath": null,
+              "Next": "BranchBComplete",
+              "Catch": [
+                {
+                  "ErrorEquals": ["States.ALL"],
+                  "Comment": "Best-effort: a failed SNS publish must not prevent the branch from completing. The champion is already live.",
+                  "ResultPath": null,
+                  "Next": "BranchBComplete"
+                }
+              ]
             },
             "ModelZooWait": {
               "Type": "Wait",

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -79,6 +79,7 @@
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export ALPHA_ENGINE_EXPERIMENT_ID=reference",
+    "export PREDICTOR_DEFER_TRAINING_EMAIL=1",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
   ],
   "RAGIngestion": [

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -288,13 +288,20 @@ class TestBranchBContents:
     def test_model_zoo_rotation_is_best_effort(self, branch_b):
         """L4544: the rotation must NEVER fail Branch B — every terminal path
         (task Catch, poll Catch, any non-success poll Status) converges to
-        BranchBComplete, since the champion already trained+promoted."""
+        BranchBComplete, since the champion already trained+promoted.
+
+        Post-defer-email change: failures now route via the
+        PublishModelZooFailureImmediate SNS alert FIRST (so a deferred-base-email
+        + zoo-failure run is never silent), then on to BranchBComplete. The
+        invariant is unchanged: no zoo failure path ever reaches BranchBFailed."""
         zoo = branch_b["ModelZooRotation"]
-        # Task-level Catch routes failure to BranchBComplete (not BranchBFailed).
+        # Task-level Catch routes failure to the alert (then BranchBComplete),
+        # NEVER to BranchBFailed.
         assert any(
-            c["Next"] == "BranchBComplete" and "States.ALL" in c["ErrorEquals"]
+            c["Next"] == "PublishModelZooFailureImmediate" and "States.ALL" in c["ErrorEquals"]
             for c in zoo["Catch"]
         )
+        assert all(c["Next"] != "BranchBFailed" for c in zoo["Catch"])
         assert zoo["Next"] == "WaitForModelZoo"
         # Same shared instance as the champion retrain.
         assert zoo["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
@@ -302,18 +309,31 @@ class TestBranchBContents:
         cmd = zoo["Parameters"]["Parameters"]["commands.$"]
         assert "--model-zoo-weekly" in cmd
         assert "$.preflight_args" in cmd
-        # Poll Catch is best-effort; the status Choice defaults to BranchBComplete.
+        # Poll Catch is best-effort; routes via the alert, never to BranchBFailed.
         wait = branch_b["WaitForModelZoo"]
         assert any(
-            c["Next"] == "BranchBComplete" and "States.ALL" in c["ErrorEquals"]
+            c["Next"] == "PublishModelZooFailureImmediate" and "States.ALL" in c["ErrorEquals"]
             for c in wait["Catch"]
         )
+        assert all(c["Next"] != "BranchBFailed" for c in wait["Catch"])
         check = branch_b["CheckModelZooStatus"]
-        assert check["Default"] == "BranchBComplete"
+        # A non-terminal poll waits; Success completes cleanly; everything else
+        # (failed/cancelled/timedout) routes to the alert then BranchBComplete.
+        assert check["Default"] == "PublishModelZooFailureImmediate"
         nexts = {c["StringEquals"]: c["Next"] for c in check["Choices"]}
         assert nexts["InProgress"] == "ModelZooWait"
         assert nexts["Pending"] == "ModelZooWait"
+        assert nexts["Success"] == "BranchBComplete"
         assert branch_b["ModelZooWait"]["Next"] == "WaitForModelZoo"
+
+        # The alert state is itself best-effort: it publishes SNS and then
+        # converges to BranchBComplete (both the success path and its own Catch),
+        # so an SNS failure cannot fail the branch.
+        alert = branch_b["PublishModelZooFailureImmediate"]
+        assert alert["Resource"] == "arn:aws:states:::sns:publish"
+        assert alert["Next"] == "BranchBComplete"
+        assert all(c["Next"] == "BranchBComplete" for c in alert["Catch"])
+        assert "PREDICTOR_DEFER_TRAINING_EMAIL" in alert["Parameters"]["Message.$"]
 
     def test_branch_b_ssm_can_resolve_instance_id(self, branch_b):
         """Branch B's SSM calls reference $.ec2_instance_id — which is


### PR DESCRIPTION
## Summary
The Saturday SF's `PredictorTraining` state now exports **`PREDICTOR_DEFER_TRAINING_EMAIL=1`** (in its command array, alongside the existing `export ALPHA_ENGINE_EXPERIMENT_ID=reference`) before invoking `spot_train.sh --full-only`. The base champion-arch retrain therefore **defers** its per-run training email to the consolidated model-zoo rotation digest — folding two emails (per-challenger storm + base retrain) into one digest detailing champion + each challenger + promotion.

## Fallback safety (no silent runs)
**Finding:** the `ModelZooRotation` state's failure paths previously routed **silently** to `BranchBComplete` (best-effort, logged only on the box) — there was **no SNS alert** on a zoo failure. With the base email now deferred to the zoo digest, a zoo failure would mean **zero email** for the whole run.

So this PR **adds** a `PublishModelZooFailureImmediate` SNS alert (mirroring the existing `PublishPredictorFailureImmediate`) and routes every `ModelZooRotation` failure path through it (task Catch, poll Catch, and any non-`Success` poll Status) before converging to `BranchBComplete`. The alert is itself **best-effort** (its own Catch + success path both go to `BranchBComplete`), so a zoo failure can never fail the branch — the only change is it can never be **silent**. `CheckModelZooStatus` gains an explicit `Success → BranchBComplete` choice; its `Default` now routes failures to the alert.

## Cross-repo dependency
Pairs with the **alpha-engine-predictor** PR (#274) that makes `train_handler.main()` read `PREDICTOR_DEFER_TRAINING_EMAIL` and adds the zoo digest email. The env var name is **identical** in both repos. This PR is **inert** until the predictor PR merges (the env is a no-op if `main()` does not yet read it), so the two PRs are **ordering-independent** — either may merge first.

## Tests (all green)
- `test_sf_research_predictor_parallel_wiring`: ModelZooRotation failure paths route via the alert, never to `BranchBFailed`; the alert is best-effort to `BranchBComplete`; `Success` completes cleanly.
- `test_sf_friday_shell_run_wiring` byte-identical fixture regenerated for the new PredictorTraining absent-path command (deliberate, reviewed change per the fixture docstring).
- **645 SF tests pass**; all Branch B `Next` targets resolve; SF JSON valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)