### PR TITLE
feat(eod-backstop): same-day EOD-pipeline backstop Lambda (config#1229)

### DIFF
--- a/infrastructure/lambdas/eod-backstop/README.md
+++ b/infrastructure/lambdas/eod-backstop/README.md
@@ -1,0 +1,52 @@
+# alpha-engine-eod-backstop
+
+Same-day backstop trigger for the EOD Step Function (`alpha-engine-eod-pipeline`). Phase 2 of the trading-day-gap arc (**config#1229**).
+
+## Why
+
+The EOD SF's **only** normal trigger is the trading daemon's shutdown hook (`daemon.py` finally block) — a deliberate "no-backstop design". If the daemon dies before that hook (crash, SSM `RunDaemon` step killed, daemon never starts), the EOD SF never fires: no `PostMarketData`, no `CaptureSnapshot`, and — the load-bearing failure — **no `eod_pnl` row for the day**. The next day's EOD reconcile then has no adjacent prior-day NAV baseline, and the headline daily return/alpha span multiple sessions (the 2026-06-24 gap → RGEN +14.92% class of bug; see config#1228 for the per-position fix and the executor's gap-aware reconcile, crucible-executor#280).
+
+## What it does
+
+EventBridge fires it **22:30 UTC MON-FRI** (well after the daemon's nominal ~20:15 UTC EOD). It starts the EOD SF **iff both**:
+
+1. **the trading box is still RUNNING** — the daemon never shut it down, so EOD never fired; and `CaptureSnapshot` needs a live IB session, which exists only while the box is up. This is therefore a **same-day-only** recovery.
+2. **no EOD execution started today** — never double-run after a daemon-triggered EOD that already completed or is mid-flight.
+
+Otherwise it is a no-op:
+- box stopped → EOD already ran (and stopped it) or the box never booted (no trading → nothing to reconcile);
+- not a trading day → no EOD expected.
+
+The EOD SF's own DynamoDB mutex (`AcquireMutex`) is the concurrency backstop if a daemon-triggered EOD is racing this one.
+
+**Not** this Lambda's job: the **late-discovery** case (box long gone, gap found days later). That is the IBKR Flex Query `eod_pnl` backfill (config#1229) — it reconstructs a past day's NAV/cash/positions from IBKR's historical statements, no live box required.
+
+## Fail-loud
+
+Per `feedback_no_silent_fails`: any AWS call failure (`ec2:DescribeInstances`, `states:ListExecutions`) raises so the EventBridge retry + Lambda-error CloudWatch alarm page the operator. The check must never be silently skipped on the one day it matters.
+
+## Deploy / safe rollout
+
+```bash
+# first-time create (EventBridge rule created DISABLED)
+bash infrastructure/lambdas/eod-backstop/deploy.sh --bootstrap
+# code update only
+bash infrastructure/lambdas/eod-backstop/deploy.sh
+```
+
+The rule ships **DISABLED** because this Lambda can start the live trading EOD pipeline. Soak it first (`--smoke` on a non-trading day or with the box down — guaranteed no-op — and review logs), then enable deliberately:
+
+```bash
+aws events enable-rule --name alpha-engine-eod-backstop-daily --region us-east-1
+```
+
+## Config
+
+| env var | default |
+|---|---|
+| `EOD_SF_ARN` | `…:stateMachine:alpha-engine-eod-pipeline` |
+| `TRADING_INSTANCE_ID` | `i-018eb3307a21329bf` |
+| `DASHBOARD_INSTANCE_ID` | `i-09b539c844515d549` |
+| `SNS_TOPIC_ARN` | `…:alpha-engine-alerts` |
+
+Cron: `cron(30 22 ? * MON-FRI *)` (mutable via `aws events put-rule`).

--- a/infrastructure/lambdas/eod-backstop/deploy.sh
+++ b/infrastructure/lambdas/eod-backstop/deploy.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-eod-backstop Lambda + its
+# EventBridge cron rule.
+#
+# Phase 2 of the trading-day-gap arc (config#1229). Same-day backstop for the
+# EOD Step Function, whose ONLY normal trigger is the daemon shutdown hook. If
+# the daemon dies before that hook, the EOD SF never fires and the day's
+# eod_pnl row goes missing → the next reconcile's headline spans multiple
+# sessions (the 2026-06-24 → RGEN +14.92% class; config#1228/#1229).
+#
+# Fires ~22:30 UTC MON-FRI (well after the daemon's ~20:15 UTC EOD). Starts the
+# EOD SF IFF the trading box is still running AND no EOD started today. See
+# index.py for the full guard rationale.
+#
+# Managed outside CloudFormation — same rationale as pipeline-watchdog /
+# sf-telegram-notifier / eod-success-friday-shell-trigger (operator-deployed
+# only, narrow OIDC blast radius).
+#
+# SAFE ROLLOUT: --bootstrap creates the EventBridge rule DISABLED. Soak the
+# Lambda via --smoke on a non-trading-day / box-down state (guaranteed no-op),
+# review the first dry firings in logs, THEN enable:
+#   aws events enable-rule --name alpha-engine-eod-backstop-daily --region us-east-1
+#
+# Usage:
+#   bash infrastructure/lambdas/eod-backstop/deploy.sh             # update code only
+#   bash infrastructure/lambdas/eod-backstop/deploy.sh --bootstrap # first-time create (rule DISABLED)
+#   bash infrastructure/lambdas/eod-backstop/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/eod-backstop/deploy.sh --smoke     # invoke once (no-op unless box up + no EOD today)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-eod-backstop"
+ROLE_NAME="alpha-engine-eod-backstop-role"
+POLICY_NAME="alpha-engine-eod-backstop-policy"
+RULE_NAME="alpha-engine-eod-backstop-daily"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge cron: 22:30 UTC MON-FRI — comfortably after the daemon's
+  # nominal ~20:15 UTC EOD in both DST regimes. Created DISABLED for safe
+  # rollout (this Lambda can START the trading EOD pipeline); enable
+  # deliberately after a soak via `aws events enable-rule`.
+  echo "  Creating EventBridge rule: ${RULE_NAME} (DISABLED)"
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --schedule-expression 'cron(30 22 ? * MON-FRI *)' \
+    --state DISABLED \
+    --description "EOD-pipeline backstop fire at 22:30 UTC MON-FRI (Lambda gates on trading-day + box-running + no-EOD-today). DISABLED until soak-reviewed." \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+
+  echo "  NOTE: rule is DISABLED. After soak: aws events enable-rule --name ${RULE_NAME} --region ${REGION}"
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (synthetic empty event — exercises the full handler) --------
+
+if $SMOKE; then
+  echo ""
+  echo "WARNING: --smoke runs the REAL handler. If today is a trading day AND the"
+  echo "         trading box is running AND no EOD started today, it WILL start the"
+  echo "         EOD Step Function. Run it only when you expect a no-op (non-trading"
+  echo "         day, or box already stopped), or when you genuinely want to recover"
+  echo "         today's missing EOD."
+  RESP=$(mktemp)
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{}' \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/eod-backstop/iam-policy.json
+++ b/infrastructure/lambdas/eod-backstop/iam-policy.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-eod-backstop:*"
+    },
+    {
+      "Sid": "DescribeTradingBox",
+      "Effect": "Allow",
+      "Action": ["ec2:DescribeInstances"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ListAndStartEodSF",
+      "Effect": "Allow",
+      "Action": [
+        "states:ListExecutions",
+        "states:StartExecution"
+      ],
+      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+    }
+  ]
+}

--- a/infrastructure/lambdas/eod-backstop/index.py
+++ b/infrastructure/lambdas/eod-backstop/index.py
@@ -1,0 +1,188 @@
+"""alpha-engine-eod-backstop — same-day EOD-pipeline trigger of last resort.
+
+The EOD Step Function (``alpha-engine-eod-pipeline``) is normally started by
+the trading daemon's shutdown hook (``daemon.py`` finally block). That is the
+SOLE trigger — a deliberate "no-backstop design". If the daemon dies before
+its shutdown hook, the SSM ``RunDaemon`` step never reaches the finally block,
+or the daemon never starts, the EOD SF never fires: no PostMarketData, no
+CaptureSnapshot, and — the load-bearing failure — NO ``eod_pnl`` ROW for the
+day. The next day's EOD reconcile then has no adjacent prior-day NAV baseline
+and the headline daily return/alpha span multiple sessions (the 2026-06-24
+gap → RGEN +14.92% class of bug; config#1229).
+
+This Lambda is the missing backstop. Triggered by EventBridge ~22:30 UTC on
+weekdays (well after the daemon's nominal ~20:15 UTC EOD), it starts the EOD
+SF IFF both:
+
+  1. the trading EC2 box is still RUNNING — the daemon never shut it down, so
+     EOD never fired; and CaptureSnapshot needs a live IB session, which only
+     exists while the box is up (this is a SAME-DAY-only recovery), AND
+  2. no EOD execution has STARTED today — so we never double-run after a
+     daemon-triggered EOD that already completed (or is mid-flight).
+
+If the box is already stopped, EOD either ran (success or failure — both end
+in stopping the box) or the box never booted (no trading → nothing to
+reconcile): either way a no-op. The late-discovery case (box long gone, gap
+found days later) is NOT this Lambda's job — that is the IBKR Flex Query
+``eod_pnl`` backfill (config#1229).
+
+The EOD SF's own DynamoDB mutex (``AcquireMutex``) is the concurrency
+backstop: if a daemon-triggered EOD is mid-flight when this fires, our
+StartExecution would only hit ``MutexConflict`` and fail cleanly — but the
+``eod_ran_today`` guard means we don't even attempt it.
+
+Fail-loud (``feedback_no_silent_fails``): any AWS call failure raises so the
+EventBridge retry + Lambda-error CloudWatch alarm page the operator. We must
+never silently skip the check on the one day it matters.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+import boto3
+
+from alpha_engine_lib.trading_calendar import is_trading_day, last_closed_trading_day
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
+
+EOD_SF_ARN = os.environ.get(
+    "EOD_SF_ARN",
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline",
+)
+# The trading box (CaptureSnapshot / EODReconcile / StopTradingInstance target)
+# and the dashboard box (DailySubstrateHealthCheck target). Mirror the daemon's
+# _trigger_eod_pipeline input shape so the SF runs identically to a normal EOD.
+TRADING_INSTANCE_ID = os.environ.get("TRADING_INSTANCE_ID", "i-018eb3307a21329bf")
+DASHBOARD_INSTANCE_ID = os.environ.get("DASHBOARD_INSTANCE_ID", "i-09b539c844515d549")
+SNS_TOPIC_ARN = os.environ.get(
+    "SNS_TOPIC_ARN", f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts"
+)
+
+# Count an EOD as "already fired today" regardless of terminal status — a
+# started-then-failed EOD still ran HandleFailure → ForceStopInstance, so the
+# box would be stopped and the box-running gate already covers it; this guard
+# additionally prevents racing a mid-flight (RUNNING) EOD.
+_STARTED_STATUSES = ("RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED")
+
+
+def _trading_box_running(ec2_client: Optional[object] = None) -> bool:
+    """True iff the trading EC2 instance is in the ``running`` state.
+
+    A stopped/terminated/absent box means EOD already ran (and stopped it) or
+    the box never booted — either way the backstop is a no-op. Raises on an
+    EC2 API failure (fail-loud)."""
+    if ec2_client is None:  # pragma: no cover — production path
+        ec2_client = boto3.client("ec2", region_name=REGION)
+    resp = ec2_client.describe_instances(InstanceIds=[TRADING_INSTANCE_ID])
+    for reservation in resp.get("Reservations", []):
+        for inst in reservation.get("Instances", []):
+            state = (inst.get("State") or {}).get("Name")
+            logger.info("Trading box %s state=%s", TRADING_INSTANCE_ID, state)
+            return state == "running"
+    logger.info("Trading box %s not found in describe_instances", TRADING_INSTANCE_ID)
+    return False
+
+
+def _eod_ran_today(now_utc: datetime, sf_client: Optional[object] = None) -> bool:
+    """True iff at least one EOD SF execution STARTED since 00:00 UTC today.
+
+    At the ~22:30 UTC firing time, today's expected EOD (~20:00–21:30 UTC) is
+    within the since-midnight window, while the prior trading day's EOD is not
+    — so this is trading-day-correct without a per-day marker. Raises on a
+    ListExecutions failure (fail-loud)."""
+    if sf_client is None:  # pragma: no cover — production path
+        sf_client = boto3.client("stepfunctions", region_name=REGION)
+    midnight = now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+    for status_filter in _STARTED_STATUSES:
+        next_token: Optional[str] = None
+        while True:
+            kwargs = {
+                "stateMachineArn": EOD_SF_ARN,
+                "statusFilter": status_filter,
+                "maxResults": 100,
+            }
+            if next_token:
+                kwargs["nextToken"] = next_token
+            resp = sf_client.list_executions(**kwargs)
+            for row in resp.get("executions") or []:
+                start = row.get("startDate")
+                if not hasattr(start, "astimezone"):
+                    continue
+                start_utc = (
+                    start.astimezone(timezone.utc)
+                    if start.tzinfo
+                    else start.replace(tzinfo=timezone.utc)
+                )
+                if start_utc >= midnight:
+                    logger.info(
+                        "EOD execution %s already started today (%s, %s)",
+                        row.get("name"), start_utc.isoformat(), status_filter,
+                    )
+                    return True
+            next_token = resp.get("nextToken")
+            if not next_token:
+                break
+    return False
+
+
+def _start_eod(trading_day: str, sf_client: Optional[object] = None) -> str:
+    """Start the EOD SF with the same input shape as the daemon, tagged
+    ``triggered_by=backstop``. Returns the execution ARN."""
+    if sf_client is None:  # pragma: no cover — production path
+        sf_client = boto3.client("stepfunctions", region_name=REGION)
+    resp = sf_client.start_execution(
+        stateMachineArn=EOD_SF_ARN,
+        name=f"eod-backstop-{trading_day}-{int(time.time())}",
+        input=json.dumps(
+            {
+                "trading_instance_id": [TRADING_INSTANCE_ID],
+                "ec2_instance_id": [DASHBOARD_INSTANCE_ID],
+                "sns_topic_arn": SNS_TOPIC_ARN,
+                "run_date": trading_day,
+                "triggered_by": "backstop",
+                "pipeline_role": "eod",
+            }
+        ),
+    )
+    arn = resp.get("executionArn", "")
+    logger.warning(
+        "EOD-BACKSTOP fired: trading box was still running and no EOD ran today "
+        "for trading_day=%s — started EOD SF %s",
+        trading_day, arn,
+    )
+    return arn
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    now_utc = datetime.now(timezone.utc)
+
+    # Only trading days have an expected EOD. The EventBridge rule is MON-FRI,
+    # so this skips NYSE holidays that fall on weekdays.
+    if not is_trading_day(now_utc.date()):
+        logger.info("Not a NYSE trading day (%s) — no EOD expected; no-op.", now_utc.date())
+        return {"action": "noop", "reason": "not_a_trading_day", "date": str(now_utc.date())}
+
+    trading_day = last_closed_trading_day(now_utc).isoformat()
+
+    if not _trading_box_running():
+        logger.info(
+            "Trading box not running — EOD already ran or box never booted; no-op."
+        )
+        return {"action": "noop", "reason": "trading_box_not_running", "trading_day": trading_day}
+
+    if _eod_ran_today(now_utc):
+        logger.info("An EOD execution already started today — no-op.")
+        return {"action": "noop", "reason": "eod_already_ran_today", "trading_day": trading_day}
+
+    execution_arn = _start_eod(trading_day)
+    return {"action": "started_eod", "trading_day": trading_day, "execution_arn": execution_arn}

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -1,0 +1,8 @@
+# alpha-engine-lib provides:
+#   - alpha_engine_lib.trading_calendar.{is_trading_day,last_closed_trading_day}
+#     for NYSE-holiday-aware trading-day gating
+# Pinned to match the freshness-monitor sibling watchdog Lambda; keeping the
+# pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
+# (The package still imports as ``alpha_engine_lib`` at this pin — the rename
+# to ``nousergon_lib`` lands at 0.60.0; siblings have not yet crossed it.)
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.40.0

--- a/infrastructure/lambdas/eod-backstop/test_handler.py
+++ b/infrastructure/lambdas/eod-backstop/test_handler.py
@@ -1,0 +1,144 @@
+"""Unit tests for the alpha-engine-eod-backstop Lambda (config#1229).
+
+The backstop starts the EOD SF IFF the trading box is still running AND no
+EOD ran today; it is a no-op otherwise and fail-loud on AWS errors.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import index
+
+
+def _ec2(state: str | None):
+    """An EC2 client mock whose trading instance reports ``state`` (None →
+    instance absent)."""
+    cli = MagicMock()
+    if state is None:
+        cli.describe_instances.return_value = {"Reservations": []}
+    else:
+        cli.describe_instances.return_value = {
+            "Reservations": [{"Instances": [{"State": {"Name": state}}]}]
+        }
+    return cli
+
+
+def _sf(exec_start: datetime | None):
+    """A Step Functions client mock. ``exec_start`` (a tz-aware datetime) seeds
+    one EOD execution under the RUNNING status; None → no executions."""
+    cli = MagicMock()
+
+    def _list(**kwargs):
+        if kwargs.get("statusFilter") == "RUNNING" and exec_start is not None:
+            return {"executions": [{"name": "eod-x", "startDate": exec_start}]}
+        return {"executions": []}
+
+    cli.list_executions.side_effect = _list
+    cli.start_execution.return_value = {
+        "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:eod-backstop-x"
+    }
+    return cli
+
+
+# ── Detection helpers ─────────────────────────────────────────────────────────
+
+
+class TestBoxRunning:
+    def test_running_true(self):
+        assert index._trading_box_running(_ec2("running")) is True
+
+    def test_stopped_false(self):
+        assert index._trading_box_running(_ec2("stopped")) is False
+
+    def test_absent_false(self):
+        assert index._trading_box_running(_ec2(None)) is False
+
+
+class TestEodRanToday:
+    NOW = datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc)
+
+    def test_execution_started_today_is_true(self):
+        started = datetime(2026, 6, 25, 20, 15, tzinfo=timezone.utc)
+        assert index._eod_ran_today(self.NOW, _sf(started)) is True
+
+    def test_yesterdays_execution_is_not_today(self):
+        started = datetime(2026, 6, 24, 20, 15, tzinfo=timezone.utc)
+        assert index._eod_ran_today(self.NOW, _sf(started)) is False
+
+    def test_no_executions_is_false(self):
+        assert index._eod_ran_today(self.NOW, _sf(None)) is False
+
+
+# ── Handler decision matrix ───────────────────────────────────────────────────
+
+
+class TestHandler:
+    TRADING_NOW = datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc)  # Thursday
+
+    def _run(self, *, trading_day=True, box="running", eod_started=None):
+        with patch("index.datetime") as dt, \
+             patch("index.is_trading_day", return_value=trading_day), \
+             patch("index.last_closed_trading_day", return_value=self.TRADING_NOW.date()), \
+             patch("index._trading_box_running", return_value=(box == "running")), \
+             patch("index._eod_ran_today", return_value=(eod_started is not None)), \
+             patch("index._start_eod", return_value="arn:exec:backstop") as start:
+            dt.now.return_value = self.TRADING_NOW
+            result = index.handler({}, None)
+        return result, start
+
+    def test_starts_eod_when_box_up_and_no_eod_today(self):
+        result, start = self._run(box="running", eod_started=None)
+        assert result["action"] == "started_eod"
+        assert result["execution_arn"] == "arn:exec:backstop"
+        start.assert_called_once()
+
+    def test_noop_when_box_stopped(self):
+        result, start = self._run(box="stopped")
+        assert result["action"] == "noop" and result["reason"] == "trading_box_not_running"
+        start.assert_not_called()
+
+    def test_noop_when_eod_already_ran(self):
+        result, start = self._run(box="running", eod_started=self.TRADING_NOW)
+        assert result["action"] == "noop" and result["reason"] == "eod_already_ran_today"
+        start.assert_not_called()
+
+    def test_noop_when_not_a_trading_day(self):
+        result, start = self._run(trading_day=False)
+        assert result["action"] == "noop" and result["reason"] == "not_a_trading_day"
+        start.assert_not_called()
+
+
+class TestStartEodInput:
+    def test_start_execution_mirrors_daemon_input(self):
+        sf = _sf(None)
+        index._start_eod("2026-06-25", sf)
+        kwargs = sf.start_execution.call_args.kwargs
+        assert kwargs["stateMachineArn"].endswith("alpha-engine-eod-pipeline")
+        assert kwargs["name"].startswith("eod-backstop-2026-06-25-")
+        import json
+        payload = json.loads(kwargs["input"])
+        assert payload["triggered_by"] == "backstop"
+        assert payload["pipeline_role"] == "eod"
+        assert payload["run_date"] == "2026-06-25"
+        assert payload["trading_instance_id"] == [index.TRADING_INSTANCE_ID]
+
+
+# ── Fail-loud ─────────────────────────────────────────────────────────────────
+
+
+class TestFailLoud:
+    def test_describe_instances_error_raises(self):
+        cli = MagicMock()
+        cli.describe_instances.side_effect = RuntimeError("ec2 down")
+        with pytest.raises(RuntimeError):
+            index._trading_box_running(cli)
+
+    def test_list_executions_error_raises(self):
+        cli = MagicMock()
+        cli.list_executions.side_effect = RuntimeError("states down")
+        with pytest.raises(RuntimeError):
+            index._eod_ran_today(datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc), cli)


