### PR TITLE
fix(eod-sf): mark EOD steps deployed so SSM token wins over stale .env (config#1148)

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -74,6 +74,8 @@
             "set -o pipefail",
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "export ALPHA_ENGINE_DEPLOYED=1",
+            "export FLOW_DOCTOR_ENABLED=1",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/postmarket-data.log \"s3://alpha-engine-research/_ssm_logs/postmarket-data/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python weekly_collector.py --daily --skip-arctic-append 2>&1 | tee /var/log/postmarket-data.log"
@@ -186,6 +188,8 @@
             "set -o pipefail",
             "cd /home/ec2-user/alpha-engine-data",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "export ALPHA_ENGINE_DEPLOYED=1",
+            "export FLOW_DOCTOR_ENABLED=1",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/postmarket-arctic-append.log \"s3://alpha-engine-research/_ssm_logs/postmarket-arctic-append/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python weekly_collector.py --daily-arctic-append 2>&1 | tee /var/log/postmarket-arctic-append.log"
@@ -276,6 +280,8 @@
             "set -o pipefail",
             "cd /home/ec2-user/alpha-engine",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "export ALPHA_ENGINE_DEPLOYED=1",
+            "export FLOW_DOCTOR_ENABLED=1",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/snapshot.log \"s3://alpha-engine-research/_ssm_logs/snapshot/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python executor/snapshot_capturer.py 2>&1 | tee /var/log/snapshot.log"
@@ -374,6 +380,8 @@
             "set -o pipefail",
             "cd /home/ec2-user/alpha-engine",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
+            "export ALPHA_ENGINE_DEPLOYED=1",
+            "export FLOW_DOCTOR_ENABLED=1",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/eod.log \"s3://alpha-engine-research/_ssm_logs/eod/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python executor/eod_reconcile.py 2>&1 | tee /var/log/eod.log"


### PR DESCRIPTION
## What
Adds `export ALPHA_ENGINE_DEPLOYED=1` + `export FLOW_DOCTOR_ENABLED=1` to all 4 EOD SF python steps (PostMarketData, PostMarketArcticAppend, CaptureSnapshot, EODReconcile).

## Why
The weekday SF already marks its SSM steps deployed; the **EOD SF was the laggard** — it `source`s the legacy `~/.alpha-engine.env` but never set `ALPHA_ENGINE_DEPLOYED`. So `nousergon_lib`'s flow-doctor secret seed treated the EOD run as non-deployed and let the **stale** sourced `FLOW_DOCTOR_GITHUB_TOKEN` win over SSM — which is exactly why the github_issue 403 storm originated in `eod_reconcile` (config#1148).

## Pairs with
nousergon-lib #125 (SSM-authoritative seed when deployed). With `DEPLOYED=1` set here, the seed overwrites the stale sourced token with the live SSM value. Order-independent for correctness; the fix takes effect once both this deploy and the lib repin reach the box.

`FLOW_DOCTOR_ENABLED=1` added for parity with the weekday SF (explicit activation + strict posture on the deployed EOD path).

## Tests / deploy
- SF wiring suite green (89: pipefail, eod-skipgate, eod-substrate, mutex).
- This repo auto-deploys the Step Functions on merge to main — merging redeploys the EOD SF live.

config#1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)