### PR TITLE
feat(metron): consensus-research spine artifact (free sources) — metron-ops#105

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import time
 from datetime import date, datetime, timezone
 from typing import Any, Callable
@@ -108,6 +109,14 @@ TECHNICALS_PREFIX = "market_data/technicals/"
 # aggregate (medians + member counts, no per-ticker rows). Weekly cadence (multiples move
 # quarterly; the median of ~900 names is stable week to week).
 VALUATION_MEDIANS_PREFIX = "market_data/valuation_medians/"
+# Analyst consensus — per-held-symbol consensus rating + price targets + #analysts, the
+# "consensus research" inputs to the Holdings Sentiment/Consensus band + the per-holding
+# attractiveness score (metron-ops#105). FREE sources only (yfinance recommendationKey +
+# targetMean/MedianPrice + numberOfAnalystOpinions, optionally Finnhub rating buckets via
+# the canonical analyst_sources adapters). Forward consensus EPS/revenue ESTIMATES are a
+# PAID feed (IBES/Visible Alpha) — NOT emitted here; the consumer scaffolds those columns
+# as "N/A · paid feed" and they populate when metron-ops#107 wires the paid source.
+ANALYST_PREFIX = "market_data/analyst/"
 # yfinance Ticker.info keys the valuation-medians pass reads per universe symbol. Mirrors
 # the multiple subset of FUNDAMENTALS_INFO_KEYS (same source + semantics as the per-holding
 # fundamentals → the band and the row are directly comparable) plus sector/country to group.
@@ -140,6 +149,7 @@ FUNDAMENTALS_SCHEMA_VERSION = 3  # v3: + totalDebt/totalCash/ebitda/freeCashflow
 INTRADAY_SCHEMA_VERSION = 2  # v2: additive `indices` map (major-index ETF proxies)
 TECHNICALS_SCHEMA_VERSION = 1
 VALUATION_MEDIANS_SCHEMA_VERSION = 1
+ANALYST_SCHEMA_VERSION = 1  # consensus rating + price targets + #analysts (free sources)
 BASE_CURRENCY = "USD"
 DEFAULT_HISTORY_PERIOD = "10y"  # mirrors the predictor price_cache 10y convention
 BENCHMARK = "SPY"  # the attribution benchmark whose GICS sector weights we publish
@@ -178,6 +188,8 @@ EarningsSource = Callable[[list[str]], dict[str, str]]
 MacroSource = Callable[[list[str]], dict[str, list[tuple[str, float]]]]
 # A fundamentals source maps yf_symbols → {yf_symbol: {info_key: value}}.
 FundamentalsSource = Callable[[list[str]], dict[str, dict]]
+# An analyst source maps yf_symbols → {yf_symbol: {consensus_rating, mean_target, …}}.
+AnalystSource = Callable[[list[str]], dict[str, dict]]
 # An intraday source maps yf_symbols → {yf_symbol: quote dict} (see _yfinance_intraday).
 IntradaySource = Callable[[list[str]], dict[str, dict]]
 # A valuation source maps yf_symbols → {yf_symbol: {multiple_key|sector|country: value}}
@@ -478,6 +490,65 @@ def _yfinance_fundamentals(yf_symbols: list[str]) -> dict[str, dict]:
             out[sym] = fields
     logger.info("[metron_market_data] fundamentals: %d/%d symbols covered", len(out), len(yf_symbols))
     _log_yf_coverage("fundamentals", yf_symbols, out)
