### PR TITLE
fix(iam): grant GHA deploy role on alpha-engine-predictor-health-check

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -59,7 +59,7 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director"
       ]
@@ -103,8 +103,8 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-health-check:*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator:*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director",


### PR DESCRIPTION
Root cause: the `github-actions-lambda-deploy` role's `LambdaUpdate` + `LambdaInvokeCanary` statements listed function `alpha-engine-health-check` — but **no such Lambda exists**. The live function targeted by crucible-backtester's new `deploy.yml` (#367) is `alpha-engine-predictor-health-check`, so every backtester health-check deploy failed at `aws lambda update-function-code` with `AccessDeniedException`. The ARN had been copied from the ECR repo name (which genuinely IS `alpha-engine-health-check`, kept on line 28); the function carries the `-predictor-` infix.

Fix: corrects the 3 function ARNs (UpdateFunctionCode resource + canary InvokeFunction fn + fn:*). ECR repo grant unchanged.

⚠️ Apply-before-merge: `infrastructure/iam/apply.sh github-actions-lambda-deploy` must be applied to live IAM (admin creds) so live == branch JSON. The PR-triggered `iam-drift-check` validates branch JSON against live — it will be RED until the live apply runs, then green. The daily drift sweep compares live vs `main`, so merge promptly after apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)