### PR TITLE
feat(daily-news): standalone runner + slim deps (decouple from trading SF)

### DIFF
--- a/infrastructure/systemd/daily-news.service
+++ b/infrastructure/systemd/daily-news.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Daily news collector (standalone) — feeds morning-signal + dashboard Daily News
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=ec2-user
+Group=ec2-user
+WorkingDirectory=/home/ec2-user/alpha-engine-data
+ExecStart=/home/ec2-user/alpha-engine-data/scripts/run_daily_news_standalone.sh
+StandardOutput=journal
+StandardError=journal
+# ~20-30 min pull (Polygon 5 req/min over the ~96-ticker holdings∪signals
+# universe); 40 min cap gives headroom.
+TimeoutStartSec=2400
+# Shared-box memory guard. Measured peak RSS ~0.17 GB; cap generously.
+MemoryAccounting=yes
+MemoryHigh=500M
+MemoryMax=700M
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/systemd/daily-news.timer
+++ b/infrastructure/systemd/daily-news.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Daily news collector — 04:00 PT (DST-aware), ahead of the 05:00 morning-signal run
+Requires=daily-news.service
+
+[Timer]
+Unit=daily-news.service
+# DST-aware local time. 04:00 PT leaves a comfortable margin before the
+# 05:00 PT morning-signal generation that consumes data/news_*_daily/.
+OnCalendar=*-*-* 04:00:00 America/Los_Angeles
+Persistent=true
+RandomizedDelaySec=0
+
+[Install]
+WantedBy=timers.target

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -1,0 +1,26 @@
+# Slim dependency set for running ONLY the standalone daily-news collector
+# (`python -m collectors.daily_news`) on a memory/disk-constrained host.
+#
+# Why this exists: the full `requirements.txt` pulls the entire data stack
+# (arcticdb, voyageai, edgartools, beautifulsoup4/lxml, jsonschema, yfinance,
+# lib[arcticdb,rag,contracts], ...) — ~1.5 GB installed. The daily-news
+# collector imports NONE of those; its true external surface is just the
+# packages below (verified by tracing `collectors.daily_news`'s import
+# closure: nlp.loughran_mcdonald, news_aggregator_async, news_sources/*,
+# data/derived/news_{aggregates,articles}, polygon_client). This lets the
+# collector run on the shared dashboard box (t3.small) without the heavy
+# stack. Measured peak RSS of a full 96-ticker run: ~0.17 GB.
+#
+# Keep in lockstep with the lib pin in requirements.txt. If a future change
+# adds an import to the daily-news chain, add the dep here too (the standalone
+# run will fail loud on a missing import).
+boto3>=1.34
+pandas>=2.0
+pyarrow>=14.0
+numpy>=1.24
+requests>=2.31
+feedparser>=6.0
+anyio>=4.0
+tenacity>=8.0
+pyyaml>=6.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.59.4

--- a/scripts/run_daily_news_standalone.sh
+++ b/scripts/run_daily_news_standalone.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Standalone daily-news collector runner for the always-on dashboard box.
+#
+# Mirrors the weekday SF's RunDailyNews command, but adapted to run OUTSIDE
+# the trading Step Function on the shared dashboard EC2 box, using a slim,
+# news-only venv (requirements-daily-news.txt) so it doesn't need the full
+# data stack (arcticdb/voyageai/etc.). Triggered by daily-news.timer at
+# 04:00 PT — ahead of the 05:00 morning-signal run that consumes the
+# data/news_*_daily/ artifact. Also still consumed by the dashboard
+# "Daily News" console page.
+#
+# Best-effort refresh (git pull + slim pip) so a merged change is live on the
+# next run, mirroring morning-signal's refresh-on-run; a transient git/pip blip
+# must never block the pull (the collector is itself fail-soft per source).
+set -uo pipefail
+
+REPO=/home/ec2-user/alpha-engine-data
+CONFIG_REPO=/home/ec2-user/alpha-engine-config
+LOG=/home/ec2-user/daily-news.log   # user-writable (service runs as ec2-user)
+
+export FLOW_DOCTOR_ENABLED=1
+export ALPHA_ENGINE_DEPLOYED=1
+
+cd "$REPO"
+
+# Upload the run log to S3 on exit for observability (best-effort, never fatal).
+trap 'aws s3 cp "$LOG" "s3://alpha-engine-research/_ssm_logs/daily-news-standalone/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log" --only-show-errors 2>/dev/null || true' EXIT
+
+{
+  echo "=== daily-news standalone run $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  # Refresh code + slim deps (best-effort).
+  git pull --ff-only origin main || true
+  git -C "$CONFIG_REPO" pull --ff-only origin main || true
+  .venv/bin/pip install -q -r requirements-daily-news.txt || true
+} > "$LOG" 2>&1
+
+# Load runtime env (Polygon key, AWS creds, etc.). bash `source` handles both
+# `export K=V` and bare `K=V` lines.
+set -a
+# shellcheck disable=SC1091
+source /home/ec2-user/.alpha-engine.env 2>/dev/null || true
+set +a
+
+.venv/bin/python -m collectors.daily_news >> "$LOG" 2>&1
+rc=$?
+echo "=== daily-news standalone exit rc=$rc $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" >> "$LOG"
+exit $rc


### PR DESCRIPTION
## What

Decouples the **daily-news collector** from the weekday trading Step Function so it can run early on the always-on dashboard box — ahead of the 05:00 PT **morning-signal** podcast that now consumes `data/news_*_daily/`. Today the in-SF `RunDailyNews` finishes ~06:23 (after the daemon), far too late for a 05:00 brief.

## Why a slim dep set

The full `requirements.txt` pulls the entire data stack (~1.5 GB: arcticdb, voyageai, edgartools, bs4/lxml, jsonschema, yfinance, lib[arcticdb,rag,contracts]). `collectors.daily_news` imports **none** of those — verified by tracing its import closure (`nlp.loughran_mcdonald`, `news_aggregator_async`, `news_sources/*`, `data/derived/news_{aggregates,articles}`, `polygon_client`). The slim venv is **368 MB**, and a full 96-ticker run measured **~0.17 GB peak RSS** — safe on the shared t3.small dashboard box (976 MB free + swap).

## Contents
- `requirements-daily-news.txt` — slim, news-only deps (lockstep lib pin with `requirements.txt`).
- `scripts/run_daily_news_standalone.sh` — refresh-on-run (best-effort `git pull` + slim `pip`), sources `.alpha-engine.env`, runs the collector, uploads log to S3. Fail-soft.
- `infrastructure/systemd/daily-news.{service,timer}` — oneshot + 04:00 PT DST-aware timer, memory-capped.

## Sequencing (no coverage gap)
The in-SF `RunDailyNews` state is **intentionally left in place** here. Once the standalone run is soak-verified for a few days, a follow-up PR removes it from `step_function_daily.json`. Until then both produce the artifact (idempotent, last-writer-wins); morning-signal reads the 04:00 version.

## Consumers
Only `alpha-engine-dashboard/views/Daily_News.py` (the console "Daily News" page) + morning-signal read these artifacts — nothing in trading/research/predictor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)