### PR TITLE
refactor(freshness-monitor): rename flag MNEMON_ -> CRUCIBLE_FRESHNESS_MONITOR_ENABLED

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -15,7 +15,7 @@
 # spot-orphan-reaper / changelog-cloudwatch-mirror (keeps the
 # github-actions-lambda-deploy OIDC role's blast radius narrow;
 # operator-deployed only). Phase 6 cutover flips
-# MNEMON_FRESHNESS_MONITOR_ENABLED via
+# CRUCIBLE_FRESHNESS_MONITOR_ENABLED via
 # `aws lambda update-function-configuration` without redeploying.
 #
 # Usage:
@@ -158,7 +158,7 @@ if $BOOTSTRAP; then
   ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
   if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
     echo "  Creating Lambda: ${FUNCTION_NAME}"
-    # ENFORCE mode: MNEMON_FRESHNESS_MONITOR_ENABLED=true.
+    # ENFORCE mode: CRUCIBLE_FRESHNESS_MONITOR_ENABLED=true.
     # Phase 6 cutover EXECUTED 2026-06-25 after a ~1mo observe soak (the
     # monitor correctly detected the missed 6/20 Saturday cycle the whole
     # time but stayed muted). Code is now the source of truth for the flag —
@@ -172,7 +172,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 120 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,MNEMON_FRESHNESS_MONITOR_ENABLED=true}' \
+      --environment 'Variables={LOG_LEVEL=INFO,CRUCIBLE_FRESHNESS_MONITOR_ENABLED=true}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -28,7 +28,7 @@ invocation:
      ``dedup_key=resolve_dedup_key(spec, now)`` — dedup collapses
      4×/hour retries to one alert per cycle per artifact.
   6. **OBSERVE-mode gate**: when env
-     ``MNEMON_FRESHNESS_MONITOR_ENABLED`` is anything other than
+     ``CRUCIBLE_FRESHNESS_MONITOR_ENABLED`` is anything other than
      ``"true"`` (case-insensitive), alerts are suppressed but the
      check results and heartbeat are still emitted. Phase 6 cutover
      flips the env var via ``aws lambda update-function-configuration``
