### PR TITLE
feat(corporate-actions): dividends — detection + registry capture + total-return math (PR5 config#1433)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -1350,11 +1350,13 @@ def _collect_window(
                     if r.get("status") == "applied" and r.get("n_rows_adjusted", 0) > 0
                 )
                 logger.info(
-                    "corporate_actions.sync: %d detected, %d restatement(s) "
-                    "applied across %d store(s) over [%s..%s] (run_id=%s)",
+                    "corporate_actions.sync: %d split(s) detected, %d "
+                    "restatement(s) applied across %d store(s), %d dividend(s) "
+                    "recorded (CRSP-separate, no price restate, no email) over "
+                    "[%s..%s] (run_id=%s)",
                     len(sync_result.detected), n_applied,
-                    len(sync_result.applied), min(window_dates), max(window_dates),
-                    window_dates[0],
+                    len(sync_result.applied), len(sync_result.dividends),
+                    min(window_dates), max(window_dates), window_dates[0],
                 )
             except Exception as exc:
                 logger.warning(

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -46,6 +46,7 @@ import hashlib
 import logging
 from dataclasses import dataclass, field
 
+import numpy as np
 import pandas as pd
 
 import split_factor
@@ -61,12 +62,15 @@ __all__ = [
     "STORE_DAILY_CLOSES_ARCHIVE",
     "SyncResult",
     "expected_factor",
+    "dividend_factor",
+    "total_return_series",
     "apply",
     "sync",
     "detect_splits",
     "detect_dividends",
     "detect_renames",
     "splits_from_events",
+    "dividends_from_events",
 ]
 
 # Action types implemented this PR. Dividends/renames are modeled (fields exist)
@@ -192,6 +196,32 @@ class CorporateAction:
             raw=dict(raw or {}),
         )
 
+    @classmethod
+    def from_dividend(
+        cls,
+        ticker: str,
+        ex_date: str,
+        cash_amount: float,
+        dividend_kind: str | None = None,
+        *,
+        source: str = "polygon",
+        raw: dict | None = None,
+    ) -> "CorporateAction":
+        """Build a cash-dividend action; ``action_id`` is derived
+        deterministically from ``(type, ticker, ex_date, cash_amount:kind)`` so
+        two dividends on different ex dates OR different amounts never collide
+        (the ``_detail`` discriminator folds in ``cash_amount``; ``ex_date`` is
+        already in the id payload)."""
+        return cls(
+            type=_TYPE_DIVIDEND,
+            ticker=str(ticker),
+            ex_date=str(ex_date),
+            cash_amount=float(cash_amount),
+            dividend_kind=(str(dividend_kind) if dividend_kind is not None else None),
+            source=source,
+            raw=dict(raw or {}),
+        )
+
     # ── (de)serialization ────────────────────────────────────────────────
     def to_dict(self) -> dict:
         """JSON-serializable view (the registry persists this + audit fields)."""
@@ -287,6 +317,103 @@ def expected_factor(action: CorporateAction) -> float:
     )
 
 
