### PR TITLE
refactor(freshness-monitor): name the flag FRESHNESS_MONITOR_ENABLED (drop brand prefix)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -15,7 +15,7 @@
 # spot-orphan-reaper / changelog-cloudwatch-mirror (keeps the
 # github-actions-lambda-deploy OIDC role's blast radius narrow;
 # operator-deployed only). Phase 6 cutover flips
-# CRUCIBLE_FRESHNESS_MONITOR_ENABLED via
+# FRESHNESS_MONITOR_ENABLED via
 # `aws lambda update-function-configuration` without redeploying.
 #
 # Usage:
@@ -158,7 +158,7 @@ if $BOOTSTRAP; then
   ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
   if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
     echo "  Creating Lambda: ${FUNCTION_NAME}"
-    # ENFORCE mode: CRUCIBLE_FRESHNESS_MONITOR_ENABLED=true.
+    # ENFORCE mode: FRESHNESS_MONITOR_ENABLED=true.
     # Phase 6 cutover EXECUTED 2026-06-25 after a ~1mo observe soak (the
     # monitor correctly detected the missed 6/20 Saturday cycle the whole
     # time but stayed muted). Code is now the source of truth for the flag —
@@ -172,7 +172,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 120 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,CRUCIBLE_FRESHNESS_MONITOR_ENABLED=true}' \
+      --environment 'Variables={LOG_LEVEL=INFO,FRESHNESS_MONITOR_ENABLED=true}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -28,7 +28,7 @@ invocation:
      ``dedup_key=resolve_dedup_key(spec, now)`` — dedup collapses
      4×/hour retries to one alert per cycle per artifact.
   6. **OBSERVE-mode gate**: when env
-     ``CRUCIBLE_FRESHNESS_MONITOR_ENABLED`` is anything other than
+     ``FRESHNESS_MONITOR_ENABLED`` is anything other than
      ``"true"`` (case-insensitive), alerts are suppressed but the
      check results and heartbeat are still emitted. Phase 6 cutover
      flips the env var via ``aws lambda update-function-configuration``
