### PR TITLE
feat(corporate-actions): registry-driven split restatement + blocking audit (PR3 config#1433)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -43,7 +43,8 @@ from features.compute import (
     _SKIP_TICKERS,
     _UNIVERSE_EXTRA,
     _apply_daily_delta,
-    audit_split_jumps,
+    _build_registry,
+    audit_action_jumps,
     _is_sector_etf,
     _load_parquet_from_s3,
     _load_sector_map,
@@ -51,6 +52,7 @@ from features.compute import (
     _load_cached_alternative,
     make_source_series,
 )
+from corporate_actions import CorporateActionAuditError
 from store.arctic_store import (
     OHLCV_COLS as _CANONICAL_OHLCV_COLS,
     PROVENANCE_COL as _CANONICAL_PROVENANCE_COL,
@@ -385,28 +387,47 @@ def backfill(
     # ``features/compute.py::_apply_daily_delta`` so both feature-snapshot and
     # backfill share the same freshness semantics.
     if not dry_run:
-        price_data, split_tickers = _apply_daily_delta(s3, bucket, today_str, price_data)
+        # Shared registry: the same instance drives detection/restatement in
+        # ``_apply_daily_delta`` AND the post-condition audit below, so the
+        # audit sees this run's just-detected actions.
+        registry = _build_registry(s3, bucket)
+        price_data, split_tickers = _apply_daily_delta(
+            s3, bucket, today_str, price_data, registry=registry,
+        )
         if split_tickers:
-            # data#1298: these tickers had a split detected and their FULL
-            # history restated by the polygon-authoritative factor before the
-            # full-series ``lib.write`` below, so ArcticDB is rewritten on one
-            # continuous adjusted scale (train == serve), not windowed-patched.
+            # data#1298: these tickers had a registered split detected and their
+            # FULL history restated by the polygon-authoritative factor before
+            # the full-series ``lib.write`` below, so ArcticDB is rewritten on
+            # one continuous adjusted scale (train == serve), not windowed.
             log.info(
                 "Split restatement applied to %d ticker(s) before ArcticDB "
                 "rewrite (data#1298): %s",
                 len(split_tickers), sorted(split_tickers),
             )
 
-        # Standing split-jump audit guard (data#1298): a residual >45% daily
-        # move means a split slipped past restatement. Surface it loudly so the
-        # discontinuity can't land in ArcticDB silently.
-        residual = audit_split_jumps(price_data)
-        if residual:
-            log.error(
-                "Split-jump audit: %d ticker(s) STILL carry an un-restated "
-                ">45%% daily move after delta+restate (data#1298) — investigate "
-                "/ re-restate before downstream training: %s",
-                len(residual), {t: residual[t] for t in sorted(residual)[:20]},
+        # BLOCKING, registry-aware split-jump audit (PR3 §3, config#1433): the
+        # post-condition on the materialized series, evaluated BEFORE any
+        # ``lib.write``. A residual jump that a registered action EXPLAINS is a
+        # MISSED restatement of a KNOWN action (data#1298 corruption) → RAISE so
+        # the discontinuity cannot land in ArcticDB. A residual with NO
+        # registered action is SUSPECTED (legit large move / polygon-missed) →
+        # WARN and proceed (a real ±33% move must not halt training).
+        audit = audit_action_jumps(price_data, registry)
+        if audit.suspected:
+            log.warning(
+                "Split-jump audit: %d ticker(s) carry a SUSPECTED large move "
+                "with NO registered action (legitimate move or polygon-missed) "
+                "— proceeding, not blocking: %s",
+                len(audit.suspected),
+                {t: audit.suspected[t] for t in sorted(audit.suspected)[:20]},
+            )
+        if audit.missed:
+            raise CorporateActionAuditError(
+                f"Split-jump audit: {len(audit.missed)} ticker(s) STILL carry "
+                f"an un-flattened KNOWN registered split (data#1298) after "
+                f"delta+restate — refusing to write the discontinuity to "
+                f"ArcticDB: "
+                f"{ {t: audit.missed[t] for t in sorted(audit.missed)[:20]} }"
             )
 
     macro = _extract_macro_series(price_data)

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -56,7 +56,9 @@ log = logging.getLogger(__name__)
 __all__ = [
     "CorporateAction",
     "CorporateActionRegistry",
+    "CorporateActionAuditError",
     "expected_factor",
+    "apply",
     "detect_splits",
     "detect_dividends",
     "detect_renames",
@@ -68,6 +70,32 @@ __all__ = [
 _TYPE_SPLIT = "split"
 _TYPE_DIVIDEND = "dividend"
 _TYPE_RENAME = "rename"
+
+# The logical store a restatement targets. Both the Saturday full backfill
+# (rebuilds from the S3 price cache) and the daily feature-snapshot delta
+# (reads the already-restated ArcticDB) write into / read from the SAME
+# logical store, so the applied-marker namespace is shared — that is exactly
+# what makes ``apply`` exactly-once across the two paths (the daily snapshot
+# load of an already-restated series sees the backfill's applied marker and
+# skips, the double-apply guard of PR3 §4).
+STORE_ARCTICDB_UNIVERSE = "arcticdb_universe"
+
+
+class CorporateActionAuditError(RuntimeError):
+    """A KNOWN, registered corporate action was left un-flattened in a series
+    about to be written to a training store.
+
+    This is the BLOCKING half of the registry-aware post-condition audit
+    (``audit_action_jumps`` → backfill chokepoint, PR3 §3): a residual
+    split-magnitude jump that a registered action *explains* (the action's
+    ex_date sits at the jump and the move matches its factor) means the
+    restatement of a known action was MISSED — the data#1298 corruption class.
+    It is raised so the ArcticDB ``lib.write`` cannot land the discontinuity
+    silently. It is DISTINCT from a *suspected* residual — a large move with NO
+    registered action explaining it (a legitimate earnings move, or a
+    polygon-missed action) — which is a WARN, never a raise, so a real ±33%
+    move does not halt the pipeline.
+    """
 
 
 @dataclass(frozen=True)
@@ -235,6 +263,125 @@ def expected_factor(action: CorporateAction) -> float:
         f"expected_factor not implemented for action type {action.type!r} "
         "(only splits implemented this PR)"
     )
+
+
+def apply(
+    df: pd.DataFrame,
+    actions: list["CorporateAction"],
+    *,
+    store: str,
+    registry: "CorporateActionRegistry | None" = None,
+    run_id: str | None = None,
+) -> tuple[pd.DataFrame, list[dict]]:
+    """Restate a SINGLE ticker's price frame so its full history is corporate-
+    action-consistent, routing all split restatement through ``split_factor``.
+
+    ``df`` is one ticker's OHLCV(+) frame (DatetimeIndex). ``actions`` are the
+    ``CorporateAction``s that pertain to THAT frame's ticker (the caller filters
+    by ticker — this PR only restates SPLIT actions; a dividend/rename action
+    passed in raises ``NotImplementedError`` because their factor math ships in a
+    later PR). The full-history multiplicative restatement itself is delegated to
+    :func:`split_factor.restate_series_for_splits` (price ×factor, volume ÷factor
+    for every row strictly before each split's ex_date) — this function never
+    re-derives the factor convention.
+
+    Idempotency — registry-backed, DECOUPLED from source purity
+    -----------------------------------------------------------
+    ``restate_series_for_splits`` is NOT idempotent on its own (it always applies
+    the FULL cumulative factor), so re-applying it to an already-restated series
+    double-adjusts. Two layers guard against that:
+
+      * When a ``registry`` is supplied, an action already marked applied to
+        ``store`` (``registry.is_applied``) is SKIPPED (``status="noop"``) — this
+        is the exactly-once marker that makes the daily feature-snapshot path
+        (which reads the already-restated ArcticDB universe) a no-op rather than
+        a double-apply (PR3 §4), and that survives re-runs durably via S3.
+        After a real restatement the action is ``registry.mark_applied``-ed.
+      * When ``registry is None`` (direct unit tests / dry-run), there is no
+        durable marker — idempotency is then purely STRUCTURAL: the caller is
+        expected to restate from the raw/un-restated source each time, and
+        ``restate_series_for_splits`` yields the same result for the same raw
+        input (re-running it on its OWN output would double-adjust, which is why
+        the registry markers exist for the production reruns).
+
+    The BLOCKING ``audit_action_jumps`` post-condition (PR3 §3) is the
+    correctness backstop on top of both: any residual / double-applied
+    discontinuity at a registered action's ex_date is surfaced (and, at the
+    training-write chokepoint, RAISED) rather than landing silently.
+
+    Returns ``(restated_df, applied_results)`` where each ``applied_result`` is
+    ``{"action_id", "store", "n_rows_adjusted", "factor", "status"}`` and
+    ``status`` is ``"applied"`` (restated this call) or ``"noop"`` (already
+    applied per the registry — not re-adjusted).
+    """
+    applied_results: list[dict] = []
+    if df is None or getattr(df, "empty", True) or not actions:
+        return df, applied_results
+
+    # Only splits are restated this PR. A dividend/rename action reaching here
+    # is a caller error (detect_dividends/detect_renames are NotImplemented), so
+    # fail loud rather than silently dropping it.
+    split_actions: list[CorporateAction] = []
+    for a in actions:
+        if a.type == _TYPE_SPLIT:
+            split_actions.append(a)
+        elif a.type in (_TYPE_DIVIDEND, _TYPE_RENAME):
+            raise NotImplementedError(
+                f"corporate_actions.apply: {a.type!r} actions are deferred to a "
+                "later PR of the program (splits only this PR)"
+            )
+        else:
+            raise ValueError(
+                f"corporate_actions.apply: unknown action type {a.type!r}"
+            )
+
+    if not split_actions:
+        return df, applied_results
+
+    idx = df.index if isinstance(df.index, pd.DatetimeIndex) else pd.to_datetime(df.index)
+
+    events_to_apply: list[CorporateAction] = []
+    for a in split_actions:
+        factor = expected_factor(a)  # == split_from / split_to (authoritative)
+        # Exactly-once: skip an action already folded into this store.
+        if registry is not None and registry.is_applied(store, a.action_id):
+            applied_results.append({
+                "action_id": a.action_id,
+                "store": store,
+                "n_rows_adjusted": 0,
+                "factor": factor,
+                "status": "noop",
+            })
+            continue
+        events_to_apply.append(a)
+
+    if not events_to_apply:
+        return df, applied_results
+
+    events = [
+        {
+            "execution_date": a.ex_date,
+            "split_from": a.split_from,
+            "split_to": a.split_to,
+        }
+        for a in events_to_apply
+    ]
+    restated = split_factor.restate_series_for_splits(df, events)
+
+    for a in events_to_apply:
+        ex = pd.Timestamp(a.ex_date).normalize()
+        n_rows_adjusted = int((idx < ex).sum())
+        applied_results.append({
+            "action_id": a.action_id,
+            "store": store,
+            "n_rows_adjusted": n_rows_adjusted,
+            "factor": expected_factor(a),
+            "status": "applied",
+        })
+        if registry is not None:
+            registry.mark_applied(a, store, run_id=run_id)
+
+    return restated, applied_results
 
 
 def splits_from_events(events: list[dict]) -> list["CorporateAction"]:

--- a/corporate_actions/registry.py
+++ b/corporate_actions/registry.py
@@ -124,11 +124,15 @@ class CorporateActionRegistry:
                 k = obj.get("Key")
                 if k and k.endswith(".json"):
                     keys.append(k)
-            if resp.get("IsTruncated"):
-                token = resp.get("NextContinuationToken")
-                if not token:
-                    break
-            else:
+            if not resp.get("IsTruncated"):
+                break
+            # Continue ONLY on a real (non-empty string) continuation token. S3
+            # always supplies one when IsTruncated is True; refusing anything
+            # else (None / empty / a non-str) is a hard guard against an
+            # unbounded pagination loop on a malformed or degenerate paginator
+            # response — terminate rather than spin.
+            token = resp.get("NextContinuationToken")
+            if not isinstance(token, str) or not token:
                 break
         return keys
 

--- a/features/compute.py
+++ b/features/compute.py
@@ -36,7 +36,9 @@ import numpy as np
 import pandas as pd
 
 import hashlib
+from dataclasses import dataclass
 
+import corporate_actions as ca
 from features.cross_sectional import apply_factor_zscores
 from features.feature_engineer import FEATURES, FEATURE_CFG, MIN_ROWS_FOR_FEATURES, compute_features
 from features.registry import upload_registry
@@ -48,8 +50,28 @@ log = logging.getLogger(__name__)
 DEFAULT_BUCKET = "alpha-engine-research"
 FEATURE_STORE_PREFIX = "features/"
 
-# Large-move warning threshold (>45% daily return, e.g. stock splits, VIX spikes)
-_SPLIT_RETURN_THRESHOLD = 0.45
+# Registry-aware split-jump audit (PR3, config#1433). The screen threshold is
+# the DIAGNOSTIC band — it must be low enough to SURFACE sub-45% splits
+# (3-for-2 = -33%, 4-for-3 = -25%) so the latent bug the old >45% heuristic
+# missed becomes visible. The BLOCKING raise condition is NOT this magnitude —
+# it is registry-driven (a residual jump that a registered action EXPLAINS),
+# which is what lets a sub-45% registered split be caught WITHOUT false-failing
+# on a legitimate large move (a real ±33% earnings move has no registered
+# action, so it is only ever WARN-classified as "suspected").
+_ACTION_JUMP_SCREEN_THRESHOLD = 0.18
+# A residual un-flattened split jump is the split factor multiplied by the real
+# overnight move, so the observed boundary ratio is "factor × (1 ± small)" — a
+# loose relative tol (vs the registry's exact 0.5% same-date tol) confirms the
+# residual jump IS the split (not a coincident legit move on a flattened
+# boundary) without requiring the move to equal the factor to feed-rounding.
+_AUDIT_FACTOR_REL_TOL = 0.15
+# The un-flattened jump appears at the first trading row on/after the split's
+# ex_date; allow a few days' slack for weekend/holiday gaps between ex_date and
+# the first observed row.
+_AUDIT_EX_DATE_WINDOW_DAYS = 4
+# The logical store split restatement targets (shared by the Saturday backfill
+# and the daily feature-snapshot delta — see corporate_actions.STORE_*).
+_RESTATE_STORE = ca.STORE_ARCTICDB_UNIVERSE
 
 # Closed-set of provenance source values written to the `source` column on
 # universe rows. Stored as a pandas Categorical so the in-memory cost is
@@ -222,8 +244,70 @@ def _load_delta_from_daily_closes(
     return ticker_rows
 
 
+def _build_registry(s3, bucket: str):
+    """Construct a ``CorporateActionRegistry`` from an S3 client + bucket, or
+    ``None`` when no usable client is available.
+
+    Returning ``None`` keeps legacy positional / dry-run callers (and unit
+    tests that pass ``s3=None``) free of S3 + polygon I/O: with no registry,
+    ``_apply_daily_delta`` performs no corporate-action detection or
+    restatement (production callers — backfill, feature-snapshot — always pass
+    a registry).
+    """
+    if s3 is None:
+        return None
+    try:
+        return ca.CorporateActionRegistry(s3, bucket)
+    except Exception as exc:  # noqa: BLE001 - degrade, never hard-fail the load
+        log.warning(
+            "could not build corporate-action registry (%s) — split "
+            "restatement degraded this pass", exc,
+        )
+        return None
+
+
+def _detect_split_actions(
+    start_date, end_date, registry, *, run_id: str,
+) -> dict[str, list]:
+    """AUTHORITATIVELY detect splits executing in ``[start_date, end_date]`` via
+    polygon, persist each in the registry (write-if-absent), and group them by
+    ticker.
+
+    This REPLACES the old ">45% single-day return" magnitude heuristic that
+    *triggered* restatement: that heuristic silently MISSED sub-45% splits
+    (3-for-2 = -33%, 4-for-3 = -25%) and could false-trigger on a legitimate
+    large move. The polygon split feed is the authoritative trigger; magnitude
+    no longer gates restatement. Returns ``{}`` (degrade) on any detection
+    failure — a detection miss must never hard-fail the load; the blocking
+    audit is the backstop for a genuinely missed restatement.
+    """
+    start_str = pd.Timestamp(start_date).strftime("%Y-%m-%d")
+    end_str = pd.Timestamp(end_date).strftime("%Y-%m-%d")
+    try:
+        actions = ca.detect_splits(start_str, end_str)
+    except Exception as exc:  # noqa: BLE001 - detect_splits already degrades
+        log.warning(
+            "corporate-action split detection failed (%s) — no restatement "
+            "this pass", exc,
+        )
+        return {}
+    by_ticker: dict[str, list] = {}
+    for action in actions:
+        if registry is not None:
+            try:
+                registry.record_detected(action, run_id=run_id)
+            except Exception as exc:  # noqa: BLE001 - provenance write best-effort
+                log.warning(
+                    "record_detected failed for %s (%s) — continuing",
+                    action.action_id, exc,
+                )
+        by_ticker.setdefault(action.ticker, []).append(action)
+    return by_ticker
+
+
 def _apply_daily_delta(
     s3, bucket: str, date_str: str, price_data: dict[str, pd.DataFrame],
+    *, registry=None,
 ) -> tuple[dict[str, pd.DataFrame], set[str]]:
     """
     Append daily_closes delta rows to price DataFrames.
@@ -233,8 +317,16 @@ def _apply_daily_delta(
        the target date (not just the target date's file).
     2. Uses ``duplicated(keep='last')`` so delta rows override cache rows
        on the same date.
-    3. Detects splits (>45% single-day return) and returns those tickers
-       for yfinance re-fetch.
+    3. Restates EVERY registered split (regardless of magnitude) through
+       ``corporate_actions.apply`` — authoritative polygon detection replaces
+       the old >45% trigger, fixing the latent sub-45% miss (PR3, config#1433).
+       Restatement is exactly-once via the registry's applied markers, so the
+       feature-snapshot path's load of an already-restated ArcticDB series is a
+       no-op rather than a double-apply.
+
+    ``registry`` (keyword-only) is a ``CorporateActionRegistry``; when ``None``
+    (legacy positional callers / ``s3=None`` tests) NO corporate-action
+    detection or restatement is performed.
 
     Returns (updated_price_data, split_tickers).
     """
@@ -264,6 +356,15 @@ def _apply_daily_delta(
     if not ticker_rows:
         log.info("No daily_closes delta files found — using cache as-is")
         return price_data, set()
+
+    # Registry-driven, authoritative split detection over the delta window
+    # (PR3, config#1433). No-op when no registry (legacy / dry-run callers).
+    actions_by_ticker: dict[str, list] = {}
+    if registry is not None:
+        actions_by_ticker = _detect_split_actions(
+            slim_last_date, today, registry,
+            run_id=f"apply_daily_delta:{date_str}",
+        )
 
     split_tickers: set[str] = set()
     n_updated = 0
@@ -301,35 +402,36 @@ def _apply_daily_delta(
         # keep="last" so delta rows win on duplicate dates (matches predictor)
         combined = combined[~combined.index.duplicated(keep="last")].sort_index()
 
-        # Split detection → full-history RESTATEMENT (data#1298).
+        # Registry-driven full-history RESTATEMENT (data#1298, PR3 config#1433).
         #
         # The ArcticDB universe is append-only + windowed: a split restates the
         # FULL adjusted history, but ArcticDB only ever got a recent window
         # patched, leaving a split-boundary discontinuity that corrupts
-        # cross-boundary TRAINING features (verified on DD 2026-06-24). The
-        # root-cause fix is to back-adjust the ENTIRE pre-split window by the
-        # polygon-AUTHORITATIVE split factor here, at the point the full series
-        # is materialized for the downstream ``lib.write`` — so the series
-        # written to ArcticDB is continuous and on one adjusted scale
-        # (train == serve). We restate at WRITE time (not read time) because the
-        # backfill path already rewrites the full symbol; doing the restate in
-        # the read/window path would have to re-derive factors on every query
-        # and would not durably fix the stored discontinuity.
+        # cross-boundary TRAINING features. We back-adjust the ENTIRE pre-split
+        # window by the polygon-authoritative split factor here, where the full
+        # series is materialized for the downstream ``lib.write`` (train ==
+        # serve, continuous on one adjusted scale).
         #
-        # yfinance ``auto_adjust`` LAGS a fresh split, so it cannot be trusted
-        # for restatement — the factor must come from polygon (see split_factor).
-        returns = combined["Close"].pct_change().dropna()
-        if (returns.abs() > _SPLIT_RETURN_THRESHOLD).any():
-            restated = _restate_split_window(ticker, combined)
-            if restated is not None:
-                combined = restated
+        # Restatement is now triggered by an AUTHORITATIVE registered split (not
+        # the old >45% magnitude heuristic, which silently missed sub-45%
+        # splits), and routed through ``corporate_actions.apply`` with
+        # registry-backed exactly-once idempotency: an action already marked
+        # applied to this store is skipped, so re-applying to an already-
+        # restated series (the daily snapshot loads the restated ArcticDB) is a
+        # no-op rather than a double-apply.
+        ticker_actions = actions_by_ticker.get(ticker)
+        if ticker_actions:
+            combined, applied = ca.apply(
+                combined, ticker_actions,
+                store=_RESTATE_STORE,
+                registry=registry,
+                run_id=f"apply_daily_delta:{date_str}",
+            )
+            if any(
+                r["status"] == "applied" and r["n_rows_adjusted"] > 0
+                for r in applied
+            ):
                 split_tickers.add(ticker)
-            else:
-                log.warning(
-                    "Large move in %s (>45%% daily return) but no polygon split "
-                    "factor available — using data as-is (audit guard should flag)",
-                    ticker,
-                )
 
         price_data[ticker] = combined
         n_updated += 1
@@ -338,70 +440,106 @@ def _apply_daily_delta(
     return price_data, split_tickers
 
 
-def _restate_split_window(
-    ticker: str, df: pd.DataFrame, *, client=None,
-) -> pd.DataFrame | None:
-    """Back-adjust ``df``'s pre-split history by the polygon-authoritative
-    cumulative split factor so the full series is split-consistent (data#1298).
+@dataclass(frozen=True)
+class ActionJumpAudit:
+    """Result of :func:`audit_action_jumps` — residual jumps partitioned by
+    whether a registered corporate action EXPLAINS them.
 
-    Returns the restated frame, or ``None`` when no polygon split factor is
-    available (no events / polygon unreachable / events all predate the series)
-    so the caller can fall back to "use as-is" + the audit guard. The actual
-    factor math lives in :mod:`split_factor`; this wrapper isolates the
-    (network) polygon lookup so it can be patched out in tests.
+    ``missed`` (``{ticker: [(date, daily_return, action_id), ...]}``) is the
+    BLOCKING class: a registered split that was left un-flattened (data#1298
+    corruption). ``suspected`` (``{ticker: [(date, daily_return), ...]}``) is a
+    large move with NO registered action — a legit move or polygon-missed
+    action — WARN only, never blocking.
     """
-    try:
-        from split_factor import restate_series_for_splits, split_events
 
-        events = split_events(ticker, client=client)
-    except Exception as exc:  # network / auth / import — never hard-fail the run
-        log.warning(
-            "Split restatement for %s could not load polygon factors (%s) — "
-            "leaving series un-restated; audit guard should flag it",
-            ticker, exc,
-        )
-        return None
-    if not events:
-        return None
-    restated = restate_series_for_splits(df, events)
-    if restated is df:
-        # No row actually changed (every split predates the series) — treat as
-        # "no restatement available" so the >45%% move is still surfaced.
-        return None
-    log.info(
-        "Restated %s full history on polygon split factor (%d event(s)) — "
-        "ArcticDB write will be split-consistent (data#1298)",
-        ticker, len(events),
-    )
-    return restated
+    missed: dict[str, list[tuple[str, float, str]]]
+    suspected: dict[str, list[tuple[str, float]]]
 
 
-def audit_split_jumps(
+def _explaining_split(actions: list, jump_date: pd.Timestamp, ret: float):
+    """Return the registered split action that EXPLAINS an un-flattened jump at
+    ``jump_date`` (daily return ``ret``), or ``None``.
+
+    A match requires BOTH (i) the action's ex_date sits at the jump (the
+    un-flattened boundary appears at the first row on/after the ex_date) and
+    (ii) the observed boundary ratio ``close[d]/close[d-1] = 1+ret`` matches the
+    split factor within ``_AUDIT_FACTOR_REL_TOL`` — so it is the SPLIT, not a
+    coincident legitimate move on an already-flattened boundary.
+    """
+    observed = 1.0 + float(ret)  # close[d] / close[d-1]
+    for action in actions:
+        try:
+            ex = pd.Timestamp(action.ex_date).normalize()
+        except Exception:  # noqa: BLE001 - malformed ex_date, skip candidate
+            continue
+        if abs((ex - jump_date).days) > _AUDIT_EX_DATE_WINDOW_DAYS:
+            continue
+        try:
+            expected = ca.expected_factor(action)  # == split_from / split_to
+        except Exception:  # noqa: BLE001 - non-split / missing ratio, skip
+            continue
+        if expected <= 0:
+            continue
+        if abs(observed - expected) <= _AUDIT_FACTOR_REL_TOL * expected:
+            return action
+    return None
+
+
+def audit_action_jumps(
     price_data: dict[str, pd.DataFrame],
+    registry,
     *,
-    threshold: float = _SPLIT_RETURN_THRESHOLD,
-) -> dict[str, list[tuple[str, float]]]:
-    """Data-quality invariant: scan each series for an un-restated split jump.
+    screen_threshold: float = _ACTION_JUMP_SCREEN_THRESHOLD,
+) -> ActionJumpAudit:
+    """Registry-aware data-quality post-condition over the materialized series.
 
-    Returns ``{ticker: [(date_str, daily_return), ...]}`` for every ticker whose
-    Close series still contains a ``|daily return| > threshold`` move. A clean,
-    fully-restated universe returns ``{}``. Surfacing this makes the data#1298
-    bug class impossible to land SILENTLY — a residual discontinuity (the
-    restate failed, or a new split slipped past) is now a visible invariant
-    violation an operator/cron can alert on and auto-restate.
+    For every residual ``|daily move| > screen_threshold``, classify it:
+
+      * **MISSED** — a registered split's ex_date sits at the jump AND the move
+        matches its factor → the restatement of a KNOWN action was missed (the
+        data#1298 corruption class). BLOCKING at the training-write chokepoint.
+      * **SUSPECTED** — a large move with NO registered action explaining it (a
+        legit ±33% earnings move, or a polygon-missed action). WARN only.
+
+    The RAISE condition (``missed``) is registry-driven, NOT raw magnitude —
+    which is exactly what lets a sub-45% registered split be caught without
+    false-failing on a legitimate large move. ``screen_threshold`` is the
+    diagnostic floor (low enough to surface sub-45% splits). ``registry`` may
+    be ``None`` — then no action can explain anything and every residual is
+    ``suspected``.
     """
-    offenders: dict[str, list[tuple[str, float]]] = {}
+    splits_by_ticker: dict[str, list] = {}
+    if registry is not None:
+        try:
+            for action in registry.list_actions(types=["split"]):
+                splits_by_ticker.setdefault(action.ticker, []).append(action)
+        except Exception as exc:  # noqa: BLE001 - degrade to all-suspected
+            log.warning(
+                "audit_action_jumps: registry list_actions failed (%s) — "
+                "treating all residuals as suspected", exc,
+            )
+
+    missed: dict[str, list[tuple[str, float, str]]] = {}
+    suspected: dict[str, list[tuple[str, float]]] = {}
     for ticker, df in price_data.items():
         if df is None or df.empty or "Close" not in df.columns:
             continue
         returns = df["Close"].pct_change().dropna()
-        hits = returns[returns.abs() > threshold]
-        if not hits.empty:
-            offenders[ticker] = [
-                (pd.Timestamp(idx).strftime("%Y-%m-%d"), float(val))
-                for idx, val in hits.items()
-            ]
-    return offenders
+        hits = returns[returns.abs() > screen_threshold]
+        if hits.empty:
+            continue
+        ticker_actions = splits_by_ticker.get(ticker, [])
+        for idx, val in hits.items():
+            jump_date = pd.Timestamp(idx).normalize()
+            date_str = jump_date.strftime("%Y-%m-%d")
+            action = _explaining_split(ticker_actions, jump_date, float(val))
+            if action is not None:
+                missed.setdefault(ticker, []).append(
+                    (date_str, float(val), action.action_id)
+                )
+            else:
+                suspected.setdefault(ticker, []).append((date_str, float(val)))
+    return ActionJumpAudit(missed=missed, suspected=suspected)
 
 
 _MACRO_SLIM_KEYS = {
@@ -494,7 +632,33 @@ def _load_prices_and_macro(
         return {}, {}
 
     price_data = dict(source)
-    price_data, _split_tickers = _apply_daily_delta(s3, bucket, date_str, price_data)
+    registry = _build_registry(s3, bucket)
+    price_data, _split_tickers = _apply_daily_delta(
+        s3, bucket, date_str, price_data, registry=registry,
+    )
+
+    # Inference-side post-condition: LOUD-BUT-LOGGED, never raises here. The
+    # snapshot must not silently halt inference on a residual, and the BLOCKING
+    # gate is the backfill training-write chokepoint (a residual here is a
+    # known-issue signal, not a corruption of the written snapshot per se).
+    if registry is not None:
+        audit = audit_action_jumps(price_data, registry)
+        if audit.missed:
+            log.error(
+                "feature-snapshot load: %d ticker(s) carry an un-flattened "
+                "KNOWN registered split (data#1298) — %s",
+                len(audit.missed),
+                {t: audit.missed[t] for t in sorted(audit.missed)[:20]},
+            )
+        if audit.suspected:
+            log.warning(
+                "feature-snapshot load: %d ticker(s) carry a suspected large "
+                "move with no registered action (legit move / polygon-missed) "
+                "— %s",
+                len(audit.suspected),
+                {t: audit.suspected[t] for t in sorted(audit.suspected)[:20]},
+            )
+
     macro = _extract_macro(price_data, source)
 
     return price_data, macro

--- a/tests/test_backfill_no_regression.py
+++ b/tests/test_backfill_no_regression.py
@@ -173,7 +173,7 @@ def test_full_backfill_calls_apply_daily_delta():
     universe_lib = MagicMock()
     macro_lib = MagicMock()
 
-    delta_mock = MagicMock(side_effect=lambda s3, b, d, pd_: (pd_, set()))
+    delta_mock = MagicMock(side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set()))
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
          patch.object(_bf, "_apply_daily_delta", delta_mock), \
@@ -210,7 +210,7 @@ def test_full_backfill_calls_regression_preflight():
     regression_mock = MagicMock()
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
-         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
          patch.object(_bf, "_load_current_constituents", return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value={}), \
@@ -246,7 +246,7 @@ def test_ticker_filter_skips_regression_preflight():
     regression_mock = MagicMock()
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
-         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression", regression_mock), \
          patch.object(_bf, "_load_current_constituents", return_value=set(price_data.keys())), \
          patch.object(_bf, "_extract_macro_series", return_value={}), \
@@ -315,7 +315,7 @@ def test_backfill_skips_tickers_absent_from_constituents():
     macro_lib = MagicMock()
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
-         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_load_current_constituents",
                       return_value={"AAPL", "MSFT"}), \
@@ -356,7 +356,7 @@ def test_backfill_hard_fails_when_constituents_load_fails():
     price_data = {"AAPL": _ohlcv("2024-01-01", n=400)}
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
-         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_load_current_constituents",
                       side_effect=RuntimeError("S3 503")), \

--- a/tests/test_backfill_unified_and_macro_scoping.py
+++ b/tests/test_backfill_unified_and_macro_scoping.py
@@ -172,7 +172,7 @@ def _run_backfill_with_mocks(**backfill_kwargs):
     )
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
-         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_load_current_constituents",
                       return_value=set(price_data.keys())), \
@@ -265,7 +265,7 @@ def test_short_history_ticker_gets_feature_columns_written():
         return out
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
-         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_load_current_constituents",
                       return_value=set(price_data.keys())), \
@@ -348,7 +348,7 @@ def test_backfill_writes_vwap_when_input_parquet_lacks_it():
         return out
 
     with patch.object(_bf, "_load_full_cache", return_value=price_data), \
-         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_: (pd_, set())), \
+         patch.object(_bf, "_apply_daily_delta", side_effect=lambda s3, b, d, pd_, **_kw: (pd_, set())), \
          patch.object(_bf, "_assert_no_arctic_regression"), \
          patch.object(_bf, "_load_current_constituents",
                       return_value=set(price_data.keys())), \

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -8,11 +8,71 @@ mocking in ``tests/test_daily_closes_skip_if_canonical.py``).
 
 from __future__ import annotations
 
+import io
+
 from unittest.mock import MagicMock
 
+import numpy as np
+import pandas as pd
 import pytest
+from botocore.exceptions import ClientError
 
 import corporate_actions as ca
+from corporate_actions import CorporateActionRegistry
+from split_factor import restate_series_for_splits
+
+
+class _FakeS3:
+    """Minimal in-memory S3 double (per-bucket key→bytes store) — mirrors the
+    one in ``tests/test_corporate_actions_registry.py`` so ``apply`` can be
+    exercised against a faithful write-if-absent / read-back registry."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+        self.put_calls = 0
+
+    def _client_error(self, code: str, op: str) -> ClientError:
+        return ClientError({"Error": {"Code": code, "Message": "missing"}}, op)
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._client_error("404", "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._client_error("NoSuchKey", "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.put_calls += 1
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"fake"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _registry():
+    return CorporateActionRegistry(_FakeS3(), "alpha-engine-research")
+
+
+def _unfolded_reverse_split_frame():
+    """A DD-style series un-restated across a 1-for-3 REVERSE split (ex 6/24):
+    pre-split rows on the OLD (~$48) scale, post-split on the NEW (~$144)
+    scale — a ~3x boundary jump that restatement must remove."""
+    pre_dates = pd.bdate_range("2026-06-01", "2026-06-23")
+    post_dates = pd.bdate_range("2026-06-24", "2026-07-01")
+    pre = pd.Series(np.linspace(47.5, 48.5, len(pre_dates)), index=pre_dates)
+    post = pd.Series(np.linspace(142.5, 145.5, len(post_dates)), index=post_dates)
+    close = pd.concat([pre, post])
+    return pd.DataFrame(
+        {
+            "Open": close, "High": close * 1.01, "Low": close * 0.99,
+            "Close": close, "Volume": np.full(len(close), 1_000_000.0),
+        }
+    )
 
 
 class TestActionIdDeterminism:
@@ -115,3 +175,89 @@ class TestDetectSplits:
             ca.detect_dividends("2026-06-01", "2026-06-30")
         with pytest.raises(NotImplementedError):
             ca.detect_renames("2026-06-01", "2026-06-30")
+
+
+class TestApply:
+    _STORE = ca.STORE_ARCTICDB_UNIVERSE
+
+    def test_restates_split_with_parity_to_restate_series(self):
+        """``apply`` (registry=None) restates a split series identically to a
+        direct ``restate_series_for_splits`` — it must not re-derive the factor
+        convention, only route through it."""
+        df = _unfolded_reverse_split_frame()
+        action = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+
+        out, results = ca.apply(df, [action], store=self._STORE, registry=None)
+
+        events = [{"execution_date": "2026-06-24", "split_from": 3, "split_to": 1}]
+        expected = restate_series_for_splits(df, events)
+        pd.testing.assert_frame_equal(out, expected)
+
+        # The boundary jump is gone (fully continuous), and the applied_result
+        # captures the contract fields.
+        assert out["Close"].pct_change().abs().max() < 0.45
+        assert len(results) == 1
+        r = results[0]
+        assert r["action_id"] == action.action_id
+        assert r["store"] == self._STORE
+        assert r["status"] == "applied"
+        assert r["factor"] == pytest.approx(3.0)
+        assert r["n_rows_adjusted"] == int(df.index.size - 6)  # 6 post-split rows
+
+    def test_registry_idempotency_second_apply_is_noop(self):
+        """Applying the SAME action twice WITH a registry: the first restates +
+        marks applied; the second is a registry noop (no double-adjust)."""
+        reg = _registry()
+        df = _unfolded_reverse_split_frame()
+        action = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+
+        out1, res1 = ca.apply(df, [action], store=self._STORE, registry=reg, run_id="r1")
+        assert res1[0]["status"] == "applied"
+        assert res1[0]["n_rows_adjusted"] > 0
+        assert reg.is_applied(self._STORE, action.action_id) is True
+
+        # Second call on the ALREADY-restated frame: marker short-circuits →
+        # noop, frame returned unchanged (NOT double-adjusted).
+        out2, res2 = ca.apply(out1, [action], store=self._STORE, registry=reg, run_id="r2")
+        assert res2[0]["status"] == "noop"
+        assert res2[0]["n_rows_adjusted"] == 0
+        pd.testing.assert_frame_equal(out2, out1)
+
+    def test_registry_idempotency_guards_reapply_to_unrestated_source(self):
+        """The marker is DECOUPLED from source purity: once marked applied,
+        re-applying to the still-UN-restated source is a noop (the double-apply
+        guard for the already-restated-store read path) — it does NOT silently
+        double-adjust the raw frame."""
+        reg = _registry()
+        df = _unfolded_reverse_split_frame()
+        action = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+
+        ca.apply(df, [action], store=self._STORE, registry=reg, run_id="r1")
+        # Feed the ORIGINAL un-restated frame again — marker present → noop.
+        out2, res2 = ca.apply(df, [action], store=self._STORE, registry=reg, run_id="r2")
+        assert res2[0]["status"] == "noop"
+        pd.testing.assert_frame_equal(out2, df)  # untouched, not double-adjusted
+
+    def test_without_registry_structural_idempotency_from_raw(self):
+        """registry=None → idempotency is structural: re-running on the same raw
+        source yields the identical result (deterministic full-factor restate)."""
+        df = _unfolded_reverse_split_frame()
+        action = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+        out_a, _ = ca.apply(df, [action], store=self._STORE, registry=None)
+        out_b, _ = ca.apply(df, [action], store=self._STORE, registry=None)
+        pd.testing.assert_frame_equal(out_a, out_b)
+
+    def test_dividend_action_raises_not_implemented(self):
+        df = _unfolded_reverse_split_frame()
+        div = ca.CorporateAction(
+            type="dividend", ticker="DD", ex_date="2026-06-24", cash_amount=0.5,
+        )
+        with pytest.raises(NotImplementedError):
+            ca.apply(df, [div], store=self._STORE, registry=None)
+
+    def test_empty_inputs_are_safe_noops(self):
+        df = _unfolded_reverse_split_frame()
+        out, res = ca.apply(df, [], store=self._STORE, registry=None)
+        assert out is df and res == []
+        out2, res2 = ca.apply(pd.DataFrame(), [ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)], store=self._STORE)
+        assert res2 == []

--- a/tests/test_split_restatement.py
+++ b/tests/test_split_restatement.py
@@ -17,15 +17,53 @@ Covers:
 
 from __future__ import annotations
 
+import io
+
 import numpy as np
 import pandas as pd
 import pytest
+from botocore.exceptions import ClientError
 
+import corporate_actions as ca
 import features.compute as compute
+from corporate_actions import CorporateActionRegistry
 from split_factor import (
     cumulative_factor,
     restate_series_for_splits,
 )
+
+
+class _FakeS3:
+    """Minimal in-memory S3 double so the registry round-trips write-if-absent /
+    read-back without a live bucket (mirrors tests/test_corporate_actions*.py)."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def _err(self, code, op):
+        return ClientError({"Error": {"Code": code, "Message": "x"}}, op)
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("404", "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("NoSuchKey", "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"x"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _registry():
+    return CorporateActionRegistry(_FakeS3(), "alpha-engine-research")
 
 
 # ── factor math ──────────────────────────────────────────────────────────────
@@ -104,122 +142,189 @@ def test_restate_noop_when_split_predates_series():
     assert out is df
 
 
-# ── _apply_daily_delta restates on detection ─────────────────────────────────
+# ── registry-driven detection + restatement in _apply_daily_delta ────────────
 
 
-class _FakePolygon:
-    """Stand-in for PolygonClient.get_splits — no network."""
-
-    def __init__(self, mapping):
-        self._mapping = mapping
-
-    def get_splits(self, ticker):
-        return list(self._mapping.get(ticker, []))
-
-
-def _close_only(df):
-    return df["Close"]
-
-
-def test_apply_daily_delta_restates_split_ticker(monkeypatch):
-    """DD-style: a split jump in the merged series triggers a full-history
-    restatement via the polygon factor, and the ticker is reported as a
-    split_ticker. The materialized series (which feeds the ArcticDB write) is
-    continuous."""
-    # Base (price_cache) history on the OLD (~$48) scale, ending 6/12.
+def _delta_split_frame(pre_close, post_close, *, exec_date="2026-06-24"):
+    """A (base price_data, delta_rows) pair shaped like the real data#1298
+    boundary: base ends 6/12 on the OLD (pre-split) scale; the delta carries
+    pre-exec dates still on the OLD scale and exec-onward on the NEW scale."""
     base_dates = pd.bdate_range("2026-06-01", "2026-06-12")
     base = pd.DataFrame(
         {
-            "Open": np.linspace(47.0, 48.0, len(base_dates)),
-            "High": np.linspace(47.5, 48.5, len(base_dates)),
-            "Low": np.linspace(46.5, 47.5, len(base_dates)),
-            "Close": np.linspace(47.0, 48.0, len(base_dates)),
+            "Open": np.full(len(base_dates), pre_close),
+            "High": np.full(len(base_dates), pre_close * 1.01),
+            "Low": np.full(len(base_dates), pre_close * 0.99),
+            "Close": np.full(len(base_dates), float(pre_close)),
             "Volume": np.full(len(base_dates), 1_000_000.0),
         },
         index=base_dates,
     )
-    price_data = {"DD": base}
-
-    # Delta rows: pre-execution dates (6/15..6/23) are still on the OLD (~$48)
-    # scale (the reverse split is effective 6/24); only 6/24 onward is on the
-    # NEW (~$144) scale. This is the real shape that produces the data#1298
-    # boundary jump — restatement must lift the old-scale rows by ×3.
-    exec_date = pd.Timestamp("2026-06-24")
-    delta_dates = pd.bdate_range("2026-06-15", "2026-06-24")
+    ex = pd.Timestamp(exec_date)
+    delta_dates = pd.bdate_range("2026-06-15", exec_date)
     delta_rows = [
         {
             "date": d,
-            "Open": 48.0, "High": 48.5, "Low": 47.5,
-            "Close": 48.0, "Volume": 1_000_000, "source": "polygon",
+            "Open": pre_close, "High": pre_close * 1.01, "Low": pre_close * 0.99,
+            "Close": float(pre_close), "Volume": 1_000_000, "source": "polygon",
         }
-        if d < exec_date
+        if d < ex
         else {
             "date": d,
-            "Open": 144.0, "High": 145.0, "Low": 143.0,
-            "Close": 144.0, "Volume": 333_000, "source": "polygon",
+            "Open": post_close, "High": post_close * 1.01, "Low": post_close * 0.99,
+            "Close": float(post_close), "Volume": 1_000_000, "source": "polygon",
         }
         for d in delta_dates
     ]
+    return base, delta_rows
+
+
+def test_apply_daily_delta_restates_reverse_split(monkeypatch):
+    """DD-style 1-for-3 reverse split: registry-driven detection restates the
+    full pre-split window, the ticker is reported, and the series is continuous.
+    The applied action is recorded as applied to the store (idempotency marker).
+    """
+    base, delta_rows = _delta_split_frame(48.0, 144.0)
+    price_data = {"DD": base}
+    base_dates = base.index
 
     monkeypatch.setattr(
-        compute, "_load_delta_from_daily_closes",
-        lambda *a, **k: {"DD": delta_rows},
+        compute, "_load_delta_from_daily_closes", lambda *a, **k: {"DD": delta_rows},
     )
-    # Patch the polygon lookup used by _restate_split_window.
-    fake = _FakePolygon({"DD": [{"execution_date": "2026-06-24",
-                                 "split_from": 3, "split_to": 1}]})
-    import split_factor
-    monkeypatch.setattr(
-        split_factor, "split_events",
-        lambda ticker, client=None: fake.get_splits(ticker),
-    )
+    action = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+    monkeypatch.setattr(ca, "detect_splits", lambda *a, **k: [action])
 
+    reg = _registry()
     out, split_tickers = compute._apply_daily_delta(
-        s3=None, bucket="b", date_str="2026-06-24", price_data=price_data,
+        s3=None, bucket="b", date_str="2026-06-24", price_data=price_data, registry=reg,
     )
 
-    assert "DD" in split_tickers, "split should have been detected + restated"
+    assert "DD" in split_tickers
     series = out["DD"]["Close"]
-    # No residual >45% boundary jump — the full series is split-consistent.
-    assert series.pct_change().abs().max() < 0.45
-    # The old-scale pre-split rows were lifted onto the ~$144 scale.
-    assert series.loc[base_dates[0]] > 120
+    assert series.pct_change().abs().max() < 0.45        # continuous
+    assert series.loc[base_dates[0]] > 120                # lifted onto ~$144 scale
+    assert reg.is_applied("arcticdb_universe", action.action_id) is True
 
 
-def test_apply_daily_delta_no_factor_leaves_series_but_audit_flags(monkeypatch):
-    """If polygon has no factor (e.g. unreachable), the series is left as-is
-    (not silently mangled) AND the audit guard surfaces the discontinuity."""
+def test_apply_daily_delta_restates_sub45_split_old_heuristic_missed(monkeypatch):
+    """HEADLINE regression fix: a 3-for-2 forward split (-33% boundary move) is
+    BELOW the old 45% heuristic's trigger, so the old code SILENTLY left it
+    un-restated. Registry-driven detection now restates it regardless of
+    magnitude — the series is flattened."""
+    # 3-for-2 forward: split_from=2, split_to=3 (factor 2/3). OLD ~$90 →
+    # NEW ~$60 at the boundary: a -33% move the old >45% trigger would miss.
+    base, delta_rows = _delta_split_frame(90.0, 60.0)
+    price_data = {"TST": base}
+
+    # The boundary move the old heuristic would have seen is sub-45% — proving
+    # the old code's latent miss (it only restated on |move| > 0.45).
+    pre_restate = pd.concat(
+        [base["Close"], pd.Series([60.0], index=[pd.Timestamp("2026-06-24")])]
+    )
+    assert 0.18 < pre_restate.pct_change().abs().max() < 0.45
+
+    monkeypatch.setattr(
+        compute, "_load_delta_from_daily_closes", lambda *a, **k: {"TST": delta_rows},
+    )
+    action = ca.CorporateAction.from_split("TST", "2026-06-24", 2, 3)
+    monkeypatch.setattr(ca, "detect_splits", lambda *a, **k: [action])
+
+    reg = _registry()
+    out, split_tickers = compute._apply_daily_delta(
+        s3=None, bucket="b", date_str="2026-06-24", price_data=price_data, registry=reg,
+    )
+
+    assert "TST" in split_tickers, "sub-45% registered split must be restated"
+    series = out["TST"]["Close"]
+    # Fully flattened: no residual move above the diagnostic screen threshold.
+    assert series.pct_change().abs().max() < 0.18
+    # Pre-split rows lifted onto the post-split (~$60) scale (×2/3).
+    assert series.iloc[0] == pytest.approx(60.0, rel=0.02)
+
+
+def test_apply_daily_delta_double_apply_guard(monkeypatch):
+    """PR3 §4: the feature-snapshot path loads the ALREADY-restated ArcticDB and
+    re-applies the delta. An action already marked applied to the store is a
+    registry noop — re-applying must NOT double-adjust the continuous series."""
+    # Continuous (already-restated) series: everything on the post-split scale.
     base_dates = pd.bdate_range("2026-06-01", "2026-06-12")
     base = pd.DataFrame(
-        {"Open": 48.0, "High": 48.5, "Low": 47.5, "Close": 48.0, "Volume": 1e6},
+        {"Open": 144.0, "High": 145.0, "Low": 143.0, "Close": 144.0, "Volume": 1e6},
         index=base_dates,
     )
     price_data = {"DD": base}
     delta_dates = pd.bdate_range("2026-06-15", "2026-06-24")
     delta_rows = [
         {"date": d, "Open": 144.0, "High": 145.0, "Low": 143.0,
-         "Close": 144.0, "Volume": 333_000, "source": "polygon"}
+         "Close": 144.0, "Volume": 1_000_000, "source": "polygon"}
         for d in delta_dates
     ]
     monkeypatch.setattr(
-        compute, "_load_delta_from_daily_closes",
-        lambda *a, **k: {"DD": delta_rows},
+        compute, "_load_delta_from_daily_closes", lambda *a, **k: {"DD": delta_rows},
     )
-    import split_factor
-    monkeypatch.setattr(split_factor, "split_events", lambda ticker, client=None: [])
+    action = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+    monkeypatch.setattr(ca, "detect_splits", lambda *a, **k: [action])
+
+    reg = _registry()
+    # The split was already applied to this store by a prior (backfill) pass.
+    reg.mark_applied(action, "arcticdb_universe", run_id="prior")
 
     out, split_tickers = compute._apply_daily_delta(
-        s3=None, bucket="b", date_str="2026-06-24", price_data=price_data,
+        s3=None, bucket="b", date_str="2026-06-24", price_data=price_data, registry=reg,
     )
-    assert "DD" not in split_tickers  # nothing restated
-    offenders = compute.audit_split_jumps(out)
-    assert "DD" in offenders  # the audit guard catches it
+
+    assert "DD" not in split_tickers          # noop — not re-restated
+    series = out["DD"]["Close"]
+    # If it had double-applied (×3 on the pre-6/24 rows) the series would jump
+    # ~3x at the boundary; it stays flat/continuous.
+    assert series.pct_change().abs().max() < 0.05
+    assert series.max() == pytest.approx(144.0, rel=0.05)
 
 
-def test_audit_split_jumps_clean_universe():
+# ── registry-aware audit: missed (BLOCKING) vs suspected (WARN) ───────────────
+
+
+def _unrestated_reverse_jump(ticker_close_pre=48.0, ticker_close_post=144.0):
+    pre_dates = pd.bdate_range("2026-06-01", "2026-06-23")
+    post_dates = pd.bdate_range("2026-06-24", "2026-07-01")
+    close = pd.concat([
+        pd.Series(np.full(len(pre_dates), ticker_close_pre), index=pre_dates),
+        pd.Series(np.full(len(post_dates), ticker_close_post), index=post_dates),
+    ])
+    return pd.DataFrame({"Close": close, "Volume": np.full(len(close), 1e6)})
+
+
+def test_audit_action_jumps_clean_universe():
     dates = pd.bdate_range("2026-01-01", "2026-03-01")
     df = pd.DataFrame({"Close": np.linspace(100, 120, len(dates))}, index=dates)
-    assert compute.audit_split_jumps({"AAPL": df}) == {}
+    audit = compute.audit_action_jumps({"AAPL": df}, _registry())
+    assert audit.missed == {} and audit.suspected == {}
+
+
+def test_audit_action_jumps_missed_when_registered_split_unflattened():
+    """A residual jump that a REGISTERED split explains (ex_date at the jump,
+    move matches the factor) is MISSED — the BLOCKING class."""
+    reg = _registry()
+    reg.record_detected(
+        ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1), run_id="r",
+    )
+    price_data = {"DD": _unrestated_reverse_jump(48.0, 144.0)}  # ×3 jump at 6/24
+    audit = compute.audit_action_jumps(price_data, reg)
+    assert "DD" in audit.missed
+    assert "DD" not in audit.suspected
+
+
+def test_audit_action_jumps_suspected_when_no_registered_action():
+    """A large move (±33%) with NO registered action is SUSPECTED (WARN only) —
+    a legitimate earnings move must never be a blocking miss."""
+    # ~ -33% single-day move, no registered split.
+    dates = pd.bdate_range("2026-06-01", "2026-06-10")
+    close = pd.Series(np.full(len(dates), 100.0), index=dates)
+    close.iloc[5] = 67.0  # -33% earnings gap
+    price_data = {"ER": pd.DataFrame({"Close": close})}
+    audit = compute.audit_action_jumps(price_data, _registry())
+    assert "ER" in audit.suspected
+    assert "ER" not in audit.missed
 
 
 # ── real ArcticDB (LMDB) round-trip ──────────────────────────────────────────
