### PR TITLE
feat(metron): publish index-proxy + fund-proxy close_history & intraday fund_proxies map

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -66,6 +66,15 @@ RISK_FACTOR_ETFS = [
     "SPY", "MTUM", "QUAL", "USMV", "VLUE", "SIZE",  # market + iShares MSCI USA style factors
     "XLB", "XLC", "XLE", "XLF", "XLI", "XLK", "XLP", "XLRE", "XLU", "XLV", "XLY",  # GICS sector SPDRs
 ]
+# Tracking-proxy ETFs for late-striking mutual funds (Metron fund-NAV estimate). A mutual
+# fund's NAV strikes hours after the EOD run, so its same-day move is estimated from a proxy
+# ETF tracking the same exposure (metron api/services/fund_proxy.py: FNILX→SPY large-cap,
+# FZILX/FTIHX→IXUS total-intl-ex-US). The FULL distinct proxy set — these are NOT held, so
+# their close_history (reconcile fallback) + a dedicated intraday `fund_proxies` quote map
+# (the same-day estimate) must be published here or the spine has no proxy data. SPY's
+# close_history already comes via RISK_FACTOR_ETFS; the union just guarantees coverage and
+# gives the live estimate a single source for every proxy. All USD.
+FUND_PROXY_ETFS = ["SPY", "IXUS"]
 # Reference data — GICS sector per held symbol + SPY's sector weights (Brinson
 # attribution), and each held symbol's next earnings date (Calendar page). Moves
 # Metron's last yfinance fetches to the spine so Metron reads ALL external data here.
@@ -152,7 +161,7 @@ SECTORS_SCHEMA_VERSION = 2  # v2: additive `countries` map (yf_symbol → countr
 EARNINGS_SCHEMA_VERSION = 1
 MACRO_SCHEMA_VERSION = 2  # v2: added next_release (per series) + release_events (metron-ops#49)
 FUNDAMENTALS_SCHEMA_VERSION = 3  # v3: + totalDebt/totalCash/ebitda/freeCashflow (balance sheet)
-INTRADAY_SCHEMA_VERSION = 2  # v2: additive `indices` map (major-index ETF proxies)
+INTRADAY_SCHEMA_VERSION = 3  # v3: additive `fund_proxies` map (mutual-fund tracking-proxy ETF quotes)
 TECHNICALS_SCHEMA_VERSION = 1
 VALUATION_MEDIANS_SCHEMA_VERSION = 1
 ANALYST_SCHEMA_VERSION = 1  # consensus rating + price targets + #analysts (free sources)
@@ -776,10 +785,14 @@ def collect_history(
     if not holdings:
         return {"status": "skipped", "reason": "empty metron universe", "universe": 0}
     ccy_by_yf = {h["yf_symbol"]: h["currency"] for h in holdings}
-    # Held symbols + the factor/sector ETFs Metron's risk/attribution need (USD,
-    # independent of holdings) — without these the spine can't serve their close_history
-    # and risk/attribution stay blank (metron-ops#43).
-    hist_symbols = sorted(set(ccy_by_yf) | set(RISK_FACTOR_ETFS))
+    # Held symbols + the factor/sector ETFs Metron's risk/attribution need (metron-ops#43),
+    # + the major-index ETF proxies (so the Overview markets strip resolves YTD/LTM for
+    # QQQ/IWM/ONEQ — not just SPY, which only worked because it's in RISK_FACTOR_ETFS),
+    # + the fund-proxy ETFs (close_history backstop for the late-fund-NAV reconcile). All
+    # USD, independent of holdings — without them the spine has no close_history for these.
+    hist_symbols = sorted(
+        set(ccy_by_yf) | set(RISK_FACTOR_ETFS) | set(INDEX_PROXY_SYMBOLS) | set(FUND_PROXY_ETFS)
+    )
     closes = (close_history_source or _yfinance_close_history)(hist_symbols)
     fx = (fx_history_source or _yfinance_fx_history)(currencies)
     if dry_run:
@@ -1516,8 +1529,9 @@ def collect_intraday(
 
         market_data/intraday/latest.json
             {schema_version, as_of_utc, source: "yfinance_delayed",
-             quotes:  {yf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}},
-             indices: {etf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}}}
+             quotes:       {yf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}},
+             indices:      {etf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}},
+             fund_proxies: {etf_symbol: {last, open, prev_close, session_date, prev_session_date, currency}}}
 
     ``last`` is ~15-min delayed. Runs every 5 min via a systemd timer on the trading box
     (infrastructure/systemd/metron-intraday.timer), gated on the NYSE session window
