### PR TITLE
feat(freshness-monitor): grant s3:ListBucket + cut over to ENFORCE mode

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -158,9 +158,12 @@ if $BOOTSTRAP; then
   ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
   if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
     echo "  Creating Lambda: ${FUNCTION_NAME}"
-    # OBSERVE-mode default: MNEMON_FRESHNESS_MONITOR_ENABLED=false.
-    # Phase 6 cutover flips via update-function-configuration without
-    # redeploying. ≥2 weekly soak cycles before flip.
+    # ENFORCE mode: MNEMON_FRESHNESS_MONITOR_ENABLED=true.
+    # Phase 6 cutover EXECUTED 2026-06-25 after a ~1mo observe soak (the
+    # monitor correctly detected the missed 6/20 Saturday cycle the whole
+    # time but stayed muted). Code is now the source of truth for the flag —
+    # a fresh bootstrap comes up enforcing. For an already-deployed function,
+    # flip live via `aws lambda update-function-configuration` (no redeploy).
     run aws lambda create-function \
       --function-name "${FUNCTION_NAME}" \
       --runtime python3.12 \
@@ -169,7 +172,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 120 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,MNEMON_FRESHNESS_MONITOR_ENABLED=false}' \
+      --environment 'Variables={LOG_LEVEL=INFO,MNEMON_FRESHNESS_MONITOR_ENABLED=true}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else

--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -33,6 +33,12 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/*"
     },
     {
+      "Sid": "S3ListBucketProbe",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::alpha-engine-research"
+    },
+    {
       "Sid": "S3WriteMonitorArtifacts",
       "Effect": "Allow",
       "Action": ["s3:PutObject"],


### PR DESCRIPTION
## Why

Make the artifact-freshness monitor the single authoritative **"did the required artifact get produced?"** alert surface, replacing per-consumer heuristics — the proximate trigger being the executor `eod_reconcile` 5-day signals lookback that paged ERROR on 2026-06-25 (`No signals found within 5 days`).

Root cause of that page: the 6/20 Saturday cycle produced **no artifacts** (an off-cycle `full` run on 6/19 suppressed the cron by design, then failed at `WaitForEvaluator`/DataLimitExceeded; subsequent runs were `zoo-verify` skip_research). The freshness monitor detected this every 15 min — but stayed **muted in observe mode** (`0 alerted`), so the only thing that eventually paged was the executor's ad-hoc lookback, 5 days late.

## Changes

1. **iam-policy.json** — add bucket-level `s3:ListBucket` on `arn:aws:s3:::alpha-engine-research`. Without it, S3 HEAD on a **missing** key returns 403, which `artifact_freshness._classify_client_error` files as `probe_failed` (opaque) instead of honest `missing`. Observe-mode logs (6/25) showed `research_signals` + 21 other criticals as `probe_failed status=403` — they were actually **absent**. With ListBucket, missing keys → 404 → `missing`, so a genuinely-absent critical artifact alerts correctly.
2. **deploy.sh** — flip `MNEMON_FRESHNESS_MONITOR_ENABLED` `false`→`true` (Phase 6 cutover). ~1mo observe soak; code is now source of truth for the flag.

## Deploy sequencing

The **live** enforce-flip (`update-function-configuration`) is deferred until the in-flight off-cycle refresh (`offcycle-full-20260625-210857`) lands fresh artifacts — flipping while everything is stale would flood alerts for the very staleness being repaired. The ListBucket grant is applied live immediately (read-only, zero alerting impact in observe mode) to verify honest states first.

## Tests

34 passed — `test_handler.py` (31) + `test_artifact_registry_coverage.py` (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)