### PR TITLE
feat(saturday-sf): groom dispatcher — run backlog groom after a successful Saturday SF

### DIFF
--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/README.md
@@ -1,0 +1,65 @@
+# saturday-sf-success-groom-dispatcher
+
+Runs the daily backlog groom **after a successful Saturday SF**, so the fresh
+post-Director backlog (including the Director's just-filed weekly proposals) gets
+groomed immediately rather than waiting for the next scheduled 10pm-PT run.
+
+## How it fits
+
+```
+alpha-engine-saturday-pipeline  ──SUCCEEDED──▶  EventBridge rule
+  (status change event)                         alpha-engine-saturday-succeeded-groom
+                                                        │ target
+                                                        ▼
+                                          THIS Lambda (repository_dispatch)
+                                                        │ type: saturday-sf-success-groom
+                                                        ▼
+                            nousergon/alpha-engine-config :: backlog-groom.yml
+                                          (on: repository_dispatch → FULL groom)
+```
+
+It mirrors the failure-side sibling `saturday-sf-watch-dispatcher` and **reuses the
+same SSM PAT** (`/alpha-engine/saturday_sf_watch/github_pat`) for the
+repository_dispatch — no new credential.
+
+## Why this and not an in-SF task
+
+The Saturday SF definition (`step_function.json`) is deliberately **untouched** — an
+EventBridge rule on the SF's terminal `SUCCEEDED` status is zero-risk relative to
+editing the pipeline, and reuses the proven watch-dispatcher pattern. Functionally
+identical to "run the groom once the Saturday SF completes."
+
+## Contract & safety
+
+- **Fires only on `SUCCEEDED`** (the rule scopes it; the handler re-checks
+  defensively so a mis-scoped rule can never fire on a non-success).
+- **Best-effort, non-fatal**: a GitHub/SSM outage logs WARN + is returned in the
+  result, never raises. The scheduled nightly groom is the backstop.
+- **Kill-switch**: set the Lambda env `GROOM_DISPATCH_ENABLED=false` to disable
+  without removing the rule.
+
+## Deploy (operator-managed, outside CloudFormation)
+
+```bash
+bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh --bootstrap  # first time: role + lambda + rule
+bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh              # update code only
+bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh --dry-run    # preview
+bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh --smoke      # ⚠ fires a REAL groom run
+```
+
+Merging the PR has **zero live effect** until an operator runs `--bootstrap`.
+`--smoke` invokes the Lambda with a synthetic SUCCEEDED event and (since
+`GROOM_DISPATCH_ENABLED` defaults on) **triggers an actual groom run** — use
+intentionally.
+
+## Prerequisite in alpha-engine-config
+
+`backlog-groom.yml` must listen for the trigger:
+
+```yaml
+on:
+  repository_dispatch:
+    types: [saturday-sf-success-groom]
+```
+
+(added alongside the existing `schedule` + `workflow_dispatch` triggers).

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-saturday-sf-success-groom-dispatcher
+# Lambda and wire its EventBridge trigger (Saturday SF SUCCEEDED only).
+#
+# On a successful Saturday SF, this Lambda repository_dispatches the backlog
+# groom (nousergon/alpha-engine-config :: backlog-groom.yml, type
+# `saturday-sf-success-groom`) so the fresh post-Director backlog gets groomed
+# immediately. Mirrors the failure-side sibling `saturday-sf-watch-dispatcher`.
+#
+# Managed OUTSIDE CloudFormation — same rationale as the watch sibling +
+# sf-telegram-notifier (keeps the github-actions-lambda-deploy OIDC role's blast
+# radius narrow; operator-deployed only). Merging the PR has ZERO live effect
+# until an operator runs this with --bootstrap.
+#
+# Usage:
+#   bash .../saturday-sf-success-groom-dispatcher/deploy.sh             # update code only
+#   bash .../saturday-sf-success-groom-dispatcher/deploy.sh --bootstrap # first-time create + wire EventBridge
+#   bash .../saturday-sf-success-groom-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../saturday-sf-success-groom-dispatcher/deploy.sh --smoke     # invoke once with a synthetic SUCCEEDED event
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-saturday-sf-success-groom-dispatcher"
+ROLE_NAME="alpha-engine-saturday-sf-success-groom-dispatcher-role"
+POLICY_NAME="alpha-engine-saturday-sf-success-groom-dispatcher-policy"
+RULE_NAME="alpha-engine-saturday-succeeded-groom"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 30 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge rule: Saturday SF SUCCEEDED ONLY.
+  echo "  Creating EventBridge rule: ${RULE_NAME}"
+  EVENT_PATTERN=$(cat <<EOF
+{
+  "source": ["aws.states"],
+  "detail-type": ["Step Functions Execution Status Change"],
+  "detail": {
+    "stateMachineArn": [
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
+    ],
+    "status": ["SUCCEEDED"]
+  }
+}
+EOF
+)
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --event-pattern "${EVENT_PATTERN}" \
+    --description "Saturday SF SUCCEEDED → backlog groom (repository_dispatch via groom dispatcher)" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (synthetic SUCCEEDED event) ---------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (synthetic SUCCEEDED event)..."
+  RESP=$(mktemp)
+  PAYLOAD=$(cat <<'EOF'
+{
+  "source": "aws.states",
+  "detail-type": "Step Functions Execution Status Change",
+  "detail": {
+    "status": "SUCCEEDED",
+    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
+    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:smoke-test",
+    "name": "smoke-test",
+    "startDate": 0,
+    "stopDate": 60000
+  }
+}
+EOF
+)
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload "${PAYLOAD}" \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/iam-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-saturday-sf-success-groom-dispatcher:*"
+    },
+    {
+      "Sid": "GroomDispatchPAT",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat"
+    }
+  ]
+}

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/index.py
@@ -1,0 +1,120 @@
+"""alpha-engine-saturday-sf-success-groom-dispatcher — run the backlog groom
+after a SUCCESSFUL Saturday SF.
+
+Brian's ask (2026-06-26): once the Saturday pipeline completes — after the
+Director has filed its weekly proposals — run the daily backlog groom again so
+the fresh backlog state (including the Director's just-filed items) gets groomed
+immediately, rather than waiting for the next scheduled 10pm-PT run. Added while
+still building confidence that the daily groom is as thorough as intended.
+
+Wiring mirrors the failure-side sibling `saturday-sf-watch-dispatcher`: a
+dedicated EventBridge rule on the Saturday SF's SUCCEEDED status targets this
+Lambda, which sends a `repository_dispatch` (type `saturday-sf-success-groom`)
+to `nousergon/alpha-engine-config`, where `backlog-groom.yml` listens for it and
+runs a FULL groom. Reuses the same SSM-stored fine-grained PAT
+(`/alpha-engine/saturday_sf_watch/github_pat`) the watch sibling uses for
+repository_dispatch — no new credential.
+
+Best-effort with a recording surface (CLAUDE.md no-silent-fails secondary
+carve-out): a GitHub/SSM outage logs WARN and is returned in the result but does
+NOT raise — triggering the groom is a convenience, NOT the Saturday pipeline's
+deliverable, and the scheduled nightly groom is the backstop. EventBridge's
+delivery retries + the Lambda error metric still record a hard failure.
+
+Managed OUTSIDE CloudFormation (same rationale as the watch sibling): operator-
+deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live effect until
+bootstrapped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+# Kill-switch: set GROOM_DISPATCH_ENABLED=false on the Lambda to disable the
+# trigger without removing the EventBridge rule. Default ON (Brian wants it live).
+DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
+DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
+DISPATCH_EVENT_TYPE = os.environ.get("DISPATCH_EVENT_TYPE", "saturday-sf-success-groom")
+GITHUB_PAT_SSM_PARAM = os.environ.get(
+    "GITHUB_PAT_SSM_PARAM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+_DISPATCH_TIMEOUT_SEC = 15
+
+
+def _get_github_pat() -> str:
+    """Read the fine-grained PAT (SecureString) from SSM. Never logged."""
+    ssm = boto3.client("ssm", region_name=REGION)
+    resp = ssm.get_parameter(Name=GITHUB_PAT_SSM_PARAM, WithDecryption=True)
+    return resp["Parameter"]["Value"]
+
+
+def _dispatch_groom(execution_name: str, start_date) -> dict:
+    """Fire the repository_dispatch that triggers backlog-groom.yml. Best-effort:
+    records the outcome, never raises (secondary path)."""
+    if not DISPATCH_ENABLED:
+        return {"dispatched": False, "reason": "disabled"}
+    try:
+        pat = _get_github_pat()
+        payload = {
+            "event_type": DISPATCH_EVENT_TYPE,
+            "client_payload": {
+                "trigger": "saturday-sf-success",
+                "execution_name": execution_name,
+                "start_date": start_date,
+            },
+        }
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{DISPATCH_REPO}/dispatches",
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {pat}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "saturday-sf-success-groom-dispatcher",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=_DISPATCH_TIMEOUT_SEC) as resp:
+            status_code = resp.status
+        logger.info(
+            "groom repository_dispatch sent to %s (type=%s, http=%s)",
+            DISPATCH_REPO,
+            DISPATCH_EVENT_TYPE,
+            status_code,
+        )
+        return {"dispatched": True, "status_code": status_code}
+    except Exception as exc:  # noqa: BLE001 — secondary path, recorded not raised
+        logger.warning("groom repository_dispatch failed (non-fatal): %s", exc)
+        return {"dispatched": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """EventBridge handler — fires only on Saturday SF SUCCEEDED, per the
+    dedicated rule `alpha-engine-saturday-succeeded-groom`. A defensive status
+    re-check guarantees a mis-scoped rule can never fire the groom on a
+    non-success terminal state.
+    """
+    detail = event.get("detail") or {}
+    status = detail.get("status", "UNKNOWN")
+    sm_name = (detail.get("stateMachineArn") or "").rsplit(":", 1)[-1]
+    execution_name = detail.get("name", "")
+    logger.info(
+        "Saturday-SF success groom trigger: sf=%s status=%s exec=%s",
+        sm_name,
+        status,
+        execution_name,
+    )
+    if status != "SUCCEEDED":
+        logger.info("status %s != SUCCEEDED — no groom dispatch", status)
+        return {"dispatched": False, "reason": f"status={status}"}
+    result = _dispatch_groom(execution_name, detail.get("startDate"))
+    return {"status": status, "groom": result}

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/requirements.txt
@@ -1,0 +1,5 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned here for an
+# explicit, reproducible package build (mirrors the watch-dispatcher sibling).
+# No alpha-engine/nousergon lib dependency — this Lambda only reads one SSM
+# parameter and POSTs a repository_dispatch via urllib.
+boto3>=1.34.0

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/test_handler.py
@@ -1,0 +1,93 @@
+"""Unit tests for the Saturday-SF success → groom dispatcher.
+
+No AWS / GitHub calls — SSM and urllib are monkeypatched. Validates: only
+SUCCEEDED dispatches; the kill-switch short-circuits; a SUCCEEDED event posts the
+correct repository_dispatch to alpha-engine-config; failures are recorded, not
+raised.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def _load(monkeypatch, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    import index
+
+    importlib.reload(index)
+    return index
+
+
+def test_non_succeeded_does_not_dispatch(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        idx, "_dispatch_groom", lambda *a, **k: calls.__setitem__("n", calls["n"] + 1)
+    )
+    out = idx.handler({"detail": {"status": "FAILED"}}, None)
+    assert out["dispatched"] is False
+    assert calls["n"] == 0
+
+
+def test_disabled_flag_short_circuits(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="false")
+    out = idx.handler({"detail": {"status": "SUCCEEDED", "name": "x"}}, None)
+    assert out["groom"]["dispatched"] is False
+    assert out["groom"]["reason"] == "disabled"
+
+
+def test_succeeded_dispatches_correct_repository_dispatch(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
+    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
+    captured = {}
+
+    class _Resp:
+        status = 204
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        captured["auth"] = req.headers.get("Authorization")
+        return _Resp()
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    event = {
+        "detail": {
+            "status": "SUCCEEDED",
+            "name": "sat-run-1",
+            "stateMachineArn": "arn:aws:states:us-east-1:1:stateMachine:alpha-engine-saturday-pipeline",
+        }
+    }
+    out = idx.handler(event, None)
+    assert out["groom"]["dispatched"] is True
+    assert out["groom"]["status_code"] == 204
+    assert captured["url"].endswith("/repos/nousergon/alpha-engine-config/dispatches")
+    assert captured["body"]["event_type"] == "saturday-sf-success-groom"
+    assert captured["body"]["client_payload"]["execution_name"] == "sat-run-1"
+    assert captured["auth"] == "Bearer tok"
+
+
+def test_dispatch_failure_is_recorded_not_raised(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
+    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
+
+    def _boom(req, timeout=0):
+        raise RuntimeError("github down")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
+    out = idx.handler({"detail": {"status": "SUCCEEDED", "name": "x"}}, None)
+    assert out["groom"]["dispatched"] is False
+    assert "github down" in out["groom"]["error"]


### PR DESCRIPTION
New operator-deployed Lambda + EventBridge rule that fires the backlog groom after the Saturday SF SUCCEEDS (mirrors the failure-side saturday-sf-watch-dispatcher). EventBridge-on-SF-success → repository_dispatch (saturday-sf-success-groom) to alpha-engine-config backlog-groom.yml (FULL groom). Reuses the same SSM PAT. SF definition UNTOUCHED.

Pairs with alpha-engine-config#1268 (the workflow trigger).

Managed outside CloudFormation: merging has ZERO live effect until deploy.sh --bootstrap. 4 unit tests pass.

Generated with Claude Code