### PR TITLE
feat(crypto): BTC HD-wallet (xpub/ypub/zpub) balance via gap-limit derivation

### DIFF
--- a/collectors/crypto_balances.py
+++ b/collectors/crypto_balances.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import time
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Iterable
@@ -55,6 +56,17 @@ _COINGECKO = "https://api.coingecko.com/api/v3/simple/price"
 # chain → (CoinGecko id, display symbol)
 _COIN = {"BTC": ("bitcoin", "BTC"), "ETH": ("ethereum", "ETH")}
 
+# BTC extended-public-key (HD wallet) support. A single BTC address is NOT the wallet balance
+# — funds are spread across many addresses derived from one seed — so a self-custody wallet is
+# tracked by its xpub/ypub/zpub, from which we derive + sum every address. Prefix → BIP script
+# type: xpub=BIP44 legacy P2PKH, ypub=BIP49 P2SH-P2WPKH, zpub=BIP84 native-segwit P2WPKH.
+_XPUB_PREFIXES = ("xpub", "ypub", "zpub")
+# Gap limit: stop a branch after this many consecutive unused (tx_count==0) addresses (BIP44).
+_GAP_LIMIT = 20
+# Small politeness delay between per-address Esplora queries during a gap-limit scan, so a
+# many-address wallet doesn't trip the public providers' rate limits.
+_SCAN_DELAY_S = 0.05
+
 
 # ── HTTP via stdlib (no third-party dep → a dependency-free Lambda zip, no platform wheels) ─
 
@@ -79,18 +91,73 @@ def _post_json(url: str, payload: dict) -> Any:
 # ── Chain balance fetchers (injectable for tests) ───────────────────────────────────────
 
 
-def fetch_btc_balance(address: str) -> float:
-    """Confirmed BTC balance for ``address`` (funded − spent txo sums, sats → BTC). Tries each
-    Esplora provider in order; raises only if all fail (caught by the per-address fail-soft)."""
+def _is_extended_key(s: str) -> bool:
+    """True if ``s`` is a BTC extended public key (HD wallet) rather than a plain address."""
+    return s[:4] in _XPUB_PREFIXES
+
+
+def _esplora_address_stats(address: str) -> tuple[int, int, int]:
+    """``(funded_sats, spent_sats, tx_count)`` (confirmed) for a single BTC address, trying each
+    Esplora provider in order. Raises only if all fail (caught by the per-address fail-soft)."""
     last_err: Exception | None = None
     for base in _BTC_ESPLORA:
         try:
             cs = _get_json(f"{base}/address/{address}").get("chain_stats", {})
-            sats = int(cs.get("funded_txo_sum", 0)) - int(cs.get("spent_txo_sum", 0))
-            return sats / 1e8
+            return (
+                int(cs.get("funded_txo_sum", 0)),
+                int(cs.get("spent_txo_sum", 0)),
+                int(cs.get("tx_count", 0)),
+            )
         except Exception as e:  # noqa: BLE001 - try the next provider
             last_err = e
     raise RuntimeError(f"all BTC providers failed; last: {last_err}")
+
+
+def fetch_btc_balance(address: str) -> float:
+    """Confirmed BTC balance, in BTC. Dispatches: an extended public key (xpub/ypub/zpub) is an
+    HD wallet → derive + sum all its addresses; otherwise a single address (funded − spent)."""
+    if _is_extended_key(address):
+        return fetch_btc_xpub_balance(address)
+    funded, spent, _ = _esplora_address_stats(address)
+    return (funded - spent) / 1e8
+
+
+def _xpub_address_fn(xpub: str):
+    """Return ``child_hdkey -> address`` for the script type implied by the key's prefix
+    (xpub→P2PKH, ypub→P2SH-P2WPKH, zpub→P2WPKH). Imports embit lazily so the module loads
+    without the dep (only the xpub path needs it)."""
+    from embit import script
+
+    prefix = xpub[:4]
+    if prefix == "zpub":
+        return lambda c: script.p2wpkh(c).address()
+    if prefix == "ypub":
+        return lambda c: script.p2sh(script.p2wpkh(c)).address()
+    return lambda c: script.p2pkh(c).address()  # xpub (legacy)
+
+
+def fetch_btc_xpub_balance(xpub: str, *, gap_limit: int = _GAP_LIMIT) -> float:
+    """Total confirmed BTC across an HD wallet, in BTC. Derives addresses on both the receive
+    (0) and change (1) branches and sums their balances, extending each branch until
+    ``gap_limit`` consecutive unused (tx_count==0) addresses — the standard HD-wallet scan.
+    Derivation is client-side (trustless) via embit, verified against the BIP84 test vector."""
+    from embit import bip32
+
+    root = bip32.HDKey.from_string(xpub)
+    to_addr = _xpub_address_fn(xpub)
+    total_sats = 0
+    for branch in (0, 1):  # external (receive) + internal (change)
+        gap = 0
+        i = 0
+        while gap < gap_limit:
+            address = to_addr(root.derive([branch, i]))
+            funded, spent, tx_count = _esplora_address_stats(address)
+            total_sats += funded - spent
+            gap = 0 if tx_count else gap + 1
+            i += 1
+            if _SCAN_DELAY_S:
+                time.sleep(_SCAN_DELAY_S)
+    return total_sats / 1e8
 
 
 def fetch_eth_balance(address: str) -> float:

