### PR TITLE
feat(daily-news): macro+tech topic news (curated RSS) + podcast-ready digest

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 DAILY_PREFIX = "data/news_aggregates_daily"
 ARTICLES_PREFIX = "data/news_articles_daily"
+DIGEST_PREFIX = "data/news_digest_daily"
 HOLDINGS_UNIVERSE_KEY = "robodashboard/holdings_universe.json"
 DEFAULT_LOOKBACK_HOURS = 24
 DEFAULT_BUCKET = "alpha-engine-research"
@@ -246,6 +247,7 @@ def collect(
     articles_status = "ok"
     articles_key = None
     articles_rows = 0
+    articles_df = None
     try:
         from data.derived.news_articles import articles_build_and_write
 
@@ -271,6 +273,68 @@ def collect(
             type(e).__name__, e,
         )
 
+    # ── Podcast-ready combined digest (portfolio + macro + tech) ─────────────
+    # Combines the per-ticker article records ALREADY in memory (portfolio
+    # section) with curated macro/tech RSS headlines (topic_news) into a single
+    # small JSON the daily-brief / podcast consumer reads from latest.json in
+    # one GET. Same fail-soft posture as the article companion above (per
+    # [[feedback_no_silent_fails]] — acceptable category: secondary artifact
+    # hung off a path whose PRIMARY deliverable already landed):
+    #   (a) Failure modes swallowed: topic RSS fetch is down/garbled (→ empty
+    #       macro/tech, digest still written); OR the digest build/write itself
+    #       fails (S3 hiccup, schema bug).
+    #   (b) Primary survives: the aggregate (and article companion) already
+    #       landed above; consumers of those are unaffected.
+    #   (c) Recording surface: WARN logs here AND ``digest_status`` /
+    #       ``topic_status`` on the returned status dict (SF/logs capture it).
+    # Topic-fetch failure must NEVER block the digest: we still write it with
+    # the portfolio section populated and empty macro/tech.
+    digest_status = "ok"
+    digest_key = None
+    topic_status = "ok"
+    try:
+        topics: dict = {}
+        try:
+            from collectors.topic_news import fetch_topics
+
+            topics = fetch_topics(["macro", "tech"], hours=hours)
+        except Exception as e:  # noqa: BLE001 — topic fetch is best-effort; degrade to empty
+            topic_status = "error"
+            topics = {}
+            logger.warning(
+                "[daily_news] topic-news fetch FAILED (%s: %s) — "
+                "writing digest with empty macro/tech",
+                type(e).__name__, e,
+            )
+
+        from data.derived.news_digest import build_digest, write_digest
+
+        digest = build_digest(
+            articles_df=articles_df,
+            topics=topics,
+            digest_date=agg_date,
+        )
+        digest_key = write_digest(
+            digest,
+            s3_client=s3_client,
+            bucket=bucket,
+            prefix=DIGEST_PREFIX,
+        )
+        logger.info(
+            "[daily_news] wrote digest to s3://%s/%s (portfolio=%d macro=%d tech=%d)",
+            bucket, digest_key,
+            len(digest["sections"]["portfolio"]),
+            len(digest["sections"]["macro"]),
+            len(digest["sections"]["tech"]),
+        )
+    except Exception as e:  # noqa: BLE001 — fail-soft secondary artifact (see above)
+        digest_status = "error"
+        logger.warning(
+            "[daily_news] digest build/write FAILED (%s: %s) — "
+            "aggregate + article artifacts already landed, continuing",
+            type(e).__name__, e,
+        )
+
     return {
         "status": "ok",
         "tickers": len(universe),
@@ -280,6 +344,9 @@ def collect(
         "articles_status": articles_status,
         "articles_key": articles_key,
         "articles_rows": articles_rows,
+        "digest_status": digest_status,
+        "digest_key": digest_key,
+        "topic_status": topic_status,
     }
 
 

--- a/collectors/topic_news.py
+++ b/collectors/topic_news.py
@@ -1,0 +1,235 @@
+"""Topic news fetcher — curated free RSS feeds for ``macro`` + ``tech``.
+
+The per-ticker daily news path (``collectors.daily_news``) answers "what is
+happening to the names we hold/track". This module answers the complementary
+"what is happening in the world" — broad macro/markets and tech headlines —
+from a small, hand-curated set of stable, free RSS feeds. It is the second
+input to the podcast-ready daily *digest* (see ``collectors.daily_news`` →
+``data.derived.news_digest``).
+
+Design (mirrors ``collectors/news_sources/yahoo_rss.py``):
+
+- Pure ``feedparser`` — no API keys, no LLM, deterministic.
+- Fail-soft PER FEED: a single dead/garbled feed logs a WARN and is skipped;
+  it never kills the topic (mirrors the per-source fail-soft in the ticker
+  path). A topic with every feed down simply returns ``[]``.
+- Recency filter: drop entries older than ``hours`` (default 24) by published
+  date; entries with no parseable date are kept (treated as "just now") so a
+  feed that omits timestamps still contributes.
+- Dedupe by normalized URL then title (first occurrence wins, so the
+  highest-priority feed in the list keeps the canonical entry).
+- Cap per topic to ``per_topic_cap`` (default 15) by recency descending — the
+  digest stays a bounded, podcast-readable size.
+
+Returns ``{"macro": [Article, ...], "tech": [Article, ...]}`` where each
+Article is a small dict ``{"title","source","published","excerpt","url"}``
+(``published`` is UTC ISO-8601 with a trailing ``Z``, or ``""`` when the feed
+omitted a date).
+
+The feed URLs below were verified live (HTTP 200 + non-empty feedparser parse)
+on 2026-06-15. They are all free, no-auth, broadly stable publisher feeds.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ── Curated feeds ──────────────────────────────────────────────────────
+#
+# (display_source_name, feed_url). Order matters: on a URL/title dedupe the
+# EARLIER feed wins, so list higher-signal publishers first. All verified
+# live 2026-06-15 (HTTP 200 + feedparser parse with timestamped entries).
+TOPIC_FEEDS: dict[str, list[tuple[str, str]]] = {
+    "macro": [
+        # CNBC "Economy" feed.
+        ("CNBC", "https://www.cnbc.com/id/20910258/device/rss/rss.html"),
+        # MarketWatch top stories (Dow Jones canonical RSS host).
+        ("MarketWatch", "https://feeds.content.dowjones.io/public/rss/mw_topstories"),
+        # NPR "Economy" feed.
+        ("NPR", "https://feeds.npr.org/1006/rss.xml"),
+    ],
+    "tech": [
+        ("TechCrunch", "https://techcrunch.com/feed/"),
+        ("Ars Technica", "https://feeds.arstechnica.com/arstechnica/index"),
+        ("The Verge", "https://www.theverge.com/rss/index.xml"),
+    ],
+}
+
+DEFAULT_LOOKBACK_HOURS = 24
+DEFAULT_PER_TOPIC_CAP = 15
+
+# Cap raw entries pulled per feed BEFORE filtering — bound the work even if a
+# feed is unusually large. Mirrors yahoo_rss.py's per-feed [:50] slice.
+_PER_FEED_ENTRY_CAP = 50
+
+
+def _iso_z(dt: datetime) -> str:
+    """UTC ISO-8601 with a trailing ``Z`` (matches the artifact sidecars)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_url(url: str) -> str:
+    """Cheap dedupe key — strip a trailing slash + lowercase the scheme/host
+    portion is overkill here; we only need stable equality across the same
+    feed re-listing a story, so a strip + lower is sufficient."""
+    return url.strip().rstrip("/").lower()
+
+
+def _parse_entry(
+    entry: Any,
+    *,
+    source: str,
+    cutoff: datetime,
+) -> dict[str, str] | None:
+    """Map one feedparser entry to the small Article dict, applying the
+    recency filter. Returns ``None`` when the entry is too old or malformed.
+
+    Entries with NO parseable published date are KEPT (published="") — a feed
+    that omits timestamps should still contribute rather than be silently
+    dropped.
+    """
+    try:
+        url = (entry.get("link") or "").strip()
+        title = (entry.get("title") or "").strip()
+        if not url or not title:
+            return None
+
+        pub_struct = entry.get("published_parsed") or entry.get("updated_parsed")
+        if pub_struct:
+            published_dt = datetime(*pub_struct[:6], tzinfo=timezone.utc)
+            if published_dt < cutoff:
+                return None
+            published = _iso_z(published_dt)
+        else:
+            # No date → keep, but mark unknown (sorts last in recency order).
+            published = ""
+
+        excerpt = (entry.get("summary") or entry.get("description") or "").strip()
+        return {
+            "title": title,
+            "source": source,
+            "published": published,
+            "excerpt": excerpt,
+            "url": url,
+        }
+    except Exception as e:  # noqa: BLE001 — schema drift on one entry must not kill the feed
+        logger.warning("[topic_news] schema drift on entry from %s: %s", source, e)
+        return None
+
+
+def _fetch_feed(
+    feedparser_module: Any,
+    *,
+    source: str,
+    url: str,
+    cutoff: datetime,
+) -> list[dict[str, str]]:
+    """Fetch + parse a single feed. Fail-soft: any error → WARN + ``[]`` so a
+    dead feed never kills the topic."""
+    try:
+        feed = feedparser_module.parse(url)
+    except Exception as e:  # noqa: BLE001 — network/parse failure is per-feed fail-soft
+        logger.warning("[topic_news] feed fetch failed for %s (%s): %s", source, url, e)
+        return []
+
+    out: list[dict[str, str]] = []
+    for entry in (getattr(feed, "entries", None) or [])[:_PER_FEED_ENTRY_CAP]:
+        article = _parse_entry(entry, source=source, cutoff=cutoff)
+        if article is not None:
+            out.append(article)
+    logger.info("[topic_news] %s: %d entries within %s", source, len(out), url)
+    return out
+
+
+def _dedupe(articles: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Dedupe by normalized URL, then by title (first occurrence wins)."""
+    seen_urls: set[str] = set()
+    seen_titles: set[str] = set()
+    out: list[dict[str, str]] = []
+    for a in articles:
+        ukey = _normalize_url(a["url"])
+        tkey = a["title"].strip().lower()
+        if ukey in seen_urls or tkey in seen_titles:
+            continue
+        seen_urls.add(ukey)
+        seen_titles.add(tkey)
+        out.append(a)
+    return out
+
+
+def _by_recency_desc(articles: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Sort newest-first. Empty ``published`` (unknown date) sorts last."""
+    return sorted(articles, key=lambda a: a.get("published") or "", reverse=True)
+
+
+def fetch_topic(
+    topic: str,
+    *,
+    hours: int = DEFAULT_LOOKBACK_HOURS,
+    per_topic_cap: int = DEFAULT_PER_TOPIC_CAP,
+    feedparser_module: Any = None,
+) -> list[dict[str, str]]:
+    """Fetch one topic's curated feeds → deduped, recency-capped Article list.
+
+    ``feedparser_module`` is injectable for testing — production leaves it
+    None and the module is lazy-imported.
+    """
+    feeds = TOPIC_FEEDS.get(topic)
+    if not feeds:
+        logger.warning("[topic_news] unknown topic %r — no feeds configured", topic)
+        return []
+
+    if feedparser_module is None:
+        import feedparser
+
+        feedparser_module = feedparser
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    collected: list[dict[str, str]] = []
+    for source, url in feeds:
+        collected.extend(
+            _fetch_feed(feedparser_module, source=source, url=url, cutoff=cutoff)
+        )
+
+    deduped = _dedupe(collected)
+    ordered = _by_recency_desc(deduped)
+    capped = ordered[:per_topic_cap]
+    logger.info(
+        "[topic_news] topic=%s collected=%d deduped=%d capped=%d",
+        topic, len(collected), len(deduped), len(capped),
+    )
+    return capped
+
+
+def fetch_topics(
+    topics: list[str] | None = None,
+    *,
+    hours: int = DEFAULT_LOOKBACK_HOURS,
+    per_topic_cap: int = DEFAULT_PER_TOPIC_CAP,
+    feedparser_module: Any = None,
+) -> dict[str, list[dict[str, str]]]:
+    """Fetch all requested topics (default: ``macro`` + ``tech``).
+
+    Each topic is independently fail-soft: a topic whose feeds are all down
+    returns ``[]`` for that key without affecting the others. The whole call
+    never raises on network/parse failure — the worst case is an all-empty
+    result, which the digest builder treats as "no topic news today".
+    """
+    if topics is None:
+        topics = ["macro", "tech"]
+    return {
+        topic: fetch_topic(
+            topic,
+            hours=hours,
+            per_topic_cap=per_topic_cap,
+            feedparser_module=feedparser_module,
+        )
+        for topic in topics
+    }

--- a/data/derived/news_digest.py
+++ b/data/derived/news_digest.py
@@ -1,0 +1,228 @@
+"""Daily news *digest* — the podcast-ready combined artifact.
+
+Where ``news_aggregates`` (per-ticker rollup) and ``news_articles`` (raw
+per-article feed) are the machine/human substrates for the HELD + TRACKED
+universe, the digest is a single small JSON that combines three sections for
+a daily-brief / podcast consumer:
+
+    sections.portfolio  ← the most-newsworthy per-ticker stories (derived from
+                          the ``NewsArticleRecord`` rows ``daily_news.collect``
+                          already produced — no extra fetch)
+    sections.macro      ← curated macro/markets RSS headlines (topic_news)
+    sections.tech       ← curated tech RSS headlines (topic_news)
+
+It is written to ``data/news_digest_daily/`` with BOTH a dated history object
+(``{run_id}.json``) AND a ``latest.json`` that holds the FULL digest (not a
+pointer) so the consumer reads it in a single GET.
+
+CONTRACT (``schema_version: 1``):
+
+    {
+      "schema_version": 1,
+      "date": "YYYY-MM-DD",
+      "generated_at": "<ISO8601 UTC>",
+      "sections": {
+        "portfolio": [{"ticker","title","source","published","excerpt","sentiment","url"}],
+        "macro":     [{"title","source","published","excerpt","url"}],
+        "tech":      [{"title","source","published","excerpt","url"}]
+      }
+    }
+
+Deterministic, no LLM, no API spend (topic_news is plain feedparser; the
+portfolio section is derived from already-fetched records).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date as Date
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = 1
+"""Bump on any breaking change to the digest contract. Consumers gate on
+the top-level ``schema_version`` field."""
+
+DEFAULT_S3_BUCKET = "alpha-engine-research"
+DEFAULT_S3_PREFIX = "data/news_digest_daily"
+
+# Cap the portfolio section so the digest stays a bounded, podcast-readable
+# size. Selected by newsworthiness (see ``_select_portfolio``).
+DEFAULT_PORTFOLIO_CAP = 30
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _select_portfolio(
+    articles_df: pd.DataFrame,
+    *,
+    cap: int = DEFAULT_PORTFOLIO_CAP,
+) -> list[dict[str, Any]]:
+    """Pick the most-newsworthy per-ticker portfolio stories from the raw
+    ``NewsArticleRecord`` DataFrame.
+
+    Each row of ``articles_df`` is one canonical (deduped) story carrying a
+    ``tickers_json`` list. The digest's portfolio section is a flat
+    per-(ticker, story) list, so a multi-ticker story expands into one entry
+    per ticker.
+
+    "Newsworthy" ranking, descending:
+      1. absolute LM sentiment magnitude (a strongly +/- story matters more
+         than a neutral one),
+      2. recency (``published_at``).
+
+    The DataFrame is the raw-article companion shape from
+    ``data.derived.news_articles`` (columns: ``title``, ``url``,
+    ``tickers_json``, ``primary_source``, ``published_at``, ``body_excerpt``,
+    ``lm_sentiment``). Missing columns degrade gracefully to empty/zero.
+    """
+    if articles_df is None or len(articles_df) == 0:
+        return []
+
+    df = articles_df.copy()
+    # Defensive: ensure the columns we read exist.
+    for col, default in (
+        ("title", ""),
+        ("url", ""),
+        ("tickers_json", "[]"),
+        ("primary_source", ""),
+        ("published_at", ""),
+        ("body_excerpt", ""),
+        ("lm_sentiment", 0.0),
+    ):
+        if col not in df.columns:
+            df[col] = default
+
+    df["_abs_sentiment"] = df["lm_sentiment"].fillna(0.0).abs()
+    df = df.sort_values(
+        ["_abs_sentiment", "published_at"], ascending=[False, False]
+    )
+
+    entries: list[dict[str, Any]] = []
+    for _, row in df.iterrows():
+        try:
+            tickers = json.loads(row["tickers_json"]) or []
+        except (TypeError, ValueError):
+            tickers = []
+        for ticker in tickers:
+            entries.append(
+                {
+                    "ticker": str(ticker),
+                    "title": str(row["title"]),
+                    "source": str(row["primary_source"]),
+                    "published": str(row["published_at"]),
+                    "excerpt": str(row["body_excerpt"]),
+                    "sentiment": round(float(row["lm_sentiment"] or 0.0), 6),
+                    "url": str(row["url"]),
+                }
+            )
+            if len(entries) >= cap:
+                return entries
+    return entries
+
+
+def build_digest(
+    *,
+    articles_df: pd.DataFrame,
+    topics: dict[str, list[dict[str, Any]]] | None,
+    digest_date: Date,
+    portfolio_cap: int = DEFAULT_PORTFOLIO_CAP,
+) -> dict[str, Any]:
+    """Assemble the digest dict from the portfolio article records + the
+    macro/tech topic results.
+
+    ``topics`` may be ``None`` or partial (a topic fetch that failed) — the
+    corresponding section is emitted as an empty list. The portfolio section
+    is always populated from ``articles_df`` regardless of topic state.
+    """
+    topics = topics or {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "date": digest_date.isoformat(),
+        "generated_at": _iso_now(),
+        "sections": {
+            "portfolio": _select_portfolio(articles_df, cap=portfolio_cap),
+            "macro": list(topics.get("macro") or []),
+            "tech": list(topics.get("tech") or []),
+        },
+    }
+
+
+def write_digest(
+    digest: dict[str, Any],
+    *,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+    run_id: str | None = None,
+) -> str:
+    """Write the digest JSON to S3 as BOTH a dated history object
+    (``{prefix}/{run_id}.json``) AND ``{prefix}/latest.json`` (the FULL
+    digest — consumers read it directly in one GET).
+
+    Uses the canonical ``alpha_engine_lib.eval_artifacts`` run_id +
+    artifact/latest key helpers so the digest history shares the listing
+    conventions of the sibling daily artifacts. Returns the dated artifact
+    key.
+    """
+    from alpha_engine_lib.eval_artifacts import (
+        eval_artifact_key,
+        eval_latest_key,
+        new_eval_run_id,
+    )
+
+    run_id = run_id or new_eval_run_id()
+    artifact_key = eval_artifact_key(prefix, run_id, basename="digest.json")
+    latest_key = eval_latest_key(prefix)
+
+    body = json.dumps(digest, separators=(",", ":")).encode("utf-8")
+    s3_client.put_object(
+        Bucket=bucket, Key=artifact_key, Body=body, ContentType="application/json"
+    )
+    # latest.json carries the FULL digest, not a pointer — one-GET consumer.
+    s3_client.put_object(
+        Bucket=bucket, Key=latest_key, Body=body, ContentType="application/json"
+    )
+    n = digest.get("sections", {})
+    logger.info(
+        "[news_digest] wrote digest to s3://%s/%s (portfolio=%d macro=%d tech=%d; latest=%s)",
+        bucket, artifact_key,
+        len(n.get("portfolio", [])), len(n.get("macro", [])), len(n.get("tech", [])),
+        latest_key,
+    )
+    return artifact_key
+
+
+def read_digest(
+    *,
+    s3_client: Any,
+    bucket: str = DEFAULT_S3_BUCKET,
+    prefix: str = DEFAULT_S3_PREFIX,
+) -> dict[str, Any]:
+    """Consumer-side read of the latest digest (one GET on ``latest.json``).
+    Returns an empty-schema digest dict when no artifact exists."""
+    from alpha_engine_lib.eval_artifacts import eval_latest_key
+
+    latest_key = eval_latest_key(prefix)
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=latest_key)
+        return json.loads(obj["Body"].read())
+    except Exception as e:  # noqa: BLE001 — missing/garbled artifact → empty schema
+        logger.info(
+            "[news_digest] latest digest read failed for %s (%s)",
+            latest_key, type(e).__name__,
+        )
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "date": None,
+            "generated_at": None,
+            "sections": {"portfolio": [], "macro": [], "tech": []},
+        }

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -83,6 +83,7 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "data/derived/analyst_revisions.py": 2,
     "data/derived/news_aggregates.py": 2,
     "data/derived/news_articles.py": 2,  # raw-article parquet + latest.json sidecar
+    "data/derived/news_digest.py": 2,  # podcast digest: {run_id}.json + latest.json
     "data/snapshotter/analyst_daily.py": 2,
     "features/compute.py": 1,
     "features/registry.py": 1,

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -183,3 +183,105 @@ def test_collect_article_companion_failure_is_fail_soft(
     assert out["rows"] == 7
     assert out["articles_status"] == "error"  # failure recorded, not silent
     assert out["articles_key"] is None
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_digest.write_digest")
+@patch("data.derived.news_digest.build_digest")
+@patch("collectors.topic_news.fetch_topics")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_collect_writes_combined_digest(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_topics,
+    mock_build, mock_write_digest, mock_ensure,
+):
+    """collect() also produces the podcast-ready digest (portfolio + macro +
+    tech) from the already-fetched article records, in the same flow."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock(); agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("data/news_aggregates_daily/run/result.parquet", agg_df)
+    art_df = MagicMock(); art_df.__len__ = lambda self: 12
+    mock_articles.return_value = ("data/news_articles_daily/run/articles.parquet", art_df)
+    mock_topics.return_value = {"macro": [{"title": "m"}], "tech": [{"title": "t"}]}
+    mock_build.return_value = {
+        "sections": {"portfolio": [], "macro": [{"title": "m"}], "tech": [{"title": "t"}]}
+    }
+    mock_write_digest.return_value = "data/news_digest_daily/run/digest.json"
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3)
+
+    assert out["status"] == "ok"
+    assert out["digest_status"] == "ok"
+    assert out["topic_status"] == "ok"
+    assert out["digest_key"] == "data/news_digest_daily/run/digest.json"
+    # The digest builder received the in-memory article DataFrame + topics.
+    assert mock_build.call_args.kwargs["articles_df"] is art_df
+    assert mock_build.call_args.kwargs["topics"]["macro"] == [{"title": "m"}]
+    assert mock_write_digest.call_args.kwargs["prefix"] == daily_news.DIGEST_PREFIX
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_digest.write_digest")
+@patch("data.derived.news_digest.build_digest")
+@patch("collectors.topic_news.fetch_topics")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_collect_digest_topic_failure_is_fail_soft(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_topics,
+    mock_build, mock_write_digest, mock_ensure,
+):
+    """A topic-RSS failure must NOT block the digest: it's still written with
+    the portfolio section populated and empty topics — recorded on
+    topic_status, never silent, never fatal."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock(); agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("k/result.parquet", agg_df)
+    art_df = MagicMock(); art_df.__len__ = lambda self: 12
+    mock_articles.return_value = ("k/articles.parquet", art_df)
+    mock_topics.side_effect = RuntimeError("RSS down")
+    mock_build.return_value = {"sections": {"portfolio": [{}], "macro": [], "tech": []}}
+    mock_write_digest.return_value = "data/news_digest_daily/run/digest.json"
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3)
+
+    assert out["status"] == "ok"             # primary deliverable survived
+    assert out["topic_status"] == "error"     # topic failure recorded
+    assert out["digest_status"] == "ok"       # digest STILL written
+    # Digest was built with empty topics despite the RSS failure.
+    assert mock_build.call_args.kwargs["topics"] == {}
+    mock_write_digest.assert_called_once()
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_digest.build_digest")
+@patch("collectors.topic_news.fetch_topics")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_collect_digest_write_failure_is_fail_soft(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_topics,
+    mock_build, mock_ensure,
+):
+    """A failure building/writing the digest must NOT fail the run — the
+    aggregate + article artifacts already landed; recorded on digest_status."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock(); agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("k/result.parquet", agg_df)
+    art_df = MagicMock(); art_df.__len__ = lambda self: 12
+    mock_articles.return_value = ("k/articles.parquet", art_df)
+    mock_topics.return_value = {"macro": [], "tech": []}
+    mock_build.side_effect = RuntimeError("schema bug")
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3)
+
+    assert out["status"] == "ok"
+    assert out["digest_status"] == "error"
+    assert out["digest_key"] is None

--- a/tests/test_news_digest.py
+++ b/tests/test_news_digest.py
@@ -1,0 +1,237 @@
+"""Tests for data/derived/news_digest.py — the podcast-ready combined digest.
+
+Asserts the digest CONTRACT shape exactly, the portfolio-section derivation
++ newsworthiness selection + cap, fail-soft empty topics, and the
+S3 write (dated history object + full latest.json) round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from io import BytesIO
+
+import pandas as pd
+import pytest
+
+from data.derived.news_articles import build_news_articles_df
+from data.derived.news_digest import (
+    DEFAULT_S3_PREFIX,
+    SCHEMA_VERSION,
+    build_digest,
+    read_digest,
+    write_digest,
+)
+
+from collectors.news_aggregator import AggregatedNewsArticle, NewsAggregator
+from collectors.nlp.pipeline import NewsNLPOutput
+from collectors.nlp.protocols import SentimentScore
+
+from alpha_engine_lib.sources import NewsArticle
+
+
+# ── helpers (mirror tests/test_news_articles.py) ───────────────────────
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _variant(source: str, *, body="body", url="https://x/1", title="t") -> NewsArticle:
+    return NewsArticle(
+        tickers=("AAPL",), title=title, body_excerpt=body, url=url,
+        published_at=_now(), source=source, fetched_at=_now(),
+        headline_authors=None, tags=(),
+    )
+
+
+def _aggregated(*, fingerprint, tickers=("AAPL",), sources=("polygon",),
+                title="Story", url="https://x.com/a", published_at=None):
+    variants = tuple(_variant(s, title=title) for s in sources)
+    return AggregatedNewsArticle(
+        canonical_title=title, canonical_url=url, tickers=tickers,
+        earliest_published_at=published_at or _now(),
+        variants=variants, canonical_fingerprint=fingerprint,
+    )
+
+
+def _lm(fp, *, composite):
+    return SentimentScore(
+        scorer="loughran_mcdonald", article_fingerprint=fp, composite=composite,
+        positive_word_count=0, negative_word_count=0,
+        uncertainty_word_count=0, total_token_count=10,
+    )
+
+
+def _articles_df(articles, nlp=None):
+    return build_news_articles_df(
+        articles=articles, nlp_output=nlp or NewsNLPOutput(),
+        aggregate_date=date(2026, 5, 13), aggregator=NewsAggregator(sources=[]),
+    )
+
+
+_TOPICS = {
+    "macro": [{"title": "Fed holds", "source": "CNBC", "published": "2026-05-13T12:00:00Z",
+               "excerpt": "No change.", "url": "https://x/fed"}],
+    "tech": [{"title": "New chip", "source": "TechCrunch", "published": "2026-05-13T13:00:00Z",
+              "excerpt": "Fast.", "url": "https://x/chip"}],
+}
+
+
+# ── contract shape ─────────────────────────────────────────────────────
+
+
+class TestBuildDigestContract:
+    def test_top_level_contract_keys(self):
+        df = _articles_df([_aggregated(fingerprint="a")])
+        d = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))
+        assert d["schema_version"] == SCHEMA_VERSION
+        assert d["date"] == "2026-05-13"
+        assert d["generated_at"].endswith("Z")
+        assert set(d["sections"].keys()) == {"portfolio", "macro", "tech"}
+
+    def test_portfolio_entry_shape(self):
+        df = _articles_df(
+            [_aggregated(fingerprint="a", tickers=("AAPL",))],
+            nlp=NewsNLPOutput(sentiment_scores=[_lm("a", composite=-0.12)]),
+        )
+        d = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))
+        p = d["sections"]["portfolio"]
+        assert len(p) == 1
+        assert set(p[0].keys()) == {
+            "ticker", "title", "source", "published", "excerpt", "sentiment", "url",
+        }
+        assert p[0]["ticker"] == "AAPL"
+        assert p[0]["sentiment"] == pytest.approx(-0.12)
+
+    def test_macro_tech_sections_passthrough(self):
+        df = _articles_df([_aggregated(fingerprint="a")])
+        d = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))
+        assert d["sections"]["macro"] == _TOPICS["macro"]
+        assert d["sections"]["tech"] == _TOPICS["tech"]
+        # Topic entries must NOT carry a ticker/sentiment field.
+        assert set(d["sections"]["macro"][0].keys()) == {
+            "title", "source", "published", "excerpt", "url",
+        }
+
+    def test_multi_ticker_story_expands_per_ticker(self):
+        df = _articles_df([_aggregated(fingerprint="a", tickers=("AAPL", "MSFT"))])
+        d = build_digest(articles_df=df, topics={}, digest_date=date(2026, 5, 13))
+        tickers = {e["ticker"] for e in d["sections"]["portfolio"]}
+        assert tickers == {"AAPL", "MSFT"}
+
+
+class TestPortfolioSelection:
+    def test_ranked_by_abs_sentiment_then_recency(self):
+        arts = [
+            _aggregated(fingerprint="neutral", title="neutral", tickers=("A",)),
+            _aggregated(fingerprint="bad", title="bad", tickers=("B",)),
+            _aggregated(fingerprint="good", title="good", tickers=("C",)),
+        ]
+        nlp = NewsNLPOutput(sentiment_scores=[
+            _lm("neutral", composite=0.0),
+            _lm("bad", composite=-0.9),
+            _lm("good", composite=0.5),
+        ])
+        df = _articles_df(arts, nlp=nlp)
+        d = build_digest(articles_df=df, topics={}, digest_date=date(2026, 5, 13))
+        titles = [e["title"] for e in d["sections"]["portfolio"]]
+        # |−0.9| > |0.5| > |0.0|
+        assert titles == ["bad", "good", "neutral"]
+
+    def test_portfolio_cap(self):
+        arts = [
+            _aggregated(fingerprint=f"fp{i}", title=f"t{i}", tickers=(f"T{i}",),
+                        url=f"https://x/{i}")
+            for i in range(10)
+        ]
+        df = _articles_df(arts)
+        d = build_digest(articles_df=df, topics={}, digest_date=date(2026, 5, 13),
+                         portfolio_cap=4)
+        assert len(d["sections"]["portfolio"]) == 4
+
+    def test_empty_articles_empty_portfolio(self):
+        df = _articles_df([])
+        d = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))
+        assert d["sections"]["portfolio"] == []
+        assert len(d["sections"]["macro"]) == 1  # topics still present
+
+
+class TestTopicFailSoft:
+    def test_none_topics_yields_empty_macro_tech_but_full_portfolio(self):
+        df = _articles_df([_aggregated(fingerprint="a", tickers=("AAPL",))])
+        d = build_digest(articles_df=df, topics=None, digest_date=date(2026, 5, 13))
+        assert d["sections"]["macro"] == []
+        assert d["sections"]["tech"] == []
+        assert len(d["sections"]["portfolio"]) == 1
+
+    def test_partial_topics_missing_key_is_empty(self):
+        df = _articles_df([_aggregated(fingerprint="a")])
+        d = build_digest(articles_df=df, topics={"macro": _TOPICS["macro"]},
+                         digest_date=date(2026, 5, 13))
+        assert len(d["sections"]["macro"]) == 1
+        assert d["sections"]["tech"] == []
+
+
+# ── S3 round-trip (in-memory mock; no moto dep) ────────────────────────
+
+
+class _InMemoryS3:
+    def __init__(self):
+        self._store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self._store[(Bucket, Key)] = Body
+        return {"ETag": "stub"}
+
+    def get_object(self, *, Bucket, Key):
+        if (Bucket, Key) not in self._store:
+            raise KeyError(f"NoSuchKey: {Bucket}/{Key}")
+        return {"Body": BytesIO(self._store[(Bucket, Key)])}
+
+
+class TestWriteReadDigest:
+    def test_write_both_dated_and_latest_full_digest(self):
+        s3 = _InMemoryS3()
+        df = _articles_df([_aggregated(fingerprint="a")])
+        digest = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))
+        key = write_digest(digest, s3_client=s3, run_id="2605131934")
+
+        assert key == "data/news_digest_daily/2605131934_digest.json"
+        latest_key = "data/news_digest_daily/latest.json"
+        assert ("alpha-engine-research", key) in s3._store
+        assert ("alpha-engine-research", latest_key) in s3._store
+
+        # latest.json holds the FULL digest, not a pointer.
+        latest = json.loads(s3._store[("alpha-engine-research", latest_key)])
+        assert latest["schema_version"] == SCHEMA_VERSION
+        assert "sections" in latest
+        assert latest["sections"]["macro"] == _TOPICS["macro"]
+        # Dated history object is byte-identical to latest.
+        dated = json.loads(s3._store[("alpha-engine-research", key)])
+        assert dated == latest
+
+    def test_read_digest_returns_full_payload(self):
+        s3 = _InMemoryS3()
+        df = _articles_df([_aggregated(fingerprint="a", tickers=("AAPL",))])
+        digest = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))
+        write_digest(digest, s3_client=s3, run_id="2605131934")
+
+        out = read_digest(s3_client=s3)
+        assert out["date"] == "2026-05-13"
+        assert out["sections"]["portfolio"][0]["ticker"] == "AAPL"
+
+    def test_read_missing_digest_returns_empty_schema(self):
+        s3 = _InMemoryS3()
+        out = read_digest(s3_client=s3)
+        assert out["schema_version"] == SCHEMA_VERSION
+        assert out["sections"] == {"portfolio": [], "macro": [], "tech": []}
+        assert out["date"] is None
+
+
+def test_default_prefix_is_digest_daily():
+    assert DEFAULT_S3_PREFIX == "data/news_digest_daily"
+
+
+def test_schema_version_pinned():
+    assert SCHEMA_VERSION == 1

--- a/tests/test_topic_news.py
+++ b/tests/test_topic_news.py
@@ -1,0 +1,210 @@
+"""Tests for collectors/topic_news.py — curated macro/tech RSS topic fetcher.
+
+No live network: a fake feedparser module is injected. Covers parsing of the
+small Article dict, the recency filter, URL/title dedupe, the per-topic cap,
+and per-feed fail-soft (one dead feed must not kill the topic).
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from collectors import topic_news
+
+
+def _struct(dt: datetime) -> time.struct_time:
+    """A feedparser-style ``*_parsed`` value (UTC struct_time)."""
+    return dt.astimezone(timezone.utc).timetuple()
+
+
+class _Entry(dict):
+    """feedparser entries support both attribute and .get() access; the code
+    under test uses .get(), so a plain dict suffices."""
+
+
+def _entry(
+    *,
+    title="A headline",
+    link="https://example.com/a",
+    summary="An excerpt.",
+    published: datetime | None = None,
+    no_date: bool = False,
+) -> dict:
+    e = {"title": title, "link": link, "summary": summary}
+    if not no_date and published is not None:
+        e["published_parsed"] = _struct(published)
+    return e
+
+
+class _FakeFeed:
+    def __init__(self, entries):
+        self.entries = entries
+        self.bozo = False
+
+
+class _FakeFeedparser:
+    """Maps URL → list of entries (or an exception to simulate a dead feed)."""
+
+    def __init__(self, by_url):
+        self._by_url = by_url
+        self.calls: list[str] = []
+
+    def parse(self, url):
+        self.calls.append(url)
+        val = self._by_url.get(url)
+        if isinstance(val, Exception):
+            raise val
+        return _FakeFeed(val or [])
+
+
+def _macro_urls() -> list[str]:
+    return [url for _, url in topic_news.TOPIC_FEEDS["macro"]]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def test_fetch_topic_parses_article_dict_shape():
+    urls = _macro_urls()
+    fp = _FakeFeedparser({
+        urls[0]: [_entry(title="Fed holds rates", link="https://x/fed",
+                         summary="No change.", published=_now())],
+    })
+    out = topic_news.fetch_topic("macro", feedparser_module=fp)
+    assert len(out) == 1
+    a = out[0]
+    assert set(a.keys()) == {"title", "source", "published", "excerpt", "url"}
+    assert a["title"] == "Fed holds rates"
+    assert a["source"] == "CNBC"  # first macro feed's display name
+    assert a["url"] == "https://x/fed"
+    assert a["excerpt"] == "No change."
+    assert a["published"].endswith("Z")
+
+
+def test_recency_filter_drops_old_entries():
+    urls = _macro_urls()
+    old = _now() - timedelta(hours=48)
+    fresh = _now() - timedelta(hours=1)
+    fp = _FakeFeedparser({
+        urls[0]: [
+            _entry(title="old", link="https://x/old", published=old),
+            _entry(title="fresh", link="https://x/fresh", published=fresh),
+        ],
+    })
+    out = topic_news.fetch_topic("macro", hours=24, feedparser_module=fp)
+    titles = [a["title"] for a in out]
+    assert titles == ["fresh"]
+
+
+def test_entry_without_date_is_kept_with_empty_published():
+    urls = _macro_urls()
+    fp = _FakeFeedparser({
+        urls[0]: [_entry(title="undated", link="https://x/u", no_date=True)],
+    })
+    out = topic_news.fetch_topic("macro", feedparser_module=fp)
+    assert len(out) == 1
+    assert out[0]["published"] == ""
+
+
+def test_dedupe_by_url_first_feed_wins():
+    urls = _macro_urls()
+    # Same URL appears in two feeds; the earlier feed's entry wins.
+    fp = _FakeFeedparser({
+        urls[0]: [_entry(title="from CNBC", link="https://x/dup", published=_now())],
+        urls[1]: [_entry(title="from MW", link="https://x/dup/", published=_now())],
+    })
+    out = topic_news.fetch_topic("macro", feedparser_module=fp)
+    assert len(out) == 1
+    assert out[0]["source"] == "CNBC"
+
+
+def test_dedupe_by_title():
+    urls = _macro_urls()
+    fp = _FakeFeedparser({
+        urls[0]: [_entry(title="Same Story", link="https://x/1", published=_now())],
+        urls[1]: [_entry(title="same story", link="https://x/2", published=_now())],
+    })
+    out = topic_news.fetch_topic("macro", feedparser_module=fp)
+    assert len(out) == 1
+
+
+def test_per_topic_cap_keeps_most_recent():
+    urls = _macro_urls()
+    base = _now()
+    entries = [
+        _entry(title=f"h{i}", link=f"https://x/{i}", published=base - timedelta(minutes=i))
+        for i in range(20)
+    ]
+    fp = _FakeFeedparser({urls[0]: entries})
+    out = topic_news.fetch_topic("macro", per_topic_cap=5, feedparser_module=fp)
+    assert len(out) == 5
+    # Newest-first: h0 (most recent) … h4
+    assert [a["title"] for a in out] == ["h0", "h1", "h2", "h3", "h4"]
+
+
+def test_dead_feed_is_fail_soft_does_not_kill_topic():
+    urls = _macro_urls()
+    fp = _FakeFeedparser({
+        urls[0]: RuntimeError("network down"),
+        urls[1]: [_entry(title="survivor", link="https://x/s", published=_now())],
+    })
+    out = topic_news.fetch_topic("macro", feedparser_module=fp)
+    # The dead feed[0] was skipped; feed[1]'s entry survived.
+    assert [a["title"] for a in out] == ["survivor"]
+    assert urls[0] in fp.calls and urls[1] in fp.calls
+
+
+def test_entry_missing_url_or_title_skipped():
+    urls = _macro_urls()
+    fp = _FakeFeedparser({
+        urls[0]: [
+            {"title": "no link", "summary": "s"},          # no link
+            {"link": "https://x/notitle", "summary": "s"},  # no title
+            _entry(title="ok", link="https://x/ok", published=_now()),
+        ],
+    })
+    out = topic_news.fetch_topic("macro", feedparser_module=fp)
+    assert [a["title"] for a in out] == ["ok"]
+
+
+def test_unknown_topic_returns_empty():
+    fp = _FakeFeedparser({})
+    assert topic_news.fetch_topic("sports", feedparser_module=fp) == []
+    assert fp.calls == []  # no feeds configured → no fetch
+
+
+def test_fetch_topics_returns_both_topics():
+    macro_urls = [u for _, u in topic_news.TOPIC_FEEDS["macro"]]
+    tech_urls = [u for _, u in topic_news.TOPIC_FEEDS["tech"]]
+    fp = _FakeFeedparser({
+        macro_urls[0]: [_entry(title="macro1", link="https://x/m1", published=_now())],
+        tech_urls[0]: [_entry(title="tech1", link="https://x/t1", published=_now())],
+    })
+    out = topic_news.fetch_topics(feedparser_module=fp)
+    assert set(out.keys()) == {"macro", "tech"}
+    assert [a["title"] for a in out["macro"]] == ["macro1"]
+    assert [a["title"] for a in out["tech"]] == ["tech1"]
+
+
+def test_fetch_topics_topic_with_all_feeds_down_is_empty_not_raising():
+    macro_urls = [u for _, u in topic_news.TOPIC_FEEDS["macro"]]
+    tech_urls = [u for _, u in topic_news.TOPIC_FEEDS["tech"]]
+    by_url = {u: RuntimeError("down") for u in macro_urls}
+    by_url[tech_urls[0]] = [_entry(title="tech survives", link="https://x/t", published=_now())]
+    fp = _FakeFeedparser(by_url)
+    out = topic_news.fetch_topics(feedparser_module=fp)
+    assert out["macro"] == []                       # all macro feeds down → empty
+    assert [a["title"] for a in out["tech"]] == ["tech survives"]
+
+
+def test_curated_feeds_are_https_and_nonempty():
+    """Lightweight guard on the hardcoded feed list — every topic has feeds,
+    each is an (name, https-url) pair."""
+    assert set(topic_news.TOPIC_FEEDS.keys()) == {"macro", "tech"}
+    for topic, feeds in topic_news.TOPIC_FEEDS.items():
+        assert feeds, f"{topic} has no feeds"
+        for name, url in feeds:
+            assert name and isinstance(name, str)
+            assert url.startswith("https://"), f"{topic} feed {url} not https"


### PR DESCRIPTION
## What
Extends the daily-news collector to also pull **macro** + **tech** topic news from curated free RSS feeds, and emit a single **podcast-ready JSON digest** (`data/news_digest_daily/latest.json`) combining portfolio (ticker) news + macro + tech.

## Why
morning-signal's prompt covers Portfolio / Markets / Macro / Tech segments that can be fed from free sources (Polygon/GDELT/Yahoo for tickers; RSS for macro/tech) instead of paid Anthropic `web_search`. The political-pulse + local segments stay on web search (no free source). The digest is the contract a downstream consumer (morning-signal) injects into its prompt.

## Contents
- `collectors/topic_news.py` — `feedparser` RSS fetcher for macro (CNBC Economy, MarketWatch, NPR Economy) + tech (TechCrunch, Ars Technica, The Verge); per-feed fail-soft, 24h recency filter, dedupe, per-topic cap.
- `data/derived/news_digest.py` — builds + writes the `schema_version:1` digest (`{run_id}.json` history + `latest.json` full digest). Portfolio section derived from in-memory `NewsArticleRecord`s, ranked, capped ~30.
- `collectors/daily_news.py` — integrates digest build/write into `collect()`. **Fail-soft**: topic-fetch failure → empty macro/tech + portfolio still populated (`topic_status`); digest failure → run still `ok` (`digest_status`); aggregate/article writes untouched.
- Tests: `test_topic_news.py`, `test_news_digest.py`, + 3 in `test_daily_news.py` (all mocked). **Full suite: 2058 passed, 2 pre-existing skips.**

No dependency changes (feedparser already in `requirements.txt` + `requirements-daily-news.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)