### PR TITLE
Part of #1277: L1 cross-source agreement gate at settled-close ingestion

### DIFF
--- a/sources/cross_source_gate.py
+++ b/sources/cross_source_gate.py
@@ -1,0 +1,270 @@
+"""sources/cross_source_gate.py — L1 independent cross-source agreement gate.
+
+Part of the market-value integrity framework (alpha-engine-config#1277, Phase 2 /
+Layer-1). Phase 1 (config#1276) proved L0 (settled-only store) + L3 (T+1
+re-reconcile) on the EOD SPY artifact. THIS module is the next self-contained
+slice: an **independent cross-source agreement gate at ingestion**.
+
+Principle (from #1277): *no number a human acts on should be trusted unless it is
+agreed by ≥2 independent sources*. A single-source "golden" close is not
+institutional — config#1276 showed a silently-wrong single-source SPY close drove
+a bad EOD number. So at settled-close ingestion we require ≥2 independent vendors
+(e.g. Polygon settled daily aggregate primary + yfinance check) to agree on the
+close within a small tolerance (~5-10 bps). On agreement we record the value with
+a provenance tag (which sources, the agreement bps); on disagreement beyond
+tolerance we **quarantine** the value (flag it provisional, emit a discrepancy
+record) rather than silently picking one source.
+
+Design boundaries (deliberate, smallest-slice):
+
+  * This is the GATE LOGIC + a thin two-source fetch helper — pure, deterministic,
+    and network-free at its core so it is fully unit-testable on fixture prices.
+    It does NOT yet rewire ``collectors.daily_closes.collect`` to route every
+    ticker through the gate (that is the wider Phase-2 wiring); it provides the
+    institutional primitive the wiring will call, sited in the ingestion/reconcile
+    seam (``sources/``) — NOT at each downstream read site.
+  * Fail-soft: if one source is unavailable the gate does not crash ingestion; it
+    records a *single-source-provisional* decision (flagged), so downstream NAV/PnL
+    can see "this is not cross-checked" rather than getting nothing or a hard error.
+
+Relationship to existing infra: ``collectors.daily_closes._log_close_discrepancies``
+already *logs* polygon-vs-prior drift when polygon overwrites a yfinance cell, but
+it only logs — it neither tags accepted values with cross-source provenance nor
+quarantines a disagreement. This module is the missing gate that turns that
+observation into an institutional accept/quarantine decision with provenance.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Default agreement tolerance. #1277 / L1 calls for ~5-10 bps; 1 bp = 0.0001.
+# Configurable per call (``tolerance_bps=``) and centrally overridable here.
+DEFAULT_TOLERANCE_BPS: float = 7.5
+
+
+class GateStatus(str, Enum):
+    """Outcome of the cross-source agreement gate for one settled close."""
+
+    AGREED = "agreed"                                  # >=2 sources within tolerance — accept + provenance
+    QUARANTINED = "quarantined"                        # >=2 sources DISAGREE beyond tolerance — flag, do not pick one
+    SINGLE_SOURCE_PROVISIONAL = "single_source_provisional"  # only 1 source available — accept-but-flagged
+    NO_DATA = "no_data"                                # zero usable sources — nothing to record
+
+
+# Statuses whose value is safe to publish into a settled artifact unflagged.
+# Only AGREED clears the gate cleanly; everything else carries a flag so
+# downstream NAV/PnL knows the number is not cross-checked.
+_CLEAN_STATUSES = frozenset({GateStatus.AGREED})
+
+
+@dataclass(frozen=True)
+class SourceClose:
+    """One independent source's settled close for a single (ticker, date).
+
+    ``price`` is None when the source was queried but returned no usable settled
+    value (missing bar, NaN, vendor outage); such entries are treated as "source
+    unavailable" by the gate, not as a zero price.
+    """
+
+    source: str
+    price: Optional[float]
+
+    @property
+    def usable(self) -> bool:
+        return self.price is not None and self.price > 0
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Result of the L1 gate: the accepted value (if any) + provenance + flag.
+
+    ``flagged`` is True for everything that is not a clean cross-source agreement,
+    so a caller can persist ``provisional=flagged`` exactly as the config#1276
+    Phase-1 provisional flag does. ``provenance`` is a compact, human-readable
+    audit tag suitable for L4 provenance surfacing
+    (e.g. ``"polygon=734.30 yfinance=734.32 agree@0.27bps"``).
+    """
+
+    ticker: str
+    date: str
+    status: GateStatus
+    value: Optional[float]                 # the close to record; None for NO_DATA / QUARANTINED
+    sources_used: tuple[str, ...]          # the sources that contributed a usable price
+    agreement_bps: Optional[float]         # observed max pairwise spread in bps (None if <2 usable)
+    tolerance_bps: float
+    provenance: str                        # compact audit string for L4 surfacing
+    discrepancy: Optional[dict] = field(default=None)  # populated on QUARANTINE for the discrepancy lake
+
+    @property
+    def flagged(self) -> bool:
+        """True unless this is a clean >=2-source agreement (provisional otherwise)."""
+        return self.status not in _CLEAN_STATUSES
+
+    @property
+    def accepted(self) -> bool:
+        """True when a value is safe to record (clean OR single-source-provisional)."""
+        return self.value is not None
+
+
+def _pairwise_max_bps(prices: list[float]) -> float:
+    """Max pairwise spread across ``prices`` in basis points.
+
+    Spread is relative to the smaller price of each pair (a conservative
+    denominator — it makes the bps slightly larger, so the gate errs toward
+    flagging rather than toward silently trusting). With 2 sources this is just
+    the single pair. Caller guarantees len(prices) >= 2 and all > 0.
+    """
+    worst = 0.0
+    for i in range(len(prices)):
+        for j in range(i + 1, len(prices)):
+            hi, lo = max(prices[i], prices[j]), min(prices[i], prices[j])
+            bps = (hi - lo) / lo * 10_000.0
+            worst = max(worst, bps)
+    return worst
+
+
+def evaluate(
+    ticker: str,
+    date: str,
+    closes: list[SourceClose],
+    *,
+    tolerance_bps: float = DEFAULT_TOLERANCE_BPS,
+) -> GateDecision:
+    """Run the L1 cross-source agreement gate on already-fetched settled closes.
+
+    PURE + network-free — this is the institutional decision logic. Callers fetch
+    each source's close (see :func:`gate_settled_close` for a registry-driven
+    two-source fetch helper) and hand the results here.
+
+    Semantics:
+
+      * >=2 usable sources AGREE within ``tolerance_bps``  -> AGREED, value = mean,
+        ``flagged=False``, provenance lists every source + the observed bps.
+      * >=2 usable sources DISAGREE beyond tolerance        -> QUARANTINED,
+        ``value=None`` (we refuse to silently pick one), a ``discrepancy`` record
+        is attached for the discrepancy lake, ``flagged=True``.
+      * exactly 1 usable source                             -> SINGLE_SOURCE_PROVISIONAL,
+        value = that source's price, ``flagged=True`` (fail-soft: ingestion is not
+        blocked, but the number is marked not-cross-checked).
+      * 0 usable sources                                    -> NO_DATA, ``value=None``.
+
+    The mean (not "primary wins") is used on agreement because within tolerance the
+    sources are, by construction, indistinguishable to ~<1 bp of NAV impact and the
+    mean is the lower-variance estimator; provenance still records both raw values.
+    """
+    usable = [c for c in closes if c.usable]
+    sources_used = tuple(c.source for c in usable)
+
+    if not usable:
+        return GateDecision(
+            ticker=ticker, date=date, status=GateStatus.NO_DATA, value=None,
+            sources_used=(), agreement_bps=None, tolerance_bps=tolerance_bps,
+            provenance=f"{ticker}@{date}: no usable source",
+        )
+
+    if len(usable) == 1:
+        only = usable[0]
+        logger.warning(
+            "L1 single-source-provisional %s @ %s: only %s available (price=%.4f) "
+            "— recorded FLAGGED (not cross-checked); downstream must treat as provisional",
+            ticker, date, only.source, only.price,
+        )
+        return GateDecision(
+            ticker=ticker, date=date, status=GateStatus.SINGLE_SOURCE_PROVISIONAL,
+            value=only.price, sources_used=sources_used, agreement_bps=None,
+            tolerance_bps=tolerance_bps,
+            provenance=(
+                f"{ticker}@{date}: {only.source}={only.price:.4f} "
+                f"single-source PROVISIONAL (no cross-check)"
+            ),
+        )
+
+    prices = [c.price for c in usable]  # all > 0 by ``usable``
+    spread_bps = _pairwise_max_bps(prices)
+    detail = " ".join(f"{c.source}={c.price:.4f}" for c in usable)
+
+    if spread_bps <= tolerance_bps:
+        value = sum(prices) / len(prices)
+        logger.info(
+            "L1 cross-source AGREED %s @ %s: %s agree@%.2fbps (tol=%.1fbps) value=%.4f",
+            ticker, date, detail, spread_bps, tolerance_bps, value,
+        )
+        return GateDecision(
+            ticker=ticker, date=date, status=GateStatus.AGREED, value=value,
+            sources_used=sources_used, agreement_bps=spread_bps,
+            tolerance_bps=tolerance_bps,
+            provenance=f"{ticker}@{date}: {detail} agree@{spread_bps:.2f}bps",
+        )
+
+    # Disagreement beyond tolerance — QUARANTINE. We deliberately do NOT pick a
+    # source; emitting None forces the caller to flag/hold rather than build NAV
+    # on an unreconciled single-source outlier (the config#1276 failure class).
+    discrepancy = {
+        "ticker": ticker,
+        "date": date,
+        "spread_bps": round(spread_bps, 4),
+        "tolerance_bps": tolerance_bps,
+        "sources": {c.source: c.price for c in usable},
+    }
+    logger.error(
+        "L1 cross-source QUARANTINE %s @ %s: %s disagree@%.2fbps > tol=%.1fbps "
+        "— value withheld (NOT recorded), discrepancy emitted; investigate before "
+        "downstream NAV/PnL consumes this date",
+        ticker, date, detail, spread_bps, tolerance_bps,
+    )
+    return GateDecision(
+        ticker=ticker, date=date, status=GateStatus.QUARANTINED, value=None,
+        sources_used=sources_used, agreement_bps=spread_bps,
+        tolerance_bps=tolerance_bps,
+        provenance=f"{ticker}@{date}: {detail} DISAGREE@{spread_bps:.2f}bps QUARANTINED",
+        discrepancy=discrepancy,
+    )
+
+
+def gate_settled_close(
+    ticker: str,
+    date: str,
+    *,
+    primary_source: str = "polygon",
+    check_source: str = "yfinance",
+    tolerance_bps: float = DEFAULT_TOLERANCE_BPS,
+) -> GateDecision:
+    """Fetch ``ticker``'s settled close from two registered adapters and gate it.
+
+    Thin, registry-driven wrapper over :func:`evaluate` for live use at the
+    ingestion seam. The two sources and the tolerance are configurable; both
+    default to the #1277 L1 recommendation (Polygon primary + yfinance check,
+    ~5-10 bps).
+
+    FAIL-SOFT: each source fetch is independently guarded — a vendor outage,
+    auth failure, or empty bar degrades that source to "unavailable" (price=None)
+    rather than raising, so one broken vendor yields a single-source-provisional
+    decision instead of crashing ingestion. (Network-touching; the pure
+    :func:`evaluate` is what the unit tests exercise on fixtures.)
+    """
+    from .registry import get_adapter
+
+    def _one(source_name: str) -> SourceClose:
+        try:
+            adapter = get_adapter(source_name)
+            bars = adapter.fetch_ohlcv([ticker], date, strict=False)
+            for bar in bars:
+                if bar.ticker.lstrip("^") == ticker.lstrip("^") and bar.close:
+                    return SourceClose(source=source_name, price=float(bar.close))
+            return SourceClose(source=source_name, price=None)
+        except Exception as exc:  # fail-soft: never let one vendor crash ingestion
+            logger.warning(
+                "L1 gate: source %s unavailable for %s @ %s (%s) — degrading to "
+                "single-source path",
+                source_name, ticker, date, exc,
+            )
+            return SourceClose(source=source_name, price=None)
+
+    closes = [_one(primary_source), _one(check_source)]
+    return evaluate(ticker, date, closes, tolerance_bps=tolerance_bps)

