### PR TITLE
fix(dates): default weekly/daily collector keys to trading_day, not calendar (config#1014)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -826,7 +826,10 @@ def _daily_append_impl(
     structurally unchanged.
     """
     s3 = boto3.client("s3")
-    date_str = date_str or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if date_str is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        date_str = default_run_date()
     today_ts = pd.Timestamp(date_str)
     t0 = time.time()
 
@@ -1812,7 +1815,9 @@ def main():
     )
 
     result = daily_append(
-        date_str=args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        # config#1014: pass args.date through; daily_append() defaults a None
+        # date_str to the trading-day axis via dates.default_run_date().
+        date_str=args.date,
         bucket=args.bucket,
         dry_run=args.dry_run,
         skip_if_exists=args.skip_if_exists,

--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -535,7 +535,10 @@ def collect(
     Returns:
         dict with status, tickers_processed, tickers_failed, errors
     """
-    run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
     s3 = boto3.client("s3")
 
     # Resolve ticker list

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -442,7 +442,10 @@ def collect(
     if window_days < 1:
         raise ValueError(f"window_days must be >= 1, got {window_days}")
 
-    run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
 
     if window_days > 1:
         return _collect_window(

--- a/collectors/macro.py
+++ b/collectors/macro.py
@@ -117,7 +117,9 @@ def collect(
         dict with status and any errors
     """
     if run_date is None:
-        run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
 
     macro = _fetch_fred()
     market = _fetch_market_prices()

--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -552,7 +552,10 @@ def collect(
     """Read Metron's held universe → fetch EOD closes + FX → write the two artifacts
     (dated + ``latest``). Returns a status dict. ``close_source``/``fx_source`` inject
     fetchers for tests; ``s3_client`` injects a fake S3."""
-    run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")
@@ -664,7 +667,10 @@ def collect_reference(
         market_data/earnings/latest.json   {schema_version, as_of, earnings: {yf_symbol: date_iso}}
 
     Keyed by yf_symbol (consistent with the closes artifact). Injectable sources/S3."""
-    run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")
@@ -712,7 +718,10 @@ def collect_macro(
     curated CPI/employment/claims releases) for the Macro "Next expected" column + the
     Calendar page (metron-ops#49/#13). Injectable source(s)/S3 for tests; FRED key from
     ``alpha_engine_lib.secrets`` when not injected."""
-    run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")
@@ -804,7 +813,10 @@ def collect_fundamentals(
     ``FUNDAMENTALS_INFO_KEYS`` — the consumer owns display/unit semantics and pins
     ``schema_version``. Daily cadence (fundamentals move quarterly; daily is plenty).
     Injectable source/S3 for tests."""
-    run_date = run_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")

--- a/collectors/short_interest.py
+++ b/collectors/short_interest.py
@@ -99,7 +99,9 @@ def collect(
         ok_count >= MIN_OK_RATIO * ticker_count, else ``"error"``.
     """
     if run_date is None:
-        run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
 
     if not tickers:
         return {

--- a/dates.py
+++ b/dates.py
@@ -1,0 +1,77 @@
+"""dates.py — repo-local chokepoint for default artifact-keying dates.
+
+config#1014 (trading-day axis migration: alpha-engine-data weekly/daily
+collector keys). Every collector / builder entrypoint historically defaulted
+its ``run_date`` / ``--date`` to the *calendar* date::
+
+    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+On a Saturday (or any non-trading day / pre-open weekday morning) the calendar
+date is NOT the session the data is about, so the artifact gets keyed on the
+wrong axis (e.g. ``market_data/weekly/2026-06-27/`` on a Saturday instead of
+Friday's ``2026-06-26/`` close). Producers and consumers currently *agree* on
+calendar keying, so this module is the single place the default is migrated to
+the trading-day axis — mirroring the predictor fix (crucible-predictor#289,
+config#1015) which routed ``train_handler``'s default through
+``alpha_engine_lib.dates.now_dual().trading_day``.
+
+Root-cause, not band-aid: rather than 12 scattered ``now_dual()`` patches with
+12 copies of the try/except fallback, every default-date site calls
+``default_run_date()`` here. The lib chokepoint (``now_dual``) lives in
+``alpha_engine_lib.dates`` and is reachable from this repo at the pinned
+``nousergon-lib@v0.59.4`` (requirements.txt) — so this is a clean import, no
+lib release/pin bump required.
+
+Backward-compat: when an explicit ``--date`` / ``run_date`` is passed (the SF
+production path threads one via ``$.run_date`` / ``RUN_DATE``), this helper is
+NOT consulted — behaviour is unchanged. The trading-day default only takes
+effect on the manual / ad-hoc / daily-cron path that previously fell through to
+calendar ``now()``. No historical artifact is re-keyed or orphaned.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+
+def default_run_date(now: datetime | None = None) -> str:
+    """Resolve the default artifact-keying date on the trading-day axis.
+
+    Returns the last *closed* NYSE session as an ISO ``YYYY-MM-DD`` string via
+    the fleet-canonical ``alpha_engine_lib.dates.now_dual().trading_day``
+    chokepoint. Falls back to the calendar UTC date only if the lib lookup
+    raises — date defaulting must never block a collection run.
+
+    Args:
+        now: optional timezone-aware moment (mainly for tests). Defaults to
+            current UTC time inside ``now_dual``.
+
+    Returns:
+        ISO ``YYYY-MM-DD`` string. On a non-trading day this is the most recent
+        session whose 4:00 PM ET close has occurred (e.g. Saturday -> Friday).
+    """
+    try:
+        from alpha_engine_lib.dates import now_dual
+
+        dd = now_dual(now=now) if now is not None else now_dual()
+        log.info(
+            "default_run_date: resolved trading_day=%s (calendar=%s)",
+            dd.trading_day,
+            dd.calendar_date,
+        )
+        return dd.trading_day
+    except Exception:  # noqa: BLE001 — date defaulting must not block a run
+        ref = now or datetime.now(timezone.utc)
+        if ref.tzinfo is None:
+            ref = ref.replace(tzinfo=timezone.utc)
+        fallback = ref.astimezone(timezone.utc).strftime("%Y-%m-%d")
+        log.warning(
+            "default_run_date: could not resolve trading_day via "
+            "alpha_engine_lib.dates.now_dual; fell back to calendar date %s",
+            fallback,
+            exc_info=True,
+        )
+        return fallback

--- a/features/compute.py
+++ b/features/compute.py
@@ -713,8 +713,10 @@ def main():
         description="Compute and write feature store snapshots to S3",
     )
     parser.add_argument(
-        "--date", default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        help="Target date (YYYY-MM-DD, default: today UTC)",
+        # config#1014: default resolved below on the trading-day axis (not
+        # calendar now()) so a Saturday run keys features/{Fri}/ not /{Sat}/.
+        "--date", default=None,
+        help="Target date (YYYY-MM-DD, default: last closed trading day)",
     )
     parser.add_argument(
         "--dry-run", action="store_true",
@@ -730,6 +732,11 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        args.date = default_run_date()
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,

--- a/tests/test_trading_day_collector_keys.py
+++ b/tests/test_trading_day_collector_keys.py
@@ -1,0 +1,141 @@
+"""Trading-day axis for default collector/builder artifact keys (config#1014).
+
+The weekly/daily collector chain historically defaulted ``run_date`` /
+``--date`` to the *calendar* UTC date::
+
+    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+On a Saturday (the weekly SF firing day) the calendar date is NOT a trading
+session, so artifacts mis-keyed to Saturday instead of Friday's close
+(``market_data/weekly/{Sat}/``, ``staging/daily_closes/{Sat}.parquet``,
+``features/{Sat}/schema_version.json``, the ArcticDB macro-index bar, ...).
+
+This pins the root-cause fix: a single repo chokepoint, ``dates.default_run_date()``,
+which routes the default through the fleet-canonical
+``alpha_engine_lib.dates.now_dual().trading_day`` (mirroring the predictor
+fix crucible-predictor#289 / config#1015). The chokepoint is reached by every
+``... or default_run_date()`` / ``if run_date is None`` default site.
+
+Backward-compat contract (also pinned here): when an explicit date is passed
+(the SF production path threads ``$.run_date`` / ``RUN_DATE``), the helper is
+NOT consulted — historical artifacts are never re-keyed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+import dates
+
+
+# Saturday 2026-06-27; Friday 2026-06-26 is the last closed NYSE session.
+_SATURDAY = datetime(2026, 6, 27, 12, 0, tzinfo=timezone.utc)
+_FRIDAY_ISO = "2026-06-26"
+# Sunday 2026-06-28 also attributes back to Friday 2026-06-26.
+_SUNDAY = datetime(2026, 6, 28, 23, 0, tzinfo=timezone.utc)
+
+
+def test_saturday_default_run_date_keys_to_friday():
+    """The core defect: a Saturday default must resolve to Friday's session,
+    not Saturday's calendar date."""
+    assert dates.default_run_date(now=_SATURDAY) == _FRIDAY_ISO
+
+
+def test_sunday_default_run_date_keys_to_friday():
+    assert dates.default_run_date(now=_SUNDAY) == _FRIDAY_ISO
+
+
+def test_weekday_after_close_keys_to_that_session():
+    """A weekday after the 4pm ET close attributes to that day's session."""
+    # Friday 2026-06-26 21:00 UTC = 17:00 ET, after the close.
+    fri_after_close = datetime(2026, 6, 26, 21, 0, tzinfo=timezone.utc)
+    assert dates.default_run_date(now=fri_after_close) == _FRIDAY_ISO
+
+
+def test_returns_iso_string():
+    out = dates.default_run_date(now=_SATURDAY)
+    assert isinstance(out, str)
+    # ISO YYYY-MM-DD round-trips.
+    datetime.strptime(out, "%Y-%m-%d")
+
+
+def test_fallback_to_calendar_on_lib_failure(monkeypatch):
+    """Date defaulting must never block a run: if the lib lookup raises, fall
+    back to the calendar UTC date (the prior behaviour) rather than crashing."""
+    import alpha_engine_lib.dates as lib_dates
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated trading-calendar outage")
+
+    monkeypatch.setattr(lib_dates, "now_dual", _boom)
+    # Saturday calendar date is returned as the documented fallback.
+    assert dates.default_run_date(now=_SATURDAY) == "2026-06-27"
+
+
+def test_no_now_argument_does_not_raise():
+    """Smoke: zero-arg call (the real production signature) returns a valid
+    ISO date for 'now'."""
+    out = dates.default_run_date()
+    datetime.strptime(out, "%Y-%m-%d")
+
+
+# ── Default-site wiring: each entrypoint routes its None-default through the
+#    chokepoint (so a Saturday run keys to Friday). We assert the wiring at the
+#    source level rather than booting the heavy ArcticDB/S3 collectors. ──────
+
+
+@pytest.mark.parametrize(
+    "module_path, marker",
+    [
+        ("weekly_collector.py", "args.date or default_run_date()"),
+        ("collectors/daily_closes.py", "default_run_date()"),
+        ("collectors/metron_market_data.py", "default_run_date()"),
+        ("collectors/macro.py", "default_run_date()"),
+        ("collectors/short_interest.py", "default_run_date()"),
+        ("collectors/alternative.py", "default_run_date()"),
+        ("builders/daily_append.py", "default_run_date()"),
+        ("features/compute.py", "default_run_date()"),
+    ],
+)
+def test_entrypoint_routes_default_through_chokepoint(module_path, marker):
+    import pathlib
+
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    src = (repo / module_path).read_text()
+    assert marker in src, (
+        f"{module_path} no longer routes its default date through "
+        f"dates.default_run_date() — config#1014 regression."
+    )
+
+
+def test_no_calendar_now_default_remains_in_migrated_sites():
+    """Regression pin: none of the migrated entrypoints may reintroduce a
+    calendar ``... or datetime.now(timezone.utc).strftime(\"%Y-%m-%d\")``
+    default for run_date/date_str."""
+    import pathlib
+
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    bad = 'or datetime.now(timezone.utc).strftime("%Y-%m-%d")'
+    offenders = []
+    for module_path in [
+        "weekly_collector.py",
+        "collectors/daily_closes.py",
+        "collectors/metron_market_data.py",
+        "collectors/macro.py",
+        "collectors/short_interest.py",
+        "collectors/alternative.py",
+        "builders/daily_append.py",
+        "features/compute.py",
+    ]:
+        src = (repo / module_path).read_text()
+        for i, line in enumerate(src.splitlines(), 1):
+            stripped = line.strip()
+            if bad in stripped and ("run_date" in stripped or "date_str" in stripped):
+                offenders.append(f"{module_path}:{i}: {stripped}")
+    assert not offenders, (
+        "Calendar-now default reintroduced at a migrated artifact-keying "
+        "site (config#1014). Route through dates.default_run_date():\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -851,9 +851,11 @@ def test_arctic_append_reads_constituents_by_run_date_not_pointer():
     drops the churn-out tickers.
     """
     config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
-    # No --date → run_date resolves to today's UTC calendar date (the date
-    # MorningEnrich wrote constituents under), and target_date to prior
-    # trading day. The two differ; the append must read by the RUN date.
+    # No --date → run_date resolves to the trading-day-axis default (config#1014:
+    # the date MorningEnrich wrote constituents under, mirroring
+    # ``run_date = args.date or default_run_date()`` in _run_morning_enrich), and
+    # target_date to the prior trading day. The two differ; the append must read
+    # by the RUN date.
     args = SimpleNamespace(date=None, dry_run=False)
 
     seen = {}
@@ -877,10 +879,15 @@ def test_arctic_append_reads_constituents_by_run_date_not_pointer():
     assert seen.get("run_date") is not None, (
         "must read constituents by run_date direct, not the latest_weekly pointer"
     )
-    # Run date is today's UTC calendar date, distinct from the prior-trading-day
-    # target_date the append row is keyed on.
-    today_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    assert seen["run_date"] == today_utc
+    # Run date is the trading-day-axis default (config#1014) — the same
+    # chokepoint expression _run_morning_arctic_append uses — distinct from the
+    # prior-trading-day target_date the append row is keyed on. Assert against
+    # the chokepoint directly so the test is axis-correct and not flaky across
+    # the NYSE close (a raw calendar-now string would diverge from the migrated
+    # trading_day default on weekends/pre-open).
+    import dates
+
+    assert seen["run_date"] == dates.default_run_date()
     # The fresh universe is what flows into expected_tickers.
     assert captured and set(captured[0]["expected_tickers"]) == {"AAPL", "MSFT", "NVDA"}
 

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -80,6 +80,7 @@ from collectors import constituents, prices, macro, universe_returns, signal_ret
 from builders._price_cache_writeboth import (
     price_cache_write_prefixes as _price_cache_write_prefixes,
 )
+from dates import default_run_date  # config#1014: trading-day-axis default
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +261,7 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
     price_cfg = config.get("price_cache", {})
     market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
     ur_cfg = config.get("universe_returns", {})
-    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    run_date = args.date or default_run_date()
     dry_run = args.dry_run
     only = args.only
     reg = _build_registry(config, args, run_date)
@@ -503,7 +504,7 @@ def _run_phase2(config: dict, args: argparse.Namespace) -> dict:
     """Phase 2: alternative data for promoted tickers (after research)."""
     bucket = config["bucket"]
     market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
-    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    run_date = args.date or default_run_date()
     dry_run = args.dry_run
     reg = _build_registry(config, args, run_date)
 
@@ -1147,7 +1148,7 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
                 cons_result = constituents.collect(
                     bucket=bucket,
                     s3_prefix=market_prefix,
-                    run_date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+                    run_date=default_run_date(),  # config#1014: trading-day axis
                     dry_run=False,
                 )
             results["collectors"]["constituents_preflight"] = cons_result
@@ -1699,7 +1700,7 @@ def _load_daily_universe_tickers(config: dict) -> list[str]:
 def _run_daily(config: dict, args: argparse.Namespace) -> dict:
     """Daily mode: capture today's OHLCV closes for all tracked tickers."""
     bucket = config["bucket"]
-    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    run_date = args.date or default_run_date()
     dry_run = args.dry_run
     daily_cfg = config.get("daily_closes", {})
     reg = _build_registry(config, args, run_date)
@@ -1917,7 +1918,7 @@ def _run_daily_arctic_append(config: dict, args: argparse.Namespace) -> dict:
     daily_closes parquet that this append reads, so this state runs after it.
     """
     bucket = config["bucket"]
-    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    run_date = args.date or default_run_date()
     dry_run = args.dry_run
     results: dict = {
         "mode": "daily_arctic_append",

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -1459,11 +1459,12 @@ def _run_morning_arctic_append(config: dict, args: argparse.Namespace) -> dict:
     # via ``builders._constituents_loader``; this is the third in-repo reader.
     tickers: list[str] = []
     market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
-    # Calendar run date == the date MorningEnrich wrote constituents under
-    # (``run_date = args.date or now_utc`` in _run_morning_enrich). Mirror that
-    # expression exactly so we read the file this run produced — NOT
-    # target_date, which is the prior trading day the append ROW is keyed on.
-    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # Run date == the date MorningEnrich wrote constituents under
+    # (``run_date = args.date or default_run_date()`` in _run_morning_enrich,
+    # config#1014 trading-day axis). Mirror that expression exactly so we read
+    # the file this run produced — NOT target_date, which is the prior trading
+    # day the append ROW is keyed on.
+    run_date = args.date or default_run_date()
     try:
         from builders._constituents_loader import load_constituents_for_run_date
         s3 = boto3.client("s3")


### PR DESCRIPTION
Closes nousergon/alpha-engine-config#1014

## What
Every weekly/daily collector + builder entrypoint defaulted its `run_date` / `--date` to the **calendar** UTC date:

```python
run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
```

On a Saturday (the weekly SF firing day) the calendar date is **not** a trading session, so artifact-keying mis-attributed to Saturday instead of Friday's close. This migrates the default to the trading-day axis.

## Root cause
The defect is the **calendar default**, not 12 independent bugs. Fixed at the correct layer: a single repo chokepoint `dates.default_run_date()` that resolves the last closed NYSE session via the fleet-canonical `alpha_engine_lib.dates.now_dual().trading_day`, with a calendar fallback that never blocks a run. This mirrors the predictor fix (crucible-predictor#289 / config#1015) which routed `train_handler`'s default through the same `now_dual().trading_day` chokepoint.

**now_dual-exposure finding (the gating question):** RESOLVED — reachable. `nousergon-data` already depends on `alpha-engine-lib @ nousergon-lib@v0.59.4` (requirements.txt), and `now_dual` lives in `alpha_engine_lib.dates` at that exact pin. Verified import + Saturday semantics in the groom runner: `now_dual(now=2026-06-27 Sat).trading_day == "2026-06-26"` (Fri). **Clean import — no lib release / pin bump required.** The morning-queue "gated on now_dual exposure for data" concern does not apply at v0.59.4.

## Sites migrated (all 12, Python default-date layer)
- `weekly_collector.py`: `_run_phase1`, `_run_phase2`, `_run_daily`, `_run_daily_arctic_append` orchestration roots + `morning_constituents` direct-keyed write
- `collectors/daily_closes.py` (`staging/daily_closes/{date}.parquet`)
- `collectors/metron_market_data.py` (x4 collect entrypoints)
- `collectors/macro.py`, `collectors/short_interest.py`, `collectors/alternative.py`
- `builders/daily_append.py` (inner `daily_append()` + `main()` → ArcticDB macro-index bar + `market_data/weekly/{date}/manifest.json` + reads `staging/daily_closes/{date}.parquet`)
- `features/compute.py` (`features/{date}/schema_version.json` + snapshot)

## Backward-compat story (data-correctness critical)
- **Producers + consumers currently agree on calendar keying**, so a blind producer-only flip would orphan readers. This migration avoids that: the helper is consulted **only when no explicit date is passed**. When a date is threaded (`--date` / `$.run_date` / `RUN_DATE`), behaviour is byte-for-byte unchanged — **no historical artifact is re-keyed or orphaned, no read site needs to change in lockstep.**
- The weekly SF `DataPhase1` / `MorningEnrich` states invoke `weekly_collector.py` **bare** (verified: no `--date`, no `RUN_DATE` in those states), so they fall through to the now-trading-day default — i.e. the dominant Saturday data-collection path is corrected end-to-end.
- `_run_morning_enrich` keeps its existing PT-aware `_previous_trading_day` resolution (already trading-day-correct); untouched.

## Scope boundary (intentionally out of scope)
The SF `InitializeInput` stamps `run_date = date($$.Execution.StartTime)` (calendar) and threads `RUN_DATE` **only** into the downstream **backtest / predictor / evaluator** spot stages (`backtest/{date}/` axis — the subject of the separate `test_sf_run_date_threading` fix). That is a *different* artifact axis from issue #1014's collector keys and is not migrated here. `sf_preflight:971`'s `today` is staleness-math / RNG-seed only (artifact keys there already use the trading-day-correct `prior_trading_day`), so it is not a mis-keyed write site.

## CI / tests
- `python -m py_compile` clean on all 9 modified modules.
- New `tests/test_trading_day_collector_keys.py`: **15 passed** — proves Saturday/Sunday default → Friday's session, weekday-after-close → that session, ISO shape, lib-failure → calendar fallback, every entrypoint routes its default through the chokepoint, and a regression pin against reintroducing a calendar `now()` default.
- Existing `test_freshness_uses_trading_days`, `test_universe_returns_trading_day`, `test_sf_run_date_threading`, weekly_collector + daily_append/daily_closes/metron/alternative/macro/short_interest suites: **456 passed** under the migration.
- The only failing test in the touched range is `test_alternative_key_scrub_and_edgar_tmp::test_edgar_redirect...` — a **pre-existing** `ModuleNotFoundError: edgar.httpclient` (edgartools packaging mismatch in the runner), confirmed failing identically on clean `origin/main`; unrelated to this change.

Validate locally:
```
pip install -e . && python -m pytest tests/test_trading_day_collector_keys.py tests/test_freshness_uses_trading_days.py -q
```

Ready for review — **do not merge before Brian reviews.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)