### PR TITLE
fix(eod-sf): split slow daily_append into its own PostMarketArcticAppend state

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -64,7 +64,7 @@
     },
     "PostMarketData": {
       "Type": "Task",
-      "Comment": "Capture today's closing prices via yfinance + append to ArcticDB (runs on ae-trading). Hard-fails on non-zero exit via pipefail so tee does not mask python failures.",
+      "Comment": "Capture today's closing prices via yfinance + compute the feature-store snapshot (runs on ae-trading). The slow ArcticDB daily_append is split out into the separate PostMarketArcticAppend state (2026-06-16) — mirrors the weekday MorningEnrich + MorningArcticAppend split (L4608) — because the monolithic --daily run exceeded the 1200s SSM executionTimeout mid-append on 2026-06-16 → SIGKILL → whole EOD pipeline failed. Hard-fails on non-zero exit via pipefail so tee does not mask python failures.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -76,13 +76,13 @@
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/postmarket-data.log \"s3://alpha-engine-research/_ssm_logs/postmarket-data/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "python weekly_collector.py --daily 2>&1 | tee /var/log/postmarket-data.log"
+            "python weekly_collector.py --daily --skip-arctic-append 2>&1 | tee /var/log/postmarket-data.log"
           ],
-          "executionTimeout": ["1200"]
+          "executionTimeout": ["1800"]
         },
-        "TimeoutSeconds": 1200
+        "TimeoutSeconds": 1800
       },