--- a/tests/test_cross_source_gate.py
+++ b/tests/test_cross_source_gate.py
@@ -1,0 +1,219 @@
+"""Unit tests for the L1 cross-source agreement gate (config#1277, Phase 2 / L1).
+
+Fixture prices only — no live network. Locks the institutional invariants:
+
+  * >=2 sources AGREE within tolerance      -> accepted + provenance, unflagged.
+  * >=2 sources DISAGREE beyond tolerance   -> quarantined, value withheld, flagged.
+  * exactly 1 source available              -> single-source-provisional, flagged.
+  * 0 sources                               -> no_data.
+  * tolerance is configurable (bps).
+  * the live two-source helper fail-soft when one vendor raises.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sources.cross_source_gate import (
+    DEFAULT_TOLERANCE_BPS,
+    GateStatus,
+    SourceClose,
+    evaluate,
+    gate_settled_close,
+)
+
+
+# ----------------------------------------------------------------------------
+# Agreement: two sources within tolerance -> accepted + provenance, unflagged.
+# ----------------------------------------------------------------------------
+def test_sources_agree_accepted_with_provenance():
+    # 734.30 vs 734.32 -> spread ~0.27 bps, well within default 7.5 bps.
+    closes = [
+        SourceClose("polygon", 734.30),
+        SourceClose("yfinance", 734.32),
+    ]
+    d = evaluate("SPY", "2026-06-25", closes)
+
+    assert d.status is GateStatus.AGREED
+    assert d.flagged is False
+    assert d.accepted is True
+    # mean of the two agreeing sources
+    assert d.value == pytest.approx((734.30 + 734.32) / 2)
+    assert set(d.sources_used) == {"polygon", "yfinance"}
+    assert d.agreement_bps is not None and d.agreement_bps < DEFAULT_TOLERANCE_BPS
+    assert "polygon=734.30" in d.provenance
+    assert "yfinance=734.32" in d.provenance
+    assert "agree@" in d.provenance
+
+
+def test_exact_match_is_zero_bps_agreement():
+    d = evaluate("AAPL", "2026-06-25", [
+        SourceClose("polygon", 200.0),
+        SourceClose("yfinance", 200.0),
+    ])
+    assert d.status is GateStatus.AGREED
+    assert d.agreement_bps == pytest.approx(0.0)
+    assert d.value == pytest.approx(200.0)
+
+
+# ----------------------------------------------------------------------------
+# Disagreement beyond tolerance -> quarantined, value withheld, flagged.
+# ----------------------------------------------------------------------------
+def test_sources_disagree_quarantined():
+    # 100.00 vs 105.00 -> ~500 bps, far beyond tolerance.
+    d = evaluate("XYZ", "2026-06-25", [
+        SourceClose("polygon", 100.00),
+        SourceClose("yfinance", 105.00),
+    ])
+    assert d.status is GateStatus.QUARANTINED
+    assert d.flagged is True
+    assert d.accepted is False
+    # we MUST NOT silently pick one source
+    assert d.value is None
+    # discrepancy record emitted for the discrepancy lake
+    assert d.discrepancy is not None
+    assert d.discrepancy["ticker"] == "XYZ"
+    assert d.discrepancy["sources"] == {"polygon": 100.00, "yfinance": 105.00}
+    assert d.discrepancy["spread_bps"] > d.tolerance_bps
+    assert "DISAGREE" in d.provenance and "QUARANTINED" in d.provenance
+
+
+def test_just_over_tolerance_quarantines():
+    # 8 bps spread with default 7.5 bps tolerance -> quarantine.
+    base = 100.0
+    other = base * (1 + 8e-4)  # +8 bps
+    d = evaluate("T", "2026-06-25", [
+        SourceClose("polygon", base),
+        SourceClose("yfinance", other),
+    ])
+    assert d.status is GateStatus.QUARANTINED
+    assert d.value is None
+
+
+def test_just_under_tolerance_agrees():
+    # 7 bps spread with default 7.5 bps tolerance -> agree.
+    base = 100.0
+    other = base * (1 + 7e-4)  # +7 bps
+    d = evaluate("T", "2026-06-25", [
+        SourceClose("polygon", base),
+        SourceClose("yfinance", other),
+    ])
+    assert d.status is GateStatus.AGREED
+    assert d.value == pytest.approx((base + other) / 2)
+
+
+# ----------------------------------------------------------------------------
+# Single source available -> single-source-provisional, flagged, value kept.
+# ----------------------------------------------------------------------------
+def test_one_source_missing_single_source_provisional():
+    d = evaluate("SPY", "2026-06-25", [
+        SourceClose("polygon", 734.30),
+        SourceClose("yfinance", None),       # vendor unavailable
+    ])
+    assert d.status is GateStatus.SINGLE_SOURCE_PROVISIONAL
+    assert d.flagged is True
+    assert d.accepted is True                # fail-soft: value retained
+    assert d.value == pytest.approx(734.30)
+    assert d.sources_used == ("polygon",)
+    assert d.agreement_bps is None
+    assert "PROVISIONAL" in d.provenance
+
+
+def test_nonpositive_price_treated_as_unavailable():
+    # A 0/negative price is NOT a usable source (don't trust a 0 close).
+    d = evaluate("SPY", "2026-06-25", [
+        SourceClose("polygon", 734.30),
+        SourceClose("yfinance", 0.0),
+    ])
+    assert d.status is GateStatus.SINGLE_SOURCE_PROVISIONAL
+    assert d.value == pytest.approx(734.30)
+
+
+# ----------------------------------------------------------------------------
+# No usable source -> no_data.
+# ----------------------------------------------------------------------------
+def test_no_sources_no_data():
+    d = evaluate("SPY", "2026-06-25", [
+        SourceClose("polygon", None),
+        SourceClose("yfinance", None),
+    ])
+    assert d.status is GateStatus.NO_DATA
+    assert d.value is None
+    assert d.accepted is False
+    assert d.flagged is True
+
+
+# ----------------------------------------------------------------------------
+# Tolerance is configurable.
+# ----------------------------------------------------------------------------
+def test_tolerance_is_configurable():
+    closes = [SourceClose("polygon", 100.0), SourceClose("yfinance", 100.3)]  # 30 bps
+    # tight 10 bps tolerance -> quarantine
+    assert evaluate("X", "d", closes, tolerance_bps=10).status is GateStatus.QUARANTINED
+    # loose 50 bps tolerance -> agree
+    assert evaluate("X", "d", closes, tolerance_bps=50).status is GateStatus.AGREED
+
+
+def test_three_sources_use_worst_pairwise_spread():
+    # Two tight + one outlier: worst pair must drive the quarantine decision.
+    d = evaluate("X", "d", [
+        SourceClose("polygon", 100.00),
+        SourceClose("yfinance", 100.01),
+        SourceClose("tiingo", 102.00),
+    ], tolerance_bps=10)
+    assert d.status is GateStatus.QUARANTINED
+    assert len(d.sources_used) == 3
+
+
+# ----------------------------------------------------------------------------
+# Live two-source helper: fail-soft when a vendor raises.
+# ----------------------------------------------------------------------------
+def test_gate_settled_close_failsoft_on_vendor_error():
+    class _Bar:
+        def __init__(self, ticker, close):
+            self.ticker = ticker
+            self.close = close
+
+    class _GoodAdapter:
+        def fetch_ohlcv(self, tickers, run_date, *, strict=False):
+            return [_Bar("SPY", 734.30)]
+
+    class _BrokenAdapter:
+        def fetch_ohlcv(self, tickers, run_date, *, strict=False):
+            raise RuntimeError("vendor 503")
+
+    def _fake_get_adapter(name):
+        return _GoodAdapter() if name == "polygon" else _BrokenAdapter()
+
+    with patch("sources.registry.get_adapter", side_effect=_fake_get_adapter):
+        d = gate_settled_close("SPY", "2026-06-25")
+
+    # broken check source -> single-source-provisional, ingestion not crashed
+    assert d.status is GateStatus.SINGLE_SOURCE_PROVISIONAL
+    assert d.value == pytest.approx(734.30)
+    assert d.flagged is True
+
+
+def test_gate_settled_close_agrees_via_helper():
+    class _Bar:
+        def __init__(self, ticker, close):
+            self.ticker = ticker
+            self.close = close
+
+    class _Adapter:
+        def __init__(self, px):
+            self.px = px
+
+        def fetch_ohlcv(self, tickers, run_date, *, strict=False):
+            return [_Bar("SPY", self.px)]
+
+    def _fake_get_adapter(name):
+        return _Adapter(734.30) if name == "polygon" else _Adapter(734.33)
+
+    with patch("sources.registry.get_adapter", side_effect=_fake_get_adapter):
+        d = gate_settled_close("SPY", "2026-06-25", tolerance_bps=10)
+
+    assert d.status is GateStatus.AGREED
+    assert d.value == pytest.approx((734.30 + 734.33) / 2)


### PR DESCRIPTION
## Part of #1277 (umbrella stays open)

Market-value integrity framework, **Phase 2 / Layer-1 (L1)**: an independent cross-source agreement gate at settled-close ingestion. Phase 1 (config#1276: settled-only store L0 + T+1 re-reconcile L3, provisional flag) is already shipped; this is the next self-contained slice. Not `Closes` — #1277 is a multi-phase umbrella that stays open until all phases ship.

### Why
Per #1277: *no number a human acts on should be trusted unless it is agreed by ≥2 independent sources.* config#1276 showed a silently-wrong single-source SPY close drove a bad EOD number. Today `collectors.daily_closes._log_close_discrepancies` only **logs** polygon-vs-prior drift — it neither tags accepted values with cross-source provenance nor quarantines a disagreement. This adds the missing institutional accept/quarantine decision.

### Gate design (sources / tolerance / flag)
- **Sources:** two independent vendors, configurable. Defaults to Polygon (primary) + yfinance (check), per #1277 L1.
- **Tolerance:** configurable basis points, `DEFAULT_TOLERANCE_BPS = 7.5` (in the #1277 ~5-10 bps band). Spread is max pairwise, relative to the smaller price (conservative — errs toward flagging).
- **Outcomes (`GateStatus`):**
  - `AGREED` — ≥2 sources within tolerance → record the **mean**, `flagged=False`, provenance tag lists both raw values + observed bps (e.g. `SPY@2026-06-25: polygon=734.30 yfinance=734.32 agree@0.27bps`).
  - `QUARANTINED` — ≥2 sources disagree beyond tolerance → **value withheld (`None`)**, never silently pick one; a `discrepancy` record (sources, spread_bps, tolerance) is emitted for the discrepancy lake; `flagged=True`; logs at ERROR.
  - `SINGLE_SOURCE_PROVISIONAL` — only one source usable → **fail-soft**: keep that value but `flagged=True` (downstream NAV/PnL sees "not cross-checked"). Ingestion is not blocked/crashed.
  - `NO_DATA` — zero usable sources → `value=None`.
- A non-positive price (0/negative close) is treated as "source unavailable", not trusted as a real close.

### Where it sits in the ingestion path
`sources/cross_source_gate.py` lives in the provider-agnostic ingestion/reconcile seam (`sources/`, alongside `contract.py`/`registry.py`) — the natural home for a cross-source check, **not** at each downstream read site. Two surfaces:
- `evaluate(ticker, date, closes, *, tolerance_bps=...)` — pure, deterministic, network-free decision logic.
- `gate_settled_close(ticker, date, *, primary_source, check_source, tolerance_bps)` — thin registry-driven two-source fetch helper for live use; each source fetch is independently guarded (vendor outage/auth/empty bar → unavailable, not a raise).

### Scope boundary (deliberate, smallest slice)
This lands the institutional **primitive** + its tests. It does NOT yet rewire `collectors.daily_closes.collect` to route every ticker through the gate (the wider Phase-2 wiring to `ARTIFACT_REGISTRY` / flow-doctor). Purely additive; no existing artifact or consumer changes.

### CI status / tests
`tests/test_cross_source_gate.py` — fixture prices, **no live network**: agree→accepted+provenance, disagree→quarantined (value withheld), one-source-missing→single-source-provisional, no-data, configurable tolerance, 3-source worst-pairwise, and the helper's fail-soft path. **12 passed** locally (`python -m pytest tests/test_cross_source_gate.py`).

### Caveat
The pure `evaluate()` logic and the helper's fail-soft path are fully unit-validated on fixtures. The live two-source fetch against real Polygon/yfinance settled aggregates is exercised only via mocked adapters here (no live vendor calls in CI); end-to-end behavior against live vendor responses is unvalidated in this PR. Validate live with: `python -c "from sources.cross_source_gate import gate_settled_close; print(gate_settled_close('SPY', '2026-06-25'))"` (requires Polygon/yfinance credentials + network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)