@@ -1552,7 +1566,15 @@ def collect_intraday(
     for q in indices.values():
         q["currency"] = BASE_CURRENCY
 
-    n_suspect = _flag_suspect_quotes(quotes) + _flag_suspect_quotes(indices)
+    # Fund-proxy ETF quotes — the same-day move that estimates a late-striking mutual fund's
+    # return (metron fund_proxy.py). Kept in a DEDICATED map (not `indices`, which is the 4
+    # headline-index proxies) so the consumer has one clean source for every proxy and IXUS
+    # never reads as a headline index. Always fetched, independent of holdings.
+    fund_proxies = fetch(list(FUND_PROXY_ETFS))
+    for q in fund_proxies.values():
+        q["currency"] = BASE_CURRENCY
+
+    n_suspect = _flag_suspect_quotes(quotes) + _flag_suspect_quotes(indices) + _flag_suspect_quotes(fund_proxies)
     if n_suspect:
         logger.warning("[metron_market_data] %d intraday quote(s) flagged suspect (>40%% vs prev close)", n_suspect)
     artifact = {
@@ -1561,18 +1583,22 @@ def collect_intraday(
         "source": "yfinance_delayed",
         "quotes": dict(sorted(quotes.items())),
         "indices": dict(sorted(indices.items())),
+        "fund_proxies": dict(sorted(fund_proxies.items())),
     }
     if dry_run:
-        logger.info("[metron_market_data] DRY-RUN intraday: %d quotes, %d indices (not written)",
-                    len(quotes), len(indices))
-        return {"status": "ok_dry_run", "quotes": len(quotes), "indices": len(indices)}
+        logger.info("[metron_market_data] DRY-RUN intraday: %d quotes, %d indices, %d fund-proxies (not written)",
+                    len(quotes), len(indices), len(fund_proxies))
+        return {"status": "ok_dry_run", "quotes": len(quotes), "indices": len(indices),
+                "fund_proxies": len(fund_proxies)}
     try:
         _write_json(s3_client, bucket, f"{INTRADAY_PREFIX}latest.json", artifact)
     except Exception as e:  # fail loud — the timer unit's journal + freshness scan record it
         logger.error("[metron_market_data] intraday write failed: %s", e)
         return {"status": "error", "error": str(e)}
-    logger.info("[metron_market_data] wrote %d intraday quotes + %d indices", len(quotes), len(indices))
-    return {"status": "ok", "universe": len(holdings), "quotes": len(quotes), "indices": len(indices)}
+    logger.info("[metron_market_data] wrote %d intraday quotes + %d indices + %d fund-proxies",
+                len(quotes), len(indices), len(fund_proxies))
+    return {"status": "ok", "universe": len(holdings), "quotes": len(quotes),
+            "indices": len(indices), "fund_proxies": len(fund_proxies)}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -155,13 +155,19 @@ class TestHistory:
             return {s: [("2026-06-11", 100.0)] for s in syms}
 
         result = mmd.collect_history(bucket="b", s3_client=s3, close_history_source=close_hist, fx_history_source=lambda c: {})
+        # Factor/sector ETFs + the index proxies (markets-strip YTD/LTM) + the fund-proxy
+        # ETFs (late-fund-NAV reconcile backstop) must all be requested + published.
         assert set(mmd.RISK_FACTOR_ETFS) <= set(requested)  # all factor ETFs requested
+        assert set(mmd.INDEX_PROXY_SYMBOLS) <= set(requested)  # QQQ/IWM/ONEQ get close_history → YTD/LTM
+        assert set(mmd.FUND_PROXY_ETFS) <= set(requested)  # IXUS published for the fund reconcile
         assert "AAPL" in requested  # held symbols still included
         puts = _puts(s3)
-        for etf in ("SPY", "XLK", "MTUM"):
+        for etf in ("SPY", "XLK", "MTUM", "QQQ", "IWM", "ONEQ", "IXUS"):
             key = f"market_data/close_history/{etf}.json"
             assert key in puts and puts[key]["currency"] == "USD"
-        assert result["close_series"] == len(set(["AAPL", "1299.HK", *mmd.RISK_FACTOR_ETFS]))
+        assert result["close_series"] == len(set(
+            ["AAPL", "1299.HK", *mmd.RISK_FACTOR_ETFS, *mmd.INDEX_PROXY_SYMBOLS, *mmd.FUND_PROXY_ETFS]
+        ))
 
     def test_history_dry_run_and_empty_universe(self):
         s3 = _universe_s3(_UNIVERSE)
@@ -442,6 +448,12 @@ class TestIntraday:
         "IWM": {"last": 215.3, "open": 216.0, "prev_close": 216.5,
                 "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
     }
+    # Fund-proxy quotes — SPY already in _INDEX_QUOTES; IXUS is the intl proxy. The real
+    # fetcher is called separately for the fund-proxy set, so the stub must know IXUS too.
+    _FUND_PROXY_QUOTES = {
+        "IXUS": {"last": 72.4, "open": 72.0, "prev_close": 71.9,
+                 "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
+    }
 
     @staticmethod
     def _stub(*maps):
@@ -465,14 +477,16 @@ class TestIntraday:
     def test_writes_quotes_with_currency_when_open_and_app_active(self):
         s3 = self._s3()
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES),
+            bucket="b", s3_client=s3,
+            intraday_source=self._stub(self._QUOTES, self._INDEX_QUOTES, self._FUND_PROXY_QUOTES),
             now=self._RTH,
         )
         assert result["status"] == "ok" and result["quotes"] == 2 and result["indices"] == 4
+        assert result["fund_proxies"] == len(mmd.FUND_PROXY_ETFS)
         puts = _puts(s3)
         assert set(puts) == {"market_data/intraday/latest.json"}
         art = puts["market_data/intraday/latest.json"]
-        assert art["schema_version"] == mmd.INTRADAY_SCHEMA_VERSION == 2
+        assert art["schema_version"] == mmd.INTRADAY_SCHEMA_VERSION == 3
         assert art["source"] == "yfinance_delayed"
         assert art["as_of_utc"] == "2026-06-12T15:00:00Z"
         # Currency joined from the universe (the consumer FX-converts the P&L legs).
@@ -483,6 +497,10 @@ class TestIntraday:
         assert set(art["indices"]) == set(mmd.INDEX_PROXY_SYMBOLS)
         assert art["indices"]["SPY"]["currency"] == "USD"
         assert art["indices"]["SPY"]["last"] == 605.2 and art["indices"]["SPY"]["prev_close"] == 602.4
+        # Fund proxies land under a DEDICATED `fund_proxies` map (USD), not `indices`.
+        assert set(art["fund_proxies"]) == set(mmd.FUND_PROXY_ETFS)
+        assert "IXUS" in art["fund_proxies"] and art["fund_proxies"]["IXUS"]["currency"] == "USD"
+        assert art["fund_proxies"]["IXUS"]["last"] == 72.4
 
     def test_index_proxies_fetched_even_with_empty_universe(self):
         """The markets strip is market context — published even when nothing is held."""


### PR DESCRIPTION
## Why
Two data-spine gaps surfaced from the Metron portfolio page (portfolio.nousergon.ai):

### 1. Markets-strip YTD/LTM blank for QQQ/IWM/ONEQ (only SPY populated)
`collect_history` built `hist_symbols = held ∪ RISK_FACTOR_ETFS`. **SPY rendered only because it happens to be in `RISK_FACTOR_ETFS`**; the index proxies ONEQ/QQQ/IWM had no `close_history` published, so the consumer's `index_period_returns` had nothing to compute → `—`. TODAY worked for all four because the intraday `indices` map already carries them; only the history was missing.

**Fix:** add `INDEX_PROXY_SYMBOLS` to the `close_history` symbol set.

### 2. Provision the spine for late-striking mutual-fund support
Fidelity ZERO funds (FNILX/FZILX/FTIHX) strike NAV hours after the EOD run, so they read "flat" and distort portfolio TWR. The Metron consumer (follow-up PRs) will **estimate** a fund's same-day move from a tracking-proxy ETF and **reconcile** to the struck NAV. This PR provisions the proxy data:
- `FUND_PROXY_ETFS = [SPY, IXUS]` added to `close_history` (reconcile backstop).
- New intraday **`fund_proxies`** map — dedicated, separate from `indices` so IXUS never reads as a headline index — carrying the proxy quotes the same-day estimate needs.
- `INTRADAY_SCHEMA_VERSION` 2 → 3 (purely additive; the consumer does not gate on the version → backward-compatible).

## Sequencing
Producer-first per S3 contract safety — these artifacts must exist before the Metron consumer reads them. This is PR-1 of 3 (PR-2: metron schema + reconcile; PR-3: metron live proxy estimate, which depends on the new `fund_proxies` artifact baking).

## Tests
- `tests/test_metron_market_data.py` — 32 pass (close_history now includes index + fund proxies; intraday asserts schema v3 + the `fund_proxies` map).
- `tests/test_metron_etf_drift_guard.py` — green (RISK_FACTOR_ETFS unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)