### PR TITLE
feat(collectors): universe_classification — sector/country/industry for the ~900 universe

### DIFF
--- a/collectors/universe_classification.py
+++ b/collectors/universe_classification.py
@@ -1,0 +1,274 @@
+"""
+universe_classification.py — Sector / country-of-domicile / industry per ticker
+for the full S&P 500 + S&P 400 universe, written to S3.
+
+The system already gets GICS *sector* for the ~900-name universe from the
+Wikipedia constituents pass (``collectors/constituents.py``), and Metron gets
+sector+country for its HELD universe from ``collectors/metron_market_data.py``
+(``market_data/sectors/latest.json``, v2). What was missing was a
+**country-of-domicile + industry classification for the whole research
+universe** — the dimension the new ~900-stock universe scoreboard
+(crucible-research ``scoring/universe_board.py`` →
+``scanner/universe/{date}/universe.json``) filters on alongside sector and the
+factor/valuation metrics. This producer fills that gap from the same
+``yfinance Ticker.info`` source Metron's classification pass already uses
+(``info['sector']`` + ``info['country']`` + ``info['industry']``) — a
+zero-new-dependency reuse of a proven production path (FMP's ``/stable``
+profile endpoint caps at 250 calls/day and can't cover 900, so yfinance is
+both the cheaper and the already-trusted source for this field).
+
+Country/industry domicile is near-static (it changes only on a redomicile or
+reclassification), so the weekly Saturday cadence is ample and the artifact is
+a single ``latest.json`` (plus a dated copy for provenance).
+
+Output:
+  ``s3://<bucket>/market_data/universe_classification/{run_date}.json``
+  ``s3://<bucket>/market_data/universe_classification/latest.json``
+
+Schema (versioned — consumers pin on ``schema_version``):
+  {
+    "schema_version": 1,
+    "as_of": "YYYY-MM-DD",
+    "source": "yfinance",
+    "ticker_count": int,        # tickers requested
+    "ok_count": int,            # tickers with at least one populated field
+    "data": {
+      "<TICKER>": {
+        "sector":   str | null,   # GICS sector (info['sector'])
+        "country":  str | null,   # country of domicile (info['country'])
+        "industry": str | null,   # GICS sub-industry (info['industry'])
+      },
+      ...
+    }
+  }
+
+Failure semantics mirror ``collectors/short_interest.py``: per-ticker errors
+are logged and recorded as an all-null row (a coverage gap, never a guessed
+value); the collector returns ``status="ok"`` as long as at least
+``_MIN_OK_RATIO`` of tickers produce some populated field, else
+``status="error"`` (no partial write) so ``hard_fail_until_stable`` in
+``weekly_collector.main`` aborts the run rather than publishing a thin
+artifact.
+
+Entry point: ``python -m collectors.universe_classification [--date YYYY-MM-DD] [--dry-run]``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUCKET = "alpha-engine-research"
+UNIVERSE_CLASSIFICATION_PREFIX = "market_data/universe_classification/"
+UNIVERSE_CLASSIFICATION_SCHEMA_VERSION = 1
+
+# Per-ticker delay between yfinance ``Ticker.info`` calls. Same rationale +
+# value as short_interest.py — empirically ~0.4s/call avoids HTTP 429 storms
+# while keeping the full-universe pass under ~10 min on the Saturday spot.
+_DEFAULT_DELAY_SECS = 0.4
+
+# Minimum fraction of requested tickers that must produce *some* populated
+# field for the run to count as OK. Below this we suspect a yfinance outage /
+# IP block rather than genuine missing classification, and hard-fail instead
+# of publishing a thin artifact (no-silent-fails).
+_MIN_OK_RATIO = 0.50
+
+# info keys → artifact field. Country/industry are the value-add over the
+# Wikipedia sector pass; sector is carried too so a downstream consumer that
+# wants one classification artifact need not also read constituents.json.
+_INFO_FIELDS: dict[str, str] = {
+    "sector": "sector",
+    "country": "country",
+    "industry": "industry",
+}
+
+
+def collect(
+    bucket: str,
+    tickers: list[str],
+    s3_prefix: str = "market_data/",
+    run_date: str | None = None,
+    inter_request_delay: float = _DEFAULT_DELAY_SECS,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Collect sector/country/industry classification for ``tickers`` → S3.
+
+    Parameters
+    ----------
+    bucket : str
+        S3 bucket for the JSON output.
+    tickers : list[str]
+        Symbols to classify. Typically the full S&P 500 + S&P 400 universe
+        produced by the constituents collector earlier in the same run.
+    s3_prefix : str
+        Market-data S3 prefix (typically ``"market_data/"``). The artifact
+        lands at ``{s3_prefix}universe_classification/{run_date}.json`` plus a
+        ``latest.json`` sidecar.
+    run_date : str
+        YYYY-MM-DD stamp; defaults to today (trading-day axis).
+    inter_request_delay : float
+        Seconds to sleep between per-ticker yfinance calls.
+    dry_run : bool
+        If True, classify ~5 tickers and skip the S3 write.
+
+    Returns
+    -------
+    dict
+        ``{status, ticker_count, ok_count, ...}``. ``status="ok"`` if
+        ok_count >= MIN_OK_RATIO * ticker_count, else ``"error"``.
+    """
+    if run_date is None:
+        from dates import default_run_date  # config#1014: trading-day axis
+
+        run_date = default_run_date()
+
+    if not tickers:
+        return {
+            "status": "error",
+            "error": "no tickers provided — universe classification needs the constituents list",
+        }
+
+    # In dry-run, sample the first few tickers to validate yfinance is
+    # reachable without paying the full ~10 min collection cost.
+    fetch_list = tickers[:5] if dry_run else tickers
+
+    try:
+        import yfinance as yf
+    except ImportError as exc:
+        return {
+            "status": "error",
+            "error": f"yfinance not importable: {exc}",
+        }
+
+    payload: dict[str, dict] = {}
+    ok_count = 0
+    err_count = 0
+    started = time.time()
+
+    for i, ticker in enumerate(fetch_list):
+        if i > 0 and inter_request_delay > 0:
+            time.sleep(inter_request_delay)
+        row = {field: None for field in _INFO_FIELDS.values()}
+        try:
+            info = yf.Ticker(ticker).info or {}
+            for info_key, field in _INFO_FIELDS.items():
+                v = info.get(info_key)
+                if v:
+                    row[field] = str(v)
+            if any(v is not None for v in row.values()):
+                ok_count += 1
+        except Exception as exc:
+            err_count += 1
+            logger.debug("classification fetch failed for %s: %s", ticker, exc)
+
+        payload[ticker] = row
+
+        if (i + 1) % 100 == 0:
+            elapsed = time.time() - started
+            logger.info(
+                "universe classification progress: %d/%d (%d ok, %d err) in %.0fs",
+                i + 1, len(fetch_list), ok_count, err_count, elapsed,
+            )
+
+    elapsed = time.time() - started
+    ok_ratio = ok_count / max(len(fetch_list), 1)
+    logger.info(
+        "universe classification done: %d/%d ok (%.1f%%), %d errors, %.0fs",
+        ok_count, len(fetch_list), ok_ratio * 100, err_count, elapsed,
+    )
+
+    artifact = {
+        "schema_version": UNIVERSE_CLASSIFICATION_SCHEMA_VERSION,
+        "as_of": run_date,
+        "source": "yfinance",
+        "ticker_count": len(fetch_list),
+        "ok_count": ok_count,
+        "data": payload,
+    }
+
+    if dry_run:
+        return {
+            "status": "ok_dry_run",
+            "ticker_count": len(fetch_list),
+            "ok_count": ok_count,
+            "duration_seconds": round(elapsed, 1),
+        }
+
+    if ok_ratio < _MIN_OK_RATIO:
+        return {
+            "status": "error",
+            "error": (
+                f"only {ok_count}/{len(fetch_list)} tickers ({ok_ratio:.1%}) had populated "
+                f"classification data — below {_MIN_OK_RATIO:.0%} threshold. yfinance "
+                f"outage or IP block suspected; not writing partial output."
+            ),
+            "ticker_count": len(fetch_list),
+            "ok_count": ok_count,
+        }
+
+    s3 = boto3.client("s3")
+    body = json.dumps(artifact, indent=2, default=str)
+    dated_key = f"{s3_prefix}universe_classification/{run_date}.json"
+    latest_key = f"{s3_prefix}universe_classification/latest.json"
+    _put(s3, bucket, dated_key, body)
+    _put(s3, bucket, latest_key, body)
+    logger.info(
+        "Wrote universe_classification to s3://%s/{%s,%s} (%d tickers, %d populated)",
+        bucket, dated_key, latest_key, len(fetch_list), ok_count,
+    )
+
+    return {
+        "status": "ok",
+        "ticker_count": len(fetch_list),
+        "ok_count": ok_count,
+        "duration_seconds": round(elapsed, 1),
+    }
+
+
+def _put(s3_client, bucket: str, key: str, body: str) -> None:
+    """The ONE put_object site in this module — dated + latest both route here
+    so the artifact-registry coverage guard pins a single count."""
+    s3_client.put_object(
+        Bucket=bucket, Key=key, Body=body, ContentType="application/json",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m collectors.universe_classification", description=__doc__,
+    )
+    parser.add_argument("--date", default=None, help="YYYY-MM-DD run date (default: today)")
+    parser.add_argument("--dry-run", action="store_true", help="Sample 5 tickers, skip S3 write")
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET, help="S3 bucket")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    from collectors import constituents
+
+    existing = constituents.load_from_s3(args.bucket, "market_data/") or {}
+    tickers = existing.get("tickers", [])
+    if not tickers:
+        logger.error("No constituents available in S3 — run the constituents collector first")
+        return 1
+
+    result = collect(
+        bucket=args.bucket,
+        tickers=tickers,
+        run_date=args.date,
+        dry_run=args.dry_run,
+    )
+    logger.info("universe_classification result: %s", result)
+    return 0 if result.get("status", "").startswith("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -78,6 +78,7 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "collectors/metron_market_data.py": 1,  # one _write_json site → market_data/eod_closes/* + market_data/fx/*
     "collectors/prices.py": 1,
     "collectors/short_interest.py": 1,
+    "collectors/universe_classification.py": 1,  # market_data/universe_classification/{date,latest}.json — sector/country/industry for the ~900 universe board
     "collectors/signal_returns.py": 1,
     "collectors/universe_returns.py": 1,
     "data/cache.py": 1,

--- a/tests/test_universe_classification.py
+++ b/tests/test_universe_classification.py
@@ -1,0 +1,164 @@
+"""Tests for collectors/universe_classification.py.
+
+Mocks yfinance ``Ticker.info`` to exercise the collector without hitting the
+network. Locks the invariants that mirror collectors/short_interest.py:
+  1. A well-populated info dict produces correctly-shaped sector/country/industry.
+  2. The artifact carries schema_version + the dated AND latest keys are both
+     written from a single PUT helper.
+  3. Per-ticker exceptions don't crash the run; the row gets all-null fields
+     (a coverage gap, never a guessed value).
+  4. Below-threshold ok_ratio returns status=error rather than writing a partial
+     artifact to S3.
+  5. Empty tickers / dry-run short-circuit without an S3 write.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from collectors import universe_classification as uc
+
+
+def _make_yf(info_by_ticker: dict[str, dict]) -> MagicMock:
+    """Build a yfinance mock where Ticker(t).info returns info_by_ticker[t]."""
+    yf_mock = MagicMock()
+
+    def ticker_factory(t):
+        ticker_obj = MagicMock()
+        ticker_obj.info = info_by_ticker.get(t, {})
+        return ticker_obj
+
+    yf_mock.Ticker.side_effect = ticker_factory
+    return yf_mock
+
+
+def test_well_populated_info_produces_typed_output_and_both_keys():
+    yf_mock = _make_yf({
+        "AAPL": {"sector": "Technology", "country": "United States", "industry": "Consumer Electronics"},
+        "LIN": {"sector": "Materials", "country": "Ireland", "industry": "Specialty Chemicals"},
+    })
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.universe_classification.boto3.client", return_value=fake_s3):
+        result = uc.collect(
+            bucket="test-bucket",
+            tickers=["AAPL", "LIN"],
+            run_date="2026-06-28",
+            inter_request_delay=0.0,
+        )
+
+    assert result["status"] == "ok"
+    assert result["ok_count"] == 2
+
+    # Dated + latest keys both written from the single PUT helper.
+    written_keys = {c.kwargs["Key"] for c in fake_s3.put_object.call_args_list}
+    assert written_keys == {
+        "market_data/universe_classification/2026-06-28.json",
+        "market_data/universe_classification/latest.json",
+    }
+
+    body = json.loads(fake_s3.put_object.call_args_list[0].kwargs["Body"])
+    assert body["schema_version"] == uc.UNIVERSE_CLASSIFICATION_SCHEMA_VERSION
+    assert body["as_of"] == "2026-06-28"
+    assert body["data"]["LIN"] == {
+        "sector": "Materials", "country": "Ireland", "industry": "Specialty Chemicals",
+    }
+
+
+def test_partial_info_keeps_populated_fields():
+    """A ticker missing industry still contributes sector+country (no fabrication)."""
+    yf_mock = _make_yf({"MSFT": {"sector": "Technology", "country": "United States"}})
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.universe_classification.boto3.client", return_value=fake_s3):
+        result = uc.collect(
+            bucket="test-bucket", tickers=["MSFT"], run_date="2026-06-28", inter_request_delay=0.0,
+        )
+    assert result["status"] == "ok"
+    body = json.loads(fake_s3.put_object.call_args_list[0].kwargs["Body"])
+    assert body["data"]["MSFT"] == {
+        "sector": "Technology", "country": "United States", "industry": None,
+    }
+
+
+def test_per_ticker_exception_does_not_crash():
+    yf_mock = MagicMock()
+
+    def ticker_factory(t):
+        if t == "BAD":
+            raise RuntimeError("yfinance internal error")
+        ticker_obj = MagicMock()
+        ticker_obj.info = {"sector": "Technology", "country": "United States", "industry": "Software"}
+        return ticker_obj
+
+    yf_mock.Ticker.side_effect = ticker_factory
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.universe_classification.boto3.client", return_value=fake_s3):
+        result = uc.collect(
+            bucket="test-bucket",
+            tickers=["GOOD1", "BAD", "GOOD2"],
+            run_date="2026-06-28",
+            inter_request_delay=0.0,
+        )
+
+    assert result["status"] == "ok"
+    assert result["ok_count"] == 2  # GOOD1 + GOOD2
+    body = json.loads(fake_s3.put_object.call_args_list[0].kwargs["Body"])
+    assert body["data"]["BAD"] == {"sector": None, "country": None, "industry": None}
+
+
+def test_below_threshold_returns_error_no_s3_write():
+    """If <50% of tickers populate any field, status=error and no S3 write."""
+    yf_mock = MagicMock()
+
+    def ticker_factory(t):
+        ticker_obj = MagicMock()
+        ticker_obj.info = (
+            {"sector": "Technology", "country": "United States", "industry": "Software"}
+            if t == "AAPL" else {}
+        )
+        return ticker_obj
+
+    yf_mock.Ticker.side_effect = ticker_factory
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.universe_classification.boto3.client", return_value=fake_s3):
+        result = uc.collect(
+            bucket="test-bucket",
+            tickers=["AAPL", "MSFT", "GOOG", "AMZN", "META"],
+            run_date="2026-06-28",
+            inter_request_delay=0.0,
+        )
+
+    assert result["status"] == "error"
+    assert "below 50% threshold" in result["error"].lower()
+    fake_s3.put_object.assert_not_called()
+
+
+def test_dry_run_samples_first_five_no_s3_write():
+    yf_mock = _make_yf({
+        t: {"sector": "Technology", "country": "United States", "industry": "Software"}
+        for t in ["A", "B", "C", "D", "E", "F", "G"]
+    })
+    fake_s3 = MagicMock()
+    with patch.dict("sys.modules", {"yfinance": yf_mock}), \
+         patch("collectors.universe_classification.boto3.client", return_value=fake_s3):
+        result = uc.collect(
+            bucket="test-bucket",
+            tickers=["A", "B", "C", "D", "E", "F", "G"],
+            run_date="2026-06-28",
+            inter_request_delay=0.0,
+            dry_run=True,
+        )
+
+    assert result["status"] == "ok_dry_run"
+    assert result["ticker_count"] == 5  # capped to first 5
+    fake_s3.put_object.assert_not_called()
+
+
+def test_empty_tickers_list_errors_immediately():
+    result = uc.collect(bucket="test-bucket", tickers=[], run_date="2026-06-28")
+    assert result["status"] == "error"
+    assert "no tickers" in result["error"].lower()

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -80,7 +80,7 @@ setup_logging(
     exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
 )
 
-from collectors import constituents, prices, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest, metron_market_data
+from collectors import constituents, prices, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest, metron_market_data, universe_classification
 from builders._price_cache_writeboth import (
     price_cache_read_prefixes as _price_cache_read_prefixes,
     price_cache_write_prefixes as _price_cache_write_prefixes,
@@ -392,6 +392,46 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
     elif only in (None, "short_interest") and not si_enabled:
         logger.info("short_interest collector disabled via config — skipping")
         results["collectors"]["short_interest"] = {"status": "ok", "skipped": "disabled_in_config"}
+
+    # ── 4c. Universe classification ──────────────────────────────────────────
+    # Per-ticker yfinance Ticker.info scrape for sector/country-of-domicile/
+    # industry over the full S&P 500+400 universe — the country dimension the
+    # ~900-stock universe scoreboard (crucible-research scoring/universe_board.py)
+    # filters on alongside sector and the factor/valuation metrics. Domicile is
+    # near-static, so the weekly Saturday cadence is ample; the artifact is a
+    # single latest.json (+ dated copy). ~10 min on the spot off the constituents
+    # list already fetched earlier in this phase.
+    #
+    # Gated by config["universe_classification"]["enabled"] (default True), same
+    # soft-launch pattern as short_interest: flip enabled=false to run once
+    # manually with --only universe_classification, then back to true once stable.
+    uc_cfg = config.get("universe_classification", {})
+    uc_enabled = uc_cfg.get("enabled", True)
+    if only in (None, "universe_classification") and uc_enabled:
+        logger.info("=" * 60)
+        logger.info("COLLECTING: universe classification")
+        logger.info("=" * 60)
+        if not tickers:
+            logger.warning("No tickers available — skipping universe classification")
+            results["collectors"]["universe_classification"] = {
+                "status": "skipped", "reason": "no tickers",
+            }
+        else:
+            results["collectors"]["universe_classification"] = _phase_collect(
+                reg, "universe_classification",
+                lambda: universe_classification.collect(
+                    bucket=bucket,
+                    tickers=tickers,
+                    s3_prefix=market_prefix,
+                    run_date=run_date,
+                    inter_request_delay=uc_cfg.get("inter_request_delay", 0.4),
+                    dry_run=dry_run,
+                ),
+                artifact_key=f"{market_prefix}universe_classification/{run_date}.json",
+            )
+    elif only in (None, "universe_classification") and not uc_enabled:
+        logger.info("universe_classification collector disabled via config — skipping")
+        results["collectors"]["universe_classification"] = {"status": "ok", "skipped": "disabled_in_config"}
 
     # ── 5. Universe returns ──────────────────────────────────────────────────
     if only in (None, "universe_returns"):
@@ -2589,7 +2629,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--only",
-        choices=["constituents", "prices", "macro", "short_interest", "universe_returns", "alternative", "daily_closes", "features", "arcticdb"],
+        choices=["constituents", "prices", "macro", "short_interest", "universe_classification", "universe_returns", "alternative", "daily_closes", "features", "arcticdb"],
         help="Run a single collector instead of all",
     )
     # Phase-registry recovery controls (L4528 — markers under data/{date}/.phases/).


### PR DESCRIPTION
## What

New weekly Phase-1 collector `collectors/universe_classification.py` scraping `yfinance Ticker.info` (sector + country-of-domicile + industry) for the full S&P 500+400 universe →

```
market_data/universe_classification/{run_date}.json
market_data/universe_classification/latest.json
```

## Why

This is **PR A of a 3-PR arc** to expose all ~900 scanner stocks with per-stock metrics + an attractiveness rating on the private dashboard (Brian's ask). The arc:
- **A (this PR, nousergon-data):** the country/domicile classification dimension — the one classification the system lacked universe-wide.
- **B (crucible-research):** `scoring/universe_board.py` → `scanner/universe/{date}/universe.json` joining the 6 pillar factor scores + an equal-weight `attractiveness_score` + raw valuation/fundamental/technical metrics + sector + **country (this artifact)** + scanner gate flags.
- **C (crucible-dashboard):** a private-console board page, sortable + filterable by attractiveness/pillar/metric ranges, sector, country, and gate status.

GICS sector already comes from the Wikipedia constituents pass; Metron already gets sector+country for its HELD universe from `metron_market_data`. The missing piece was **country of domicile for the whole research universe**.

**Source = yfinance**, not FMP: FMP `/stable` profile caps at 250 calls/day and can't cover 900; yfinance is the same proven path `metron_market_data`'s classification pass already uses (`info['sector']` + `info['country']` + `info['industry']`), so zero new dependency surface. Domicile is near-static → weekly Saturday cadence is ample.

## How

- Mirrors `collectors/short_interest.py` exactly: per-ticker fail-soft (all-null row = coverage gap, never a guessed value), `MIN_OK_RATIO` 0.50 hard-fail (no partial write per no-silent-fails), single PUT helper, config-gated soft-launch (`universe_classification.enabled`, default True).
- Wired into `weekly_collector._run_phase1` after `short_interest`, plus `--only universe_classification`.
- Tests mirror `test_short_interest.py`; artifact-registry coverage guard pinned (1 PUT site).

## Out of scope / follow-ups

- **ARTIFACT_REGISTRY.yaml freshness entry** is deliberately NOT added here: registering ahead of the first production run yields a false `state=missing` until next Saturday SF (per the register-with-or-after-producer rule). Will be added in the alpha-engine-config docs PR once the producer has run once.

## Tests

`pytest tests/test_universe_classification.py tests/test_short_interest.py tests/test_artifact_registry_coverage.py` → 14 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)