### PR TITLE
feat(features): SIZE Barra loading (market_cap_raw + size_zscore) — config#1142

### DIFF
--- a/collectors/fundamentals.py
+++ b/collectors/fundamentals.py
@@ -243,6 +243,12 @@ NEUTRAL = {
     "payout_ratio": 0.0,
     "dividend_yield": 0.0,
     "capex_growth_5y": 0.0,
+    # SIZE pillar substrate (config#1142) — raw market cap (absolute units).
+    # Surfaced from the already-fetched ``marketCapitalization`` metric;
+    # the feature engineer takes log() and the cross-sectional pass emits
+    # the Barra SIZE loading (size_zscore). 0.0 here -> size NaN downstream
+    # (log guard), so a missing-cap ticker is excluded rather than mis-sized.
+    "market_cap_raw": 0.0,
 }
 
 
@@ -302,6 +308,16 @@ def _fetch_single_ticker(ticker: str) -> dict:
     else:
         fcf_yield_raw = 0.0
 
+    # SIZE pillar substrate (config#1142): persist the already-fetched raw
+    # market cap, UN-clipped / UN-normalized (it is the ``_raw`` column).
+    # ``marketCapitalization`` is surfaced as Finnhub reports it (the same
+    # source the fcf_yield ratio above already consumes). Non-positive /
+    # missing -> 0.0; the feature engineer's log() guard maps 0.0 -> NaN so
+    # a capless ticker is EXCLUDED from the SIZE cross-section, never mis-
+    # sized. The SIZE loading is scale-invariant (a constant log shift is
+    # removed by cross-sectional z-scoring), so the native unit is fine.
+    market_cap_raw = market_cap if (market_cap and market_cap > 0) else 0.0
+
     # ── Growth pillar substrate (Phase 3a of attractiveness-pillars-260520) ──
     # 3-year CAGR signals from Finnhub. Smoother than TTM YoY for
     # composite ranking (base-effect noise + single-quarter anomalies
@@ -347,6 +363,11 @@ def _fetch_single_ticker(ticker: str) -> dict:
         "payout_ratio": _clip(payout_ratio_raw, 0.0, 2.0),
         "dividend_yield": _clip(dividend_yield_raw, 0.0, 0.20),
         "capex_growth_5y": _clip(capex_growth_5y_raw, -1.0, 2.0),
+        # SIZE pillar substrate (config#1142): raw market cap in USD,
+        # deliberately UN-clipped/UN-normalized (it's a _raw column). The
+        # SIZE loading's log + cross-sectional z-score downstream tames the
+        # scale; clipping here would corrupt the absolute units.
+        "market_cap_raw": market_cap_raw,
     }
 
 

--- a/features/SCHEMA.md
+++ b/features/SCHEMA.md
@@ -168,6 +168,7 @@ parity.
 | `payout_ratio` | 0–2 clipped ratio | TTM dividends / net income | predictor |
 | `dividend_yield` | decimal pct (bare-named convention) | indicated annual dividend yield | predictor |
 | `capex_growth_5y` | decimal pct (bare-named convention) | 5y CAPEX growth | predictor |
