### PR TITLE
chore: repoint GitHub refs after nousergon rename

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install alpha-engine-lib for deploy.sh alerts call
-        run: pip install "alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.26.0"
+        run: pip install "alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.26.0"
 
       - name: Deploy Phase 2 Lambda (alpha-engine-data-collector)
         working-directory: alpha-engine-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.59.4" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This repo is **public**. `config.yaml` is gitignored locally; real values (S3 bu
 | Predictor | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) |
 | Backtester | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) |
 | Dashboard | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) |
-| Library | [`alpha-engine-lib`](https://github.com/cipher813/alpha-engine-lib) |
+| Library | [`alpha-engine-lib`](https://github.com/nousergon/nousergon-lib) |
 | Docs | [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) |
 
 ## License

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -31,7 +31,7 @@ ECR_REPO="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${FUNCTION_NAME}"
 echo "=== Building container image for $FUNCTION_NAME ==="
 
 # alpha-engine-lib is installed inside the Dockerfile via pip from
-# git+https://github.com/cipher813/alpha-engine-lib@v0.3.0 (public repo
+# git+https://github.com/nousergon/nousergon-lib@v0.3.0 (public repo
 # since 2026-05-03). No vendor staging needed.
 
 docker build --platform linux/amd64 --provenance=false -t "$FUNCTION_NAME:latest" .

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.20.0

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,5 +1,5 @@
 # Pinned to alpha-engine-lib v0.40.0 (the artifact_freshness substrate
 # was introduced here). Bumping this is a substrate-change PR — not
 # something to do absent-mindedly during a code-only refresh.
-alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.40.0
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.40.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.20.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -6,4 +6,4 @@
 # Pinned to match sf-telegram-notifier + eod-success-friday-shell-trigger
 # sibling Lambdas; keeping the pin coherent across sibling Lambdas avoids
 # divergence on lib-side helpers.
-alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.28.1
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.28.1

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match alpha-engine-data/requirements.txt — the main data Lambda
 # already runs on this version, so reusing it keeps the lib substrate
 # coherent across all alpha-engine-data Lambdas.
-alpha-engine-lib @ git+https://github.com/cipher813/alpha-engine-lib@v0.20.0
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.20.0

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -497,7 +497,7 @@ dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null
     dnf install -y -q python3 python3-pip python3-devel git gcc
 echo "Using: \$(\$PYTHON_BIN --version)"
 
-git clone --depth 1 --branch ${BRANCH} https://github.com/cipher813/alpha-engine-data.git /home/ec2-user/alpha-engine-data
+git clone --depth 1 --branch ${BRANCH} https://github.com/nousergon/nousergon-data.git /home/ec2-user/alpha-engine-data
 
 mkdir -p /home/ec2-user/alpha-engine-config/data
 aws s3 cp ${S3_STAGING}/config.yaml /home/ec2-user/alpha-engine-config/data/config.yaml --region ${AWS_REGION} --quiet

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0
 anyio>=4.0
 tenacity>=8.0
 pyyaml>=6.0
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.59.4
+alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag,contracts] @ git+https://github.com/cipher813/alpha-engine-lib@v0.59.4
+alpha-engine-lib[arcticdb,flow_doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -32,10 +32,10 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 _REQUIREMENTS_PIN_RE = re.compile(
-    r"alpha-engine-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/cipher813/alpha-engine-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"
+    r"alpha-engine-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/nousergon/nousergon-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"
 )
 _DOCKERFILE_PIN_RE = re.compile(
-    r'"alpha-engine-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/cipher813/alpha-engine-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"'
+    r'"alpha-engine-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/nousergon/nousergon-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"'
 )
 
 


### PR DESCRIPTION
Repoints the alpha-engine-lib pin URL across requirements/Dockerfile/deploy.yml/5 lambda requirements + the spot_data_weekly clone URL to the renamed nousergon repos, and updates the lockstep regex. config#1097.