### PR TITLE
fix(price_cache): W3 cutover — retire write-both, reference/ is sole home

### DIFF
--- a/builders/_price_cache_writeboth.py
+++ b/builders/_price_cache_writeboth.py
@@ -29,9 +29,12 @@ from __future__ import annotations
 
 from typing import Any
 
-# Wave 3 PR1 — legacy primary, new mirror. The cutover PR (Wave 3 PR4) flips
-# ``PRICE_CACHE_NEW_PREFIX`` to first position and removes the legacy entry
-# from ``price_cache_write_prefixes`` (one-line edit at that time).
+# Wave 3 PR4 (cutover, DONE) — ``reference/price_cache/`` is the sole write +
+# read home. ``PRICE_CACHE_LEGACY_PREFIX`` is retained only as the
+# production-default *sentinel* the prod call sites still pass (the helper
+# translates it to the reference prefix) and so the constant remains importable
+# for any historical reference; the legacy tree itself is removed live via
+# ``aws s3 rm --recursive s3://alpha-engine-research/predictor/price_cache/``.
 PRICE_CACHE_LEGACY_PREFIX = "predictor/price_cache/"
 PRICE_CACHE_NEW_PREFIX = "reference/price_cache/"
 
@@ -39,45 +42,46 @@ PRICE_CACHE_NEW_PREFIX = "reference/price_cache/"
 def price_cache_write_prefixes(primary: str = PRICE_CACHE_LEGACY_PREFIX) -> list[str]:
     """Return the active write prefixes for ticker parquet uploads.
 
-    During the Wave 3 write-both soak (this PR through Wave 3 PR4 cutover):
+    Wave 3 PR4 cutover (this edit) retired the write-both soak: ticker
+    parquets now write to ``reference/price_cache/`` ONLY. The legacy
+    ``predictor/price_cache/`` tree is no longer written and is removed
+    live via ``aws s3 rm --recursive`` once this lands.
 
-      * ``primary == "predictor/price_cache/"`` (the production default) →
-        ``["predictor/price_cache/", "reference/price_cache/"]`` — every
-        ticker-parquet write hits both prefixes byte-for-byte.
+      * ``primary == "predictor/price_cache/"`` (the production-default
+        sentinel that prod call sites still pass) → ``["reference/price_cache/"]``
+        — the sole surviving home.
       * ``primary`` is any other string (custom prefix from a test or a
-        config override) → ``[primary]`` — single-write fallback. Tests
-        that need to assert a single-prefix write pass an explicit custom
-        prefix; production paths use the default and get write-both.
+        config override) → ``[primary]`` — single-write, prefix honored
+        verbatim.
 
     Callers wrap their upload in::
 
         for prefix in price_cache_write_prefixes(s3_prefix):
             s3.upload_file(local_path, bucket, f"{prefix}{ticker}.parquet")
 
-    The order is deterministic (legacy first, new second) so a fail-fast
-    upload error on the legacy prefix preserves the existing pre-Wave-3
-    failure semantics — the new prefix never silently masks a legacy
-    write failure.
+    The default-sentinel argument is kept (rather than retargeting the
+    call sites) so the helper stays the single chokepoint for the prefix
+    contract — call sites pass their config-derived ``s3_prefix`` and the
+    helper owns the legacy→reference translation.
     """
     if primary == PRICE_CACHE_LEGACY_PREFIX:
