### PR TITLE
fix(sf): bounded auto-retry + jitter hardening on Saturday spot-data steps (config#1059)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -200,11 +200,24 @@
       "Retry": [
         {
           "ErrorEquals": [
-            "States.TaskFailed"
+            "States.TaskFailed",
+            "States.Timeout"
           ],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 60,
-          "BackoffRate": 1.0
+          "MaxAttempts": 4,
+          "IntervalSeconds": 30,
+          "BackoffRate": 2.0,
+          "MaxDelaySeconds": 300,
+          "JitterStrategy": "FULL"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 30,
+          "BackoffRate": 2.0,
+          "MaxDelaySeconds": 300,
+          "JitterStrategy": "FULL"
         }
       ],
       "Catch": [
@@ -275,12 +288,33 @@
           "Next": "MorningEnrichWait"
         }
       ],
-      "Default": "ExtractMorningEnrichError"
+      "Default": "MorningEnrichRetryGate"
     },
     "MorningEnrichWait": {
       "Type": "Wait",
       "Seconds": 30,
       "Next": "WaitForMorningEnrich"
+    },
+    "MorningEnrichRetryGate": {
+      "Type": "Choice",
+      "Comment": "SOTA bounded auto-retry (config#1059): re-issue MorningEnrich ONCE on a polled non-Success SSM status before giving up (idempotent re-run on the same always-on instance). Absent counter => re-issue; counter=1 => give up to ExtractMorningEnrichError.",
+      "Choices": [
+        {
+          "And": [
+            { "Variable": "$.morning_enrich_attempts", "IsPresent": true },
+            { "Variable": "$.morning_enrich_attempts", "NumericGreaterThanEquals": 1 }
+          ],
+          "Next": "ExtractMorningEnrichError"
+        }
+      ],
+      "Default": "MorningEnrichReissue"
+    },
+    "MorningEnrichReissue": {
+      "Type": "Pass",
+      "Comment": "Mark one re-issue consumed (morning_enrich_attempts=1) and loop back to MorningEnrich.",
+      "Result": 1,
+      "ResultPath": "$.morning_enrich_attempts",
+      "Next": "MorningEnrich"
     },
     "CheckSkipDataPhase1": {
       "Type": "Choice",
@@ -321,11 +355,24 @@
       "Retry": [
         {
           "ErrorEquals": [
-            "States.TaskFailed"
+            "States.TaskFailed",
+            "States.Timeout"
           ],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 60,
-          "BackoffRate": 1.0
+          "MaxAttempts": 4,
+          "IntervalSeconds": 30,
+          "BackoffRate": 2.0,
+          "MaxDelaySeconds": 300,
+          "JitterStrategy": "FULL"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 30,
+          "BackoffRate": 2.0,
+          "MaxDelaySeconds": 300,
+          "JitterStrategy": "FULL"
         }
       ],
       "Catch": [
@@ -396,12 +443,33 @@
           "Next": "DataPhase1Wait"
         }
       ],
-      "Default": "ExtractDataPhase1Error"
+      "Default": "DataPhase1RetryGate"
     },
     "DataPhase1Wait": {
       "Type": "Wait",
       "Seconds": 30,
       "Next": "WaitForDataPhase1"
+    },
+    "DataPhase1RetryGate": {
+      "Type": "Choice",
+      "Comment": "SOTA bounded auto-retry (config#1059): a polled non-Success SSM status on this idempotent batch step is retriable, not terminal. Re-issue DataPhase1 ONCE on the same always-on instance ($.ec2_instance_id) before giving up — re-running is safe (the data job overwrites the same run_date S3 keys). Absent counter => first failure => re-issue; counter present (=1) => second failure => give up to ExtractDataPhase1Error. Keeps the scheduled execution alive through a transient blip so it succeeds first-pass (moves unattended_first_pass_rate).",
+      "Choices": [
+        {
+          "And": [
+            { "Variable": "$.data_phase1_attempts", "IsPresent": true },
+            { "Variable": "$.data_phase1_attempts", "NumericGreaterThanEquals": 1 }
+          ],
+          "Next": "ExtractDataPhase1Error"
+        }
+      ],
+      "Default": "DataPhase1Reissue"
+    },
+    "DataPhase1Reissue": {
+      "Type": "Pass",
+      "Comment": "Mark one re-issue consumed (data_phase1_attempts=1) and loop back to DataPhase1 for an idempotent re-run.",
+      "Result": 1,
+      "ResultPath": "$.data_phase1_attempts",
+      "Next": "DataPhase1"
     },
     "Scanner": {
       "Type": "Task",
@@ -478,11 +546,24 @@
       "Retry": [
         {
           "ErrorEquals": [
-            "States.TaskFailed"
+            "States.TaskFailed",
+            "States.Timeout"
           ],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 60,
-          "BackoffRate": 1.0
+          "MaxAttempts": 4,
+          "IntervalSeconds": 30,
+          "BackoffRate": 2.0,
+          "MaxDelaySeconds": 300,
+          "JitterStrategy": "FULL"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 30,
+          "BackoffRate": 2.0,
+          "MaxDelaySeconds": 300,
+          "JitterStrategy": "FULL"
         }
       ],
       "Catch": [
@@ -553,12 +634,33 @@
           "Next": "RAGIngestionWait"
         }
       ],
