### PR TITLE
feat(infra): EventBridge-Scheduler scheduled-groom dispatcher (reliable groom cadence, config#1322)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -1,0 +1,113 @@
+# scheduled-groom-dispatcher
+
+Fires the autonomous backlog groom on a **reliable, on-time cadence** via
+**EventBridge Scheduler → `repository_dispatch`**, replacing the
+`backlog-groom.yml` GitHub Actions `schedule:` crons, which are best-effort and
+fire late or are silently dropped (config#1322).
+
+> **Status: UNVALIDATED.** This is the IaC + handler only. It has **zero live
+> effect** until an operator runs `deploy.sh --bootstrap`, and the GHA
+> `schedule:` crons stay live as a belt-and-suspenders backstop until a multi-day
+> on-time-firing soak confirms this path (see **Soak** below). Only then can the
+> GHA crons be removed.
+
+## How it fits
+
+```
+EventBridge Scheduler rules (UTC, cron)              THIS Lambda
+  alpha-engine-scheduled-groom-0700-sunfri  ─┐       (repository_dispatch)
+  alpha-engine-scheduled-groom-1500-sunfri  ─┼─────▶  type: scheduled-groom
+  alpha-engine-scheduled-groom-2300-daily   ─┘        client_payload.run_mode
+                                                              │
+                                                              ▼
+                            nousergon/alpha-engine-config :: backlog-groom.yml
+                         (on: repository_dispatch[scheduled-groom] → run_mode-routed groom)
+```
+
+It mirrors the sibling `saturday-sf-success-groom-dispatcher` and **reuses the
+same SSM PAT** (`/alpha-engine/saturday_sf_watch/github_pat`) for the
+repository_dispatch — no new credential. The EventBridge Scheduler conventions
+(`scheduler.amazonaws.com` execution role, `cron()` expression, OFF
+flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
+
+## Cadence — one-for-one with the GHA crons it replaces
+
+| Scheduler rule | Expression (UTC) | GHA cron replaced | PT | Day mask | run_mode |
+|---|---|---|---|---|---|
+| `…-0700-sunfri` | `cron(0 7 ? * SUN-FRI *)` | `0 7 * * 0-5` | 12am | Sun–Fri (skips Sat) | full |
+| `…-1500-sunfri` | `cron(0 15 ? * SUN-FRI *)` | `0 15 * * 0-5` | 8am | Sun–Fri (skips Sat) | full |
+| `…-2300-daily` | `cron(0 23 * * ? *)` | `0 23 * * *` | 4pm | daily incl. Sat | full |
+
+The Sat-skip rationale is carried verbatim from `backlog-groom.yml`: the two
+Sun–Fri rules avoid colliding with the 09:00-UTC Crucible Saturday pipeline; the
+daily 23:00 rule runs every day (Brian wants the Sat 4pm-PT groom retained).
+
+EventBridge Scheduler cron uses 6 fields `cron(min hour day-of-month month
+day-of-week year)` with `?` for an unspecified day field and `SUN-FRI` for the
+day-of-week mask.
+
+## Run-mode routing
+
+Each schedule passes a JSON input `{"run_mode": "...", "schedule": "..."}`. The
+Lambda forwards `run_mode` into `client_payload` (also as `phase` for
+forward-compat); `backlog-groom.yml`'s run-mode step reads
+`github.event.client_payload.run_mode` to route `full` vs `sweep`. All three
+current rules are `full` (the drain-phase default). An unknown/missing run_mode
+degrades to `full`.
+
+## Contract & safety
+
+- **Fail-loud** (UNLIKE the convenience success-dispatcher): a scheduled groom
+  IS the deliverable — it replaces the cron the workflow depends on — so a
+  GitHub/SSM failure **RAISES**, letting EventBridge's retries + the Lambda
+  error metric surface a dropped pass. (Wire a CloudWatch alarm on the function
+  `Errors` metric during bootstrap-ops to page on it.)
+- **Kill-switch**: set the Lambda env `GROOM_DISPATCH_ENABLED=false` to disable
+  without deleting the Scheduler rules.
+- **Narrow IAM**: the Lambda role reads only the one SSM PAT + its own log
+  group; the Scheduler execution role can `lambda:InvokeFunction` this function
+  only.
+
+## Deploy (operator-managed, outside CloudFormation)
+
+```bash
+bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap  # first time: roles + lambda + 3 schedules
+bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh              # update code only
+bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --dry-run    # preview
+bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --smoke      # ⚠ fires a REAL groom run
+```
+
+Merging the PR has **zero live effect** until an operator runs `--bootstrap`.
+`--smoke` invokes the Lambda with a synthetic schedule event and (since
+`GROOM_DISPATCH_ENABLED` defaults on) **triggers an actual groom run** — use
+intentionally.
+
+## Validation — apply + on-time-firing soak (REQUIRED before removing GHA crons)
+
+1. **Prereq**: the `alpha-engine-config` PR adding the `scheduled-groom`
+   dispatch type + run-mode routing must be merged (cross-linked below).
+2. **Apply**: `bash …/deploy.sh --bootstrap` (operator with AWS creds).
+3. **Verify wiring**: `aws scheduler list-schedules --name-prefix
+   alpha-engine-scheduled-groom --region us-east-1` shows all three; `--smoke`
+   produces a backlog-groom run in alpha-engine-config Actions.
+4. **Soak (multi-day)**: confirm each rule fires **on time** for a week — compare
+   the EventBridge/Lambda CloudWatch invocation timestamps against the cron and
+   confirm a matching `repository_dispatch` (`scheduled-groom`) backlog-groom run
+   appears within a minute. Watch the Lambda `Errors` metric stays at 0.
+5. **Cut over**: only after the soak confirms reliable on-time firing, remove the
+   three `schedule:` crons from `backlog-groom.yml` (a follow-up PR), leaving
+   EventBridge as the sole scheduler. Until then both run (the workflow's
+   `concurrency` group serialises any rare overlap, so the belt-and-suspenders
+   window is harmless).
+
+## Prerequisite in alpha-engine-config
+
+`backlog-groom.yml` must listen for the trigger and honor the run-mode:
+
+```yaml
+on:
+  repository_dispatch:
+    types: [saturday-sf-success-groom, scheduled-groom]
+```
+
+(the run-mode step reads `github.event.client_payload.run_mode`).

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-scheduled-groom-dispatcher Lambda
+# and wire its three EventBridge Scheduler rules (the reliable replacement for
+# the backlog-groom GHA `schedule:` crons — config#1322).
+#
+# Each Scheduler rule fires THIS Lambda on cadence; the Lambda repository_
+# dispatches the backlog groom (nousergon/alpha-engine-config :: backlog-groom.yml,
+# type `scheduled-groom`) carrying the run-mode in client_payload. Mirrors the
+# sibling `saturday-sf-success-groom-dispatcher`; EventBridge Scheduler conventions
+# (scheduler.amazonaws.com role, cron() expression, flexible-time-window) mirror
+# `infrastructure/run_weekly_offcycle.sh`.
+#
+# Cadence (UTC, mirrors the GHA crons exactly):
+#   07:00 Sun-Fri   cron(0 7 ? * SUN-FRI *)   FULL   # 12am PT, skips Sat
+#   15:00 Sun-Fri   cron(0 15 ? * SUN-FRI *)  FULL   # 8am PT, skips Sat
+#   23:00 daily     cron(0 23 * * ? *)        FULL   # 4pm PT, every day incl. Sat
+#
+# Managed OUTSIDE CloudFormation — same rationale as the sibling dispatchers
+# (keeps the github-actions-lambda-deploy OIDC role's blast radius narrow;
+# operator-deployed only). Merging the PR has ZERO live effect until an operator
+# runs this with --bootstrap, AND the GHA `schedule:` crons stay live as a
+# backstop until a multi-day on-time-firing soak confirms this path.
+#
+# Usage:
+#   bash .../scheduled-groom-dispatcher/deploy.sh             # update code only
+#   bash .../scheduled-groom-dispatcher/deploy.sh --bootstrap # first-time create + wire EventBridge Scheduler
+#   bash .../scheduled-groom-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../scheduled-groom-dispatcher/deploy.sh --smoke     # invoke once with a synthetic schedule event (⚠ fires a REAL groom)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-scheduled-groom-dispatcher"
+ROLE_NAME="alpha-engine-scheduled-groom-dispatcher-role"
+POLICY_NAME="alpha-engine-scheduled-groom-dispatcher-policy"
+# EventBridge Scheduler execution role (assumed by scheduler.amazonaws.com to
+# invoke the Lambda). Single-target blast radius: lambda:InvokeFunction on this
+# function only.
+SCHED_ROLE_NAME="alpha-engine-scheduled-groom-dispatcher-scheduler-role"
+SCHED_POLICY_NAME="invoke-scheduled-groom-dispatcher"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
+
+# Schedule definitions: name | cron expression (UTC) | JSON input (run_mode + label).
+# Mirrors backlog-groom.yml's three `schedule:` crons one-for-one.
+SCHED_NAMES=(
+  "alpha-engine-scheduled-groom-0700-sunfri"
+  "alpha-engine-scheduled-groom-1500-sunfri"
+  "alpha-engine-scheduled-groom-2300-daily"
+)
+SCHED_CRONS=(
+  "cron(0 7 ? * SUN-FRI *)"
+  "cron(0 15 ? * SUN-FRI *)"
+  "cron(0 23 * * ? *)"
+)
+SCHED_INPUTS=(
+  '{"run_mode":"full","schedule":"0 7 * * 0-5"}'
+  '{"run_mode":"full","schedule":"0 15 * * 0-5"}'
+  '{"run_mode":"full","schedule":"0 23 * * *"}'
+)
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # --- 2a. Lambda execution role + inline policy ---
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  # --- 2b. Lambda function ---
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 30 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2c. EventBridge Scheduler execution role (invoke this Lambda only) ---
+  SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${SCHED_ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} on the groom cadence" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${SCHED_ROLE_NAME}"
+  fi
+  SCHED_INVOKE_POLICY=$(cat <<EOF
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["lambda:InvokeFunction"],"Resource":"${FN_ARN}"}]}
+EOF
+)
+  echo "  Applying Scheduler invoke policy: ${SCHED_POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${SCHED_ROLE_NAME}" \
+    --policy-name "${SCHED_POLICY_NAME}" \
+    --policy-document "${SCHED_INVOKE_POLICY}"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for Scheduler role propagation..."
+    sleep 10
+  fi
+
+  # --- 2d. The three EventBridge Scheduler rules ---
+  for i in "${!SCHED_NAMES[@]}"; do
+    name="${SCHED_NAMES[$i]}"
+    cron="${SCHED_CRONS[$i]}"
+    input="${SCHED_INPUTS[$i]}"
+    target=$(cat <<EOF
+{"Arn":"${FN_ARN}","RoleArn":"${SCHED_ROLE_ARN}","Input":"$(printf '%s' "$input" | sed 's/"/\\"/g')"}
+EOF
+)
+    if aws scheduler get-schedule --name "${name}" --region "${REGION}" \
+        --query 'Name' --output text >/dev/null 2>&1; then
+      echo "  Updating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler update-schedule \
+        --name "${name}" \
+        --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" \
+        --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" \
+        --region "${REGION}" \
+        --query 'ScheduleArn' --output text
+    else
+      echo "  Creating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler create-schedule \
+        --name "${name}" \
+        --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" \
+        --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" \
+        --region "${REGION}" \
+        --query 'ScheduleArn' --output text
+    fi
+    # Fail-loud: verify it landed.
+    if ! $DRY_RUN; then
+      aws scheduler get-schedule --name "${name}" --region "${REGION}" \
+        --query 'Name' --output text >/dev/null \
+        || { echo "ERROR: Scheduler rule ${name} not found after create/update" >&2; exit 1; }
+    fi
+  done
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (synthetic schedule event) ----------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (synthetic schedule event, run_mode=full)..."
+  RESP=$(mktemp)
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{"run_mode":"full","schedule":"smoke-test"}' \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-scheduled-groom-dispatcher:*"
+    },
+    {
+      "Sid": "GroomDispatchPAT",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat"
+    }
+  ]
+}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1,0 +1,143 @@
+"""alpha-engine-scheduled-groom-dispatcher — fire the backlog groom on an
+EventBridge-Scheduler-driven cadence (the reliable replacement for the GHA
+`schedule:` crons).
+
+Why this exists (config#1322): GitHub Actions `schedule:` is best-effort and
+routinely fires late or is silently dropped, which defeats the DRAIN-PHASE
+3×/day cadence (config#1312). Today's `0 23 * * *` run was never created, and
+yesterday's fired ~2h late. EventBridge Scheduler gives guaranteed, on-time
+firing with a CloudWatch trail.
+
+Wiring mirrors the sibling `saturday-sf-success-groom-dispatcher`: three
+EventBridge Scheduler rules (07:00 / 15:00 / 23:00 UTC, with the same Sun–Fri /
+daily day-masks the GHA crons use) each target THIS Lambda, which sends a
+`repository_dispatch` (type `scheduled-groom`) to
+`nousergon/alpha-engine-config`, where `backlog-groom.yml` consumes it. The
+schedule's own input carries `run_mode`/`phase`, which the Lambda forwards in
+`client_payload` so the workflow's run-mode step routes the right drain pass.
+
+Reuses the SAME SSM-stored fine-grained PAT
+(`/alpha-engine/saturday_sf_watch/github_pat`) the sibling dispatchers use for
+repository_dispatch — no new credential.
+
+Fail-loud (UNLIKE the convenience-side success dispatcher): a scheduled groom
+IS the deliverable here — it replaces the cron the workflow depends on — so a
+GitHub/SSM failure RAISES, letting EventBridge's retries + the Lambda error
+metric + a CloudWatch alarm surface the miss, rather than silently swallowing a
+dropped pass (the exact failure mode #1322 is fixing).
+
+Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
+operator-deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live
+effect until bootstrapped, and the GHA `schedule:` crons stay in place as a
+belt-and-suspenders backstop until a multi-day on-time-firing soak confirms the
+EventBridge path before they can be removed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+# Kill-switch: set GROOM_DISPATCH_ENABLED=false on the Lambda to disable the
+# trigger without deleting the EventBridge Scheduler rules. Default ON.
+DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
+DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
+DISPATCH_EVENT_TYPE = os.environ.get("DISPATCH_EVENT_TYPE", "scheduled-groom")
+GITHUB_PAT_SSM_PARAM = os.environ.get(
+    "GITHUB_PAT_SSM_PARAM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+# Valid run-modes the workflow's run-mode step honors. Anything else falls back
+# to "full" so a malformed schedule input can never wedge the dispatch.
+_VALID_RUN_MODES = {"full", "sweep"}
+_DEFAULT_RUN_MODE = "full"
+_DISPATCH_TIMEOUT_SEC = 15
+
+
+def _get_github_pat() -> str:
+    """Read the fine-grained PAT (SecureString) from SSM. Never logged."""
+    ssm = boto3.client("ssm", region_name=REGION)
+    resp = ssm.get_parameter(Name=GITHUB_PAT_SSM_PARAM, WithDecryption=True)
+    return resp["Parameter"]["Value"]
+
+
+def _resolve_run_mode(event: dict) -> str:
+    """Pull the desired run-mode from the EventBridge Scheduler input.
+
+    Each Scheduler rule passes a JSON input like {"run_mode": "full",
+    "schedule": "0 7 * * 0-5"}. An unknown/missing run_mode degrades to FULL
+    (the drain-phase default — all three current crons are full grooms).
+    """
+    rm = str(event.get("run_mode") or _DEFAULT_RUN_MODE).strip().lower()
+    if rm not in _VALID_RUN_MODES:
+        logger.warning("unknown run_mode %r — defaulting to %s", rm, _DEFAULT_RUN_MODE)
+        rm = _DEFAULT_RUN_MODE
+    return rm
+
+
+def _dispatch_groom(run_mode: str, schedule_label: str) -> dict:
+    """Fire the repository_dispatch that triggers backlog-groom.yml.
+
+    Fail-loud: a scheduled groom is the deliverable (it replaces the cron the
+    workflow depends on), so any failure RAISES so EventBridge retries + the
+    Lambda error metric surface the miss. Returns the success result.
+    """
+    if not DISPATCH_ENABLED:
+        logger.warning("GROOM_DISPATCH_ENABLED=false — scheduled groom NOT dispatched")
+        return {"dispatched": False, "reason": "disabled"}
+    pat = _get_github_pat()
+    payload = {
+        "event_type": DISPATCH_EVENT_TYPE,
+        "client_payload": {
+            "trigger": "eventbridge-scheduled",
+            "run_mode": run_mode,
+            # `phase` is an alias of run_mode kept for forward-compat with any
+            # future multi-phase drain routing; the workflow reads run_mode.
+            "phase": run_mode,
+            "schedule": schedule_label,
+        },
+    }
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{DISPATCH_REPO}/dispatches",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {pat}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "scheduled-groom-dispatcher",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=_DISPATCH_TIMEOUT_SEC) as resp:
+        status_code = resp.status
+    logger.info(
+        "scheduled-groom repository_dispatch sent to %s (type=%s, run_mode=%s, http=%s)",
+        DISPATCH_REPO,
+        DISPATCH_EVENT_TYPE,
+        run_mode,
+        status_code,
+    )
+    return {"dispatched": True, "status_code": status_code, "run_mode": run_mode}
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """EventBridge Scheduler handler — fires the backlog groom on cadence.
+
+    `event` is the schedule's configured JSON input, e.g.
+    {"run_mode": "full", "schedule": "0 23 * * *"}.
+    """
+    event = event or {}
+    run_mode = _resolve_run_mode(event)
+    schedule_label = str(event.get("schedule") or "unknown")
+    logger.info(
+        "scheduled groom trigger: run_mode=%s schedule=%s", run_mode, schedule_label
+    )
+    result = _dispatch_groom(run_mode, schedule_label)
+    return {"groom": result}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -1,0 +1,5 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned here for an
+# explicit, reproducible package build (mirrors the sibling dispatchers).
+# No alpha-engine/nousergon lib dependency — this Lambda only reads one SSM
+# parameter and POSTs a repository_dispatch via urllib.
+boto3>=1.34.0

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -1,0 +1,117 @@
+"""Unit tests for the EventBridge-Scheduler → scheduled groom dispatcher.
+
+No AWS / GitHub calls — SSM and urllib are monkeypatched. Validates: a schedule
+event posts the correct repository_dispatch to alpha-engine-config carrying the
+run_mode; run_mode normalisation/fallback; the kill-switch short-circuits; and
+(UNLIKE the convenience success-dispatcher) a dispatch failure RAISES so
+EventBridge retries + the error metric surface a dropped pass.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def _load(monkeypatch, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    import index
+
+    importlib.reload(index)
+    return index
+
+
+def _stub_resp(status=204):
+    class _Resp:
+        def __init__(self):
+            self.status = status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    return _Resp()
+
+
+def test_schedule_event_dispatches_correct_repository_dispatch(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
+    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
+    captured = {}
+
+    def _fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        captured["auth"] = req.headers.get("Authorization")
+        return _stub_resp(204)
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    assert out["groom"]["dispatched"] is True
+    assert out["groom"]["status_code"] == 204
+    assert out["groom"]["run_mode"] == "full"
+    assert captured["url"].endswith("/repos/nousergon/alpha-engine-config/dispatches")
+    assert captured["body"]["event_type"] == "scheduled-groom"
+    assert captured["body"]["client_payload"]["run_mode"] == "full"
+    assert captured["body"]["client_payload"]["phase"] == "full"
+    assert captured["body"]["client_payload"]["schedule"] == "0 23 * * *"
+    assert captured["auth"] == "Bearer tok"
+
+
+def test_unknown_run_mode_falls_back_to_full(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
+    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
+    captured = {}
+
+    def _fake_urlopen(req, timeout=0):
+        captured["body"] = json.loads(req.data.decode())
+        return _stub_resp(204)
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    out = idx.handler({"run_mode": "bogus"}, None)
+    assert out["groom"]["run_mode"] == "full"
+    assert captured["body"]["client_payload"]["run_mode"] == "full"
+
+
+def test_sweep_run_mode_is_forwarded(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
+    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
+    captured = {}
+
+    def _fake_urlopen(req, timeout=0):
+        captured["body"] = json.loads(req.data.decode())
+        return _stub_resp(204)
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    out = idx.handler({"run_mode": "sweep"}, None)
+    assert out["groom"]["run_mode"] == "sweep"
+    assert captured["body"]["client_payload"]["run_mode"] == "sweep"
+
+
+def test_disabled_flag_short_circuits(monkeypatch):
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="false")
+    out = idx.handler({"run_mode": "full"}, None)
+    assert out["groom"]["dispatched"] is False
+    assert out["groom"]["reason"] == "disabled"
+
+
+def test_dispatch_failure_raises(monkeypatch):
+    # Fail-loud: a scheduled groom is the deliverable, so a GitHub failure must
+    # RAISE (EventBridge retries + the Lambda error metric record the miss).
+    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
+    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
+
+    def _boom(req, timeout=0):
+        raise RuntimeError("github down")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
+    with pytest.raises(RuntimeError, match="github down"):
+        idx.handler({"run_mode": "full"}, None)


### PR DESCRIPTION
## Summary

Adds **`scheduled-groom-dispatcher`** — an EventBridge-Scheduler-driven Lambda that fires the autonomous backlog groom on a reliable, on-time cadence via `repository_dispatch`, the SOTA replacement for the `backlog-groom.yml` GitHub Actions `schedule:` crons (which are best-effort and fire late or are silently dropped — config#1322).

`Advances nousergon/alpha-engine-config#1322`

## Design

```
EventBridge Scheduler rules (UTC, cron)              THIS Lambda
  alpha-engine-scheduled-groom-0700-sunfri  ─┐       (repository_dispatch)
  alpha-engine-scheduled-groom-1500-sunfri  ─┼─────▶  type: scheduled-groom
  alpha-engine-scheduled-groom-2300-daily   ─┘        client_payload.run_mode
                                                              │
                                                              ▼
                            nousergon/alpha-engine-config :: backlog-groom.yml
```

Three EventBridge Scheduler rules, one-for-one with the GHA crons they replace:

| Scheduler rule | Expression (UTC) | GHA cron | Day mask | run_mode |
|---|---|---|---|---|
| `…-0700-sunfri` | `cron(0 7 ? * SUN-FRI *)` | `0 7 * * 0-5` | Sun–Fri (skips Sat) | full |
| `…-1500-sunfri` | `cron(0 15 ? * SUN-FRI *)` | `0 15 * * 0-5` | Sun–Fri (skips Sat) | full |
| `…-2300-daily` | `cron(0 23 * * ? *)` | `0 23 * * *` | daily incl. Sat | full |

- **Mirrors the sibling** `saturday-sf-success-groom-dispatcher`: same SSM PAT (`/alpha-engine/saturday_sf_watch/github_pat`) — no new credential; same `deploy.sh` packaging/bootstrap conventions; same outside-CloudFormation operator-deploy model.
- **EventBridge Scheduler conventions** (scheduler.amazonaws.com execution role, `cron()` expression, OFF flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
- **Run-mode routing**: each schedule passes `{"run_mode": "...", "schedule": "..."}`; the Lambda forwards it into `client_payload.run_mode`, which the workflow's run-mode step honors (full/sweep). All three current rules are `full`; unknown/missing degrades to `full`.
- **Fail-loud** (unlike the convenience success-dispatcher): a scheduled groom IS the deliverable, so a GitHub/SSM failure RAISES so EventBridge retries + the Lambda `Errors` metric surface a dropped pass.
- **Narrow IAM**: Lambda role reads only the one SSM PAT + its log group; the Scheduler execution role can `lambda:InvokeFunction` this function only. **Kill-switch**: `GROOM_DISPATCH_ENABLED=false`.

## Belt-and-suspenders

The GHA `schedule:` crons stay live in `backlog-groom.yml` until a multi-day on-time-firing soak confirms this path (the workflow's `concurrency` group serialises any rare overlap, so running both is harmless). Only then are the crons removed (follow-up PR).

## Status: UNVALIDATED — pending AWS apply + firing soak

Merging has **zero live effect** until an operator runs `deploy.sh --bootstrap`. Validation steps:
1. Merge the cross-linked alpha-engine-config workflow change (adds the `scheduled-groom` type + run-mode routing).
2. `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap` (operator with AWS creds).
3. Verify: `aws scheduler list-schedules --name-prefix alpha-engine-scheduled-groom` shows all three; `--smoke` produces a backlog-groom run.
4. **Soak (multi-day)**: confirm each rule fires on time for ~a week (compare CloudWatch invocation timestamps vs cron; confirm a matching `scheduled-groom` backlog-groom run within a minute; Lambda `Errors` stays 0).
5. Cut over: remove the three `schedule:` crons from `backlog-groom.yml`.

## Lint / tests

- `python3 -c "import ast; ast.parse(open('index.py').read())"` → **OK**
- `python3 -m pytest test_handler.py -q` → **5 passed** (dispatch payload/url/auth, run-mode fallback, sweep forwarding, kill-switch, fail-loud raise)
- `bash -n deploy.sh` → **OK**; `iam-policy.json` valid JSON

## Cross-link

Paired with the alpha-engine-config workflow change. That side could **not** be opened as a PR: the groom PAT lacks the `workflow` / Workflows:write permission, so any edit to `.github/workflows/backlog-groom.yml` is rejected by both git push and the Contents API. The ready-to-apply patch + details are in nousergon/alpha-engine-config#1322 (issuecomment-4823046348). Grant the PAT Workflows:write (or apply the patch) to land it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
