### PR TITLE
feat(saturday-sf-watch): M4 — independent Sat→Monday integrity sentinel

### DIFF
--- a/infrastructure/lambdas/saturday-integrity-sentinel/README.md
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/README.md
@@ -1,0 +1,57 @@
+# saturday-integrity-sentinel
+
+**Saturday-SF Watch — M4.** The independent Sat→Monday swallow safeguard for the
+autonomous resilience agent. Spec: [nousergon/alpha-engine-config#1227](https://github.com/nousergon/alpha-engine-config/issues/1227).
+
+## What it does
+
+Monday ~12:30 UTC (15 min before the weekday SF), it reads the freshness-monitor's
+pre-computed `saturday_sf` cycle-completion verdict
+(`s3://alpha-engine-research/_freshness_monitor/cycle_verdict.json`) and pages a
+**GO / NO-GO**: are last Saturday's critical artifacts (signals, predictor
+weights manifest, constituents, training summary, …) actually present + fresh,
+so it's safe to trade on them today?
+
+- **GO** → silent heartbeat Telegram.
+- **NO-GO** (cycle incomplete, OR uncertain: verdict missing / monitor stale /
+  no `saturday_sf` row) → **LOUD** Telegram naming the missing/stale artifacts +
+  a marker at `consolidated/saturday_integrity/{date}.json` (dashboard surface).
+
+## Why it's the real safeguard
+
+The agent (M2c) reports what it fixed; this sentinel does **not** trust that
+report. It reads the freshness-monitor's verdict, which is derived by HEAD-ing
+the artifacts in S3 directly — **independent of the agent**. A swallow (a "fix"
+that left an artifact silently stale/missing while the SF went green) can fool
+the agent's self-report but cannot fool an S3 probe. It also fires even when
+freshness-monitor *alerting* is in OBSERVE mode (the verdict is computed
+regardless of the alert gate), so the Monday GO/NO-GO is never silenced.
+
+**Non-blocking by design** (Brian-ratified): it does not touch the weekday SF —
+it pages + marks, within the Sat→Mon buffer, so a miss is caught before/at Monday
+open without halting trading.
+
+**Fail-loud on uncertainty:** for a safety check, ambiguity = NO-GO. A missing or
+stale `cycle_verdict.json` pages loud rather than assuming GO. The marker write
+RAISES on failure (primary); Telegram is best-effort.
+
+## Deploy (operator; zero live effect until --bootstrap)
+
+```
+bash infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh --dry-run
+bash infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh --bootstrap  # role + Lambda + Monday cron
+bash infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh              # code-only update
+bash infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh --smoke      # invoke now (reads live verdict)
+```
+
+## Test
+
+```
+python3 -m pytest infrastructure/lambdas/saturday-integrity-sentinel/test_handler.py -q
+```
+
+## Follow-up
+
+A dashboard banner on the **Saturday SF Watch** page (views/37) reading the
+latest `consolidated/saturday_integrity/{date}.json` marker — quick additive
+surface; the loud Telegram NO-GO is the primary safeguard.