-      "TimeoutSeconds": 1260,
+      "TimeoutSeconds": 1860,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],
@@ -134,7 +134,7 @@
       "Type": "Choice",
       "Comment": "Default routes to HandleFailure so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed.",
       "Choices": [
-        { "Variable": "$.postmarket_poll.Status", "StringEquals": "Success", "Next": "CheckSkipCaptureSnapshot" },
+        { "Variable": "$.postmarket_poll.Status", "StringEquals": "Success", "Next": "CheckSkipPostMarketArcticAppend" },
         { "Variable": "$.postmarket_poll.Status", "StringEquals": "InProgress", "Next": "PostMarketWait" },
         { "Variable": "$.postmarket_poll.Status", "StringEquals": "Pending", "Next": "PostMarketWait" },
         { "Variable": "$.postmarket_poll.Status", "StringEquals": "Delayed", "Next": "PostMarketWait" }
@@ -159,6 +159,110 @@
       "Type": "Wait",
       "Seconds": 15,
       "Next": "WaitForPostMarketData"
+    },
+    "CheckSkipPostMarketArcticAppend": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate. Input {\"skip_post_market_arctic_append\": true} routes past PostMarketArcticAppend to the next gate (CheckSkipCaptureSnapshot); missing flag = run as normal. The slow ArcticDB daily_append was split out of PostMarketData 2026-06-16 (mirrors the weekday MorningArcticAppend split, L4608) — as its own state it gets a longer timeout decoupled from the feature compute, and a recovery rerun can skip whichever half already completed. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.skip_post_market_arctic_append", "IsPresent": true},
+            {"Variable": "$.skip_post_market_arctic_append", "BooleanEquals": true}
+          ],
+          "Next": "CheckSkipCaptureSnapshot"
+        }
+      ],
+      "Default": "PostMarketArcticAppend"
+    },
+    "PostMarketArcticAppend": {
+      "Type": "Task",
+      "Comment": "LOAD-BEARING: ArcticDB universe daily_append for today's post-market closes — writes the OHLCV row + recomputed features that EOD reconcile + predictor inference read next. Split out of PostMarketData 2026-06-16: the append is the slow part and the monolithic --daily run exceeded PostMarketData's 1200s executionTimeout mid-append → SIGKILL → whole EOD pipeline failed (no reconcile, no EOD email). Own longer timeout (2400s) decoupled from the feature compute; reads the daily_closes PostMarketData just wrote. Failure → HandleFailure. Hard-fails on non-zero exit via pipefail so tee does not mask python failures.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -o pipefail",
+            "cd /home/ec2-user/alpha-engine-data",
+            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "source .venv/bin/activate",
+            "trap 'aws s3 cp /var/log/postmarket-arctic-append.log \"s3://alpha-engine-research/_ssm_logs/postmarket-arctic-append/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
+            "python weekly_collector.py --daily-arctic-append 2>&1 | tee /var/log/postmarket-arctic-append.log"
+          ],
+          "executionTimeout": ["2400"]
+        },
+        "TimeoutSeconds": 2400
+      },
+      "TimeoutSeconds": 2460,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Hard-fail: EOD reconcile + predictor read the ArcticDB universe next. Don't paper over an append failure.",
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.postmarket_arctic_result",
+      "Next": "WaitForPostMarketArcticAppend"
+    },
+    "WaitForPostMarketArcticAppend": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.postmarket_arctic_result.Command.CommandId",
+        "InstanceId.$": "$.trading_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.postmarket_arctic_poll",
+      "Next": "CheckPostMarketArcticAppendStatus"
+    },
+    "CheckPostMarketArcticAppendStatus": {
+      "Type": "Choice",
+      "Comment": "LOAD-BEARING like CheckPostMarketStatus: only Success proceeds (to CaptureSnapshot); any other terminal SSM status → HandleFailure (reconcile must not run on a stale ArcticDB universe). Only InProgress/Pending/Delayed keep polling.",
+      "Choices": [
+        { "Variable": "$.postmarket_arctic_poll.Status", "StringEquals": "Success", "Next": "CheckSkipCaptureSnapshot" },
+        { "Variable": "$.postmarket_arctic_poll.Status", "StringEquals": "InProgress", "Next": "PostMarketArcticAppendWait" },
+        { "Variable": "$.postmarket_arctic_poll.Status", "StringEquals": "Pending", "Next": "PostMarketArcticAppendWait" },
+        { "Variable": "$.postmarket_arctic_poll.Status", "StringEquals": "Delayed", "Next": "PostMarketArcticAppendWait" }
+      ],
+      "Default": "PostMarketArcticAppendStatusError"
+    },
+    "PostMarketArcticAppendStatusError": {
+      "Type": "Pass",
+      "Comment": "Choice Default path — synthesize $.error from poll result so HandleFailure's JsonToString($.error) has something to stringify.",
+      "Parameters": {
+        "source": "post_market_arctic_append_status",
+        "status.$": "$.postmarket_arctic_poll.Status",
+        "status_details.$": "$.postmarket_arctic_poll.StatusDetails",
+        "response_code.$": "$.postmarket_arctic_poll.ResponseCode",
+        "command_id.$": "$.postmarket_arctic_poll.CommandId",
+        "instance_id.$": "$.postmarket_arctic_poll.InstanceId"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "PostMarketArcticAppendWait": {
+      "Type": "Wait",
+      "Seconds": 20,
+      "Next": "WaitForPostMarketArcticAppend"
     },
     "CaptureSnapshot": {
       "Type": "Task",
@@ -419,14 +523,14 @@
     },
     "CheckSkipPostMarketData": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4607). Input {\"skip_post_market_data\": true} routes past PostMarketData to the next gate (CheckSkipCaptureSnapshot); missing flag = run as normal. Mirrors the Saturday SF CheckSkip<State> structure so the EOD pipeline is rerunnable task-by-task — an operator recovery rerun resumes at the first incomplete task instead of re-running completed upstream work (e.g. an EODReconcile failure rerun should not re-run PostMarketData + CaptureSnapshot). Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Comment": "Per-task rerun gate (L4607). Input {\"skip_post_market_data\": true} routes past PostMarketData to the next gate (CheckSkipPostMarketArcticAppend); missing flag = run as normal. Mirrors the Saturday SF CheckSkip<State> structure so the EOD pipeline is rerunnable task-by-task — an operator recovery rerun resumes at the first incomplete task instead of re-running completed upstream work (e.g. an EODReconcile failure rerun should not re-run PostMarketData + CaptureSnapshot). Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_post_market_data", "IsPresent": true},
             {"Variable": "$.skip_post_market_data", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipCaptureSnapshot"
+          "Next": "CheckSkipPostMarketArcticAppend"
         }
       ],
       "Default": "PostMarketData"

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -22,8 +22,12 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_eod.json"
 
 # (gate, task, skip_flag, next_after_skip) in pipeline order.