-        return [PRICE_CACHE_LEGACY_PREFIX, PRICE_CACHE_NEW_PREFIX]
+        return [PRICE_CACHE_NEW_PREFIX]
     return [primary]
 
 
 def price_cache_read_prefixes(primary: str = PRICE_CACHE_LEGACY_PREFIX) -> list[str]:
     """Return active READ prefixes in fallback order.
 
-    Companion to :func:`price_cache_write_prefixes` — the Wave-3 reader
-    migration (PR3+) iterates this in fallback order so the new prefix
-    is consulted first and the legacy prefix is the safety net during
-    the soak window.
+    Companion to :func:`price_cache_write_prefixes`. Wave-3 PR4 cutover
+    (this edit) dropped the legacy ``predictor/price_cache/`` fallback in
+    the same change that retired write-both: with the producer writing
+    only ``reference/price_cache/`` and the legacy tree slated for
+    ``aws s3 rm``, reads resolve from ``reference/`` alone.
 
-      * ``primary == "predictor/price_cache/"`` (the production default) →
-        ``["reference/price_cache/", "predictor/price_cache/"]``: try
-        the new prefix first (post-PR4 it's the sole survivor), fall
-        back to legacy on miss for the soak period.
-      * ``primary`` is any other string → ``[primary]`` (single-read
-        fallback, mirrors the test-friendly write-side semantics).
+      * ``primary == "predictor/price_cache/"`` (the production-default
+        sentinel) → ``["reference/price_cache/"]``: the sole surviving home.
+      * ``primary`` is any other string → ``[primary]`` (single-read,
+        prefix honored verbatim — mirrors the write-side semantics).
 
     Callers wrap their reads in::
 
@@ -86,12 +90,9 @@ def price_cache_read_prefixes(primary: str = PRICE_CACHE_LEGACY_PREFIX) -> list[
                 return s3.get_object(Bucket=bucket, Key=f"{prefix}{name}")
             except ClientError:
                 continue
-
-    At Wave-3 PR4 cutover the legacy entry is removed here in the same
-    edit that flips the write helper — one-line change in each.
     """
     if primary == PRICE_CACHE_LEGACY_PREFIX:
-        return [PRICE_CACHE_NEW_PREFIX, PRICE_CACHE_LEGACY_PREFIX]
+        return [PRICE_CACHE_NEW_PREFIX]
     return [primary]
 
 

--- a/tests/test_chronic_polygon_gap_self_heal.py
+++ b/tests/test_chronic_polygon_gap_self_heal.py
@@ -89,8 +89,11 @@ def _stub_universe_lib(ticker_to_last_date: dict[str, str | None]):
 
 
 def _stub_s3_with_pcache(parquet_dfs_by_ticker: dict[str, pd.DataFrame]):
-    """S3 stub that serves predictor/price_cache/{T}.parquet from a dict
-    of in-memory DataFrames; raises NoSuchKey for absent tickers."""
+    """S3 stub that serves reference/price_cache/{T}.parquet from a dict
+    of in-memory DataFrames; raises NoSuchKey for absent tickers.
+
+    Wave-3 PR4 cutover: the self-heal read/write chain is reference-only,
+    so the stub serves + records the ``reference/price_cache/`` prefix."""
     s3 = MagicMock()
 
     class _NoSuchKey(Exception):
@@ -102,7 +105,7 @@ def _stub_s3_with_pcache(parquet_dfs_by_ticker: dict[str, pd.DataFrame]):
 
     def _get_object(Bucket, Key):
         for ticker, df in parquet_dfs_by_ticker.items():
-            if Key == f"predictor/price_cache/{ticker}.parquet":
+            if Key == f"reference/price_cache/{ticker}.parquet":
                 buf = io.BytesIO()
                 df.to_parquet(buf, engine="pyarrow")
                 buf.seek(0)
@@ -162,7 +165,7 @@ def test_self_heal_backfills_pstg_via_yfinance_and_invokes_per_ticker_backfill()
     """The 2026-05-09 incident exact path: PSTG at 5/5 in ArcticDB,
     target=5/8, yfinance has 5/6 + 5/7 + 5/8. Self-heal must:
       - yfinance-fetch [5/6, 5/8]
-      - patch predictor/price_cache/PSTG.parquet with new rows (deduped)
+      - patch reference/price_cache/PSTG.parquet with new rows (deduped)
       - invoke builders.backfill(ticker_filter='PSTG') so the ArcticDB
         write goes through the same per-ticker compute_features path.
     """
@@ -203,9 +206,12 @@ def test_self_heal_backfills_pstg_via_yfinance_and_invokes_per_ticker_backfill()
     assert healed["new_last_date"] == "2026-05-08"
     assert len(result["errors"]) == 0
 
