### PR TITLE
fix(sf): close 256KB DataLimitExceeded class on weekday + EOD SFs (config#1163)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -176,6 +176,13 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent",
+        "StandardOutputContent.$": "$.StandardOutputContent"
+      },
       "ResultPath": "$.trading_day_poll",
       "Next": "CheckTradingDayResult"
     },
@@ -299,6 +306,12 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent"
+      },
       "ResultPath": "$.morning_enrich_poll",
       "Next": "CheckMorningEnrichStatus"
     },
@@ -428,6 +441,12 @@
           "ResultPath": "$.chronic_gap_error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent"
+      },
       "ResultPath": "$.chronic_gap_poll",
       "Next": "CheckChronicGapStatus"
     },
@@ -867,6 +886,12 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent"
+      },
       "ResultPath": "$.planner_poll",
       "Next": "CheckMorningPlannerStatus"
     },
@@ -994,6 +1019,12 @@
           "ResultPath": "$.daily_news_error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent"
+      },
       "ResultPath": "$.daily_news_poll",
       "Next": "CheckDailyNewsStatus"
     },
@@ -1114,6 +1145,12 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent"
+      },
       "ResultPath": "$.arctic_append_poll",
       "Next": "CheckMorningArcticAppendStatus"
     },

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -129,6 +129,13 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "CommandId.$": "$.CommandId",
+        "InstanceId.$": "$.InstanceId"
+      },
       "ResultPath": "$.postmarket_poll",
       "Next": "CheckPostMarketStatus"
     },
@@ -235,6 +242,13 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "CommandId.$": "$.CommandId",
+        "InstanceId.$": "$.InstanceId"
+      },
       "ResultPath": "$.postmarket_arctic_poll",
       "Next": "CheckPostMarketArcticAppendStatus"
     },
@@ -335,6 +349,13 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "CommandId.$": "$.CommandId",
+        "InstanceId.$": "$.InstanceId"
+      },
       "ResultPath": "$.snapshot_poll",
       "Next": "CheckSnapshotStatus"
     },
@@ -434,6 +455,13 @@
           "ResultPath": "$.error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "CommandId.$": "$.CommandId",
+        "InstanceId.$": "$.InstanceId"
+      },
       "ResultPath": "$.eod_poll",
       "Next": "CheckEODStatus"
     },
@@ -526,6 +554,13 @@
           "ResultPath": "$.substrate_check_error"
         }
       ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "CommandId.$": "$.CommandId",
+        "InstanceId.$": "$.InstanceId"
+      },
       "ResultPath": "$.substrate_check_poll",
       "Next": "StopTradingInstance"
     },

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -360,11 +360,34 @@ class TestWeekdaySSMFlowDoctorOrdering:
 # Parameters / Choices / ResultPath / InputPath, then filtering to
 # top-level fields (single segment after `$`).
 def _eod_referenced_input_fields() -> frozenset[str]:
-    sf_text = _SF_EOD.read_text()
-    # Match `"$.foo"` or `"$.foo.bar"` — capture the FIRST segment.
+    # Walk the parsed SF and capture the FIRST segment of every string value
+    # that STARTS with ``$.`` (equivalent to the old ``"$.`` text regex, since
+    # ``"$.`` only ever opens a JSON string value) — EXCEPT inside a
+    # ``ResultSelector`` block. Within a ResultSelector ``$`` rebinds to the raw
+    # task result, so its ``"$.Status"`` / ``"$.CommandId"`` RHS values are NOT
+    # top-level SF-state fields (config#1163: the weekday/EOD poll-trim
+    # ResultSelectors introduced exactly these and must not pollute the
+    # top-level namespace registry, which would otherwise mask a real future
+    # ``$.Status`` ResultPath collision).
     import re
 
