### PR TITLE
fix(metron-intraday): make UI-heartbeat demand gate opt-in (always-warm owner build)

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -1242,10 +1242,15 @@ def in_us_market_window(now: datetime | None = None) -> bool:
     return open_min <= et.hour * 60 + et.minute <= close_min
 
 
-# The demand gate: Metron's web layer touches this key while the app is actively
-# being used (throttled heartbeat — see metron api/services/data_spine.py). The
-# intraday producer fetches ONLY while the heartbeat is fresh, so a closed app
-# costs zero quote fetches. Missing key = app never opened → skip.
+# The (opt-in) demand gate: Metron's web layer touches this key while the app is
+# actively being used (throttled heartbeat — see metron api/services/data_spine.py).
+# When the gate is ON (``require_heartbeat=True``, set for a multi-tenant deployment via
+# the ``--require-heartbeat`` flag) the producer fetches ONLY while the heartbeat is fresh,
+# so a closed app costs zero quote fetches. The gate is OFF by default: on the single-tenant
+# owner build the strip is 4 globally-shared ETF symbols + a small held universe — one fetch
+# serves everyone — so we keep it warm every session tick rather than inflict a multi-minute
+# cold-start (a frozen morning quote) on the owner every time the app has been idle >10 min.
+# Re-enable before multi-tenant by adding ``--require-heartbeat`` to the systemd unit.
 UI_HEARTBEAT_KEY = "metron/ui_heartbeat.json"
 HEARTBEAT_FRESH_SECONDS = 600  # 10 min — two missed 5-min ticks ends the session
 