--- a/infrastructure/lambdas/crypto-balances/deploy.sh
+++ b/infrastructure/lambdas/crypto-balances/deploy.sh
@@ -63,15 +63,18 @@ if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
-# ----- 1. Package: vendor the handler + collector + zip ----------------------
-# No third-party deps — the collector uses only stdlib (urllib) + boto3 (runtime-provided),
-# so the zip is just two .py files (no pip, no platform-specific wheels).
+# ----- 1. Package: deps (embit) + vendor the handler + collector + zip -------
+# embit is pure-Python-capable + ships a prebuilt linux_x86_64 libsecp256k1, so `pip install
+# -t` on any host yields a Lambda-safe package (no platform-wheel selection). The collector is
+# vendored flat (it has no intra-repo imports); boto3 comes from the runtime.
 
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
 
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
-# Vendor the tested collector flat next to the handler (it has no intra-repo imports).
 cp "${REPO_ROOT}/collectors/crypto_balances.py" "${PKG}/crypto_balances.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")

--- a/infrastructure/lambdas/crypto-balances/requirements.txt
+++ b/infrastructure/lambdas/crypto-balances/requirements.txt
@@ -1,0 +1,6 @@
+# Bundled into the deployment zip via `pip install -t`. ONLY embit (BTC HD-wallet xpub
+# derivation) — it's pure-Python-capable and ships a prebuilt linux_x86_64 libsecp256k1 (the
+# Lambda arch) with a pure-Python fallback, so `pip install -t` on any host yields a Lambda-safe
+# package (no platform-wheel selection). boto3 is NOT listed — the python3.12 runtime provides
+# it, and bundling it would bloat the zip by ~17 MB for nothing.
+embit>=0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ pyarrow>=14.0
 yfinance>=0.2.36
 requests>=2.31
 pyyaml>=6.0
+# Bitcoin HD-wallet (xpub/ypub/zpub) derivation for the crypto-balances producer
+# (collectors/crypto_balances.py). Pure-Python-capable (ships a prebuilt linux libsecp256k1
+# + a pure fallback) → Lambda-safe, no platform wheels. metron-ops#111.
+embit>=0.7.0
 numpy>=1.24
 feedparser>=6.0
 beautifulsoup4>=4.12

--- a/tests/test_crypto_balances.py
+++ b/tests/test_crypto_balances.py
@@ -17,6 +17,9 @@ from collectors import crypto_balances as cb
 
 _BTC = "bc1q9zpgru5j9q3dccf6n5xm9wglv5jh0w8r4d5xkp"
 _ETH = "0x52908400098527886e0f7030069857d2e4169ee7"
+# Canonical BIP84 test vector (mnemonic "abandon abandon … about"): zpub + its m/…/0/0 address.
+_ZPUB = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs"
+_ZPUB_FIRST_RECEIVE = "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
 _NOW = datetime(2026, 6, 29, 12, 0, tzinfo=UTC)
 
 
@@ -171,7 +174,52 @@ class TestProviderFallback:
         def fake_get(url):
             if url.startswith(cb._BTC_ESPLORA[0]):
                 raise RuntimeError("blockstream down")
-            return {"chain_stats": {"funded_txo_sum": 150_000_000, "spent_txo_sum": 50_000_000}}  # 1 BTC
+            return {"chain_stats": {"funded_txo_sum": 150_000_000, "spent_txo_sum": 50_000_000, "tx_count": 1}}  # 1 BTC
 
         monkeypatch.setattr(cb, "_get_json", fake_get)
