### PR TITLE
chore: repoint remaining GitHub refs to nousergon (flow-doctor + deploy workflows)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Append to system-wide deploy changelog
         if: always()
-        uses: cipher813/alpha-engine-docs/.github/actions/append-changelog@main
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
         with:
           deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
           deploy_workflow: deploy-infrastructure.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Append to system-wide deploy changelog
         if: always()
-        uses: cipher813/alpha-engine-docs/.github/actions/append-changelog@main
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
         with:
           deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
           deploy_workflow: deploy.yml

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,6 +1,6 @@
 # alpha-engine-data — Code Index
 
-> Index of entry points, key files, and data contracts. Companion to [README.md](README.md). System overview lives in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs).
+> Index of entry points, key files, and data contracts. Companion to [README.md](README.md). System overview lives in [`alpha-engine-docs`](https://github.com/nousergon/nousergon-docs).
 
 ## Module purpose
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![ArcticDB](https://img.shields.io/badge/ArcticDB-0e1117?style=flat-square)](https://docs.arcticdb.io/)
 [![Polygon.io](https://img.shields.io/badge/Polygon.io-1a73e8?style=flat-square)](https://polygon.io/)
 [![License: AGPL-3.0-only](https://img.shields.io/badge/License-AGPL--3.0--only-yellow?style=flat-square)](LICENSE)
-[![Phase 2 · Reliability](https://img.shields.io/badge/Phase_2-Reliability-e9c46a?style=flat-square)](https://github.com/cipher813/alpha-engine-docs#phase-trajectory)
+[![Phase 2 · Reliability](https://img.shields.io/badge/Phase_2-Reliability-e9c46a?style=flat-square)](https://github.com/nousergon/nousergon-docs#phase-trajectory)
 
 Centralized data collection, storage, and distribution. Owns the price universe (ArcticDB), macro indicators, universe returns, the engineered feature store, the RAG ingestion step, and per-ticker alternative data.
 
-> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs). Code index lives in [`OVERVIEW.md`](OVERVIEW.md).
+> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/nousergon/nousergon-docs). Code index lives in [`OVERVIEW.md`](OVERVIEW.md).
 
 ## What this does
 
@@ -49,19 +49,19 @@ Quality gates run automatically after each refresh: OHLC ordering, zero-price, e
 
 ## Configuration
 
-This repo is **public**. `config.yaml` is gitignored locally; real values (S3 bucket names, API keys, email recipients) live in the private [`alpha-engine-config`](https://github.com/cipher813/alpha-engine-config) repo. Architecture and approach are public; specific values are private.
+This repo is **public**. `config.yaml` is gitignored locally; real values (S3 bucket names, API keys, email recipients) live in the private [`alpha-engine-config`](https://github.com/nousergon/alpha-engine-config) repo. Architecture and approach are public; specific values are private.
 
 ## Sister repos
 
 | Module | Repo |
 |---|---|
-| Executor | [`alpha-engine`](https://github.com/cipher813/alpha-engine) |
-| Research | [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) |
-| Predictor | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) |
-| Backtester | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) |
-| Dashboard | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) |
+| Executor | [`alpha-engine`](https://github.com/nousergon/crucible-executor) |
+| Research | [`alpha-engine-research`](https://github.com/nousergon/crucible-research) |
+| Predictor | [`alpha-engine-predictor`](https://github.com/nousergon/crucible-predictor) |
+| Backtester | [`alpha-engine-backtester`](https://github.com/nousergon/crucible-backtester) |
+| Dashboard | [`alpha-engine-dashboard`](https://github.com/nousergon/crucible-dashboard) |
 | Library | [`alpha-engine-lib`](https://github.com/nousergon/nousergon-lib) |
-| Docs | [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) |
+| Docs | [`alpha-engine-docs`](https://github.com/nousergon/nousergon-docs) |
 
 ## License
 

--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -1,5 +1,5 @@
 flow_name: data-collector
-repo: cipher813/alpha-engine-data
+repo: nousergon/nousergon-data
 owner: "@brianmcmahon"
 notify:
   - type: email
@@ -9,7 +9,7 @@ notify:
     smtp_port: 587
     smtp_password: ${GMAIL_APP_PASSWORD}
   - type: github
-    repo: cipher813/alpha-engine-data
+    repo: nousergon/nousergon-data
     token: ${FLOW_DOCTOR_GITHUB_TOKEN}
     # 0.6.0rc2 soak: file an issue on failure (default) AND auto-apply the
     # flow-doctor:fix label so the flow-doctor-fix workflow generates a fix

--- a/flow-doctor.yaml.example
+++ b/flow-doctor.yaml.example
@@ -11,7 +11,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 flow_name: data-collector
-repo: cipher813/alpha-engine-data
+repo: nousergon/nousergon-data
 owner: "@brianmcmahon"
 notify:
   - type: email
@@ -21,7 +21,7 @@ notify:
     smtp_port: 587
     smtp_password: ${GMAIL_APP_PASSWORD}
   - type: github
-    repo: cipher813/alpha-engine-data
+    repo: nousergon/nousergon-data
     token: ${FLOW_DOCTOR_GITHUB_TOKEN}
 store:
   type: sqlite

--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -6,7 +6,7 @@
 # Phase 3 of the artifact-freshness-monitor arc (plan doc at
 # ~/Development/alpha-engine-docs/private/artifact-freshness-monitor-260527.md).
 # Loads `private-docs/ARTIFACT_REGISTRY.yaml` from the operator's local
-# clone of cipher813/alpha-engine-config and uploads it to
+# clone of nousergon/alpha-engine-config and uploads it to
 # s3://alpha-engine-research/_freshness_monitor/ARTIFACT_REGISTRY.yaml.
 # Validates the registry locally before upload — a malformed registry
 # never reaches S3.
@@ -77,7 +77,7 @@ print('index.py syntax OK')
 
 if [[ ! -f "${REGISTRY_LOCAL}" ]]; then
   echo "❌ Registry not found at ${REGISTRY_LOCAL}"
-  echo "   Clone cipher813/alpha-engine-config into ~/Development/ or set CONFIG_REPO"
+  echo "   Clone nousergon/alpha-engine-config into ~/Development/ or set CONFIG_REPO"
   exit 1
 fi
 

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -172,7 +172,7 @@ class TestFlowDoctorYamlSchema:
         for key in ("flow_name", "repo", "notify", "store", "rate_limits"):
             assert key in cfg, f"missing top-level key: {key}"
         assert cfg["flow_name"] == "data-collector"
-        assert cfg["repo"] == "cipher813/alpha-engine-data"
+        assert cfg["repo"] == "nousergon/nousergon-data"
 
     def test_yaml_has_email_and_github_notify_channels(self):
         import yaml


### PR DESCRIPTION
Repoint remaining stale GitHub-repo references after the org/repo rename (`cipher813/alpha-engine-*` -> `nousergon/*`).

## Changes
- `flow-doctor.yaml` + `flow-doctor.yaml.example`: `repo` slug `cipher813/alpha-engine-data` -> `nousergon/nousergon-data` (top-level + github notify channel)
- `tests/test_flow_doctor_wiring.py`: coupled `cfg["repo"]` assertion
- `.github/workflows/deploy.yml` + `deploy-infrastructure.yml`: `append-changelog` action -> `nousergon/nousergon-docs`
- `infrastructure/lambdas/freshness-monitor/deploy.sh`: config clone slug -> `nousergon/alpha-engine-config`
- `README.md` + `OVERVIEW.md`: sister-repo / docs links per rename map

## Not touched (per instructions)
- S3 bucket `alpha-engine-research` (boto3/`s3://`/`bucket:` strings)
- IAM role / Lambda / SF / ECR names
- `alpha_engine_lib` import path; lib pins (repointed in a prior PR)
- Local dir paths (`~/Development/alpha-engine-config`)

## Test
`tests/test_flow_doctor_wiring.py` — 14 passed (run with project venv python; the coupled flow-doctor repo-slug assertion is green).

Refs config#1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
