### PR TITLE
fix(saturday-sf-watch): M4 reads check_results.json (cycle_verdict.json not produced)

### DIFF
--- a/infrastructure/lambdas/saturday-integrity-sentinel/README.md
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/README.md
@@ -6,16 +6,22 @@ autonomous resilience agent. Spec: [nousergon/alpha-engine-config#1227](https://
 ## What it does
 
 Monday ~12:30 UTC (15 min before the weekday SF), it reads the freshness-monitor's
-pre-computed `saturday_sf` cycle-completion verdict
-(`s3://alpha-engine-research/_freshness_monitor/cycle_verdict.json`) and pages a
+per-spec `check_results.json`
+(`s3://alpha-engine-research/_freshness_monitor/check_results.json`), computes the
+`saturday_sf`-critical completeness itself, and pages a
 **GO / NO-GO**: are last Saturday's critical artifacts (signals, predictor
 weights manifest, constituents, training summary, …) actually present + fresh,
 so it's safe to trade on them today?
 
 - **GO** → silent heartbeat Telegram.
-- **NO-GO** (cycle incomplete, OR uncertain: verdict missing / monitor stale /
-  no `saturday_sf` row) → **LOUD** Telegram naming the missing/stale artifacts +
-  a marker at `consolidated/saturday_integrity/{date}.json` (dashboard surface).
+- **NO-GO** (a critical artifact missing/stale, OR uncertain: check_results
+  missing / monitor stale / no `saturday_sf`-critical rows) → **LOUD** Telegram
+  naming the missing/stale artifacts + a marker at
+  `consolidated/saturday_integrity/{date}.json` (dashboard surface).
+
+It computes completeness from the per-spec rows (the reliably-produced source)
+rather than the derived `cycle_verdict.json`, which the deployed freshness-monitor
+does not emit — depending on a maybe-absent artifact would false-alarm every Monday.
 
 ## Why it's the real safeguard
 

