### PR TITLE
fix(deploy): auto-deploy EOD Step Function on merge (config#1173)

### DIFF
--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -65,7 +65,8 @@ echo ""
 echo "==> Stamping Step Function definitions with git SHA..."
 SAT_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
 DAILY_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
-trap "rm -f '$SAT_STAMPED' '$DAILY_STAMPED'" EXIT
+EOD_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
+trap "rm -f '$SAT_STAMPED' '$DAILY_STAMPED' '$EOD_STAMPED'" EXIT
 python3 -c "
 import json, sys
 path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -87,11 +88,22 @@ if orig.startswith('[git:'):
 d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
 json.dump(d, open(path_out, 'w'), indent=2)
 " "$SCRIPT_DIR/step_function_daily.json" "$DAILY_STAMPED" "$GIT_SHA"
+python3 -c "
+import json, sys
+path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(path_in))
+orig = d.get('Comment', '')
+if orig.startswith('[git:'):
+    orig = orig.split(' ', 1)[1] if ' ' in orig else ''
+d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
+json.dump(d, open(path_out, 'w'), indent=2)
+" "$SCRIPT_DIR/step_function_eod.json" "$EOD_STAMPED" "$GIT_SHA"
 
 echo ""
 echo "==> Uploading Step Function definitions to S3..."
 aws s3 cp "$SAT_STAMPED" "s3://$BUCKET/infrastructure/step_function.json" --quiet
 aws s3 cp "$DAILY_STAMPED" "s3://$BUCKET/infrastructure/step_function_daily.json" --quiet
+aws s3 cp "$EOD_STAMPED" "s3://$BUCKET/infrastructure/step_function_eod.json" --quiet
 echo "  Uploaded to s3://$BUCKET/infrastructure/"
 
 # ── 3. Update Step Functions directly ────────────────────────────────────────
@@ -100,6 +112,7 @@ echo "==> Updating Step Function definitions..."
 
 SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
 DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-weekday-pipeline"
+EOD_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
 
 # Pass the definition via file:// — NOT inline "$(cat ...)". The Saturday ASL is
 # ~131 KB and growing (one state per pipeline step); combined with the AWS
@@ -115,6 +128,15 @@ echo "  Saturday pipeline updated."
 
 aws stepfunctions update-state-machine --state-machine-arn "$DAILY_ARN" --definition "file://$DAILY_STAMPED" --query "updateDate" --output text
 echo "  Weekday pipeline updated."
+
+# EOD SF (alpha-engine-eod-pipeline) — folded into auto-deploy 2026-06-23 (config#1173).
+# Previously deployed only by the manual infrastructure/update_eod_pipeline_sf.sh, which
+# nothing triggered on merge, so merged EOD SF changes silently never reached the live
+# state machine (drift hit 2026-06-22 via #458's nousergon_lib migration). Same
+# stamp + S3-copy + file:// update-state-machine pattern as Saturday/weekday above, so all
+# three orchestration SFs now stay in lockstep with origin/main on every merge.
+aws stepfunctions update-state-machine --state-machine-arn "$EOD_ARN" --definition "file://$EOD_STAMPED" --query "updateDate" --output text
+echo "  EOD pipeline updated."
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────
 echo ""

--- a/infrastructure/update_eod_pipeline_sf.sh
+++ b/infrastructure/update_eod_pipeline_sf.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 # update_eod_pipeline_sf.sh — Apply the canonical EOD pipeline SF definition.
 #
+# NOTE (2026-06-23, config#1173): the EOD SF is now auto-deployed on every
+# merge to main by deploy-infrastructure.sh (alongside the Saturday + weekday
+# SFs), so this script is no longer required for normal merges. It is retained
+# only as a manual fallback for out-of-band EOD-SF redeploys (e.g. re-applying
+# the on-disk definition without a merge, or recovering from a failed
+# deploy-infrastructure run). Note: unlike the auto-deploy path, this script
+# applies the definition WITHOUT the [git:<sha>] Comment stamp.
+#
 # Reads the state-machine definition from
 # infrastructure/step_function_eod.json (single source of truth, same
 # pattern as deploy_step_function.sh for the Saturday SF) and applies

