### PR TITLE
fix(daily_closes): split-aware polygon skip-canonical (config#717)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -24,6 +24,9 @@ Two collection modes (selected via the ``source`` parameter):
     masks the failure. When an existing parquet is being overwritten
     (the yfinance EOD pass wrote first), per-ticker Close discrepancy
     is logged so corporate-action drift / data-quality issues are visible.
+    With ``skip_if_canonical=True`` (window mode) the polygon side skips
+    dates already fully polygon-canonical EXCEPT those a recent split
+    restated — see ``collect``'s ``skip_if_canonical`` doc (config#717).
 
   * ``auto`` (default, legacy) — historical behavior: polygon → FRED →
     yfinance fallback chain. Kept for backfill and one-shot scripts that
@@ -344,6 +347,120 @@ def _previous_business_days(run_date: str, n: int) -> list[str]:
     return dates
 
 
+def _polygon_date_fully_canonical(
+    existing_df: pd.DataFrame,
+    tickers: list[str],
+) -> bool:
+    """True iff every STOCK ticker in ``tickers`` is already polygon-canonical
+    in ``existing_df`` — i.e. present with ``source="polygon"`` and a non-null
+    ``Close`` (config#717).
+
+    Only equities are considered: the FRED-index macro tickers
+    (^TNX/^VIX/^IRX/^VIX3M) never come from polygon, so they neither block a
+    polygon skip nor get demoted by one. If the parquet predates the ``source``
+    column (legacy write), it can't be proven canonical → returns False so the
+    legacy always-fetch path is preserved. An empty stock universe is vacuously
+    canonical (nothing for polygon to fetch).
+    """
+    if "source" not in existing_df.columns:
+        return False
+    stock_tickers = [t for t in tickers if t.lstrip("^") not in _FRED_INDEX_MAP]
+    if not stock_tickers:
+        return True
+    index = set(str(t) for t in existing_df.index)
+    for t in stock_tickers:
+        store_key = t.lstrip("^")
+        if store_key not in index:
+            return False
+        row = existing_df.loc[store_key]
+        if row.get("source") != "polygon" or pd.isna(row.get("Close")):
+            return False
+    return True
+
+
+# config#717: a split with execution date E retroactively restates the polygon
+# *adjusted* close of every date STRICTLY BEFORE E. So the split-aware polygon
+# skip-canonical optimization must re-fetch any window date that a recently
+# executed split would have restated, even if that date's parquet is already
+# fully polygon-canonical. We only consider splits whose execution date is
+# recent enough to plausibly touch a trailing window — anything older than the
+# window's oldest date can't restate a date inside the window that isn't already
+# correct (the date that needed restating was healed when the split first
+# landed). A small forward buffer covers a split announced with a near-future
+# effective date that polygon already lists.
+_SPLIT_LOOKAHEAD_DAYS = 7
+
+
+def _fetch_recent_split_dates(
+    window_dates: list[str],
+    *,
+    client=None,
+) -> set[str]:
+    """Return the subset of ``window_dates`` whose polygon adjusted close a
+    recently executed split has retroactively restated (config#717).
+
+    A split executing on date E divides/multiplies the adjusted close of every
+    date strictly before E. We query polygon for ALL splits executing in the
+    window's span (plus a small forward buffer) in ONE call, then mark every
+    window date that falls strictly before any such split's execution date as
+    "touched" — those must be re-fetched so the stored adjusted close stays on
+    the current scale; the rest are safe to skip if already canonical.
+
+    On any failure (403, network, empty) returns an empty set — i.e. NOTHING is
+    marked touched. The caller's skip decision then degrades safely: a date is
+    skipped only when it is BOTH fully canonical AND not touched, so an empty
+    "touched" set just means the canonical-only check governs. (If a split is
+    silently missed, the existing per-fetch discrepancy logging on the dates
+    that ARE fetched, plus the next pass's coverage, remain the backstop.)
+    """
+    if not window_dates:
+        return set()
+    if client is None:
+        try:
+            from polygon_client import polygon_client
+
+            client = polygon_client()
+        except Exception as exc:  # import / construction failure — degrade
+            logger.warning(
+                "config#717: could not obtain polygon client for split scan "
+                "(%s) — proceeding without corporate-action skip protection",
+                _scrub_api_key(exc),
+            )
+            return set()
+    oldest = min(window_dates)
+    newest = max(window_dates)
+    lookahead = (
+        datetime.strptime(newest, "%Y-%m-%d") + timedelta(days=_SPLIT_LOOKAHEAD_DAYS)
+    ).strftime("%Y-%m-%d")
+    try:
+        splits = client.get_recent_splits(oldest, lookahead)
+    except Exception as exc:
+        logger.warning(
+            "config#717: polygon split scan failed (%s) — proceeding without "
+            "corporate-action skip protection (canonical-only skip still applies)",
+            _scrub_api_key(exc),
+        )
+        return set()
+    if not splits:
+        return set()
+    touched: set[str] = set()
+    for ev in splits:
+        e = ev.get("execution_date")
+        if not e:
+            continue
+        for d in window_dates:
+            if d < e:  # ISO dates compare lexicographically == chronologically
+                touched.add(d)
+    if touched:
+        logger.info(
+            "config#717: %d split event(s) in [%s..%s] restate %d window date(s) "
+            "— those will be re-fetched (not skipped): %s",
+            len(splits), oldest, lookahead, len(touched),
+            ", ".join(sorted(touched)),
+        )
+    return touched
+
+
 def collect(
     bucket: str,
     tickers: list[str],
@@ -354,6 +471,7 @@ def collect(
     window_days: int = 1,
     skip_if_canonical: bool = False,
     fred_window_cache: dict[str, list[tuple[str, float]]] | None = None,
+    split_touched_dates: set[str] | None = None,
     equities_source: str = "polygon",
     index_source: str = "fred",
     fallback_source: str = "yfinance",
@@ -398,18 +516,37 @@ def collect(
                     cells that are NaN. Coverage gate evaluates the
                     merged-output denominator (existing canonical rows
                     contribute as if freshly fetched).
-                  - ``polygon_only`` mode: flag is *ignored*. Per
-                    2026-05-10 design decision (option a) polygon always
-                    re-overwrites within the window — this catches
-                    corporate-action backfills that retroactively shift
-                    polygon's adjusted close. The 14/day grouped-daily
-                    contract still holds because polygon makes one call
-                    per date in the window regardless of skip behavior.
+                  - ``polygon_only`` mode (config#717): the flag is now
+                    HONORED, split-aware. A date is skipped (no polygon
+                    grouped-daily call) iff its parquet is already fully
+                    polygon-canonical (every stock ticker present with
+                    ``source="polygon"`` + non-null ``Close``) AND no
+                    recently executed corporate action restated it. A
+                    split with execution date E retroactively divides /
+                    multiplies the adjusted close of every date BEFORE E,
+                    so those dates are re-fetched even when canonical;
+                    ``split_touched_dates`` carries the set of such dates
+                    (detected via the polygon splits endpoint, one
+                    range-scoped call per window). The discrepancy-logging
+                    / coalesce path stays intact for the dates that ARE
+                    fetched. Previously (option a) polygon blanket-ignored
+                    the flag and re-fetched every date — the 2026-06-03
+                    30-min-timeout root cause.
                   - ``auto`` mode: flag applied to the yfinance step
                     only; polygon step always runs.
 
                 Default False preserves legacy single-date overwrite
                 semantics for non-window callers.
+        split_touched_dates: set[str] | None = None
+                config#717. The set of dates a recently executed corporate
+                action (split) restated — these are re-fetched by the
+                polygon_only skip-canonical path even when their parquet is
+                already canonical. Computed once per window by
+                ``_collect_window`` (one range-scoped polygon splits call)
+                and threaded into each per-date ``collect``. A standalone
+                single-date polygon_only + skip_if_canonical caller computes
+                it inline. ``None`` ⇒ treated as "nothing touched" (the
+                canonical-only check then governs).
 
     Returns:
         Single-date mode (``window_days=1``): dict with ``status``,
@@ -462,6 +599,19 @@ def collect(
             fallback_source=fallback_source,
         )
 
+    # Single-date split-aware skip protection: when a window caller drives
+    # per-date collect()s it passes ``split_touched_dates`` down (computed once
+    # for the whole window). A standalone single-date polygon_only +
+    # skip_if_canonical caller (rare) computes it here for just this date so the
+    # corporate-action guard is never bypassed.
+    if (
+        source == "polygon_only"
+        and skip_if_canonical
+        and split_touched_dates is None
+        and window_days == 1
+    ):
+        split_touched_dates = _fetch_recent_split_dates([run_date])
+
     s3 = boto3.client("s3")
     key = f"{s3_prefix}{run_date}.parquet"
 
@@ -506,6 +656,14 @@ def collect(
             # rows means we fall back to the legacy destructive overwrite, so
             # warn loudly. The coverage gate still runs on the FRESH fetch, so
             # a real polygon outage is not masked by retained rows.
+            #
+            # config#717: split-aware skip-canonical. When skip_if_canonical=True
+            # the polygon side ALSO skips a date whose parquet is already fully
+            # polygon-canonical (every stock ticker has source="polygon" + a
+            # non-null Close) — EXCEPT dates a recent corporate action restated
+            # (``split_touched_dates``), which must be re-fetched so the stored
+            # adjusted close stays on the current scale. Mirrors the yfinance
+            # side's canonical-skip structure for consistency.
             try:
                 obj = s3.get_object(Bucket=bucket, Key=key)
                 existing_df = pd.read_parquet(io.BytesIO(obj["Body"].read()), engine="pyarrow")
@@ -523,6 +681,32 @@ def collect(
                     "will coalesce (retain-on-empty, priority-ranked) and log Close discrepancies",
                     last_modified.isoformat(), len(existing_close_for_discrepancy),
                 )
+                if skip_if_canonical and not dry_run:
+                    touched = split_touched_dates or set()
+                    is_touched = run_date in touched
+                    fully_canonical = _polygon_date_fully_canonical(
+                        existing_df, tickers,
+                    )
+                    if fully_canonical and not is_touched:
+                        logger.info(
+                            "[skip_if_canonical] polygon_only %s: parquet fully "
+                            "polygon-canonical and no recent corporate action "
+                            "restates it — skipping polygon re-fetch (saves one "
+                            "grouped-daily call)",
+                            run_date,
+                        )
+                        return {
+                            "status": "ok",
+                            "tickers_captured": 0,
+                            "skipped": True,
+                            "skipped_reason": "polygon_canonical",
+                            "source": source,
+                        }
+                    logger.info(
+                        "[skip_if_canonical] polygon_only %s: re-fetching "
+                        "(fully_canonical=%s, corporate_action_touched=%s)",
+                        run_date, fully_canonical, is_touched,
+                    )
             except Exception as exc:
                 logger.warning(
                     "polygon_only: failed to read existing parquet for coalesce/discrepancy "
@@ -852,8 +1036,15 @@ def _collect_window(
     ``skip_if_canonical=True`` propagates to every per-date call so the
     yfinance side skips tickers that already have an authoritative
     source in the existing parquet — keeps steady-state yfinance batch
-    cost near zero across the window. Polygon side ignores the flag
-    (option a, always overwrites).
+    cost near zero across the window. The polygon side now honors the
+    flag too (config#717): a date whose parquet is already fully
+    polygon-canonical is skipped (no grouped-daily call) UNLESS a
+    recently executed split restated its adjusted close. Those
+    corporate-action-touched dates are detected once for the whole
+    window via a single range-scoped polygon splits call
+    (``_fetch_recent_split_dates``) and threaded into each per-date
+    ``collect`` as ``split_touched_dates`` so the per-date polygon cost
+    drops to "only the dates that actually changed".
 
     Returns an aggregate dict; see ``collect`` docstring's "Window mode"
     return-shape section for the schema.
@@ -875,6 +1066,16 @@ def _collect_window(
             datetime.strptime(_oldest, "%Y-%m-%d") - timedelta(days=10)
         ).strftime("%Y-%m-%d")
         fred_window_cache = _fetch_fred_window(fred_tickers, _start, window_dates[0])
+    # ── config#717: scan corporate actions once for the whole window ─────────
+    # polygon_only + skip_if_canonical skips already-canonical dates to save the
+    # per-date grouped-daily call (the 2026-06-03 30-min-timeout root cause),
+    # but a split retroactively restates the adjusted close of every date before
+    # its execution date — those MUST be re-fetched. One range-scoped splits
+    # call covers the whole window (no per-date corporate-action I/O). Only run
+    # when the optimization is actually active.
+    split_touched_dates: set[str] | None = None
+    if source == "polygon_only" and skip_if_canonical and not dry_run:
+        split_touched_dates = _fetch_recent_split_dates(window_dates)
     # The newest date in the window is the TARGET date — the one
     # downstream (predictor inference / eod_reconcile) actually reads.
     # The older dates are best-effort *historical backfill*: a per-date
@@ -924,6 +1125,7 @@ def _collect_window(
                 window_days=1,
                 skip_if_canonical=skip_if_canonical,
                 fred_window_cache=fred_window_cache,  # L4492: 1 ranged call/series
+                split_touched_dates=split_touched_dates,  # config#717
                 equities_source=equities_source,
                 index_source=index_source,
                 fallback_source=fallback_source,

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -315,6 +315,57 @@ class PolygonClient:
         results.sort(key=lambda r: r["execution_date"])
         return results
 
+    def get_recent_splits(self, start_date: str, end_date: str) -> list[dict]:
+        """Fetch ALL corporate splits executing in ``[start_date, end_date]``.
+
+        Unlike :meth:`get_splits` (one ticker, full history), this queries the
+        ``/v3/reference/splits`` endpoint by ``execution_date`` range WITHOUT a
+        ticker filter — so the whole market's splits in a window come back in
+        ONE call (the endpoint paginates; we take the first page, ample for the
+        handful of splits that execute in a ~2-week window). This is what lets
+        the daily-closes polygon window skip already-canonical dates while still
+        re-fetching dates whose adjusted close a recent split has restated
+        (config#717), at a bounded one-call-per-window cost.
+
+        Returns ``[{"ticker": str, "execution_date": "YYYY-MM-DD",
+        "split_from": int, "split_to": int}]`` sorted ascending by date. A
+        forward N-for-1 split is ``split_from=1, split_to=N``; a reverse 1-for-N
+        split is ``split_from=N, split_to=1``. Malformed rows are skipped; a 403
+        (free-tier / bad key) returns ``[]`` so the caller degrades to the
+        legacy always-fetch behavior rather than hard-failing the window.
+        """
+        results: list[dict] = []
+        try:
+            data = self._get(
+                "/v3/reference/splits",
+                params={
+                    "execution_date.gte": start_date,
+                    "execution_date.lte": end_date,
+                    "limit": 1000,
+                    "order": "asc",
+                    "sort": "execution_date",
+                },
+            )
+        except PolygonForbiddenError:
+            return []
+        for r in data.get("results", []) or []:
+            exec_date = r.get("execution_date")
+            sf = r.get("split_from")
+            st = r.get("split_to")
+            ticker = r.get("ticker")
+            if not exec_date or not sf or not st or not ticker:
+                continue
+            results.append(
+                {
+                    "ticker": str(ticker),
+                    "execution_date": str(exec_date),
+                    "split_from": int(sf),
+                    "split_to": int(st),
+                }
+            )
+        results.sort(key=lambda r: r["execution_date"])
+        return results
+
     def get_daily_bars(
         self,
         ticker: str,

--- a/tests/test_daily_closes_skip_if_canonical.py
+++ b/tests/test_daily_closes_skip_if_canonical.py
@@ -277,59 +277,206 @@ class TestSkipCanonicalYfinanceOnly:
         assert result.get("status") == "ok"
 
 
-# ── skip_if_canonical=True with polygon_only (option a — flag ignored) ──────
+# ── skip_if_canonical=True with polygon_only (config#717: split-aware skip) ──
 
 
-class TestSkipCanonicalPolygonOnlyIgnoresFlag:
-    """polygon_only mode ignores skip_if_canonical per option (a) —
-    polygon always overwrites within the window so corporate-action
-    backfills are absorbed. The 14/day grouped-daily contract still
-    holds because polygon makes one call per date regardless of
-    skip behavior."""
+def _polygon_side_factory(polygon_calls: list, close: float = 99.0):
+    """A ``_fetch_polygon_closes`` stand-in that records each call's date and
+    appends a fresh polygon row per ticker."""
 
-    def test_polygon_only_does_not_skip_canonical_polygon_tickers(self):
-        """Existing parquet has polygon-source rows — polygon_only mode
-        should still fetch every date in the window, ignoring the
-        skip flag."""
+    def _polygon_side(tickers, run_date, records, source):
+        polygon_calls.append(run_date)
+        for t in tickers:
+            records.append({
+                "ticker": t.lstrip("^"), "date": run_date,
+                "Open": close, "High": close, "Low": close, "Close": close,
+                "Adj_Close": close, "Volume": 1, "VWAP": close,
+                "source": "polygon",
+            })
+        return len(tickers)
+
+    return _polygon_side
+
+
+class TestSkipCanonicalPolygonOnlySplitAware:
+    """config#717: polygon_only + skip_if_canonical now skips a date whose
+    parquet is already fully polygon-canonical, EXCEPT dates a recently
+    executed split restated (those re-fetch so the adjusted close stays on
+    the current scale). Root-cause fix for the 2026-06-03 30-min timeout —
+    polygon previously blanket-ignored the flag and re-fetched every date."""
+
+    def test_skips_clean_canonical_polygon_date(self):
+        """All stock tickers polygon-canonical + no recent split → skip the
+        polygon grouped-daily call entirely."""
         s3 = _existing_parquet_with_sources({
             "AAPL": {"Close": 150.0, "source": "polygon"},
             "MSFT": {"Close": 300.0, "source": "polygon"},
         })
         polygon_calls: list = []
-
-        def _polygon_side(tickers, run_date, records, source):
-            polygon_calls.append(run_date)
-            for t in tickers:
-                records.append({
-                    "ticker": t.lstrip("^"), "date": run_date,
-                    "Open": 99.0, "High": 99.0, "Low": 99.0, "Close": 99.0,
-                    "Adj_Close": 99.0, "Volume": 1, "VWAP": 99.0,
-                    "source": "polygon",
-                })
-            return len(tickers)
-
         with patch("collectors.daily_closes.boto3.client", return_value=s3):
             with patch.object(
-                daily_closes, "_fetch_polygon_closes", side_effect=_polygon_side,
+                daily_closes, "_fetch_polygon_closes",
+                side_effect=_polygon_side_factory(polygon_calls),
             ), patch.object(
                 daily_closes, "_fetch_yfinance_closes", return_value=0
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_recent_split_dates", return_value=set(),
+            ):
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL", "MSFT"],
+                    run_date="2026-05-08",
+                    source="polygon_only", skip_if_canonical=True,
+                )
+        # Skipped: no polygon fetch, no S3 write, status ok+skipped.
+        assert polygon_calls == []
+        s3.put_object.assert_not_called()
+        assert result.get("skipped") is True
+        assert result.get("skipped_reason") == "polygon_canonical"
+
+    def test_refetches_date_touched_by_split(self):
+        """A split restating this date (date < execution_date) forces a
+        re-fetch even though the parquet is fully canonical."""
+        s3 = _existing_parquet_with_sources({
+            "AAPL": {"Close": 1500.0, "source": "polygon"},  # pre-split price
+            "MSFT": {"Close": 300.0, "source": "polygon"},
+        })
+        polygon_calls: list = []
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes",
+                side_effect=_polygon_side_factory(polygon_calls),
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_recent_split_dates",
+                return_value={"2026-05-08"},  # AAPL 10:1 executed after this date
+            ):
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL", "MSFT"],
+                    run_date="2026-05-08",
+                    source="polygon_only", skip_if_canonical=True,
+                )
+        # Re-fetched: one grouped-daily call, parquet rewritten with split-
+        # adjusted close.
+        assert polygon_calls == ["2026-05-08"]
+        assert result.get("skipped") is not True
+        out_df = pd.read_parquet(
+            io.BytesIO(s3.put_object.call_args.kwargs["Body"]), engine="pyarrow",
+        )
+        assert out_df.loc["AAPL", "Close"] == 99.0  # fresh restated value
+
+    def test_refetches_when_split_touched_dates_passed_directly(self):
+        """The window path threads ``split_touched_dates`` down — verify the
+        per-date collect honors it (and does not re-scan splits itself)."""
+        s3 = _existing_parquet_with_sources({
+            "AAPL": {"Close": 1500.0, "source": "polygon"},
+        })
+        polygon_calls: list = []
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes",
+                side_effect=_polygon_side_factory(polygon_calls),
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_recent_split_dates",
+            ) as scan_mock:
+                daily_closes.collect(
+                    bucket="b", tickers=["AAPL"],
+                    run_date="2026-05-08",
+                    source="polygon_only", skip_if_canonical=True,
+                    split_touched_dates={"2026-05-08"},
+                )
+        # split_touched_dates supplied → no inline split scan, and re-fetched.
+        scan_mock.assert_not_called()
+        assert polygon_calls == ["2026-05-08"]
+
+    def test_refetches_non_canonical_date(self):
+        """A ticker missing polygon source (legacy yfinance row) means the
+        date is NOT fully polygon-canonical → re-fetch even with no split."""
+        s3 = _existing_parquet_with_sources({
+            "AAPL": {"Close": 150.0, "source": "polygon"},
+            "MSFT": {"Close": 300.0, "source": "yfinance"},  # not polygon
+        })
+        polygon_calls: list = []
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes",
+                side_effect=_polygon_side_factory(polygon_calls),
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_recent_split_dates", return_value=set(),
             ):
                 daily_closes.collect(
                     bucket="b", tickers=["AAPL", "MSFT"],
                     run_date="2026-05-08",
                     source="polygon_only", skip_if_canonical=True,
                 )
-        # Polygon was called once (one grouped-daily for the date) and
-        # fetched both tickers regardless of their canonical state.
-        assert len(polygon_calls) == 1
-        # Verify the output overwrote the existing rows with fresh polygon data.
-        put_call = s3.put_object.call_args
-        out_df = pd.read_parquet(io.BytesIO(put_call.kwargs["Body"]), engine="pyarrow")
-        # Fresh polygon data has Close=99 (vs existing 150/300).
-        assert out_df.loc["AAPL", "Close"] == 99.0
-        assert out_df.loc["MSFT", "Close"] == 99.0
+        assert polygon_calls == ["2026-05-08"]
+
+    def test_first_fetch_no_existing_parquet_still_works(self):
+        """No existing parquet (first fetch) → polygon must fetch + write,
+        skip logic never triggers."""
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject",
+        )
+        s3.put_object.return_value = {"ETag": '"abc"'}
+        polygon_calls: list = []
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes",
+                side_effect=_polygon_side_factory(polygon_calls),
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_recent_split_dates", return_value=set(),
+            ):
+                result = daily_closes.collect(
+                    bucket="b", tickers=["AAPL", "MSFT"],
+                    run_date="2026-05-08",
+                    source="polygon_only", skip_if_canonical=True,
+                )
+        assert polygon_calls == ["2026-05-08"]
+        assert result.get("status") == "ok"
+        assert result.get("skipped") is not True
+
+    def test_legacy_default_polygon_overwrites_without_flag(self):
+        """skip_if_canonical=False (default) preserves the legacy overwrite —
+        polygon always re-fetches, no split scan."""
+        s3 = _existing_parquet_with_sources({
+            "AAPL": {"Close": 150.0, "source": "polygon"},
+        }, last_modified=datetime(2026, 5, 7, 21, 0, 0, tzinfo=timezone.utc))
+        polygon_calls: list = []
+        with patch("collectors.daily_closes.boto3.client", return_value=s3):
+            with patch.object(
+                daily_closes, "_fetch_polygon_closes",
+                side_effect=_polygon_side_factory(polygon_calls),
+            ), patch.object(
+                daily_closes, "_fetch_yfinance_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_fred_closes", return_value=0
+            ), patch.object(
+                daily_closes, "_fetch_recent_split_dates",
+            ) as scan_mock:
+                daily_closes.collect(
+                    bucket="b", tickers=["AAPL"],
+                    run_date="2026-05-08",
+                    source="polygon_only",  # skip_if_canonical defaults False
+                )
+        assert polygon_calls == ["2026-05-08"]
+        scan_mock.assert_not_called()
 
 
 # ── Read-failure fallback ───────────────────────────────────────────────────
@@ -412,3 +559,117 @@ class TestSkipCanonicalDefaultsFalse:
         # Legacy short-circuit: no yfinance call, returns "skipped".
         yf_mock.assert_not_called()
         assert result.get("skipped") is True
+
+
+# ── config#717 helper unit tests ────────────────────────────────────────────
+
+
+class TestPolygonDateFullyCanonical:
+    def test_all_polygon_canonical_returns_true(self):
+        df = pd.DataFrame(
+            [{"Close": 1.0, "source": "polygon"},
+             {"Close": 2.0, "source": "polygon"}],
+            index=pd.Index(["AAPL", "MSFT"], name="ticker"),
+        )
+        assert daily_closes._polygon_date_fully_canonical(df, ["AAPL", "MSFT"]) is True
+
+    def test_missing_ticker_returns_false(self):
+        df = pd.DataFrame(
+            [{"Close": 1.0, "source": "polygon"}],
+            index=pd.Index(["AAPL"], name="ticker"),
+        )
+        assert daily_closes._polygon_date_fully_canonical(df, ["AAPL", "MSFT"]) is False
+
+    def test_non_polygon_source_returns_false(self):
+        df = pd.DataFrame(
+            [{"Close": 1.0, "source": "yfinance"}],
+            index=pd.Index(["AAPL"], name="ticker"),
+        )
+        assert daily_closes._polygon_date_fully_canonical(df, ["AAPL"]) is False
+
+    def test_nan_close_returns_false(self):
+        df = pd.DataFrame(
+            [{"Close": float("nan"), "source": "polygon"}],
+            index=pd.Index(["AAPL"], name="ticker"),
+        )
+        assert daily_closes._polygon_date_fully_canonical(df, ["AAPL"]) is False
+
+    def test_no_source_column_returns_false(self):
+        df = pd.DataFrame(
+            [{"Close": 1.0}], index=pd.Index(["AAPL"], name="ticker"),
+        )
+        assert daily_closes._polygon_date_fully_canonical(df, ["AAPL"]) is False
+
+    def test_index_tickers_do_not_block_skip(self):
+        """FRED-index macro tickers never come from polygon — they must not
+        block a polygon skip nor be required to have source='polygon'."""
+        df = pd.DataFrame(
+            [{"Close": 1.0, "source": "polygon"},
+             {"Close": 20.0, "source": "fred"}],
+            index=pd.Index(["AAPL", "VIX"], name="ticker"),
+        )
+        # ^VIX is a FRED-index ticker; only AAPL (equity) must be polygon.
+        assert daily_closes._polygon_date_fully_canonical(df, ["AAPL", "^VIX"]) is True
+
+    def test_empty_stock_universe_vacuously_canonical(self):
+        df = pd.DataFrame(
+            [{"Close": 20.0, "source": "fred"}],
+            index=pd.Index(["VIX"], name="ticker"),
+        )
+        assert daily_closes._polygon_date_fully_canonical(df, ["^VIX"]) is True
+
+
+class TestFetchRecentSplitDates:
+    def test_marks_dates_before_split_execution(self):
+        client = MagicMock()
+        client.get_recent_splits.return_value = [
+            {"ticker": "AAPL", "execution_date": "2026-05-09",
+             "split_from": 1, "split_to": 10},
+        ]
+        window = ["2026-05-11", "2026-05-08", "2026-05-07"]  # newest-first
+        touched = daily_closes._fetch_recent_split_dates(window, client=client)
+        # Dates strictly before 2026-05-09 are restated.
+        assert touched == {"2026-05-08", "2026-05-07"}
+        # One range-scoped call covering [oldest .. newest+lookahead].
+        assert client.get_recent_splits.call_count == 1
+        args = client.get_recent_splits.call_args.args
+        assert args[0] == "2026-05-07"  # oldest
+
+    def test_no_splits_returns_empty(self):
+        client = MagicMock()
+        client.get_recent_splits.return_value = []
+        touched = daily_closes._fetch_recent_split_dates(
+            ["2026-05-08"], client=client,
+        )
+        assert touched == set()
+
+    def test_split_after_whole_window_touches_all(self):
+        client = MagicMock()
+        client.get_recent_splits.return_value = [
+            {"ticker": "X", "execution_date": "2026-06-01",
+             "split_from": 1, "split_to": 2},
+        ]
+        window = ["2026-05-09", "2026-05-08"]
+        touched = daily_closes._fetch_recent_split_dates(window, client=client)
+        assert touched == {"2026-05-09", "2026-05-08"}
+
+    def test_split_predating_window_touches_nothing(self):
+        client = MagicMock()
+        client.get_recent_splits.return_value = [
+            {"ticker": "X", "execution_date": "2026-05-07",
+             "split_from": 1, "split_to": 2},
+        ]
+        window = ["2026-05-09", "2026-05-08"]
+        touched = daily_closes._fetch_recent_split_dates(window, client=client)
+        assert touched == set()
+
+    def test_scan_failure_degrades_to_empty(self):
+        client = MagicMock()
+        client.get_recent_splits.side_effect = RuntimeError("polygon down")
+        touched = daily_closes._fetch_recent_split_dates(
+            ["2026-05-08"], client=client,
+        )
+        assert touched == set()
+
+    def test_empty_window_returns_empty(self):
+        assert daily_closes._fetch_recent_split_dates([]) == set()

--- a/tests/test_polygon_client.py
+++ b/tests/test_polygon_client.py
@@ -184,3 +184,57 @@ def test_get_splits_forbidden_returns_empty():
     client = _make_client()
     with patch.object(client, "_get", side_effect=PolygonForbiddenError("403")):
         assert client.get_splits("DD") == []
+
+
+# ── get_recent_splits (config#717: window-wide corporate-action scan) ────────
+
+
+def test_get_recent_splits_range_scoped_single_call():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ticker": "AAPL", "execution_date": "2026-05-09",
+             "split_from": 1, "split_to": 10},
+            {"ticker": "FOO", "execution_date": "2026-05-08",
+             "split_from": 2, "split_to": 1},
+        ],
+        "status": "OK",
+    }
+    with patch.object(client, "_get", return_value=resp) as mock_get:
+        out = client.get_recent_splits("2026-05-01", "2026-05-15")
+    assert mock_get.call_count == 1
+    # Range filter passed to the splits endpoint (no ticker filter).
+    _, kwargs = mock_get.call_args
+    params = kwargs["params"]
+    assert params["execution_date.gte"] == "2026-05-01"
+    assert params["execution_date.lte"] == "2026-05-15"
+    assert "ticker" not in params
+    # Sorted ascending; carries ticker.
+    assert [e["execution_date"] for e in out] == ["2026-05-08", "2026-05-09"]
+    assert out[1]["ticker"] == "AAPL"
+
+
+def test_get_recent_splits_skips_malformed_rows():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ticker": "AAPL", "execution_date": "2026-05-09",
+             "split_from": 1, "split_to": 10},
+            {"ticker": None, "execution_date": "2026-05-08",
+             "split_from": 2, "split_to": 1},  # missing ticker
+            {"ticker": "BAR", "execution_date": None,
+             "split_from": 2, "split_to": 1},  # missing date
+        ]
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_recent_splits("2026-05-01", "2026-05-15")
+    assert out == [
+        {"ticker": "AAPL", "execution_date": "2026-05-09",
+         "split_from": 1, "split_to": 10},
+    ]
+
+
+def test_get_recent_splits_forbidden_returns_empty():
+    client = _make_client()
+    with patch.object(client, "_get", side_effect=PolygonForbiddenError("403")):
+        assert client.get_recent_splits("2026-05-01", "2026-05-15") == []


