### PR TITLE
fix(sf): migrate executor/dashboard-box -m invocations to nousergon_lib (unbreaks trading-day gate + substrate checks)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -2818,7 +2818,7 @@
             "source .venv/bin/activate",
             "pip install --quiet --upgrade -r requirements.txt",
             "trap 'aws s3 cp /var/log/substrate-health-check.log \"s3://alpha-engine-research/_ssm_logs/substrate-health-check/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "python -m alpha_engine_lib.transparency --cadence weekly --alert 2>&1 | tee /var/log/substrate-health-check.log",
+            "python -m nousergon_lib.transparency --cadence weekly --alert 2>&1 | tee /var/log/substrate-health-check.log",
             "echo '--- constituents drift check ---' | tee -a /var/log/substrate-health-check.log",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data && /home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m validators.constituents_drift_check 2>&1 | tee -a /var/log/substrate-health-check.log || true"

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -133,7 +133,7 @@
             "export ALPHA_ENGINE_DEPLOYED=1",
             "cd /home/ec2-user/alpha-engine",
             "source .venv/bin/activate",
-            "python -m alpha_engine_lib.trading_calendar"
+            "python -m nousergon_lib.trading_calendar"
           ],
           "executionTimeout": ["30"]
         },

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -482,7 +482,7 @@
             "source .venv/bin/activate",
             "pip install --quiet --upgrade -r requirements.txt",
             "trap 'aws s3 cp /var/log/substrate-health-check-daily.log \"s3://alpha-engine-research/_ssm_logs/substrate-health-check-daily/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "python -m alpha_engine_lib.transparency --cadence daily --alert 2>&1 | tee /var/log/substrate-health-check-daily.log"
+            "python -m nousergon_lib.transparency --cadence daily --alert 2>&1 | tee /var/log/substrate-health-check-daily.log"
           ],
           "executionTimeout": ["180"]
         },

--- a/tests/test_sf_eod_substrate_check_wiring.py
+++ b/tests/test_sf_eod_substrate_check_wiring.py
@@ -130,7 +130,7 @@ class TestCommandShape:
 
     def test_invokes_transparency_module(self, commands):
         assert any(
-            "python -m alpha_engine_lib.transparency" in cmd for cmd in commands
+            "python -m nousergon_lib.transparency" in cmd for cmd in commands
         )
 
     def test_passes_cadence_daily(self, commands):

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -132,7 +132,7 @@ class TestCommandShape:
 
     def test_invokes_transparency_module(self, commands):
         assert any(
-            "python -m alpha_engine_lib.transparency" in cmd for cmd in commands
+            "python -m nousergon_lib.transparency" in cmd for cmd in commands
         )
 
     def test_passes_cadence_weekly(self, commands):


### PR DESCRIPTION
## What broke

Two repos have crossed to the renamed package (**nousergon-lib 0.60.x**): the **executor** box (0.60.2, crucible-executor#270) and the **dashboard** box (0.60.1, #233). The renamed package ships a *deprecated* import shim for `alpha_engine_lib`, but the shim's meta-path loader doesn't implement runpy's `get_code`, so **`python -m alpha_engine_lib.<module>` fails on crossed boxes**:

```
AttributeError: '_AliasLoader' object has no attribute 'get_code'
```

Three live SF command strings run `-m alpha_engine_lib.*` on those crossed boxes and broke:

| SF | State | Box | Module | Impact |
|---|---|---|---|---|
| weekday | CheckTradingDay | executor (0.60.2) | `trading_calendar` | **FAIL-OPEN** — Catch → `TradingDayCheckFailed` → proceeds; a real NYSE holiday would no longer halt. Surfaced 2026-06-22 (first run after executor crossed). |
| EOD | DailySubstrateHealthCheck | dashboard (0.60.1) | `transparency` | fail-soft → substrate health check silently not running |
| Saturday | WeeklySubstrateHealthCheck | dashboard (0.60.1) | `transparency` | same |

## Fix

Complete the migration for these crossed-box invocations — switch the command strings to the canonical **`nousergon_lib`** name. We do **not** patch the deprecated shim (that would extend the layer we're retiring). The two SF-string wiring assertions are updated in lockstep.

**Deliberately NOT changed:** the 12 `ssm_log_capture` invocations run on **spot boxes still pinned to alpha-engine-lib 0.59.x** (old name = the real package; `nousergon_lib` isn't installed there) — switching them would break those boxes. They migrate when those repos cross. Data-repo own imports + `test_weekly_collector_morning_enrich` / `test_substrate_alarms_script` likewise stay on `alpha_engine_lib` (data is still on 0.59.4).

## Tests
- Updated + ran the substrate/trading-day wiring tests (89 passed) and the full SF/lib-pin/wiring selection (**741 passed, 1 skipped** — the CI-skipped pipeline-status drift guard). JSON validated.
- SFs auto-deploy on merge to `main`.

Part of completing the `alpha_engine_lib → nousergon_lib` conversion; companion executor + dashboard repo-internal migrations + a fleet tracking issue follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)