### PR TITLE
feat(metron): publish major-index ETF proxies in the intraday artifact

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -77,8 +77,16 @@ FUNDAMENTALS_INFO_KEYS = [
 ]
 # Intraday — last/open/prior-close per held symbol, refreshed every 15 min during US
 # regular trading hours by a systemd timer on the trading box (config#1023). Single
-# `latest.json` key (no dated files — 26 writes/day would litter the prefix).
+# `latest.json` key (no dated files — 26 writes/day would litter the prefix). The same
+# artifact also carries the major-index proxies (see INDEX_PROXY_SYMBOLS).
 INTRADAY_PREFIX = "market_data/intraday/"
+# Major US-index ETF proxies for Metron's Overview "markets" strip — refreshed in the
+# same intraday run (market context, fetched independent of the held universe). The
+# index VALUES (^GSPC / ^IXIC / ^RUT) carry a separate index license; the tradeable ETF
+# prices are ordinary equity trades, so the ETF is published as the index proxy and
+# Metron maps each symbol to the index it tracks. Quotes land under the artifact's
+# `indices` key (same per-symbol shape as held `quotes`).
+INDEX_PROXY_SYMBOLS = ["SPY", "QQQ", "IWM"]
 CLOSES_SCHEMA_VERSION = 1
 FX_SCHEMA_VERSION = 1
 CLOSE_HISTORY_SCHEMA_VERSION = 1
@@ -87,7 +95,7 @@ SECTORS_SCHEMA_VERSION = 1
 EARNINGS_SCHEMA_VERSION = 1
 MACRO_SCHEMA_VERSION = 1
 FUNDAMENTALS_SCHEMA_VERSION = 1
-INTRADAY_SCHEMA_VERSION = 1
+INTRADAY_SCHEMA_VERSION = 2  # v2: additive `indices` map (major-index ETF proxies)
 BASE_CURRENCY = "USD"
 DEFAULT_HISTORY_PERIOD = "10y"  # mirrors the predictor price_cache 10y convention
 BENCHMARK = "SPY"  # the attribution benchmark whose GICS sector weights we publish
@@ -853,25 +861,43 @@ def metron_app_active(bucket: str, s3_client: Any, now: datetime | None = None) 
         return False
 
 
+def _flag_suspect_quotes(quotes: dict[str, dict]) -> int:
+    """Flag (never drop) any quote moving >40% vs prior close — almost always a bad
+    scrape or an unadjusted corporate action, not a real move. Marks ``suspect: true``
+    in place (no fabrication: the consumer renders a warning, not a wild P&L leg) and
+    returns the count flagged."""
+    n_suspect = 0
+    for q in quotes.values():
+        prev = q.get("prev_close") or 0.0
+        if prev and abs(q.get("last", prev) / prev - 1.0) > 0.40:
+            q["suspect"] = True
+            n_suspect += 1
+    return n_suspect
+
+
 def collect_intraday(
     *, bucket: str = DEFAULT_BUCKET, dry_run: bool = False, s3_client: Any = None,
     intraday_source: IntradaySource | None = None, force: bool = False,
     now: datetime | None = None,
 ) -> dict:
-    """Write the intraday-quotes artifact for Metron's held universe (config#1023 —
-    the 15-minute Today-view feed, consumed by metron-ops#23):
+    """Write the intraday-quotes artifact for Metron's held universe + the major-index
+    proxies (config#1023 — the 15-minute Today-view feed + the Overview markets strip,
+    consumed by metron-ops#23):
 
         market_data/intraday/latest.json
             {schema_version, as_of_utc, source: "yfinance_delayed",
-             quotes: {yf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}}}
+             quotes:  {yf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}},
+             indices: {etf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}}}
 
     ``last`` is ~15-min delayed. Runs every 5 min via a systemd timer on the trading
     box (infrastructure/systemd/metron-intraday.timer), double-gated: the NYSE
     session window (exchange calendar incl. half-days) AND the Metron UI heartbeat
     (``metron_app_active``) — quotes are fetched only while the market is open AND
     the app is actually being used. Outside either gate it returns ``skipped``
