### PR TITLE
Remove redundant RunDailyNews chain from weekday trading SF

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -953,104 +953,7 @@
         }
       ],
       "ResultPath": "$.daemon_result",
-      "Next": "CheckSkipRunDailyNews"
-    },
-
-    "RunDailyNews": {
-      "Type": "Task",
-      "Comment": "Secondary daily news pull for the held + tracked universe (robodashboard holdings ∪ AE signals universe). Writes data/news_aggregates_daily/ for the robodashboard morning brief + AE consumers. Runs AFTER RunDaemon so it never delays the trading path. FAIL-SOFT: news must never fail the weekday SF — the Catch here, the WaitForDailyNews Catch, and the CheckDailyNewsStatus Default all route to PipelineComplete. ~50-70-ticker pull, concurrent fan-in via AsyncNewsAggregator (sources overlap), Polygon-bound at 5 req/min ≈ 12-14 min; executionTimeout 1800s gives headroom over that floor (bumped from 1200s 2026-06-09 — the sync aggregator summed sources sequentially and TimedOut every weekday, silently producing nothing; ROADMAP L4573).",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-      "Parameters": {
-        "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.trading_instance_id",
-        "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "export FLOW_DOCTOR_ENABLED=1",
-            "export ALPHA_ENGINE_DEPLOYED=1",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-data",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
-            "trap 'aws s3 cp /var/log/daily-news.log \"s3://alpha-engine-research/_ssm_logs/daily-news/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/daily-news.log",
-            "python -m collectors.daily_news 2>&1 | tee -a /var/log/daily-news.log"
-          ],
-          "executionTimeout": ["1800"]
-        }
-      },
-      "TimeoutSeconds": 1860,
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Comment": "Daily news is secondary — a send failure must not fail the SF.",
-          "Next": "PipelineComplete",
-          "ResultPath": "$.daily_news_error"
-        }
-      ],
-      "ResultPath": "$.daily_news_result",
-      "Next": "WaitForDailyNews"
-    },
-
-    "WaitForDailyNews": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-      "Parameters": {
-        "CommandId.$": "$.daily_news_result.Command.CommandId",
-        "InstanceId.$": "$.trading_instance_id[0]"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Ssm.InvocationDoesNotExistException",
-            "Ssm.InvocationDoesNotExist"
-          ],
-          "MaxAttempts": 10,
-          "IntervalSeconds": 10,
-          "BackoffRate": 1.5
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Comment": "Fail-soft — a poll failure ends the SF cleanly, no news that day.",
-          "Next": "PipelineComplete",
-          "ResultPath": "$.daily_news_error"
-        }
-      ],
-      "ResultSelector": {
-        "Status.$": "$.Status",
-        "ResponseCode.$": "$.ResponseCode",
-        "StatusDetails.$": "$.StatusDetails",
-        "StandardErrorContent.$": "$.StandardErrorContent"
-      },
-      "ResultPath": "$.daily_news_poll",
-      "Next": "CheckDailyNewsStatus"
-    },
-
-    "CheckDailyNewsStatus": {
-      "Type": "Choice",
-      "Comment": "Daily news is fail-soft: any terminal status (Success OR failure) ends the SF via PipelineComplete; only keep polling while InProgress/Pending.",
-      "Choices": [
-        {
-          "Variable": "$.daily_news_poll.Status",
-          "StringEquals": "InProgress",
-          "Next": "DailyNewsWait"
-        },
-        {
-          "Variable": "$.daily_news_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "DailyNewsWait"
-        }
-      ],
-      "Default": "PipelineComplete"
-    },
-
-    "DailyNewsWait": {
-      "Type": "Wait",
-      "Seconds": 30,
-      "Next": "WaitForDailyNews"
+      "Next": "PipelineComplete"
     },
 
     "CheckSkipMorningEnrich": {
@@ -1231,32 +1134,17 @@
 
     "CheckSkipRunDaemon": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daemon\": true} routes past RunDaemon (the daemon restart) to the next gate (CheckSkipRunDailyNews); missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daemon\": true} routes past RunDaemon (the daemon restart) directly to PipelineComplete; missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.skip_run_daemon", "IsPresent": true},
             {"Variable": "$.skip_run_daemon", "BooleanEquals": true}
           ],
