### PR TITLE
fix(weekday-sf): move NYSE trading-day check off the box into a pre-boot Lambda gate (config#1430)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -116,124 +116,52 @@
           "Next": "HandleFailure"
         }
       ],
-      "Default": "StartExecutorEC2"
+      "Default": "TradingDayGate"
     },
 
-    "CheckTradingDay": {
+    "TradingDayGate": {
       "Type": "Task",
-      "Comment": "Skip pipeline on NYSE holidays. Runs on ae-trading via the alpha-engine-lib trading_calendar module (no repo clone needed — lib is installed in alpha-engine venv).",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Comment": "NYSE trading-day gate, run BEFORE StartExecutorEC2. Invokes the predictor Lambda (action=check_trading_day) — pure calendar math, no box dependency. Replaces the prior on-box SSM trading_calendar check whose stdout was unreliably captured on a just-cold-booted instance (2026-06-30 false trading-day-check failure alert; config#1430). On holiday the box is never booted.",
+      "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
-        "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.trading_instance_id",
-        "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "export FLOW_DOCTOR_ENABLED=1",
-            "export ALPHA_ENGINE_DEPLOYED=1",
-            "cd /home/ec2-user/alpha-engine",
-            "source .venv/bin/activate",
-            "python -m nousergon_lib.trading_calendar"
-          ],
-          "executionTimeout": ["30"]
-        },
-        "TimeoutSeconds": 30
-      },
-      "TimeoutSeconds": 60,
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "TradingDayCheckFailed",
-          "ResultPath": "$.error"
-        }
-      ],
-      "ResultPath": "$.trading_day_result",
-      "Next": "WaitForTradingDayCheck"
-    },
-
-    "WaitForTradingDayCheck": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-      "Parameters": {
-        "CommandId.$": "$.trading_day_result.Command.CommandId",
-        "InstanceId.$": "$.trading_instance_id[0]"
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": { "action": "check_trading_day" }
       },
       "Retry": [
         {
-          "ErrorEquals": [
-            "Ssm.InvocationDoesNotExistException",
-            "Ssm.InvocationDoesNotExist"
-          ],
-          "MaxAttempts": 5,
-          "IntervalSeconds": 5,
-          "BackoffRate": 1.5
+          "ErrorEquals": ["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException","Lambda.TooManyRequestsException","States.TaskFailed"],
+          "IntervalSeconds": 3,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
         }
       ],
       "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "TradingDayCheckFailed",
-          "ResultPath": "$.error"
-        }
+        { "ErrorEquals": ["States.ALL"], "Next": "TradingDayGateFailed", "ResultPath": "$.trading_day_gate_error" }
       ],
-      "ResultSelector": {
-        "Status.$": "$.Status",
-        "ResponseCode.$": "$.ResponseCode",
-        "StatusDetails.$": "$.StatusDetails",
-        "StandardErrorContent.$": "$.StandardErrorContent",
-        "StandardOutputContent.$": "$.StandardOutputContent"
-      },
-      "ResultPath": "$.trading_day_poll",
-      "Next": "CheckTradingDayResult"
+      "ResultPath": "$.trading_day_gate",
+      "Next": "TradingDayGateChoice"
     },
 