-    # Patched parquet got written with the fresh rows merged in
-    pcache_key = "predictor/price_cache/PSTG.parquet"
+    # Patched parquet got written with the fresh rows merged in (reference-only)
+    pcache_key = "reference/price_cache/PSTG.parquet"
     assert pcache_key in s3.written
+    assert not any(
+        k.startswith("predictor/price_cache/") for k in s3.written
+    )
     written_df = pd.read_parquet(io.BytesIO(s3.written[pcache_key]))
     assert pd.Timestamp("2026-05-08") in written_df.index
     assert pd.Timestamp("2026-05-06") in written_df.index

--- a/tests/test_daily_append_parquet_warmup.py
+++ b/tests/test_daily_append_parquet_warmup.py
@@ -300,38 +300,32 @@ def test_load_parquet_warmup_prefers_new_prefix(monkeypatch):
     )
 
 
-def test_load_parquet_warmup_falls_back_to_legacy_on_new_prefix_miss(monkeypatch):
-    """When the new prefix is empty (e.g. the soak-window backfill hasn't
-    seeded a brand-new ticker yet) the legacy fallback is consulted; if
-    legacy has the parquet the helper returns it.
+def test_load_parquet_warmup_does_not_consult_legacy_after_cutover(monkeypatch):
+    """Wave-3 PR4 cutover: the legacy fallback is dropped. A miss on the
+    ``reference/`` prefix is the end of the chain — the helper does NOT fall
+    back to ``predictor/price_cache/`` (which is removed live via
+    ``aws s3 rm``). A new-prefix NoSuchKey degrades straight to None.
     """
-    good_df = pd.DataFrame(
-        {"Open": [1.0], "High": [1.0], "Low": [1.0], "Close": [1.0], "Volume": [1]},
-        index=pd.DatetimeIndex(["2026-04-20"]),
-    )
     calls: list[str] = []
 
     def _stub(_s3, _bucket, key):
         calls.append(key)
-        if key.startswith("reference/"):
-            raise _fake_client_error("NoSuchKey")
-        return good_df
+        raise _fake_client_error("NoSuchKey")
 
     monkeypatch.setattr(daily_append, "load_parquet_from_s3", _stub)
 
     result = daily_append._load_parquet_warmup(MagicMock(), "b", "AAPL")
-    assert result is not None
-    assert calls == [
-        "reference/price_cache/AAPL.parquet",
-        "predictor/price_cache/AAPL.parquet",
-    ], "Fallback order must be new → legacy (read = write reversed)."
+    assert result is None
+    assert calls == ["reference/price_cache/AAPL.parquet"], (
+        "Post-cutover the read chain is reference-only — the legacy "
+        "predictor/price_cache/ prefix must NOT be consulted."
+    )
 
 
-def test_load_parquet_warmup_returns_none_when_absent_in_both_prefixes(monkeypatch):
-    """A ticker absent from BOTH prefixes is a genuine "not in price
-    cache yet" state (brand-new constituent the weekly backfill hasn't
-    picked up). Both prefix lookups must be attempted before the helper
-    degrades to None — a single-prefix NoSuchKey is no longer sufficient.
+def test_load_parquet_warmup_returns_none_when_absent_from_reference(monkeypatch):
+    """A ticker absent from ``reference/`` is a genuine "not in price cache
+    yet" state (brand-new constituent the weekly backfill hasn't picked up).
+    Post-cutover that's a single-prefix lookup — no legacy second attempt.
     """
     calls: list[str] = []
 
