### PR TITLE
feat(corporate-actions): unified sync orchestration + daily_append basis-consistency (PR4 config#1433)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -717,6 +717,63 @@ def _build_writer_id() -> str:
     return f"daily_append-{user}-pid{os.getpid()}"
 
 
+def _ensure_history_restated(
+    ticker: str,
+    hist: pd.DataFrame,
+    actions: list,
+    registry,
+    universe_lib,
+    date_str: str,
+) -> pd.DataFrame:
+    """Basis-consistency guard (PR4, config#1433): restate ``ticker``'s FULL
+    ArcticDB history for any registered split NOT yet applied to the universe,
+    BEFORE today's (post-split-scale) row is spliced onto it.
+
+    daily_append appends today's polygon row onto an ArcticDB history that may
+    still be pre-split until Saturday's backfill. The morning ``daily_closes``
+    sync (earlier in the weekday SF) normally restates the universe first, so in
+    steady state ``is_applied`` is already True here and this is a fast no-op.
+    This is the ROBUST backstop for "sync missed/skipped / standalone run": we
+    restate-then-append rather than ever appending onto an un-restated history.
+
+    WRITE-THEN-MARK: the ``arcticdb_universe`` applied marker is the shared
+    exactly-once contract with both ``sync`` and the Saturday backfill — it is
+    written ONLY after the full-history rewrite lands, so a failed rewrite never
+    leaves the marker (and a later read) believing the history is restated when
+    it is not. Returns the (possibly restated) history to splice today's row on.
+    """
+    import corporate_actions as _ca
+
+    pending = [
+        a for a in actions
+        if not registry.is_applied(_ca.STORE_ARCTICDB_UNIVERSE, a.action_id)
+    ]
+    if not pending:
+        return hist
+
+    run_id = f"daily_append:{date_str}"
+    # registry=None ⇒ apply does the math + row counts WITHOUT marking, so the
+    # mark below is strictly write-then-mark.
+    restated, applied = _ca.apply(
+        hist, pending, store=_ca.STORE_ARCTICDB_UNIVERSE, registry=None, run_id=run_id,
+    )
+    n_changed = sum(1 for r in applied if r["n_rows_adjusted"] > 0)
+    if n_changed:
+        log.warning(
+            "daily_append basis-consistency: %s ArcticDB history was NOT yet "
+            "restated for %d registered split(s) (morning sync missed/skipped) "
+            "— restating full history BEFORE append so today's row lands on a "
+            "continuous adjusted scale, not a split-boundary splice (data#1298)",
+            ticker, n_changed,
+        )
+        universe_lib.write(
+            ticker, to_arctic_canonical(restated), prune_previous_versions=True,
+        )
+    for a in pending:
+        registry.mark_applied(a, _ca.STORE_ARCTICDB_UNIVERSE, run_id=run_id)
+    return restated if n_changed else hist
+
+
 def daily_append(
     date_str: str | None = None,
     bucket: str = DEFAULT_BUCKET,
@@ -1199,6 +1256,29 @@ def _daily_append_impl(
     # JSON / unknown types — fail fast before the chunked pass begins).
     block_anomaly_types = _load_block_anomaly_types()
 
+    # ── Corporate-action basis-consistency guard setup (PR4, config#1433) ────
+    # Build the registry + the registered splits grouped by ticker ONCE.
+    # Registry-driven (NO polygon call). In steady state every relevant split is
+    # already applied (the morning sync did it), so the per-ticker guard below is
+    # a cheap ``is_applied`` no-op; it only does work as a backstop when a
+    # symbol's history is somehow still un-restated when we are about to append.
+    ca_registry = None
+    splits_by_ticker: dict[str, list] = {}
+    if not dry_run:
+        try:
+            import corporate_actions as _ca
+
+            ca_registry = _ca.CorporateActionRegistry(s3, bucket)
+            for _action in ca_registry.list_actions(types=["split"]):
+                splits_by_ticker.setdefault(_action.ticker, []).append(_action)
+        except Exception as exc:
+            log.warning(
+                "daily_append: corporate-action registry unavailable (%s) — "
+                "basis-consistency guard inactive this run", exc,
+            )
+            ca_registry = None
+            splits_by_ticker = {}
+
     # ── 4. Chunked universe pass ─────────────────────────────────────────────
     # The full-universe Phase 1+2 in one shot holds ~900 ticker histories in
     # memory simultaneously (~180MB peak resident) — on the 2GB t3.small
@@ -1293,6 +1373,29 @@ def _daily_append_impl(
                 if np.isnan(bar["Close"]):
                     n_skip += 1
                     continue
+
+                # ── basis-consistency guard (PR4, config#1433) ──────────────
+                # Before splicing today's (post-split-scale) row onto this
+                # symbol's history, ensure the history is restated for any
+                # registered split (restate-then-append, never append onto an
+                # un-restated basis). No-op in steady state (morning sync did it).
+                if ca_registry is not None and ticker in splits_by_ticker:
+                    try:
+                        hist = _ensure_history_restated(
+                            ticker, hist, splits_by_ticker[ticker],
+                            ca_registry, universe_lib, date_str,
+                        )
+                        hists_by_ticker[ticker] = hist
+                    except Exception as exc:
+                        # Fail-loud (recorded), but a single symbol's guard
+                        # failure must not abort the whole universe pass; the
+                        # Saturday backfill's BLOCKING audit remains the gate.
+                        log.warning(
+                            "daily_append basis-consistency guard failed for %s "
+                            "(%s) — appending on the existing basis; Saturday "
+                            "backfill audit remains the correctness gate",
+                            ticker, exc,
+                        )
 
                 new_row_data = {col: bar.get(col, np.nan) for col in OHLCV_COLS}
                 # Carry per-row provenance through to the ArcticDB write. Source

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -545,6 +545,7 @@ def _build_corporate_action_registry(
             )
 
     registry = None
+    detected_actions: list = []
     if not dry_run and bucket:
         try:
             import corporate_actions
@@ -553,6 +554,7 @@ def _build_corporate_action_registry(
                 boto3.client("s3"), bucket
             )
             actions = corporate_actions.splits_from_events(events)
+            detected_actions = actions
             n_new = 0
             for action in actions:
                 try:
@@ -580,7 +582,12 @@ def _build_corporate_action_registry(
                 _scrub_api_key(exc),
             )
             registry = None
-    return registry, touched
+            detected_actions = []
+    # The detected actions are returned so the window orchestrator can hand them
+    # (with the registry) to ``corporate_actions.sync`` WITHOUT a second polygon
+    # call (PR4, config#1433) — the single ``_recent_split_events`` fetch above
+    # is reused for detection, the config#717 skip-set, AND the sync restatement.
+    return registry, touched, detected_actions
 
 
 def _send_corporate_action_email(actions: list, run_date: str) -> None:
@@ -796,12 +803,14 @@ def collect(
             and skip_if_canonical
             and split_touched_dates is None
         ):
-            registry, split_touched_dates = _build_corporate_action_registry(
-                [run_date],
-                bucket,
-                dry_run=dry_run,
-                run_id=run_date,
-                need_touched=True,
+            registry, split_touched_dates, _detected_actions = (
+                _build_corporate_action_registry(
+                    [run_date],
+                    bucket,
+                    dry_run=dry_run,
+                    run_id=run_date,
+                    need_touched=True,
+                )
             )
 
     s3 = boto3.client("s3")
@@ -1296,13 +1305,63 @@ def _collect_window(
     split_touched_dates: set[str] | None = None
     registry = None
     if source == "polygon_only" and skip_if_canonical and not dry_run:
-        registry, split_touched_dates = _build_corporate_action_registry(
-            window_dates,
-            bucket,
-            dry_run=dry_run,
-            run_id=window_dates[0],  # target date identifies the window run
-            need_touched=True,
+        registry, split_touched_dates, detected_actions = (
+            _build_corporate_action_registry(
+                window_dates,
+                bucket,
+                dry_run=dry_run,
+                run_id=window_dates[0],  # target date identifies the window run
+                need_touched=True,
+            )
         )
+        # ── PR4 (config#1433): unified corporate-action sync, ONCE at the START ─
+        # Restate ALL stores (the daily_closes archive parquets + the ArcticDB
+        # universe) for every detected split BEFORE the per-date collect loop
+        # (re-)writes parquets and BEFORE downstream daily_append reads the
+        # universe — so the split-boundary discontinuity is flattened up front
+        # instead of re-forming mid-week between Saturday backfills. Reuses the
+        # registry + actions already detected above (NO extra polygon call), and
+        # is scoped to the requested universe. Best-effort: a sync failure WARNs
+        # and the morning collection proceeds (the per-date discrepancy logging,
+        # the morning polygon re-fetch, and the blocking Saturday backfill audit
+        # all remain in place).
+        if registry is not None and detected_actions:
+            try:
+                import corporate_actions
+
+                sync_result = corporate_actions.sync(
+                    boto3.client("s3"),
+                    bucket,
+                    min(window_dates),
+                    max(window_dates),
+                    stores=[
+                        corporate_actions.STORE_DAILY_CLOSES_ARCHIVE,
+                        corporate_actions.STORE_ARCTICDB_UNIVERSE,
+                    ],
+                    run_id=window_dates[0],
+                    tickers=tickers,
+                    registry=registry,
+                    actions=detected_actions,
+                )
+                n_applied = sum(
+                    1
+                    for store_results in sync_result.applied.values()
+                    for r in store_results
+                    if r.get("status") == "applied" and r.get("n_rows_adjusted", 0) > 0
+                )
+                logger.info(
+                    "corporate_actions.sync: %d detected, %d restatement(s) "
+                    "applied across %d store(s) over [%s..%s] (run_id=%s)",
+                    len(sync_result.detected), n_applied,
+                    len(sync_result.applied), min(window_dates), max(window_dates),
+                    window_dates[0],
+                )
+            except Exception as exc:
+                logger.warning(
+                    "corporate_actions.sync failed (%s) — proceeding with the "
+                    "morning collection; per-date re-fetch + Saturday backfill "
+                    "audit remain the heal", _scrub_api_key(exc),
+                )
     # The newest date in the window is the TARGET date — the one
     # downstream (predictor inference / eod_reconcile) actually reads.
     # The older dates are best-effort *historical backfill*: a per-date

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -57,8 +57,12 @@ __all__ = [
     "CorporateAction",
     "CorporateActionRegistry",
     "CorporateActionAuditError",
+    "STORE_ARCTICDB_UNIVERSE",
+    "STORE_DAILY_CLOSES_ARCHIVE",
+    "SyncResult",
     "expected_factor",
     "apply",
+    "sync",
     "detect_splits",
     "detect_dividends",
     "detect_renames",
@@ -79,6 +83,24 @@ _TYPE_RENAME = "rename"
 # load of an already-restated series sees the backfill's applied marker and
 # skips, the double-apply guard of PR3 §4).
 STORE_ARCTICDB_UNIVERSE = "arcticdb_universe"
+
+# The per-date ``staging/daily_closes/{date}.parquet`` archive — the second
+# store ``sync`` (PR4, config#1433) restates in place. Unlike the ArcticDB
+# universe (rebuilt from the S3 price cache every Saturday), a daily-closes
+# parquet is a cross-sectional SNAPSHOT (index=ticker, one trading date per
+# file) that CANNOT be re-derived from a raw source on demand inside ``sync``
+# (polygon grouped-daily is rate-limited + best-effort, and the morning
+# pass's own polygon re-fetch is a separate, opportunistic mechanism). So the
+# durable registry ``applied`` marker is the SOLE idempotency guard for this
+# store — and it is recorded at PER-(action_id, store, DATE) granularity
+# (the marker store passed to the registry is ``f"{STORE_DAILY_CLOSES_ARCHIVE}
+# /{date}"``), NOT a single per-(action_id, store) marker. Rationale: the live
+# window slides forward and a per-date parquet can ENTER the affected set on a
+# later run (a missing/late date materializes); a coarse per-store marker would
+# then skip that newly-present parquet and leave a split-boundary discontinuity
+# in it. A per-date marker guarantees each parquet is restated exactly once,
+# whenever it first appears, regardless of when the others were done.
+STORE_DAILY_CLOSES_ARCHIVE = "daily_closes_archive"
 
 
 class CorporateActionAuditError(RuntimeError):
@@ -382,6 +404,379 @@ def apply(
             registry.mark_applied(a, store, run_id=run_id)
 
     return restated, applied_results
+
+
+# ── sync: unified, pre-read orchestration across ALL stores (PR4, config#1433) ─
+
+# Price / volume columns a daily-closes archive parquet carries that a split
+# restates (mirrors split_factor.restate_series_for_splits' defaults; only the
+# columns actually present in a given parquet are touched).
+_ARCHIVE_PRICE_COLS = ("Open", "High", "Low", "Close", "VWAP", "Adj_Close")
+_ARCHIVE_VOLUME_COLS = ("Volume",)
+# Relative tolerance for the daily-closes archive SCALE VERIFICATION (old vs
+# already-restated). Splits are integer ratios (factor <= 0.5 or >= 2), so the
+# observed pre→post boundary ratio is either ~factor (un-restated) or ~1.0
+# (already restated) — both well separated from each other, so a generous tol
+# absorbs multi-day price drift without confusing the two regimes.
+_ARCHIVE_SCALE_REL_TOL = 0.15
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Summary returned by :func:`sync`.
+
+    * ``detected`` — the split :class:`CorporateAction`s detected/recorded over
+      the window this run (write-if-absent into the registry).
+    * ``applied`` — ``{store: [apply_result_dict, ...]}``; each dict carries
+      ``action_id`` / ``store`` / ``ticker`` / ``n_rows_adjusted`` / ``factor``
+      / ``status`` (``"applied"`` | ``"noop"`` | ``"skipped"``) plus, for the
+      daily-closes archive, a ``date``.
+    * ``notices`` — the subset of ``detected`` that actually restated at least
+      one row in at least one store this run (the operator-notification set:
+      "the system saw this action and brought the stores onto its scale").
+    """
+
+    detected: list = field(default_factory=list)
+    applied: dict = field(default_factory=dict)
+    notices: list = field(default_factory=list)
+
+
+def _scrub(exc: object) -> str:
+    """Scrub a polygon apiKey from an exception/text before logging (lazy import
+    so ``corporate_actions`` stays free of a hard ``polygon_client`` dep)."""
+    try:
+        from polygon_client import _scrub_api_key
+
+        return _scrub_api_key(exc)
+    except Exception:  # noqa: BLE001 - logging-path fallback, never raise
+        return str(exc)
+
+
+def _sync_arcticdb_universe(
+    bucket: str, ticker: str, actions: list, registry, run_id: str | None,
+) -> list[dict]:
+    """Mid-week restatement of ONE ArcticDB universe symbol (the gap PR4 closes).
+
+    Reads the symbol's FULL series, restates every not-yet-applied split via the
+    shared :func:`apply` math, and rewrites it so daily-appended rows land on a
+    continuous adjusted scale BEFORE ``daily_append`` reads (today the universe
+    history is only restated at Saturday backfill, so the split-boundary
+    discontinuity re-forms mid-week).
+
+    WRITE-THEN-MARK: the registry ``applied`` marker is the contract
+    ``builders/daily_append.py``'s basis-consistency guard trusts to mean "the
+    ArcticDB history is on the restated scale". So the marker is written ONLY
+    after the ``lib.write`` actually lands — a mark-before-write would let a
+    failed rewrite leave daily_append appending onto an un-restated history
+    (the exact corruption this arc prevents). We therefore drive ``apply`` with
+    ``registry=None`` (math + is_applied skip handled here) and mark explicitly.
+    """
+    from store.arctic_store import get_universe_lib, to_arctic_canonical
+
+    lib = get_universe_lib(bucket)
+    try:
+        df = lib.read(ticker).data
+    except Exception as exc:  # noqa: BLE001 - symbol absent ⇒ nothing to restate
+        log.info(
+            "corporate_actions.sync: %s not in ArcticDB universe — no arctic "
+            "restate (%s)", ticker, _scrub(exc),
+        )
+        return []
+
+    results: list[dict] = []
+    pending: list = []
+    for a in actions:
+        if registry is not None and registry.is_applied(STORE_ARCTICDB_UNIVERSE, a.action_id):
+            results.append({
+                "action_id": a.action_id, "store": STORE_ARCTICDB_UNIVERSE,
+                "ticker": ticker, "n_rows_adjusted": 0,
+                "factor": expected_factor(a), "status": "noop",
+            })
+        else:
+            pending.append(a)
+    if not pending:
+        return results
+
+    # registry=None: compute the restatement + per-action row counts WITHOUT
+    # marking, so the mark below is strictly write-then-mark.
+    restated, applied_math = apply(
+        df, pending, store=STORE_ARCTICDB_UNIVERSE, registry=None, run_id=run_id,
+    )
+    if any(r["n_rows_adjusted"] > 0 for r in applied_math):
+        lib.write(ticker, to_arctic_canonical(restated), prune_previous_versions=True)
+    if registry is not None:
+        for a in pending:
+            registry.mark_applied(a, STORE_ARCTICDB_UNIVERSE, run_id=run_id)
+    for r in applied_math:
+        r = dict(r)
+        r["ticker"] = ticker
+        results.append(r)
+    return results
+
+
+def _read_archive_parquet(s3, bucket: str, prefix: str, date: str):
+    """Read ``{prefix}{date}.parquet`` (index=ticker) or ``None`` if absent."""
+    import io
+
+    key = f"{prefix}{date}.parquet"
+    try:
+        obj = s3.get_object(Bucket=bucket, Key=key)
+    except Exception:  # noqa: BLE001 - missing / unreadable ⇒ caller skips date
+        return None
+    try:
+        return pd.read_parquet(io.BytesIO(obj["Body"].read()), engine="pyarrow")
+    except Exception as exc:  # noqa: BLE001 - corrupt parquet ⇒ skip, never crash
+        log.warning(
+            "corporate_actions.sync: could not read %s (%s) — skipping date",
+            key, _scrub(exc),
+        )
+        return None
+
+
+def _write_archive_parquet(s3, bucket: str, prefix: str, date: str, df) -> None:
+    import io
+
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy", index=True)
+    buf.seek(0)
+    s3.put_object(
+        Bucket=bucket, Key=f"{prefix}{date}.parquet", Body=buf.getvalue(),
+        ContentType="application/octet-stream",
+    )
+
+
+def _classify_archive_scale(c_candidate, c_post, factor: float) -> str:
+    """Is the candidate row on the OLD (pre-split) or already-restated scale?
+
+    Uses the post-split reference close ``c_post`` (a window date on/after the
+    ex date, definitionally on the current scale). The observed boundary ratio
+    ``c_post / c_candidate`` is ~``factor`` when the candidate is un-restated and
+    ~``1.0`` once it has been lifted onto the post-split scale. Returns
+    ``"old"`` | ``"new"`` | ``"unknown"`` (the last when no reference is
+    available or the ratio is ambiguous — in which case ``sync`` conservatively
+    declines to multiply, leaving the morning polygon re-fetch / Saturday
+    backfill as the heal, so it can NEVER double-apply onto an already-restated
+    parquet — the only-the-marker-guards-this-store risk).
+    """
+    try:
+        cc = float(c_candidate)
+        cp = float(c_post)
+    except (TypeError, ValueError):
+        return "unknown"
+    if not (cc > 0 and cp > 0 and factor > 0):
+        return "unknown"
+    ratio = cp / cc
+    if abs(ratio - factor) <= _ARCHIVE_SCALE_REL_TOL * factor:
+        return "old"
+    if abs(ratio - 1.0) <= _ARCHIVE_SCALE_REL_TOL:
+        return "new"
+    return "unknown"
+
+
+def _sync_daily_closes_archive(
+    s3, bucket: str, ticker: str, actions: list, window_dates: list[str],
+    registry, run_id: str | None, *, prefix: str = "staging/daily_closes/",
+) -> list[dict]:
+    """Restate ONE ticker's rows across the affected daily-closes archive
+    parquets in the live window — in place, per-date, idempotently.
+
+    Idempotency is PURELY registry-marker driven (a per-date parquet cannot be
+    re-derived from a raw source here), at PER-(action_id, store, DATE)
+    granularity. To stay safe against the morning pass's SEPARATE polygon
+    re-fetch (which also restates touched dates, via ``adjusted=true``), every
+    multiply is gated on a boundary SCALE VERIFICATION
+    (:func:`_classify_archive_scale`): a parquet already on the post-split scale
+    is NOT multiplied (only marked) — so neither a sync re-run NOR an
+    independent polygon re-fetch can double-adjust it. WRITE-THEN-MARK as well.
+    """
+    from split_factor import restate_series_for_splits
+
+    results: list[dict] = []
+    wdates = sorted(window_dates)
+    for a in actions:
+        ex = pd.Timestamp(a.ex_date).normalize()
+        factor = expected_factor(a)
+        affected = [d for d in wdates if pd.Timestamp(d).normalize() < ex]
+        post_dates = [d for d in wdates if pd.Timestamp(d).normalize() >= ex]
+        # Post-split reference close for scale verification (earliest on/after ex).
+        c_post = None
+        for pd_date in post_dates:
+            post_df = _read_archive_parquet(s3, bucket, prefix, pd_date)
+            if post_df is not None and ticker in post_df.index and "Close" in post_df.columns:
+                c_post = post_df.at[ticker, "Close"]
+                break
+        for d in affected:
+            store_d = f"{STORE_DAILY_CLOSES_ARCHIVE}/{d}"
+            if registry is not None and registry.is_applied(store_d, a.action_id):
+                results.append({
+                    "action_id": a.action_id, "store": STORE_DAILY_CLOSES_ARCHIVE,
+                    "ticker": ticker, "date": d, "n_rows_adjusted": 0,
+                    "factor": factor, "status": "noop",
+                })
+                continue
+            df_d = _read_archive_parquet(s3, bucket, prefix, d)
+            if df_d is None or ticker not in df_d.index or "Close" not in df_d.columns:
+                # Parquet missing / ticker absent — nothing to restate (and do
+                # NOT mark, so a later run re-checks once it materializes).
+                continue
+            scale = _classify_archive_scale(df_d.at[ticker, "Close"], c_post, factor)
+            if scale == "old":
+                cols = [
+                    c for c in (*_ARCHIVE_PRICE_COLS, *_ARCHIVE_VOLUME_COLS)
+                    if c in df_d.columns
+                ]
+                tmp = df_d.loc[[ticker], cols].copy()
+                tmp.index = pd.DatetimeIndex([pd.Timestamp(d)])
+                ev = [{
+                    "execution_date": a.ex_date,
+                    "split_from": a.split_from, "split_to": a.split_to,
+                }]
+                restated_tmp = restate_series_for_splits(tmp, ev)
+                for col in cols:
+                    df_d.at[ticker, col] = restated_tmp.iloc[0][col]
+                _write_archive_parquet(s3, bucket, prefix, d, df_d)
+                if registry is not None:
+                    registry.mark_applied(a, store_d, run_id=run_id)
+                results.append({
+                    "action_id": a.action_id, "store": STORE_DAILY_CLOSES_ARCHIVE,
+                    "ticker": ticker, "date": d, "n_rows_adjusted": 1,
+                    "factor": factor, "status": "applied",
+                })
+            elif scale == "new":
+                # Already on the post-split scale (e.g. the morning polygon
+                # re-fetch restated it on a prior run) — record the marker so we
+                # don't re-examine, but DO NOT multiply.
+                if registry is not None:
+                    registry.mark_applied(a, store_d, run_id=run_id)
+                results.append({
+                    "action_id": a.action_id, "store": STORE_DAILY_CLOSES_ARCHIVE,
+                    "ticker": ticker, "date": d, "n_rows_adjusted": 0,
+                    "factor": factor, "status": "noop",
+                })
+            else:
+                # Unverifiable scale (no reference / ambiguous ratio) — decline to
+                # multiply (cannot prove old-scale ⇒ refuse to risk a double
+                # adjust). Leave UN-marked; the morning polygon re-fetch / Saturday
+                # backfill remain the heal. Recorded, not silently dropped.
+                log.warning(
+                    "corporate_actions.sync: cannot verify %s %s scale on %s "
+                    "(no post-split reference in window) — skipping archive "
+                    "restate, leaving heal to polygon re-fetch / backfill",
+                    ticker, a.human(), d,
+                )
+                results.append({
+                    "action_id": a.action_id, "store": STORE_DAILY_CLOSES_ARCHIVE,
+                    "ticker": ticker, "date": d, "n_rows_adjusted": 0,
+                    "factor": factor, "status": "skipped",
+                })
+    return results
+
+
+def sync(
+    s3,
+    bucket: str,
+    start_date,
+    end_date,
+    *,
+    stores: list[str],
+    run_id: str,
+    tickers: list[str] | None = None,
+    registry: "CorporateActionRegistry | None" = None,
+    actions: list | None = None,
+) -> SyncResult:
+    """Unified corporate-action restatement across ALL ``stores`` (PR4,
+    config#1433) — ONE pre-read orchestration entry point so the split-boundary
+    discontinuity is flattened BEFORE any consumer reads.
+
+    (a) Detects splits over ``[start_date, end_date]`` (or REUSES the
+    already-detected ``actions`` — the morning collector passes both its
+    ``registry`` and the splits it already scanned, so ``sync`` adds NO extra
+    polygon call) and records each write-if-absent. (b) For each detected split
+    and each requested store, restates the affected ticker(s) — SKIPPING any
+    ``(action, store)`` the registry already marks applied — and marks applied.
+    (c) Returns a :class:`SyncResult` summary.
+
+    Per-store topology:
+
+      * ``STORE_ARCTICDB_UNIVERSE`` — read the symbol's full series, restate via
+        the shared :func:`apply` math, write back (the mid-week restatement that
+        keeps daily-appended rows consistent; idempotent vs the Saturday
+        backfill via the shared ``arcticdb_universe`` applied marker — backfill
+        sees ``is_applied=True`` and will not re-apply, per PR3 §4).
+      * ``STORE_DAILY_CLOSES_ARCHIVE`` — restate the per-date archive parquets in
+        the live window in place; idempotency is registry-marker-only, at
+        per-(action_id, store, date) granularity, with a boundary scale check so
+        it can never double-adjust an already-restated parquet.
+
+    Splits-only this PR (dividends/renames are not detected yet). Best-effort +
+    fail-loud: a per-store / per-ticker failure WARNs (apiKey scrubbed) and
+    continues — the PRIMARY morning collection must not die because one symbol's
+    restatement failed — but the failure is RECORDED (never silently swallowed),
+    and the blocking backfill audit (PR3 §3) remains the train-write correctness
+    gate.
+    """
+    start_str = pd.Timestamp(start_date).strftime("%Y-%m-%d")
+    end_str = pd.Timestamp(end_date).strftime("%Y-%m-%d")
+    if registry is None:
+        registry = CorporateActionRegistry(s3, bucket)
+
+    # (a) detect (or reuse) + record write-if-absent.
+    if actions is None:
+        actions = detect_splits(start_str, end_str)
+    ticker_set = set(tickers) if tickers is not None else None
+    detected: list = []
+    for a in actions:
+        if a.type != _TYPE_SPLIT:
+            continue
+        try:
+            registry.record_detected(a, run_id=run_id)
+        except Exception as exc:  # noqa: BLE001 - provenance write best-effort
+            log.warning(
+                "corporate_actions.sync: record_detected failed for %s (%s)",
+                a.action_id, _scrub(exc),
+            )
+        detected.append(a)
+
+    # Restatement is scoped to the requested ticker universe (when given); the
+    # detected/recorded set above is NOT scoped (the discrepancy classifier and
+    # provenance trail want every detected action).
+    by_ticker: dict[str, list] = {}
+    for a in detected:
+        if ticker_set is not None and a.ticker not in ticker_set:
+            continue
+        by_ticker.setdefault(a.ticker, []).append(a)
+
+    window_dates = [d.strftime("%Y-%m-%d") for d in pd.bdate_range(start_str, end_str)]
+
+    applied: dict[str, list] = {store: [] for store in stores}
+    restated_action_ids: set[str] = set()
+    for store in stores:
+        for ticker, tactions in by_ticker.items():
+            try:
+                if store == STORE_ARCTICDB_UNIVERSE:
+                    res = _sync_arcticdb_universe(
+                        bucket, ticker, tactions, registry, run_id,
+                    )
+                elif store == STORE_DAILY_CLOSES_ARCHIVE:
+                    res = _sync_daily_closes_archive(
+                        s3, bucket, ticker, tactions, window_dates, registry, run_id,
+                    )
+                else:
+                    raise ValueError(f"corporate_actions.sync: unknown store {store!r}")
+            except Exception as exc:  # noqa: BLE001 - per-store/ticker degrade
+                log.warning(
+                    "corporate_actions.sync: restate failed for store=%s "
+                    "ticker=%s (%s) — continuing; backfill audit remains the "
+                    "correctness gate", store, ticker, _scrub(exc),
+                )
+                continue
+            applied[store].extend(res)
+            for r in res:
+                if r.get("status") == "applied" and r.get("n_rows_adjusted", 0) > 0:
+                    restated_action_ids.add(r["action_id"])
+
+    notices = [a for a in detected if a.action_id in restated_action_ids]
+    return SyncResult(detected=detected, applied=applied, notices=notices)
 
 
 def splits_from_events(events: list[dict]) -> list["CorporateAction"]:

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -93,6 +93,12 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # is grandfathered out of ARTIFACT_REGISTRY.yaml (no freshness row) per "never
     # register a freshness entry ahead of/without a periodic producer".
     "corporate_actions/registry.py": 1,
+    # corporate_actions.sync (PR4, config#1433) rewrites the EXISTING
+    # staging/daily_closes/{date}.parquet archive IN PLACE (split restatement) —
+    # it produces no NEW artifact (that prefix already has its freshness SLA via
+    # the daily_closes collector), so no new ARTIFACT_REGISTRY row is required;
+    # this single PUT site is the in-place archive write-back.
+    "corporate_actions/__init__.py": 1,
     "data/cache.py": 1,
     "data/derived/analyst_revisions.py": 2,
     "data/derived/news_aggregates.py": 2,

--- a/tests/test_corporate_actions_sync.py
+++ b/tests/test_corporate_actions_sync.py
@@ -1,0 +1,347 @@
+"""corporate_actions.sync — unified, pre-read restatement across ALL stores
+(PR4 of the unified corporate-actions program, config#1433).
+
+``sync`` is the ONE orchestration entry point invoked BEFORE consumers read, so
+the split-boundary discontinuity is flattened up front instead of re-forming
+mid-week between Saturday backfills. These tests pin:
+
+  * end-to-end: a registered split → the ArcticDB universe symbol is restated
+    AND the daily_closes archive window parquets are restated in place, with
+    per-store / per-date applied markers written.
+  * archive idempotency (the key new risk: a per-date parquet cannot be
+    re-derived from a raw source here, so the registry marker is the only guard)
+    — re-running sync is a NO-OP (no double-restate), verified via is_applied +
+    value parity, AND a parquet already on the post-split scale is detected by
+    the boundary scale-check and NOT multiplied.
+  * daily_append basis-consistency: appending after a mid-week split lands on a
+    restated history (no boundary discontinuity); and the double-apply guard
+    (sync already restated ArcticDB ⇒ daily_append does not re-apply).
+  * backfill interplay: a Saturday backfill after a mid-week sync does NOT
+    double-restate (the shared arcticdb_universe marker is is_applied=True).
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+import corporate_actions as ca
+from corporate_actions import CorporateActionRegistry
+from split_factor import restate_series_for_splits
+
+
+# ── in-memory S3 double (registry markers + daily_closes parquet round-trip) ──
+
+
+class _FakeS3:
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def _err(self, code, op):
+        return ClientError({"Error": {"Code": code, "Message": "x"}}, op)
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("404", "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("NoSuchKey", "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"x"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+_BUCKET = "alpha-engine-research"
+_PREFIX = "staging/daily_closes/"
+# DD's real 2026-06-24 event: 1-for-3 REVERSE split (split_from=3, split_to=1)
+# → pre-split prices MULTIPLY by 3 to reach the post-reverse-split scale.
+_EX = "2026-06-24"
+_OLD = 48.0
+_NEW = 144.0
+
+
+def _put_daily_closes(s3, date: str, rows: dict[str, dict]):
+    """Write a daily_closes snapshot parquet (index=ticker, OHLCV columns)."""
+    df = pd.DataFrame.from_dict(rows, orient="index")
+    df.index.name = "ticker"
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy", index=True)
+    s3.put_object(Bucket=_BUCKET, Key=f"{_PREFIX}{date}.parquet", Body=buf.getvalue())
+
+
+def _read_daily_closes(s3, date: str) -> pd.DataFrame:
+    obj = s3.get_object(Bucket=_BUCKET, Key=f"{_PREFIX}{date}.parquet")
+    return pd.read_parquet(io.BytesIO(obj["Body"].read()), engine="pyarrow")
+
+
+def _row(close: float) -> dict:
+    return {
+        "Open": close, "High": close * 1.01, "Low": close * 0.99,
+        "Close": close, "Volume": 1_000_000.0, "VWAP": close, "source": "polygon",
+    }
+
+
+def _seed_window_parquets(s3):
+    """6/22, 6/23 pre-split (OLD $48 scale); 6/24 post-split (NEW $144 scale).
+
+    Mirrors the real data#1298 boundary: the morning re-fetch has put 6/24 on the
+    new scale but the trailing pre-ex parquets are still un-restated.
+    """
+    _put_daily_closes(s3, "2026-06-22", {"DD": _row(_OLD), "AAPL": _row(200.0)})
+    _put_daily_closes(s3, "2026-06-23", {"DD": _row(_OLD), "AAPL": _row(201.0)})
+    _put_daily_closes(s3, "2026-06-24", {"DD": _row(_NEW), "AAPL": _row(202.0)})
+
+
+def _seed_arctic_unrestated(tmp_path, ticker="DD"):
+    """A REAL LMDB ArcticDB universe seeded with an UN-restated DD history: pre-
+    6/24 rows on the OLD ($48) scale, post on the NEW ($144) → a ~3x boundary
+    jump that sync's arctic restatement must flatten."""
+    adb = pytest.importorskip("arcticdb")
+    pre_dates = pd.bdate_range("2026-06-01", "2026-06-23")
+    post_dates = pd.bdate_range("2026-06-24", "2026-07-01")
+    close = pd.concat([
+        pd.Series(np.full(len(pre_dates), _OLD), index=pre_dates),
+        pd.Series(np.full(len(post_dates), _NEW), index=post_dates),
+    ])
+    df = pd.DataFrame({
+        "Open": close, "High": close * 1.01, "Low": close * 0.99,
+        "Close": close, "Volume": np.full(len(close), 1e6),
+    })
+    ac = adb.Arctic(f"lmdb://{tmp_path}")
+    lib = ac.get_library("universe", create_if_missing=True)
+    lib.write(ticker, df)
+    return lib
+
+
+def _dd_split():
+    return ca.CorporateAction.from_split("DD", _EX, 3, 1)  # 1-for-3 reverse
+
+
+# ── end-to-end: arctic universe + daily_closes archive both restated ──────────
+
+
+def test_sync_restates_both_stores_and_writes_markers(tmp_path, monkeypatch):
+    s3 = _FakeS3()
+    _seed_window_parquets(s3)
+    lib = _seed_arctic_unrestated(tmp_path)
+    import store.arctic_store as arctic_store
+    monkeypatch.setattr(arctic_store, "get_universe_lib", lambda *a, **k: lib)
+
+    reg = CorporateActionRegistry(s3, _BUCKET)
+    action = _dd_split()
+
+    result = ca.sync(
+        s3, _BUCKET, "2026-06-22", "2026-06-24",
+        stores=[ca.STORE_DAILY_CLOSES_ARCHIVE, ca.STORE_ARCTICDB_UNIVERSE],
+        run_id="2026-06-24", tickers=["DD", "AAPL"], registry=reg, actions=[action],
+    )
+
+    # ── ArcticDB universe: full history flattened, marker written ────────────
+    assert reg.is_applied(ca.STORE_ARCTICDB_UNIVERSE, action.action_id) is True
+    dd = lib.read("DD").data
+    assert dd["Close"].pct_change().abs().max() < 0.05      # continuous
+    assert dd["Close"].iloc[0] == pytest.approx(_NEW, rel=0.02)  # pre lifted ×3
+
+    # ── daily_closes archive: pre-ex parquets restated in place ──────────────
+    for d in ("2026-06-22", "2026-06-23"):
+        df_d = _read_daily_closes(s3, d)
+        assert df_d.at["DD", "Close"] == pytest.approx(_NEW, rel=1e-6)   # 48 → 144
+        assert df_d.at["DD", "VWAP"] == pytest.approx(_NEW, rel=1e-6)
+        assert df_d.at["DD", "Volume"] == pytest.approx(1_000_000 / 3, rel=1e-3)
+        # untouched ticker unchanged
+        assert df_d.at["AAPL", "Close"] == pytest.approx(200.0 if d == "2026-06-22" else 201.0)
+        store_d = f"{ca.STORE_DAILY_CLOSES_ARCHIVE}/{d}"
+        assert reg.is_applied(store_d, action.action_id) is True
+
+    # post-ex parquet (6/24) is NOT a pre-split date → untouched
+    df_post = _read_daily_closes(s3, "2026-06-24")
+    assert df_post.at["DD", "Close"] == pytest.approx(_NEW, rel=1e-6)
+
+    # ── SyncResult shape ─────────────────────────────────────────────────────
+    assert action in result.detected
+    assert action in result.notices                       # it restated rows
+    assert set(result.applied) == {
+        ca.STORE_DAILY_CLOSES_ARCHIVE, ca.STORE_ARCTICDB_UNIVERSE,
+    }
+
+
+def test_sync_rerun_is_a_noop_no_double_restate(tmp_path, monkeypatch):
+    """Re-running sync must NOT double-restate: markers gate both stores. Assert
+    via is_applied + value parity against the first run's restated values."""
+    s3 = _FakeS3()
+    _seed_window_parquets(s3)
+    lib = _seed_arctic_unrestated(tmp_path)
+    import store.arctic_store as arctic_store
+    monkeypatch.setattr(arctic_store, "get_universe_lib", lambda *a, **k: lib)
+
+    reg = CorporateActionRegistry(s3, _BUCKET)
+    action = _dd_split()
+    common = dict(
+        stores=[ca.STORE_DAILY_CLOSES_ARCHIVE, ca.STORE_ARCTICDB_UNIVERSE],
+        run_id="2026-06-24", tickers=["DD"], registry=reg, actions=[action],
+    )
+
+    ca.sync(s3, _BUCKET, "2026-06-22", "2026-06-24", **common)
+    arctic_after_first = lib.read("DD").data["Close"].copy()
+    archive_after_first = {
+        d: _read_daily_closes(s3, d).at["DD", "Close"] for d in ("2026-06-22", "2026-06-23")
+    }
+
+    # A fresh registry pointing at the SAME S3 — markers persist in S3, so the
+    # second sync sees is_applied=True everywhere and restates nothing.
+    reg2 = CorporateActionRegistry(s3, _BUCKET)
+    result2 = ca.sync(s3, _BUCKET, "2026-06-22", "2026-06-24",
+                      stores=common["stores"], run_id="2026-06-25",
+                      tickers=["DD"], registry=reg2, actions=[action])
+
+    # No second restatement happened anywhere.
+    assert result2.notices == []
+    flat = [r for rs in result2.applied.values() for r in rs]
+    assert all(r["status"] == "noop" for r in flat)
+
+    # Value parity — NOT double-applied (would have ×3'd again).
+    pd.testing.assert_series_equal(lib.read("DD").data["Close"], arctic_after_first)
+    for d, v in archive_after_first.items():
+        assert _read_daily_closes(s3, d).at["DD", "Close"] == pytest.approx(v, rel=1e-9)
+        assert _read_daily_closes(s3, d).at["DD", "Close"] == pytest.approx(_NEW, rel=1e-6)
+
+
+def test_sync_archive_already_restated_parquet_not_double_applied(tmp_path, monkeypatch):
+    """The marker is the ONLY idempotency guard for the archive, but sync also
+    boundary-verifies scale so an independent mechanism (the morning polygon
+    re-fetch) that already restated a parquet — leaving NO sync marker — is NOT
+    multiplied a second time. Pre-ex parquets are ALREADY on the $144 scale."""
+    s3 = _FakeS3()
+    # All window dates ALREADY on the post-split ($144) scale (re-fetch healed
+    # them), but NO sync marker exists yet.
+    _put_daily_closes(s3, "2026-06-22", {"DD": _row(_NEW)})
+    _put_daily_closes(s3, "2026-06-23", {"DD": _row(_NEW)})
+    _put_daily_closes(s3, "2026-06-24", {"DD": _row(_NEW)})
+    lib = _seed_arctic_unrestated(tmp_path)
+    import store.arctic_store as arctic_store
+    monkeypatch.setattr(arctic_store, "get_universe_lib", lambda *a, **k: lib)
+
+    reg = CorporateActionRegistry(s3, _BUCKET)
+    action = _dd_split()
+    ca.sync(s3, _BUCKET, "2026-06-22", "2026-06-24",
+            stores=[ca.STORE_DAILY_CLOSES_ARCHIVE], run_id="2026-06-24",
+            tickers=["DD"], registry=reg, actions=[action])
+
+    # Parquets stay on the $144 scale — NOT multiplied to $432.
+    for d in ("2026-06-22", "2026-06-23"):
+        assert _read_daily_closes(s3, d).at["DD", "Close"] == pytest.approx(_NEW, rel=1e-6)
+        # The date is recorded applied (so we never re-examine it).
+        assert reg.is_applied(f"{ca.STORE_DAILY_CLOSES_ARCHIVE}/{d}", action.action_id)
+
+
+# ── daily_append basis-consistency + double-apply guard ───────────────────────
+
+
+def _unrestated_reverse_jump():
+    pre_dates = pd.bdate_range("2026-06-01", "2026-06-23")
+    post_dates = pd.bdate_range("2026-06-24", "2026-07-01")
+    close = pd.concat([
+        pd.Series(np.full(len(pre_dates), _OLD), index=pre_dates),
+        pd.Series(np.full(len(post_dates), _NEW), index=post_dates),
+    ])
+    return pd.DataFrame({
+        "Open": close, "High": close * 1.01, "Low": close * 0.99,
+        "Close": close, "Volume": np.full(len(close), 1e6),
+    })
+
+
+def test_daily_append_guard_restates_unrestated_history_before_append(monkeypatch):
+    """daily_append's basis-consistency guard: when a registered split is NOT yet
+    applied to the ArcticDB universe (sync missed/skipped), the guard restates
+    the FULL history (write-then-mark) so today's row lands on a continuous
+    scale — never spliced onto an un-restated basis."""
+    from builders.daily_append import _ensure_history_restated
+
+    reg = CorporateActionRegistry(_FakeS3(), _BUCKET)
+    action = _dd_split()
+    reg.record_detected(action, run_id="r")
+    hist = _unrestated_reverse_jump()
+    assert hist["Close"].pct_change().abs().max() > 0.45      # boundary jump present
+
+    universe_lib = MagicMock()
+    out = _ensure_history_restated("DD", hist, [action], reg, universe_lib, "2026-06-24")
+
+    # History restated → continuous, written back, marker set (write-then-mark).
+    assert out["Close"].pct_change().abs().max() < 0.05
+    assert out["Close"].iloc[0] == pytest.approx(_NEW, rel=0.02)
+    universe_lib.write.assert_called_once()
+    assert reg.is_applied(ca.STORE_ARCTICDB_UNIVERSE, action.action_id) is True
+
+    # Splice today's (post-split-scale) row onto the RESTATED history → no jump.
+    today = pd.Timestamp("2026-07-02")
+    spliced = pd.concat([out["Close"], pd.Series([_NEW], index=[today])])
+    assert spliced.pct_change().abs().max() < 0.05
+
+
+def test_daily_append_guard_noop_when_already_restated(monkeypatch):
+    """Double-apply guard: when sync already restated the ArcticDB universe
+    (is_applied=True), daily_append's guard does NOT re-apply — the history is
+    returned untouched and no second full-series write happens."""
+    from builders.daily_append import _ensure_history_restated
+
+    reg = CorporateActionRegistry(_FakeS3(), _BUCKET)
+    action = _dd_split()
+    reg.record_detected(action, run_id="r")
+    # sync (or the Saturday backfill) already applied it to this store.
+    reg.mark_applied(action, ca.STORE_ARCTICDB_UNIVERSE, run_id="sync")
+
+    # An ALREADY-continuous history (post-restate). The guard must leave it alone.
+    dates = pd.bdate_range("2026-06-01", "2026-07-01")
+    cont = pd.DataFrame({
+        "Open": _NEW, "High": _NEW * 1.01, "Low": _NEW * 0.99,
+        "Close": _NEW, "Volume": 1e6,
+    }, index=dates)
+    universe_lib = MagicMock()
+    out = _ensure_history_restated("DD", cont, [action], reg, universe_lib, "2026-06-24")
+
+    assert out is cont                              # untouched (same object)
+    universe_lib.write.assert_not_called()          # no re-restate
+
+
+# ── backfill interplay: shared marker ⇒ Saturday backfill does not re-restate ─
+
+
+def test_backfill_apply_is_noop_after_sync_marked_arctic(tmp_path, monkeypatch):
+    """The Saturday backfill restates via ``corporate_actions.apply(store=
+    arcticdb_universe, registry=...)``. After a mid-week ``sync`` marked the same
+    (action, arcticdb_universe), the backfill path is a registry NOOP — no
+    double-restate (the shared exactly-once marker, PR3 §4 / PR4)."""
+    s3 = _FakeS3()
+    _seed_window_parquets(s3)
+    lib = _seed_arctic_unrestated(tmp_path)
+    import store.arctic_store as arctic_store
+    monkeypatch.setattr(arctic_store, "get_universe_lib", lambda *a, **k: lib)
+
+    reg = CorporateActionRegistry(s3, _BUCKET)
+    action = _dd_split()
+    ca.sync(s3, _BUCKET, "2026-06-22", "2026-06-24",
+            stores=[ca.STORE_ARCTICDB_UNIVERSE], run_id="2026-06-24",
+            tickers=["DD"], registry=reg, actions=[action])
+    restated_close = lib.read("DD").data["Close"].copy()
+
+    # Saturday backfill loads a (freshly materialized) DD frame and runs apply
+    # with the SAME registry — it must skip (is_applied=True), not re-multiply.
+    bf_frame = lib.read("DD").data
+    out, results = ca.apply(
+        bf_frame, [action], store=ca.STORE_ARCTICDB_UNIVERSE, registry=reg, run_id="sat",
+    )
+    assert [r["status"] for r in results] == ["noop"]
+    pd.testing.assert_series_equal(out["Close"], restated_close)


### PR DESCRIPTION
## PR4 of the unified corporate-actions program (epic config#1433)

ONE pre-read orchestration entry point — `corporate_actions.sync(...)` — invoked **before** consumers read, so the split-boundary discontinuity stops re-forming mid-week between Saturday backfills (the splice flagged in the design review). Builds on the merged #547 (foundation + registry + registry-aware discrepancy classification) and #550 (registry-driven `apply` + blocking backfill audit).

### 1. `corporate_actions.sync(...)` orchestration
`sync(s3, bucket, start_date, end_date, *, stores, run_id, tickers=None, registry=None, actions=None) -> SyncResult` detects (or **reuses** already-detected) splits, records them write-if-absent, and restates each requested store — skipping any `(action, store)` already `is_applied`. Per-store topology:

- **`STORE_ARCTICDB_UNIVERSE`** — read the symbol's full series, restate via the shared #550 `apply()` math, write back. This is the **mid-week restatement** that keeps daily-appended rows consistent (today the ArcticDB history is only restated at Saturday backfill). Shares the `arcticdb_universe` applied-marker namespace with the backfill, so the Saturday backfill sees `is_applied=True` and does **not** re-apply (PR3 §4).
- **`STORE_DAILY_CLOSES_ARCHIVE = "daily_closes_archive"`** (NEW) — restate the per-date `staging/daily_closes/{date}.parquet` files in the live window **in place**.

**Archive idempotency design + marker granularity.** A daily-closes parquet is a cross-sectional snapshot (index=ticker, one trading date per file) that cannot be re-derived from a raw source inside `sync`, so the durable registry `applied` marker is the **sole** idempotency guard — recorded at **per-`(action_id, store, date)`** granularity (the marker store is `f"{STORE_DAILY_CLOSES_ARCHIVE}/{date}"`), **not** a single per-`(action_id, store)` marker. Rationale: the live window slides forward and a per-date parquet can **enter** the affected set on a later run (a missing/late date materializes); a coarse per-store marker would then skip that newly-present parquet and leave a discontinuity. A per-date marker guarantees each parquet is restated exactly once, whenever it first appears.

**No double-apply against the morning polygon re-fetch.** config#717 independently restates touched dates via polygon `adjusted=true`. To make `sync`'s multiply safe against that untracked mechanism, every archive multiply is gated on a **boundary scale-check** (`_classify_archive_scale`): a parquet already on the post-split scale is recorded (marked) but **not** multiplied. So neither a sync re-run nor an independent re-fetch can double-adjust a parquet. **Write-then-mark** throughout (the marker is set only after the rewrite lands — the daily_append guard trusts it).

Best-effort + fail-loud: a per-store/per-ticker failure WARNs (apiKey scrubbed) and continues so the primary collection survives, but the failure is recorded; the blocking backfill audit (#550) remains the train-write correctness gate. Splits-only (pre-CRSP-basis = PR7; dividends/renames not detected yet).

### 2. Wired into the morning collector
`collectors/daily_closes._collect_window` invokes `sync(...)` **once at the START** of the morning run (before `_log_close_discrepancies` and before downstream `daily_append` reads), gated identically to the config#717 split scan (`polygon_only` + `skip_if_canonical` + not `dry_run`). It **reuses the registry + the splits already scanned** by config#717 (`_build_corporate_action_registry` now also returns the detected actions) — **no third polygon call**. #547's registry-aware discrepancy classification is unchanged.

### 3. daily_append basis-consistency
`builders/daily_append` gains a guard: before splicing today's (post-split-scale) row, it restates-then-appends any symbol whose registered split is **not yet applied** to `arcticdb_universe` — **never appending onto an un-restated history**. Registry-driven (no polygon call); a cheap `is_applied` no-op in steady state (the morning sync already restated). The **double-apply guard**: when sync already restated ArcticDB (`is_applied=True`), the guard returns the history untouched and does not re-write. Write-then-mark, so a failed rewrite never leaves the marker (and the guard) believing a history is restated when it is not.

### Deploy-packaging
`daily_closes` / `daily_append` / `corporate_actions` run only on **EC2** (full git checkout). The data Lambda Dockerfile COPYs only `collectors/` + `store/` (+ a few root modules) — it does **not** include `corporate_actions/` or `builders/`. `collectors/__init__.py` is empty and `collectors.alternative` (the Phase-2 collector) imports **none** of the new chain (verified: importing it leaks no `corporate_actions` / `builders.daily_append` / `collectors.daily_closes` / `store.arctic_store`). All new imports in `daily_closes`/`daily_append` are lazy/function-level. **No Dockerfile change needed.**

### Confirmation: daily_append never appends onto un-restated history
The morning `sync` restates `arcticdb_universe` (mid-week) before `daily_append` runs in the weekday SF; the daily_append guard is the robust backstop that **restates-then-appends** when the universe is somehow still un-restated, so today's row always lands on a continuous adjusted scale.

### Tests
`tests/test_corporate_actions_sync.py` (real LMDB ArcticDB + in-memory S3):
- `sync` end-to-end: a registered split → arcticdb_universe symbol restated + daily_closes archive window parquets restated + per-store/per-date markers written; SyncResult shape.
- archive idempotency: re-running sync is a NO-OP (is_applied + value parity, no `×3` again); a parquet already on the post-split scale is detected and **not** multiplied.
- daily_append basis-consistency: restate-then-append flattens the boundary; double-apply guard is a no-op when already applied.
- backfill interplay: `apply(store=arcticdb_universe, registry=...)` is a NOOP after a mid-week sync marked it.

Local: 6 new + 43 existing corporate-actions/split tests pass; full affected slice **482 passed**; full suite collects (2381) with no import errors. CI (py3.12 + fresh `nousergon-lib` v0.70.0) is the authoritative gate (local venv carries a stale lib; a local-only shim was used to import `features`/`builders`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
