### PR TITLE
fix(saturday-sf): migrate spot-launcher -m alpha_engine_lib -> nousergon_lib (CONFIRMED MorningEnrich blocker)

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -150,7 +150,7 @@ if [ "$CANARY_STATUS" != "OK" ] && [ "$CANARY_STATUS" != "SKIPPED" ]; then
   # alert per (Lambda, version) — lib v0.24.0 substrate (L221
   # retrofit 2026-05-22). Best-effort; trailing || true never
   # overrides the deploy's exit 1.
-  python3 -m alpha_engine_lib.alerts publish \
+  python3 -m nousergon_lib.alerts publish \
     --severity error \
     --source "alpha-engine-data/infrastructure/deploy.sh" \
     --dedup-key "canary-fail-${FUNCTION_NAME}-v${VERSION}" \

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -120,7 +120,7 @@ if [[ "${SMOKE_ARG}" == "--smoke" ]]; then
   if [ -x "$(dirname "$0")/../../../.venv/bin/python" ]; then
     _alert_python="$(dirname "$0")/../../../.venv/bin/python"
   fi
-  "$_alert_python" -m alpha_engine_lib.alerts publish \
+  "$_alert_python" -m nousergon_lib.alerts publish \
     --severity info \
     --no-telegram \
     --source alpha-engine-data/changelog-incident-mirror/deploy.sh \

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -23,7 +23,7 @@
 # **2026-05-27 — SSH/SCP → SSM transport migration (ROADMAP L342 PR 2).**
 # Communication with the spot is now via `aws ssm send-command`
 # (IAM-authenticated, CloudTrail-audited) wrapped at the lib chokepoint
-# `python -m alpha_engine_lib.ssm_dispatcher run`. No port-22 inbound on
+# `python -m nousergon_lib.ssm_dispatcher run`. No port-22 inbound on
 # the spot SG; no ssh / scp / ssh-keyscan. The private config.yaml is
 # staged to a temporary S3 prefix the dispatcher controls and pulled
 # down by the spot via its existing `alpha-engine-executor-profile` IAM
@@ -219,7 +219,7 @@ echo "  Run mode      : $RUN_MODE"
 echo "  Spot attempt  : $SPOT_ATTEMPT/$MAX_SPOT_ATTEMPTS  (relaunch on confirmed spot interruption)"
 echo "  Preflight-only: $PREFLIGHT_ONLY  (1 = boot + preflight + exit 0, NO fetch/write)"
 echo "  S3 bucket     : $S3_BUCKET"
-echo "  Transport     : SSM via lib chokepoint (python -m alpha_engine_lib.ssm_dispatcher)"
+echo "  Transport     : SSM via lib chokepoint (python -m nousergon_lib.ssm_dispatcher)"
 echo ""
 
 # ── Preflight ───────────────────────────────────────────────────────────────
@@ -340,7 +340,7 @@ trap on_exit EXIT
 
 echo "==> Requesting spot instance (lib CLI rotation: types=[$INSTANCE_TYPES], subnets=[$SUBNETS])..."
 