+        assert cb.fetch_btc_balance(_BTC) == 1.0
+
+
+class TestXpub:
+    """HD-wallet (xpub/ypub/zpub) support — a single BTC address isn't the wallet balance, so
+    self-custody wallets are tracked by an extended key whose addresses we derive + sum."""
+
+    def test_is_extended_key(self):
+        assert cb._is_extended_key(_ZPUB)
+        assert not cb._is_extended_key(_BTC)
+
+    def test_derivation_matches_bip84_vector(self, monkeypatch):
+        # Real embit derivation: the first receive address must be the canonical BIP84 vector.
+        seen: list[str] = []
+
+        def fake_stats(addr):
+            seen.append(addr)
+            return (0, 0, 0)  # all empty → the scan terminates at the gap limit
+
+        monkeypatch.setattr(cb, "_esplora_address_stats", fake_stats)
+        monkeypatch.setattr(cb, "_SCAN_DELAY_S", 0)
+        assert cb.fetch_btc_xpub_balance(_ZPUB, gap_limit=3) == 0.0
+        assert seen[0] == _ZPUB_FIRST_RECEIVE
+
+    def test_gap_limit_sums_then_stops(self, monkeypatch):
+        calls = {"n": 0}
+
+        def fake_stats(addr):
+            calls["n"] += 1
+            if calls["n"] == 1:  # first receive address holds a net 1 BTC
+                return (150_000_000, 50_000_000, 1)
+            return (0, 0, 0)
+
+        monkeypatch.setattr(cb, "_esplora_address_stats", fake_stats)
+        monkeypatch.setattr(cb, "_SCAN_DELAY_S", 0)
+        assert cb.fetch_btc_xpub_balance(_ZPUB, gap_limit=3) == 1.0
+        # receive: 0 used + 3 empty (gap hits 3) = 4 calls; change: 3 empty = 3 calls → 7 total.
+        assert calls["n"] == 7
+
+    def test_fetch_btc_dispatches_xpub(self, monkeypatch):
+        monkeypatch.setattr(cb, "fetch_btc_xpub_balance", lambda x, **k: 2.5)
+        assert cb.fetch_btc_balance(_ZPUB) == 2.5
+
+    def test_fetch_btc_single_address_path(self, monkeypatch):
+        monkeypatch.setattr(cb, "_esplora_address_stats", lambda a: (150_000_000, 50_000_000, 1))
         assert cb.fetch_btc_balance(_BTC) == 1.0


### PR DESCRIPTION
## Why
First live run with real wallets: BTC read **0.0** while the wallet holds funds. Root cause isn't a bug — a **single BTC address ≠ the wallet balance**. A self-custody HD wallet spreads funds across many addresses derived from one seed; the pasted address was an empty receive address. (ETH worked because it's account-based — one address = balance.) Verified self-custody HD with Brian → track BTC by its **extended public key**.

## What
- `fetch_btc_balance()` dispatches: an extended key (xpub/ypub/zpub) → `fetch_btc_xpub_balance()`; else the single-address path.
- `fetch_btc_xpub_balance()`: derives the **receive (0) + change (1)** branches with standard **gap-limit scanning** (stop after 20 consecutive unused), summing each address's confirmed balance via the Esplora fallback providers. Derivation is **client-side / trustless** via embit; prefix → script type (xpub=P2PKH, ypub=P2SH-P2WPKH, zpub=P2WPKH). Small inter-call delay to respect provider rate limits.
- **embit** added to requirements + the Lambda bundle. Pure-Python-capable, ships a prebuilt `linux_x86_64 libsecp256k1` (the Lambda arch) with a pure-Python fallback → **Lambda-safe, no platform wheels**. embit-only zip ≈ **1 MB** (boto3 stays runtime-provided).

## Verified
Tests assert derivation against the **canonical BIP84 vector** (first receive address == `bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu`), the gap-limit **sum + termination**, and the xpub-vs-single-address dispatch. (Manually confirmed embit also matches the BIP49 ypub vector.) **16 collector tests green.**

Pairs with the Metron consumer PR (accept an xpub in the BTC field). After both merge: redeploy the Lambda and the next run sums the HD wallet. (metron-ops#111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)