### PR TITLE
fix(prices): run 10y price-cache refresh under the yfinance noise chokepoint (config#1029 follow-up)

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -30,13 +30,13 @@ Entry point: ``python -m collectors.metron_market_data [--date YYYY-MM-DD] [--dr
 from __future__ import annotations
 
 import argparse
-import contextlib
-import functools
 import json
 import logging
 import time
 from datetime import date, datetime, timezone
 from typing import Any, Callable
+
+from collectors.yfinance_quiet import log_yf_coverage, quiet_yfinance, yf_quiet
 
 logger = logging.getLogger(__name__)
 
@@ -173,36 +173,23 @@ def load_metron_universe(bucket: str, s3_client: Any) -> tuple[list[dict], list[
 
 
 # ── yfinance fetchers (default sources) ─────────────────────────────────────
+#
+# The yfinance log-noise chokepoint (quiet_yfinance / yf_quiet / log_yf_coverage)
+# lives in collectors/yfinance_quiet.py — an in-repo single source of truth since
+# the same bug class recurred through collectors/prices.py (2026-06-19, config#1029
+# follow-up). The underscored names below are kept as thin backward-compat aliases
+# so existing call sites + tests read unchanged.
 
+_quiet_yfinance = quiet_yfinance
+_yf_quiet = yf_quiet
 
-@contextlib.contextmanager
-def _quiet_yfinance():
-    """Demote yfinance's internal logger to CRITICAL for the duration of a fetch.
-
-    yfinance logs its own ERROR record per failing symbol — ≥5 distinctly-worded
-    messages for ONE unpriceable ticker (quoteSummary 404, "possibly delisted"
-    in two forms, "1 Failed download:", per-period repeats). Flow Doctor keys
-    dedup on message text, so each line became its own report/email — the
-    2026-06-12 PCKM storm (config#1029). Failure recording is NOT lost: each
-    fetcher aggregates per-symbol coverage into one record per run via
-    ``_log_yf_coverage`` below, which is the named recording surface.
-    """
-    yf_logger = logging.getLogger("yfinance")
-    prior_level = yf_logger.level
-    yf_logger.setLevel(logging.CRITICAL)
-    try:
-        yield
-    finally:
-        yf_logger.setLevel(prior_level)
-
-
-def _yf_quiet(fn):
-    """Run a yfinance fetcher under ``_quiet_yfinance`` (see rationale there)."""
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        with _quiet_yfinance():
-            return fn(*args, **kwargs)
-    return wrapper
+# Metron-specific coverage context: many holdings are non-listed instruments
+# (e.g. 401(k) CITs) yfinance can never price — they're broker-snapshot-priced
+# and belong out of the published universe (config#1029).
+_METRON_COVERAGE_NOTE = (
+    "non-listed instruments (e.g. 401(k) CITs) are broker-snapshot-priced in "
+    "Metron and belong out of the published universe (config#1029)"
+)
 
 
 def _log_yf_coverage(
@@ -212,29 +199,10 @@ def _log_yf_coverage(
     *,
     error_on_empty: bool = False,
 ) -> None:
-    """One aggregated coverage record per artifact per run (config#1029).
-
-    Replaces yfinance's per-symbol ERROR spray (demoted by ``_quiet_yfinance``):
-    symbols with no data are reported as a SINGLE WARN naming them all. A full
-    miss on a non-empty request escalates to ERROR only where the caller says
-    the artifact is load-bearing (``error_on_empty`` — closes), so a Yahoo
-    outage surfaces once, loudly, instead of once per artifact per symbol.
-    """
-    missing = sorted(set(requested) - set(covered))
-    if not missing:
-        return
-    if error_on_empty and not covered:
-        logger.error(
-            "[metron_market_data] %s: yfinance returned NO data for any of %d requested "
-            "symbols (%s) — full-miss on a load-bearing artifact (provider outage?)",
-            kind, len(missing), ", ".join(missing),
-        )
-        return
-    logger.warning(
-        "[metron_market_data] %s: no yfinance data for %d/%d symbols: %s — "
-        "non-listed instruments (e.g. 401(k) CITs) are broker-snapshot-priced "
-        "in Metron and belong out of the published universe (config#1029)",
-        kind, len(missing), len(requested), ", ".join(missing),
+    """Metron wrapper over :func:`yfinance_quiet.log_yf_coverage` (config#1029)."""
+    log_yf_coverage(
+        logger, kind, requested, covered,
+        error_on_empty=error_on_empty, note=_METRON_COVERAGE_NOTE,
     )
 
 

--- a/collectors/prices.py
+++ b/collectors/prices.py
@@ -29,6 +29,7 @@ import pandas as pd
 import yfinance as yf
 
 from builders._price_cache_writeboth import price_cache_write_prefixes
+from collectors.yfinance_quiet import log_yf_coverage, yf_quiet
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +159,7 @@ def _find_stale_fast(
     return stale
 
 
+@yf_quiet
 def _refresh_stale(
     s3,
     bucket: str,
@@ -166,7 +168,15 @@ def _refresh_stale(
     fetch_period: str,
     batch_size: int,
 ) -> tuple[int, list[str]]:
-    """Batch-fetch stale tickers from yfinance and upload to S3."""
+    """Batch-fetch stale tickers from yfinance and upload to S3.
+
+    Runs under ``yf_quiet`` (collectors/yfinance_quiet.py): yfinance's
+    per-symbol "possibly delisted" ERROR spray is demoted so one transient/
+    unpriceable ticker can't storm Flow Doctor with a report per worded
+    variant (the 2026-06-19 PCAR recurrence of the config#1029 PCKM storm).
+    The replacement recording surface is the aggregated ``log_yf_coverage``
+    record emitted before returning.
+    """
     import time
 
     logger.info("Refreshing %d stale tickers (period=%s) ...", len(stale), fetch_period)
@@ -242,4 +252,18 @@ def _refresh_stale(
             )
 
     logger.info("Price cache refresh complete: %d / %d tickers updated", refreshed, len(stale))
+
+    # Single aggregated record per run — the named recording surface that
+    # replaces yfinance's suppressed per-symbol ERROR spray. error_on_empty:
+    # the 10y price cache is load-bearing (GBM training reads it), so a total
+    # miss escalates to one loud ERROR (provider outage); a partial miss is one
+    # WARN naming the unpriceable tickers (transient/rate-limit this run, or
+    # persistent delisting/rename candidates for universe pruning).
+    covered = set(stale) - set(failed_tickers)
+    log_yf_coverage(
+        logger, "price_cache_refresh", stale, covered, error_on_empty=True,
+        note="stale tickers with no yfinance data this run — transient/rate-limit "
+             "misses retry next refresh; persistent misses are delisting/rename "
+             "candidates for universe pruning",
+    )
     return refreshed, failed_tickers

--- a/collectors/yfinance_quiet.py
+++ b/collectors/yfinance_quiet.py
@@ -1,0 +1,106 @@
+"""Shared yfinance log-noise suppression + per-run coverage aggregation.
+
+yfinance logs its own ERROR record per failing symbol — ≥5 distinctly-worded
+messages for ONE unpriceable ticker (``quoteSummary`` 404, "possibly delisted"
+in two forms, "1 Failed download:", per-period repeats). Flow Doctor keys its
+dedup on message text, so each line becomes its own report/email:
+
+  * the 2026-06-12 PCKM storm via ``collectors/metron_market_data.py``
+    (config#1029), and
+  * the 2026-06-19 PCAR recurrence via the un-wrapped 10y price-cache refresh
+    in ``collectors/prices.py`` — three Flow Doctor issues for ONE active,
+    non-delisted ticker (the LLM diagnosis even hallucinated a delisting).
+
+The chokepoint: demote yfinance's internal logger to CRITICAL for the duration
+of each fetch (:func:`quiet_yfinance` / :func:`yf_quiet`), and replace the
+suppressed per-symbol spray with ONE aggregated coverage record per artifact
+per run (:func:`log_yf_coverage`) — the named recording surface, so a real
+provider outage still surfaces once, loudly, instead of once per symbol.
+
+Extracted from ``collectors/metron_market_data.py`` on 2026-06-19 as an
+in-repo single source of truth the moment the SAME bug class recurred through
+a second collector. Lifting this into ``nousergon_lib`` is the cross-repo
+chokepoint follow-up, gated on nousergon-data crossing to lib >=0.60.2 (the
+alias-shim ``importlib.resources`` fix required by the ``[contracts]`` extra).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import logging
+from collections.abc import Callable, Collection, Iterable
+
+__all__ = ["quiet_yfinance", "yf_quiet", "log_yf_coverage"]
+
+
+@contextlib.contextmanager
+def quiet_yfinance():
+    """Demote yfinance's internal logger to CRITICAL for the duration of a fetch.
+
+    yfinance emits an ERROR record per failing symbol (and several distinctly
+    worded variants per symbol). Without this, each line is its own Flow Doctor
+    report. Failure recording is NOT lost — callers aggregate per-run coverage
+    via :func:`log_yf_coverage`, the named recording surface.
+    """
+    yf_logger = logging.getLogger("yfinance")
+    prior_level = yf_logger.level
+    yf_logger.setLevel(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        yf_logger.setLevel(prior_level)
+
+
+def yf_quiet(fn: Callable) -> Callable:
+    """Run a yfinance fetcher under :func:`quiet_yfinance` (see rationale there)."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with quiet_yfinance():
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def log_yf_coverage(
+    logger: logging.Logger,
+    kind: str,
+    requested: Iterable[str],
+    covered: Collection[str] | dict,
+    *,
+    error_on_empty: bool = False,
+    note: str = "",
+) -> None:
+    """One aggregated coverage record per artifact per run (config#1029).
+
+    Replaces yfinance's per-symbol ERROR spray (demoted by
+    :func:`quiet_yfinance`): symbols with no data are reported as a SINGLE WARN
+    naming them all. A full miss on a non-empty request escalates to ERROR only
+    where the caller marks the artifact load-bearing (``error_on_empty``), so a
+    Yahoo outage surfaces once, loudly, instead of once per artifact per symbol.
+
+    Args:
+        logger: the caller's module logger (carries attribution).
+        kind: short artifact label, e.g. ``"closes"`` / ``"price_cache_refresh"``.
+        requested: every symbol the fetch asked for.
+        covered: symbols that came back with data (set, list, or the result dict
+            whose keys are the covered symbols).
+        error_on_empty: escalate a total miss to ERROR (load-bearing artifact).
+        note: optional caller context appended to the message.
+    """
+    missing = sorted(set(requested) - set(covered))
+    if not missing:
+        return
+    suffix = f" — {note}" if note else ""
+    if error_on_empty and not covered:
+        logger.error(
+            "%s: yfinance returned NO data for any of %d requested symbols (%s) "
+            "— full-miss on a load-bearing artifact (provider outage?)%s",
+            kind, len(missing), ", ".join(missing), suffix,
+        )
+        return
+    logger.warning(
+        "%s: no yfinance data for %d/%d symbols: %s%s",
+        kind, len(missing), len(requested), ", ".join(missing), suffix,
+    )

--- a/tests/test_prices_yf_noise.py
+++ b/tests/test_prices_yf_noise.py
@@ -1,0 +1,21 @@
+"""prices.py price-cache refresh must run under the yfinance noise chokepoint.
+
+The 2026-06-19 PCAR recurrence: collectors/prices.py::_refresh_stale called
+yf.download WITHOUT the quiet_yfinance chokepoint that metron_market_data.py
+adopted in config#1029. yfinance's multi-form "possibly delisted" ERROR spray
+therefore escaped to Flow Doctor as three issues (#451/#452/#453) for ONE
+active, non-delisted ticker (PCAR / PACCAR Inc.). This guards the wrap so the
+storm can't silently regress.
+"""
+
+from __future__ import annotations
+
+from collectors import prices
+
+
+def test_refresh_stale_runs_under_quiet_yfinance():
+    # The decorator is the chokepoint: the 10y refresh fetch must run quieted,
+    # or one transient/unpriceable ticker storms Flow Doctor again.
+    assert hasattr(prices._refresh_stale, "__wrapped__"), (
+        "_refresh_stale must be decorated with @yf_quiet (yfinance noise chokepoint)"
+    )

--- a/tests/test_yfinance_quiet.py
+++ b/tests/test_yfinance_quiet.py
@@ -1,0 +1,104 @@
+"""Shared yfinance log-noise chokepoint (collectors/yfinance_quiet.py).
+
+In-repo single source of truth extracted from metron_market_data.py when the
+config#1029 PCKM-storm bug class recurred through prices.py (2026-06-19 PCAR).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from collectors.yfinance_quiet import log_yf_coverage, quiet_yfinance, yf_quiet
+
+
+class TestQuietYfinance:
+    def test_demotes_yfinance_logger_inside_and_restores_after(self):
+        yf_logger = logging.getLogger("yfinance")
+        yf_logger.setLevel(logging.DEBUG)
+        try:
+            with quiet_yfinance():
+                assert yf_logger.level == logging.CRITICAL
+                # The storm failure mode: yfinance ERROR records must not pass
+                # the logger's own level while a fetch is in flight.
+                assert not yf_logger.isEnabledFor(logging.ERROR)
+            assert yf_logger.level == logging.DEBUG
+        finally:
+            yf_logger.setLevel(logging.NOTSET)
+
+    def test_restores_level_even_when_fetch_raises(self):
+        yf_logger = logging.getLogger("yfinance")
+        yf_logger.setLevel(logging.INFO)
+        try:
+            with pytest.raises(RuntimeError):
+                with quiet_yfinance():
+                    raise RuntimeError("batch failed")
+            assert yf_logger.level == logging.INFO
+        finally:
+            yf_logger.setLevel(logging.NOTSET)
+
+    def test_yf_quiet_decorator_runs_quieted_and_preserves_wrapped(self):
+        seen = {}
+
+        @yf_quiet
+        def fetch():
+            seen["level"] = logging.getLogger("yfinance").level
+            return "ok"
+
+        yf_logger = logging.getLogger("yfinance")
+        yf_logger.setLevel(logging.DEBUG)
+        try:
+            assert fetch() == "ok"
+            assert seen["level"] == logging.CRITICAL
+            assert hasattr(fetch, "__wrapped__")  # functools.wraps chokepoint marker
+            assert yf_logger.level == logging.DEBUG  # restored
+        finally:
+            yf_logger.setLevel(logging.NOTSET)
+
+
+class TestLogYfCoverage:
+    def test_full_coverage_logs_nothing(self, caplog):
+        logger = logging.getLogger("test.yfq")
+        with caplog.at_level(logging.DEBUG):
+            log_yf_coverage(logger, "closes", ["AAPL"], {"AAPL"}, error_on_empty=True)
+        assert not caplog.records
+
+    def test_partial_miss_is_one_warning_naming_all_missing(self, caplog):
+        logger = logging.getLogger("test.yfq")
+        with caplog.at_level(logging.DEBUG):
+            log_yf_coverage(logger, "closes", ["AAPL", "PCAR", "ANET"], {"AAPL", "ANET"})
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warns) == 1
+        assert "PCAR" in warns[0].message and "1/3" in warns[0].message
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+    def test_covered_accepts_a_result_dict(self, caplog):
+        # Callers pass the result dict directly — its KEYS are the covered set.
+        logger = logging.getLogger("test.yfq")
+        with caplog.at_level(logging.DEBUG):
+            log_yf_coverage(logger, "closes", ["AAPL", "PCAR"], {"AAPL": (1.0, "d")})
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warns) == 1 and "PCAR" in warns[0].message
+
+    def test_full_miss_on_load_bearing_artifact_is_single_error(self, caplog):
+        logger = logging.getLogger("test.yfq")
+        with caplog.at_level(logging.DEBUG):
+            log_yf_coverage(logger, "closes", ["AAPL", "ANET"], set(), error_on_empty=True)
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "AAPL" in errors[0].message and "ANET" in errors[0].message
+
+    def test_full_miss_on_best_effort_artifact_stays_warn(self, caplog):
+        logger = logging.getLogger("test.yfq")
+        with caplog.at_level(logging.DEBUG):
+            log_yf_coverage(logger, "earnings", ["AAPL"], set())
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert [r for r in caplog.records if r.levelno == logging.WARNING]
+
+    def test_note_is_appended(self, caplog):
+        logger = logging.getLogger("test.yfq")
+        with caplog.at_level(logging.DEBUG):
+            log_yf_coverage(logger, "closes", ["PCAR"], set(), note="universe-prune candidate")
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warns) == 1 and "universe-prune candidate" in warns[0].message


### PR DESCRIPTION
## Why

The 2026-06-19 PCAR storm: `collectors/prices.py::_refresh_stale` (the weekly 10y price-cache refresh) called `yf.download` **without** the `_quiet_yfinance` + `_log_yf_coverage` suppression that `collectors/metron_market_data.py` adopted in the 2026-06-12 PCKM-storm fix (config#1029).

yfinance emits its `possibly delisted; no price data found` ERROR in several worded variants (`['PCAR']`, `$PCAR`, `1 Failed download:`). Flow Doctor dedups on message text, so **one** active, non-delisted ticker became **three** Flow Doctor issues (#451 / #452 / #453) → three emails. The LLM diagnosis even hallucinated a December-2023 Berkshire Hathaway acquisition of PACCAR — which never happened. (The three issues are closed as false positives.)

## Fix — in-repo chokepoint

Rather than mirror the suppression a second time (or drag the disproportionate `0.59.4 → ≥0.60.2` lib crossing into a noise fix), this extracts the chokepoint into an **in-repo single source of truth** the moment the bug class recurred through a second collector:

- **`collectors/yfinance_quiet.py`** (new) — `quiet_yfinance` (ctx mgr), `yf_quiet` (decorator), `log_yf_coverage` (logger-parametrized aggregator).
- **`metron_market_data.py`** — imports the shared module; underscored names kept as thin backward-compat aliases so call sites + the existing noise test read unchanged.
- **`prices.py::_refresh_stale`** — decorated `@yf_quiet`; emits **one** aggregated `log_yf_coverage` record per run (`error_on_empty=True` — the 10y cache is load-bearing for GBM training, so a total miss is one loud ERROR; a partial miss is one WARN naming the unpriceable tickers).

The fix is **entrypoint-independent** (`_FLOW_DOCTOR_EXCLUDE_PATTERNS` is empty `[]` in all three entrypoints, so suppression rightly lives at the fetch source).

## Follow-up

Lifting the chokepoint into `nousergon_lib` (true cross-repo single source of truth) is filed as a P1 on `alpha-engine-config`, **gated** on `nousergon-data` crossing `0.59.4 → ≥0.60.2` (the alias-shim `importlib.resources` fix the `[contracts]` extra needs).

## Tests
- New `tests/test_yfinance_quiet.py` (canonical API) + `tests/test_prices_yf_noise.py` (guards the `_refresh_stale` wrap).
- Existing `tests/test_metron_yf_noise_aggregation.py` still green via aliases.
- **Full suite: 2100 passed, 2 skipped** locally (`.venv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
