### PR TITLE
feat(saturday-sf-watch): M2a — repository_dispatch to the autonomous agent

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
@@ -18,8 +18,34 @@ Lambda:
    artifact location (the `sf-telegram-notifier` already pinged loud on the same
    FAILED event — this is the additive watch record, not a duplicate alert).
 
-It does **not** invoke any agent, touch any repo/IAM/SF definition, or rerun
-anything. `AGENT_DISPATCH_ENABLED` (default `false`) is the M2 seam.
+## M2 — agent dispatch (behind a flag, default OFF)
+
+When `AGENT_DISPATCH_ENABLED=true`, **after** writing the watch-log (so the
+agent reads fresh context) the Lambda also fires a GitHub `repository_dispatch`
+(`event_type=saturday-sf-failure`) to `DISPATCH_REPO`
+(`nousergon/alpha-engine-config`), passing the failure context
+(`execution_arn`, `failed_state`, `cause`, `run_date`, `watch_log_key`,
+`is_preflight`). That triggers the autonomous resilience-agent GHA workflow,
+which diagnoses → fixes → **merges** → **reruns the SF from the failed step**,
+then reports back (enriches the watch-log + dashboard + Telegram).
+
+The dispatch is **best-effort with a recording surface** (CLAUDE.md
+no-silent-fails secondary carve-out): a GitHub/SSM outage logs `WARNING` and is
+returned in `agent_dispatch.error`, but does NOT raise — the primary observe
+deliverable (watch-log) already landed. The PAT is read from SSM
+(`/alpha-engine/saturday_sf_watch/github_pat`, SecureString) at dispatch time
+and is never logged.
+
+**Activation (operator steps — keep `AGENT_DISPATCH_ENABLED=false` until done):**
+1. Mint a dedicated fine-grained PAT scoped to the Saturday-SF-path repos
+   (contents + pull-requests write) and store it:
+   `aws ssm put-parameter --name /alpha-engine/saturday_sf_watch/github_pat --type SecureString --value <PAT>`.
+2. Re-apply the dispatcher role policy so the new `AgentDispatchPAT` SSM grant
+   lands: `bash …/deploy.sh --bootstrap` (idempotent) — or `aws iam
+   put-role-policy` directly.
+3. Land the agent GHA workflow + scoped OIDC role (M2c, alpha-engine-config).
+4. Flip the flag:
+   `aws lambda update-function-configuration --function-name alpha-engine-saturday-sf-watch-dispatcher --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=true}' --query LastUpdateStatus --output text`.
 
 ## Why it's not a second notifier
 
