### PR TITLE
fix(deploy): COPY dates.py into Lambda image (config#1014 canary regression)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,14 @@ RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://gith
 COPY collectors/ ${LAMBDA_TASK_ROOT}/collectors/
 COPY polygon_client.py ${LAMBDA_TASK_ROOT}/
 COPY weekly_collector.py ${LAMBDA_TASK_ROOT}/
+# dates.py — repo-root chokepoint imported (``from dates import default_run_date``)
+# top-level in weekly_collector.py and lazily in collectors/* + builders/* +
+# features/compute.py (config#1014 trading-day-axis default). Added 2026-06-25
+# (#464) WITHOUT a matching COPY here, so every deploy since canary-failed with
+# ``No module named 'dates'`` and rolled back — the same latent bug class as the
+# ``validators/`` COPY below (2026-05-18) and ``polygon_client.py``. Any new
+# repo-root module imported by Lambda code MUST be COPYied here.
+COPY dates.py ${LAMBDA_TASK_ROOT}/
 COPY store/ ${LAMBDA_TASK_ROOT}/store/
 # validators/ — top-level imports in collectors/alternative.py +
 # collectors/fundamentals.py (added 2026-05-16 via PR #254 per-collector


### PR DESCRIPTION
Root cause: PR #464 added the repo-root chokepoint module `dates.py` (config#1014 trading-day axis) and imported it (`from dates import default_run_date`) top-level in `weekly_collector.py` and lazily across `collectors/*`, `builders/*`, `features/compute.py` — but never added a matching `COPY` to the Lambda `Dockerfile`. Every push-to-main deploy since #464 built an image without `dates.py`, so the dry_run canary failed with `No module named 'dates'` and auto-rolled-back to v163.

Impact: production stayed safe (canary-first), but no new data-collector code could reach `live`, and the config#1014 trading-day-keying fix itself never went live.

Same latent class as the documented `validators/` COPY (2026-05-18) and `polygon_client.py`.

Verified locally: built the image and invoked `handler({"dry_run": true})` — the import chain (`collectors.alternative` -> `from dates import default_run_date`) now resolves; the canary only stops on missing API-key env vars, which are present in the live Lambda.

CI: green expected (Dockerfile-only; build verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)