### PR TITLE
freshness-monitor: import alerts.publish from krepis — config#1339

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -24,7 +24,7 @@ invocation:
      — the monitor monitors itself; substrate-health-check daily
      watches the heartbeat.
   5. For misses past SLA (``state ∈ {missing, stale, probe_failed}``),
-     route to :func:`alpha_engine_lib.alerts.publish` with
+     route to :func:`krepis.alerts.publish` with
      ``dedup_key=resolve_dedup_key(spec, now)`` — dedup collapses
      4×/hour retries to one alert per cycle per artifact.
   6. **OBSERVE-mode gate**: when env
@@ -54,7 +54,7 @@ from typing import Any
 import boto3
 import yaml
 
-from alpha_engine_lib.alerts import publish
+from krepis.alerts import publish
 from alpha_engine_lib.artifact_freshness import (
     ArtifactSpec,
     CheckResult,


### PR DESCRIPTION
Repoints the freshness-monitor Lambda's alerts import off the deprecated `alpha_engine_lib.alerts` alias shim to the canonical `krepis.alerts` (the alerts module relocated to krepis/MIT at nousergon-lib v0.66.0).

The Lambda pins nousergon-lib v0.73.0, which hard-deps `krepis>=0.2.0`, so krepis is already in the image — no requirements change. The test patches `index.publish` directly, so the import-source swap stays green: `test_handler.py` — **44 passed**.

Part of nousergon/alpha-engine-config#1339. (pipeline-watchdog is left for a separate change — it pins nousergon-lib v0.28.1, pre-rename, so it needs a lib-pin bump before it can target krepis; tracked in the issue.)