### PR TITLE
feat(changelog-incident-mirror): --apply-iam flag for IAM-apply parity (config#865)

### DIFF
--- a/infrastructure/lambdas/changelog-incident-mirror/README.md
+++ b/infrastructure/lambdas/changelog-incident-mirror/README.md
@@ -44,7 +44,7 @@ section.
 |---|---|
 | `index.py` | Lambda handler source (Python 3.12, arm64, 256 MB, 30s) |
 | `iam-policy.json` | Inline policy attached to the function's role |
-| `deploy.sh` | One-shot redeploy script (updates function code only) |
+| `deploy.sh` | Redeploy script (updates function code; `--apply-iam` re-applies the inline role policy, config#865) |
 | `README.md` | this file |
 
 The Lambda's function name, role name, SNS subscription, and Lambda
@@ -66,11 +66,17 @@ Their config:
 bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh
 # or with smoke test:
 bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh --smoke
+# re-apply the inline execution-role policy after an iam-policy.json change:
+bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh --apply-iam
 ```
 
 The script packages `index.py` into a zip, calls
 `aws lambda update-function-code`, and waits for the update to
-settle. Auth uses your local AWS CLI creds — the personal IAM user
+settle. `--apply-iam` additionally creates the execution role if
+missing and overwrites the inline `changelog-incident-mirror-s3`
+policy from `iam-policy.json` (idempotent), bringing IAM-apply
+parity with the sibling cloudwatch-mirror's `--bootstrap` block so
+policy changes no longer need a manual `aws iam put-role-policy`. Auth uses your local AWS CLI creds — the personal IAM user
 (`cipher813`) has enough perms; the `github-actions-lambda-deploy`
 OIDC role intentionally does not.
 

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -6,13 +6,22 @@
 # (see this directory's README.md for why). The first-time creation +
 # IAM role + SNS subscription were done via CloudFormation back when
 # this lived in the orchestration stack; orphaning preserved the live
-# resources via DeletionPolicy: Retain. As a result, this script only
-# needs to update the function CODE — IAM, subscription, and permission
-# are already wired up.
+# resources via DeletionPolicy: Retain. By default this script only
+# updates the function CODE — IAM, subscription, and permission are
+# already wired up.
+#
+# IAM-apply parity (config#865): pass --apply-iam to (re)apply the
+# inline execution-role policy from iam-policy.json, mirroring the
+# sibling changelog-cloudwatch-mirror's --bootstrap IAM block. The
+# operation is idempotent (create-role-if-missing + put-role-policy
+# overwrite-in-place), so re-running with no policy diff is a no-op.
+# Without this flag, an iam-policy.json change (e.g. the quarantine
+# PutObject grant) required a manual `aws iam put-role-policy`.
 #
 # Usage:
 #   bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh
 #   bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh --dry-run
+#   bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh --apply-iam
 #
 # Auth: uses active AWS CLI creds. Personal IAM user (cipher813) has
 # enough perms; the github-actions-lambda-deploy OIDC role does NOT —
@@ -23,15 +32,29 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-changelog-incident-mirror"
+# Execution role + inline policy name — see README.md "Recreate from scratch".
+# Kept in sync with the cloudwatch-mirror sibling's ROLE_NAME/POLICY_NAME vars.
+ROLE_NAME="alpha-engine-changelog-incident-mirror"
+POLICY_NAME="changelog-incident-mirror-s3"
 REGION="${AWS_REGION:-us-east-1}"
 
 DRY_RUN=false
+APPLY_IAM=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
+    --apply-iam) APPLY_IAM=true ;;
     -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
   esac
 done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
 
 # Validate index.py syntax + run handler smoke tests locally before shipping.
 python3 -c "
@@ -49,6 +72,42 @@ if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   echo "Running handler smoke tests..."
   python3 "${SCRIPT_DIR}/test_handler.py" >/dev/null
   echo "  ✓ Smoke tests pass"
+fi
+
+# ----- IAM apply (opt-in, config#865) ---------------------------------------
+# Mirror the cloudwatch-mirror sibling's --bootstrap IAM block so an
+# iam-policy.json change can ship without a manual `aws iam put-role-policy`.
+# Idempotent: create the execution role only if missing, then overwrite the
+# inline policy in place. Trust policy + managed AWSLambdaBasicExecutionRole
+# are first-time concerns handled in README "Recreate from scratch"; this
+# flag intentionally only re-applies the inline S3 policy that actually
+# drifts, matching cloudwatch-mirror's put-role-policy semantics.
+if $APPLY_IAM; then
+  echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+    run aws iam attach-role-policy \
+      --role-name "${ROLE_NAME}" \
+      --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    if ! $DRY_RUN; then
+      echo "  Waiting 10s for IAM role propagation..."
+      sleep 10
+    fi
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+  echo "  ✓ IAM applied."
 fi
 
 # Ensure the live Lambda env has the new structured-prefix var. Idempotent —


### PR DESCRIPTION
## What

Adds an opt-in `--apply-iam` flag to `changelog-incident-mirror/deploy.sh`, bringing IAM-apply parity with the sibling `changelog-cloudwatch-mirror/deploy.sh` (which re-applies its inline policy under `--bootstrap`).

## Why

Before this, the incident-mirror deploy.sh only ran `update-function-code`. Any `iam-policy.json` change — e.g. the `changelog/quarantine/*` `s3:PutObject` grant — required a manual `aws iam put-role-policy` outside the deploy path (the asymmetry called out in config#865).

## How

`--apply-iam` (idempotent):
- creates the execution role `alpha-engine-changelog-incident-mirror` + attaches `AWSLambdaBasicExecutionRole` only if the role is missing,
- always overwrites the inline `changelog-incident-mirror-s3` policy from `iam-policy.json` via `aws iam put-role-policy` — same semantics as the cloudwatch-mirror `--bootstrap` block.

Default (no flag) behavior is unchanged: code-only update. README updated.

## Validation

- `bash -n deploy.sh` clean.
- `deploy.sh --dry-run --apply-iam` prints the expected idempotent create-role-if-missing + `put-role-policy` commands.
- Existing handler smoke tests (13) still pass.
- **Unvalidated here** (no live AWS creds in groom env): the real `aws iam` calls. Validate with: `bash infrastructure/lambdas/changelog-incident-mirror/deploy.sh --apply-iam` under operator AWS creds (idempotent; safe to re-run).

Closes nousergon/alpha-engine-config#865

🤖 Generated with [Claude Code](https://claude.com/claude-code)