### PR TITLE
changelog capture completeness: add infra Lambdas to TARGET_FUNCTIONS (Phase B)

### DIFF
--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/README.md
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/README.md
@@ -44,11 +44,12 @@ Log-group prefix → vocab.yaml subsystem (matching order; first-match wins):
 
 Operator can refine via a follow-up `changelog-log --event-type investigation` entry whose `git_refs` reference the original event_id.
 
-## Subscription targets (11 Lambdas)
+## Subscription targets (21 Lambdas)
 
 The deploy script wires subscription filters to every alpha-engine Lambda **except** the two changelog-mirror Lambdas (recursion guard — if this Lambda errors, its log lines must not feed back into itself).
 
 ```
+# Pipeline / producer Lambdas
 alpha-engine-data-collector
 alpha-engine-ec2-lifecycle
 alpha-engine-predictor-health-check
@@ -60,6 +61,19 @@ alpha-engine-research-eval-judge
 alpha-engine-research-eval-rolling-mean
 alpha-engine-research-rationale-clustering
 alpha-engine-research-runner
+
+# Operational / infra Lambdas (capture completeness — config#1273 Phase B;
+# subsystem defaults to "infrastructure")
+alpha-engine-eod-backstop
+alpha-engine-eod-success-friday-shell-trigger
+alpha-engine-freshness-monitor
+alpha-engine-friday-shell-run-report
+alpha-engine-pipeline-watchdog
+alpha-engine-saturday-integrity-sentinel
+alpha-engine-saturday-sf-success-groom-dispatcher
+alpha-engine-saturday-sf-watch-dispatcher
+alpha-engine-sf-telegram-notifier
+alpha-engine-spot-orphan-reaper
 ```
 
 ## Recursion guard

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
@@ -52,6 +52,21 @@ TARGET_FUNCTIONS=(
   "alpha-engine-research-eval-rolling-mean"
   "alpha-engine-research-rationale-clustering"
   "alpha-engine-research-runner"
+  # Operational/infra Lambdas — capture completeness (config#1273 Phase B).
+  # Their ERROR/CRITICAL/timeout logs now mirror into the changelog event-lake
+  # (subsystem inferred as "infrastructure" by default). The two changelog
+  # mirrors are deliberately EXCLUDED per the recursion guard above and get a
+  # CloudWatch Errors alarm instead (watch-the-watchers — config#1273 follow-up).
+  "alpha-engine-eod-backstop"
+  "alpha-engine-eod-success-friday-shell-trigger"
+  "alpha-engine-freshness-monitor"
+  "alpha-engine-friday-shell-run-report"
+  "alpha-engine-pipeline-watchdog"
+  "alpha-engine-saturday-integrity-sentinel"
+  "alpha-engine-saturday-sf-success-groom-dispatcher"
+  "alpha-engine-saturday-sf-watch-dispatcher"
+  "alpha-engine-sf-telegram-notifier"
+  "alpha-engine-spot-orphan-reaper"
 )
 
 DRY_RUN=false


### PR DESCRIPTION
## Changelog capture completeness — Phase B (config#1273)

The `changelog-cloudwatch-mirror`'s `TARGET_FUNCTIONS` covered only the 11 big pipeline Lambdas; the operational/infra Lambdas were absent, so their failures never reached the unified changelog event-lake. This adds the **10** of them (subsystem auto-inferred as `infrastructure`), matching the README's stated intent ("every alpha-engine Lambda except the two changelog mirrors").

**This is the SOTA resolution of the config#1260 data-lambda gap** — universal CloudWatch-error capture into `changelog/entries/`, **no per-lambda flow-doctor wiring, zero circularity** (capture != alert).

- The 2 changelog mirrors stay **excluded** (recursion guard) → CloudWatch Errors alarm follow-up.
- **Operator step after merge:** `deploy.sh --wire-subs` attaches the subscription filters to the 10 new log groups (capture activates then).

deploy.sh syntax-checked; README synced (11→21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)