### PR TITLE
feat(infra): migrate spot_drift_detection.sh off SSH/SCP onto SSM + S3 (config#893)

### DIFF
--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -13,6 +13,17 @@
 # micro entirely. Roadmap P2: consider bundling onto the PredictorTraining
 # spot since drift depends on predictor weights produced by that step.
 #
+# Transport: dispatcher→spot communication is via `aws ssm send-command`
+# (routed through the lib chokepoint `python -m nousergon_lib.ssm_dispatcher`,
+# lib v0.35.0+) — NO ssh / scp / ssh-keyscan and NO port-22 inbound
+# dependency. This is the SSH/SCP→SSM migration of config#893's drift
+# sibling, mirroring spot_data_weekly.sh #330 / spot_backtest.sh #405 /
+# spot_train.sh #168 1:1. The spot pulls everything over HTTPS git-clone
+# (lib is public) + its IAM role's S3 grant; the drift workload reads the
+# alpha-engine-research bucket directly, so unlike the data/backtest paths
+# there is NO private config.yaml to S3-stage — the only dispatcher-side
+# S3 use is the SSM stdout-overflow / diagnostics prefix.
+#
 # Non-blocking: drift failures should not halt the Saturday pipeline — the
 # SF's DriftDetection step has a Catch → Backtester so an error here only
 # fires an alert. This launcher still exits non-zero on failure so the
@@ -59,14 +70,36 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ── Spot configuration ──────────────────────────────────────────────────────
 AWS_REGION="${AWS_REGION:-us-east-1}"
+# S3 bucket for SSM stdout-overflow + diagnostics staging (the drift
+# workload itself reads/writes the alpha-engine-research bucket directly
+# via the lib's DEFAULT_BUCKET — this is only the dispatcher's transport
+# scratch namespace). Matches the sibling spot scripts' S3_BUCKET default.
+S3_BUCKET="${S3_BUCKET:-alpha-engine-research}"
 BRANCH="${BRANCH:-main}"
 INSTANCE_TYPE="c5.large"
-AMI_ID="ami-0c421724a94bba6d6"
+# Lib CLI rotates across these on capacity error (ec2_spot exit 64 when
+# every type × subnet combination is exhausted). c5.large-first list keeps
+# the existing cost/perf profile.
+INSTANCE_TYPES="${INSTANCE_TYPES:-c5.large,m5.large,c6i.large,c5a.large}"
+AMI_ID="ami-0c421724a94bba6d6"      # Amazon Linux 2023 x86_64
+# Key-pair name kept ONLY for compatibility with
+# nousergon_lib.ec2_spot's --key-name flag — the spot still launches
+# with this key associated, but NOTHING in this script SSH's into the
+# instance. Communication is via SSM; the key remains as a manual
+# break-glass option (operator can `ssh -i ~/.ssh/...pem` only if the
+# security group's port-22 inbound rule is temporarily re-opened, which
+# it should NOT be in steady state — see ROADMAP L342 PR 5).
 KEY_NAME="alpha-engine-key"
-KEY_FILE="$HOME/.ssh/alpha-engine-key.pem"
 SECURITY_GROUP="sg-03cd3c4bd91e610b0"
-SUBNET_ID="subnet-e07166ec"
+# All 6 default-VPC subnets across us-east-1{a,b,c,d,e,f}; the lib CLI
+# rotates across this list on capacity error. Mirrors spot_data_weekly.sh.
+SUBNETS="${SUBNETS:-subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,subnet-c670118d,subnet-7cff7c43,subnet-e07166ec}"
 IAM_PROFILE="alpha-engine-executor-profile"
+# Lib CLI path: ae-dashboard is the SSM target instance for the Saturday-SF
+# spot states; the dispatcher's .venv has nousergon-lib installed (see
+# deploy-on-merge.sh in the dashboard repo). Bare `python3` resolves to
+# system python which does NOT carry the lib — use the full venv path.
+LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
 # Spot-side watchdog budget: DriftDetection workload is ~5 min; 30 min
 # of headroom covers pip install + preflight + retries. If the workload
 # legitimately needs longer, bump this — don't silently rely on the
@@ -100,135 +133,186 @@ echo "  Run mode      : $RUN_MODE"
 echo "  Preflight-only: $PREFLIGHT_ONLY  (1 = boot + read-only preflight + exit 0, NO scan/fetch/write)"
 echo ""
 
-# ── Preflight ───────────────────────────────────────────────────────────────
-if [ ! -f "$KEY_FILE" ]; then
-    echo "ERROR: SSH key not found at $KEY_FILE"
-    exit 1
-fi
-# Note: alpha-engine-lib was flipped public 2026-05-03; spot installs it
+# ── Launch spot ──────────────────────────────────────────────────────────────
+# INSTANCE_ID / S3_STAGING are read at trap-FIRE time, so they pick up the
+# values assigned after a successful launch below; both default empty so
+# cleanup is a no-op if we never got that far.
+INSTANCE_ID=""
+S3_STAGING=""
+
+cleanup() {
+    if [ -n "$INSTANCE_ID" ]; then
+        echo ""
+        echo "==> Terminating spot instance $INSTANCE_ID..."
+        aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
+        echo "  Instance terminated."
+    fi
+    [ -n "$S3_STAGING" ] && aws s3 rm "$S3_STAGING" --recursive --quiet 2>/dev/null || true
+    return 0
+}
+trap cleanup EXIT
+
+# Note: alpha-engine-lib was flipped public 2026-05-03; the spot installs it
 # directly from git+https with no auth required.
 
-# ── Launch spot ──────────────────────────────────────────────────────────────
-echo "==> Requesting spot instance ($INSTANCE_TYPE)..."
-INSTANCE_ID=$(aws ec2 run-instances \
+echo "==> Requesting spot instance (lib CLI rotation: types=[$INSTANCE_TYPES], subnets=[$SUBNETS])..."
+INSTANCE_ID=$("$LIB_PYTHON" -m nousergon_lib.ec2_spot launch \
+    --types "$INSTANCE_TYPES" \
+    --subnets "$SUBNETS" \
     --image-id "$AMI_ID" \
-    --instance-type "$INSTANCE_TYPE" \
     --key-name "$KEY_NAME" \
-    --security-group-ids "$SECURITY_GROUP" \
-    --subnet-id "$SUBNET_ID" \
-    --iam-instance-profile Name="$IAM_PROFILE" \
-    --instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time","InstanceInterruptionBehavior":"terminate"}}' \
-    --instance-initiated-shutdown-behavior terminate \
-    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3"}}]' \
-    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=alpha-engine-drift-$(date +%Y%m%d)}]" \
-    --region "$AWS_REGION" \
-    --query 'Instances[0].InstanceId' \
-    --output text)
+    --security-group "$SECURITY_GROUP" \
+    --iam-profile "$IAM_PROFILE" \
+    --name "alpha-engine-drift-$(date +%Y%m%d)" \
+    --region "$AWS_REGION")
+ec2_spot_rc=$?
+if [ "$ec2_spot_rc" -ne 0 ] || [ -z "$INSTANCE_ID" ]; then
+    if [ "$ec2_spot_rc" -eq 64 ]; then
+        echo "ERROR: capacity exhausted across all instance_type × subnet combinations. Wait + retry, or expand the lists." >&2
+    fi
+    exit "${ec2_spot_rc:-1}"
+fi
 
 echo "  Instance ID: $INSTANCE_ID"
 