@@ -343,7 +337,7 @@ def test_load_parquet_warmup_returns_none_when_absent_in_both_prefixes(monkeypat
 
     result = daily_append._load_parquet_warmup(MagicMock(), "b", "NEWIPO")
     assert result is None
-    assert len(calls) == 2, (
-        "When the new prefix is missing the helper must still try legacy "
-        "before declaring the ticker absent."
+    assert calls == ["reference/price_cache/NEWIPO.parquet"], (
+        "Post-cutover only the reference prefix is consulted before "
+        "declaring the ticker absent."
     )

--- a/tests/test_fred_history_fetcher.py
+++ b/tests/test_fred_history_fetcher.py
@@ -273,9 +273,9 @@ class TestBackfillToS3:
         assert result["per_ticker"]["HYOAS"]["status"] == "ok"
 
     def test_uploads_to_s3_when_not_dry_run(self):
-        """Wave 3 PR1: each FRED-sourced ticker writes to BOTH legacy
-        (``predictor/price_cache/``) and new (``reference/price_cache/``)
-        prefixes. PR4 cutover will flip this back to a single key."""
+        """Wave 3 PR4 (cutover): each FRED-sourced ticker writes to ONLY the
+        new ``reference/price_cache/`` prefix — write-both is retired and the
+        legacy ``predictor/price_cache/`` write is GONE."""
         with self._patch_fetch_returning(), \
              patch("collectors.fred_history.boto3.client") as mock_boto:
             mock_s3 = MagicMock()
@@ -286,17 +286,14 @@ class TestBackfillToS3:
                 dry_run=False,
             )
         assert result["dry_run"] is False
-        # upload_file called twice — once per write-both prefix
-        assert mock_s3.upload_file.call_count == 2
+        # upload_file called once — single (reference-only) write post-cutover.
+        assert mock_s3.upload_file.call_count == 1
         keys = sorted(
             call.args[2] for call in mock_s3.upload_file.call_args_list
         )
-        assert keys == [
-            "predictor/price_cache/TWO.parquet",
-            "reference/price_cache/TWO.parquet",
-        ]
-        # Both writes hit the same bucket + same local file
+        assert keys == ["reference/price_cache/TWO.parquet"]
+        assert not any(
+            k.startswith("predictor/price_cache/") for k in keys
+        )
         buckets = {call.args[1] for call in mock_s3.upload_file.call_args_list}
         assert buckets == {"test-bucket"}
-        local_paths = {call.args[0] for call in mock_s3.upload_file.call_args_list}
-        assert len(local_paths) == 1  # same local parquet body for both uploads

--- a/tests/test_price_cache_writeboth.py
+++ b/tests/test_price_cache_writeboth.py
@@ -1,18 +1,17 @@
-"""Wave 3 PR1 — producer-side write-both regression suite.
+"""Wave 3 PR4 (cutover) — producer-side single-prefix regression suite.
 
 Covers:
-  * The ``price_cache_write_prefixes`` helper itself (legacy default → both,
-    custom prefix → single).
+  * The ``price_cache_write_prefixes`` / ``price_cache_read_prefixes`` helpers
+    themselves: the production-default sentinel now resolves to
+    ``reference/price_cache/`` ONLY (legacy dropped), custom prefix → single.
   * Each of the three production writers (``collectors/prices.py``,
-    ``collectors/fred_history.py``, ``weekly_collector._patch_chronic_gap_ticker``
+    ``collectors/fred_history.py``, ``weekly_collector._self_heal_chronic_polygon_gaps``
     via its module-scoped chronic-gap path) calls into the helper and ends up
-    putting ticker parquets at BOTH the legacy and new prefix, with identical
-    bodies and key shape.
+    putting ticker parquets at ONLY the new ``reference/price_cache/`` prefix.
 
-These tests pin the Wave 3 write-both contract so a future "delete the legacy
-write" refactor can't quietly skip a writer — every active prod path is
-exercised. PR4 cutover edits the helper + flips these tests to expect a
-single-prefix write.
+These tests pin the Wave 3 cutover contract: write-both is retired and the
+legacy ``predictor/price_cache/`` prefix is GONE from both the write and read
+chains. Any regression that re-introduces a legacy write/read fails here.
 """
 
 from __future__ import annotations
@@ -37,23 +36,23 @@ from builders._price_cache_writeboth import (
 # ---------------------------------------------------------------------------
 
 
-def test_default_returns_both_prefixes_legacy_first():
-    """Production default → write-both with legacy ordered first.
-
-    Order matters: legacy first so a permission/quota failure on the legacy
-    prefix preserves pre-Wave-3 fail-loud semantics — the new prefix never
-    silently masks a legacy write failure.
+def test_default_writes_reference_only_legacy_dropped():
+    """Wave-3 PR4 cutover: production default → single write to the new
+    ``reference/price_cache/`` prefix. The legacy ``predictor/price_cache/``
+    entry is GONE — write-both is retired.
     """
     out = price_cache_write_prefixes()
-    assert out == [PRICE_CACHE_LEGACY_PREFIX, PRICE_CACHE_NEW_PREFIX]
+    assert out == [PRICE_CACHE_NEW_PREFIX]
+    assert PRICE_CACHE_LEGACY_PREFIX not in out
 
 
-def test_explicit_legacy_returns_both_prefixes():
-    """Callers that pass the legacy prefix explicitly get the same result as
-    callers that use the default — protects against config-layer regressions
-    where ``s3_prefix`` is read from yaml and matches the legacy string."""
+def test_explicit_legacy_sentinel_resolves_to_reference_only():
+    """The legacy string is still the production-default sentinel the prod
+    call sites pass (config ``s3_prefix``). Post-cutover it resolves to the
+    reference prefix ONLY — never writes to the legacy tree."""
     out = price_cache_write_prefixes(PRICE_CACHE_LEGACY_PREFIX)
-    assert out == [PRICE_CACHE_LEGACY_PREFIX, PRICE_CACHE_NEW_PREFIX]
+    assert out == [PRICE_CACHE_NEW_PREFIX]
+    assert PRICE_CACHE_LEGACY_PREFIX not in out
 
 
 def test_custom_prefix_returns_single():
@@ -78,18 +77,20 @@ def test_new_prefix_is_not_legacy():
 # ---------------------------------------------------------------------------
 
 
-def test_read_helper_default_returns_new_first_legacy_second():
-    """The read order is the WRITE order REVERSED — new prefix consulted
-    first so consumers see the post-PR4 home as soon as the soak begins;
-    legacy is the fallback during the soak window only.
+def test_read_helper_default_resolves_reference_only():
+    """Wave-3 PR4 cutover: the read chain drops the legacy fallback. With the
+    producer writing only ``reference/`` and the legacy tree slated for
+    ``aws s3 rm``, reads resolve from ``reference/`` alone.
     """
     out = price_cache_read_prefixes()
-    assert out == [PRICE_CACHE_NEW_PREFIX, PRICE_CACHE_LEGACY_PREFIX]
+    assert out == [PRICE_CACHE_NEW_PREFIX]
+    assert PRICE_CACHE_LEGACY_PREFIX not in out
 
 
-def test_read_helper_explicit_legacy_returns_new_first_legacy_second():
+def test_read_helper_explicit_legacy_sentinel_resolves_reference_only():
     out = price_cache_read_prefixes(PRICE_CACHE_LEGACY_PREFIX)
-    assert out == [PRICE_CACHE_NEW_PREFIX, PRICE_CACHE_LEGACY_PREFIX]
+    assert out == [PRICE_CACHE_NEW_PREFIX]
+    assert PRICE_CACHE_LEGACY_PREFIX not in out
 
 
 def test_read_helper_custom_prefix_returns_single():
@@ -123,49 +124,29 @@ def _make_paginator(pages_by_prefix: dict[str, list[list[dict]]]):
     return s3
 
 
-def test_list_price_cache_keys_default_iterates_new_then_legacy():
-    """Aggregate listing under the production default consults the new
-    prefix first then the legacy prefix; tickers present in BOTH only
-    surface once (first-prefix-wins, deduped by basename).
+def test_list_price_cache_keys_default_lists_reference_only():
+    """Wave-3 PR4 cutover: aggregate listing under the production default
+    consults the new ``reference/`` prefix ONLY — the legacy leg is dropped
+    from the read chain, so any keys still lingering under the legacy prefix
+    (pre-``aws s3 rm``) are NOT listed.
     """
     new_keys = [{"Key": f"{PRICE_CACHE_NEW_PREFIX}AAPL.parquet"},
                 {"Key": f"{PRICE_CACHE_NEW_PREFIX}MSFT.parquet"}]
     legacy_keys = [{"Key": f"{PRICE_CACHE_LEGACY_PREFIX}AAPL.parquet"},
-                   {"Key": f"{PRICE_CACHE_LEGACY_PREFIX}MSFT.parquet"}]
+                   {"Key": f"{PRICE_CACHE_LEGACY_PREFIX}MSFT.parquet"},
+                   {"Key": f"{PRICE_CACHE_LEGACY_PREFIX}ZZZZ.parquet"}]
     s3 = _make_paginator({
         PRICE_CACHE_NEW_PREFIX: [new_keys],
         PRICE_CACHE_LEGACY_PREFIX: [legacy_keys],
     })
 
     out = list_price_cache_keys(s3, "alpha-engine-research")
