### PR TITLE
feat(sf): parallel model-zoo fan-out — ResolveZooSpecs → Map(per-spec spot) → ModelZooSelect (config#1083)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1462,7 +1462,7 @@
                 {
                   "Variable": "$.predictor_poll.Status",
                   "StringEquals": "Success",
-                  "Next": "ModelZooRotation"
+                  "Next": "ResolveZooSpecs"
                 },
                 {
                   "Variable": "$.predictor_poll.Status",
@@ -1513,15 +1513,273 @@
                 }
               ]
             },
-            "ModelZooRotation": {
+            "ResolveZooSpecs": {
               "Type": "Task",
-              "Comment": "L4544: after the champion retrain SUCCEEDS, train the weekly model-zoo rotation (challenger variants) + immediate leak-free-CPCV selection on the SAME spot instance, off the live-trading path. Observe-first: writes predictor/model_zoo/leaderboard/{date}.json and only PROMOTES if MODEL_ZOO_AUTO_PROMOTE_WINNER is set. BEST-EFFORT: every failure path routes to BranchBComplete (the champion already trained+promoted; a rotation failure must NEVER fail the Saturday SF). Budget=1 challenger/week (predictor.yaml model_zoo_weekly_budget) round-robins the 3 specs; each is ~one full train, so this extends Branch B by ~one champion-train.",
+              "Comment": "config#1083 PARALLEL fan-out, step 1 (dispatcher SSM on the box, fast, NO spot): resolve the spec ids this rotation should train via list-rotation-specs, emitting a JSON array on stdout (the budget-N stalest active specs). The preamble (git pull + config stage) is redirected to stderr so StandardOutputContent is JUST the array, which ParseZooSpecs lifts into $.zoo_specs (the Map ItemsPath). BEST-EFFORT: a resolve/parse failure routes to PublishModelZooFailureImmediate then BranchBComplete (the champion already trained+promoted; the rotation must NEVER fail the Saturday SF).",
               "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
               "Parameters": {
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-model-zoo --log /var/log/predictor-model-zoo.log -- bash infrastructure/spot_train.sh --model-zoo-weekly{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','{ sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main; sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main; sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml; } 1>&2','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference','/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m training.model_zoo list-rotation-specs --bucket alpha-engine-research 2>/dev/null')",
+                  "executionTimeout": [
+                    "600"
+                  ]
+                },
+                "TimeoutSeconds": 600
+              },
+              "TimeoutSeconds": 660,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "States.TaskFailed",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: resolve failure must NEVER fail the branch. Alert (not silent) then converge to BranchBComplete.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultPath": "$.resolve_zoo_result",
+              "Next": "WaitResolveZoo"
+            },
+            "WaitResolveZoo": {
+              "Type": "Task",
+              "Comment": "Poll the ResolveZooSpecs SSM command; capture StandardOutputContent (the JSON spec-id array).",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+              "Parameters": {
+                "CommandId.$": "$.resolve_zoo_result.Command.CommandId",
+                "InstanceId.$": "$.ec2_instance_id[0]"
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Ssm.InvocationDoesNotExistException",
+                    "Ssm.InvocationDoesNotExist"
+                  ],
+                  "MaxAttempts": 10,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: poll failure routes via the alert, never to BranchBFailed.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultPath": "$.resolve_zoo_poll",
+              "Next": "CheckResolveZooStatus"
+            },
+            "CheckResolveZooStatus": {
+              "Type": "Choice",
+              "Comment": "Success leads to ParseZooSpecs (lift the JSON array); InProgress/Pending wait; anything else alerts then BranchBComplete (best-effort).",
+              "Choices": [
+                {
+                  "Variable": "$.resolve_zoo_poll.Status",
+                  "StringEquals": "InProgress",
+                  "Next": "ResolveZooWait"
+                },
+                {
+                  "Variable": "$.resolve_zoo_poll.Status",
+                  "StringEquals": "Pending",
+                  "Next": "ResolveZooWait"
+                },
+                {
+                  "Variable": "$.resolve_zoo_poll.Status",
+                  "StringEquals": "Success",
+                  "Next": "ParseZooSpecs"
+                }
+              ],
+              "Default": "PublishModelZooFailureImmediate"
+            },
+            "ResolveZooWait": {
+              "Type": "Wait",
+              "Seconds": 15,
+              "Next": "WaitResolveZoo"
+            },
+            "ParseZooSpecs": {
+              "Type": "Pass",
+              "Comment": "config#1083: lift the resolved JSON spec-id array (StandardOutputContent of ResolveZooSpecs) into $.zoo_specs for the Map ItemsPath. Reached ONLY after CheckResolveZooStatus=Success, where the SSM command exited 0 and stdout is the CLI json.dumps(ids) output - always a valid JSON array (possibly empty, which runs zero Map iterations; ModelZooSelect then handles the empty pool). A Pass state cannot carry a Catch (it cannot throw); the upstream poll-status gate is the failure boundary - any non-success ResolveZooSpecs outcome routes to PublishModelZooFailureImmediate BEFORE this state is reached.",
+              "Parameters": {
+                "zoo_specs.$": "States.StringToJson($.resolve_zoo_poll.StandardOutputContent)"
+              },
+              "ResultPath": "$.parsed_zoo",
+              "Next": "ModelZooTrainMap"
+            },
+            "ModelZooTrainMap": {
+              "Type": "Map",
+              "Comment": "config#1083 PARALLEL fan-out, step 2: train one challenger PER spec id, each on its OWN memory-isolated spot, concurrently. MaxConcurrency 4 bounds in-flight spots. PER-ITERATION ERROR ISOLATION (the key robustness property): each iteration ends in a branch-local Pass terminal (TrainSpecOK / TrainSpecFailed, both End:true) recording status as DATA so an iteration NEVER throws; a single challenger crashing (OOM / KeyError / spot interruption) does NOT abort its siblings; selection proceeds with the survivors. ToleratedFailurePercentage 100 is a defense-in-depth backstop (iterations already self-terminate as success). ItemSelector threads ec2_instance_id + preflight_args + the per-item spec id into each iteration.",
+              "ItemsPath": "$.parsed_zoo.zoo_specs",
+              "MaxConcurrency": 4,
+              "ToleratedFailurePercentage": 100,
+              "ItemSelector": {
+                "spec_id.$": "$$.Map.Item.Value",
+                "ec2_instance_id.$": "$.ec2_instance_id",
+                "preflight_args.$": "$.preflight_args"
+              },
+              "ItemProcessor": {
+                "ProcessorConfig": {
+                  "Mode": "INLINE"
+                },
+                "StartAt": "TrainSpecDispatch",
+                "States": {
+                  "TrainSpecDispatch": {
+                    "Type": "Task",
+                    "Comment": "Launch a dedicated spot for THIS spec via spot_train.sh --model-zoo-spec <id>. Dispatcher SSM on the box (the script launches the actual spot internally). Honors $.preflight_args for shell-run dry mode.",
+                    "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+                    "Parameters": {
+                      "DocumentName": "AWS-RunShellScript",
+                      "InstanceIds.$": "$.ec2_instance_id",
+                      "Parameters": {
+                        "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
+                        "executionTimeout": [
+                          "5400"
+                        ]
+                      },
+                      "TimeoutSeconds": 5400
+                    },
+                    "TimeoutSeconds": 5460,
+                    "Retry": [
+                      {
+                        "ErrorEquals": [
+                          "States.TaskFailed",
+                          "States.Timeout"
+                        ],
+                        "MaxAttempts": 1,
+                        "IntervalSeconds": 180,
+                        "BackoffRate": 2.0,
+                        "Comment": "Single best-effort retry (e.g. spot interruption) for this one spec."
+                      }
+                    ],
+                    "Catch": [
+                      {
+                        "ErrorEquals": [
+                          "States.ALL"
+                        ],
+                        "Comment": "This spec dispatch failed; record as data, do NOT throw (sibling iterations must proceed).",
+                        "Next": "TrainSpecFailed",
+                        "ResultPath": "$.error"
+                      }
+                    ],
+                    "ResultPath": "$.train_spec_result",
+                    "Next": "WaitTrainSpec"
+                  },
+                  "WaitTrainSpec": {
+                    "Type": "Task",
+                    "Comment": "Poll this spec SSM command until complete.",
+                    "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+                    "Parameters": {
+                      "CommandId.$": "$.train_spec_result.Command.CommandId",
+                      "InstanceId.$": "$.ec2_instance_id[0]"
+                    },
+                    "Retry": [
+                      {
+                        "ErrorEquals": [
+                          "Ssm.InvocationDoesNotExistException",
+                          "Ssm.InvocationDoesNotExist"
+                        ],
+                        "MaxAttempts": 10,
+                        "IntervalSeconds": 30,
+                        "BackoffRate": 1.5
+                      }
+                    ],
+                    "Catch": [
+                      {
+                        "ErrorEquals": [
+                          "States.ALL"
+                        ],
+                        "Comment": "Poll failure for this spec; record as data, never throw.",
+                        "Next": "TrainSpecFailed",
+                        "ResultPath": "$.error"
+                      }
+                    ],
+                    "ResultPath": "$.train_spec_poll",
+                    "Next": "CheckTrainSpecStatus"
+                  },
+                  "CheckTrainSpecStatus": {
+                    "Type": "Choice",
+                    "Comment": "Success leads to TrainSpecOK; InProgress/Pending wait; anything else (this spec spot OOM/errored) leads to TrainSpecFailed (recorded as data, NOT a throw, so siblings proceed - the per-spec isolation win).",
+                    "Choices": [
+                      {
+                        "Variable": "$.train_spec_poll.Status",
+                        "StringEquals": "InProgress",
+                        "Next": "TrainSpecWait"
+                      },
+                      {
+                        "Variable": "$.train_spec_poll.Status",
+                        "StringEquals": "Pending",
+                        "Next": "TrainSpecWait"
+                      },
+                      {
+                        "Variable": "$.train_spec_poll.Status",
+                        "StringEquals": "Success",
+                        "Next": "TrainSpecOK"
+                      }
+                    ],
+                    "Default": "TrainSpecFailed"
+                  },
+                  "TrainSpecWait": {
+                    "Type": "Wait",
+                    "Seconds": 60,
+                    "Next": "WaitTrainSpec"
+                  },
+                  "TrainSpecOK": {
+                    "Type": "Pass",
+                    "Comment": "This spec trained + registered its challenger. End:true so the Map iteration SUCCEEDS (never cancels sibling iterations).",
+                    "Parameters": {
+                      "spec_status": "OK",
+                      "spec_id.$": "$.spec_id"
+                    },
+                    "End": true
+                  },
+                  "TrainSpecFailed": {
+                    "Type": "Pass",
+                    "Comment": "This spec training failed (spot OOM / KeyError / interruption). Records status as DATA + End:true so the iteration SUCCEEDS in SF terms - the failure is isolated to THIS spec, siblings proceed, and ModelZooSelect simply finds this spec challenger absent from the registry (tolerated). The full failure log is on the box (predictor-model-zoo-spec.log) + durable in S3 via ssm_log_capture (config#272).",
+                    "Parameters": {
+                      "spec_status": "FAILED",
+                      "spec_id.$": "$.spec_id"
+                    },
+                    "End": true
+                  }
+                }
+              },
+              "ResultPath": "$.zoo_train_results",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Backstop ONLY for a genuine Map-engine error (iterations never throw - they end success with status data). Best-effort: alert then BranchBComplete (the champion is already live). ModelZooSelect will still run on whatever registered.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "Next": "ModelZooSelect"
+            },
+            "ModelZooSelect": {
+              "Type": "Task",
+              "Comment": "config#1083 PARALLEL fan-out, step 3 (ONE spot, after the Map joins): select over whatever spec-* challengers registered for the date (failed Map iterations are simply absent - tolerated), write the leaderboard to BOTH the dated key AND latest.json, promote the winner if MODEL_ZOO_AUTO_PROMOTE_WINNER, and send the ONE consolidated digest. BEST-EFFORT: every failure path routes to PublishModelZooFailureImmediate then BranchBComplete (the champion already trained+promoted; the rotation must NEVER fail the Saturday SF). The base champion-arch retrain (PredictorTraining) ran first and competes in the same pool.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+              "Parameters": {
+                "DocumentName": "AWS-RunShellScript",
+                "InstanceIds.$": "$.ec2_instance_id",
+                "Parameters": {
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_train.sh --model-zoo-select{}',$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -1538,7 +1796,7 @@
                   "MaxAttempts": 1,
                   "IntervalSeconds": 180,
                   "BackoffRate": 2.0,
-                  "Comment": "Single best-effort retry (e.g. spot interruption); the rotation is non-critical so we do not over-retry."
+                  "Comment": "Single best-effort retry (e.g. spot interruption); selection is non-critical."
                 }
               ],
               "Catch": [
@@ -1546,7 +1804,7 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Best-effort: a rotation failure must NEVER fail the branch. The champion already trained+promoted. BUT it must NOT be SILENT: with PREDICTOR_DEFER_TRAINING_EMAIL=1 the base retrain deferred its email to the zoo digest, so a zoo failure here would otherwise produce zero email for the whole run. Route via PublishModelZooFailureImmediate (SNS alert) before converging to BranchBComplete.",
+                  "Comment": "Best-effort: a select failure must NEVER fail the branch. Alert (not silent) then converge to BranchBComplete.",
                   "Next": "PublishModelZooFailureImmediate",
                   "ResultPath": "$.model_zoo_error"
                 }
