### PR TITLE
watch-the-watchers: CloudWatch Errors alarms for alert/monitor infra

### DIFF
--- a/infrastructure/setup_changelog_observability_alarms.sh
+++ b/infrastructure/setup_changelog_observability_alarms.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# setup_changelog_observability_alarms.sh — watch-the-watchers CloudWatch
+# Errors alarms for the alert/monitoring infra Lambdas.
+#
+# Phase B of the flow-doctor SOTA arc (config#1273). Capture completeness
+# (changelog-cloudwatch-mirror TARGET_FUNCTIONS) mirrors every Lambda's
+# ERROR/CRITICAL/timeout LOG LINES into the changelog event-lake. But two
+# classes need a direct metric alarm on top:
+#
+#   1. The two changelog MIRRORS — deliberately EXCLUDED from TARGET_FUNCTIONS
+#      (recursion guard: a mirror's own ERROR must not feed back into itself),
+#      so their failures are invisible to the log-capture path. A CloudWatch
+#      Errors alarm is the ONLY direct signal that a mirror died.
+#   2. The ALERTERS (freshness-monitor, pipeline-watchdog, sentinels,
+#      sf-telegram-notifier, dispatchers) — the fleet's safety-net infra. They
+#      ARE log-captured now, but a metric Errors alarm is a real-time,
+#      belt-and-suspenders signal that the watcher itself failed (who watches
+#      the watchers).
+#
+# The alarm fires on AWS/Lambda Errors >= 1 in a 5-minute window and routes to
+# the existing alpha-engine-alerts SNS topic. treat-missing-data=notBreaching
+# keeps schedule-driven Lambdas (weekly sentinels) quiet between invocations.
+#
+# Idempotent — put-metric-alarm upserts by name; safe to re-run.
+#
+# Usage: ./infrastructure/setup_changelog_observability_alarms.sh [--dry-run]
+
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
+SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
+
+# The alert/monitoring infra: the 2 changelog mirrors + the 6 alerters.
+# (Operational producers — eod-backstop, triggers, reaper — are covered by the
+# log-capture path in TARGET_FUNCTIONS and don't need a separate metric alarm.)
+TARGET_FUNCTIONS=(
+  "alpha-engine-changelog-cloudwatch-mirror"
+  "alpha-engine-changelog-incident-mirror"
+  "alpha-engine-freshness-monitor"
+  "alpha-engine-friday-shell-run-report"
+  "alpha-engine-pipeline-watchdog"
+  "alpha-engine-saturday-integrity-sentinel"
+  "alpha-engine-saturday-sf-success-groom-dispatcher"
+  "alpha-engine-saturday-sf-watch-dispatcher"
+  "alpha-engine-sf-telegram-notifier"
+)
+
+echo "Configuring watch-the-watchers Lambda Errors alarms"
+echo "  Region:    $REGION"
+echo "  SNS topic: $SNS_TOPIC_ARN"
+echo "  Targets:   ${#TARGET_FUNCTIONS[@]} Lambdas"
+
+# Fail fast if the SNS topic is missing rather than create dangling alarms.
+if ! aws sns get-topic-attributes --topic-arn "$SNS_TOPIC_ARN" --region "$REGION" >/dev/null 2>&1; then
+  echo "ERROR: SNS topic $SNS_TOPIC_ARN not found. Run deploy_step_function.sh first." >&2
+  exit 1
+fi
+
+run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+
+for fn in "${TARGET_FUNCTIONS[@]}"; do
+  alarm_name="alpha-engine-lambda-errors-${fn#alpha-engine-}"
+  echo "  -> $alarm_name (FunctionName=$fn)"
+  run aws cloudwatch put-metric-alarm \
+    --region "$REGION" \
+    --alarm-name "$alarm_name" \
+    --alarm-description "Watch-the-watchers: fires when ${fn} (alert/monitoring infra) reports >=1 Lambda invocation error in a 5-minute window. The two changelog mirrors are excluded from changelog-cloudwatch-mirror's TARGET_FUNCTIONS (recursion guard), so this metric alarm is their only direct failure signal; for the alerters it is a real-time belt-and-suspenders on top of log capture. treat-missing-data=notBreaching keeps schedule-driven Lambdas quiet between invocations. config#1273 Phase B." \
+    --namespace "AWS/Lambda" \
+    --metric-name "Errors" \
+    --dimensions "Name=FunctionName,Value=${fn}" \
+    --statistic "Sum" \
+    --period 300 \
+    --evaluation-periods 1 \
+    --datapoints-to-alarm 1 \
+    --threshold 1 \
+    --comparison-operator "GreaterThanOrEqualToThreshold" \
+    --treat-missing-data "notBreaching" \
+    --alarm-actions "$SNS_TOPIC_ARN" \
+    --ok-actions "$SNS_TOPIC_ARN" >/dev/null
+done
+
+echo "Done — ${#TARGET_FUNCTIONS[@]} alarms upserted."