+# PostMarketArcticAppend was split out of PostMarketData 2026-06-16 (the slow
+# daily_append, mirroring the weekday MorningArcticAppend split L4608) — it gets
+# its own skip-gate so a recovery rerun can skip whichever half already completed.
 _CHAIN = [
-    ("CheckSkipPostMarketData", "PostMarketData", "skip_post_market_data", "CheckSkipCaptureSnapshot"),
+    ("CheckSkipPostMarketData", "PostMarketData", "skip_post_market_data", "CheckSkipPostMarketArcticAppend"),
+    ("CheckSkipPostMarketArcticAppend", "PostMarketArcticAppend", "skip_post_market_arctic_append", "CheckSkipCaptureSnapshot"),
     ("CheckSkipCaptureSnapshot", "CaptureSnapshot", "skip_capture_snapshot", "CheckSkipEODReconcile"),
     ("CheckSkipEODReconcile", "EODReconcile", "skip_eod_reconcile", "CheckSkipDailySubstrateHealthCheck"),
     ("CheckSkipDailySubstrateHealthCheck", "DailySubstrateHealthCheck", "skip_daily_substrate_health_check", "StopTradingInstance"),
@@ -56,8 +60,13 @@ class TestEntryEdgesRouteThroughGates:
                     if "States.ALL" in c["ErrorEquals"]]
         assert failopen == ["CheckSkipPostMarketData"]
 
