### PR TITLE
Rename fleet SFs to ne- function-descriptive names (data + CFN/deploy/IAM cutover)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -130,7 +130,7 @@ Resources:
   SaturdayPipeline:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: alpha-engine-saturday-pipeline
+      StateMachineName: ne-weekly-freshness-pipeline
       RoleArn: !Ref StepFunctionsRoleArn
       DefinitionS3Location:
         Bucket: alpha-engine-research
@@ -145,7 +145,7 @@ Resources:
   WeekdayPipeline:
     Type: AWS::StepFunctions::StateMachine
     Properties:
-      StateMachineName: alpha-engine-weekday-pipeline
+      StateMachineName: ne-preopen-trading-pipeline
       RoleArn: !Ref StepFunctionsRoleArn
       DefinitionS3Location:
         Bucket: alpha-engine-research

--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -106,37 +106,65 @@ aws s3 cp "$DAILY_STAMPED" "s3://$BUCKET/infrastructure/step_function_daily.json
 aws s3 cp "$EOD_STAMPED" "s3://$BUCKET/infrastructure/step_function_eod.json" --quiet
 echo "  Uploaded to s3://$BUCKET/infrastructure/"
 
-# ── 3. Update Step Functions directly ────────────────────────────────────────
+# ── 3. Update Step Function definitions (existence-aware) ────────────────────
+# Push the stamped ASL to each live state machine. CFN owns CREATION of the two
+# CFN-managed SFs (weekly-freshness, preopen-trading) via DefinitionS3Location —
+# on a fresh stack OR a StateMachineName change (a CFN replacement) it reads the
+# S3 copy uploaded in step 2. So here: UPDATE the SF if it exists, and for the
+# CFN pair SKIP-if-absent (CFN creates it in step 4 from S3). The post-close
+# (EOD) SF is NOT in CloudFormation — this script is its sole manager — so for it
+# we CREATE-if-absent. This keeps the deploy idempotent ACROSS the 2026-06-29
+# ne- rename cutover (config#1381), where the renamed SFs do not yet exist on the
+# first post-merge deploy. Pre-rename names: alpha-engine-{saturday,weekday,eod}.
 echo ""
 echo "==> Updating Step Function definitions..."
 
-SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
-DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-weekday-pipeline"
-EOD_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"
+DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline"
+EOD_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
+# Shared SF execution role (the CFN StepFunctionsRoleArn default; all three
+# orchestration SFs run under it). Used only for the EOD create-if-absent path.
+SF_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-step-functions-role"
 
-# Pass the definition via file:// — NOT inline "$(cat ...)". The Saturday ASL is
-# ~131 KB and growing (one state per pipeline step); combined with the AWS
+sf_exists() {
+    aws stepfunctions describe-state-machine --state-machine-arn "$1" --query "name" --output text >/dev/null 2>&1
+}
+
+# Pass the definition via file:// — NOT inline "$(cat ...)". The weekly-freshness
+# ASL is ~131 KB and growing (one state per pipeline step); combined with the AWS
 # session-token env on the CI runner, an inline arg blows past the effective
 # ARG_MAX and the runner aborts with "aws: Argument list too long" (exit 126),
 # which silently leaves the live SF stamp behind origin/main HEAD and trips the
 # deploy-drift preflight on the next pipeline run. file:// reads from disk, so
 # the definition size is bounded only by the SF service limit (1 MB), not ARG_MAX.
-# Regression: 2026-06-04 — the Director SF state pushed the Saturday ASL over the
-# line and broke this deploy.
-aws stepfunctions update-state-machine --state-machine-arn "$SAT_ARN" --definition "file://$SAT_STAMPED" --query "updateDate" --output text
-echo "  Saturday pipeline updated."
+# Regression: 2026-06-04 — the Director SF state pushed the ASL over the line.
 
-aws stepfunctions update-state-machine --state-machine-arn "$DAILY_ARN" --definition "file://$DAILY_STAMPED" --query "updateDate" --output text
-echo "  Weekday pipeline updated."
+# CFN-managed SF: update if present, else defer creation to CloudFormation (step 4).
+update_or_defer_to_cfn() {
+    local arn="$1" stamped="$2" label="$3"
+    if sf_exists "$arn"; then
+        aws stepfunctions update-state-machine --state-machine-arn "$arn" --definition "file://$stamped" --query "updateDate" --output text
+        echo "  $label updated."
+    else
+        echo "  $label absent — CloudFormation will create it from S3 in step 4 (rename cutover)."
+    fi
+}
 
-# EOD SF (alpha-engine-eod-pipeline) — folded into auto-deploy 2026-06-23 (config#1173).
-# Previously deployed only by the manual infrastructure/update_eod_pipeline_sf.sh, which
-# nothing triggered on merge, so merged EOD SF changes silently never reached the live
-# state machine (drift hit 2026-06-22 via #458's nousergon_lib migration). Same
-# stamp + S3-copy + file:// update-state-machine pattern as Saturday/weekday above, so all
-# three orchestration SFs now stay in lockstep with origin/main on every merge.
-aws stepfunctions update-state-machine --state-machine-arn "$EOD_ARN" --definition "file://$EOD_STAMPED" --query "updateDate" --output text
-echo "  EOD pipeline updated."
+# Standalone SF (not in CFN — EOD): update if present, else create.
+update_or_create() {
+    local arn="$1" stamped="$2" name="$3" label="$4"
+    if sf_exists "$arn"; then
+        aws stepfunctions update-state-machine --state-machine-arn "$arn" --definition "file://$stamped" --query "updateDate" --output text
+        echo "  $label updated."
+    else
+        aws stepfunctions create-state-machine --name "$name" --definition "file://$stamped" --role-arn "$SF_ROLE_ARN" --query "stateMachineArn" --output text
+        echo "  $label created (was absent — rename cutover)."
+    fi
+}
+
+update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline"
+update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline"
+update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post-close trading pipeline"
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────
 echo ""

--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -29,7 +29,7 @@ REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-STATE_MACHINE_NAME="alpha-engine-saturday-pipeline"
+STATE_MACHINE_NAME="ne-weekly-freshness-pipeline"
 ROLE_NAME="alpha-engine-step-functions-role"
 SNS_TOPIC_NAME="alpha-engine-alerts"
 EVENTBRIDGE_RULE="alpha-engine-saturday"

--- a/infrastructure/deploy_step_function_daily.sh
+++ b/infrastructure/deploy_step_function_daily.sh
@@ -19,7 +19,7 @@ REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-STATE_MACHINE_NAME="alpha-engine-weekday-pipeline"
+STATE_MACHINE_NAME="ne-preopen-trading-pipeline"
 ROLE_NAME="alpha-engine-step-functions-role"  # reuse from Saturday pipeline
 SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
 EVENTBRIDGE_RULE="alpha-engine-weekday"

--- a/infrastructure/iam/alpha-engine-eventbridge-sfn-role.json
+++ b/infrastructure/iam/alpha-engine-eventbridge-sfn-role.json
@@ -5,8 +5,8 @@
             "Effect": "Allow",
             "Action": "states:StartExecution",
             "Resource": [
-                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
-                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+                "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+                "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline"
             ]
         }
     ]

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -111,13 +111,18 @@
       "Sid": "InfraDeploySFDefinition",
       "Effect": "Allow",
       "Action": [
+        "states:CreateStateMachine",
         "states:UpdateStateMachine",
+        "states:DeleteStateMachine",
         "states:DescribeStateMachine",
         "states:ListTagsForResource",
         "states:TagResource",
         "states:UntagResource"
       ],
