### PR TITLE
feat(crypto): BTC xpub all-script-types + ERC-20 token holdings (ETH)

### DIFF
--- a/collectors/crypto_balances.py
+++ b/collectors/crypto_balances.py
@@ -56,6 +56,13 @@ _COINGECKO = "https://api.coingecko.com/api/v3/simple/price"
 # chain → (CoinGecko id, display symbol)
 _COIN = {"BTC": ("bitcoin", "BTC"), "ETH": ("ethereum", "ETH")}
 
+# ERC-20 token balances for an ETH address. Blockscout's v2 API returns every token's balance
+# AND a USD ``exchange_rate`` in one keyless call — so spam/airdrop tokens (the bulk of any
+# active address's holdings) self-filter: they have no exchange_rate and are dropped. Only
+# tokens worth at least this many USD are emitted, to keep dust out of the view.
+_BLOCKSCOUT_TOKENS = "https://eth.blockscout.com/api/v2/addresses/{address}/token-balances"
+_TOKEN_MIN_USD = 1.0
+
 # BTC extended-public-key (HD wallet) support. A single BTC address is NOT the wallet balance
 # — funds are spread across many addresses derived from one seed — so a self-custody wallet is
 # tracked by its xpub/ypub/zpub, from which we derive + sum every address. Prefix → BIP script
@@ -122,41 +129,46 @@ def fetch_btc_balance(address: str) -> float:
     return (funded - spent) / 1e8
 
 
-def _xpub_address_fn(xpub: str):
-    """Return ``child_hdkey -> address`` for the script type implied by the key's prefix
-    (xpub→P2PKH, ypub→P2SH-P2WPKH, zpub→P2WPKH). Imports embit lazily so the module loads
-    without the dep (only the xpub path needs it)."""
+def _xpub_address_fns(xpub: str) -> list:
+    """``[child_hdkey -> address, …]`` — the script type(s) to derive for this key. ypub/zpub
+    version bytes are unambiguous (one type). A bare ``xpub`` is AMBIGUOUS: many wallets
+    (notably Ledger) export a native-segwit OR wrapped-segwit account as a plain xpub, so we
+    derive ALL THREE (P2PKH / P2SH-P2WPKH / P2WPKH) and sum — an account only uses one type, so
+    the unused ones contribute 0 while the funded one is found. Imports embit lazily."""
     from embit import script
 
     prefix = xpub[:4]
     if prefix == "zpub":
-        return lambda c: script.p2wpkh(c).address()
+        return [lambda c: script.p2wpkh(c).address()]
     if prefix == "ypub":
-        return lambda c: script.p2sh(script.p2wpkh(c)).address()
-    return lambda c: script.p2pkh(c).address()  # xpub (legacy)
+        return [lambda c: script.p2sh(script.p2wpkh(c)).address()]
+    return [  # xpub — try every script type
+        lambda c: script.p2wpkh(c).address(),
+        lambda c: script.p2sh(script.p2wpkh(c)).address(),
+        lambda c: script.p2pkh(c).address(),
+    ]
 
 
 def fetch_btc_xpub_balance(xpub: str, *, gap_limit: int = _GAP_LIMIT) -> float:
-    """Total confirmed BTC across an HD wallet, in BTC. Derives addresses on both the receive
-    (0) and change (1) branches and sums their balances, extending each branch until
+    """Total confirmed BTC across an HD wallet, in BTC. For each candidate script type, derives
+    the receive (0) + change (1) branches and sums balances, extending each branch until
     ``gap_limit`` consecutive unused (tx_count==0) addresses — the standard HD-wallet scan.
     Derivation is client-side (trustless) via embit, verified against the BIP84 test vector."""
     from embit import bip32
 
     root = bip32.HDKey.from_string(xpub)
-    to_addr = _xpub_address_fn(xpub)
     total_sats = 0
-    for branch in (0, 1):  # external (receive) + internal (change)
-        gap = 0
-        i = 0
-        while gap < gap_limit:
-            address = to_addr(root.derive([branch, i]))
-            funded, spent, tx_count = _esplora_address_stats(address)
-            total_sats += funded - spent
-            gap = 0 if tx_count else gap + 1
-            i += 1
-            if _SCAN_DELAY_S:
-                time.sleep(_SCAN_DELAY_S)
+    for to_addr in _xpub_address_fns(xpub):
+        for branch in (0, 1):  # external (receive) + internal (change)
+            gap = 0
+            i = 0
+            while gap < gap_limit:
+                funded, spent, tx_count = _esplora_address_stats(to_addr(root.derive([branch, i])))
+                total_sats += funded - spent
+                gap = 0 if tx_count else gap + 1
+                i += 1
+                if _SCAN_DELAY_S:
+                    time.sleep(_SCAN_DELAY_S)
     return total_sats / 1e8
 
 
@@ -175,6 +187,40 @@ def fetch_eth_balance(address: str) -> float:
         except Exception as e:  # noqa: BLE001 - try the next RPC
             last_err = e
     raise RuntimeError(f"all ETH RPCs failed; last: {last_err}")
+
+
+def fetch_eth_tokens(address: str) -> list[dict]:
+    """Priced ERC-20 token holdings for ``address`` as ``[{symbol, balance, price_usd,
+    value_usd, contract}, …]`` via Blockscout v2. Keeps only tokens with a USD exchange_rate
+    and value ≥ ``_TOKEN_MIN_USD`` (so spam/airdrop tokens, which carry no rate, drop out).
+    Best-effort — the caller treats a failure as "no tokens" so native ETH still publishes."""
+    data = _get_json(_BLOCKSCOUT_TOKENS.format(address=address))
+    out: list[dict] = []
+    for entry in data or []:
+        tok = entry.get("token") or {}
+        if tok.get("type") != "ERC-20":
+            continue
+        rate = tok.get("exchange_rate")
+        if not rate:
+            continue  # unpriced → spam/airdrop, drop
+        try:
+            decimals = int(tok.get("decimals") or 18)
+            balance = int(entry["value"]) / 10**decimals
+            price = float(rate)
+        except (TypeError, ValueError, KeyError):
+            continue
+        value = balance * price
+        if value < _TOKEN_MIN_USD:
+            continue
+        out.append({
+            "symbol": tok.get("symbol") or "?",
+            "balance": balance,
+            "price_usd": price,
+            "value_usd": value,
+            "contract": tok.get("address"),
+        })
+    out.sort(key=lambda t: t["value_usd"], reverse=True)
+    return out
 
 
 def fetch_prices(symbols: Iterable[str]) -> dict[str, float]:
@@ -227,6 +273,7 @@ def collect(
     s3_client: Any = None,
     balance_fetchers: dict[str, Callable[..., float]] | None = None,
     price_fetcher: Callable[..., dict[str, float]] | None = None,
+    eth_token_fetcher: Callable[[str], list[dict]] | None = None,
     now: datetime | None = None,
     dry_run: bool = False,
 ) -> dict:
@@ -237,6 +284,7 @@ def collect(
     now = now or datetime.now(UTC)
     fetchers = balance_fetchers or _BALANCE_FETCHERS
     price_fn = price_fetcher or fetch_prices
+    token_fn = eth_token_fetcher or fetch_eth_tokens
     if s3_client is None:
         import boto3
         s3_client = boto3.client("s3")
@@ -277,6 +325,14 @@ def collect(
             row["price_usd"] = px
             row["value_usd"] = bal * px
         balances.append(row)
+        # ETH: also enumerate priced ERC-20 token holdings (one row each). Best-effort — a
+        # token-fetch failure leaves the native ETH row in place (WARN, never abort the entry).
+        if chain == "ETH":
+            try:
+                for tok in token_fn(address):
+                    balances.append({"chain": "ETH", "address": address, **tok})
+            except Exception as e:  # noqa: BLE001 - tokens are additive to native ETH
+                logger.warning("[crypto_balances] ETH token fetch failed for %s: %s", address, e)
 
     if not balances:
         logger.warning("[crypto_balances] every address fetch failed (%d) — not writing", n_failed)
@@ -285,7 +341,7 @@ def collect(
     artifact = {
         "schema_version": HOLDINGS_SCHEMA_VERSION,
         "as_of_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "source": "blockstream+eth_rpc+coingecko",
+        "source": "blockstream+eth_rpc+coingecko+blockscout",
         "balances": balances,
         "prices": {s: prices[s] for s in sorted(prices)},
     }

--- a/infrastructure/lambdas/crypto-balances/deploy.sh
+++ b/infrastructure/lambdas/crypto-balances/deploy.sh
@@ -109,7 +109,7 @@ if $BOOTSTRAP; then
     echo "  Creating Lambda: ${FUNCTION_NAME}"
     run aws lambda create-function --function-name "${FUNCTION_NAME}" \
       --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
-      --zip-file "fileb://${ZIP}" --timeout 60 --memory-size 256 \
+      --zip-file "fileb://${ZIP}" --timeout 120 --memory-size 256 \
       --environment 'Variables={LOG_LEVEL=INFO,CRYPTO_BALANCES_ENABLED=true,MARKET_DATA_BUCKET=alpha-engine-research}' \
       --region "${REGION}" --query 'FunctionArn' --output text
   else
@@ -162,6 +162,12 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+# Ensure the runtime config matches (idempotent) — the BTC all-script-types xpub scan + ETH
+# token enumeration need headroom beyond the original 60s.
+echo "Ensuring timeout/memory: 120s / 256MB"
+run aws lambda update-function-configuration --function-name "${FUNCTION_NAME}" \
+  --timeout 120 --memory-size 256 --region "${REGION}" --query 'LastUpdateStatus' --output text
 echo "✓ Code deployed."
 
 # ----- 4. Smoke (real invoke — writes crypto/holdings.json if addresses exist) ---

--- a/tests/test_crypto_balances.py
+++ b/tests/test_crypto_balances.py
@@ -20,6 +20,9 @@ _ETH = "0x52908400098527886e0f7030069857d2e4169ee7"
 # Canonical BIP84 test vector (mnemonic "abandon abandon … about"): zpub + its m/…/0/0 address.
 _ZPUB = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs"
 _ZPUB_FIRST_RECEIVE = "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+# A bare xpub (BIP44 account key of the same test mnemonic) — its script type is ambiguous, so
+# the scanner derives all three types (the real-world Ledger-exports-segwit-as-xpub case).
+_XPUB = "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"
 _NOW = datetime(2026, 6, 29, 12, 0, tzinfo=UTC)
 
 
@@ -64,6 +67,7 @@ def test_happy_path_writes_balances_and_values():
         s3_client=s3,
         balance_fetchers=_fetchers({"BTC": 0.5, "ETH": 2.0}),
         price_fetcher=lambda syms: {"BTC": 60000.0, "ETH": 3000.0},
+        eth_token_fetcher=lambda a: [],
         now=_NOW,
     )
     assert r["status"] == "ok" and r["n_balances"] == 2 and r["n_failed"] == 0
@@ -81,6 +85,7 @@ def test_per_address_failure_is_soft():
         s3_client=s3,
         balance_fetchers=_fetchers({"BTC": 0.5, "ETH": RuntimeError("rpc down")}),
         price_fetcher=lambda syms: {"BTC": 60000.0},
+        eth_token_fetcher=lambda a: [],
         now=_NOW,
     )
     assert r["status"] == "ok" and r["n_balances"] == 1 and r["n_failed"] == 1
@@ -120,7 +125,7 @@ def test_all_failed_does_not_write():
     r = cb.collect(
         s3_client=s3,
         balance_fetchers=_fetchers({"ETH": RuntimeError("down")}),
-        price_fetcher=lambda syms: {}, now=_NOW,
+        price_fetcher=lambda syms: {}, eth_token_fetcher=lambda a: [], now=_NOW,
     )
     assert r["status"] == "error" and s3.put_object.call_count == 0
 
@@ -223,3 +228,74 @@ class TestXpub:
     def test_fetch_btc_single_address_path(self, monkeypatch):
         monkeypatch.setattr(cb, "_esplora_address_stats", lambda a: (150_000_000, 50_000_000, 1))
         assert cb.fetch_btc_balance(_BTC) == 1.0
+
+    def test_zpub_one_script_type_xpub_all_three(self):
+        assert len(cb._xpub_address_fns(_ZPUB)) == 1   # unambiguous version → P2WPKH only
+        assert len(cb._xpub_address_fns(_XPUB)) == 3   # ambiguous → scan P2PKH/P2SH-WPKH/P2WPKH
+
+    def test_xpub_scans_every_script_type(self, monkeypatch):
+        # All addresses empty → each script type's two branches hit the gap limit. With 3 types
+        # the scan does 3× the work of a single-type (zpub) key — proves all types are scanned.
+        monkeypatch.setattr(cb, "_SCAN_DELAY_S", 0)
+        n = {"x": 0, "z": 0}
+
+        monkeypatch.setattr(cb, "_esplora_address_stats", lambda a: (n.__setitem__("x", n["x"] + 1), (0, 0, 0))[1])
+        assert cb.fetch_btc_xpub_balance(_XPUB, gap_limit=2) == 0.0
+        monkeypatch.setattr(cb, "_esplora_address_stats", lambda a: (n.__setitem__("z", n["z"] + 1), (0, 0, 0))[1])
+        assert cb.fetch_btc_xpub_balance(_ZPUB, gap_limit=2) == 0.0
+        assert n["x"] == 3 * n["z"]  # 3 script types vs 1
+
+
+class TestEthTokens:
+    """ERC-20 token holdings for an ETH address (Blockscout v2). Only tokens with a USD
+    exchange_rate + value ≥ $1 are kept — spam/airdrop tokens (no rate) self-filter."""
+
+    def _blockscout(self):
+        return [
+            {"value": str(752_800_000_000_000_000), "token": {
+                "type": "ERC-20", "symbol": "STETH", "decimals": "18",
+                "exchange_rate": "1618.23", "address": "0xae7"}},
+            {"value": str(10**18), "token": {  # spam: no exchange_rate → dropped
+                "type": "ERC-20", "symbol": "SPAM", "decimals": "18",
+                "exchange_rate": None, "address": "0xspam"}},
+            {"value": str(10**17), "token": {  # dust: 0.1 × $0.001 = $0.0001 < $1 → dropped
+                "type": "ERC-20", "symbol": "DUST", "decimals": "18",
+                "exchange_rate": "0.001", "address": "0xdust"}},
+        ]
+
+    def test_filters_spam_and_dust(self, monkeypatch):
+        monkeypatch.setattr(cb, "_get_json", lambda url: self._blockscout())
+        toks = cb.fetch_eth_tokens(_ETH)
+        assert [t["symbol"] for t in toks] == ["STETH"]
+        assert toks[0]["value_usd"] == pytest.approx(0.7528 * 1618.23)
+        assert toks[0]["contract"] == "0xae7"
+
+    def test_collect_emits_native_eth_plus_token_rows(self):
+        s3 = _s3(_universe(("ETH", _ETH)))
+        r = cb.collect(
+            s3_client=s3,
+            balance_fetchers={"ETH": lambda a: 0.5},
+            price_fetcher=lambda syms: {"ETH": 2000.0},
+            eth_token_fetcher=lambda a: [{"symbol": "STETH", "balance": 1.0, "price_usd": 1600.0, "value_usd": 1600.0, "contract": "0xae7"}],
+            now=_NOW,
+        )
+        assert r["status"] == "ok" and r["n_balances"] == 2  # native ETH + 1 token
+        art = _puts(s3)[cb.HOLDINGS_KEY]
+        syms = [b["symbol"] for b in art["balances"]]
+        assert syms == ["ETH", "STETH"]
+        assert art["balances"][1]["value_usd"] == 1600.0
+
+    def test_token_fetch_failure_keeps_native_eth(self):
+        s3 = _s3(_universe(("ETH", _ETH)))
+
+        def _boom(a):
+            raise RuntimeError("blockscout down")
+
+        r = cb.collect(
+            s3_client=s3,
+            balance_fetchers={"ETH": lambda a: 0.5},
+            price_fetcher=lambda syms: {"ETH": 2000.0},
+            eth_token_fetcher=_boom, now=_NOW,
+        )
+        assert r["status"] == "ok" and r["n_balances"] == 1  # native ETH survives
+        assert _puts(s3)[cb.HOLDINGS_KEY]["balances"][0]["symbol"] == "ETH"


### PR DESCRIPTION
Two gaps surfaced once real wallets were tracked (both diagnosed live against Brian's wallets):

## 1. BTC xpub read 0.0
The wallet exported a **native-segwit account as a bare `xpub`** (Ledger does this), but `xpub` was mapped only to legacy P2PKH → derived empty `1...` addresses while the funds sit at `bc1q`. The `xpub` version byte is **ambiguous**, so now we derive **all three** script types (P2PKH / P2SH-P2WPKH / P2WPKH) and sum — an account uses one type, so the others contribute 0 and the funded one (here P2WPKH) is found. ypub/zpub stay single-type. *(Diagnosed: deriving p2wpkh from the xpub finds the funded `bc1q` addresses.)*

## 2. ETH tokens invisible (~$2.6k)
Only native ETH was fetched. Add `fetch_eth_tokens()` via **Blockscout v2**, which returns each token's balance **and** USD `exchange_rate` keyless. **Spam/airdrop tokens self-filter** — ~50 of the 63 held carry no rate and drop out; keep tokens priced ≥ \$1. `collect()` emits the native ETH row **plus one row per priced token** (same address); a token-fetch failure is fail-soft (native ETH still publishes). *(Verified: surfaces STETH \$1,218 / ETHX \$733 / STKAAVE \$550 / … = \$2,585.)*

`deploy.sh` bumps timeout 60→120s (the 3× xpub scan + token call need headroom), idempotent on the update path.

## Tests
xpub scans all 3 types (vs 1 for zpub); token spam/dust filtering; `collect` emits native+token rows; token failure keeps native ETH. **28 collector tests green.**

Pairs with the Metron consumer (render multiple positions per ETH wallet). (metron-ops#111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)