### PR TITLE
feat(metron-market-data): publish country of domicile in spine sectors artifact

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -373,17 +373,6 @@ def _yfinance_classification(yf_symbols: list[str]) -> tuple[dict[str, str], dic
     return sectors, countries
 
 
-def _yfinance_sectors(yf_symbols: list[str]) -> dict[str, str]:
-    """GICS sector per held symbol (the sector half of ``_yfinance_classification``)."""
-    return _yfinance_classification(yf_symbols)[0]
-
-
-def _yfinance_countries(yf_symbols: list[str]) -> dict[str, str]:
-    """Country of domicile per held symbol (the country half of
-    ``_yfinance_classification``)."""
-    return _yfinance_classification(yf_symbols)[1]
-
-
 @_yf_quiet
 def _yfinance_spy_weights() -> dict[str, float]:
     """SPY's live GICS sector weights (canonical label → fraction) via

--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -103,7 +103,7 @@ CLOSES_SCHEMA_VERSION = 1
 FX_SCHEMA_VERSION = 1
 CLOSE_HISTORY_SCHEMA_VERSION = 1
 FX_HISTORY_SCHEMA_VERSION = 1
-SECTORS_SCHEMA_VERSION = 1
+SECTORS_SCHEMA_VERSION = 2  # v2: additive `countries` map (yf_symbol → country of domicile)
 EARNINGS_SCHEMA_VERSION = 1
 MACRO_SCHEMA_VERSION = 2  # v2: added next_release (per series) + release_events (metron-ops#49)
 FUNDAMENTALS_SCHEMA_VERSION = 1
@@ -135,9 +135,11 @@ FxSource = Callable[[list[str]], dict[str, float]]
 # History sources map symbols/currencies → {key: [(date_iso, value), …]} ascending.
 CloseHistorySource = Callable[[list[str]], dict[str, list[tuple[str, float]]]]
 FxHistorySource = Callable[[list[str]], dict[str, list[tuple[str, float]]]]
-# Reference sources: sectors maps yf_symbols → {yf_symbol: gics}; benchmark weights is a
+# Reference sources: sectors maps yf_symbols → {yf_symbol: gics}; countries maps
+# yf_symbols → {yf_symbol: country-of-domicile}; benchmark weights is a
 # 0-arg → {sector: weight}; earnings maps yf_symbols → {yf_symbol: date_iso}.
 SectorSource = Callable[[list[str]], dict[str, str]]
+CountrySource = Callable[[list[str]], dict[str, str]]
 BenchmarkWeightsSource = Callable[[], dict[str, float]]
 EarningsSource = Callable[[list[str]], dict[str, str]]
 # A macro source maps FRED series ids → {series_id: [(date_iso, value), …]} ascending.
@@ -341,24 +343,45 @@ def _yfinance_fx_history(currencies: list[str], period: str = DEFAULT_HISTORY_PE
 
 
 @_yf_quiet
-def _yfinance_sectors(yf_symbols: list[str]) -> dict[str, str]:
-    """Canonical GICS sector per held symbol via ``yf.Ticker(sym).info['sector']``.
-    Fail-soft: an unclassifiable symbol is omitted (Metron shows a coverage gap)."""
+def _yfinance_classification(yf_symbols: list[str]) -> tuple[dict[str, str], dict[str, str]]:
+    """Canonical GICS sector AND country-of-domicile per held symbol from a SINGLE
+    ``yf.Ticker(sym).info`` pass (``info['sector']`` + ``info['country']``) — country is
+    a zero-extra-API-cost addition to the existing sector fetch. Returns
+    ``(sectors, countries)``. Fail-soft per symbol: an unclassifiable symbol is omitted
+    from the respective map (Metron shows a coverage gap, never a guessed value)."""
     try:
         import yfinance as yf
     except ImportError:  # pragma: no cover
-        return {}
-    out: dict[str, str] = {}
+        return {}, {}
+    sectors: dict[str, str] = {}
+    countries: dict[str, str] = {}
     for sym in yf_symbols:
         try:
-            sector = (yf.Ticker(sym).info or {}).get("sector")
+            info = yf.Ticker(sym).info or {}
+            sector = info.get("sector")
             if sector:
-                out[sym] = str(sector)
+                sectors[sym] = str(sector)
+            country = info.get("country")
+            if country:
+                countries[sym] = str(country)
         except Exception as e:
-            logger.warning("[metron_market_data] sector fetch failed for %s: %s", sym, e)
-    logger.info("[metron_market_data] sectors: %d/%d classified", len(out), len(yf_symbols))
-    _log_yf_coverage("sectors", yf_symbols, out)
-    return out
+            logger.warning("[metron_market_data] classification fetch failed for %s: %s", sym, e)
+    logger.info("[metron_market_data] sectors: %d/%d classified, countries: %d/%d domiciled",
+                len(sectors), len(yf_symbols), len(countries), len(yf_symbols))
+    _log_yf_coverage("sectors", yf_symbols, sectors)
+    _log_yf_coverage("countries", yf_symbols, countries)
+    return sectors, countries
+
+
+def _yfinance_sectors(yf_symbols: list[str]) -> dict[str, str]:
+    """GICS sector per held symbol (the sector half of ``_yfinance_classification``)."""
+    return _yfinance_classification(yf_symbols)[0]
+
+
+def _yfinance_countries(yf_symbols: list[str]) -> dict[str, str]:
+    """Country of domicile per held symbol (the country half of
+    ``_yfinance_classification``)."""
+    return _yfinance_classification(yf_symbols)[1]
 
 
 @_yf_quiet
@@ -660,15 +683,17 @@ def collect_history(
 def collect_reference(
     *, bucket: str = DEFAULT_BUCKET, run_date: str | None = None, dry_run: bool = False,
     s3_client: Any = None, sector_source: SectorSource | None = None,
+    country_source: CountrySource | None = None,
     benchmark_source: BenchmarkWeightsSource | None = None, earnings_source: EarningsSource | None = None,
 ) -> dict:
     """Write the GICS-sectors + earnings reference artifacts for Metron's held universe —
     moving Metron's last external (yfinance) fetches to the spine:
 
-        market_data/sectors/latest.json   {schema_version, as_of, sectors: {yf_symbol: gics}, spy_sector_weights: {sector: weight}}
+        market_data/sectors/latest.json   {schema_version, as_of, sectors: {yf_symbol: gics}, countries: {yf_symbol: country}, spy_sector_weights: {sector: weight}}
         market_data/earnings/latest.json   {schema_version, as_of, earnings: {yf_symbol: date_iso}}
 
-    Keyed by yf_symbol (consistent with the closes artifact). Injectable sources/S3."""
+    Keyed by yf_symbol (consistent with the closes artifact). Injectable sources/S3.
+    Sector + country share a single ``.info`` pass when neither is injected."""
     if run_date is None:
         from dates import default_run_date  # config#1014: trading-day axis
 
@@ -680,26 +705,36 @@ def collect_reference(
     if not holdings:
         return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
     yf_symbols = sorted({h["yf_symbol"] for h in holdings})
-    sectors = (sector_source or _yfinance_sectors)(yf_symbols)
+    # Sector + country come from one ``.info`` pass; an injected source overrides its
+    # dimension (tests), and the shared fetch only runs if a real fetch is still needed.
+    fetched_sectors: dict[str, str] | None = None
+    fetched_countries: dict[str, str] | None = None
+    if sector_source is None or country_source is None:
+        fetched_sectors, fetched_countries = _yfinance_classification(yf_symbols)
+    sectors = sector_source(yf_symbols) if sector_source else (fetched_sectors or {})
+    countries = country_source(yf_symbols) if country_source else (fetched_countries or {})
     spy_weights = (benchmark_source or _yfinance_spy_weights)()
     earnings = (earnings_source or _yfinance_earnings)(yf_symbols)
     sectors_artifact = {"schema_version": SECTORS_SCHEMA_VERSION, "as_of": run_date,
-                        "sectors": dict(sorted(sectors.items())), "spy_sector_weights": dict(sorted(spy_weights.items()))}
+                        "sectors": dict(sorted(sectors.items())),
+                        "countries": dict(sorted(countries.items())),
+                        "spy_sector_weights": dict(sorted(spy_weights.items()))}
     earnings_artifact = {"schema_version": EARNINGS_SCHEMA_VERSION, "as_of": run_date,
                          "earnings": dict(sorted(earnings.items()))}
     if dry_run:
-        logger.info("[metron_market_data] DRY-RUN reference: %d sectors, %d spy-weights, %d earnings",
-                    len(sectors), len(spy_weights), len(earnings))
-        return {"status": "ok_dry_run", "sectors": len(sectors), "earnings": len(earnings)}
+        logger.info("[metron_market_data] DRY-RUN reference: %d sectors, %d countries, %d spy-weights, %d earnings",
+                    len(sectors), len(countries), len(spy_weights), len(earnings))
+        return {"status": "ok_dry_run", "sectors": len(sectors), "countries": len(countries), "earnings": len(earnings)}
     try:
         _write_json(s3_client, bucket, f"{SECTORS_PREFIX}latest.json", sectors_artifact)
         _write_json(s3_client, bucket, f"{EARNINGS_PREFIX}latest.json", earnings_artifact)
     except Exception as e:  # fail loud
         logger.error("[metron_market_data] reference write failed: %s", e)
         return {"status": "error", "error": str(e)}
-    logger.info("[metron_market_data] wrote %d sectors + %d spy-weights + %d earnings",
-                len(sectors), len(spy_weights), len(earnings))
-    return {"status": "ok", "sectors": len(sectors), "spy_weights": len(spy_weights), "earnings": len(earnings)}
+    logger.info("[metron_market_data] wrote %d sectors + %d countries + %d spy-weights + %d earnings",
+                len(sectors), len(countries), len(spy_weights), len(earnings))
+    return {"status": "ok", "sectors": len(sectors), "countries": len(countries),
+            "spy_weights": len(spy_weights), "earnings": len(earnings)}
 
 
 def collect_macro(

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 from unittest.mock import MagicMock
 
 from collectors import metron_market_data as mmd
@@ -223,31 +224,52 @@ class TestMacro:
 
 
 class TestReference:
-    def test_writes_sectors_and_earnings_keyed_by_yf_symbol(self):
+    def test_writes_sectors_countries_and_earnings_keyed_by_yf_symbol(self):
         s3 = _universe_s3(_UNIVERSE)
         result = mmd.collect_reference(
             bucket="b", run_date="2026-06-11", s3_client=s3,
             sector_source=lambda syms: {"AAPL": "Technology", "1299.HK": "Financial Services"},
+            country_source=lambda syms: {"AAPL": "United States", "1299.HK": "Hong Kong"},
             benchmark_source=lambda: {"Technology": 0.30, "Financial Services": 0.13},
             earnings_source=lambda syms: {"AAPL": "2026-07-30"},
         )
-        assert result["status"] == "ok" and result["sectors"] == 2 and result["earnings"] == 1
+        assert result["status"] == "ok" and result["sectors"] == 2 and result["countries"] == 2 and result["earnings"] == 1
         puts = _puts(s3)
         assert set(puts) == {"market_data/sectors/latest.json", "market_data/earnings/latest.json"}
         sec = puts["market_data/sectors/latest.json"]
         assert sec["schema_version"] == mmd.SECTORS_SCHEMA_VERSION
         assert sec["sectors"] == {"1299.HK": "Financial Services", "AAPL": "Technology"}
+        assert sec["countries"] == {"1299.HK": "Hong Kong", "AAPL": "United States"}
         assert sec["spy_sector_weights"]["Technology"] == 0.30
         assert puts["market_data/earnings/latest.json"]["earnings"] == {"AAPL": "2026-07-30"}
+
+    def test_sector_and_country_share_one_info_pass(self):
+        """When neither source is injected, the single ``.info`` pass populates both maps."""
+        s3 = _universe_s3(_UNIVERSE)
+        calls = {"n": 0}
+
+        def fake_classify(yf_symbols):
+            calls["n"] += 1
+            return ({"AAPL": "Technology"}, {"AAPL": "United States"})
+
+        with mock.patch.object(mmd, "_yfinance_classification", fake_classify), \
+             mock.patch.object(mmd, "_yfinance_spy_weights", lambda: {}), \
+             mock.patch.object(mmd, "_yfinance_earnings", lambda s: {}):
+            result = mmd.collect_reference(bucket="b", run_date="2026-06-11", s3_client=s3)
+        assert calls["n"] == 1  # one shared pass, not one per dimension
+        assert result["sectors"] == 1 and result["countries"] == 1
+        sec = _puts(s3)["market_data/sectors/latest.json"]
+        assert sec["countries"] == {"AAPL": "United States"}
 
     def test_reference_dry_run_and_empty_universe(self):
         s3 = _universe_s3(_UNIVERSE)
         r = mmd.collect_reference(bucket="b", run_date="2026-06-11", dry_run=True, s3_client=s3,
-                                  sector_source=lambda s: {"AAPL": "Technology"}, benchmark_source=lambda: {}, earnings_source=lambda s: {})
+                                  sector_source=lambda s: {"AAPL": "Technology"}, country_source=lambda s: {"AAPL": "United States"},
+                                  benchmark_source=lambda: {}, earnings_source=lambda s: {})
         assert r["status"] == "ok_dry_run"
         s3.put_object.assert_not_called()
         s3b = _universe_s3({"holdings": [], "currencies": []})
-        assert mmd.collect_reference(bucket="b", s3_client=s3b, sector_source=lambda s: {}, benchmark_source=lambda: {}, earnings_source=lambda s: {})["status"] == "skipped"
+        assert mmd.collect_reference(bucket="b", s3_client=s3b, sector_source=lambda s: {}, country_source=lambda s: {}, benchmark_source=lambda: {}, earnings_source=lambda s: {})["status"] == "skipped"
 
 
 class TestFundamentals:

--- a/tests/test_metron_yf_noise_aggregation.py
+++ b/tests/test_metron_yf_noise_aggregation.py
@@ -46,7 +46,7 @@ class TestQuietYfinance:
         # run quieted, or one bad symbol storms Flow Doctor again.
         for fn in (
             mmd._yfinance_closes, mmd._yfinance_fx, mmd._yf_history,
-            mmd._yfinance_sectors, mmd._yfinance_spy_weights,
+            mmd._yfinance_classification, mmd._yfinance_spy_weights,
             mmd._yfinance_earnings, mmd._yfinance_fundamentals,
             mmd._yfinance_intraday,
         ):


### PR DESCRIPTION
## What

Adds a `countries` map (`yf_symbol → country of domicile`) to `market_data/sectors/latest.json`, sourced from the **same** `yf.Ticker(sym).info` pass that already resolves the GICS sector — so country is a zero-extra-API-cost addition to the existing reference fetch.

Metron consumes this (separate PR: `nousergon/metron` `feat/holdings-performers-geo`) to:
- classify each holding **US vs international** by domicile, and
- show a **Country** column on the Holdings table.

## Changes
- `_yfinance_sectors` → `_yfinance_classification`: one `.info` pass returns `(sectors, countries)`; thin `_yfinance_sectors`/`_yfinance_countries` wrappers retained.
- `collect_reference`: new injectable `country_source`; publishes `countries` into the sectors artifact; single shared fetch when neither source is injected (test asserts one pass).
- `SECTORS_SCHEMA_VERSION` 1 → 2 (additive `countries` field; consumers are fail-soft, so backward-compatible — a v1 artifact / missing field reads as empty).

## Tests
`tests/test_metron_market_data.py` — country published keyed by yf_symbol; sector+country share one `.info` pass; dry-run/empty paths updated. `25 passed` locally; schema-contract + etf-drift suites green.

## CI
Producer reference tests green locally. Additive S3 schema change — no consumer break (Metron reads `countries` fail-soft; the metron PR can merge before or after this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)