### PR TITLE
feat(corporate-actions): ticker renames + ArcticDB symbol migration + split_factor cleanup (PR6 config#1433)

### DIFF
--- a/builders/prune_delisted_tickers.py
+++ b/builders/prune_delisted_tickers.py
@@ -1,5 +1,15 @@
 """builders/prune_delisted_tickers.py — orchestrated delisted-ticker cleanup.
 
+Before any deletion, RENAME-triggered migration runs (corporate-actions PR6,
+config#1433): a candidate going missing may be a 1:1 ticker RENAME, not a
+delisting. Each candidate is checked against polygon's ticker-events API; a
+``ticker_change`` where the candidate is the OLD ticker MIGRATES its ArcticDB
+history to the new symbol key (predictor continuity) and removes it from the
+prune set. Mergers of the acquired symbol have no ticker_change and prune as a
+delisting (NOT spliced). HISTORY-SAFETY: a candidate whose rename detection /
+migration FAILS is SKIPPED this pass — never pruned on a detection failure, so
+a polygon outage cannot delete a renamed symbol's history before it migrates.
+
 Removes ArcticDB universe symbols that meet BOTH conditions:
 
   (A) Absent from the latest ``market_data/weekly/{date}/constituents.json``
@@ -42,14 +52,51 @@ from datetime import datetime, timedelta, timezone
 import boto3
 import pandas as pd
 
+import corporate_actions as ca
 from builders._constituents_loader import load_constituents_for_run_date
 from features.compute import DEFAULT_BUCKET, _SKIP_TICKERS, _is_sector_etf
+from polygon_client import polygon_client
 from store.arctic_store import get_universe_lib
 
 log = logging.getLogger(__name__)
 
 DEFAULT_ABSENT_DAYS = 14
 AUDIT_PREFIX = "builders/prune_audit/"
+
+
+def _build_registry(s3, bucket: str):
+    """Construct a ``CorporateActionRegistry`` from an S3 client + bucket, or
+    ``None`` when no usable client is available (mirrors
+    ``features.compute._build_registry``). Used by the rename-migration phase to
+    record renames + enforce exactly-once ArcticDB symbol migration."""
+    if s3 is None:
+        return None
+    try:
+        return ca.CorporateActionRegistry(s3, bucket)
+    except Exception as exc:  # noqa: BLE001 - degrade, never hard-fail the prune
+        log.warning(
+            "could not build corporate-action registry (%s) — rename "
+            "migration degraded this pass", exc,
+        )
+        return None
+
+
+def _build_rename_client():
+    """Construct a polygon client for rename detection, or ``None`` on failure.
+
+    Indirected through a module-level seam (``builders.prune_delisted_tickers.
+    polygon_client``) so tests patch it without a live API call. A construction
+    failure degrades to ``None`` → the caller treats EVERY candidate as a
+    detection failure and prunes none of them this pass (history-safety)."""
+    try:
+        return polygon_client()
+    except Exception as exc:  # noqa: BLE001 - degrade, never hard-fail the prune
+        log.warning(
+            "could not construct polygon client for rename detection (%s) — "
+            "no rename detection this pass; refusing to prune on an "
+            "unverifiable candidate set (history-safety)", exc,
+        )
+        return None
 
 
 def _load_latest_constituents(
@@ -210,6 +257,87 @@ def prune_delisted_tickers(
             len(candidates),
         )
 
+    # ── PR6: rename-triggered ArcticDB migration BEFORE the prune deletion ───
+    # A prune candidate going missing from constituents/daily_closes may be a
+    # 1:1 ticker RENAME (e.g. FB -> META), NOT a delisting. Query polygon
+    # ticker-events for every candidate FIRST: a ``ticker_change`` where the
+    # candidate is the OLD ticker means it was renamed → MIGRATE its full
+    # ArcticDB history to the new key (predictor continuity) and REMOVE it from
+    # the prune set. A genuine delist / merger-OF-THE-ACQUIRED has no
+    # ticker_change and prunes as today (mergers are NOT spliced).
+    #
+    # Ordering is load-bearing: migration MUST run before the deletion loop, or
+    # the prune would delete the orphaned old-symbol history before it can be
+    # carried over.
+    #
+    # HISTORY-SAFETY: a candidate whose rename DETECTION (or migration) FAILS
+    # is SKIPPED this pass — never pruned on a failure. A polygon outage must
+    # not cause a renamed symbol's history to be wrongly deleted; the candidate
+    # is re-examined next pass once detection succeeds.
+    registry = _build_registry(s3, bucket)
+    rename_client = _build_rename_client()
+    run_id = f"prune-{today.strftime('%Y-%m-%d')}"
+    migrated: list[dict] = []
+    skipped_rename_detect_failed: list[str] = []
+    skip_prune: set[str] = set()
+
+    if candidates and (registry is None or rename_client is None):
+        # Cannot run rename detection (no registry or no polygon client) → we
+        # cannot confirm any candidate is a delist vs a rename. Refuse to prune
+        # blind this pass (history-safety).
+        log.warning(
+            "prune: rename detection unavailable (registry=%s polygon=%s) — "
+            "refusing to prune %d candidate(s) this pass (history-safety)",
+            registry is not None, rename_client is not None, len(candidates),
+        )
+        skipped_rename_detect_failed = list(candidates)
+        skip_prune = set(candidates)
+    elif candidates:
+        detection = ca.detect_renames(candidates, client=rename_client)
+        for action in detection.renames:
+            old_t, new_t = action.old_ticker, action.new_ticker
+            record = {
+                "old_ticker": old_t,
+                "new_ticker": new_t,
+                "ex_date": action.ex_date,
+                "action_id": action.action_id,
+                "migrated": False,
+            }
+            if apply:
+                try:
+                    did = ca.migrate_symbol(
+                        universe_lib, old_t, new_t,
+                        registry=registry, run_id=run_id, ex_date=action.ex_date,
+                    )
+                    record["migrated"] = bool(did)
+                    skip_prune.add(old_t)  # migrated (or already-applied) — not a delist
+                    log.warning(
+                        "RENAME-MIGRATED ticker=%s -> %s ex_date=%s applied=%s",
+                        old_t, new_t, action.ex_date, did,
+                    )
+                except Exception as exc:  # noqa: BLE001 - skip, never prune the rename
+                    log.warning(
+                        "migrate_symbol failed for %s -> %s (%s) — NOT pruning "
+                        "%s this pass (history-safety)", old_t, new_t, exc, old_t,
+                    )
+                    record["error"] = str(exc)
+                    skip_prune.add(old_t)
+                    skipped_rename_detect_failed.append(old_t)
+            else:
+                log.info(
+                    "DRY-RUN would migrate ticker=%s -> %s ex_date=%s",
+                    old_t, new_t, action.ex_date,
+                )
+                skip_prune.add(old_t)  # in dry-run, exclude from the would-prune set too
+            migrated.append(record)
+        # Candidates whose ticker-events query RAISED — skip pruning this pass.
+        for cand in sorted(detection.failed_candidates):
+            skip_prune.add(cand)
+            skipped_rename_detect_failed.append(cand)
+
+    if skip_prune:
+        candidates = [c for c in candidates if c not in skip_prune]
+
     pruned: list[dict] = []
     skipped_recent: list[dict] = []
     skipped_unreadable: list[str] = []
@@ -268,16 +396,21 @@ def prune_delisted_tickers(
         "pruned_count": len(pruned),
         "skipped_recent_count": len(skipped_recent),
         "skipped_unreadable_count": len(skipped_unreadable),
+        "migrated_count": len([m for m in migrated if m.get("migrated")]),
+        "skipped_rename_detect_failed_count": len(skipped_rename_detect_failed),
         "pruned": pruned,
         "skipped_recent": skipped_recent,
         "skipped_unreadable": skipped_unreadable,
+        "migrated": migrated,
+        "skipped_rename_detect_failed": sorted(set(skipped_rename_detect_failed)),
     }
 
     log.info(
-        "prune_delisted_tickers: applied=%s candidates=%d pruned=%d "
-        "skipped_recent=%d skipped_unreadable=%d",
-        apply, len(candidates), len(pruned),
+        "prune_delisted_tickers: applied=%s pruned=%d migrated=%d "
+        "skipped_recent=%d skipped_unreadable=%d skipped_rename_detect_failed=%d",
+        apply, len(pruned), summary["migrated_count"],
         len(skipped_recent), len(skipped_unreadable),
+        len(skipped_rename_detect_failed),
     )
 
     # Always write the audit, even on dry-run + zero-prune — gives Sat

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -3,8 +3,9 @@
 WHY THIS EXISTS (unified corporate-actions program, config#1431):
     Corporate actions (splits, dividends, renames) retroactively restate a
     ticker's adjusted price history. The data pipeline already DETECTS splits
-    (``polygon_client.get_recent_splits`` + ``split_factor.py``) and RESTATES
-    them into the ArcticDB universe (data#1298), but it had no first-class,
+    (``polygon_client.get_recent_splits`` + the split-factor math, now in
+    ``corporate_actions._split_math``) and RESTATES them into the ArcticDB
+    universe (data#1298), but it had no first-class,
     auditable *model* of a corporate action and no durable record of which
     actions were detected/applied. That gap produced two symptoms:
 
@@ -17,27 +18,28 @@ WHY THIS EXISTS (unified corporate-actions program, config#1431):
          action X to store Y", which a robust restatement path needs to stay
          idempotent across reruns.
 
-    This module is the FOUNDATION layer of the program (PR1+PR2): a frozen
-    ``CorporateAction`` dataclass with a deterministic ``action_id``, a
-    polygon-backed ``detect_splits`` built ON ``split_factor.py`` (the
-    authoritative factor convention), and a ``CorporateActionRegistry`` (S3
-    JSON) that makes the split-restatement discrepancy classification
-    *registry-authoritative* rather than text-heuristic.
+    The program's foundation is a frozen ``CorporateAction`` dataclass with a
+    deterministic ``action_id``, polygon-backed detectors (``detect_splits`` /
+    ``detect_dividends`` / ``detect_renames``) built ON the split-factor math
+    (``corporate_actions._split_math``, the authoritative factor convention),
+    and a ``CorporateActionRegistry`` (S3 JSON) that makes the split-restatement
+    discrepancy classification *registry-authoritative* rather than
+    text-heuristic, and the per-(action, store) restatement idempotent.
 
-    This PR is behavior-ADDITIVE: it does NOT change the existing
-    split-RESTATEMENT path (``split_factor.restate_series_for_splits`` /
-    ArcticDB write) — that is a later PR. It only adds the module + registry
-    and RECLASSIFIES the discrepancy log (confirmed split -> WARN, not ERROR)
-    plus one informational notification.
+    The split RESTATEMENT path lives in :func:`apply` / :func:`sync` (PR3/PR4);
+    dividends are RECORDED ONLY (CRSP-separate total-return series, PR5); and
+    ticker RENAMES (PR6) are an identity-preserving 1:1 symbol remap migrated by
+    :func:`migrate_symbol` rather than a price restatement — mergers of the
+    acquired symbol are NOT spliced, they delist via the existing prune path.
 
-CONVENTION (inherited from ``split_factor.py``):
+CONVENTION (the split factor, in ``corporate_actions._split_math``):
     A forward N-for-1 split (``split_from=1, split_to=N``) divides the adjusted
     price by N for every date STRICTLY BEFORE the ex (execution) date. A reverse
     1-for-N split (``split_from=N, split_to=1``) multiplies by N. The per-event
     multiplicative factor applied to dates strictly before ``ex_date`` is
     therefore ``split_from / split_to`` — and we delegate to
-    ``split_factor.cumulative_factor`` so this module never re-derives the
-    authoritative factor independently.
+    :func:`cumulative_factor` so this module never re-derives the authoritative
+    factor independently.
 """
 
 from __future__ import annotations
@@ -49,7 +51,11 @@ from dataclasses import dataclass, field
 import numpy as np
 import pandas as pd
 
-import split_factor
+from corporate_actions._split_math import (
+    cumulative_factor,
+    restate_series_for_splits,
+    split_events,
+)
 from corporate_actions.registry import CorporateActionRegistry
 
 log = logging.getLogger(__name__)
@@ -71,10 +77,19 @@ __all__ = [
     "detect_renames",
     "splits_from_events",
     "dividends_from_events",
+    "renames_from_events",
+    "RenameDetection",
+    "migrate_symbol",
+    # split-factor math re-exported from the package (moved out of the
+    # deprecated top-level ``split_factor.py`` shim, PR6 config#1433).
+    "cumulative_factor",
+    "restate_series_for_splits",
+    "split_events",
 ]
 
-# Action types implemented this PR. Dividends/renames are modeled (fields exist)
-# but their detection/factor are deferred to later PRs of the program.
+# Action types. Splits restate the price level (apply/sync); dividends are
+# RECORDED ONLY (CRSP-separate, PR5); renames are an identity-preserving 1:1
+# symbol remap migrated by migrate_symbol (PR6) — never a price restatement.
 _TYPE_SPLIT = "split"
 _TYPE_DIVIDEND = "dividend"
 _TYPE_RENAME = "rename"
@@ -142,10 +157,10 @@ class CorporateAction:
     # split fields
     split_from: int | None = None
     split_to: int | None = None
-    # dividend fields (modeled now, detected in a later PR)
+    # dividend fields (detected by detect_dividends, recorded CRSP-separate)
     cash_amount: float | None = None
     dividend_kind: str | None = None
-    # rename fields (modeled now, detected in a later PR)
+    # rename fields (detected by detect_renames; migrated by migrate_symbol)
     old_ticker: str | None = None
     new_ticker: str | None = None
     # provenance
@@ -222,6 +237,37 @@ class CorporateAction:
             raw=dict(raw or {}),
         )
 