-    refs = set(re.findall(r'"\$\.([A-Za-z_][A-Za-z0-9_]*)', sf_text))
+    refs: set[str] = set()
+
+    def _walk(obj) -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k == "ResultSelector":
+                    continue
+                _walk(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                _walk(v)
+        elif isinstance(obj, str):
+            m = re.match(r"\$\.([A-Za-z_][A-Za-z0-9_]*)", obj)
+            if m:
+                refs.add(m.group(1))
+
+    _walk(json.loads(_SF_EOD.read_text()))
     return frozenset(refs)
 
 

--- a/tests/test_sf_poll_resultselector.py
+++ b/tests/test_sf_poll_resultselector.py
@@ -1,4 +1,5 @@
-"""Guards the ResultSelector that keeps SSM stdout out of Saturday-SF state.
+"""Guards the ResultSelector that keeps SSM stdout out of SF state across ALL
+three Step Functions (Saturday / weekday / EOD).
 
 2026-06-06 — the Saturday SF FAILED with ``States.DataLimitExceeded``:
 ``ResearchPredictorParallel returned a result with a size exceeding the
@@ -10,20 +11,21 @@ tripled it past 256 KB. Fix: those 3 got a ``ResultSelector`` dropping stdout.
 
 2026-06-19 — **the same class recurred at ``WaitForEvaluator``**: the
 2026-06-06 fix (and the prior version of THIS test) covered only the 3 states
-in that incident's path, leaving the later Saturday poll states still dumping
-full stdout. The evaluator's large stdout blew the 256 KB limit and killed the
-run before ReportCard/Director/NotifyComplete.
+in that incident's path. Expanded to close the class for the **Saturday SF**.
 
-This test now closes the class for the **Saturday SF**: it discovers EVERY
-``aws-sdk:ssm:getCommandInvocation`` poll state and requires each to carry a
-``ResultSelector`` that keeps ``Status`` and drops ``StandardOutputContent`` —
-UNLESS a downstream state legitimately reads ``$.<poll>.StandardOutputContent``
-(e.g. ``WaitResolveZoo``, whose stdout carries the resolved zoo spec list). Full
-SSM stdout is shipped to S3 (``_ssm_logs/``), so nothing is lost for diagnosis.
-
-Weekday + EOD SF poll states have different downstream field needs (EOD reads
-``.CommandId``/``.InstanceId``; the trading-day check reads stdout) and are
-tracked + fixed separately — see the follow-up issue referenced in the PR.
+2026-06-22 (config#1163) — **closed the same latent class on the weekday + EOD
+SFs.** Their poll states carried full stdout too; ``HandleFailure`` on both
+serializes the entire ``$`` state (``States.JsonToString($)``), so accumulated
+poll stdouts are exactly the bloat that re-trips 256 KB. The weekday/EOD polls
+have *different* downstream field needs than Saturday — the weekday
+trading-day check reads ``.StandardOutputContent`` (MARKET_CLOSED / TRADING
+DAY marker), and every EOD ``*StatusError`` Pass state reads
+``.Status``/``.StatusDetails``/``.ResponseCode``/``.CommandId``/``.InstanceId``
+off its poll — so the guard below is generic: it discovers EVERY field a
+downstream state reads off each poll's ResultPath and requires the
+ResultSelector to keep exactly those (plus ``Status``), while dropping the
+unbounded ``StandardOutputContent`` unless it is itself read. Full SSM stdout
+is shipped to S3 (``_ssm_logs/``), so nothing is lost for diagnosis.
 """
 
 from __future__ import annotations
@@ -34,8 +36,12 @@ from pathlib import Path
 
 import pytest
 
-_SF = Path(__file__).resolve().parent.parent / "infrastructure" / "step_function.json"
-_SF_TEXT = _SF.read_text()
+_INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+_SF_FILES = {
+    "saturday": _INFRA / "step_function.json",
+    "weekday": _INFRA / "step_function_daily.json",
+    "eod": _INFRA / "step_function_eod.json",
+}
 
 
 def _walk_states(states: dict):
@@ -53,52 +59,72 @@ def _walk_states(states: dict):
 
 
 def _poll_states():
-    sf = json.loads(_SF_TEXT)
+    """Yield (sf, name, state, sf_text) for every SSM getCommandInvocation poll
+    across all three SFs."""
     out = []
-    for name, st in _walk_states(sf.get("States", {})):
-        if "aws-sdk:ssm:getCommandInvocation" in str(st.get("Resource", "")):
-            out.append((name, st))
+    for sf, path in _SF_FILES.items():
+        text = path.read_text()
+        sf_def = json.loads(text)
+        for name, st in _walk_states(sf_def.get("States", {})):
+            if "aws-sdk:ssm:getCommandInvocation" in str(st.get("Resource", "")):
+                out.append((sf, name, st, text))
     return out
 
 
-def _stdout_read_downstream(result_path: str) -> bool:
-    """Does any state read ``$.<poll>.StandardOutputContent``? Then stdout must
-    be kept in that poll's ResultSelector (it's a real data dependency)."""
+_POLLS = _poll_states()
+
+
+def _fields_read_downstream(result_path: str, sf_text: str) -> set:
+    """Every field read off ``$.<poll>.<Field>`` anywhere in the SF. Each such
+    field is a real data dependency the ResultSelector MUST keep."""
     if not result_path:
-        return False
-    # The read may be a bare field or wrapped in a States.StringToJson(...) /
-    # States.Format(...) intrinsic, so match the path fragment, not a quoted key.
-    return f"{result_path}.StandardOutputContent" in _SF_TEXT
+        return set()
+    esc = re.escape(result_path)
+    return set(re.findall(rf"{esc}\.([A-Za-z][A-Za-z0-9]*)", sf_text))
+
+
+def _rs_keeps(rs: dict) -> set:
+    """Field names a ResultSelector keeps (strip the trailing ``.$``)."""
+    return {k[:-2] if k.endswith(".$") else k for k in rs}
 
 
 def test_found_poll_states() -> None:
-    # Vacuous-pass guard: the Saturday SF has many SSM poll states.
-    assert len(_poll_states()) >= 10, "expected the Saturday SF SSM poll states"
+    # Vacuous-pass guard: all three SFs together carry many SSM poll states.
+    assert len(_POLLS) >= 15, "expected SSM poll states across the three SFs"
+    assert {sf for sf, _, _, _ in _POLLS} == {"saturday", "weekday", "eod"}
 
 
 @pytest.mark.parametrize(
-    "name,st", _poll_states(), ids=[n for n, _ in _poll_states()]
+    "sf,name,st,sf_text",
+    _POLLS,
+    ids=[f"{sf}:{name}" for sf, name, _, _ in _POLLS],
 )
-def test_poll_state_trims_or_keeps_stdout_intentionally(name: str, st: dict) -> None:
+def test_poll_state_trims_or_keeps_stdout_intentionally(
+    sf: str, name: str, st: dict, sf_text: str
+) -> None:
     rs = st.get("ResultSelector")
     assert rs is not None, (
-        f"{name} is an SSM getCommandInvocation poll with NO ResultSelector — its "
-        f"full result (incl. ~24 KB StandardOutputContent) rides in state and can "
-        f"re-trip the 256 KB limit (2026-06-06 ResearchPredictorParallel; "
-        f"2026-06-19 WaitForEvaluator)."
+        f"[{sf}] {name} is an SSM getCommandInvocation poll with NO "
+        f"ResultSelector — its full result (incl. ~24 KB StandardOutputContent) "
+        f"rides in state and can re-trip the 256 KB limit (2026-06-06 "
+        f"ResearchPredictorParallel; 2026-06-19 WaitForEvaluator; the weekday + "
+        f"EOD HandleFailure both serialize all of $ via JsonToString)."
     )
-    assert any(k.startswith("Status") for k in rs), (
-        f"{name} ResultSelector dropped Status, which Check*Status reads."
+    keeps = _rs_keeps(rs)
+    assert any(k.startswith("Status") for k in keeps), (
+        f"[{sf}] {name} ResultSelector dropped Status, which Check*Status reads."
     )
-    keeps_stdout = any("StandardOutputContent" in k for k in rs)
-    needs_stdout = _stdout_read_downstream(st.get("ResultPath", ""))
-    if needs_stdout:
-        assert keeps_stdout, (
-            f"{name}: a downstream state reads {st.get('ResultPath')}."
-            f"StandardOutputContent, so the ResultSelector MUST keep it."
-        )
-    else:
-        assert not keeps_stdout, (
-            f"{name} keeps StandardOutputContent but nothing reads it — that is "
-            f"the unbounded field behind both 256 KB failures. Drop it."
+
+    needed = _fields_read_downstream(st.get("ResultPath", ""), sf_text)
+    missing = needed - keeps
+    assert not missing, (
+        f"[{sf}] {name}: downstream states read {sorted(missing)} off "
+        f"{st.get('ResultPath')} but the ResultSelector drops them — that "
+        f"breaks the consumer (e.g. EOD *StatusError reads CommandId/InstanceId)."
+    )
+
+    if "StandardOutputContent" not in needed:
+        assert "StandardOutputContent" not in keeps, (
+            f"[{sf}] {name} keeps StandardOutputContent but nothing reads it — "
+            f"that is the unbounded field behind every 256 KB failure. Drop it."
         )


### PR DESCRIPTION
Closes the weekday + EOD half of the `States.DataLimitExceeded` (>256KB SF state) class — the Saturday SF was fixed in #377/#456; **config#1163** tracks weekday + EOD.

## Root cause
The weekday + EOD `getCommandInvocation` poll states stored the **entire** invocation result — incl. the ~24KB `StandardOutputContent` SSM run-log — in SF state. `HandleFailure` on **both** SFs serializes the whole `$` state via `States.JsonToString($)`, so accumulated poll stdouts are exactly the bloat that re-trips the 256KB limit. The **weekday 6/22 scheduled run failed first-pass** (needed manual recovery), holding `unattended_first_pass_rate` below target and silently eating the research-edge measurement cadence — the coupling the Director flagged on #1059 ("substrate gates every repair loop").

## Fix
Add a `ResultSelector` to every weekday + EOD poll state, keeping ONLY the fields a downstream state actually reads and dropping the unbounded stdout:

| SF | polls | kept | stdout |
|---|---|---|---|
| weekday | 5 of 6 | `Status,ResponseCode,StatusDetails,StandardErrorContent` | dropped |
| weekday | `WaitForTradingDayCheck` | + `StandardOutputContent` | **kept** (matched vs `*MARKET_CLOSED*` / `*TRADING DAY*`) |
| EOD | all 5 | `Status,ResponseCode,StatusDetails,CommandId,InstanceId` | dropped |

EOD keeps `CommandId`/`InstanceId` because every `*StatusError` Pass state reads them off its poll. Full SSM stdout still ships to S3 (`_ssm_logs/`) for diagnosis.

## Tests
- `test_sf_poll_resultselector.py` generalized from Saturday-only to **all three** SFs and strengthened: it now discovers EVERY field a downstream state reads off each poll's ResultPath and requires the ResultSelector to keep exactly those (catches a future edit that drops EOD's `CommandId`), while still requiring `StandardOutputContent` be dropped unless read.
- `test_sf_payload_uniqueness.py::_eod_referenced_input_fields` now excludes `ResultSelector` subtrees from the top-level-field scan — a ResultSelector rebinds `$` to the raw task result, so its `"$.Status"`/`"$.CommandId"` RHS values are NOT top-level state fields and must not pollute the namespace registry (which would otherwise mask a real future `$.Status` ResultPath collision).

## Verification
- Full data-repo suite: **2127 passed, 2 skipped**.
- `aws stepfunctions validate-state-machine-definition` on both edited defs: **OK, no diagnostics**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)