-INSTANCE_ID=$("$LIB_PYTHON" -m alpha_engine_lib.ec2_spot launch \
+INSTANCE_ID=$("$LIB_PYTHON" -m nousergon_lib.ec2_spot launch \
     --types "$INSTANCE_TYPES" \
     --subnets "$SUBNETS" \
     --image-id "$AMI_ID" \
@@ -400,7 +400,7 @@ done
 # ── SSM dispatch primitive (lib chokepoint) ──────────────────────────────────
 # run_ssm "<description>" [timeout_seconds] <<HEREDOC ... HEREDOC
 #
-# Thin wrapper around `python -m alpha_engine_lib.ssm_dispatcher run` (lib
+# Thin wrapper around `python -m nousergon_lib.ssm_dispatcher run` (lib
 # v0.35.0+). The lib base64-wraps the script body (read from stdin via the
 # `--script-stdin` flag) for AWS-RunShellScript transport, polls
 # get-command-invocation, streams StandardOutputContent delta to this
@@ -437,7 +437,7 @@ done
 # (substrate is failure-only).
 run_ssm() {
     local description="$1" timeout_s="${2:-3600}"
-    "$LIB_PYTHON" -m alpha_engine_lib.ssm_dispatcher run \
+    "$LIB_PYTHON" -m nousergon_lib.ssm_dispatcher run \
         --instance-id "$INSTANCE_ID" \
         --description "data-weekly: $description" \
         --timeout "$timeout_s" \

--- a/tests/test_spot_data_weekly_interruption_retry.py
+++ b/tests/test_spot_data_weekly_interruption_retry.py
@@ -4,7 +4,7 @@ infrastructure/spot_data_weekly.sh.
 Origin: 2026-05-30 Saturday SF DataPhase1 failure. The nested data spot
 (i-02e498e018441751f, c5.large/us-east-1a) was reclaimed by AWS *mid-
 workload* with spot-request status `instance-terminated-no-capacity`.
-The lib launcher (alpha_engine_lib.ec2_spot) rotates instance_type ×
+The lib launcher (nousergon_lib.ec2_spot) rotates instance_type ×
 subnet on *acquisition* capacity errors, but nothing relaunched after a
 *mid-run* reclamation — the workload SSM command returned ResponseCode
 -1, the orchestrator exited 1, and the entire weekly pipeline failed.
@@ -67,7 +67,7 @@ class TestTrapInstalledBeforeLaunch:
         covers an all-combinations-exhausted launch (rc 64), not only a
         mid-run reclamation."""
         trap_at = text.index("trap on_exit EXIT")
-        launch_at = text.index("alpha_engine_lib.ec2_spot launch")
+        launch_at = text.index("nousergon_lib.ec2_spot launch")
         assert trap_at < launch_at, (
             "trap on_exit EXIT must be installed before the spot launch."
         )

--- a/tests/test_spot_data_weekly_ssm_transport.py
+++ b/tests/test_spot_data_weekly_ssm_transport.py
@@ -2,7 +2,7 @@
 
 Origin: ROADMAP L342 PR 2 — the 2026-05-27 SSH/SCP→SSM migration moved
 all dispatcher→spot communication to the lib chokepoint
-``python -m alpha_engine_lib.ssm_dispatcher`` (lib v0.35.0+). Without
+``python -m nousergon_lib.ssm_dispatcher`` (lib v0.35.0+). Without
 these chokepoint tests, a future refactor could silently re-introduce
 SSH+SCP (the prior transport) and re-open the port-22 dependency the
 migration was designed to retire.
@@ -66,7 +66,7 @@ def test_no_top_level_ssh_invocation():
 
     Replaces the pre-2026-05-27 SSH dispatch (``ssh -i $KEY_FILE
     ec2-user@$PUBLIC_IP "<cmd>"``) with ``python -m
-    alpha_engine_lib.ssm_dispatcher`` (lib v0.35.0+). Any new ``ssh``
+    nousergon_lib.ssm_dispatcher`` (lib v0.35.0+). Any new ``ssh``
     invocation surfaces as an immediate red CI signal.
 
     Allow-list: none. Inside heredoc bodies (the spot-side shell
@@ -87,7 +87,7 @@ def test_no_top_level_ssh_invocation():
         f"spot_data_weekly.sh:\n"
         + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
         + "\n\nThe 2026-05-27 SSH→SSM migration moved all dispatch to "
-        "``python -m alpha_engine_lib.ssm_dispatcher``. Re-introducing "
+        "``python -m nousergon_lib.ssm_dispatcher``. Re-introducing "
         "ssh re-opens the port-22 dependency the migration retired. "
         "If the change is deliberate, update this test + ROADMAP L342 "
         "PR 5 (the planned port-22 SG revoke)."
@@ -139,15 +139,15 @@ def test_no_ssh_keyscan_invocation():
 
 def test_uses_lib_ssm_dispatcher_chokepoint():
     """The migration's load-bearing surface: ``python -m
-    alpha_engine_lib.ssm_dispatcher`` MUST appear in the script. Pinning
+    nousergon_lib.ssm_dispatcher`` MUST appear in the script. Pinning
     this catches a regression where a future PR replaces the lib CLI
     with an inline ``aws ssm send-command`` bash helper (the
     alpha-engine-predictor #168 pre-lift pattern that L342 explicitly
     lifts to the lib chokepoint)."""
     body = _SCRIPT.read_text()
-    assert "alpha_engine_lib.ssm_dispatcher" in body, (
+    assert "nousergon_lib.ssm_dispatcher" in body, (
         "spot_data_weekly.sh does not reference "
-        "alpha_engine_lib.ssm_dispatcher. The 2026-05-27 migration uses "
+        "nousergon_lib.ssm_dispatcher. The 2026-05-27 migration uses "
         "the lib chokepoint as the SSM dispatch path; re-introducing a "
         "raw `aws ssm send-command` bash helper would undo the lift to "
         "``alpha-engine-lib`` v0.35.0."
@@ -206,7 +206,7 @@ def test_no_inline_aws_ssm_send_command():
         f"Found {len(offenders)} non-comment ``aws ssm send-command`` "
         f"invocations in spot_data_weekly.sh:\n"
         + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
-        + "\n\nRoute through ``python -m alpha_engine_lib.ssm_dispatcher "
+        + "\n\nRoute through ``python -m nousergon_lib.ssm_dispatcher "
         "run`` instead — that's the chokepoint v0.35.0 lifted."
     )
 
@@ -254,7 +254,7 @@ def test_no_residual_key_file_dispatch_use():
         + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
         + "\n\nThe migration retired the SSH key file as a dispatch "
         "credential. KEY_NAME stays as a launch attribute for "
-        "alpha_engine_lib.ec2_spot's --key-name flag (break-glass "
+        "nousergon_lib.ec2_spot's --key-name flag (break-glass "
         "operator SSH only); KEY_FILE / SSH_OPTS should not appear "
         "anywhere."
     )


### PR DESCRIPTION
## 🔴 CONFIRMED Saturday-SF / Friday-shell blocker — please review+merge before Sat 09:00 UTC

The most recent Saturday-pipeline run (`offcycle-full-20260625-210857`) halted at **MorningEnrich** with `AttributeError: '_AliasLoader' object has no attribute 'get_code'` — the `python -m alpha_engine_lib.<sub>` runpy bug. data#483 fixed the early `ssm_log_capture` caller, but **`spot_data_weekly.sh` (the weekly data-spot launcher) still calls `-m alpha_engine_lib.ec2_spot` (line 343) and `-m alpha_engine_lib.ssm_dispatcher` (line 440)** via `$LIB_PYTHON`.

`$LIB_PYTHON` = the **dashboard venv**, which crossed to **nousergon-lib 0.60.2** (post-rename, alias shim) since the 6/19 shell run — so those `-m` calls now fail.

### Confirmed on the box (`i-09b539c844515d549`, dashboard venv)
```
nousergon-lib 0.60.2
-m alpha_engine_lib.ec2_spot        -> FAILS (runpy)
-m alpha_engine_lib.ssm_dispatcher  -> FAILS (runpy)
-m nousergon_lib.{ec2_spot,ssm_dispatcher,alerts} -> all OK
```

### Fix (config#1245 sweep, scoped to the SF path)
- `spot_data_weekly.sh`: `ec2_spot launch` + `ssm_dispatcher run` → `nousergon_lib` (+ matching comments/echo)
- `deploy.sh` + `changelog-incident-mirror/deploy.sh`: `alerts publish` → `nousergon_lib`
- `test_spot_data_weekly_ssm_transport.py`: assertions updated to the new module name

`import alpha_engine_lib` sites are unaffected (the shim supports import; only `-m` breaks) and left as-is. Script runs from the box's `git fetch origin main` at SF runtime, so **merge alone deploys it** — no separate deploy step.

**Verification:** transport test 9/9 green; `bash -n` clean; `nousergon_lib` variants confirmed runnable on the box.

### Still open (not in this PR)
`crucible-research/...:307` also calls `-m alpha_engine_lib.alerts publish` (a later, best-effort SF-path alert). Tracked for a follow-up; not the MorningEnrich blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
