### PR TITLE
deps(freshness-monitor): bump lib pin -> nousergon-lib v0.62.0 (recency model)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,5 +1,10 @@
-# Pinned to alpha-engine-lib v0.40.0 (the artifact_freshness substrate
-# was introduced here). Bumping this is a substrate-change PR — not
-# something to do absent-mindedly during a code-only refresh.
-alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.40.0
+# Pinned to nousergon-lib v0.62.0 — the artifact_freshness RECENCY
+# redesign (PR #128): freshness is judged by the most-recent instance vs a
+# cron-tick-minus-slack floor, not an exact cron-date key. This is what
+# makes the monitor robust to off-cycle runs (the 6/19 full run satisfying
+# the 6/20 cycle) and the {trading_day} anchor. Name changed alpha-engine-lib
+# -> nousergon-lib at the 0.60 rename; index.py's alpha_engine_lib imports
+# keep working via the compat shim (lib >=0.60.2). Bumping this is a
+# substrate-change PR — not a code-only refresh.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.62.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -96,9 +96,25 @@ def fake_s3():
     def _get(*, Bucket, Key):
         return {"Body": io.BytesIO(client._registry_body)}
 
+    def _paginate(*, Bucket, Prefix):
+        # Recency model (nousergon-lib >=0.62.0): date-templated probes LIST
+        # the prefix and take the newest matching object. Derive the listing
+        # from the same _head_returns table so a single per-key fixture entry
+        # feeds both the fixed-key HEAD path and the date-templated LIST path.
+        contents = [
+            {"Key": k, "LastModified": v["LastModified"]}
+            for k, v in client._head_returns.items()
+            if k.startswith(Prefix) and isinstance(v, dict) and "LastModified" in v
+        ]
+        return iter([{"Contents": contents}])
+
+    paginator = mock.Mock()
+    paginator.paginate.side_effect = _paginate
+
     client.head_object.side_effect = _head
     client.put_object.side_effect = _put
     client.get_object.side_effect = _get
+    client.get_paginator.return_value = paginator
     return client
 
 
@@ -283,6 +299,15 @@ def test_handler_probe_failed_routes_to_critical(
             raise _ClientError403()
         raise _ClientError404()
     fake_s3.head_object.side_effect = _head
+
+    # Recency model (lib >=0.62.0) LISTs the prefix for date-templated keys —
+    # make the LIST 403 for probe_fresh's prefix so the canonical probe is
+    # authoritative-failed (the monitor itself is blind → probe_failed).
+    def _paginate_403(*, Bucket, Prefix):
+        if Prefix.startswith("path/"):
+            raise _ClientError403()
+        return iter([{"Contents": []}])
+    fake_s3.get_paginator.return_value.paginate.side_effect = _paginate_403
 
     import importlib
     import index


### PR DESCRIPTION
Picks up the artifact_freshness RECENCY redesign (nousergon-lib#128, v0.62.0): the monitor judges freshness by the most-recent instance vs a cron-tick-minus-slack floor, not an exact cron-date key — robust to off-cycle runs (the 6/19 full run satisfying the 6/20 cycle) + the {trading_day} anchor. Closes the false-positive burst (config#1230); subsumes the off-by-one (config#1237).

- requirements.txt: `alpha-engine-lib @ ...@v0.40.0` -> `nousergon-lib @ ...@v0.62.0` (name change at the 0.60 rename; index.py alpha_engine_lib imports work via the shim >=0.60.2).
- test_handler.py: recency model LISTs prefixes -> fake S3 gains a list_objects_v2 paginator (from the same _head_returns table); probe_failed test makes the LIST 403.

Validated via `deploy.sh --dry-run`: 31 tests pass against v0.62.0, package builds. Follow-up to the now-merged rename #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)