### PR TITLE
ci: alert on main deploy/codeql failure (Telegram, config#1128)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -63,3 +63,11 @@ jobs:
         with:
           deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
           deploy_workflow: deploy-infrastructure.yml
+
+  # Alert (Telegram) on genuine post-merge failure of this workflow on the
+  # default branch. Reusable workflow + transport in nousergon-lib. config#1128.
+  notify-main-failure:
+    needs: [deploy-infrastructure]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,3 +93,11 @@ jobs:
         with:
           deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
           deploy_workflow: deploy.yml
+
+  # Alert (Telegram) on genuine post-merge failure of this workflow on the
+  # default branch. Reusable workflow + transport in nousergon-lib. config#1128.
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What
Adds the `notify-main-failure` job (Telegram via the shared nousergon-lib reusable workflow) to this repos **deploy / codeql / infra** workflow(s), gated on `failure() && github.ref == refs/heads/main`.

## Why
Extends the CI-failure-notify coverage (config#1128) from `test` to the deploy-class push:main workflows, so a real post-merge deploy/codeql failure reaches Telegram. This is the prerequisite for turning OFF the built-in GitHub Actions failure email org-wide without losing real-failure coverage. Transient PR-branch reds stay silent (gate is default-branch + failure only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)