-cleanup() {
-    echo ""
-    echo "==> Terminating spot instance $INSTANCE_ID..."
-    aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
-    echo "  Instance terminated."
-}
-trap cleanup EXIT
+RUN_ID="$(date +%Y%m%dT%H%M%SZ)-${INSTANCE_ID}"
+S3_STAGING_PREFIX="tmp/spot_drift_detection/${RUN_ID}"
+# S3_STAGING is consumed by cleanup() (declared with the trap above);
+# assigning it here arms staging-prefix removal now that the launch
+# succeeded. (S3 lifecycle on tmp/ is the belt-and-suspenders if the trap
+# never fires.)
+S3_STAGING="s3://${S3_BUCKET}/${S3_STAGING_PREFIX}"
 
 echo "==> Waiting for instance to enter running state..."
 aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$AWS_REGION"
 
-PUBLIC_IP=$(aws ec2 describe-instances \
-    --instance-ids "$INSTANCE_ID" \
-    --query 'Reservations[0].Instances[0].PublicIpAddress' \
-    --output text \
-    --region "$AWS_REGION")
-
-if [ "$PUBLIC_IP" = "None" ] || [ -z "$PUBLIC_IP" ]; then
-    echo "ERROR: Instance has no public IP. Check subnet/VPC configuration."
-    exit 1
-fi
-
-echo "  Public IP: $PUBLIC_IP"
-
-# ── Wait for SSH ─────────────────────────────────────────────────────────────
-echo "==> Waiting for SSH to become available..."
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o LogLevel=ERROR"
-for i in $(seq 1 30); do
-    if ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "echo ok" 2>/dev/null; then
-        echo "  SSH ready."
+# ── Wait for the SSM agent to register ────────────────────────────────────────
+# Replaces the old SSH-readiness poll. AL2023 ships the SSM agent; with the
+# instance profile's AmazonSSMManagedInstanceCore (in alpha-engine-executor-profile)
+# it registers within ~1 min.
+echo "==> Waiting for SSM agent to come Online..."
+for i in $(seq 1 36); do  # 36 × 5s = 180s budget
+    ping=$(aws ssm describe-instance-information \
+        --filters "Key=InstanceIds,Values=$INSTANCE_ID" \
+        --query 'InstanceInformationList[0].PingStatus' \
+        --output text --region "$AWS_REGION" 2>/dev/null || true)
+    if [ "$ping" = "Online" ]; then
+        echo "  SSM agent Online."
         break
     fi
