### PR TITLE
fix(crypto): multi-provider RPC fallback — cloudflare-eth.com is dead

### DIFF
--- a/collectors/crypto_balances.py
+++ b/collectors/crypto_balances.py
@@ -38,8 +38,19 @@ HOLDINGS_SCHEMA_VERSION = 1
 
 _HTTP_TIMEOUT = 15
 _UA = {"User-Agent": "nousergon-crypto-balances/1.0"}
-_BLOCKSTREAM = "https://blockstream.info/api/address/{address}"
-_ETH_RPC = "https://cloudflare-eth.com"
+# Each chain has MULTIPLE free, no-key public providers tried in order — no single endpoint
+# is a SPOF (Cloudflare's cloudflare-eth.com gateway, the original sole ETH RPC, started
+# returning -32603 once deprecated; that one dead endpoint silently zeroed every ETH wallet).
+# BTC: Esplora-compatible address API (Blockstream → mempool.space fallback, same schema).
+_BTC_ESPLORA = ["https://blockstream.info/api", "https://mempool.space/api"]
+# ETH: JSON-RPC eth_getBalance on reliable keyless public nodes (PublicNode + dRPC both
+# verified live 2026-06-29; llamarpc kept as a last resort). NOT Ankr's public endpoint — it
+# now requires an API key, so it's a dead free fallback.
+_ETH_RPCS = [
+    "https://ethereum-rpc.publicnode.com",
+    "https://eth.drpc.org",
+    "https://eth.llamarpc.com",
+]
 _COINGECKO = "https://api.coingecko.com/api/v3/simple/price"
 # chain → (CoinGecko id, display symbol)
 _COIN = {"BTC": ("bitcoin", "BTC"), "ETH": ("ethereum", "ETH")}
@@ -69,19 +80,34 @@ def _post_json(url: str, payload: dict) -> Any:
 
 
 def fetch_btc_balance(address: str) -> float:
-    """Confirmed BTC balance for ``address`` (funded − spent txo sums, sats → BTC)."""
-    cs = _get_json(_BLOCKSTREAM.format(address=address)).get("chain_stats", {})
-    sats = int(cs.get("funded_txo_sum", 0)) - int(cs.get("spent_txo_sum", 0))
-    return sats / 1e8
+    """Confirmed BTC balance for ``address`` (funded − spent txo sums, sats → BTC). Tries each
+    Esplora provider in order; raises only if all fail (caught by the per-address fail-soft)."""
+    last_err: Exception | None = None
+    for base in _BTC_ESPLORA:
+        try:
+            cs = _get_json(f"{base}/address/{address}").get("chain_stats", {})
+            sats = int(cs.get("funded_txo_sum", 0)) - int(cs.get("spent_txo_sum", 0))
+            return sats / 1e8
+        except Exception as e:  # noqa: BLE001 - try the next provider
+            last_err = e
+    raise RuntimeError(f"all BTC providers failed; last: {last_err}")
 
 
 def fetch_eth_balance(address: str) -> float:
-    """Native ETH balance for ``address`` via JSON-RPC ``eth_getBalance`` (wei → ETH)."""
+    """Native ETH balance for ``address`` via JSON-RPC ``eth_getBalance`` (wei → ETH). Tries
+    each public RPC in order; a node-level JSON-RPC error counts as a failure and falls through
+    to the next. Raises only if all RPCs fail."""
     payload = {"jsonrpc": "2.0", "method": "eth_getBalance", "params": [address, "latest"], "id": 1}
-    body = _post_json(_ETH_RPC, payload)
-    if "error" in body:
-        raise RuntimeError(f"eth_getBalance error: {body['error']}")
-    return int(body["result"], 16) / 1e18
+    last_err: Exception | None = None
+    for rpc in _ETH_RPCS:
+        try:
+            body = _post_json(rpc, payload)
+            if "error" in body:
+                raise RuntimeError(f"{rpc} eth_getBalance error: {body['error']}")
+            return int(body["result"], 16) / 1e18
+        except Exception as e:  # noqa: BLE001 - try the next RPC
+            last_err = e
+    raise RuntimeError(f"all ETH RPCs failed; last: {last_err}")
 
 
 def fetch_prices(symbols: Iterable[str]) -> dict[str, float]:

--- a/tests/test_crypto_balances.py
+++ b/tests/test_crypto_balances.py
@@ -11,6 +11,8 @@ import json
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 from collectors import crypto_balances as cb
 
 _BTC = "bc1q9zpgru5j9q3dccf6n5xm9wglv5jh0w8r4d5xkp"
@@ -129,3 +131,47 @@ def test_dry_run_does_not_write():
         now=_NOW, dry_run=True,
     )
     assert r["status"] == "dry-run" and s3.put_object.call_count == 0
+
+
+class TestProviderFallback:
+    """Each chain has multiple public providers tried in order — no single endpoint is a SPOF
+    (the original sole ETH RPC, cloudflare-eth.com, went dead and silently zeroed ETH)."""
+
+    def test_eth_falls_through_to_next_rpc(self, monkeypatch):
+        calls = []
+
+        def fake_post(url, payload):
+            calls.append(url)
+            if url == cb._ETH_RPCS[0]:
+                raise RuntimeError("rpc 0 unreachable")
+            return {"result": hex(2 * 10**18)}  # 2 ETH
+
+        monkeypatch.setattr(cb, "_post_json", fake_post)
+        assert cb.fetch_eth_balance(_ETH) == 2.0
+        assert calls[:2] == cb._ETH_RPCS[:2]
+
+    def test_eth_jsonrpc_error_falls_through(self, monkeypatch):
+        def fake_post(url, payload):
+            if url == cb._ETH_RPCS[0]:
+                return {"error": {"code": -32603, "message": "Internal error"}}  # the cloudflare failure
+            return {"result": hex(10**18)}  # 1 ETH
+
+        monkeypatch.setattr(cb, "_post_json", fake_post)
+        assert cb.fetch_eth_balance(_ETH) == 1.0
+
+    def test_eth_all_rpcs_fail_raises(self, monkeypatch):
+        def _boom(url, payload):
+            raise RuntimeError("down")
+
+        monkeypatch.setattr(cb, "_post_json", _boom)
+        with pytest.raises(RuntimeError):
+            cb.fetch_eth_balance(_ETH)
+
+    def test_btc_falls_through_to_mempool(self, monkeypatch):
+        def fake_get(url):
+            if url.startswith(cb._BTC_ESPLORA[0]):
+                raise RuntimeError("blockstream down")
+            return {"chain_stats": {"funded_txo_sum": 150_000_000, "spent_txo_sum": 50_000_000}}  # 1 BTC
+
+        monkeypatch.setattr(cb, "_get_json", fake_get)
+        assert cb.fetch_btc_balance(_BTC) == 1.0


### PR DESCRIPTION
## Symptom
First live run after wallets were added to the `/crypto` page: **BTC fetched fine, ETH failed**. The producer wrote BTC only; the page shows ETH as "Pending sync".

## Root cause
The sole ETH RPC, `https://cloudflare-eth.com`, returns `{'code': -32603, 'message': 'Internal error'}` — **Cloudflare deprecated its public Ethereum gateway**. One dead free endpoint silently zeroed every ETH wallet: a single-provider SPOF.

## Fix
Give **each chain a fallback list**, tried in order, raising only if *all* fail (the per-address fail-soft then records it):
- **ETH**: PublicNode → dRPC → llamarpc. PublicNode + dRPC both **verified live** against the real wallet (returns 0.269 ETH). Dropped Ankr's public endpoint — it now **requires an API key**, so it's a dead free fallback.
- **BTC**: Blockstream → mempool.space (same Esplora schema).

## Verified live (2026-06-29)
```
OK  https://ethereum-rpc.publicnode.com -> 0x3bc8fdaee0c92bc   (0.269 ETH)
OK  https://eth.drpc.org                -> 0x3bc8fdaee0c92bc
fetch_eth_balance -> 0.26924824819483106 ETH
```

## Tests
`TestProviderFallback`: ETH falls through on an unreachable RPC **and** on a JSON-RPC error (the exact cloudflare failure), all-fail raises, BTC falls through to mempool. **18 green.**

After merge: redeploy the Lambda code (`deploy.sh`, no `--bootstrap`) and the next run picks up ETH. (metron-ops#111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)