### PR TITLE
fix(groom-dispatcher): install git+python3.12 in SSM prelude before clone (config#1432)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -109,6 +109,11 @@ def _bootstrap_command(run_mode: str, run_url: str) -> str:
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
 fail() {{ echo "[groom-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+# Stock AL2023 ships neither git nor python3.12. Install BEFORE the clone (git is
+# needed now; python3.12 gives the groom the same interpreter as the GHA runner —
+# mirrors spot_data_weekly.sh's bootstrap, which installs the same set).
+dnf install -y -q git python3.12 python3.12-pip >/dev/null 2>&1 \
+  || fail "runtime install (git/python3.12) failed"
 PAT=$(aws ssm get-parameter --name {GROOM_GH_PAT_SSM} --with-decryption \
   --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
 [ -n "$PAT" ] || fail "PAT empty"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -103,6 +103,10 @@ def test_schedule_event_launches_spot_and_sends_async_ssm(monkeypatch):
     sent = idx._test_ssm.sent[0]
     cmd = sent["Parameters"]["commands"][0]
     assert "groom_spot_bootstrap.sh --mode full" in cmd
+    # AL2023 ships neither git nor python3.12 — the prelude must install them
+    # BEFORE the clone (regression guard for the first cutover failure).
+    assert "dnf install -y -q git python3.12" in cmd
+    assert cmd.index("dnf install") < cmd.index("git clone")
     assert sent["Parameters"]["executionTimeout"] == [str(idx.MAX_RUNTIME_SECONDS)]
 
 


### PR DESCRIPTION
First cutover smoke FAILED with `git: command not found` — stock AL2023 ships neither git nor python3.12, but the prelude `git clone`d before installing them. Adds `dnf install -y -q git python3.12 python3.12-pip` to the prelude before the clone (mirrors spot_data_weekly.sh line 496). python3.12 keeps the groom on the same interpreter as the GHA runner. Regression guard added to test_handler. **Cutover-blocking fix** — needs merge + redeploy. 6 tests pass. Companion: config python PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)