### PR TITLE
fix(weekday-sf): read arctic-append constituents by run_date, not stale latest_weekly pointer

### DIFF
--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -812,12 +812,15 @@ def test_arctic_append_runs_daily_append_and_is_load_bearing():
     returns failed (load-bearing) when the append errors."""
     config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
     args = SimpleNamespace(date="2026-04-22", dry_run=False)
-    fake_constituents = MagicMock()
-    fake_constituents.load_from_s3.return_value = {"tickers": ["AAPL", "MSFT"]}
+
+    def _fake_loader(s3, bucket, run_date=None):
+        return ({"AAPL", "MSFT"}, run_date or "2026-04-22")
 
     # happy path
     calls = []
-    with patch("weekly_collector.constituents", fake_constituents), \
+    with patch("weekly_collector.boto3.client", return_value=MagicMock()), \
+         patch("builders._constituents_loader.load_constituents_for_run_date",
+               side_effect=_fake_loader), \
          patch("builders.daily_append.daily_append",
                side_effect=lambda **k: calls.append(k) or {"status": "ok"}):
         ok = weekly_collector._run_morning_arctic_append(config, args)
@@ -825,10 +828,61 @@ def test_arctic_append_runs_daily_append_and_is_load_bearing():
     assert calls and calls[0]["date_str"] == "2026-04-22"
 
     # load-bearing: append raises → failed
-    with patch("weekly_collector.constituents", fake_constituents), \
+    with patch("weekly_collector.boto3.client", return_value=MagicMock()), \
+         patch("builders._constituents_loader.load_constituents_for_run_date",
+               side_effect=_fake_loader), \
          patch("builders.daily_append.daily_append", side_effect=RuntimeError("boom")):
         bad = weekly_collector._run_morning_arctic_append(config, args)
     assert bad["status"] == "failed"
+
+
+def test_arctic_append_reads_constituents_by_run_date_not_pointer():
+    """REGRESSION (2026-06-25 weekday-SF halt): _run_morning_arctic_append must
+    load constituents via the run_date-DIRECT read, NOT the latest_weekly.json
+    pointer.
+
+    The pointer only advances on the weekly Saturday _write_manifest; daily
+    MorningEnrich writes the fresh dated weekly/{run_date}/constituents.json
+    but leaves the pointer stale. On an S&P-reconstitution week the pointer's
+    prior universe still lists the churn-out tickers — which are absent from
+    today's daily_closes — so daily_append's missing-from-closes guard counts
+    them as a data gap and halts the SF. Reading by run_date passes the FRESH
+    universe to expected_tickers, where the straggler-exclusion correctly
+    drops the churn-out tickers.
+    """
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    # No --date → run_date resolves to today's UTC calendar date (the date
+    # MorningEnrich wrote constituents under), and target_date to prior
+    # trading day. The two differ; the append must read by the RUN date.
+    args = SimpleNamespace(date=None, dry_run=False)
+
+    seen = {}
+
+    def _fake_loader(s3, bucket, run_date=None):
+        seen["run_date"] = run_date
+        # Fresh universe — churn-out tickers already removed.
+        return ({"AAPL", "MSFT", "NVDA"}, run_date)
+
+    captured = []
+    with patch("weekly_collector.boto3.client", return_value=MagicMock()), \
+         patch("builders._constituents_loader.load_constituents_for_run_date",
+               side_effect=_fake_loader), \
+         patch("builders.daily_append.daily_append",
+               side_effect=lambda **k: captured.append(k) or {"status": "ok"}):
+        out = weekly_collector._run_morning_arctic_append(config, args)
+
+    assert out["status"] == "ok"
+    # The loader was called with an explicit run_date (direct read), NOT None
+    # (which would be the stale-pointer fallback path).
+    assert seen.get("run_date") is not None, (
+        "must read constituents by run_date direct, not the latest_weekly pointer"
+    )
+    # Run date is today's UTC calendar date, distinct from the prior-trading-day
+    # target_date the append row is keyed on.
+    today_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    assert seen["run_date"] == today_utc
+    # The fresh universe is what flows into expected_tickers.
+    assert captured and set(captured[0]["expected_tickers"]) == {"AAPL", "MSFT", "NVDA"}
 
 
 # ── EOD daily_append split: PostMarketData + PostMarketArcticAppend (2026-06-16) ──

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -1440,13 +1440,59 @@ def _run_morning_arctic_append(config: dict, args: argparse.Namespace) -> dict:
     # Load the constituents MorningEnrich just refreshed to S3 (post-prune
     # universe scope for daily_append's expected-ticker check). S3 → Wikipedia
     # fallback, mirroring _run_daily.
+    #
+    # MUST read THIS run's dated constituents directly, NOT the
+    # ``latest_weekly.json`` pointer. The pointer only advances on the weekly
+    # (Saturday) ``_write_manifest``; daily MorningEnrich writes the dated
+    # ``weekly/{run_date}/constituents.json`` but leaves the pointer alone. So
+    # a pointer-following read (``constituents.load_from_s3``) returns the
+    # PRIOR weekly universe — and on an S&P-reconstitution week that universe
+    # still lists the churn-out tickers. They are absent from today's
+    # daily_closes (collected against the fresh universe), so daily_append's
+    # missing-from-closes guard counts them as a data gap and halts the SF.
+    # (2026-06-25: pointer stuck at 2026-06-19; BLKB/BRBR/CNXC/COTY/CPB/POOL/
+    # SATS dropped in the 06-22 reconstitution → 7 > threshold 5 → halt.)
+    # The straggler-exclusion in daily_append only works when expected_tickers
+    # is the FRESH universe; reading by run_date restores that invariant.
+    # Same pointer-vs-direct-read TOCTOU defect class closed for backfill/prune
+    # via ``builders._constituents_loader``; this is the third in-repo reader.
     tickers: list[str] = []
     market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
+    # Calendar run date == the date MorningEnrich wrote constituents under
+    # (``run_date = args.date or now_utc`` in _run_morning_enrich). Mirror that
+    # expression exactly so we read the file this run produced — NOT
+    # target_date, which is the prior trading day the append ROW is keyed on.
+    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
     try:
-        existing = constituents.load_from_s3(bucket, market_prefix)
-        if existing:
-            tickers = existing.get("tickers", [])
-            logger.info("Loaded %d tickers from S3 constituents", len(tickers))
+        from builders._constituents_loader import load_constituents_for_run_date
+        s3 = boto3.client("s3")
+        try:
+            tickers_set, weekly_date = load_constituents_for_run_date(
+                s3, bucket, run_date=run_date
+            )
+            tickers = sorted(tickers_set)
+            logger.info(
+                "Loaded %d tickers from S3 constituents (run_date=%s direct)",
+                len(tickers), weekly_date,
+            )
+        except Exception as direct_exc:
+            # Standalone append rerun on a day MorningEnrich didn't run (no
+            # dated file). Fall back to the pointer — stale-but-present beats
+            # empty; the straggler-exclusion degrades gracefully to the prior
+            # weekly universe, same as before this fix.
+            logger.warning(
+                "Direct constituents read for run_date=%s failed (%s) — "
+                "falling back to latest_weekly.json pointer",
+                run_date, direct_exc,
+            )
+            tickers_set, weekly_date = load_constituents_for_run_date(
+                s3, bucket, run_date=None
+            )
+            tickers = sorted(tickers_set)
+            logger.info(
+                "Loaded %d tickers from S3 constituents (pointer→%s fallback)",
+                len(tickers), weekly_date,
+            )
     except Exception as exc:
         logger.warning("S3 constituents load failed — will try Wikipedia fallback: %s", exc)
     if not tickers:


### PR DESCRIPTION
## Problem

Weekday SF (`alpha-engine-weekday-pipeline`) **FAILED 2026-06-25** at `MorningArcticAppend`:

```
RuntimeError: daily_append: 7 tickers in ArcticDB universe missing from today's daily_closes parquet (threshold=5).
Missing: ['BLKB', 'BRBR', 'CNXC', 'COTY', 'CPB', 'POOL', 'SATS']
```

(The DD reverse-split flow-doctor emails in the same batch are non-fatal observability — not the halt cause.)

## Root cause

`_run_morning_arctic_append` loaded constituents via `constituents.load_from_s3`, which follows the **`latest_weekly.json` pointer**. That pointer only advances on the weekly (Saturday) `_write_manifest`; daily `MorningEnrich` writes the fresh dated `weekly/{run_date}/constituents.json` but leaves the pointer alone.

On the **June 2026 S&P quarterly reconstitution** (effective Mon 06-22), BLKB/BRBR/CNXC/COTY/CPB/POOL/SATS dropped from the index. But the pointer was stuck at **2026-06-19** (pre-reconstitution), so `expected_tickers` still listed all 7. They're absent from today's `daily_closes` (collected against the fresh universe), so `daily_append`'s missing-from-closes guard counted them as a data gap → 7 > threshold 5 → **SF halt**.

`daily_append` already has straggler-exclusion logic that drops churn-out tickers — but only when `expected_tickers` is the *fresh* universe. The stale pointer defeated it.

### Verified
| constituents source | missing-from-closes |
|---|---|
| stale `06-19` (pointer) | **7** → halt |
| fresh `06-25` (this run) | **0** → clean pass |

## Fix

Read THIS run's dated constituents directly via the existing `builders._constituents_loader.load_constituents_for_run_date(run_date=...)` chokepoint — the same pointer-vs-direct-read TOCTOU defect class already closed for `backfill` + `prune` (this is the third in-repo reader). Falls back to the pointer only when the dated file is absent (standalone append rerun on a day MorningEnrich didn't run). The handler docstring already stated this intent ("Reads the constituents MorningEnrich just refreshed") — the implementation now matches it.

## Tests
- New regression test `test_arctic_append_reads_constituents_by_run_date_not_pointer` (asserts run_date-direct, not pointer).
- Updated `test_arctic_append_runs_daily_append_and_is_load_bearing` for the new loader.
- `test_weekly_collector_morning_enrich` (38) + daily_append/constituents-loader/SF-wiring suites (97) all green locally.

## Rerun
After merge, rerun the weekday SF for 2026-06-25 (skip-flag fresh execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)