@@ -1282,7 +1287,7 @@ def _flag_suspect_quotes(quotes: dict[str, dict]) -> int:
 def collect_intraday(
     *, bucket: str = DEFAULT_BUCKET, dry_run: bool = False, s3_client: Any = None,
     intraday_source: IntradaySource | None = None, force: bool = False,
-    now: datetime | None = None,
+    now: datetime | None = None, require_heartbeat: bool = False,
 ) -> dict:
     """Write the intraday-quotes artifact for Metron's held universe + the major-index
     proxies (config#1023 — the 15-minute Today-view feed + the Overview markets strip,
@@ -1293,23 +1298,24 @@ def collect_intraday(
              quotes:  {yf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}},
              indices: {etf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}}}
 
-    ``last`` is ~15-min delayed. Runs every 5 min via a systemd timer on the trading
-    box (infrastructure/systemd/metron-intraday.timer), double-gated: the NYSE
-    session window (exchange calendar incl. half-days) AND the Metron UI heartbeat
-    (``metron_app_active``) — quotes are fetched only while the market is open AND
-    the app is actually being used. Outside either gate it returns ``skipped``
-    without fetching (``force`` overrides both, for manual runs). The major-index ETF
-    proxies (``INDEX_PROXY_SYMBOLS``) are market context — fetched every run regardless
-    of the held universe, so a brand-new account still gets the markets strip. A quote
-    moving >40% vs prior close carries ``suspect: true`` (flagged, never dropped). Single
-    ``latest.json`` key — consumers see staleness via ``as_of_utc``. Injectable
-    source/S3 for tests."""
+    ``last`` is ~15-min delayed. Runs every 5 min via a systemd timer on the trading box
+    (infrastructure/systemd/metron-intraday.timer), gated on the NYSE session window
+    (exchange calendar incl. half-days). When ``require_heartbeat`` (the multi-tenant
+    demand gate — OFF by default, see ``UI_HEARTBEAT_KEY``) it ALSO gates on a fresh Metron
+    UI heartbeat so a closed app costs zero fetches; OFF, it stays warm every session tick
+    so the owner never sees a frozen morning quote after the app was idle. Outside the
+    market window it returns ``skipped`` without fetching (``force`` overrides every gate,
+    for manual runs). The major-index ETF proxies (``INDEX_PROXY_SYMBOLS``) are market
+    context — fetched every run regardless of the held universe, so a brand-new account
+    still gets the markets strip. A quote moving >40% vs prior close carries
+    ``suspect: true`` (flagged, never dropped). Single ``latest.json`` key — consumers see
+    staleness via ``as_of_utc``. Injectable source/S3 for tests."""
     if not force and not in_us_market_window(now):
         return {"status": "skipped", "reason": "outside US market window"}
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")
-    if not force and not metron_app_active(bucket, s3_client, now):
+    if require_heartbeat and not force and not metron_app_active(bucket, s3_client, now):
         return {"status": "skipped", "reason": "metron app inactive (no fresh UI heartbeat)"}
     fetch = intraday_source or _yfinance_intraday
 
@@ -1359,13 +1365,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fundamentals", action="store_true", help="also write the tearsheet-fundamentals artifact")
     parser.add_argument("--only-intraday", action="store_true",
                         help="write ONLY the intraday-quotes artifact (the 5-min timer entry; "
-                             "no-op outside the NYSE session or without a fresh Metron UI heartbeat, unless --force)")
+                             "no-op outside the NYSE session unless --force)")
+    parser.add_argument("--require-heartbeat", action="store_true",
+                        help="ALSO gate --only-intraday on a fresh Metron UI heartbeat (the "
+                             "multi-tenant demand gate — OFF by default so the single-tenant owner "
+                             "build stays warm every session tick)")
     parser.add_argument("--force", action="store_true",
                         help="bypass the market-window AND app-heartbeat gates for --only-intraday")
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
     if args.only_intraday:
-        intra = collect_intraday(bucket=args.bucket, dry_run=args.dry_run, force=args.force)
+        intra = collect_intraday(bucket=args.bucket, dry_run=args.dry_run, force=args.force,
+                                 require_heartbeat=args.require_heartbeat)
         logger.info("[metron_market_data] intraday done: %s", intra)
         return 0 if intra.get("status") in ("ok", "ok_dry_run", "skipped") else 1
     result = collect(bucket=args.bucket, run_date=args.date, dry_run=args.dry_run)

--- a/infrastructure/systemd/metron-intraday.service
+++ b/infrastructure/systemd/metron-intraday.service
@@ -1,7 +1,11 @@
 # Metron intraday-quotes producer (config#1023) — one shot per timer tick.
 # Writes market_data/intraday/latest.json (last / open / prior close per held
-# symbol, ~15-min delayed) for Metron's Today view. The collector itself gates
-# on the US market window AND the Metron UI heartbeat, so off-gate ticks exit "skipped" without fetching.
+# symbol + the major-index ETF proxies, ~15-min delayed) for Metron's Today view
+# and Overview markets strip. The collector gates on the US market window; off-session
+# ticks exit "skipped" without fetching. The UI-heartbeat demand gate is opt-in —
+# append --require-heartbeat below to stop fetching when no Metron app is open
+# (multi-tenant cost control; left OFF on this single-tenant owner build so the strip
+# stays warm and never freezes at the morning quote after the app has been idle).
 # Installed on the trading box by infrastructure/install-metron-intraday.sh;
 # S3 write rides the instance role (executor-role already has market_data/*).
 [Unit]

--- a/infrastructure/systemd/metron-intraday.timer
+++ b/infrastructure/systemd/metron-intraday.timer
@@ -1,10 +1,11 @@
 # Every 5 minutes while the trading box is up. The box's lifecycle bounds the
-# day; the collector itself double-gates each tick on the NYSE session calendar
-# (holidays + half-days via alpha_engine_lib.trading_calendar) AND the Metron UI
-# heartbeat — quotes are fetched only while the market is open and the app is
-# actually in use, so off-gate ticks cost one S3 GET and exit.
+# day; the collector gates each tick on the NYSE session calendar (holidays +
+# half-days via alpha_engine_lib.trading_calendar) so off-session ticks cost one
+# S3 GET and exit. The Metron UI-heartbeat demand gate is OPT-IN (--require-heartbeat,
+# OFF on this single-tenant owner build so the strip never freezes after the app is
+# idle) — add it to the service ExecStart before a multi-tenant deployment.
 [Unit]
-Description=Metron intraday quotes every 5 min (session + app-heartbeat gated in-process)
+Description=Metron intraday quotes every 5 min (NYSE-session gated in-process)
 
 [Timer]
 OnCalendar=*-*-* *:00/5:00

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -386,24 +386,54 @@ class TestIntraday:
         assert q["suspect"] is True
         assert q["last"] == 350.0  # flagged, never clamped/dropped — no fabrication
 
-    def test_skips_without_fresh_heartbeat(self):
-        """The demand gate: Metron closed (no/stale heartbeat) → zero quote fetches."""
+    def test_default_stays_warm_without_heartbeat(self):
+        """Owner build (gate OFF): in-session ticks publish even with no/stale heartbeat,
+        so the markets strip never freezes at the morning quote after the app is idle."""
+        # No heartbeat key at all → still writes (heartbeat never read).
+        absent = self._s3(heartbeat_offset_s=None)
+        r1 = mmd.collect_intraday(
+            bucket="b", s3_client=absent, intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
+            now=self._RTH,
+        )
+        assert r1["status"] == "ok" and r1["indices"] == 4
+        assert absent.put_object.called
+        # Stale heartbeat (older than HEARTBEAT_FRESH_SECONDS) → still writes.
+        stale = self._s3(heartbeat_offset_s=mmd.HEARTBEAT_FRESH_SECONDS + 60)
+        r2 = mmd.collect_intraday(
+            bucket="b", s3_client=stale, intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
+            now=self._RTH,
+        )
+        assert r2["status"] == "ok" and _puts(stale)["market_data/intraday/latest.json"]
+
+    def test_require_heartbeat_gate_skips_when_inactive(self):
+        """The opt-in demand gate (multi-tenant): Metron closed (no/stale heartbeat) →
+        zero quote fetches when require_heartbeat=True."""
         calls = []
         source = lambda s: calls.append(1) or {}
         # No heartbeat key at all.
         absent = self._s3(heartbeat_offset_s=None)
-        r1 = mmd.collect_intraday(bucket="b", s3_client=absent, intraday_source=source, now=self._RTH)
+        r1 = mmd.collect_intraday(
+            bucket="b", s3_client=absent, intraday_source=source, now=self._RTH, require_heartbeat=True,
+        )
         assert r1["status"] == "skipped" and "heartbeat" in r1["reason"]
         # Stale heartbeat (older than HEARTBEAT_FRESH_SECONDS).
         stale = self._s3(heartbeat_offset_s=mmd.HEARTBEAT_FRESH_SECONDS + 60)
-        r2 = mmd.collect_intraday(bucket="b", s3_client=stale, intraday_source=source, now=self._RTH)
+        r2 = mmd.collect_intraday(
+            bucket="b", s3_client=stale, intraday_source=source, now=self._RTH, require_heartbeat=True,
+        )
         assert r2["status"] == "skipped" and "heartbeat" in r2["reason"]
         assert not calls and not absent.put_object.called and not stale.put_object.called
-        # force bypasses BOTH gates (manual/debug runs).
+        # A fresh heartbeat opens the gate → writes.
+        active = mmd.collect_intraday(
+            bucket="b", s3_client=self._s3(), intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
+            now=self._RTH, require_heartbeat=True,
+        )
+        assert active["status"] == "ok"
+        # force bypasses BOTH gates even with the gate on (manual/debug runs).
         forced = mmd.collect_intraday(
             bucket="b", s3_client=self._s3(heartbeat_offset_s=None),
             intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
-            now=self._RTH, force=True,
+            now=self._RTH, force=True, require_heartbeat=True,
         )
         assert forced["status"] == "ok"
 


### PR DESCRIPTION
## Problem

Brian flagged the Metron Overview MARKETS strip stuck at "as of 6:55 AM (delayed)" hours into the trading day. Root cause: a **cold-start** baked into the intraday producer's demand gate.

The 5-min `metron-intraday` systemd timer (on the trading box) double-gated each tick on (a) the NYSE session window AND (b) a fresh Metron UI heartbeat (≤10 min). When the app sat idle >10 min the heartbeat went stale, the producer skipped every tick, and `market_data/intraday/latest.json` froze at the last write. On reopen it took one heartbeat refresh + one timer tick (+ one strip poll) to catch up — so the owner saw a multi-hour-old quote during the catch-up window.

## Fix

The demand gate exists to spare a **multi-tenant** deployment idle quote fetches. But the strip is 4 globally-shared ETF proxies (`SPY/ONEQ/QQQ/IWM`) plus a small held universe — **one fetch serves every tenant**. Gating that on per-user activity buys almost nothing and costs the owner a cold-start.

Make the heartbeat gate **opt-in** (`require_heartbeat`, OFF by default). The single-tenant owner build now stays warm every NYSE-session tick (markets strip **and** Today-view NAV), eliminating the cold-start. `--force` still bypasses every gate for manual runs.

**Re-enable before multi-tenant**: add `--require-heartbeat` to `infrastructure/systemd/metron-intraday.service` ExecStart.

## Changes
- `collectors/metron_market_data.py`: `require_heartbeat` param (default False); `--require-heartbeat` CLI flag; docstrings/module comment.
- `infrastructure/systemd/metron-intraday.{timer,service}`: comments reflect opt-in gate + the re-enable step.
- `tests/test_metron_market_data.py`: new `test_default_stays_warm_without_heartbeat` (owner build writes on stale/absent heartbeat) + `test_require_heartbeat_gate_skips_when_inactive` (gate still works when enabled). 26 passed locally.

## Deploy
The systemd unit already runs every 5 min; no infra change required — next tick stays warm. Service/timer comment edits take effect on next `install-metron-intraday.sh` run (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)