-      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-*-pipeline"
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-*-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-*-pipeline"
+      ]
     },
     {
       "Sid": "InfraDeployResourceCRUD",

--- a/infrastructure/lambdas/eod-backstop/README.md
+++ b/infrastructure/lambdas/eod-backstop/README.md
@@ -1,6 +1,6 @@
 # alpha-engine-eod-backstop
 
-Same-day backstop trigger for the EOD Step Function (`alpha-engine-eod-pipeline`). Phase 2 of the trading-day-gap arc (**config#1229**).
+Same-day backstop trigger for the EOD Step Function (`ne-postclose-trading-pipeline`). Phase 2 of the trading-day-gap arc (**config#1229**).
 
 ## Why
 
@@ -44,7 +44,7 @@ aws events enable-rule --name alpha-engine-eod-backstop-daily --region us-east-1
 
 | env var | default |
 |---|---|
-| `EOD_SF_ARN` | `…:stateMachine:alpha-engine-eod-pipeline` |
+| `EOD_SF_ARN` | `…:stateMachine:ne-postclose-trading-pipeline` |
 | `TRADING_INSTANCE_ID` | `i-018eb3307a21329bf` |
 | `DASHBOARD_INSTANCE_ID` | `i-09b539c844515d549` |
 | `SNS_TOPIC_ARN` | `…:alpha-engine-alerts` |

--- a/infrastructure/lambdas/eod-backstop/iam-policy.json
+++ b/infrastructure/lambdas/eod-backstop/iam-policy.json
@@ -24,7 +24,7 @@
         "states:ListExecutions",
         "states:StartExecution"
       ],
-      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
     }
   ]
 }

--- a/infrastructure/lambdas/eod-backstop/index.py
+++ b/infrastructure/lambdas/eod-backstop/index.py
@@ -1,6 +1,6 @@
 """alpha-engine-eod-backstop — same-day EOD-pipeline trigger of last resort.
 
-The EOD Step Function (``alpha-engine-eod-pipeline``) is normally started by
+The EOD Step Function (``ne-postclose-trading-pipeline``) is normally started by
 the trading daemon's shutdown hook (``daemon.py`` finally block). That is the
 SOLE trigger — a deliberate "no-backstop design". If the daemon dies before
 its shutdown hook, the SSM ``RunDaemon`` step never reaches the finally block,
@@ -57,7 +57,7 @@ ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
 
 EOD_SF_ARN = os.environ.get(
     "EOD_SF_ARN",
-    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline",
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline",
 )
 # The trading box (CaptureSnapshot / EODReconcile / StopTradingInstance target)
 # and the dashboard box (DailySubstrateHealthCheck target). Mirror the daemon's

--- a/infrastructure/lambdas/eod-backstop/test_handler.py
+++ b/infrastructure/lambdas/eod-backstop/test_handler.py
@@ -39,7 +39,7 @@ def _sf(exec_start: datetime | None):
 
     cli.list_executions.side_effect = _list
     cli.start_execution.return_value = {
-        "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:eod-backstop-x"
+        "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:eod-backstop-x"
     }
     return cli
 
@@ -117,7 +117,7 @@ class TestStartEodInput:
         sf = _sf(None)
         index._start_eod("2026-06-25", sf)
         kwargs = sf.start_execution.call_args.kwargs
-        assert kwargs["stateMachineArn"].endswith("alpha-engine-eod-pipeline")
+        assert kwargs["stateMachineArn"].endswith("ne-postclose-trading-pipeline")
         assert kwargs["name"].startswith("eod-backstop-2026-06-25-")
         import json
         payload = json.loads(kwargs["input"])

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/README.md
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/README.md
@@ -1,7 +1,7 @@
 # eod-success-friday-shell-trigger
 
 Subscribes to EventBridge `Step Functions Execution Status Change` events
-for `alpha-engine-eod-pipeline` SUCCEEDED transitions and, when the
+for `ne-postclose-trading-pipeline` SUCCEEDED transitions and, when the
 underlying trading_day is a Friday, starts the Saturday Step Function in
 shell-run mode (`shell_run: true`).
 
@@ -70,7 +70,7 @@ EOD SF reaches SUCCEEDED
        ▼
 EventBridge default bus
    (aws.states / Step Functions Execution Status Change,
-    filtered to alpha-engine-eod-pipeline + SUCCEEDED only)
+    filtered to ne-postclose-trading-pipeline + SUCCEEDED only)
        │
        ▼
 alpha-engine-eod-success-friday-shell-trigger
@@ -78,7 +78,7 @@ alpha-engine-eod-success-friday-shell-trigger
        ├──► last_closed_trading_day(stopDate UTC) → trading_day
        │
        └──► if trading_day.weekday() == FRI:
-                states:StartExecution on alpha-engine-saturday-pipeline
+                states:StartExecution on ne-weekly-freshness-pipeline
                 with input { ec2_instance_id, sns_topic_arn, shell_run: true }
 ```
 
@@ -107,7 +107,7 @@ changelog-cloudwatch-mirror convention.
 
 - `logs:CreateLogGroup/Stream + PutLogEvents` on the Lambda's own log group
 - `states:StartExecution` on
-  `arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline`
+  `arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline`
   (single-target scope — cannot start any other SF)
 
 ## Cutover plan

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
@@ -3,7 +3,7 @@
 # Lambda and wire its EventBridge EOD-SUCCEEDED trigger.
 #
 # This Lambda subscribes to `aws.states` / "Step Functions Execution Status
-# Change" events for `alpha-engine-eod-pipeline` SUCCEEDED transitions only.
+# Change" events for `ne-postclose-trading-pipeline` SUCCEEDED transitions only.
 # On every EOD success it derives trading_day via the canonical
 # `alpha_engine_lib.trading_calendar.last_closed_trading_day` (handles UTC
 # rollover) and, if trading_day.weekday()==4 (Friday), invokes the Saturday
@@ -139,7 +139,7 @@ if $BOOTSTRAP; then
   "detail-type": ["Step Functions Execution Status Change"],
   "detail": {
     "stateMachineArn": [
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
     ],
     "status": ["SUCCEEDED"]
   }
@@ -199,8 +199,8 @@ if $SMOKE; then
   "detail-type": "Step Functions Execution Status Change",
   "detail": {
     "status": "SUCCEEDED",
-    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline",
-    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:smoke-test",
+    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
+    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:smoke-test",
     "name": "smoke-test",
     "startDate": 1779827700000,
     "stopDate": 1779828300000

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/iam-policy.json
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/iam-policy.json
@@ -15,7 +15,7 @@
       "Sid": "StartSaturdayShellRun",
       "Effect": "Allow",
       "Action": ["states:StartExecution"],
-      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
+      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
     }
   ]
 }

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
@@ -1,7 +1,7 @@
 """alpha-engine-eod-success-friday-shell-trigger — kick the weekly shell-run.
 
 Subscribes to EventBridge ``Step Functions Execution Status Change`` events,
