### PR TITLE
feat(saturday-sf-watch): M1 observe-only dispatcher (Lambda + EventBridge)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
@@ -1,0 +1,74 @@
+# saturday-sf-watch-dispatcher
+
+**Saturday-SF Watch — M1 (OBSERVE).** First slice of the autonomous
+Saturday-SF resilience arc. Spec: [nousergon/alpha-engine-config#1227](https://github.com/nousergon/alpha-engine-config/issues/1227).
+
+## What it does (M1)
+
+On a **Saturday SF terminal failure** (`FAILED` / `TIMED_OUT` / `ABORTED`) this
+Lambda:
+
+1. Reads the failure cause (`DescribeExecution`) and the **failed state name**
+   (`GetExecutionHistory` — the entered-but-not-exited state).
+2. Appends an event to the **watch-log artifact**
+   `s3://alpha-engine-research/consolidated/saturday_sf_watch/{run_date}.json`
+   (the contract the M3 dashboard page reads; repeated failures in one Saturday
+   accumulate).
+3. Sends a **distinct, SILENT** Telegram receipt naming the failed state + the
+   artifact location (the `sf-telegram-notifier` already pinged loud on the same
+   FAILED event — this is the additive watch record, not a duplicate alert).
+
+It does **not** invoke any agent, touch any repo/IAM/SF definition, or rerun
+anything. `AGENT_DISPATCH_ENABLED` (default `false`) is the M2 seam.
+
+## Why it's not a second notifier
+
+`alpha-engine-sf-telegram-notifier` already covers generic SF notification
+(all three SFs, all statuses). This Lambda's distinct concerns are the
+**Saturday-failure-only trigger** (the seam the agent will hang off), the
+**watch-log artifact contract**, and a Saturday-scoped IAM surface — kept
+separate so the notifier's IAM stays narrow.
+
+## Fail-loud posture
+
+- **Primary** (RAISES on failure): the watch-log S3 write — a broken producer
+  must surface via the Lambda error metric + CW alarm.
+- **Best-effort** (logged WARN, recorded in artifact): `DescribeExecution` /
+  `GetExecutionHistory` enrichment and the Telegram receipt.
+
+## Deploy
+
+Managed outside CloudFormation (operator-deployed; keeps the GHA OIDC role's
+blast radius narrow). **Merging the PR has zero live effect** — an operator
+bootstraps it:
+
+```
+bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh --dry-run    # preview
+bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh --bootstrap  # first-time: role + Lambda + EventBridge rule
+bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh              # code-only update
+bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh --smoke      # synthetic FAILED invoke
+```
+
+## Test
+
+```
+python3 -m pytest infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py -q
+```
+
+## Event shape (EventBridge `aws.states` / Step Functions Execution Status Change)
+
+```
+detail.status:           FAILED | TIMED_OUT | ABORTED   (rule-scoped)
+detail.stateMachineArn:  arn:...:stateMachine:alpha-engine-saturday-pipeline
+detail.executionArn:     execution arn
+detail.name:             execution id
+detail.startDate:        epoch ms
+```
+
+## Next milestones (see #1227)
+
+- **M2** — wire `repository_dispatch` (behind `AGENT_DISPATCH_ENABLED`) to the
+  agent GHA workflow; run propose-only.
+- **M3** — "Saturday SF Watch" dashboard page reading the watch-log artifact.
+- **M4** — independent artifact-integrity gate on the weekday pre-run.
+- **M5** — flip autonomous merge after the propose-only soak earns trust.

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-saturday-sf-watch-dispatcher
+# Lambda and wire its EventBridge trigger (Saturday SF terminal failure only).
+#
+# Saturday-SF Watch arc, M1 (OBSERVE). The Lambda writes a watch-log artifact
+# to s3://alpha-engine-research/consolidated/saturday_sf_watch/{run_date}.json
+# and sends a SILENT Telegram receipt. It invokes NO agent (AGENT_DISPATCH_ENABLED
+# default false). Spec: nousergon/alpha-engine-config#1227.
+#
+# Managed outside CloudFormation — same rationale as sf-telegram-notifier +
+# spot-orphan-reaper (keeps the github-actions-lambda-deploy OIDC role's blast
+# radius narrow; operator-deployed only). Merging the PR has ZERO live effect
+# until an operator runs this with --bootstrap.
+#
+# Usage:
+#   bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh             # update code only
+#   bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh --bootstrap # first-time create + wire EventBridge
+#   bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh --smoke     # invoke once with a synthetic FAILED event
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-saturday-sf-watch-dispatcher"
+ROLE_NAME="alpha-engine-saturday-sf-watch-dispatcher-role"
+POLICY_NAME="alpha-engine-saturday-sf-watch-dispatcher-policy"
+RULE_NAME="alpha-engine-saturday-sf-watch-failed"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge rule: Saturday SF terminal-failure statuses ONLY.
+  echo "  Creating EventBridge rule: ${RULE_NAME}"
+  EVENT_PATTERN=$(cat <<EOF
+{
+  "source": ["aws.states"],
+  "detail-type": ["Step Functions Execution Status Change"],
+  "detail": {
+    "stateMachineArn": [
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
+    ],
+    "status": ["FAILED", "TIMED_OUT", "ABORTED"]
+  }
+}
+EOF
+)
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --event-pattern "${EVENT_PATTERN}" \
+    --description "Saturday SF terminal failure → alpha-engine-saturday-sf-watch-dispatcher (OBSERVE)" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (synthetic FAILED event) ------------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (synthetic FAILED event)..."
+  RESP=$(mktemp)
+  PAYLOAD=$(cat <<'EOF'
+{
+  "source": "aws.states",
+  "detail-type": "Step Functions Execution Status Change",
+  "detail": {
+    "status": "FAILED",
+    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
+    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:smoke-test",
+    "name": "smoke-test",
+    "startDate": 0,
+    "stopDate": 60000
+  }
+}
+EOF
+)
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload "${PAYLOAD}" \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -1,0 +1,39 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-saturday-sf-watch-dispatcher:*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    },
+    {
+      "Sid": "ReadSaturdaySFExecution",
+      "Effect": "Allow",
+      "Action": [
+        "states:DescribeExecution",
+        "states:GetExecutionHistory"
+      ],
+      "Resource": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:*"
+    },
+    {
+      "Sid": "WatchLogArtifactRW",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/saturday_sf_watch/*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -1,0 +1,288 @@
+"""alpha-engine-saturday-sf-watch-dispatcher — Saturday-SF Watch, M1 (OBSERVE).
+
+First slice of the Saturday-SF Watch arc (spec: nousergon/alpha-engine-config#1227).
+The arc's end state is an autonomous, SOTA-steered resilience agent that, on a
+Saturday SF (`alpha-engine-saturday-pipeline`) failure, diagnoses + enacts an
+institutional-grade reliability fix and reruns from the failed step
+(ask-forgiveness posture). This Lambda is **M1**: the dedicated trigger path +
+the watch-log artifact contract, in **OBSERVE mode only**. It does NOT invoke
+any agent and does NOT touch any repo, IAM, or SF definition.
+
+**Why this is NOT a second notifier.** The fleet already has
+`alpha-engine-sf-telegram-notifier` (subscribes to all three SFs / all statuses,
+pings loud on FAILED with the cause). Re-implementing notification here would be
+the redundant-path anti-pattern. This Lambda's distinct responsibilities are:
+
+  1. A **Saturday-only, terminal-failure-only** trigger (its own EventBridge rule
+     `alpha-engine-saturday-sf-watch-failed`) — the seam the M2 agent dispatch
+     will hang off.
+  2. The **watch-log artifact** at
+     ``s3://{WATCH_BUCKET}/consolidated/saturday_sf_watch/{run_date}.json`` — the
+     contract the M3 dashboard page reads. Establishing it now means the
+     dashboard + agent halves build against a stable shape.
+  3. A **distinct, SILENT** Telegram record (the notifier already buzzed loud) that
+     names the failed state + the artifact location and states OBSERVE mode.
+
+**Fail-loud (CLAUDE.md no-silent-fails).** The watch-log artifact write is the
+primary deliverable in OBSERVE mode → it RAISES on failure so a broken producer
+surfaces via the Lambda error metric + CW alarm. Enrichment (DescribeExecution /
+GetExecutionHistory) and the Telegram record are secondary observability hung off
+the primary path: their failure is logged at WARNING and recorded in the artifact
+(``cause``/``failed_state`` become null with a reason) — the artifact still
+records that a failure was detected.
+
+**M2 seam.** ``AGENT_DISPATCH_ENABLED`` (default ``"false"``) is read and echoed
+in the return value + artifact so the cutover to agent dispatch is a single env
+flip. M1 contains NO dispatch code — the ``repository_dispatch`` call is added in
+M2. Until then this Lambda is inert beyond observing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime, timezone
+
+import boto3
+
+from alpha_engine_lib.telegram import send_message
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
+WATCH_PREFIX = os.environ.get("WATCH_PREFIX", "consolidated/saturday_sf_watch")
+# M2 seam — default OFF. M1 never dispatches; this is read + echoed only.
+AGENT_DISPATCH_ENABLED = (
+    os.environ.get("AGENT_DISPATCH_ENABLED", "false").lower() == "true"
+)
+
+SATURDAY_SF_NAME = "alpha-engine-saturday-pipeline"
+SCHEMA_VERSION = 1
+_CAUSE_MAX_CHARS = 600
+# Bound the history scan: fetch the newest N events (reverseOrder), reconstruct
+# chronological order locally to find the entered-but-not-exited state. The
+# failed state's enclosing StateEntered is always in the tail of the history.
+_HISTORY_MAX_EVENTS = 1000
+
+
+def _sf_client():
+    return boto3.client("stepfunctions", region_name=REGION)
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=REGION)
+
+
+def _describe_execution(execution_arn: str) -> dict | None:
+    """Best-effort DescribeExecution → top-level error/cause + input. None on error."""
+    if not execution_arn:
+        return None
+    try:
+        return _sf_client().describe_execution(executionArn=execution_arn)
+    except Exception as exc:  # noqa: BLE001 — enrichment, recorded in artifact
+        logger.warning("describe_execution failed for %s: %s", execution_arn, exc)
+        return None
+
+
+def _failure_cause(describe_resp: dict | None) -> str:
+    if not describe_resp:
+        return ""
+    error = (describe_resp.get("error") or "").strip()
+    cause = (describe_resp.get("cause") or "").strip()
+    snippet = f"{error}: {cause}" if (error and cause) else (error or cause)
+    if len(snippet) > _CAUSE_MAX_CHARS:
+        snippet = snippet[: _CAUSE_MAX_CHARS - 1] + "…"
+    return snippet
+
+
+def _is_preflight(describe_resp: dict | None) -> bool:
+    """True iff execution input has ``shell_run=true`` (the Friday-PM dry-pass)."""
+    if not describe_resp:
+        return False
+    try:
+        payload = json.loads(describe_resp.get("input") or "{}")
+    except (ValueError, TypeError):
+        return False
+    return bool(payload.get("shell_run"))
+
+
+def _failed_state_from_history(execution_arn: str) -> str | None:
+    """Return the name of the state that was active (entered, not yet exited)
+    when the execution failed — i.e. the culprit state.
+
+    Fetches the newest ``_HISTORY_MAX_EVENTS`` events (reverseOrder), reverses
+    them to chronological order, and tracks the entered-but-not-exited state via
+    a forward scan. A state that fails enters but never cleanly exits, so it is
+    the one left dangling at the terminal failure event. Best-effort: returns
+    ``None`` on any API error (recorded in the artifact).
+    """
+    if not execution_arn:
+        return None
+    try:
+        resp = _sf_client().get_execution_history(
+            executionArn=execution_arn,
+            maxResults=_HISTORY_MAX_EVENTS,
+            reverseOrder=True,
+            includeExecutionData=False,
+        )
+    except Exception as exc:  # noqa: BLE001 — enrichment, recorded in artifact
+        logger.warning("get_execution_history failed for %s: %s", execution_arn, exc)
+        return None
+
+    events = list(reversed(resp.get("events", [])))  # → chronological
+    current: str | None = None
+    for ev in events:
+        etype = ev.get("type", "")
+        if etype.endswith("StateEntered"):
+            det = ev.get("stateEnteredEventDetails") or {}
+            current = det.get("name") or current
+        elif etype.endswith("StateExited"):
+            det = ev.get("stateExitedEventDetails") or {}
+            if det.get("name") == current:
+                current = None
+    return current
+
+
+def _run_date(describe_resp: dict | None, detail: dict) -> str:
+    """Resolve the Saturday firing date (YYYY-MM-DD) for the artifact key.
+
+    Prefers the execution input's ``run_date`` (the canonical key the pipeline
+    stamps its artifacts with), then the execution ``startDate`` epoch-ms, then
+    ``now`` UTC. Keeps the watch-log aligned with the artifacts it will later
+    report integrity on.
+    """
+    if describe_resp:
+        try:
+            payload = json.loads(describe_resp.get("input") or "{}")
+            rd = payload.get("run_date")
+            if isinstance(rd, str) and rd:
+                return rd
+        except (ValueError, TypeError):
+            pass
+    start_ms = detail.get("startDate")
+    if isinstance(start_ms, (int, float)) and start_ms > 0:
+        return datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc).date().isoformat()
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _artifact_key(run_date: str) -> str:
+    return f"{WATCH_PREFIX}/{run_date}.json"
+
+
+def _load_existing(s3, key: str) -> dict:
+    """Read the existing watch-log for this date (so repeated failures in one
+    Saturday accumulate), or a fresh skeleton. A missing object (404/403) is the
+    common first-failure-of-the-day case, NOT an error."""
+    try:
+        obj = s3.get_object(Bucket=WATCH_BUCKET, Key=key)
+        data = json.loads(obj["Body"].read())
+        if isinstance(data, dict) and isinstance(data.get("events"), list):
+            return data
+    except Exception as exc:  # noqa: BLE001 — absence is expected; bad blob is recoverable
+        code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+        if code not in {"NoSuchKey", "404", "403"}:
+            logger.warning("could not read existing watch-log %s: %s", key, exc)
+    return {"schema_version": SCHEMA_VERSION, "events": []}
+
+
+def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str) -> dict:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    cause = _failure_cause(describe_resp)
+    failed_state = _failed_state_from_history(detail.get("executionArn", ""))
+    return {
+        "detected_at": now_iso,
+        "status": detail.get("status", "UNKNOWN"),
+        "state_machine": (detail.get("stateMachineArn") or "").rsplit(":", 1)[-1],
+        "execution_name": detail.get("name", ""),
+        "execution_arn": detail.get("executionArn", ""),
+        "failed_state": failed_state,
+        "cause": cause or None,
+        "is_preflight": _is_preflight(describe_resp),
+        # Filled by the M2+ agent; null in OBSERVE mode.
+        "lane": None,
+        "action": "observe",
+        "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
+    }
+
+
+def _write_watch_log(s3, run_date: str, record: dict) -> str:
+    """Append the event to the date's watch-log and write it back. PRIMARY
+    deliverable — RAISES on failure (fail-loud: a broken producer must surface
+    via the Lambda error metric + CW alarm, never silently)."""
+    key = _artifact_key(run_date)
+    doc = _load_existing(s3, key)
+    doc["schema_version"] = SCHEMA_VERSION
+    doc["run_date"] = run_date
+    doc["updated_at"] = record["detected_at"]
+    doc["events"].append(record)
+    s3.put_object(
+        Bucket=WATCH_BUCKET,
+        Key=key,
+        Body=json.dumps(doc, indent=2, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+    return key
+
+
+def _notify(record: dict, key: str) -> bool:
+    """Distinct, SILENT Telegram record. The sf-telegram-notifier already pinged
+    loud on this FAILED event; this is the additive watch receipt (which state,
+    where the artifact is, OBSERVE mode). Best-effort — never raises."""
+    label = "Saturday Preflight SF" if record["is_preflight"] else "Saturday SF"
+    lines = [
+        f"\U0001f6f0️ *Saturday-SF Watch — OBSERVE*",
+        f"{label}: {record['status']}",
+    ]
+    if record.get("failed_state"):
+        lines.append(f"Failed state: {record['failed_state']}")
+    if record.get("cause"):
+        lines.append(f"Cause: {record['cause']}")
+    lines.append(f"Watch log: s3://{WATCH_BUCKET}/{key}")
+    lines.append("_autonomous fix DISABLED (M1 observe-only)_")
+    try:
+        return bool(send_message("\n".join(lines), disable_notification=True))
+    except Exception as exc:  # noqa: BLE001 — secondary observability
+        logger.warning("watch Telegram record failed (non-fatal): %s", exc)
+        return False
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """EventBridge handler — fires only on Saturday SF terminal failure
+    (FAILED / TIMED_OUT / ABORTED), per the dedicated rule
+    ``alpha-engine-saturday-sf-watch-failed``.
+    """
+    detail = event.get("detail") or {}
+    sm_name = (detail.get("stateMachineArn") or "").rsplit(":", 1)[-1]
+    status = detail.get("status", "UNKNOWN")
+    logger.info("Saturday-SF Watch: sf=%s status=%s (OBSERVE)", sm_name, status)
+
+    # Defensive: the rule scopes to the Saturday SF, but never act on anything else.
+    if sm_name != SATURDAY_SF_NAME:
+        logger.warning("ignoring non-Saturday SF event: %s", sm_name)
+        return {"ignored": True, "state_machine": sm_name, "status": status}
+
+    describe_resp = _describe_execution(detail.get("executionArn", ""))
+    run_date = _run_date(describe_resp, detail)
+    record = _build_event_record(detail, describe_resp, run_date)
+
+    s3 = _s3_client()
+    key = _write_watch_log(s3, run_date, record)  # PRIMARY — fail-loud
+    telegram_sent = _notify(record, key)          # secondary — best-effort
+
+    logger.info(
+        "Saturday-SF Watch recorded: run_date=%s failed_state=%s key=%s telegram=%s",
+        run_date, record.get("failed_state"), key, telegram_sent,
+    )
+    return {
+        "status": status,
+        "state_machine": sm_name,
+        "run_date": run_date,
+        "failed_state": record.get("failed_state"),
+        "watch_log_key": key,
+        "telegram_sent": telegram_sent,
+        "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
+        "action": "observe",
+    }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,0 +1,5 @@
+# Pinned to match alpha-engine-data/requirements.txt (the main data Lambda) so
+# the lib substrate stays coherent across alpha-engine-data Lambdas and stays
+# above the Saturday-SF LibPinDriftCheck v0.39.0 floor. Only the stable
+# `telegram.send_message` primitive is used here — no extras required.
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -1,0 +1,240 @@
+"""Unit tests for saturday-sf-watch-dispatcher index.handler (M1, OBSERVE).
+
+Stubs ``alpha_engine_lib.telegram.send_message`` (no live Telegram) and mocks
+boto3 stepfunctions + s3 clients. Asserts: watch-log artifact written (append +
+fresh-skeleton), failed-state extraction from history, fail-loud on the S3 write,
+best-effort enrichment + Telegram, non-Saturday guard, and the M2 dispatch seam
+stays OFF.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub the lib before importing the handler (CI runners pre-pip-install).
+_lib_pkg = types.ModuleType("alpha_engine_lib")
+_telegram_mod = types.ModuleType("alpha_engine_lib.telegram")
+_telegram_mod.send_message = MagicMock(return_value=True)
+_lib_pkg.telegram = _telegram_mod
+sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
+sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
+WEEKDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+
+
+class FakeClientError(Exception):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+def _event(status: str = "FAILED", sm_arn: str = SATURDAY_ARN, **overrides) -> dict:
+    detail = {
+        "status": status,
+        "stateMachineArn": sm_arn,
+        "executionArn": f"arn:aws:states:us-east-1:711398986525:execution:{sm_arn.rsplit(':', 1)[-1]}:exec-001",
+        "name": "exec-001",
+        "startDate": 1_700_000_000_000,  # 2023-11-14 UTC
+        "stopDate": 1_700_000_060_000,
+    }
+    detail.update(overrides)
+    return {"detail": detail}
+
+
+def _history_chrono_to_resp(chrono: list[dict]) -> dict:
+    # Handler calls get_execution_history(reverseOrder=True) then reverses to
+    # chronological — so the API returns newest-first.
+    return {"events": list(reversed(chrono))}
+
+
+_DEFAULT_HISTORY = [
+    {"type": "ExecutionStarted"},
+    {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "MorningEnrich"}},
+    {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "MorningEnrich"}},
+    {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "RAGIngestion"}},
+    {"type": "TaskFailed"},
+    {"type": "ExecutionFailed"},
+]
+
+
+def _make_clients(*, describe=None, history=None, existing=None, put=None):
+    """Return (factory, sf_mock, s3_mock). ``existing`` None → get_object 404."""
+    sf = MagicMock()
+    sf.describe_execution.return_value = describe if describe is not None else {
+        "input": "{}", "error": "States.TaskFailed", "cause": "RAGIngestion failed",
+    }
+    sf.get_execution_history.return_value = _history_chrono_to_resp(
+        history if history is not None else _DEFAULT_HISTORY
+    )
+    s3 = MagicMock()
+    if existing is None:
+        s3.get_object.side_effect = FakeClientError("404")
+    else:
+        body = MagicMock()
+        body.read.return_value = json.dumps(existing).encode()
+        s3.get_object.return_value = {"Body": body}
+    if put is not None:
+        s3.put_object.side_effect = put
+
+    def factory(name, region_name=None):
+        return sf if name == "stepfunctions" else s3
+
+    return factory, sf, s3
+
+
+@pytest.fixture(autouse=True)
+def reset_telegram():
+    _telegram_mod.send_message.reset_mock()
+    _telegram_mod.send_message.return_value = True
+    yield
+
+
+def test_failed_writes_watch_log_and_returns_state():
+    factory, sf, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+
+    assert result["status"] == "FAILED"
+    assert result["failed_state"] == "RAGIngestion"
+    assert result["action"] == "observe"
+    assert result["agent_dispatch_enabled"] is False
+    # run_date from startDate (no input run_date) → 2023-11-14
+    assert result["run_date"] == "2023-11-14"
+    assert result["watch_log_key"] == "consolidated/saturday_sf_watch/2023-11-14.json"
+
+    s3.put_object.assert_called_once()
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    assert written["schema_version"] == index.SCHEMA_VERSION
+    assert written["run_date"] == "2023-11-14"
+    assert len(written["events"]) == 1
+    ev = written["events"][0]
+    assert ev["failed_state"] == "RAGIngestion"
+    assert ev["cause"] == "States.TaskFailed: RAGIngestion failed"
+    assert ev["action"] == "observe"
+    assert ev["agent_dispatch_enabled"] is False
+
+
+def test_telegram_is_silent_and_records_artifact_location():
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        index.handler(_event("FAILED"), None)
+    _telegram_mod.send_message.assert_called_once()
+    text = _telegram_mod.send_message.call_args.args[0]
+    kwargs = _telegram_mod.send_message.call_args.kwargs
+    assert kwargs["disable_notification"] is True  # notifier already buzzed loud
+    assert "Saturday-SF Watch — OBSERVE" in text
+    assert "Failed state: RAGIngestion" in text
+    assert "consolidated/saturday_sf_watch/2023-11-14.json" in text
+    assert "observe-only" in text
+
+
+def test_run_date_prefers_input_run_date():
+    factory, _, s3 = _make_clients(describe={
+        "input": json.dumps({"run_date": "2026-06-20", "shell_run": False}),
+        "error": "E", "cause": "C",
+    })
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    assert result["run_date"] == "2026-06-20"
+    assert s3.put_object.call_args.kwargs["Key"] == "consolidated/saturday_sf_watch/2026-06-20.json"
+
+
+def test_existing_watch_log_is_appended_not_overwritten():
+    existing = {
+        "schema_version": 1, "run_date": "2023-11-14",
+        "events": [{"status": "FAILED", "failed_state": "MorningEnrich", "action": "observe"}],
+    }
+    factory, _, s3 = _make_clients(existing=existing)
+    with patch("index.boto3.client", side_effect=factory):
+        index.handler(_event("FAILED"), None)
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    assert len(written["events"]) == 2  # prior + this one
+    assert written["events"][0]["failed_state"] == "MorningEnrich"
+    assert written["events"][1]["failed_state"] == "RAGIngestion"
+
+
+def test_s3_put_failure_raises_fail_loud():
+    factory, _, _ = _make_clients(put=RuntimeError("S3 down"))
+    with patch("index.boto3.client", side_effect=factory):
+        with pytest.raises(RuntimeError, match="S3 down"):
+            index.handler(_event("FAILED"), None)
+
+
+def test_history_api_error_still_writes_artifact_with_null_state():
+    factory, sf, s3 = _make_clients()
+    sf.get_execution_history.side_effect = RuntimeError("throttled")
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    assert result["failed_state"] is None  # enrichment degraded
+    s3.put_object.assert_called_once()  # artifact still written (fail-loud only on S3)
+
+
+def test_describe_error_still_writes_artifact():
+    factory, sf, s3 = _make_clients()
+    sf.describe_execution.side_effect = RuntimeError("throttled")
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    # cause unavailable, run_date falls back to startDate
+    assert result["run_date"] == "2023-11-14"
+    s3.put_object.assert_called_once()
+
+
+def test_telegram_failure_is_non_fatal():
+    _telegram_mod.send_message.side_effect = RuntimeError("bot down")
+    factory, _, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    assert result["telegram_sent"] is False
+    s3.put_object.assert_called_once()  # primary deliverable survived
+
+
+def test_preflight_shell_run_marks_record():
+    factory, _, s3 = _make_clients(describe={
+        "input": json.dumps({"shell_run": True}), "error": "E", "cause": "C",
+    })
+    with patch("index.boto3.client", side_effect=factory):
+        index.handler(_event("FAILED"), None)
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    assert written["events"][0]["is_preflight"] is True
+    text = _telegram_mod.send_message.call_args.args[0]
+    assert "Saturday Preflight SF" in text
+
+
+def test_non_saturday_sf_is_ignored():
+    factory, _, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["ignored"] is True
+    s3.put_object.assert_not_called()
+
+
+@pytest.mark.parametrize("status", ["TIMED_OUT", "ABORTED"])
+def test_other_terminal_statuses_recorded(status):
+    factory, _, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event(status), None)
+    assert result["status"] == status
+    s3.put_object.assert_called_once()
+
+
+def test_failed_state_none_when_state_exited_cleanly():
+    # A history where the entered state also exited → no dangling culprit.
+    clean = [
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "Foo"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "Foo"}},
+        {"type": "ExecutionFailed"},
+    ]
+    factory, _, _ = _make_clients(history=clean)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    assert result["failed_state"] is None


### PR DESCRIPTION
## Saturday-SF Watch — M1 (OBSERVE)

First slice of the autonomous Saturday-SF resilience arc. Spec + decision trail: **nousergon/alpha-engine-config#1227**.

### What this adds
An operator-deployed Lambda `alpha-engine-saturday-sf-watch-dispatcher` + a dedicated EventBridge rule `alpha-engine-saturday-sf-watch-failed` (Saturday SF, `FAILED`/`TIMED_OUT`/`ABORTED` only). On a Saturday SF terminal failure it:
1. Captures the **failed-state name** (`GetExecutionHistory` — the entered-but-not-exited state) + cause (`DescribeExecution`).
2. Appends to the **watch-log artifact** `s3://alpha-engine-research/consolidated/saturday_sf_watch/{run_date}.json` — the contract the **M3 dashboard page** will read (repeated failures in a day accumulate).
3. Sends a **distinct, SILENT** Telegram receipt (the existing `sf-telegram-notifier` already buzzed loud on the same event — this is the additive watch record).

### Scope discipline
- **OBSERVE only** — invokes no agent, touches no repo/IAM/SF definition. `AGENT_DISPATCH_ENABLED` (default `false`) is the M2 seam; M1 contains **no** dispatch code.
- **Not a second notifier** — verified the fleet already has generic FAILED notification; this Lambda's distinct concerns are the Saturday-failure-only agent-dispatch seam, the watch-log contract, and a Saturday-scoped IAM surface. Avoids the redundant-path anti-pattern.
- **Fail-loud** — the watch-log S3 write RAISES (primary deliverable surfaces via Lambda error metric + CW alarm); enrichment + Telegram are best-effort (logged WARN, degraded fields recorded in the artifact).

### Deploy / blast radius
Operator-deployed (outside CloudFormation, like `sf-telegram-notifier`). **Merging this PR has ZERO live effect** — it activates only when an operator runs `deploy.sh --bootstrap`. No SF definition or IAM change rides this PR.

### CI status
Green locally:
- `test_handler.py` — **13 passed** (artifact append + fresh-skeleton, failed-state extraction, fail-loud on S3 write, best-effort enrichment/Telegram, non-Saturday guard, M2 seam off).
- `test_artifact_registry_coverage.py` — **3 passed** (`infrastructure/lambdas/` is scope-exempt; the watch-log is failure-only so it intentionally carries no freshness SLA — registering it would false-alarm on healthy Saturdays).
- `test_lib_pin_lockstep.py` / `test_dockerfile_copies_match_deployed_imports.py` — root-/main-container-scoped, do not touch this Lambda.

Will confirm GH Actions CI green after push.

### Next milestones (#1227)
- **M2** — wire `repository_dispatch` (behind the flag) to the agent GHA; propose-only soak.
- **M3** — "Saturday SF Watch" dashboard page.
- **M4** — independent artifact-integrity gate on the weekday pre-run.
- **M5** — flip autonomous merge after the soak earns trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
