### PR TITLE
fix(gdelt): honor 429 Retry-After with one bounded retry per ticker (config#663)

### DIFF
--- a/collectors/news_sources/gdelt.py
+++ b/collectors/news_sources/gdelt.py
@@ -49,6 +49,16 @@ _GDELT_DOC_API = "https://api.gdeltproject.org/api/v2/doc/doc"
 _INTER_REQUEST_SLEEP_SECONDS = 1.0
 
 
+# GDELT periodically returns HTTP 429 under load (it has no documented hard
+# rate cap, so the 1s inter-request spacing is heuristic). Without honoring
+# Retry-After, every 429 dropped that ticker's coverage on the daily pull
+# (the fail-soft `continue` path) — config#663. On a 429 we wait the
+# server-advertised Retry-After (clamped) and retry the ticker ONCE before
+# giving up, recovering breadth without stalling the whole pull.
+_RETRY_AFTER_FALLBACK_SECONDS = 2.0
+_RETRY_AFTER_MAX_SECONDS = 30.0
+
+
 class GdeltNewsAdapter:
     """GDELT 2.0 DOC API adapter. Implements ``NewsSource``.
 
@@ -94,24 +104,70 @@ class GdeltNewsAdapter:
                 "enddatetime": end.strftime("%Y%m%d%H%M%S"),
                 "sort": "DateDesc",
             }
-            try:
-                resp = self._http.get(
-                    _GDELT_DOC_API,
-                    params=params,
-                    timeout=20,
-                )
-                resp.raise_for_status()
-                payload = resp.json()
-            except Exception as e:
-                logger.warning(
-                    "[gdelt_news] fetch failed for %s: %s", ticker, e
-                )
+            payload = self._fetch_one(ticker, params)
+            if payload is None:
                 continue
             for item in payload.get("articles", []) or []:
                 article = _to_article(item, ticker=ticker)
                 if article is not None:
                     articles.append(article)
         return articles
+
+    def _fetch_one(self, ticker: str, params: dict) -> dict | None:
+        """Fetch one ticker's articles, honoring a 429 ``Retry-After`` with a
+        single bounded retry. Returns the parsed JSON payload, or ``None`` on
+        terminal failure (the caller skips the ticker — fail-soft)."""
+        for attempt in range(2):  # one initial + one retry-after-429
+            try:
+                resp = self._http.get(
+                    _GDELT_DOC_API,
+                    params=params,
+                    timeout=20,
+                )
+            except Exception as e:
+                logger.warning(
+                    "[gdelt_news] fetch failed for %s: %s", ticker, e
+                )
+                return None
+
+            if getattr(resp, "status_code", None) == 429 and attempt == 0:
+                wait = _retry_after_seconds(resp)
+                logger.warning(
+                    "[gdelt_news] 429 for %s — honoring Retry-After=%.1fs "
+                    "then retrying once", ticker, wait,
+                )
+                time.sleep(wait)
+                continue
+
+            try:
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as e:
+                logger.warning(
+                    "[gdelt_news] fetch failed for %s: %s", ticker, e
+                )
+                return None
+        return None
+
+
+def _retry_after_seconds(resp: Any) -> float:
+    """Parse a 429 response's ``Retry-After`` header into a clamped sleep.
+
+    Honors the integer-seconds form (the only form GDELT/CDN proxies emit in
+    practice). Falls back to a small fixed wait when the header is missing or
+    unparseable, and clamps to ``_RETRY_AFTER_MAX_SECONDS`` so a hostile or
+    buggy header can't stall the whole daily pull."""
+    headers = getattr(resp, "headers", None) or {}
+    raw = headers.get("Retry-After")
+    wait = _RETRY_AFTER_FALLBACK_SECONDS
+    if raw is not None:
+        try:
+            wait = float(int(str(raw).strip()))
+        except (TypeError, ValueError):
+            wait = _RETRY_AFTER_FALLBACK_SECONDS
+    if wait < 0:
+        wait = _RETRY_AFTER_FALLBACK_SECONDS
+    return min(wait, _RETRY_AFTER_MAX_SECONDS)
 
 
 def _build_query(ticker: str, company_name: str) -> str:

--- a/tests/test_news_sources_and_aggregator.py
+++ b/tests/test_news_sources_and_aggregator.py
@@ -25,7 +25,11 @@ from collectors.news_aggregator import (
 )
 from collectors.news_sources.benzinga import BenzingaNewsAdapter
 from collectors.news_sources.bloomberg import BloombergNewsAdapter
-from collectors.news_sources.gdelt import GdeltNewsAdapter, _build_query
+from collectors.news_sources.gdelt import (
+    GdeltNewsAdapter,
+    _build_query,
+    _retry_after_seconds,
+)
 from collectors.news_sources.polygon import PolygonNewsAdapter
 from collectors.news_sources.ravenpack import RavenpackNewsAdapter
 from collectors.news_sources.yahoo_rss import YahooRssNewsAdapter
@@ -226,6 +230,103 @@ class TestGdeltNewsAdapter:
         adapter.fetch(["UNKNOWN"])
         params_used = fake_http.get.call_args.kwargs["params"]
         assert "UNKNOWN" in params_used["query"]
+
+    def test_429_honors_retry_after_then_succeeds(self, monkeypatch):
+        """A 429 with Retry-After is waited out and the ticker is retried
+        once — recovering coverage instead of dropping the ticker (config#663)."""
+        slept: list[float] = []
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep",
+            lambda s: slept.append(s),
+        )
+
+        resp_429 = MagicMock(status_code=429, headers={"Retry-After": "3"})
+        resp_ok = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"articles": [{
+                "url": "https://x.com/y",
+                "title": "recovered",
+                "seendate": "20260512T143000Z",
+            }]}),
+            raise_for_status=MagicMock(return_value=None),
+        )
+        fake_http = MagicMock()
+        fake_http.get.side_effect = [resp_429, resp_ok]
+
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={"AAPL": "Apple"},
+            http=fake_http,
+            inter_request_sleep=0.0,
+        )
+        out = adapter.fetch(["AAPL"])
+        assert len(out) == 1
+        assert out[0].title == "recovered"
+        assert fake_http.get.call_count == 2
+        # Honored the server-advertised Retry-After (3s), clamped under max.
+        assert 3.0 in slept
+
+    def test_429_twice_drops_ticker_fail_soft(self, monkeypatch):
+        """A persistent 429 (retry also 429) drops the ticker without
+        raising — only one retry, no infinite loop."""
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep", lambda s: None
+        )
+        resp_429 = MagicMock(status_code=429, headers={"Retry-After": "1"})
+        fake_http = MagicMock()
+        fake_http.get.side_effect = [resp_429, resp_429]
+
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={"AAPL": "Apple"},
+            http=fake_http,
+            inter_request_sleep=0.0,
+        )
+        out = adapter.fetch(["AAPL"])
+        assert out == []
+        assert fake_http.get.call_count == 2  # initial + one retry, no more
+
+    def test_429_on_one_ticker_does_not_block_others(self, monkeypatch):
+        """A 429 (then-drop) on one ticker still lets the rest of the batch
+        return — breadth degrades, pull does not fail."""
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep", lambda s: None
+        )
+        resp_429 = MagicMock(status_code=429, headers={})
+        resp_ok = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"articles": [{
+                "url": "https://x.com/msft",
+                "title": "msft ok",
+                "seendate": "20260512T143000Z",
+            }]}),
+            raise_for_status=MagicMock(return_value=None),
+        )
+        fake_http = MagicMock()
+        # AAPL: 429 then 429 (dropped); MSFT: ok
+        fake_http.get.side_effect = [resp_429, resp_429, resp_ok]
+
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={"AAPL": "Apple", "MSFT": "Microsoft"},
+            http=fake_http,
+            inter_request_sleep=0.0,
+        )
+        out = adapter.fetch(["AAPL", "MSFT"])
+        assert len(out) == 1
+        assert out[0].title == "msft ok"
+
+    @pytest.mark.parametrize(
+        "header,expected",
+        [
+            ({"Retry-After": "5"}, 5.0),
+            ({"Retry-After": "0"}, 0.0),
+            ({}, 2.0),                       # missing → fallback
+            ({"Retry-After": "garbage"}, 2.0),  # unparseable → fallback
+            ({"Retry-After": "-7"}, 2.0),    # negative → fallback
+            ({"Retry-After": "999"}, 30.0),  # clamped to max
+        ],
+    )
+    def test_retry_after_seconds_parsing(self, header, expected):
+        resp = MagicMock(headers=header)
+        assert _retry_after_seconds(resp) == expected
 
 
 # ── Yahoo RSS adapter ──────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
