### PR TITLE
feat(infra): off-cycle weekly-run wrapper (run_weekly_offcycle.sh)

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -10,3 +10,43 @@ removal. Operators: find them at `nous-ergon-ops/<this-repo>/<same-path>`.
 - `backfill_reference_price_cache.sh`, `setup_eval_quality_alarm.sh` (one-shot backfill/alarm setup)
 - `iam/github-actions-lambda-deploy.trust.json` (trust doc; excluded from check-drift.py's glob)
 - `cloudformation/resources-to-import.json` + `cloudformation/RECOVERY.md` (RECOVERY.md completes its Phase-1 move)
+
+## Off-cycle weekly runs — `run_weekly_offcycle.sh`
+
+Fire the weekly Saturday pipeline **off-schedule** (holiday weeks, schedule
+shifts, ad-hoc rehearsals) without hand-building the `start-execution` JSON.
+The two production triggers are:
+
+- **Friday shell run** — event-driven via the
+  `eod-success-friday-shell-trigger` Lambda (fires on Friday EOD success).
+  On a **holiday Friday there is no EOD success → no shell run**, so the
+  manual `shell` verb is the only way to get the rehearsal that week.
+- **Saturday full run** — the `alpha-engine-saturday` EventBridge cron
+  (`cron(0 9 ? * SAT *)`).
+
+```bash
+bash infrastructure/run_weekly_offcycle.sh shell      # rehearsal now (additive, safe anytime)
+bash infrastructure/run_weekly_offcycle.sh full       # full weekly now + suppress next Sat cron
+bash infrastructure/run_weekly_offcycle.sh full --dry-run
+bash infrastructure/run_weekly_offcycle.sh status     # cron state + pending re-enable + recent runs
+bash infrastructure/run_weekly_offcycle.sh restore    # re-enable Sat cron + drop pending re-enable (escape hatch)
+```
+
+**Why `full` touches the cron.** A `full` run is *not* additive — if a
+scheduled Saturday fire follows it the weekly pipeline runs twice (wasted
+spot $, double model-zoo rotation, artifact clobber). So `full`:
+
+1. ensures a narrowly-scoped EventBridge Scheduler role
+   (`alpha-engine-offcycle-cron-role`, `events:EnableRule` on the Saturday
+   rule only),
+2. registers a **one-time** re-enable schedule at the skipped Saturday
+   09:30 UTC (`ActionAfterCompletion=DELETE` → self-cleans),
+3. **then** disables the cron, **then** starts the execution.
+
+Re-enable is scheduled+verified *before* the cron is disabled, so any
+failure aborts with the rule still ENABLED (re-enabling an enabled rule is
+a no-op). Zero manual follow-up — next week's cadence is untouched. The
+input contracts are pinned by `tests/test_run_weekly_offcycle.py`.
+
+Holiday-week recipe (e.g. Juneteenth Fri): `shell` first → wait for
+SUCCEEDED → `full` (they share the t3.small box, so run sequentially).

--- a/infrastructure/run_weekly_offcycle.sh
+++ b/infrastructure/run_weekly_offcycle.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# run_weekly_offcycle.sh — fire the weekly Saturday pipeline OFF-SCHEDULE.
+#
+# Low-friction operator wrapper for the two weekly triggers when you need to
+# run them on a non-standard day (holiday weeks, schedule shifts, ad-hoc
+# rehearsals). It reproduces — byte-for-byte — the two production input
+# contracts so an off-cycle run is indistinguishable from the scheduled one:
+#
+#   * `shell` — the Friday rehearsal. Mirrors the input built by the
+#     `alpha-engine-eod-success-friday-shell-trigger` Lambda
+#     (`shell_run=true`, `pipeline_role="shell-run"`). PURELY ADDITIVE — the
+#     shell run boots spots + validates bootstrap/import/clone/lib-pin/wiring
+#     and short-circuits the workloads; it never conflicts with the Saturday
+#     cron, so it is safe to fire any time. On a holiday Friday there is no
+#     EOD success, so the Lambda never fires and this is the ONLY way to get
+#     the rehearsal.
+#
+#   * `full` — the canonical weekly run. Mirrors the `alpha-engine-saturday`
+#     EventBridge cron target input (`pipeline_role="weekly"`, no
+#     `shell_run`). A `full` run is NOT additive: if a scheduled Saturday
+#     cron fire follows it, the weekly pipeline would run TWICE (wasted spot
+#     $, double model-zoo rotation, artifact clobber). So `full` SUPPRESSES
+#     the next Saturday cron fire and registers a one-time EventBridge
+#     Scheduler job that AUTO RE-ENABLES the rule right after that skipped
+#     fire — zero manual follow-up, next week's cadence untouched.
+#
+# Fail-loud ordering for `full`: the auto re-enable is scheduled and verified
+# BEFORE the cron rule is disabled, and the cron is disabled + verified BEFORE
+# the execution starts. Any failure aborts in a SAFE state (rule left ENABLED;
+# re-enabling an already-enabled rule is an idempotent no-op that self-deletes).
+#
+# Verbs:
+#   shell             start a shell-run (rehearsal) now
+#   full              start a full weekly run now + suppress next Saturday cron
+#   restore           re-enable the Saturday cron now + drop any pending
+#                     re-enable schedule (manual escape hatch)
+#   status            show cron-rule state, pending re-enable schedule, recent runs
+#
+# Usage:
+#   bash infrastructure/run_weekly_offcycle.sh shell
+#   bash infrastructure/run_weekly_offcycle.sh full
+#   bash infrastructure/run_weekly_offcycle.sh full --dry-run
+#   bash infrastructure/run_weekly_offcycle.sh restore
+#   bash infrastructure/run_weekly_offcycle.sh status
+#
+# Auth: uses active AWS CLI creds (personal IAM user has enough perms).
+# Deliberately operator-run, not wired into CI — same convention as
+# infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+SF_NAME="alpha-engine-saturday-pipeline"
+SF_ARN="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:${SF_NAME}"
+SATURDAY_RULE="alpha-engine-saturday"
+SATURDAY_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${SATURDAY_RULE}"
+
+# These two MUST match the live cron target + the friday-shell Lambda inputs.
+# Pinned by tests/test_run_weekly_offcycle.py against the CFN / Lambda source.
+EC2_INSTANCE_ID="i-09b539c844515d549"
+SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
+
+# Auto re-enable infra (one-time EventBridge Scheduler job + its execution role)
+REENABLE_ROLE_NAME="alpha-engine-offcycle-cron-role"
+REENABLE_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${REENABLE_ROLE_NAME}"
+REENABLE_SCHEDULE_PREFIX="reenable-saturday-"
+REENABLE_UNIVERSAL_TARGET="arn:aws:scheduler:::aws-sdk:eventbridge:enableRule"
+
+DRY_RUN=false
+VERB=""
+for arg in "$@"; do
+  case "$arg" in
+    shell|full|restore|status) VERB="$arg" ;;
+    --dry-run) DRY_RUN=true ;;
+    -h|--help) sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "ERROR: unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$VERB" ]]; then
+  echo "ERROR: a verb is required (shell | full | restore | status)" >&2
+  echo "       run with --help for usage" >&2
+  exit 2
+fi
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+utc_stamp() { date -u +%Y%m%d-%H%M%S; }
+utc_date()  { date -u +%Y-%m-%d; }
+
+# Next Saturday on/after today (UTC). Used to skip exactly the upcoming cron fire.
+next_saturday_utc() {
+  # date(1) on macOS (BSD) vs Linux (GNU) differ; probe and branch.
+  if date -u -v +1d >/dev/null 2>&1; then
+    # BSD date (macOS)
+    local d=0 dow
+    while [[ $d -lt 7 ]]; do
+      dow=$(date -u -v +"${d}"d +%u)   # %u: 1=Mon..7=Sun; Saturday=6
+      if [[ "$dow" == "6" ]]; then
+        date -u -v +"${d}"d +%Y-%m-%d
+        return 0
+      fi
+      d=$((d + 1))
+    done
+  else
+    # GNU date (Linux / CI)
+    local d=0 dow
+    while [[ $d -lt 7 ]]; do
+      dow=$(date -u -d "+${d} day" +%u)
+      if [[ "$dow" == "6" ]]; then
+        date -u -d "+${d} day" +%Y-%m-%d
+        return 0
+      fi
+      d=$((d + 1))
+    done
+  fi
+  echo "ERROR: could not compute next Saturday" >&2
+  return 1
+}
+
+# ── input builders (the two production contracts) ───────────────────────────
+
+shell_input() {
+  cat <<EOF
+{"ec2_instance_id": ["${EC2_INSTANCE_ID}"], "sns_topic_arn": "${SNS_TOPIC_ARN}", "shell_run": true, "pipeline_role": "shell-run"}
+EOF
+}
+
+full_input() {
+  cat <<EOF
+{"ec2_instance_id": ["${EC2_INSTANCE_ID}"], "sns_topic_arn": "${SNS_TOPIC_ARN}", "pipeline_role": "weekly"}
+EOF
+}
+
+start_execution() {
+  local name="$1" input="$2"
+  echo "Starting ${SF_NAME} execution: ${name}"
+  echo "  input: ${input}"
+  if $DRY_RUN; then
+    echo "DRY: aws stepfunctions start-execution --name ${name} ..."
+    return 0
+  fi
+  local arn
+  arn=$(aws stepfunctions start-execution \
+    --state-machine-arn "${SF_ARN}" \
+    --name "${name}" \
+    --input "${input}" \
+    --region "${REGION}" \
+    --query 'executionArn' --output text)
+  echo "  ✓ started: ${arn}"
+  echo "  console: https://${REGION}.console.aws.amazon.com/states/home?region=${REGION}#/v2/executions/details/${arn}"
+}
+
+# ── cron-rule helpers ───────────────────────────────────────────────────────
+
+rule_state() {
+  aws events describe-rule --name "${SATURDAY_RULE}" --region "${REGION}" \
+    --query 'State' --output text
+}
+
+# Idempotently ensure the EventBridge Scheduler execution role exists with
+# events:EnableRule on the Saturday rule only (single-target blast radius).
+ensure_reenable_role() {
+  if aws iam get-role --role-name "${REENABLE_ROLE_NAME}" \
+      --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  re-enable role exists: ${REENABLE_ROLE_NAME}"
+    return 0
+  fi
+  echo "  creating re-enable role: ${REENABLE_ROLE_NAME}"
+  local trust policy
+  trust='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  policy=$(cat <<EOF
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["events:EnableRule"],"Resource":"${SATURDAY_RULE_ARN}"}]}
+EOF
+)
+  run aws iam create-role \
+    --role-name "${REENABLE_ROLE_NAME}" \
+    --assume-role-policy-document "${trust}" \
+    --description "EventBridge Scheduler role: re-enable ${SATURDAY_RULE} after an off-cycle full run" \
+    --query 'Role.RoleName' --output text
+  run aws iam put-role-policy \
+    --role-name "${REENABLE_ROLE_NAME}" \
+    --policy-name "enable-saturday-rule" \
+    --policy-document "${policy}"
+  if ! $DRY_RUN; then
+    echo "  waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+}
+
+# Create (or replace) the one-time re-enable schedule for the given UTC date.
+# Self-deletes after firing (ActionAfterCompletion=DELETE).
+schedule_reenable() {
+  local sat_date="$1"
+  local sched_name="${REENABLE_SCHEDULE_PREFIX}${sat_date}"
+  # Re-enable at 09:30 UTC — 30 min AFTER the 09:00 cron fire window, so the
+  # rule stays DISABLED through the skipped fire, then comes back for next week.
+  local at_expr="at(${sat_date}T09:30:00)"
+  local target
+  target=$(cat <<EOF
+{"Arn":"${REENABLE_UNIVERSAL_TARGET}","RoleArn":"${REENABLE_ROLE_ARN}","Input":"{\"Name\":\"${SATURDAY_RULE}\"}"}
+EOF
+)
+  # Replace any stale schedule of the same name (create fails on conflict).
+  if aws scheduler get-schedule --name "${sched_name}" --region "${REGION}" \
+      --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  replacing existing re-enable schedule: ${sched_name}"
+    run aws scheduler delete-schedule --name "${sched_name}" --region "${REGION}"
+  fi
+  echo "  scheduling auto re-enable: ${sched_name} → ${at_expr} UTC"
+  run aws scheduler create-schedule \
+    --name "${sched_name}" \
+    --schedule-expression "${at_expr}" \
+    --schedule-expression-timezone "UTC" \
+    --flexible-time-window '{"Mode":"OFF"}' \
+    --action-after-completion DELETE \
+    --target "${target}" \
+    --region "${REGION}" \
+    --query 'ScheduleArn' --output text
+  # Verify it landed before we touch the cron rule (fail-loud).
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${sched_name}" --region "${REGION}" \
+      --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: re-enable schedule not found after create — aborting BEFORE disabling cron" >&2; exit 1; }
+  fi
+}
+
+# ── verbs ───────────────────────────────────────────────────────────────────
+
+do_shell() {
+  echo "== OFF-CYCLE SHELL RUN (rehearsal) =="
+  start_execution "offcycle-shell-$(utc_stamp)" "$(shell_input)"
+  echo "Shell run is additive — Saturday cron untouched."
+}
+
+do_full() {
+  echo "== OFF-CYCLE FULL WEEKLY RUN =="
+  local sat_date
+  sat_date=$(next_saturday_utc)
+  echo "Upcoming Saturday cron fire to SUPPRESS: ${sat_date} 09:00 UTC"
+  echo "Auto re-enable scheduled for:           ${sat_date} 09:30 UTC"
+  echo ""
+  echo "[1/3] ensure re-enable infra + schedule (BEFORE disabling cron)"
+  ensure_reenable_role
+  schedule_reenable "${sat_date}"
+  echo ""
+  echo "[2/3] disable Saturday cron"
+  run aws events disable-rule --name "${SATURDAY_RULE}" --region "${REGION}"
+  if ! $DRY_RUN; then
+    local st
+    st=$(rule_state)
+    [[ "$st" == "DISABLED" ]] \
+      || { echo "ERROR: ${SATURDAY_RULE} state is '${st}', expected DISABLED — aborting BEFORE starting run" >&2; exit 1; }
+    echo "  ✓ ${SATURDAY_RULE} is DISABLED"
+  fi
+  echo ""
+  echo "[3/3] start full weekly execution"
+  start_execution "offcycle-full-$(utc_stamp)" "$(full_input)"
+  echo ""
+  echo "Done. Saturday cron will auto re-enable at ${sat_date} 09:30 UTC."
+  echo "To restore manually at any time: bash $0 restore"
+}
+
+do_restore() {
+  echo "== RESTORE SATURDAY CRON =="
+  run aws events enable-rule --name "${SATURDAY_RULE}" --region "${REGION}"
+  if ! $DRY_RUN; then
+    local st
+    st=$(rule_state)
+    [[ "$st" == "ENABLED" ]] \
+      || { echo "ERROR: ${SATURDAY_RULE} state is '${st}', expected ENABLED" >&2; exit 1; }
+    echo "  ✓ ${SATURDAY_RULE} is ENABLED"
+  fi
+  # Drop any pending re-enable schedules (now redundant).
+  local names
+  names=$(aws scheduler list-schedules --name-prefix "${REENABLE_SCHEDULE_PREFIX}" \
+    --region "${REGION}" --query 'Schedules[].Name' --output text 2>/dev/null || true)
+  if [[ -n "${names}" ]]; then
+    for n in ${names}; do
+      echo "  deleting pending re-enable schedule: ${n}"
+      run aws scheduler delete-schedule --name "${n}" --region "${REGION}"
+    done
+  else
+    echo "  no pending re-enable schedules"
+  fi
+}
+
+do_status() {
+  echo "== OFF-CYCLE STATUS =="
+  echo "Saturday cron (${SATURDAY_RULE}): $(rule_state)"
+  echo ""
+  echo "Pending re-enable schedules:"
+  aws scheduler list-schedules --name-prefix "${REENABLE_SCHEDULE_PREFIX}" \
+    --region "${REGION}" --query 'Schedules[].Name' --output text 2>/dev/null \
+    | tr '\t' '\n' | sed 's/^/  /' | grep . || echo "  (none)"
+  echo ""
+  echo "Recent ${SF_NAME} executions:"
+  aws stepfunctions list-executions --state-machine-arn "${SF_ARN}" \
+    --max-results 5 --region "${REGION}" \
+    --query 'executions[].{name:name,status:status,start:startDate}' --output table
+}
+
+case "$VERB" in
+  shell)   do_shell ;;
+  full)    do_full ;;
+  restore) do_restore ;;
+  status)  do_status ;;
+esac