-    def test_post_market_success_enters_snapshot_gate(self, states):
+    def test_post_market_success_enters_arctic_append_gate(self, states):
         succ = [c["Next"] for c in states["CheckPostMarketStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["CheckSkipPostMarketArcticAppend"]
+
+    def test_arctic_append_success_enters_snapshot_gate(self, states):
+        succ = [c["Next"] for c in states["CheckPostMarketArcticAppendStatus"]["Choices"]
                 if c.get("StringEquals") == "Success"]
         assert succ == ["CheckSkipCaptureSnapshot"]
 
@@ -107,8 +116,15 @@ class TestPaths:
         # Cost-guard cleanup must ALWAYS run.
         assert order == ["StopTradingInstance"]
 
-    def test_skip_post_market_resumes_at_snapshot(self, states):
+    def test_skip_post_market_resumes_at_arctic_append(self, states):
         order = self._walk(states, skip_flags={"skip_post_market_data"})
         assert "PostMarketData" not in order
+        assert order[0] == "PostMarketArcticAppend"
+        assert order[-1] == "StopTradingInstance"
+
+    def test_skip_post_market_and_arctic_append_resumes_at_snapshot(self, states):
+        order = self._walk(states, skip_flags={"skip_post_market_data", "skip_post_market_arctic_append"})
+        assert "PostMarketData" not in order
+        assert "PostMarketArcticAppend" not in order
         assert order[0] == "CaptureSnapshot"
         assert order[-1] == "StopTradingInstance"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -403,6 +403,11 @@ class TestEODSFTopLevelFieldsClosed:
             "force_stop_result",
             "postmarket_poll",
             "postmarket_result",
+            # PostMarketArcticAppend (2026-06-16) — slow daily_append split out
+            # of PostMarketData into its own state (mirrors MorningArcticAppend
+            # L4608); emits its own send/poll ResultPaths.
+            "postmarket_arctic_poll",
+            "postmarket_arctic_result",
             "snapshot_poll",
             "snapshot_result",
             "stop_result",
@@ -422,6 +427,7 @@ class TestEODSFTopLevelFieldsClosed:
             # optional boolean skip flag from the execution input so an
             # operator recovery rerun can resume at the first incomplete task.
             "skip_post_market_data",
+            "skip_post_market_arctic_append",
             "skip_capture_snapshot",
             "skip_eod_reconcile",
             "skip_daily_substrate_health_check",

--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -831,6 +831,75 @@ def test_arctic_append_runs_daily_append_and_is_load_bearing():
     assert bad["status"] == "failed"
 
 
+# ── EOD daily_append split: PostMarketData + PostMarketArcticAppend (2026-06-16) ──
+
+
+def test_daily_arctic_append_routes_via_run_weekly():
+    """run_weekly must dispatch --daily-arctic-append to _run_daily_arctic_append."""
+    args = SimpleNamespace(
+        morning_enrich=False, morning_arctic_append=False,
+        daily_arctic_append=True, chronic_gap_heal=False, daily=False,
+    )
+    with patch("weekly_collector._run_daily_arctic_append",
+               return_value={"status": "ok", "mode": "daily_arctic_append"}) as ap:
+        out = weekly_collector.run_weekly({"bucket": "b"}, args)
+    ap.assert_called_once()
+    assert out["mode"] == "daily_arctic_append"
+
+
+def test_daily_skip_arctic_append_does_not_append():
+    """--daily --skip-arctic-append (EOD PostMarketData) suppresses the inline
+    daily_append — the separate PostMarketArcticAppend SF state runs it instead."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(
+        date="2026-06-16", dry_run=True, morning_enrich=False,
+        daily=True, only=None, skip_arctic_append=True,
+    )
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL"]}
+    append_calls = []
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("weekly_collector.daily_closes.collect",
+               return_value={"status": "ok_dry_run", "polygon": 0, "fred": 4,
+                             "yfinance": 1, "tickers_captured": 5, "source": "yfinance_only"}), \
+         patch("features.compute.compute_and_write", return_value={"status": "ok"}), \
+         patch("builders.daily_append.daily_append",
+               side_effect=lambda **k: append_calls.append(k) or {"status": "ok"}):
+        result = weekly_collector._run_daily(config, args)
+    assert append_calls == [], "daily_append must not run inline when --skip-arctic-append"
+    assert "arcticdb" not in result["collectors"]
+
+
+def test_daily_arctic_append_runs_daily_append_with_skip_if_exists_and_is_load_bearing():
+    """_run_daily_arctic_append runs daily_append for today's date with
+    skip_if_exists=True (cheap reruns) and returns failed (load-bearing) on error."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    args = SimpleNamespace(date="2026-06-16", dry_run=False)
+    fake_constituents = MagicMock()
+    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL", "MSFT"]}
+
+    calls = []
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.daily_append.daily_append",
+               side_effect=lambda **k: calls.append(k) or {"status": "ok"}):
+        ok = weekly_collector._run_daily_arctic_append(config, args)
+    assert ok["status"] == "ok" and ok["mode"] == "daily_arctic_append"
+    assert calls and calls[0]["date_str"] == "2026-06-16"
+    assert calls[0]["skip_if_exists"] is True, (
+        "EOD append must keep skip_if_exists=True so an operator rerun "
+        "short-circuits tickers whose row already landed (matches the inline "
+        "block it was split out of)."
+    )
+    # macro daily tickers must be in the expected_tickers scope (same as _run_daily)
+    assert "SPY" in calls[0]["expected_tickers"]
+
+    # load-bearing: append raises → failed
+    with patch("weekly_collector.constituents", fake_constituents), \
+         patch("builders.daily_append.daily_append", side_effect=RuntimeError("boom")):
+        bad = weekly_collector._run_daily_arctic_append(config, args)
+    assert bad["status"] == "failed"
+
+
 # ── chronic-gap heal hard timeout (L4605) ───────────────────────────────────
 
 

--- a/tests/test_weekly_collector_preflight_mode_mapping.py
+++ b/tests/test_weekly_collector_preflight_mode_mapping.py
@@ -68,9 +68,13 @@ def test_morning_enrich_not_mapped_to_daily():
 
 
 def test_daily_mode_mapping_unchanged():
-    """The genuine --daily weekday path still maps to 'daily' (we only
-    repointed --morning-enrich)."""
+    """The genuine --daily weekday path still maps to 'daily'. The EOD split
+    (2026-06-16) also routes --daily-arctic-append through the same 'daily'
+    preflight (it reads daily_closes + the ArcticDB universe — same surface)."""
     src = _main_source()
-    assert "elif args.daily:" in src
-    after = src[src.index("elif args.daily:"):]
-    assert 'mode = "daily"' in after.split("else:")[0]
+    assert "elif args.daily" in src
+    after = src[src.index("elif args.daily"):]
+    branch = after.split("else:")[0]
+    assert 'mode = "daily"' in branch
+    # The split-out append state shares the daily preflight surface.
+    assert 'daily_arctic_append' in branch

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -224,6 +224,9 @@ def run_weekly(config: dict, args: argparse.Namespace) -> dict:
     if getattr(args, "morning_arctic_append", False):
         return _run_morning_arctic_append(config, args)
 
+    if getattr(args, "daily_arctic_append", False):
+        return _run_daily_arctic_append(config, args)
+
     if getattr(args, "chronic_gap_heal", False):
         return _run_chronic_gap_heal(config, args)
 
@@ -1641,6 +1644,49 @@ def _run_chronic_gap_heal(config: dict, args: argparse.Namespace) -> dict:
     return results
 
 
+# Macro symbols are not S&P constituents but are core daily predictor inputs
+# (vix_level, vix_term_slope, yield_10y, yield_curve_slope, sector-relative
+# features). Appending them lets builders/daily_append.py update the ArcticDB
+# macro library every weekday — pre-ArcticDB, the predictor Lambda fetched these
+# from yfinance on each run; post-migration, the write path moved here. ETFs
+# come from polygon; indices (^-prefix) fall through to FRED then yfinance in
+# daily_closes.collect. Shared by the EOD --daily collector and the split-out
+# --daily-arctic-append state so both pass daily_append the SAME expected_tickers.
+_MACRO_DAILY_TICKERS = [
+    "SPY", "GLD", "USO",
+    "XLB", "XLC", "XLE", "XLF", "XLI", "XLK",
+    "XLP", "XLRE", "XLU", "XLV", "XLY",
+    "^VIX", "^VIX3M", "^TNX", "^IRX",
+]
+
+
+def _load_daily_universe_tickers(config: dict) -> list[str]:
+    """Load the daily universe (S3 constituents → Wikipedia fallback) plus the
+    macro daily tickers. Shared by :func:`_run_daily` and
+    :func:`_run_daily_arctic_append` so a split EOD run (PostMarketData computes,
+    PostMarketArcticAppend appends) feeds daily_append the identical
+    expected-ticker scope. Returns ``[]`` when no constituents are resolvable —
+    callers treat that as a hard failure."""
+    tickers: list[str] = []
+    market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
+    try:
+        existing = constituents.load_from_s3(config["bucket"], market_prefix)
+        if existing:
+            tickers = existing.get("tickers", [])
+            logger.info("Loaded %d tickers from S3 constituents", len(tickers))
+    except Exception as exc:
+        logger.warning("S3 constituents load failed — will try Wikipedia fallback: %s", exc)
+    if not tickers:
+        try:
+            tickers, _, _, _, _ = constituents._fetch_constituents()
+            logger.info("Loaded %d tickers from Wikipedia (S3 fallback)", len(tickers))
+        except Exception as exc:
+            logger.error("Wikipedia constituents fallback failed: %s", exc)
+    if not tickers:
+        return []
+    return list(dict.fromkeys(tickers + _MACRO_DAILY_TICKERS))
+
+
 def _run_daily(config: dict, args: argparse.Namespace) -> dict:
     """Daily mode: capture today's OHLCV closes for all tracked tickers."""
     bucket = config["bucket"]
@@ -1656,42 +1702,11 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
         "collectors": {},
     }
 
