### PR TITLE
feat(freshness-monitor): auto-deploy Lambda code on merge

### DIFF
--- a/.github/workflows/deploy-freshness-monitor.yml
+++ b/.github/workflows/deploy-freshness-monitor.yml
@@ -1,0 +1,87 @@
+name: Deploy freshness-monitor
+
+# Auto-deploy the alpha-engine-freshness-monitor Lambda CODE on merge to main.
+#
+# Why this exists: the freshness-monitor was previously operator-deployed only
+# (its function ARN was deliberately omitted from the github-actions-lambda-
+# deploy role's enumerated grant). The 2026-06-26 open_orders active-window fix
+# shipped to the registry + lib but couldn't go live without a manual deploy.sh
+# — so a registry/lib fix sat inert. This closes that gap: any change under
+# infrastructure/lambdas/freshness-monitor/** redeploys the Lambda code.
+#
+# Separation of concerns: this deploys CODE only (deploy.sh --code-only). The
+# artifact REGISTRY is owned by alpha-engine-config and pushed to S3 by its own
+# sync-artifact-registry.yml on registry merges — so this job needs no
+# ae-config clone and never touches the registry.
+#
+# IAM: the github-actions-lambda-deploy role's LambdaUpdate grant was collapsed
+# from an enumerated function list to arn:...:function:alpha-engine-* (which now
+# covers this function and freed ~4.6KB under the 10,240-char inline-policy
+# ceiling). Apply via infrastructure/iam/apply.sh at merge.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/freshness-monitor/**'
+      - '.github/workflows/deploy-freshness-monitor.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-freshness-monitor-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy freshness-monitor Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy freshness-monitor (code-only)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/freshness-monitor/deploy.sh --code-only
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-freshness-monitor \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-freshness-monitor.yml
+
+  # Alert (Telegram) on genuine post-merge failure on the default branch.
+  # Reusable workflow + transport in nousergon-lib. config#1128.
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -43,25 +43,7 @@
         "lambda:CreateAlias"
       ],
       "Resource": [
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-submit",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-poll",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-process",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-aggregate-costs",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-scanner",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director"
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
       ]
     },
     {
@@ -71,44 +53,8 @@
         "lambda:InvokeFunction"
       ],
       "Resource": [
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-alerts:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-submit",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-submit:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-poll",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-poll:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-process",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge-process:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-aggregate-costs",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-aggregate-costs:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-scanner",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-scanner:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator:*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator-director:*"
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*:*"
       ]
     },
     {

--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -11,15 +11,24 @@
 # Validates the registry locally before upload — a malformed registry
 # never reaches S3.
 #
-# Managed outside CloudFormation — same rationale as sf-telegram-notifier /
-# spot-orphan-reaper / changelog-cloudwatch-mirror (keeps the
-# github-actions-lambda-deploy OIDC role's blast radius narrow;
-# operator-deployed only). Phase 6 cutover flips
-# FRESHNESS_MONITOR_ENABLED via
+# Managed outside CloudFormation — same packaging rationale as
+# sf-telegram-notifier / spot-orphan-reaper / changelog-cloudwatch-mirror.
+# CODE auto-deploys on merge to main via
+# `.github/workflows/deploy-freshness-monitor.yml` (path-filtered to
+# `infrastructure/lambdas/freshness-monitor/**`), which runs this script
+# with `--code-only` under the github-actions-lambda-deploy OIDC role
+# (granted `lambda:UpdateFunctionCode` on `alpha-engine-*`). The artifact
+# REGISTRY is owned by alpha-engine-config and uploaded to S3 by its own
+# `sync-artifact-registry.yml` on registry merges — so `--code-only` skips
+# the registry validation + upload here (no ae-config clone needed in CI).
+# The full (non-`--code-only`) path remains the operator command for a
+# from-a-laptop deploy that also re-pushes the registry. Phase 6 cutover
+# flips FRESHNESS_MONITOR_ENABLED via
 # `aws lambda update-function-configuration` without redeploying.
 #
 # Usage:
-#   bash infrastructure/lambdas/freshness-monitor/deploy.sh             # update code + registry
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh             # update code + registry (operator; needs ae-config clone)
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh --code-only # update code ONLY (CI path; no registry, no ae-config clone)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --bootstrap # first-time create + wire EventBridge
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --dry-run   # show actions, do not apply
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --smoke     # invoke once after deploy
@@ -47,11 +56,13 @@ REGISTRY_S3_KEY="_freshness_monitor/ARTIFACT_REGISTRY.yaml"
 DRY_RUN=false
 BOOTSTRAP=false
 SMOKE=false
+CODE_ONLY=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
     --bootstrap) BOOTSTRAP=true ;;
     --smoke) SMOKE=true ;;
