### PR TITLE
feat(crypto): wallet-balance producer for Metron's crypto page (BTC+ETH)

### DIFF
--- a/collectors/crypto_balances.py
+++ b/collectors/crypto_balances.py
@@ -1,0 +1,211 @@
+"""Crypto wallet-balance producer for Metron's standalone crypto page (metron-ops#111).
+
+Metron publishes the wallet-address fetch universe to ``metron/crypto/wallet_addresses.json``;
+this collector reads it, queries each chain for the on-chain balance, prices the coins, and
+writes ``crypto/holdings.json`` for Metron to read back. Metron itself makes NO chain calls —
+this is the same data-spine split as the EOD/intraday market-data producers.
+
+v1 scope: BTC + ETH via free, no-API-key public endpoints —
+  * BTC: Blockstream Esplora address API (confirmed funded − spent, in sats).
+  * ETH: a public JSON-RPC ``eth_getBalance`` (wei).
+  * prices: CoinGecko simple price (USD).
+Adding a chain = a balance fetcher here + a validator in Metron's ``crypto`` service; the S3
+artifact contract is unchanged. To scale past a handful of coins, swap the per-chain fetchers
+for a multi-chain aggregator behind this same ``collect`` signature.
+
+Fail-soft PER ADDRESS: one chain/RPC error skips that address (WARN + counter — the recording
+surface), never zeroes it and never aborts the whole artifact. A run with zero readable
+addresses writes nothing (there is nothing to say).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections.abc import Callable, Iterable
+from datetime import UTC, datetime
+from typing import Any
+
+import requests
+
+logger = logging.getLogger("crypto_balances")
+
+DEFAULT_BUCKET = "alpha-engine-research"
+WALLET_ADDRESSES_KEY = "metron/crypto/wallet_addresses.json"   # Metron → producer (input)
+HOLDINGS_KEY = "crypto/holdings.json"                          # producer → Metron (output)
+HOLDINGS_SCHEMA_VERSION = 1
+
+_HTTP_TIMEOUT = 15
+_BLOCKSTREAM = "https://blockstream.info/api/address/{address}"
+_ETH_RPC = "https://cloudflare-eth.com"
+_COINGECKO = "https://api.coingecko.com/api/v3/simple/price"
+# chain → (CoinGecko id, display symbol)
+_COIN = {"BTC": ("bitcoin", "BTC"), "ETH": ("ethereum", "ETH")}
+
+
+# ── Chain balance fetchers (injectable for tests) ───────────────────────────────────────
+
+
+def fetch_btc_balance(address: str, *, session: requests.Session) -> float:
+    """Confirmed BTC balance for ``address`` (funded − spent txo sums, sats → BTC)."""
+    r = session.get(_BLOCKSTREAM.format(address=address), timeout=_HTTP_TIMEOUT)
+    r.raise_for_status()
+    cs = r.json().get("chain_stats", {})
+    sats = int(cs.get("funded_txo_sum", 0)) - int(cs.get("spent_txo_sum", 0))
+    return sats / 1e8
+
+
+def fetch_eth_balance(address: str, *, session: requests.Session) -> float:
+    """Native ETH balance for ``address`` via JSON-RPC ``eth_getBalance`` (wei → ETH)."""
+    payload = {"jsonrpc": "2.0", "method": "eth_getBalance", "params": [address, "latest"], "id": 1}
+    r = session.post(_ETH_RPC, json=payload, timeout=_HTTP_TIMEOUT)
+    r.raise_for_status()
+    body = r.json()
+    if "error" in body:
+        raise RuntimeError(f"eth_getBalance error: {body['error']}")
+    return int(body["result"], 16) / 1e18
+
+
+def fetch_prices(symbols: Iterable[str], *, session: requests.Session) -> dict[str, float]:
+    """``{symbol: usd_price}`` for the given chain symbols via CoinGecko simple price."""
+    ids = sorted({_COIN[s][0] for s in symbols if s in _COIN})
+    if not ids:
+        return {}
+    r = session.get(
+        _COINGECKO, params={"ids": ",".join(ids), "vs_currencies": "usd"}, timeout=_HTTP_TIMEOUT
+    )
+    r.raise_for_status()
+    data = r.json()
+    out: dict[str, float] = {}
+    for sym, (cg_id, _) in _COIN.items():
+        usd = data.get(cg_id, {}).get("usd")
+        if usd is not None:
+            out[sym] = float(usd)
+    return out
+
+
+_BALANCE_FETCHERS: dict[str, Callable[..., float]] = {
+    "BTC": fetch_btc_balance,
+    "ETH": fetch_eth_balance,
+}
+
+
+# ── S3 helpers ──────────────────────────────────────────────────────────────────────────
+
+
+def _read_json(s3_client: Any, bucket: str, key: str) -> dict | None:
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
+        return json.loads(obj["Body"].read())
+    except Exception:
+        return None
+
+
+def _write_json(s3_client: Any, bucket: str, key: str, obj: dict) -> None:
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(obj, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+# ── Orchestration ───────────────────────────────────────────────────────────────────────
+
+
+def collect(
+    *,
+    bucket: str = DEFAULT_BUCKET,
+    s3_client: Any = None,
+    session: requests.Session | None = None,
+    balance_fetchers: dict[str, Callable[..., float]] | None = None,
+    price_fetcher: Callable[..., dict[str, float]] | None = None,
+    now: datetime | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Read the wallet-address universe, fetch balances + prices, write ``crypto/holdings.json``.
+
+    Returns a small status dict. ``s3_client`` / ``session`` / the fetchers are injectable for
+    tests. Per-address failures are WARN-logged + counted (``n_failed``), never fatal."""
+    now = now or datetime.now(UTC)
+    fetchers = balance_fetchers or _BALANCE_FETCHERS
+    price_fn = price_fetcher or fetch_prices
+    if s3_client is None:
+        import boto3
+        s3_client = boto3.client("s3")
+    if session is None:
+        session = requests.Session()
+
+    universe = _read_json(s3_client, bucket, WALLET_ADDRESSES_KEY)
+    addresses = (universe or {}).get("addresses", [])
+    if not addresses:
+        logger.info("[crypto_balances] no wallet addresses published — nothing to do")
+        return {"status": "skipped", "reason": "no addresses"}
+
+    chains_present = {str(a.get("chain", "")).upper() for a in addresses}
+    try:
+        prices = price_fn(chains_present, session=session)
+    except Exception as e:  # noqa: BLE001 - prices are best-effort; balances still publish
+        logger.warning("[crypto_balances] price fetch failed (values omitted this cycle): %s", e)
+        prices = {}
+
+    balances: list[dict] = []
+    n_failed = 0
+    for a in addresses:
+        chain = str(a.get("chain", "")).upper()
+        address = str(a.get("address", ""))
+        fetcher = fetchers.get(chain)
+        if fetcher is None or not address:
+            n_failed += 1
+            logger.warning("[crypto_balances] unsupported/empty entry skipped: %r", a)
+            continue
+        try:
+            bal = fetcher(address, session=session)
+        except Exception as e:  # noqa: BLE001 - per-address fail-soft (recorded), never abort
+            n_failed += 1
+            logger.warning("[crypto_balances] %s balance fetch failed for %s: %s", chain, address, e)
+            continue
+        symbol = _COIN.get(chain, (None, chain))[1]
+        px = prices.get(chain)
+        row = {"chain": chain, "address": address, "symbol": symbol, "balance": bal}
+        if px is not None:
+            row["price_usd"] = px
+            row["value_usd"] = bal * px
+        balances.append(row)
+
+    if not balances:
+        logger.warning("[crypto_balances] every address fetch failed (%d) — not writing", n_failed)
+        return {"status": "error", "reason": "all fetches failed", "n_failed": n_failed}
+
+    artifact = {
+        "schema_version": HOLDINGS_SCHEMA_VERSION,
+        "as_of_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source": "blockstream+eth_rpc+coingecko",
+        "balances": balances,
+        "prices": {s: prices[s] for s in sorted(prices)},
+    }
+    if dry_run:
+        logger.info("[crypto_balances] dry-run: %d balances, %d failed (no write)", len(balances), n_failed)
+        return {"status": "dry-run", "n_balances": len(balances), "n_failed": n_failed}
+
+    _write_json(s3_client, bucket, HOLDINGS_KEY, artifact)
+    logger.info(
+        "[crypto_balances] wrote %d balances (%d failed) → s3://%s/%s",
+        len(balances), n_failed, bucket, HOLDINGS_KEY,
+    )
+    return {"status": "ok", "n_balances": len(balances), "n_failed": n_failed}
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(prog="python -m collectors.crypto_balances", description=__doc__)
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    result = collect(bucket=args.bucket, dry_run=args.dry_run)
+    return 0 if result.get("status") in ("ok", "dry-run", "skipped") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/install-metron-crypto.sh
+++ b/infrastructure/install-metron-crypto.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Install/refresh the Metron crypto wallet-balance timer on the trading box (metron-ops#111).
+# One-time (and after unit-file edits) via SSM:
+#   aws ssm send-command --instance-ids <trading-box> --document-name AWS-RunShellScript \
+#     --parameters 'commands=["sudo bash /home/ec2-user/alpha-engine-data/infrastructure/install-metron-crypto.sh"]'
+# Idempotent: re-copies units, daemon-reloads, enables + starts the timer.
+# NOTE: the instance role must allow s3:PutObject on crypto/* of the shared bucket (in
+# addition to market_data/*) before this writes — see metron-ops#111.
+set -euo pipefail
+
+REPO_DIR="/home/ec2-user/alpha-engine-data"
+UNIT_DIR="${REPO_DIR}/infrastructure/systemd"
+
+cp "${UNIT_DIR}/metron-crypto.service" /etc/systemd/system/metron-crypto.service
+cp "${UNIT_DIR}/metron-crypto.timer" /etc/systemd/system/metron-crypto.timer
+systemctl daemon-reload
+systemctl enable --now metron-crypto.timer
+systemctl list-timers metron-crypto.timer --no-pager
+echo "metron-crypto.timer installed and started"

--- a/infrastructure/systemd/metron-crypto.service
+++ b/infrastructure/systemd/metron-crypto.service
@@ -1,0 +1,19 @@
+# Metron crypto wallet-balance producer (metron-ops#111) — one shot per timer tick.
+# Reads Metron's published wallet-address universe (metron/crypto/wallet_addresses.json),
+# queries BTC/ETH balances via free public endpoints (Blockstream + a public ETH JSON-RPC),
+# prices via CoinGecko, and writes crypto/holdings.json for Metron's standalone crypto page.
+# Crypto is 24/7 (no market window) so the timer runs around the clock; per-address fetch
+# failures are WARN-logged + counted, never fatal. S3 write rides the instance role
+# (executor-role needs crypto/* in addition to market_data/* — see metron-ops#111).
+# Installed by infrastructure/install-metron-crypto.sh.
+[Unit]
+Description=Metron crypto wallet-balance producer (alpha-engine-data)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ec2-user
+WorkingDirectory=/home/ec2-user/alpha-engine-data
+ExecStart=/home/ec2-user/alpha-engine-data/.venv/bin/python -m collectors.crypto_balances
+TimeoutStartSec=300

--- a/infrastructure/systemd/metron-crypto.timer
+++ b/infrastructure/systemd/metron-crypto.timer
@@ -1,0 +1,13 @@
+# Every 15 minutes, around the clock — crypto trades 24/7, so (unlike the intraday
+# market-data timer) there is no NYSE-session gate. A tick with no published wallet
+# addresses costs one S3 GET and exits "skipped". (metron-ops#111)
+[Unit]
+Description=Metron crypto wallet-balance producer every 15 min (24/7)
+
+[Timer]
+OnCalendar=*-*-* *:00/15:00
+AccuracySec=60
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -69,6 +69,11 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "builders/prune_delisted_tickers.py": 1,
     "collectors/alternative.py": 3,
     "collectors/constituents.py": 2,
+    # crypto/holdings.json — Metron crypto-page wallet balances (metron-ops#111). The
+    # ARTIFACT_REGISTRY freshness row is DEFERRED until the producer is live (IAM + timer
+    # installed) per "never register a freshness entry ahead of its producer" — registering
+    # now would report a false state=missing. Tracked in metron-ops#111.
+    "collectors/crypto_balances.py": 1,
     "collectors/daily_closes.py": 1,
     "collectors/daily_closes_fred_repair.py": 1,
     "collectors/fred_history.py": 1,

--- a/tests/test_crypto_balances.py
+++ b/tests/test_crypto_balances.py
@@ -1,0 +1,131 @@
+"""Crypto wallet-balance producer (metron-ops#111).
+
+Reads Metron's published wallet-address universe, fetches per-chain balances + prices, and
+writes ``crypto/holdings.json``. Covers the happy path, per-address fail-soft, the
+no-addresses / all-failed skips, the dry-run no-write path, and price-fetch degradation.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from collectors import crypto_balances as cb
+
+_BTC = "bc1q9zpgru5j9q3dccf6n5xm9wglv5jh0w8r4d5xkp"
+_ETH = "0x52908400098527886e0f7030069857d2e4169ee7"
+_NOW = datetime(2026, 6, 29, 12, 0, tzinfo=UTC)
+
+
+def _s3(universe: dict | None) -> MagicMock:
+    s3 = MagicMock()
+
+    def _get(Bucket, Key):
+        if Key == cb.WALLET_ADDRESSES_KEY and universe is not None:
+            body = MagicMock()
+            body.read.return_value = json.dumps(universe).encode()
+            return {"Body": body}
+        raise Exception("NoSuchKey")
+
+    s3.get_object.side_effect = _get
+    return s3
+
+
+def _puts(s3: MagicMock) -> dict[str, dict]:
+    return {c.kwargs["Key"]: json.loads(c.kwargs["Body"].decode()) for c in s3.put_object.call_args_list}
+
+
+def _universe(*pairs: tuple[str, str]) -> dict:
+    return {"schema_version": 1, "addresses": [{"chain": c, "address": a} for c, a in pairs]}
+
+
+def _fetchers(balances: dict[str, float]):
+    """Balance fetchers keyed by chain, returning a canned balance (or raising for an
+    address mapped to an Exception)."""
+    def _make(chain):
+        def _fetch(address, *, session):
+            val = balances[chain]
+            if isinstance(val, Exception):
+                raise val
+            return val
+        return _fetch
+    return {c: _make(c) for c in balances}
+
+
+def test_happy_path_writes_balances_and_values():
+    s3 = _s3(_universe(("BTC", _BTC), ("ETH", _ETH)))
+    r = cb.collect(
+        s3_client=s3, session=MagicMock(),
+        balance_fetchers=_fetchers({"BTC": 0.5, "ETH": 2.0}),
+        price_fetcher=lambda syms, *, session: {"BTC": 60000.0, "ETH": 3000.0},
+        now=_NOW,
+    )
+    assert r["status"] == "ok" and r["n_balances"] == 2 and r["n_failed"] == 0
+    art = _puts(s3)[cb.HOLDINGS_KEY]
+    assert art["schema_version"] == 1 and art["as_of_utc"] == "2026-06-29T12:00:00Z"
+    by_chain = {b["chain"]: b for b in art["balances"]}
+    assert by_chain["BTC"]["balance"] == 0.5 and by_chain["BTC"]["value_usd"] == 30000.0
+    assert by_chain["ETH"]["value_usd"] == 6000.0
+    assert art["prices"] == {"BTC": 60000.0, "ETH": 3000.0}
+
+
+def test_per_address_failure_is_soft():
+    s3 = _s3(_universe(("BTC", _BTC), ("ETH", _ETH)))
+    r = cb.collect(
+        s3_client=s3, session=MagicMock(),
+        balance_fetchers=_fetchers({"BTC": 0.5, "ETH": RuntimeError("rpc down")}),
+        price_fetcher=lambda syms, *, session: {"BTC": 60000.0},
+        now=_NOW,
+    )
+    assert r["status"] == "ok" and r["n_balances"] == 1 and r["n_failed"] == 1
+    art = _puts(s3)[cb.HOLDINGS_KEY]
+    assert [b["chain"] for b in art["balances"]] == ["BTC"]
+
+
+def test_price_failure_still_writes_balances_without_value():
+    s3 = _s3(_universe(("BTC", _BTC)))
+
+    def _boom(syms, *, session):
+        raise RuntimeError("coingecko 429")
+
+    r = cb.collect(
+        s3_client=s3, session=MagicMock(),
+        balance_fetchers=_fetchers({"BTC": 1.0}), price_fetcher=_boom, now=_NOW,
+    )
+    assert r["status"] == "ok"
+    row = _puts(s3)[cb.HOLDINGS_KEY]["balances"][0]
+    assert row["balance"] == 1.0 and "value_usd" not in row and "price_usd" not in row
+
+
+def test_no_addresses_skips_without_write():
+    s3 = _s3(_universe())
+    r = cb.collect(s3_client=s3, session=MagicMock(), now=_NOW)
+    assert r["status"] == "skipped" and s3.put_object.call_count == 0
+
+
+def test_missing_universe_artifact_skips():
+    s3 = _s3(None)
+    r = cb.collect(s3_client=s3, session=MagicMock(), now=_NOW)
+    assert r["status"] == "skipped" and s3.put_object.call_count == 0
+
+
+def test_all_failed_does_not_write():
+    s3 = _s3(_universe(("ETH", _ETH)))
+    r = cb.collect(
+        s3_client=s3, session=MagicMock(),
+        balance_fetchers=_fetchers({"ETH": RuntimeError("down")}),
+        price_fetcher=lambda syms, *, session: {}, now=_NOW,
+    )
+    assert r["status"] == "error" and s3.put_object.call_count == 0
+
+
+def test_dry_run_does_not_write():
+    s3 = _s3(_universe(("BTC", _BTC)))
+    r = cb.collect(
+        s3_client=s3, session=MagicMock(),
+        balance_fetchers=_fetchers({"BTC": 1.0}),
+        price_fetcher=lambda syms, *, session: {"BTC": 50000.0},
+        now=_NOW, dry_run=True,
+    )
+    assert r["status"] == "dry-run" and s3.put_object.call_count == 0


### PR DESCRIPTION
## What
New collector that powers Metron's standalone crypto page (**metron-ops#111**). Reads Metron's published wallet-address universe (`metron/crypto/wallet_addresses.json`), queries on-chain balances + USD prices, and writes `crypto/holdings.json` — the same data-spine producer/consumer split as the EOD/intraday market-data producers (Metron makes no chain calls).

Pairs with the consumer PR **nousergon/metron#139**.

## How
- **`collectors/crypto_balances.py`**:
  - **BTC** via Blockstream Esplora address API (confirmed `funded − spent` txo sums, sats → BTC).
  - **ETH** via a public JSON-RPC `eth_getBalance` (wei → ETH).
  - **prices** via CoinGecko simple price (USD).
  - All **free, no API key**. Fetchers + S3 client + HTTP session are injectable for tests.
  - **Fail-soft per address** (one chain/RPC error → WARN + `n_failed`, never zeroes or aborts the artifact — the "no silent fails" rule's recording surface); price-fetch failure still publishes balances without `value_usd`; no published addresses / all-failed → no write.
- **systemd**: `metron-crypto.{service,timer}` — every 15 min, **24/7** (crypto has no market window, unlike `metron-intraday`) + `install-metron-crypto.sh`.

## Artifact contract
Writes `crypto/holdings.json`:
```json
{"schema_version":1,"as_of_utc":"…Z","source":"blockstream+eth_rpc+coingecko",
 "balances":[{"chain":"BTC","address":"…","symbol":"BTC","balance":0.5,"price_usd":…,"value_usd":…}],
 "prices":{"BTC":…,"ETH":…}}
```
Adding a chain = a balance fetcher here + a validator in Metron's `crypto` service; the contract is unchanged. To scale past a few coins, swap the per-chain fetchers for a multi-chain aggregator behind the same `collect()`.

## Tests
`test_crypto_balances.py` — happy path + computed values, per-address fail-soft, price-failure degradation, no-addresses / all-failed / dry-run no-write paths. **7 passed.**

## Deploy follow-up (called out, not in this PR)
1. The trading-box **instance role needs `s3:PutObject` on `crypto/*`** (in addition to `market_data/*`) before the timer writes.
2. Install on the box via SSM: `sudo bash …/infrastructure/install-metron-crypto.sh`.

Both tracked in metron-ops#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)