### PR TITLE
chore(deps): pin krepis>=0.6.0 for cost PriceCard 1h field (config#1332)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,11 @@ arcticdb>=6.11
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
 nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0
+# krepis floor: sf_preflight.py reads the operator pricing override
+# (cost/model_pricing.yaml) via alpha_engine_lib.cost -> krepis.cost.PriceCard,
+# which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,
+# present only in krepis>=0.6.0 — an older krepis rejects the YAML. Pinned
+# directly (not via a nousergon-lib bump, which would drag the in-flight,
+# 7/3-cutover SF-rename refs in lib 0.74.0 into this repo). Floor guarantees
+# the upgrade even on a non-fresh venv.
+krepis>=0.6.0


### PR DESCRIPTION
## What
Adds a direct `krepis>=0.6.0` floor pin to `requirements.txt`.

## Why
This repo's `sf_preflight.py` reads the operator pricing override (`cost/model_pricing.yaml`) via `alpha_engine_lib.cost` → `krepis.cost.PriceCard`, which is `model_config = ConfigDict(extra="forbid")`. **nousergon/alpha-engine-config#1332** adds the `cache_create_1h_per_1m` field to that YAML — a field present only in **krepis ≥ 0.6.0** (released today, krepis#5/#7). An older krepis rejects the whole YAML with `ValidationError`, breaking cost tracking.

This repo currently reaches krepis transitively through `nousergon-lib@v0.70.0` (`krepis>=0.2.0` floor), which a stale 0.5.0 venv satisfies without upgrading. The direct floor **guarantees** krepis ≥ 0.6.0 even on a non-fresh venv.

## Why a direct krepis pin, not a nousergon-lib bump
The architecturally-broader fix (raise nousergon-lib's krepis floor + repin this repo to the new lib) is **deliberately avoided**: nousergon-lib 0.74.0 carries the in-flight **SF-rename-to-`ne-` refs (#143), soak-gated to the 7/3 cutover** — repinning 0.70→0.74 would drag not-yet-cutover SF-rename behavior into this repo for a P3 cost feature. The surgical krepis pin is correctly scoped.

## Gate
This is **part 2 of the #1332 unblock chain** (krepis 0.6.0 release = part 1, merged). Once this + the sibling `crucible-research pin` pin merge and deploy, #1332 (the operator YAML) can merge.

## Validation
- `test_lib_pin_lockstep.py` (nousergon-lib pin unchanged) + `test_flow_doctor_wiring.py` green locally. The lockstep guard checks only the nousergon-lib pin; the new krepis line keeps it green, and the Dockerfile installs the rest of `requirements.txt` so the floor propagates to the image.

Refs nousergon/alpha-engine-config#1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)