### PR TITLE
fix(freshness-monitor): thread continuous active-window fields + repin lib v0.63.0

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -120,6 +120,11 @@ _SPEC_FIELDS = frozenset(
         "recovery_key_template",
         "calendar_aware",
         "interval_minutes",
+        # Continuous active-window bounds (nousergon-lib >= v0.63.0) — scope a
+        # market-hours-only producer (the executor daemon's open_orders
+        # snapshot) so the 24/7 continuous floor doesn't false-alarm overnight.
+        "active_trading_days_only",
+        "active_hours_utc",
     }
 )
 

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,10 +1,12 @@
-# Pinned to nousergon-lib v0.62.0 — the artifact_freshness RECENCY
-# redesign (PR #128): freshness is judged by the most-recent instance vs a
-# cron-tick-minus-slack floor, not an exact cron-date key. This is what
-# makes the monitor robust to off-cycle runs (the 6/19 full run satisfying
-# the 6/20 cycle) and the {trading_day} anchor. Name changed alpha-engine-lib
-# -> nousergon-lib at the 0.60 rename; index.py's alpha_engine_lib imports
-# keep working via the compat shim (lib >=0.60.2). Bumping this is a
-# substrate-change PR — not a code-only refresh.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.62.0
+# Pinned to nousergon-lib v0.63.0 — adds the continuous active-window gate
+# (active-window for market-hours-only producers): a continuous spec may
+# carry active_trading_days_only / active_hours_utc so a daemon that only
+# writes during the NYSE session (open_orders) is judged fresh when idle
+# off-window instead of false-alarming every interval (the 2026-06-26
+# open_orders overnight alert storm). Builds on the v0.62.0 RECENCY redesign
+# (PR #128: most-recent instance vs a cron-tick-minus-slack floor). Name
+# changed alpha-engine-lib -> nousergon-lib at the 0.60 rename; index.py's
+# alpha_engine_lib imports keep working via the compat shim (lib >=0.60.2).
+# Bumping this is a substrate-change PR — not a code-only refresh.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.63.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -179,6 +179,32 @@ artifacts:
     assert specs[0].created_at == date(2025, 1, 1)
 
 
+def test_load_registry_threads_active_window_fields(fake_s3):
+    """Continuous active-window fields (nousergon-lib >=0.63.0) must survive
+    the _SPEC_FIELDS strip and thread through to ArtifactSpec, with
+    active_hours_utc coerced from a YAML list to a tuple."""
+    fake_s3._registry_body = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+artifacts:
+  - artifact_id: open_orders_latest
+    s3_key_template: "trades/open_orders/latest.json"
+    cadence: continuous
+    interval_minutes: 30
+    sla_minutes_after_cron: 15
+    severity: warning
+    owner_repo: alpha-engine
+    created_at: "2025-01-01"
+    active_trading_days_only: true
+    active_hours_utc: [14, 21]
+"""
+    import index
+    spec = index.load_registry(fake_s3, "buck", "key")[0]
+    assert spec.active_trading_days_only is True
+    assert spec.active_hours_utc == (14, 21)
+
+
 # ── handler — alerts disabled (OBSERVE mode) ────────────────────────────────
 
 


### PR DESCRIPTION
## Why

Fixes the 2026-06-26 `open_orders_latest` **every-30-min overnight alert storm**. The executor daemon writes `trades/open_orders/latest.json` only during the NYSE session, but it was modelled as a 24/7 continuous-30min artifact, so the recency floor (now−45min) flagged it stale every interval off-session. The robust fix adds a continuous **active-window** gate in `nousergon-lib` v0.63.0 (nousergon/nousergon-lib#130).

## What

- Repin `nousergon-lib @ v0.62.0 → v0.63.0`.
- Add the two new `continuous` fields (`active_trading_days_only`, `active_hours_utc`) to `_SPEC_FIELDS` so they survive the registry-load strip and reach `ArtifactSpec`.
- `+1` test (`test_load_registry_threads_active_window_fields`): the fields thread through and `active_hours_utc` coerces list→tuple. 32 handler tests pass locally against v0.63.0.

## CI / deploy notes

- Repo CI (`ci.yml`) installs only the **root** `requirements.txt` and runs `tests/` — it does **not** touch the freshness-monitor subdir, so this PR's CI is unaffected by the `@v0.63.0` pin (the tag publishes when #130 merges).
- `deploy.yml`'s path filter excludes `infrastructure/lambdas/freshness-monitor/**`, so **merging does not auto-deploy**. The monitor is operator-deployed via `infrastructure/lambdas/freshness-monitor/deploy.sh` — the fix goes live on the next manual deploy (after #130 is tagged).

**Merge order:** nousergon/nousergon-lib#130 → this → config registry PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)