-    if [ "$i" -eq 30 ]; then
-        echo "ERROR: SSH not available after 150s"
+    if [ "$i" -eq 36 ]; then
+        echo "ERROR: SSM agent not Online after 180s (instance $INSTANCE_ID)"
         exit 1
     fi
     sleep 5
 done
 
-run_remote() {
-    ssh $SSH_OPTS -i "$KEY_FILE" ec2-user@"$PUBLIC_IP" "$@"
+# ── SSM dispatch primitive (lib chokepoint) ──────────────────────────────────
+# run_ssm "<description>" [timeout_seconds] <<HEREDOC ... HEREDOC
+#
+# Thin wrapper around `python -m nousergon_lib.ssm_dispatcher run` (lib
+# v0.35.0+). The lib base64-wraps the script body (read from stdin via the
+# `--script-stdin` flag) for AWS-RunShellScript transport, polls
+# get-command-invocation, streams StandardOutputContent delta to this
+# process's stdout, and propagates the inner script's exit status (0 on
+# Success; 1 on Failed/TimedOut/Cancelled). Full stdout/stderr beyond
+# SSM's 24KB inline cap is written to the --output-bucket /
+# --output-key-prefix for post-mortem.
+#
+# Stdin-fed by design (mirrors spot_data_weekly.sh #330): the spot script
+# bodies contain shell metachars which break the `"$(cat <<HEREDOC ...)"`
+# command-substitution pattern the predictor pre-lift run_remote used.
+# Reading from stdin keeps the body verbatim.
+#
+# L394 cascade: --diagnostics-bucket + --diagnostics-prefix activate the
+# lib v0.39.0 chokepoint that writes a JSON failure record (status +
+# command_id + 4KB stdout/stderr tails + instance_id) to
+# s3://${S3_BUCKET}/_spot_diagnostics/ae-data/{YYYY-MM-DD}.json on
+# terminal non-Success. Best-effort write inside the lib; the inner SSM
+# exit code is preserved. No-op on Success (substrate is failure-only).
+run_ssm() {
+    local description="$1" timeout_s="${2:-3600}"
+    "$LIB_PYTHON" -m nousergon_lib.ssm_dispatcher run \
+        --instance-id "$INSTANCE_ID" \
+        --description "drift-detection: $description" \
+        --timeout "$timeout_s" \
+        --output-bucket "$S3_BUCKET" \
+        --output-key-prefix "${S3_STAGING_PREFIX}/ssm-output" \
+        --region "$AWS_REGION" \
+        --diagnostics-bucket "$S3_BUCKET" \
+        --diagnostics-prefix "_spot_diagnostics/ae-data" \
+        --script-stdin
 }
 
-# ── Spot-side watchdog ──────────────────────────────────────────────────────
-# Dispatcher-side `trap cleanup EXIT` only fires when THIS bash script
-# exits cleanly. If the dispatcher SSM command is cancelled, the
-# dispatcher EC2 is stopped mid-run, or the shell gets SIGKILLed, the
-# trap never runs and the spot orphans until manually terminated.
-# Installs a transient systemd timer on the spot that fires
-# shutdown -h now after MAX_RUNTIME_SECONDS regardless of dispatcher
-# state. AL2023's InstanceInitiatedShutdownBehavior=terminate makes
-# the shutdown a termination (matches run-instances flag above).
-echo "==> Installing spot-side watchdog (${MAX_RUNTIME_SECONDS}s = $((MAX_RUNTIME_SECONDS / 60)) min)..."
-run_remote "sudo systemd-run --on-active=${MAX_RUNTIME_SECONDS} --unit=alpha-engine-watchdog --description='alpha-engine spot hard-timeout' /sbin/shutdown -h now"
+# Each run_ssm step is a fresh SSM shell with a minimal env. The
+# .env-deprecation arc deleted the sourced .env, so AWS_REGION /
+# AWS_DEFAULT_REGION (which boto3 + alpha_engine_lib.preflight.check_env_vars
+# require) are no longer set unless each step's export line sets them.
+# Same #247 regression as sibling spot scripts. System is single-region
+# us-east-1 (matches this file's own ${AWS_REGION:-us-east-1} defaults).
+#
+# PYTHON_BIN is set per-block via `command -v python3.12 || command -v
+# python3`; PYTHONPATH points at the sibling alpha-engine-predictor clone
+# (drift_detector lives in alpha-engine-data/monitoring/ but imports from
+# alpha-engine-predictor). AL2023 spots install python3.12 but have no bare
+# `python` symlink.
+read -r -d '' ENV_SOURCE <<'ENV_EOF' || true
+export HOME=/home/ec2-user
+export XDG_CACHE_HOME=/tmp
+export AWS_REGION=us-east-1
+export AWS_DEFAULT_REGION=us-east-1
+export PYTHONPATH=/home/ec2-user/alpha-engine-predictor
+command -v python3.12 >/dev/null && PYTHON_BIN=python3.12 || PYTHON_BIN=python3
+export PYTHON_BIN
+ENV_EOF
 
-# ── Bootstrap python + git ───────────────────────────────────────────────────
-echo "==> Bootstrapping spot environment..."
-run_remote bash -s <<'BOOTSTRAP'
-set -euo pipefail
-sudo dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null || \
-    sudo dnf install -y -q python3 python3-pip python3-devel git gcc
-mkdir -p ~/.ssh
-ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-BOOTSTRAP
-
-# ── Clone alpha-engine-data + alpha-engine-predictor ─────────────────────────
-# drift_detector lives in alpha-engine-data/monitoring/ but imports from
-# alpha-engine-predictor via PYTHONPATH. Both must be present.
-echo "==> Cloning alpha-engine-data + alpha-engine-predictor (branch: $BRANCH)..."
-# Repos renamed + moved to the nousergon org 2026-06-15; local checkout dirs
-# stay alpha-engine-* (dir-name ≠ repo-name split). Clone the new slugs
-# explicitly rather than depending on GitHub's chained rename/transfer 301
+# ── Bootstrap spot: watchdog + python + git + clone both repos ──────────────
+# Single SSM call covering: spot-side hard-timeout watchdog,
+# python3.12/git install, and clone of BOTH alpha-engine-data and
+# alpha-engine-predictor (drift_detector reads predictor weights + data
+# slim cache via PYTHONPATH). Watchdog rationale: dispatcher-side
+# `trap cleanup EXIT` only fires when THIS script exits cleanly. If the
+# dispatcher SSM command is cancelled, the dispatcher EC2 is stopped
+# mid-run, or the shell gets SIGKILLed, the trap never runs and the spot
+# orphans until manually terminated. systemd-run shuts the box down after
+# MAX_RUNTIME_SECONDS regardless of dispatcher state. AL2023's
+# InstanceInitiatedShutdownBehavior for spots defaults to terminate.
+#
+# Repos renamed + moved to the nousergon org 2026-06-15; local checkout
+# dirs stay alpha-engine-* (dir-name ≠ repo-name split). Clone the new
+# slugs explicitly rather than depending on GitHub's rename/transfer 301
 # redirect from the old cipher813 paths.
-run_remote "git clone --depth 1 --branch $BRANCH https://github.com/nousergon/nousergon-data.git /home/ec2-user/alpha-engine-data"
-run_remote "git clone --depth 1 --branch $BRANCH https://github.com/nousergon/crucible-predictor.git /home/ec2-user/alpha-engine-predictor"
+echo "==> Bootstrapping spot (watchdog, python, clone both repos)..."
+run_ssm "bootstrap" 600 <<BOOTSTRAP
+set -eo pipefail
+${ENV_SOURCE}
+
+# Spot-side hard-timeout watchdog (see bootstrap-step rationale above).
+systemd-run --on-active=${MAX_RUNTIME_SECONDS} --unit=alpha-engine-watchdog \
+    --description='alpha-engine spot hard-timeout' /sbin/shutdown -h now
+
+dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null || \
+    dnf install -y -q python3 python3-pip python3-devel git gcc
+echo "Using: \$(\$PYTHON_BIN --version)"
+
+git clone --depth 1 --branch ${BRANCH} https://github.com/nousergon/nousergon-data.git /home/ec2-user/alpha-engine-data
+git clone --depth 1 --branch ${BRANCH} https://github.com/nousergon/crucible-predictor.git /home/ec2-user/alpha-engine-predictor
+echo "Bootstrap complete: both repos cloned (data + predictor sibling for PYTHONPATH)."
+BOOTSTRAP
 
 # ── Install dependencies ─────────────────────────────────────────────────────
 # alpha-engine-lib is public; pip installs it from git+https with no auth.
 echo "==> Installing Python dependencies..."
-run_remote bash -s <<'DEPS'
-set -euo pipefail
+run_ssm "deps" 900 <<DEPS
+set -eo pipefail
+${ENV_SOURCE}
 cd /home/ec2-user/alpha-engine-data
 
-if command -v python3.12 &>/dev/null; then
-    PIP="python3.12 -m pip"
-else
-    PIP="python3 -m pip"
-fi
-
-$PIP install --upgrade pip -q
-$PIP install -q -r requirements.txt
-$PIP install -q 'numpy<2'
-
+\$PYTHON_BIN -m pip install --upgrade pip -q
+\$PYTHON_BIN -m pip install -q -r requirements.txt
+\$PYTHON_BIN -m pip install -q 'numpy<2'
 echo "Dependencies installed."
 DEPS
-
-REMOTE_PYTHON=$(run_remote "command -v python3.12 || command -v python3")
-# AWS_REGION/AWS_DEFAULT_REGION re-export: same #241 regression as
-# spot_data_weekly.sh — the spot shell no longer sources a .env, so the
-# region env vars boto3 + lib preflight depend on must be set explicitly
-# from the dispatcher-side $AWS_REGION (set above with us-east-1 fallback).
-ENV_SOURCE="export XDG_CACHE_HOME=/tmp; export PYTHONPATH=/home/ec2-user/alpha-engine-predictor; export AWS_REGION=$AWS_REGION; export AWS_DEFAULT_REGION=$AWS_REGION;"
 
 # ── Smoke-only: imports + --help ─────────────────────────────────────────────
 if [ "$RUN_MODE" = "smoke-only" ]; then
@@ -236,13 +320,13 @@ if [ "$RUN_MODE" = "smoke-only" ]; then
     echo "═══════════════════════════════════════════════════════════════"
     echo "  SMOKE TEST"
     echo "═══════════════════════════════════════════════════════════════"
-    run_remote bash -s <<SMOKE
-set -euo pipefail
-cd /home/ec2-user/alpha-engine-data
+    run_ssm "smoke" 600 <<SMOKE
+set -eo pipefail
 ${ENV_SOURCE}
+cd /home/ec2-user/alpha-engine-data
 
 echo "==> Smoke: python -m monitoring.drift_detector --help"
-$REMOTE_PYTHON -m monitoring.drift_detector --help 2>&1 | head -20
+\$PYTHON_BIN -m monitoring.drift_detector --help 2>&1 | head -20
 SMOKE
 
     echo "==> Smoke complete — instance will be terminated."
@@ -252,7 +336,7 @@ fi
 # ── Preflight-only (Friday shell-run dry path) ──────────────────────────────
 # Closes the DriftDetection skip-exception in ROADMAP "Friday shell-run —
 # per-module dry-path activation". Runs ONLY a read-only preflight then
-# `exit 0` strictly BEFORE the `run_remote bash -s <<DRIFT` block below —
+# `exit 0` strictly BEFORE the `run_ssm "drift"` block below —
 # `monitoring.drift_detector` (the SOLE code that does ANY S3 get_object/
 # put_object of the drift report, SNS publish on alert, and which this
 # launcher's CloudWatch put-metric-data heartbeat trails) is therefore
@@ -284,13 +368,18 @@ if [ "$PREFLIGHT_ONLY" = "1" ]; then
     echo "  PREFLIGHT-ONLY: DriftDetection"
     echo "  (boot + read-only preflight + exit 0 — NO scan, NO fetch, NO write)"
     echo "═══════════════════════════════════════════════════════════════"
-    run_remote bash -s <<PREFLIGHT_ONLY_BLOCK
-set -euo pipefail
+    run_ssm "preflight-only" 600 <<'PREFLIGHT_ONLY_BLOCK'
+set -eo pipefail
+export HOME=/home/ec2-user
+export XDG_CACHE_HOME=/tmp
+export AWS_REGION=us-east-1
+export AWS_DEFAULT_REGION=us-east-1
+export PYTHONPATH=/home/ec2-user/alpha-engine-predictor
+command -v python3.12 >/dev/null && PYTHON_BIN=python3.12 || PYTHON_BIN=python3
 cd /home/ec2-user/alpha-engine-data
-${ENV_SOURCE}
 
-echo "Starting read-only preflight at \$(date)"
-if ! $REMOTE_PYTHON - <<'PYEOF'
+echo "Starting read-only preflight at $(date)"
+if ! $PYTHON_BIN - <<'PYEOF'
 import sys
 
 from alpha_engine_lib.preflight import BasePreflight
@@ -320,7 +409,7 @@ then
     echo "ERROR: DriftDetection preflight failed (bootstrap-class breakage caught ~12h before Saturday)." >&2
     exit 1
 fi
-echo "DriftDetection preflight-only OK at \$(date) — NO scan, NO fetch, NO write."
+echo "DriftDetection preflight-only OK at $(date) — NO scan, NO fetch, NO write."
 PREFLIGHT_ONLY_BLOCK
 
     echo ""
@@ -336,13 +425,13 @@ echo "════════════════════════�
 echo "  DRIFT DETECTION"
 echo "═══════════════════════════════════════════════════════════════"
 
-run_remote bash -s <<DRIFT
-set -euo pipefail
-cd /home/ec2-user/alpha-engine-data
+run_ssm "drift" "$MAX_RUNTIME_SECONDS" <<DRIFT
+set -eo pipefail
 ${ENV_SOURCE}
+cd /home/ec2-user/alpha-engine-data
 
 echo "Starting drift_detector at \$(date)"
-if ! $REMOTE_PYTHON -m monitoring.drift_detector --alert 2>&1; then
+if ! \$PYTHON_BIN -m monitoring.drift_detector --alert 2>&1; then
     echo "ERROR: drift_detector failed." >&2
     exit 1
 fi

--- a/tests/test_spot_drift_detection_ssm_transport.py
+++ b/tests/test_spot_drift_detection_ssm_transport.py
@@ -1,0 +1,222 @@
+"""Pin the SSH→SSM transport migration in infrastructure/spot_drift_detection.sh.
+
+Origin: config#893 — "Migrate spot_train.sh (+ siblings) off SSH/SCP onto
+SSM + S3 staging". The drift sibling was the one spot launcher the
+2026-05-27 migration arc (ROADMAP L342 PR 2/3/4) missed: it still launched
+with a hard ``$KEY_FILE`` SSH-key dependency, polled for SSH readiness, and
+dispatched every spot-side step via ``ssh -i $KEY_FILE ec2-user@$PUBLIC_IP``
++ ``ssh-keyscan``. This test pins the migration to the lib chokepoint
+``python -m nousergon_lib.ssm_dispatcher`` (lib v0.35.0+), mirroring
+tests/test_spot_data_weekly_ssm_transport.py 1:1.
+
+The shape of each test mirrors that sibling — a regex-based "forbidden
+phrase" assertion on the launcher source. The lib chokepoint is the
+canonical path; any reintroduction of SSH/SCP at the top-level dispatch
+surface fails loud at PR time and re-opens the port-22 dependency the
+migration retired.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "infrastructure" / "spot_drift_detection.sh"
+
+
+def _script_lines() -> list[tuple[int, str]]:
+    """Return (line_no, line) tuples, comment lines stripped.
+
+    Comment lines may legitimately reference SSH / SCP / port-22 in
+    historical-context prose (e.g. "the spot still launches with this key
+    ... for break-glass operator SSH only"); only non-comment lines are
+    subject to the forbidden-phrase chokepoint.
+    """
+    assert _SCRIPT.exists(), f"spot_drift_detection.sh missing at {_SCRIPT}"
+    out: list[tuple[int, str]] = []
+    for i, raw in enumerate(_SCRIPT.read_text().splitlines(), start=1):
+        stripped = raw.strip()
+        if stripped.startswith("#"):
+            continue
+        out.append((i, raw))
+    return out
+
+
+def test_spot_drift_detection_script_exists():
+    """Guards against accidental script deletion. Without the script,
+    the chokepoint assertions below silently no-op."""
+    assert _SCRIPT.exists(), (
+        f"infrastructure/spot_drift_detection.sh missing at {_SCRIPT}. "
+        "This script drives the Saturday SF DriftDetection spot; CI cannot "
+        "validate its SSM transport invariant without it."
+    )
+
+
+def test_no_top_level_ssh_invocation():
+    """No ``ssh ...`` command on any non-comment line.
+
+    Replaces the pre-migration SSH dispatch (``ssh -i $KEY_FILE
+    ec2-user@$PUBLIC_IP "<cmd>"`` + the SSH-readiness poll) with
+    ``python -m nousergon_lib.ssm_dispatcher``. Any new ``ssh``
+    invocation surfaces as an immediate red CI signal and re-opens the
+    port-22 dependency the migration retired.
+    """
+    offenders = [
+        (n, line)
+        for n, line in _script_lines()
+        if re.search(r"\bssh\s+-\w+", line) or re.search(r"^\s*ssh\s+", line)
+    ]
+    assert not offenders, (
+        f"Found {len(offenders)} non-comment ``ssh`` invocations in "
+        f"spot_drift_detection.sh:\n"
+        + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+        + "\n\nThe config#893 SSH→SSM migration moved all dispatch to "
+        "``python -m nousergon_lib.ssm_dispatcher``. Re-introducing ssh "
+        "re-opens the port-22 dependency the migration retired."
+    )
+
+
+def test_no_top_level_scp_invocation():
+    """No ``scp ...`` command on any non-comment line.
+
+    The drift launcher never SCP'd a config (the workload reads the
+    alpha-engine-research bucket directly), but pin scp-free anyway so a
+    future change can't introduce an scp config-push instead of the S3
+    staging pattern the siblings use.
+    """
+    offenders = [
+        (n, line)
+        for n, line in _script_lines()
+        if re.search(r"\bscp\s+-\w+", line) or re.search(r"^\s*scp\s+", line)
+    ]
+    assert not offenders, (
+        f"Found {len(offenders)} non-comment ``scp`` invocations in "
+        f"spot_drift_detection.sh:\n"
+        + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+    )
+
+
+def test_no_ssh_keyscan_invocation():
+    """No ``ssh-keyscan`` invocation — the pre-migration bootstrap had
+    ``ssh-keyscan github.com >> ~/.ssh/known_hosts``. Post-migration the
+    spot clones via HTTPS (no host-key concern) and the dispatcher never
+    SSHs in, so the keyscan step is dead code; re-introducing it would
+    silently re-introduce the SSH bootstrap dependency."""
+    offenders = [
+        (n, line)
+        for n, line in _script_lines()
+        if "ssh-keyscan" in line
+    ]
+    assert not offenders, (
+        f"Found {len(offenders)} ``ssh-keyscan`` invocations in "
+        f"spot_drift_detection.sh:\n"
+        + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+    )
+
+
+def test_uses_lib_ssm_dispatcher_chokepoint():
+    """The migration's load-bearing surface: ``python -m
+    nousergon_lib.ssm_dispatcher`` MUST appear in the script. Pinning
+    this catches a regression where a future PR replaces the lib CLI
+    with an inline ``aws ssm send-command`` bash helper (the predictor
+    #168 pre-lift pattern that L342 explicitly lifts to the lib
+    chokepoint)."""
+    body = _SCRIPT.read_text()
+    assert "nousergon_lib.ssm_dispatcher" in body, (
+        "spot_drift_detection.sh does not reference "
+        "nousergon_lib.ssm_dispatcher. The config#893 migration uses the "
+        "lib chokepoint as the SSM dispatch path."
+    )
+
+
+def test_uses_lib_ec2_spot_launcher():
+    """Launch goes through ``python -m nousergon_lib.ec2_spot`` (the same
+    capacity-rotating launcher the data/backtest siblings use), not a raw
+    ``aws ec2 run-instances`` with a hard ``--key-name`` SSH dependency."""
+    body = _SCRIPT.read_text()
+    assert "nousergon_lib.ec2_spot" in body, (
+        "spot_drift_detection.sh does not launch via nousergon_lib.ec2_spot; "
+        "the migration routes launch through the lib's capacity-rotating CLI."
+    )
+
+
+def test_run_ssm_passes_diagnostics_flags():
+    """L394 cascade — ``run_ssm`` MUST pass both ``--diagnostics-bucket``
+    and ``--diagnostics-prefix`` so terminal non-Success in any spot SSM
+    step writes a JSON failure record per the lib v0.39.0 contract. Both
+    flags must be present — the lib's partial-config guard makes a missing
+    flag a silent no-op."""
+    body = _SCRIPT.read_text()
+    assert "--diagnostics-bucket" in body, (
+        "spot_drift_detection.sh does not pass --diagnostics-bucket to the "
+        "lib CLI. L394 cascade requires both --diagnostics-bucket and "
+        "--diagnostics-prefix together."
+    )
+    assert "--diagnostics-prefix" in body, (
+        "spot_drift_detection.sh does not pass --diagnostics-prefix."
+    )
+    # Prefix scopes to ae-data so cascade siblings write to disjoint S3
+    # namespaces — the drift launcher lives in the data repo.
+    assert "_spot_diagnostics/ae-data" in body, (
+        "spot_drift_detection.sh --diagnostics-prefix must scope to "
+        "_spot_diagnostics/ae-data (the data-repo cascade namespace)."
+    )
+
+
+def test_no_inline_aws_ssm_send_command():
+    """The script MUST NOT call ``aws ssm send-command`` directly — that
+    bypasses the lib chokepoint and reverts to the predictor #168 pre-lift
+    pattern, losing the InvocationDoesNotExist registration grace, stdout
+    streaming, and consistent S3 output-key layout the lib CLI provides.
+
+    Excludes comment lines (prose may legitimately mention the API name)."""
+    offenders = [
+        (n, line)
+        for n, line in _script_lines()
+        if "aws ssm send-command" in line
+    ]
+    assert not offenders, (
+        f"Found {len(offenders)} non-comment ``aws ssm send-command`` "
+        f"invocations in spot_drift_detection.sh:\n"
+        + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+        + "\n\nRoute through ``python -m nousergon_lib.ssm_dispatcher run`` "
+        "instead — that's the chokepoint v0.35.0 lifted."
+    )
+
+
+def test_no_residual_key_file_dispatch_use():
+    """Post-migration the SSH key file is no longer used for dispatch (the
+    spot launches WITH the key for break-glass operator SSH only). Any
+    remaining ``$KEY_FILE`` or ``$SSH_OPTS`` reference in a NON-COMMENT
+    line means the migration is incomplete.
+
+    Allow-list: the ``KEY_NAME`` variable for the lib.ec2_spot
+    ``--key-name`` launch flag stays — that's an instance attribute, not
+    dispatch transport.
+    """
+    forbidden = ["$KEY_FILE", "${KEY_FILE}", "$SSH_OPTS", "${SSH_OPTS}", "$PUBLIC_IP", "${PUBLIC_IP}"]
+    offenders: list[tuple[int, str]] = []
+    for n, line in _script_lines():
+        if any(token in line for token in forbidden):
+            offenders.append((n, line))
+    assert not offenders, (
+        f"Found {len(offenders)} residual KEY_FILE / SSH_OPTS / PUBLIC_IP "
+        f"uses in non-comment lines of spot_drift_detection.sh:\n"
+        + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+        + "\n\nThe migration retired the SSH key file + public-IP SSH "
+        "target as dispatch credentials. KEY_NAME stays as a launch "
+        "attribute for nousergon_lib.ec2_spot's --key-name flag."
+    )
+
+
+def test_waits_for_ssm_agent_not_ssh():
+    """Readiness poll must be the SSM-agent PingStatus probe, not the old
+    SSH-readiness loop."""
+    body = _SCRIPT.read_text()
+    assert "describe-instance-information" in body and "PingStatus" in body, (
+        "spot_drift_detection.sh must poll SSM agent PingStatus for "
+        "readiness (replacing the old SSH-readiness loop)."
+    )


### PR DESCRIPTION
## What

Migrates `infrastructure/spot_drift_detection.sh` off SSH/SCP onto SSM `send-command` (via the lib chokepoint `python -m nousergon_lib.ssm_dispatcher`) + lib-CLI spot launch, completing the **"+ siblings"** scope of config#893.

The DriftDetection spot launcher was the **one spot sibling the 2026-05-27 migration arc missed**. PR2 (`spot_data_weekly.sh` #330), PR3 (`spot_backtest.sh` #405) and the predictor `spot_train.sh` (#168) all moved to SSM; verification against live `origin/main` showed `spot_drift_detection.sh` still on the old transport:

- `aws ec2 run-instances` with a hard `$KEY_FILE` SSH-key existence check (`ERROR: SSH key not found`)
- SSH-readiness poll (`ssh -i $KEY_FILE ... "echo ok"`)
- every spot-side step dispatched via `ssh -i $KEY_FILE ec2-user@$PUBLIC_IP` (`run_remote`)
- `ssh-keyscan github.com` in bootstrap

## Change (1:1 with the migrated siblings)

- Launch via `python -m nousergon_lib.ec2_spot launch` — capacity-rotating across types×subnets, no SSH dependency. `--key-name` retained **only** as a break-glass instance attribute.
- SSM-agent `PingStatus` readiness poll replaces the SSH-readiness loop.
- `run_ssm()` lib chokepoint (`ssm_dispatcher run --script-stdin`) for watchdog / bootstrap / deps / smoke / preflight / drift, with `--diagnostics-bucket` + `--diagnostics-prefix _spot_diagnostics/ae-data` (L394 cascade).
- HTTPS git-clone of both repos (data + predictor for PYTHONPATH); no `ssh-keyscan`/known_hosts.
- `cleanup()` terminates the instance **and** removes the S3 staging prefix.

No private `config.yaml` to S3-stage here (the drift workload reads the `alpha-engine-research` bucket directly), so the only dispatcher-side S3 use is the SSM stdout-overflow / diagnostics prefix.

All run-mode + ordering invariants preserved: `--smoke-only`, `--preflight-only` (read-only `BasePreflight` + import-only drift smoke, `exit 0` before any scan), `--instance-type`, `--branch`. The `PREFLIGHT_ONLY` guard still precedes the DRIFT heredoc and the CloudWatch heartbeat.

## Tests / CI

- New `tests/test_spot_drift_detection_ssm_transport.py` — mirrors `test_spot_data_weekly_ssm_transport.py` (forbidden-phrase: no ssh/scp/ssh-keyscan/`$KEY_FILE`/`$PUBLIC_IP`/inline `aws ssm send-command`; chokepoint present; diagnostics flags; SSM-agent readiness).
- Locally green: the new test + existing `test_spot_drift_detection_preflight_only.py` + `test_spot_env_source_aws_region.py` + `test_sf_friday_shell_run_wiring.py` (15 + 59 passed).
- `shellcheck` clean modulo the **same two informational findings as the accepted sibling** `spot_data_weekly.sh` (SC2034 `REPO_ROOT`, SC2015 on the `aws s3 rm` cleanup line); `bash -n` OK. CI (`ci.yml`) runs `pytest tests/ -v`, no shellcheck gate.

## ⚠️ DRAFT — what is NOT validated from the runner

This changes **AWS-side transport behavior I cannot exercise from a CI runner** — no live SSM round-trip, no spot launch, no real drift run. Specifically unvalidated:

- the live **`ec2_spot launch` → SSM-agent-Online → `ssm_dispatcher run` round-trip** against a real spot (lib-version pin, IAM `ssm:SendCommand`/`AmazonSSMManagedInstanceCore` on `alpha-engine-executor-profile`, AL2023 `python3.12` install)
- the spot-side **dual-repo PYTHONPATH** drift run end-to-end

### Brian's one validation command

```
AWS_REGION=us-east-1 bash infrastructure/spot_drift_detection.sh --preflight-only
```

(boots a real spot via the new SSM transport, runs the read-only preflight, `exit 0` — zero scan/fetch/write. A clean run proves the full SSM round-trip without touching the drift workload.) Then a real `--smoke-only`, then leave to the natural Saturday SF DriftDetection step.

Note: port-22 SG ingress revoke on `sg-03cd3c4bd91e610b0` remains the separately-tracked operator chore (ROADMAP L342 PR5) once all spots have run clean on SSM — out of scope for this code PR.

Refs #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