--- a/tests/test_run_weekly_offcycle.py
+++ b/tests/test_run_weekly_offcycle.py
@@ -1,0 +1,143 @@
+"""Pins the off-cycle weekly runner's input contracts + safety ordering.
+
+``infrastructure/run_weekly_offcycle.sh`` fires the Saturday pipeline
+off-schedule. Its whole value is that an off-cycle run is byte-identical to
+the scheduled one, so these tests pin the two production input contracts the
+script must reproduce:
+
+  * ``shell`` input == the ``alpha-engine-eod-success-friday-shell-trigger``
+    Lambda input (``shell_run=true`` + ``pipeline_role="shell-run"``).
+  * ``full`` input == the ``alpha-engine-saturday`` EventBridge cron target
+    input (``pipeline_role="weekly"``, NO ``shell_run``).
+
+If the live CFN cron input or the Lambda input drifts, the corresponding
+assertion here fails — forcing the runner to be re-synced rather than
+silently firing a stale contract.
+
+It also pins the ``full``-path safety invariant: the auto re-enable schedule
+is created BEFORE the cron rule is disabled (so a failure never leaves the
+weekly cadence silently dead).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+_RUNNER = _INFRA / "run_weekly_offcycle.sh"
+_CFN = _INFRA / "cloudformation" / "alpha-engine-orchestration.yaml"
+_LAMBDA = _INFRA / "lambdas" / "eod-success-friday-shell-trigger" / "index.py"
+
+
+@pytest.fixture(scope="module")
+def runner_text() -> str:
+    return _RUNNER.read_text()
+
+
+def _dry_run_input(verb: str) -> dict:
+    """Run the script in --dry-run and parse the EXPANDED execution input.
+
+    Tests the real shell-variable expansion (catches a mistyped constant),
+    not just the static heredoc text. The --dry-run path only touches ``aws``
+    inside guarded ``if`` conditions, so it works with no AWS creds / no CLI.
+    """
+    proc = subprocess.run(
+        ["bash", str(_RUNNER), verb, "--dry-run"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "AWS_REGION": "us-east-1", "ACCOUNT_ID": "711398986525"},
+    )
+    assert proc.returncode == 0, f"{verb} --dry-run failed:\n{proc.stderr}"
+    m = re.search(r"^\s*input:\s*(\{.*\})\s*$", proc.stdout, re.MULTILINE)
+    assert m, f"no 'input:' line in {verb} --dry-run output:\n{proc.stdout}"
+    return json.loads(m.group(1))
+
+
+def _builder_body(text: str, fn_name: str) -> str:
+    """Slice a shell function body ``fn_name() { ... }`` from the script."""
+    m = re.search(rf"{fn_name}\(\)\s*\{{(.*?)\n\}}", text, re.DOTALL)
+    assert m, f"{fn_name}() not found in runner"
+    return m.group(1)
+
+
+def test_runner_exists_and_executable() -> None:
+    assert _RUNNER.exists(), "run_weekly_offcycle.sh missing"
+    assert os.access(_RUNNER, os.X_OK), "run_weekly_offcycle.sh must be executable"
+
+
+def test_shell_input_contract() -> None:
+    obj = _dry_run_input("shell")
+    assert obj["shell_run"] is True
+    assert obj["pipeline_role"] == "shell-run"
+    assert obj["ec2_instance_id"] == ["i-09b539c844515d549"]
+    assert obj["sns_topic_arn"].endswith(":alpha-engine-alerts")
+
+
+def test_full_input_contract() -> None:
+    obj = _dry_run_input("full")
+    assert obj["pipeline_role"] == "weekly"
+    assert "shell_run" not in obj, "full weekly run must NOT set shell_run"
+    assert obj["ec2_instance_id"] == ["i-09b539c844515d549"]
+    assert obj["sns_topic_arn"].endswith(":alpha-engine-alerts")
+
+
+def test_full_input_matches_live_cron_target() -> None:
+    """The ``full`` builder must reproduce the CFN SaturdayTrigger Input."""
+    cfn = _CFN.read_text()
+    block = cfn.split("SaturdayTrigger:", 1)[1].split("WeekdayTrigger:", 1)[0]
+    # Narrow to the Input: !Sub | heredoc (the surrounding region carries a
+    # comment mentioning "shell_run mode" that is not part of the target input).
+    after_input = block.split("Input:", 1)[1]
+    # The JSON closes with a "}" on its own (dedented) line; the inline
+    # ${MicroInstanceId} braces are not line-leading, so this stops correctly.
+    m = re.search(r".*?\n\s*\}", after_input, re.DOTALL)
+    assert m, "could not isolate the SaturdayTrigger Input JSON"
+    input_block = m.group(0)
+    assert '"pipeline_role": "weekly"' in input_block
+    assert "shell_run" not in input_block
+    assert _dry_run_input("full")["pipeline_role"] == "weekly"
+
+
+def test_shell_input_matches_lambda() -> None:
+    """The ``shell`` builder must reproduce the friday-shell Lambda input."""
+    lam = _LAMBDA.read_text()
+    assert '"shell_run": True' in lam or '"shell_run": true' in lam.lower()
+    assert '"pipeline_role"' in lam and "shell-run" in lam
+    obj = _dry_run_input("shell")
+    assert obj["shell_run"] is True
+    assert obj["pipeline_role"] == "shell-run"
+
+
+def test_full_targets_correct_state_machine(runner_text: str) -> None:
+    assert "alpha-engine-saturday-pipeline" in runner_text
+
+
+def test_full_suppresses_then_starts_safely(runner_text: str) -> None:
+    """Fail-loud ordering: schedule re-enable, THEN disable cron, THEN start."""
+    body = _builder_body(runner_text, "do_full")
+    i_schedule = body.index("schedule_reenable")
+    i_disable = body.index("disable-rule")
+    i_start = body.index("start_execution")
+    assert i_schedule < i_disable < i_start, (
+        "do_full must schedule the auto re-enable before disabling the cron, "
+        "and disable the cron before starting the execution"
+    )
+
+
+def test_reenable_role_scoped_to_saturday_rule(runner_text: str) -> None:
+    """The scheduler role grants events:EnableRule on the Saturday rule ONLY."""
+    assert "events:EnableRule" in runner_text
+    assert "scheduler.amazonaws.com" in runner_text
+    # The inline policy Resource is the single Saturday rule ARN.
+    assert "rule/${SATURDAY_RULE}" in runner_text or "SATURDAY_RULE_ARN" in runner_text
+
+
+def test_reenable_schedule_self_deletes(runner_text: str) -> None:
+    assert "--action-after-completion DELETE" in runner_text


### PR DESCRIPTION
## What

Adds `infrastructure/run_weekly_offcycle.sh` — a low-friction operator wrapper to fire the **Saturday weekly pipeline off-schedule** (holiday weeks, schedule shifts, ad-hoc rehearsals) without hand-building `start-execution` JSON.

The two production triggers today:
- **Friday shell run** — event-driven via the `eod-success-friday-shell-trigger` Lambda. On a **holiday Friday there's no EOD success → no shell run**, so the manual `shell` verb is the only way to get the rehearsal that week.
- **Saturday full run** — the `alpha-engine-saturday` EventBridge cron.

## Verbs

| verb | does |
|---|---|
| `shell` | rehearsal now — mirrors the Lambda input (`shell_run=true`, `pipeline_role=shell-run`). Purely additive, cron untouched. |
| `full` | full weekly now — mirrors the cron target input (`pipeline_role=weekly`). Suppresses the next Saturday cron fire + schedules a self-deleting auto re-enable at 09:30 UTC. |
| `restore` | re-enable the cron + drop any pending re-enable (escape hatch). |
| `status` | cron state + pending re-enable + recent runs. |

`--dry-run` on any verb.

## Why `full` touches the cron

A `full` run is **not additive** — a scheduled Saturday fire following it would double-run the weekly pipeline (wasted spot $, double model-zoo rotation, artifact clobber). **Fail-loud ordering:** the one-time EventBridge Scheduler re-enable job is created + verified *before* the cron is disabled, and the cron is disabled + verified *before* the execution starts — any failure aborts with the rule still `ENABLED`. The scheduler role (`alpha-engine-offcycle-cron-role`) is scoped to `events:EnableRule` on the Saturday rule only.

## Tests

`tests/test_run_weekly_offcycle.py` pins both input contracts against the live CFN cron target + the Lambda source (drift guard), the fail-loud ordering, and the scheduler-role scope. Run locally: 9 passed.

## Dogfood

Used this branch's script to run this week's off-cycle (Juneteenth holiday): `shell` fired, then `full` with Sat 6/20 cron suppression + auto re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)