+    --code-only) CODE_ONLY=true ;;
     -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
   esac
 done
@@ -74,17 +85,23 @@ print('index.py syntax OK')
 "
 
 # ----- 0b. Verify ae-config clone present (registry validation runs later) -
+# Skipped under --code-only: the registry is owned + S3-synced by
+# alpha-engine-config (sync-artifact-registry.yml), so a code-only CI
+# deploy needs no ae-config clone.
 
-if [[ ! -f "${REGISTRY_LOCAL}" ]]; then
-  echo "❌ Registry not found at ${REGISTRY_LOCAL}"
-  echo "   Clone nousergon/alpha-engine-config into ~/Development/ or set CONFIG_REPO"
-  exit 1
-fi
+if ! $CODE_ONLY; then
+  if [[ ! -f "${REGISTRY_LOCAL}" ]]; then
+    echo "❌ Registry not found at ${REGISTRY_LOCAL}"
+    echo "   Clone nousergon/alpha-engine-config into ~/Development/ or set CONFIG_REPO"
+    echo "   (or pass --code-only to deploy code without re-pushing the registry)"
+    exit 1
+  fi
 
-if [[ ! -f "${REGISTRY_VALIDATOR}" ]]; then
-  echo "❌ Validator not found at ${REGISTRY_VALIDATOR}"
-  echo "   alpha-engine-config must be at the post-PR-#344 commit (artifact-registry-bootstrap merged)"
-  exit 1
+  if [[ ! -f "${REGISTRY_VALIDATOR}" ]]; then
+    echo "❌ Validator not found at ${REGISTRY_VALIDATOR}"
+    echo "   alpha-engine-config must be at the post-PR-#344 commit (artifact-registry-bootstrap merged)"
+    exit 1
+  fi
 fi
 
 # ----- 1. Package: pip install runtime deps into $PKG ----------------------
@@ -103,9 +120,12 @@ python3 -m pip install \
 # ----- 1a. Validate registry locally before upload --------------------------
 # Runs AFTER step 1's pip install — the validator imports yaml which isn't
 # guaranteed in the caller's bare python. PYTHONPATH=$PKG resolves it.
+# Skipped under --code-only (alpha-engine-config CI validates + uploads it).
 
-echo "Validating registry locally before upload..."
-PYTHONPATH="${PKG}" python3 "${REGISTRY_VALIDATOR}" --registry "${REGISTRY_LOCAL}"
+if ! $CODE_ONLY; then
+  echo "Validating registry locally before upload..."
+  PYTHONPATH="${PKG}" python3 "${REGISTRY_VALIDATOR}" --registry "${REGISTRY_LOCAL}"
+fi
 
 # ----- 1b. Preflight handler unit tests with runtime deps available --------
 # Runs AFTER step 1's pip install so the test's `import index` succeeds
@@ -267,14 +287,20 @@ fi
 echo "✓ Code deployed."
 
 # ----- 4. Upload registry to S3 ---------------------------------------------
+# Skipped under --code-only: alpha-engine-config's sync-artifact-registry.yml
+# owns the registry → S3 upload on registry merges. Keeping it here too would
+# double-write (harmless) but requires the ae-config clone the CI path lacks.
 