@@ -1556,7 +1814,7 @@
             },
             "WaitForModelZoo": {
               "Type": "Task",
-              "Comment": "Poll the model-zoo rotation SSM command until complete.",
+              "Comment": "Poll the ModelZooSelect SSM command until complete.",
               "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
               "Parameters": {
                 "CommandId.$": "$.model_zoo_result.Command.CommandId",
@@ -1578,7 +1836,7 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Best-effort: poll failure must not fail the branch — but must not be SILENT either (the base retrain deferred its email to the zoo digest). Alert via PublishModelZooFailureImmediate, then converge to BranchBComplete.",
+                  "Comment": "Best-effort: poll failure must not fail the branch - but must not be SILENT either (the base retrain deferred its email to the zoo digest). Alert via PublishModelZooFailureImmediate, then converge to BranchBComplete.",
                   "Next": "PublishModelZooFailureImmediate",
                   "ResultPath": "$.model_zoo_error"
                 }
@@ -1588,7 +1846,7 @@
             },
             "CheckModelZooStatus": {
               "Type": "Choice",
-              "Comment": "Any non-success routes to PublishModelZooFailureImmediate (SNS alert) then BranchBComplete — the rotation is best-effort and its failure is logged on the box (predictor-model-zoo.log); the champion is already live. The alert is required because PREDICTOR_DEFER_TRAINING_EMAIL=1 deferred the base retrain's email to the zoo digest, so a silent zoo failure would otherwise mean zero email for the run.",
+              "Comment": "Any non-success routes to PublishModelZooFailureImmediate (SNS alert) then BranchBComplete - selection is best-effort and its failure is logged on the box (predictor-model-zoo-select.log); the champion is already live. The alert is required because PREDICTOR_DEFER_TRAINING_EMAIL=1 deferred the base retrain email to the zoo digest, so a silent zoo failure would otherwise mean zero email for the run.",
               "Choices": [
                 {
                   "Variable": "$.model_zoo_poll.Status",

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -467,6 +467,12 @@ class TestEODSFTopLevelFieldsClosed:
 # 10 → 11 on 2026-06-08 (ROADMAP L4544): ModelZooRotation — the best-effort
 # model-zoo weekly rotation + CPCV selection, sequential after PredictorTraining
 # success in Branch B (same spot instance, off the live-trading path).
+# Still 11 on config#1083 (2026-06-15): ModelZooRotation was REPLACED by the
+# parallel fan-out — ResolveZooSpecs (NOT a spot; runs list-rotation-specs on the
+# box) → ModelZooTrainMap (per-spec spots, but TrainSpecDispatch lives in the Map
+# ItemProcessor, which _flatten_states does NOT descend into) → ModelZooSelect
+# (the one flat-level spot launcher that takes ModelZooRotation's slot). Net
+# flat-level spot count is unchanged at 11.
 _EXPECTED_SATURDAY_SPOT_STATE_COUNT = 11
 
 

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -69,6 +69,11 @@ _BRANCH_B_STATES = {
     "CheckSkipPredictorTraining", "PredictorTraining",
     "WaitForPredictorTraining", "CheckPredictorStatus", "PredictorWait",
     "ExtractPredictorError", "PublishPredictorFailureImmediate",
+    # config#1083 parallel model-zoo fan-out: ResolveZooSpecs -> Map -> Select.
+    "ResolveZooSpecs", "WaitResolveZoo", "CheckResolveZooStatus",
+    "ResolveZooWait", "ParseZooSpecs", "ModelZooTrainMap", "ModelZooSelect",
+    "WaitForModelZoo", "CheckModelZooStatus", "ModelZooWait",
+    "PublishModelZooFailureImmediate",
     "BranchBComplete", "BranchBFailed",
 }
 
@@ -100,13 +105,14 @@ def branch_b(parallel) -> dict:
 
 def _own_targets(st: dict) -> list[str]:
     """Next/Default/Catch.Next of THIS state, NOT descending into a
-    Parallel's Branches (those are validated in their own state space)."""
+    Parallel's Branches or a Map's ItemProcessor/Iterator (those are
+    validated in their own state space)."""
     out: list[str] = []
 
     def rec(o) -> None:
         if isinstance(o, dict):
             for k, v in o.items():
-                if k == "Branches":
+                if k in ("Branches", "ItemProcessor", "Iterator"):
                     continue
                 if k in ("Next", "Default") and isinstance(v, str):
                     out.append(v)
@@ -275,65 +281,117 @@ class TestBranchBContents:
             "WaitForPredictorTraining"
         )
 
-    def test_predictor_success_routes_to_model_zoo_rotation(self, branch_b):
-        # L4544: champion-retrain success now flows into the best-effort model-zoo
-        # rotation before the branch completes (skip path still → BranchBComplete).
+    def test_predictor_success_routes_to_resolve_zoo_specs(self, branch_b):
+        # config#1083: champion-retrain success now flows into the parallel
+        # model-zoo fan-out, starting with ResolveZooSpecs (skip path still →
+        # BranchBComplete).
         success = [
             c["Next"]
             for c in branch_b["CheckPredictorStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == ["ModelZooRotation"]
+        assert success == ["ResolveZooSpecs"]
 
-    def test_model_zoo_rotation_is_best_effort(self, branch_b):
-        """L4544: the rotation must NEVER fail Branch B — every terminal path
-        (task Catch, poll Catch, any non-success poll Status) converges to
-        BranchBComplete, since the champion already trained+promoted.
+    def test_zoo_fanout_pipeline_wiring(self, branch_b):
+        """config#1083: ResolveZooSpecs → (poll) → ParseZooSpecs → ModelZooTrainMap
+        (Map, per-spec spot) → ModelZooSelect → (poll) → BranchBComplete. Every
+        failure path is best-effort (routes via the alert, never BranchBFailed)."""
+        # ResolveZooSpecs dispatches list-rotation-specs on the box.
+        resolve = branch_b["ResolveZooSpecs"]
+        assert resolve["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
+        rcmd = resolve["Parameters"]["Parameters"]["commands.$"]
+        assert "list-rotation-specs" in rcmd
+        assert all(c["Next"] != "BranchBFailed" for c in resolve["Catch"])
+        assert resolve["Next"] == "WaitResolveZoo"
+        # Resolve poll → CheckResolveZooStatus: Success → ParseZooSpecs.
+        check_resolve = branch_b["CheckResolveZooStatus"]
+        rnexts = {c["StringEquals"]: c["Next"] for c in check_resolve["Choices"]}
+        assert rnexts["Success"] == "ParseZooSpecs"
+        assert check_resolve["Default"] == "PublishModelZooFailureImmediate"
+        # ParseZooSpecs lifts the JSON array into $.parsed_zoo.zoo_specs.
+        parse = branch_b["ParseZooSpecs"]
+        assert parse["Type"] == "Pass"
+        assert "StringToJson" in parse["Parameters"]["zoo_specs.$"]
+        assert "Catch" not in parse  # a Pass cannot carry a Catch (AWS schema)
+        assert parse["Next"] == "ModelZooTrainMap"
 
-        Post-defer-email change: failures now route via the
-        PublishModelZooFailureImmediate SNS alert FIRST (so a deferred-base-email
-        + zoo-failure run is never silent), then on to BranchBComplete. The
-        invariant is unchanged: no zoo failure path ever reaches BranchBFailed."""
-        zoo = branch_b["ModelZooRotation"]
-        # Task-level Catch routes failure to the alert (then BranchBComplete),
-        # NEVER to BranchBFailed.
+    def test_model_zoo_train_map_per_spec_isolation(self, branch_b):
+        """THE robustness property: the Map fans out one spot PER spec, and each
+        iteration self-terminates as success (recording status as data), so one
+        challenger crashing never aborts its siblings."""
+        m = branch_b["ModelZooTrainMap"]
+        assert m["Type"] == "Map"
+        assert m["ItemsPath"] == "$.parsed_zoo.zoo_specs"
+        assert isinstance(m["MaxConcurrency"], int) and m["MaxConcurrency"] >= 1
+        # Backstop tolerance so a Map-engine error never aborts survivors.
+        assert m["ToleratedFailurePercentage"] == 100
+        # Each item carries the spec id + shared SSM context.
+        assert m["ItemSelector"]["spec_id.$"] == "$$.Map.Item.Value"
+        assert m["ItemSelector"]["ec2_instance_id.$"] == "$.ec2_instance_id"
+        proc = m["ItemProcessor"]["States"]
+        # The dispatch invokes the per-spec spot mode with the item's spec id.
+        dcmd = proc["TrainSpecDispatch"]["Parameters"]["Parameters"]["commands.$"]
+        assert "--model-zoo-spec" in dcmd
+        assert "$.spec_id" in dcmd
+        assert "$.preflight_args" in dcmd
+        # PER-ITERATION ISOLATION: both terminals are End:true Pass states
+        # recording status as DATA — the iteration NEVER throws.
+        for term in ("TrainSpecOK", "TrainSpecFailed"):
+            assert proc[term]["Type"] == "Pass"
+            assert proc[term]["End"] is True
+        # A failed/cancelled/timed-out spec routes to TrainSpecFailed (data),
+        # NOT a throw — siblings proceed.
+        cts = proc["CheckTrainSpecStatus"]
+        assert cts["Default"] == "TrainSpecFailed"
+        # The dispatch + poll Catches record failure as data (TrainSpecFailed),
+        # never throwing out of the iteration.
+        assert all(c["Next"] == "TrainSpecFailed" for c in proc["TrainSpecDispatch"]["Catch"])
+        assert all(c["Next"] == "TrainSpecFailed" for c in proc["WaitTrainSpec"]["Catch"])
+        # The Map state's own Catch is a best-effort backstop, never BranchBFailed.
+        assert all(c["Next"] != "BranchBFailed" for c in m["Catch"])
+        assert m["Next"] == "ModelZooSelect"
+
+    def test_model_zoo_select_is_best_effort(self, branch_b):
+        """config#1083: ModelZooSelect runs the selection on ONE spot after the
+        Map joins; every failure path converges to BranchBComplete via the alert,
+        never BranchBFailed (the champion already trained+promoted)."""
+        sel = branch_b["ModelZooSelect"]
+        assert sel["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
+        scmd = sel["Parameters"]["Parameters"]["commands.$"]
+        assert "--model-zoo-select" in scmd
+        assert "$.preflight_args" in scmd
         assert any(
             c["Next"] == "PublishModelZooFailureImmediate" and "States.ALL" in c["ErrorEquals"]
-            for c in zoo["Catch"]
+            for c in sel["Catch"]
         )
-        assert all(c["Next"] != "BranchBFailed" for c in zoo["Catch"])
-        assert zoo["Next"] == "WaitForModelZoo"
-        # Same shared instance as the champion retrain.
-        assert zoo["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
-        # The command invokes the rotation entrypoint, honoring shell-run preflight.
-        cmd = zoo["Parameters"]["Parameters"]["commands.$"]
-        assert "--model-zoo-weekly" in cmd
-        assert "$.preflight_args" in cmd
-        # Poll Catch is best-effort; routes via the alert, never to BranchBFailed.
+        assert all(c["Next"] != "BranchBFailed" for c in sel["Catch"])
+        assert sel["Next"] == "WaitForModelZoo"
+        # Select poll Catch is best-effort; routes via the alert, never BranchBFailed.
         wait = branch_b["WaitForModelZoo"]
-        assert any(
-            c["Next"] == "PublishModelZooFailureImmediate" and "States.ALL" in c["ErrorEquals"]
-            for c in wait["Catch"]
-        )
         assert all(c["Next"] != "BranchBFailed" for c in wait["Catch"])
         check = branch_b["CheckModelZooStatus"]
-        # A non-terminal poll waits; Success completes cleanly; everything else
-        # (failed/cancelled/timedout) routes to the alert then BranchBComplete.
         assert check["Default"] == "PublishModelZooFailureImmediate"
         nexts = {c["StringEquals"]: c["Next"] for c in check["Choices"]}
         assert nexts["InProgress"] == "ModelZooWait"
         assert nexts["Pending"] == "ModelZooWait"
         assert nexts["Success"] == "BranchBComplete"
         assert branch_b["ModelZooWait"]["Next"] == "WaitForModelZoo"
-
-        # The alert state is itself best-effort: it publishes SNS and then
-        # converges to BranchBComplete (both the success path and its own Catch),
-        # so an SNS failure cannot fail the branch.
+        # The alert state is itself best-effort.
         alert = branch_b["PublishModelZooFailureImmediate"]
         assert alert["Resource"] == "arn:aws:states:::sns:publish"
         assert alert["Next"] == "BranchBComplete"
         assert all(c["Next"] == "BranchBComplete" for c in alert["Catch"])
         assert "PREDICTOR_DEFER_TRAINING_EMAIL" in alert["Parameters"]["Message.$"]
+
+    def test_model_zoo_map_iterator_no_dangling(self, branch_b):
+        """The Map's iterator namespace is self-consistent (all Next/Default/Catch
+        targets resolve within the iterator's own States)."""
+        proc = branch_b["ModelZooTrainMap"]["ItemProcessor"]
+        names = set(proc["States"])
+        assert proc["StartAt"] in names
+        for n, st in proc["States"].items():
+            for t in _own_targets(st):
+                assert t in names, f"Map iterator dangling: {n} -> {t}"
 
     def test_branch_b_ssm_can_resolve_instance_id(self, branch_b):
         """Branch B's SSM calls reference $.ec2_instance_id — which is


### PR DESCRIPTION
## config#1083 — parallel model-zoo fan-out in the Saturday SF

Replaces the single sequential `ModelZooRotation` state (Branch B, after PredictorTraining) with a fan-out so each challenger trains on its **own memory-isolated spot, concurrently** instead of sequentially on one spot.

```
CheckPredictorStatus=Success
  → ResolveZooSpecs        (dispatcher SSM on the box, NO spot — runs `list-rotation-specs`, emits a JSON spec-id array on stdout)
  → WaitResolveZoo (poll) → ParseZooSpecs   (States.StringToJson → $.parsed_zoo.zoo_specs)
  → ModelZooTrainMap       (Map, MaxConcurrency 4, ItemsPath $.parsed_zoo.zoo_specs)
       per iteration: TrainSpecDispatch (spot_train.sh --model-zoo-spec <id>)
         → WaitTrainSpec (poll) → CheckTrainSpecStatus
         → TrainSpecOK | TrainSpecFailed   (both End:true Pass — status as DATA)
  → ModelZooSelect         (ONE spot, spot_train.sh --model-zoo-select)
  → WaitForModelZoo (poll) → CheckModelZooStatus → BranchBComplete
```

### Per-spec error isolation (the key robustness win)
Each Map iteration self-terminates as **success** recording OK/FAILED as data — an iteration **never throws**, so one challenger crashing (OOM / KeyError / spot interruption) does **not** abort its siblings. `ModelZooSelect` then finds the failed spec's challenger simply absent from the registry (tolerated). `ToleratedFailurePercentage: 100` is a defense-in-depth backstop. Two prior sequential runs botched because a single per-challenger crash killed the whole rotation.

### Best-effort preserved end-to-end
Every failure path (resolve / Map backstop / select / all polls) routes to `PublishModelZooFailureImmediate` (#431, kept) then `BranchBComplete` — a zoo failure **never** fails the Saturday SF and is never silent (the base retrain defers its email to the zoo digest). The base champion-arch retrain (`PredictorTraining`) is unchanged, runs first, and competes in the same selection pool.

### Validation
- `aws stepfunctions validate-state-machine-definition` → **OK, zero diagnostics**.
- Tests updated: `test_sf_research_predictor_parallel_wiring.py` rewritten for the fan-out (per-spec isolation, Map wiring, best-effort select, iterator no-dangling); `_own_targets` skips Map `ItemProcessor`; `_BRANCH_B_STATES` extended; payload-uniqueness spot-state count stays **11** (`ModelZooSelect` takes `ModelZooRotation`'s flat slot; `TrainSpecDispatch` lives in the Map iterator, which `_flatten_states` doesn't descend into).
- **Full data suite green: 2029 passed, 2 skipped.**

### Merge order (cross-repo dependency)
The spot modes (`--model-zoo-spec`, `--model-zoo-select`) and the `list-rotation-specs` CLI this SF calls ship in **alpha-engine-predictor PR #275**. That PR **must merge to `main` FIRST**, then this data PR (otherwise the SF would call spot modes that don't yet exist on the box's predictor checkout). The spot mode names + CLI subcommands match the predictor PR exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