-      "Default": "ExtractRAGIngestionError"
+      "Default": "RAGIngestionRetryGate"
     },
     "RAGIngestionWait": {
       "Type": "Wait",
       "Seconds": 30,
       "Next": "WaitForRAGIngestion"
+    },
+    "RAGIngestionRetryGate": {
+      "Type": "Choice",
+      "Comment": "SOTA bounded auto-retry (config#1059): re-issue RAGIngestion ONCE on a polled non-Success SSM status before giving up (idempotent re-run on the same always-on instance). Absent counter => re-issue; counter=1 => give up to ExtractRAGIngestionError.",
+      "Choices": [
+        {
+          "And": [
+            { "Variable": "$.rag_ingestion_attempts", "IsPresent": true },
+            { "Variable": "$.rag_ingestion_attempts", "NumericGreaterThanEquals": 1 }
+          ],
+          "Next": "ExtractRAGIngestionError"
+        }
+      ],
+      "Default": "RAGIngestionReissue"
+    },
+    "RAGIngestionReissue": {
+      "Type": "Pass",
+      "Comment": "Mark one re-issue consumed (rag_ingestion_attempts=1) and loop back to RAGIngestion.",
+      "Result": 1,
+      "ResultPath": "$.rag_ingestion_attempts",
+      "Next": "RAGIngestion"
     },
     "CheckSkipRegimeSubstrate": {
       "Type": "Choice",

--- a/tests/test_sf_backtest_parity_split_wiring.py
+++ b/tests/test_sf_backtest_parity_split_wiring.py
@@ -230,6 +230,8 @@ class TestChainOrdering:
                 name is None
                 or name.startswith("Extract")
                 or name.endswith("Wait")
+                or name.endswith("RetryGate")
+                or name.endswith("Reissue")
                 or name in ("HandleFailure", "FailExecution")
             )
 

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -56,6 +56,8 @@ class TestQuartetPresence:
             "CheckMorningEnrichStatus",
             "MorningEnrichWait",
             "ExtractMorningEnrichError",
+            "MorningEnrichRetryGate",
+            "MorningEnrichReissue",
         ],
     )
     def test_state_exists(self, states, name):
@@ -136,11 +138,34 @@ class TestChainOrdering:
         assert nexts["Pending"] == "MorningEnrichWait"
         assert states["MorningEnrichWait"]["Next"] == "WaitForMorningEnrich"
 
-    def test_status_default_extracts_error(self, states):
+    def test_status_default_routes_through_bounded_retry_to_error(self, states):
+        """A non-Success poll status now routes through the bounded
+        auto-retry gate (config#1059) before terminating at the error
+        path: one idempotent re-issue, then ExtractMorningEnrichError on
+        give-up. Keeps the scheduled run alive through a transient blip
+        so it succeeds first-pass (moves unattended_first_pass_rate)."""
         assert (
             states["CheckMorningEnrichStatus"]["Default"]
-            == "ExtractMorningEnrichError"
+            == "MorningEnrichRetryGate"
         )
