### PR TITLE
daily_news: --require-digest hard-fails the box runner on a soft/empty digest

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -140,14 +140,24 @@ def collect(
     run_date: str | None = None,
     hours: int = DEFAULT_LOOKBACK_HOURS,
     dry_run: bool = False,
+    require_digest: bool = False,
     s3_client: Any = None,
 ) -> dict:
     """Pull daily news for the held + tracked universe and write the daily
     aggregates parquet (``data/news_aggregates_daily/``).
 
-    Returns a status dict. This is a SECONDARY artifact — callers should treat
-    a non-``ok`` status as a soft degrade (no news that day), never a hard
-    failure of any primary pipeline.
+    Returns a status dict. The aggregate is the PRIMARY artifact; the
+    raw-article companion and the podcast-ready digest are SECONDARY and
+    fail-soft by default — callers (e.g. the weekday SF) treat a non-``ok``
+    status as a soft degrade, never a hard failure of any primary pipeline.
+
+    ``require_digest`` PROMOTES the digest to a hard requirement of THIS run:
+    when set, a digest that failed to build/write or that is empty makes
+    ``collect`` return an ``error`` status (so ``main`` exits non-zero). The
+    standalone box runner passes this so ``daily-news.service`` fails — and
+    the ``Requires=`` coupling blocks the morning-signal pod — rather than
+    letting a soft-failed/empty digest feed a degraded episode. The SF path
+    leaves it ``False``, preserving the digest's fail-soft posture there.
     """
     if s3_client is None:
         import boto3