-    # Load tickers: S3 constituents → Wikipedia fallback
-    tickers: list[str] = []
-    market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
-    try:
-        existing = constituents.load_from_s3(bucket, market_prefix)
-        if existing:
-            tickers = existing.get("tickers", [])
-            logger.info("Loaded %d tickers from S3 constituents", len(tickers))
-    except Exception as exc:
-        logger.warning("S3 constituents load failed — will try Wikipedia fallback: %s", exc)
-    if not tickers:
-        try:
-            tickers, _, _, _, _ = constituents._fetch_constituents()
-            logger.info("Loaded %d tickers from Wikipedia (S3 fallback)", len(tickers))
-        except Exception as exc:
-            logger.error("Wikipedia constituents fallback failed: %s", exc)
-
+    tickers = _load_daily_universe_tickers(config)
     if not tickers:
         logger.error("No tickers available for daily closes")
         results["status"] = "failed"
         return results
-
-    # Macro symbols are not S&P constituents but are core daily predictor inputs
-    # (vix_level, vix_term_slope, yield_10y, yield_curve_slope, sector-relative
-    # features). Appending them here lets builders/daily_append.py update the
-    # ArcticDB macro library every weekday — pre-ArcticDB, the predictor Lambda
-    # fetched these from yfinance on each run; post-migration, the write path
-    # moved here. ETFs come from polygon; indices (^-prefix) fall through to
-    # FRED then yfinance in daily_closes.collect.
-    MACRO_DAILY_TICKERS = [
-        "SPY", "GLD", "USO",
-        "XLB", "XLC", "XLE", "XLF", "XLI", "XLK",
-        "XLP", "XLRE", "XLU", "XLV", "XLY",
-        "^VIX", "^VIX3M", "^TNX", "^IRX",
-    ]
-    tickers = list(dict.fromkeys(tickers + MACRO_DAILY_TICKERS))
 
     logger.info("=" * 60)
     logger.info("COLLECTING: daily closes")