+        gate = states["MorningEnrichRetryGate"]
+        # Give-up path: counter already consumed -> terminate at error.
+        give_up = [
+            c["Next"] for c in gate["Choices"]
+            if c["Next"] == "ExtractMorningEnrichError"
+        ]
+        assert give_up == ["ExtractMorningEnrichError"], (
+            "bounded-retry gate must still terminate at "
+            "ExtractMorningEnrichError once the re-issue budget is spent"
+        )
+        # First-failure path: re-issue once, looping back to the step.
+        assert gate["Default"] == "MorningEnrichReissue"
+        reissue = states["MorningEnrichReissue"]
+        assert reissue["Next"] == "MorningEnrich", (
+            "re-issue must loop back to the MorningEnrich step for an "
+            "idempotent re-run"
+        )
+        assert reissue["ResultPath"] == "$.morning_enrich_attempts"
 
     def test_morning_enrich_is_reachable_before_data_phase1(self, sf, states):
         """Walk the HAPPY path from StartAt (skip-gates take Default = run

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -655,6 +655,8 @@ class TestInboundRewireAndDownstreamUnchanged:
                 name is None
                 or name.startswith("Extract")
                 or name.endswith("Wait")
+                or name.endswith("RetryGate")
+                or name.endswith("Reissue")
                 or name in ("HandleFailure", "FailExecution")
             )
 


### PR DESCRIPTION
## What / why (config#1059)

Root-causes and fixes the dominant driver of `unattended_first_pass_rate` ~0.83 — scheduled Saturday runs fail first-pass on transient infra blips and need manual skip-flag recovery. The substrate metric only counts a cycle unattended-OK when the **scheduled** run succeeds with **zero** same-date recovery, so only **in-line** retry (keeping the scheduled execution alive) can move it.

**Concrete failure:** the 6/13 scheduled cron failed at `CheckDataPhase1Status` Default (SSM command finished with a *failed status*) → `HandleFailure`, then the manual `recovery-260613-research-teams-skipflags` run completed green. Recent failed scheduled runs died at varied transient points (DataPhase1, Scanner, EvalJudge, AcquireMutex) — structural, not one-off.

## The gap

`DataPhase1` / `MorningEnrich` / `RAGIngestion` (EC2-spot SSM `sendCommand`) had:
- `Retry` = `MaxAttempts:1, ErrorEquals:["States.TaskFailed"], BackoffRate:1.0` — no backoff, no jitter, and `Ssm.*` service exceptions weren't retried at all; and
- `CheckXStatus.Default` (polled Failed/TimedOut status) → `HandleFailure` with **no retry**.

## Fix (SOTA — validated, `validate-state-machine-definition` = `OK`)

1. **Retry hardening** on each `sendCommand`: exponential backoff (`2.0`) + **full jitter** + `MaxDelaySeconds:300` + a `States.ALL` retrier so transient SSM service exceptions retry instead of failing the run.
2. **Bounded auto-re-issue** on the polled-failure path: `CheckXStatus.Default → XRetryGate` (Choice) → **one idempotent re-issue** of the step on the same always-on `$.ec2_instance_id` (`XReissue` Pass sets `attempts=1`) → give up to `ExtractXError` on the second failure. The happy path + InProgress/Pending wait loop are **untouched** — only the failure `Default` reroutes.

Because the give-up gate uses an `IsPresent` guard, the re-issue Pass only runs on the *first* failure, so it just sets the counter to a constant `1` (no `MathAdd`). Re-issue is safe: the data job overwrites the same `run_date` S3 keys, and the spot worker is launched *inside* `spot_data_weekly.sh` (which has its own reclaim-retry) — re-issue just re-sends the SSM command to the stable instance, no re-launch.

## Tests

- Updated `test_sf_morning_enrich_split_wiring` to guard the new bounded-retry wiring (Default → gate → re-issue-once → step; give-up → `ExtractMorningEnrichError`).
- Taught the two happy-path walkers (`test_sf_research_predictor_parallel_wiring`, `test_sf_backtest_parity_split_wiring`) that `*RetryGate` / `*Reissue` are off the main path.
- **Full data-repo suite: 2073 passed, 2 skipped.** AWS ASL validation: OK.

## Deploy / timing

Auto-deploys to the live SF via `deploy-infrastructure.yml` (`update-state-machine`) on merge. **Intended to merge before Sat 6/20 so that run integration-tests the fix** — if a step hits a transient blip, 6/20 should now self-recover unattended; if anything's wrong, 6/20 surfaces it and manual recovery (the current status quo) still works.

## Fast-follow (noted, not in this PR)

Same Retry hardening on the Lambda-task steps (EvalJudge throttle) + Scanner, which also appeared in recent first-pass failures. Also worth a check: whether the lib pipeline-status registry needs the new states mapped (they're retry plumbing, not pipeline stages — the status page should ignore them).

config#1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)