-    without fetching (``force`` overrides both, for manual runs). A quote moving
-    >40% vs prior close carries ``suspect: true`` (flagged, never dropped). Single
+    without fetching (``force`` overrides both, for manual runs). The major-index ETF
+    proxies (``INDEX_PROXY_SYMBOLS``) are market context — fetched every run regardless
+    of the held universe, so a brand-new account still gets the markets strip. A quote
+    moving >40% vs prior close carries ``suspect: true`` (flagged, never dropped). Single
     ``latest.json`` key — consumers see staleness via ``as_of_utc``. Injectable
     source/S3 for tests."""
     if not force and not in_us_market_window(now):
@@ -881,21 +907,21 @@ def collect_intraday(
         s3_client = boto3.client("s3")
     if not force and not metron_app_active(bucket, s3_client, now):
         return {"status": "skipped", "reason": "metron app inactive (no fresh UI heartbeat)"}
+    fetch = intraday_source or _yfinance_intraday
+
+    # Held-universe quotes (may be empty — a brand-new account still gets the index strip).
     holdings, _ = load_metron_universe(bucket, s3_client)
-    if not holdings:
-        return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
     ccy_by_yf = {h["yf_symbol"]: h["currency"] for h in holdings}
-    quotes = (intraday_source or _yfinance_intraday)(sorted(ccy_by_yf))
-    n_suspect = 0
+    quotes = fetch(sorted(ccy_by_yf)) if ccy_by_yf else {}
     for sym, q in quotes.items():
         q["currency"] = ccy_by_yf.get(sym, "USD")
-        # Sanity flag — a >40% jump vs prior close is almost always a bad scrape or
-        # an unadjusted corporate action, not a real move. Flag, never drop/clamp
-        # (no fabrication): the consumer renders a warning instead of a wild P&L leg.
-        prev = q.get("prev_close") or 0.0
-        if prev and abs(q.get("last", prev) / prev - 1.0) > 0.40:
-            q["suspect"] = True
-            n_suspect += 1
+
+    # Major-index ETF proxies — market context, always fetched (independent of holdings).
+    indices = fetch(list(INDEX_PROXY_SYMBOLS))
+    for q in indices.values():
+        q["currency"] = BASE_CURRENCY
+
+    n_suspect = _flag_suspect_quotes(quotes) + _flag_suspect_quotes(indices)
     if n_suspect:
         logger.warning("[metron_market_data] %d intraday quote(s) flagged suspect (>40%% vs prev close)", n_suspect)
     artifact = {
@@ -903,17 +929,19 @@ def collect_intraday(
         "as_of_utc": (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "source": "yfinance_delayed",
         "quotes": dict(sorted(quotes.items())),
+        "indices": dict(sorted(indices.items())),
     }
     if dry_run:
-        logger.info("[metron_market_data] DRY-RUN intraday: %d quotes (not written)", len(quotes))
-        return {"status": "ok_dry_run", "quotes": len(quotes)}
+        logger.info("[metron_market_data] DRY-RUN intraday: %d quotes, %d indices (not written)",
+                    len(quotes), len(indices))
+        return {"status": "ok_dry_run", "quotes": len(quotes), "indices": len(indices)}
     try:
         _write_json(s3_client, bucket, f"{INTRADAY_PREFIX}latest.json", artifact)
     except Exception as e:  # fail loud — the timer unit's journal + freshness scan record it
         logger.error("[metron_market_data] intraday write failed: %s", e)
         return {"status": "error", "error": str(e)}
-    logger.info("[metron_market_data] wrote %d intraday quotes", len(quotes))
-    return {"status": "ok", "universe": len(holdings), "quotes": len(quotes)}
+    logger.info("[metron_market_data] wrote %d intraday quotes + %d indices", len(quotes), len(indices))
+    return {"status": "ok", "universe": len(holdings), "quotes": len(quotes), "indices": len(indices)}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -241,6 +241,23 @@ class TestIntraday:
         "1299.HK": {"last": 64.8, "open": 64.1, "prev_close": 64.2,
                     "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
     }
+    _INDEX_QUOTES = {
+        "SPY": {"last": 605.2, "open": 603.0, "prev_close": 602.4,
+                "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
+        "QQQ": {"last": 540.1, "open": 538.5, "prev_close": 537.0,
+                "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
+        "IWM": {"last": 215.3, "open": 216.0, "prev_close": 216.5,
+                "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
+    }
+
+    @staticmethod
+    def _stub(*maps):
+        """An input-aware intraday source: returns only the requested symbols it knows
+        (mirrors the real fetcher, which is called separately for held + index symbols)."""
+        merged: dict[str, dict] = {}
+        for m in maps:
+            merged.update(m)
+        return lambda syms: {s: dict(merged[s]) for s in syms if s in merged}
 
     # Friday 2026-06-12 15:00 UTC = 11:00 ET — mid-session (EDT).
     _RTH = datetime(2026, 6, 12, 15, 0, tzinfo=timezone.utc)
@@ -255,27 +272,42 @@ class TestIntraday:
     def test_writes_quotes_with_currency_when_open_and_app_active(self):
         s3 = self._s3()
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=lambda s: {k: dict(v) for k, v in self._QUOTES.items()},
+            bucket="b", s3_client=s3, intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
             now=self._RTH,
         )
-        assert result["status"] == "ok" and result["quotes"] == 2
+        assert result["status"] == "ok" and result["quotes"] == 2 and result["indices"] == 3
         puts = _puts(s3)
         assert set(puts) == {"market_data/intraday/latest.json"}
         art = puts["market_data/intraday/latest.json"]
-        assert art["schema_version"] == mmd.INTRADAY_SCHEMA_VERSION
+        assert art["schema_version"] == mmd.INTRADAY_SCHEMA_VERSION == 2
         assert art["source"] == "yfinance_delayed"
         assert art["as_of_utc"] == "2026-06-12T15:00:00Z"
         # Currency joined from the universe (the consumer FX-converts the P&L legs).
         assert art["quotes"]["1299.HK"]["currency"] == "HKD"
         # Normal moves carry no suspect flag.
         assert "suspect" not in art["quotes"]["AAPL"]
+        # Index proxies land under `indices` (USD), same per-symbol shape as quotes.
+        assert set(art["indices"]) == set(mmd.INDEX_PROXY_SYMBOLS)
+        assert art["indices"]["SPY"]["currency"] == "USD"
+        assert art["indices"]["SPY"]["last"] == 605.2 and art["indices"]["SPY"]["prev_close"] == 602.4
+
+    def test_index_proxies_fetched_even_with_empty_universe(self):
+        """The markets strip is market context — published even when nothing is held."""
+        empty = self._s3(universe={"holdings": [], "currencies": []})
+        result = mmd.collect_intraday(
+            bucket="b", s3_client=empty, intraday_source=self._stub(self._INDEX_QUOTES), now=self._RTH,
+        )
+        assert result["status"] == "ok" and result["quotes"] == 0 and result["indices"] == 3
+        art = _puts(empty)["market_data/intraday/latest.json"]
+        assert art["quotes"] == {}
+        assert set(art["indices"]) == set(mmd.INDEX_PROXY_SYMBOLS)
 
     def test_suspect_flag_on_extreme_move_never_dropped(self):
         s3 = self._s3()
         quotes = {"AAPL": {"last": 350.0, "open": 200.5, "prev_close": 201.5,
                            "session_date": "2026-06-12", "prev_session_date": "2026-06-11"}}
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=lambda s: quotes, now=self._RTH
+            bucket="b", s3_client=s3, intraday_source=self._stub(quotes), now=self._RTH
         )
         assert result["status"] == "ok"
         art = _puts(s3)["market_data/intraday/latest.json"]
@@ -299,7 +331,7 @@ class TestIntraday:
         # force bypasses BOTH gates (manual/debug runs).
         forced = mmd.collect_intraday(
             bucket="b", s3_client=self._s3(heartbeat_offset_s=None),
-            intraday_source=lambda s: {k: dict(v) for k, v in self._QUOTES.items()},
+            intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
             now=self._RTH, force=True,
         )
         assert forced["status"] == "ok"
@@ -335,13 +367,11 @@ class TestIntraday:
         assert mmd.in_us_market_window(mk(2026, 11, 27, 18, 5))
         assert not mmd.in_us_market_window(mk(2026, 11, 27, 19, 0))  # old heuristic said open
 
-    def test_intraday_dry_run_and_empty_universe(self):
+    def test_intraday_dry_run_writes_nothing(self):
         s3 = self._s3()
         result = mmd.collect_intraday(
             bucket="b", s3_client=s3, dry_run=True,
-            intraday_source=lambda s: {k: dict(v) for k, v in self._QUOTES.items()}, now=self._RTH,
+            intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES), now=self._RTH,
         )
-        assert result["status"] == "ok_dry_run"
+        assert result["status"] == "ok_dry_run" and result["quotes"] == 2 and result["indices"] == 3
         assert not s3.put_object.called
-        empty = self._s3(universe={"holdings": [], "currencies": []})
-        assert mmd.collect_intraday(bucket="b", s3_client=empty, now=self._RTH)["status"] == "skipped"


### PR DESCRIPTION
## What

Extend `collect_intraday` (Metron market-data producer) to also fetch the major US-index ETF proxies — **SPY / QQQ / IWM** (S&P 500 / Nasdaq 100 / Russell 2000) — every run and write them under a new additive `indices` key in `market_data/intraday/latest.json`. `INTRADAY_SCHEMA_VERSION` 1 → 2 (additive — existing `quotes` consumers unaffected).

## Why

Metron's Overview gains an intraday "markets" strip (consumer PR: metron `feat/overview-index-strip`). Index *values* (^GSPC/^IXIC/^RUT) carry a separate index license; the tradeable ETF *prices* are ordinary equity trades, so the ETF is the published proxy.

## Notes

- Index proxies are fetched **independent of the held universe** (market context — a brand-new account still gets the strip), behind the **same** NYSE-session + UI-heartbeat demand gates as held quotes.
- **Same single `_write_json` PUT site** → the artifact-coverage guard count is unchanged.
- Suspect-flagging (>40% vs prior close) factored into `_flag_suspect_quotes` and applied to both held quotes and index quotes.
- Source is still yfinance-derived; the consumer feature is **feed-gated (Pro)** so it never serves in the no-feed beta until the licensed feed lands (then the provider-agnostic adapter swaps the source — config#1082).

## Tests

`tests/test_metron_market_data.py` — new: index proxies written under `indices` with USD currency + correct shape; fetched even with an empty held universe; dry-run counts. Full file + artifact-coverage guard green locally (31 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)