### PR TITLE
fix(digest): exclude GDELT from portfolio + fresh high-freq macro feeds

### DIFF
--- a/collectors/topic_news.py
+++ b/collectors/topic_news.py
@@ -46,11 +46,16 @@ logger = logging.getLogger(__name__)
 # live 2026-06-15 (HTTP 200 + feedparser parse with timestamped entries).
 TOPIC_FEEDS: dict[str, list[tuple[str, str]]] = {
     "macro": [
-        # CNBC "Economy" feed.
-        ("CNBC", "https://www.cnbc.com/id/20910258/device/rss/rss.html"),
-        # MarketWatch top stories (Dow Jones canonical RSS host).
-        ("MarketWatch", "https://feeds.content.dowjones.io/public/rss/mw_topstories"),
-        # NPR "Economy" feed.
+        # CNBC "Top News" — high-frequency business/markets/economy headlines
+        # (~29 fresh items within 24h). Chosen over CNBC "Economy" (id
+        # 20910258) and MarketWatch MarketPulse, which are LOW-FREQUENCY
+        # topical feeds whose newest items lag 3+ days — outside the 24h
+        # lookback (verified 2026-06-15). NOTE: CNBC rejects feedparser's
+        # default UA (returns 0); _BROWSER_UA below is required.
+        ("CNBC", "https://www.cnbc.com/id/100003114/device/rss/rss.html"),
+        # CNBC "Finance" — markets/finance depth.
+        ("CNBC Finance", "https://www.cnbc.com/id/10000664/device/rss/rss.html"),
+        # NPR "Business/Economy" — clean macro supplement.
         ("NPR", "https://feeds.npr.org/1006/rss.xml"),
     ],
     "tech": [
@@ -66,6 +71,12 @@ DEFAULT_PER_TOPIC_CAP = 15
 # Cap raw entries pulled per feed BEFORE filtering — bound the work even if a
 # feed is unusually large. Mirrors yahoo_rss.py's per-feed [:50] slice.
 _PER_FEED_ENTRY_CAP = 50
+
+# Some feeds (notably CNBC) reject feedparser's default User-Agent and return
+# an empty body — passing a browser-like UA is required or the feed silently
+# yields 0 entries (the CNBC-Economy feed returned nothing in production until
+# this was set). Harmless for feeds that don't care.
+_BROWSER_UA = "Mozilla/5.0 (compatible; alpha-engine-news/1.0; +https://nousergon.ai)"
 
 
 def _iso_z(dt: datetime) -> str:
@@ -134,7 +145,9 @@ def _fetch_feed(
     """Fetch + parse a single feed. Fail-soft: any error → WARN + ``[]`` so a
     dead feed never kills the topic."""
     try:
-        feed = feedparser_module.parse(url)
+        # agent= sends a browser-like UA; some feeds (CNBC) return an empty
+        # body to feedparser's default UA. feedparser accepts `agent` kwarg.
+        feed = feedparser_module.parse(url, agent=_BROWSER_UA)
     except Exception as e:  # noqa: BLE001 — network/parse failure is per-feed fail-soft
         logger.warning("[topic_news] feed fetch failed for %s (%s): %s", source, url, e)
         return []

--- a/data/derived/news_digest.py
+++ b/data/derived/news_digest.py
@@ -101,6 +101,17 @@ def _select_portfolio(
         if col not in df.columns:
             df[col] = default
 
+    # GDELT keyword-matches ticker symbols/fragments ("meta-analysis" → META,
+    # "MDT" → unrelated articles), polluting the portfolio section with false
+    # positives (verified 2026-06-15: 19/30 portfolio items were GDELT noise).
+    # Polygon (API-tagged) + Yahoo (per-ticker RSS) are ticker-accurate, so the
+    # portfolio digest uses only those. GDELT remains valid for the macro/tech
+    # topic sections (keyword/topic news by design) — this filter is
+    # portfolio-only.
+    df = df[df["primary_source"].astype(str).str.lower() != "gdelt"]
+    if len(df) == 0:
+        return []
+
     df["_abs_sentiment"] = df["lm_sentiment"].fillna(0.0).abs()
     df = df.sort_values(
         ["_abs_sentiment", "published_at"], ascending=[False, False]

--- a/tests/test_news_digest.py
+++ b/tests/test_news_digest.py
@@ -150,6 +150,30 @@ class TestPortfolioSelection:
                          portfolio_cap=4)
         assert len(d["sections"]["portfolio"]) == 4
 
+    def test_portfolio_excludes_gdelt_source(self):
+        # GDELT keyword-matches tickers → false positives; the portfolio section
+        # must use only ticker-accurate sources (Polygon/Yahoo), never GDELT.
+        df = _articles_df([
+            _aggregated(fingerprint="g", sources=("gdelt",),
+                        title="GDELT false positive", url="https://x/g"),
+            _aggregated(fingerprint="p", sources=("polygon",),
+                        title="Polygon real", url="https://x/p"),
+        ])
+        d = build_digest(articles_df=df, topics={}, digest_date=date(2026, 5, 13))
+        titles = [e["title"] for e in d["sections"]["portfolio"]]
+        assert "Polygon real" in titles
+        assert "GDELT false positive" not in titles
+        assert all(e["source"].lower() != "gdelt" for e in d["sections"]["portfolio"])
+
+    def test_portfolio_all_gdelt_yields_empty(self):
+        df = _articles_df([
+            _aggregated(fingerprint="g1", sources=("gdelt",), title="noise1", url="https://x/g1"),
+            _aggregated(fingerprint="g2", sources=("gdelt",), title="noise2", url="https://x/g2"),
+        ])
+        d = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))
+        assert d["sections"]["portfolio"] == []
+        assert len(d["sections"]["macro"]) == 1  # topics unaffected
+
     def test_empty_articles_empty_portfolio(self):
         df = _articles_df([])
         d = build_digest(articles_df=df, topics=_TOPICS, digest_date=date(2026, 5, 13))

--- a/tests/test_topic_news.py
+++ b/tests/test_topic_news.py
@@ -50,7 +50,8 @@ class _FakeFeedparser:
         self._by_url = by_url
         self.calls: list[str] = []
 
-    def parse(self, url):
+    def parse(self, url, **kwargs):
+        # Accept feedparser's optional kwargs (e.g. agent=) like the real API.
         self.calls.append(url)
         val = self._by_url.get(url)
         if isinstance(val, Exception):


### PR DESCRIPTION
## What
Fixes two data-quality problems caught by live verification of the news digest (the morning-signal consumer was disabled pending this — config#1087):

1. **Portfolio: exclude GDELT.** 19/30 portfolio items were GDELT false positives (it keyword-matches ticker fragments — `meta-analysis`→META, `MDT`→unrelated). The portfolio section now uses only ticker-accurate sources (Polygon API-tagged + Yahoo per-ticker RSS). GDELT remains valid for the macro/tech topic sections.
2. **Macro: fresh, high-frequency feeds.** CNBC "Economy" (20910258) + MarketWatch MarketPulse are low-frequency topical feeds whose newest items lag 3+ days → 0 within the 24h lookback. Swapped to CNBC "Top News" (~29 fresh/24h, markets/econ) + CNBC Finance + NPR. Live-verified: macro now returns 15 fresh on-topic items ("Oil prices fall 5%", "Trump giving Warsh room to reshape the Fed").
   - Also: **feedparser's default UA is rejected by CNBC** (returns 0 entries) — `_fetch_feed` now passes a browser `agent=`.

Tech feeds unchanged (already clean). Tests: +2 portfolio-GDELT-exclusion tests; mock feedparser accepts `agent=`. 43 affected tests pass (incl. artifact-registry coverage).

Closes config#1087. After merge → box pulls → re-enable `news_context` in the morning-signal SSM config → verify on the next 04:00 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)