### PR TITLE
feat(infra): CloudWatch alarm on L274 MutexConflict SF Fail rate (config#729)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -565,6 +565,137 @@ Resources:
       AlarmActions:
         - !Ref AlertsTopic
 
+  # --------------------------------------------------------------------------
+  # L274 MutexConflict alarms (config#729)
+  # --------------------------------------------------------------------------
+  # The SF MutualExclusionGuard (L274) fails a duplicate-trigger execution with
+  # a terminal `MutexConflict` Fail. Today that's only visible in SF execution
+  # history + the SNS HandleFailure email. These metric-filters + alarms add a
+  # CloudWatch signal on the RATE of MutexConflict Fails per SF — the first
+  # non-zero count is the operator-action signal to investigate the duplicate
+  # trigger source (CFN drift, EB internal retry, operator double-paste,
+  # cross-region replay).
+  #
+  # Path chosen (per the issue's "lowest-substrate" guidance): a CloudWatch Logs
+  # metric filter on each SF's execution log group, matching the MutexConflict
+  # Cause text, into a custom AlphaEngine/StepFunctions metric — no new Lambda /
+  # EB-cron substrate. SF logging is enabled at level=ERROR with
+  # includeExecutionData=true (deploy_step_function*.sh), so the ExecutionFailed
+  # event carries the `MutexConflict` Error/Cause into the log group.
+  #
+  # The 3 log groups are created by the SF deploy scripts as
+  # /aws/stepfunctions/<state-machine-name>; the metric filters reference them
+  # by name (independent of whether the SF itself is CFN- or script-managed —
+  # the EOD pipeline is script-managed via update_eod_pipeline_sf.sh).
+  #
+  # Threshold is 1 over a 24h window (first fire = page) with
+  # TreatMissingData=notBreaching so the steady state (zero MutexConflicts) is OK.
+
+  WeekdayMutexConflictMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/stepfunctions/alpha-engine-weekday-pipeline
+      FilterPattern: '"MutexConflict"'
+      MetricTransformations:
+        - MetricNamespace: AlphaEngine/StepFunctions
+          MetricName: MutexConflictFails
+          MetricValue: '1'
+          DefaultValue: 0
+          Dimensions:
+            - Key: StateMachine
+              Value: alpha-engine-weekday-pipeline
+
+  SaturdayMutexConflictMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/stepfunctions/alpha-engine-saturday-pipeline
+      FilterPattern: '"MutexConflict"'
+      MetricTransformations:
+        - MetricNamespace: AlphaEngine/StepFunctions
+          MetricName: MutexConflictFails
+          MetricValue: '1'
+          DefaultValue: 0
+          Dimensions:
+            - Key: StateMachine
+              Value: alpha-engine-saturday-pipeline
+
+  EodMutexConflictMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/stepfunctions/alpha-engine-eod-pipeline
+      FilterPattern: '"MutexConflict"'
+      MetricTransformations:
+        - MetricNamespace: AlphaEngine/StepFunctions
+          MetricName: MutexConflictFails
+          MetricValue: '1'
+          DefaultValue: 0
+          Dimensions:
+            - Key: StateMachine
+              Value: alpha-engine-eod-pipeline
+
+  WeekdayMutexConflictAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alpha-engine-weekday-mutex-conflict
+      AlarmDescription: >-
+        L274 MutexConflict Fail on the weekday pipeline (duplicate-trigger guard
+        fired). First occurrence = investigate the duplicate-trigger source.
+      Namespace: AlphaEngine/StepFunctions
+      MetricName: MutexConflictFails
+      Dimensions:
+        - Name: StateMachine
+          Value: alpha-engine-weekday-pipeline
+      Statistic: Sum
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlertsTopic
+
+  SaturdayMutexConflictAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alpha-engine-saturday-mutex-conflict
+      AlarmDescription: >-
+        L274 MutexConflict Fail on the saturday pipeline (duplicate-trigger guard
+        fired). First occurrence = investigate the duplicate-trigger source.
+      Namespace: AlphaEngine/StepFunctions
+      MetricName: MutexConflictFails
+      Dimensions:
+        - Name: StateMachine
+          Value: alpha-engine-saturday-pipeline
+      Statistic: Sum
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlertsTopic
+
+  EodMutexConflictAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: alpha-engine-eod-mutex-conflict
+      AlarmDescription: >-
+        L274 MutexConflict Fail on the eod pipeline (duplicate-trigger guard
+        fired). First occurrence = investigate the duplicate-trigger source.
+      Namespace: AlphaEngine/StepFunctions
+      MetricName: MutexConflictFails
+      Dimensions:
+        - Name: StateMachine
+          Value: alpha-engine-eod-pipeline
+      Statistic: Sum
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlertsTopic
+
 # ============================================================================
 # Outputs
 # ============================================================================

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -425,6 +425,63 @@ class TestCfnExecutionMutexTable:
         )
 
 