### PR DESCRIPTION
## Phase 2 (part 1 of 3) of the trading-day-gap arc — config#1229

The EOD-row gap is the one Layers 1+2 (config#1228) flag but don't fully fix at the **headline** level. This is the *prevention* half: stop the `eod_pnl` row from going missing in the most common failure mode.

### Why
The EOD SF's only normal trigger is the daemon shutdown hook (a deliberate "no-backstop design"). If the daemon dies before that hook, the EOD SF never fires → no `eod_pnl` row → the next reconcile's headline spans multiple sessions (2026-06-24 → RGEN +14.92% class).

### What
A standalone scheduled Lambda (`infrastructure/lambdas/eod-backstop`), mirroring the `pipeline-watchdog` / `eod-success-friday-shell-trigger` sibling pattern. Fires **22:30 UTC MON-FRI** and starts the EOD SF **iff** the trading box is still running **and** no EOD started today. No-op otherwise. Fail-loud on AWS errors.

- **Does NOT touch the live EOD SF JSON** — only conditionally *starts* the SF, exactly as the daemon does. The SF's own DynamoDB mutex is the concurrency backstop.
- **Same-day only** (CaptureSnapshot needs a live IB session). The late-discovery case is the **IBKR Flex Query backfill** (part 2, still to build).

### Safe rollout
`deploy.sh --bootstrap` creates the EventBridge rule **DISABLED** (this Lambda can start the live trading EOD pipeline). Soak via `--smoke` (no-op on a non-trading day / box-down), review logs, then `aws events enable-rule`. **Not yet deployed — left for your review + deliberate enable.**

### Tests
13 unit tests (box state; eod-ran-today window; full handler decision matrix; daemon-matching SF input; fail-loud). Run at deploy time via `deploy.sh` step 0 (matching the watchdog-sibling convention — CI scope is `tests/`). Repo suite: 2176 passed, 3 skipped.

### Remaining Phase 2 (config#1229)
- **part 2 — IBKR Flex Query `eod_pnl` backfill** (the general late-recovery; needs a one-time IBKR Flex Query + token setup in the paper account).
- **part 3 — registry-driven remediation** (promote the freshness monitor from alert → dispatch-backfill; depends on parts 1–2 existing).