+| `market_cap_raw` | raw market cap, absolute units (`_raw` suffix) | Finnhub `marketCapitalization`, un-clipped / un-normalized; base input to the Barra SIZE loading `size_zscore` (scale-invariant) | predictor; research (Barra SIZE loading source for score-neutralization, config#1142); executor risk-model (potential consumer) |
 
 ### Factor loadings (cross-sectional, daily refresh)
 
@@ -191,6 +192,7 @@ outlier ticker cannot dominate the downstream factor-return regression
 | `dist_from_52w_high_zscore` | z-score | Cross-sectional z of `dist_from_52w_high`, ±3σ winsorized | executor (proximity-to-high / reversal-risk loading, C.3) |
 | `pe_ratio_zscore` | z-score | Cross-sectional z of `pe_ratio`, ±3σ winsorized | executor (Barra VALUE proxy via 1/PE direction, C.3) |
 | `roe_zscore` | z-score | Cross-sectional z of `roe`, ±3σ winsorized | executor (Barra QUALITY — profitability loading, C.3) |
+| `size_zscore` | z-score | Cross-sectional z of `log(market_cap_raw)`, ±3σ winsorized (log pre-transform; non-positive cap → NaN, excluded) | research (Barra SIZE loading for momentum+beta+size score-neutralization, config#1142); executor risk-model (Barra SIZE — potential C.3 consumer) |
 
 ---
 

--- a/features/cross_sectional.py
+++ b/features/cross_sectional.py
@@ -40,6 +40,9 @@ log = logging.getLogger(__name__)
 #   • dist-from-52w-high — proximity-to-high / reversal-risk factor
 #   • value (1/PE proxy) — Barra's VALUE family
 #   • quality (ROE) — Barra's QUALITY / profitability factor
+#   • size (log market cap) — Barra's SIZE factor (config#1142) — completes
+#     the institutional Barra set; uses a log pre-transform (see
+#     FACTOR_LOADING_TRANSFORMS) because SIZE is canonically z(log(mktcap)).
 FACTOR_LOADING_SOURCES: dict[str, str] = {
     "momentum_20d":         "momentum_20d_zscore",
     "return_60d":           "return_60d_zscore",
@@ -49,6 +52,32 @@ FACTOR_LOADING_SOURCES: dict[str, str] = {
     "dist_from_52w_high":   "dist_from_52w_high_zscore",
     "pe_ratio":             "pe_ratio_zscore",
     "roe":                  "roe_zscore",
+    "market_cap_raw":       "size_zscore",
+}
+
+
+def _log_positive(series: pd.Series) -> pd.Series:
+    """np.log with a non-positive guard: x <= 0 (or non-finite) -> NaN.
+
+    Barra SIZE = z-score of log(market cap). Raw market cap is fat-right-
+    tailed, so the z-score is taken on the log scale. A 0.0 / negative /
+    missing market cap (the collector's NEUTRAL default for a capless or
+    uncovered ticker) maps to NaN here, which the cross-sectional z-score
+    excludes — the ticker is dropped from the SIZE cross-section rather than
+    being assigned a spurious extreme-small loading. Fail-soft, additive.
+    """
+    arr = series.astype(float)
+    return pd.Series(
+        np.where(arr > 0.0, np.log(arr.where(arr > 0.0)), np.nan),
+        index=series.index,
+    )
+
+
+# Optional per-source PRE-TRANSFORM applied before winsorize+z-score.
+# Default (source absent here) is identity. SIZE is the first user: it
+# z-scores log(market_cap_raw), not raw market cap.
+FACTOR_LOADING_TRANSFORMS: dict[str, "callable"] = {
+    "market_cap_raw": _log_positive,
 }
 
 _WINSORIZE_SIGMA = 3.0
@@ -138,5 +167,9 @@ def apply_factor_zscores(
             )
             out[dst] = np.nan
             continue
-        out[dst] = _winsorize_and_zscore(out[src].astype(float))
+        col = out[src].astype(float)
+        transform = FACTOR_LOADING_TRANSFORMS.get(src)
+        if transform is not None:
+            col = transform(col)
+        out[dst] = _winsorize_and_zscore(col)
     return out

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -181,6 +181,11 @@ FEATURES = [
     "payout_ratio",
     "dividend_yield",
     "capex_growth_5y",
+    # SIZE pillar substrate (config#1142) — raw market cap in USD. The base
+    # input to the Barra SIZE loading (size_zscore below); itself a feature
+    # column so it lands in the cross-sectional panel apply_factor_zscores
+    # reads. Persisted from Finnhub's already-fetched marketCapitalization.
+    "market_cap_raw",
     # v3.1 additions — longer-horizon + overnight/intraday decomposition +
     # reversal-native signals. Predictor ROADMAP P2: collapse FLAT +
     # test whether 5d is reversal or momentum regime. 2026-04-15: neutral
@@ -234,6 +239,11 @@ FEATURES = [
     "dist_from_52w_high_zscore",
     "pe_ratio_zscore",
     "roe_zscore",
+    # SIZE (config#1142) — completes the institutional Barra factor set.
+    # Cross-sectional ±3σ-winsorized z-score of log(market_cap_raw),
+    # emitted by apply_factor_zscores (log pre-transform registered in
+    # cross_sectional.FACTOR_LOADING_TRANSFORMS). Barra SIZE loading.
+    "size_zscore",
 ]
 
 MIN_ROWS_FOR_FEATURES = 265  # 252 warmup + buffer
@@ -795,6 +805,8 @@ def compute_features(
         df["payout_ratio"] = _safe_float(fundamental_data.get("payout_ratio"), 0.0)
         df["dividend_yield"] = _safe_float(fundamental_data.get("dividend_yield"), 0.0)
         df["capex_growth_5y"] = _safe_float(fundamental_data.get("capex_growth_5y"), 0.0)
+        # SIZE pillar substrate (config#1142) — raw market cap in USD.
+        df["market_cap_raw"] = _safe_float(fundamental_data.get("market_cap_raw"), 0.0)
     else:
         df["pe_ratio"] = 0.0
         df["pb_ratio"] = 0.0
@@ -809,6 +821,8 @@ def compute_features(
         df["payout_ratio"] = 0.0
         df["dividend_yield"] = 0.0
         df["capex_growth_5y"] = 0.0
+        # SIZE pillar substrate (config#1142) — 0.0 -> log() guard -> size NaN.
+        df["market_cap_raw"] = 0.0
 
     # Rows with NaN features are NOT dropped — see module docstring. A
     # feature whose rolling-window warmup exceeds the available history

--- a/features/registry.py
+++ b/features/registry.py
@@ -128,8 +128,13 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("payout_ratio", "fundamental", "TTM dividends / net income (0-2 clipped); Stewardship pillar input — retention rate = 1 - payout drives reinvestment", source="fmp", refresh="quarterly"),
     FeatureEntry("dividend_yield", "fundamental", "Indicated annual dividend yield (decimal, 0-0.2 clipped); Stewardship pillar input", source="fmp", refresh="quarterly"),
     FeatureEntry("capex_growth_5y", "fundamental", "5-year CAPEX growth (decimal); Stewardship pillar input — reinvestment intensity proxy", source="fmp", refresh="quarterly"),
+    # SIZE pillar substrate (config#1142) — raw market cap, absolute units
+    # (the _raw suffix encodes absolute / un-normalized units). Surfaced from
+    # Finnhub's already-fetched marketCapitalization; UN-clipped/UN-normalized.
+    # Base input to the Barra SIZE loading (size_zscore); scale-invariant.
+    FeatureEntry("market_cap_raw", "fundamental", "Raw market capitalization (absolute units, un-normalized) surfaced from Finnhub marketCapitalization. Base input to the Barra SIZE factor loading (size_zscore).", source="finnhub", refresh="quarterly"),
 
-    # ── Factor loadings (8) — C.1 of optimizer-sota-upgrades-260526 ──────────
+    # ── Factor loadings (9) — C.1 of optimizer-sota-upgrades-260526 ──────────
     # Cross-sectional ±3σ-winsorized z-scores of canonical Barra-style factors.
     # Columns of the factor-loading matrix B for the executor's Σ = B·F·Bᵀ + D
     # risk decomposition (workstream C.3). Computed POST-assembly in
@@ -142,6 +147,7 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("dist_from_52w_high_zscore", "factor_loading", "Cross-sectional z-score of dist_from_52w_high (winsorized ±3σ). Proximity-to-high / reversal-risk loading.", source="derived", refresh="daily"),
     FeatureEntry("pe_ratio_zscore", "factor_loading", "Cross-sectional z-score of pe_ratio (winsorized ±3σ). Barra VALUE loading (proxy via 1/PE direction).", source="derived", refresh="daily"),
     FeatureEntry("roe_zscore", "factor_loading", "Cross-sectional z-score of roe (winsorized ±3σ). Barra QUALITY / profitability loading.", source="derived", refresh="daily"),
+    FeatureEntry("size_zscore", "factor_loading", "Cross-sectional z-score of log(market_cap_raw) (winsorized ±3σ). Barra SIZE loading (config#1142) — completes the institutional Barra factor set.", source="derived", refresh="daily"),
 ]
 
 # Quick lookup by name

--- a/tests/test_factor_loading_zscore.py
+++ b/tests/test_factor_loading_zscore.py
@@ -93,7 +93,7 @@ class TestWinsorizeAndZscore:
 
 class TestApplyFactorZscores:
     def _baseline_panel(self):
-        """Synthetic cross-sectional panel with 50 tickers and all 8
+        """Synthetic cross-sectional panel with 50 tickers and all 9
         source columns populated. Each column has a distinct scale to
         verify standardization handles heterogeneous units."""
         rng = np.random.default_rng(7)
@@ -107,6 +107,10 @@ class TestApplyFactorZscores:
             "dist_from_52w_high":  rng.uniform(-0.30, 0.0, 50),
             "pe_ratio":            rng.lognormal(3.0, 0.3, 50),
             "roe":                 rng.normal(0.12, 0.08, 50),
+            # SIZE (config#1142): raw market cap in USD, fat-right-tailed
+            # (lognormal — realistic $1B–$2T cross-section). The size_zscore
+            # loading log-transforms this before z-scoring.
+            "market_cap_raw":      rng.lognormal(24.0, 1.5, 50),
         })
 
     def test_emits_all_eight_factor_loading_columns(self):
@@ -172,14 +176,16 @@ class TestApplyFactorZscores:
         # Default emit not invoked
         assert "momentum_20d_zscore" not in out.columns
 
-    def test_default_source_map_matches_eight_canonical_factors(self):
-        """The default factor set is the v1 canonical Barra-style loading
-        matrix. Adding a 9th factor here also requires CATALOG + SCHEMA.md
-        updates — keep this test as the chokepoint."""
-        assert len(FACTOR_LOADING_SOURCES) == 8
+    def test_default_source_map_matches_canonical_barra_factors(self):
+        """The default factor set is the canonical institutional Barra-style
+        loading matrix. SIZE (config#1142) completes the set at 9 factors.
+        Adding a 10th factor here also requires CATALOG + SCHEMA.md updates —
+        keep this test as the chokepoint."""
+        assert len(FACTOR_LOADING_SOURCES) == 9
         expected_sources = {
             "momentum_20d", "return_60d", "beta_60d", "idio_vol_60d",
             "realized_vol_63d", "dist_from_52w_high", "pe_ratio", "roe",
+            "market_cap_raw",
         }
         assert set(FACTOR_LOADING_SOURCES.keys()) == expected_sources
 
@@ -215,6 +221,72 @@ class TestApplyFactorZscores:
                 f"Column {dst} has z-score outside ±4.5σ after winsorization: "
                 f"max={float(z.abs().max()):.4f}"
             )
+
+
+class TestSizeLoading:
+    """SIZE Barra loading (config#1142) — z-score of log(market_cap_raw).
+
+    The SIZE factor is unique in the set: it applies a log PRE-transform
+    before winsorize+z-score (raw market cap is fat-right-tailed; Barra
+    SIZE is canonically z(log(mktcap))). These tests pin (a) the log is
+    actually applied, (b) non-positive caps are excluded (fail-soft), and
+    (c) the emitted loading is a finite, centered z-score on real data.
+    """
+
+    def _cap_panel(self, n: int = 60):
+        rng = np.random.default_rng(11)
+        # Realistic market caps spanning small ($300M) to mega ($2T).
+        caps = rng.lognormal(mean=24.0, sigma=1.8, size=n)
+        return pd.DataFrame({
+            "ticker": [f"T{i:02d}" for i in range(n)],
+            "market_cap_raw": caps,
+        })
+
+    def test_size_zscore_emitted(self):
+        out = apply_factor_zscores(self._cap_panel())
+        assert "size_zscore" in out.columns
+
+    def test_size_zscore_is_finite_centered_unit_std(self):
+        out = apply_factor_zscores(self._cap_panel())
+        z = out["size_zscore"].dropna()
+        assert len(z) > 0
+        assert np.isfinite(z).all(), "size_zscore must be finite on positive caps"
+        assert abs(float(z.mean())) < 0.05
+        assert abs(float(z.std(ddof=0)) - 1.0) < 0.1
+
+    def test_size_uses_log_transform_not_raw(self):
+        """The loading must z-score LOG(mktcap), not raw mktcap. Proof: a
+        mega-cap outlier (10× the next-largest) on the RAW scale would, after
+        winsorization, sit at the clip bound; on the LOG scale it is far
+        closer to the bulk. So z(log) and z(raw) differ materially — the
+        emitted column must match z(log)."""
+        from features.cross_sectional import _log_positive, _winsorize_and_zscore
+        df = self._cap_panel()
+        out = apply_factor_zscores(df)
+        expected = _winsorize_and_zscore(_log_positive(df["market_cap_raw"]))
+        pd.testing.assert_series_equal(
+            out["size_zscore"], expected, check_names=False,
+        )
+        # And it must NOT equal the raw (no-transform) z-score.
+        raw_z = _winsorize_and_zscore(df["market_cap_raw"].astype(float))
+        assert not np.allclose(
+            out["size_zscore"].to_numpy(), raw_z.to_numpy(), equal_nan=True,
+        ), "size_zscore appears to skip the log pre-transform"
+
+    def test_non_positive_cap_excluded_not_raised(self):
+        """A 0.0 / negative market cap (collector NEUTRAL default for a
+        capless ticker) must map to NaN (excluded), never raise, never
+        produce -inf from log(0)."""
+        df = self._cap_panel(n=40)
+        df.loc[0, "market_cap_raw"] = 0.0        # NEUTRAL default
+        df.loc[1, "market_cap_raw"] = -5.0       # pathological negative
+        out = apply_factor_zscores(df)
+        z = out["size_zscore"]
+        assert pd.isna(z.iloc[0]), "zero cap must -> NaN (excluded)"
+        assert pd.isna(z.iloc[1]), "negative cap must -> NaN (excluded)"
+        # The rest are finite and the column never contains ±inf.
+        assert np.isfinite(z.iloc[2:]).all()
+        assert not np.isinf(z.to_numpy()).any()
 
 
 class TestFactorLoadingsRegisteredInSchema:


### PR DESCRIPTION
## Summary

Completes the institutional **Barra factor set** by adding the missing **SIZE** loading (momentum / beta / value / quality / resvol / volatility already existed). Unblocks **config#1142**'s momentum+beta+size score-neutralization.

Market cap was **already fetched** from Finnhub (`stock/metric?metric=all` -> `marketCapitalization`, verified live for all sampled tickers) and consumed to compute `fcf_yield`, but it was never persisted. This change surfaces it and emits the SIZE loading.

## New columns

| Column | Suffix | Meaning |
|---|---|---|
| `market_cap_raw` | `_raw` | Raw market cap (absolute units, un-clipped / un-normalized); base input to SIZE |
| `size_zscore` | `_zscore` | Cross-sectional ±3σ-winsorized z-score of `log(market_cap_raw)` — Barra SIZE loading |

## Changes

- **`collectors/fundamentals.py`** — persist `market_cap_raw` (surface the already-computed `market_cap`, un-clipped) in `_fetch_single_ticker`'s return dict + `NEUTRAL` (default 0.0). Not added to the value-range gate (unbounded `_raw` column by design).
- **`features/feature_engineer.py`** — `market_cap_raw` flows from `fundamental_data` into the feature DataFrame exactly like `pe_ratio`/`roe`; both columns added to `FEATURES` so `market_cap_raw` lands in the cross-sectional panel that `apply_factor_zscores` reads.
- **`features/cross_sectional.py`** — map `market_cap_raw` -> `size_zscore`; added a `FACTOR_LOADING_TRANSFORMS` log pre-transform hook (Barra SIZE = z(log(mktcap))). Non-positive cap -> NaN -> excluded.
- **`features/SCHEMA.md`** + **`features/registry.py`** — rows for both columns.
- **`tests/test_factor_loading_zscore.py`** — baseline panel + canonical-set count updated to 9; new `TestSizeLoading` (log applied, non-positive excluded, finite centered z-score).

## Safety — additive + fail-soft

Runs on the critical Saturday DataPhase1 path. `market_cap_raw` missing / `<= 0` -> `log()` guard -> `size` NaN -> ticker **excluded** from the SIZE cross-section, never raises, never produces ±inf. No existing column semantics changed; schema-contract test not weakened (suffix rule satisfied by `_raw` / `_zscore`, SCHEMA + registry rows added).

## Data flow confirmed

`Finnhub marketCapitalization` -> `_fetch_single_ticker` (`market_cap_raw`) -> `collect()` snapshot -> `compute_features(fundamental_data=...)` sets `df["market_cap_raw"]` -> in `FEATURES` -> `compute.py` panel -> `apply_factor_zscores` (log + winsorize + z) -> `size_zscore`.

## Tests

`pytest tests/ -q`: **2077 passed, 2 skipped** (full suite). Schema-contract + factor-loading + fundamentals targeted run green. `py_compile` clean on all changed files.
