### PR TITLE
fix(sf): drop redundant per-spec git pull in model-zoo Map (concurrent-pull race)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1748,7 +1748,7 @@
                       "DocumentName": "AWS-RunShellScript",
                       "InstanceIds.$": "$.ec2_instance_id",
                       "Parameters": {
-                        "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
+                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m alpha_engine_lib.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
                         "executionTimeout": [
                           "5400"
                         ]


### PR DESCRIPTION
**Real root-cause fix for the model-zoo TrainSpecFailed (config#1138) — affects live Saturdays, not just dry runs.**

**Root cause (confirmed from SSM command stderr):** `ModelZooTrainMap` (`MaxConcurrency=4`) had every per-spec `TrainSpecDispatch` run `git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main` (+ config pull + `predictor.yaml` cp) on the **same shared checkout**. Four concurrent pulls race on the working tree:
```
fatal: Cannot fast-forward to multiple branches.
failed to run commands: exit status 128
```
That is what the 2026-06-18 dry rehearsal hit (3 of 4 specs failed). The `Ssm.InvocationDoesNotExist` seen at the SF level was a secondary symptom. It would **also silently drop challenger specs on every live Saturday** — and 6/20 is the first real run with parallel model-zoo under full concurrency.

**Fix:** `ResolveZooSpecs` runs **once** before the Map and already does the identical pull + config pull + `predictor.yaml` cp, so the per-spec repetition is pure redundancy. Removed it from `TrainSpecDispatch`. The checkout is already at fresh `main`; each spec's `spot_train.sh` clones the repo fresh on its own spot anyway. **`MaxConcurrency` stays 4** — real parallelism preserved; only the racy shared-tree write is removed.

**Validation:** JSON valid (83 states); 634 SF/wiring tests pass. Auto-deploys via `deploy-infrastructure.yml` on merge (re-stamps the live Saturday SF).

Closes #1138 (config repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)