### PR TITLE
fix(universe): restate splits full-history before ArcticDB write (#1298)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -43,6 +43,7 @@ from features.compute import (
     _SKIP_TICKERS,
     _UNIVERSE_EXTRA,
     _apply_daily_delta,
+    audit_split_jumps,
     _is_sector_etf,
     _load_parquet_from_s3,
     _load_sector_map,
@@ -384,7 +385,29 @@ def backfill(
     # ``features/compute.py::_apply_daily_delta`` so both feature-snapshot and
     # backfill share the same freshness semantics.
     if not dry_run:
-        price_data, _split_tickers = _apply_daily_delta(s3, bucket, today_str, price_data)
+        price_data, split_tickers = _apply_daily_delta(s3, bucket, today_str, price_data)
+        if split_tickers:
+            # data#1298: these tickers had a split detected and their FULL
+            # history restated by the polygon-authoritative factor before the
+            # full-series ``lib.write`` below, so ArcticDB is rewritten on one
+            # continuous adjusted scale (train == serve), not windowed-patched.
+            log.info(
+                "Split restatement applied to %d ticker(s) before ArcticDB "
+                "rewrite (data#1298): %s",
+                len(split_tickers), sorted(split_tickers),
+            )
+
+        # Standing split-jump audit guard (data#1298): a residual >45% daily
+        # move means a split slipped past restatement. Surface it loudly so the
+        # discontinuity can't land in ArcticDB silently.
+        residual = audit_split_jumps(price_data)
+        if residual:
+            log.error(
+                "Split-jump audit: %d ticker(s) STILL carry an un-restated "
+                ">45%% daily move after delta+restate (data#1298) — investigate "
+                "/ re-restate before downstream training: %s",
+                len(residual), {t: residual[t] for t in sorted(residual)[:20]},
+            )
 
     macro = _extract_macro_series(price_data)
     sector_map = _load_sector_map(s3, bucket)

--- a/features/compute.py
+++ b/features/compute.py
@@ -301,18 +301,107 @@ def _apply_daily_delta(
         # keep="last" so delta rows win on duplicate dates (matches predictor)
         combined = combined[~combined.index.duplicated(keep="last")].sort_index()
 
-        # Split detection: log warning but still use the data.
-        # The weekly price collector handles splits properly during
-        # Saturday DataPhase1; feature compute trusts upstream data.
+        # Split detection → full-history RESTATEMENT (data#1298).
+        #
+        # The ArcticDB universe is append-only + windowed: a split restates the
+        # FULL adjusted history, but ArcticDB only ever got a recent window
+        # patched, leaving a split-boundary discontinuity that corrupts
+        # cross-boundary TRAINING features (verified on DD 2026-06-24). The
+        # root-cause fix is to back-adjust the ENTIRE pre-split window by the
+        # polygon-AUTHORITATIVE split factor here, at the point the full series
+        # is materialized for the downstream ``lib.write`` — so the series
+        # written to ArcticDB is continuous and on one adjusted scale
+        # (train == serve). We restate at WRITE time (not read time) because the
+        # backfill path already rewrites the full symbol; doing the restate in
+        # the read/window path would have to re-derive factors on every query
+        # and would not durably fix the stored discontinuity.
+        #
+        # yfinance ``auto_adjust`` LAGS a fresh split, so it cannot be trusted
+        # for restatement — the factor must come from polygon (see split_factor).
         returns = combined["Close"].pct_change().dropna()
         if (returns.abs() > _SPLIT_RETURN_THRESHOLD).any():
-            log.warning("Large move detected in %s (>45%% daily return) — using data as-is", ticker)
+            restated = _restate_split_window(ticker, combined)
+            if restated is not None:
+                combined = restated
+                split_tickers.add(ticker)
+            else:
+                log.warning(
+                    "Large move in %s (>45%% daily return) but no polygon split "
+                    "factor available — using data as-is (audit guard should flag)",
+                    ticker,
+                )
 
         price_data[ticker] = combined
         n_updated += 1
 
     log.info("Applied daily delta: %d tickers updated", n_updated)
     return price_data, split_tickers
+
+
+def _restate_split_window(
+    ticker: str, df: pd.DataFrame, *, client=None,
+) -> pd.DataFrame | None:
+    """Back-adjust ``df``'s pre-split history by the polygon-authoritative
+    cumulative split factor so the full series is split-consistent (data#1298).
+
+    Returns the restated frame, or ``None`` when no polygon split factor is
+    available (no events / polygon unreachable / events all predate the series)
+    so the caller can fall back to "use as-is" + the audit guard. The actual
+    factor math lives in :mod:`split_factor`; this wrapper isolates the
+    (network) polygon lookup so it can be patched out in tests.
+    """
+    try:
+        from split_factor import restate_series_for_splits, split_events
+
+        events = split_events(ticker, client=client)
+    except Exception as exc:  # network / auth / import — never hard-fail the run
+        log.warning(
+            "Split restatement for %s could not load polygon factors (%s) — "
+            "leaving series un-restated; audit guard should flag it",
+            ticker, exc,
+        )
+        return None
+    if not events:
+        return None
+    restated = restate_series_for_splits(df, events)
+    if restated is df:
+        # No row actually changed (every split predates the series) — treat as
+        # "no restatement available" so the >45%% move is still surfaced.
+        return None
+    log.info(
+        "Restated %s full history on polygon split factor (%d event(s)) — "
+        "ArcticDB write will be split-consistent (data#1298)",
+        ticker, len(events),
+    )
+    return restated
+
+
+def audit_split_jumps(
+    price_data: dict[str, pd.DataFrame],
+    *,
+    threshold: float = _SPLIT_RETURN_THRESHOLD,
+) -> dict[str, list[tuple[str, float]]]:
+    """Data-quality invariant: scan each series for an un-restated split jump.
+
+    Returns ``{ticker: [(date_str, daily_return), ...]}`` for every ticker whose
+    Close series still contains a ``|daily return| > threshold`` move. A clean,
+    fully-restated universe returns ``{}``. Surfacing this makes the data#1298
+    bug class impossible to land SILENTLY — a residual discontinuity (the
+    restate failed, or a new split slipped past) is now a visible invariant
+    violation an operator/cron can alert on and auto-restate.
+    """
+    offenders: dict[str, list[tuple[str, float]]] = {}
+    for ticker, df in price_data.items():
+        if df is None or df.empty or "Close" not in df.columns:
+            continue
+        returns = df["Close"].pct_change().dropna()
+        hits = returns[returns.abs() > threshold]
+        if not hits.empty:
+            offenders[ticker] = [
+                (pd.Timestamp(idx).strftime("%Y-%m-%d"), float(val))
+                for idx, val in hits.items()
+            ]
+    return offenders
 
 
 _MACRO_SLIM_KEYS = {

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -273,6 +273,48 @@ class PolygonClient:
             "vwap": r.get("vw"),
         }
 
+    def get_splits(self, ticker: str) -> list[dict]:
+        """Fetch the corporate-split history for one ticker (authoritative).
+
+        Polygon is the authoritative corporate-action source (see data#1298):
+        yfinance ``auto_adjust`` LAGS a fresh split (it back-adjusts only the
+        most recent rows for a day or two), so it cannot be trusted to restate
+        a freshly-split ArcticDB universe series. The polygon ``/v3/reference/
+        splits`` endpoint carries the exact effective date + ratio the day the
+        split lands.
+
+        Returns a list of ``{"execution_date": "YYYY-MM-DD",
+        "split_from": int, "split_to": int}`` sorted ascending by date. A
+        forward N-for-1 split is ``split_from=1, split_to=N`` (one old share
+        becomes N new shares → adjusted price divides by N); a reverse 1-for-N
+        split is ``split_from=N, split_to=1``. The per-event multiplicative
+        factor applied to prices BEFORE the execution date is
+        ``split_from / split_to``.
+        """
+        results: list[dict] = []
+        try:
+            data = self._get(
+                "/v3/reference/splits",
+                params={"ticker": ticker, "limit": 1000, "order": "asc"},
+            )
+        except PolygonForbiddenError:
+            return []
+        for r in data.get("results", []) or []:
+            exec_date = r.get("execution_date")
+            sf = r.get("split_from")
+            st = r.get("split_to")
+            if not exec_date or not sf or not st:
+                continue
+            results.append(
+                {
+                    "execution_date": str(exec_date),
+                    "split_from": int(sf),
+                    "split_to": int(st),
+                }
+            )
+        results.sort(key=lambda r: r["execution_date"])
+        return results
+
     def get_daily_bars(
         self,
         ticker: str,

--- a/split_factor.py
+++ b/split_factor.py
@@ -1,0 +1,148 @@
+"""
+split_factor.py — polygon-authoritative split factors for full-history restatement.
+
+WHY THIS EXISTS (data#1298):
+    The ArcticDB universe library (predictor TRAINING input) is append-only +
+    windowed-reconciled. When a ticker splits, yfinance back-adjusts its ENTIRE
+    price history (so ``predictor/price_cache/`` — the INFERENCE store — stays
+    split-clean), but ArcticDB only ever got a recent N-day window patched. A
+    split restates the FULL adjusted history, so a windowed patch leaves a
+    split-boundary discontinuity (verified on DD 2026-06-24: +201% / -66% /
+    +200% artificial jumps in a live S&P constituent's return series). That
+    corrupts every feature computed across the boundary and — via cross-sectional
+    rank normalization — perturbs the whole cohort's ranks on those dates.
+
+    The ROOT-CAUSE fix is a full-history RESTATEMENT on detection: when a split
+    is detected, back-adjust EVERY price strictly before the split's execution
+    date by the cumulative split factor, so the full series materialized for the
+    ArcticDB write is continuous and on ONE adjusted scale (train == serve).
+
+WHY POLYGON, NOT yfinance:
+    yfinance ``auto_adjust`` LAGS a fresh split — on the DD split it had adjusted
+    only 6/18+ (×3) and left <=6/17 on the old scale for a day or two. So
+    yfinance cannot be trusted to restate a *fresh* split. Polygon's
+    ``/v3/reference/splits`` endpoint carries the exact effective date + ratio
+    the day the split lands and is the authoritative factor + validator.
+
+CONVENTION:
+    A forward N-for-1 split (``split_from=1, split_to=N``) divides the adjusted
+    price by N for every date BEFORE the execution date. A reverse 1-for-N split
+    (``split_from=N, split_to=1``) multiplies by N. The per-event multiplicative
+    factor applied to dates strictly before ``execution_date`` is therefore
+    ``split_from / split_to``. Multiple splits compound multiplicatively.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+# A factor whose distance from 1.0 is below this is treated as "no split"
+# (absorbs feed float noise; real splits are integer ratios >= 2:1).
+_FACTOR_NOOP_TOL = 1e-9
+
+
+def split_events(ticker: str, client=None) -> list[dict]:
+    """Return polygon's split events for ``ticker`` (ascending by date).
+
+    Each event is ``{"execution_date": "YYYY-MM-DD", "split_from": int,
+    "split_to": int}``. ``client`` defaults to the polygon singleton; pass an
+    explicit (or fake) client in tests to avoid a live API call.
+    """
+    if client is None:
+        from polygon_client import polygon_client
+
+        client = polygon_client()
+    return client.get_splits(ticker)
+
+
+def cumulative_factor(
+    events: list[dict],
+    on_or_before_date,
+    *,
+    reference_date=None,
+) -> float:
+    """Cumulative multiplicative price factor to put ``on_or_before_date`` on
+    the ``reference_date`` adjusted scale.
+
+    A split with ``execution_date`` E applies factor ``split_from/split_to`` to
+    every price on dates strictly before E. ``cumulative_factor`` multiplies the
+    factors of every split whose execution date falls in
+    ``(on_or_before_date, reference_date]`` — i.e. every split that occurred
+    AFTER the given date but on/before the reference (default: the latest event
+    date, i.e. "the current scale"). Prices already on or after the most recent
+    split return ``1.0``.
+
+    This is the per-row factor used to back-adjust a price series so its whole
+    history sits on one continuous adjusted scale.
+    """
+    d = pd.Timestamp(on_or_before_date).normalize()
+    factor = 1.0
+    for ev in events:
+        e = pd.Timestamp(ev["execution_date"]).normalize()
+        if reference_date is not None and e > pd.Timestamp(reference_date).normalize():
+            continue
+        if e > d:
+            factor *= ev["split_from"] / ev["split_to"]
+    return factor
+
+
+def restate_series_for_splits(
+    df: pd.DataFrame,
+    events: list[dict],
+    *,
+    price_cols=("Open", "High", "Low", "Close", "VWAP", "Adj_Close"),
+    volume_cols=("Volume",),
+) -> pd.DataFrame:
+    """Back-adjust a price DataFrame so its full history is split-consistent.
+
+    For every split event, every row STRICTLY BEFORE the execution date has its
+    price columns multiplied by ``split_from/split_to`` and its volume columns
+    divided by the same factor (share count moves inversely to price). Rows on
+    or after the latest split are left untouched — they already define the
+    current adjusted scale. Returns a new frame (input is not mutated); a frame
+    with no in-range splits is returned unchanged (no copy).
+
+    This puts the ENTIRE series on one adjusted scale, eliminating the
+    split-boundary discontinuity that corrupts cross-boundary training features
+    (data#1298). Idempotent on an already-restated series only insofar as the
+    caller restates from a raw/un-restated source — it always applies the FULL
+    cumulative factor, so it must be fed the source series, not a previously
+    restated one (mirrors yfinance's full back-adjust + the price_cache heal).
+    """
+    if df.empty or not events:
+        return df
+
+    idx = df.index
+    if not isinstance(idx, pd.DatetimeIndex):
+        idx = pd.to_datetime(idx)
+
+    # Per-row cumulative factor relative to the latest (current) scale.
+    factors = pd.Series(
+        [cumulative_factor(events, ts) for ts in idx],
+        index=df.index,
+        dtype="float64",
+    )
+
+    if (factors.sub(1.0).abs() <= _FACTOR_NOOP_TOL).all():
+        # No row needs restating (all splits predate the series, or none in range).
+        return df
+
+    out = df.copy()
+    for col in price_cols:
+        if col in out.columns:
+            out[col] = out[col] * factors
+    for col in volume_cols:
+        if col in out.columns:
+            # Volume scales inversely; keep integer-ish volumes round.
+            out[col] = (out[col] / factors).round()
+    log.info(
+        "Restated %d row(s) across %d split event(s) — full-history "
+        "split-consistent (data#1298)",
+        int((factors.sub(1.0).abs() > _FACTOR_NOOP_TOL).sum()),
+        len(events),
+    )
+    return out

--- a/tests/test_polygon_client.py
+++ b/tests/test_polygon_client.py
@@ -129,3 +129,58 @@ def test_403_does_not_pollute_grouped_daily_cache():
             "re-hit the API so an upgraded plan / different time window "
             "succeeds without manual cache busting."
         )
+
+
+# ── get_splits (data#1298: authoritative split factor source) ────────────────
+
+
+def _splits_response(events: list[dict]) -> dict:
+    """Shape of polygon /v3/reference/splits results."""
+    return {
+        "results": [
+            {
+                "execution_date": e["execution_date"],
+                "split_from": e["split_from"],
+                "split_to": e["split_to"],
+                "ticker": e.get("ticker", "DD"),
+            }
+            for e in events
+        ],
+        "status": "OK",
+    }
+
+
+def test_get_splits_parses_and_sorts():
+    client = _make_client()
+    resp = _splits_response(
+        [
+            {"execution_date": "2026-06-24", "split_from": 3, "split_to": 1},
+            {"execution_date": "2019-06-03", "split_from": 1, "split_to": 3},
+        ]
+    )
+    with patch.object(client, "_get", return_value=resp) as mock_get:
+        out = client.get_splits("DD")
+    assert mock_get.call_count == 1
+    # Sorted ascending by execution_date.
+    assert [e["execution_date"] for e in out] == ["2019-06-03", "2026-06-24"]
+    assert out[1] == {"execution_date": "2026-06-24", "split_from": 3, "split_to": 1}
+
+
+def test_get_splits_skips_malformed_rows():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"execution_date": "2026-06-24", "split_from": 3, "split_to": 1},
+            {"execution_date": None, "split_from": 2, "split_to": 1},  # bad date
+            {"execution_date": "2025-01-01", "split_from": 0, "split_to": 1},  # bad ratio
+        ]
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_splits("DD")
+    assert out == [{"execution_date": "2026-06-24", "split_from": 3, "split_to": 1}]
+
+
+def test_get_splits_forbidden_returns_empty():
+    client = _make_client()
+    with patch.object(client, "_get", side_effect=PolygonForbiddenError("403")):
+        assert client.get_splits("DD") == []

--- a/tests/test_split_restatement.py
+++ b/tests/test_split_restatement.py
@@ -1,0 +1,262 @@
+"""data#1298 — ArcticDB universe must restate splits (full-history back-adjust).
+
+The ArcticDB universe (predictor TRAINING input) is append-only + windowed, so a
+split that restates the FULL adjusted history left only a recent window patched —
+a split-boundary discontinuity that corrupts cross-boundary training features.
+These tests pin the root-cause fix: a detected split triggers a full-history
+restatement by the polygon-AUTHORITATIVE factor, so the series materialized for
+the ArcticDB ``lib.write`` is continuous and on one adjusted scale.
+
+Covers:
+  * cumulative_factor / restate_series_for_splits factor math (forward + reverse)
+  * _apply_daily_delta restates the pre-split window on detection (DD-style)
+  * the audit guard catches an injected (un-restated) discontinuity
+  * round-trip through a real ArcticDB (LMDB) library: the read window is
+    continuous post-restate, and a return feature across the boundary is correct
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import features.compute as compute
+from split_factor import (
+    cumulative_factor,
+    restate_series_for_splits,
+)
+
+
+# ── factor math ──────────────────────────────────────────────────────────────
+
+
+def test_cumulative_factor_forward_split():
+    # 3-for-1 forward split on 6/24: split_from=1, split_to=3 → pre-split prices
+    # divide by 3 to reach the current (post-split) scale.
+    events = [{"execution_date": "2026-06-24", "split_from": 1, "split_to": 3}]
+    assert cumulative_factor(events, "2026-06-12") == pytest.approx(1 / 3)
+    assert cumulative_factor(events, "2026-06-23") == pytest.approx(1 / 3)
+    # On/after the execution date the price is already on the current scale.
+    assert cumulative_factor(events, "2026-06-24") == pytest.approx(1.0)
+    assert cumulative_factor(events, "2026-06-25") == pytest.approx(1.0)
+
+
+def test_cumulative_factor_reverse_split():
+    # DD's real event: 1-for-3 REVERSE (split_from=3, split_to=1) → pre-split
+    # prices MULTIPLY by 3 to reach the higher post-reverse-split scale.
+    events = [{"execution_date": "2026-06-24", "split_from": 3, "split_to": 1}]
+    assert cumulative_factor(events, "2026-06-12") == pytest.approx(3.0)
+    assert cumulative_factor(events, "2026-06-24") == pytest.approx(1.0)
+
+
+def test_cumulative_factor_compounds():
+    events = [
+        {"execution_date": "2026-01-10", "split_from": 1, "split_to": 2},
+        {"execution_date": "2026-06-24", "split_from": 1, "split_to": 3},
+    ]
+    # Before both → 1/2 * 1/3
+    assert cumulative_factor(events, "2026-01-05") == pytest.approx(1 / 6)
+    # Between them → only the later split applies
+    assert cumulative_factor(events, "2026-03-01") == pytest.approx(1 / 3)
+    assert cumulative_factor(events, "2026-07-01") == pytest.approx(1.0)
+
+
+def test_restate_series_reverse_split_is_continuous():
+    # Synthetic DD: smooth ~$48 trend pre-split, ~3x ($144) trend post reverse
+    # split, but with the un-restated history left on the old ($48) scale → a
+    # ~3x jump at the boundary. Restating must remove the boundary jump.
+    pre_dates = pd.bdate_range("2026-06-01", "2026-06-23")
+    post_dates = pd.bdate_range("2026-06-24", "2026-07-01")
+    pre = pd.Series(np.linspace(47.5, 48.5, len(pre_dates)), index=pre_dates)
+    post = pd.Series(np.linspace(142.5, 145.5, len(post_dates)), index=post_dates)
+    close = pd.concat([pre, post])
+    df = pd.DataFrame(
+        {
+            "Open": close, "High": close * 1.01, "Low": close * 0.99,
+            "Close": close, "Volume": 1_000_000.0,
+        }
+    )
+
+    # Before restatement: a >45% boundary jump exists.
+    raw_ret = df["Close"].pct_change().abs().max()
+    assert raw_ret > 0.45
+
+    events = [{"execution_date": "2026-06-24", "split_from": 3, "split_to": 1}]
+    out = restate_series_for_splits(df, events)
+
+    # After restatement: no daily move exceeds 45% — fully continuous.
+    assert out["Close"].pct_change().abs().max() < 0.45
+    # Pre-split rows are now on the post-split (~$144) scale.
+    assert out["Close"].loc[pre_dates[-1]] == pytest.approx(48.0 * 3, rel=0.05)
+    # Volume scaled inversely.
+    assert out["Volume"].loc[pre_dates[0]] == pytest.approx(1_000_000 / 3, rel=0.01)
+    # Post-split rows untouched.
+    assert out["Close"].loc[post_dates[0]] == pytest.approx(df["Close"].loc[post_dates[0]])
+
+
+def test_restate_noop_when_split_predates_series():
+    dates = pd.bdate_range("2026-06-01", "2026-06-10")
+    df = pd.DataFrame({"Close": np.linspace(100, 110, len(dates))}, index=dates)
+    events = [{"execution_date": "2020-01-01", "split_from": 1, "split_to": 2}]
+    out = restate_series_for_splits(df, events)
+    # Every row is after the split → unchanged (same object, no copy).
+    assert out is df
+
+
+# ── _apply_daily_delta restates on detection ─────────────────────────────────
+
+
+class _FakePolygon:
+    """Stand-in for PolygonClient.get_splits — no network."""
+
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def get_splits(self, ticker):
+        return list(self._mapping.get(ticker, []))
+
+
+def _close_only(df):
+    return df["Close"]
+
+
+def test_apply_daily_delta_restates_split_ticker(monkeypatch):
+    """DD-style: a split jump in the merged series triggers a full-history
+    restatement via the polygon factor, and the ticker is reported as a
+    split_ticker. The materialized series (which feeds the ArcticDB write) is
+    continuous."""
+    # Base (price_cache) history on the OLD (~$48) scale, ending 6/12.
+    base_dates = pd.bdate_range("2026-06-01", "2026-06-12")
+    base = pd.DataFrame(
+        {
+            "Open": np.linspace(47.0, 48.0, len(base_dates)),
+            "High": np.linspace(47.5, 48.5, len(base_dates)),
+            "Low": np.linspace(46.5, 47.5, len(base_dates)),
+            "Close": np.linspace(47.0, 48.0, len(base_dates)),
+            "Volume": np.full(len(base_dates), 1_000_000.0),
+        },
+        index=base_dates,
+    )
+    price_data = {"DD": base}
+
+    # Delta rows: pre-execution dates (6/15..6/23) are still on the OLD (~$48)
+    # scale (the reverse split is effective 6/24); only 6/24 onward is on the
+    # NEW (~$144) scale. This is the real shape that produces the data#1298
+    # boundary jump — restatement must lift the old-scale rows by ×3.
+    exec_date = pd.Timestamp("2026-06-24")
+    delta_dates = pd.bdate_range("2026-06-15", "2026-06-24")
+    delta_rows = [
+        {
+            "date": d,
+            "Open": 48.0, "High": 48.5, "Low": 47.5,
+            "Close": 48.0, "Volume": 1_000_000, "source": "polygon",
+        }
+        if d < exec_date
+        else {
+            "date": d,
+            "Open": 144.0, "High": 145.0, "Low": 143.0,
+            "Close": 144.0, "Volume": 333_000, "source": "polygon",
+        }
+        for d in delta_dates
+    ]
+
+    monkeypatch.setattr(
+        compute, "_load_delta_from_daily_closes",
+        lambda *a, **k: {"DD": delta_rows},
+    )
+    # Patch the polygon lookup used by _restate_split_window.
+    fake = _FakePolygon({"DD": [{"execution_date": "2026-06-24",
+                                 "split_from": 3, "split_to": 1}]})
+    import split_factor
+    monkeypatch.setattr(
+        split_factor, "split_events",
+        lambda ticker, client=None: fake.get_splits(ticker),
+    )
+
+    out, split_tickers = compute._apply_daily_delta(
+        s3=None, bucket="b", date_str="2026-06-24", price_data=price_data,
+    )
+
+    assert "DD" in split_tickers, "split should have been detected + restated"
+    series = out["DD"]["Close"]
+    # No residual >45% boundary jump — the full series is split-consistent.
+    assert series.pct_change().abs().max() < 0.45
+    # The old-scale pre-split rows were lifted onto the ~$144 scale.
+    assert series.loc[base_dates[0]] > 120
+
+
+def test_apply_daily_delta_no_factor_leaves_series_but_audit_flags(monkeypatch):
+    """If polygon has no factor (e.g. unreachable), the series is left as-is
+    (not silently mangled) AND the audit guard surfaces the discontinuity."""
+    base_dates = pd.bdate_range("2026-06-01", "2026-06-12")
+    base = pd.DataFrame(
+        {"Open": 48.0, "High": 48.5, "Low": 47.5, "Close": 48.0, "Volume": 1e6},
+        index=base_dates,
+    )
+    price_data = {"DD": base}
+    delta_dates = pd.bdate_range("2026-06-15", "2026-06-24")
+    delta_rows = [
+        {"date": d, "Open": 144.0, "High": 145.0, "Low": 143.0,
+         "Close": 144.0, "Volume": 333_000, "source": "polygon"}
+        for d in delta_dates
+    ]
+    monkeypatch.setattr(
+        compute, "_load_delta_from_daily_closes",
+        lambda *a, **k: {"DD": delta_rows},
+    )
+    import split_factor
+    monkeypatch.setattr(split_factor, "split_events", lambda ticker, client=None: [])
+
+    out, split_tickers = compute._apply_daily_delta(
+        s3=None, bucket="b", date_str="2026-06-24", price_data=price_data,
+    )
+    assert "DD" not in split_tickers  # nothing restated
+    offenders = compute.audit_split_jumps(out)
+    assert "DD" in offenders  # the audit guard catches it
+
+
+def test_audit_split_jumps_clean_universe():
+    dates = pd.bdate_range("2026-01-01", "2026-03-01")
+    df = pd.DataFrame({"Close": np.linspace(100, 120, len(dates))}, index=dates)
+    assert compute.audit_split_jumps({"AAPL": df}) == {}
+
+
+# ── real ArcticDB (LMDB) round-trip ──────────────────────────────────────────
+
+
+def test_arcticdb_window_read_continuous_after_restate(tmp_path):
+    """End-to-end: the restated, split-consistent series written to a REAL
+    ArcticDB library reads back continuous, and a return feature computed ACROSS
+    the split boundary is correct (no artificial jump)."""
+    adb = pytest.importorskip("arcticdb")
+
+    pre_dates = pd.bdate_range("2026-06-01", "2026-06-23")
+    post_dates = pd.bdate_range("2026-06-24", "2026-07-01")
+    pre = pd.Series(np.linspace(47.5, 48.5, len(pre_dates)), index=pre_dates)
+    post = pd.Series(np.linspace(142.5, 145.5, len(post_dates)), index=post_dates)
+    close = pd.concat([pre, post])
+    df = pd.DataFrame({"Close": close, "Volume": np.full(len(close), 1e6)})
+
+    events = [{"execution_date": "2026-06-24", "split_from": 3, "split_to": 1}]
+    restated = restate_series_for_splits(df, events)
+
+    ac = adb.Arctic(f"lmdb://{tmp_path}")
+    lib = ac.get_library("universe", create_if_missing=True)
+    lib.write("DD", restated)
+
+    # Windowed read spanning the split boundary (mirrors the predictor's
+    # windowed materialization).
+    got = lib.read(
+        "DD",
+        date_range=(pd.Timestamp("2026-06-18"), pd.Timestamp("2026-06-26")),
+    ).data
+
+    # No artificial boundary jump in the read window.
+    assert got["Close"].pct_change().abs().max() < 0.45
+    # A 1-day return feature computed across the split boundary is small/real,
+    # not the ~3x split artifact.
+    boundary_ret = (
+        got["Close"].loc[post_dates[0]] / got["Close"].loc[pre_dates[-1]] - 1
+    )
+    assert abs(boundary_ret) < 0.1


### PR DESCRIPTION
Closes #1298

## Root cause
The ArcticDB **universe** library (predictor **TRAINING** input) is append-only + windowed-reconciled. When a ticker splits, yfinance back-adjusts its **entire** history — so `predictor/price_cache/` (the **inference** store) stays split-clean — but ArcticDB only ever got a recent N-day window patched. A split restates the **full** adjusted history, so the windowed patch leaves a **split-boundary discontinuity** (verified on DD 2026-06-24: +201% / -66% / +200% artificial jumps in a live S&P constituent). That corrupts every feature computed across the boundary and, via cross-sectional rank normalization, perturbs the whole cohort's ranks on those dates — train/serve skew.

`features/compute._apply_daily_delta` already **detected** splits (>45% daily move) but did nothing with them — it returned an always-empty `split_tickers` set and logged "using data as-is".

## Layer chosen: WRITE-time restate (not read-time factor)
When a split is detected while materializing the full series for the downstream `lib.write`, back-adjust the **entire pre-split window** by the polygon-authoritative cumulative factor, so the series written to ArcticDB is continuous and on **one** adjusted scale (train == serve).

Why write-time, not read-time:
- The backfill path **already rewrites the full symbol** (`lib.write(full_series)`) — restating there is the natural chokepoint and durably heals the **stored** discontinuity.
- A read-time factor would have to re-derive cumulative factors on **every** windowed query and would never fix the stored series — the corruption would persist for any consumer not going through the adjusted reader. That is a bandaid, not a root-cause fix.

Why **polygon**, not yfinance: yfinance `auto_adjust` **lags** a fresh split (on DD it left ≤6/17 on the old scale for a day), so it cannot restate a fresh split. Polygon `/v3/reference/splits` carries the exact effective date + ratio the day the split lands and is the authoritative factor + validator.

## Changes
- `polygon_client.get_splits()` — authoritative split history `(execution_date, split_from, split_to)`.
- `split_factor.py` (new) — `cumulative_factor` + `restate_series_for_splits` (forward + reverse splits, multi-split compounding, volume scaled inversely; non-mutating).
- `features/compute._apply_daily_delta` — on detection, restate the full window via the polygon factor and populate `split_tickers`. If no factor is available (polygon unreachable / no events), the series is left **un-restated** (never silently mangled) for the audit guard to flag.
- `features/compute.audit_split_jumps()` + wiring in `builders/backfill.py` — standing data-quality invariant: any residual `|daily return| > 45%` after delta+restate is surfaced loudly, so this bug class can't land silently.

## Tests / CI status
`pytest tests/` — **2233 passed, 8 skipped** locally (Python 3.12, `arcticdb==6.18.3`).
New `tests/test_split_restatement.py` covers:
- factor math: forward, reverse, multi-split compounding, no-op when split predates series;
- `_apply_daily_delta` restates a DD-style reverse-split series + reports it in `split_tickers`;
- the no-factor path leaves the series intact **and** the audit guard catches the discontinuity;
- a **real ArcticDB (LMDB) round-trip**: the windowed read across the split boundary is continuous and a cross-boundary 1-day return feature is correct (not the ~3x split artifact).
Plus `tests/test_polygon_client.py::test_get_splits_*`.

## Why DRAFT — what's unvalidated
The code path and factor math are fully unit/integration-tested (incl. a real ArcticDB backend), but two things need the live environment before this is marked ready:
1. **Live polygon `/v3/reference/splits` response shape** — tested against the documented `(execution_date, split_from, split_to)` schema with a faked client; not yet against a live key on this runner (no `POLYGON_API_KEY`). Validate: `POLYGON_API_KEY=… python -c "from polygon_client import polygon_client as p; print(p().get_splits('DD'))"` (expect the 2026-06-24 3-for-1 + history).
2. **Production end-to-end restate against the real universe** needs Linux compute with S3/ArcticDB creds (macOS ArcticDB write crash documented in #1298; CI/Linux unaffected). Validate: `python -m builders.backfill --ticker DD` on the data box, then assert `audit_split_jumps` reports no residual >45% jump for DD.

DD itself was already restated **by hand** on all three layers per #1298's last comment; this PR makes the restatement **systemic/in-pipeline** so the next splitter heals automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)