@@ -100,7 +100,7 @@ _DEFAULT_LOOKBACK = {
 # other than literal "true" (case-insensitive) suppresses alerts. Check
 # results + heartbeat are emitted regardless.
 ALERTS_ENABLED = (
-    os.environ.get("MNEMON_FRESHNESS_MONITOR_ENABLED", "false").lower() == "true"
+    os.environ.get("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "false").lower() == "true"
 )
 
 # ArtifactSpec field set — used to strip extra YAML keys (e.g., the

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -181,9 +181,9 @@ def _patch_now(monkeypatch, fixed):
 def test_handler_observe_mode_does_not_alert(
     monkeypatch, yaml_registry_body, fake_s3, fixed_now
 ):
-    """OBSERVE mode (MNEMON_FRESHNESS_MONITOR_ENABLED unset) writes
+    """OBSERVE mode (CRUCIBLE_FRESHNESS_MONITOR_ENABLED unset) writes
     heartbeat + check_results but suppresses alerts.publish."""
-    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
     fake_s3._registry_body = yaml_registry_body
 
     # Mark probe_fresh as actually fresh (HEAD returns within cycle).
@@ -228,9 +228,9 @@ def test_handler_observe_mode_does_not_alert(
 def test_handler_alerts_enabled_fires_with_dedup_key(
     monkeypatch, yaml_registry_body, fake_s3, fixed_now
 ):
-    """Production mode (MNEMON_FRESHNESS_MONITOR_ENABLED=true) routes
+    """Production mode (CRUCIBLE_FRESHNESS_MONITOR_ENABLED=true) routes
     misses past SLA to alerts.publish with the resolved dedup key."""
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     fake_s3._registry_body = yaml_registry_body
 
     cycle_tick = datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)
@@ -267,7 +267,7 @@ def test_handler_probe_failed_routes_to_critical(
     """probe_failed (e.g., 403) routes to critical regardless of the
     spec's severity — the monitor itself is broken; operator must know.
     Plan §3 invariant 6."""
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     fake_s3._registry_body = yaml_registry_body
 
     class _ClientError403(Exception):
@@ -312,7 +312,7 @@ def test_handler_per_spec_exception_does_not_sink_pass(
     placeholder) should result in probe_failed for that spec, not a
     handler-level raise. The other specs in the registry still get
     probed."""
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     # `{ticker}` is NOT a supported placeholder in the substrate's
     # _format_key — str.format will raise KeyError.
     fake_s3._registry_body = b"""\
@@ -360,7 +360,7 @@ def test_handler_observe_to_production_cutover_via_env_flip(
     fake_s3._registry_body = yaml_registry_body
 
     # Pass 1: OBSERVE mode.
-    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
     import importlib
     import index
     importlib.reload(index)
@@ -373,7 +373,7 @@ def test_handler_observe_to_production_cutover_via_env_flip(
     assert publish_mock.call_count == 0
 
     # Pass 2: env flipped to true, reload, re-invoke.
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     fake_s3._put_calls.clear()
     importlib.reload(index)
     _patch_now(monkeypatch, fixed_now)
@@ -389,7 +389,7 @@ def test_handler_observe_to_production_cutover_via_env_flip(
 
 
 def test_maybe_alert_skips_fresh_state(monkeypatch, fixed_now):
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -409,7 +409,7 @@ def test_maybe_alert_skips_fresh_state(monkeypatch, fixed_now):
 
 
 def test_maybe_alert_skips_missing_within_sla_grace(monkeypatch, fixed_now):
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -430,7 +430,7 @@ def test_maybe_alert_skips_missing_within_sla_grace(monkeypatch, fixed_now):
 
 
 def test_maybe_alert_fires_missing_past_sla(monkeypatch, fixed_now):
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -458,7 +458,7 @@ def test_maybe_alert_fires_missing_past_sla(monkeypatch, fixed_now):
 
 def test_maybe_alert_probe_failed_uses_critical_severity(monkeypatch, fixed_now):
     """probe_failed always escalates to critical regardless of spec."""
-    monkeypatch.setenv("MNEMON_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -669,7 +669,7 @@ def _run_handler(monkeypatch, fake_s3, fixed_now, *, registry_body):
     """Invoke the handler in OBSERVE mode with boto3 routed to fake_s3
     (which also serves boto3.client('cloudwatch') — put_metric_data lands
     on the same recording mock)."""
-    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
     fake_s3._registry_body = registry_body
     import importlib
     import index
@@ -770,7 +770,7 @@ def test_handler_cycle_rollup_failure_is_non_fatal(
     primary check_results + heartbeat are still written and the handler
     returns with cycle_verdicts={}."""
     fake_s3._registry_body = yaml_registry_body
-    monkeypatch.delenv("MNEMON_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
     import importlib
     import index
     importlib.reload(index)


### PR DESCRIPTION
## Why
The enable flag was `MNEMON_FRESHNESS_MONITOR_ENABLED` — a stray prefix from when the monitor was authored (2026-05-27, **before** the Crucible brand). It is a one-off (no other `MNEMON_` vars in the repo) and has nothing to do with **mnemon**, the separate MIT memory product. This monitor guards the **Crucible** fleet's S3 artifacts, so the flag belongs under `CRUCIBLE_`.

Follow-up to the now-merged #474 (IAM ListBucket + enforce cutover). Renamed across `index.py` (gate + docstring), `deploy.sh` (bootstrap env + comments), `test_handler.py` — 19 refs. **31 tests pass.**

## ⚠️ Deploy coordination (no enforce gap)
The LIVE function currently reads the OLD name `MNEMON_FRESHNESS_MONITOR_ENABLED=true` (enforce active). `deploy.sh` sets env only on CREATE, not UPDATE — so once this code deploys (reading `CRUCIBLE_`), the function falls back to observe until the new var is set. The deploy step MUST, in the same window:
```
aws lambda update-function-configuration --function-name alpha-engine-freshness-monitor \
  --environment Variables="{LOG_LEVEL=INFO,CRUCIBLE_FRESHNESS_MONITOR_ENABLED=true}"
```
(adds `CRUCIBLE_=true`, drops stale `MNEMON_`). Until then live stays on old var + old code = enforce uninterrupted.

## Follow-ups
- `OBSERVATION_REGISTRY.yaml` (config repo) still names the old flag — update on the docs PR.
- `SYSTEM_STATE_changelog.md` is historical, left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)