### PR TITLE
feat(daily_append): count + emit schema_drift_incidents (fail-loud)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import gc
 import io
 import json
@@ -47,6 +48,21 @@ from features.compute import (
 )
 from arcticdb.version_store.library import ReadRequest, UpdatePayload, WritePayload
 from arcticdb_ext.version_store import DataError
+# Schema-drift exception family — RAISED (not returned-as-DataError) when a
+# row's column set / dtypes / order no longer match the persisted ArcticDB
+# stream descriptor. ``StreamDescriptorMismatch`` is the canonical case
+# (2026-05-21 EOD incident); ``SchemaException`` / ``NormalizationException``
+# are its siblings under ``ArcticException`` for the same "row shape ≠ stored
+# descriptor" class. These propagate out of update()/write()/update_batch()/
+# write_batch() rather than landing in a per-symbol DataError, so before
+# config#1150 they aborted the run UNCOUNTED. We count-then-re-raise (fail-loud).
+from arcticdb.exceptions import (
+    NormalizationException,
+    SchemaException,
+    StreamDescriptorMismatch,
+)
+
+_SCHEMA_DRIFT_EXC = (StreamDescriptorMismatch, SchemaException, NormalizationException)
 
 from store.arctic_store import (
     OHLCV_COLS as _CANONICAL_OHLCV_COLS,
@@ -316,6 +332,114 @@ def _emit_quality_gate_metrics(
             "quality-gate record is the load-bearing Flow Doctor surface.",
             exc,
         )
+
+
+def _emit_schema_drift_metric(count: int) -> None:
+    """Emit ``AlphaEngine/Data/daily_append_schema_drift_count`` gauge.
+
+    ``count`` is the number of ArcticDB schema-drift write failures
+    (``StreamDescriptorMismatch`` / ``SchemaException`` /
+    ``NormalizationException``) seen on the universe + macro write paths this
+    run. Emitted on EVERY run (zero on a clean run) so the evaluator's
+    trailing-4w Sum has a continuous baseline — a missing datapoint then means
+    "producer didn't run", not "zero incidents". Best-effort: a CloudWatch
+    error WARNs but does NOT mask the schema-drift exception itself, which
+    still propagates and fails the run loud. Mirrors ``_emit_quality_gate_metrics``.
+    """
+    try:
+        cw = boto3.client("cloudwatch")
+        cw.put_metric_data(
+            Namespace="AlphaEngine/Data",
+            MetricData=[{
+                "MetricName": "daily_append_schema_drift_count",
+                "Value": float(count),
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:
+        log.warning(
+            "CloudWatch daily_append_schema_drift_count metric failed: %s. "
+            "Not blocking daily_append — the count is observability hung off "
+            "the schema-drift failure path; the incident itself still raises.",
+            exc,
+        )
+
+
+def _write_schema_drift_manifest(s3, bucket: str, date_str: str, count: int) -> None:
+    """Persist the per-run schema-drift count to ``market_data/weekly/{date}/manifest.json``.
+
+    The durable, pull-based artifact companion to the CloudWatch metric —
+    written on EVERY run (including a clean run, count==0) so the artifact
+    reflects the last run's true state. Best-effort: an S3 error WARNs but
+    does NOT mask the schema-drift exception. ``schema_drift_incidents`` is
+    merged into any existing manifest so a co-located key from another writer
+    is preserved.
+    """
+    key = f"market_data/weekly/{date_str}/manifest.json"
+    manifest: dict = {}
+    try:
+        existing = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+        loaded = json.loads(existing)
+        if isinstance(loaded, dict):
+            manifest = loaded
+    except Exception:
+        # No prior manifest (common) — start fresh. A malformed/absent object
+        # is not worth failing the run over; we overwrite with our keys.
+        manifest = {}
+    manifest["schema_drift_incidents"] = int(count)
+    manifest["schema_drift_writer"] = "alpha-engine-data:builders/daily_append.py"
+    manifest["schema_drift_written_at"] = datetime.now(timezone.utc).isoformat()
+    manifest.setdefault("date", date_str)
+    try:
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=json.dumps(manifest, indent=2).encode("utf-8"),
+            ContentType="application/json",
+        )
+    except Exception as exc:
+        log.warning(
+            "manifest.json schema-drift write failed (s3://%s/%s): %s. "
+            "Not blocking daily_append — CloudWatch carries the same count and "
+            "the incident itself still raises.",
+            bucket, key, exc,
+        )
+
+
+@contextlib.contextmanager
+def _count_schema_drift(counter: list[int], *, on_drift=None):
+    """Count an ArcticDB schema-drift write failure, then RE-RAISE it (fail-loud).
+
+    Wrap an ArcticDB write call (update / write / update_batch / write_batch).
+    On a schema-drift exception (``_SCHEMA_DRIFT_EXC``) we increment
+    ``counter[0]``, invoke ``on_drift(counter[0])`` (the durable CloudWatch +
+    manifest emit, so the count survives the abort) if supplied, and re-raise
+    the original exception unchanged — the count is observability hung off the
+    existing failure path, NEVER a swallow. The run still fails loud. Non-schema
+    exceptions pass straight through, uncounted.
+    """
+    try:
+        yield
+    except _SCHEMA_DRIFT_EXC as exc:
+        counter[0] += 1
+        log.error(
+            "ArcticDB schema-drift write failure #%d this run: %s: %s — "
+            "counting then re-raising (fail-loud; the row shape no longer "
+            "matches the persisted stream descriptor).",
+            counter[0], type(exc).__name__, exc,
+        )
+        if on_drift is not None:
+            # Emit-on-abort so the incident lands in CloudWatch + manifest even
+            # though the run is about to fail. Best-effort: the emit itself must
+            # never mask the original schema-drift exception.
+            try:
+                on_drift(counter[0])
+            except Exception as emit_exc:  # pragma: no cover - defensive
+                log.warning(
+                    "schema-drift emit-on-abort failed: %s (original incident "
+                    "still re-raised below)", emit_exc,
+                )
+        raise
 
 
 def _scan_universe_and_emit_freshness_receipt(
@@ -751,6 +875,23 @@ def _daily_append_impl(
     # 08:39 PT manual rerun reproduced this — Step Function marked SUCCEEDED,
     # macro/SPY stayed at 4/10 for 5 days until an inference-side preflight
     # caught it.
+    # ── Schema-drift incident counter (config#1150 Batch B) ──────────────────
+    # Counts ArcticDB schema-drift write failures (StreamDescriptorMismatch /
+    # SchemaException / NormalizationException — see _SCHEMA_DRIFT_EXC) across
+    # BOTH the macro/sector and the chunked universe write paths this run.
+    # Single-element list so the inner write blocks share one mutable count.
+    # Before config#1150 these exceptions propagated UNCOUNTED — a descriptor
+    # regression was invisible to the report card until an operator noticed the
+    # failed run by hand. ``_emit_schema_drift`` writes the count to CloudWatch +
+    # manifest.json; on a clean run it fires once at the end (count 0), and on a
+    # schema-drift abort the _count_schema_drift wrapper fires it before the
+    # exception re-raises so the incident still lands.
+    n_schema_drift = [0]
+
+    def _emit_schema_drift(count: int) -> None:
+        _emit_schema_drift_metric(count)
+        _write_schema_drift_manifest(s3, bucket, date_str, count)
+
     macro_missing_from_closes: list[str] = []
     macro_updated: list[str] = []
     sector_updated: list[str] = []
@@ -775,7 +916,8 @@ def _daily_append_impl(
                     index=pd.DatetimeIndex([today_ts]),
                 )
                 new_row.index.name = "date"
-                mode = _write_row_backfill_safe(macro_lib, key, new_row)
+                with _count_schema_drift(n_schema_drift, on_drift=_emit_schema_drift):
+                    mode = _write_row_backfill_safe(macro_lib, key, new_row)
                 macro_updated.append(key)
                 macro_write_modes[key] = mode
             except Exception as exc:
@@ -799,7 +941,8 @@ def _daily_append_impl(
                     index=pd.DatetimeIndex([today_ts]),
                 )
                 new_row.index.name = "date"
-                mode = _write_row_backfill_safe(macro_lib, sym, new_row)
+                with _count_schema_drift(n_schema_drift, on_drift=_emit_schema_drift):
+                    mode = _write_row_backfill_safe(macro_lib, sym, new_row)
                 sector_updated.append(sym)
                 macro_write_modes[sym] = mode
             except Exception as exc:
@@ -1440,14 +1583,24 @@ def _daily_append_impl(
 
         if update_payloads or write_payloads:
             t_write0 = time.time()
-            update_results = (
-                universe_lib.update_batch(update_payloads, upsert=True)
-                if update_payloads else []
-            )
-            write_results = (
-                universe_lib.write_batch(write_payloads, prune_previous_versions=True)
-                if write_payloads else []
-            )
+            # A per-symbol schema mismatch comes back as a DataError in the
+            # results list (handled in _aggregate → n_err). A BATCH-LEVEL
+            # descriptor mismatch — the 2026-05-21 EOD incident, where the
+            # whole update_batch aborts before producing per-symbol results —
+            # RAISES StreamDescriptorMismatch out of the call. Count that here,
+            # emit the incident (the wrapper fires _emit_schema_drift before the
+            # exception escapes), then re-raise (fail-loud): a batch-level
+            # descriptor mismatch is a real data-integrity failure, not a
+            # per-ticker hiccup.
+            with _count_schema_drift(n_schema_drift, on_drift=_emit_schema_drift):
+                update_results = (
+                    universe_lib.update_batch(update_payloads, upsert=True)
+                    if update_payloads else []
+                )
+                write_results = (
+                    universe_lib.write_batch(write_payloads, prune_previous_versions=True)
+                    if write_payloads else []
+                )
             write_wall = time.time() - t_write0
             log.info(
                 "Batch writes: %d updates + %d backfills in %.1fs",
@@ -1550,6 +1703,7 @@ def _daily_append_impl(
         "tickers_quality_warned": n_quality_warned,
         "quality_anomaly_counts": dict(quality_counts_by_type),
         "quality_block_anomaly_types": sorted(block_anomaly_types),
+        "schema_drift_incidents": n_schema_drift[0],
         "load_seconds": round(t_load, 1),
         "total_seconds": round(t_total, 1),
         "dry_run": dry_run,
@@ -1572,6 +1726,11 @@ def _daily_append_impl(
         _emit_quality_gate_metrics(
             quality_counts_by_type, n_quality_blocked, n_quality_warned,
         )
+        # Clean-run schema-drift emit (count 0, or any non-fatal residual). On a
+        # schema-drift ABORT this line is never reached — the _count_schema_drift
+        # wrapper already emitted the incident before re-raising — so the count
+        # always lands exactly once, on both the clean and the fail-loud path.
+        _emit_schema_drift(n_schema_drift[0])
 
     # Hard-fail on high error rate. ``n_ok == 0`` alone is NOT a failure
     # signal — it correctly occurs when every ticker hit the

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -63,7 +63,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # to RAG-corpus S3 not the freshness-monitored production bucket).
 EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "builders/_price_cache_writeboth.py": 1,
-    "builders/daily_append.py": 1,
+    "builders/daily_append.py": 2,  # universe_freshness.json + weekly/<date>/manifest.json (schema_drift_incidents, config#1150)
     "builders/migrate_universe_feature_order.py": 1,
     "builders/migrate_universe_vwap.py": 1,
     "builders/prune_delisted_tickers.py": 1,

--- a/tests/test_daily_append_schema_drift.py
+++ b/tests/test_daily_append_schema_drift.py
@@ -1,0 +1,234 @@
+"""Tests for the schema_drift_incidents instrumentation in daily_append.
+
+config#1150 Batch B. Before this change an ArcticDB
+``StreamDescriptorMismatch`` (the 2026-05-21 EOD incident) propagated out of
+the universe / macro write paths UNCOUNTED — invisible to the report card
+until an operator noticed the failed run by hand. The instrumentation is a
+COUNTED wrapper hung off the existing failure path:
+
+  (a) the per-run counter increments on a schema-drift error,
+  (b) the error is STILL RAISED after counting (fail-loud — NEVER swallowed),
+  (c) the count lands in CloudWatch + ``market_data/weekly/{date}/manifest.json``.
+
+These three properties are exactly what this module locks.
+"""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from arcticdb.exceptions import (
+    NormalizationException,
+    SchemaException,
+    StreamDescriptorMismatch,
+)
+
+from builders.daily_append import (
+    _SCHEMA_DRIFT_EXC,
+    _count_schema_drift,
+    _emit_schema_drift_metric,
+    _write_schema_drift_manifest,
+)
+
+_DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
+
+
+def _source() -> str:
+    return _DAILY_APPEND.read_text()
+
+
+class _InMemoryS3:
+    """Minimal in-memory S3 mock (put_object + get_object). No moto dep —
+    mirrors tests/test_news_aggregates.py::_InMemoryS3."""
+
+    class _NoSuchKey(Exception):
+        pass
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self._store[(Bucket, Key)] = Body
+        return {"ETag": "stub"}
+
+    def get_object(self, *, Bucket, Key):
+        if (Bucket, Key) not in self._store:
+            raise self._NoSuchKey(f"NoSuchKey: {Bucket}/{Key}")
+        return {"Body": BytesIO(self._store[(Bucket, Key)])}
+
+
+def _mismatch() -> StreamDescriptorMismatch:
+    """Construct a StreamDescriptorMismatch the way ArcticDB raises it."""
+    try:
+        # The C++-bound ctor signature varies across versions; fall back to a
+        # message-only construction if the rich ctor isn't accepted.
+        return StreamDescriptorMismatch("SYM", "expected", "actual")  # type: ignore[call-arg]
+    except TypeError:
+        return StreamDescriptorMismatch("descriptor mismatch on SYM")
+
+
+# ── (a) + (b): the counter increments AND the error is re-raised ────────────
+
+class TestCountSchemaDriftWrapper:
+    def test_schema_drift_increments_then_reraises(self):
+        """Counter increments by one AND the original exception re-raises
+        (fail-loud — the run still fails)."""
+        counter = [0]
+        with pytest.raises(StreamDescriptorMismatch):
+            with _count_schema_drift(counter):
+                raise _mismatch()
+        assert counter[0] == 1, "schema-drift incident must be counted"
+
+    def test_reraises_the_exact_exception_not_swallowed(self):
+        """The SAME exception object propagates — proves it is re-raised, not
+        replaced/swallowed."""
+        counter = [0]
+        exc = _mismatch()
+        with pytest.raises(StreamDescriptorMismatch) as caught:
+            with _count_schema_drift(counter):
+                raise exc
+        assert caught.value is exc
+
+    @pytest.mark.parametrize("exc_cls", [SchemaException, NormalizationException])
+    def test_sibling_schema_exceptions_also_counted(self, exc_cls):
+        counter = [0]
+        with pytest.raises(exc_cls):
+            with _count_schema_drift(counter):
+                raise exc_cls("schema-shape failure")
+        assert counter[0] == 1
+
+    def test_clean_write_does_not_increment(self):
+        counter = [0]
+        with _count_schema_drift(counter):
+            pass  # a write that succeeds
+        assert counter[0] == 0
+
+    def test_non_schema_exception_passes_through_uncounted(self):
+        """A non-schema error (e.g. a connectivity RuntimeError) must NOT be
+        counted as schema drift and must still propagate."""
+        counter = [0]
+        with pytest.raises(ValueError):
+            with _count_schema_drift(counter):
+                raise ValueError("unrelated failure")
+        assert counter[0] == 0
+
+    def test_on_drift_emit_fires_before_reraise(self):
+        """The emit-on-abort callback runs with the incremented count BEFORE
+        the exception re-raises — so the incident lands in CloudWatch +
+        manifest even on a fail-loud abort."""
+        counter = [0]
+        emitted: list[int] = []
+        with pytest.raises(StreamDescriptorMismatch):
+            with _count_schema_drift(counter, on_drift=emitted.append):
+                raise _mismatch()
+        assert emitted == [1], "emit-on-abort must fire once with the count"
+
+    def test_on_drift_emit_failure_does_not_mask_incident(self):
+        """If the emit itself throws, the ORIGINAL schema-drift exception must
+        still re-raise — observability must never eat the incident."""
+        counter = [0]
+
+        def _boom(_count):
+            raise RuntimeError("cloudwatch down")
+
+        with pytest.raises(StreamDescriptorMismatch):
+            with _count_schema_drift(counter, on_drift=_boom):
+                raise _mismatch()
+        assert counter[0] == 1
+
+    def test_exc_tuple_members(self):
+        assert StreamDescriptorMismatch in _SCHEMA_DRIFT_EXC
+        assert SchemaException in _SCHEMA_DRIFT_EXC
+        assert NormalizationException in _SCHEMA_DRIFT_EXC
+
+
+# ── (c): the count lands in manifest.json ───────────────────────────────────
+
+class TestSchemaDriftManifest:
+    def test_count_lands_in_manifest_json(self):
+        s3 = _InMemoryS3()
+        _write_schema_drift_manifest(s3, "alpha-engine-research", "2026-06-23", 3)
+        key = "market_data/weekly/2026-06-23/manifest.json"
+        assert ("alpha-engine-research", key) in s3._store
+        manifest = json.loads(s3._store[("alpha-engine-research", key)])
+        assert manifest["schema_drift_incidents"] == 3
+        assert manifest["date"] == "2026-06-23"
+        assert "schema_drift_written_at" in manifest
+
+    def test_zero_count_still_written(self):
+        """A clean run (count 0) still writes the manifest so the artifact
+        reflects the last run's true state."""
+        s3 = _InMemoryS3()
+        _write_schema_drift_manifest(s3, "b", "2026-06-23", 0)
+        manifest = json.loads(s3._store[("b", "market_data/weekly/2026-06-23/manifest.json")])
+        assert manifest["schema_drift_incidents"] == 0
+
+    def test_merges_into_existing_manifest(self):
+        """A co-located key written by another producer is preserved."""
+        s3 = _InMemoryS3()
+        key = "market_data/weekly/2026-06-23/manifest.json"
+        s3.put_object(
+            Bucket="b", Key=key,
+            Body=json.dumps({"other_producer_field": "keep-me"}).encode(),
+        )
+        _write_schema_drift_manifest(s3, "b", "2026-06-23", 2)
+        manifest = json.loads(s3._store[("b", key)])
+        assert manifest["other_producer_field"] == "keep-me"
+        assert manifest["schema_drift_incidents"] == 2
+
+    def test_s3_error_does_not_raise(self):
+        """A manifest write error is best-effort — must not fail the run
+        (CloudWatch carries the same count, and the incident itself raises
+        elsewhere)."""
+        s3 = MagicMock()
+        s3.get_object.side_effect = Exception("no prior")
+        s3.put_object.side_effect = Exception("s3 down")
+        # Must not raise.
+        _write_schema_drift_manifest(s3, "b", "2026-06-23", 1)
+
+
+# ── CloudWatch emit ─────────────────────────────────────────────────────────
+
+class TestSchemaDriftMetric:
+    def test_emits_named_metric(self):
+        cw = MagicMock()
+        with patch("builders.daily_append.boto3.client", return_value=cw):
+            _emit_schema_drift_metric(4)
+        cw.put_metric_data.assert_called_once()
+        kwargs = cw.put_metric_data.call_args.kwargs
+        assert kwargs["Namespace"] == "AlphaEngine/Data"
+        md = kwargs["MetricData"][0]
+        assert md["MetricName"] == "daily_append_schema_drift_count"
+        assert md["Value"] == 4.0
+        assert md["Unit"] == "Count"
+
+    def test_cloudwatch_error_does_not_raise(self):
+        with patch("builders.daily_append.boto3.client", side_effect=Exception("cw down")):
+            _emit_schema_drift_metric(1)  # best-effort, must not raise
+
+
+# ── source-level: both write paths are wrapped (no UNCOUNTED path) ──────────
+
+class TestWritePathsWrapped:
+    def test_universe_batch_write_is_wrapped(self):
+        src = _source()
+        assert "with _count_schema_drift(n_schema_drift, on_drift=_emit_schema_drift):" in src
+        # The batch writes must live INSIDE a _count_schema_drift block.
+        assert "universe_lib.update_batch(update_payloads, upsert=True)" in src
+
+    def test_macro_write_is_wrapped(self):
+        src = _source()
+        # The macro/sector _write_row_backfill_safe calls must be inside a
+        # _count_schema_drift wrapper.
+        assert "with _count_schema_drift(n_schema_drift, on_drift=_emit_schema_drift):\n" \
+               "                    mode = _write_row_backfill_safe(macro_lib, key, new_row)" in src
+
+    def test_count_in_result_and_emitted_on_clean_path(self):
+        src = _source()
+        assert '"schema_drift_incidents": n_schema_drift[0],' in src
+        assert "_emit_schema_drift(n_schema_drift[0])" in src


### PR DESCRIPTION
## What

Wires the **producer** half of `schema_drift_incidents` (critical) — Report-card Batch B, the deferred component of nousergon/alpha-engine-config#1150. The `data_quality_incidents` sibling is already done; this mirrors its pattern.

## Root cause

`builders/daily_append.py` writes the universe library via `update_batch` / `write_batch` and the macro/sector libraries via `_write_row_backfill_safe`. A **batch-level** ArcticDB `StreamDescriptorMismatch` (the 2026-05-21 EOD incident) — or its siblings `SchemaException` / `NormalizationException` — is *raised* out of those calls (unlike a per-symbol mismatch, which comes back as a `DataError` and is already counted into `n_err`). Before this change those raised exceptions propagated **UNCOUNTED**: no CloudWatch metric, no artifact, so a descriptor regression was invisible to the report card until an operator noticed the failed run by hand.

## Change (institutional, not a bandaid)

A counted wrapper hung off the **existing failure path** at the true write-call boundary:

- `_count_schema_drift(counter, on_drift=...)` context manager wraps the universe batch writes and the macro/sector `_write_row_backfill_safe` calls. On a schema-drift exception it increments a per-run counter, emits the running count, then **re-raises the original exception unchanged**.
- **FAIL-LOUD PRESERVED:** the exception is never swallowed — the run still fails. The counter is observability, full stop.
- Emitted to **CloudWatch** `AlphaEngine/Data/daily_append_schema_drift_count` + the durable **`market_data/weekly/{date}/manifest.json`** artifact (`schema_drift_incidents` key, merged so co-located keys survive).
- Emitted **exactly once**: on a clean run via the end-of-run hook (count `0`, so the evaluator's trailing-4w Sum has a continuous baseline → a missing datapoint means "producer didn't run", not "zero incidents"); on a schema-drift abort by the wrapper *before* the exception escapes, so the incident still lands.
- `schema_drift_incidents` added to the run result dict.

Mirrors the `data_quality_incidents` pattern (`tickers_quality_blocked` / `quality_anomaly_counts` / `_emit_quality_gate_metrics`) in the same file.

## Tests

`tests/test_daily_append_schema_drift.py` (18 cases) covers the three required properties:
- **(a)** the counter increments on a simulated schema-drift error (+ siblings, + non-schema errors pass through uncounted);
- **(b)** the **exact** exception is STILL RAISED after counting (fail-loud), incl. *emit-failure-does-not-mask-the-incident*;
- **(c)** the count lands in `manifest.json` (+ merge / zero-count / S3-error-tolerant), and the CloudWatch metric is correctly named.

Source-level guards lock both write paths as wrapped.

### Local test status — GREEN
- `tests/test_daily_append_schema_drift.py`: **18 passed**
- Full suite (`pytest tests/`): **2141 passed, 6 skipped** (`AWS_REGION=us-east-1`, arcticdb 6.18.3, full `requirements.txt`).
- Bumped the `daily_append.py` PUT-site pin in `tests/test_artifact_registry_coverage.py` (1→2) for the new manifest artifact.

## Follow-up (out of scope for this PR)
Register the new `market_data/weekly/{date}/manifest.json` artifact in `alpha-engine-config/private-docs/ARTIFACT_REGISTRY.yaml` (separate repo). The producer CI guard here only pins the per-file PUT count, which is updated.

## Soak note
A clean run emits `0`, so the metric self-activates on the next deployed EOD/daily run. Per the issue, **soak ≥1 EOD before the evaluator grades it** so the trailing-4w Sum reflects real data.

Toward nousergon/alpha-engine-config#1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)