GDELT periodically returns HTTP 429 under load (no documented hard rate cap, so the adapter's 1s inter-request spacing is heuristic). The fail-soft per-ticker `except Exception: continue` path dropped **every** 429'd ticker outright, degrading GDELT breadth on the daily pull. config#663: many of the 88 tickers 429'd while Polygon (177) + Yahoo (469) were unaffected.

## Root cause
The adapter had no `Retry-After` handling — a 429 was indistinguishable from any other failure and the ticker was silently dropped.

## Fix
On a 429, parse the server-advertised `Retry-After` (integer-seconds form, clamped to `[0, 30s]`; fallback 2s when missing / unparseable / negative) and retry the ticker **once** before giving up. A persistent 429 still drops the ticker fail-soft — no infinite loop, no whole-batch stall. Breadth degrades gracefully instead of dropping recoverable tickers.

## Tests
+6 tests: retry-then-succeed (honors advertised wait), retry-then-drop (one retry only), one-bad-ticker-doesn't-block-the-batch, and a `_retry_after_seconds` parse/clamp/fallback matrix. Full `test_news_sources_and_aggregator` + `test_async_and_cache` + `test_daily_news` suites green (85 passed).

Closes nousergon/alpha-engine-config#663

🤖 Generated with [Claude Code](https://claude.com/claude-code)