### PR TITLE
fix(iam): grant deploy role SNS publish for canary-failure alert (config#1216)

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -270,6 +270,23 @@
         "dynamodb:UpdateTimeToLive"
       ],
       "Resource": "arn:aws:dynamodb:us-east-1:711398986525:table/alpha-engine-sf-execution-mutex"
+    },
+    {
+      "Sid": "CanaryFailureAlertSnsPublish",
+      "Effect": "Allow",
+      "Action": [
+        "sns:Publish"
+      ],
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    },
+    {
+      "Sid": "CanaryFailureAlertDedupMarker",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/_alerts/_dedup/*"
     }
   ]
 }


### PR DESCRIPTION
## Problem

When a deploy canary legitimately fails, `infrastructure/deploy.sh` rolls back the Lambda alias and then calls `python3 -m nousergon_lib.alerts publish` to fail loud. The `github-actions-lambda-deploy` role was **denied** on the alert surface, so the alert itself failed:

- `sns:Publish` on `arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts` → `AuthorizationError` (fatal — no alert published)
- dedup-marker S3 access → `AccessDenied` (non-fatal; fail-safes to publish, defeating L221 dedup)

Observed in nousergon-data Deploy run `28181261854` — the canary correctly rolled back, then the in-script fail-loud alert silently failed. Workflow-level `notify-main-failure` still telegrammed Brian, but the in-script surface violated the fail-loud default.

## Fix

Add two least-privilege statements to `infrastructure/iam/github-actions-lambda-deploy.json`:

- `CanaryFailureAlertSnsPublish` — `sns:Publish` on `alpha-engine-alerts` (the fatal denial).
- `CanaryFailureAlertDedupMarker` — `s3:GetObject`/`s3:PutObject` on `alpha-engine-research/_alerts/_dedup/*` so the dedup marker check/write works.

Verified the exact AWS surface against `krepis.alerts` (the impl behind `nousergon_lib.alerts`): the dedup path uses `get_object`/`put_object` on the hashed marker key `_alerts/_dedup/{sha1}.json` — **not** `ListBucket` as the issue text guessed. Scoped the grant accordingly, mirroring the `freshness-monitor` lambda's `iam-policy.json` precedent.

**Deliberately omitted:** SSM read for `TELEGRAM_BOT_TOKEN`. Telegram coverage already exists via the workflow-level `notify-main-failure` job, and granting a deploy role read on a secret token is an unjustified privilege widening (the issue flags this tradeoff explicitly).

## Validation

- JSON parses; statement count 20→22.
- `tests/test_deploy_infrastructure_sf_coverage.py` + `tests/test_sf_iam_lambda_grants.py`: **9 passed, 1 skipped** locally (the policy-parsing/grant-coverage tests).

**Not runtime-validated here** (no AWS creds in the unattended runner). To apply + confirm live:

```
infrastructure/iam/apply.sh github-actions-lambda-deploy
```

then verify by the next real canary rollback alerting cleanly, or a forced-canary-fail dry run.

Closes nousergon/alpha-engine-config#1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)