+class TestCfnMutexConflictAlarms:
+    """The CFN template must wire a CloudWatch metric-filter + alarm per SF on
+    the L274 MutexConflict Fail (config#729). First non-zero count is the
+    operator-action signal to investigate the duplicate-trigger source. Raw-text
+    parsing per the TestCfnExecutionMutexTable precedent (CFN tags need a custom
+    loader)."""
+
+    # The 3 SF execution log groups carry the MutexConflict Cause at
+    # logging level=ERROR + includeExecutionData=true.
+    SF_NAMES = (
+        "alpha-engine-weekday-pipeline",
+        "alpha-engine-saturday-pipeline",
+        "alpha-engine-eod-pipeline",
+    )
+
+    @pytest.fixture(scope="class")
+    def cfn_text(self) -> str:
+        return CFN_PATH.read_text()
+
+    @pytest.mark.parametrize("sf_name", SF_NAMES)
+    def test_metric_filter_present_for_each_sf(self, cfn_text, sf_name):
+        assert f"/aws/stepfunctions/{sf_name}" in cfn_text, (
+            f"missing AWS::Logs::MetricFilter LogGroupName for {sf_name} — "
+            f"without it MutexConflict Fails on that SF produce no CW metric "
+            f"and no alarm can fire (config#729)"
+        )
+
+    def test_metric_filter_matches_mutexconflict(self, cfn_text):
+        assert "AWS::Logs::MetricFilter" in cfn_text
+        # The filter pattern must key on the MutexConflict Cause text so it only
+        # counts duplicate-trigger Fails, not every SF error.
+        assert "MutexConflictFails" in cfn_text, (
+            "the MutexConflict metric transformation must emit a dedicated "
+            "MutexConflictFails metric (config#729)"
+        )
+
+    @pytest.mark.parametrize("sf_name", SF_NAMES)
+    def test_alarm_present_for_each_sf(self, cfn_text, sf_name):
+        # alpha-engine-<cadence>-mutex-conflict
+        cadence = sf_name.split("-")[2]  # weekday / saturday / eod
+        alarm_name = f"alpha-engine-{cadence}-mutex-conflict"
+        assert alarm_name in cfn_text, (
+            f"missing CloudWatch alarm {alarm_name} for {sf_name} — the "
+            f"MutexConflict metric exists but nobody is paged on it (config#729)"
+        )
+
+    def test_alarms_route_to_alerts_topic(self, cfn_text):
+        # Each mutex-conflict alarm must page the existing AlertsTopic, not
+        # silently sit as a metric. Anchor on the first alarm block.
+        anchor = cfn_text.index("WeekdayMutexConflictAlarm:")
+        block = cfn_text[anchor : anchor + 900]
+        assert "!Ref AlertsTopic" in block, (
+            "MutexConflict alarm must fire the AlertsTopic SNS — otherwise it "
+            "is observability-only and defeats the config#729 goal"
+        )
+
+
 # ---------------------------------------------------------------------------
 # IAM — SF role has dynamodb:PutItem on the mutex table only
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds a CloudWatch metric-filter + alarm per Step Function on the L274 `MutexConflict` Fail, so the **first** duplicate-trigger occurrence pages the operator instead of only landing in SF execution history + the SNS HandleFailure email.

Closes nousergon/alpha-engine-config#729.

## Approach (lowest-substrate path from the issue)

- 3x `AWS::Logs::MetricFilter` on `/aws/stepfunctions/{weekday,saturday,eod}-pipeline`, matching the `MutexConflict` Cause text into `AlphaEngine/StepFunctions::MutexConflictFails` (per-StateMachine dimension).
- 3x `AWS::CloudWatch::Alarm` (threshold **1 / 24h**, `TreatMissingData: notBreaching`) to the existing `alpha-engine-alerts` SNS topic.
- **No new Lambda / EB-cron substrate.**

SF logging is already `level=ERROR` + `includeExecutionData=true` (`deploy_step_function*.sh`), so the `ExecutionFailed` event carries the `MutexConflict` Cause into the log group. The EOD pipeline (script-managed) is covered because filters reference log groups **by name**.

## Tests
- `cfn-lint` clean (only pre-existing W2001 warnings).
- Added `TestCfnMutexConflictAlarms` (8 assertions); **56 passed** (was 48).

## DRAFT — unvalidated piece
The alarm **wiring** is statically validated, but no MutexConflict has fired (guard is working), so the runtime transition can't be exercised here. Closes-when requires the operator to validate the alarm-vs-SNS signal.

**Brian's validation command** (after merge + `deploy-infrastructure.sh`):
```
aws cloudwatch set-alarm-state --alarm-name alpha-engine-weekday-mutex-conflict \
  --state-value ALARM --state-reason 'config#729 synthetic validation' --region us-east-1
# confirm the alpha-engine-alerts email arrives, then let it self-reset to OK
```

Generated with Claude Code