### PR TITLE
refactor(crypto): drop requests for stdlib urllib — dependency-free Lambda

### DIFF
--- a/collectors/crypto_balances.py
+++ b/collectors/crypto_balances.py
@@ -23,11 +23,11 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import urllib.parse
+import urllib.request
 from collections.abc import Callable, Iterable
 from datetime import UTC, datetime
 from typing import Any
-
-import requests
 
 logger = logging.getLogger("crypto_balances")
 
@@ -37,6 +37,7 @@ HOLDINGS_KEY = "crypto/holdings.json"                          # producer → Me
 HOLDINGS_SCHEMA_VERSION = 1
 
 _HTTP_TIMEOUT = 15
+_UA = {"User-Agent": "nousergon-crypto-balances/1.0"}
 _BLOCKSTREAM = "https://blockstream.info/api/address/{address}"
 _ETH_RPC = "https://cloudflare-eth.com"
 _COINGECKO = "https://api.coingecko.com/api/v3/simple/price"
@@ -44,39 +45,52 @@ _COINGECKO = "https://api.coingecko.com/api/v3/simple/price"
 _COIN = {"BTC": ("bitcoin", "BTC"), "ETH": ("ethereum", "ETH")}
 
 
+# ── HTTP via stdlib (no third-party dep → a dependency-free Lambda zip, no platform wheels) ─
+
+
+def _get_json(url: str) -> Any:
+    """GET ``url`` → parsed JSON. Raises (HTTPError/URLError) on a non-2xx or network error —
+    callers fail soft per address."""
+    req = urllib.request.Request(url, headers=_UA)
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as r:  # noqa: S310 - fixed https hosts
+        return json.loads(r.read())
+
+
+def _post_json(url: str, payload: dict) -> Any:
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(), method="POST",
+        headers={**_UA, "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as r:  # noqa: S310 - fixed https host
+        return json.loads(r.read())
+
+
 # ── Chain balance fetchers (injectable for tests) ───────────────────────────────────────
 
 
-def fetch_btc_balance(address: str, *, session: requests.Session) -> float:
+def fetch_btc_balance(address: str) -> float:
     """Confirmed BTC balance for ``address`` (funded − spent txo sums, sats → BTC)."""
-    r = session.get(_BLOCKSTREAM.format(address=address), timeout=_HTTP_TIMEOUT)
-    r.raise_for_status()
-    cs = r.json().get("chain_stats", {})
+    cs = _get_json(_BLOCKSTREAM.format(address=address)).get("chain_stats", {})
     sats = int(cs.get("funded_txo_sum", 0)) - int(cs.get("spent_txo_sum", 0))
     return sats / 1e8
 
 
-def fetch_eth_balance(address: str, *, session: requests.Session) -> float:
+def fetch_eth_balance(address: str) -> float:
     """Native ETH balance for ``address`` via JSON-RPC ``eth_getBalance`` (wei → ETH)."""
     payload = {"jsonrpc": "2.0", "method": "eth_getBalance", "params": [address, "latest"], "id": 1}
-    r = session.post(_ETH_RPC, json=payload, timeout=_HTTP_TIMEOUT)
-    r.raise_for_status()
-    body = r.json()
+    body = _post_json(_ETH_RPC, payload)
     if "error" in body:
         raise RuntimeError(f"eth_getBalance error: {body['error']}")
     return int(body["result"], 16) / 1e18
 
 
-def fetch_prices(symbols: Iterable[str], *, session: requests.Session) -> dict[str, float]:
+def fetch_prices(symbols: Iterable[str]) -> dict[str, float]:
     """``{symbol: usd_price}`` for the given chain symbols via CoinGecko simple price."""
     ids = sorted({_COIN[s][0] for s in symbols if s in _COIN})
     if not ids:
         return {}
-    r = session.get(
-        _COINGECKO, params={"ids": ",".join(ids), "vs_currencies": "usd"}, timeout=_HTTP_TIMEOUT
-    )
-    r.raise_for_status()
-    data = r.json()
+    url = _COINGECKO + "?" + urllib.parse.urlencode({"ids": ",".join(ids), "vs_currencies": "usd"})
+    data = _get_json(url)
     out: dict[str, float] = {}
     for sym, (cg_id, _) in _COIN.items():
         usd = data.get(cg_id, {}).get("usd")
@@ -118,7 +132,6 @@ def collect(
     *,
     bucket: str = DEFAULT_BUCKET,
     s3_client: Any = None,
-    session: requests.Session | None = None,
     balance_fetchers: dict[str, Callable[..., float]] | None = None,
     price_fetcher: Callable[..., dict[str, float]] | None = None,
     now: datetime | None = None,
@@ -126,16 +139,14 @@ def collect(
 ) -> dict:
     """Read the wallet-address universe, fetch balances + prices, write ``crypto/holdings.json``.
 
-    Returns a small status dict. ``s3_client`` / ``session`` / the fetchers are injectable for
-    tests. Per-address failures are WARN-logged + counted (``n_failed``), never fatal."""
+    Returns a small status dict. ``s3_client`` + the fetchers are injectable for tests.
+    Per-address failures are WARN-logged + counted (``n_failed``), never fatal."""
     now = now or datetime.now(UTC)
     fetchers = balance_fetchers or _BALANCE_FETCHERS
     price_fn = price_fetcher or fetch_prices
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")
-    if session is None:
-        session = requests.Session()
 
     universe = _read_json(s3_client, bucket, WALLET_ADDRESSES_KEY)
     addresses = (universe or {}).get("addresses", [])
@@ -145,7 +156,7 @@ def collect(
 
     chains_present = {str(a.get("chain", "")).upper() for a in addresses}
     try:
-        prices = price_fn(chains_present, session=session)
+        prices = price_fn(chains_present)
     except Exception as e:  # noqa: BLE001 - prices are best-effort; balances still publish
         logger.warning("[crypto_balances] price fetch failed (values omitted this cycle): %s", e)
         prices = {}
@@ -161,7 +172,7 @@ def collect(
             logger.warning("[crypto_balances] unsupported/empty entry skipped: %r", a)
             continue
         try:
-            bal = fetcher(address, session=session)
+            bal = fetcher(address)
         except Exception as e:  # noqa: BLE001 - per-address fail-soft (recorded), never abort
             n_failed += 1
             logger.warning("[crypto_balances] %s balance fetch failed for %s: %s", chain, address, e)

--- a/infrastructure/lambdas/crypto-balances/deploy.sh
+++ b/infrastructure/lambdas/crypto-balances/deploy.sh
@@ -63,13 +63,12 @@ if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
-# ----- 1. Package: pip install deps + vendor the collector + zip -------------
+# ----- 1. Package: vendor the handler + collector + zip ----------------------
+# No third-party deps — the collector uses only stdlib (urllib) + boto3 (runtime-provided),
+# so the zip is just two .py files (no pip, no platform-specific wheels).
 
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
-
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 # Vendor the tested collector flat next to the handler (it has no intra-repo imports).

--- a/infrastructure/lambdas/crypto-balances/index.py
+++ b/infrastructure/lambdas/crypto-balances/index.py
@@ -8,7 +8,7 @@ guaranteed around-the-clock execution with a CloudWatch trail and zero box coupl
 EventBridge-Scheduler wiring mirrors the sibling ``scheduled-groom-dispatcher``.
 
 Reuses the tested ``collectors.crypto_balances.collect()`` — vendored next to this handler
-by ``deploy.sh`` (it has no intra-repo imports, only stdlib + requests + boto3) — which reads
+by ``deploy.sh`` (it has no intra-repo imports, only stdlib + boto3) — which reads
 ``metron/crypto/wallet_addresses.json``, fetches BTC/ETH balances + prices, and writes
 ``crypto/holdings.json``.
 

--- a/infrastructure/lambdas/crypto-balances/requirements.txt
+++ b/infrastructure/lambdas/crypto-balances/requirements.txt
@@ -1,5 +1,0 @@
-# Bundled into the deployment zip via `pip install -t` (mirrors the sibling lambdas).
-# requests is needed by the vendored collectors/crypto_balances.py fetchers (BTC/ETH/price
-# HTTP). boto3 is provided by the Lambda python3.12 runtime; pinned for a reproducible build.
-requests>=2.31
-boto3>=1.34.0

--- a/tests/test_crypto_balances.py
+++ b/tests/test_crypto_balances.py
@@ -44,7 +44,7 @@ def _fetchers(balances: dict[str, float]):
     """Balance fetchers keyed by chain, returning a canned balance (or raising for an
     address mapped to an Exception)."""
     def _make(chain):
-        def _fetch(address, *, session):
+        def _fetch(address):
             val = balances[chain]
             if isinstance(val, Exception):
                 raise val
@@ -56,9 +56,9 @@ def _fetchers(balances: dict[str, float]):
 def test_happy_path_writes_balances_and_values():
     s3 = _s3(_universe(("BTC", _BTC), ("ETH", _ETH)))
     r = cb.collect(
-        s3_client=s3, session=MagicMock(),
+        s3_client=s3,
         balance_fetchers=_fetchers({"BTC": 0.5, "ETH": 2.0}),
-        price_fetcher=lambda syms, *, session: {"BTC": 60000.0, "ETH": 3000.0},
+        price_fetcher=lambda syms: {"BTC": 60000.0, "ETH": 3000.0},
         now=_NOW,
     )
     assert r["status"] == "ok" and r["n_balances"] == 2 and r["n_failed"] == 0
@@ -73,9 +73,9 @@ def test_happy_path_writes_balances_and_values():
 def test_per_address_failure_is_soft():
     s3 = _s3(_universe(("BTC", _BTC), ("ETH", _ETH)))
     r = cb.collect(
-        s3_client=s3, session=MagicMock(),
+        s3_client=s3,
         balance_fetchers=_fetchers({"BTC": 0.5, "ETH": RuntimeError("rpc down")}),
-        price_fetcher=lambda syms, *, session: {"BTC": 60000.0},
+        price_fetcher=lambda syms: {"BTC": 60000.0},
         now=_NOW,
     )
     assert r["status"] == "ok" and r["n_balances"] == 1 and r["n_failed"] == 1
@@ -86,11 +86,11 @@ def test_per_address_failure_is_soft():
 def test_price_failure_still_writes_balances_without_value():
     s3 = _s3(_universe(("BTC", _BTC)))
 
-    def _boom(syms, *, session):
+    def _boom(syms):
         raise RuntimeError("coingecko 429")
 
     r = cb.collect(
-        s3_client=s3, session=MagicMock(),
+        s3_client=s3,
         balance_fetchers=_fetchers({"BTC": 1.0}), price_fetcher=_boom, now=_NOW,
     )
     assert r["status"] == "ok"
@@ -100,22 +100,22 @@ def test_price_failure_still_writes_balances_without_value():
 
 def test_no_addresses_skips_without_write():
     s3 = _s3(_universe())
-    r = cb.collect(s3_client=s3, session=MagicMock(), now=_NOW)
+    r = cb.collect(s3_client=s3, now=_NOW)
     assert r["status"] == "skipped" and s3.put_object.call_count == 0
 
 
 def test_missing_universe_artifact_skips():
     s3 = _s3(None)
-    r = cb.collect(s3_client=s3, session=MagicMock(), now=_NOW)
+    r = cb.collect(s3_client=s3, now=_NOW)
     assert r["status"] == "skipped" and s3.put_object.call_count == 0
 
 
 def test_all_failed_does_not_write():
     s3 = _s3(_universe(("ETH", _ETH)))
     r = cb.collect(
-        s3_client=s3, session=MagicMock(),
+        s3_client=s3,
         balance_fetchers=_fetchers({"ETH": RuntimeError("down")}),
-        price_fetcher=lambda syms, *, session: {}, now=_NOW,
+        price_fetcher=lambda syms: {}, now=_NOW,
     )
     assert r["status"] == "error" and s3.put_object.call_count == 0
 
@@ -123,9 +123,9 @@ def test_all_failed_does_not_write():
 def test_dry_run_does_not_write():
     s3 = _s3(_universe(("BTC", _BTC)))
     r = cb.collect(
-        s3_client=s3, session=MagicMock(),
+        s3_client=s3,
         balance_fetchers=_fetchers({"BTC": 1.0}),
-        price_fetcher=lambda syms, *, session: {"BTC": 50000.0},
+        price_fetcher=lambda syms: {"BTC": 50000.0},
         now=_NOW, dry_run=True,
     )
     assert r["status"] == "dry-run" and s3.put_object.call_count == 0


### PR DESCRIPTION
## Why
Surfaced while preparing the `deploy.sh --bootstrap` for the crypto-balances Lambda (metron-ops#111): bundling `requests` is fragile.
- Building `requests`' transitive wheels (e.g. `charset-normalizer`) on macOS for the Lambda **Linux** runtime risks a platform-mismatch `.so`.
- The deploy's own validation step (`python3 -m pytest test_handler.py` under bare system python) couldn't import the collector without `requests` installed.

For **three simple HTTP calls**, stdlib `urllib` is the robust choice: zero third-party deps, no platform wheels, a ~5 KB zip, faster cold start.

## What
- **`collectors/crypto_balances.py`**: replace the `requests`-based fetchers with `urllib` (`_get_json`/`_post_json`); drop the `session` param from the fetchers and `collect()`. Behavior is identical — a non-2xx / network error raises (`HTTPError`/`URLError`) and is caught by the same per-address fail-soft path that `raise_for_status()` fed before.
- **tests**: drop the injected `session` kwarg from the fakes (they still inject fetchers, so no network).
- **lambda**: remove `requirements.txt` + the `pip install` packaging step (the zip is now just `index.py` + the vendored collector); fix the stale "requests" docstring mention.

## Verified
- Handler test passes under **bare system `python3`** (no `requests`) — so the deploy's validation step works.
- `deploy.sh --bootstrap --dry-run` packages a clean **5 KB** zip and prints the correct bootstrap plan (lambda role + policy, function, scheduler role + policy, `rate(15 minutes)` schedule).
- 14 tests green (handler 4 + collector 7 + artifact-registry pin 3).

Last prerequisite before `deploy.sh --bootstrap` goes live (metron-ops#111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)