+    @classmethod
+    def from_rename(
+        cls,
+        old_ticker: str,
+        new_ticker: str,
+        ex_date: str,
+        *,
+        source: str = "polygon",
+        raw: dict | None = None,
+    ) -> "CorporateAction":
+        """Build a ticker-rename action (1:1 identity-preserving symbol remap).
+
+        A rename is the polygon ``ticker_change`` event: on ``ex_date`` the
+        entity's symbol changes from ``old_ticker`` to ``new_ticker`` (e.g.
+        FB -> META on 2022-06-09). ``ticker`` is set to ``old_ticker`` so the
+        action keys off the symbol the pipeline already holds (the one going
+        missing from constituents) — that is the side the migration reads from.
+        ``action_id`` is derived deterministically from
+        ``(type, old_ticker, ex_date, old->new)`` so the same rename folds to
+        one id across reruns (the write-once exactly-once migration property).
+        """
+        return cls(
+            type=_TYPE_RENAME,
+            ticker=str(old_ticker),
+            ex_date=str(ex_date),
+            old_ticker=str(old_ticker),
+            new_ticker=str(new_ticker),
+            source=source,
+            raw=dict(raw or {}),
+        )
+
     # ── (de)serialization ────────────────────────────────────────────────
     def to_dict(self) -> dict:
         """JSON-serializable view (the registry persists this + audit fields)."""
@@ -288,7 +334,7 @@ def expected_factor(action: CorporateAction) -> float:
     (``split_from=2, split_to=1``) yields ``2.0`` (pre-split prices double on
     the post-split adjusted scale); a forward 10-for-1 split
     (``split_from=1, split_to=10``) yields ``0.1`` (pre-split prices are divided
-    by 10). We DELEGATE to ``split_factor.cumulative_factor`` (the authoritative
+    by 10). We DELEGATE to :func:`cumulative_factor` (the authoritative
     convention) rather than re-deriving the ratio independently — the cumulative
     factor of a single event evaluated one day before the ex date is exactly
     ``split_from/split_to``.
@@ -308,7 +354,7 @@ def expected_factor(action: CorporateAction) -> float:
         day_before = (
             pd.Timestamp(action.ex_date) - pd.Timedelta(days=1)
         ).strftime("%Y-%m-%d")