+    return out
+
+
+# Consensus-rating ladder → a signed numeric score in [-1, +1] so the consumer can
+# average / band it without re-deriving the ordering. strongBuy=+1 … strongSell=-1.
+_RATING_SCORE = {
+    "strongBuy": 1.0, "buy": 0.5, "hold": 0.0, "sell": -0.5, "strongSell": -1.0,
+}
+
+
+@_yf_quiet
+def _yfinance_analyst(yf_symbols: list[str]) -> dict[str, dict]:
+    """Consensus research per held symbol via the canonical free analyst adapter(s)
+    → ``{yf_symbol: {consensus_rating, rating_score, mean_target, median_target,
+    num_analysts}}``.
+
+    FREE sources only: ``YfinanceAnalystAdapter`` (recommendationKey + target
+    mean/median + #analysts) is primary; if ``FINNHUB_API_KEY`` is set, the
+    ``FinnhubAnalystAdapter`` rating buckets backfill a missing consensus_rating
+    (Finnhub's price target is paid-tier, so targets stay from yfinance). Forward
+    consensus EPS/revenue estimates are a PAID feed and are intentionally NOT
+    fetched here. Fail-soft per symbol; a symbol with no resolvable snapshot is
+    omitted (coverage gap, not zeros)."""
+    from collectors.analyst_sources import YfinanceAnalystAdapter
+
+    yf_adapter = YfinanceAnalystAdapter()
+    finnhub_adapter = None
+    if os.environ.get("FINNHUB_API_KEY"):
+        try:
+            from collectors.analyst_sources import FinnhubAnalystAdapter
+            finnhub_adapter = FinnhubAnalystAdapter()
+        except Exception as e:  # pragma: no cover - optional backfill
+            logger.warning("[metron_market_data] Finnhub analyst adapter unavailable: %s", e)
+
+    out: dict[str, dict] = {}
+    for sym in yf_symbols:
+        snap = yf_adapter.fetch(sym)
+        rating = snap.consensus_rating if snap else None
+        # Finnhub backfills ONLY a missing rating (targets stay from yfinance).
+        if rating is None and finnhub_adapter is not None:
+            fh = finnhub_adapter.fetch(sym)
+            if fh is not None and fh.consensus_rating is not None:
+                rating = fh.consensus_rating
+                if snap is None:
+                    snap = fh
+        if snap is None:
+            continue
+        fields = {
+            "consensus_rating": rating,
+            "rating_score": _RATING_SCORE.get(rating) if rating else None,
+            "mean_target": snap.mean_target,
+            "median_target": snap.median_target,
+            "num_analysts": snap.num_analysts,
+        }
+        # Omit a symbol that resolved to an empty snapshot (all None) — coverage gap.
+        if any(v is not None for v in fields.values()):
+            out[sym] = {k: v for k, v in fields.items() if v is not None}
+    logger.info("[metron_market_data] analyst: %d/%d symbols covered", len(out), len(yf_symbols))
+    _log_yf_coverage("analyst", yf_symbols, out)
     return out
 
 
