### PR TITLE
feat(metron-market-data): publish ONEQ (Nasdaq Composite) index proxy

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -92,11 +92,13 @@ FUNDAMENTALS_INFO_KEYS = [
 INTRADAY_PREFIX = "market_data/intraday/"
 # Major US-index ETF proxies for Metron's Overview "markets" strip — refreshed in the
 # same intraday run (market context, fetched independent of the held universe). The
-# index VALUES (^GSPC / ^IXIC / ^RUT) carry a separate index license; the tradeable ETF
-# prices are ordinary equity trades, so the ETF is published as the index proxy and
-# Metron maps each symbol to the index it tracks. Quotes land under the artifact's
-# `indices` key (same per-symbol shape as held `quotes`).
-INDEX_PROXY_SYMBOLS = ["SPY", "QQQ", "IWM"]
+# index VALUES (^GSPC / ^IXIC / ^NDX / ^RUT) carry a separate index license; the tradeable
+# ETF prices are ordinary equity trades, so the ETF is published as the index proxy and
+# Metron maps each symbol to the index it tracks. ONEQ (Nasdaq Composite) and QQQ
+# (Nasdaq-100) are both carried because the broad Composite and the mega-cap-100 routinely
+# diverge intraday — the headline "Nasdaq" most readers see is the Composite. Quotes land
+# under the artifact's `indices` key (same per-symbol shape as held `quotes`).
+INDEX_PROXY_SYMBOLS = ["SPY", "ONEQ", "QQQ", "IWM"]
 CLOSES_SCHEMA_VERSION = 1
 FX_SCHEMA_VERSION = 1
 CLOSE_HISTORY_SCHEMA_VERSION = 1

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -291,6 +291,8 @@ class TestIntraday:
     _INDEX_QUOTES = {
         "SPY": {"last": 605.2, "open": 603.0, "prev_close": 602.4,
                 "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
+        "ONEQ": {"last": 101.4, "open": 100.8, "prev_close": 100.5,
+                 "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
         "QQQ": {"last": 540.1, "open": 538.5, "prev_close": 537.0,
                 "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
         "IWM": {"last": 215.3, "open": 216.0, "prev_close": 216.5,
@@ -322,7 +324,7 @@ class TestIntraday:
             bucket="b", s3_client=s3, intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
             now=self._RTH,
         )
-        assert result["status"] == "ok" and result["quotes"] == 2 and result["indices"] == 3
+        assert result["status"] == "ok" and result["quotes"] == 2 and result["indices"] == 4
         puts = _puts(s3)
         assert set(puts) == {"market_data/intraday/latest.json"}
         art = puts["market_data/intraday/latest.json"]
@@ -344,7 +346,7 @@ class TestIntraday:
         result = mmd.collect_intraday(
             bucket="b", s3_client=empty, intraday_source=self._stub(self._INDEX_QUOTES), now=self._RTH,
         )
-        assert result["status"] == "ok" and result["quotes"] == 0 and result["indices"] == 3
+        assert result["status"] == "ok" and result["quotes"] == 0 and result["indices"] == 4
         art = _puts(empty)["market_data/intraday/latest.json"]
         assert art["quotes"] == {}
         assert set(art["indices"]) == set(mmd.INDEX_PROXY_SYMBOLS)
@@ -420,5 +422,5 @@ class TestIntraday:
             bucket="b", s3_client=s3, dry_run=True,
             intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES), now=self._RTH,
         )
-        assert result["status"] == "ok_dry_run" and result["quotes"] == 2 and result["indices"] == 3
+        assert result["status"] == "ok_dry_run" and result["quotes"] == 2 and result["indices"] == 4
         assert not s3.put_object.called


### PR DESCRIPTION
## What

Adds **ONEQ** (Fidelity Nasdaq Composite Index ETF) to `INDEX_PROXY_SYMBOLS` so the intraday artifact (`market_data/intraday/latest.json`) carries the broad **Nasdaq Composite** alongside `QQQ` (Nasdaq-100).

## Why

Brian flagged that Metron's "Markets" strip showed "Nasdaq +70bps" while the financial press said the Nasdaq was down. Root cause: the tile uses QQQ = Nasdaq-**100**, and on 2026-06-25 the broad Composite (`^IXIC`, −0.4%) diverged from the mega-cap 100 (`^NDX`/QQQ, +0.9%) on negative breadth. The headline "Nasdaq" most readers see is the **Composite**, which wasn't tracked at all. ONEQ tracks `^IXIC` to within ~1bp.

ETF proxy = ordinary equity trade → clear of the index-value license, same pattern as the existing SPY/QQQ/IWM proxies.

## Consumer

Paired with metron PR (adds the `ONEQ → "Nasdaq Composite"` label + widens the strip + populates YTD/LTM). The consumer is order-independent: until this deploys + the collector runs, Metron's `load_indices` just skips the absent symbol.

## Tests

`tests/test_metron_market_data.py` — index-proxy assertions auto-track `INDEX_PROXY_SYMBOLS` (fixture + counts updated 3→4). `pytest tests/test_metron_market_data.py` green (24 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)