### PR TITLE
chore(infra): retire dead ssm_secrets.py residuals (config#890)

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -12,7 +12,10 @@
 #   2. IAM role created (alpha-engine-data-role)
 #   3. ECR repository: alpha-engine-data-collector
 #   4. Docker installed and running
-#   5. .env file with FMP_API_KEY, EDGAR_IDENTITY
+#   5. Secrets (FMP_API_KEY, FINNHUB_API_KEY, EDGAR_IDENTITY, …) present in SSM
+#      Parameter Store under /alpha-engine/* — the Lambda reads them at runtime
+#      via get_secret(); no .env is built into or sourced by this deploy
+#      (config#890 .env→SSM arc).
 #
 # Usage: ./infrastructure/deploy.sh
 

--- a/tests/test_no_secret_environ_reads.py
+++ b/tests/test_no_secret_environ_reads.py
@@ -42,11 +42,12 @@ _PINNED_SECRETS = frozenset(
     ]
 )
 
-# Files that are explicitly allowed to read secrets via os.environ — the
-# legacy ssm_secrets.py bulk-load shim is the only one; it covers
-# non-migrated reads in this repo and other repos pending PRs 3-7. The
-# shim itself is removed in PR 9 of the arc.
-_ALLOWED_FILES = frozenset(["ssm_secrets.py"])
+# Files that are explicitly allowed to read secrets via os.environ. The
+# legacy ``ssm_secrets.py`` bulk-load shim was the only entry; it was removed
+# in PR 9 of the .env→SSM arc (config#890), so the allowlist is now empty and
+# the invariant applies to every module. Re-add a filename here only if a new
+# deliberate shim is ever introduced.
+_ALLOWED_FILES: frozenset[str] = frozenset()
 
 _ENV_READ_RE = re.compile(
     r'os\.(?:environ\.get|getenv)\(\s*["\']([A-Z_][A-Z0-9_]*)["\']'


### PR DESCRIPTION
## What

P3 residual housekeeping from the `.env`→SSM migration (config#890). `ssm_secrets.py` was removed in PR 9 of that arc, but stale references survived:

- **`tests/test_no_secret_environ_reads.py`** — `_ALLOWED_FILES` whitelisted `ssm_secrets.py` so that file was exempt from the no-secret-`os.environ`-read invariant. The file is gone, so the entry was dead. Now an **empty frozenset**, meaning the invariant applies to every module. Test still passes locally → nothing in the repo relied on the exception.
- **`infrastructure/deploy.sh`** — prerequisite comment still listed "`.env` file with FMP_API_KEY, EDGAR_IDENTITY". The Lambda reads secrets from SSM via `get_secret()` at runtime; no `.env` is built into or sourced by this deploy. Corrected the comment.

## Not included (token scope)
A third dead residual — the `'ssm_secrets.py'` entry in the `paths:` filter of `.github/workflows/deploy.yml` (a filter that can never match now) — is **not** in this PR because this bot's token lacks the GitHub `workflow` scope. **One-line follow-up for a maintainer:** delete that `- 'ssm_secrets.py'` line from `.github/workflows/deploy.yml`.

## Validation
- `python -m pytest tests/test_no_secret_environ_reads.py` → 1 passed (with the now-empty allowlist).
- `bash -n infrastructure/deploy.sh` clean.
- No runtime behavior change.

Refs config#890 (P3 residual housekeeping). Does not fully close it — the operator `rm ~/.alpha-engine.env` + the SF `source` line + the daemon `EnvironmentFile` remain.