### PR TITLE
fix(deps): hyphenate flow-doctor extra so it resolves on old pip (config#1178)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,10 @@ edgartools>=2.0
 voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11
-# flow-doctor is pulled in transitively via alpha-engine-lib[flow_doctor].
+# flow-doctor is pulled in transitively via alpha-engine-lib[flow-doctor].
+# NOTE: the extra MUST be hyphenated — setuptools normalizes the lib's
+# `flow_doctor` extra to `Provides-Extra: flow-doctor`; older pip doesn't
+# normalize underscore->hyphen, so `[flow_doctor]` silently drops it (config#1178).
 # psycopg2-binary + pgvector now come via [rag] (added in lib v0.3.0,
 # direct pins dropped 2026-05-20 after >2-week soak on v0.20.0).
 # v0.30.0 + v0.31.0 add the cost-telemetry SDK adapter
@@ -29,4 +32,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow_doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4
+alpha-engine-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4


### PR DESCRIPTION
Fleet sweep for config#1178 (follows crucible-dashboard#236 + crucible-executor#275).

## Why
setuptools normalizes the lib's `flow_doctor` extra to `Provides-Extra: flow-doctor` (hyphen). Older pip does **not** normalize underscore↔hyphen, so `[flow_doctor]` resolves the package but **silently drops the extra** — leaving flow-doctor stale or absent (no error, just a WARN). Switched to the PEP 685-canonical `[flow-doctor]`, which resolves on every pip version.

Same defect class that took down the dashboard console (crucible-dashboard#236). Preventive here — this repo is still on alpha-engine-lib 0.59.x and reinstalls fresh each run, so the extra-drop (if any) is non-fatal observability. Hyphenating now removes the latent failure ahead of the eventual nousergon-lib 0.60.x crossing.

## Change
One-line `requirements.txt` extra: `flow_doctor` → `flow-doctor` (+ explanatory note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)