### PR TITLE
feat(config): experiment-package-first config.yaml in load_config (config#1042)

### DIFF
--- a/tests/test_load_config_experiment_package.py
+++ b/tests/test_load_config_experiment_package.py
@@ -1,0 +1,48 @@
+"""Experiment-package precedence for weekly_collector.load_config (config#1042)."""
+
+import os
+from pathlib import Path
+
+import yaml
+
+import weekly_collector
+
+
+def _write(p: Path, data: dict) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(data))
+
+
+def test_experiment_package_wins_over_legacy(tmp_path, monkeypatch):
+    """experiments/$EXP/data/config.yaml resolves ahead of legacy data/config.yaml."""
+    home = tmp_path / "home"
+    cfg_repo = home / "alpha-engine-config"
+    _write(cfg_repo / "data" / "config.yaml", {"source": "legacy"})
+    _write(cfg_repo / "experiments" / "reference" / "data" / "config.yaml", {"source": "package"})
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.delenv("ALPHA_ENGINE_EXPERIMENT_ID", raising=False)
+
+    assert weekly_collector.load_config()["source"] == "package"
+
+
+def test_experiment_id_selects_slot(tmp_path, monkeypatch):
+    """A non-default ALPHA_ENGINE_EXPERIMENT_ID selects its own package slot."""
+    home = tmp_path / "home"
+    cfg_repo = home / "alpha-engine-config"
+    _write(cfg_repo / "experiments" / "reference" / "data" / "config.yaml", {"source": "reference"})
+    _write(cfg_repo / "experiments" / "myexp" / "data" / "config.yaml", {"source": "myexp"})
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.setenv("ALPHA_ENGINE_EXPERIMENT_ID", "myexp")
+
+    assert weekly_collector.load_config()["source"] == "myexp"
+
+
+def test_falls_back_to_legacy_when_no_package(tmp_path, monkeypatch):
+    """With no experiment-package file, the legacy data/config.yaml still resolves."""
+    home = tmp_path / "home"
+    cfg_repo = home / "alpha-engine-config"
+    _write(cfg_repo / "data" / "config.yaml", {"source": "legacy"})
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.delenv("ALPHA_ENGINE_EXPERIMENT_ID", raising=False)
+
+    assert weekly_collector.load_config()["source"] == "legacy"

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -85,13 +85,22 @@ logger = logging.getLogger(__name__)
 
 
 def load_config(path: str = "config.yaml") -> dict:
-    """Load config.yaml from config repo or local fallback."""
-    # Search config repo first, then local
-    search_paths = [
-        Path.home() / "alpha-engine-config" / "data" / "config.yaml",
-        Path(__file__).parent.parent / "alpha-engine-config" / "data" / "config.yaml",
-        Path(path),
+    """Load config.yaml, experiment-package first (config#1042).
+
+    Search order mirrors features/feature_engineer.py::_load_feature_cfg_overrides:
+    experiments/$ALPHA_ENGINE_EXPERIMENT_ID/data/config.yaml (default experiment
+    ``reference``) first, then the legacy top-level alpha-engine-config/data/config.yaml,
+    then the repo-local fallback (``path``). The experiment-package layer was already
+    live in feature_engineer; this closes the gap that file's docstring references.
+    """
+    exp = os.environ.get("ALPHA_ENGINE_EXPERIMENT_ID", "reference")
+    roots = [
+        Path.home() / "alpha-engine-config",
+        Path(__file__).parent.parent / "alpha-engine-config",
     ]
+    search_paths = [r / "experiments" / exp / "data" / "config.yaml" for r in roots]
+    search_paths += [r / "data" / "config.yaml" for r in roots]
+    search_paths.append(Path(path))
     for p in search_paths:
         if p.exists():
             with open(p) as f:


### PR DESCRIPTION
Data half of **config#1042** (experiment-package adoption).

## What
`weekly_collector.load_config` now resolves `data/config.yaml` from `experiments/$ALPHA_ENGINE_EXPERIMENT_ID/data/config.yaml` (default experiment `reference`) **ahead of** the legacy top-level `alpha-engine-config/data/config.yaml`, then the repo-local fallback (`path`).

## Why this is a real gap, not a no-op
`features/feature_engineer.py::_load_feature_cfg_overrides` already had the experiment-package layer and its docstring claims it *"mirrors weekly_collector.load_config + the package layer"* — but `load_config` itself never got that layer. This closes the inconsistency so both data-side loaders resolve identically.

## Tests
`tests/test_load_config_experiment_package.py` — package-wins-over-legacy, slot selection by `ALPHA_ENGINE_EXPERIMENT_ID`, legacy fallback when no package file. **3 passed**, plus **62** related `weekly_collector` tests green (`.venv`).

## Sibling PRs (config#1042 arc)
- crucible-executor#271 (risk.yaml loader) — open.
- backtester `config.yaml` loader — next.
- Lib consolidation + legacy-dir removal (config#1042 step 4, gated on all loader PRs merging) — follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)