### PR TITLE
feat(freshness-monitor): thread run_calendar + repin nousergon-lib v0.73.0

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -154,9 +154,16 @@ _SPEC_FIELDS = frozenset(
         "recovery_key_template",
         "calendar_aware",
         "interval_minutes",
-        # Continuous active-window bounds (nousergon-lib >= v0.63.0) — scope a
-        # market-hours-only producer (the executor daemon's open_orders
-        # snapshot) so the 24/7 continuous floor doesn't false-alarm overnight.
+        # Continuous run-calendar (nousergon-lib >= v0.73.0) — the single
+        # source of truth for a continuous artifact's calendar-awareness
+        # (trading_days / all_days / market_hours). Drives both the idle
+        # short-circuit and a trading-day-aware freshness floor.
+        "run_calendar",
+        # Continuous active-window bounds. active_hours_utc is the
+        # market_hours session window (nousergon-lib >= v0.63.0); the
+        # active_trading_days_only boolean is DEPRECATED (subsumed by
+        # run_calendar="trading_days") but still parsed during the
+        # S3-contract-safe migration window.
         "active_trading_days_only",
         "active_hours_utc",
     }

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,12 +1,16 @@
-# Pinned to nousergon-lib v0.63.0 — adds the continuous active-window gate
-# (active-window for market-hours-only producers): a continuous spec may
-# carry active_trading_days_only / active_hours_utc so a daemon that only
-# writes during the NYSE session (open_orders) is judged fresh when idle
-# off-window instead of false-alarming every interval (the 2026-06-26
-# open_orders overnight alert storm). Builds on the v0.62.0 RECENCY redesign
-# (PR #128: most-recent instance vs a cron-tick-minus-slack floor). Name
-# changed alpha-engine-lib -> nousergon-lib at the 0.60 rename; index.py's
+# Pinned to nousergon-lib v0.73.0 — adds the continuous `run_calendar` enum
+# (trading_days / all_days / market_hours): the single source of truth for a
+# continuous artifact's calendar-awareness, driving BOTH the idle
+# short-circuit AND a trading-day-aware freshness floor. Fixes the
+# Monday-morning false positive that the v0.63.0 active-window gate left
+# unfixed (the wall-clock `now - interval - sla` floor reaches back across
+# the weekend and flags a daily trading-day producer stale before its run;
+# the trading-day floor counts only session days). v0.63.0 added the
+# active-window gate (open_orders overnight storm); v0.62.0 the RECENCY
+# redesign (PR #128). active_trading_days_only is now DEPRECATED (subsumed
+# by run_calendar="trading_days"); honored as a fallback during migration.
+# Name changed alpha-engine-lib -> nousergon-lib at the 0.60 rename; index.py's
 # alpha_engine_lib imports keep working via the compat shim (lib >=0.60.2).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.63.0
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.73.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -205,6 +205,31 @@ artifacts:
     assert spec.active_hours_utc == (14, 21)
 
 
+def test_load_registry_threads_run_calendar(fake_s3):
+    """The continuous run_calendar enum (nousergon-lib >=0.73.0) must survive
+    the _SPEC_FIELDS strip and thread through to ArtifactSpec — the field that
+    ties a daily trading-day producer's freshness floor to the trading
+    calendar (config#1297 continuous-cadence fold-in)."""
+    fake_s3._registry_body = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+artifacts:
+  - artifact_id: health_alpha_engine_data
+    s3_key_template: "health/daily_data.json"
+    cadence: continuous
+    interval_minutes: 1440
+    sla_minutes_after_cron: 60
+    severity: warning
+    owner_repo: alpha-engine-data
+    created_at: "2025-01-01"
+    run_calendar: trading_days
+"""
+    import index
+    spec = index.load_registry(fake_s3, "buck", "key")[0]
+    assert spec.run_calendar == "trading_days"
+
+
 # ── handler — alerts disabled (OBSERVE mode) ────────────────────────────────
 
 


### PR DESCRIPTION
## What
Wire the continuous `run_calendar` enum (nousergon-lib v0.73.0) through the freshness-monitor registry loader, and repin the lib.

## Changes
- `index.py`: `_SPEC_FIELDS += "run_calendar"` so the loader threads it from the registry YAML into `ArtifactSpec` (mirrors `active_hours_utc`). Documents `active_trading_days_only` as deprecated.
- `requirements.txt`: repin `nousergon-lib` v0.63.0 → **v0.73.0**.
- `test_handler.py`: `test_load_registry_threads_run_calendar`. **44 passed** locally against the v0.73 lib.

## ⛔ Gated
**Blocked on nousergon-lib#141 merge + `v0.73.0` auto-tag** (the repin target). CI here will be **red on the `pip install` step until that tag exists** — this is red-by-design, not a broken PR. Once #141 merges and `auto-tag.yml` creates `v0.73.0`, re-run CI → green.

Pairs with the alpha-engine-config registry migration. Refs config#1297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)