### PR TITLE
docs(cf): fix dead ROADMAP pointer in SNS-mirror orphan cross-ref (alpha-engine-config#860)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -121,8 +121,9 @@ Resources:
   # resources lived in this stack, every CI deploy hit a perm-cascade on
   # the github-actions-lambda-deploy OIDC role (iam:TagRole, iam:GetRole,
   # ...). Orphaning the Lambda kept the OIDC role narrow and removed the
-  # cascade. See ROADMAP "SNS-mirror Lambda — orphan vs CF management"
-  # for the full trade-off + future reconsideration triggers.
+  # cascade. See alpha-engine-config#860 "SNS-mirror Lambda — orphan vs CF
+  # management" (migrated from ROADMAP.md on 2026-06-11, config PR #623) for
+  # the full trade-off + future reconsideration triggers.
 
   # --------------------------------------------------------------------------
   # Step Functions — Saturday Pipeline


### PR DESCRIPTION
## What
The orchestration CF template (`infrastructure/cloudformation/alpha-engine-orchestration.yaml`) carries an `AlertsTopic` cross-ref comment explaining why the `changelog-incident-mirror` Lambda is managed **outside** the CF stack. That comment is the **explicit discoverability mitigation** the orphan decision (alpha-engine-config#860) depends on — the orphan trades away CF `detect-drift` coverage in exchange for this documented pointer.

## The defect
The comment pointed at `ROADMAP "SNS-mirror Lambda — orphan vs CF management"`. `ROADMAP.md` was **migrated to GitHub issues on 2026-06-11** (config PR #623), so that pointer is now dead — a future operator following it lands nowhere. Surfaced while revisiting alpha-engine-config#860.

## The fix
Repoint the cross-ref at the live tracking issue **alpha-engine-config#860** (noting the ROADMAP→issues migration provenance) so the trade-off + reconsideration triggers stay reachable from the template.

Comment-only — **zero resource changes**. Template still parses (validated locally with a CloudFormation-intrinsic-tolerant YAML loader). Does not touch `.github/workflows/*`.

Refs alpha-engine-config#860

🤖 Generated with [Claude Code](https://claude.com/claude-code)