@@ -913,6 +984,51 @@ def collect_fundamentals(
         return {"status": "error", "error": str(e)}
     logger.info("[metron_market_data] wrote fundamentals for %d/%d symbols", len(fundamentals), len(yf_symbols))
     return {"status": "ok", "universe": len(holdings), "fundamentals": len(fundamentals)}
+
+
+def collect_analyst(
+    *, bucket: str = DEFAULT_BUCKET, run_date: str | None = None, dry_run: bool = False,
+    s3_client: Any = None, analyst_source: AnalystSource | None = None,
+) -> dict:
+    """Write the consensus-research artifact for Metron's held universe
+    (metron-ops#105 — Holdings Sentiment/Consensus band + attractiveness score):
+
+        market_data/analyst/latest.json
+            {schema_version, as_of, source: "yfinance+finnhub", analyst:
+                {yf_symbol: {consensus_rating, rating_score, mean_target,
+                             median_target, num_analysts}}}
+
+    FREE sources only (see ``_yfinance_analyst``). The consumer derives
+    price-target upside vs the live price and owns display semantics; forward
+    consensus EPS/revenue ESTIMATES are a paid feed scaffolded N/A downstream.
+    Daily cadence (ratings/targets move slowly; daily is plenty). Injectable
+    source/S3 for tests. Mirrors ``collect_fundamentals``."""
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
+    if s3_client is None:
+        import boto3
+        s3_client = boto3.client("s3")
+    holdings, _ = load_metron_universe(bucket, s3_client)
+    if not holdings:
+        return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
+    yf_symbols = sorted({h["yf_symbol"] for h in holdings})
+    analyst = (analyst_source or _yfinance_analyst)(yf_symbols)
+    artifact = {
+        "schema_version": ANALYST_SCHEMA_VERSION, "as_of": run_date,
+        "source": "yfinance+finnhub", "analyst": dict(sorted(analyst.items())),
+    }
+    if dry_run:
+        logger.info("[metron_market_data] DRY-RUN analyst: %d symbols (not written)", len(analyst))
+        return {"status": "ok_dry_run", "analyst": len(analyst)}
+    try:
+        _write_json(s3_client, bucket, f"{ANALYST_PREFIX}latest.json", artifact)
+    except Exception as e:  # fail loud to the phase registry
+        logger.error("[metron_market_data] analyst write failed: %s", e)
+        return {"status": "error", "error": str(e)}
+    logger.info("[metron_market_data] wrote analyst for %d/%d symbols", len(analyst), len(yf_symbols))
+    return {"status": "ok", "universe": len(holdings), "analyst": len(analyst)}
 
 
 # ── Technicals (derived from close_history — no new fetch) ────────────────────
@@ -1363,6 +1479,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--reference", action="store_true", help="also write sectors/earnings artifacts")
     parser.add_argument("--macro", action="store_true", help="also write the macro-indicators artifact")
     parser.add_argument("--fundamentals", action="store_true", help="also write the tearsheet-fundamentals artifact")
+    parser.add_argument("--analyst", action="store_true", help="also write the consensus-research artifact (free sources)")
     parser.add_argument("--only-intraday", action="store_true",
                         help="write ONLY the intraday-quotes artifact (the 5-min timer entry; "
                              "no-op outside the NYSE session unless --force)")
@@ -1398,6 +1515,10 @@ def main(argv: list[str] | None = None) -> int:
         fund = collect_fundamentals(bucket=args.bucket, run_date=args.date, dry_run=args.dry_run)
         logger.info("[metron_market_data] fundamentals done: %s", fund)
         ok = ok and fund.get("status") in ("ok", "ok_dry_run", "skipped")
+    if args.analyst:
+        ana = collect_analyst(bucket=args.bucket, run_date=args.date, dry_run=args.dry_run)
+        logger.info("[metron_market_data] analyst done: %s", ana)
+        ok = ok and ana.get("status") in ("ok", "ok_dry_run", "skipped")
     return 0 if ok else 1
 
 

--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -513,7 +513,9 @@ def _yfinance_analyst(yf_symbols: list[str]) -> dict[str, dict]:
     fetched here. Fail-soft per symbol; a symbol with no resolvable snapshot is
     omitted (coverage gap, not zeros)."""
     from collectors.analyst_sources import YfinanceAnalystAdapter
-    from nousergon_lib.secrets import get_secret  # secrets via the lib, never os.environ
+    from alpha_engine_lib.secrets import get_secret  # secrets via the lib, never os.environ
+    # (alpha_engine_lib, not nousergon_lib: this repo pins a pre-rename lib (<0.60.0)
+    # where only the alpha_engine_lib name exists — matches finnhub_client.py.)
 
     yf_adapter = YfinanceAnalystAdapter()
     finnhub_adapter = None

--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import time
 from datetime import date, datetime, timezone
 from typing import Any, Callable
@@ -514,10 +513,11 @@ def _yfinance_analyst(yf_symbols: list[str]) -> dict[str, dict]:
     fetched here. Fail-soft per symbol; a symbol with no resolvable snapshot is
     omitted (coverage gap, not zeros)."""
     from collectors.analyst_sources import YfinanceAnalystAdapter
+    from nousergon_lib.secrets import get_secret  # secrets via the lib, never os.environ
 
     yf_adapter = YfinanceAnalystAdapter()
     finnhub_adapter = None
-    if os.environ.get("FINNHUB_API_KEY"):
+    if get_secret("FINNHUB_API_KEY", required=False, default=""):
         try:
             from collectors.analyst_sources import FinnhubAnalystAdapter
             finnhub_adapter = FinnhubAnalystAdapter()

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -361,7 +361,8 @@ class TestAnalyst:
         monkeypatch.setattr(
             "collectors.analyst_sources.YfinanceAnalystAdapter", lambda: _FakeAdapter()
         )
-        monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+        # No Finnhub key → no rating backfill (secrets via the lib, not os.environ).
+        monkeypatch.setattr("nousergon_lib.secrets.get_secret", lambda *a, **k: "")
         out = mmd._yfinance_analyst(["AAPL", "MSFT", "NOPE", "MISS"])
         assert set(out) == {"AAPL", "MSFT"}  # empty + miss omitted
         assert out["AAPL"]["rating_score"] == 1.0  # strongBuy

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -303,6 +303,72 @@ class TestFundamentals:
         assert mmd.collect_fundamentals(bucket="b", s3_client=empty)["status"] == "skipped"
 
 
+class TestAnalyst:
+    def test_writes_consensus_keyed_by_yf_symbol(self):
+        s3 = _universe_s3(_UNIVERSE)
+        source = lambda syms: {
+            "AAPL": {"consensus_rating": "buy", "rating_score": 0.5,
+                     "mean_target": 240.0, "median_target": 238.0, "num_analysts": 38},
+            "1299.HK": {"consensus_rating": "strongBuy", "rating_score": 1.0,
+                        "mean_target": 95.0, "num_analysts": 12},
+        }
+        result = mmd.collect_analyst(
+            bucket="b", run_date="2026-06-26", s3_client=s3, analyst_source=source
+        )
+        assert result["status"] == "ok" and result["analyst"] == 2
+        puts = _puts(s3)
+        assert set(puts) == {"market_data/analyst/latest.json"}
+        art = puts["market_data/analyst/latest.json"]
+        assert art["schema_version"] == mmd.ANALYST_SCHEMA_VERSION
+        assert art["source"] == "yfinance+finnhub"
+        # Pass-through: values land exactly as the source returned them.
+        assert art["analyst"]["AAPL"]["mean_target"] == 240.0
+        assert art["analyst"]["1299.HK"]["rating_score"] == 1.0
+
+    def test_analyst_dry_run_and_empty_universe(self):
+        s3 = _universe_s3(_UNIVERSE)
+        result = mmd.collect_analyst(
+            bucket="b", s3_client=s3, dry_run=True,
+            analyst_source=lambda s: {"AAPL": {"consensus_rating": "hold"}},
+        )
+        assert result["status"] == "ok_dry_run"
+        assert not s3.put_object.called
+        empty = _universe_s3({"holdings": [], "currencies": []})
+        assert mmd.collect_analyst(bucket="b", s3_client=empty)["status"] == "skipped"
+
+    def test_yfinance_analyst_derives_rating_score_and_omits_empty(self, monkeypatch):
+        """`_yfinance_analyst` maps the rating ladder → signed score, drops None
+        fields, and omits a symbol whose snapshot is entirely empty (coverage gap,
+        not zeros)."""
+        from types import SimpleNamespace
+
+        snaps = {
+            "AAPL": SimpleNamespace(consensus_rating="strongBuy", mean_target=240.0,
+                                    median_target=238.0, num_analysts=40),
+            "MSFT": SimpleNamespace(consensus_rating="sell", mean_target=None,
+                                    median_target=None, num_analysts=5),
+            # entirely empty → omitted
+            "NOPE": SimpleNamespace(consensus_rating=None, mean_target=None,
+                                    median_target=None, num_analysts=None),
+            # adapter returns None (fetch miss) → omitted
+            "MISS": None,
+        }
+
+        class _FakeAdapter:
+            def fetch(self, ticker):
+                return snaps.get(ticker)
+
+        monkeypatch.setattr(
+            "collectors.analyst_sources.YfinanceAnalystAdapter", lambda: _FakeAdapter()
+        )
+        monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+        out = mmd._yfinance_analyst(["AAPL", "MSFT", "NOPE", "MISS"])
+        assert set(out) == {"AAPL", "MSFT"}  # empty + miss omitted
+        assert out["AAPL"]["rating_score"] == 1.0  # strongBuy
+        assert out["MSFT"]["rating_score"] == -0.5  # sell
+        assert "mean_target" not in out["MSFT"]  # None dropped
+
+
 class TestIntraday:
     _QUOTES = {
         "AAPL": {"last": 202.1, "open": 200.5, "prev_close": 201.5,

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -362,7 +362,7 @@ class TestAnalyst:
             "collectors.analyst_sources.YfinanceAnalystAdapter", lambda: _FakeAdapter()
         )
         # No Finnhub key → no rating backfill (secrets via the lib, not os.environ).
-        monkeypatch.setattr("nousergon_lib.secrets.get_secret", lambda *a, **k: "")
+        monkeypatch.setattr("alpha_engine_lib.secrets.get_secret", lambda *a, **k: "")
         out = mmd._yfinance_analyst(["AAPL", "MSFT", "NOPE", "MISS"])
         assert set(out) == {"AAPL", "MSFT"}  # empty + miss omitted
         assert out["AAPL"]["rating_score"] == 1.0  # strongBuy

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -2093,6 +2093,15 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
         lambda: metron_market_data.collect_technicals(bucket=bucket, run_date=run_date, dry_run=dry_run),
         artifact_key=f"{metron_market_data.TECHNICALS_PREFIX}latest.json",
     )
+    # Consensus research (rating + price targets + #analysts) for Metron's Holdings
+    # Sentiment/Consensus band + per-holding attractiveness score (metron-ops#105).
+    # FREE sources only (yfinance + optional Finnhub rating buckets); forward consensus
+    # ESTIMATES are a paid feed scaffolded N/A in the consumer (metron-ops#107).
+    results["collectors"]["metron_analyst_data"] = _phase_collect(
+        reg, "metron_analyst_data",
+        lambda: metron_market_data.collect_analyst(bucket=bucket, run_date=run_date, dry_run=dry_run),
+        artifact_key=f"{metron_market_data.ANALYST_PREFIX}latest.json",
+    )
 
     # Module health stamp for daily_data — scoped to daily_closes only. The
     # executor gate at alpha-engine/executor/main.py reads this key to decide


### PR DESCRIPTION
**metron-ops#105 (Phase 1) — the spine producer.** First of the per-holding attractiveness/sentiment arc.

## What
New `collect_analyst()` writes `market_data/analyst/latest.json` over Metron's **held** universe — per-symbol `{consensus_rating, rating_score ∈ [-1,+1], mean_target, median_target, num_analysts}`. FREE sources only via the canonical `analyst_sources` adapters (yfinance primary; Finnhub backfills a missing rating when `FINNHUB_API_KEY` set — Finnhub targets are paid so stay from yfinance). Wired as the `metron_analyst_data` phase after technicals + a `--analyst` CLI flag. Mirrors `collect_fundamentals`.

Forward consensus EPS/revenue **estimates** are a paid feed — NOT emitted; the Metron consumer scaffolds those columns as `N/A · paid feed` (metron-ops#107).

## Tests
`TestAnalyst` (orchestration + dry-run + empty-universe skip + rating-score derivation / empty-symbol omission). Full collector suite green (29). PUT-site guard green.

## Sequencing
Needs the config `ARTIFACT_REGISTRY` entry for `market_data/analyst/latest.json` (separate alpha-engine-config PR). **Order:** merge + deploy this producer first, let it produce one artifact, THEN merge the registry entry (or register with grace) so the freshness monitor doesn't alert on a not-yet-existing key.

Downstream (separate PRs): metron consumer services + Holdings band + tearsheet panel; then the composite attractiveness score (metron-ops#106).