-    # AAPL + MSFT each appear exactly once, both anchored on the new prefix.
+    # Only the reference-prefix keys surface; the legacy-only ZZZZ is ignored.
     assert out == [
         f"{PRICE_CACHE_NEW_PREFIX}AAPL.parquet",
         f"{PRICE_CACHE_NEW_PREFIX}MSFT.parquet",
-    ], "First-prefix-wins must dedupe by {ticker}.parquet basename."
-
-
-def test_list_price_cache_keys_falls_back_to_legacy_for_missing_basenames():
-    """When the new prefix is partially populated (soak-window backfill
-    hasn't picked up every ticker yet), legacy fills the gaps so the
-    aggregate set stays complete — the whole point of keeping the
-    legacy fallback live during the soak.
-    """
-    # Only AAPL has been mirrored to new yet; MSFT still legacy-only.
-    new_keys = [{"Key": f"{PRICE_CACHE_NEW_PREFIX}AAPL.parquet"}]
-    legacy_keys = [{"Key": f"{PRICE_CACHE_LEGACY_PREFIX}AAPL.parquet"},
-                   {"Key": f"{PRICE_CACHE_LEGACY_PREFIX}MSFT.parquet"}]
-    s3 = _make_paginator({
-        PRICE_CACHE_NEW_PREFIX: [new_keys],
-        PRICE_CACHE_LEGACY_PREFIX: [legacy_keys],
-    })
-
-    out = list_price_cache_keys(s3, "alpha-engine-research")
-    # AAPL from new (first-wins), MSFT from legacy (gap-fill).
-    assert out == [
-        f"{PRICE_CACHE_NEW_PREFIX}AAPL.parquet",
-        f"{PRICE_CACHE_LEGACY_PREFIX}MSFT.parquet",
     ]
