### PR TITLE
fix(iam): grant GHA deploy role UpdateStateMachine on EOD pipeline (config#1173)

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -171,10 +171,7 @@
         "states:TagResource",
         "states:UntagResource"
       ],
-      "Resource": [
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
-      ]
+      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-*-pipeline"
     },
     {
       "Sid": "InfraDeployResourceCRUD",

--- a/tests/test_deploy_infrastructure_sf_coverage.py
+++ b/tests/test_deploy_infrastructure_sf_coverage.py
@@ -21,6 +21,9 @@ For each ``infrastructure/step_function*.json`` we assert the deploy script:
 
 from __future__ import annotations
 
+import fnmatch
+import json
+import re
 from pathlib import Path
 
 import pytest
@@ -28,6 +31,7 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _INFRA = _REPO_ROOT / "infrastructure"
 _DEPLOY = _INFRA / "deploy-infrastructure.sh"
+_GHA_DEPLOY_POLICY = _INFRA / "iam" / "github-actions-lambda-deploy.json"
 
 # The orchestration SF definitions that ship in infrastructure/ and are expected
 # to be auto-deployed on merge. Discovered by glob so a newly added SF file is
@@ -87,4 +91,87 @@ def test_eod_state_machine_is_auto_deployed() -> None:
     assert "alpha-engine-eod-pipeline" in script, (
         "alpha-engine-eod-pipeline state machine not deployed by "
         "deploy-infrastructure.sh (config#1173 regression)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# IAM-grant coverage — the gap that let config#1173's deploy block merge green
+# yet fail at runtime with AccessDeniedException on states:UpdateStateMachine.
+#
+# The script-coverage tests above prove deploy-infrastructure.sh *attempts* to
+# update every SF. They do NOT prove the GHA deploy role is *allowed* to. On
+# 2026-06-24 the EOD deploy block ran but the role's inline policy listed only
+# the Saturday + weekday ARNs, so the EOD update-state-machine call 403'd, the
+# CF stamp never advanced, and the weekday pipeline's DeployDriftCheck halted
+# the live trading run. This guard closes that bug class: every state machine
+# the deploy script applies MUST be granted states:UpdateStateMachine in
+# github-actions-lambda-deploy.json.
+# ---------------------------------------------------------------------------
+
+
+def _sf_names_deployed_by_script() -> set[str]:
+    """State-machine names the deploy script applies via update-state-machine.
+
+    The ARNs are assembled from shell vars (``...:stateMachine:<name>``); we
+    lift the trailing pipeline names from the literal ARN-suffix strings rather
+    than resolve the shell, which is sufficient because the names are written
+    in full in the script.
+    """
+    script = _DEPLOY.read_text()
+    return set(re.findall(r"stateMachine:(alpha-engine-[a-z0-9-]+pipeline)", script))
+
+
+def _sf_arn_patterns_granted_in_policy() -> list[str]:
+    """state-machine ARN patterns granted states:UpdateStateMachine by the role.
+
+    Returns the trailing ``stateMachine:<pattern>`` portion of every Resource
+    ARN on a statement that grants ``states:UpdateStateMachine``. Patterns may
+    contain IAM ``*`` wildcards (e.g. ``alpha-engine-*-pipeline``); coverage is
+    matched with fnmatch so a naming-convention wildcard correctly covers each
+    concrete pipeline.
+    """
+    policy = json.loads(_GHA_DEPLOY_POLICY.read_text())
+    patterns: list[str] = []
+    for stmt in policy.get("Statement", []):
+        actions = stmt.get("Action", [])
+        if isinstance(actions, str):
+            actions = [actions]
+        if "states:UpdateStateMachine" not in actions:
+            continue
+        resources = stmt.get("Resource", [])
+        if isinstance(resources, str):
+            resources = [resources]
+        for arn in resources:
+            m = re.search(r"stateMachine:([A-Za-z0-9*_.-]+)$", arn)
+            if m:
+                patterns.append(m.group(1))
+    return patterns
+
+
+def test_every_deployed_sf_is_granted_update_state_machine() -> None:
+    """Each SF the deploy script applies must be UpdateStateMachine-grantable.
+
+    Pins the config#1173 / 2026-06-24 runtime AccessDenied: a new SF wired into
+    deploy-infrastructure.sh whose name is not covered by the GHA deploy role's
+    UpdateStateMachine grant fails CI here instead of silently 403'ing on merge
+    and halting the next live pipeline run on stale-stamp drift.
+    """
+    deployed = _sf_names_deployed_by_script()
+    patterns = _sf_arn_patterns_granted_in_policy()
+    assert deployed, "no state-machine names parsed from deploy-infrastructure.sh"
+    assert patterns, (
+        "github-actions-lambda-deploy.json grants states:UpdateStateMachine on "
+        "no stateMachine resource"
+    )
+    missing = sorted(
+        name for name in deployed
+        if not any(fnmatch.fnmatchcase(name, pat) for pat in patterns)
+    )
+    assert not missing, (
+        f"deploy-infrastructure.sh applies update-state-machine to {missing} "
+        f"but no Resource pattern in github-actions-lambda-deploy.json grants "
+        f"states:UpdateStateMachine on them (granted patterns: {patterns}). The "
+        f"GHA deploy role will 403 at runtime, the CF stamp will not advance, "
+        f"and the next pipeline run halts on DeployDriftCheck (config#1173). "
+        f"Add/extend an ARN pattern in the InfraDeploySFDefinition statement."
     )


### PR DESCRIPTION
## Problem

The 2026-06-24 weekday trading pipeline FAILED at its first gate (`DeployDriftCheck` → `cf_drift: sha_mismatch`, stack `12bb8c8` != main HEAD `eaf50b2`).

Root cause: PR #462 (config#1173) folded the EOD SF into `deploy-infrastructure.sh`'s auto-deploy block, but the GHA deploy role's inline policy granted `states:UpdateStateMachine` on only the **saturday + weekday** pipelines. The first post-#462 merge's `deploy-infrastructure.yml` run **failed** on the EOD `update-state-machine` call:

```
AccessDeniedException ... github-actions-lambda-deploy ... not authorized to
perform: states:UpdateStateMachine on alpha-engine-eod-pipeline
```

→ "Deploy orchestration infrastructure" exited 254 → CF stamp never advanced → weekday `DeployDriftCheck` halted on stale-stamp drift.

## Fix (root cause + chokepoint)

1. **IAM grant** — `InfraDeploySFDefinition` Resource collapsed from 3 enumerated pipeline ARNs to the naming-convention wildcard `arn:...:stateMachine:alpha-engine-*-pipeline`. Covers the EOD pipeline, **dissolves the "forgot the IAM grant for a new SF" class**, and keeps the inline policy under IAM's 10,240-byte ceiling (a third full ARN pushed the minified doc to 10,304 > 10,240 — the policy had hit the limit). Applied live via `apply.sh` ahead of merge; the role is already in sync.

2. **Chokepoint guard** — the deploy-coverage test asserted the *script* deploys every SF but not that IAM *allows* it (the exact hole #462 fell through). New `test_every_deployed_sf_is_granted_update_state_machine` fnmatch-matches every state-machine name the script updates against the policy's UpdateStateMachine Resource patterns, failing CI loudly on the next forgotten grant.

## Verification

- `89 passed, 1 skipped` across SF/IAM/deploy guards.
- Re-ran `deploy-infrastructure.yml` (workflow_dispatch) post-IAM-apply → **success**; CF + EOD SF restamped to `eaf50b2`.
- Re-invoked the drift Lambda live: `has_drift=false`, `stack_sha==eaf50b2`. Tomorrow's scheduled weekday run will pass the gate.

Today's run itself was not re-driven for trading — the fix completed after market close (~19:19 PT); re-running post-close would needlessly boot the executor against a closed session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)