-filtered to ``alpha-engine-eod-pipeline`` + ``SUCCEEDED``. On every EOD-SF
+filtered to ``ne-postclose-trading-pipeline`` + ``SUCCEEDED``. On every EOD-SF
 success the handler computes the trading_day this execution closed against
 and, if that trading_day is a Friday, starts the Saturday Step Function in
 shell-run mode (``shell_run: true``) so the spot instances boot for real
@@ -58,9 +58,9 @@ REGION = os.environ.get("AWS_REGION", "us-east-1")
 ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
 
 SATURDAY_SF_ARN = (
-    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"
 )
-EOD_SF_NAME = "alpha-engine-eod-pipeline"
+EOD_SF_NAME = "ne-postclose-trading-pipeline"
 
 TRADING_EC2_INSTANCE_ID = os.environ.get(
     "TRADING_EC2_INSTANCE_ID", "i-09b539c844515d549"

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/test_handler.py
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/test_handler.py
@@ -31,10 +31,10 @@ import index  # noqa: E402
 
 
 EOD_ARN = (
-    "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+    "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
 )
 SATURDAY_ARN = (
-    "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
+    "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
 )
 
 
@@ -54,7 +54,7 @@ def _event(
     detail: dict = {
         "status": status,
         "stateMachineArn": sm_arn,
-        "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:exec-001",
+        "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:exec-001",
         "name": "exec-001",
         "startDate": _epoch_ms(2026, 5, 22, 20, 15),
         "stopDate": stop_date_ms
@@ -81,7 +81,7 @@ def _patch_sfn(start_execution_return: dict | None = None, side_effect=None):
         fake_client.start_execution.return_value = (
             start_execution_return
             or {
-                "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:friday-shell-test",
+                "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:friday-shell-test",
                 "startDate": datetime(2026, 5, 22, 20, 25, tzinfo=timezone.utc),
             }
         )
@@ -165,7 +165,7 @@ def test_wrong_state_machine_arn_logs_and_returns_without_firing():
     """Defensive: rule filter mismatch should NOT raise but also not fire."""
     sfn_patch, fake_client = _patch_sfn()
     weekday_arn = (
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline"
     )
     with sfn_patch:
         result = index.handler(_event(sm_arn=weekday_arn), None)

--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -63,9 +63,9 @@
       "Effect": "Allow",
       "Action": ["states:StartExecution"],
       "Resource": [
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
       ]
     },
     {

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -967,7 +967,7 @@ artifacts:
     created_at: 2025-01-01
     recovery:
       type: step_function
-      target: "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+      target: "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline"
       params:
         trigger: freshness_monitor_backfill
         trading_day: "{trading_day}"
@@ -1032,7 +1032,7 @@ def test_recovery_dispatches_once_on_confirmed_miss(monkeypatch, fake_s3, fixed_
     assert result["dispatched"] == 1
     sf.start_execution.assert_called_once()
     kwargs = sf.start_execution.call_args.kwargs
-    assert kwargs["stateMachineArn"].endswith("alpha-engine-weekday-pipeline")
+    assert kwargs["stateMachineArn"].endswith("ne-preopen-trading-pipeline")
     payload = json.loads(kwargs["input"])
     assert payload["trigger"] == "freshness_monitor_backfill"
     # The placeholder resolved to a concrete ISO date (not the literal token).

--- a/infrastructure/lambdas/friday-shell-run-report/README.md
+++ b/infrastructure/lambdas/friday-shell-run-report/README.md
@@ -7,7 +7,7 @@ preflight of the Saturday Step Function). Closes ROADMAP **L658** design point 5
 
 ## What it does
 
-Subscribes (EventBridge) to `alpha-engine-saturday-pipeline` **terminal**
+Subscribes (EventBridge) to `ne-weekly-freshness-pipeline` **terminal**
 execution-status transitions (`SUCCEEDED` / `FAILED` / `TIMED_OUT` / `ABORTED`).
 For executions that ran in **shell-run mode** (`shell_run: true` /
 `pipeline_role: "shell-run"` — started by the sibling

--- a/infrastructure/lambdas/friday-shell-run-report/deploy.sh
+++ b/infrastructure/lambdas/friday-shell-run-report/deploy.sh
@@ -3,7 +3,7 @@
 # and wire its EventBridge trigger.
 #
 # Subscribes to `aws.states` / "Step Functions Execution Status Change" events
-# for `alpha-engine-saturday-pipeline` terminal transitions (SUCCEEDED / FAILED
+# for `ne-weekly-freshness-pipeline` terminal transitions (SUCCEEDED / FAILED
 # / TIMED_OUT / ABORTED). The handler no-ops on real Saturday runs and, for
 # shell-run executions (shell_run=true), reads the execution history and writes
 # the consolidated report to s3://alpha-engine-research/friday-shell-run/{date}/
@@ -104,7 +104,7 @@ if $BOOTSTRAP; then
   "source": ["aws.states"],
   "detail-type": ["Step Functions Execution Status Change"],
   "detail": {
-    "stateMachineArn": ["arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"],
+    "stateMachineArn": ["arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"],
     "status": ["SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"]
   }
 }

--- a/infrastructure/lambdas/friday-shell-run-report/iam-policy.json
+++ b/infrastructure/lambdas/friday-shell-run-report/iam-policy.json
@@ -15,7 +15,7 @@
       "Sid": "ReadSaturdayExecutionHistory",
       "Effect": "Allow",
       "Action": ["states:GetExecutionHistory"],
-      "Resource": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:*"
+      "Resource": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*"
     },
     {
       "Sid": "WriteShellRunReport",

--- a/infrastructure/lambdas/friday-shell-run-report/index.py
+++ b/infrastructure/lambdas/friday-shell-run-report/index.py
@@ -1,7 +1,7 @@
 """alpha-engine-friday-shell-run-report — consolidate the Friday shell-run result.
 
 Subscribes to EventBridge ``Step Functions Execution Status Change`` events for
-the ``alpha-engine-saturday-pipeline`` state machine (terminal transitions:
+the ``ne-weekly-freshness-pipeline`` state machine (terminal transitions:
 SUCCEEDED / FAILED / TIMED_OUT / ABORTED). For executions that ran in **shell-run
 mode** (``shell_run: true`` / ``pipeline_role: "shell-run"`` in the execution
 input — the Friday-PM dry preflight of the Saturday SF), the handler reads the
@@ -43,7 +43,7 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
-SATURDAY_SF_NAME = "alpha-engine-saturday-pipeline"
+SATURDAY_SF_NAME = "ne-weekly-freshness-pipeline"
 S3_BUCKET = os.environ.get("S3_BUCKET", "alpha-engine-research")
 SNS_TOPIC_ARN = os.environ.get(
     "SNS_TOPIC_ARN", f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts"

--- a/infrastructure/lambdas/friday-shell-run-report/test_handler.py
+++ b/infrastructure/lambdas/friday-shell-run-report/test_handler.py
@@ -27,8 +27,8 @@ sys.modules.setdefault("alpha_engine_lib.trading_calendar", _tc)
 sys.path.insert(0, str(Path(__file__).parent))
 import index  # noqa: E402
 
-SAT_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
-_EXEC_ARN = "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:friday-shell-2026-06-12-eodname"
+SAT_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
+_EXEC_ARN = "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:friday-shell-2026-06-12-eodname"
 
 
 def _ts(sec: int) -> datetime:
@@ -117,7 +117,7 @@ def test_non_shell_run_is_a_noop():
 
 def test_wrong_state_machine_ignored():
     side, s3, _ = _fake_clients([])
-    bad = _event("SUCCEEDED", sm_arn="arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline")
+    bad = _event("SUCCEEDED", sm_arn="arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline")
     with patch("index.boto3.client", side_effect=side):
         out = index.handler(bad, None)
     assert out["reported"] is False and out["reason"] == "wrong_event"

--- a/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
+++ b/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
@@ -16,9 +16,9 @@
       "Effect": "Allow",
       "Action": ["states:ListExecutions"],
       "Resource": [
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
       ]
     },
     {

--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -15,14 +15,14 @@ plan doc §3.5.
 
 **Per-SF watchdog semantics:**
 
-  - **Weekday SF** (``alpha-engine-weekday-pipeline``)
+  - **Weekday SF** (``ne-preopen-trading-pipeline``)
       Watch-day: TODAY is a trading day. If trading_calendar reports that
       ``last_closed_trading_day(now_utc).date() == now_utc.date() - 1``
       (i.e., the prior calendar day was a trading session), the Weekday SF
       should have fired today by 13:00 UTC. Alert if 0 executions started
       in the last 24h.
 
-  - **EOD SF** (``alpha-engine-eod-pipeline``)
+  - **EOD SF** (``ne-postclose-trading-pipeline``)
       Watch-day: same condition as Weekday — EOD fires after the trading
       day's daemon shutdown, which only happens on trading days. Window
       is TRADING-DAY-AWARE, NOT a fixed 24h calendar window: today's EOD
@@ -36,7 +36,7 @@ plan doc §3.5.
       the 2026-05-26 morning false-positive Telegram alert that drove
       this fix.
 
-  - **Saturday SF** (``alpha-engine-saturday-pipeline``)
+  - **Saturday SF** (``ne-weekly-freshness-pipeline``)
       Watch-day: TODAY is Sunday (weekday 6) — Saturday SF fires at 09:00
       UTC Saturday; by Sunday 14:00 UTC any missed firing is 24+h overdue.
       Alert if 0 executions started in the last 7 days. (One CW alarm with
@@ -98,13 +98,13 @@ REGION = os.environ.get("AWS_REGION", "us-east-1")
 ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
 
 SATURDAY_SF_ARN = (
-    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"
 )
 WEEKDAY_SF_ARN = (
-    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:alpha-engine-weekday-pipeline"
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline"
 )
 EOD_SF_ARN = (
-    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
 )
 
 # Watchdog-specific SNS topic — distinct from `alpha-engine-alerts` per

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/README.md
@@ -7,7 +7,7 @@ groomed immediately rather than waiting for the next scheduled 10pm-PT run.
 ## How it fits
 
 ```
-alpha-engine-saturday-pipeline  ──SUCCEEDED──▶  EventBridge rule
+ne-weekly-freshness-pipeline  ──SUCCEEDED──▶  EventBridge rule
   (status change event)                         alpha-engine-saturday-succeeded-groom
                                                         │ target
                                                         ▼

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
@@ -132,7 +132,7 @@ if $BOOTSTRAP; then
   "detail-type": ["Step Functions Execution Status Change"],
   "detail": {
     "stateMachineArn": [
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"
     ],
     "status": ["SUCCEEDED"]
   }
@@ -191,8 +191,8 @@ if $SMOKE; then
   "detail-type": "Step Functions Execution Status Change",
   "detail": {
     "status": "SUCCEEDED",
-    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
-    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:smoke-test",
+    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:smoke-test",
     "name": "smoke-test",
     "startDate": 0,
     "stopDate": 60000

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/test_handler.py
@@ -68,7 +68,7 @@ def test_succeeded_dispatches_correct_repository_dispatch(monkeypatch):
         "detail": {
             "status": "SUCCEEDED",
             "name": "sat-run-1",
-            "stateMachineArn": "arn:aws:states:us-east-1:1:stateMachine:alpha-engine-saturday-pipeline",
+            "stateMachineArn": "arn:aws:states:us-east-1:1:stateMachine:ne-weekly-freshness-pipeline",
         }
     }
     out = idx.handler(event, None)

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
@@ -85,7 +85,7 @@ python3 -m pytest infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handl
 
 ```
 detail.status:           FAILED | TIMED_OUT | ABORTED   (rule-scoped)
-detail.stateMachineArn:  arn:...:stateMachine:alpha-engine-saturday-pipeline
+detail.stateMachineArn:  arn:...:stateMachine:ne-weekly-freshness-pipeline
 detail.executionArn:     execution arn
 detail.name:             execution id
 detail.startDate:        epoch ms

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -140,9 +140,9 @@ if $BOOTSTRAP; then
   "detail-type": ["Step Functions Execution Status Change"],
   "detail": {
     "stateMachineArn": [
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-weekday-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
     ],
     "status": ["FAILED", "TIMED_OUT", "ABORTED"]
   }
@@ -201,8 +201,8 @@ if $SMOKE; then
   "detail-type": "Step Functions Execution Status Change",
   "detail": {
     "status": "FAILED",
-    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
-    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:smoke-test",
+    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:smoke-test",
     "name": "smoke-test",
     "startDate": 0,
     "stopDate": 60000

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -34,9 +34,9 @@
         "states:GetExecutionHistory"
       ],
       "Resource": [
-        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-weekday-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*"
+        "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*"
       ]
     },
     {

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -1,8 +1,8 @@
 """alpha-engine-sf-watch-dispatcher — Fleet-SF Watch.
 
 On a terminal failure of ANY of the three fleet Step Functions — Saturday
-(`alpha-engine-saturday-pipeline`), Weekday (`alpha-engine-weekday-pipeline`),
-or EOD (`alpha-engine-eod-pipeline`) — this dispatcher writes a watch-log
+(`ne-weekly-freshness-pipeline`), Weekday (`ne-preopen-trading-pipeline`),
+or EOD (`ne-postclose-trading-pipeline`) — this dispatcher writes a watch-log
 artifact and (when `AGENT_DISPATCH_ENABLED=true`) fires a `repository_dispatch`
 that triggers the autonomous resilience agent (diagnose→fix→merge→rerun) in
 `alpha-engine-config`. Generalized from the Saturday-only dispatcher
@@ -72,16 +72,29 @@ _DISPATCH_TIMEOUT_SEC = 15
 # watch-log contract, dispatch, the agent charter — is pipeline-agnostic.
 # Each pipeline routes to its OWN watch-log prefix + repository_dispatch event
 # type (cadence-filterable) and its OWN kill-switch (charter-enforced).
+# `cadence_slug` is the FROZEN cadence label (saturday/weekday/eod) — the SFs
+# were renamed to function-descriptive ne- names (config#1381) but the derived
+# cadence-keyed resources (watch-log prefix, dispatch type, the charter's
+# /alpha-engine/<slug>_sf_watch/ kill-switch param) were intentionally NOT
+# renamed. The slug is the single source of truth for that mapping and is passed
+# to the agent so the charter never has to parse it back out of the SF name.
+# `label` is the human cadence label for the Telegram receipt.
 PIPELINES: dict[str, dict[str, str]] = {
-    "alpha-engine-saturday-pipeline": {
+    "ne-weekly-freshness-pipeline": {
+        "cadence_slug": "saturday",
+        "label": "Weekly Freshness",
         "watch_prefix": "consolidated/saturday_sf_watch",
         "dispatch_event_type": "saturday-sf-failure",
     },
-    "alpha-engine-weekday-pipeline": {
+    "ne-preopen-trading-pipeline": {
+        "cadence_slug": "weekday",
+        "label": "Pre-open Trading",
         "watch_prefix": "consolidated/weekday_sf_watch",
         "dispatch_event_type": "weekday-sf-failure",
     },
-    "alpha-engine-eod-pipeline": {
+    "ne-postclose-trading-pipeline": {
+        "cadence_slug": "eod",
+        "label": "Post-close Trading",
         "watch_prefix": "consolidated/eod_sf_watch",
         "dispatch_event_type": "eod-sf-failure",
     },
@@ -257,11 +270,12 @@ def _write_watch_log(s3, watch_prefix: str, run_date: str, record: dict) -> str:
 
 
 def _pipeline_label(pipeline_name: str) -> str:
-    """SF name → human cadence label for the Telegram receipt."""
-    slug = pipeline_name.removeprefix("alpha-engine-").removesuffix("-pipeline")
-    return {"saturday": "Saturday", "weekday": "Weekday", "eod": "EOD"}.get(
-        slug, slug or pipeline_name
-    )
+    """SF name → human cadence label for the Telegram receipt (from PIPELINES)."""
+    cfg = PIPELINES.get(pipeline_name)
+    if cfg:
+        return cfg["label"]
+    # Fallback for an unregistered name: strip the ne-/-pipeline affixes.
+    return pipeline_name.removeprefix("ne-").removesuffix("-pipeline") or pipeline_name
 
 
 def _notify(record: dict, key: str, pipeline_name: str) -> bool:
@@ -324,6 +338,7 @@ def _maybe_dispatch_agent(
             "event_type": event_type,
             "client_payload": {
                 "pipeline_name": pipeline_name,
+                "cadence_slug": cfg["cadence_slug"],
                 "state_machine_arn": sm_arn,
                 "execution_arn": record.get("execution_arn", ""),
                 "failed_state": record.get("failed_state"),

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -28,9 +28,9 @@ sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
 sys.path.insert(0, str(Path(__file__).parent))
 import index  # noqa: E402
 
-SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
-WEEKDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
-EOD_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
+WEEKDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline"
+EOD_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
 UNREGISTERED_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:some-other-pipeline"
 
 
@@ -135,7 +135,7 @@ def test_telegram_is_silent_and_records_artifact_location():
     kwargs = _telegram_mod.send_message.call_args.kwargs
     assert kwargs["disable_notification"] is True  # notifier already buzzed loud
     assert "Fleet-SF Watch — OBSERVE" in text
-    assert "Saturday SF: FAILED" in text  # pipeline-aware label
+    assert "Weekly Freshness SF: FAILED" in text  # pipeline-aware label
     assert "Failed state: RAGIngestion" in text
     assert "consolidated/saturday_sf_watch/2023-11-14.json" in text
     assert "observe-only" in text
@@ -210,7 +210,7 @@ def test_preflight_shell_run_marks_record():
     written = json.loads(s3.put_object.call_args.kwargs["Body"])
     assert written["events"][0]["is_preflight"] is True
     text = _telegram_mod.send_message.call_args.args[0]
-    assert "Saturday Preflight SF" in text
+    assert "Weekly Freshness Preflight SF" in text
 
 
 def test_unregistered_sf_is_ignored():
@@ -225,11 +225,11 @@ def test_weekday_sf_routes_to_weekday_prefix_and_label():
     factory, _, s3 = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
-    assert result["state_machine"] == "alpha-engine-weekday-pipeline"
+    assert result["state_machine"] == "ne-preopen-trading-pipeline"
     assert result["watch_log_key"] == "consolidated/weekday_sf_watch/2023-11-14.json"
     assert s3.put_object.call_args.kwargs["Key"].startswith("consolidated/weekday_sf_watch/")
     text = _telegram_mod.send_message.call_args.args[0]
-    assert "Weekday SF: FAILED" in text
+    assert "Pre-open Trading SF: FAILED" in text
 
 
 def test_eod_sf_routes_to_eod_prefix():
@@ -238,7 +238,7 @@ def test_eod_sf_routes_to_eod_prefix():
         result = index.handler(_event("FAILED", sm_arn=EOD_ARN), None)
     assert result["watch_log_key"] == "consolidated/eod_sf_watch/2023-11-14.json"
     text = _telegram_mod.send_message.call_args.args[0]
-    assert "EOD SF: FAILED" in text
+    assert "Post-close Trading SF: FAILED" in text
 
 
 @pytest.mark.parametrize("status", ["TIMED_OUT", "ABORTED"])
@@ -308,7 +308,7 @@ def test_dispatch_enabled_fires_repository_dispatch(monkeypatch):
     assert sent["url"].endswith("/repos/nousergon/alpha-engine-config/dispatches")
     assert sent["data"]["event_type"] == "saturday-sf-failure"
     cp = sent["data"]["client_payload"]
-    assert cp["pipeline_name"] == "alpha-engine-saturday-pipeline"
+    assert cp["pipeline_name"] == "ne-weekly-freshness-pipeline"
     assert cp["state_machine_arn"] == SATURDAY_ARN
     assert cp["failed_state"] == "RAGIngestion"
     assert cp["run_date"] == "2023-11-14"
@@ -335,7 +335,7 @@ def test_dispatch_routes_weekday_event_type(monkeypatch):
     assert result["agent_dispatch"]["event_type"] == "weekday-sf-failure"
     assert sent["data"]["event_type"] == "weekday-sf-failure"
     cp = sent["data"]["client_payload"]
-    assert cp["pipeline_name"] == "alpha-engine-weekday-pipeline"
+    assert cp["pipeline_name"] == "ne-preopen-trading-pipeline"
     assert cp["state_machine_arn"] == WEEKDAY_ARN
 
 

--- a/infrastructure/lambdas/sf-telegram-notifier/README.md
+++ b/infrastructure/lambdas/sf-telegram-notifier/README.md
@@ -13,9 +13,9 @@ SF JSON definitions.
 
 | SF | Source ARN suffix | Pretty label |
 | --- | --- | --- |
-| Saturday weekly pipeline | `alpha-engine-saturday-pipeline` | `Saturday SF` |
-| Weekday daily pipeline   | `alpha-engine-weekday-pipeline`  | `Weekday SF` |
-| EOD post-market pipeline | `alpha-engine-eod-pipeline`      | `EOD SF` |
+| Saturday weekly pipeline | `ne-weekly-freshness-pipeline` | `Saturday SF` |
+| Weekday daily pipeline   | `ne-preopen-trading-pipeline`  | `Weekday SF` |
+| EOD post-market pipeline | `ne-postclose-trading-pipeline`      | `EOD SF` |
 
 | Status | Emoji | Push? | Extra detail |
 | --- | --- | --- | --- |

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -132,9 +132,9 @@ if $BOOTSTRAP; then
   "detail-type": ["Step Functions Execution Status Change"],
   "detail": {
     "stateMachineArn": [
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-saturday-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-weekday-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
     ],
     "status": ["RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"]
   }
@@ -193,8 +193,8 @@ if $SMOKE; then
   "detail-type": "Step Functions Execution Status Change",
   "detail": {
     "status": "SUCCEEDED",
-    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
-    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:smoke-test",
+    "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+    "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:smoke-test",
     "name": "smoke-test",
     "startDate": 0,
     "stopDate": 60000

--- a/infrastructure/lambdas/sf-telegram-notifier/index.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/index.py
@@ -41,21 +41,21 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 
 _SF_LABELS: dict[str, str] = {
-    "alpha-engine-saturday-pipeline": "Saturday SF",
-    "alpha-engine-weekday-pipeline": "Weekday SF",
-    "alpha-engine-eod-pipeline": "EOD SF",
+    "ne-weekly-freshness-pipeline": "Weekly Freshness SF",
+    "ne-preopen-trading-pipeline": "Pre-open Trading SF",
+    "ne-postclose-trading-pipeline": "Post-close Trading SF",
 }
 
-# 2026-05-23 Preflight Pipeline rename: when the Saturday SF runs as
+# 2026-05-23 Preflight Pipeline rename: when the weekly-freshness SF runs as
 # the Friday-PM preflight dry-pass (input ``shell_run=true``), surface a
-# distinct ``Saturday Preflight SF`` label in the Telegram message so
+# distinct ``Weekly Freshness Preflight SF`` label in the Telegram message so
 # the operator can tell the two flavors apart in the channel at a
 # glance. The state machine name is the same (the dry-pass IS the
-# Saturday SF with dry inputs per CLAUDE.md "don't add redundant paths
+# weekly-freshness SF with dry inputs per CLAUDE.md "don't add redundant paths
 # around load-bearing scheduled infra"); we differentiate via the
 # execution input flag, not via a separate SF.
 _PREFLIGHT_LABEL_OVERRIDE: dict[str, str] = {
-    "alpha-engine-saturday-pipeline": "Saturday Preflight SF",
+    "ne-weekly-freshness-pipeline": "Weekly Freshness Preflight SF",
 }
 
 _STATUS_EMOJI: dict[str, str] = {

--- a/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
@@ -28,9 +28,9 @@ sys.path.insert(0, str(Path(__file__).parent))
 import index  # noqa: E402
 
 
-SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline"
-WEEKDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
-EOD_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
+WEEKDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline"
+EOD_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
 
 
 def _event(status: str, sm_arn: str = SATURDAY_ARN, **detail_overrides) -> dict:
@@ -59,7 +59,7 @@ def test_running_sends_silent_message_without_duration_or_cause():
 
     _telegram_mod.send_message.assert_called_once()
     text, kwargs = _telegram_mod.send_message.call_args.args[0], _telegram_mod.send_message.call_args.kwargs
-    assert "Saturday SF — RUNNING" in text
+    assert "Weekly Freshness SF — RUNNING" in text
     assert "Execution: exec-001" in text
     assert "Duration:" not in text
     assert "Cause:" not in text
@@ -75,7 +75,7 @@ def test_succeeded_sends_loud_message_with_duration():
 
     text = _telegram_mod.send_message.call_args.args[0]
     kwargs = _telegram_mod.send_message.call_args.kwargs
-    assert "Weekday SF — SUCCEEDED" in text
+    assert "Pre-open Trading SF — SUCCEEDED" in text
     assert "Duration: 1m" in text
     assert kwargs["disable_notification"] is False
     assert result["silent"] is False
@@ -105,7 +105,7 @@ def test_failed_fetches_and_includes_cause():
     )
     text = _telegram_mod.send_message.call_args.args[0]
     kwargs = _telegram_mod.send_message.call_args.kwargs
-    assert "EOD SF — FAILED" in text
+    assert "Post-close Trading SF — FAILED" in text
     assert "Cause: States.TaskFailed: EODReconcile state failed: NoCredentialsError" in text
     assert kwargs["disable_notification"] is False
     assert result["status"] == "FAILED"
@@ -120,7 +120,7 @@ def test_failed_with_describe_execution_error_still_sends():
         result = index.handler(event, None)
 
     text = _telegram_mod.send_message.call_args.args[0]
-    assert "Saturday SF — FAILED" in text
+    assert "Weekly Freshness SF — FAILED" in text
     assert "Cause:" not in text  # enrichment silently dropped
     assert result["telegram_sent"] is True
 
@@ -146,7 +146,7 @@ def test_timed_out_sends_loud_message():
     index.handler(event, None)
     text = _telegram_mod.send_message.call_args.args[0]
     kwargs = _telegram_mod.send_message.call_args.kwargs
-    assert "Saturday SF — TIMED_OUT" in text
+    assert "Weekly Freshness SF — TIMED_OUT" in text
     assert kwargs["disable_notification"] is False
 
 
@@ -155,7 +155,7 @@ def test_aborted_sends_loud_message():
     index.handler(event, None)
     text = _telegram_mod.send_message.call_args.args[0]
     kwargs = _telegram_mod.send_message.call_args.kwargs
-    assert "Saturday SF — ABORTED" in text
+    assert "Weekly Freshness SF — ABORTED" in text
     assert kwargs["disable_notification"] is False
 
 
@@ -175,15 +175,15 @@ def test_send_message_failure_returned_in_result():
 
 
 def test_label_lookup_table_covers_all_three_sfs():
-    assert index._SF_LABELS["alpha-engine-saturday-pipeline"] == "Saturday SF"
-    assert index._SF_LABELS["alpha-engine-weekday-pipeline"] == "Weekday SF"
-    assert index._SF_LABELS["alpha-engine-eod-pipeline"] == "EOD SF"
+    assert index._SF_LABELS["ne-weekly-freshness-pipeline"] == "Weekly Freshness SF"
+    assert index._SF_LABELS["ne-preopen-trading-pipeline"] == "Pre-open Trading SF"
+    assert index._SF_LABELS["ne-postclose-trading-pipeline"] == "Post-close Trading SF"
 
 
 class TestPreflightLabel:
-    """2026-05-23 rename: the Saturday SF's Friday-PM dry-pass execution
-    (input ``shell_run=true``) surfaces 'Saturday Preflight SF' in the
-    Telegram message instead of 'Saturday SF', so the operator can tell
+    """2026-05-23 rename: the Weekly Freshness SF's Friday-PM dry-pass execution
+    (input ``shell_run=true``) surfaces 'Weekly Freshness Preflight SF' in the
+    Telegram message instead of 'Weekly Freshness SF', so the operator can tell
     a green/red preflight result apart from a real Saturday result at a
     glance. Same state machine; differentiated via execution input flag.
     """
@@ -202,12 +202,12 @@ class TestPreflightLabel:
         with patch("index.boto3.client", return_value=fake_sf_client):
             index.handler(event, None)
         text = _telegram_mod.send_message.call_args.args[0]
-        assert "Saturday Preflight SF — SUCCEEDED" in text, (
-            f"shell_run=true on Saturday SF must surface "
-            f"'Saturday Preflight SF' label; got: {text!r}"
+        assert "Weekly Freshness Preflight SF — SUCCEEDED" in text, (
+            f"shell_run=true on Weekly Freshness SF must surface "
+            f"'Weekly Freshness Preflight SF' label; got: {text!r}"
         )
-        # Default label must NOT appear (Saturday SF != Saturday Preflight SF)
-        assert "Saturday SF —" not in text
+        # Default label must NOT appear (Weekly Freshness SF != Weekly Freshness Preflight SF)
+        assert "Weekly Freshness SF —" not in text
 
     def test_saturday_without_shell_run_uses_default_label(self):
         event = _event("SUCCEEDED", sm_arn=SATURDAY_ARN)
@@ -220,7 +220,7 @@ class TestPreflightLabel:
         with patch("index.boto3.client", return_value=fake_sf_client):
             index.handler(event, None)
         text = _telegram_mod.send_message.call_args.args[0]
-        assert "Saturday SF — SUCCEEDED" in text
+        assert "Weekly Freshness SF — SUCCEEDED" in text
         assert "Preflight" not in text
 
     def test_saturday_with_shell_run_false_uses_default_label(self):
@@ -236,13 +236,13 @@ class TestPreflightLabel:
         with patch("index.boto3.client", return_value=fake_sf_client):
             index.handler(event, None)
         text = _telegram_mod.send_message.call_args.args[0]
-        assert "Saturday SF — SUCCEEDED" in text
+        assert "Weekly Freshness SF — SUCCEEDED" in text
         assert "Preflight" not in text
 
     def test_non_saturday_sf_with_shell_run_true_keeps_default_label(self):
-        """Defensive: shell_run=true on Weekday or EOD SF (which can't
+        """Defensive: shell_run=true on Weekday or Post-close Trading SF (which can't
         actually happen in practice) keeps the default label — only the
-        Saturday SF has a Preflight variant."""
+        Weekly Freshness SF has a Preflight variant."""
         event = _event("SUCCEEDED", sm_arn=WEEKDAY_ARN)
         fake_sf_client = MagicMock()
         fake_sf_client.describe_execution.return_value = {
@@ -253,12 +253,12 @@ class TestPreflightLabel:
         with patch("index.boto3.client", return_value=fake_sf_client):
             index.handler(event, None)
         text = _telegram_mod.send_message.call_args.args[0]
-        assert "Weekday SF — SUCCEEDED" in text
+        assert "Pre-open Trading SF — SUCCEEDED" in text
         assert "Preflight" not in text
 
     def test_describe_execution_error_falls_back_to_default_label(self):
         """boto3 hiccup must not break the notify path — falls back to
-        the default 'Saturday SF' label (the alert still fires)."""
+        the default 'Weekly Freshness SF' label (the alert still fires)."""
         event = _event("SUCCEEDED", sm_arn=SATURDAY_ARN)
         fake_sf_client = MagicMock()
         fake_sf_client.describe_execution.side_effect = RuntimeError(
@@ -267,7 +267,7 @@ class TestPreflightLabel:
         with patch("index.boto3.client", return_value=fake_sf_client):
             result = index.handler(event, None)
         text = _telegram_mod.send_message.call_args.args[0]
-        assert "Saturday SF — SUCCEEDED" in text
+        assert "Weekly Freshness SF — SUCCEEDED" in text
         assert result["telegram_sent"] is True
 
     def test_malformed_input_json_falls_back_to_default_label(self):
@@ -283,13 +283,13 @@ class TestPreflightLabel:
         with patch("index.boto3.client", return_value=fake_sf_client):
             index.handler(event, None)
         text = _telegram_mod.send_message.call_args.args[0]
-        assert "Saturday SF — FAILED" in text
+        assert "Weekly Freshness SF — FAILED" in text
         # The cause enrichment STILL works — parsing input is independent
         # of error/cause extraction.
         assert "Cause: E: C" in text
 
     def test_failed_preflight_includes_both_label_and_cause(self):
-        """Combined path: a FAILED Saturday Preflight SF event must
+        """Combined path: a FAILED Weekly Freshness Preflight SF event must
         surface BOTH the Preflight label AND the cause enrichment from
         a single DescribeExecution call."""
         event = self._saturday_preflight_event("FAILED")
@@ -304,14 +304,14 @@ class TestPreflightLabel:
         # Verify single boto3 client call (not duplicated for preflight + cause)
         bc.assert_called_once_with("stepfunctions", region_name=index.REGION)
         text = _telegram_mod.send_message.call_args.args[0]
-        assert "Saturday Preflight SF — FAILED" in text
+        assert "Weekly Freshness Preflight SF — FAILED" in text
         assert "Cause: States.TaskFailed: MorningEnrich state failed" in text
 
     def test_preflight_label_override_map_pins_saturday_only(self):
         """The override map is intentionally Saturday-only — the
-        weekday + EOD SFs don't have a preflight variant."""
+        weekday + Post-close Trading SFs don't have a preflight variant."""
         assert index._PREFLIGHT_LABEL_OVERRIDE == {
-            "alpha-engine-saturday-pipeline": "Saturday Preflight SF",
+            "ne-weekly-freshness-pipeline": "Weekly Freshness Preflight SF",
         }
 
 

--- a/infrastructure/run_weekly_offcycle.sh
+++ b/infrastructure/run_weekly_offcycle.sh
@@ -52,7 +52,7 @@ set -euo pipefail
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 
-SF_NAME="alpha-engine-saturday-pipeline"
+SF_NAME="ne-weekly-freshness-pipeline"
 SF_ARN="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:${SF_NAME}"
 SATURDAY_RULE="alpha-engine-saturday"
 SATURDAY_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${SATURDAY_RULE}"

--- a/infrastructure/update_eod_pipeline_sf.sh
+++ b/infrastructure/update_eod_pipeline_sf.sh
@@ -12,7 +12,7 @@
 # Reads the state-machine definition from
 # infrastructure/step_function_eod.json (single source of truth, same
 # pattern as deploy_step_function.sh for the Saturday SF) and applies
-# it to alpha-engine-eod-pipeline. The JSON file is the authoritative
+# it to ne-postclose-trading-pipeline. The JSON file is the authoritative
 # definition — wiring tests pin its contents.
 #
 # Idempotent: re-running with the same definition is a no-op (AWS only
@@ -28,7 +28,7 @@ DEFN_FILE="$SCRIPT_DIR/step_function_eod.json"
 
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
-SM_ARN="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+SM_ARN="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
 
 echo "=== Alpha Engine EOD Pipeline — SF Definition Update ==="
 echo "  Region:        $REGION"

--- a/sf_preflight.py
+++ b/sf_preflight.py
@@ -2,7 +2,7 @@
 sf_preflight.py — Predict whether the Saturday SF would succeed BEFORE
 launching a spot.
 
-Today's Saturday SF (alpha-engine-saturday-pipeline) is a 50-min spot run
+Today's Saturday SF (ne-weekly-freshness-pipeline) is a 50-min spot run
 that costs 1 polygon API call (free-tier 5/min budget) per attempt and a
 spot bootstrap (~3 min wall-clock + IAM/SSM dance). Repeated launch-fail
 cycles burn polygon quota and operator hours. This module simulates the

--- a/tests/test_deploy_infrastructure_sf_coverage.py
+++ b/tests/test_deploy_infrastructure_sf_coverage.py
@@ -2,7 +2,7 @@
 ``infrastructure/`` MUST be auto-deployed by ``deploy-infrastructure.sh``.
 
 This pins the fix for config#1173: the EOD SF (``step_function_eod.json`` →
-``alpha-engine-eod-pipeline``) used to be deployed ONLY by the manual
+``ne-postclose-trading-pipeline``) used to be deployed ONLY by the manual
 ``update_eod_pipeline_sf.sh``, which nothing triggered on merge. Merged EOD SF
 changes therefore silently never reached the live state machine (drift hit
 2026-06-22 via #458's ``nousergon_lib`` migration — weekday + Saturday
@@ -61,17 +61,20 @@ def test_sf_definition_uploaded_to_s3(sf_file: str) -> None:
 
 
 def test_update_state_machine_called_for_each_sf() -> None:
-    """Each SF definition has a corresponding update-state-machine deploy.
+    """Each SF definition has a corresponding deploy in the script.
 
-    We count the ``update-state-machine`` invocations rather than tie each to a
-    literal ARN string (the ARNs are built from shell vars) and require at least
-    one per SF definition file.
+    We count the DISTINCT state-machine names the script applies (parsed from the
+    ``...:stateMachine:<name>`` ARN strings) rather than literal
+    ``update-state-machine`` occurrences: since the 2026-06-29 ne- rename the
+    deploy uses existence-aware helpers (``update_or_defer_to_cfn`` /
+    ``update_or_create``) so the CFN-managed pair is create-deferred to the stack
+    and the literal call count no longer maps 1:1 to SFs. Require at least one
+    deployed name per SF definition file.
     """
-    script = _DEPLOY.read_text()
-    n_updates = script.count("aws stepfunctions update-state-machine")
-    assert n_updates >= len(_SF_FILES), (
-        f"deploy-infrastructure.sh has {n_updates} update-state-machine "
-        f"call(s) for {len(_SF_FILES)} SF definition file(s) "
+    deployed = _sf_names_deployed_by_script()
+    assert len(deployed) >= len(_SF_FILES), (
+        f"deploy-infrastructure.sh applies {len(deployed)} state machine(s) "
+        f"({sorted(deployed)}) for {len(_SF_FILES)} SF definition file(s) "
         f"({_SF_FILES}); every orchestration SF must be applied on merge "
         f"(config#1173)."
     )
@@ -81,15 +84,15 @@ def test_eod_state_machine_is_auto_deployed() -> None:
     """Explicit pin for the config#1173 regression target.
 
     The EOD SF + its state-machine name must both be wired into the deploy
-    script so the auto-deploy path covers ``alpha-engine-eod-pipeline``.
+    script so the auto-deploy path covers ``ne-postclose-trading-pipeline``.
     """
     script = _DEPLOY.read_text()
     assert "step_function_eod.json" in script, (
         "EOD SF definition not referenced by deploy-infrastructure.sh "
         "(config#1173 regression)."
     )
-    assert "alpha-engine-eod-pipeline" in script, (
-        "alpha-engine-eod-pipeline state machine not deployed by "
+    assert "ne-postclose-trading-pipeline" in script, (
+        "ne-postclose-trading-pipeline state machine not deployed by "
         "deploy-infrastructure.sh (config#1173 regression)."
     )
 
@@ -118,7 +121,9 @@ def _sf_names_deployed_by_script() -> set[str]:
     in full in the script.
     """
     script = _DEPLOY.read_text()
-    return set(re.findall(r"stateMachine:(alpha-engine-[a-z0-9-]+pipeline)", script))
+    return set(
+        re.findall(r"stateMachine:((?:alpha-engine|ne)-[a-z0-9-]+pipeline)", script)
+    )
 
 
 def _sf_arn_patterns_granted_in_policy() -> list[str]:

--- a/tests/test_run_weekly_offcycle.py
+++ b/tests/test_run_weekly_offcycle.py
@@ -116,7 +116,7 @@ def test_shell_input_matches_lambda() -> None:
 
 
 def test_full_targets_correct_state_machine(runner_text: str) -> None:
-    assert "alpha-engine-saturday-pipeline" in runner_text
+    assert "ne-weekly-freshness-pipeline" in runner_text
 
 
 def test_full_suppresses_then_starts_safely(runner_text: str) -> None:


### PR DESCRIPTION
**Linchpin** of the fleet SF rename (config#1381) — the CloudFormation/deploy/IAM cutover plus the data-side consumers. Pairs with crucible-executor#309, crucible-dashboard#265, the config charter PR, and the nousergon-lib `PIPELINE_LABELS` PR.

| Old | New |
|---|---|
| `alpha-engine-saturday-pipeline` | `ne-weekly-freshness-pipeline` |
| `alpha-engine-weekday-pipeline` | `ne-preopen-trading-pipeline` |
| `alpha-engine-eod-pipeline` | `ne-postclose-trading-pipeline` |

## What
Bulk literal rename across 40 files (CFN `StateMachineName`, deploy/IAM/Lambda constants, tests, READMEs). **Intentionally NOT renamed:** CFN logical IDs (`SaturdayPipeline`/`WeekdayPipeline` — the `!Ref` targets auto-resolve to the new ARNs), EventBridge rule names (`alpha-engine-saturday`/`-weekday`), and the frozen cadence labels (`saturday_sf`/`weekday_sf`/`eod_sf`, `*-sf-failure`, `*_sf_watch` SSM) — a separate axis, tracked as the config#1381 follow-up.

**Cutover-critical changes beyond the literal swap:**
- **`deploy-infrastructure.sh`** — existence-aware SF deploy. AWS can't rename a state machine, so on the first post-merge deploy the new names don't exist yet. The two CFN-managed SFs are *update-if-exists / defer-creation-to-CFN-if-absent* (the CFN replacement creates them from `DefinitionS3Location`); the post-close (EOD) SF — not in CFN — is *update-if-exists / create-if-absent* under the shared SF execution role.
- **`iam/github-actions-lambda-deploy.json`** — `InfraDeploySFDefinition` now grants `states:CreateStateMachine` + `DeleteStateMachine` (CFN creates the new SFs + deletes the old on replacement; the EOD path self-creates) on **both** `alpha-engine-*-pipeline` (old, for the cutover delete) and `ne-*-pipeline` (new). **Without this the cutover deploy 403s and halts the next run on DeployDriftCheck** — the exact 2026-06-24 failure class the coverage guard pins.
- **sf-watch dispatcher** — `PIPELINES` gains `cadence_slug` + `label`; the frozen cadence is the SoT for the watch-prefix / dispatch-type / kill-switch mapping and is passed to the agent so the charter never parses the SF name. `_pipeline_label` reads `PIPELINES`; `cadence_slug` added to the dispatch payload.
- **sf-telegram-notifier** — display labels → Weekly Freshness / Pre-open Trading / Post-close Trading SF.
- **`test_deploy_infrastructure_sf_coverage`** — taught the `ne-` names + the helper-function structure; guard intent preserved (every SF file deployed; every deployed SF `UpdateStateMachine`-granted).

## Tests
All changed lambda/infra tests green (dispatcher 20, notifier 20, deploy-coverage 7, run_weekly_offcycle 9, eod-backstop/friday-shell/watchdog/etc.). **2 pre-existing freshness-monitor failures** are shared-venv lib staleness (venv 0.62.0 vs the branch's `v0.73.0` pin; `index.py` untouched here) — CI installs the pin and passes.

## Safety / rollout (observe-first, operator-timed)
**No live effect on merge of this PR alone** — the CFN replacement + IAM apply are the cutover, and the merge *is* what triggers `deploy-infrastructure.yml`. Per config#1381: apply the IAM **first**, then merge at a safe window (after Fri post-close / before Sat weekly) so no trading session is exposed. The renamed SFs lose old execution history (S3 artifacts persist); old EOD SF deleted manually in Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