--- a/tests/test_changelog_observability_alarms_script.py
+++ b/tests/test_changelog_observability_alarms_script.py
@@ -1,0 +1,67 @@
+"""Pins the watch-the-watchers alarm setup script (config#1273 Phase B).
+
+`infrastructure/setup_changelog_observability_alarms.sh` puts CloudWatch
+Errors alarms on the alert/monitoring infra Lambdas → the alpha-engine-alerts
+SNS topic. A silent regression here is dangerous (the alarms are the only
+direct failure signal for the changelog mirrors, which are excluded from the
+log-capture path), so this test pins the load-bearing constants:
+
+- SNS topic typo → alarms fire but no one is paged.
+- Wrong metric namespace/name → the alarm watches nothing.
+- A changelog mirror dropped from the target list → its failures go fully dark
+  (no capture AND no alarm).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "infrastructure"
+    / "setup_changelog_observability_alarms.sh"
+)
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _SCRIPT.read_text()
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT.is_file()
+    assert _SCRIPT.stat().st_mode & 0o111, "script must be chmod +x"
+
+
+def test_bash_syntax_is_valid():
+    result = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True)
+    assert result.returncode == 0, result.stderr.decode()
+
+
+def test_sns_topic_is_alpha_engine_alerts(script_text):
+    assert "alpha-engine-alerts" in script_text
+    assert "--alarm-actions" in script_text and "--ok-actions" in script_text
+
+
+def test_watches_the_lambda_errors_metric(script_text):
+    assert '--namespace "AWS/Lambda"' in script_text
+    assert '--metric-name "Errors"' in script_text
+    # schedule-driven Lambdas must stay quiet between invocations
+    assert '--treat-missing-data "notBreaching"' in script_text
+
+
+@pytest.mark.parametrize(
+    "mirror",
+    [
+        "alpha-engine-changelog-cloudwatch-mirror",
+        "alpha-engine-changelog-incident-mirror",
+    ],
+)
+def test_both_changelog_mirrors_are_alarmed(script_text, mirror):
+    # The mirrors are EXCLUDED from changelog-cloudwatch-mirror's
+    # TARGET_FUNCTIONS (recursion guard), so this alarm is their only failure
+    # signal — they must never drop out of the target list.
+    assert mirror in script_text, f"{mirror} must be in the alarm target list"


### PR DESCRIPTION
## Watch-the-watchers alarms — Phase B (config#1273)

Complements the capture-completeness PR (#495). `setup_changelog_observability_alarms.sh` puts a CloudWatch **Errors** alarm (AWS/Lambda Errors >=1 in 5 min → `alpha-engine-alerts` SNS) on the alert/monitoring infra.

- The 2 changelog **mirrors** are excluded from `TARGET_FUNCTIONS` (recursion guard) → this metric alarm is their **only** direct failure signal.
- The 6 alerters are log-captured but get a real-time belt-and-suspenders alarm.
- `treat-missing-data=notBreaching` keeps schedule-driven Lambdas quiet; idempotent.

Test pins the SNS target, the AWS/Lambda Errors metric, notBreaching, and that both mirrors stay in the list (6 pass).

**Operator step after merge:** `./infrastructure/setup_changelog_observability_alarms.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)