### PR TITLE
fix(infra): MutexConflict metric filters — distinct metric name, no dimensions (unblock deploy)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -617,9 +617,17 @@ Resources:
   # The filters key on the MutexConflict Cause text in the SF FailedEvent (logged
   # at level=ERROR + includeExecutionData=true via the LoggingConfiguration
   # above). DependsOn the log group so CFN creates the destination before the
-  # filter. DefaultValue is OMITTED (it is mutually exclusive with Dimensions in
-  # AWS::Logs::MetricFilter); the alarm's TreatMissingData=notBreaching covers
-  # the zero-conflict steady state (no match -> no data point -> alarm OK).
+  # filter.
+  #
+  # Per-SF attribution is via a DISTINCT MetricName per filter — NOT a Dimension.
+  # AWS::Logs::MetricFilter only permits dimensions whose VALUE is a token
+  # extracted from the filter pattern (e.g. `$.field`); a literal dimension value
+  # is rejected at create with "filter pattern does not support dimensions". Our
+  # pattern is a plain text match, so we give each SF its own metric name and
+  # point its alarm at that name. (DefaultValue is also omitted — it is mutually
+  # exclusive with dimensions and unnecessary here: the alarm's
+  # TreatMissingData=notBreaching covers the zero-conflict steady state, where no
+  # match -> no data point -> alarm OK.)
   #
   # EOD (ne-postclose-trading-pipeline) is intentionally NOT covered here: it is
   # script-managed (update_eod_pipeline_sf.sh, logging still OFF) and is
@@ -633,11 +641,8 @@ Resources:
       FilterPattern: '"MutexConflict"'
       MetricTransformations:
         - MetricNamespace: AlphaEngine/StepFunctions
-          MetricName: MutexConflictFails
+          MetricName: WeeklyFreshnessMutexConflictFails
           MetricValue: '1'
-          Dimensions:
-            - Key: StateMachine
-              Value: ne-weekly-freshness-pipeline
 
   PreopenTradingMutexConflictMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -647,11 +652,8 @@ Resources:
       FilterPattern: '"MutexConflict"'
       MetricTransformations:
         - MetricNamespace: AlphaEngine/StepFunctions
-          MetricName: MutexConflictFails
+          MetricName: PreopenTradingMutexConflictFails
           MetricValue: '1'
-          Dimensions:
-            - Key: StateMachine
-              Value: ne-preopen-trading-pipeline
 
   WeeklyFreshnessMutexConflictAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -662,10 +664,7 @@ Resources:
         (duplicate-trigger guard fired). First occurrence = investigate the
         duplicate-trigger source.
       Namespace: AlphaEngine/StepFunctions
-      MetricName: MutexConflictFails
-      Dimensions:
-        - Name: StateMachine
-          Value: ne-weekly-freshness-pipeline
+      MetricName: WeeklyFreshnessMutexConflictFails
       Statistic: Sum
       Period: 86400
       EvaluationPeriods: 1
@@ -684,10 +683,7 @@ Resources:
         (duplicate-trigger guard fired). First occurrence = investigate the
         duplicate-trigger source.
       Namespace: AlphaEngine/StepFunctions
-      MetricName: MutexConflictFails
-      Dimensions:
-        - Name: StateMachine
-          Value: ne-preopen-trading-pipeline
+      MetricName: PreopenTradingMutexConflictFails
       Statistic: Sum
       Period: 86400
       EvaluationPeriods: 1

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -547,16 +547,34 @@ class TestCfnMutexConflictAlarms:
             "MutexConflictFails metric (config#729)"
         )
 
-    def test_metric_filter_omits_defaultvalue(self, cfn_text):
-        # DefaultValue + Dimensions are mutually exclusive in AWS::Logs::
-        # MetricFilter; including both fails CFN create (the #516 deploy break).
+    def test_metric_filters_have_no_dimensions(self, cfn_text):
+        # AWS::Logs::MetricFilter rejects a metric transformation with Dimensions
+        # unless the dimension VALUE is a token extracted from the filter pattern
+        # ("the specified filter pattern does not support dimensions" — the
+        # #537-deploy break). Our pattern is a plain text match, so per-SF
+        # attribution is via DISTINCT MetricName, NOT Dimensions. Pin that the
+        # filter region carries no Dimensions and no DefaultValue.
         mf_start = cfn_text.index("MutexConflictMetricFilter")
         # Scan from the first metric filter to the first alarm block.
         mf_region = cfn_text[mf_start : cfn_text.index("MutexConflictAlarm")]
-        assert "DefaultValue" not in mf_region, (
-            "MutexConflict metric filters must NOT set DefaultValue — it is "
-            "mutually exclusive with Dimensions and fails CFN create"
+        assert "Dimensions" not in mf_region, (
+            "MutexConflict metric filters must NOT set Dimensions — a literal "
+            "dimension value is rejected at CFN create; use a distinct "
+            "MetricName per SF instead"
         )
+        assert "DefaultValue" not in mf_region, (
+            "MutexConflict metric filters must NOT set DefaultValue"
+        )
+
+    def test_each_sf_has_distinct_metric_name(self, cfn_text):
+        # Per-SF attribution requires a unique metric name per filter (no
+        # dimensions), each referenced by its own alarm.
+        for metric in ("WeeklyFreshnessMutexConflictFails",
+                       "PreopenTradingMutexConflictFails"):
+            assert cfn_text.count(metric) >= 2, (
+                f"{metric} must appear in both its metric filter and its alarm "
+                f"(distinct-metric-name attribution, config#729)"
+            )
 
     @pytest.mark.parametrize("sf_name", SF_NAMES)
     def test_alarm_present_for_each_sf(self, cfn_text, sf_name):


### PR DESCRIPTION
## Why — `main` Deploy Infrastructure red again (after #537 merged)
#537's deploy reached CFN CREATE and failed:
```
AWS::Logs::MetricFilter: The specified filter pattern does not support dimensions
```
`AWS::Logs::MetricFilter` only permits a metric-transformation `Dimensions` entry whose **value is a token extracted from the filter pattern** (e.g. `$.field`). A **literal** dimension value (`ne-weekly-freshness-pipeline`) on a plain `"MutexConflict"` text-match pattern is rejected at create. (This also lurked in #516, which failed earlier on the `DefaultValue`+`Dimensions` conflict.) Stack rolled back cleanly → live pipelines unaffected; `main` deploy red until this merges.

## Fix
Drop `Dimensions` entirely and give each SF its **own metric name** — `WeeklyFreshnessMutexConflictFails` / `PreopenTradingMutexConflictFails` — each watched by its own alarm. Distinct-metric-name is the idiomatic per-source attribution for text-match metric filters (dimensions are for pattern-extracted fields only). LogGroups + `LoggingConfiguration` + alarms otherwise unchanged.

Test (`TestCfnMutexConflictAlarms`) now pins **no `Dimensions`** + **distinct metric name per SF** so this class can't regress.

## Verification
- 58 mutex-wiring tests pass; `aws cloudformation validate-template` clean.
- Could not run the live CFN deploy myself (auto-mode blocks privileged infra mutation). The remaining unproven piece — the SF `LoggingConfiguration` — is **low-risk restoration of known-good config**: the SF execution role already carries all vended-logs perms, the account has 0/10 Logs resource policies (room to spare), and the pre-rename SFs logged at ERROR in this same account/role (old log groups still present). The metric-filter dimensions bug was the only *novel* failure, and it's fixed here.
- Deploy confirms on merge. To verify first, run `bash infrastructure/deploy-infrastructure.sh` from `~/worktrees/data-mf-fix` (deploys this corrected template to live; merge then becomes a no-op green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)