### PR TITLE
feat(corporate-actions): CRSP total_return_close schema + offline scratch-basis migration + fail-loud reconciliation (PR7-7a, config#1434)

### DIFF
--- a/builders/migrate_universe_crsp_basis.py
+++ b/builders/migrate_universe_crsp_basis.py
@@ -1,0 +1,806 @@
+"""builders/migrate_universe_crsp_basis.py — OFFLINE CRSP-basis universe build.
+
+Corporate-actions program PR7, step 7a (epic config#1433 / config#1434).
+=========================================================================
+
+This is the **offline, build-the-evidence** step of the CRSP/Barra basis
+migration. It reconstructs every universe ticker on ONE clean,
+polygon-authoritative basis and writes the result to a **SCRATCH** ArcticDB
+library (default ``universe_crsp``) — it NEVER touches the live ``universe``
+library, the live champion, or any consumer. The live basis flip
+(``feature_engineer.py`` close basis + ne-data/predictor labels), the
+dual-writer wiring, and ``prices.py auto_adjust=False`` are all GATED to
+PR7-7c, after the shadow-retrain + backtest gate of 7b.
+
+Target representation (per ticker), per the approved plan §7a:
+    Close              = split-adjusted price LEVEL (polygon-authoritative;
+                         changes only on splits).
+    total_return_close = NEW column — the split-adjusted series further
+                         dividend-back-adjusted via the registry dividend
+                         events (``corporate_actions.total_return_series``);
+                         the SEPARATE total-return axis (does NOT mutate Close).
+    53 feature columns = recomputed on ``total_return_close`` (via
+                         ``compute_features(..., close_col="total_return_close")``)
+                         for the scratch build only.
+
+Per ticker the script:
+  1. Re-pulls RAW (unadjusted) prices over the full history — yfinance
+     ``auto_adjust=False`` (mirrors ``collectors/prices.py`` but raw).
+  2. Applies polygon SPLITS to get the split-adjusted ``Close`` LEVEL
+     (``corporate_actions.apply`` → ``_split_math.restate_series_for_splits``).
+  3. Derives ``total_return_close`` from polygon DIVIDENDS
+     (``corporate_actions.get_dividends`` + ``total_return_series``).
+  4. **Reconciles** the derived ``total_return_close`` against the retiring
+     yfinance total-return ``Close`` (read from the LIVE ``universe`` library)
+     per ticker: max relative deviation, classify within-tol vs OUT-OF-TOL.
+     FAILS LOUD (raises / non-zero exit) on any ticker whose OUT-OF-TOL
+     residual is not an operator-acknowledged known divergence — no silent
+     skip, no "unscoreable" sentinel (Brian standing feedback). A missing /
+     doubled / mis-ratio'd split or dividend surfaces here before it can reach
+     the model.
+  5. ``--apply`` only: recomputes the 53 features on ``total_return_close`` and
+     writes the full per-ticker series to the SCRATCH library via
+     ``to_arctic_canonical`` (+ a factor-momentum second pass).
+
+The reconciliation report is emitted to S3 (audit JSON) and summarised in the
+log. Both series are total-return and anchored at the latest split-adjusted
+price, so within tolerance they should be identical up to feed rounding; the
+NEW one is polygon-authoritative.
+
+NOTE — this PR ships the SCRIPT + tests only. The actual 10y / ~900-ticker
+scratch-library build is a separate OPERATIONAL (spot) run; do NOT run this
+against a live/large ArcticDB from a dev box.
+
+Template / mirrored design: ``builders/migrate_universe_feature_order.py``
+(dry-run → ThreadPool → S3 audit, per-ticker error capture, idempotent skip)
+and ``builders/backfill.py`` (the universe-library write shape).
+
+Usage::
+
+    python -m builders.migrate_universe_crsp_basis                      # dry-run reconcile + report
+    python -m builders.migrate_universe_crsp_basis --apply              # write scratch lib
+    python -m builders.migrate_universe_crsp_basis --tickers AAPL,MMM   # subset (testing)
+    python -m builders.migrate_universe_crsp_basis --scratch-lib universe_crsp_v2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import boto3
+import numpy as np
+import pandas as pd
+
+import corporate_actions as ca
+from features.compute import DEFAULT_BUCKET
+from store.arctic_store import (
+    TOTAL_RETURN_COL,
+    get_scratch_universe_lib,
+    get_universe_lib,
+    to_arctic_canonical,
+)
+
+log = logging.getLogger(__name__)
+
+AUDIT_PREFIX = "builders/migrate_universe_crsp_basis_audit/"
+DEFAULT_SCRATCH_LIB = "universe_crsp"
+DEFAULT_WORKERS = 8
+
+# Both the derived total_return_close and the retiring yfinance Close are
+# TOTAL-RETURN series anchored at the latest (post-action) split-adjusted
+# price, so within feed-rounding they should be identical. 2% is a generous
+# band that absorbs provider close-price rounding + a stray T+1 print without
+# masking a missing/doubled action (which moves the boundary by the action
+# factor — a dividend ~0.5–3%/event compounding, a split 50%+).
+DEFAULT_RECONCILE_REL_TOL = 0.02
+
+# Window (calendar days) for attributing an out-of-tol residual's worst date
+# to the nearest registered corporate action — diagnostic only (the report
+# names the likely culprit action); it does NOT gate the fail-loud decision.
+_ACTION_ATTRIBUTION_WINDOW_DAYS = 5
+
+# The logical store passed to corporate_actions.apply for the scratch
+# split restatement. A DISTINCT store name (not STORE_ARCTICDB_UNIVERSE) so
+# the offline build's applied-markers can never collide with / pollute the
+# live universe restatement markers. We pass registry=None anyway (structural
+# idempotency: we always restate from the freshly re-pulled raw source), so no
+# marker is actually written — but the distinct name is defense in depth.
+SCRATCH_RESTATE_STORE = "crsp_scratch_build"
+
+
+# ── reconciliation record ────────────────────────────────────────────────────
+
+
+@dataclass
+class ReconcileRecord:
+    """Per-ticker reconciliation of the NEW total_return_close vs the retiring
+    yfinance total-return Close."""
+
+    ticker: str
+    status: str  # "within_tol" | "out_of_tol" | "no_overlap"
+    n_common_dates: int
+    max_rel_dev: float
+    max_dev_date: str | None
+    explained: bool
+    explanation: str
+    nearest_action: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "ticker": self.ticker,
+            "status": self.status,
+            "n_common_dates": self.n_common_dates,
+            "max_rel_dev": self.max_rel_dev,
+            "max_dev_date": self.max_dev_date,
+            "explained": self.explained,
+            "explanation": self.explanation,
+            "nearest_action": self.nearest_action,
+        }
+
+
+@dataclass
+class TickerOutcome:
+    """Per-ticker pipeline outcome carried back from the worker."""
+
+    ticker: str
+    outcome: str  # "ok" | "fetch_empty" | "no_old_close" | "error"
+    reconcile: ReconcileRecord | None = None
+    n_rows: int = 0
+    n_splits: int = 0
+    n_dividends: int = 0
+    error: str | None = None
+    written: bool = False
+    new_df: pd.DataFrame | None = field(default=None, repr=False)
+
+
+# ── raw price fetch (yfinance auto_adjust=False) ──────────────────────────────
+
+
+def fetch_raw_prices(ticker: str, *, period: str = "max") -> pd.DataFrame:
+    """Re-pull RAW (unadjusted) daily OHLCV for one ticker via yfinance
+    ``auto_adjust=False`` — so polygon is the SINGLE corporate-action authority
+    (we apply polygon splits/dividends to this raw series ourselves).
+
+    Mirrors ``collectors/prices.py`` (same index normalization) but with
+    ``auto_adjust=False`` and drops the yfinance ``Adj Close`` column (we do not
+    use yfinance's adjustment — that is exactly the basis we are retiring).
+    Returns a DatetimeIndex-sorted frame with ``Open/High/Low/Close/Volume``;
+    raises on an empty/failed pull (fail-loud — a silent empty would corrupt the
+    reconstruction).
+    """
+    import yfinance as yf
+
+    raw = yf.download(
+        tickers=ticker,
+        period=period,
+        interval="1d",
+        auto_adjust=False,  # RAW: do NOT let yfinance adjust — polygon is authority
+        progress=False,
+        group_by="ticker",
+        threads=False,
+    )
+    if raw is None or len(raw) == 0:
+        raise RuntimeError(f"yfinance returned no rows for {ticker} (auto_adjust=False)")
+
+    # yfinance returns a MultiIndex (ticker, field) when group_by="ticker".
+    if isinstance(raw.columns, pd.MultiIndex):
+        if ticker in raw.columns.get_level_values(0):
+            raw = raw[ticker].copy()
+        else:
+            raw = raw.droplevel(0, axis=1).copy()
+
+    if "Close" not in raw.columns:
+        raise RuntimeError(f"yfinance frame for {ticker} missing Close column")
+
+    raw = raw.dropna(subset=["Close"])
+    if raw.empty:
+        raise RuntimeError(f"yfinance frame for {ticker} empty after dropna(Close)")
+
+    idx = pd.to_datetime(raw.index)
+    if idx.tz is not None:
+        idx = idx.tz_convert("UTC").tz_localize(None)
+    raw.index = idx
+    raw = raw.sort_index()
+
+    keep = [c for c in ("Open", "High", "Low", "Close", "Volume") if c in raw.columns]
+    return raw[keep]
+
+
+# ── core: per-ticker basis reconstruction (pure, network-free) ────────────────
+
+
+def reconstruct_basis(
+    ticker: str,
+    raw_df: pd.DataFrame,
+    split_actions: list,
+    dividend_actions: list,
+) -> tuple[pd.DataFrame, list[dict]]:
+    """Reconstruct one ticker on the CRSP basis from a RAW price frame.
+
+    Returns ``(df, applied_split_results)`` where ``df`` is the raw frame with
+    ``Close`` replaced by the split-adjusted price LEVEL and a NEW
+    ``total_return_close`` column (split-adjusted + dividend-back-adjusted).
+
+    Steps:
+      * SPLIT restatement → ``Close`` (price LEVEL) via ``corporate_actions.apply``
+        (routes through ``_split_math.restate_series_for_splits``). registry=None:
+        structural idempotency (we always restate from the freshly-pulled raw).
+      * ``total_return_close`` via ``corporate_actions.total_return_series`` over
+        the dividend events — the SEPARATE total-return axis; it does NOT mutate
+        ``Close``.
+
+    Pure: no network / S3 / ArcticDB — the migration's network fetch + I/O live
+    in the orchestration, so this is unit-testable with hand-built fakes.
+    """
+    if raw_df is None or raw_df.empty:
+        return raw_df, []
+
+    # 1. SPLIT-adjusted Close LEVEL. apply() filters to splits, raises on a
+    #    stray dividend/rename, and delegates the factor math.
+    split_adj, applied = ca.apply(
+        raw_df,
+        split_actions,
+        store=SCRATCH_RESTATE_STORE,
+        registry=None,
+    )
+
+    # 2. SEPARATE total-return axis (does NOT mutate split_adj["Close"]).
+    tr_close = ca.total_return_series(split_adj, dividend_actions)
+
+    out = split_adj.copy()
+    out[TOTAL_RETURN_COL] = tr_close.reindex(out.index)
+    return out, applied
+
+
+def recompute_features_on_tr(
+    df: pd.DataFrame,
+    *,
+    spy_series: pd.Series | None = None,
+    vix_series: pd.Series | None = None,
+    sector_etf_series: pd.Series | None = None,
+    tnx_series: pd.Series | None = None,
+    irx_series: pd.Series | None = None,
+    gld_series: pd.Series | None = None,
+    uso_series: pd.Series | None = None,
+    vix3m_series: pd.Series | None = None,
+    earnings_data: dict | None = None,
+    revision_data: dict | None = None,
+    options_data: dict | None = None,
+    fundamental_data: dict | None = None,
+) -> pd.DataFrame:
+    """Recompute the 53 features with ``total_return_close`` as the close basis.
+
+    Thin wrapper over ``features.feature_engineer.compute_features`` pinning
+    ``close_col=TOTAL_RETURN_COL`` — the single basis chokepoint the live flip
+    (PR7-7c) will set as the default. Open/High/Low stay raw (split-adjusted
+    level), matching the plan's single-chokepoint design.
+    """
+    from features.feature_engineer import compute_features
+
+    return compute_features(
+        df,
+        spy_series=spy_series,
+        vix_series=vix_series,
+        sector_etf_series=sector_etf_series,
+        tnx_series=tnx_series,
+        irx_series=irx_series,
+        gld_series=gld_series,
+        uso_series=uso_series,
+        vix3m_series=vix3m_series,
+        earnings_data=earnings_data,
+        revision_data=revision_data,
+        options_data=options_data,
+        fundamental_data=fundamental_data,
+        close_col=TOTAL_RETURN_COL,
+    )
+
+
+def _nearest_action(date: pd.Timestamp, actions: list, window_days: int) -> object | None:
+    """Return the registered action whose ex_date is closest to ``date`` within
+    ``window_days`` (diagnostic attribution), or ``None``."""
+    best = None
+    best_gap = None
+    for a in actions or []:
+        try:
+            ex = pd.Timestamp(a.ex_date).normalize()
+        except Exception:  # noqa: BLE001 - malformed ex_date, skip candidate
+            continue
+        gap = abs((ex - date).days)
+        if gap <= window_days and (best_gap is None or gap < best_gap):
+            best, best_gap = a, gap
+    return best
+
+
+def reconcile_total_return(
+    ticker: str,
+    new_tr_close: pd.Series,
+    old_close: pd.Series,
+    *,
+    split_actions: list | None = None,
+    dividend_actions: list | None = None,
+    rel_tol: float = DEFAULT_RECONCILE_REL_TOL,
+    known_divergence: bool = False,
+) -> ReconcileRecord:
+    """Compare the NEW ``total_return_close`` against the retiring yfinance
+    total-return ``Close`` for one ticker.
+
+    Aligns the two series on their common dates, computes the per-date relative
+    deviation ``|new - old| / |old|`` and takes its max. Classifies:
+
+      * ``within_tol`` — ``max_rel_dev <= rel_tol``: the expected case (both are
+        total-return, identical up to feed rounding; the new one is
+        polygon-authoritative). ``explained=True``.
+      * ``out_of_tol`` — ``max_rel_dev > rel_tol``: a missing / doubled /
+        mis-ratio'd split or dividend, OR a real polygon-vs-yfinance data
+        divergence. ``explained`` is ``True`` ONLY if the operator passed
+        ``known_divergence=True`` for this ticker (an acknowledged, documented
+        divergence) — otherwise ``False`` (the fail-loud case).
+      * ``no_overlap`` — no common dates to compare. Treated as UNEXPLAINED
+        (``explained=False``): a ticker we cannot reconcile is a fail-loud
+        condition, not a silent skip.
+
+    Attributes the worst-deviation date to the nearest registered action (within
+    ``_ACTION_ATTRIBUTION_WINDOW_DAYS``) for the report — diagnostic only.
+    """
+    new_tr_close = new_tr_close.dropna()
+    old_close = old_close.dropna()
+    common = new_tr_close.index.intersection(old_close.index)
+    if len(common) == 0:
+        return ReconcileRecord(
+            ticker=ticker,
+            status="no_overlap",
+            n_common_dates=0,
+            max_rel_dev=float("inf"),
+            max_dev_date=None,
+            explained=False,
+            explanation=(
+                "no common dates between new total_return_close and old "
+                "yfinance Close — cannot reconcile (fail-loud, not skipped)"
+            ),
+        )
+
+    a = new_tr_close.reindex(common).to_numpy(dtype="float64")
+    b = old_close.reindex(common).to_numpy(dtype="float64")
+    denom = np.where(np.abs(b) > 1e-12, np.abs(b), np.nan)
+    rel_dev = np.abs(a - b) / denom
+    # NaN denom (old close ~0) → ignore that date rather than emit inf.
+    rel_dev = np.where(np.isfinite(rel_dev), rel_dev, 0.0)
+    worst_pos = int(np.argmax(rel_dev))
+    max_rel_dev = float(rel_dev[worst_pos])
+    max_dev_date = pd.Timestamp(common[worst_pos]).strftime("%Y-%m-%d")
+
+    all_actions = list(split_actions or []) + list(dividend_actions or [])
+    near = _nearest_action(
+        pd.Timestamp(common[worst_pos]).normalize(),
+        all_actions,
+        _ACTION_ATTRIBUTION_WINDOW_DAYS,
+    )
+    nearest_action = near.human() if near is not None else None
+
+    if max_rel_dev <= rel_tol:
+        return ReconcileRecord(
+            ticker=ticker,
+            status="within_tol",
+            n_common_dates=len(common),
+            max_rel_dev=max_rel_dev,
+            max_dev_date=max_dev_date,
+            explained=True,
+            explanation=f"within tol ({max_rel_dev:.4%} <= {rel_tol:.2%})",
+            nearest_action=nearest_action,
+        )
+
+    if known_divergence:
+        explanation = (
+            f"OUT-OF-TOL ({max_rel_dev:.4%} > {rel_tol:.2%}) at {max_dev_date} "
+            f"but operator-acknowledged known divergence"
+            + (f" (nearest action: {nearest_action})" if nearest_action else "")
+        )
+        return ReconcileRecord(
+            ticker=ticker,
+            status="out_of_tol",
+            n_common_dates=len(common),
+            max_rel_dev=max_rel_dev,
+            max_dev_date=max_dev_date,
+            explained=True,
+            explanation=explanation,
+            nearest_action=nearest_action,
+        )
+
+    explanation = (
+        f"OUT-OF-TOL ({max_rel_dev:.4%} > {rel_tol:.2%}) at {max_dev_date} — "
+        f"likely a missing/doubled/mis-ratio'd split or dividend, or a real "
+        f"polygon-vs-yfinance divergence"
+        + (f"; nearest registered action: {nearest_action}" if nearest_action
+           else "; NO registered action near this date")
+    )
+    return ReconcileRecord(
+        ticker=ticker,
+        status="out_of_tol",
+        n_common_dates=len(common),
+        max_rel_dev=max_rel_dev,
+        max_dev_date=max_dev_date,
+        explained=False,
+        explanation=explanation,
+        nearest_action=nearest_action,
+    )
+
+
+# ── orchestration ─────────────────────────────────────────────────────────────
+
+
+def _read_old_close(universe_lib, ticker: str) -> pd.Series | None:
+    """Read the retiring yfinance total-return Close for ``ticker`` from the
+    LIVE universe library (READ ONLY — the live lib is never written here)."""
+    try:
+        df = universe_lib.read(ticker).data
+    except Exception:  # noqa: BLE001 - missing symbol / read failure
+        return None
+    if df is None or df.empty or "Close" not in df.columns:
+        return None
+    s = df["Close"]
+    s.index = pd.to_datetime(s.index)
+    return s
+
+
+def _write_audit(s3, bucket: str, summary: dict) -> None:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    key = f"{AUDIT_PREFIX}{ts}.json"
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(summary, indent=2, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+    log.info("Wrote reconciliation audit to s3://%s/%s", bucket, key)
+
+
+def migrate_universe_crsp_basis(
+    *,
+    bucket: str = DEFAULT_BUCKET,
+    scratch_lib: str = DEFAULT_SCRATCH_LIB,
+    apply: bool = False,
+    tickers_override: list[str] | None = None,
+    rel_tol: float = DEFAULT_RECONCILE_REL_TOL,
+    known_divergence_tickers: frozenset[str] | None = None,
+    workers: int | None = None,
+    raw_fetch=None,
+    client=None,
+    macro: dict | None = None,
+    sector_map: dict | None = None,
+    fundamentals: dict | None = None,
+    alt_data: dict | None = None,
+) -> dict:
+    """Reconstruct the universe on the CRSP basis into a SCRATCH library and
+    emit a per-ticker reconciliation report. FAILS LOUD on any unexplained
+    out-of-tolerance residual.
+
+    NEVER writes the live ``universe`` library: scratch writes go through
+    ``get_scratch_universe_lib`` (which refuses the live names), and the live
+    universe is opened READ-ONLY for the retiring-Close reconciliation baseline.
+
+    Parameters
+    ----------
+    scratch_lib
+        SCRATCH ArcticDB library name (default ``universe_crsp``). Must not be a
+        live name — enforced by ``get_scratch_universe_lib``.
+    apply
+        If True, recompute features and WRITE the reconstructed series to the
+        scratch library. Default False (dry-run: reconcile + report only).
+    rel_tol
+        Reconciliation relative-deviation tolerance.
+    known_divergence_tickers
+        Operator-acknowledged documented divergences — these tickers' out-of-tol
+        residuals are reported but do NOT fail the run. Default: none (every
+        out-of-tol residual fails loud).
+    raw_fetch / client
+        Injectable RAW-price fetcher ``(ticker) -> DataFrame`` and polygon client
+        (for tests / alternate sources). Default: yfinance ``auto_adjust=False``
+        + the polygon singleton.
+    macro / sector_map / fundamentals / alt_data
+        Feature-recompute inputs (apply path only). Loaded from S3/ArcticDB when
+        not injected.
+
+    Returns
+    -------
+    summary dict with the reconciliation report + write outcome.
+    """
+    known_divergence_tickers = known_divergence_tickers or frozenset()
+    workers = workers or int(
+        os.environ.get("MIGRATE_UNIVERSE_CRSP_WORKERS", str(DEFAULT_WORKERS))
+    )
+    raw_fetch = raw_fetch or fetch_raw_prices
+
+    s3 = boto3.client("s3")
+    universe_lib = get_universe_lib(bucket)  # READ-ONLY baseline source
+
+    arctic_symbols = sorted(universe_lib.list_symbols())
+    log.info("Live universe holds %d symbols (read-only reconciliation baseline)",
+             len(arctic_symbols))
+
+    if tickers_override is not None:
+        targets = sorted(set(tickers_override) & set(arctic_symbols))
+        ignored = sorted(set(tickers_override) - set(arctic_symbols))
+        if ignored:
+            log.warning(
+                "Skipping %d --tickers not in the live universe: %s",
+                len(ignored), ignored,
+            )
+    else:
+        targets = arctic_symbols
+
+    # Open the scratch lib eagerly even on dry-run so a bad --scratch-lib name
+    # fails immediately (the guard refuses live names), not after the work.
+    scratch = get_scratch_universe_lib(scratch_lib, bucket)
+    if apply:
+        # Feature-recompute inputs (apply path only). Lazy-loaded so dry-run +
+        # tests don't pay the cost.
+        if macro is None:
+            macro = _load_macro_series(s3, bucket)
+        if sector_map is None:
+            from features.compute import _load_sector_map
+
+            sector_map = _load_sector_map(s3, bucket)
+        if fundamentals is None:
+            from features.compute import _load_cached_fundamentals
+
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            fundamentals = _load_cached_fundamentals(s3, bucket, today)
+        if alt_data is None:
+            from features.compute import _load_cached_alternative
+
+            alt_data = _load_cached_alternative(s3, bucket)
+    macro = macro or {}
+    sector_map = sector_map or {}
+    fundamentals = fundamentals or {}
+    alt_data = alt_data or {}
+
+    def _process_one(ticker: str) -> TickerOutcome:
+        try:
+            old_close = _read_old_close(universe_lib, ticker)
+            if old_close is None:
+                return TickerOutcome(ticker, "no_old_close")
+
+            raw_df = raw_fetch(ticker)
+            if raw_df is None or raw_df.empty:
+                return TickerOutcome(ticker, "fetch_empty")
+
+            split_actions = ca.get_splits(ticker, client=client)
+            dividend_actions = ca.get_dividends(ticker, client=client)
+
+            new_df, _applied = reconstruct_basis(
+                ticker, raw_df, split_actions, dividend_actions,
+            )
+
+            rec = reconcile_total_return(
+                ticker,
+                new_df[TOTAL_RETURN_COL],
+                old_close,
+                split_actions=split_actions,
+                dividend_actions=dividend_actions,
+                rel_tol=rel_tol,
+                known_divergence=ticker in known_divergence_tickers,
+            )
+
+            out = TickerOutcome(
+                ticker, "ok",
+                reconcile=rec,
+                n_rows=len(new_df),
+                n_splits=len(split_actions),
+                n_dividends=len(dividend_actions),
+            )
+
+            if apply:
+                sector_etf_sym = sector_map.get(ticker)
+                featured = recompute_features_on_tr(
+                    new_df,
+                    spy_series=macro.get("SPY"),
+                    vix_series=macro.get("VIX"),
+                    sector_etf_series=(macro.get(sector_etf_sym) if sector_etf_sym else None),
+                    tnx_series=macro.get("TNX"),
+                    irx_series=macro.get("IRX"),
+                    gld_series=macro.get("GLD"),
+                    uso_series=macro.get("USO"),
+                    vix3m_series=macro.get("VIX3M"),
+                    earnings_data=(alt_data.get(ticker, {}) or {}).get("earnings"),
+                    revision_data=(alt_data.get(ticker, {}) or {}).get("revisions"),
+                    options_data=(alt_data.get(ticker, {}) or {}).get("options"),
+                    fundamental_data=fundamentals.get(ticker),
+                )
+                out.new_df = featured
+            return out
+        except Exception as exc:  # noqa: BLE001 - capture per-ticker, surface in report
+            return TickerOutcome(ticker, "error", error=str(exc))
+
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        outcomes = list(pool.map(_process_one, targets))
+    elapsed = time.time() - t0
+
+    # ── partition outcomes ────────────────────────────────────────────────────
+    records: list[ReconcileRecord] = []
+    errors: list[dict] = []
+    no_old_close: list[str] = []
+    fetch_empty: list[str] = []
+    written = 0
+
+    for o in outcomes:
+        if o.outcome == "ok" and o.reconcile is not None:
+            records.append(o.reconcile)
+        elif o.outcome == "no_old_close":
+            no_old_close.append(o.ticker)
+        elif o.outcome == "fetch_empty":
+            fetch_empty.append(o.ticker)
+        elif o.outcome == "error":
+            errors.append({"ticker": o.ticker, "error": o.error})
+            log.error("CRSP migration error for %s: %s", o.ticker, o.error)
+
+    # ── WRITE scratch (apply) — only after all reconciliations computed ───────
+    if apply:
+        for o in outcomes:
+            if o.outcome == "ok" and o.new_df is not None and not o.new_df.empty:
+                try:
+                    scratch.write(o.ticker, to_arctic_canonical(o.new_df))
+                    o.written = True
+                    written += 1
+                except Exception as exc:  # noqa: BLE001
+                    errors.append({"ticker": o.ticker, "stage": "scratch_write",
+                                   "error": str(exc)})
+                    log.error("Scratch write failed for %s: %s", o.ticker, exc)
+
+    within_tol = [r for r in records if r.status == "within_tol"]
+    out_of_tol = [r for r in records if r.status == "out_of_tol"]
+    no_overlap = [r for r in records if r.status == "no_overlap"]
+    # FAIL-LOUD set: every out-of-tol or no-overlap record not explained.
+    unexplained = [r for r in records if not r.explained]
+
+    for r in out_of_tol + no_overlap:
+        lvl = log.warning if r.explained else log.error
+        lvl("RECONCILE %s status=%s max_rel_dev=%.4f date=%s — %s",
+            r.ticker, r.status, r.max_rel_dev, r.max_dev_date, r.explanation)
+
+    summary = {
+        "status": "ok" if (not unexplained and not errors) else "fail",
+        "applied": apply,
+        "scratch_lib": scratch_lib,
+        "rel_tol": rel_tol,
+        "live_universe_size": len(arctic_symbols),
+        "targets_count": len(targets),
+        "reconciled_count": len(records),
+        "within_tol_count": len(within_tol),
+        "out_of_tol_count": len(out_of_tol),
+        "no_overlap_count": len(no_overlap),
+        "unexplained_count": len(unexplained),
+        "no_old_close_count": len(no_old_close),
+        "fetch_empty_count": len(fetch_empty),
+        "errors_count": len(errors),
+        "written_count": written,
+        "elapsed_seconds": round(elapsed, 1),
+        "workers": workers,
+        "reconciliations": [r.to_dict() for r in records],
+        "unexplained": [r.to_dict() for r in unexplained],
+        "no_old_close": no_old_close,
+        "fetch_empty": fetch_empty,
+        "errors": errors,
+        "known_divergence_tickers": sorted(known_divergence_tickers),
+    }
+
+    # Persist the report BEFORE raising so the evidence survives a fail-loud.
+    _write_audit(s3, bucket, summary)
+
+    log.info(
+        "migrate_universe_crsp_basis: applied=%s targets=%d reconciled=%d "
+        "within_tol=%d out_of_tol=%d no_overlap=%d unexplained=%d errors=%d "
+        "written=%d elapsed=%.1fs",
+        apply, len(targets), len(records), len(within_tol), len(out_of_tol),
+        len(no_overlap), len(unexplained), len(errors), written, elapsed,
+    )
+
+    # ── FAIL LOUD ─────────────────────────────────────────────────────────────
+    # No silent skip, no "unscoreable" sentinel (Brian standing feedback): an
+    # unexplained out-of-tol / no-overlap residual means a missing/doubled
+    # action or a real basis divergence reached the reconstruction — it MUST
+    # halt the build before the scratch basis is trusted for the shadow retrain.
+    if unexplained:
+        raise RuntimeError(
+            f"CRSP reconciliation FAILED LOUD: {len(unexplained)} ticker(s) "
+            f"carry an unexplained out-of-tolerance residual (rel_tol={rel_tol:.2%}). "
+            f"Each is a missing/doubled/mis-ratio'd split or dividend, an "
+            f"un-reconcilable ticker, or a real polygon-vs-yfinance divergence — "
+            f"localize and fix the action (or acknowledge via "
+            f"--known-divergence) before trusting the scratch basis. First 20: "
+            f"{[r.to_dict() for r in unexplained[:20]]}"
+        )
+    if errors:
+        raise RuntimeError(
+            f"CRSP migration had {len(errors)} per-ticker error(s) — see audit. "
+            f"First 20: {errors[:20]}"
+        )
+
+    return summary
+
+
+def _load_macro_series(s3, bucket: str) -> dict[str, pd.Series]:
+    """Load the macro/SPY/sector-ETF Close series for the feature recompute.
+
+    Reuses ``features.compute`` loaders (ArcticDB universe+macro) so the scratch
+    feature recompute sees the same macro context the live build does. READ
+    ONLY. Degrades to ``{}`` (features fall back to defaults) on failure rather
+    than blocking the reconciliation, which needs no macro.
+    """
+    try:
+        from features.compute import _extract_macro, _load_price_source
+
+        source = _load_price_source(s3, bucket)
+        if not source:
+            return {}
+        return _extract_macro(source, source)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("macro load for CRSP feature recompute failed (%s) — "
+                    "features will use defaults", exc)
+        return {}
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Recompute features + WRITE the scratch library. Default: dry-run "
+             "(reconcile + report only, no writes).",
+    )
+    parser.add_argument(
+        "--scratch-lib", default=DEFAULT_SCRATCH_LIB,
+        help=f"Scratch ArcticDB library name (default: {DEFAULT_SCRATCH_LIB}). "
+             "Must NOT be a live name (universe/macro).",
+    )
+    parser.add_argument(
+        "--tickers",
+        help="Comma-separated subset of tickers (default: all live-universe symbols).",
+    )
+    parser.add_argument(
+        "--rel-tol", type=float, default=DEFAULT_RECONCILE_REL_TOL,
+        help=f"Reconciliation relative-deviation tolerance (default: {DEFAULT_RECONCILE_REL_TOL}).",
+    )
+    parser.add_argument(
+        "--known-divergence",
+        help="Comma-separated tickers whose out-of-tol residual is an "
+             "operator-acknowledged known divergence (reported, not fatal).",
+    )
+    parser.add_argument(
+        "--bucket", default=DEFAULT_BUCKET,
+        help=f"S3 bucket (default: {DEFAULT_BUCKET})",
+    )
+    args = parser.parse_args()
+
+    tickers_override = (
+        [t.strip() for t in args.tickers.split(",") if t.strip()]
+        if args.tickers else None
+    )
+    known = (
+        frozenset(t.strip() for t in args.known_divergence.split(",") if t.strip())
+        if args.known_divergence else frozenset()
+    )
+
+    result = migrate_universe_crsp_basis(
+        bucket=args.bucket,
+        scratch_lib=args.scratch_lib,
+        apply=args.apply,
+        tickers_override=tickers_override,
+        rel_tol=args.rel_tol,
+        known_divergence_tickers=known,
+    )
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -75,6 +75,8 @@ __all__ = [
     "detect_splits",
     "detect_dividends",
     "detect_renames",
+    "get_splits",
+    "get_dividends",
     "splits_from_events",
     "dividends_from_events",
     "renames_from_events",
@@ -1040,6 +1042,96 @@ def splits_from_events(events: list[dict]) -> list["CorporateAction"]:
             )
         )
     return actions
+
+
+def get_splits(ticker: str, *, client=None) -> list["CorporateAction"]:
+    """Per-ticker, FULL-history split events for ``ticker`` as
+    ``CorporateAction``s (type="split", ex_date = polygon execution_date).
+
+    Sibling of :func:`detect_splits` (which scans the whole market over a
+    date RANGE for the daily sync) — this is the one-ticker, full-history
+    fetch the offline CRSP-basis migration (PR7, config#1434) needs to
+    reconstruct a ticker's entire split-adjusted history. Wraps
+    ``polygon_client.get_splits`` (which returns ``{"execution_date",
+    "split_from", "split_to"}`` dicts WITHOUT a ticker key) and injects the
+    ticker so each event maps to a content-addressed split ``CorporateAction``.
+    The client is constructed lazily (mirroring :func:`detect_splits`) and any
+    construction/fetch failure DEGRADES GRACEFULLY to ``[]`` (apiKey scrubbed)
+    — never hard-fails the caller; the migration's reconciliation backstop is
+    what catches a genuinely missing split.
+    """
+    if client is None:
+        try:
+            from polygon_client import polygon_client
+
+            client = polygon_client()
+        except Exception as exc:  # import / construction failure — degrade
+            from polygon_client import _scrub_api_key
+
+            log.warning(
+                "corporate_actions.get_splits: could not obtain polygon client "
+                "(%s) — returning no splits for %s",
+                _scrub_api_key(exc), ticker,
+            )
+            return []
+    try:
+        events = client.get_splits(ticker)
+    except Exception as exc:
+        from polygon_client import _scrub_api_key
+
+        log.warning(
+            "corporate_actions.get_splits: polygon split fetch failed for %s "
+            "(%s) — returning no splits",
+            ticker, _scrub_api_key(exc),
+        )
+        return []
+    # client.get_splits omits the ticker key; inject it so splits_from_events
+    # can build the content-addressed action.
+    return splits_from_events([{**ev, "ticker": ticker} for ev in events])
+
+
+def get_dividends(ticker: str, *, client=None) -> list["CorporateAction"]:
+    """Per-ticker, FULL-history cash-dividend events for ``ticker`` as
+    ``CorporateAction``s (type="dividend", ex_date = polygon ex_dividend_date,
+    cash_amount + dividend_kind populated).
+
+    Sibling of :func:`detect_dividends` (whole-market range scan) — the
+    one-ticker, full-history fetch the offline CRSP-basis migration (PR7,
+    config#1434) consumes to build the SEPARATE total-return series
+    (``total_return_series``). Dividends are CRSP-separate: these actions are
+    NEVER passed to a price-store ``apply`` (which raises on a dividend) —
+    they feed only the total-return-axis math. Wraps
+    ``polygon_client.get_dividends`` (returns ``{"ex_dividend_date",
+    "cash_amount", "dividend_type"}`` dicts WITHOUT a ticker key); injects the
+    ticker, constructs the client lazily, and DEGRADES GRACEFULLY to ``[]`` on
+    any failure (apiKey scrubbed).
+    """
+    if client is None:
+        try:
+            from polygon_client import polygon_client
+
+            client = polygon_client()
+        except Exception as exc:  # import / construction failure — degrade
+            from polygon_client import _scrub_api_key
+
+            log.warning(
+                "corporate_actions.get_dividends: could not obtain polygon "
+                "client (%s) — returning no dividends for %s",
+                _scrub_api_key(exc), ticker,
+            )
+            return []
+    try:
+        events = client.get_dividends(ticker)
+    except Exception as exc:
+        from polygon_client import _scrub_api_key
+
+        log.warning(
+            "corporate_actions.get_dividends: polygon dividend fetch failed "
+            "for %s (%s) — returning no dividends",
+            ticker, _scrub_api_key(exc),
+        )
+        return []
+    return dividends_from_events([{**ev, "ticker": ticker} for ev in events])
 
 
 def detect_splits(

--- a/features/SCHEMA.md
+++ b/features/SCHEMA.md
@@ -64,6 +64,33 @@ lift of this contract from alpha-engine-data into
 
 ---
 
+## 2a. Price-basis columns (CRSP — NOT feature-catalog entries)
+
+These are price/return LEVEL columns persisted on the universe library
+alongside the feature catalog. They are **not** in `registry.py::CATALOG`
+or §3 (those are the engineered features); they are the price basis the
+features are computed *from*. Canonical column order is the single source
+of truth in `store/arctic_store.py` (`OHLCV_COLS` + `TOTAL_RETURN_COL` +
+`source` + FEATURES).
+
+| Column | Units | Compute | Consumers |
+|---|---|---|---|
+| `Close` | absolute price (split-adjusted LEVEL) | polygon-authoritative split restatement (`corporate_actions.apply` → `_split_math.restate_series_for_splits`); changes only on splits | features (basis), executor, research, predictor |
+| `total_return_close` | absolute price (split-adjusted + dividend-back-adjusted; total-return axis) | `Close` further back-adjusted by registry dividend events via `corporate_actions.total_return_series` — a SEPARATE series that does NOT mutate `Close` | features (basis at PR7-7c cutover), predictor label (7c) |
+
+**Status (PR7-7a, config#1434):** `total_return_close` is ADDITIVE and,
+as of this PR, written ONLY to the OFFLINE scratch CRSP-basis library
+(`builders/migrate_universe_crsp_basis.py` → `universe_crsp`). The live
+`universe` library does not yet carry it, and the feature/label basis
+still reads `Close`. The flip of the feature basis
+(`feature_engineer.py` `close_col` default → `total_return_close`), the
+ne-data + predictor label flip, and the `backfill`/`daily_append`
+dual-writer are GATED to PR7-7c after the shadow-retrain + backtest gate.
+Placed immediately after `Close` in the canonical layout so the price-level
+and return-basis columns sit adjacent.
+
+---
+
 ## 3. Field catalog — units, compute, consumers
 
 Sorted by group, matching `features/registry.py::CATALOG`. Every entry

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -312,6 +312,7 @@ def compute_features(
     fundamental_data: dict | None = None,
     vix3m_series: pd.Series | None = None,
     xsect_dispersion: pd.Series | None = None,
+    close_col: str = "Close",
 ) -> pd.DataFrame:
     """
     Compute all technical, macro, and alternative data features for a full OHLCV DataFrame.
@@ -321,6 +322,15 @@ def compute_features(
     df : pd.DataFrame
         Must contain columns: Close, Volume (Open/High/Low optional).
         Index should be a DatetimeIndex sorted ascending.
+    close_col : str, default "Close"
+        The column used as the price series that feeds every close-derived
+        feature (the single basis chokepoint — ~70 downstream feature sites
+        inherit it). Defaults to ``"Close"`` (the live behaviour — unchanged).
+        The corporate-actions CRSP migration (PR7, config#1434) passes
+        ``close_col="total_return_close"`` to recompute features on the
+        total-return basis for the OFFLINE scratch build, WITHOUT mutating
+        this default. The live flip of the default basis is gated to PR7-7c.
+        Open/High/Low stay raw (split-adjusted level) by design.
     spy_series : SPY Close prices (DatetimeIndex).
     vix_series : VIX Close prices (DatetimeIndex).
     sector_etf_series : Sector ETF Close prices (DatetimeIndex).
@@ -360,7 +370,12 @@ def compute_features(
     if not df.index.is_monotonic_increasing:
         df = df.sort_index()
 
-    close = df["Close"].astype(float)
+    if close_col not in df.columns:
+        raise KeyError(
+            f"compute_features: close_col {close_col!r} not in df columns "
+            f"{list(df.columns)}"
+        )
+    close = df[close_col].astype(float)
     volume = df["Volume"].astype(float) if "Volume" in df.columns else pd.Series(0.0, index=df.index)
 
     # ── RSI ─────────────────────────────────────────────────────────────────

--- a/store/arctic_store.py
+++ b/store/arctic_store.py
@@ -40,6 +40,27 @@ ARCTIC_PREFIX = "arcticdb"
 OHLCV_COLS: list[str] = ["Open", "High", "Low", "Close", "Volume", "VWAP"]
 PROVENANCE_COL: str = "source"
 
+# CRSP total-return basis column (corporate-actions PR7, config#1434).
+# ``Close`` stays the split-adjusted price LEVEL (polygon-authoritative);
+# ``total_return_close`` is that same series further dividend-back-adjusted
+# (the SEPARATE total-return axis built by
+# ``corporate_actions.total_return_series``). It is persisted immediately
+# AFTER ``Close`` in the canonical layout so the price-level and
+# return-basis columns sit adjacent. ADDITIVE: it is absent on every live
+# ``universe`` symbol today (the ``to_arctic_canonical`` guard makes it a
+# no-op there) and is laid down only on the OFFLINE scratch CRSP-basis
+# build (``builders/migrate_universe_crsp_basis.py``). The live basis flip
+# (features + label recomputed on this column) is gated to PR7-7c after the
+# shadow-retrain/backtest gate — NOT this PR.
+TOTAL_RETURN_COL: str = "total_return_close"
+
+# Live ArcticDB library names a scratch migration must NEVER target. The
+# offline CRSP-basis build writes a distinct scratch library
+# (e.g. ``universe_crsp``); ``get_scratch_universe_lib`` refuses these
+# names structurally so a misconfigured ``--scratch-lib`` can't clobber
+# the live universe / macro libraries the live pipeline reads.
+_LIVE_LIB_NAMES: frozenset[str] = frozenset({"universe", "macro"})
+
 _arctic_instance: adb.Arctic | None = None
 
 
@@ -68,6 +89,31 @@ def get_macro_lib(bucket: str | None = None) -> adb.library.Library:
     """Get the macro library (market-wide time series)."""
     arctic = _get_arctic(bucket)
     return arctic.get_library("macro", create_if_missing=True)
+
+
+def get_scratch_universe_lib(name: str, bucket: str | None = None) -> adb.library.Library:
+    """Get a SCRATCH universe-shaped library for an offline migration build.
+
+    Used by ``builders/migrate_universe_crsp_basis.py`` (corporate-actions
+    PR7-7a, config#1434) to write the reconstructed CRSP-basis universe into
+    an isolated library (default ``universe_crsp``) WITHOUT ever touching the
+    live ``universe`` library the daily/weekly pipelines read.
+
+    Structurally refuses the live library names (``universe`` / ``macro``):
+    a scratch build must use a distinct name, so a misconfigured
+    ``--scratch-lib`` can never clobber live data. This is the single
+    chokepoint enforcing the "offline, live-untouched" contract — every
+    scratch write goes through here.
+    """
+    if name in _LIVE_LIB_NAMES:
+        raise ValueError(
+            f"refusing to open {name!r} as a scratch library — it is a LIVE "
+            f"ArcticDB library the live pipeline reads. A scratch migration "
+            f"must use a distinct name (e.g. 'universe_crsp'). Live names: "
+            f"{sorted(_LIVE_LIB_NAMES)}"
+        )
+    arctic = _get_arctic(bucket)
+    return arctic.get_library(name, create_if_missing=True)
 
 
 def reset_connection():
@@ -131,8 +177,12 @@ def to_arctic_canonical(
 
     Behaviour:
         - Intersect-then-reorder. Columns outside
-          ``OHLCV_COLS + [PROVENANCE_COL] + features`` are DROPPED
-          (matches the prior per-site recipe).
+          ``OHLCV_COLS + [TOTAL_RETURN_COL] + [PROVENANCE_COL] + features``
+          are DROPPED (matches the prior per-site recipe).
+        - ``TOTAL_RETURN_COL`` (``total_return_close``), when present, is
+          placed immediately AFTER ``Close`` (CRSP basis, PR7 config#1434).
+          Absent on live universe symbols → the layout is byte-identical to
+          the pre-PR7 ``OHLCV + source + features`` order there (additive).
         - Empty frames pass through unchanged (no copy).
         - Frames already in canonical order and free of categoricals
           pass through unchanged (no copy).
@@ -156,8 +206,22 @@ def to_arctic_canonical(
         from features.feature_engineer import FEATURES as _FEATURES
         features = _FEATURES
 
+    # Build the OHLCV head, splicing total_return_close in right after Close
+    # (CRSP basis, PR7 config#1434). The guard keeps this a no-op for live
+    # universe symbols (which carry no total_return_close column).
+    head: list[str] = []
+    for c in OHLCV_COLS:
+        if c in df.columns:
+            head.append(c)
+        if c == "Close" and TOTAL_RETURN_COL in df.columns:
+            head.append(TOTAL_RETURN_COL)
+    # Degenerate guard: total_return_close present but no Close (shouldn't
+    # happen in practice) — still keep it rather than silently dropping it.
+    if TOTAL_RETURN_COL in df.columns and TOTAL_RETURN_COL not in head:
+        head.append(TOTAL_RETURN_COL)
+
     canonical: list[str] = (
-        [c for c in OHLCV_COLS if c in df.columns]
+        head
         + ([PROVENANCE_COL] if PROVENANCE_COL in df.columns else [])
         + [f for f in features if f in df.columns]
     )

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -64,6 +64,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "builders/_price_cache_writeboth.py": 1,
     "builders/daily_append.py": 2,  # universe_freshness.json + weekly/<date>/manifest.json (schema_drift_incidents, config#1150)
+    # builders/migrate_universe_crsp_basis_audit/{ts}.json — the per-ticker CRSP
+    # reconciliation REPORT (corporate-actions PR7-7a, config#1434). Like the
+    # other one-off migration-audit PUTs (feature_order / vwap below), this is an
+    # EVENT-DRIVEN operator-run artifact, NOT a periodic freshness-SLA artifact:
+    # there is no cadence to monitor and the migration is a manual spot run, so it
+    # is grandfathered out of ARTIFACT_REGISTRY.yaml (no freshness row) — pinned
+    # here only to force operator review of the new PUT site.
+    "builders/migrate_universe_crsp_basis.py": 1,
     "builders/migrate_universe_feature_order.py": 1,
     "builders/migrate_universe_vwap.py": 1,
     "builders/prune_delisted_tickers.py": 1,

--- a/tests/test_migrate_universe_crsp_basis.py
+++ b/tests/test_migrate_universe_crsp_basis.py
@@ -1,0 +1,410 @@
+"""Tests for builders/migrate_universe_crsp_basis.py + the additive CRSP schema.
+
+Corporate-actions PR7-7a (epic config#1433 / config#1434). The migration is the
+OFFLINE, build-the-evidence step: it reconstructs the universe on the CRSP basis
+(Close = split-adjusted LEVEL, NEW total_return_close = split-adjusted +
+dividend-back-adjusted) into a SCRATCH ArcticDB library and emits a per-ticker
+reconciliation report that FAILS LOUD on any unexplained residual.
+
+These tests pin:
+  * schema: total_return_close lands immediately AFTER Close in the canonical
+    order; to_arctic_canonical accepts it; absent → live layout is unchanged.
+  * get_scratch_universe_lib refuses the live library names (never writes live).
+  * reconstruct_basis: split-adjusted Close LEVEL + total_return_close on a
+    ticker with a KNOWN split AND KNOWN dividend (TR == hand-computed
+    yfinance-auto_adjust-equivalent within tol).
+  * compute_features(close_col=...) shim feeds the chosen close column.
+  * reconcile: a clean ticker is within_tol; an injected missing-dividend /
+    wrong-split residual is OUT-OF-TOL + unexplained.
+  * orchestration: writes go to the SCRATCH lib (never universe); a clean run
+    succeeds + is idempotent; an unexplained residual RAISES (fail-loud).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import corporate_actions as ca
+from store.arctic_store import (
+    OHLCV_COLS,
+    PROVENANCE_COL,
+    TOTAL_RETURN_COL,
+    get_scratch_universe_lib,
+    to_arctic_canonical,
+)
+from builders import migrate_universe_crsp_basis as m
+from builders.migrate_universe_crsp_basis import (
+    ReconcileRecord,
+    reconcile_total_return,
+    reconstruct_basis,
+)
+
+
+# ── schema: total_return_close canonical placement ───────────────────────────
+
+
+def test_total_return_close_placed_immediately_after_close():
+    feats = ["rsi_14", "momentum_20d"]
+    cols = list(OHLCV_COLS) + [TOTAL_RETURN_COL, PROVENANCE_COL] + feats
+    idx = pd.date_range("2024-01-01", periods=4, freq="B")
+    df = pd.DataFrame({c: np.linspace(1.0, 2.0, 4) for c in cols}, index=idx)
+    df[PROVENANCE_COL] = "yfinance"
+
+    out = to_arctic_canonical(df, features=feats)
+    expected = [
+        "Open", "High", "Low", "Close", TOTAL_RETURN_COL, "Volume", "VWAP",
+        PROVENANCE_COL, *feats,
+    ]
+    assert list(out.columns) == expected
+    # total_return_close is adjacent to Close.
+    assert out.columns[out.columns.get_loc("Close") + 1] == TOTAL_RETURN_COL
+
+
+def test_canonical_unchanged_when_total_return_close_absent():
+    """A live-universe-shaped frame (no total_return_close) is laid out exactly
+    as before — the schema change is additive."""
+    feats = ["rsi_14", "momentum_20d"]
+    cols = list(OHLCV_COLS) + [PROVENANCE_COL] + feats
+    idx = pd.date_range("2024-01-01", periods=4, freq="B")
+    df = pd.DataFrame({c: np.linspace(1.0, 2.0, 4) for c in cols}, index=idx)
+    df[PROVENANCE_COL] = "yfinance"
+
+    out = to_arctic_canonical(df, features=feats)
+    assert list(out.columns) == list(OHLCV_COLS) + [PROVENANCE_COL] + feats
+    assert TOTAL_RETURN_COL not in out.columns
+
+
+# ── get_scratch_universe_lib refuses live names ──────────────────────────────
+
+
+def test_get_scratch_universe_lib_refuses_live_universe():
+    with pytest.raises(ValueError, match="universe"):
+        get_scratch_universe_lib("universe")
+
+
+def test_get_scratch_universe_lib_refuses_macro():
+    with pytest.raises(ValueError, match="macro"):
+        get_scratch_universe_lib("macro")
+
+
+# ── reconstruct_basis: split LEVEL + total_return_close derivation ────────────
+
+
+def _raw_split_div_frame():
+    """Raw (unadjusted) frame: a 2-for-1 forward split at index 4 (price halves
+    100→50) and a $0.50 dividend ex at index 2."""
+    idx = pd.bdate_range("2026-06-01", periods=6)
+    raw = pd.DataFrame(
+        {"Close": [100.0, 100.0, 100.0, 100.0, 50.0, 50.0],
+         "Volume": [1e6] * 6},
+        index=idx,
+    )
+    split = ca.CorporateAction.from_split("X", idx[4].strftime("%Y-%m-%d"), 1, 2)
+    div = ca.CorporateAction.from_dividend("X", idx[2].strftime("%Y-%m-%d"), 0.5, "CD")
+    return raw, [split], [div]
+
+
+def test_reconstruct_basis_close_is_split_adjusted_level():
+    raw, splits, divs = _raw_split_div_frame()
+    out, applied = reconstruct_basis("X", raw, splits, divs)
+    # 2-for-1: pre rows (0-3) ×0.5 → flat split-adjusted level 50.
+    assert list(out["Close"].to_numpy()) == pytest.approx([50.0] * 6)
+    assert any(r["status"] == "applied" for r in applied)
+
+
+def test_reconstruct_basis_total_return_close_back_adjusts_dividend():
+    raw, splits, divs = _raw_split_div_frame()
+    out, _ = reconstruct_basis("X", raw, splits, divs)
+    # total_return_close = split-adjusted close, rows<ex_div (0,1) ×0.99
+    # (close_prev = split-adj 50, $0.50 div → 1 - 0.5/50 = 0.99).
+    assert TOTAL_RETURN_COL in out.columns
+    assert list(out[TOTAL_RETURN_COL].to_numpy()) == pytest.approx(
+        [49.5, 49.5, 50.0, 50.0, 50.0, 50.0]
+    )
+    # Close (the LEVEL) is NOT mutated by the dividend back-adjust.
+    assert list(out["Close"].to_numpy()) == pytest.approx([50.0] * 6)
+
+
+def test_reconstruct_basis_matches_yfinance_autoadjust_within_tol():
+    """The derived total_return_close equals the yfinance auto_adjust-equivalent
+    total-return close (split + dividend adjusted) up to tol — the whole premise
+    of the migration (both are total-return; the new one is polygon-authoritative)."""
+    raw, splits, divs = _raw_split_div_frame()
+    out, _ = reconstruct_basis("X", raw, splits, divs)
+    # Hand-computed yfinance auto_adjust close for the same actions.
+    yf_autoadjust = pd.Series(
+        [49.5, 49.5, 50.0, 50.0, 50.0, 50.0], index=out.index,
+    )
+    rec = reconcile_total_return(
+        "X", out[TOTAL_RETURN_COL], yf_autoadjust,
+        split_actions=splits, dividend_actions=divs, rel_tol=0.02,
+    )
+    assert rec.status == "within_tol"
+    assert rec.explained is True
+
+
+# ── compute_features close_col shim ──────────────────────────────────────────
+
+
+def test_compute_features_uses_close_col():
+    from features.feature_engineer import compute_features
+
+    idx = pd.bdate_range("2024-01-01", periods=60)
+    close = pd.Series(np.linspace(100.0, 130.0, 60), index=idx)
+    # A NON-proportional basis (like a compounding dividend back-adjust) — a
+    # constant scale factor would cancel in ratio features, so vary it.
+    tr = close * np.linspace(0.8, 1.0, 60)
+    df = pd.DataFrame(
+        {"Open": close, "High": close * 1.01, "Low": close * 0.99,
+         "Close": close, "Volume": 1e6, TOTAL_RETURN_COL: tr},
+        index=idx,
+    )
+    on_close = compute_features(df, close_col="Close")
+    on_tr = compute_features(df, close_col=TOTAL_RETURN_COL)
+    # price_vs_ma50 is a close-derived feature; the two bases must differ.
+    a = on_close["price_vs_ma50"].dropna().to_numpy()
+    b = on_tr["price_vs_ma50"].dropna().to_numpy()
+    assert a.size and b.size
+    assert not np.allclose(a, b)
+
+
+def test_compute_features_missing_close_col_raises():
+    from features.feature_engineer import compute_features
+
+    idx = pd.bdate_range("2024-01-01", periods=5)
+    df = pd.DataFrame({"Close": np.linspace(1, 2, 5), "Volume": 1e6}, index=idx)
+    with pytest.raises(KeyError, match="total_return_close"):
+        compute_features(df, close_col=TOTAL_RETURN_COL)
+
+
+# ── reconcile classification ─────────────────────────────────────────────────
+
+
+def test_reconcile_clean_ticker_within_tol():
+    idx = pd.bdate_range("2026-06-01", periods=6)
+    new = pd.Series([49.5, 49.5, 50.0, 50.0, 50.0, 50.0], index=idx)
+    old = new * 1.001  # 0.1% feed rounding
+    rec = reconcile_total_return("X", new, old, rel_tol=0.02)
+    assert rec.status == "within_tol"
+    assert rec.explained is True
+
+
+def test_reconcile_missing_dividend_is_out_of_tol_unexplained():
+    """yfinance applied an extra/larger dividend our registry lacks → the old
+    total-return Close sits below ours pre-ex by more than tol."""
+    idx = pd.bdate_range("2026-06-01", periods=6)
+    new = pd.Series([49.5, 49.5, 50.0, 50.0, 50.0, 50.0], index=idx)
+    old = pd.Series([47.0, 47.0, 50.0, 50.0, 50.0, 50.0], index=idx)  # ~5% off pre-ex
+    rec = reconcile_total_return("X", new, old, rel_tol=0.02)
+    assert rec.status == "out_of_tol"
+    assert rec.explained is False
+    assert rec.max_rel_dev > 0.02
+
+
+def test_reconcile_wrong_split_is_out_of_tol_unexplained():
+    """A doubled/mis-ratio'd split leaves a large boundary divergence."""
+    idx = pd.bdate_range("2026-06-01", periods=6)
+    new = pd.Series([50.0] * 6, index=idx)
+    old = pd.Series([100.0, 100.0, 100.0, 100.0, 50.0, 50.0], index=idx)  # split not applied
+    rec = reconcile_total_return("X", new, old, rel_tol=0.02)
+    assert rec.status == "out_of_tol"
+    assert rec.explained is False
+
+
+def test_reconcile_known_divergence_is_explained():
+    idx = pd.bdate_range("2026-06-01", periods=6)
+    new = pd.Series([49.5, 49.5, 50.0, 50.0, 50.0, 50.0], index=idx)
+    old = pd.Series([47.0, 47.0, 50.0, 50.0, 50.0, 50.0], index=idx)
+    rec = reconcile_total_return("X", new, old, rel_tol=0.02, known_divergence=True)
+    assert rec.status == "out_of_tol"
+    assert rec.explained is True
+
+
+def test_reconcile_no_overlap_is_unexplained():
+    new = pd.Series([50.0] * 3, index=pd.bdate_range("2026-06-01", periods=3))
+    old = pd.Series([50.0] * 3, index=pd.bdate_range("2020-06-01", periods=3))
+    rec = reconcile_total_return("X", new, old, rel_tol=0.02)
+    assert rec.status == "no_overlap"
+    assert rec.explained is False
+
+
+# ── orchestration: scratch-only writes, idempotency, fail-loud ───────────────
+
+
+class _FakePolygon:
+    """Per-ticker polygon double: get_splits / get_dividends return the raw
+    polygon event-dict shapes corporate_actions.get_splits/get_dividends parse."""
+
+    def __init__(self, splits: dict, dividends: dict):
+        self._splits = splits
+        self._dividends = dividends
+
+    def get_splits(self, ticker):
+        return self._splits.get(ticker, [])
+
+    def get_dividends(self, ticker):
+        return self._dividends.get(ticker, [])
+
+
+def _patch_orchestration(monkeypatch, *, old_closes: dict, scratch_lib=None):
+    """Wire the migration's live (read-only) universe lib, scratch lib, and s3
+    audit so the orchestration runs fully in-memory."""
+    live_lib = MagicMock()
+    live_lib.list_symbols.return_value = list(old_closes.keys())
+
+    def _read(ticker):
+        result = MagicMock()
+        result.data = pd.DataFrame({"Close": old_closes[ticker]})
+        return result
+
+    live_lib.read.side_effect = _read
+
+    scratch = scratch_lib if scratch_lib is not None else MagicMock()
+
+    monkeypatch.setattr(m, "get_universe_lib", lambda *a, **k: live_lib)
+    monkeypatch.setattr(m, "get_scratch_universe_lib", lambda *a, **k: scratch)
+    monkeypatch.setattr(m, "boto3", MagicMock())
+    return live_lib, scratch
+
+
+def _clean_setup():
+    """A single clean ticker whose reconstruction matches its old yfinance Close."""
+    raw, splits, divs = _raw_split_div_frame()
+    raw_frames = {"X": raw}
+    idx = raw.index
+    old_closes = {"X": pd.Series([49.5, 49.5, 50.0, 50.0, 50.0, 50.0], index=idx)}
+    client = _FakePolygon(
+        splits={"X": [{"execution_date": idx[4].strftime("%Y-%m-%d"),
+                       "split_from": 1, "split_to": 2}]},
+        dividends={"X": [{"ex_dividend_date": idx[2].strftime("%Y-%m-%d"),
+                          "cash_amount": 0.5, "dividend_type": "CD"}]},
+    )
+    return raw_frames, old_closes, client
+
+
+def test_orchestration_dry_run_clean_succeeds_no_writes(monkeypatch):
+    raw_frames, old_closes, client = _clean_setup()
+    live_lib, scratch = _patch_orchestration(monkeypatch, old_closes=old_closes)
+
+    result = m.migrate_universe_crsp_basis(
+        apply=False,
+        raw_fetch=lambda t: raw_frames[t],
+        client=client,
+        rel_tol=0.02,
+        workers=1,
+    )
+    assert result["status"] == "ok"
+    assert result["within_tol_count"] == 1
+    assert result["unexplained_count"] == 0
+    assert result["written_count"] == 0
+    scratch.write.assert_not_called()
+    # The live universe lib was only ever READ, never written.
+    live_lib.write.assert_not_called()
+
+
+def test_orchestration_fail_loud_on_unexplained_residual(monkeypatch):
+    raw_frames, old_closes, client = _clean_setup()
+    # Corrupt the old Close so the reconstruction diverges beyond tol with no
+    # acknowledged divergence → must FAIL LOUD.
+    old_closes["X"] = pd.Series([40.0, 40.0, 50.0, 50.0, 50.0, 50.0],
+                                index=raw_frames["X"].index)
+    live_lib, scratch = _patch_orchestration(monkeypatch, old_closes=old_closes)
+
+    with pytest.raises(RuntimeError, match="FAILED LOUD"):
+        m.migrate_universe_crsp_basis(
+            apply=False,
+            raw_fetch=lambda t: raw_frames[t],
+            client=client,
+            rel_tol=0.02,
+            workers=1,
+        )
+    # Live lib never written even on the failing path.
+    live_lib.write.assert_not_called()
+
+
+def test_orchestration_known_divergence_does_not_fail(monkeypatch):
+    raw_frames, old_closes, client = _clean_setup()
+    old_closes["X"] = pd.Series([40.0, 40.0, 50.0, 50.0, 50.0, 50.0],
+                                index=raw_frames["X"].index)
+    _patch_orchestration(monkeypatch, old_closes=old_closes)
+
+    result = m.migrate_universe_crsp_basis(
+        apply=False,
+        raw_fetch=lambda t: raw_frames[t],
+        client=client,
+        rel_tol=0.02,
+        known_divergence_tickers=frozenset({"X"}),
+        workers=1,
+    )
+    assert result["status"] == "ok"
+    assert result["out_of_tol_count"] == 1
+    assert result["unexplained_count"] == 0
+
+
+def test_orchestration_apply_writes_scratch_lib_only(monkeypatch, tmp_path):
+    """Apply path: the reconstructed series is written to a REAL (LMDB) scratch
+    library, and the live universe lib is never written."""
+    adb = pytest.importorskip("arcticdb")
+    ac = adb.Arctic(f"lmdb://{tmp_path}")
+    scratch = ac.get_library("universe_crsp", create_if_missing=True)
+
+    raw_frames, old_closes, client = _clean_setup()
+    live_lib, _ = _patch_orchestration(
+        monkeypatch, old_closes=old_closes, scratch_lib=scratch,
+    )
+
+    result = m.migrate_universe_crsp_basis(
+        apply=True,
+        raw_fetch=lambda t: raw_frames[t],
+        client=client,
+        rel_tol=0.02,
+        workers=1,
+        macro={}, sector_map={}, fundamentals={}, alt_data={},
+    )
+    assert result["status"] == "ok"
+    assert result["written_count"] == 1
+    # Written to the SCRATCH lib...
+    assert "X" in scratch.list_symbols()
+    stored = scratch.read("X").data
+    assert TOTAL_RETURN_COL in stored.columns
+    # Close is the split-adjusted LEVEL; total_return_close is dividend-adjusted.
+    assert list(stored["Close"].to_numpy()) == pytest.approx([50.0] * 6)
+    assert list(stored[TOTAL_RETURN_COL].to_numpy()) == pytest.approx(
+        [49.5, 49.5, 50.0, 50.0, 50.0, 50.0]
+    )
+    # ...and NEVER the live universe lib.
+    live_lib.write.assert_not_called()
+
+
+def test_orchestration_apply_is_idempotent(monkeypatch, tmp_path):
+    adb = pytest.importorskip("arcticdb")
+    ac = adb.Arctic(f"lmdb://{tmp_path}")
+    scratch = ac.get_library("universe_crsp", create_if_missing=True)
+
+    raw_frames, old_closes, client = _clean_setup()
+    _patch_orchestration(monkeypatch, old_closes=old_closes, scratch_lib=scratch)
+
+    kwargs = dict(
+        apply=True, raw_fetch=lambda t: raw_frames[t], client=client,
+        rel_tol=0.02, workers=1,
+        macro={}, sector_map={}, fundamentals={}, alt_data={},
+    )
+    r1 = m.migrate_universe_crsp_basis(**kwargs)
+    r2 = m.migrate_universe_crsp_basis(**kwargs)
+    assert r1["written_count"] == 1
+    assert r2["written_count"] == 1
+    # Re-run overwrites in place — one symbol, not duplicated.
+    assert scratch.list_symbols() == ["X"]
+
+
+def test_record_round_trips_to_dict():
+    rec = ReconcileRecord(
+        ticker="X", status="within_tol", n_common_dates=6, max_rel_dev=0.001,
+        max_dev_date="2026-06-01", explained=True, explanation="ok",
+    )
+    d = rec.to_dict()
+    assert d["ticker"] == "X" and d["status"] == "within_tol"


### PR DESCRIPTION
PR7-step-7a of the corporate-actions program (epic config#1433 / config#1434) — the **OFFLINE, build-the-evidence** step.

Reconstructs the universe on the CRSP basis into a **SCRATCH** ArcticDB library and emits a per-ticker **reconciliation report that fails loud** on any unexplained residual. The live `universe` library, the live champion, and every consumer are **UNTOUCHED**. The live basis flip (`feature_engineer.py` close basis + ne-data/predictor labels), the `backfill`/`daily_append` dual-writer, and `prices.py auto_adjust=False` are all **GATED to 7c**, after the shadow-retrain + backtest gate of 7b.

## What this PR ships

**Schema (additive)** — `store/arctic_store.py`
- New `TOTAL_RETURN_COL = "total_return_close"`, spliced into `to_arctic_canonical` **immediately after `Close`**. No-op for live universe symbols (presence-guarded) — the pre-PR7 `OHLCV + source + FEATURES` layout is byte-identical there. `Close` meaning in the live write path is unchanged.
- `get_scratch_universe_lib(name)` — scratch-lib chokepoint that **refuses the live names** (`universe`/`macro`), so a misconfigured `--scratch-lib` can never clobber live data.

**Migration script** `builders/migrate_universe_crsp_basis.py` (template: `migrate_universe_feature_order.py` — dry-run/apply, ThreadPool, per-ticker error capture, S3 audit JSON, idempotent)
- Per ticker: raw re-pull (yfinance `auto_adjust=False`) → polygon SPLIT restatement (`corporate_actions.apply` → `_split_math.restate_series_for_splits`) → split-adjusted `Close` LEVEL.
- `total_return_close` derived from polygon DIVIDENDS (`corporate_actions.get_dividends` + `total_return_series`) — a SEPARATE total-return axis that does **not** mutate `Close`.
- `--apply` recomputes the 53 features on `total_return_close` (`compute_features(close_col=...)`) and writes **only the scratch lib** via `to_arctic_canonical`.
- **Reconcile**: new `total_return_close` vs the retiring yfinance total-return `Close` (read-only from the live universe) per ticker → max relative deviation, classify within-tol vs OUT-OF-TOL. **FAILS LOUD** (raise + non-zero exit) on any out-of-tol / no-overlap residual unless the ticker is an operator-acknowledged `--known-divergence`. No silent skip, no "unscoreable" sentinel. The report is persisted to S3 **before** raising.
- `--dry-run` (reconcile + report only), `--apply` (write scratch), `--tickers` subset, `--scratch-lib`, `--rel-tol`.

**Supporting**
- `corporate_actions.get_splits` / `get_dividends` — per-ticker full-history fetchers returning `CorporateAction`s (the authority-module API the migration consumes; avoids reaching into `polygon_client` from the builder — M0 contract discipline).
- `feature_engineer.compute_features` gains `close_col="Close"` (default unchanged — live behaviour preserved; the live flip of the default basis is gated to 7c). Single chokepoint per the plan; Open/High/Low stay raw level by design.
- `tests/test_migrate_universe_crsp_basis.py` — schema placement, scratch-lib guard, split/dividend derivation (TR == yfinance-autoadjust within tol), `close_col` shim, reconcile classification (clean within-tol; injected missing-dividend / wrong-split → out-of-tol + fail-loud), orchestration (scratch-only writes via real LMDB, idempotency, fail-loud raise).
- `test_artifact_registry_coverage.py` pins the new audit-JSON PUT (count=1, grandfathered as a one-off migration audit — no freshness row, mirroring `migrate_universe_feature_order`/`vwap`).
- `features/SCHEMA.md` documents `total_return_close` as a price-basis column (NOT a feature-catalog entry, so not in §3/CATALOG).

## Scope / safety
- **Writes ONLY a scratch lib** (`universe_crsp` by default); the live `universe`/champion are never written (enforced structurally by `get_scratch_universe_lib`, and asserted in tests).
- **Does NOT flip the live feature/label basis** — `compute_features` default stays `Close`; the feature/label flips, dual-writer, and `auto_adjust=False` are gated to 7c.
- **Script + tests only.** The actual ~900-ticker 10y scratch-library build is a separate operational (spot) run — NOT performed here and NOT run against any real/live ArcticDB.

## Tests
Targeted suite green locally (repo `.venv`):
`test_migrate_universe_crsp_basis.py` (23) + `test_corporate_actions*.py` + `test_split_restatement.py` + `test_schema_contract.py` + `test_artifact_registry_coverage.py` + `test_migrate_universe_feature_order.py` + `test_schema_roundtrip.py` + `test_daily_append_schema_drift.py` — **143 passed**. Import smoke + `--help` verified.

Pre-existing/environmental: `test_feature_cfg_package.py` (2) fail **locally only** because the `nousergon_lib` config resolver leaks into the real sibling `alpha-engine-config` checkout (memory `reference_nousergon_lib_config_resolver_sibling_root_hermeticity_260629`); the region is byte-identical to `origin/main` and untouched by this PR — green in CI (no sibling checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