+# ── dividends: total-return factor MATH (CRSP/Barra basis) ───────────────────
+#
+# Dividends are tracked as a SEPARATE total-return series and MUST NOT be folded
+# into the stored split-adjusted price LEVEL (Brian-decided, config#1433). The
+# primitives below compute that distinct series; they NEVER mutate a price store
+# or a feature. PR7 consumes the registry-recorded dividend events to build +
+# persist the total-return series under the new schema — these are the math it
+# will call. Kept here (not in split_factor) because the split factor convention
+# is multiplicative on the price LEVEL whereas a dividend factor is a back-adjust
+# applied to a SEPARATE return series.
+
+
+def dividend_factor(cash_amount: float, close_prev: float) -> float:
+    """The CRSP/yfinance total-return back-adjust factor for one cash dividend.
+
+    A dividend of ``cash_amount`` going ex when the prior close is ``close_prev``
+    back-adjusts every PRE-ex price by ``1 - cash_amount/close_prev`` to build a
+    total-return series (the post-ex price drop by the dividend is "added back"
+    into the pre-ex prices so the series is continuous through the ex-date drop).
+    This is the standard CRSP/Barra adjustment factor; it is applied to a
+    SEPARATE total-return series, never to the stored split-adjusted price level.
+
+    ``close_prev`` must be > 0 (the trading day BEFORE the ex-date). The factor is
+    in ``(0, 1]`` for a normal dividend (``0 < cash_amount < close_prev``).
+    """
+    cash = float(cash_amount)
+    cp = float(close_prev)
+    if not (cp > 0):
+        raise ValueError(
+            f"dividend_factor: close_prev must be > 0, got {close_prev!r}"
+        )
+    return 1.0 - cash / cp
+
+
+def total_return_series(
+    price_df: pd.DataFrame,
+    dividend_actions: list["CorporateAction"],
+    *,
+    close_col: str = "Close",
+) -> pd.Series:
+    """Build a SEPARATE total-return-adjusted close from a (split-adjusted) price
+    series + the dividend events — the CRSP primitive (config#1433).
+
+    ``price_df`` is one ticker's price frame (DatetimeIndex), already on whatever
+    split-adjusted scale the caller maintains. ``dividend_actions`` are the
+    ``type="dividend"`` :class:`CorporateAction`s for that ticker. Returns a NEW
+    ``pd.Series`` (the total-return close); **it does NOT mutate ``price_df``** and
+    is wired into NO store/feature — PR7 consumes it.
+
+    Method (mirrors ``split_factor`` compounding correctness, but on a return
+    series): process dividends OLDEST→NEWEST; for each ex-date E, read the close
+    on the trading day strictly BEFORE E from the RUNNING series, compute
+    ``dividend_factor(cash, close_prev)``, and multiply every row STRICTLY BEFORE
+    E by that factor. Oldest→newest ordering keeps each factor's ``close_prev`` on
+    the un-back-adjusted scale (an earlier dividend only touches rows before its
+    own — earlier — ex-date, which are strictly before this dividend's
+    ``close_prev`` row), so the factors compound multiplicatively exactly like
+    CRSP. Splits and dividends stay INDEPENDENT: ``price_df`` carries the split
+    adjustment on the price level; this returns that series further
+    dividend-adjusted on the SEPARATE total-return axis.
+
+    Dividends whose ex-date is on/before the first row (no earlier row to adjust)
+    contribute nothing and are skipped. The input series order/index is preserved.
+    """
+    if price_df is None or getattr(price_df, "empty", True):
+        return pd.Series(dtype="float64", name="tr_close")
+    if close_col not in price_df.columns:
+        raise KeyError(
+            f"total_return_series: close_col {close_col!r} not in price_df columns "
+            f"{list(price_df.columns)}"
+        )
+    idx = (
+        price_df.index
+        if isinstance(price_df.index, pd.DatetimeIndex)
+        else pd.to_datetime(price_df.index)
+    )
+    # Operate on a private numpy copy so price_df is never mutated; close_prev is
+    # always read from this RUNNING array (the compounding state).
+    vals = price_df[close_col].to_numpy(dtype="float64").copy()
+    ts = pd.DatetimeIndex(idx).normalize().to_numpy()
+
+    divs = [a for a in (dividend_actions or []) if a.type == _TYPE_DIVIDEND]
+    divs.sort(key=lambda a: pd.Timestamp(a.ex_date).normalize())
+    for a in divs:
+        if a.cash_amount is None:
+            continue
+        ex = np.datetime64(pd.Timestamp(a.ex_date).normalize())
+        before = ts < ex
+        if not before.any():
+            continue  # ex-date at/before first row — nothing earlier to adjust
+        prev_pos = int(np.nonzero(before)[0][-1])  # last row strictly before ex
+        factor = dividend_factor(a.cash_amount, vals[prev_pos])
+        vals[before] = vals[before] * factor
+
+    return pd.Series(vals, index=price_df.index, name="tr_close")
+
+
 def apply(
     df: pd.DataFrame,
     actions: list["CorporateAction"],
@@ -340,17 +467,31 @@ def apply(
     if df is None or getattr(df, "empty", True) or not actions:
         return df, applied_results
 
-    # Only splits are restated this PR. A dividend/rename action reaching here
-    # is a caller error (detect_dividends/detect_renames are NotImplemented), so
-    # fail loud rather than silently dropping it.
+    # Only splits mutate the stored PRICE LEVEL. A dividend reaching here is a
+    # caller error: dividends are CRSP-SEPARATE — they are tracked as a distinct
+    # total-return series (see ``dividend_factor`` / ``total_return_series``) and
+    # MUST NOT be folded into the split-adjusted price level ``apply`` restates.
+    # The registry is the dividend persistence layer (``sync`` records them, does
+    # NOT apply them); PR7 consumes the recorded events to build + persist the TR
+    # series under the new schema. So we fail loud rather than ever multiplying a
+    # price by a dividend factor here. Renames are likewise not a price-level
+    # restatement (deferred to a later PR).
     split_actions: list[CorporateAction] = []
     for a in actions:
         if a.type == _TYPE_SPLIT:
             split_actions.append(a)
-        elif a.type in (_TYPE_DIVIDEND, _TYPE_RENAME):
+        elif a.type == _TYPE_DIVIDEND:
             raise NotImplementedError(
-                f"corporate_actions.apply: {a.type!r} actions are deferred to a "
-                "later PR of the program (splits only this PR)"
+                "corporate_actions.apply: dividend actions are CRSP-separate and "
+                "must NOT mutate the split-adjusted price level — use "
+                "total_return_series to build the SEPARATE total-return series "
+                "(sync records dividends to the registry; PR7 persists the TR "
+                "series). Passing a dividend to apply() is a caller error."
+            )
+        elif a.type == _TYPE_RENAME:
+            raise NotImplementedError(
+                "corporate_actions.apply: rename actions are deferred to a later "
+                "PR of the program (splits only mutate the price level here)"
             )
         else:
             raise ValueError(
@@ -434,11 +575,21 @@ class SyncResult:
     * ``notices`` — the subset of ``detected`` that actually restated at least
       one row in at least one store this run (the operator-notification set:
       "the system saw this action and brought the stores onto its scale").
+      SPLITS ONLY — dividends are NEVER notices (CRSP-separate, sub-threshold,
+      and frequent; see ``dividends``).
+    * ``dividends`` — the dividend :class:`CorporateAction`s detected/recorded
+      over the window this run (write-if-absent into the registry). RECORDED
+      ONLY: dividends are CRSP-separate, never applied to a price store, and —
+      because they are frequent (~quarterly × hundreds of names) and cause
+      sub-5% ex-date drops (below the discrepancy ERROR band) — they emit NO
+      per-dividend email/notice (that would be noise). The count feeds the
+      summary log only; PR7 consumes the recorded events to build the TR series.
     """
 
     detected: list = field(default_factory=list)
     applied: dict = field(default_factory=dict)
     notices: list = field(default_factory=list)
+    dividends: list = field(default_factory=list)
 
 
 def _scrub(exc: object) -> str:
@@ -683,6 +834,7 @@ def sync(
     tickers: list[str] | None = None,
     registry: "CorporateActionRegistry | None" = None,
     actions: list | None = None,
+    dividend_actions: list | None = None,
 ) -> SyncResult:
     """Unified corporate-action restatement across ALL ``stores`` (PR4,
     config#1433) — ONE pre-read orchestration entry point so the split-boundary
@@ -708,7 +860,12 @@ def sync(
         per-(action_id, store, date) granularity, with a boundary scale check so
         it can never double-adjust an already-restated parquet.
 
-    Splits-only this PR (dividends/renames are not detected yet). Best-effort +
+    Dividends are ALSO detected + recorded over the window (one extra
+    ``get_recent_dividends`` call, or the reused ``dividend_actions``), but
+    RECORDED ONLY — they are CRSP-separate (tracked as a distinct total-return
+    series, never folded into the price level) and frequent + sub-threshold, so
+    they restate NO store and emit NO per-dividend email/notice; only their
+    count enters the summary. Renames are not detected yet. Best-effort +
     fail-loud: a per-store / per-ticker failure WARNs (apiKey scrubbed) and
     continues — the PRIMARY morning collection must not die because one symbol's
     restatement failed — but the failure is RECORDED (never silently swallowed),
@@ -736,6 +893,36 @@ def sync(
                 a.action_id, _scrub(exc),
             )
         detected.append(a)
+
+    # (a') detect (or reuse) + RECORD dividends — CRSP-separate, RECORDED ONLY.
+    # Dividends never restate a price store (they are tracked as a distinct
+    # total-return series, built later by PR7 from these recorded events) and
+    # never become a notice/email (frequent + sub-5% ex-date drop, below the
+    # discrepancy ERROR band). One extra polygon call (gated like the split scan
+    # — sync is only invoked on the live, non-dry-run path), or the reused
+    # ``dividend_actions`` when the caller already scanned them. A detection miss
+    # degrades to [] inside detect_dividends and must never fail the sync.
+    if dividend_actions is None:
+        try:
+            dividend_actions = detect_dividends(start_str, end_str)
+        except Exception as exc:  # noqa: BLE001 - detection best-effort
+            log.warning(
+                "corporate_actions.sync: dividend detection failed (%s) — "
+                "recording no dividends this run", _scrub(exc),
+            )
+            dividend_actions = []
+    dividends: list = []
+    for a in dividend_actions or []:
+        if a.type != _TYPE_DIVIDEND:
+            continue
+        try:
+            registry.record_detected(a, run_id=run_id)
+        except Exception as exc:  # noqa: BLE001 - provenance write best-effort
+            log.warning(
+                "corporate_actions.sync: record_detected failed for dividend "
+                "%s (%s)", a.action_id, _scrub(exc),
+            )
+        dividends.append(a)
 
     # Restatement is scoped to the requested ticker universe (when given); the
     # detected/recorded set above is NOT scoped (the discrepancy classifier and
@@ -776,7 +963,9 @@ def sync(
                     restated_action_ids.add(r["action_id"])
 
     notices = [a for a in detected if a.action_id in restated_action_ids]
-    return SyncResult(detected=detected, applied=applied, notices=notices)
+    return SyncResult(
+        detected=detected, applied=applied, notices=notices, dividends=dividends,
+    )
 
 
 def splits_from_events(events: list[dict]) -> list["CorporateAction"]:
@@ -853,11 +1042,85 @@ def detect_splits(
     return splits_from_events(events)
 
 
-def detect_dividends(start_date: str, end_date: str, *, client=None):
-    """Not implemented this PR (modeled fields exist; detection is a later PR)."""
-    raise NotImplementedError(
-        "detect_dividends is deferred to a later PR of the corporate-actions program"
-    )
+def dividends_from_events(events: list[dict]) -> list["CorporateAction"]:
+    """Map polygon ``get_recent_dividends`` event dicts to ``CorporateAction``s.
+
+    Each event is ``{"ticker", "ex_dividend_date", "cash_amount",
+    "dividend_type"}``. Pure transform (no I/O) so callers that already fetched
+    the events can reuse them WITHOUT a second polygon call. Malformed rows
+    (missing ticker / ex date / non-positive cash amount) are skipped — the same
+    discipline ``polygon_client.get_recent_dividends`` applies, re-asserted here
+    so a hand-built event list is also guarded.
+    """
+    actions: list[CorporateAction] = []
+    for ev in events or []:
+        ticker = ev.get("ticker")
+        ex_date = ev.get("ex_dividend_date")
+        cash = ev.get("cash_amount")
+        if not ticker or not ex_date or cash is None:
+            continue
+        try:
+            cash_f = float(cash)
+        except (TypeError, ValueError):
+            continue
+        if cash_f <= 0:
+            continue
+        actions.append(
+            CorporateAction.from_dividend(
+                ticker=str(ticker),
+                ex_date=str(ex_date),
+                cash_amount=cash_f,
+                dividend_kind=ev.get("dividend_type"),
+                source="polygon",
+                raw=dict(ev),
+            )
+        )
+    return actions
+
+
+def detect_dividends(
+    start_date: str,
+    end_date: str,
+    *,
+    client=None,
+) -> list["CorporateAction"]:
+    """Detect all cash dividends going ex in ``[start_date, end_date]`` as
+    ``CorporateAction``s (type="dividend", ex_date = polygon ex_dividend_date,
+    cash_amount + dividend_kind populated).
+
+    Mirrors :func:`detect_splits`: wraps ``polygon_client.get_recent_dividends``
+    (the whole-market, one-call range scan), constructs the client lazily, and
+    DEGRADES GRACEFULLY to ``[]`` on any construction/fetch failure (apiKey
+    scrubbed) — a dividend detection miss must never hard-fail the data
+    pipeline. Dividends are RECORDED ONLY (CRSP-separate): the returned actions
+    feed ``sync``'s registry capture, never a price-store ``apply``.
+    """
+    if client is None:
+        try:
+            from polygon_client import polygon_client
+
+            client = polygon_client()
+        except Exception as exc:  # import / construction failure — degrade
+            from polygon_client import _scrub_api_key
+
+            log.warning(
+                "corporate_actions.detect_dividends: could not obtain polygon "
+                "client (%s) — returning no detected dividends",
+                _scrub_api_key(exc),
+            )
+            return []
+    try:
+        events = client.get_recent_dividends(start_date, end_date)
+    except Exception as exc:
+        from polygon_client import _scrub_api_key
+
+        log.warning(
+            "corporate_actions.detect_dividends: polygon dividend scan failed "
+            "(%s) — returning no detected dividends",
+            _scrub_api_key(exc),
+        )
+        return []
+    return dividends_from_events(events)
 
 
 def detect_renames(start_date: str, end_date: str, *, client=None):

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -366,6 +366,109 @@ class PolygonClient:
         results.sort(key=lambda r: r["execution_date"])
         return results
 
+    def get_dividends(self, ticker: str) -> list[dict]:
+        """Fetch the cash-dividend history for one ticker (authoritative).
+
+        Sibling of :meth:`get_splits` for the corporate-actions program
+        (config#1433). Dividends are tracked as a SEPARATE total-return series
+        (CRSP/Barra basis) and are NEVER folded into the stored split-adjusted
+        price level — this endpoint is the authoritative source of the cash
+        amount + ex-dividend date the total-return-factor math consumes.
+
+        Queries ``/v3/reference/dividends?ticker=`` (full history, paginated;
+        we take the first page — ``limit=1000`` is ample for decades of
+        quarterly dividends). Returns a list of
+        ``{"ex_dividend_date": "YYYY-MM-DD", "cash_amount": float,
+        "dividend_type": str, ...}`` sorted ascending by ex_dividend_date.
+        Malformed rows (missing ex date / non-positive cash amount) are
+        skipped; a 403 (free-tier / bad key) returns ``[]`` so a dividend
+        detection miss degrades gracefully rather than hard-failing.
+        """
+        results: list[dict] = []
+        try:
+            data = self._get(
+                "/v3/reference/dividends",
+                params={"ticker": ticker, "limit": 1000, "order": "asc"},
+            )
+        except PolygonForbiddenError:
+            return []
+        for r in data.get("results", []) or []:
+            ex_date = r.get("ex_dividend_date")
+            cash = r.get("cash_amount")
+            if not ex_date or cash is None:
+                continue
+            try:
+                cash_f = float(cash)
+            except (TypeError, ValueError):
+                continue
+            if cash_f <= 0:
+                continue
+            results.append(
+                {
+                    "ex_dividend_date": str(ex_date),
+                    "cash_amount": cash_f,
+                    "dividend_type": str(r.get("dividend_type") or ""),
+                }
+            )
+        results.sort(key=lambda r: r["ex_dividend_date"])
+        return results
+
+    def get_recent_dividends(self, start_date: str, end_date: str) -> list[dict]:
+        """Fetch ALL cash dividends going ex in ``[start_date, end_date]``.
+
+        Sibling of :meth:`get_recent_splits` — queries the
+        ``/v3/reference/dividends`` endpoint by ``ex_dividend_date`` range
+        WITHOUT a ticker filter, so the whole market's dividends in a window
+        come back in ONE call (the endpoint paginates; we take the first page,
+        ample for a ~2-week window even though dividends are far more frequent
+        than splits — hundreds of names go ex per quarter). This is the
+        one-call-per-window scan the corporate-actions ``sync`` uses to RECORD
+        dividend events into the registry (CRSP-separate: recorded only, never
+        applied to a price store).
+
+        Returns ``[{"ticker": str, "ex_dividend_date": "YYYY-MM-DD",
+        "cash_amount": float, "dividend_type": str}]`` sorted ascending by ex
+        date. Malformed rows (missing ticker / ex date / non-positive cash
+        amount) are skipped; a 403 (free-tier / bad key) returns ``[]`` so the
+        caller degrades gracefully rather than hard-failing the window.
+        """
+        results: list[dict] = []
+        try:
+            data = self._get(
+                "/v3/reference/dividends",
+                params={
+                    "ex_dividend_date.gte": start_date,
+                    "ex_dividend_date.lte": end_date,
+                    "limit": 1000,
+                    "order": "asc",
+                    "sort": "ex_dividend_date",
+                },
+            )
+        except PolygonForbiddenError:
+            return []
+        for r in data.get("results", []) or []:
+            ex_date = r.get("ex_dividend_date")
+            cash = r.get("cash_amount")
+            ticker = r.get("ticker")
+            if not ticker or not ex_date or cash is None:
+                continue
+            try:
+                cash_f = float(cash)
+            except (TypeError, ValueError):
+                continue
+            if cash_f <= 0:
+                continue
+            results.append(
+                {
+                    "ticker": str(ticker),
+                    "ex_dividend_date": str(ex_date),
+                    "cash_amount": cash_f,
+                    "dividend_type": str(r.get("dividend_type") or ""),
+                }
+            )
+        results.sort(key=lambda r: r["ex_dividend_date"])
+        return results
+
     def get_daily_bars(
         self,
         ticker: str,

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -170,9 +170,8 @@ class TestDetectSplits:
         client.get_recent_splits.side_effect = RuntimeError("polygon down")
         assert ca.detect_splits("2026-06-01", "2026-06-30", client=client) == []
 
-    def test_dividends_and_renames_not_implemented(self):
-        with pytest.raises(NotImplementedError):
-            ca.detect_dividends("2026-06-01", "2026-06-30")
+    def test_renames_not_implemented(self):
+        # Dividends are now implemented (PR5); renames remain deferred.
         with pytest.raises(NotImplementedError):
             ca.detect_renames("2026-06-01", "2026-06-30")
 

--- a/tests/test_corporate_actions_dividends.py
+++ b/tests/test_corporate_actions_dividends.py
@@ -1,0 +1,347 @@
+"""PR5 (config#1433) — dividend detection + total-return-factor MATH primitives.
+
+CRSP/Barra basis (Brian-decided): dividends are tracked as a SEPARATE
+total-return series and MUST NOT be folded into the stored split-adjusted price
+level. PR5 is detection + registry capture + TR-factor math + sync wiring — it
+changes NO stored price/feature/label/schema. These tests pin:
+
+  * ``polygon_client.get_dividends`` / ``get_recent_dividends`` — parse polygon
+    dividend rows, skip malformed, 403 → [].
+  * ``corporate_actions.detect_dividends`` — maps polygon events to dividend
+    ``CorporateAction``s with stable, distinct ``action_id``s.
+  * ``dividend_factor`` + ``total_return_series`` — the CRSP back-adjust (a $1
+    dividend on a $100 close → pre-ex prices ×0.99), compounding multiple
+    dividends, split×dividend INDEPENDENCE, and NON-mutation of the input frame.
+  * ``sync`` RECORDS dividends (registry write-if-absent) but applies them to NO
+    price store and emits NO notice/email (CRSP-separate + sub-threshold).
+"""
+
+from __future__ import annotations
+
+import io
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+import corporate_actions as ca
+from corporate_actions import CorporateActionRegistry
+from polygon_client import PolygonClient, PolygonForbiddenError
+from split_factor import restate_series_for_splits
+
+
+# ── polygon_client.get_dividends / get_recent_dividends ──────────────────────
+
+
+def _make_client() -> PolygonClient:
+    return PolygonClient(api_key="test-key", calls_per_min=5)
+
+
+def test_get_dividends_parses_and_sorts():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ex_dividend_date": "2026-06-10", "cash_amount": 0.24,
+             "dividend_type": "CD"},
+            {"ex_dividend_date": "2026-03-10", "cash_amount": 0.22,
+             "dividend_type": "CD"},
+        ],
+        "status": "OK",
+    }
+    with patch.object(client, "_get", return_value=resp) as mock_get:
+        out = client.get_dividends("HON")
+    assert mock_get.call_count == 1
+    # Sorted ascending by ex_dividend_date.
+    assert [d["ex_dividend_date"] for d in out] == ["2026-03-10", "2026-06-10"]
+    assert out[1] == {"ex_dividend_date": "2026-06-10", "cash_amount": 0.24,
+                      "dividend_type": "CD"}
+    # ticker filter passed (full history, no range).
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"]["ticker"] == "HON"
+
+
+def test_get_dividends_skips_malformed_rows():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ex_dividend_date": "2026-06-10", "cash_amount": 0.24,
+             "dividend_type": "CD"},
+            {"ex_dividend_date": None, "cash_amount": 0.5},          # bad date
+            {"ex_dividend_date": "2026-01-01", "cash_amount": 0.0},  # non-positive
+            {"ex_dividend_date": "2026-02-01", "cash_amount": -1.0},  # negative
+            {"ex_dividend_date": "2026-03-01"},                      # missing cash
+        ]
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_dividends("HON")
+    assert [d["ex_dividend_date"] for d in out] == ["2026-06-10"]
+
+
+def test_get_dividends_forbidden_returns_empty():
+    client = _make_client()
+    with patch.object(client, "_get", side_effect=PolygonForbiddenError("403")):
+        assert client.get_dividends("HON") == []
+
+
+def test_get_recent_dividends_range_scoped_single_call():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ticker": "AAPL", "ex_dividend_date": "2026-05-09",
+             "cash_amount": 0.25, "dividend_type": "CD"},
+            {"ticker": "MSFT", "ex_dividend_date": "2026-05-08",
+             "cash_amount": 0.75, "dividend_type": "CD"},
+        ],
+        "status": "OK",
+    }
+    with patch.object(client, "_get", return_value=resp) as mock_get:
+        out = client.get_recent_dividends("2026-05-01", "2026-05-15")
+    assert mock_get.call_count == 1
+    _, kwargs = mock_get.call_args
+    params = kwargs["params"]
+    assert params["ex_dividend_date.gte"] == "2026-05-01"
+    assert params["ex_dividend_date.lte"] == "2026-05-15"
+    assert "ticker" not in params  # whole-market scan
+    # Sorted ascending; carries ticker.
+    assert [d["ex_dividend_date"] for d in out] == ["2026-05-08", "2026-05-09"]
+    assert out[1]["ticker"] == "AAPL"
+
+
+def test_get_recent_dividends_skips_malformed_rows():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ticker": "AAPL", "ex_dividend_date": "2026-05-09",
+             "cash_amount": 0.25, "dividend_type": "CD"},
+            {"ticker": None, "ex_dividend_date": "2026-05-08",
+             "cash_amount": 0.75},                                    # missing ticker
+            {"ticker": "BAR", "ex_dividend_date": None,
+             "cash_amount": 0.5},                                     # missing date
+            {"ticker": "BAZ", "ex_dividend_date": "2026-05-07",
+             "cash_amount": 0.0},                                     # non-positive
+        ]
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_recent_dividends("2026-05-01", "2026-05-15")
+    assert [d["ticker"] for d in out] == ["AAPL"]
+
+
+def test_get_recent_dividends_forbidden_returns_empty():
+    client = _make_client()
+    with patch.object(client, "_get", side_effect=PolygonForbiddenError("403")):
+        assert client.get_recent_dividends("2026-05-01", "2026-05-15") == []
+
+
+# ── corporate_actions.detect_dividends ───────────────────────────────────────
+
+
+def _fake_div_client(events):
+    client = MagicMock()
+    client.get_recent_dividends.return_value = events
+    return client
+
+
+def test_detect_dividends_maps_to_actions():
+    client = _fake_div_client([
+        {"ticker": "AAPL", "ex_dividend_date": "2026-05-09",
+         "cash_amount": 0.25, "dividend_type": "CD"},
+        {"ticker": "MSFT", "ex_dividend_date": "2026-05-08",
+         "cash_amount": 0.75, "dividend_type": "CD"},
+    ])
+    actions = ca.detect_dividends("2026-05-01", "2026-05-15", client=client)
+    assert client.get_recent_dividends.call_count == 1
+    assert {a.ticker for a in actions} == {"AAPL", "MSFT"}
+    aapl = next(a for a in actions if a.ticker == "AAPL")
+    assert aapl.type == "dividend"
+    assert aapl.ex_date == "2026-05-09"
+    assert aapl.cash_amount == 0.25
+    assert aapl.dividend_kind == "CD"
+    assert aapl.raw["cash_amount"] == 0.25
+
+
+def test_detect_dividends_action_ids_stable_and_distinct():
+    a = ca.CorporateAction.from_dividend("AAPL", "2026-05-09", 0.25, "CD")
+    a_again = ca.CorporateAction.from_dividend("AAPL", "2026-05-09", 0.25, "CD")
+    diff_date = ca.CorporateAction.from_dividend("AAPL", "2026-08-09", 0.25, "CD")
+    diff_amt = ca.CorporateAction.from_dividend("AAPL", "2026-05-09", 0.26, "CD")
+    # Stable (content-addressed) and 16-char.
+    assert a.action_id == a_again.action_id
+    assert len(a.action_id) == 16
+    # Distinct on date AND on amount (so two dividends never collide).
+    assert a.action_id != diff_date.action_id
+    assert a.action_id != diff_amt.action_id
+    # Distinct from a split on the same ticker/date.
+    split = ca.CorporateAction.from_split("AAPL", "2026-05-09", 1, 4)
+    assert a.action_id != split.action_id
+
+
+def test_detect_dividends_fetch_failure_degrades_to_empty():
+    client = MagicMock()
+    client.get_recent_dividends.side_effect = RuntimeError("polygon down")
+    assert ca.detect_dividends("2026-05-01", "2026-05-15", client=client) == []
+
+
+# ── dividend_factor + total_return_series (CRSP primitive) ───────────────────
+
+
+def test_dividend_factor_basic():
+    # $1 dividend on a $100 prior close → pre-ex prices ×0.99.
+    assert ca.dividend_factor(1.0, 100.0) == pytest.approx(0.99)
+    assert ca.dividend_factor(0.0, 100.0) == pytest.approx(1.0)
+
+
+def test_dividend_factor_guards_close_prev():
+    with pytest.raises(ValueError):
+        ca.dividend_factor(1.0, 0.0)
+    with pytest.raises(ValueError):
+        ca.dividend_factor(1.0, -5.0)
+
+
+def _flat_close_frame(closes, start="2026-06-01"):
+    idx = pd.bdate_range(start, periods=len(closes))
+    return pd.DataFrame({"Close": np.asarray(closes, dtype="float64")}, index=idx)
+
+
+def test_total_return_series_single_dividend_back_adjusts_pre_ex():
+    df = _flat_close_frame([100.0, 100.0, 100.0, 100.0, 100.0])
+    ex = df.index[3].strftime("%Y-%m-%d")  # close_prev = index[2] = 100 → 0.99
+    div = ca.CorporateAction.from_dividend("X", ex, 1.0, "CD")
+    tr = ca.total_return_series(df, [div])
+    # Rows STRICTLY before ex (0,1,2) ×0.99; rows on/after ex unchanged.
+    assert list(tr.to_numpy()) == pytest.approx([99.0, 99.0, 99.0, 100.0, 100.0])
+    assert tr.name == "tr_close"
+    # Index preserved.
+    assert list(tr.index) == list(df.index)
+
+
+def test_total_return_series_compounds_multiple_dividends_oldest_to_newest():
+    df = _flat_close_frame([100.0, 100.0, 100.0, 100.0, 100.0])
+    ex1 = df.index[2].strftime("%Y-%m-%d")  # close_prev = index[1]=100 → f1=0.99
+    ex2 = df.index[4].strftime("%Y-%m-%d")  # close_prev = index[3]=100 → f2=0.98
+    d1 = ca.CorporateAction.from_dividend("X", ex1, 1.0, "CD")
+    d2 = ca.CorporateAction.from_dividend("X", ex2, 2.0, "CD")
+    # Order of the input list must not matter (sorted oldest→newest internally).
+    tr = ca.total_return_series(df, [d2, d1])
+    # rows<ex1 (0,1): f1*f2 = 0.9702 → 97.02; row2 (in [ex1,ex2)): f2 → 98;
+    # row3 (in [ex1,ex2)): f2 → 98; row4 (>=ex2): unchanged 100.
+    assert list(tr.to_numpy()) == pytest.approx([97.02, 97.02, 98.0, 98.0, 100.0])
+
+
+def test_total_return_series_does_not_mutate_input():
+    df = _flat_close_frame([100.0, 100.0, 100.0, 100.0, 100.0])
+    df["Volume"] = 1_000_000.0
+    before = df.copy(deep=True)
+    ex = df.index[3].strftime("%Y-%m-%d")
+    ca.total_return_series(df, [ca.CorporateAction.from_dividend("X", ex, 1.0)])
+    pd.testing.assert_frame_equal(df, before)
+
+
+def test_total_return_series_independent_of_split_adjustment():
+    """Split adjusts the PRICE LEVEL; dividend adjusts a SEPARATE TR series. The
+    TR series is the split-adjusted price further dividend-adjusted — the two
+    operations compose independently and the split restatement is untouched."""
+    # Un-restated 1-for-3 REVERSE split (ex at index 3): pre rows $40, post $120.
+    idx = pd.bdate_range("2026-06-01", periods=5)
+    raw = pd.DataFrame(
+        {"Close": [40.0, 40.0, 40.0, 120.0, 120.0], "Volume": [3e6] * 5},
+        index=idx,
+    )
+    ex_split = idx[3].strftime("%Y-%m-%d")
+    split_events = [{"execution_date": ex_split, "split_from": 3, "split_to": 1}]
+    split_adj = restate_series_for_splits(raw, split_events)
+    # After split restatement the close is flat $120 (pre rows ×3).
+    assert list(split_adj["Close"].to_numpy()) == pytest.approx([120.0] * 5)
+
+    split_adj_snapshot = split_adj.copy(deep=True)
+    # Dividend ex at index 2 (before split ex): close_prev = split_adj close[1]
+    # = 120 → factor = 1 - 1.2/120 = 0.99.
+    ex_div = idx[2].strftime("%Y-%m-%d")
+    div = ca.CorporateAction.from_dividend("DD", ex_div, 1.20, "CD")
+    tr = ca.total_return_series(split_adj, [div])
+
+    # TR = split-adjusted close, with rows<ex_div (0,1) ×0.99.
+    assert list(tr.to_numpy()) == pytest.approx([118.8, 118.8, 120.0, 120.0, 120.0])
+    # Independence: the split restatement frame is NOT mutated by the TR math.
+    pd.testing.assert_frame_equal(split_adj, split_adj_snapshot)
+
+
+# ── sync: records dividends, restates NO store, emits NO notice ──────────────
+
+
+class _FakeS3:
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def _err(self, code, op):
+        return ClientError({"Error": {"Code": code, "Message": "x"}}, op)
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("404", "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("NoSuchKey", "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"x"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+_BUCKET = "alpha-engine-research"
+
+
+def test_sync_records_dividends_but_applies_to_no_store_and_no_notice():
+    s3 = _FakeS3()
+    reg = CorporateActionRegistry(s3, _BUCKET)
+    div = ca.CorporateAction.from_dividend("AAPL", "2026-05-09", 0.25, "CD")
+
+    result = ca.sync(
+        s3, _BUCKET, "2026-05-08", "2026-05-12",
+        stores=[ca.STORE_DAILY_CLOSES_ARCHIVE],
+        run_id="2026-05-12",
+        tickers=["AAPL"],
+        registry=reg,
+        actions=[],                 # no splits (avoids any restatement path)
+        dividend_actions=[div],     # injected → no live polygon call
+    )
+
+    # Recorded into the registry (write-if-absent).
+    assert reg.get_action(div.action_id) is not None
+    # Surfaced in SyncResult.dividends; never a split-detected nor a notice.
+    assert [a.action_id for a in result.dividends] == [div.action_id]
+    assert result.detected == []
+    assert result.notices == []   # CRSP-separate + sub-threshold → no email/notice
+    # Applied to NO price store: no applied marker for the dividend in any store.
+    assert reg.is_applied(ca.STORE_DAILY_CLOSES_ARCHIVE, div.action_id) is False
+    assert reg.is_applied(ca.STORE_ARCTICDB_UNIVERSE, div.action_id) is False
+    # And nothing was restated (no daily_closes parquet writes occurred).
+    assert all(
+        not k.endswith(".parquet") for k in s3.store
+    ), "sync must not write any price parquet for a dividend"
+
+
+def test_sync_dividend_record_is_idempotent_across_reruns():
+    s3 = _FakeS3()
+    reg = CorporateActionRegistry(s3, _BUCKET)
+    div = ca.CorporateAction.from_dividend("AAPL", "2026-05-09", 0.25, "CD")
+    kwargs = dict(
+        stores=[ca.STORE_DAILY_CLOSES_ARCHIVE], run_id="r", tickers=["AAPL"],
+        registry=reg, actions=[], dividend_actions=[div],
+    )
+    r1 = ca.sync(s3, _BUCKET, "2026-05-08", "2026-05-12", **kwargs)
+    r2 = ca.sync(s3, _BUCKET, "2026-05-08", "2026-05-12", **kwargs)
+    assert [a.action_id for a in r1.dividends] == [div.action_id]
+    assert [a.action_id for a in r2.dividends] == [div.action_id]
+    # One detected record persisted (content-addressed key); rerun is a no-op.
+    div_keys = [k for k in s3.store if div.action_id in k]
+    assert len(div_keys) == 1


### PR DESCRIPTION
PR5 of the unified corporate-actions program (epic config#1433) — dividend detection (`get_dividends` / `get_recent_dividends`, `detect_dividends`) + registry capture via `sync` + total-return-factor math primitives (`dividend_factor`, `total_return_series`).

**CRSP-separate, low-risk:** NO price / feature / label / ArcticDB-schema change. Dividends are tracked as a SEPARATE total-return series and **do NOT mutate the stored split-adjusted price level** — PR7 consumes the recorded dividend events to build + persist the TR series under the new schema. PR5 is detection + registry capture + math primitives + sync wiring only.

## What lands

**`polygon_client`**
- `get_dividends(ticker)` — `/v3/reference/dividends` full history, ascending by `ex_dividend_date`, skips malformed rows (missing ex date / cash ≤ 0), 403 → `[]`. Mirrors `get_splits`.
- `get_recent_dividends(start, end)` — whole-market `ex_dividend_date` range scan in ONE call (no ticker filter), ascending, skips malformed, 403 → `[]`. Mirrors `get_recent_splits`.

**`corporate_actions`**
- `detect_dividends()` implemented (replaces the `NotImplementedError` stub) + `dividends_from_events()` pure transform. Deterministic, distinct `action_id`s (the `_detail` discriminator folds in `cash_amount`; `ex_date` is already in the id payload, so two dividends on different dates/amounts never collide). Graceful `[]` degrade like `detect_splits`.
- `dividend_factor(cash_amount, close_prev)` = `1 - cash_amount/close_prev` (CRSP/yfinance back-adjust, guards `close_prev > 0`).
- `total_return_series(price_df, dividend_actions, *, close_col="Close")` — builds a SEPARATE total-return-adjusted close from a split-adjusted price series, compounding factors oldest→newest (each ex-date back-adjusts all strictly-earlier rows by its factor, using the close on the trading day before the ex-date from the running series). **Returns a new Series; does NOT mutate `price_df`; wired into no store/feature.**
- `apply()` now **fails loud (CRSP-explicit)** if handed a dividend — dividends must never multiply the price level.
- `sync()` ALSO detects + `record_detected` dividends over the window (one extra `get_recent_dividends` call, gated like the split scan — only on the live non-dry-run path; reusable via a new `dividend_actions=` arg). **RECORDED ONLY:** no price store restated, **no per-dividend email/notice** (dividends are frequent — ~quarterly × hundreds of names — and cause sub-5% ex-date drops, below the discrepancy ERROR band, so a per-dividend notice would be noise). `SyncResult` gains a `dividends` field; the informational email stays SPLITS-ONLY; the summary log carries the dividend count.

**Discrepancy classifier:** confirmed NO change needed — a dividend price drop is < 5% so it logs WARN/INFO, never ERROR. No false-ERROR from dividends; the #547 splits classification is unaffected.

## Tests

New `tests/test_corporate_actions_dividends.py` (17 tests):
- `get_dividends` / `get_recent_dividends`: parse + sort, skip malformed, 403 → `[]`.
- `detect_dividends`: maps polygon events to dividend `CorporateAction`s with stable, distinct `action_id`s.
- `dividend_factor` + `total_return_series`: `$1` div on a `$100` close → pre-ex prices ×0.99; compounding multiple dividends (oldest→newest, order-independent input); split×dividend independence (split on price level + dividend on the TR series compose independently, split frame untouched); `total_return_series` does NOT mutate the input frame.
- `sync`: records dividends (registry write-if-absent), applies them to NO price store (no applied marker, no parquet write), emits NO notice; idempotent across reruns.

Updated the now-obsolete `test_dividends_and_renames_not_implemented` → `test_renames_not_implemented` (dividends are implemented this PR; renames remain deferred).

**Local results** (repo `.venv`, py3.13 — CI py3.12 + fresh lib is authoritative): `tests/test_polygon_client.py tests/test_corporate_actions.py tests/test_corporate_actions_registry.py tests/test_corporate_actions_sync.py tests/test_corporate_actions_dividends.py` → **65 passed**. Guard tests `test_artifact_registry_coverage.py` + `test_schema_contract.py` → **12 passed** (no new `s3.put_object` site, no new dep). `daily_closes` suite → 119 passed. (The 4 `test_corporate_actions_sync.py` arctic tests required a local-only stub of the stale venv's missing `nousergon_lib.config` submodule — uncommitted; green under CI's fresh lib.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