@@ -291,6 +301,7 @@ def collect(
     # the portfolio section populated and empty macro/tech.
     digest_status = "ok"
     digest_key = None
+    digest_total = 0
     topic_status = "ok"
     try:
         topics: dict = {}
@@ -314,6 +325,10 @@ def collect(
             topics=topics,
             digest_date=agg_date,
         )
+        _sections = digest.get("sections", {})
+        digest_total = sum(
+            len(_sections.get(s, [])) for s in ("portfolio", "macro", "tech")
+        )
         digest_key = write_digest(
             digest,
             s3_client=s3_client,
@@ -323,9 +338,9 @@ def collect(
         logger.info(
             "[daily_news] wrote digest to s3://%s/%s (portfolio=%d macro=%d tech=%d)",
             bucket, digest_key,
-            len(digest["sections"]["portfolio"]),
-            len(digest["sections"]["macro"]),
-            len(digest["sections"]["tech"]),
+            len(_sections.get("portfolio", [])),
+            len(_sections.get("macro", [])),
+            len(_sections.get("tech", [])),
         )
     except Exception as e:  # noqa: BLE001 — fail-soft secondary artifact (see above)
         digest_status = "error"
@@ -335,8 +350,26 @@ def collect(
             type(e).__name__, e,
         )
 
+    # By default the digest is secondary/fail-soft → overall status stays
+    # "ok" as long as the PRIMARY aggregate landed. With ``require_digest``
+    # the digest is a hard requirement of this run: a failed-to-write or
+    # empty digest fails the whole run (→ main() exit 1 → daily-news.service
+    # fails → morning-signal's Requires= blocks the pod). The aggregate +
+    # article artifacts already wrote to S3 above, so the dashboard's Daily
+    # News page is unaffected by this exit code.
+    status = "ok"
+    if require_digest and (digest_status != "ok" or digest_total == 0):
+        status = "error"
+        logger.error(
+            "[daily_news] require_digest set but digest is unusable "
+            "(digest_status=%s, items=%d) — failing the run so the "
+            "morning-signal consumer blocks rather than narrating a "
+            "soft-failed/empty digest",
+            digest_status, digest_total,
+        )
+
     return {
-        "status": "ok",
+        "status": status,
         "tickers": len(universe),
         "articles": len(articles),
         "rows": int(len(df)),
@@ -346,6 +379,7 @@ def collect(
         "articles_rows": articles_rows,
         "digest_status": digest_status,
         "digest_key": digest_key,
+        "digest_total": digest_total,
         "topic_status": topic_status,
     }
 
@@ -388,9 +422,24 @@ def main() -> int:
         action="store_true",
         help="Fetch + NLP but don't write the parquet.",
     )
+    parser.add_argument(
+        "--require-digest",
+        action="store_true",
+        help=(
+            "Treat the podcast digest as a hard requirement: exit non-zero "
+            "if it failed to build/write or is empty. Used by the standalone "
+            "box runner so daily-news.service fails (and morning-signal's "
+            "Requires= blocks the pod) rather than feeding a soft-failed "
+            "digest. Leave unset in the weekday SF (digest stays fail-soft)."
+        ),
+    )
     args = parser.parse_args()
     result = collect(
-        args.bucket, run_date=args.date, hours=args.hours, dry_run=args.dry_run
+        args.bucket,
+        run_date=args.date,
+        hours=args.hours,
+        dry_run=args.dry_run,
+        require_digest=args.require_digest,
     )
     logger.info("[daily_news] complete: %s", result)
     return 0 if result.get("status", "").startswith("ok") or result["status"] == "skipped" else 1

--- a/scripts/run_daily_news_standalone.sh
+++ b/scripts/run_daily_news_standalone.sh
@@ -41,7 +41,14 @@ set -a
 source /home/ec2-user/.alpha-engine.env 2>/dev/null || true
 set +a
 
-.venv/bin/python -m collectors.daily_news >> "$LOG" 2>&1
+# --require-digest: this box runner feeds the morning-signal podcast, whose
+# consumer treats the digest as a hard prerequisite. Exit non-zero if the
+# digest failed/empty so this service fails and morning-signal's Requires=
+# blocks the pod, rather than letting a soft-failed digest feed a degraded
+# episode. (The weekday SF invokes daily_news WITHOUT this flag — digest stays
+# fail-soft there.) The aggregate + article artifacts the dashboard reads
+# already wrote before the digest step, so they're unaffected by this exit.
+.venv/bin/python -m collectors.daily_news --require-digest >> "$LOG" 2>&1
 rc=$?
 echo "=== daily-news standalone exit rc=$rc $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" >> "$LOG"
 exit $rc

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -285,3 +285,126 @@ def test_collect_digest_write_failure_is_fail_soft(
     assert out["status"] == "ok"
     assert out["digest_status"] == "error"
     assert out["digest_key"] is None
+
+
+# ── require_digest: digest promoted to a hard requirement of the run ──────────
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_digest.build_digest")
+@patch("collectors.topic_news.fetch_topics")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_require_digest_fails_run_when_digest_write_errors(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_topics,
+    mock_build, mock_ensure,
+):
+    """With require_digest, a digest build/write failure fails the whole run
+    (so daily-news.service exits non-zero and morning-signal's Requires=
+    blocks the pod) — unlike the default fail-soft path."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock(); agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("k/result.parquet", agg_df)
+    art_df = MagicMock(); art_df.__len__ = lambda self: 12
+    mock_articles.return_value = ("k/articles.parquet", art_df)
+    mock_topics.return_value = {"macro": [], "tech": []}
+    mock_build.side_effect = RuntimeError("schema bug")
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3, require_digest=True)
+
+    assert out["status"] == "error"        # run fails → main() exits 1
+    assert out["digest_status"] == "error"
+    assert out["rows"] == 7                 # aggregate still landed for the dashboard
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_digest.write_digest")
+@patch("data.derived.news_digest.build_digest")
+@patch("collectors.topic_news.fetch_topics")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_require_digest_fails_run_when_digest_empty(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_topics,
+    mock_build, mock_write_digest, mock_ensure,
+):
+    """An empty digest (zero items across all sections) fails the run under
+    require_digest, even though the write itself succeeded."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock(); agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("k/result.parquet", agg_df)
+    art_df = MagicMock(); art_df.__len__ = lambda self: 12
+    mock_articles.return_value = ("k/articles.parquet", art_df)
+    mock_topics.return_value = {"macro": [], "tech": []}
+    mock_build.return_value = {"sections": {"portfolio": [], "macro": [], "tech": []}}
+    mock_write_digest.return_value = "data/news_digest_daily/run/digest.json"
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3, require_digest=True)
+
+    assert out["status"] == "error"
+    assert out["digest_status"] == "ok"    # write succeeded; emptiness is the failure
+    assert out["digest_total"] == 0
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_digest.write_digest")
+@patch("data.derived.news_digest.build_digest")
+@patch("collectors.topic_news.fetch_topics")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_require_digest_passes_when_digest_nonempty(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_topics,
+    mock_build, mock_write_digest, mock_ensure,
+):
+    """A fresh, non-empty digest satisfies require_digest → run is ok."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock(); agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("k/result.parquet", agg_df)
+    art_df = MagicMock(); art_df.__len__ = lambda self: 12
+    mock_articles.return_value = ("k/articles.parquet", art_df)
+    mock_topics.return_value = {"macro": [{"title": "m"}], "tech": []}
+    mock_build.return_value = {"sections": {"portfolio": [{"ticker": "AAPL"}], "macro": [{"title": "m"}], "tech": []}}
+    mock_write_digest.return_value = "data/news_digest_daily/run/digest.json"
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3, require_digest=True)
+
+    assert out["status"] == "ok"
+    assert out["digest_total"] == 2
+
+
+@patch("collectors.daily_news.ensure_lm_master_dict")
+@patch("data.derived.news_digest.write_digest")
+@patch("data.derived.news_digest.build_digest")
+@patch("collectors.topic_news.fetch_topics")
+@patch("data.derived.news_articles.articles_build_and_write")
+@patch("data.derived.news_aggregates.aggregate_and_write")
+@patch("collectors.daily_news._build_nlp_pipeline")
+@patch("collectors.daily_news._build_aggregator")
+def test_default_stays_fail_soft_on_empty_digest(
+    mock_agg, mock_nlp, mock_write, mock_articles, mock_topics,
+    mock_build, mock_write_digest, mock_ensure,
+):
+    """Without require_digest (the SF path), an empty digest is still a soft
+    degrade — status stays ok so the weekday SF isn't regressed."""
+    mock_agg.return_value = _fake_aggregator()
+    agg_df = MagicMock(); agg_df.__len__ = lambda self: 7
+    mock_write.return_value = ("k/result.parquet", agg_df)
+    art_df = MagicMock(); art_df.__len__ = lambda self: 12
+    mock_articles.return_value = ("k/articles.parquet", art_df)
+    mock_topics.return_value = {"macro": [], "tech": []}
+    mock_build.return_value = {"sections": {"portfolio": [], "macro": [], "tech": []}}
+    mock_write_digest.return_value = "data/news_digest_daily/run/digest.json"
+
+    s3 = _mock_s3(holdings=["AAPL"], signals_universe=["MSFT"])
+    out = daily_news.collect("b", s3_client=s3)  # require_digest defaults False
+
+    assert out["status"] == "ok"
+    assert out["digest_total"] == 0


### PR DESCRIPTION
## Producer half of the "soft-failed news digest → no pod" policy

Companion to morning-signal#70 (the consumer guard). Together they enforce: **a morning-signal pod is not generated from a soft-failed news digest.**

### Problem

`daily_news.collect()` returns `status: "ok"` whenever the **primary aggregate** landed — even if the digest build/write threw (`digest_status: "error"`) or the digest is empty. So the standalone box runner exits `0`, `daily-news.service` shows success, and morning-signal's `Requires=daily-news.service` lets a soft-failed/empty digest feed a degraded pod. The digest's fail-soft posture is correct for the **weekday SF** (where it's genuinely secondary), but wrong for the **box runner that feeds the podcast**.

### Change

- `collect(require_digest=False)`: when set, a digest that failed to build/write **or** is empty (zero items across all sections) makes `collect()` return `status: "error"` → `main()` exits `1` → `daily-news.service` fails → morning-signal's `Requires=` blocks the pod.
- `run_daily_news_standalone.sh` passes `--require-digest` (the box runner only).
- The **weekday SF** invokes `daily_news` *without* the flag → digest stays secondary/fail-soft → **no SF regression**.
- The aggregate + raw-article artifacts (what the dashboard "Daily News" page reads) already wrote to S3 *before* the digest step, so they're unaffected by the non-zero exit.
- Adds `digest_total` to the status dict.

### Deploy note (one-cycle lag, harmless)

The box runner refreshes code *inside* the script (`git pull` near the top), so the new `--require-digest` flag on the script's last line reliably takes effect on the **run after** the merge propagates; the immediately-next run uses the new `collect()` code but the old (no-flag) invocation → fail-soft. This is fine: **the consumer guard (morning-signal#70) enforces the policy from its very next run** (morning-signal refreshes via `ExecStartPre git reset --hard`), so the gap is covered. This PR is defense-in-depth that surfaces the failure one step earlier/louder.

### Tests

`require_digest` fails the run on digest write-error and on empty digest; passes on a non-empty digest; the default (no-flag) SF path stays fail-soft on an empty digest. Affected suites green locally: **32 passed** (`test_daily_news.py` + `test_news_digest.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)