@@ -260,3 +365,79 @@ def test_arcticdb_window_read_continuous_after_restate(tmp_path):
         got["Close"].loc[post_dates[0]] / got["Close"].loc[pre_dates[-1]] - 1
     )
     assert abs(boundary_ret) < 0.1
+
+
+# ── backfill train chokepoint: BLOCKING audit ────────────────────────────────
+
+
+def _backfill_common_mocks(_bf, monkeypatch, price_data, registry):
+    """Patch backfill's loaders up to (and past) the audit so a single
+    in-universe symbol flows through without S3 / ArcticDB / polygon."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr(_bf, "_load_full_cache", lambda *a, **k: dict(price_data))
+    monkeypatch.setattr(_bf, "_build_registry", lambda *a, **k: registry)
+    monkeypatch.setattr(_bf, "_apply_daily_delta", lambda *a, **k: (dict(price_data), set()))
+    monkeypatch.setattr(_bf.boto3, "client", lambda *a, **k: MagicMock())
+
+
+def test_backfill_raises_on_missed_registered_split(monkeypatch):
+    """At the train chokepoint, a residual jump that a REGISTERED split explains
+    (un-flattened KNOWN action) raises CorporateActionAuditError BEFORE any
+    ArcticDB write — the data#1298 corruption cannot land silently."""
+    from builders import backfill as _bf
+    from corporate_actions import CorporateActionAuditError
+
+    reg = _registry()
+    reg.record_detected(
+        ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1), run_id="r",
+    )
+    price_data = {"DD": _unrestated_reverse_jump(48.0, 144.0)}
+    _backfill_common_mocks(_bf, monkeypatch, price_data, reg)
+
+    with pytest.raises(CorporateActionAuditError):
+        _bf.backfill(ticker_filter=None)
+
+
+def test_backfill_proceeds_on_suspected_only(monkeypatch):
+    """A large move with NO registered action is SUSPECTED → WARN, NOT blocking:
+    the backfill proceeds past the audit (a real ±33% move must not halt it)."""
+    from unittest.mock import MagicMock
+
+    from builders import backfill as _bf
+
+    # A clean in-universe ticker plus a suspected (unexplained) -33% move; the
+    # registry is EMPTY so nothing explains the jump.
+    dates = pd.date_range("2024-01-01", periods=400, freq="B")
+    close = pd.Series(100.0 + np.arange(400) * 0.01, index=dates)
+    close.iloc[200] = close.iloc[199] * 0.67  # -33%, no registered action
+    aapl = pd.DataFrame(
+        {"Open": close, "High": close * 1.01, "Low": close * 0.99,
+         "Close": close, "Volume": 1_000_000.0},
+        index=dates,
+    )
+    price_data = {"AAPL": aapl}
+    reg = _registry()  # empty → the jump is "suspected", never "missed"
+    _backfill_common_mocks(_bf, monkeypatch, price_data, reg)
+
+    universe_lib = MagicMock()
+    macro_lib = MagicMock()
+    monkeypatch.setattr(_bf, "_assert_no_arctic_regression", lambda *a, **k: None)
+    monkeypatch.setattr(_bf, "_load_current_constituents", lambda *a, **k: {"AAPL"})
+    monkeypatch.setattr(_bf, "_extract_macro_series", lambda *a, **k: {})
+    monkeypatch.setattr(_bf, "_load_sector_map", lambda *a, **k: {"AAPL": "XLK"})
+    monkeypatch.setattr(_bf, "_load_cached_fundamentals", lambda *a, **k: {})
+    monkeypatch.setattr(_bf, "_load_cached_alternative", lambda *a, **k: {})
+    monkeypatch.setattr(_bf, "_build_macro_features_df", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(_bf, "compute_features", lambda df, **_: df)
+    monkeypatch.setattr(_bf, "get_universe_lib", lambda *a, **k: universe_lib)
+    monkeypatch.setattr(_bf, "get_macro_lib", lambda *a, **k: macro_lib)
+    monkeypatch.setattr(
+        _bf, "_scan_universe_and_emit_freshness_receipt",
+        lambda *a, **k: {"n_symbols_checked": 1, "stalest_symbol": "AAPL",
+                         "stalest_age_trading_days": 1, "all_fresh": True},
+    )
+
+    # Must NOT raise CorporateActionAuditError — proceeds to a normal summary.
+    result = _bf.backfill(ticker_filter=None)
+    assert result.get("status") != "error"


### PR DESCRIPTION
**PR3 of the unified corporate-actions program (epic config#1433).** Correctness-critical: this changes the split-RESTATEMENT path on the predictor's ArcticDB training input, replacing the >45%-daily-move HEURISTIC trigger with **authoritative registry-driven detection** and adding a **blocking, registry-aware post-condition audit**.

### What changed
- **`corporate_actions.apply(df, actions, *, store, registry=None, run_id=None)`** — routes all split restatement through `split_factor.restate_series_for_splits` with **registry-backed exactly-once idempotency**: an action already `is_applied` to the store is skipped (`status="noop"`); after a real restatement it is `mark_applied`. `registry=None` falls back to structural idempotency (restate from raw source). Splits only — dividend/rename raise `NotImplementedError`. New `CorporateActionAuditError`.
- **`features/compute._apply_daily_delta`** — REMOVES the `>45%` magnitude trigger and replaces it with authoritative polygon detection (`detect_splits` + `record_detected`) routed through `corporate_actions.apply`. Restatement now fires for **every registered split regardless of magnitude**.
- **`audit_split_jumps` → `audit_action_jumps(price_data, registry)`** — registry-aware classification. A residual jump a registered split **explains** (its ex_date sits at the jump AND the move matches the factor) → `missed` (BLOCKING). A large move with **no** registered action → `suspected` (WARN). The RAISE condition is registry-driven, **not raw magnitude**.
- **Backfill train chokepoint** (before `lib.write`) — raises `CorporateActionAuditError` on any `missed`; `suspected`-only logs WARN and proceeds.
- **Double-apply guard** (PR3 §4) — the feature-snapshot path loads the already-restated ArcticDB then re-applies the delta; the `is_applied` marker makes re-applying a registered action a no-op. Verified by test.
- **`registry._list_keys` pagination hardened** to require a real string continuation token (this PR is the first wide caller of `list_actions`; guards against an unbounded pagination loop on a degenerate/mock paginator response — production-safe).

### Headline
- **Sub-45% splits (3-for-2 = −33%, 4-for-3 = −25%) are now restated** — the old heuristic silently missed them (latent-bug fix).
- The **blocking audit raises only on a KNOWN registered split left un-flattened**, never on a legitimate large move (a real ±33% earnings move has no registered action → only WARN-classified as `suspected`, never halts the pipeline).
- **Training-data values may change** for tickers that had a previously-missed sub-45% split — this is a **correctness fix**.

### Scope
Still **pre-CRSP-basis (PR7)** — **no dividend/label changes** here.

### Tests
`corporate_actions.apply` parity vs direct `restate_series_for_splits`; registry idempotency (second apply → noop, no double-adjust) + structural idempotency without a registry; **registry-driven sub-45% (3-for-2) restatement** (headline regression-fix); double-apply guard on the already-restated path; `audit_action_jumps` missed-vs-suspected; backfill **raises on missed / proceeds on suspected**; existing ArcticDB round-trip + provenance + backfill-regression suites green.

Local: `corporate_actions`/`registry`/`split_restatement` + affected backfill/provenance suites pass (143 tests across touched-file-adjacent suites). The local venv carries a stale lib (`nousergon_lib.config` absent) — CI (py3.12 fresh lib) is the authoritative gate; verified `features.compute`/`builders.backfill` import + test cleanly under a local shim of the missing submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