--- a/infrastructure/lambdas/saturday-integrity-sentinel/iam-policy.json
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/iam-policy.json
@@ -21,10 +21,10 @@
       ]
     },
     {
-      "Sid": "ReadFreshnessVerdict",
+      "Sid": "ReadFreshnessCheckResults",
       "Effect": "Allow",
       "Action": ["s3:GetObject"],
-      "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/cycle_verdict.json"
+      "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/check_results.json"
     },
     {
       "Sid": "WriteIntegrityMarker",

--- a/infrastructure/lambdas/saturday-integrity-sentinel/index.py
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/index.py
@@ -2,9 +2,10 @@
 
 The **independent** Sat→Monday swallow safeguard for the autonomous resilience
 agent (config#1227). The agent (M2c) reports what it fixed; this sentinel does
-NOT trust that report. It reads the freshness-monitor's pre-computed
-``saturday_sf`` cycle-completion verdict — which is derived by probing S3
-directly, independent of the agent — and answers ONE question Monday pre-open:
+NOT trust that report. It reads the freshness-monitor's per-spec
+``check_results.json`` — derived by probing S3 directly, independent of the
+agent — computes the ``saturday_sf``-critical completeness itself, and answers
+ONE question Monday pre-open:
 
     Are last Saturday's critical artifacts (signals, predictor weights manifest,
     constituents, training summary, …) actually present + fresh, so it is safe to
@@ -16,15 +17,15 @@ does not touch the weekday SF; it pages Brian + writes a dashboard marker so the
 miss is caught before/at Monday open, within the Sat→Mon buffer.
 
 **Why independent matters.** A swallow can fool the agent's own report but cannot
-fool the freshness-monitor (which HEADs the artifacts in S3). Reading its verdict
+fool the freshness-monitor (which HEADs the artifacts in S3). Reading its results
 is what makes this a real safeguard rather than a second self-report. It also
-fires even when freshness-monitor *alerting* is in OBSERVE mode (the verdict is
-computed regardless of the alert gate), so the Monday GO/NO-GO is never silenced.
+fires even when freshness-monitor *alerting* is in OBSERVE mode (check_results is
+written regardless of the alert gate), so the Monday GO/NO-GO is never silenced.
 
-**Fail-loud on uncertainty.** For a safety check, ambiguity = NO-GO: a missing or
-stale ``cycle_verdict.json`` (monitor down) pages loud rather than assuming GO.
-The marker write is the primary deliverable (RAISES on failure); Telegram is
-best-effort.
+**Fail-loud on uncertainty.** For a safety check, ambiguity = NO-GO: missing or
+stale ``check_results.json`` (monitor down), or no saturday_sf-critical rows,
+pages loud rather than assuming GO. The marker write is the primary deliverable
+(RAISES on failure); Telegram is best-effort.
 """
 
 from __future__ import annotations
@@ -43,15 +44,25 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
-CYCLE_VERDICT_KEY = os.environ.get(
-    "CYCLE_VERDICT_KEY", "_freshness_monitor/cycle_verdict.json"
+# The per-spec freshness results (reliably produced every 15 min). We compute the
+# saturday_sf-critical completeness HERE rather than depending on the derived
+# `cycle_verdict.json`, which the deployed freshness-monitor does not emit
+# (2026-06-25: only check_results/heartbeat/history exist in S3). Depending on a
+# maybe-absent derived artifact would make this safety net false-alarm every
+# Monday and train the operator to ignore it.
+CHECK_RESULTS_KEY = os.environ.get(
+    "CHECK_RESULTS_KEY", "_freshness_monitor/check_results.json"
 )
 MARKER_PREFIX = os.environ.get(
     "MARKER_PREFIX", "consolidated/saturday_integrity"
 )
 TARGET_CADENCE = "saturday_sf"
-# If the freshness verdict itself is older than this, the monitor may be down →
-# treat as uncertain (NO-GO), don't trust a stale GO.
+TARGET_SEVERITY = "critical"
+# Per-spec states that count as "present + safe to trade on" (mirrors the
+# freshness substrate's cycle_completion, which filters to severity=critical).
+_OK_STATES = frozenset({"fresh", "grace_period"})
+# If check_results itself is older than this, the monitor may be down → treat as
+# uncertain (NO-GO); don't trust a stale GO.
 VERDICT_STALE_HOURS = float(os.environ.get("VERDICT_STALE_HOURS", "3"))
 
 
@@ -59,14 +70,14 @@ def _s3():
     return boto3.client("s3", region_name=REGION)
 
 
-def _read_cycle_verdict(s3) -> dict | None:
+def _read_check_results(s3) -> dict | None:
     try:
-        obj = s3.get_object(Bucket=BUCKET, Key=CYCLE_VERDICT_KEY)
+        obj = s3.get_object(Bucket=BUCKET, Key=CHECK_RESULTS_KEY)
         return json.loads(obj["Body"].read())
     except Exception as exc:  # noqa: BLE001 — absence IS a finding (NO-GO), handled by caller
         code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
         if code not in {"NoSuchKey", "404", "403"}:
-            logger.warning("could not read %s: %s", CYCLE_VERDICT_KEY, exc)
+            logger.warning("could not read %s: %s", CHECK_RESULTS_KEY, exc)
         return None
 
 
@@ -84,47 +95,49 @@ def _verdict_age_hours(doc: dict, now: datetime) -> float | None:
 
 
 def _evaluate(doc: dict | None, now: datetime) -> dict:
-    """Return a GO/NO-GO verdict dict. NO-GO on incomplete OR on any uncertainty
-    (missing verdict / stale monitor / absent saturday_sf row)."""
+    """Return a GO/NO-GO verdict by computing saturday_sf-critical completeness
+    from the freshness check_results rows. NO-GO on any incomplete artifact OR on
+    uncertainty (results missing / monitor stale / no saturday_sf-critical rows)."""
     if doc is None:
         return {
             "go": False, "uncertain": True,
-            "reason": "freshness cycle_verdict.json unavailable — cannot confirm Saturday integrity",
+            "reason": "freshness check_results.json unavailable — cannot confirm Saturday integrity",
             "missing": [], "stale": [],
         }
     age = _verdict_age_hours(doc, now)
     if age is not None and age > VERDICT_STALE_HOURS:
         return {
             "go": False, "uncertain": True,
-            "reason": f"freshness verdict is stale ({age:.1f}h old > {VERDICT_STALE_HOURS}h) — monitor may be down",
+            "reason": f"freshness check_results is stale ({age:.1f}h old > {VERDICT_STALE_HOURS}h) — monitor may be down",
             "missing": [], "stale": [],
         }
-    sat = next(
-        (v for v in doc.get("verdicts", []) if v.get("cadence") == TARGET_CADENCE),
-        None,
-    )
-    if sat is None:
+    critical = [
+        r for r in doc.get("results", [])
+        if r.get("cadence") == TARGET_CADENCE and r.get("severity") == TARGET_SEVERITY
+    ]
+    if not critical:
         return {
             "go": False, "uncertain": True,
-            "reason": f"no {TARGET_CADENCE} verdict in cycle_verdict.json",
+            "reason": f"no {TARGET_CADENCE}/{TARGET_SEVERITY} rows in check_results — registry coverage gap?",
             "missing": [], "stale": [],
         }
-    if sat.get("complete"):
+    bad = [r for r in critical if r.get("state") not in _OK_STATES]
+    if not bad:
         return {
             "go": True, "uncertain": False,
-            "reason": f"all {sat.get('n_required')} critical {TARGET_CADENCE} artifacts present",
-            "cycle_label": sat.get("cycle_label"),
+            "reason": f"all {len(critical)} critical {TARGET_CADENCE} artifacts present",
             "missing": [], "stale": [],
         }
+    missing = [r.get("artifact_id") for r in bad if r.get("state") == "missing"]
+    stale = [r.get("artifact_id") for r in bad if r.get("state") != "missing"]
     return {
         "go": False, "uncertain": False,
         "reason": (
-            f"{TARGET_CADENCE} cycle INCOMPLETE "
-            f"({sat.get('n_satisfied')}/{sat.get('n_required')} critical artifacts)"
+            f"{TARGET_CADENCE} INCOMPLETE "
+            f"({len(critical) - len(bad)}/{len(critical)} critical artifacts present)"
         ),
-        "cycle_label": sat.get("cycle_label"),
-        "missing": sat.get("missing", []),
-        "stale": sat.get("stale", []),
+        "missing": missing,
+        "stale": stale,
     }
 
 
@@ -174,7 +187,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     run_date = now.date().isoformat()
     s3 = _s3()
 
-    doc = _read_cycle_verdict(s3)
+    doc = _read_check_results(s3)
     verdict = _evaluate(doc, now)
     verdict["checked_at"] = now.isoformat()
 

--- a/infrastructure/lambdas/saturday-integrity-sentinel/test_handler.py
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/test_handler.py
@@ -1,8 +1,9 @@
 """Unit tests for saturday-integrity-sentinel (M4).
 
 Stubs alpha_engine_lib.telegram.send_message and mocks the S3 client. Asserts
-the GO/NO-GO evaluation (complete / incomplete / uncertain), loud-vs-silent
-Telegram, fail-loud marker write, and best-effort Telegram.
+the GO/NO-GO evaluation computed from the freshness `check_results.json` rows
+(complete / incomplete / uncertain), loud-vs-silent Telegram, fail-loud marker
+write, and best-effort Telegram.
 """
 
 from __future__ import annotations
@@ -32,13 +33,25 @@ class FakeClientError(Exception):
         self.response = {"Error": {"Code": code}}
 
 
-def _s3(verdict_doc=None, missing=False, put=None):
+def _row(artifact_id, state, cadence="saturday_sf", severity="critical"):
+    return {"artifact_id": artifact_id, "cadence": cadence,
+            "severity": severity, "state": state}
+
+
+def _doc(rows, run_at=None):
+    d = {"results": rows}
+    if run_at:
+        d["run_at"] = run_at
+    return d
+
+
+def _s3(doc=None, missing=False, put=None):
     s3 = MagicMock()
     if missing:
         s3.get_object.side_effect = FakeClientError("404")
     else:
         body = MagicMock()
-        body.read.return_value = json.dumps(verdict_doc).encode()
+        body.read.return_value = json.dumps(doc).encode()
         s3.get_object.return_value = {"Body": body}
     if put is not None:
         s3.put_object.side_effect = put
@@ -57,79 +70,72 @@ def _run(s3):
         return index.handler({}, None)
 
 
-def test_go_when_saturday_cycle_complete():
-    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": True,
-                         "n_required": 10, "n_satisfied": 10}]}
-    s3 = _s3(doc)
-    result = _run(s3)
+def test_go_when_all_saturday_critical_fresh():
+    rows = [
+        _row("research_signals", "fresh"),
+        _row("predictor_meta_weights_manifest", "fresh"),
+        _row("constituents_dated", "grace_period"),       # grace counts as OK
+        _row("macro_snapshot", "missing", severity="warning"),     # warning ignored
+        _row("weekday_thing", "missing", cadence="weekday_sf"),    # other cadence ignored
+    ]
+    result = _run(_s3(_doc(rows)))
     assert result["go"] is True
     assert result["uncertain"] is False
-    s3.put_object.assert_called_once()
-    # GO pings silent (heartbeat), not a loud alert.
     assert _telegram_mod.send_message.call_args.kwargs["disable_notification"] is True
-    text = _telegram_mod.send_message.call_args.args[0]
-    assert "Saturday Integrity — GO" in text
+    assert "Saturday Integrity — GO" in _telegram_mod.send_message.call_args.args[0]
 
 
-def test_nogo_when_incomplete_pages_loud():
-    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": False,
-                         "n_required": 10, "n_satisfied": 8,
-                         "missing": ["research_signals"], "stale": []}]}
-    s3 = _s3(doc)
+def test_nogo_when_a_critical_artifact_missing_pages_loud():
+    rows = [
+        _row("research_signals", "missing"),
+        _row("constituents_dated", "stale"),
+        _row("predictor_meta_weights_manifest", "fresh"),
+    ]
+    s3 = _s3(_doc(rows))
     result = _run(s3)
     assert result["go"] is False
     assert result["uncertain"] is False
     kwargs = _telegram_mod.send_message.call_args.kwargs
     assert kwargs["disable_notification"] is False  # LOUD
-    text = _telegram_mod.send_message.call_args.args[0]
-    assert "NO-GO" in text
-    assert "research_signals" in text
+    assert "NO-GO" in _telegram_mod.send_message.call_args.args[0]
     written = json.loads(s3.put_object.call_args.kwargs["Body"])
-    assert written["go"] is False
     assert written["missing"] == ["research_signals"]
+    assert written["stale"] == ["constituents_dated"]
 
 
-def test_uncertain_when_verdict_missing():
-    s3 = _s3(missing=True)
-    result = _run(s3)
+def test_uncertain_when_check_results_missing():
+    result = _run(_s3(missing=True))
     assert result["go"] is False
     assert result["uncertain"] is True
     assert "unavailable" in result["reason"]
     assert _telegram_mod.send_message.call_args.kwargs["disable_notification"] is False
 
 
-def test_uncertain_when_verdict_stale():
-    doc = {"run_at": "2020-01-01T00:00:00+00:00",
-           "verdicts": [{"cadence": "saturday_sf", "complete": True,
-                         "n_required": 10, "n_satisfied": 10}]}
-    s3 = _s3(doc)
+def test_uncertain_when_results_stale():
+    s3 = _s3(_doc([_row("research_signals", "fresh")], run_at="2020-01-01T00:00:00+00:00"))
     result = _run(s3)
     assert result["go"] is False
     assert result["uncertain"] is True
     assert "stale" in result["reason"]
 
 
-def test_uncertain_when_no_saturday_row():
-    doc = {"verdicts": [{"cadence": "weekday_sf", "complete": True}]}
-    s3 = _s3(doc)
-    result = _run(s3)
+def test_uncertain_when_no_saturday_critical_rows():
+    rows = [_row("x", "fresh", cadence="weekday_sf"),
+            _row("y", "fresh", severity="warning")]
+    result = _run(_s3(_doc(rows)))
     assert result["go"] is False
     assert result["uncertain"] is True
 
 
 def test_marker_write_failure_raises_fail_loud():
-    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": True,
-                         "n_required": 10, "n_satisfied": 10}]}
-    s3 = _s3(doc, put=RuntimeError("S3 down"))
+    s3 = _s3(_doc([_row("research_signals", "fresh")]), put=RuntimeError("S3 down"))
     with pytest.raises(RuntimeError, match="S3 down"):
         _run(s3)
 
 
 def test_telegram_failure_is_non_fatal():
     _telegram_mod.send_message.side_effect = RuntimeError("bot down")
-    doc = {"verdicts": [{"cadence": "saturday_sf", "complete": False,
-                         "n_required": 10, "n_satisfied": 9, "missing": ["x"]}]}
-    s3 = _s3(doc)
+    s3 = _s3(_doc([_row("research_signals", "missing")]))
     result = _run(s3)
     assert result["telegram_sent"] is False
-    s3.put_object.assert_called_once()  # primary deliverable survived
+    s3.put_object.assert_called_once()


### PR DESCRIPTION
## M4 fix — read check_results.json (not cycle_verdict.json)

**Caught during live activation.** The deployed freshness-monitor writes `check_results.json` + `heartbeat.json` + `history.json` but NOT `cycle_verdict.json` (the derived rollup the original M4 depended on). So the M4 sentinel returned `uncertain NO-GO` on every invoke — a safety net that always cries wolf gets ignored.

**Robust fix:** compute the `saturday_sf`-critical completeness directly from the reliably-produced per-spec `check_results.json` (filter cadence=saturday_sf + severity=critical; GO iff all states in {fresh, grace_period}). Drops the dependency on the maybe-absent derived artifact. Same GO/NO-GO + fail-loud-on-uncertainty semantics; same independence from the agent. IAM grant retargeted. 7 tests green.

Follow-up filed separately for the freshness-monitor cycle_verdict drift (deployed image predates the feature).
