### PR TITLE
feat(groom-dispatcher): launch EC2 spot instead of repository_dispatch (config#1432, part 2/2)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -1,32 +1,41 @@
 # scheduled-groom-dispatcher
 
 Fires the autonomous backlog groom on a **reliable, on-time cadence** via
-**EventBridge Scheduler → `repository_dispatch`**, replacing the
-`backlog-groom.yml` GitHub Actions `schedule:` crons, which are best-effort and
-fire late or are silently dropped (config#1322).
+**EventBridge Scheduler → a dedicated EC2 spot box** (config#1322 for the
+cadence; config#1432 for the spot move). EventBridge Scheduler replaces the
+best-effort GHA `schedule:` crons; the spot box replaces the GitHub-hosted
+runner so the ~hours-long groom stops burning the org's 2,000 included
+PRIVATE-repo GHA Actions minutes (public repos are free; the groom ran in the
+private `alpha-engine-config` repo). The box runs the SAME
+`scripts/groom_run.sh` entrypoint the GHA workflow uses (single source of truth),
+then self-terminates (~$2/mo).
 
 > **Status: UNVALIDATED.** This is the IaC + handler only. It has **zero live
-> effect** until an operator runs `deploy.sh --bootstrap`, and the GHA
-> `schedule:` crons stay live as a belt-and-suspenders backstop until a multi-day
-> on-time-firing soak confirms this path (see **Soak** below). Only then can the
-> GHA crons be removed.
+> effect** until an operator runs `deploy.sh --bootstrap`. **Cutover** (config#1432):
+> after a manual `--smoke` spot run validates end-to-end, deploy this AND disable
+> the GHA `schedule:` crons in `backlog-groom.yml` together — so there is no
+> double-groom and no gap. `workflow_dispatch` stays as the manual escape hatch.
 
 ## How it fits
 
 ```
-EventBridge Scheduler rules (UTC, cron)              THIS Lambda
-  alpha-engine-scheduled-groom-0700-sunfri  ─┐       (repository_dispatch)
-  alpha-engine-scheduled-groom-2300-daily   ─┴─────▶  type: scheduled-groom
-                                                      client_payload.run_mode
-                                                              │
-                                                              ▼
-                            nousergon/alpha-engine-config :: backlog-groom.yml
-                         (on: repository_dispatch[scheduled-groom] → run_mode-routed groom)
+EventBridge Scheduler rules (UTC, cron)            THIS Lambda
+  alpha-engine-scheduled-groom-0700-sunfri  ─┐      1. nousergon_lib.ec2_spot.launch()
+  alpha-engine-scheduled-groom-2300-daily   ─┴────▶    (spot; on-demand fallback)
+                                                    2. wait instance running + SSM Online
+                                                    3. async ssm send-command (detached):
+                                                          │
+                                                          ▼
+   EC2 spot box (AL2023, alpha-engine-executor-profile)
+     prelude: read PAT (SSM) → clone alpha-engine-config
+       → infrastructure/groom_spot_bootstrap.sh --mode <full|sweep>
+         → scripts/groom_run.sh  (budget gate → driver/sweep → digest-verify)
+     → shutdown -h now (InstanceInitiatedShutdownBehavior=terminate)
 ```
 
-It mirrors the sibling `saturday-sf-success-groom-dispatcher` and **reuses the
-same SSM PAT** (`/alpha-engine/saturday_sf_watch/github_pat`) for the
-repository_dispatch — no new credential. The EventBridge Scheduler conventions
+The **box** reads the cross-repo PAT (`/alpha-engine/saturday_sf_watch/github_pat`)
+and all other secrets itself from SSM via its instance profile — no new
+credential, and this Lambda needs no secret access. The EventBridge Scheduler conventions
 (`scheduler.amazonaws.com` execution role, `cron()` expression, OFF
 flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-scheduled-groom-dispatcher Lambda
-# and wire its EventBridge Scheduler rules (the reliable replacement for
-# the backlog-groom GHA `schedule:` crons — config#1322).
+# and wire its EventBridge Scheduler rules (config#1322, #1432).
 #
-# Each Scheduler rule fires THIS Lambda on cadence; the Lambda repository_
-# dispatches the backlog groom (nousergon/alpha-engine-config :: backlog-groom.yml,
-# type `scheduled-groom`) carrying the run-mode in client_payload. Mirrors the
-# sibling `saturday-sf-success-groom-dispatcher`; EventBridge Scheduler conventions
-# (scheduler.amazonaws.com role, cron() expression, flexible-time-window) mirror
-# `infrastructure/run_weekly_offcycle.sh`.
+# Each Scheduler rule fires THIS Lambda on cadence; the Lambda LAUNCHES A
+# DEDICATED EC2 SPOT BOX (nousergon_lib.ec2_spot, on-demand fallback) and fires an
+# async SSM command that clones nousergon/alpha-engine-config and runs the SAME
+# scripts/groom_run.sh entrypoint the GHA workflow uses, then self-terminates.
+# This moves the heavy ~hours-long groom OFF the org's 2,000 included PRIVATE-repo
+# GHA Actions minutes (config#1432; was: a repository_dispatch into backlog-groom.yml).
+# EventBridge Scheduler conventions (scheduler.amazonaws.com role, cron()
+# expression, flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole (the
+# executor role) + ssm:SendCommand. The BOX reads all secrets itself from SSM via
+# its instance profile (alpha-engine-executor-role → ssm:GetParameter on
+# /alpha-engine/*), so the Lambda needs NO secret access.
 #
 # Cadence (UTC, mirrors the GHA crons exactly). Reduced 3->2/day on 2026-06-29
 # (the 15:00 UTC / 8am-PT run was dropped per usage pacing):
@@ -22,8 +28,10 @@
 # Managed OUTSIDE CloudFormation — same rationale as the sibling dispatchers
 # (keeps the github-actions-lambda-deploy OIDC role's blast radius narrow;
 # operator-deployed only). Merging the PR has ZERO live effect until an operator
-# runs this with --bootstrap, AND the GHA `schedule:` crons stay live as a
-# backstop until a multi-day on-time-firing soak confirms this path.
+# runs this with --bootstrap. CUTOVER (config#1432): after a manual --smoke spot
+# run validates end-to-end, deploy this AND disable the GHA `schedule:` crons in
+# backlog-groom.yml together (so there is no double-groom and no gap). NOTE:
+# --smoke fires a REAL groom on a REAL spot box.
 #
 # Usage:
 #   bash .../scheduled-groom-dispatcher/deploy.sh             # update code only

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -12,10 +12,33 @@
       "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-scheduled-groom-dispatcher:*"
     },
     {
-      "Sid": "GroomDispatchPAT",
+      "Sid": "LaunchGroomSpot",
       "Effect": "Allow",
-      "Action": ["ssm:GetParameter"],
-      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat"
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateTags",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassExecutorProfileRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-executor-role",
+      "Condition": {
+        "StringEquals": { "iam:PassedToService": "ec2.amazonaws.com" }
+      }
+    },
+    {
+      "Sid": "SsmRunGroomBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1,80 +1,96 @@
-"""alpha-engine-scheduled-groom-dispatcher — fire the backlog groom on an
-EventBridge-Scheduler-driven cadence (the reliable replacement for the GHA
-`schedule:` crons).
+"""alpha-engine-scheduled-groom-dispatcher — launch the backlog groom on a
+dedicated EC2 spot box on an EventBridge-Scheduler-driven cadence.
 
-Why this exists (config#1322): GitHub Actions `schedule:` is best-effort and
-routinely fires late or is silently dropped, which defeats the DRAIN-PHASE
-3×/day cadence (config#1312). Today's `0 23 * * *` run was never created, and
-yesterday's fired ~2h late. EventBridge Scheduler gives guaranteed, on-time
-firing with a CloudWatch trail.
+WHY SPOT, NOT GITHUB ACTIONS (config#1432): the 2-3×/day FULL grooms run a
+~hours-long Claude Code agent. Running them on GitHub-hosted runners in the
+PRIVATE `alpha-engine-config` repo burned the org's 2,000 included Actions
+minutes (100% used 2026-06-29; public repos are free/unlimited). This Lambda now
+launches a capacity-resilient EC2 spot box (~$2/mo) that runs the SAME
+`scripts/groom_run.sh` entrypoint the GHA workflow uses, then self-terminates.
 
-Wiring mirrors the sibling `saturday-sf-success-groom-dispatcher`: three
-EventBridge Scheduler rules (07:00 / 15:00 / 23:00 UTC, with the same Sun–Fri /
-daily day-masks the GHA crons use) each target THIS Lambda, which sends a
-`repository_dispatch` (type `scheduled-groom`) to
-`nousergon/alpha-engine-config`, where `backlog-groom.yml` consumes it. The
-schedule's own input carries `run_mode`/`phase`, which the Lambda forwards in
-`client_payload` so the workflow's run-mode step routes the right drain pass.
+Mechanism (mirrors the fleet gold-standard `spot_data_weekly.sh`, reusing both
+fleet chokepoints — no lib change):
+  1. `nousergon_lib.ec2_spot.launch()` rotates instance_type × subnet on capacity
+     error; on SpotCapacityExhausted across all pools we relaunch ON-DEMAND
+     (spot=False) so a capacity dip never starves a groom.
+  2. Wait for the instance to run + its SSM agent to come Online.
+  3. Fire an ASYNC, detached `ssm send-command` (AWS-RunShellScript) carrying a
+     small prelude: fetch the PAT from SSM, clone alpha-engine-config, then
+     `exec infrastructure/groom_spot_bootstrap.sh`. The box self-terminates
+     (InstanceInitiatedShutdownBehavior=terminate + a watchdog). The Lambda
+     returns immediately — it does NOT babysit the multi-hour run.
 
-Reuses the SAME SSM-stored fine-grained PAT
-(`/alpha-engine/saturday_sf_watch/github_pat`) the sibling dispatchers use for
-repository_dispatch — no new credential.
+The box reads ALL secrets itself from SSM via its instance profile
+(alpha-engine-executor-profile → alpha-engine-executor-role, which already has
+ssm:GetParameter on /alpha-engine/*), so this Lambda needs NO secret access — it
+only needs ec2:RunInstances, iam:PassRole (the executor role), and ssm:SendCommand.
 
-Fail-loud (UNLIKE the convenience-side success dispatcher): a scheduled groom
-IS the deliverable here — it replaces the cron the workflow depends on — so a
-GitHub/SSM failure RAISES, letting EventBridge's retries + the Lambda error
-metric + a CloudWatch alarm surface the miss, rather than silently swallowing a
-dropped pass (the exact failure mode #1322 is fixing).
+Fail-loud (a scheduled groom IS the deliverable): a launch/SSM failure RAISES so
+EventBridge retries + the Lambda error metric + a CloudWatch alarm surface the
+miss, rather than silently dropping a pass.
 
-Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
-operator-deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live
-effect until bootstrapped, and the GHA `schedule:` crons stay in place as a
-belt-and-suspenders backstop until a multi-day on-time-firing soak confirms the
-EventBridge path before they can be removed.
+Managed OUTSIDE CloudFormation (same as before): operator-deployed via
+`deploy.sh --bootstrap`. Merging the PR has ZERO live effect until the new code +
+IAM are deployed AND the GHA `schedule:` crons are disabled (the gated cutover).
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import urllib.request
+import time
 
 import boto3
+from nousergon_lib import ec2_spot
+from nousergon_lib.ec2_spot import SpotCapacityExhausted
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
-# Kill-switch: set GROOM_DISPATCH_ENABLED=false on the Lambda to disable the
-# trigger without deleting the EventBridge Scheduler rules. Default ON.
+# Kill-switch: GROOM_DISPATCH_ENABLED=false disables the trigger without deleting
+# the EventBridge Scheduler rules. Default ON.
 DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
-DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
-DISPATCH_EVENT_TYPE = os.environ.get("DISPATCH_EVENT_TYPE", "scheduled-groom")
-GITHUB_PAT_SSM_PARAM = os.environ.get(
-    "GITHUB_PAT_SSM_PARAM", "/alpha-engine/saturday_sf_watch/github_pat"
-)
-# Valid run-modes the workflow's run-mode step honors. Anything else falls back
-# to "full" so a malformed schedule input can never wedge the dispatch.
+
+# ── Spot launch config (env-overridable; defaults mirror spot_data_weekly.sh) ──
+# t3/t3a/t2 .medium (4 GB) across all 6 default-VPC subnets; the lib CLI rotates
+# on capacity error. Cheap-first type order biases pool selection toward price.
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get("GROOM_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium").split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "GROOM_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("GROOM_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("GROOM_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("GROOM_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+IAM_PROFILE = os.environ.get("GROOM_IAM_PROFILE", "alpha-engine-executor-profile")
+VOLUME_SIZE_GB = int(os.environ.get("GROOM_VOLUME_SIZE_GB", "40"))  # node + claude-code + repo clones
+
+GROOM_REPO = os.environ.get("GROOM_REPO", "nousergon/alpha-engine-config")
+GROOM_BRANCH = os.environ.get("GROOM_BRANCH", "main")
+# The BOX reads the PAT via its instance profile (this Lambda does not).
+GROOM_GH_PAT_SSM = os.environ.get("GROOM_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat")
+# Hard ceiling for the on-box SSM command (matches the bootstrap watchdog). The
+# in-run soft budget (~340 min) is the binding stop; this is the backstop.
+MAX_RUNTIME_SECONDS = int(os.environ.get("GROOM_MAX_RUNTIME_SECONDS", "21600"))
+SSM_ONLINE_BUDGET_SEC = int(os.environ.get("GROOM_SSM_ONLINE_BUDGET_SEC", "180"))
+CW_LOG_GROUP = os.environ.get("GROOM_CW_LOG_GROUP", "/alpha-engine/groom-spot")
+
 _VALID_RUN_MODES = {"full", "sweep"}
 _DEFAULT_RUN_MODE = "full"
-_DISPATCH_TIMEOUT_SEC = 15
-
-
-def _get_github_pat() -> str:
-    """Read the fine-grained PAT (SecureString) from SSM. Never logged."""
-    ssm = boto3.client("ssm", region_name=REGION)
-    resp = ssm.get_parameter(Name=GITHUB_PAT_SSM_PARAM, WithDecryption=True)
-    return resp["Parameter"]["Value"]
 
 
 def _resolve_run_mode(event: dict) -> str:
-    """Pull the desired run-mode from the EventBridge Scheduler input.
-
-    Each Scheduler rule passes a JSON input like {"run_mode": "full",
-    "schedule": "0 7 * * 0-5"}. An unknown/missing run_mode degrades to FULL
-    (the drain-phase default — all three current crons are full grooms).
-    """
+    """Pull run-mode from the EventBridge Scheduler input; unknown/missing → full."""
     rm = str(event.get("run_mode") or _DEFAULT_RUN_MODE).strip().lower()
     if rm not in _VALID_RUN_MODES:
         logger.warning("unknown run_mode %r — defaulting to %s", rm, _DEFAULT_RUN_MODE)
@@ -82,62 +98,136 @@ def _resolve_run_mode(event: dict) -> str:
     return rm
 
 
-def _dispatch_groom(run_mode: str, schedule_label: str) -> dict:
-    """Fire the repository_dispatch that triggers backlog-groom.yml.
+def _bootstrap_command(run_mode: str, run_url: str) -> str:
+    """The async SSM RunShellScript body: fetch PAT, clone config, exec bootstrap.
 
-    Fail-loud: a scheduled groom is the deliverable (it replaces the cron the
-    workflow depends on), so any failure RAISES so EventBridge retries + the
-    Lambda error metric surface the miss. Returns the success result.
+    Runs as root on the box. The heavy, version-controlled logic lives in the
+    repo's infrastructure/groom_spot_bootstrap.sh; this prelude is only the
+    minimal clone glue (it needs the PAT before it can clone the private repo).
+    Any prelude failure shuts the box down so a botched launch never idles.
     """
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+fail() {{ echo "[groom-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+PAT=$(aws ssm get-parameter --name {GROOM_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/alpha-engine-config
+git clone --depth 1 --branch {GROOM_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{GROOM_REPO}.git" \
+  /home/ec2-user/alpha-engine-config || fail "clone failed"
+cd /home/ec2-user/alpha-engine-config
+exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"
+"""
+
+
+def _launch_instance() -> tuple[str, str]:
+    """Launch the groom box; spot first, on-demand fallback on capacity exhaustion."""
+    common = dict(
+        image_id=AMI_ID,
+        key_name=KEY_NAME,
+        security_group_ids=[SECURITY_GROUP],
+        iam_instance_profile=IAM_PROFILE,
+        volume_size_gb=VOLUME_SIZE_GB,
+        shutdown_behavior="terminate",
+        tag_name="alpha-engine-groom-spot",
+        region=REGION,
+    )
+    try:
+        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=True, **common)
+        return iid, "spot"
+    except SpotCapacityExhausted:
+        logger.warning(
+            "spot capacity exhausted across all type×subnet pools — relaunching ON-DEMAND"
+        )
+        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=False, **common)
+        return iid, "on-demand"
+
+
+def _wait_ssm_online(instance_id: str) -> None:
+    """Block until the instance is running AND its SSM agent registers Online."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    ssm = boto3.client("ssm", region_name=REGION)
+    ec2.get_waiter("instance_running").wait(
+        InstanceIds=[instance_id], WaiterConfig={"Delay": 5, "MaxAttempts": 40}
+    )
+    deadline = time.time() + SSM_ONLINE_BUDGET_SEC
+    while time.time() < deadline:
+        info = ssm.describe_instance_information(
+            Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
+        ).get("InstanceInformationList", [])
+        if info and info[0].get("PingStatus") == "Online":
+            logger.info("SSM agent Online for %s", instance_id)
+            return
+        time.sleep(5)
+    raise RuntimeError(
+        f"SSM agent not Online after {SSM_ONLINE_BUDGET_SEC}s for {instance_id}"
+    )
+
+
+def _send_bootstrap(instance_id: str, run_mode: str, run_url: str) -> str:
+    """Fire the async, detached SSM command that runs the groom + self-terminates."""
+    ssm = boto3.client("ssm", region_name=REGION)
+    resp = ssm.send_command(
+        InstanceIds=[instance_id],
+        DocumentName="AWS-RunShellScript",
+        Comment=f"backlog groom ({run_mode}) — config#1432",
+        Parameters={
+            "commands": [_bootstrap_command(run_mode, run_url)],
+            # Execution timeout (NOT the start timeout) — without this SSM kills the
+            # command at the 3600s default, guillotining a multi-hour groom.
+            "executionTimeout": [str(MAX_RUNTIME_SECONDS)],
+        },
+        TimeoutSeconds=600,  # time to START delivering before giving up
+        CloudWatchOutputConfig={
+            "CloudWatchLogGroupName": CW_LOG_GROUP,
+            "CloudWatchOutputEnabled": True,
+        },
+    )
+    return resp["Command"]["CommandId"]
+
+
+def _launch_groom_spot(run_mode: str, schedule_label: str) -> dict:
+    """Launch + bootstrap the groom box. Fail-loud — any error RAISES."""
     if not DISPATCH_ENABLED:
-        logger.warning("GROOM_DISPATCH_ENABLED=false — scheduled groom NOT dispatched")
-        return {"dispatched": False, "reason": "disabled"}
-    pat = _get_github_pat()
-    payload = {
-        "event_type": DISPATCH_EVENT_TYPE,
-        "client_payload": {
-            "trigger": "eventbridge-scheduled",
-            "run_mode": run_mode,
-            # `phase` is an alias of run_mode kept for forward-compat with any
-            # future multi-phase drain routing; the workflow reads run_mode.
-            "phase": run_mode,
-            "schedule": schedule_label,
-        },
-    }
-    req = urllib.request.Request(
-        f"https://api.github.com/repos/{DISPATCH_REPO}/dispatches",
-        data=json.dumps(payload).encode("utf-8"),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {pat}",
-            "Accept": "application/vnd.github+json",
-            "Content-Type": "application/json",
-            "User-Agent": "scheduled-groom-dispatcher",
-        },
+        logger.warning("GROOM_DISPATCH_ENABLED=false — groom spot NOT launched")
+        return {"launched": False, "reason": "disabled"}
+
+    instance_id, market = _launch_instance()
+    logger.info("launched groom box %s (%s)", instance_id, market)
+    _wait_ssm_online(instance_id)
+    run_url = (
+        f"https://{REGION}.console.aws.amazon.com/cloudwatch/home?region={REGION}"
+        f"#logsV2:log-groups/log-group/$252Falpha-engine$252Fgroom-spot"
+        f"$3FfilterPattern$3D{instance_id}"
     )
-    with urllib.request.urlopen(req, timeout=_DISPATCH_TIMEOUT_SEC) as resp:
-        status_code = resp.status
+    command_id = _send_bootstrap(instance_id, run_mode, run_url)
     logger.info(
-        "scheduled-groom repository_dispatch sent to %s (type=%s, run_mode=%s, http=%s)",
-        DISPATCH_REPO,
-        DISPATCH_EVENT_TYPE,
+        "groom dispatched: instance=%s market=%s command=%s run_mode=%s schedule=%s",
+        instance_id,
+        market,
+        command_id,
         run_mode,
-        status_code,
+        schedule_label,
     )
-    return {"dispatched": True, "status_code": status_code, "run_mode": run_mode}
+    return {
+        "launched": True,
+        "instance_id": instance_id,
+        "market": market,
+        "command_id": command_id,
+        "run_mode": run_mode,
+    }
 
 
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
-    """EventBridge Scheduler handler — fires the backlog groom on cadence.
+    """EventBridge Scheduler handler — launches the groom spot box on cadence.
 
-    `event` is the schedule's configured JSON input, e.g.
-    {"run_mode": "full", "schedule": "0 23 * * *"}.
+    `event` is the schedule's JSON input, e.g. {"run_mode": "full", "schedule": "0 23 * * *"}.
     """
     event = event or {}
     run_mode = _resolve_run_mode(event)
     schedule_label = str(event.get("schedule") or "unknown")
-    logger.info(
-        "scheduled groom trigger: run_mode=%s schedule=%s", run_mode, schedule_label
-    )
-    result = _dispatch_groom(run_mode, schedule_label)
+    logger.info("scheduled groom trigger: run_mode=%s schedule=%s", run_mode, schedule_label)
+    result = _launch_groom_spot(run_mode, schedule_label)
     return {"groom": result}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -1,5 +1,10 @@
 # boto3 is provided by the Lambda python3.12 runtime; pinned here for an
 # explicit, reproducible package build (mirrors the sibling dispatchers).
-# No alpha-engine/nousergon lib dependency — this Lambda only reads one SSM
-# parameter and POSTs a repository_dispatch via urllib.
 boto3>=1.34.0
+# ec2_spot launch chokepoint (capacity-resilient spot/on-demand rotation) — the
+# dispatcher launches the groom box via nousergon_lib.ec2_spot instead of
+# re-implementing run_instances (config#1432). Pin matches the repo's lib pin
+# (root requirements.txt @v0.70.0). Base package only (no extras) — ec2_spot needs
+# just boto3, which the runtime provides; base deps (pydantic/pyyaml/requests) are
+# light and well under the Lambda size limit.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.70.0

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -1,117 +1,155 @@
-"""Unit tests for the EventBridge-Scheduler → scheduled groom dispatcher.
+"""Unit tests for the EventBridge-Scheduler → groom-spot dispatcher (config#1432).
 
-No AWS / GitHub calls — SSM and urllib are monkeypatched. Validates: a schedule
-event posts the correct repository_dispatch to alpha-engine-config carrying the
-run_mode; run_mode normalisation/fallback; the kill-switch short-circuits; and
-(UNLIKE the convenience success-dispatcher) a dispatch failure RAISES so
-EventBridge retries + the error metric surface a dropped pass.
+Hermetic: `nousergon_lib.ec2_spot` and `boto3` are stubbed in sys.modules BEFORE
+importing index, so the tests run without either installed (matching how
+deploy.sh runs them with bare python3). Validates: a schedule event launches a
+spot box and fires an async SSM command carrying the run_mode; the on-demand
+fallback on spot capacity exhaustion; run_mode normalisation; the kill-switch
+short-circuit; and fail-loud (a launch failure RAISES so EventBridge retries +
+the error metric surface the miss).
 """
 
 from __future__ import annotations
 
 import importlib
-import json
 import os
 import sys
+import types
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 
 
-def _load(monkeypatch, **env):
-    for k, v in env.items():
+# ── Stub nousergon_lib.ec2_spot + boto3 before importing index ─────────────────
+class _SpotLaunchError(Exception):
+    pass
+
+
+class _SpotCapacityExhausted(_SpotLaunchError):
+    pass
+
+
+def _install_stubs(launch_impl, boto_clients):
+    ec2_spot_mod = types.ModuleType("nousergon_lib.ec2_spot")
+    ec2_spot_mod.SpotLaunchError = _SpotLaunchError
+    ec2_spot_mod.SpotCapacityExhausted = _SpotCapacityExhausted
+    ec2_spot_mod.launch = launch_impl
+    pkg = types.ModuleType("nousergon_lib")
+    pkg.ec2_spot = ec2_spot_mod
+    sys.modules["nousergon_lib"] = pkg
+    sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
+
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: boto_clients[name]
+    sys.modules["boto3"] = boto3_mod
+
+
+class _FakeWaiter:
+    def wait(self, **kw):
+        return None
+
+
+class _FakeEc2:
+    def get_waiter(self, name):
+        return _FakeWaiter()
+
+
+class _FakeSsm:
+    def __init__(self):
+        self.sent = []
+
+    def describe_instance_information(self, **kw):
+        return {"InstanceInformationList": [{"PingStatus": "Online"}]}
+
+    def send_command(self, **kw):
+        self.sent.append(kw)
+        return {"Command": {"CommandId": "cmd-123"}}
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None):
+    for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
+    ssm = _FakeSsm()
+    clients = {"ec2": _FakeEc2(), "ssm": ssm}
+    if launch_impl is None:
+        launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
+    _install_stubs(launch_impl, clients)
     import index
 
     importlib.reload(index)
+    index._test_ssm = ssm  # expose for assertions
     return index
 
 
-def _stub_resp(status=204):
-    class _Resp:
-        def __init__(self):
-            self.status = status
+def test_schedule_event_launches_spot_and_sends_async_ssm(monkeypatch):
+    calls = {}
 
-        def __enter__(self):
-            return self
+    def _launch(types_, subnets, **kw):
+        calls["spot"] = kw.get("spot")
+        calls["profile"] = kw.get("iam_instance_profile")
+        return "i-abc"
 
-        def __exit__(self, *a):
-            return False
-
-    return _Resp()
-
-
-def test_schedule_event_dispatches_correct_repository_dispatch(monkeypatch):
-    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
-    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
-    captured = {}
-
-    def _fake_urlopen(req, timeout=0):
-        captured["url"] = req.full_url
-        captured["body"] = json.loads(req.data.decode())
-        captured["auth"] = req.headers.get("Authorization")
-        return _stub_resp(204)
-
-    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    idx = _load(monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
-    assert out["groom"]["dispatched"] is True
-    assert out["groom"]["status_code"] == 204
-    assert out["groom"]["run_mode"] == "full"
-    assert captured["url"].endswith("/repos/nousergon/alpha-engine-config/dispatches")
-    assert captured["body"]["event_type"] == "scheduled-groom"
-    assert captured["body"]["client_payload"]["run_mode"] == "full"
-    assert captured["body"]["client_payload"]["phase"] == "full"
-    assert captured["body"]["client_payload"]["schedule"] == "0 23 * * *"
-    assert captured["auth"] == "Bearer tok"
+    g = out["groom"]
+    assert g["launched"] is True
+    assert g["instance_id"] == "i-abc"
+    assert g["market"] == "spot"
+    assert g["command_id"] == "cmd-123"
+    assert g["run_mode"] == "full"
+    assert calls["spot"] is True
+    # The async SSM command carries the bootstrap that runs the FULL groom.
+    sent = idx._test_ssm.sent[0]
+    cmd = sent["Parameters"]["commands"][0]
+    assert "groom_spot_bootstrap.sh --mode full" in cmd
+    assert sent["Parameters"]["executionTimeout"] == [str(idx.MAX_RUNTIME_SECONDS)]
+
+
+def test_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        if kw.get("spot"):
+            raise _SpotCapacityExhausted("no capacity in any pool")
+        return "i-ondemand"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"run_mode": "full", "schedule": "x"}, None)
+    assert out["groom"]["market"] == "on-demand"
+    assert out["groom"]["instance_id"] == "i-ondemand"
+    assert seen == [True, False]  # tried spot, then on-demand
 
 
 def test_unknown_run_mode_falls_back_to_full(monkeypatch):
-    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
-    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
-    captured = {}
-
-    def _fake_urlopen(req, timeout=0):
-        captured["body"] = json.loads(req.data.decode())
-        return _stub_resp(204)
-
-    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler({"run_mode": "bogus"}, None)
     assert out["groom"]["run_mode"] == "full"
-    assert captured["body"]["client_payload"]["run_mode"] == "full"
+    assert "--mode full" in idx._test_ssm.sent[0]["Parameters"]["commands"][0]
 
 
 def test_sweep_run_mode_is_forwarded(monkeypatch):
-    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
-    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
-    captured = {}
-
-    def _fake_urlopen(req, timeout=0):
-        captured["body"] = json.loads(req.data.decode())
-        return _stub_resp(204)
-
-    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler({"run_mode": "sweep"}, None)
     assert out["groom"]["run_mode"] == "sweep"
-    assert captured["body"]["client_payload"]["run_mode"] == "sweep"
+    assert "--mode sweep" in idx._test_ssm.sent[0]["Parameters"]["commands"][0]
 
 
 def test_disabled_flag_short_circuits(monkeypatch):
-    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="false")
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "false"})
     out = idx.handler({"run_mode": "full"}, None)
-    assert out["groom"]["dispatched"] is False
+    assert out["groom"]["launched"] is False
     assert out["groom"]["reason"] == "disabled"
+    assert idx._test_ssm.sent == []  # nothing launched
 
 
-def test_dispatch_failure_raises(monkeypatch):
-    # Fail-loud: a scheduled groom is the deliverable, so a GitHub failure must
+def test_launch_failure_raises(monkeypatch):
+    # Fail-loud: a scheduled groom is the deliverable, so a launch failure must
     # RAISE (EventBridge retries + the Lambda error metric record the miss).
-    idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
-    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
+    def _boom(types_, subnets, **kw):
+        raise _SpotLaunchError("RunInstances denied")
 
-    def _boom(req, timeout=0):
-        raise RuntimeError("github down")
-
-    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
-    with pytest.raises(RuntimeError, match="github down"):
+    idx = _load(monkeypatch, launch_impl=_boom, env={"GROOM_DISPATCH_ENABLED": "true"})
+    with pytest.raises(_SpotLaunchError, match="RunInstances denied"):
         idx.handler({"run_mode": "full"}, None)


### PR DESCRIPTION
Part 2 of 2 for **config#1432** — companion to alpha-engine-config#1435. Moves the 2×/day scheduled backlog groom off GitHub Actions onto a dedicated EC2 spot box so it stops burning the org's 2,000 included private-repo Actions minutes (100% used 2026-06-29; public repos are free).

## What changed (`scheduled-groom-dispatcher`)
- **`index.py`** — rewritten: instead of `repository_dispatch` into `backlog-groom.yml`, it now `nousergon_lib.ec2_spot.launch()`es a capacity-resilient spot box (**on-demand fallback** on `SpotCapacityExhausted`), waits for SSM-online, then fires an **async detached `ssm send-command`** (executionTimeout 6h) that clones `alpha-engine-config` and runs the shared **`scripts/groom_run.sh`** via `groom_spot_bootstrap.sh`, then self-terminates. Lambda returns immediately. Fail-loud on launch/SSM error.
- **`iam-policy.json`** — drop the PAT read (the **box** reads all secrets via its instance profile `alpha-engine-executor-role`); add `ec2:RunInstances` + `iam:PassRole` (executor role, `PassedToService=ec2`) + `ssm:SendCommand`.
- **`requirements.txt`** — add `nousergon-lib @v0.70.0` (matches repo pin) for `ec2_spot`.
- **`test_handler.py`** — rewritten (hermetic stubs): launch + on-demand fallback + run-mode normalize + kill-switch + fail-loud. 6 passed locally (also under the repo venv with the real lib).
- **`deploy.sh` / `README.md`** — updated for the spot mechanism; cutover runbook.

## Reuses fleet primitives — no lib change
Mirrors the gold-standard `spot_data_weekly.sh`: same AMI, key, SG, 6 subnets, `alpha-engine-executor-profile`, and the `ec2_spot` chokepoint. The box's profile already has `ssm:GetParameter` on `/alpha-engine/*` (reads the groom secrets incl. the new `/alpha-engine/groom/claude_code_oauth_token`) and `AmazonSSMManagedInstanceCore` (CW log output).

## Gated cutover (NOT in this merge)
Merging has **zero live effect** until an operator runs `deploy.sh --bootstrap`. Cutover = `--smoke` validate a real spot run → deploy this **and** disable the GHA `schedule:` crons in #1435 **together** (no double-groom, no gap). `workflow_dispatch` stays as the manual escape hatch.

## Follow-up (noted on config#1432)
The once-weekly `saturday-sf-success-groom` still runs on GHA; move it to spot too if post-cutover private minutes are still tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
