### PR TITLE
fix(sf-watch): resurrect dead Fleet-SF Watch trigger + cover live EOD (config#1408)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -142,7 +142,8 @@ if $BOOTSTRAP; then
     "stateMachineArn": [
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
     ],
     "status": ["FAILED", "TIMED_OUT", "ABORTED"]
   }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -36,7 +36,8 @@
       "Resource": [
         "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*",
         "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*"
+        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*"
       ]
     },
     {

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -98,6 +98,18 @@ PIPELINES: dict[str, dict[str, str]] = {
         "watch_prefix": "consolidated/eod_sf_watch",
         "dispatch_event_type": "eod-sf-failure",
     },
+    # TRANSITIONAL (remove at the SF-rename cutover — config#1408 / re-exam
+    # 2026-07-03). The EOD SF still runs under its OLD name `alpha-engine-eod-
+    # pipeline` (saturday/weekday already renamed; EOD lags). Until cutover, the
+    # LIVE failures arrive under the old ARN, so the registry must recognize it —
+    # otherwise the handler ignores the event (the 2026-06-29 dead-watch gap).
+    # Routes to the SAME eod cadence resources as ne-postclose-trading-pipeline.
+    "alpha-engine-eod-pipeline": {
+        "cadence_slug": "eod",
+        "label": "Post-close Trading",
+        "watch_prefix": "consolidated/eod_sf_watch",
+        "dispatch_event_type": "eod-sf-failure",
+    },
 }
 SCHEMA_VERSION = 1
 _CAUSE_MAX_CHARS = 600

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -364,3 +364,42 @@ def test_pat_never_appears_in_result(monkeypatch):
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED"), None)
     assert "ghp_SECRET_TOKEN" not in json.dumps(result)
+
+
+def _deploy_sh_rule_arns() -> set[str]:
+    """Parse the SF names out of deploy.sh's EventBridge EVENT_PATTERN
+    stateMachineArn list — the literal ARNs the live rule will match."""
+    import re
+
+    text = (Path(__file__).parent / "deploy.sh").read_text()
+    # The pattern lives in a heredoc; pull every stateMachine:<name> token that
+    # appears inside the EVENT_PATTERN block's stateMachineArn array.
+    start = text.index('"stateMachineArn"')
+    end = text.index("]", start)
+    block = text[start:end]
+    return set(re.findall(r"stateMachine:([A-Za-z0-9-]+)", block))
+
+
+def test_registry_and_eventbridge_rule_are_in_lockstep():
+    """REGRESSION GUARD (config#1408, 2026-06-29 dead-watch): every SF name in
+    index.PIPELINES MUST appear in deploy.sh's EventBridge rule pattern. The
+    handler ignores any SF not in the rule's ARN list never even reaches it;
+    any SF not in PIPELINES is ignored by the handler. The two must not drift —
+    that drift is exactly what silently disabled the watcher (code generalized
+    to 3 pipelines, the rule left at a single deleted ARN)."""
+    rule_arns = _deploy_sh_rule_arns()
+    registry = set(index.PIPELINES)
+    missing_from_rule = registry - rule_arns
+    assert not missing_from_rule, (
+        f"PIPELINES entries not covered by the EventBridge rule in deploy.sh: "
+        f"{sorted(missing_from_rule)} — their failures would never invoke the "
+        f"dispatcher. Add them to the EVENT_PATTERN stateMachineArn list."
+    )
+
+
+def test_live_old_named_eod_is_registered_during_rename_transition():
+    """Until the SF-rename cutover (config#1408 / re-exam 2026-07-03) the EOD SF
+    still runs as `alpha-engine-eod-pipeline`. Drop this assertion when the old
+    ARN is removed from the registry + rule at cutover."""
+    assert "alpha-engine-eod-pipeline" in index.PIPELINES
+    assert index.PIPELINES["alpha-engine-eod-pipeline"]["cadence_slug"] == "eod"


### PR DESCRIPTION
Closes the trigger half of config#1408.

## Problem
The Fleet-SF Watch resilience agent was **silently dead** — it caught nothing for today's `alpha-engine-eod-pipeline` deploy-drift failure (2026-06-29), and would catch nothing for any pipeline.

1. **Trigger fired on a deleted SF.** The live EventBridge rule `alpha-engine-saturday-sf-watch-failed` still carried its pre-generalization pattern — a single `stateMachineArn`, `alpha-engine-saturday-pipeline`, which no longer exists (renamed → `ne-weekly-freshness-pipeline`). It matched nothing. The dispatcher *code* was generalized to a 3-pipeline registry (data#525) but the rule was never re-bootstrapped, and this lambda is **operator-deploy-only** (merge has zero live effect).
2. **Live EOD runs under the OLD name.** The registry + rule used only the new `ne-*` names, but the EOD SF still runs as `alpha-engine-eod-pipeline` (saturday/weekday renamed; EOD lags until the 7/3 cutover). So even if the rule fired, the handler would `{"ignored": true}` it (`PIPELINES.get(name)` miss).

## Fix (transitional — removed at the rename cutover, re-exam 2026-07-03)
- `index.PIPELINES`: add `alpha-engine-eod-pipeline` → eod cadence cfg (aliases `ne-postclose-trading-pipeline`)
- `deploy.sh` EVENT_PATTERN: add the old EOD ARN (4 ARNs now)
- `iam-policy.json`: add the old EOD execution ARN for `DescribeExecution`/`GetExecutionHistory` (else enrichment AccessDenied → degraded watch-log)
- `test_handler.py`: **regression guard** asserting every `PIPELINES` key is present in `deploy.sh`'s rule pattern — so "code generalized, trigger left behind" can never recur silently

## Tests
`22 passed` (20 existing + 2 new guards).

## Deploy (operator — PENDING)
This lambda is managed outside CloudFormation; **merge has no live effect**. Resurrection requires an operator to run:
```
bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh --bootstrap
```
which rewrites the EventBridge rule pattern (4 ARNs) + the IAM role policy + the lambda code. I attempted this live but the Claude Code auto-mode classifier correctly gated it (production IAM + EventBridge change needs explicit per-action approval). **The live rule is still pointed at the deleted `alpha-engine-saturday-pipeline` until this runs — the watcher remains dead until then.** `--dry-run` was verified (correct 4-ARN pattern).