--- a/tests/test_deploy_infrastructure_sf_coverage.py
+++ b/tests/test_deploy_infrastructure_sf_coverage.py
@@ -1,0 +1,90 @@
+"""Deploy-coverage guard: every orchestration Step Function definition in
+``infrastructure/`` MUST be auto-deployed by ``deploy-infrastructure.sh``.
+
+This pins the fix for config#1173: the EOD SF (``step_function_eod.json`` →
+``alpha-engine-eod-pipeline``) used to be deployed ONLY by the manual
+``update_eod_pipeline_sf.sh``, which nothing triggered on merge. Merged EOD SF
+changes therefore silently never reached the live state machine (drift hit
+2026-06-22 via #458's ``nousergon_lib`` migration — weekday + Saturday
+auto-deployed, EOD did not).
+
+Same deploy-gap class as the CFN-target-uniqueness / drift-stamp guards: a new
+``step_function_*.json`` added to ``infrastructure/`` without a matching
+deploy block in ``deploy-infrastructure.sh`` reintroduces exactly this silent
+drift. This test fails loudly the moment that happens, forcing the author to
+wire the new SF into the auto-deploy flow.
+
+For each ``infrastructure/step_function*.json`` we assert the deploy script:
+  1. uploads the (stamped) definition to ``s3://.../infrastructure/<file>``, and
+  2. applies it via ``aws stepfunctions update-state-machine``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+_DEPLOY = _INFRA / "deploy-infrastructure.sh"
+
+# The orchestration SF definitions that ship in infrastructure/ and are expected
+# to be auto-deployed on merge. Discovered by glob so a newly added SF file is
+# covered automatically.
+_SF_FILES = sorted(p.name for p in _INFRA.glob("step_function*.json"))
+
+
+def test_deploy_script_and_sf_definitions_present() -> None:
+    assert _DEPLOY.is_file(), f"missing {_DEPLOY}"
+    # Guards against the glob silently matching nothing (e.g. a refactor that
+    # renames the files) and turning the per-file checks into vacuous passes.
+    assert _SF_FILES, "no step_function*.json definitions found in infrastructure/"
+
+
+@pytest.mark.parametrize("sf_file", _SF_FILES)
+def test_sf_definition_uploaded_to_s3(sf_file: str) -> None:
+    """Every SF definition is staged to S3 by the deploy script."""
+    script = _DEPLOY.read_text()
+    assert (
+        f"s3://$BUCKET/infrastructure/{sf_file}" in script
+    ), (
+        f"{sf_file} is not uploaded to S3 by deploy-infrastructure.sh — a "
+        f"merged change to it would silently never reach the live state "
+        f"machine (config#1173). Add an `aws s3 cp` line mirroring the "
+        f"Saturday/weekday/EOD blocks."
+    )
+
+
+def test_update_state_machine_called_for_each_sf() -> None:
+    """Each SF definition has a corresponding update-state-machine deploy.
+
+    We count the ``update-state-machine`` invocations rather than tie each to a
+    literal ARN string (the ARNs are built from shell vars) and require at least
+    one per SF definition file.
+    """
+    script = _DEPLOY.read_text()
+    n_updates = script.count("aws stepfunctions update-state-machine")
+    assert n_updates >= len(_SF_FILES), (
+        f"deploy-infrastructure.sh has {n_updates} update-state-machine "
+        f"call(s) for {len(_SF_FILES)} SF definition file(s) "
+        f"({_SF_FILES}); every orchestration SF must be applied on merge "
+        f"(config#1173)."
+    )
+
+
+def test_eod_state_machine_is_auto_deployed() -> None:
+    """Explicit pin for the config#1173 regression target.
+
+    The EOD SF + its state-machine name must both be wired into the deploy
+    script so the auto-deploy path covers ``alpha-engine-eod-pipeline``.
+    """
+    script = _DEPLOY.read_text()
+    assert "step_function_eod.json" in script, (
+        "EOD SF definition not referenced by deploy-infrastructure.sh "
+        "(config#1173 regression)."
+    )
+    assert "alpha-engine-eod-pipeline" in script, (
+        "alpha-engine-eod-pipeline state machine not deployed by "
+        "deploy-infrastructure.sh (config#1173 regression)."
+    )


### PR DESCRIPTION
Closes nousergon/alpha-engine-config#1173

## Root cause
`deploy-infrastructure.sh` (run by `deploy-infrastructure.yml` on every push to main) deployed only the Saturday (`step_function.json` → `alpha-engine-saturday-pipeline`) and weekday (`step_function_daily.json` → `alpha-engine-weekday-pipeline`) Step Functions. The EOD SF (`step_function_eod.json` → `alpha-engine-eod-pipeline`) was deployed only by the **manual** `update_eod_pipeline_sf.sh`, which nothing triggered on merge — so merged EOD SF changes silently never reached the live state machine. This drift was hit 2026-06-22 when #458's `nousergon_lib` migration auto-deployed the weekday + Saturday SFs but left the EOD SF stale until it was manually re-applied.

## Fix (deploy-orchestration layer, root cause — additive)
Fold the EOD SF into `deploy-infrastructure.sh`, mirroring the existing Saturday/weekday blocks exactly:
- Stamp the `Comment` field with the git SHA (same idempotent re-stamp logic).
- Upload to `s3://alpha-engine-research/infrastructure/step_function_eod.json`.
- Apply via `aws stepfunctions update-state-machine` using `file://` (not inline — same ARG_MAX-safe pattern as the other two).

The Saturday/weekday stamp + S3 + update calls are byte-for-byte unchanged. `update_eod_pipeline_sf.sh` is demoted to a documented manual fallback (header note; not deleted).

Note: `alpha-engine-eod-pipeline` is not defined in the CloudFormation template (`alpha-engine-orchestration.yaml` only manages the Saturday + weekday state machines) — it is an out-of-band/imported state machine, consistent with it only ever having been updated via the manual script's `update-state-machine`. The new deploy block uses the same direct `update-state-machine` path, so it works regardless of CF management.

## New regression guard
`tests/test_deploy_infrastructure_sf_coverage.py` — asserts every `infrastructure/step_function*.json` is both staged to S3 and applied via `update-state-machine` by `deploy-infrastructure.sh`, plus an explicit pin for the EOD SF + `alpha-engine-eod-pipeline`. A future SF added without a deploy block now fails CI loudly instead of silently drifting.

## Validation
- `bash -n` clean on `deploy-infrastructure.sh` and `update_eod_pipeline_sf.sh`.
- `shellcheck`: only pre-existing SC2064 warnings (the new trap line follows the same intentional early-expansion pattern as the existing ones; no new warning class).
- New coverage test + existing EOD wiring tests (`test_sf_eod_substrate_check_wiring.py`, `test_sf_eod_skipgate_wiring.py`): **40 passed**.
- Verified the SHA-stamp transform produces valid JSON for the EOD definition (34 States preserved); EOD definition is ~31 KB, well within the SF 1 MB limit.

## Caveat
The live-deploy effect (the EOD state machine's `updateDate` advancing) is only observable on the next merge-to-main `deploy-infrastructure.yml` run — I have no AWS access to dry-run `update-state-machine` against the real account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)