### PR TITLE
chore(groom-dispatcher): drop 1500-sunfri schedule + add prune reconciliation

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -16,8 +16,8 @@ fire late or are silently dropped (config#1322).
 ```
 EventBridge Scheduler rules (UTC, cron)              THIS Lambda
   alpha-engine-scheduled-groom-0700-sunfri  ─┐       (repository_dispatch)
-  alpha-engine-scheduled-groom-1500-sunfri  ─┼─────▶  type: scheduled-groom
-  alpha-engine-scheduled-groom-2300-daily   ─┘        client_payload.run_mode
+  alpha-engine-scheduled-groom-2300-daily   ─┴─────▶  type: scheduled-groom
+                                                      client_payload.run_mode
                                                               │
                                                               ▼
                             nousergon/alpha-engine-config :: backlog-groom.yml
@@ -35,12 +35,17 @@ flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 | Scheduler rule | Expression (UTC) | GHA cron replaced | PT | Day mask | run_mode |
 |---|---|---|---|---|---|
 | `…-0700-sunfri` | `cron(0 7 ? * SUN-FRI *)` | `0 7 * * 0-5` | 12am | Sun–Fri (skips Sat) | full |
-| `…-1500-sunfri` | `cron(0 15 ? * SUN-FRI *)` | `0 15 * * 0-5` | 8am | Sun–Fri (skips Sat) | full |
 | `…-2300-daily` | `cron(0 23 * * ? *)` | `0 23 * * *` | 4pm | daily incl. Sat | full |
 
-The Sat-skip rationale is carried verbatim from `backlog-groom.yml`: the two
-Sun–Fri rules avoid colliding with the 09:00-UTC Crucible Saturday pipeline; the
-daily 23:00 rule runs every day (Brian wants the Sat 4pm-PT groom retained).
+> **Reduced 3→2/day on 2026-06-29** (usage pacing): the former
+> `…-1500-sunfri` rule (`cron(0 15 ? * SUN-FRI *)`, 8am PT) was dropped.
+> `deploy.sh` step 2e prunes it from live on the next `--bootstrap`; the matching
+> `0 15 * * 0-5` GHA cron is removed in the same change.
+
+The Sat-skip rationale is carried verbatim from `backlog-groom.yml`: the
+`…-0700-sunfri` rule avoids colliding with the 09:00-UTC Crucible Saturday
+pipeline; the daily 23:00 rule runs every day (Brian wants the Sat 4pm-PT groom
+retained).
 
 EventBridge Scheduler cron uses 6 fields `cron(min hour day-of-month month
 day-of-week year)` with `?` for an unspecified day field and `SUN-FRI` for the
@@ -51,7 +56,7 @@ day-of-week mask.
 Each schedule passes a JSON input `{"run_mode": "...", "schedule": "..."}`. The
 Lambda forwards `run_mode` into `client_payload` (also as `phase` for
 forward-compat); `backlog-groom.yml`'s run-mode step reads
-`github.event.client_payload.run_mode` to route `full` vs `sweep`. All three
+`github.event.client_payload.run_mode` to route `full` vs `sweep`. Both
 current rules are `full` (the drain-phase default). An unknown/missing run_mode
 degrades to `full`.
 
@@ -71,7 +76,7 @@ degrades to `full`.
 ## Deploy (operator-managed, outside CloudFormation)
 
 ```bash
-bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap  # first time: roles + lambda + 3 schedules
+bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap  # roles + lambda + schedules (creates/updates from SCHED_NAMES; prunes orphaned rules)
 bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh              # update code only
 bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --dry-run    # preview
 bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --smoke      # ⚠ fires a REAL groom run
@@ -88,14 +93,14 @@ intentionally.
    dispatch type + run-mode routing must be merged (cross-linked below).
 2. **Apply**: `bash …/deploy.sh --bootstrap` (operator with AWS creds).
 3. **Verify wiring**: `aws scheduler list-schedules --name-prefix
-   alpha-engine-scheduled-groom --region us-east-1` shows all three; `--smoke`
+   alpha-engine-scheduled-groom --region us-east-1` shows both; `--smoke`
    produces a backlog-groom run in alpha-engine-config Actions.
 4. **Soak (multi-day)**: confirm each rule fires **on time** for a week — compare
    the EventBridge/Lambda CloudWatch invocation timestamps against the cron and
    confirm a matching `repository_dispatch` (`scheduled-groom`) backlog-groom run
    appears within a minute. Watch the Lambda `Errors` metric stays at 0.
 5. **Cut over**: only after the soak confirms reliable on-time firing, remove the
-   three `schedule:` crons from `backlog-groom.yml` (a follow-up PR), leaving
+   remaining `schedule:` crons from `backlog-groom.yml` (a follow-up PR), leaving
    EventBridge as the sole scheduler. Until then both run (the workflow's
    `concurrency` group serialises any rare overlap, so the belt-and-suspenders
    window is harmless).

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-scheduled-groom-dispatcher Lambda
-# and wire its three EventBridge Scheduler rules (the reliable replacement for
+# and wire its EventBridge Scheduler rules (the reliable replacement for
 # the backlog-groom GHA `schedule:` crons — config#1322).
 #
 # Each Scheduler rule fires THIS Lambda on cadence; the Lambda repository_
@@ -10,10 +10,14 @@
 # (scheduler.amazonaws.com role, cron() expression, flexible-time-window) mirror
 # `infrastructure/run_weekly_offcycle.sh`.
 #
-# Cadence (UTC, mirrors the GHA crons exactly):
+# Cadence (UTC, mirrors the GHA crons exactly). Reduced 3->2/day on 2026-06-29
+# (the 15:00 UTC / 8am-PT run was dropped per usage pacing):
 #   07:00 Sun-Fri   cron(0 7 ? * SUN-FRI *)   FULL   # 12am PT, skips Sat
-#   15:00 Sun-Fri   cron(0 15 ? * SUN-FRI *)  FULL   # 8am PT, skips Sat
 #   23:00 daily     cron(0 23 * * ? *)        FULL   # 4pm PT, every day incl. Sat
+#
+# SCHED_NAMES is the source of truth: any live scheduler rule under the
+# alpha-engine-scheduled-groom- prefix that is NOT in SCHED_NAMES is PRUNED
+# (deleted) on deploy, so removing a cadence here removes it live too.
 #
 # Managed OUTSIDE CloudFormation — same rationale as the sibling dispatchers
 # (keeps the github-actions-lambda-deploy OIDC role's blast radius narrow;
@@ -45,22 +49,21 @@ FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
 SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
 
 # Schedule definitions: name | cron expression (UTC) | JSON input (run_mode + label).
-# Mirrors backlog-groom.yml's three `schedule:` crons one-for-one.
+# Mirrors backlog-groom.yml's `schedule:` crons one-for-one.
 SCHED_NAMES=(
   "alpha-engine-scheduled-groom-0700-sunfri"
-  "alpha-engine-scheduled-groom-1500-sunfri"
   "alpha-engine-scheduled-groom-2300-daily"
 )
 SCHED_CRONS=(
   "cron(0 7 ? * SUN-FRI *)"
-  "cron(0 15 ? * SUN-FRI *)"
   "cron(0 23 * * ? *)"
 )
 SCHED_INPUTS=(
   '{"run_mode":"full","schedule":"0 7 * * 0-5"}'
-  '{"run_mode":"full","schedule":"0 15 * * 0-5"}'
   '{"run_mode":"full","schedule":"0 23 * * *"}'
 )
+# Prefix used to discover live rules for prune reconciliation (see step 2d).
+SCHED_PREFIX="alpha-engine-scheduled-groom-"
 
 DRY_RUN=false
 BOOTSTRAP=false
@@ -187,7 +190,7 @@ EOF
     sleep 10
   fi
 
-  # --- 2d. The three EventBridge Scheduler rules ---
+  # --- 2d. The EventBridge Scheduler rules ---
   for i in "${!SCHED_NAMES[@]}"; do
     name="${SCHED_NAMES[$i]}"
     cron="${SCHED_CRONS[$i]}"
@@ -223,6 +226,29 @@ EOF
       aws scheduler get-schedule --name "${name}" --region "${REGION}" \
         --query 'Name' --output text >/dev/null \
         || { echo "ERROR: Scheduler rule ${name} not found after create/update" >&2; exit 1; }
+    fi
+  done
+
+  # --- 2e. Prune reconciliation: delete any live rule under SCHED_PREFIX that is
+  # no longer in SCHED_NAMES (so dropping a cadence above removes it live too,
+  # rather than silently orphaning a still-firing schedule). Added 2026-06-29
+  # alongside the 3->2/day reduction (the 1500-sunfri rule is the first prunee).
+  echo "  Pruning orphaned Scheduler rules under prefix ${SCHED_PREFIX}..."
+  LIVE_RULES=$(aws scheduler list-schedules --name-prefix "${SCHED_PREFIX}" \
+    --region "${REGION}" --query 'Schedules[].Name' --output text 2>/dev/null || echo "")
+  for live in ${LIVE_RULES}; do
+    keep=false
+    for want in "${SCHED_NAMES[@]}"; do
+      [ "${live}" = "${want}" ] && { keep=true; break; }
+    done
+    if ! $keep; then
+      echo "    Deleting orphaned Scheduler rule: ${live}"
+      run aws scheduler delete-schedule --name "${live}" --region "${REGION}"
+      if ! $DRY_RUN; then
+        aws scheduler get-schedule --name "${live}" --region "${REGION}" \
+          --query 'Name' --output text >/dev/null 2>&1 \
+          && { echo "ERROR: Scheduler rule ${live} still present after delete" >&2; exit 1; }
+      fi
     fi
   done
 fi


### PR DESCRIPTION
Reduce the `scheduled-groom` EventBridge cadence from **3 → 2/day** (usage pacing): drop the `alpha-engine-scheduled-groom-1500-sunfri` rule (08:00 PT / 15:00 UTC, Sun–Fri), keeping `0700-sunfri` + `2300-daily`.

**Robust fix for the silent-orphan gap:** the create/update loop never pruned — removing an entry from `SCHED_NAMES` left the live rule firing. Added **step 2e prune reconciliation**: any live rule under the `alpha-engine-scheduled-groom-` prefix not in `SCHED_NAMES` is deleted on `--bootstrap` (fail-loud verify). `SCHED_NAMES` is now the source of truth, so dropping a cadence removes it live.

Header cadence + README updated (diagram, table, deploy/verify counts).

Pairs with alpha-engine-config PR dropping the GHA `0 15 * * 0-5` fallback cron. `deploy.sh --bootstrap` is operator-run (outside CFN); merging has zero live effect until then. The live `1500-sunfri` rule is being deleted out-of-band so the primary stops immediately.

Verified: `bash -n` clean, `test_handler.py` 5 passed, prune-decision dry-run targets only `1500-sunfri`.