-        return split_factor.cumulative_factor([ev], day_before)
+        return cumulative_factor([ev], day_before)
     # TODO(corporate-actions program): implement dividend / rename expected
     # factors in a later PR. Fail loud rather than silently returning 1.0.
     raise NotImplementedError(
@@ -324,7 +370,7 @@ def expected_factor(action: CorporateAction) -> float:
 # primitives below compute that distinct series; they NEVER mutate a price store
 # or a feature. PR7 consumes the registry-recorded dividend events to build +
 # persist the total-return series under the new schema — these are the math it
-# will call. Kept here (not in split_factor) because the split factor convention
+# will call. Kept here (not in _split_math) because the split factor convention
 # is multiplicative on the price LEVEL whereas a dividend factor is a back-adjust
 # applied to a SEPARATE return series.
 
@@ -366,7 +412,7 @@ def total_return_series(
     ``pd.Series`` (the total-return close); **it does NOT mutate ``price_df``** and
     is wired into NO store/feature — PR7 consumes it.
 
-    Method (mirrors ``split_factor`` compounding correctness, but on a return
+    Method (mirrors the split-factor compounding correctness, but on a return
     series): process dividends OLDEST→NEWEST; for each ex-date E, read the close
     on the trading day strictly BEFORE E from the RUNNING series, compute
     ``dividend_factor(cash, close_prev)``, and multiply every row STRICTLY BEFORE
@@ -423,14 +469,15 @@ def apply(
     run_id: str | None = None,
 ) -> tuple[pd.DataFrame, list[dict]]:
     """Restate a SINGLE ticker's price frame so its full history is corporate-
-    action-consistent, routing all split restatement through ``split_factor``.
+    action-consistent, routing all split restatement through the split-factor
+    math (``corporate_actions._split_math``).
 
     ``df`` is one ticker's OHLCV(+) frame (DatetimeIndex). ``actions`` are the
     ``CorporateAction``s that pertain to THAT frame's ticker (the caller filters
     by ticker — this PR only restates SPLIT actions; a dividend/rename action
     passed in raises ``NotImplementedError`` because their factor math ships in a
     later PR). The full-history multiplicative restatement itself is delegated to
-    :func:`split_factor.restate_series_for_splits` (price ×factor, volume ÷factor
+    :func:`restate_series_for_splits` (price ×factor, volume ÷factor
     for every row strictly before each split's ex_date) — this function never
     re-derives the factor convention.
 
@@ -529,7 +576,7 @@ def apply(
         }
         for a in events_to_apply
     ]
-    restated = split_factor.restate_series_for_splits(df, events)
+    restated = restate_series_for_splits(df, events)
 
     for a in events_to_apply:
         ex = pd.Timestamp(a.ex_date).normalize()
@@ -550,7 +597,7 @@ def apply(
 # ── sync: unified, pre-read orchestration across ALL stores (PR4, config#1433) ─
 
 # Price / volume columns a daily-closes archive parquet carries that a split
-# restates (mirrors split_factor.restate_series_for_splits' defaults; only the
+# restates (mirrors restate_series_for_splits' defaults; only the
 # columns actually present in a given parquet are touched).
 _ARCHIVE_PRICE_COLS = ("Open", "High", "Low", "Close", "VWAP", "Adj_Close")
 _ARCHIVE_VOLUME_COLS = ("Volume",)
@@ -740,8 +787,6 @@ def _sync_daily_closes_archive(
     is NOT multiplied (only marked) — so neither a sync re-run NOR an
     independent polygon re-fetch can double-adjust it. WRITE-THEN-MARK as well.
     """
-    from split_factor import restate_series_for_splits
-
     results: list[dict] = []
     wdates = sorted(window_dates)
     for a in actions:
@@ -1123,8 +1168,214 @@ def detect_dividends(
     return dividends_from_events(events)
 
 
-def detect_renames(start_date: str, end_date: str, *, client=None):
-    """Not implemented this PR (modeled fields exist; detection is a later PR)."""
-    raise NotImplementedError(
-        "detect_renames is deferred to a later PR of the corporate-actions program"
+def renames_from_events(candidate: str, events: list[dict]) -> list["CorporateAction"]:
+    """Map polygon ticker-events rename pairs to rename ``CorporateAction``s for
+    ONE candidate.
+
+    ``events`` is :meth:`polygon_client.PolygonClient.get_ticker_events` output —
+    ``[{"date", "old_ticker", "new_ticker"}]`` ascending. Emits a rename action
+    for every pair whose ``old_ticker`` equals ``candidate`` (the candidate was
+    renamed AWAY to ``new_ticker`` — the 1:1 identity-preserving remap this PR
+    migrates). Pairs where the candidate is the NEW side (it is the survivor of
+    some earlier rename, still live) are NOT emitted — only the symbol going
+    missing triggers a migration off itself. Pure transform (no I/O); malformed
+    or no-op (old == new) rows are skipped.
+    """
+    actions: list[CorporateAction] = []
+    for ev in events or []:
+        old_t = ev.get("old_ticker")
+        new_t = ev.get("new_ticker")
+        date = ev.get("date")
+        if not old_t or not new_t or not date or old_t == new_t:
+            continue
+        if str(old_t) != str(candidate):
+            continue
+        actions.append(
+            CorporateAction.from_rename(
+                old_ticker=str(old_t),
+                new_ticker=str(new_t),
+                ex_date=str(date),
+                source="polygon",
+                raw=dict(ev),
+            )
+        )
+    return actions
+
+
+@dataclass
+class RenameDetection:
+    """Result of a prune-triggered ticker-rename scan over candidate tickers.
+
+    ``renames`` — the detected old->new rename ``CorporateAction``s (one per
+    candidate that polygon reports as the OLD side of a ``ticker_change``).
+
+    ``failed_candidates`` — candidates whose ticker-events query RAISED (polygon
+    unreachable / 5xx / unexpected, or client construction failed). The prune
+    wiring MUST NOT prune these this pass: a detection OUTAGE must never delete a
+    symbol that might be a rename. They are retried next pass.
+
+    A candidate queried successfully with NO ``ticker_change`` is in NEITHER set
+    — it is a CONFIRMED non-rename (genuine delist / merger-of-acquired) and is
+    safe to prune as a delisting.
+    """
+
+    renames: list = field(default_factory=list)
+    failed_candidates: set = field(default_factory=set)
+
+
+def detect_renames(candidate_tickers, *, client=None) -> "RenameDetection":
+    """Prune-triggered ticker-rename detection (corporate-actions PR6,
+    config#1433).
+
+    polygon has NO "all renames in a date range" endpoint — the ticker-events
+    API is PER-TICKER — so detection is not a range scan. The natural signal is
+    already in the pipeline: a symbol going MISSING from constituents /
+    daily_closes (a prune candidate) is what flags it for examination. For each
+    candidate we query :meth:`PolygonClient.get_ticker_events` and emit a rename
+    when the candidate is the OLD side of a ``ticker_change`` (it was renamed
+    away — an identity-preserving 1:1 remap whose ArcticDB history :func:
+    `migrate_symbol` carries to the new key so the predictor stays continuous).
+
+    A candidate with NO ticker_change is a genuine delist or a
+    merger-OF-THE-ACQUIRED — NOT spliced (merging two companies' histories is
+    poison for the predictor); it falls through to the existing prune path.
+
+    HISTORY-SAFETY (the load-bearing failure semantics): detection is
+    best-effort but its FAILURE is NEVER silently treated as "no rename". A
+    candidate whose query RAISES is recorded in ``failed_candidates`` so the
+    prune wiring SKIPS pruning it this pass — a polygon outage must not cause a
+    renamed symbol's history to be wrongly deleted before it can be migrated.
+    Only a SUCCESSFUL query that returns no rename confirms a candidate is safe
+    to prune. Returns a :class:`RenameDetection`.
+    """
+    result = RenameDetection()
+    candidates = [str(t) for t in (candidate_tickers or [])]
+    if not candidates:
+        return result
+    if client is None:
+        try:
+            from polygon_client import polygon_client
+
+            client = polygon_client()
+        except Exception as exc:  # noqa: BLE001 - construction failure degrades
+            # We cannot confirm ANY candidate is not a rename — treat EVERY
+            # candidate as a detection failure (none confirmed safe to prune).
+            log.warning(
+                "corporate_actions.detect_renames: could not obtain polygon "
+                "client (%s) — skipping rename detection for %d candidate(s); "
+                "none confirmed safe to prune this pass (history-safety)",
+                _scrub(exc), len(candidates),
+            )
+            result.failed_candidates.update(candidates)
+            return result
+    for cand in candidates:
+        try:
+            events = client.get_ticker_events(cand)
+        except Exception as exc:  # noqa: BLE001 - per-candidate degrade + RECORD
+            log.warning(
+                "corporate_actions.detect_renames: ticker-events query failed "
+                "for %s (%s) — NOT pruning this candidate this pass "
+                "(history-safety)", cand, _scrub(exc),
+            )
+            result.failed_candidates.add(cand)
+            continue
+        result.renames.extend(renames_from_events(cand, events))
+    return result
+
+
+def migrate_symbol(
+    universe_lib,
+    old_ticker: str,
+    new_ticker: str,
+    *,
+    registry: "CorporateActionRegistry",
+    run_id: str,
+    ex_date: str | None = None,
+) -> bool:
+    """Migrate ONE ArcticDB universe symbol ``old_ticker`` -> ``new_ticker`` for
+    a 1:1 ticker rename (corporate-actions PR6, config#1433).
+
+    Identity-preserving remap: read ``old_ticker``'s FULL series, write it
+    VERBATIM under the ``new_ticker`` key, delete ``old_ticker`` — so the
+    predictor keeps a CONTINUOUS history across the rename (e.g. FB's history
+    lives under META). The frame is re-keyed AS READ (no re-projection): it was
+    already written through the canonical chokepoint, and a pure remap must not
+    transform the data it carries.
+
+    EXACTLY-ONCE via the registry ``arcticdb_universe`` applied marker, keyed on
+    the rename ``action_id``. WRITE-THEN-MARK: the marker is written ONLY after
+    the new key is written AND the old key deleted, so a mid-migration failure
+    never leaves a false "applied" marker (a re-run re-attempts cleanly).
+    Idempotent: a second call sees ``is_applied`` True and returns ``False``
+    without touching ArcticDB. ``ex_date`` makes the marker id match the detected
+    rename's ``action_id`` (the prune wiring passes the detected action's
+    ex_date); a standalone call may omit it.
+
+    NEW-ALREADY-EXISTS (safe choice, documented): if ``new_ticker`` already
+    holds its OWN history, we do NOT overwrite or merge it — merging two real
+    histories is exactly the splice this program forbids (a live ``new_ticker``
+    series is already maintained by ``daily_append``; the orphaned ``old_ticker``
+    series is the SAME entity pre-rename and is now superseded). We log a WARN,
+    delete the orphaned ``old_ticker`` key so it cannot linger as a phantom
+    constituent, mark applied, and return ``True``.
+
+    Returns ``True`` if a migration (or its idempotent new-exists cleanup) ran
+    this call, ``False`` if it was already applied.
+    """
+    action = CorporateAction.from_rename(
+        old_ticker=old_ticker,
+        new_ticker=new_ticker,
+        ex_date=str(ex_date) if ex_date is not None else "",
     )
+    if registry is not None and registry.is_applied(STORE_ARCTICDB_UNIVERSE, action.action_id):
+        log.info(
+            "corporate_actions.migrate_symbol: %s -> %s already applied "
+            "(action_id=%s) — noop", old_ticker, new_ticker, action.action_id,
+        )
+        return False
+
+    # Record the rename action for provenance (write-if-absent; harmless if the
+    # prune wiring already recorded it).
+    if registry is not None:
+        try:
+            registry.record_detected(action, run_id=run_id)
+        except Exception as exc:  # noqa: BLE001 - provenance best-effort
+            log.warning(
+                "corporate_actions.migrate_symbol: record_detected failed for "
+                "%s (%s)", action.action_id, _scrub(exc),
+            )
+
+    # Source must exist to migrate. If the old key is gone, there is nothing to
+    # carry — treat as a no-op success (a prior run may have migrated + deleted).
+    if not universe_lib.has_symbol(old_ticker):
+        log.warning(
+            "corporate_actions.migrate_symbol: %s not in ArcticDB universe — "
+            "nothing to migrate to %s", old_ticker, new_ticker,
+        )
+        return False
+
+    if universe_lib.has_symbol(new_ticker):
+        # new already has its own live history — DO NOT splice. Drop the orphaned
+        # old key so it can't masquerade as a phantom constituent.
+        log.warning(
+            "corporate_actions.migrate_symbol: %s already has ArcticDB history "
+            "— NOT overwriting/merging (no splice); deleting orphaned source %s "
+            "(superseded by the live %s series)", new_ticker, old_ticker, new_ticker,
+        )
+        universe_lib.delete(old_ticker)
+        if registry is not None:
+            registry.mark_applied(action, STORE_ARCTICDB_UNIVERSE, run_id=run_id)
+        return True
+
+    df = universe_lib.read(old_ticker).data
+    # WRITE-THEN-(DELETE)-THEN-MARK: new key written first, old deleted, marker
+    # last — a failure anywhere before the mark leaves no false "applied" record.
+    universe_lib.write(new_ticker, df, prune_previous_versions=True)
+    universe_lib.delete(old_ticker)
+    if registry is not None:
+        registry.mark_applied(action, STORE_ARCTICDB_UNIVERSE, run_id=run_id)
+    log.warning(
+        "corporate_actions.migrate_symbol: MIGRATED %s -> %s (%d rows) "
+        "action_id=%s", old_ticker, new_ticker, len(df), action.action_id,
+    )
+    return True

--- a/corporate_actions/_split_math.py
+++ b/corporate_actions/_split_math.py
@@ -1,5 +1,13 @@
-"""
-split_factor.py — polygon-authoritative split factors for full-history restatement.
+"""corporate_actions._split_math — polygon-authoritative split factor math.
+
+Moved here from the top-level ``split_factor.py`` shim (corporate-actions
+program PR6, config#1433): the split-restatement math is part of the unified
+corporate-actions model, not a stray top-level module. It is RE-EXPORTED from
+``corporate_actions`` (``from corporate_actions import cumulative_factor,
+restate_series_for_splits, split_events``) so consumers depend on the package,
+not on a loose module name. No behavior changed in the move — the factor
+convention is byte-for-byte the one validated on the DD 2026-06-24 reverse
+split.
 
 WHY THIS EXISTS (data#1298):
     The ArcticDB universe library (predictor TRAINING input) is append-only +

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -469,6 +469,70 @@ class PolygonClient:
         results.sort(key=lambda r: r["ex_dividend_date"])
         return results
 
+    def get_ticker_events(self, ticker: str) -> list[dict]:
+        """Fetch ticker-RENAME events for one ticker (corporate-actions PR6,
+        config#1433).
+
+        Queries the polygon ticker-events API
+        (``/vX/reference/tickers/{ticker}/events``). polygon resolves the
+        ticker to its underlying entity (figi/cik) and returns that entity's
+        FULL ticker history as a list of ``ticker_change`` events, each carrying
+        the ticker the entity changed TO and the date of the change (e.g. an
+        entity that IPO'd as ``FB`` on 2012-05-18 then became ``META`` on
+        2022-06-09 returns both as ``ticker_change`` events). Consecutive
+        changes — sorted ascending by date — define old->new RENAME PAIRS; the
+        EARLIEST event is the initial listing (no prior ticker) and yields no
+        pair.
+
+        There is NO whole-market "all renames in a range" endpoint — this API
+        is per-ticker — so detection is prune-triggered (a symbol going missing
+        from constituents is what flags it), see
+        ``corporate_actions.detect_renames``.
+
+        Returns ``[{"date": "YYYY-MM-DD", "old_ticker": str,
+        "new_ticker": str}]`` sorted ascending by date (one per adjacent
+        transition; no-op pairs where old == new are dropped). A 403
+        (free-tier / bad key) returns ``[]`` (mirrors :meth:`get_splits`); the
+        apiKey is scrubbed from any raised error by the shared ``_get`` path.
+        Any OTHER failure (network / 5xx after retries / unexpected) PROPAGATES
+        — ``detect_renames`` catches it per-candidate and refuses to prune that
+        candidate this pass (history-safety: a detection outage must never
+        delete a symbol that might be a rename).
+        """
+        try:
+            data = self._get(f"/vX/reference/tickers/{ticker}/events")
+        except PolygonForbiddenError:
+            return []
+        results_obj = data.get("results") or {}
+        events = results_obj.get("events") or []
+        # Collect ascending (date, new_ticker) transitions from ticker_change
+        # events; ignore any other event type the endpoint may carry.
+        changes: list[dict] = []
+        for ev in events:
+            if ev.get("type") != "ticker_change":
+                continue
+            date = ev.get("date")
+            tc = ev.get("ticker_change") or {}
+            new_t = tc.get("ticker")
+            if not date or not new_t:
+                continue
+            changes.append({"date": str(date), "ticker": str(new_t)})
+        changes.sort(key=lambda c: c["date"])
+        # Adjacent transitions form the old->new rename pairs. The earliest
+        # change is the initial listing (no prior ticker) → no pair.
+        pairs: list[dict] = []
+        for prev, cur in zip(changes, changes[1:]):
+            if prev["ticker"] == cur["ticker"]:
+                continue  # defensive: drop a no-op repeat
+            pairs.append(
+                {
+                    "date": cur["date"],
+                    "old_ticker": prev["ticker"],
+                    "new_ticker": cur["ticker"],
+                }
+            )
+        return pairs
+
     def get_daily_bars(
         self,
         ticker: str,

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -19,7 +19,7 @@ from botocore.exceptions import ClientError
 
 import corporate_actions as ca
 from corporate_actions import CorporateActionRegistry
-from split_factor import restate_series_for_splits
+from corporate_actions import restate_series_for_splits
 
 
 class _FakeS3:
@@ -170,10 +170,15 @@ class TestDetectSplits:
         client.get_recent_splits.side_effect = RuntimeError("polygon down")
         assert ca.detect_splits("2026-06-01", "2026-06-30", client=client) == []
 
-    def test_renames_not_implemented(self):
-        # Dividends are now implemented (PR5); renames remain deferred.
-        with pytest.raises(NotImplementedError):
-            ca.detect_renames("2026-06-01", "2026-06-30")
+    def test_renames_now_implemented(self):
+        # Renames are implemented (PR6): detect_renames takes CANDIDATE tickers
+        # and returns a RenameDetection (no longer a NotImplementedError stub).
+        client = MagicMock()
+        client.get_ticker_events.return_value = []
+        result = ca.detect_renames(["FOO"], client=client)
+        assert isinstance(result, ca.RenameDetection)
+        assert result.renames == []
+        assert result.failed_candidates == set()
 
 
 class TestApply:

--- a/tests/test_corporate_actions_dividends.py
+++ b/tests/test_corporate_actions_dividends.py
@@ -30,7 +30,7 @@ from botocore.exceptions import ClientError
 import corporate_actions as ca
 from corporate_actions import CorporateActionRegistry
 from polygon_client import PolygonClient, PolygonForbiddenError
-from split_factor import restate_series_for_splits
+from corporate_actions import restate_series_for_splits
 
 
 # ── polygon_client.get_dividends / get_recent_dividends ──────────────────────

--- a/tests/test_corporate_actions_renames.py
+++ b/tests/test_corporate_actions_renames.py
@@ -1,0 +1,244 @@
+"""Tests for ticker-rename detection + ArcticDB symbol migration (PR6,
+config#1433).
+
+Covers:
+  * ``CorporateAction.from_rename`` — type/fields + deterministic action_id.
+  * ``renames_from_events`` — emit a rename only when the candidate is the OLD
+    side of a ticker_change (NEW-side survivor / no-op skipped).
+  * ``detect_renames`` over CANDIDATE tickers — rename actions for ticker_changes
+    only; a delist-only candidate yields no rename; a polygon FAILURE records the
+    candidate in ``failed_candidates`` (history-safety, never silently "no
+    rename"); a client-construction failure fails ALL candidates.
+  * ``migrate_symbol`` — old->new ArcticDB round-trip (new holds old's full
+    history, old deleted), exactly-once idempotency via the registry marker, and
+    the new-already-exists no-splice path.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+import corporate_actions as ca
+from corporate_actions import CorporateActionRegistry
+
+_BUCKET = "alpha-engine-research"
+
+
+# ── in-memory S3 double (registry markers) — mirrors test_corporate_actions* ──
+
+
+class _FakeS3:
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def _err(self, code, op):
+        return ClientError({"Error": {"Code": code, "Message": "x"}}, op)
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("404", "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("NoSuchKey", "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"x"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _fake_events_client(events_by_ticker: dict[str, list[dict]], *, raise_for=None):
+    """A fake polygon client whose get_ticker_events serves canned rename pairs
+    per ticker; ``raise_for`` (a set) raises to simulate a detection failure."""
+    client = MagicMock()
+    raise_for = raise_for or set()
+
+    def fake_events(ticker):
+        if ticker in raise_for:
+            raise RuntimeError(f"polygon down for {ticker}")
+        return events_by_ticker.get(ticker, [])
+
+    client.get_ticker_events.side_effect = fake_events
+    return client
+
+
+# ── CorporateAction.from_rename ───────────────────────────────────────────────
+
+
+def test_from_rename_fields_and_deterministic_id():
+    a = ca.CorporateAction.from_rename("FB", "META", "2022-06-09")
+    assert a.type == "rename"
+    assert a.old_ticker == "FB"
+    assert a.new_ticker == "META"
+    assert a.ticker == "FB"  # keys off the OLD (missing) symbol
+    assert a.ex_date == "2022-06-09"
+    # Deterministic + content-addressed: same rename -> same id.
+    b = ca.CorporateAction.from_rename("FB", "META", "2022-06-09")
+    assert a.action_id == b.action_id
+    # A different target or date changes the id.
+    assert a.action_id != ca.CorporateAction.from_rename("FB", "MVRS", "2022-06-09").action_id
+    assert a.action_id != ca.CorporateAction.from_rename("FB", "META", "2022-06-10").action_id
+    # Round-trips through to_dict/from_dict.
+    assert ca.CorporateAction.from_dict(a.to_dict()).action_id == a.action_id
+
+
+# ── renames_from_events ───────────────────────────────────────────────────────
+
+
+def test_renames_from_events_emits_only_when_candidate_is_old():
+    events = [{"date": "2022-06-09", "old_ticker": "FB", "new_ticker": "META"}]
+    out = ca.renames_from_events("FB", events)
+    assert len(out) == 1
+    assert (out[0].old_ticker, out[0].new_ticker) == ("FB", "META")
+    # Candidate is the NEW side (survivor) — not a rename OFF this candidate.
+    assert ca.renames_from_events("META", events) == []
+
+
+def test_renames_from_events_skips_noop_and_malformed():
+    events = [
+        {"date": "2022-06-09", "old_ticker": "FB", "new_ticker": "FB"},   # no-op
+        {"date": None, "old_ticker": "FB", "new_ticker": "META"},          # bad date
+        {"date": "2022-06-09", "old_ticker": "FB", "new_ticker": None},    # bad new
+    ]
+    assert ca.renames_from_events("FB", events) == []
+
+
+# ── detect_renames over candidates ────────────────────────────────────────────
+
+
+def test_detect_renames_emits_for_ticker_change_only():
+    client = _fake_events_client({
+        "FB": [{"date": "2022-06-09", "old_ticker": "FB", "new_ticker": "META"}],
+        "DELISTME": [],  # genuine delist / merger-of-acquired → no ticker_change
+    })
+    result = ca.detect_renames(["FB", "DELISTME"], client=client)
+    assert isinstance(result, ca.RenameDetection)
+    assert result.failed_candidates == set()
+    assert len(result.renames) == 1
+    r = result.renames[0]
+    assert (r.old_ticker, r.new_ticker, r.ex_date) == ("FB", "META", "2022-06-09")
+    # The delist-only candidate produced no rename → it is NOT in failed either
+    # (confirmed safe to prune).
+    assert "DELISTME" not in result.failed_candidates
+
+
+def test_detect_renames_failure_records_candidate_not_silent():
+    """History-safety: a polygon query that RAISES must land in
+    failed_candidates (so the prune wiring skips it), NOT be silently dropped as
+    'no rename'."""
+    client = _fake_events_client(
+        {"FB": [{"date": "2022-06-09", "old_ticker": "FB", "new_ticker": "META"}]},
+        raise_for={"BROKEN"},
+    )
+    result = ca.detect_renames(["FB", "BROKEN"], client=client)
+    assert [r.old_ticker for r in result.renames] == ["FB"]
+    assert result.failed_candidates == {"BROKEN"}
+
+
+def test_detect_renames_client_construction_failure_fails_all(monkeypatch):
+    """No usable polygon client → EVERY candidate is a detection failure (none
+    confirmed safe to prune this pass)."""
+    import polygon_client as _pc
+
+    def boom(*a, **k):
+        raise RuntimeError("no api key")
+
+    monkeypatch.setattr(_pc, "polygon_client", boom)
+    result = ca.detect_renames(["FB", "AAPL"])  # client=None → tries to construct
+    assert result.renames == []
+    assert result.failed_candidates == {"FB", "AAPL"}
+
+
+def test_detect_renames_empty_input():
+    assert ca.detect_renames([]).renames == []
+    assert ca.detect_renames(None).failed_candidates == set()
+
+
+# ── migrate_symbol: real ArcticDB (LMDB) round-trip ───────────────────────────
+
+
+def _seed_symbol(tmp_path, ticker="FB", n=30):
+    adb = pytest.importorskip("arcticdb")
+    dates = pd.bdate_range("2022-04-01", periods=n)
+    close = pd.Series(np.linspace(200.0, 210.0, n), index=dates)
+    df = pd.DataFrame({
+        "Open": close, "High": close * 1.01, "Low": close * 0.99,
+        "Close": close, "Volume": np.full(n, 1e6),
+    })
+    ac = adb.Arctic(f"lmdb://{tmp_path}")
+    lib = ac.get_library("universe", create_if_missing=True)
+    lib.write(ticker, df)
+    return lib, df
+
+
+def test_migrate_symbol_round_trip_old_to_new(tmp_path):
+    lib, src = _seed_symbol(tmp_path, "FB")
+    reg = CorporateActionRegistry(_FakeS3(), _BUCKET)
+
+    did = ca.migrate_symbol(
+        lib, "FB", "META", registry=reg, run_id="r1", ex_date="2022-06-09",
+    )
+    assert did is True
+    # New key holds the OLD symbol's full history; old key gone.
+    assert lib.has_symbol("META")
+    assert not lib.has_symbol("FB")
+    got = lib.read("META").data
+    pd.testing.assert_frame_equal(got, src, check_freq=False)
+
+
+def test_migrate_symbol_idempotent_second_call_noop(tmp_path):
+    lib, _ = _seed_symbol(tmp_path, "FB")
+    reg = CorporateActionRegistry(_FakeS3(), _BUCKET)
+
+    assert ca.migrate_symbol(lib, "FB", "META", registry=reg, run_id="r1", ex_date="2022-06-09") is True
+    # Second call: registry marker already set → noop (returns False), and it
+    # must NOT touch the already-live META series.
+    meta_before = lib.read("META").data
+    did = ca.migrate_symbol(lib, "FB", "META", registry=reg, run_id="r2", ex_date="2022-06-09")
+    assert did is False
+    pd.testing.assert_frame_equal(lib.read("META").data, meta_before)
+
+
+def test_migrate_symbol_new_already_exists_no_splice(tmp_path):
+    """If the new ticker already has its OWN live history, do NOT merge/overwrite
+    (no splice) — drop the orphaned old key, mark applied."""
+    lib, _ = _seed_symbol(tmp_path, "FB", n=30)
+    # Seed META with a DIFFERENT live history.
+    adb = pytest.importorskip("arcticdb")
+    meta_dates = pd.bdate_range("2022-06-09", periods=10)
+    meta_close = pd.Series(np.linspace(300.0, 310.0, 10), index=meta_dates)
+    meta_df = pd.DataFrame({
+        "Open": meta_close, "High": meta_close, "Low": meta_close,
+        "Close": meta_close, "Volume": np.full(10, 2e6),
+    })
+    lib.write("META", meta_df)
+    reg = CorporateActionRegistry(_FakeS3(), _BUCKET)
+
+    did = ca.migrate_symbol(lib, "FB", "META", registry=reg, run_id="r1", ex_date="2022-06-09")
+    assert did is True
+    # META's live history is preserved (NOT overwritten by FB's), FB dropped.
+    assert not lib.has_symbol("FB")
+    pd.testing.assert_frame_equal(lib.read("META").data, meta_df, check_freq=False)
+    # Marked applied → a re-run is a noop.
+    action = ca.CorporateAction.from_rename("FB", "META", "2022-06-09")
+    assert reg.is_applied(ca.STORE_ARCTICDB_UNIVERSE, action.action_id)
+
+
+def test_migrate_symbol_old_absent_is_noop(tmp_path):
+    lib, _ = _seed_symbol(tmp_path, "FB")
+    reg = CorporateActionRegistry(_FakeS3(), _BUCKET)
+    # GHOST has no ArcticDB history — nothing to migrate.
+    assert ca.migrate_symbol(lib, "GHOST", "NEWX", registry=reg, run_id="r1", ex_date="2022-06-09") is False
+    assert not lib.has_symbol("NEWX")

--- a/tests/test_corporate_actions_sync.py
+++ b/tests/test_corporate_actions_sync.py
@@ -32,7 +32,7 @@ from botocore.exceptions import ClientError
 
 import corporate_actions as ca
 from corporate_actions import CorporateActionRegistry
-from split_factor import restate_series_for_splits
+from corporate_actions import restate_series_for_splits
 
 
 # ── in-memory S3 double (registry markers + daily_closes parquet round-trip) ──

--- a/tests/test_polygon_client.py
+++ b/tests/test_polygon_client.py
@@ -238,3 +238,104 @@ def test_get_recent_splits_forbidden_returns_empty():
     client = _make_client()
     with patch.object(client, "_get", side_effect=PolygonForbiddenError("403")):
         assert client.get_recent_splits("2026-05-01", "2026-05-15") == []
+
+
+# ── get_ticker_events (corporate-actions PR6: ticker-rename detection) ─────────
+
+
+def _events_response(changes: list[dict], *, name: str = "Meta Platforms, Inc.") -> dict:
+    """Shape of polygon /vX/reference/tickers/{id}/events results.
+
+    ``changes`` are ``{"date", "ticker"}`` (the ticker the entity changed TO on
+    that date) — polygon lists the IPO listing as the earliest ticker_change too.
+    """
+    return {
+        "results": {
+            "name": name,
+            "figi": "BBG000MM2P62",
+            "events": [
+                {"type": "ticker_change", "date": c["date"],
+                 "ticker_change": {"ticker": c["ticker"]}}
+                for c in changes
+            ],
+        },
+        "status": "OK",
+    }
+
+
+def test_get_ticker_events_parses_adjacent_rename_pairs():
+    """FB (IPO 2012) -> META (2022): the adjacent transition is the rename pair;
+    the earliest listing yields no pair."""
+    client = _make_client()
+    resp = _events_response([
+        {"date": "2022-06-09", "ticker": "META"},
+        {"date": "2012-05-18", "ticker": "FB"},
+    ])
+    with patch.object(client, "_get", return_value=resp) as mock_get:
+        out = client.get_ticker_events("FB")
+    assert mock_get.call_count == 1
+    # Endpoint path carries the queried ticker.
+    args, _ = mock_get.call_args
+    assert args[0] == "/vX/reference/tickers/FB/events"
+    assert out == [
+        {"date": "2022-06-09", "old_ticker": "FB", "new_ticker": "META"},
+    ]
+
+
+def test_get_ticker_events_multi_hop_chain():
+    """Two renames produce two adjacent old->new pairs, ascending by date."""
+    client = _make_client()
+    resp = _events_response([
+        {"date": "2012-05-18", "ticker": "AAA"},
+        {"date": "2018-01-02", "ticker": "BBB"},
+        {"date": "2023-03-03", "ticker": "CCC"},
+    ])
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_ticker_events("AAA")
+    assert out == [
+        {"date": "2018-01-02", "old_ticker": "AAA", "new_ticker": "BBB"},
+        {"date": "2023-03-03", "old_ticker": "BBB", "new_ticker": "CCC"},
+    ]
+
+
+def test_get_ticker_events_single_listing_no_rename():
+    """A ticker with only its IPO listing (no later change) has no rename pair —
+    the genuine-delist / merger-of-acquired signal."""
+    client = _make_client()
+    resp = _events_response([{"date": "2012-05-18", "ticker": "XYZ"}])
+    with patch.object(client, "_get", return_value=resp):
+        assert client.get_ticker_events("XYZ") == []
+
+
+def test_get_ticker_events_ignores_non_ticker_change_events():
+    client = _make_client()
+    resp = {
+        "results": {
+            "name": "X",
+            "events": [
+                {"type": "ticker_change", "date": "2012-05-18",
+                 "ticker_change": {"ticker": "OLD"}},
+                {"type": "delisted", "date": "2020-01-01"},  # not a ticker_change
+                {"type": "ticker_change", "date": "2022-06-09",
+                 "ticker_change": {"ticker": "NEW"}},
+            ],
+        },
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_ticker_events("OLD")
+    assert out == [
+        {"date": "2022-06-09", "old_ticker": "OLD", "new_ticker": "NEW"},
+    ]
+
+
+def test_get_ticker_events_forbidden_returns_empty():
+    client = _make_client()
+    with patch.object(client, "_get", side_effect=PolygonForbiddenError("403")):
+        assert client.get_ticker_events("FB") == []
+
+
+def test_get_ticker_events_empty_results_object():
+    """No results / no events key → []."""
+    client = _make_client()
+    with patch.object(client, "_get", return_value={"status": "OK"}):
+        assert client.get_ticker_events("FB") == []

--- a/tests/test_prune_delisted_tickers.py
+++ b/tests/test_prune_delisted_tickers.py
@@ -77,6 +77,13 @@ def _patch_targets(monkeypatch, *, s3_mock, universe_lib_mock):
         _mod, "boto3", MagicMock(client=lambda *a, **k: s3_mock),
     )
     monkeypatch.setattr(_mod, "get_universe_lib", lambda *a, **k: universe_lib_mock)
+    # PR6: prune now runs rename detection before deletion. Default the polygon
+    # seam to a fake that reports NO ticker_change for any candidate, so the
+    # two-condition prune invariants below behave exactly as pre-PR6 (a genuine
+    # delist with no rename). Tests that exercise renames patch this themselves.
+    no_rename_poly = MagicMock()
+    no_rename_poly.get_ticker_events.return_value = []
+    monkeypatch.setattr(_mod, "polygon_client", lambda *a, **k: no_rename_poly)
 
 
 # ── A. Two-condition invariant ─────────────────────────────────────────────────
@@ -572,3 +579,196 @@ def test_tickers_override_and_constituents_override_mutually_exclusive(monkeypat
             tickers_override=["AAPL"],
             constituents_override={"AAPL"},
         )
+
+
+# ── D. PR6: rename-triggered migration BEFORE the prune deletion ──────────────
+
+import io  # noqa: E402
+
+import numpy as np  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+
+import corporate_actions as ca  # noqa: E402
+
+
+class _FakeS3Registry:
+    """In-memory S3 double with proper 404 semantics so a real
+    CorporateActionRegistry round-trips its write-once markers (a MagicMock s3
+    would make head_object truthy and falsely report everything 'applied')."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def _err(self, code, op):
+        return ClientError({"Error": {"Code": code, "Message": "x"}}, op)
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("404", "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise self._err("NoSuchKey", "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"x"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _real_universe_lib(tmp_path, symbols: dict[str, str]):
+    """A REAL LMDB ArcticDB universe seeded with one row per symbol at the given
+    last_date (so has_symbol / read / write / delete all behave for real)."""
+    adb = pytest.importorskip("arcticdb")
+    ac = adb.Arctic(f"lmdb://{tmp_path}")
+    lib = ac.get_library("universe", create_if_missing=True)
+    for ticker, last_date in symbols.items():
+        idx = pd.DatetimeIndex([pd.Timestamp(last_date)])
+        df = pd.DataFrame(
+            {"Open": [1.0], "High": [1.0], "Low": [1.0],
+             "Close": [100.0], "Volume": [1e6]},
+            index=idx,
+        )
+        lib.write(ticker, df)
+    return lib
+
+
+def _patch_rename(monkeypatch, *, s3_mock, universe_lib, events_by_ticker, raise_for=None):
+    """Patch prune for the rename phase: boto3 + get_universe_lib + a real
+    registry (proper marker semantics) + a fake polygon ticker-events client."""
+    monkeypatch.setattr(_mod, "boto3", MagicMock(client=lambda *a, **k: s3_mock))
+    monkeypatch.setattr(_mod, "get_universe_lib", lambda *a, **k: universe_lib)
+    reg = ca.CorporateActionRegistry(_FakeS3Registry(), "alpha-engine-research")
+    monkeypatch.setattr(_mod, "_build_registry", lambda *a, **k: reg)
+
+    raise_for = raise_for or set()
+    poly = MagicMock()
+
+    def fake_events(ticker):
+        if ticker in raise_for:
+            raise RuntimeError(f"polygon down for {ticker}")
+        # Translate (date,new) into the get_ticker_events pair shape.
+        return events_by_ticker.get(ticker, [])
+
+    poly.get_ticker_events.side_effect = fake_events
+    monkeypatch.setattr(_mod, "polygon_client", lambda *a, **k: poly)
+    return reg
+
+
+def test_renamed_candidate_is_migrated_not_pruned(monkeypatch, tmp_path):
+    """FB renamed -> META: FB is MIGRATED (history under META, FB gone) and NOT
+    in the prune list; a true delist (DEAD) IS pruned. Migration runs BEFORE the
+    deletion (FB's history survives under META rather than being deleted)."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _real_universe_lib(tmp_path, {
+        "AAPL": "2026-04-25",   # in constituents → never a candidate
+        "FB": "2026-04-01",     # absent + stale → candidate, but RENAMED
+        "DEAD": "2026-04-01",   # absent + stale → candidate, true delist
+    })
+    _patch_rename(
+        monkeypatch, s3_mock=s3, universe_lib=lib,
+        events_by_ticker={
+            "FB": [{"date": "2026-04-10", "old_ticker": "FB", "new_ticker": "META"}],
+            "DEAD": [],
+        },
+    )
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True, today=pd.Timestamp("2026-04-28"),
+    )
+
+    # FB migrated, not pruned.
+    assert summary["migrated_count"] == 1
+    assert summary["migrated"][0]["old_ticker"] == "FB"
+    assert summary["migrated"][0]["new_ticker"] == "META"
+    assert summary["migrated"][0]["migrated"] is True
+    pruned_tickers = {p["ticker"] for p in summary["pruned"]}
+    assert "FB" not in pruned_tickers
+    # FB's history carried to META (proves migration ran before any delete).
+    assert lib.has_symbol("META")
+    assert not lib.has_symbol("FB")
+    # True delist pruned.
+    assert "DEAD" in pruned_tickers
+    assert not lib.has_symbol("DEAD")
+    assert lib.has_symbol("AAPL")
+
+
+def test_polygon_detection_failure_does_not_prune_candidate(monkeypatch, tmp_path):
+    """History-safety: a candidate whose ticker-events query RAISES must NOT be
+    pruned this pass (it might be an undetected rename), while a confirmed delist
+    still prunes."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _real_universe_lib(tmp_path, {
+        "AAPL": "2026-04-25",
+        "FB": "2026-04-01",     # detection RAISES → must be skipped, not pruned
+        "DEAD": "2026-04-01",   # confirmed no rename → pruned
+    })
+    _patch_rename(
+        monkeypatch, s3_mock=s3, universe_lib=lib,
+        events_by_ticker={"DEAD": []},
+        raise_for={"FB"},
+    )
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True, today=pd.Timestamp("2026-04-28"),
+    )
+
+    pruned_tickers = {p["ticker"] for p in summary["pruned"]}
+    assert "FB" not in pruned_tickers
+    assert "FB" in summary["skipped_rename_detect_failed"]
+    assert lib.has_symbol("FB")  # history preserved — NOT deleted on a failure
+    # The confirmed delist still prunes.
+    assert "DEAD" in pruned_tickers
+    assert not lib.has_symbol("DEAD")
+
+
+def test_no_polygon_client_refuses_to_prune_blind(monkeypatch, tmp_path):
+    """If the polygon client can't be constructed, rename detection is
+    impossible → refuse to prune ANY candidate this pass (history-safety)."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _real_universe_lib(tmp_path, {
+        "AAPL": "2026-04-25", "DEAD": "2026-04-01",
+    })
+    monkeypatch.setattr(_mod, "boto3", MagicMock(client=lambda *a, **k: s3))
+    monkeypatch.setattr(_mod, "get_universe_lib", lambda *a, **k: lib)
+    reg = ca.CorporateActionRegistry(_FakeS3Registry(), "alpha-engine-research")
+    monkeypatch.setattr(_mod, "_build_registry", lambda *a, **k: reg)
+    monkeypatch.setattr(_mod, "polygon_client", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no key")))
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=True, today=pd.Timestamp("2026-04-28"),
+    )
+
+    assert summary["pruned_count"] == 0
+    assert "DEAD" in summary["skipped_rename_detect_failed"]
+    assert lib.has_symbol("DEAD")
+
+
+def test_dry_run_does_not_migrate_or_prune(monkeypatch, tmp_path):
+    """apply=False: detection reports the rename but NO ArcticDB mutation."""
+    s3 = _stub_s3(constituents_tickers=["AAPL"])
+    lib = _real_universe_lib(tmp_path, {
+        "AAPL": "2026-04-25", "FB": "2026-04-01",
+    })
+    _patch_rename(
+        monkeypatch, s3_mock=s3, universe_lib=lib,
+        events_by_ticker={
+            "FB": [{"date": "2026-04-10", "old_ticker": "FB", "new_ticker": "META"}],
+        },
+    )
+
+    summary = _mod.prune_delisted_tickers(
+        absent_days=14, apply=False, today=pd.Timestamp("2026-04-28"),
+    )
+
+    # Reported as a would-migrate, but not actually migrated, and FB untouched.
+    assert summary["migrated_count"] == 0
+    assert {m["old_ticker"] for m in summary["migrated"]} == {"FB"}
+    assert lib.has_symbol("FB")
+    assert not lib.has_symbol("META")
+    assert summary["pruned_count"] == 0

--- a/tests/test_split_restatement.py
+++ b/tests/test_split_restatement.py
@@ -27,7 +27,7 @@ from botocore.exceptions import ClientError
 import corporate_actions as ca
 import features.compute as compute
 from corporate_actions import CorporateActionRegistry
-from split_factor import (
+from corporate_actions import (
     cumulative_factor,
     restate_series_for_splits,
 )
@@ -441,3 +441,32 @@ def test_backfill_proceeds_on_suspected_only(monkeypatch):
     # Must NOT raise CorporateActionAuditError — proceeds to a normal summary.
     result = _bf.backfill(ticker_filter=None)
     assert result.get("status") != "error"
+
+
+# ── PR6: split_factor.py shim consolidated into corporate_actions + deleted ───
+
+
+def test_split_factor_shim_deleted():
+    """The top-level split_factor.py shim is GONE (its math moved into
+    corporate_actions._split_math, re-exported from the package). Importing it
+    must fail so no consumer silently re-grows a dependency on the loose name."""
+    import importlib
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("split_factor")
+
+
+def test_split_math_reexported_from_package():
+    """The split-factor math is importable from the package surface (the
+    repointed import path for every former split_factor consumer)."""
+    from corporate_actions import (  # noqa: F401
+        cumulative_factor,
+        restate_series_for_splits,
+        split_events,
+    )
+
+    # Parity sanity: the moved cumulative_factor still computes the reverse-split
+    # factor (pre-ex prices ×3 for a 1-for-3 reverse split).
+    events = [{"execution_date": "2026-06-24", "split_from": 3, "split_to": 1}]
+    assert cumulative_factor(events, "2026-06-12") == pytest.approx(3.0)
+    assert cumulative_factor(events, "2026-06-24") == pytest.approx(1.0)

--- a/tests/test_spy_universe_member.py
+++ b/tests/test_spy_universe_member.py
@@ -122,6 +122,12 @@ def test_spy_in_universe_is_never_pruned_even_when_absent_and_stale(monkeypatch)
     monkeypatch.setattr(
         _prune_mod, "get_universe_lib", lambda *a, **k: lib
     )
+    # PR6: prune runs rename detection before deletion — neutralize the polygon
+    # seam (HOLX is a genuine delist, no ticker_change) so this guard tests the
+    # SKIP-protection path, not rename detection.
+    no_rename_poly = MagicMock()
+    no_rename_poly.get_ticker_events.return_value = []
+    monkeypatch.setattr(_prune_mod, "polygon_client", lambda *a, **k: no_rename_poly)
 
     summary = _prune_mod.prune_delisted_tickers(
         absent_days=14, apply=True, today=pd.Timestamp("2026-04-28")


### PR DESCRIPTION
PR6 of the unified corporate-actions program (config#1433).

## What
- **Ticker-rename detection (prune-triggered).** polygon has no "all renames in a range" endpoint — the ticker-events API is per-ticker — so detection keys off the signal already in the pipeline: a symbol going missing from constituents/daily_closes (a prune candidate). Before pruning a missing symbol, `polygon_client.get_ticker_events` is queried; a `ticker_change` where the candidate is the OLD ticker -> it was RENAMED -> migrate (don't prune). `corporate_actions.detect_renames(candidate_tickers, *, client=None)` replaces the `NotImplementedError` stub and returns a `RenameDetection(renames, failed_candidates)` (per-candidate, since the reality is per-ticker).
- **ArcticDB symbol migration (old->new).** `migrate_symbol()` reads the old symbol's full series, writes it under the new key, deletes old — identity-preserving 1:1 remap so the predictor keeps continuous history (FB's history lives under META). Registry exactly-once via the `arcticdb_universe` applied marker, WRITE-THEN-MARK (the marker is written only after the new key is written AND old deleted, so a failure never leaves a false marker). Idempotent. New-already-exists is handled as a no-splice: drop the orphaned old key, mark applied (never merge two real histories — poison for the predictor).
- **Mergers = delist-of-acquired, NOT spliced.** A merger of the acquired ticker shows up as a delisting (no `ticker_change`), so it falls through to the EXISTING prune path naturally — no special merger code.
- **Wired into `builders/prune_delisted_tickers.py`** before the deletion loop (ordering is load-bearing — migration MUST run before prune deletes the orphaned old history). Renamed candidates are migrated and removed from the prune set; non-renamed candidates prune as today; renames recorded in the registry.
- **`split_factor.py` consolidation.** The split-factor math (`cumulative_factor`, `restate_series_for_splits`, `split_events`) moved into `corporate_actions/_split_math.py`, re-exported from the `corporate_actions` package; all importers (the package + 4 test files) repointed; `split_factor.py` DELETED. `git grep split_factor` confirms nothing else references it.

## History-safety (load-bearing)
A polygon detection FAILURE (per-candidate query raises, or the client can't be constructed) does **NOT** prune the candidate this pass — it is recorded in `failed_candidates` / `skipped_rename_detect_failed` and WARNed, then re-examined next pass. A detection outage must never delete a symbol that might be a rename before it can be migrated. Detection failure is never silently treated as "no rename".

## Tests
- `get_ticker_events`: parses `ticker_change` into ascending old->new pairs (adjacent transitions; earliest listing yields no pair), multi-hop chain, ignores non-rename events, 403 -> [].
- `detect_renames`: emits renames for `ticker_change` only (delist-only candidate -> none); a FAILURE records the candidate (not silent); client-construction failure fails ALL candidates.
- `migrate_symbol`: old->new LMDB round-trip (new holds old's full history, old deleted); idempotent second-call noop via `is_applied`; new-already-exists no-splice; old-absent noop.
- prune integration: renamed candidate MIGRATED not pruned (ordered before delete — FB's history survives under META) + true delist pruned; polygon detection failure does NOT prune (history preserved); no-client refuses to prune blind; dry-run mutates nothing.
- shim: `import split_factor` now fails (file deleted); package re-export parity.

Full `tests/` suite green: **2413 passed, 3 skipped** (the 5 pre-existing `nousergon_lib.config` dev-layout false-reds — `test_feature_cfg_package` / `test_load_config_experiment_package`, confirmed failing identically on the clean base, green in CI — deselected). Run on the repo `.venv` (py3.13 + stale local lib; CI py3.12 + fresh lib is authoritative). No new S3 puts -> no artifact-registry-coverage impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