+    assert not any(k.startswith(PRICE_CACHE_LEGACY_PREFIX) for k in out)
 
 
 def test_list_price_cache_keys_custom_prefix_opts_out_of_chain():
@@ -224,12 +205,10 @@ def test_prices_refresh_uploads_to_both_prefixes(monkeypatch, tmp_path):
 
     assert refreshed == 1
     assert failed == []
-    # Both prefixes hit, same ticker, same bucket
+    # Cutover: ONLY the reference prefix is hit — legacy write retired.
     keys = sorted(k for _b, k in recorded)
-    assert keys == [
-        f"{PRICE_CACHE_LEGACY_PREFIX}AAPL.parquet",
-        f"{PRICE_CACHE_NEW_PREFIX}AAPL.parquet",
-    ]
+    assert keys == [f"{PRICE_CACHE_NEW_PREFIX}AAPL.parquet"]
+    assert not any(k.startswith(PRICE_CACHE_LEGACY_PREFIX) for _b, k in recorded)
     assert all(b == "test-bucket" for b, _ in recorded)
 
 
@@ -279,11 +258,10 @@ def test_fred_backfill_uploads_to_both_prefixes(monkeypatch):
 
     assert out["status"] == "ok"
     assert out["refreshed"] == 1
+    # Cutover: ONLY the reference prefix is hit — legacy write retired.
     keys = sorted(k for _b, k in recorded)