### PR DESCRIPTION
Closes nousergon/alpha-engine-config#717

## Problem

`collectors/daily_closes.py` `polygon_only` mode re-fetched the polygon grouped-daily endpoint for **every** date in the trailing window and only used the existing parquet for discrepancy logging. The `skip_if_canonical` optimization was an `elif` that applied to `yfinance_only`/`auto` only, so polygon blanket-ignored the flag (docstring literally said *"Polygon side ignores the flag"* / option a). On the steady-state morning pass this re-coalesced the whole window daily — dates older than ~T-3 returned `overwrote 921, new 0, 0 discrepancies` — the documented root cause of the **2026-06-03 MorningEnrich 30-min SSM timeout** (SIGKILL / RESPCODE 137).

The FRED side could blanket-skip (index levels don't restate after settlement), but polygon *adjusted* closes ARE retroactively restated by corporate actions, so polygon couldn't blanket-skip. Per the audit finding (L4493), the SOTA fix re-fetches polygon **only** for dates touched by a recent corporate action.

## Root-cause fix

Mirrors the yfinance-side skip structure for consistency:

- **`polygon_only` + `skip_if_canonical=True` now honors the flag, split-aware.** A date is skipped (no grouped-daily call, no S3 write) iff its parquet is already **fully polygon-canonical** (every stock ticker present with `source="polygon"` + non-null `Close`) **AND** no recently executed corporate action restated it.
- **Corporate-action detection via the polygon splits endpoint.** A split with execution date `E` retroactively restates the adjusted close of every date *before* `E`, so those dates re-fetch even when canonical. New `PolygonClient.get_recent_splits(start, end)` queries `/v3/reference/splits` filtered by `execution_date` range with **no ticker filter** → the whole window's splits come back in **one call**. `_fetch_recent_split_dates()` maps them to touched window dates; `_collect_window` scans once and threads `split_touched_dates` into each per-date `collect` (bounded one-call-per-window cost).
- **Discrepancy-logging + source-priority coalesce stay intact** for the dates that ARE fetched.
- **Safe degradation:** any split-scan failure (403 / network / import) → empty touched set → canonical-only check governs (never silently skips a restated date beyond what the per-fetch discrepancy logging already backstops). `dry_run` keeps the legacy always-inspect path. Legacy single-date / `skip_if_canonical=False` callers are byte-unchanged.
- Updated the stale module / `collect` / `_collect_window` docstrings.

## Tests

New / extended in `tests/test_daily_closes_skip_if_canonical.py` and `tests/test_polygon_client.py`:

- skip a clean canonical date (no fetch, no write)
- re-fetch a date touched by a split
- re-fetch when `split_touched_dates` is threaded in (window path; no inline re-scan)
- re-fetch a non-canonical date (legacy yfinance row present)
- first-fetch (no existing parquet) still fetches + writes
- legacy `skip_if_canonical=False` still overwrites, no split scan
- `_polygon_date_fully_canonical` unit cases (missing ticker, non-polygon source, NaN close, no source col, index tickers don't block, empty stock universe)
- `_fetch_recent_split_dates` unit cases (dates before execution, split after/within/predating window, scan-failure degrades, empty window)
- `get_recent_splits` client cases (range-scoped single call, malformed rows, 403→[])

```
$ python -m pytest tests/ -k "daily_closes or polygon or canonical" -q --continue-on-collection-errors
246 passed, 2005 deselected, 9 warnings, 1 error
```

The single remaining collection `error` is pre-existing and unrelated: `tests/test_async_and_cache.py` imports `tenacity` (news-aggregator dep) which isn't installed in this runner. All targeted `daily_closes` / `polygon` / `canonical` tests are green. (arcticdb / yfinance / pandas / pyarrow / boto3 installed cleanly to validate the touched path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)