-    "CheckTradingDayResult": {
+    "TradingDayGateChoice": {
       "Type": "Choice",
-      "Comment": "Check SSM status first (InProgress/Pending = poll again), then check stdout for TRADING_DAY vs MARKET_CLOSED marker. Script always exits 0 — Failed means a real error.",
+      "Comment": "Holiday/weekend (is_trading_day=false) -> skip without ever booting the box. Trading day or any non-false result -> proceed. Fail-open to trading matches the prior fail-soft posture: missing a real trading day is worse than a wasted holiday boot.",
       "Choices": [
-        {
-          "Variable": "$.trading_day_poll.Status",
-          "StringEquals": "InProgress",
-          "Next": "TradingDayCheckWait"
-        },
-        {
-          "Variable": "$.trading_day_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "TradingDayCheckWait"
-        },
-        {
-          "Variable": "$.trading_day_poll.Status",
-          "StringEquals": "Failed",
-          "Next": "TradingDayCheckFailed"
-        },
-        {
-          "And": [
-            {
-              "Variable": "$.trading_day_poll.Status",
-              "StringEquals": "Success"
-            },
-            {
-              "Variable": "$.trading_day_poll.StandardOutputContent",
-              "StringMatches": "*MARKET_CLOSED*"
-            }
-          ],
-          "Next": "StopExecutorOnHoliday"
-        },
-        {
-          "And": [
-            {
-              "Variable": "$.trading_day_poll.Status",
-              "StringEquals": "Success"
-            },
-            {
-              "Variable": "$.trading_day_poll.StandardOutputContent",
-              "StringMatches": "*TRADING DAY*"
-            }
-          ],
-          "Next": "CheckSkipMorningEnrich"
-        }
+        { "Variable": "$.trading_day_gate.Payload.is_trading_day", "BooleanEquals": false, "Next": "NotifyHolidaySkip" }
       ],
-      "Default": "TradingDayCheckFailed"
+      "Default": "StartExecutorEC2"
+    },
+
+    "TradingDayGateFailed": {
+      "Type": "Task",
+      "Comment": "Trading-day gate Lambda failed for infrastructure reasons — alert and proceed (assume trading day). Predictor inference + downstream remain gated on enrichment success.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Pipeline — Trading Day Gate Failed (Proceeding)",
+        "Message.$": "States.Format('Trading-day gate Lambda failed (infra error, not a holiday detection). Pipeline proceeding as trading day. Error: {}', States.JsonToString($.trading_day_gate_error))"
+      },
+      "ResultPath": "$.trading_day_gate_error_notify",
+      "Next": "StartExecutorEC2"
     },
 
     "MorningEnrich": {
@@ -475,52 +403,14 @@
       "Next": "WaitForChronicGap"
     },
 
-    "TradingDayCheckWait": {
-      "Type": "Wait",
-      "Seconds": 5,
-      "Next": "WaitForTradingDayCheck"
-    },
-
-    "TradingDayCheckFailed": {
-      "Type": "Task",
-      "Comment": "Trading day check failed for infrastructure reasons — alert and proceed (assume trading day). Routes to MorningEnrich same as the trading-day success path; predictor inference still gated on enrichment success.",
-      "Resource": "arn:aws:states:::sns:publish",
-      "Parameters": {
-        "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekday Pipeline — Trading Day Check Failed (Proceeding)",
-        "Message.$": "States.Format('Trading day check failed (SSM error, not a holiday detection). Pipeline proceeding as trading day. State: {}', States.JsonToString($))"
-      },
-      "ResultPath": "$.trading_day_error_notify",
-      "Next": "CheckSkipMorningEnrich"
-    },
-
-    "StopExecutorOnHoliday": {
-      "Type": "Task",
-      "Comment": "Stop ae-trading on holidays — we started it speculatively before CheckTradingDay, so clean up.",
-      "Resource": "arn:aws:states:::aws-sdk:ec2:stopInstances",
-      "Parameters": {
-        "InstanceIds.$": "$.trading_instance_id"
-      },
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Comment": "Stop failure non-fatal — EventBridge Scheduler at 1:30 PM PT is the backstop.",
-          "Next": "NotifyHolidaySkip",
-          "ResultPath": "$.holiday_stop_error"
-        }
-      ],
-      "ResultPath": "$.holiday_stop_result",
-      "Next": "NotifyHolidaySkip"
-    },
-
     "NotifyHolidaySkip": {
       "Type": "Task",
-      "Comment": "Notify that pipeline was skipped — trading_calendar stdout contains MARKET_CLOSED",
+      "Comment": "Notify that the pipeline was skipped — TradingDayGate reported is_trading_day=false (NYSE holiday/weekend). The executor box was never started (gate runs before StartExecutorEC2).",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekday Pipeline — Skipped (Market Holiday)",
-        "Message": "Daily pipeline skipped — NYSE is closed today (market holiday or weekend). No inference or trading. ae-trading stopped."
+        "Message": "Daily pipeline skipped — NYSE is closed today (market holiday or weekend). No inference or trading. The executor box was not started."
       },
       "ResultPath": "$.holiday_notify",
       "End": true