-echo "Uploading registry: ${REGISTRY_LOCAL} → s3://${REGISTRY_BUCKET}/${REGISTRY_S3_KEY}"
-run aws s3 cp \
-  "${REGISTRY_LOCAL}" \
-  "s3://${REGISTRY_BUCKET}/${REGISTRY_S3_KEY}" \
-  --region "${REGION}"
-
-echo "✓ Registry uploaded."
+if ! $CODE_ONLY; then
+  echo "Uploading registry: ${REGISTRY_LOCAL} → s3://${REGISTRY_BUCKET}/${REGISTRY_S3_KEY}"
+  run aws s3 cp \
+    "${REGISTRY_LOCAL}" \
+    "s3://${REGISTRY_BUCKET}/${REGISTRY_S3_KEY}" \
+    --region "${REGION}"
+  echo "✓ Registry uploaded."
+else
+  echo "↪ --code-only: skipping registry upload (owned by alpha-engine-config sync workflow)."
+fi
 
 # ----- 5. Smoke (direct invoke) ---------------------------------------------
 


### PR DESCRIPTION
## Why
You asked why the freshness-monitor wasn't auto-deployed — the real reason isn't just convention: the `github-actions-lambda-deploy` OIDC role grants `lambda:UpdateFunctionCode` on an **enumerated list** of function ARNs, and `alpha-engine-freshness-monitor` was deliberately left off it. So registry/lib fixes (like the 2026-06-26 open_orders active-window fix) couldn't go live without a manual `deploy.sh`. This makes it auto-deploy.

## What
- **`.github/workflows/deploy-freshness-monitor.yml`** — on push to main under `infrastructure/lambdas/freshness-monitor/**`, runs `deploy.sh --code-only` under the OIDC deploy role. Adds `workflow_dispatch`, deploy-changelog append, and `notify-main-failure` (config#1128).
- **`deploy.sh --code-only`** — deploy CODE without the ae-config clone / registry validation / registry S3 upload. The registry is owned by **alpha-engine-config** and S3-synced by its own `sync-artifact-registry.yml`, so the CI path needs neither the clone nor the registry write. The full path stays the operator command.
- **`infrastructure/iam/github-actions-lambda-deploy.json`** — collapse the enumerated `LambdaUpdate` + `LambdaInvokeCanary` function-ARN lists to `arn:...:function:alpha-engine-*`. This covers `alpha-engine-freshness-monitor` **and** shrinks the inline policy **10,163 → 5,519 chars**, clearing the 10,240 ceiling (config#1204). Consistent with the role's already-wildcarded `AddPermission`/`Tag`/`PassRole` on `alpha-engine-*`. (Trade-off accepted: code-update now reaches all `alpha-engine-*` lambdas incl. the 3 other ops lambdas — your call, wildcard-collapse.)

## ⚠️ Expected-red check: `iam-drift-check`
The IAM drift-check **will be RED on this PR by design** — the committed JSON now differs from live IAM. This is the documented chicken-and-egg (`~/.claude/CLAUDE.md`: IAM JSON rides the PR; live is applied at merge).
**Unblock at merge:** run `cd alpha-engine-data && ./infrastructure/iam/apply.sh github-actions-lambda-deploy` (needs an IAM-capable identity — cipher813), then the drift clears. Do this **before/at merge** so the first auto-deploy run has the grant live (else its `UpdateFunctionCode` 403s and you re-run via `workflow_dispatch`).

## Activation
After merge + `apply.sh`, this PR's own merge (it touches `deploy.sh` under the watched path) triggers the first auto-deploy — shipping the already-merged active-window code and **stopping the overnight `open_orders` alert storm**. Closes the deploy half of config#1251.

## Tests
IAM SF-coverage + lambda-grant + registry-coverage green; `deploy.sh --code-only --dry-run` packages, runs the 32 handler tests, and resolves lib v0.63.0 end-to-end locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)