### PR TITLE
refactor(config): delegate data config.yaml resolution to nousergon-lib resolver (#1157)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 
 # Install git — required for ``pip install git+https://...`` of
-# alpha-engine-lib below. The Lambda Python 3.12 base image does not
+# nousergon-lib below. The Lambda Python 3.12 base image does not
 # include git; pip's git-cloning command fails with "Cannot find
 # command 'git'" without this. Same fix applied to alpha-engine-research
 # Dockerfile after PR #105's lib-public flip exposed the gap. Caught
@@ -10,17 +10,17 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 # manager; ``-y`` auto-confirms.
 RUN microdnf install -y git && microdnf clean all
 
-# Install dependencies. alpha-engine-lib is installed from public git+https
+# Install dependencies. nousergon-lib is installed from public git+https
 # with the [flow_doctor] extra only — the [arcticdb,rag] extras in
 # requirements.txt are intentionally NOT pulled here, since Lambda only
 # runs Phase 2 alternative-data collection (no ArcticDB or RAG ingestion).
 # Excludes pytest / python-dotenv / pre-installed Lambda runtime deps
-# (boto3 etc.). The grep filter strips alpha-engine-lib from the
+# (boto3 etc.). The grep filter strips nousergon-lib from the
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0" && \
-    grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0" && \
+    grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4" && \
+RUN pip install --no-cache-dir "alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^alpha-engine-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -79,17 +79,24 @@ def _load_feature_cfg_overrides() -> dict:
     window to baseline would be an invisible behavior change (no-silent-
     fails: the failure surfaces at import, caught by SF preflight/CI).
     """
-    import os
     from pathlib import Path
 
     import yaml
 
-    exp = os.environ.get("ALPHA_ENGINE_EXPERIMENT_ID", "reference")
+    # Canonical experiment-package config resolver (alpha-engine-config#1157):
+    # the lift of the five inline copies into the shared-lib chokepoint. The
+    # data-specific repo-local tail (``<repo>/config.yaml``, subdir-flattened) is
+    # preserved via repo_local_fallback; the per-key validation loop below is
+    # unchanged (a present-but-unknown override key still fails loud).
+    from alpha_engine_lib.config import resolve_experiment_config
+
     repo_root = Path(__file__).resolve().parent.parent
-    roots = [Path.home() / "alpha-engine-config", repo_root.parent / "alpha-engine-config"]
-    candidates = [r / "experiments" / exp / "data" / "config.yaml" for r in roots]
-    candidates += [r / "data" / "config.yaml" for r in roots]
-    candidates.append(repo_root / "config.yaml")
+    candidates = resolve_experiment_config(
+        "data",
+        "config.yaml",
+        repo_root=repo_root,
+        repo_local_fallback=repo_root / "config.yaml",
+    )
     for path in candidates:
         if not path.exists():
             continue

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0
 anyio>=4.0
 tenacity>=8.0
 pyyaml>=6.0
-alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0
+nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0
 anyio>=4.0
 tenacity>=8.0
 pyyaml>=6.0
-alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4
+alpha-engine-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ edgartools>=2.0
 voyageai>=0.3
 jsonschema>=4.20
 arcticdb>=6.11
-# flow-doctor is pulled in transitively via alpha-engine-lib[flow-doctor].
+# flow-doctor is pulled in transitively via nousergon-lib[flow-doctor].
 # NOTE: the extra MUST be hyphenated — setuptools normalizes the lib's
 # `flow_doctor` extra to `Provides-Extra: flow-doctor`; older pip doesn't
 # normalize underscore->hyphen, so `[flow_doctor]` silently drops it (config#1178).
@@ -32,4 +32,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-alpha-engine-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.59.4
+alpha-engine-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -1,11 +1,19 @@
-"""Pin ``requirements.txt`` + ``Dockerfile`` to the same alpha-engine-lib version.
+"""Pin every lib-install surface to the same nousergon-lib version.
 
-The Dockerfile strips alpha-engine-lib from ``requirements.txt`` before
-``pip install`` (see the ``grep -vE ...alpha-engine-lib`` line in the
+(The dist was renamed ``alpha-engine-lib`` → ``nousergon-lib`` at v0.60.0;
+the historical incidents below predate the rename and reference the old
+``alpha_engine_lib`` import name accordingly — kept verbatim as the
+drift-class record.)
+
+The Dockerfile strips nousergon-lib from ``requirements.txt`` before
+``pip install`` (see the ``grep -vE ...nousergon-lib`` line in the
 Dockerfile RUN block) and instead installs the lib via a hardcoded
-``pip install "alpha-engine-lib@vX.Y.Z"`` line ABOVE that grep. So
+``pip install "nousergon-lib@vX.Y.Z"`` line ABOVE that grep. So
 bumping ``requirements.txt`` alone does NOT propagate to the Lambda
-image — the Dockerfile's hardcoded pin wins.
+image — the Dockerfile's hardcoded pin wins. The slim
+``requirements-daily-news.txt`` (standalone daily-news collector on the
+dashboard box) carries its own copy of the pin and its header demands
+lockstep with ``requirements.txt`` — so it is guarded here too.
 
 This drift class has bitten production multiple times:
 
@@ -20,7 +28,7 @@ This drift class has bitten production multiple times:
     Lambda canary failed at 17:22 UTC with the same
     ``alpha_engine_lib.secrets`` ModuleNotFoundError.
 
-This test re-greps both files on every CI run so a future single-file
+This test re-greps all three files on every CI run so a future single-file
 bump fails here, not in a canary.
 """
 
@@ -32,10 +40,10 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 _REQUIREMENTS_PIN_RE = re.compile(
-    r"alpha-engine-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/nousergon/nousergon-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"
+    r"nousergon-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/nousergon/nousergon-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"
 )
 _DOCKERFILE_PIN_RE = re.compile(
-    r'"alpha-engine-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/nousergon/nousergon-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"'
+    r'"nousergon-lib\[[^\]]*\]\s*@\s*git\+https://github\.com/nousergon/nousergon-lib@(v[0-9]+\.[0-9]+\.[0-9]+)"'
 )
 
 
@@ -43,7 +51,7 @@ def _read_pin(filename: str, regex: re.Pattern[str]) -> str:
     text = (_REPO_ROOT / filename).read_text()
     match = regex.search(text)
     assert match is not None, (
-        f"could not find alpha-engine-lib pin in {filename}"
+        f"could not find nousergon-lib pin in {filename}"
     )
     return match.group(1)
 
@@ -51,9 +59,12 @@ def _read_pin(filename: str, regex: re.Pattern[str]) -> str:
 def test_requirements_and_dockerfile_pins_match():
     req_pin = _read_pin("requirements.txt", _REQUIREMENTS_PIN_RE)
     docker_pin = _read_pin("Dockerfile", _DOCKERFILE_PIN_RE)
-    assert req_pin == docker_pin, (
-        f"alpha-engine-lib pin drift: requirements.txt={req_pin!r} but "
-        f"Dockerfile={docker_pin!r}. Both must move in lockstep — the "
-        f"Dockerfile strips lib from requirements.txt before pip install, "
-        f"so requirements-only bumps don't propagate to the Lambda image."
+    daily_news_pin = _read_pin("requirements-daily-news.txt", _REQUIREMENTS_PIN_RE)
+    assert req_pin == docker_pin == daily_news_pin, (
+        f"nousergon-lib pin drift: requirements.txt={req_pin!r}, "
+        f"Dockerfile={docker_pin!r}, requirements-daily-news.txt={daily_news_pin!r}. "
+        f"All three must move in lockstep — the Dockerfile strips lib from "
+        f"requirements.txt before pip install, so requirements-only bumps "
+        f"don't propagate to the Lambda image, and the slim daily-news file "
+        f"carries an independent copy of the pin."
     )

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -68,6 +68,10 @@ _load_dotenv()
 # captured by flow-doctor's ERROR handler.
 from alpha_engine_lib.logging import setup_logging, guard_entrypoint
 from alpha_engine_lib.phase_registry import PhaseRegistry
+# Canonical experiment-package config resolver (alpha-engine-config#1157): the
+# lift of the five inline _find_config / load_config / config_loader copies into
+# the shared-lib chokepoint. load_config below delegates to it.
+from alpha_engine_lib.config import resolve_experiment_config
 _FLOW_DOCTOR_EXCLUDE_PATTERNS: list[str] = []
 _FLOW_DOCTOR_YAML = str(Path(__file__).parent / "flow-doctor.yaml")
 setup_logging(
@@ -94,22 +98,20 @@ def load_config(path: str = "config.yaml") -> dict:
     ``reference``) first, then the legacy top-level alpha-engine-config/data/config.yaml,
     then the repo-local fallback (``path``). The experiment-package layer was already
     live in feature_engineer; this closes the gap that file's docstring references.
+
+    Delegates to the canonical nousergon-lib resolver (resolve_experiment_config,
+    alpha-engine-config#1157). The data ``Path(path)`` tail is preserved verbatim
+    via repo_local_fallback (``path`` is CWD-relative, not subdir-anchored).
     """
-    exp = os.environ.get("ALPHA_ENGINE_EXPERIMENT_ID", "reference")
-    roots = [
-        Path.home() / "alpha-engine-config",
-        Path(__file__).parent.parent / "alpha-engine-config",
-    ]
-    search_paths = [r / "experiments" / exp / "data" / "config.yaml" for r in roots]
-    search_paths += [r / "data" / "config.yaml" for r in roots]
-    search_paths.append(Path(path))
-    for p in search_paths:
-        if p.exists():
-            with open(p) as f:
-                return yaml.safe_load(f)
-    raise FileNotFoundError(
-        f"Config not found. Searched: {[str(p) for p in search_paths]}"
+    resolved = resolve_experiment_config(
+        "data",
+        "config.yaml",
+        repo_root=Path(__file__).parent,
+        repo_local_fallback=Path(path),
+        resolve=True,
     )
+    with open(resolved) as f:
+        return yaml.safe_load(f)
 
 
 def _load_chronic_polygon_gaps(config: dict) -> list[str]:


### PR DESCRIPTION
## What
Lifts the two inline experiment-package config readers into the canonical `resolve_experiment_config` (imported via the `alpha_engine_lib.config` compat alias) — the consumer-migration wave of nousergon/alpha-engine-config#1157 (5th-adoption lift; lib helper shipped in nousergon-lib#131).

- `weekly_collector.load_config(path)` — the data `Path(path)` tail preserved verbatim via `repo_local_fallback` (`path` is CWD-relative, not subdir-anchored).
- `features/feature_engineer._load_feature_cfg_overrides` — repo-local `<repo>/config.yaml` tail preserved; the per-key fail-loud validation loop (unknown override key → `KeyError`) is unchanged.

## Behavior-preserving
Resolution order (experiment-package → legacy → local) is identical.

## Pin (lockstep)
Bump the lib pin v0.59.4 → v0.70.0 across `requirements.txt`, `Dockerfile`, and `requirements-daily-news.txt`. First tagged lib release carrying `resolve_experiment_config` is v0.67.0.

**Distribution name renamed `alpha-engine-lib` → `nousergon-lib`** (commits 039d4f1, 2d7d0e0). The dist was renamed AT v0.60.0, so `alpha-engine-lib[...] @ ...@v0.70.0` resolved to a project name the repo no longer provides → pip "No matching distribution found for alpha-engine-lib (unavailable)" → CI died at install. The import-name compat shim does NOT cover the *install* name — only `import alpha_engine_lib` (which still works via the meta-path shim). The `test_lib_pin_lockstep` regexes were repointed to `nousergon-lib` and the guard extended to cover `requirements-daily-news.txt`.

## Tests
`test_load_config_experiment_package`, `test_feature_cfg_package`, `test_lib_pin_lockstep` — 8 passed against the v0.70.0 lib.

Refs nousergon/alpha-engine-config#1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)