@@ -569,7 +459,7 @@
 
     "DescribeInstanceInfo": {
       "Type": "Task",
-      "Comment": "Poll SSM-agent registration on the trading instance. Replaces the prior fixed Wait 60s, which was insufficient on cold-boot t3.small (race observed 2026-05-05 morning — Ssm.InvalidInstanceIdException at CheckTradingDay because PingStatus had not yet flipped to Online when the SSM SendCommand fired). SSMReadyChoice routes to CheckTradingDay when PingStatus=Online or HandleFailure when the bounded retry budget (~3 min) is exhausted.",
+      "Comment": "Poll SSM-agent registration on the trading instance. Replaces the prior fixed Wait 60s, which was insufficient on cold-boot t3.small (race observed 2026-05-05 morning — Ssm.InvalidInstanceIdException at the first SSM step because PingStatus had not yet flipped to Online when the SSM SendCommand fired). SSMReadyChoice routes to CheckSkipMorningEnrich (the first morning work gate; the NYSE holiday check now runs BEFORE the box boots via TradingDayGate, config#1430) when PingStatus=Online or HandleFailure when the bounded retry budget (~3 min) is exhausted.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:describeInstanceInformation",
       "Parameters": {
         "Filters": [
@@ -601,7 +491,7 @@
 
     "SSMReadyChoice": {
       "Type": "Choice",
-      "Comment": "PingStatus=Online → CheckTradingDay. Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail when budget exhausted (per feedback_no_silent_fails — agent not registering after 3 min indicates a real boot problem, not just timing).",
+      "Comment": "PingStatus=Online → CheckSkipMorningEnrich (the NYSE holiday gate already ran pre-boot via TradingDayGate, config#1430). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail when budget exhausted (per feedback_no_silent_fails — agent not registering after 3 min indicates a real boot problem, not just timing).",
       "Choices": [
         {
           "And": [
@@ -614,7 +504,7 @@
               "StringEquals": "Online"
             }
           ],
-          "Next": "CheckTradingDay"
+          "Next": "CheckSkipMorningEnrich"
         },
         {
           "Variable": "$.ssm_poll.attempts",

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -119,6 +119,10 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
 # Weekday SF — alpha-engine-predictor Lambdas
 _WEEKDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     "DeployDriftCheck": frozenset({"action"}),
+    # config#1430: NYSE trading-day gate, moved OFF the box into the
+    # predictor-inference Lambda and run BEFORE StartExecutorEC2 (replaces the
+    # cold-box SSM trading_calendar check whose stdout was unreliably captured).
+    "TradingDayGate": frozenset({"action"}),
     "PredictorInference": frozenset({"action"}),
     "CheckPredictorCoverage": frozenset({"action"}),
     "ReinvokePredictor": frozenset({"action", "tickers.$"}),

--- a/tests/test_sf_trading_day_gate_wiring.py
+++ b/tests/test_sf_trading_day_gate_wiring.py
@@ -1,0 +1,102 @@
+"""Pins the Lambda-based NYSE trading-day gate on the WEEKDAY SF (config#1430).
+
+Incident (2026-06-30): the prior holiday check ran an SSM command on the
+EC2 trading box AFTER booting it. On a cold boot the on-box command exited 0
+but SSM returned empty stdout (output-capture race), so the result Choice's
+Default branch fired a false "Trading Day Check Failed (Proceeding)" SNS alert.
+
+Robust fix: move the holiday check OFF the box into the predictor Lambda
+(``action=check_trading_day``, pure calendar math) and gate on it via a Lambda
+task BEFORE StartExecutorEC2 — mirroring the existing DeployDriftCheck
+Lambda-gate pattern in the same SF. On a holiday the box is never booted.
+
+These assertions guard the full new gate contract and that the six now-dead
+on-box-check states are gone.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
+
+# The on-box trading-day check states removed by config#1430.
+_REMOVED_STATES = [
+    "CheckTradingDay",
+    "WaitForTradingDayCheck",
+    "CheckTradingDayResult",
+    "TradingDayCheckWait",
+    "TradingDayCheckFailed",
+    "StopExecutorOnHoliday",
+]
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+class TestTradingDayGateTask:
+    def test_gate_is_lambda_invoke(self, states):
+        gate = states["TradingDayGate"]
+        assert gate["Type"] == "Task"
+        assert gate["Resource"] == "arn:aws:states:::lambda:invoke"
+
+    def test_gate_invokes_check_trading_day_action(self, states):
+        params = states["TradingDayGate"]["Parameters"]
+        assert params["Payload"]["action"] == "check_trading_day"
+        assert "predictor-inference" in params["FunctionName"]
+
+    def test_gate_catches_to_failed_and_sets_resultpath(self, states):
+        gate = states["TradingDayGate"]
+        assert gate["ResultPath"] == "$.trading_day_gate"
+        catch_targets = [c["Next"] for c in gate["Catch"]]
+        assert "TradingDayGateFailed" in catch_targets
+        assert gate["Next"] == "TradingDayGateChoice"
+
+
+class TestGateRunsBeforeBox:
+    def test_deploy_drift_gate_routes_to_trading_day_gate(self, states):
+        # The gate runs BEFORE StartExecutorEC2 — the box never boots on holidays.
+        assert states["DeployDriftGate"]["Default"] == "TradingDayGate"
+
+
+class TestTradingDayGateChoice:
+    def test_false_branch_skips_to_holiday(self, states):
+        false_branch = [
+            c["Next"]
+            for c in states["TradingDayGateChoice"]["Choices"]
+            if c.get("BooleanEquals") is False
+        ]
+        assert false_branch == ["NotifyHolidaySkip"]
+
+    def test_default_proceeds_to_start_box(self, states):
+        assert states["TradingDayGateChoice"]["Default"] == "StartExecutorEC2"
+
+    def test_choice_reads_is_trading_day_off_gate_payload(self, states):
+        var = states["TradingDayGateChoice"]["Choices"][0]["Variable"]
+        assert var == "$.trading_day_gate.Payload.is_trading_day"
+
+
+class TestTradingDayGateFailed:
+    def test_failed_proceeds_to_start_box(self, states):
+        failed = states["TradingDayGateFailed"]
+        assert failed["Resource"] == "arn:aws:states:::sns:publish"
+        assert failed["Next"] == "StartExecutorEC2"
+
+
+class TestDeadStatesRemoved:
+    @pytest.mark.parametrize("dead", _REMOVED_STATES)
+    def test_removed_state_absent(self, states, dead):
+        assert dead not in states, f"{dead} should have been removed (config#1430)"
+
+
+class TestHolidayNotifyTerminal:
+    def test_notify_holiday_skip_is_terminal(self, states):
+        nhs = states["NotifyHolidaySkip"]
+        assert nhs.get("End") is True
+        assert "Next" not in nhs

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -77,13 +77,28 @@ class TestGateShape:
 class TestEntryEdgesRouteThroughGates:
     """Every edge that used to enter a task now enters its skip-gate."""
 
-    def test_trading_day_success_enters_morning_enrich_gate(self, states):
-        nexts = [c["Next"] for c in states["CheckTradingDayResult"]["Choices"]]
-        assert "CheckSkipMorningEnrich" in nexts
-        assert "MorningEnrich" not in nexts
+    def test_trading_day_gate_runs_before_box_then_enters_morning_gate(self, states):
+        # config#1430: the NYSE holiday check moved OFF the box into the predictor
+        # Lambda and now gates BEFORE StartExecutorEC2.
+        assert states["DeployDriftGate"]["Default"] == "TradingDayGate"
+        assert states["TradingDayGateChoice"]["Default"] == "StartExecutorEC2"
+        false_branch = [
+            c["Next"]
+            for c in states["TradingDayGateChoice"]["Choices"]
+            if c.get("BooleanEquals") is False
+        ]
+        assert false_branch == ["NotifyHolidaySkip"]
+        # Once the box is up, the SSM-ready success branch enters the first morning
+        # work gate (CheckSkipMorningEnrich) — it no longer runs an on-box check.
+        online = [
+            c["Next"]
+            for c in states["SSMReadyChoice"]["Choices"]
+            if "And" in c
+        ]
+        assert online == ["CheckSkipMorningEnrich"]
 
-    def test_trading_day_check_failed_enters_morning_enrich_gate(self, states):
-        assert states["TradingDayCheckFailed"]["Next"] == "CheckSkipMorningEnrich"
+    def test_trading_day_gate_failed_proceeds_as_trading_day(self, states):
+        assert states["TradingDayGateFailed"]["Next"] == "StartExecutorEC2"
 
     def test_morning_enrich_success_enters_append_gate(self, states):
         # L4608: the slow daily_append is now its own load-bearing state behind


### PR DESCRIPTION
## config#1430 — false "Trading Day Check Failed" alert

The weekday/preopen Step Function (`ne-preopen-trading-pipeline`) checked NYSE holidays by running an **SSM command on the EC2 trading box AFTER starting it** (states: `DeployDriftGate` -> `StartExecutorEC2` -> ... -> `SSMReadyChoice` -> `CheckTradingDay` -> `WaitForTradingDayCheck` -> `CheckTradingDayResult`).

On **2026-06-30** the on-box command exited 0 but SSM returned **empty stdout** (cold-boot output-capture race). `CheckTradingDayResult`'s `Default` branch then routed to `TradingDayCheckFailed`, firing a **false "Trading Day Check Failed (Proceeding)" SNS alert** even though it was a normal trading day.

## Robust fix

Move the holiday check **off the box** into the predictor Lambda (`action=check_trading_day` on `alpha-engine-predictor-inference:live` — pure calendar math, no box dependency) and gate on it via a **Lambda task BEFORE `StartExecutorEC2`**. This mirrors the existing `DeployDriftCheck` Lambda-gate pattern already in this SF.

### Before / after flow

**Before:** `DeployDriftGate` -> `StartExecutorEC2` -> wait-for-SSM -> on-box `CheckTradingDay` (SSM stdout) -> holiday? stop box.

**After:** `DeployDriftGate` -> **`TradingDayGate` (Lambda)** -> `TradingDayGateChoice`:
- `is_trading_day == false` -> `NotifyHolidaySkip` (**box never boots**)
- else (or any non-false / infra-error result) -> `StartExecutorEC2`

The gate now runs **before** the box starts, so on holidays the executor box is **never booted** (no speculative start + stop). It removes the cold-box SSM stdout dependency entirely — the root cause of the false alert.

### Changes to `infrastructure/step_function_daily.json`
- `DeployDriftGate` `Default`: `StartExecutorEC2` -> `TradingDayGate`.
- Add `TradingDayGate` (Lambda invoke, `Catch` -> `TradingDayGateFailed`, `ResultPath: $.trading_day_gate`), `TradingDayGateChoice`, and `TradingDayGateFailed` (fail-open SNS alert -> `StartExecutorEC2`, matching the prior fail-soft posture).
- `SSMReadyChoice` success branch now enters `CheckSkipMorningEnrich` (no on-box trading-day check after boot).
- Remove the six now-dead states: `CheckTradingDay`, `WaitForTradingDayCheck`, `CheckTradingDayResult`, `TradingDayCheckWait`, `TradingDayCheckFailed`, `StopExecutorOnHoliday`.
- `NotifyHolidaySkip` comment + message updated (box was never started).

### Tests
- `tests/test_sf_weekday_skipgate_wiring.py`: replaced the two methods that referenced removed states with assertions on the new gate wiring (`DeployDriftGate.Default == TradingDayGate`, `TradingDayGateChoice` false -> `NotifyHolidaySkip` / Default -> `StartExecutorEC2`, `SSMReadyChoice` -> `CheckSkipMorningEnrich`, `TradingDayGateFailed` -> `StartExecutorEC2`). The happy-path walk test is unaffected and still passes.
- New `tests/test_sf_trading_day_gate_wiring.py`: pins the full gate contract (Lambda invoke + `action=check_trading_day` + `predictor-inference`; gate runs before `StartExecutorEC2`; Catch/ResultPath; choice routing; six removed states absent; `NotifyHolidaySkip` terminal).
- `tests/test_sf_payload_uniqueness.py`: registered `TradingDayGate` in `_WEEKDAY_PAYLOAD_KEYS` (payload-uniqueness chokepoint).

## :warning: DEPLOY ORDERING

**MERGE/DEPLOY THE COMPANION crucible-predictor PR FIRST.** This SF invokes `action=check_trading_day` on `alpha-engine-predictor-inference:live`; if this SF deploys before the predictor Lambda knows that action, the Lambda falls through to the default `predict` path.

## Local test results

- Targeted: `test_sf_weekday_skipgate_wiring.py` + `test_sf_trading_day_gate_wiring.py` + `test_sf_poll_resultselector.py` -> **70 passed** (poll test still finds 22 SSM polls across the 3 SFs, above the >=15 floor after dropping `WaitForTradingDayCheck`).
- `test_sf_payload_uniqueness.py` -> **33 passed**.
- Dangling-transition check: **0 dangling transitions, 0 unreachable states** (53 states, 94 transitions, StartAt resolves).
- Full suite: **1903 passed**, 107 failed, 56 collection errors — all failures/errors are pre-existing local-venv staleness (missing `requests`, `nousergon_lib.config` on the stale 0.59.8 lib / py3.13, ArcticDB import) in test files this JSON-only change does not touch. No SF/wiring test fails on this branch except the two pre-existing env-stale `test_sf_preflight` cases (`ModuleNotFoundError: nousergon_lib.config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