-    assert keys == [
-        f"{PRICE_CACHE_LEGACY_PREFIX}TWO.parquet",
-        f"{PRICE_CACHE_NEW_PREFIX}TWO.parquet",
-    ]
+    assert keys == [f"{PRICE_CACHE_NEW_PREFIX}TWO.parquet"]
+    assert not any(k.startswith(PRICE_CACHE_LEGACY_PREFIX) for _b, k in recorded)
 
 
 # ---------------------------------------------------------------------------
@@ -291,11 +269,12 @@ def test_fred_backfill_uploads_to_both_prefixes(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_weekly_chronic_gap_self_heal_writes_both_prefixes(monkeypatch):
-    """``_self_heal_chronic_polygon_gaps`` reads the legacy parquet for the
-    existing-rows union, then PUTs the combined frame back. Wave 3 PR1 sends
-    the PUT to both prefixes with identical body bytes; the GET stays on
-    legacy until reader migration (PR3+)."""
+def test_weekly_chronic_gap_self_heal_writes_reference_only(monkeypatch):
+    """``_self_heal_chronic_polygon_gaps`` reads the parquet for the
+    existing-rows union via the read-prefix chain (now ``reference/`` only),
+    then PUTs the combined frame back via the write-prefix chain (also
+    ``reference/`` only). Wave 3 PR4 cutover: the PUT lands on the reference
+    prefix ONLY — the legacy write is retired."""
     import weekly_collector as wc
 
     target_date = "2026-05-12"
@@ -366,15 +345,11 @@ def test_weekly_chronic_gap_self_heal_writes_both_prefixes(monkeypatch):
     assert summary["errors"] == [], summary
     assert len(summary["healed"]) == 1, summary
 
-    # Both prefixes hit with the same ticker key, bodies identical
+    # Cutover: ONLY the reference prefix is hit — legacy write retired.
     pcache_keys = sorted(
         c["Key"] for c in put_calls if c["Key"].endswith("/PSTG.parquet")
     )
-    assert pcache_keys == [
-        f"{PRICE_CACHE_LEGACY_PREFIX}PSTG.parquet",
-        f"{PRICE_CACHE_NEW_PREFIX}PSTG.parquet",
-    ], pcache_keys
-
-    bodies = [c["Body"] for c in put_calls if c["Key"].endswith("/PSTG.parquet")]
-    assert len(bodies) == 2
-    assert bodies[0] == bodies[1]
+    assert pcache_keys == [f"{PRICE_CACHE_NEW_PREFIX}PSTG.parquet"], pcache_keys
+    assert not any(
+        c["Key"].startswith(PRICE_CACHE_LEGACY_PREFIX) for c in put_calls
+    )

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -78,6 +78,7 @@ setup_logging(
 
 from collectors import constituents, prices, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest, metron_market_data
 from builders._price_cache_writeboth import (
+    price_cache_read_prefixes as _price_cache_read_prefixes,
     price_cache_write_prefixes as _price_cache_write_prefixes,
 )
 from dates import default_run_date  # config#1014: trading-day-axis default
@@ -1020,16 +1021,24 @@ def _self_heal_chronic_polygon_gaps(
             ohlcv_cols = ["Open", "High", "Low", "Close", "Volume"]
             new_rows = yf_df[[c for c in ohlcv_cols if c in yf_df.columns]].copy()
 
-            # Wave 3 PR1: read from legacy (single source of truth during the
-            # write-both soak — readers haven't migrated yet); write to both
-            # legacy + new prefix on the put back (see
-            # builders/_price_cache_writeboth.py for soak contract)
-            pcache_key = f"predictor/price_cache/{ticker}.parquet"
-            try:
-                obj = s3.get_object(Bucket=bucket, Key=pcache_key)
-                existing_pcache = _pd.read_parquet(_io.BytesIO(obj["Body"].read()))
-            except s3.exceptions.NoSuchKey:
-                existing_pcache = _pd.DataFrame(columns=ohlcv_cols)
+            # Wave 3 PR4 (cutover): read via the read-prefix chain (now
+            # ``reference/price_cache/`` only) for the existing-rows union,
+            # then write back to the write-prefix chain (also ``reference/``
+            # only). Post-cutover both chains resolve to the reference home;
+            # the legacy ``predictor/price_cache/`` tree is removed live via
+            # ``aws s3 rm`` (see builders/_price_cache_writeboth.py).
+            existing_pcache = _pd.DataFrame(columns=ohlcv_cols)
+            for _read_prefix in _price_cache_read_prefixes():
+                try:
+                    obj = s3.get_object(
+                        Bucket=bucket, Key=f"{_read_prefix}{ticker}.parquet"
+                    )
+                    existing_pcache = _pd.read_parquet(
+                        _io.BytesIO(obj["Body"].read())
+                    )
+                    break
+                except s3.exceptions.NoSuchKey:
+                    continue
 
             combined_pcache = _pd.concat([existing_pcache, new_rows])
             combined_pcache = combined_pcache[


### PR DESCRIPTION
## Summary

Wave-3 **PR4 (cutover)** of the `predictor/` S3 namespace rationalization — **W3 slice** of nousergon/alpha-engine-config#780. Migrates the 10y per-ticker `price_cache` parquet tree from `predictor/price_cache/` to `reference/price_cache/`.

Root-cause cutover through the single write-both chokepoint `builders/_price_cache_writeboth.py` (no bandaids/guards — clean deletion of the legacy leg):

- **`price_cache_write_prefixes`** — production-default sentinel now resolves to `["reference/price_cache/"]` only. **Write-both retired.**
- **`price_cache_read_prefixes`** — legacy fallback dropped; reads resolve from `reference/` alone. `list_price_cache_keys` follows automatically (it iterates the read chain).
- **`weekly_collector._self_heal_chronic_polygon_gaps`** — the chronic-gap self-heal previously **hardcoded a legacy READ** (`predictor/price_cache/{ticker}.parquet`) before its put-back. That read would break silently after the live `aws s3 rm` of the legacy tree, losing the existing-rows union. **Migrated to the read-prefix chain** (reference-only) so the self-heal stays correct post-rm. This is the key sequencing-safety fix in this repo.

`PRICE_CACHE_LEGACY_PREFIX` is retained only as the production-default **sentinel** the prod call sites pass (`s3_prefix` default); the helper owns the legacy→reference translation, keeping it the single chokepoint.

## Tests

Flipped from the soak-era write-both/dual-read contract to the cutover contract — single reference-only write, reference-only read, legacy prefix asserted **GONE** from both chains:
- `test_price_cache_writeboth.py`, `test_daily_append_parquet_warmup.py`, `test_fred_history_fetcher.py`, `test_chronic_polygon_gap_self_heal.py`

Local run (minimal deps + `alpha-engine-lib`/`arcticdb` from git): the affected suites pass —
`test_price_cache_writeboth` (12), `test_daily_append_parquet_warmup`, `test_fred_history_fetcher`, `test_chronic_polygon_gap_self_heal`, `test_sf_preflight`, `test_preflight`, `test_backfill_no_regression`, `test_backfill_unified_and_macro_scoping` all green (126 in the combined run). CI expected green.

## Sequencing

Producer now writes only `reference/`. Readers across repos already prefer `reference/` and have their legacy fallbacks dropped in the sibling W3 PRs:
- crucible-predictor: https://github.com/nousergon/crucible-predictor/pull/293
- crucible-backtester: https://github.com/nousergon/crucible-backtester/pull/373

## DRAFT — why

The cutover assumes `reference/price_cache/` is **fully populated** live (it has been write-both for weeks, so it should be). **This runner had no AWS credentials, so that assumption could not be validated here.** Promote to ready once an operator confirms:

```
aws s3 ls s3://alpha-engine-research/reference/price_cache/ | wc -l
# should match the legacy tree's ticker-parquet count:
aws s3 ls s3://alpha-engine-research/predictor/price_cache/ | wc -l
```

## Live operator follow-up (NOT done by this PR)

After this + the two sibling reader PRs merge and ≥1 Saturday SF write cycle confirms `reference/` is current:

```
aws s3 rm --recursive s3://alpha-engine-research/predictor/price_cache/
```

Advances #780 (W3 slice).