--- a/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-saturday-integrity-sentinel
+# Lambda and wire its Monday-pre-open EventBridge cron.
+#
+# Saturday-SF Watch arc, M4 — the independent Sat→Monday swallow safeguard.
+# Reads the freshness-monitor's saturday_sf cycle verdict and pages a GO/NO-GO
+# Monday ~12:30 UTC (15 min before the weekday SF at 12:45 UTC). Non-blocking.
+# Spec: nousergon/alpha-engine-config#1227.
+#
+# Managed outside CloudFormation (operator-deployed; keeps the GHA OIDC role
+# narrow). Merging the PR has ZERO live effect until --bootstrap.
+#
+# Usage:
+#   bash …/deploy.sh             # update code only
+#   bash …/deploy.sh --bootstrap # first-time create + wire EventBridge cron
+#   bash …/deploy.sh --dry-run   # show actions, do not apply
+#   bash …/deploy.sh --smoke     # invoke once (reads the live verdict, sends Telegram)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-saturday-integrity-sentinel"
+ROLE_NAME="alpha-engine-saturday-integrity-sentinel-role"
+POLICY_NAME="alpha-engine-saturday-integrity-sentinel-policy"
+RULE_NAME="alpha-engine-saturday-integrity-monday"
+SCHEDULE="cron(30 12 ? * MON *)"   # Monday 12:30 UTC, 15 min before weekday SF
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+
+# ----- 0. Validate handler + run unit tests ---------------------------------
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package -----------------------------------------------------------
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap ---------------------------------------------------------
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" --runtime python3.12 --role "${ROLE_ARN}" \
+      --handler index.handler --zip-file "fileb://${ZIP}" --timeout 60 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  echo "  Creating EventBridge cron rule: ${RULE_NAME} (${SCHEDULE})"
+  run aws events put-rule --name "${RULE_NAME}" --schedule-expression "${SCHEDULE}" \
+    --description "Monday pre-open Saturday-integrity GO/NO-GO sentinel" --region "${REGION}" --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission --function-name "${FUNCTION_NAME}" --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code ----------------------------------------------
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"; fi
+echo "✓ Code deployed."
+
+# ----- 4. Smoke -------------------------------------------------------------
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (reads the live verdict, sends Telegram)..."
+  RESP=$(mktemp)
+  aws lambda invoke --function-name "${FUNCTION_NAME}" --cli-binary-format raw-in-base64-out --payload '{}' --region "${REGION}" "${RESP}" >/dev/null
+  cat "${RESP}"; echo ""; rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/saturday-integrity-sentinel/iam-policy.json
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/iam-policy.json
@@ -1,0 +1,36 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-saturday-integrity-sentinel:*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    },
+    {
+      "Sid": "ReadFreshnessVerdict",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/cycle_verdict.json"
+    },
+    {
+      "Sid": "WriteIntegrityMarker",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/saturday_integrity/*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/saturday-integrity-sentinel/index.py
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/index.py
@@ -1,0 +1,195 @@
+"""alpha-engine-saturday-integrity-sentinel — Saturday-SF Watch, M4.
+
+The **independent** Sat→Monday swallow safeguard for the autonomous resilience
+agent (config#1227). The agent (M2c) reports what it fixed; this sentinel does
+NOT trust that report. It reads the freshness-monitor's pre-computed
+``saturday_sf`` cycle-completion verdict — which is derived by probing S3
+directly, independent of the agent — and answers ONE question Monday pre-open:
+
+    Are last Saturday's critical artifacts (signals, predictor weights manifest,
+    constituents, training summary, …) actually present + fresh, so it is safe to
+    trade on them today?
+
+If NO (a swallow that left an artifact silently stale/missing makes the run look
+green but the verdict incomplete), it pages LOUD. It is **non-blocking** — it
+does not touch the weekday SF; it pages Brian + writes a dashboard marker so the
+miss is caught before/at Monday open, within the Sat→Mon buffer.
+
+**Why independent matters.** A swallow can fool the agent's own report but cannot
+fool the freshness-monitor (which HEADs the artifacts in S3). Reading its verdict
+is what makes this a real safeguard rather than a second self-report. It also
+fires even when freshness-monitor *alerting* is in OBSERVE mode (the verdict is
+computed regardless of the alert gate), so the Monday GO/NO-GO is never silenced.
+
+**Fail-loud on uncertainty.** For a safety check, ambiguity = NO-GO: a missing or
+stale ``cycle_verdict.json`` (monitor down) pages loud rather than assuming GO.
+The marker write is the primary deliverable (RAISES on failure); Telegram is
+best-effort.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import boto3
+
+from alpha_engine_lib.telegram import send_message
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
+CYCLE_VERDICT_KEY = os.environ.get(
+    "CYCLE_VERDICT_KEY", "_freshness_monitor/cycle_verdict.json"
+)
+MARKER_PREFIX = os.environ.get(
+    "MARKER_PREFIX", "consolidated/saturday_integrity"
+)
+TARGET_CADENCE = "saturday_sf"
+# If the freshness verdict itself is older than this, the monitor may be down →
+# treat as uncertain (NO-GO), don't trust a stale GO.
+VERDICT_STALE_HOURS = float(os.environ.get("VERDICT_STALE_HOURS", "3"))
+
+
+def _s3():
+    return boto3.client("s3", region_name=REGION)
+
+
+def _read_cycle_verdict(s3) -> dict | None:
+    try:
+        obj = s3.get_object(Bucket=BUCKET, Key=CYCLE_VERDICT_KEY)
+        return json.loads(obj["Body"].read())
+    except Exception as exc:  # noqa: BLE001 — absence IS a finding (NO-GO), handled by caller
+        code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+        if code not in {"NoSuchKey", "404", "403"}:
+            logger.warning("could not read %s: %s", CYCLE_VERDICT_KEY, exc)
+        return None
+
+
+def _verdict_age_hours(doc: dict, now: datetime) -> float | None:
+    run_at = doc.get("run_at")
+    if not run_at:
+        return None
+    try:
+        ts = datetime.fromisoformat(run_at)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return (now - ts).total_seconds() / 3600.0
+    except (ValueError, TypeError):
+        return None
+
+
+def _evaluate(doc: dict | None, now: datetime) -> dict:
+    """Return a GO/NO-GO verdict dict. NO-GO on incomplete OR on any uncertainty
+    (missing verdict / stale monitor / absent saturday_sf row)."""
+    if doc is None:
+        return {
+            "go": False, "uncertain": True,
+            "reason": "freshness cycle_verdict.json unavailable — cannot confirm Saturday integrity",
+            "missing": [], "stale": [],
+        }
+    age = _verdict_age_hours(doc, now)
+    if age is not None and age > VERDICT_STALE_HOURS:
+        return {
+            "go": False, "uncertain": True,
+            "reason": f"freshness verdict is stale ({age:.1f}h old > {VERDICT_STALE_HOURS}h) — monitor may be down",
+            "missing": [], "stale": [],
+        }
+    sat = next(
+        (v for v in doc.get("verdicts", []) if v.get("cadence") == TARGET_CADENCE),
+        None,
+    )
+    if sat is None:
+        return {
+            "go": False, "uncertain": True,
+            "reason": f"no {TARGET_CADENCE} verdict in cycle_verdict.json",
+            "missing": [], "stale": [],
+        }
+    if sat.get("complete"):
+        return {
+            "go": True, "uncertain": False,
+            "reason": f"all {sat.get('n_required')} critical {TARGET_CADENCE} artifacts present",
+            "cycle_label": sat.get("cycle_label"),
+            "missing": [], "stale": [],
+        }
+    return {
+        "go": False, "uncertain": False,
+        "reason": (
+            f"{TARGET_CADENCE} cycle INCOMPLETE "
+            f"({sat.get('n_satisfied')}/{sat.get('n_required')} critical artifacts)"
+        ),
+        "cycle_label": sat.get("cycle_label"),
+        "missing": sat.get("missing", []),
+        "stale": sat.get("stale", []),
+    }
+
+
+def _write_marker(s3, run_date: str, verdict: dict) -> str:
+    """Write the GO/NO-GO marker (dashboard surface). PRIMARY — RAISES on failure."""
+    key = f"{MARKER_PREFIX}/{run_date}.json"
+    body = json.dumps(
+        {"run_date": run_date, "checked_at": verdict["checked_at"], **verdict},
+        indent=2, default=str,
+    ).encode("utf-8")
+    s3.put_object(Bucket=BUCKET, Key=key, Body=body, ContentType="application/json")
+    return key
+
+
+def _notify(verdict: dict, key: str) -> bool:
+    """LOUD on NO-GO; silent heartbeat on GO. Best-effort — never raises."""
+    go = verdict["go"]
+    if go:
+        text = (
+            "🟢 *Saturday Integrity — GO*\n"
+            f"{verdict['reason']}\n"
+            "_safe to trade on Saturday's outputs_"
+        )
+        silent = True
+    else:
+        flag = "⚠️ UNCERTAIN" if verdict.get("uncertain") else "🔴 NO-GO"
+        lines = [f"{flag} *Saturday Integrity — NO-GO*", verdict["reason"]]
+        if verdict.get("missing"):
+            lines.append(f"Missing: {', '.join(verdict['missing'])}")
+        if verdict.get("stale"):
+            lines.append(f"Stale: {', '.join(verdict['stale'])}")
+        lines.append(f"Marker: s3://{BUCKET}/{key}")
+        lines.append("_independent of the watch agent — a swallow can't hide here_")
+        text = "\n".join(lines)
+        silent = False
+    try:
+        return bool(send_message(text, disable_notification=silent))
+    except Exception as exc:  # noqa: BLE001 — secondary observability
+        logger.warning("integrity Telegram failed (non-fatal): %s", exc)
+        return False
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """EventBridge handler — runs Monday pre-open. Reads the freshness-monitor's
+    saturday_sf completion verdict and pages a GO/NO-GO. Non-blocking."""
+    now = datetime.now(timezone.utc)
+    run_date = now.date().isoformat()
+    s3 = _s3()
+
+    doc = _read_cycle_verdict(s3)
+    verdict = _evaluate(doc, now)
+    verdict["checked_at"] = now.isoformat()
+
+    key = _write_marker(s3, run_date, verdict)  # PRIMARY — fail-loud
+    telegram_sent = _notify(verdict, key)       # secondary — best-effort
+
+    logger.info(
+        "Saturday integrity %s: %s (marker=%s telegram=%s)",
+        "GO" if verdict["go"] else "NO-GO", verdict["reason"], key, telegram_sent,
+    )
+    return {
+        "run_date": run_date,
+        "go": verdict["go"],
+        "uncertain": verdict["uncertain"],
+        "reason": verdict["reason"],
+        "marker_key": key,
+        "telegram_sent": telegram_sent,
+    }

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,0 +1,4 @@
+# Pinned to match alpha-engine-data/requirements.txt (coherent lib substrate
+# across alpha-engine-data Lambdas; above the LibPinDriftCheck v0.39.0 floor).
+# Only the stable telegram.send_message primitive is used.
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4

--- a/infrastructure/lambdas/saturday-integrity-sentinel/test_handler.py
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/test_handler.py
@@ -1,0 +1,135 @@
+"""Unit tests for saturday-integrity-sentinel (M4).
+
+Stubs alpha_engine_lib.telegram.send_message and mocks the S3 client. Asserts
+the GO/NO-GO evaluation (complete / incomplete / uncertain), loud-vs-silent
+Telegram, fail-loud marker write, and best-effort Telegram.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_lib_pkg = types.ModuleType("alpha_engine_lib")
+_telegram_mod = types.ModuleType("alpha_engine_lib.telegram")
+_telegram_mod.send_message = MagicMock(return_value=True)
+_lib_pkg.telegram = _telegram_mod
+sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
+sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+
+class FakeClientError(Exception):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+def _s3(verdict_doc=None, missing=False, put=None):
+    s3 = MagicMock()
+    if missing:
+        s3.get_object.side_effect = FakeClientError("404")
+    else:
+        body = MagicMock()
+        body.read.return_value = json.dumps(verdict_doc).encode()
+        s3.get_object.return_value = {"Body": body}
+    if put is not None:
+        s3.put_object.side_effect = put
+    return s3
+
+
+@pytest.fixture(autouse=True)
+def reset_telegram():
+    _telegram_mod.send_message.reset_mock()
+    _telegram_mod.send_message.return_value = True
+    yield
+
+
+def _run(s3):
+    with patch("index.boto3.client", return_value=s3):
+        return index.handler({}, None)
+
+
+def test_go_when_saturday_cycle_complete():
+    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": True,
+                         "n_required": 10, "n_satisfied": 10}]}
+    s3 = _s3(doc)
+    result = _run(s3)
+    assert result["go"] is True
+    assert result["uncertain"] is False
+    s3.put_object.assert_called_once()
+    # GO pings silent (heartbeat), not a loud alert.
+    assert _telegram_mod.send_message.call_args.kwargs["disable_notification"] is True
+    text = _telegram_mod.send_message.call_args.args[0]
+    assert "Saturday Integrity — GO" in text
+
+
+def test_nogo_when_incomplete_pages_loud():
+    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": False,
+                         "n_required": 10, "n_satisfied": 8,
+                         "missing": ["research_signals"], "stale": []}]}
+    s3 = _s3(doc)
+    result = _run(s3)
+    assert result["go"] is False
+    assert result["uncertain"] is False
+    kwargs = _telegram_mod.send_message.call_args.kwargs
+    assert kwargs["disable_notification"] is False  # LOUD
+    text = _telegram_mod.send_message.call_args.args[0]
+    assert "NO-GO" in text
+    assert "research_signals" in text
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    assert written["go"] is False
+    assert written["missing"] == ["research_signals"]
+
+
+def test_uncertain_when_verdict_missing():
+    s3 = _s3(missing=True)
+    result = _run(s3)
+    assert result["go"] is False
+    assert result["uncertain"] is True
+    assert "unavailable" in result["reason"]
+    assert _telegram_mod.send_message.call_args.kwargs["disable_notification"] is False
+
+
+def test_uncertain_when_verdict_stale():
+    doc = {"run_at": "2020-01-01T00:00:00+00:00",
+           "verdicts": [{"cadence": "saturday_sf", "complete": True,
+                         "n_required": 10, "n_satisfied": 10}]}
+    s3 = _s3(doc)
+    result = _run(s3)
+    assert result["go"] is False
+    assert result["uncertain"] is True
+    assert "stale" in result["reason"]
+
+
+def test_uncertain_when_no_saturday_row():
+    doc = {"verdicts": [{"cadence": "weekday_sf", "complete": True}]}
+    s3 = _s3(doc)
+    result = _run(s3)
+    assert result["go"] is False
+    assert result["uncertain"] is True
+
+
+def test_marker_write_failure_raises_fail_loud():
+    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": True,
+                         "n_required": 10, "n_satisfied": 10}]}
+    s3 = _s3(doc, put=RuntimeError("S3 down"))
+    with pytest.raises(RuntimeError, match="S3 down"):
+        _run(s3)
+
+
+def test_telegram_failure_is_non_fatal():
+    _telegram_mod.send_message.side_effect = RuntimeError("bot down")
+    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": False,
+                         "n_required": 10, "n_satisfied": 9, "missing": ["x"]}]}
+    s3 = _s3(doc)
+    result = _run(s3)
+    assert result["telegram_sent"] is False
+    s3.put_object.assert_called_once()  # primary deliverable survived


### PR DESCRIPTION
## Saturday-SF Watch — M4 (independent Sat→Monday integrity sentinel)

The swallow safeguard. Spec/posture: **config#1227** (non-blocking, Brian-ratified).

### What it does
Monday ~12:30 UTC (15 min before the weekday SF) reads the freshness-monitor's pre-computed `saturday_sf` cycle-completion verdict (`_freshness_monitor/cycle_verdict.json`) and pages a **GO / NO-GO**: are last Saturday's **10 critical artifacts** (signals, predictor weights manifest, constituents, training summary, …) present + fresh, so it's safe to trade on them today?
- **GO** → silent heartbeat. **NO-GO** (incomplete, or uncertain: verdict missing / monitor stale / no saturday_sf row) → **LOUD** Telegram naming the missing/stale artifacts + a `consolidated/saturday_integrity/{date}.json` marker.

### Why it's the *real* safeguard
The agent (M2c) reports what it fixed; this sentinel does **not** trust that report — it reads a verdict derived by HEAD-ing the artifacts in S3 directly, **independent of the agent**. A swallow that leaves an artifact silently stale/missing while the SF went green can fool the self-report but **cannot fool an S3 probe**. It also fires even when freshness-monitor *alerting* is in OBSERVE mode (the verdict is computed regardless), so the Monday GO/NO-GO is never silenced.

### Design properties
- **Non-blocking** (Brian-ratified): pages + marks; does NOT touch the weekday SF. Catches a miss within the Sat→Mon buffer.
- **Fail-loud on uncertainty:** ambiguity = NO-GO, never a silent assumed-GO. Marker write raises (primary); Telegram best-effort.
- **Builds on existing infra:** reuses the freshness-monitor's `saturday_sf` verdict (which already covers all 10 critical artifacts) rather than duplicating freshness logic.

### CI / risk
- `test_handler.py` — **7 passed** (GO / incomplete-NO-GO / 3 uncertain paths / fail-loud marker / non-fatal Telegram). Registry-coverage guard green (lambdas exempt).
- Operator-deployed → **zero live effect on merge** (activates on `deploy.sh --bootstrap`).

Follow-up: a GO/NO-GO banner on the Saturday SF Watch dashboard page (views/37) reading the marker — additive; the loud Telegram NO-GO is the primary safeguard.

Will confirm GH Actions CI green after push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