@@ -1811,23 +1826,34 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
     # that timed out the 2026-05-01 EOD SF rerun at the SSM 1200s ceiling).
     # MorningEnrich runs (_run_morning_enrich, polygon source) leave the
     # default False so polygon's true VWAP overwrites yfinance's NaN.
-    logger.info("=" * 60)
-    logger.info("APPENDING: ArcticDB universe (daily)")
-    logger.info("=" * 60)
-    from builders.daily_append import daily_append
-    # supports_auto_skip=False: ArcticDB write (no S3 key) + already cheap on
-    # re-run via skip_if_exists=True → markers + watchdog only.
-    results["collectors"]["arcticdb"] = _phase_collect(
-        reg, "arcticdb",
-        lambda: daily_append(
-            date_str=run_date,
-            bucket=bucket,
-            dry_run=dry_run,
-            skip_if_exists=True,
-            expected_tickers=tickers,
-        ),
-        supports_auto_skip=False,
-    )
+    #
+    # --skip-arctic-append: the EOD SF runs the slow daily_append as its own
+    # load-bearing PostMarketArcticAppend state (longer timeout decoupled from
+    # the feature compute), exactly mirroring the weekday MorningEnrich +
+    # MorningArcticAppend split (L4608). Without the flag (the Saturday DataPhase
+    # path) the append still runs inline here. 2026-06-16: the monolithic
+    # --daily run exceeded PostMarketData's 1200s SSM ceiling mid-append → SIGKILL.
+    if getattr(args, "skip_arctic_append", False):
+        logger.info("Skipping inline ArcticDB append (--skip-arctic-append; "
+                    "runs as the EOD SF PostMarketArcticAppend state)")
+    else:
+        logger.info("=" * 60)
+        logger.info("APPENDING: ArcticDB universe (daily)")
+        logger.info("=" * 60)
+        from builders.daily_append import daily_append
+        # supports_auto_skip=False: ArcticDB write (no S3 key) + already cheap on
+        # re-run via skip_if_exists=True → markers + watchdog only.
+        results["collectors"]["arcticdb"] = _phase_collect(
+            reg, "arcticdb",
+            lambda: daily_append(
+                date_str=run_date,
+                bucket=bucket,
+                dry_run=dry_run,
+                skip_if_exists=True,
+                expected_tickers=tickers,
+            ),
+            supports_auto_skip=False,
+        )
 
     results["completed_at"] = datetime.now(timezone.utc).isoformat()
 
@@ -1853,6 +1879,77 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
                 ", ".join(f"{k}={v.get('status', '?')}" for k, v in results["collectors"].items()),
                 duration)
 
