### PR TITLE
fix(groom-dispatcher): set $HOME + $-free run_url in SSM prelude (config#1432)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -108,6 +108,8 @@ def _bootstrap_command(run_mode: str, run_url: str) -> str:
     """
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
+# SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
+export HOME=/root
 fail() {{ echo "[groom-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
 # Stock AL2023 ships neither git nor python3.12. Install BEFORE the clone (git is
 # needed now; python3.12 gives the groom the same interpreter as the GHA runner —
@@ -202,10 +204,13 @@ def _launch_groom_spot(run_mode: str, schedule_label: str) -> dict:
     instance_id, market = _launch_instance()
     logger.info("launched groom box %s (%s)", instance_id, market)
     _wait_ssm_online(instance_id)
+    # IMPORTANT: this string is embedded in the prelude's bash double-quoted
+    # `--run-url "..."`, so it MUST NOT contain `$` — the AWS console's normal
+    # `$252F` log-group encoding would expand as positional params ($2, $5...)
+    # under `set -u` and abort the prelude. Keep it `$`-free.
     run_url = (
         f"https://{REGION}.console.aws.amazon.com/cloudwatch/home?region={REGION}"
-        f"#logsV2:log-groups/log-group/$252Falpha-engine$252Fgroom-spot"
-        f"$3FfilterPattern$3D{instance_id}"
+        f"#logsV2:log-groups (log group {CW_LOG_GROUP}, instance {instance_id})"
     )
     command_id = _send_bootstrap(instance_id, run_mode, run_url)
     logger.info(

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -107,6 +107,11 @@ def test_schedule_event_launches_spot_and_sends_async_ssm(monkeypatch):
     # BEFORE the clone (regression guard for the first cutover failure).
     assert "dnf install -y -q git python3.12" in cmd
     assert cmd.index("dnf install") < cmd.index("git clone")
+    # SSM RunShellScript has no $HOME — git config/clone need it (cutover bug #2).
+    assert "export HOME=/root" in cmd
+    # Under `set -u` in a double-quoted context, a `$`-encoded run_url ($252F...)
+    # would expand as positional params and abort the prelude (cutover bug #3).
+    assert "$252F" not in cmd
     assert sent["Parameters"]["executionTimeout"] == [str(idx.MAX_RUNTIME_SECONDS)]
 
 


### PR DESCRIPTION
2nd cutover smoke got past the clone but hit two prelude bugs: (1) `$HOME not set` broke git config/clone (SSM runs as root w/o HOME) → add `export HOME=/root`; (2) `$2: unbound variable` — run_url contained the console `$252F` encoding which bash expanded as positional params under set -u → rebuilt run_url $-free. Regression guards added. 6 tests pass. **Cutover-blocking** — merge + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)