### PR TITLE
Publish factor/sector-ETF close-history to the spine — unblocks Metron risk/attribution (metron-ops#43)

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -49,6 +49,16 @@ FX_PREFIX = "market_data/fx/"
 # reconstruction (close series) + as-of-date realized/dividend FX conversion.
 CLOSE_HISTORY_PREFIX = "market_data/close_history/"
 FX_HISTORY_PREFIX = "market_data/fx_history/"
+# Factor/sector ETFs whose close-history Metron's RISK (factor model) + ATTRIBUTION
+# (Brinson sector) need. These are NOT in any held universe, so unless their history is
+# published here the spine has no close_history for them and risk/attribution can NEVER
+# compute — metron-ops#43: the daily refresh logged `risk=False, attribution=False` with
+# `NoSuchKey` reading market_data/close_history/{XLP,XLV,...}.json. Mirrors metron
+# api/services/risk.py (SPY + STYLE_ETF) + portfolio_analytics.sectors.SECTOR_ETF; all USD.
+RISK_FACTOR_ETFS = [
+    "SPY", "MTUM", "QUAL", "USMV", "VLUE", "SIZE",  # market + iShares MSCI USA style factors
+    "XLB", "XLC", "XLE", "XLF", "XLI", "XLK", "XLP", "XLRE", "XLU", "XLV", "XLY",  # GICS sector SPDRs
+]
 # Reference data — GICS sector per held symbol + SPY's sector weights (Brinson
 # attribution), and each held symbol's next earnings date (Calendar page). Moves
 # Metron's last yfinance fetches to the spine so Metron reads ALL external data here.
@@ -649,7 +659,11 @@ def collect_history(
     if not holdings:
         return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
     ccy_by_yf = {h["yf_symbol"]: h["currency"] for h in holdings}
-    closes = (close_history_source or _yfinance_close_history)(sorted(ccy_by_yf))
+    # Held symbols + the factor/sector ETFs Metron's risk/attribution need (USD,
+    # independent of holdings) — without these the spine can't serve their close_history
+    # and risk/attribution stay blank (metron-ops#43).
+    hist_symbols = sorted(set(ccy_by_yf) | set(RISK_FACTOR_ETFS))
+    closes = (close_history_source or _yfinance_close_history)(hist_symbols)
     fx = (fx_history_source or _yfinance_fx_history)(currencies)
     if dry_run:
         logger.info("[metron_market_data] DRY-RUN history: %d close series, %d fx series", len(closes), len(fx))

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -143,6 +143,25 @@ class TestHistory:
         assert aapl["closes"] == [["2026-06-10", 200.0], ["2026-06-11", 201.5]]
         assert puts["market_data/fx_history/HKD.json"]["rates"][-1] == ["2026-06-11", 0.1282]
 
+    def test_publishes_factor_etf_history_for_risk_attribution(self):
+        # The factor/sector ETFs (SPY/MTUM/.../XLK) must be requested + published even
+        # though they're not held, or Metron's risk/attribution can't backfill (metron-ops#43).
+        s3 = _universe_s3(_UNIVERSE)
+        requested: list[str] = []
+
+        def close_hist(syms):
+            requested.extend(syms)
+            return {s: [("2026-06-11", 100.0)] for s in syms}
+
+        result = mmd.collect_history(bucket="b", s3_client=s3, close_history_source=close_hist, fx_history_source=lambda c: {})
+        assert set(mmd.RISK_FACTOR_ETFS) <= set(requested)  # all factor ETFs requested
+        assert "AAPL" in requested  # held symbols still included
+        puts = _puts(s3)
+        for etf in ("SPY", "XLK", "MTUM"):
+            key = f"market_data/close_history/{etf}.json"
+            assert key in puts and puts[key]["currency"] == "USD"
+        assert result["close_series"] == len(set(["AAPL", "1299.HK", *mmd.RISK_FACTOR_ETFS]))
+
     def test_history_dry_run_and_empty_universe(self):
         s3 = _universe_s3(_UNIVERSE)
         r = mmd.collect_history(bucket="b", dry_run=True, s3_client=s3, close_history_source=lambda s: {"AAPL": [("2026-06-11", 201.5)]}, fx_history_source=lambda c: {})


### PR DESCRIPTION
## Why
Metron's **Risk** and **Attribution** pages are permanently blank. Root cause (confirmed on the live box): `compute_risk(do_backfill=True)` + `compute_attribution(do_backfill=True)` run nightly in metron's `daily_refresh`, but they backfill factor/sector-ETF history **from the data spine** — and this producer only published **held**-ticker history. The factor ETFs aren't held, so the spine returns `NoSuchKey` for `market_data/close_history/{SPY,XLP,XLV,...}.json` and the refresh logs `risk=False, attribution=False`.

## Change
`collect_history` now also publishes close-history for the fixed factor/sector ETF set Metron needs — **SPY + MTUM/QUAL/USMV/VLUE/SIZE** (risk factor model) and the **11 GICS sector SPDRs** XLB/XLC/XLE/XLF/XLI/XLK/XLP/XLRE/XLU/XLV/XLY (Brinson attribution) — independent of holdings. (Mirrors metron `api/services/risk.py` `STYLE_ETF` + `portfolio_analytics.sectors.SECTOR_ETF`; all USD. Same single `_write_json` PUT site — coverage guard unchanged.)

## Effect
Once this runs (the producer publishes the ETF history), the next metron daily refresh backfills risk + attribution from the spine and both pages populate. No metron code change needed — `daily_refresh` already calls the backfills.

## Tests
`test_publishes_factor_etf_history_for_risk_attribution` — the ETF set is requested + each written (USD); held symbols still included. Full producer suite + artifact-coverage guard green (25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)