+    return results
+
+
+def _run_daily_arctic_append(config: dict, args: argparse.Namespace) -> dict:
+    """Standalone ArcticDB universe append for the EOD post-market path.
+
+    The daily/EOD twin of :func:`_run_morning_arctic_append`. Split out of
+    :func:`_run_daily` (2026-06-16) into its own EOD-SF state
+    (``PostMarketArcticAppend``): the monolithic ``--daily`` run does
+    daily_closes + metron collectors + feature-store compute + the SLOW
+    ``daily_append`` in one shot, and on 2026-06-16 it exceeded PostMarketData's
+    1200s SSM ``executionTimeout`` mid-append → SIGKILL → the whole EOD pipeline
+    failed (no reconcile, no EOD email). As its own state the append gets a
+    longer timeout decoupled from the feature compute, exactly mirroring the
+    weekday MorningEnrich + MorningArcticAppend split (L4608).
+
+    LOAD-BEARING: EOD reconcile + predictor inference read the ArcticDB universe
+    after this, so an append failure returns ``status="failed"`` → ``main()``
+    exits 1 → the SF's ``CheckPostMarketArcticAppendStatus`` routes to
+    HandleFailure.
+
+    Targets the same date as :func:`_run_daily` (today's UTC date, or ``--date``)
+    and passes ``skip_if_exists=True`` so an operator rerun short-circuits
+    tickers whose row already landed — identical semantics to the inline block
+    it replaces (the Saturday DataPhase path still appends inline via
+    ``--daily`` without ``--skip-arctic-append``). PostMarketData writes today's
+    daily_closes parquet that this append reads, so this state runs after it.
+    """
+    bucket = config["bucket"]
+    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    dry_run = args.dry_run
+    results: dict = {
+        "mode": "daily_arctic_append",
+        "date": run_date,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "collectors": {},
+    }
+
+    tickers = _load_daily_universe_tickers(config)
+    if not tickers:
+        logger.error("No tickers available for ArcticDB append")
+        results["status"] = "failed"
+        results["completed_at"] = datetime.now(timezone.utc).isoformat()
+        return results
+
+    logger.info("=" * 60)
+    logger.info("APPENDING: ArcticDB universe (daily-arctic-append state, %s)", run_date)
+    logger.info("=" * 60)
+    reg = _build_registry(config, args, run_date)
+    try:
+        from builders.daily_append import daily_append
+        with _maybe_phase(reg, "arcticdb"):
+            arctic_result = daily_append(
+                date_str=run_date,
+                bucket=bucket,
+                dry_run=dry_run,
+                skip_if_exists=True,
+                expected_tickers=tickers,
+            )
+        results["collectors"]["arcticdb"] = arctic_result
+        # daily_append returns its own status; surface it as the load-bearing
+        # verdict so a write failure halts the pipeline (reconcile reads next).
+        _status = arctic_result.get("status", "unknown")
+        results["status"] = "ok" if _status in ("ok", "ok_dry_run") else "failed"
+    except Exception as e:
+        logger.exception("ArcticDB daily_append (daily-arctic-append state) failed for %s", run_date)
+        results["collectors"]["arcticdb"] = {"status": "error", "error": str(e)}
+        results["status"] = "failed"
+
+    results["completed_at"] = datetime.now(timezone.utc).isoformat()
+    logger.info("ArcticDB append %s for %s", results["status"].upper(), run_date)
     return results
 
 
@@ -2140,6 +2237,14 @@ def _parse_args() -> argparse.Namespace:
              "Load-bearing: exits 1 on append failure. --date overrides target day.",
     )
     parser.add_argument(
+        "--daily-arctic-append", dest="daily_arctic_append", action="store_true",
+        help="Standalone ArcticDB universe append for the EOD post-market path "
+             "(the slow daily_append split out of --daily, 2026-06-16). The EOD SF "
+             "runs --daily --skip-arctic-append (compute) then this state with a "
+             "longer timeout. Load-bearing: exits 1 on append failure. Targets "
+             "today's UTC date (or --date); skip_if_exists short-circuits reruns.",
+    )
+    parser.add_argument(
         "--phase", type=int, choices=[1, 2], default=None,
         help="Phase 1: pre-research data. Phase 2: post-research alternative data.",
     )