@@ -65,10 +91,17 @@ detail.name:             execution id
 detail.startDate:        epoch ms
 ```
 
-## Next milestones (see #1227)
+## Milestones (see #1227)
 
-- **M2** — wire `repository_dispatch` (behind `AGENT_DISPATCH_ENABLED`) to the
-  agent GHA workflow; run propose-only.
-- **M3** — "Saturday SF Watch" dashboard page reading the watch-log artifact.
-- **M4** — independent artifact-integrity gate on the weekday pre-run.
-- **M5** — flip autonomous merge after the propose-only soak earns trust.
+- **M1** ✅ observe-only watch-log + Telegram receipt.
+- **M3** ✅ "Saturday SF Watch" dashboard page reading the watch-log.
+- **M2a** ✅ (this) `repository_dispatch` path behind `AGENT_DISPATCH_ENABLED`.
+- **M2c** — agent GHA workflow + charter + scoped OIDC role (with
+  `states:StartExecution` for the rerun) in alpha-engine-config; one-time
+  historical `workflow_dispatch` charter test, then flip the flag.
+- **M4** — independent artifact-integrity net on the weekday pre-run (parallel
+  swallow safeguard; non-blocking).
+
+**Posture (Brian-ratified):** ask-forgiveness — the agent merges the fix and
+reruns the SF from the failed step autonomously, then reports. The ONE
+forced-propose class is IAM (`put-role-policy` is human-gated).

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -21,6 +21,12 @@
       ]
     },
     {
+      "Sid": "AgentDispatchPAT",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat"
+    },
+    {
       "Sid": "ReadSaturdaySFExecution",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import urllib.request
 from datetime import date, datetime, timezone
 
 import boto3
@@ -54,10 +55,23 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
 WATCH_PREFIX = os.environ.get("WATCH_PREFIX", "consolidated/saturday_sf_watch")
-# M2 seam — default OFF. M1 never dispatches; this is read + echoed only.
+# M2 gate — default OFF. When true, a Saturday failure also fires a
+# repository_dispatch that triggers the autonomous resilience agent (which
+# diagnoses → fixes → merges → reruns from the failed step). The watch-log is
+# written FIRST (so the agent reads fresh context), THEN the dispatch fires.
 AGENT_DISPATCH_ENABLED = (
     os.environ.get("AGENT_DISPATCH_ENABLED", "false").lower() == "true"
 )
+# repository_dispatch target — the private alpha-engine-config repo hosts the
+# agent GHA workflow (on: repository_dispatch, types: [saturday-sf-failure]).
+DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
+DISPATCH_EVENT_TYPE = os.environ.get("DISPATCH_EVENT_TYPE", "saturday-sf-failure")
+# Dedicated fine-grained PAT (SecureString) scoped to the Saturday-SF-path
+# repos. Read at dispatch time only — never logged.
+GITHUB_PAT_SSM_PARAM = os.environ.get(
+    "GITHUB_PAT_SSM_PARAM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+_DISPATCH_TIMEOUT_SEC = 15
 
 SATURDAY_SF_NAME = "alpha-engine-saturday-pipeline"
 SCHEMA_VERSION = 1
@@ -249,6 +263,61 @@ def _notify(record: dict, key: str) -> bool:
         return False
 
 
+def _get_github_pat() -> str:
+    """Read the dedicated fine-grained PAT (SecureString) from SSM. Never logged."""
+    ssm = boto3.client("ssm", region_name=REGION)
+    resp = ssm.get_parameter(Name=GITHUB_PAT_SSM_PARAM, WithDecryption=True)
+    return resp["Parameter"]["Value"]
+
+
+def _maybe_dispatch_agent(record: dict, run_date: str, key: str) -> dict:
+    """When AGENT_DISPATCH_ENABLED, fire a repository_dispatch that triggers the
+    autonomous resilience-agent GHA workflow in DISPATCH_REPO.
+
+    Best-effort with a recording surface (CLAUDE.md no-silent-fails secondary
+    carve-out): a GitHub/SSM outage logs WARN and is returned in the result, but
+    does NOT raise — the primary observe deliverable (watch-log) already landed.
+    The watch-log is written BEFORE this call so the agent reads fresh context.
+    """
+    if not AGENT_DISPATCH_ENABLED:
+        return {"dispatched": False, "reason": "disabled"}
+    try:
+        pat = _get_github_pat()
+        payload = {
+            "event_type": DISPATCH_EVENT_TYPE,
+            "client_payload": {
+                "execution_arn": record.get("execution_arn", ""),
+                "failed_state": record.get("failed_state"),
+                "cause": record.get("cause"),
+                "run_date": run_date,
+                "status": record.get("status"),
+                "watch_log_key": key,
+                "is_preflight": record.get("is_preflight", False),
+            },
+        }
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{DISPATCH_REPO}/dispatches",
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {pat}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "saturday-sf-watch-dispatcher",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=_DISPATCH_TIMEOUT_SEC) as resp:
+            status_code = resp.status
+        logger.info(
+            "agent repository_dispatch sent to %s (type=%s, http=%s)",
+            DISPATCH_REPO, DISPATCH_EVENT_TYPE, status_code,
+        )
+        return {"dispatched": True, "status_code": status_code}
+    except Exception as exc:  # noqa: BLE001 — secondary path, recorded not raised
+        logger.warning("agent repository_dispatch failed (non-fatal): %s", exc)
+        return {"dispatched": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge handler — fires only on Saturday SF terminal failure
     (FAILED / TIMED_OUT / ABORTED), per the dedicated rule
@@ -271,10 +340,12 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     s3 = _s3_client()
     key = _write_watch_log(s3, run_date, record)  # PRIMARY — fail-loud
     telegram_sent = _notify(record, key)          # secondary — best-effort
+    # M2: fire the agent AFTER the watch-log lands (agent reads fresh context).
+    dispatch = _maybe_dispatch_agent(record, run_date, key)  # secondary
 
     logger.info(
-        "Saturday-SF Watch recorded: run_date=%s failed_state=%s key=%s telegram=%s",
-        run_date, record.get("failed_state"), key, telegram_sent,
+        "Saturday-SF Watch recorded: run_date=%s failed_state=%s key=%s telegram=%s dispatched=%s",
+        run_date, record.get("failed_state"), key, telegram_sent, dispatch.get("dispatched"),
     )
     return {
         "status": status,
@@ -284,5 +355,8 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "watch_log_key": key,
         "telegram_sent": telegram_sent,
         "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
-        "action": "observe",
+        "agent_dispatch": dispatch,
+        # "observe" until the agent enriches the event with its lane/action;
+        # when dispatch fires the agent owns the downstream action record.
+        "action": "dispatched" if dispatch.get("dispatched") else "observe",
     }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -238,3 +238,80 @@ def test_failed_state_none_when_state_exited_cleanly():
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED"), None)
     assert result["failed_state"] is None
+
+
+# ── M2: repository_dispatch to the autonomous agent ─────────────────────────
+
+
+class _FakeResp:
+    status = 204
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_dispatch_disabled_by_default():
+    """AGENT_DISPATCH_ENABLED defaults false → no dispatch, action stays observe."""
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    assert result["agent_dispatch"] == {"dispatched": False, "reason": "disabled"}
+    assert result["action"] == "observe"
+
+
+def test_dispatch_enabled_fires_repository_dispatch(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    sent = {}
+
+    def fake_urlopen(req, timeout=None):
+        sent["url"] = req.full_url
+        sent["data"] = json.loads(req.data)
+        sent["auth"] = req.headers.get("Authorization")
+        return _FakeResp()
+
+    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
+    factory, _, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+
+    assert result["agent_dispatch"] == {"dispatched": True, "status_code": 204}
+    assert result["action"] == "dispatched"
+    assert sent["url"].endswith("/repos/nousergon/alpha-engine-config/dispatches")
+    assert sent["data"]["event_type"] == "saturday-sf-failure"
+    cp = sent["data"]["client_payload"]
+    assert cp["failed_state"] == "RAGIngestion"
+    assert cp["run_date"] == "2023-11-14"
+    assert cp["watch_log_key"] == "consolidated/saturday_sf_watch/2023-11-14.json"
+    # Watch-log is written BEFORE dispatch (agent reads fresh context).
+    s3.put_object.assert_called_once()
+
+
+def test_dispatch_error_recorded_not_raised(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+
+    def boom():
+        raise RuntimeError("ssm denied")
+
+    monkeypatch.setattr(index, "_get_github_pat", boom)
+    factory, _, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    assert result["agent_dispatch"]["dispatched"] is False
+    assert "ssm denied" in result["agent_dispatch"]["error"]
+    s3.put_object.assert_called_once()  # primary deliverable survived
+
+
+def test_pat_never_appears_in_result(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_SECRET_TOKEN")
+    monkeypatch.setattr(
+        index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp()
+    )
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+    assert "ghp_SECRET_TOKEN" not in json.dumps(result)


### PR DESCRIPTION
## Saturday-SF Watch — M2a (repository_dispatch to the autonomous agent)

Implements the M1 dispatch seam. Spec/posture: **nousergon/alpha-engine-config#1227** (ask-forgiveness — the agent merges the fix AND reruns the SF from the failed step autonomously, then reports).

### What this adds
When `AGENT_DISPATCH_ENABLED=true`, **after** the watch-log lands the dispatcher fires a GitHub `repository_dispatch` (`event_type=saturday-sf-failure`) to `nousergon/alpha-engine-config` with the failure context (`execution_arn`, `failed_state`, `cause`, `run_date`, `watch_log_key`, `is_preflight`) → triggers the autonomous resilience-agent GHA workflow (M2c).

- **PAT** read from SSM `/alpha-engine/saturday_sf_watch/github_pat` (SecureString) at dispatch time; **never logged**. IAM gains a scoped `AgentDispatchPAT` grant (that one param only).
- **Ordering:** dispatch fires *after* the watch-log write so the agent reads fresh context.
- **Fail-loud discipline:** dispatch is best-effort with a recording surface — a GitHub/SSM outage logs WARN + returns `agent_dispatch.error`, never raises (primary observe deliverable already landed).
- **Inert until activation:** flag default stays `false`. M2a changes nothing live until the operator steps run (mint PAT → SSM param → re-apply role policy → land M2c → flip flag — documented in the README).

### CI / risk
- `test_handler.py` — **17 passed** (13 M1 + 4 M2: dispatch off by default; fires with correct target/payload when on; PAT never in the result; dispatch error recorded-not-raised).
- Artifact-registry coverage guard green (lambdas scope-exempt).
- Flag-gated + operator-activated → **zero live effect on merge.**

Will confirm GH Actions CI green after push.

### Next: M2c
Agent GHA workflow + charter + scoped OIDC role (with `states:StartExecution` for the rerun) in alpha-engine-config, then a one-time historical `workflow_dispatch` charter test before flipping the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
