### PR TITLE
feat(corporate-actions): foundation module + S3 registry + registry-aware split discrepancy classification

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -391,6 +391,72 @@ def _polygon_date_fully_canonical(
 _SPLIT_LOOKAHEAD_DAYS = 7
 
 
+def _recent_split_events(
+    window_dates: list[str],
+    *,
+    client=None,
+) -> list[dict]:
+    """Fetch ALL polygon split events executing over ``window_dates``' span
+    (plus a small forward buffer) in ONE call (config#717).
+
+    Extracted so the window scan can derive BOTH the
+    ``_fetch_recent_split_dates`` skip-set AND the ``corporate_actions``
+    detected-record set from a SINGLE polygon ``get_recent_splits`` call — no
+    second API hit (the whole point of the config#717 one-call-per-window
+    budget). Each event is ``{"ticker", "execution_date", "split_from",
+    "split_to"}``. On any failure (client construction, 403, network) DEGRADES
+    GRACEFULLY to ``[]`` (apiKey scrubbed from logs) — a corporate-action miss
+    must never hard-fail the window.
+    """
+    if not window_dates:
+        return []
+    if client is None:
+        try:
+            from polygon_client import polygon_client
+
+            client = polygon_client()
+        except Exception as exc:  # import / construction failure — degrade
+            logger.warning(
+                "config#717: could not obtain polygon client for split scan "
+                "(%s) — proceeding without corporate-action skip protection",
+                _scrub_api_key(exc),
+            )
+            return []
+    oldest = min(window_dates)
+    newest = max(window_dates)
+    lookahead = (
+        datetime.strptime(newest, "%Y-%m-%d") + timedelta(days=_SPLIT_LOOKAHEAD_DAYS)
+    ).strftime("%Y-%m-%d")
+    try:
+        return client.get_recent_splits(oldest, lookahead)
+    except Exception as exc:
+        logger.warning(
+            "config#717: polygon split scan failed (%s) — proceeding without "
+            "corporate-action skip protection (canonical-only skip still applies)",
+            _scrub_api_key(exc),
+        )
+        return []
+
+
+def _touched_dates_from_split_events(
+    window_dates: list[str],
+    splits: list[dict],
+) -> set[str]:
+    """Mark every window date strictly before any split's execution date as
+    "touched" (must be re-fetched — its adjusted close was restated)."""
+    if not splits:
+        return set()
+    touched: set[str] = set()
+    for ev in splits:
+        e = ev.get("execution_date")
+        if not e:
+            continue
+        for d in window_dates:
+            if d < e:  # ISO dates compare lexicographically == chronologically
+                touched.add(d)
+    return touched
+
+
 def _fetch_recent_split_dates(
     window_dates: list[str],
     *,
@@ -415,42 +481,13 @@ def _fetch_recent_split_dates(
     """
     if not window_dates:
         return set()
-    if client is None:
-        try:
-            from polygon_client import polygon_client
-
-            client = polygon_client()
-        except Exception as exc:  # import / construction failure — degrade
-            logger.warning(
-                "config#717: could not obtain polygon client for split scan "
-                "(%s) — proceeding without corporate-action skip protection",
-                _scrub_api_key(exc),
-            )
-            return set()
+    splits = _recent_split_events(window_dates, client=client)
+    touched = _touched_dates_from_split_events(window_dates, splits)
     oldest = min(window_dates)
     newest = max(window_dates)
     lookahead = (
         datetime.strptime(newest, "%Y-%m-%d") + timedelta(days=_SPLIT_LOOKAHEAD_DAYS)
     ).strftime("%Y-%m-%d")
-    try:
-        splits = client.get_recent_splits(oldest, lookahead)
-    except Exception as exc:
-        logger.warning(
-            "config#717: polygon split scan failed (%s) — proceeding without "
-            "corporate-action skip protection (canonical-only skip still applies)",
-            _scrub_api_key(exc),
-        )
-        return set()
-    if not splits:
-        return set()
-    touched: set[str] = set()
-    for ev in splits:
-        e = ev.get("execution_date")
-        if not e:
-            continue
-        for d in window_dates:
-            if d < e:  # ISO dates compare lexicographically == chronologically
-                touched.add(d)
     if touched:
         logger.info(
             "config#717: %d split event(s) in [%s..%s] restate %d window date(s) "
@@ -459,6 +496,141 @@ def _fetch_recent_split_dates(
             ", ".join(sorted(touched)),
         )
     return touched
+
+
+# Sentinel distinguishing "caller passed no registry, build one if applicable"
+# (a genuine standalone single-date call) from "window orchestrator explicitly
+# passed a registry (possibly None)" — so a per-date collect() driven by
+# _collect_window never builds its own registry (one per window, not one per
+# date). See collect()/_collect_window.
+_REGISTRY_UNSET = object()
+
+
+def _build_corporate_action_registry(
+    window_dates: list[str],
+    bucket: str,
+    *,
+    dry_run: bool,
+    run_id: str,
+    need_touched: bool,
+):
+    """Detect splits over ``window_dates`` in ONE polygon call and (when live)
+    build a ``CorporateActionRegistry`` with the detected splits recorded.
+
+    Returns ``(registry_or_None, split_touched_dates_or_None)``. The single
+    ``_recent_split_events`` fetch feeds BOTH the config#717 skip-set (when
+    ``need_touched``) AND the corporate-actions detected records — no second
+    polygon call. Registry construction / recording is best-effort: any failure
+    WARNs (apiKey scrubbed) and degrades to ``registry=None`` so the discrepancy
+    classifier falls back to the text ``_split_ratio_hint`` rather than
+    hard-failing the collection run.
+    """
+    if not window_dates:
+        return None, (set() if need_touched else None)
+    events = _recent_split_events(window_dates)
+    touched: set[str] | None = None
+    if need_touched:
+        touched = _touched_dates_from_split_events(window_dates, events)
+        if touched:
+            oldest, newest = min(window_dates), max(window_dates)
+            lookahead = (
+                datetime.strptime(newest, "%Y-%m-%d")
+                + timedelta(days=_SPLIT_LOOKAHEAD_DAYS)
+            ).strftime("%Y-%m-%d")
+            logger.info(
+                "config#717: %d split event(s) in [%s..%s] restate %d window "
+                "date(s) — those will be re-fetched (not skipped): %s",
+                len(events), oldest, lookahead, len(touched),
+                ", ".join(sorted(touched)),
+            )
+
+    registry = None
+    if not dry_run and bucket:
+        try:
+            import corporate_actions
+
+            registry = corporate_actions.CorporateActionRegistry(
+                boto3.client("s3"), bucket
+            )
+            actions = corporate_actions.splits_from_events(events)
+            n_new = 0
+            for action in actions:
+                try:
+                    if registry.record_detected(action, run_id=run_id):
+                        n_new += 1
+                except Exception as exc:
+                    # Per-action record failure must not lose the others or the
+                    # run — WARN (recording surface) and continue.
+                    logger.warning(
+                        "corporate_actions: record_detected failed for %s @ %s "
+                        "(%s)",
+                        action.ticker, action.ex_date, _scrub_api_key(exc),
+                    )
+            if actions:
+                logger.info(
+                    "corporate_actions: %d split action(s) detected over "
+                    "[%s..%s] (run_id=%s, %d newly recorded)",
+                    len(actions), min(window_dates), max(window_dates),
+                    run_id, n_new,
+                )
+        except Exception as exc:
+            logger.warning(
+                "corporate_actions: registry unavailable (%s) — discrepancy "
+                "classification falls back to the text split-ratio hint",
+                _scrub_api_key(exc),
+            )
+            registry = None
+    return registry, touched
+
+
+def _send_corporate_action_email(actions: list, run_date: str) -> None:
+    """Send ONE informational email summarizing confirmed corporate actions that
+    restated adjusted history this run (best-effort, NEVER raises).
+
+    These are EXPECTED restatements (a detected split), not anomalies — the
+    email exists so the operator sees "system saw HON's 1-for-2 reverse split
+    and the >5% adjusted-close jump it caused is accounted for", rather than the
+    silence of a suppressed ERROR. A send failure WARNs (recording surface per
+    the no-silent-fails rule) but must not fail the collection run.
+    """
+    if not actions:
+        return
+    n = len({a.action_id for a in actions})
+    subject = f"📋 Corporate action(s) detected & restated — {n} ticker(s)"
+    lines = [
+        "The data pipeline detected the following corporate action(s); Polygon's",
+        "adjusted history has restated the affected dates. This is EXPECTED — the",
+        "resulting >5% adjusted-close change is accounted for, no action needed.",
+        "",
+    ]
+    seen: set[str] = set()
+    for action in actions:
+        if action.action_id in seen:
+            continue
+        seen.add(action.action_id)
+        lines.append(
+            f"  • {action.ticker}: {action.human()} (ex-date {action.ex_date})"
+        )
+    lines += [
+        "",
+        "Polygon adjusted history restated; expected — no action needed.",
+    ]
+    body = "\n".join(lines)
+    try:
+        from emailer import send_email
+
+        send_email(subject, body)
+        logger.info(
+            "corporate_actions: informational email sent for %d action(s) "
+            "(run_date=%s)",
+            n, run_date,
+        )
+    except Exception as exc:
+        logger.warning(
+            "corporate_actions: informational email send failed (%s) — "
+            "restatement still logged at WARN (corporate_action_restatement)",
+            _scrub_api_key(exc),
+        )
 
 
 def collect(
@@ -475,6 +647,8 @@ def collect(
     equities_source: str = "polygon",
     index_source: str = "fred",
     fallback_source: str = "yfinance",
+    registry=_REGISTRY_UNSET,
+    _emit_ca_email: bool = True,
 ) -> dict:
     """
     Fetch OHLCV for all tickers and write to S3.
@@ -599,18 +773,36 @@ def collect(
             fallback_source=fallback_source,
         )
 
-    # Single-date split-aware skip protection: when a window caller drives
-    # per-date collect()s it passes ``split_touched_dates`` down (computed once
-    # for the whole window). A standalone single-date polygon_only +
-    # skip_if_canonical caller (rare) computes it here for just this date so the
-    # corporate-action guard is never bypassed.
-    if (
-        source == "polygon_only"
-        and skip_if_canonical
-        and split_touched_dates is None
-        and window_days == 1
-    ):
-        split_touched_dates = _fetch_recent_split_dates([run_date])
+    # Single-date split-aware skip protection + corporate-action registry: when
+    # a window caller drives per-date collect()s it passes both
+    # ``split_touched_dates`` and an explicit ``registry`` down (computed/built
+    # once for the whole window). A standalone single-date polygon_only caller
+    # (rare) builds them here for just this date — ONE polygon split fetch feeds
+    # both — so neither the config#717 skip guard nor the registry-aware
+    # discrepancy classification is bypassed.
+    if registry is _REGISTRY_UNSET:
+        registry = None
+        # Only when this standalone call would have scanned splits anyway
+        # (polygon_only + skip_if_canonical + no pre-threaded touched set): ONE
+        # _recent_split_events fetch feeds BOTH the config#717 skip-set AND the
+        # registry. When split_touched_dates was threaded in (window-driven) or
+        # skip_if_canonical is off (legacy overwrite), we neither scan nor build
+        # a registry — preserving the no-extra-call contract of those paths
+        # (registry stays None ⇒ discrepancy logging falls back to the text
+        # split-ratio hint, the pre-config#1431 behavior).
+        if (
+            source == "polygon_only"
+            and window_days == 1
+            and skip_if_canonical
+            and split_touched_dates is None
+        ):
+            registry, split_touched_dates = _build_corporate_action_registry(
+                [run_date],
+                bucket,
+                dry_run=dry_run,
+                run_id=run_date,
+                need_touched=True,
+            )
 
     s3 = boto3.client("s3")
     key = f"{s3_prefix}{run_date}.parquet"
@@ -961,8 +1153,19 @@ def collect(
     )
 
     # Discrepancy logging (polygon_only mode, when overwriting an existing parquet)
+    explained_actions: list = []
     if existing_close_for_discrepancy and polygon_count > 0:
-        _log_close_discrepancies(closes_df, existing_close_for_discrepancy, run_date)
+        explained_actions = _log_close_discrepancies(
+            closes_df, existing_close_for_discrepancy, run_date, registry=registry,
+        )
+
+    # ONE informational email per run for confirmed corporate-action
+    # restatements — but only when THIS collect() owns the email (standalone
+    # single-date call). When driven by _collect_window, the email is deferred
+    # (``_emit_ca_email=False``) and sent ONCE at the window level over all
+    # dates. Never in dry_run (registry is None there, so no explained actions).
+    if _emit_ca_email and not dry_run and explained_actions:
+        _send_corporate_action_email(explained_actions, run_date)
 
     if dry_run:
         return {
@@ -972,6 +1175,7 @@ def collect(
             "fred": fred_count,
             "yfinance": yfinance_count,
             "source": source,
+            "corporate_actions": explained_actions,
         }
 
     # ── Step 4: Write to S3 ──────────────────────────────────────────────────
@@ -996,6 +1200,7 @@ def collect(
             "fred": fred_count,
             "yfinance": yfinance_count,
             "source": source,
+            "corporate_actions": explained_actions,
         }
     except Exception as e:
         logger.error("Failed to write daily closes: %s", e)
@@ -1073,9 +1278,31 @@ def _collect_window(
     # its execution date — those MUST be re-fetched. One range-scoped splits
     # call covers the whole window (no per-date corporate-action I/O). Only run
     # when the optimization is actually active.
+    # config#1431 (corporate-actions program): ONE polygon split scan for the
+    # whole window feeds BOTH the config#717 skip-set AND the
+    # CorporateActionRegistry (detected-records + the registry-aware discrepancy
+    # classifier). Built once here and threaded into every per-date collect() as
+    # an EXPLICIT ``registry`` so no per-date call builds its own (one fetch per
+    # window, not per date). Built for polygon_only (where discrepancy logging
+    # runs) regardless of skip_if_canonical; the touched-date skip-set is only
+    # derived when skip_if_canonical is on.
+    # Gated identically to the pre-config#1431 config#717 split scan
+    # (polygon_only + skip_if_canonical + live): that path ALREADY made one
+    # ``get_recent_splits`` call per window — we now route it through
+    # ``_recent_split_events`` so the SAME single call feeds both the skip-set
+    # and the registry (no extra polygon call). A polygon_only window without
+    # skip_if_canonical neither scans nor builds a registry (registry stays None
+    # ⇒ discrepancy logging keeps the text split-ratio hint — no regression).
     split_touched_dates: set[str] | None = None
+    registry = None
     if source == "polygon_only" and skip_if_canonical and not dry_run:
-        split_touched_dates = _fetch_recent_split_dates(window_dates)
+        registry, split_touched_dates = _build_corporate_action_registry(
+            window_dates,
+            bucket,
+            dry_run=dry_run,
+            run_id=window_dates[0],  # target date identifies the window run
+            need_touched=True,
+        )
     # The newest date in the window is the TARGET date — the one
     # downstream (predictor inference / eod_reconcile) actually reads.
     # The older dates are best-effort *historical backfill*: a per-date
@@ -1109,6 +1336,7 @@ def _collect_window(
         "yfinance": 0,
         "skipped_dates": [],
         "backfill_failed_dates": [],
+        "corporate_actions": [],
     }
     # Iterate oldest → newest so the most recent date's parquet is the
     # last one written. Matches the operator mental model "the latest
@@ -1126,6 +1354,8 @@ def _collect_window(
                 skip_if_canonical=skip_if_canonical,
                 fred_window_cache=fred_window_cache,  # L4492: 1 ranged call/series
                 split_touched_dates=split_touched_dates,  # config#717
+                registry=registry,  # config#1431: one registry per window
+                _emit_ca_email=False,  # email sent ONCE at window level below
                 equities_source=equities_source,
                 index_source=index_source,
                 fallback_source=fallback_source,
@@ -1151,6 +1381,16 @@ def _collect_window(
                 aggregate[k] += result[k]
         if result.get("skipped"):
             aggregate["skipped_dates"].append(d)
+        # config#1431: accumulate confirmed corporate-action restatements across
+        # the window for the single informational email sent below.
+        if result.get("corporate_actions"):
+            aggregate["corporate_actions"].extend(result["corporate_actions"])
+
+    # config#1431: ONE informational email per window run for confirmed
+    # corporate-action restatements (deduped by action_id in the email layer).
+    # Skipped in dry_run (registry is None → no explained actions accumulate).
+    if not dry_run and aggregate["corporate_actions"]:
+        _send_corporate_action_email(aggregate["corporate_actions"], target_date)
 
     # ── Fatality is TARGET-driven, not "any per-date error" ─────────────
     _target = aggregate["per_date"].get(target_date)
@@ -1365,7 +1605,9 @@ def _log_close_discrepancies(
     new_df: pd.DataFrame,
     prior_close: dict[str, float],
     run_date: str,
-) -> None:
+    *,
+    registry=None,
+) -> list:
     """Log per-ticker Close discrepancy when polygon overwrites yfinance.
 
     A small drift (<1%) is normal — different feeds, slight tick-time offsets,
@@ -1384,11 +1626,25 @@ def _log_close_discrepancies(
     (`fred_restatement`) and are excluded from the flow-doctor ERROR filter. The
     recording surface stays (per feedback_no_silent_fails) — just at the right
     severity. Pattern observed twice (2026-05-12, 2026-06-02).
+
+    config#1431 (corporate-actions program): when a ``registry`` is supplied, a
+    >5% equity jump that the registry can attribute to a DETECTED corporate
+    action (a confirmed split whose ``expected_factor`` matches ``new/prior``)
+    is the EXPECTED adjusted-history restatement, NOT an anomaly — it logs at
+    WARN (`corporate_action_restatement`) and is excluded from the flow-doctor
+    ERROR filter (fixing the HON 1-for-2 reverse-split false-ERROR). The
+    authoritative registry takes precedence over the secondary
+    ``_split_ratio_hint`` text heuristic (which stays, now only annotating the
+    UNEXPLAINED ERROR branch). Returns the list of explained
+    ``CorporateAction``s seen this run (for the run's one informational email);
+    deduped at the email layer.
     """
     n_compared = 0
     n_warn = 0
     n_error = 0
     n_restatement = 0
+    n_corporate_action = 0
+    explained_actions: list = []
     biggest: tuple[str, float] = ("", 0.0)
     for ticker in new_df.index:
         prior = prior_close.get(str(ticker))
@@ -1407,6 +1663,28 @@ def _log_close_discrepancies(
                 ticker, run_date, prior, float(new_close), pct_diff * 100,
             )
             n_restatement += 1
+        elif (
+            pct_diff > _DISCREPANCY_ERROR_PCT
+            and registry is not None
+            and (
+                action := registry.explains_discrepancy(
+                    str(ticker), run_date, prior, float(new_close)
+                )
+            )
+            is not None
+        ):
+            # config#1431: confirmed corporate-action restatement (the registry
+            # is AUTHORITATIVE) — expected adjusted-history restatement, WARN not
+            # ERROR, excluded from the flow-doctor ERROR filter.
+            logger.warning(
+                "corporate_action_restatement %s @ %s: Close %.4f → %.4f "
+                "(%.2f%% diff vs prior parquet) — confirmed %s (registry %s), "
+                "adjusted history restated (expected, no action needed)",
+                ticker, run_date, prior, float(new_close), pct_diff * 100,
+                action.human(), action.action_id,
+            )
+            n_corporate_action += 1
+            explained_actions.append(action)
         elif pct_diff > _DISCREPANCY_ERROR_PCT:
             logger.error(
                 "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f (%.2f%% diff vs prior parquet)%s — "
@@ -1425,10 +1703,11 @@ def _log_close_discrepancies(
             biggest = (str(ticker), pct_diff)
     logger.info(
         "polygon_only discrepancy summary for %s: compared=%d warn(>1%%)=%d error(>5%%)=%d "
-        "fred_restatement(>5%%)=%d biggest=%s@%.2f%%",
-        run_date, n_compared, n_warn, n_error, n_restatement,
+        "fred_restatement(>5%%)=%d corporate_action(>5%%)=%d biggest=%s@%.2f%%",
+        run_date, n_compared, n_warn, n_error, n_restatement, n_corporate_action,
         biggest[0] or "n/a", biggest[1] * 100,
     )
+    return explained_actions
 
 
 def _fred_record(store_ticker: str, date_str: str, close: float) -> dict:

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -1,0 +1,325 @@
+"""corporate_actions — unified corporate-action model + S3 registry.
+
+WHY THIS EXISTS (unified corporate-actions program, config#1431):
+    Corporate actions (splits, dividends, renames) retroactively restate a
+    ticker's adjusted price history. The data pipeline already DETECTS splits
+    (``polygon_client.get_recent_splits`` + ``split_factor.py``) and RESTATES
+    them into the ArcticDB universe (data#1298), but it had no first-class,
+    auditable *model* of a corporate action and no durable record of which
+    actions were detected/applied. That gap produced two symptoms:
+
+      1. A confirmed split's expected adjusted-close restatement tripped the
+         daily-closes ">5% cross-source drift" ERROR band (the HON 1-for-2
+         reverse split surfaced as a false flow-doctor ERROR — exactly the
+         class of false alarm the ``_split_ratio_hint`` text band-aided but
+         could not authoritatively suppress).
+      2. No write-once provenance trail for "we detected action X / we applied
+         action X to store Y", which a robust restatement path needs to stay
+         idempotent across reruns.
+
+    This module is the FOUNDATION layer of the program (PR1+PR2): a frozen
+    ``CorporateAction`` dataclass with a deterministic ``action_id``, a
+    polygon-backed ``detect_splits`` built ON ``split_factor.py`` (the
+    authoritative factor convention), and a ``CorporateActionRegistry`` (S3
+    JSON) that makes the split-restatement discrepancy classification
+    *registry-authoritative* rather than text-heuristic.
+
+    This PR is behavior-ADDITIVE: it does NOT change the existing
+    split-RESTATEMENT path (``split_factor.restate_series_for_splits`` /
+    ArcticDB write) — that is a later PR. It only adds the module + registry
+    and RECLASSIFIES the discrepancy log (confirmed split -> WARN, not ERROR)
+    plus one informational notification.
+
+CONVENTION (inherited from ``split_factor.py``):
+    A forward N-for-1 split (``split_from=1, split_to=N``) divides the adjusted
+    price by N for every date STRICTLY BEFORE the ex (execution) date. A reverse
+    1-for-N split (``split_from=N, split_to=1``) multiplies by N. The per-event
+    multiplicative factor applied to dates strictly before ``ex_date`` is
+    therefore ``split_from / split_to`` — and we delegate to
+    ``split_factor.cumulative_factor`` so this module never re-derives the
+    authoritative factor independently.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+import split_factor
+from corporate_actions.registry import CorporateActionRegistry
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "CorporateAction",
+    "CorporateActionRegistry",
+    "expected_factor",
+    "detect_splits",
+    "detect_dividends",
+    "detect_renames",
+    "splits_from_events",
+]
+
+# Action types implemented this PR. Dividends/renames are modeled (fields exist)
+# but their detection/factor are deferred to later PRs of the program.
+_TYPE_SPLIT = "split"
+_TYPE_DIVIDEND = "dividend"
+_TYPE_RENAME = "rename"
+
+
+@dataclass(frozen=True)
+class CorporateAction:
+    """An immutable, content-addressed corporate-action record.
+
+    ``action_id`` is a DETERMINISTIC content hash (so the same real-world
+    action always maps to the same id across detections/reruns — the property
+    the write-once registry relies on for idempotency). It is computed in
+    ``__post_init__`` from ``(type, ticker, ex_date, detail)`` when left blank,
+    so any construction path (direct, ``from_split``, ``from_dict``) yields the
+    canonical id without the caller having to compute it.
+    """
+
+    type: str  # "split" | "dividend" | "rename"
+    ticker: str
+    ex_date: str  # YYYY-MM-DD; the adjustment applies to rows STRICTLY BEFORE this
+    # split fields
+    split_from: int | None = None
+    split_to: int | None = None
+    # dividend fields (modeled now, detected in a later PR)
+    cash_amount: float | None = None
+    dividend_kind: str | None = None
+    # rename fields (modeled now, detected in a later PR)
+    old_ticker: str | None = None
+    new_ticker: str | None = None
+    # provenance
+    source: str = "polygon"
+    raw: dict = field(default_factory=dict)
+    # content-addressed id — auto-derived in __post_init__ when blank
+    action_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.action_id:
+            object.__setattr__(self, "action_id", self._compute_action_id())
+
+    # ── id derivation ────────────────────────────────────────────────────
+    def _detail(self) -> str:
+        """The type-specific discriminator folded into ``action_id``."""
+        if self.type == _TYPE_SPLIT:
+            return f"{self.split_from}:{self.split_to}"
+        if self.type == _TYPE_DIVIDEND:
+            return f"{self.cash_amount}:{self.dividend_kind}"
+        if self.type == _TYPE_RENAME:
+            return f"{self.old_ticker}->{self.new_ticker}"
+        return ""
+
+    def _compute_action_id(self) -> str:
+        payload = f"{self.type}|{self.ticker}|{self.ex_date}|{self._detail()}"
+        return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+    # ── factories ────────────────────────────────────────────────────────
+    @classmethod
+    def from_split(
+        cls,
+        ticker: str,
+        ex_date: str,
+        split_from: int,
+        split_to: int,
+        *,
+        source: str = "polygon",
+        raw: dict | None = None,
+    ) -> "CorporateAction":
+        """Build a split action; ``action_id`` is derived deterministically."""
+        return cls(
+            type=_TYPE_SPLIT,
+            ticker=str(ticker),
+            ex_date=str(ex_date),
+            split_from=int(split_from),
+            split_to=int(split_to),
+            source=source,
+            raw=dict(raw or {}),
+        )
+
+    # ── (de)serialization ────────────────────────────────────────────────
+    def to_dict(self) -> dict:
+        """JSON-serializable view (the registry persists this + audit fields)."""
+        return {
+            "action_id": self.action_id,
+            "type": self.type,
+            "ticker": self.ticker,
+            "ex_date": self.ex_date,
+            "split_from": self.split_from,
+            "split_to": self.split_to,
+            "cash_amount": self.cash_amount,
+            "dividend_kind": self.dividend_kind,
+            "old_ticker": self.old_ticker,
+            "new_ticker": self.new_ticker,
+            "source": self.source,
+            "raw": self.raw,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "CorporateAction":
+        """Reconstruct from a persisted dict (ignores extra audit keys like
+        ``detected_at`` / ``detected_run_id``)."""
+        return cls(
+            type=d["type"],
+            ticker=d["ticker"],
+            ex_date=d["ex_date"],
+            split_from=d.get("split_from"),
+            split_to=d.get("split_to"),
+            cash_amount=d.get("cash_amount"),
+            dividend_kind=d.get("dividend_kind"),
+            old_ticker=d.get("old_ticker"),
+            new_ticker=d.get("new_ticker"),
+            source=d.get("source", "polygon"),
+            raw=d.get("raw") or {},
+            # Trust the persisted id if present (it is content-addressed, so it
+            # round-trips), else __post_init__ recomputes the identical value.
+            action_id=d.get("action_id", ""),
+        )
+
+    # ── human description ────────────────────────────────────────────────
+    def human(self) -> str:
+        """A human-readable one-liner, e.g. '1-for-2 reverse split'."""
+        if self.type == _TYPE_SPLIT and self.split_from and self.split_to:
+            if self.split_to >= self.split_from:
+                # forward N-for-1 (split_from=1, split_to=N)
+                n = self.split_to // self.split_from
+                return f"{n}-for-1 forward split"
+            # reverse 1-for-N (split_from=N, split_to=1)
+            n = self.split_from // self.split_to
+            return f"1-for-{n} reverse split"
+        if self.type == _TYPE_DIVIDEND:
+            return f"dividend {self.cash_amount} ({self.dividend_kind})"
+        if self.type == _TYPE_RENAME:
+            return f"rename {self.old_ticker} -> {self.new_ticker}"
+        return self.type
+
+
+def expected_factor(action: CorporateAction) -> float:
+    """The multiplicative factor applied to the adjusted CLOSE of rows STRICTLY
+    BEFORE ``action.ex_date`` once the action is reflected in the adjusted
+    history.
+
+    For a split this is ``split_from / split_to`` — a reverse 1-for-2 split
+    (``split_from=2, split_to=1``) yields ``2.0`` (pre-split prices double on
+    the post-split adjusted scale); a forward 10-for-1 split
+    (``split_from=1, split_to=10``) yields ``0.1`` (pre-split prices are divided
+    by 10). We DELEGATE to ``split_factor.cumulative_factor`` (the authoritative
+    convention) rather than re-deriving the ratio independently — the cumulative
+    factor of a single event evaluated one day before the ex date is exactly
+    ``split_from/split_to``.
+
+    Dividends/renames are not implemented this PR.
+    """
+    if action.type == _TYPE_SPLIT:
+        if not action.split_from or not action.split_to:
+            raise ValueError(
+                f"split action {action.action_id} missing split_from/split_to"
+            )
+        ev = {
+            "execution_date": action.ex_date,
+            "split_from": action.split_from,
+            "split_to": action.split_to,
+        }
+        day_before = (
+            pd.Timestamp(action.ex_date) - pd.Timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+        return split_factor.cumulative_factor([ev], day_before)
+    # TODO(corporate-actions program): implement dividend / rename expected
+    # factors in a later PR. Fail loud rather than silently returning 1.0.
+    raise NotImplementedError(
+        f"expected_factor not implemented for action type {action.type!r} "
+        "(only splits implemented this PR)"
+    )
+
+
+def splits_from_events(events: list[dict]) -> list["CorporateAction"]:
+    """Map polygon ``get_recent_splits`` event dicts to ``CorporateAction``s.
+
+    Each event is ``{"ticker", "execution_date", "split_from", "split_to"}``.
+    Pure transform (no I/O) so callers that already fetched the events (the
+    daily-closes window scan) can reuse them WITHOUT a second polygon call.
+    Malformed rows are skipped.
+    """
+    actions: list[CorporateAction] = []
+    for ev in events or []:
+        ticker = ev.get("ticker")
+        ex_date = ev.get("execution_date")
+        sf = ev.get("split_from")
+        st = ev.get("split_to")
+        if not ticker or not ex_date or not sf or not st:
+            continue
+        actions.append(
+            CorporateAction.from_split(
+                ticker=str(ticker),
+                ex_date=str(ex_date),
+                split_from=int(sf),
+                split_to=int(st),
+                source="polygon",
+                raw=dict(ev),
+            )
+        )
+    return actions
+
+
+def detect_splits(
+    start_date: str,
+    end_date: str,
+    *,
+    client=None,
+) -> list["CorporateAction"]:
+    """Detect all splits executing in ``[start_date, end_date]`` as
+    ``CorporateAction``s (type="split", ex_date = polygon execution_date).
+
+    Wraps ``polygon_client.get_recent_splits`` (the whole-market, one-call
+    range scan). The client is constructed lazily the same way
+    ``collectors/daily_closes._fetch_recent_split_dates`` does, and any
+    construction/fetch failure DEGRADES GRACEFULLY to ``[]`` (with the polygon
+    apiKey scrubbed from the log) — a corporate-action detection miss must
+    never hard-fail the data pipeline; the per-fetch discrepancy logging and
+    the next pass remain the backstop.
+    """
+    if client is None:
+        try:
+            from polygon_client import polygon_client
+
+            client = polygon_client()
+        except Exception as exc:  # import / construction failure — degrade
+            from polygon_client import _scrub_api_key
+
+            log.warning(
+                "corporate_actions.detect_splits: could not obtain polygon "
+                "client (%s) — returning no detected splits",
+                _scrub_api_key(exc),
+            )
+            return []
+    try:
+        events = client.get_recent_splits(start_date, end_date)
+    except Exception as exc:
+        from polygon_client import _scrub_api_key
+
+        log.warning(
+            "corporate_actions.detect_splits: polygon split scan failed (%s) "
+            "— returning no detected splits",
+            _scrub_api_key(exc),
+        )
+        return []
+    return splits_from_events(events)
+
+
+def detect_dividends(start_date: str, end_date: str, *, client=None):
+    """Not implemented this PR (modeled fields exist; detection is a later PR)."""
+    raise NotImplementedError(
+        "detect_dividends is deferred to a later PR of the corporate-actions program"
+    )
+
+
+def detect_renames(start_date: str, end_date: str, *, client=None):
+    """Not implemented this PR (modeled fields exist; detection is a later PR)."""
+    raise NotImplementedError(
+        "detect_renames is deferred to a later PR of the corporate-actions program"
+    )

--- a/corporate_actions/registry.py
+++ b/corporate_actions/registry.py
@@ -1,0 +1,315 @@
+"""corporate_actions.registry — S3-backed corporate-action registry.
+
+The durable, auditable store for the unified corporate-actions program
+(config#1431). Two write-once S3 JSON namespaces under ``prefix`` (default
+``corporate_actions/``):
+
+  - ``corporate_actions/actions/{action_id}.json`` — the IMMUTABLE detected
+    record (the ``CorporateAction`` fields + ``detected_at`` UTC ISO +
+    ``detected_run_id``). Written write-if-absent so a re-detection across
+    reruns never clobbers the original detection provenance.
+  - ``corporate_actions/applied/{store}/{action_id}.json`` — a write-once
+    "we applied action X to store Y (e.g. the ArcticDB universe)" marker.
+    Modeled now for the later restatement-path PR; NOT exercised by this PR.
+
+The KEY consumer-facing method this PR adds is :meth:`explains_discrepancy`,
+which lets ``collectors/daily_closes`` ask the registry — authoritatively,
+not via a text heuristic — "is this >5% adjusted-close jump explained by a
+detected corporate action?" so a confirmed split restatement logs at WARN
+(``corporate_action_restatement``) instead of tripping the flow-doctor ERROR
+band.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+from botocore.exceptions import ClientError
+
+log = logging.getLogger(__name__)
+
+# Same 0.005 tolerance used by ``collectors/daily_closes._SPLIT_RATIO_TOL``:
+# adjusted closes restate by the EXACT split factor, so 0.5% absorbs feed
+# rounding noise while still rejecting a genuine anomaly. Redefined here (rather
+# than imported) to avoid an import-time cycle with ``collectors.daily_closes``
+# (which imports this package lazily). Keep the two in lockstep.
+_SPLIT_RATIO_TOL = 0.005
+
+# ``explains_discrepancy`` ex-date plausibility window. A split with execution
+# date E restates the adjusted close of every date STRICTLY BEFORE E, so a
+# discrepancy observed on ``date`` is explained by an action whose ex_date is
+# on/after ``date`` — with a small early-leniency for edge timing (the
+# re-fetched date can coincide with / sit a day or two from the ex date) and a
+# generous upper bound (the split scan only looks a couple weeks back + a 7-day
+# forward buffer, so an ancient split must not "explain" a fresh jump).
+_EX_DATE_EARLY_LENIENCY_DAYS = 3
+_EX_DATE_MAX_AHEAD_DAYS = 60
+
+
+class CorporateActionRegistry:
+    """S3 JSON registry of detected + applied corporate actions.
+
+    Constructed with an explicit boto3 S3 client + bucket (the caller owns
+    client construction, mirroring the rest of the repo — e.g.
+    ``builders/daily_append.py``), so it is trivially testable against a fake
+    S3.
+    """
+
+    def __init__(self, s3, bucket: str, prefix: str = "corporate_actions/"):
+        self.s3 = s3
+        self.bucket = bucket
+        self.prefix = prefix if prefix.endswith("/") else prefix + "/"
+        self._actions_prefix = f"{self.prefix}actions/"
+        self._applied_prefix = f"{self.prefix}applied/"
+        # Lazy S3-loaded full index {action_id: CorporateAction} for the
+        # list_actions / get_action query API (populated once from S3 by
+        # _ensure_loaded).
+        self._cache: dict | None = None
+        # Actions DETECTED this session (recorded via record_detected). This is
+        # the authoritative input for explains_discrepancy: a split that could
+        # restate one of THIS run's dates was necessarily returned by the same
+        # window split scan that recorded it here, so explaining the run's
+        # adjusted-close jumps needs only the session set — NEVER a full S3 list
+        # (which would also be O(all-time-actions) on every comparison).
+        self._session_actions: dict = {}
+
+    # ── key helpers ──────────────────────────────────────────────────────
+    def _action_key(self, action_id: str) -> str:
+        return f"{self._actions_prefix}{action_id}.json"
+
+    def _applied_key(self, store: str, action_id: str) -> str:
+        return f"{self._applied_prefix}{store}/{action_id}.json"
+
+    # ── low-level S3 ─────────────────────────────────────────────────────
+    def _object_exists(self, key: str) -> bool:
+        try:
+            self.s3.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return False
+            raise  # auth / throttle / network — never silently treat as absent
+
+    def _get_json(self, key: str) -> dict | None:
+        try:
+            obj = self.s3.get_object(Bucket=self.bucket, Key=key)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code in ("404", "NoSuchKey"):
+                return None
+            raise
+        return json.loads(obj["Body"].read())
+
+    def _put_json(self, key: str, payload: dict) -> None:
+        self.s3.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=json.dumps(payload, indent=2, sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+
+    def _list_keys(self, prefix: str) -> list[str]:
+        keys: list[str] = []
+        token: str | None = None
+        while True:
+            kwargs = {"Bucket": self.bucket, "Prefix": prefix}
+            if token:
+                kwargs["ContinuationToken"] = token
+            resp = self.s3.list_objects_v2(**kwargs)
+            for obj in resp.get("Contents", []) or []:
+                k = obj.get("Key")
+                if k and k.endswith(".json"):
+                    keys.append(k)
+            if resp.get("IsTruncated"):
+                token = resp.get("NextContinuationToken")
+                if not token:
+                    break
+            else:
+                break
+        return keys
+
+    # ── detected records ─────────────────────────────────────────────────
+    def record_detected(self, action, *, run_id: str) -> bool:
+        """Persist an immutable detected record write-if-absent.
+
+        Returns ``True`` if a NEW record was written, ``False`` if a record for
+        this ``action_id`` already existed (idempotent across reruns). Uses a
+        head_object guard then put; a concurrent racing writer is tolerated (the
+        record is content-addressed, so a double-write is harmless — only the
+        ``detected_at`` timestamp would differ).
+        """
+        from corporate_actions import CorporateAction  # local: avoid import cycle
+
+        if not isinstance(action, CorporateAction):
+            raise TypeError(f"record_detected expects CorporateAction, got {type(action)!r}")
+        key = self._action_key(action.action_id)
+        # The action is "known to this session" regardless of whether THIS call
+        # is the one that persists it — seed the session index so
+        # explains_discrepancy can match the window's just-detected splits
+        # WITHOUT a full S3 re-list.
+        self._session_actions[action.action_id] = action
+        if self._cache is not None:
+            self._cache[action.action_id] = action
+        if self._object_exists(key):
+            return False
+        payload = {
+            **action.to_dict(),
+            "detected_at": datetime.now(timezone.utc).isoformat(),
+            "detected_run_id": run_id,
+        }
+        self._put_json(key, payload)
+        return True
+
+    def get_action(self, action_id: str):
+        """Return the detected ``CorporateAction`` for ``action_id`` or None."""
+        from corporate_actions import CorporateAction
+
+        if action_id in self._session_actions:
+            return self._session_actions[action_id]
+        if self._cache is not None and action_id in self._cache:
+            return self._cache[action_id]
+        d = self._get_json(self._action_key(action_id))
+        if d is None:
+            return None
+        return CorporateAction.from_dict(d)
+
+    def _ensure_loaded(self) -> dict:
+        """Populate + return the in-memory ``{action_id: CorporateAction}``
+        index from S3 (once)."""
+        from corporate_actions import CorporateAction
+
+        if self._cache is not None:
+            return self._cache
+        cache: dict = {}
+        for key in self._list_keys(self._actions_prefix):
+            d = self._get_json(key)
+            if not d:
+                continue
+            try:
+                action = CorporateAction.from_dict(d)
+            except Exception as exc:  # malformed persisted record — skip + WARN
+                log.warning(
+                    "corporate_actions registry: skipping malformed record %s (%s)",
+                    key, exc,
+                )
+                continue
+            cache[action.action_id] = action
+        self._cache = cache
+        return cache
+
+    def list_actions(
+        self,
+        *,
+        since: str | None = None,
+        types: list[str] | None = None,
+        ticker: str | None = None,
+    ) -> list:
+        """List detected actions, optionally filtered.
+
+        ``since`` filters on the persisted ``detected_at`` (ISO compare);
+        ``types`` / ``ticker`` filter on the action fields.
+        """
+        actions = list(self._ensure_loaded().values())
+        out = []
+        for action in actions:
+            if types and action.type not in types:
+                continue
+            if ticker and action.ticker != ticker:
+                continue
+            if since is not None:
+                # ``since`` is a detected_at floor; re-read the record's
+                # detected_at (not held on the dataclass) only if needed.
+                rec = self._get_json(self._action_key(action.action_id)) or {}
+                if (rec.get("detected_at") or "") < since:
+                    continue
+            out.append(action)
+        return out
+
+    # ── applied markers (modeled now; exercised by a later PR) ───────────
+    def is_applied(self, store: str, action_id: str) -> bool:
+        """Whether ``action_id`` has been marked applied to ``store``."""
+        return self._object_exists(self._applied_key(store, action_id))
+
+    def mark_applied(self, action, store: str, *, run_id: str | None = None) -> bool:
+        """Write a write-once applied marker for ``action`` in ``store``.
+
+        Returns ``True`` if newly written, ``False`` if already applied. NOT
+        exercised by this PR — the restatement path that calls it ships later.
+        """
+        from corporate_actions import CorporateAction
+
+        if not isinstance(action, CorporateAction):
+            raise TypeError(f"mark_applied expects CorporateAction, got {type(action)!r}")
+        key = self._applied_key(store, action.action_id)
+        if self._object_exists(key):
+            return False
+        payload = {
+            "action_id": action.action_id,
+            "store": store,
+            "ticker": action.ticker,
+            "ex_date": action.ex_date,
+            "applied_at": datetime.now(timezone.utc).isoformat(),
+            "applied_run_id": run_id,
+        }
+        self._put_json(key, payload)
+        return True
+
+    # ── the authoritative discrepancy classifier ─────────────────────────
+    def explains_discrepancy(self, ticker: str, date, prior: float, new: float):
+        """Return the registered ``CorporateAction`` that explains an adjusted-
+        close jump from ``prior`` to ``new`` on ``date`` for ``ticker``, or None.
+
+        A match requires BOTH:
+          1. the observed multiplicative factor ``new/prior`` equals the action's
+             :func:`corporate_actions.expected_factor` within ``_SPLIT_RATIO_TOL``
+             (a split restates by the EXACT factor), and
+          2. the action's ``ex_date`` is plausibly near ``date`` — on/after
+             ``date`` (a split restates dates strictly before its ex date), with
+             a few days of early leniency and a bounded look-ahead.
+
+        Only split actions are classified this PR. Matches against the splits
+        DETECTED THIS SESSION (``_session_actions``, recorded via
+        record_detected) — sufficient and authoritative for the live run, and
+        free of any S3 list. Returns the matching action (the first, by ex_date)
+        or None.
+        """
+        from corporate_actions import expected_factor
+
+        if prior is None or new is None or prior <= 0 or new <= 0:
+            return None
+        observed = float(new) / float(prior)
+        try:
+            date_ts = pd.Timestamp(date).normalize()
+        except Exception:
+            return None
+
+        candidates = [
+            a
+            for a in self._session_actions.values()
+            if a.type == "split" and a.ticker == str(ticker)
+        ]
+        # Evaluate by ex_date ascending so the earliest plausible action wins.
+        candidates.sort(key=lambda a: a.ex_date)
+        for action in candidates:
+            try:
+                ex_ts = pd.Timestamp(action.ex_date).normalize()
+            except Exception:
+                continue
+            # ex_date plausibility window relative to the discrepancy date.
+            if ex_ts < date_ts - timedelta(days=_EX_DATE_EARLY_LENIENCY_DAYS):
+                continue
+            if ex_ts > date_ts + timedelta(days=_EX_DATE_MAX_AHEAD_DAYS):
+                continue
+            try:
+                expected = expected_factor(action)
+            except (NotImplementedError, ValueError):
+                continue
+            if expected <= 0:
+                continue
+            if abs(observed - expected) / expected <= _SPLIT_RATIO_TOL:
+                return action
+        return None

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -86,6 +86,13 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "collectors/universe_classification.py": 1,  # market_data/universe_classification/{date,latest}.json — sector/country/industry for the ~900 universe board
     "collectors/signal_returns.py": 1,
     "collectors/universe_returns.py": 1,
+    # corporate_actions/actions/{action_id}.json + applied/{store}/{action_id}.json —
+    # EVENT-DRIVEN corporate-action provenance records (config#1431), written only
+    # when a split is detected/applied. NOT a periodic freshness-SLA artifact: there
+    # is no cadence to monitor and the absence of a split is not an incident, so this
+    # is grandfathered out of ARTIFACT_REGISTRY.yaml (no freshness row) per "never
+    # register a freshness entry ahead of/without a periodic producer".
+    "corporate_actions/registry.py": 1,
     "data/cache.py": 1,
     "data/derived/analyst_revisions.py": 2,
     "data/derived/news_aggregates.py": 2,

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -1,0 +1,117 @@
+"""Unit tests for the ``corporate_actions`` model layer (config#1431).
+
+Covers ``CorporateAction`` deterministic ``action_id``, ``expected_factor`` for
+forward/reverse splits (delegating to ``split_factor``), and ``detect_splits``
+mapping polygon events via a fake client (mirroring the ``get_recent_splits``
+mocking in ``tests/test_daily_closes_skip_if_canonical.py``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import corporate_actions as ca
+
+
+class TestActionIdDeterminism:
+    def test_same_inputs_yield_same_id(self):
+        a = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        b = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        assert a.action_id == b.action_id
+        assert len(a.action_id) == 16
+
+    def test_different_ratio_yields_different_id(self):
+        a = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        b = ca.CorporateAction.from_split("HON", "2026-06-27", 1, 2)
+        assert a.action_id != b.action_id
+
+    def test_different_ticker_or_date_yields_different_id(self):
+        base = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        assert (
+            ca.CorporateAction.from_split("MMM", "2026-06-27", 2, 1).action_id
+            != base.action_id
+        )
+        assert (
+            ca.CorporateAction.from_split("HON", "2026-06-28", 2, 1).action_id
+            != base.action_id
+        )
+
+    def test_explicit_id_round_trips_through_to_from_dict(self):
+        a = ca.CorporateAction.from_split("NVDA", "2026-06-10", 1, 10, raw={"x": 1})
+        b = ca.CorporateAction.from_dict(a.to_dict())
+        assert b.action_id == a.action_id
+        assert b.raw == {"x": 1}
+
+
+class TestExpectedFactor:
+    def test_forward_split_1_for_n_divides(self):
+        # forward 10-for-1 split: pre-split prices divided by 10 → factor 0.1
+        a = ca.CorporateAction.from_split("NVDA", "2026-06-10", 1, 10)
+        assert ca.expected_factor(a) == pytest.approx(0.1)
+
+    def test_reverse_split_n_for_1_multiplies(self):
+        # reverse 1-for-2 split (split_from=2, split_to=1): prices double → 2.0
+        a = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        assert ca.expected_factor(a) == pytest.approx(2.0)
+
+    def test_reverse_1_for_10_multiplies_by_10(self):
+        a = ca.CorporateAction.from_split("XYZ", "2026-06-15", 10, 1)
+        assert ca.expected_factor(a) == pytest.approx(10.0)
+
+    def test_dividend_not_implemented_this_pr(self):
+        a = ca.CorporateAction(type="dividend", ticker="AAPL", ex_date="2026-06-01", cash_amount=0.25)
+        with pytest.raises(NotImplementedError):
+            ca.expected_factor(a)
+
+    def test_human_descriptions(self):
+        assert (
+            ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1).human()
+            == "1-for-2 reverse split"
+        )
+        assert (
+            ca.CorporateAction.from_split("NVDA", "2026-06-10", 1, 10).human()
+            == "10-for-1 forward split"
+        )
+
+
+class TestDetectSplits:
+    def _fake_client(self, events):
+        client = MagicMock()
+        client.get_recent_splits.return_value = events
+        return client
+
+    def test_maps_polygon_events_to_actions(self):
+        client = self._fake_client([
+            {"ticker": "HON", "execution_date": "2026-06-27", "split_from": 2, "split_to": 1},
+            {"ticker": "NVDA", "execution_date": "2026-06-10", "split_from": 1, "split_to": 10},
+        ])
+        actions = ca.detect_splits("2026-06-01", "2026-06-30", client=client)
+        assert client.get_recent_splits.call_count == 1
+        assert {a.ticker for a in actions} == {"HON", "NVDA"}
+        hon = next(a for a in actions if a.ticker == "HON")
+        assert hon.type == "split"
+        assert hon.ex_date == "2026-06-27"
+        assert hon.split_from == 2 and hon.split_to == 1
+        assert hon.raw["execution_date"] == "2026-06-27"
+
+    def test_malformed_events_skipped(self):
+        client = self._fake_client([
+            {"ticker": "HON", "execution_date": "2026-06-27", "split_from": 2, "split_to": 1},
+            {"ticker": "BAD", "execution_date": "", "split_from": 2, "split_to": 1},
+            {"ticker": None, "execution_date": "2026-06-20", "split_from": 1, "split_to": 4},
+        ])
+        actions = ca.detect_splits("2026-06-01", "2026-06-30", client=client)
+        assert [a.ticker for a in actions] == ["HON"]
+
+    def test_fetch_failure_degrades_to_empty(self):
+        client = MagicMock()
+        client.get_recent_splits.side_effect = RuntimeError("polygon down")
+        assert ca.detect_splits("2026-06-01", "2026-06-30", client=client) == []
+
+    def test_dividends_and_renames_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            ca.detect_dividends("2026-06-01", "2026-06-30")
+        with pytest.raises(NotImplementedError):
+            ca.detect_renames("2026-06-01", "2026-06-30")

--- a/tests/test_corporate_actions_registry.py
+++ b/tests/test_corporate_actions_registry.py
@@ -1,0 +1,136 @@
+"""Tests for ``corporate_actions.registry.CorporateActionRegistry`` (config#1431).
+
+S3 is mocked with a small in-memory fake that implements the four operations
+the registry uses (``head_object`` / ``get_object`` / ``put_object`` /
+``list_objects_v2``) and raises a faithful ``ClientError`` (404 / NoSuchKey) for
+missing keys — the same boto3-error surface the production code branches on.
+This follows the suite's prevailing MagicMock-based S3 mocking
+(``tests/test_daily_closes_skip_if_canonical.py``) but models the bucket
+faithfully so write-if-absent + read-back round-trips through "S3".
+"""
+
+from __future__ import annotations
+
+import io
+
+from botocore.exceptions import ClientError
+
+import corporate_actions as ca
+from corporate_actions import CorporateActionRegistry
+
+
+class _FakeS3:
+    """Minimal in-memory S3 double (per-bucket key→bytes store)."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+        self.put_calls = 0
+
+    def _client_error(self, code: str, op: str) -> ClientError:
+        return ClientError({"Error": {"Code": code, "Message": "missing"}}, op)
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._client_error("404", "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._client_error("NoSuchKey", "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.put_calls += 1
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"fake"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _registry():
+    return CorporateActionRegistry(_FakeS3(), "alpha-engine-research")
+
+
+class TestRecordDetected:
+    def test_write_if_absent_is_idempotent(self):
+        reg = _registry()
+        action = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        assert reg.record_detected(action, run_id="2026-06-26") is True
+        s3 = reg.s3
+        puts_after_first = s3.put_calls
+        # Second call for the same action_id must NOT overwrite and returns False.
+        assert reg.record_detected(action, run_id="2026-06-26-rerun") is False
+        assert s3.put_calls == puts_after_first  # no second PUT
+
+    def test_recorded_record_is_readable_and_round_trips(self):
+        reg = _registry()
+        action = ca.CorporateAction.from_split("NVDA", "2026-06-10", 1, 10)
+        reg.record_detected(action, run_id="run-1")
+        got = reg.get_action(action.action_id)
+        assert got is not None
+        assert got.ticker == "NVDA"
+        assert got.split_to == 10
+        assert got.action_id == action.action_id
+
+    def test_list_actions_filters_by_ticker_and_type(self):
+        reg = _registry()
+        reg.record_detected(ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1), run_id="r")
+        reg.record_detected(ca.CorporateAction.from_split("NVDA", "2026-06-10", 1, 10), run_id="r")
+        assert {a.ticker for a in reg.list_actions(types=["split"])} == {"HON", "NVDA"}
+        assert [a.ticker for a in reg.list_actions(ticker="HON")] == ["HON"]
+        assert reg.list_actions(types=["dividend"]) == []
+
+
+class TestMarkApplied:
+    def test_mark_applied_write_once(self):
+        reg = _registry()
+        action = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        assert reg.is_applied("arcticdb_universe", action.action_id) is False
+        assert reg.mark_applied(action, "arcticdb_universe", run_id="r") is True
+        assert reg.is_applied("arcticdb_universe", action.action_id) is True
+        assert reg.mark_applied(action, "arcticdb_universe", run_id="r2") is False
+
+
+class TestExplainsDiscrepancy:
+    def test_hon_reverse_split_explains_2x_jump(self):
+        # HON-shaped 1-for-2 reverse split: 229.49 -> 458.98 (factor 2.0).
+        reg = _registry()
+        action = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        reg.record_detected(action, run_id="r")
+        got = reg.explains_discrepancy("HON", "2026-06-25", 229.49, 458.98)
+        assert got is not None
+        assert got.action_id == action.action_id
+        assert got.human() == "1-for-2 reverse split"
+
+    def test_unexplained_2x_with_no_registered_action_returns_none(self):
+        reg = _registry()  # empty registry
+        assert reg.explains_discrepancy("FOO", "2026-06-25", 100.0, 200.0) is None
+
+    def test_action_for_other_ticker_does_not_explain(self):
+        reg = _registry()
+        reg.record_detected(ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1), run_id="r")
+        assert reg.explains_discrepancy("MMM", "2026-06-25", 100.0, 200.0) is None
+
+    def test_wrong_factor_does_not_match(self):
+        # Registered 2:1 reverse split, but the observed jump is 3x — not a match.
+        reg = _registry()
+        reg.record_detected(ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1), run_id="r")
+        assert reg.explains_discrepancy("HON", "2026-06-25", 100.0, 300.0) is None
+
+    def test_ex_date_before_discrepancy_date_does_not_match(self):
+        # A split whose ex_date is well BEFORE the discrepancy date cannot
+        # explain it (the split restates dates strictly before its ex date).
+        reg = _registry()
+        reg.record_detected(ca.CorporateAction.from_split("HON", "2026-05-01", 2, 1), run_id="r")
+        assert reg.explains_discrepancy("HON", "2026-06-25", 229.49, 458.98) is None
+
+    def test_forward_split_factor_explains_division(self):
+        # NVDA 10-for-1 forward: 1000 -> 100 (factor 0.1).
+        reg = _registry()
+        action = ca.CorporateAction.from_split("NVDA", "2026-06-12", 1, 10)
+        reg.record_detected(action, run_id="r")
+        got = reg.explains_discrepancy("NVDA", "2026-06-10", 1000.0, 100.0)
+        assert got is not None
+        assert got.action_id == action.action_id

--- a/tests/test_daily_closes_skip_if_canonical.py
+++ b/tests/test_daily_closes_skip_if_canonical.py
@@ -322,7 +322,7 @@ class TestSkipCanonicalPolygonOnlySplitAware:
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
             ), patch.object(
-                daily_closes, "_fetch_recent_split_dates", return_value=set(),
+                daily_closes, "_recent_split_events", return_value=[],
             ):
                 result = daily_closes.collect(
                     bucket="b", tickers=["AAPL", "MSFT"],
@@ -352,8 +352,12 @@ class TestSkipCanonicalPolygonOnlySplitAware:
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
             ), patch.object(
-                daily_closes, "_fetch_recent_split_dates",
-                return_value={"2026-05-08"},  # AAPL 10:1 executed after this date
+                daily_closes, "_recent_split_events",
+                # AAPL 10:1 executes 2026-05-11, restating 2026-05-08 (date < ex)
+                return_value=[
+                    {"ticker": "AAPL", "execution_date": "2026-05-11",
+                     "split_from": 1, "split_to": 10},
+                ],
             ):
                 result = daily_closes.collect(
                     bucket="b", tickers=["AAPL", "MSFT"],
@@ -385,7 +389,7 @@ class TestSkipCanonicalPolygonOnlySplitAware:
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
             ), patch.object(
-                daily_closes, "_fetch_recent_split_dates",
+                daily_closes, "_recent_split_events",
             ) as scan_mock:
                 daily_closes.collect(
                     bucket="b", tickers=["AAPL"],
@@ -414,7 +418,7 @@ class TestSkipCanonicalPolygonOnlySplitAware:
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
             ), patch.object(
-                daily_closes, "_fetch_recent_split_dates", return_value=set(),
+                daily_closes, "_recent_split_events", return_value=[],
             ):
                 daily_closes.collect(
                     bucket="b", tickers=["AAPL", "MSFT"],
@@ -441,7 +445,7 @@ class TestSkipCanonicalPolygonOnlySplitAware:
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
             ), patch.object(
-                daily_closes, "_fetch_recent_split_dates", return_value=set(),
+                daily_closes, "_recent_split_events", return_value=[],
             ):
                 result = daily_closes.collect(
                     bucket="b", tickers=["AAPL", "MSFT"],
@@ -468,7 +472,7 @@ class TestSkipCanonicalPolygonOnlySplitAware:
             ), patch.object(
                 daily_closes, "_fetch_fred_closes", return_value=0
             ), patch.object(
-                daily_closes, "_fetch_recent_split_dates",
+                daily_closes, "_recent_split_events",
             ) as scan_mock:
                 daily_closes.collect(
                     bucket="b", tickers=["AAPL"],

--- a/tests/test_daily_closes_split_hint.py
+++ b/tests/test_daily_closes_split_hint.py
@@ -63,3 +63,122 @@ class TestOverwriteErrorCarriesHint:
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert len(errors) == 1
         assert "ratio" not in errors[0].message
+
+
+# ── config#1431: registry-aware corporate-action reclassification ───────────
+
+import io  # noqa: E402
+
+from botocore.exceptions import ClientError  # noqa: E402
+
+import corporate_actions as ca  # noqa: E402
+from corporate_actions import CorporateActionRegistry  # noqa: E402
+
+
+class _FakeS3:
+    """Minimal in-memory S3 double for seeding a CorporateActionRegistry."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"fake"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _registry_with_hon_reverse_split():
+    """Registry seeded with a HON 1-for-2 reverse split, ex-date 2026-06-27."""
+    reg = CorporateActionRegistry(_FakeS3(), "alpha-engine-research")
+    reg.record_detected(
+        ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1), run_id="r"
+    )
+    return reg
+
+
+class TestRegistryReclassifiesConfirmedSplit:
+    def test_explained_split_logs_warning_not_error(self, caplog):
+        # HON 1-for-2 reverse split restated 229.49 -> 458.98 (factor 2.0).
+        new_df = pd.DataFrame({"Close": [458.98]}, index=["HON"])
+        reg = _registry_with_hon_reverse_split()
+        with caplog.at_level(logging.DEBUG):
+            explained = daily_closes._log_close_discrepancies(
+                new_df, {"HON": 229.49}, "2026-06-25", registry=reg
+            )
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(errors) == 0  # confirmed split is NOT a flow-doctor ERROR
+        assert any("corporate_action_restatement HON" in r.message for r in warns)
+        assert len(explained) == 1
+        assert explained[0].ticker == "HON"
+
+    def test_registry_none_still_errors(self, caplog):
+        new_df = pd.DataFrame({"Close": [458.98]}, index=["HON"])
+        with caplog.at_level(logging.DEBUG):
+            explained = daily_closes._log_close_discrepancies(
+                new_df, {"HON": 229.49}, "2026-06-25", registry=None
+            )
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "polygon_only OVERWRITE HON" in errors[0].message
+        assert explained == []
+
+    def test_unexplained_jump_with_registry_still_errors(self, caplog):
+        # Registry has HON, but the jump is on MMM (no registered action) — must
+        # stay loud as an ERROR.
+        new_df = pd.DataFrame({"Close": [200.0]}, index=["MMM"])
+        reg = _registry_with_hon_reverse_split()
+        with caplog.at_level(logging.DEBUG):
+            explained = daily_closes._log_close_discrepancies(
+                new_df, {"MMM": 100.0}, "2026-06-25", registry=reg
+            )
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "polygon_only OVERWRITE MMM" in errors[0].message
+        assert explained == []
+
+
+class TestCorporateActionEmail:
+    def test_email_sent_once_for_explained_actions(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr("emailer.send_email", lambda *a, **k: calls.append((a, k)))
+        hon = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        hon_dup = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)  # same id
+        nvda = ca.CorporateAction.from_split("NVDA", "2026-06-10", 1, 10)
+        daily_closes._send_corporate_action_email([hon, hon_dup, nvda], "2026-06-25")
+        assert len(calls) == 1  # ONE email
+        subject = calls[0][0][0]
+        assert "2 ticker(s)" in subject  # deduped by action_id
+        body = calls[0][0][1]
+        assert "1-for-2 reverse split" in body
+        assert "10-for-1 forward split" in body
+
+    def test_email_not_sent_when_no_actions(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr("emailer.send_email", lambda *a, **k: calls.append(a))
+        daily_closes._send_corporate_action_email([], "2026-06-25")
+        assert calls == []
+
+    def test_email_send_failure_is_logged_not_raised(self, monkeypatch, caplog):
+        def _boom(*a, **k):
+            raise RuntimeError("smtp down")
+
+        monkeypatch.setattr("emailer.send_email", _boom)
+        hon = ca.CorporateAction.from_split("HON", "2026-06-27", 2, 1)
+        with caplog.at_level(logging.WARNING):
+            # Must NOT raise (best-effort secondary notification).
+            daily_closes._send_corporate_action_email([hon], "2026-06-25")
+        assert any("email send failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## PR1+PR2 of the unified corporate-actions program (config#1431)

**Behavior-additive.** This does NOT yet change the split-RESTATEMENT path (`split_factor.restate_series_for_splits` / the ArcticDB write) — that lands in a later PR. It adds the `corporate_actions` module + S3 registry and makes the daily-closes discrepancy classification **registry-authoritative**.

### What this fixes
A confirmed split's expected adjusted-close restatement (e.g. HON's 1-for-2 reverse split: 229.49 → 458.98, a clean 2.0x) tripped the daily-closes `>5%` cross-source-drift **ERROR** band and surfaced as a false flow-doctor ERROR. The `_split_ratio_hint` text heuristic could annotate but not authoritatively suppress it. Now a >5% jump that the registry attributes to a **detected** corporate action logs at WARN `corporate_action_restatement` (excluded from the flow-doctor ERROR filter) plus one informational email — while genuinely unexplained >5% diffs still ERROR loudly.

### Changes
- **NEW `corporate_actions/` package**
  - frozen `CorporateAction` dataclass with a deterministic, content-addressed `action_id` (`sha1(type|ticker|ex_date|detail)[:16]`); split/dividend/rename fields + provenance.
  - `expected_factor` **delegates to `split_factor.cumulative_factor`** (builds on the existing authoritative convention, does not re-derive): forward 1-for-N → `1/N`, reverse N-for-1 → `N`.
  - `detect_splits` wraps polygon `get_recent_splits`, lazily constructs the client like `daily_closes._fetch_recent_split_dates`, and degrades gracefully to `[]` (apiKey scrubbed) on any failure. `detect_dividends`/`detect_renames` modeled but raise `NotImplementedError` (later PRs).
- **NEW `CorporateActionRegistry`** (S3 JSON under `corporate_actions/`)
  - `record_detected` → write-if-absent `actions/{action_id}.json` (immutable detected record + `detected_at` + `detected_run_id`), idempotent across reruns.
  - `mark_applied`/`is_applied` → write-once `applied/{store}/{action_id}.json` (modeled now for the later restatement PR; not exercised here).
  - `explains_discrepancy(ticker, date, prior, new)` → matches `new/prior` to a detected split's `expected_factor` within the 0.005 tolerance AND an ex-date plausibility window. Matches against the **session-detected** set (the window scan returns every split in the span), so it never does a per-comparison S3 list.
- **WIRED into `collectors/daily_closes.py`**
  - ONE `_recent_split_events` fetch per window feeds BOTH the config#717 skip-set AND the registry — **no second polygon call** (refactored `_fetch_recent_split_dates` to reuse it; its return contract + direct tests unchanged).
  - `_log_close_discrepancies(..., registry=...)` gains a `corporate_action_restatement` WARN branch before the generic `>5%` ERROR branch; `_split_ratio_hint` retained as the secondary annotation on the unexplained-ERROR branch.
  - one informational email per run (deduped by `action_id`), best-effort with a WARN on send failure (no silent swallow); never sent in dry_run or when no explained actions.

### Tests (local, repo `.venv`)
- `test_corporate_actions.py` (14) + `test_corporate_actions_registry.py` (12) — new.
- `test_daily_closes_split_hint.py` — extended with reclassification + email tests (registry-explained split → WARN, n_error==0; registry=None / unexplained → ERROR; email sent once / not when none / failure logged-not-raised).
- `test_daily_closes_skip_if_canonical.py` (26) — repointed to the `_recent_split_events` seam.
- `test_artifact_registry_coverage.py` — pinned the new PUT site (event-driven provenance; grandfathered — no freshness SLA).
- **Targeted set green:** `test_corporate_actions* + test_daily_closes_split_hint + test_daily_closes_skip_if_canonical + test_daily_closes_window_days` → **81 passed**; artifact guard + config-routing + api-resilience + preclose-guard → **28 passed**. ERROR path confirmed still firing for unexplained >5% diffs (registry=None and wrong-ticker/wrong-factor cases). S3 mocked with a faithful in-memory fake (head/get/put/list over a dict) raising real `ClientError(404/NoSuchKey)`, matching the suite's MagicMock S3 convention.
- The only local failures are PRE-EXISTING, environmental: files importing `weekly_collector` fail on `nousergon_lib.config` missing in the local py3.13 stale-lib venv (resolves on CI's py3.12 + lib 0.70.0). Not touched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