@@ -2190,7 +2295,9 @@ def main() -> None:
         # _run_morning_enrich hits polygon — so a drifted key failed
         # 28min into the spot run instead of in <1s at the entry.
         mode = "morning_enrich"
-    elif args.daily:
+    elif args.daily or getattr(args, "daily_arctic_append", False):
+        # --daily-arctic-append reads the daily_closes PostMarketData wrote +
+        # the ArcticDB universe libraries — same preflight surface as --daily.
         mode = "daily"
     else:
         mode = f"phase{args.phase or 1}"


### PR DESCRIPTION
## Why
The EOD daily pipeline (`alpha-engine-eod-pipeline`) failed on **2026-06-16**. `PostMarketData` ran the whole monolithic `weekly_collector.py --daily` (daily_closes + metron collectors + feature-store compute + the slow ArcticDB `daily_append` + factor_momentum + universe-freshness scan) in **one** SSM command under a **1200s** timeout. It had been sitting right on that cliff (06-15 finished at ~19:08 of 20:00); on 06-16 the feature phase ran 22s slower, the run crossed 1200s mid-`daily_append`, and SSM **SIGKILLed** it (`ResponseCode 137` at `PT20M0.102S`) → `PostMarketStatusError` → `HandleFailure` → the whole EOD pipeline failed (no reconcile, no `eod_pnl` row, no EOD email).

This is the **un-mirrored twin** of the weekday path, which was split long ago into `MorningEnrich` (3000s) + a dedicated `MorningArcticAppend` (2400s) (L4608). Same class as #640 / #639.

## What
Mirror the weekday split onto the EOD path:

- **`weekly_collector.py`**: `--daily --skip-arctic-append` does daily_closes + metron + feature compute only; new **`--daily-arctic-append`** mode (`_run_daily_arctic_append`) runs ONLY the `daily_append` (keeps `skip_if_exists=True` for cheap operator reruns). Shared `_load_daily_universe_tickers` + `_MACRO_DAILY_TICKERS` so both halves feed `daily_append` the identical `expected_tickers` scope. Load-bearing: append failure exits 1.
- **`step_function_eod.json`**: `PostMarketData` adds `--skip-arctic-append` and gets **1800s**; new load-bearing **`PostMarketArcticAppend`** state (**2400s**) with its own poll/skip/error cluster, inserted between `PostMarketData` and `CaptureSnapshot`. `CheckSkipPostMarketData` now resumes at the append gate so a recovery rerun can skip whichever half already completed.

## Tests
- +3 collector tests: `run_weekly` dispatch, `--skip-arctic-append` suppresses the inline append, `--daily-arctic-append` keeps `skip_if_exists` + macro scope + is load-bearing.
- Updated pins: EOD skipgate-wiring (new gate + rewired success edges + rerun paths), payload-uniqueness registry (3 new fields), preflight mode-mapping.
- **Full suite: 2066 passed, 2 skipped** locally.

## Deploy (post-merge)
The EOD SF is **not** CloudFormation-managed — it is applied by `infrastructure/update_eod_pipeline_sf.sh` (direct `update-state-machine`). **Ordering matters**: the trading box must have this commit's `weekly_collector.py` (it pulls `main` each morning via `MorningEnrich`) **before** the new SF def is applied, otherwise the first EOD run would call `--daily-arctic-append` on a box without the flag. Recommended: merge → next morning the box pulls `main` → then run `update_eod_pipeline_sf.sh` before that day's EOD. First clean run = next weekday EOD.

## Incident recovery (already done this session, NOT in this PR)
The missing 06-16 EOD reconcile was backfilled manually: restarted the (paper) trading instance, captured the IB snapshot, ran `eod_reconcile.py` → `eod_pnl` row + EOD email landed (NAV $1,010,631, α −0.61%); instance re-stopped. Data (ArcticDB universe + factor_momentum) self-heals on the next weekday MorningEnrich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)