@@ -100,7 +100,7 @@ _DEFAULT_LOOKBACK = {
 # other than literal "true" (case-insensitive) suppresses alerts. Check
 # results + heartbeat are emitted regardless.
 ALERTS_ENABLED = (
-    os.environ.get("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "false").lower() == "true"
+    os.environ.get("FRESHNESS_MONITOR_ENABLED", "false").lower() == "true"
 )
 
 # ArtifactSpec field set — used to strip extra YAML keys (e.g., the

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -197,9 +197,9 @@ def _patch_now(monkeypatch, fixed):
 def test_handler_observe_mode_does_not_alert(
     monkeypatch, yaml_registry_body, fake_s3, fixed_now
 ):
-    """OBSERVE mode (CRUCIBLE_FRESHNESS_MONITOR_ENABLED unset) writes
+    """OBSERVE mode (FRESHNESS_MONITOR_ENABLED unset) writes
     heartbeat + check_results but suppresses alerts.publish."""
-    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("FRESHNESS_MONITOR_ENABLED", raising=False)
     fake_s3._registry_body = yaml_registry_body
 
     # Mark probe_fresh as actually fresh (HEAD returns within cycle).
@@ -244,9 +244,9 @@ def test_handler_observe_mode_does_not_alert(
 def test_handler_alerts_enabled_fires_with_dedup_key(
     monkeypatch, yaml_registry_body, fake_s3, fixed_now
 ):
-    """Production mode (CRUCIBLE_FRESHNESS_MONITOR_ENABLED=true) routes
+    """Production mode (FRESHNESS_MONITOR_ENABLED=true) routes
     misses past SLA to alerts.publish with the resolved dedup key."""
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     fake_s3._registry_body = yaml_registry_body
 
     cycle_tick = datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)
@@ -283,7 +283,7 @@ def test_handler_probe_failed_routes_to_critical(
     """probe_failed (e.g., 403) routes to critical regardless of the
     spec's severity — the monitor itself is broken; operator must know.
     Plan §3 invariant 6."""
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     fake_s3._registry_body = yaml_registry_body
 
     class _ClientError403(Exception):
@@ -337,7 +337,7 @@ def test_handler_per_spec_exception_does_not_sink_pass(
     placeholder) should result in probe_failed for that spec, not a
     handler-level raise. The other specs in the registry still get
     probed."""
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     # `{ticker}` is NOT a supported placeholder in the substrate's
     # _format_key — str.format will raise KeyError.
     fake_s3._registry_body = b"""\
@@ -385,7 +385,7 @@ def test_handler_observe_to_production_cutover_via_env_flip(
     fake_s3._registry_body = yaml_registry_body
 
     # Pass 1: OBSERVE mode.
-    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("FRESHNESS_MONITOR_ENABLED", raising=False)
     import importlib
     import index
     importlib.reload(index)
@@ -398,7 +398,7 @@ def test_handler_observe_to_production_cutover_via_env_flip(
     assert publish_mock.call_count == 0
 
     # Pass 2: env flipped to true, reload, re-invoke.
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     fake_s3._put_calls.clear()
     importlib.reload(index)
     _patch_now(monkeypatch, fixed_now)
@@ -414,7 +414,7 @@ def test_handler_observe_to_production_cutover_via_env_flip(
 
 
 def test_maybe_alert_skips_fresh_state(monkeypatch, fixed_now):
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -434,7 +434,7 @@ def test_maybe_alert_skips_fresh_state(monkeypatch, fixed_now):
 
 
 def test_maybe_alert_skips_missing_within_sla_grace(monkeypatch, fixed_now):
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -455,7 +455,7 @@ def test_maybe_alert_skips_missing_within_sla_grace(monkeypatch, fixed_now):
 
 
 def test_maybe_alert_fires_missing_past_sla(monkeypatch, fixed_now):
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -483,7 +483,7 @@ def test_maybe_alert_fires_missing_past_sla(monkeypatch, fixed_now):
 
 def test_maybe_alert_probe_failed_uses_critical_severity(monkeypatch, fixed_now):
     """probe_failed always escalates to critical regardless of spec."""
-    monkeypatch.setenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
     import importlib
     import index
     importlib.reload(index)
@@ -694,7 +694,7 @@ def _run_handler(monkeypatch, fake_s3, fixed_now, *, registry_body):
     """Invoke the handler in OBSERVE mode with boto3 routed to fake_s3
     (which also serves boto3.client('cloudwatch') — put_metric_data lands
     on the same recording mock)."""
-    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("FRESHNESS_MONITOR_ENABLED", raising=False)
     fake_s3._registry_body = registry_body
     import importlib
     import index
@@ -795,7 +795,7 @@ def test_handler_cycle_rollup_failure_is_non_fatal(
     primary check_results + heartbeat are still written and the handler
     returns with cycle_verdicts={}."""
     fake_s3._registry_body = yaml_registry_body
-    monkeypatch.delenv("CRUCIBLE_FRESHNESS_MONITOR_ENABLED", raising=False)
+    monkeypatch.delenv("FRESHNESS_MONITOR_ENABLED", raising=False)
     import importlib
     import index
     importlib.reload(index)


### PR DESCRIPTION
The enable flag lives only in the freshness-monitor Lambda's own `Environment.Variables` (read in index.py; nothing else shares that namespace), so a brand prefix buys no disambiguation — the bare, self-documenting name is best. Settles the churn: `MNEMON_` (wrong — mnemon is the memory product) → `CRUCIBLE_` (too narrow; the registry spans Crucible + Metron + robodashboard) → `NOUSERGON_` (umbrella but redundant for a lambda-local var) → **`FRESHNESS_MONITOR_ENABLED`**. 19 refs; `deploy.sh --dry-run`: 31 tests pass. Redeploy resets live env to `FRESHNESS_MONITOR_ENABLED=true` (enforce uninterrupted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)