-          "Next": "CheckSkipRunDailyNews"
-        }
-      ],
-      "Default": "RunDaemon"
-    },
-
-    "CheckSkipRunDailyNews": {
-      "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daily_news\": true} routes past RunDailyNews directly to PipelineComplete; missing flag = run as normal. Daily news is already fail-soft. Per feedback_preflight_fast_fail_before_expensive_work.",
-      "Choices": [
-        {
-          "And": [
-            {"Variable": "$.skip_run_daily_news", "IsPresent": true},
-            {"Variable": "$.skip_run_daily_news", "BooleanEquals": true}
-          ],
           "Next": "PipelineComplete"
         }
       ],
-      "Default": "RunDailyNews"
+      "Default": "RunDaemon"
     },
 
     "PipelineComplete": {

--- a/tests/test_sf_lib_pin_self_heal_wiring.py
+++ b/tests/test_sf_lib_pin_self_heal_wiring.py
@@ -49,8 +49,12 @@ def _data_repo_entrypoints() -> dict[str, list[str]]:
 
 
 def test_known_data_entrypoints_in_scope():
+    # RunDailyNews removed (alpha-engine-config#1089) — the standalone 04:00
+    # daily-news chain now produces the artifact, so it is no longer a weekday-SF
+    # data-repo entrypoint. MorningEnrich + MorningArcticAppend + ChronicGapSelfHeal
+    # remain (they pull alpha-engine-data and run from its venv).
     eps = set(_data_repo_entrypoints())
-    assert {"MorningEnrich", "RunDailyNews"} <= eps, sorted(eps)
+    assert {"MorningEnrich", "MorningArcticAppend", "ChronicGapSelfHeal"} <= eps, sorted(eps)
 
 
 @pytest.mark.parametrize("name", sorted(_data_repo_entrypoints()))

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -36,8 +36,7 @@ _CHAIN = [
     ("CheckSkipChronicGapHeal", "ChronicGapSelfHeal", "skip_chronic_gap_heal", "CheckSkipPredictorInference"),
     ("CheckSkipPredictorInference", "PredictorInference", "skip_predictor_inference", "CheckSkipMorningPlanner"),
     ("CheckSkipMorningPlanner", "RunMorningPlanner", "skip_morning_planner", "CheckSkipRunDaemon"),
-    ("CheckSkipRunDaemon", "RunDaemon", "skip_run_daemon", "CheckSkipRunDailyNews"),
-    ("CheckSkipRunDailyNews", "RunDailyNews", "skip_run_daily_news", "PipelineComplete"),
+    ("CheckSkipRunDaemon", "RunDaemon", "skip_run_daemon", "PipelineComplete"),
 ]
 
 
@@ -127,8 +126,11 @@ class TestEntryEdgesRouteThroughGates:
                    if c.get("StringEquals") == "Success"]
         assert success == ["CheckSkipRunDaemon"]
 
-    def test_daemon_enters_daily_news_gate(self, states):
-        assert states["RunDaemon"]["Next"] == "CheckSkipRunDailyNews"
+    def test_daemon_is_last_step(self, states):
+        # RunDailyNews removed (alpha-engine-config#1089): the standalone 04:00
+        # daily-news chain now produces the artifact, so the weekday SF ends at
+        # the daemon restart instead of routing into a news chain.
+        assert states["RunDaemon"]["Next"] == "PipelineComplete"
 
 
 class TestPaths:


### PR DESCRIPTION
Closes nousergon/alpha-engine-config#1089

## Why
The daily-news pull is now produced by the standalone systemd chain on the dashboard box at 04:00 PT (data#432/#434, 2026-06-15), feeding morning-signal + the dashboard Daily News page. The weekday trading SF's `RunDailyNews` state re-produced the same artifacts a second time (~06:23 on trading days), so it is redundant. The soak gate (Re-exam 2026-06-19) has elapsed (today 2026-06-25), so this is actionable. Also trims ~14 min off the trading instance's daily uptime.

## States removed
From `infrastructure/step_function_daily.json`:
- `RunDailyNews`
- `WaitForDailyNews`
- `CheckDailyNewsStatus`
- `DailyNewsWait`
- `CheckSkipRunDailyNews` (the per-task rerun gate that fronted the chain)

## Rewire
I traced every `Next`/`Default`/Choice transition pointing into the chain. Two edges referenced it, both now go straight to the terminal `PipelineComplete`:

| State | Edge | Before | After |
|-------|------|--------|-------|
| `RunDaemon` | `Next` | `CheckSkipRunDailyNews` | `PipelineComplete` |
| `CheckSkipRunDaemon` | skip-path `Next` | `CheckSkipRunDailyNews` | `PipelineComplete` |

`RunDaemon` is now the last work step. Its existing fail-soft `Catch` already routed to `PipelineComplete`, so failure behavior is unchanged. The `skip_run_daily_news` input flag becomes a harmless no-op. All other behavior preserved exactly.

## Test updates (same change, pinned wiring)
Two wiring-pin tests asserted the old chain and were updated to match the root-cause removal:
- `tests/test_sf_weekday_skipgate_wiring.py` — dropped the `RunDailyNews` chain row from `_CHAIN`; repointed `CheckSkipRunDaemon`'s skip-edge pin to `PipelineComplete`; renamed the daemon-edge test to assert `RunDaemon.Next == PipelineComplete`.
- `tests/test_sf_lib_pin_self_heal_wiring.py` — `RunDailyNews` is no longer a weekday-SF data-repo entrypoint; the known-in-scope set is now `MorningEnrich` / `MorningArcticAppend` / `ChronicGapSelfHeal`.

## Validation
```
$ python -c "import json; json.load(open('infrastructure/step_function_daily.json')); print('JSON valid')"
JSON valid

# dangling-ref + reachability checker
StartAt: InitializeInput (defined: True)
States defined: 56
Transition refs (Next/Default): 103
Dangling references: 0
Occurrences of 'RunDailyNews' in file: 0
Occurrences of 'WaitForDailyNews' in file: 0
Occurrences of 'CheckDailyNewsStatus' in file: 0
Occurrences of 'DailyNewsWait' in file: 0
Occurrences of 'CheckSkipRunDailyNews' in file: 0
Unreachable states from StartAt: []

$ python -m pytest tests/test_sf_weekday_skipgate_wiring.py tests/test_sf_lib_pin_self_heal_wiring.py -q
36 passed

$ python -m pytest <all SF-wiring tests> -q
157 passed, 1 skipped
```

Note: `tests/test_daily_news.py` fails (12) in CI with `ModuleNotFoundError: No module named 'anyio'` — this is pre-existing on clean `origin/main` (verified via `git stash`) and exercises the `collectors/daily_news.py` module (untouched here; still used by the standalone 04:00 chain), not the SF wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)