### PR TITLE
feat(groom): external liveness probe for silent EC2-spot groom death

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/README.md
+++ b/infrastructure/lambdas/groom-liveness-probe/README.md
@@ -1,0 +1,60 @@
+# alpha-engine-groom-liveness-probe
+
+External heartbeat for the EC2-spot backlog groom (config#1432). The groom
+self-reports its terminal state (a `groom-digest` issue + Telegram ping) **only
+when the box lives long enough to run `groom_run.sh`'s reporting trap**. This
+probe covers the modes that file *nothing*:
+
+- spot reclaim mid-run
+- OOM / kernel panic before the trap installs
+- a lost / failed SSM command
+- the `scheduled-groom-dispatcher` Lambda erroring
+- a broken / disabled EventBridge schedule (the 2026-06-29 dead-trigger class)
+
+## How it works
+
+Schedule-aware, per-trigger accounting:
+
+1. Enumerate every scheduled groom trigger in the last `GROOM_LOOKBACK_HOURS`
+   that has had `GROOM_CEILING_MIN + GROOM_MARGIN_MIN` to finish (so a still-running
+   groom never false-alarms). The schedule mirrors the dispatcher's crons
+   (07:00 Sun-Fri, 23:00 daily) and is overridable via `GROOM_SCHEDULE` (JSON).
+2. Fetch recent `groom-digest`-labeled issues from `nousergon/alpha-engine-config`
+   (success digests **and** loud-failure issues both carry the label).
+3. For each trigger, assert a digest was created inside its run window
+   `[T, T + CEILING + MARGIN]`. A trigger with no digest → that scheduled groom
+   filed no terminal report → **LOUD Telegram alert**. Per-trigger windows mean a
+   single silent death is **not masked** by the next successful run.
+4. S3 dedup state (`consolidated/groom_liveness/alerted.json`) suppresses
+   re-pinging a standing miss; generous lookback + dedup → tolerant to schedule /
+   ceiling changes (no fragile probe-time tuning).
+
+**Fail-loud:** the digest fetch is the PRIMARY input → a GitHub/SSM error RAISES
+(surfaces via the Lambda error metric + a CW alarm); a silently-skipped check is
+the exact failure this guards against. The Telegram send and the dedup-state
+write are best-effort.
+
+## Relationship to the Fleet-SF Watch
+
+This applies the Fleet-SF Watch philosophy (an external observer of a producer
+that can't be trusted to report its own death) to the groom. The groom is **not**
+a Step Function, so — unlike the three fleet pipelines — it gets no EventBridge
+terminal-failure event for the existing watcher to hang off. Wrapping the groom
+dispatch in a Step Function so the existing Fleet-SF Watch covers it natively is
+the tracked **"SF later"** follow-up; this Lambda is the **"probe now"** half.
+
+## Deploy (operator-gated, outside CloudFormation)
+
+```
+bash deploy.sh --dry-run     # show actions
+bash deploy.sh --bootstrap   # first-time: create role + Lambda + 2 Scheduler rules
+bash deploy.sh               # update code only
+bash deploy.sh --smoke       # invoke once (read-only; pings only on a REAL miss)
+```
+
+Merging the PR has **zero** live effect until an operator runs `--bootstrap`.
+Recommend wiring a CloudWatch alarm on this function's `Errors` metric (the
+fail-loud contract assumes one).
+
+Cadence (UTC): `cron(30 6 * * ? *)` and `cron(30 14 * * ? *)` — each after a
+groom's worst-case completion.

--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-groom-liveness-probe Lambda and
+# wire its EventBridge Scheduler rules.
+#
+# WHY: the EC2-spot backlog groom (config#1432) self-reports its terminal state
+# (a `groom-digest` issue + Telegram ping), but only when the box lives long
+# enough to run groom_run.sh's reporting trap. SILENT modes — spot reclaim
+# mid-run, OOM/panic before the trap, a lost SSM command, a broken dispatcher
+# Lambda, a disabled/misconfigured schedule (the 2026-06-29 dead-trigger class) —
+# file NOTHING. This probe is the external watchdog: schedule-aware, it asserts
+# every scheduled groom that has had time to finish filed a terminal digest, and
+# LOUD-pings Telegram for any that didn't. (The "probe now" half; the
+# Step-Function-wrap that would let the existing Fleet-SF Watch cover the groom
+# natively is the tracked "SF later" follow-up.)
+#
+# IAM (iam-policy.json): logs + ssm:GetParameter (Telegram creds + the shared
+# Fleet-Watch PAT) + s3 Get/Put on the dedup state key. No EC2/SSM-send — it only
+# READS state, never launches anything.
+#
+# Cadence (UTC): two runs/day, each after a groom's worst-case completion
+# (groom hard-ceiling 360 min + slack). Per-trigger windows + S3 dedup make the
+# exact times non-load-bearing (generous LOOKBACK tolerates schedule drift):
+#   06:30 daily   cron(30 6 * * ? *)   # after the 23:00 groom matures (~05:45)
+#   14:30 daily   cron(30 14 * * ? *)  # after the 07:00 Sun-Fri groom matures (~13:45)
+#
+# Managed OUTSIDE CloudFormation — mirrors the sibling dispatchers (narrow OIDC
+# blast radius, operator-deployed only). Merging the PR has ZERO live effect
+# until an operator runs this with --bootstrap.
+#
+# Usage:
+#   bash .../groom-liveness-probe/deploy.sh             # update code only
+#   bash .../groom-liveness-probe/deploy.sh --bootstrap # first-time create + wire schedules
+#   bash .../groom-liveness-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../groom-liveness-probe/deploy.sh --smoke     # invoke once (read-only check; pings only on a real miss)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-groom-liveness-probe"
+ROLE_NAME="alpha-engine-groom-liveness-probe-role"
+POLICY_NAME="alpha-engine-groom-liveness-probe-policy"
+SCHED_ROLE_NAME="alpha-engine-groom-liveness-probe-scheduler-role"
+SCHED_POLICY_NAME="invoke-groom-liveness-probe"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
+
+SCHED_NAMES=(
+  "alpha-engine-groom-liveness-0630-daily"
+  "alpha-engine-groom-liveness-1430-daily"
+)
+SCHED_CRONS=(
+  "cron(30 6 * * ? *)"
+  "cron(30 14 * * ? *)"
+)
+SCHED_PREFIX="alpha-engine-groom-liveness-"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
+      --zip-file "fileb://${ZIP}" --timeout 30 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} on the liveness cadence" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${SCHED_ROLE_NAME}"
+  fi
+  SCHED_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"lambda:InvokeFunction\"],\"Resource\":\"${FN_ARN}\"}]}"
+  echo "  Applying Scheduler invoke policy: ${SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${SCHED_ROLE_NAME}" --policy-name "${SCHED_POLICY_NAME}" \
+    --policy-document "${SCHED_INVOKE_POLICY}"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  for i in "${!SCHED_NAMES[@]}"; do
+    name="${SCHED_NAMES[$i]}"
+    cron="${SCHED_CRONS[$i]}"
+    target="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${SCHED_ROLE_ARN}\",\"Input\":\"{}\"}"
+    if aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+      echo "  Updating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler update-schedule --name "${name}" --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
+    else
+      echo "  Creating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler create-schedule --name "${name}" --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
+    fi
+    if ! $DRY_RUN; then
+      aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+        || { echo "ERROR: Scheduler rule ${name} not found after create/update" >&2; exit 1; }
+    fi
+  done
+
+  # Prune reconciliation: delete any live rule under SCHED_PREFIX not in SCHED_NAMES.
+  echo "  Pruning orphaned Scheduler rules under prefix ${SCHED_PREFIX}..."
+  LIVE_RULES=$(aws scheduler list-schedules --name-prefix "${SCHED_PREFIX}" --region "${REGION}" --query 'Schedules[].Name' --output text 2>/dev/null || echo "")
+  for live in ${LIVE_RULES}; do
+    keep=false
+    for want in "${SCHED_NAMES[@]}"; do [ "${live}" = "${want}" ] && { keep=true; break; }; done
+    if ! $keep; then
+      echo "    Deleting orphaned Scheduler rule: ${live}"
+      run aws scheduler delete-schedule --name "${live}" --region "${REGION}"
+    fi
+  done
+fi
+
+# ----- 3. Update function code (always, idempotent) -------------------------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (synthetic invoke; read-only — only pings on a REAL miss) ----
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (read-only liveness check)..."
+  RESP=$(mktemp)
+  aws lambda invoke --function-name "${FUNCTION_NAME}" --cli-binary-format raw-in-base64-out \
+    --payload '{}' --region "${REGION}" "${RESP}" >/dev/null
+  cat "${RESP}"; echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/groom-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/groom-liveness-probe/iam-policy.json
@@ -1,0 +1,36 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-groom-liveness-probe:*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    },
+    {
+      "Sid": "DigestRepoPAT",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat"
+    },
+    {
+      "Sid": "LivenessDedupState",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/groom_liveness/*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/groom-liveness-probe/index.py
+++ b/infrastructure/lambdas/groom-liveness-probe/index.py
@@ -1,0 +1,282 @@
+"""alpha-engine-groom-liveness-probe — external heartbeat for the EC2-spot groom.
+
+The backlog groom (config#1432) self-reports its terminal state: a clean run
+files a ``groom-digest`` issue, a loud failure/timeout files a ``groom-digest``
+failure issue, and both ping Telegram. That covers the **loud** failure modes.
+It does NOT cover the **silent** ones — a spot reclaim mid-run, the box OOMing
+or panicking before ``groom_run.sh`` installs its reporting trap, an SSM command
+that never lands, the dispatcher Lambda erroring, or the EventBridge schedule
+being broken/disabled (the 2026-06-29 dead-trigger class). In every silent mode
+NO terminal artifact is filed for a scheduled run — and nothing notices.
+
+This probe is the independent watchdog. It is schedule-aware: it knows when a
+groom was *supposed* to run, and for each scheduled trigger that has had time to
+finish, it asserts a ``groom-digest`` issue was filed inside that run's window.
+A trigger with no terminal report → the box died silently or never launched →
+LOUD Telegram alert (the one surface the groom's own self-report could not
+reach). Per-trigger accounting (not just "latest digest age") so a single silent
+death masked by the next successful groom is still caught.
+
+Mirrors the Fleet-SF Watch philosophy (nousergon/alpha-engine-config#1227) — an
+external observer of a producer that cannot be trusted to report its own death —
+applied to the groom, which (unlike the three fleet SFs) is not a Step Function
+and so gets no EventBridge terminal-failure event. (SF-wrap follow-up tracked
+separately; this is the "probe now" half.)
+
+**Fail-loud (CLAUDE.md no-silent-fails).** Reading the digest issues is the
+PRIMARY input → a GitHub/SSM error RAISES so the check's absence surfaces via the
+Lambda error metric + CW alarm (a silently-skipped liveness check is itself the
+silent failure this guards against). The Telegram alert is the delivery surface;
+its failure is logged + returned but does not raise (the missed-run finding is
+still in the structured return + logs).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+from alpha_engine_lib.telegram import send_message
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+# De-dup state: ISO timestamps of trigger windows already alerted, so a standing
+# miss isn't re-pinged on every probe run. S3 (not in-Lambda) because the probe is
+# stateless across invocations. Generous lookback + this state = tolerant to
+# schedule/ceiling changes (no fragile probe-time tuning needed for once-per-miss).
+WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
+STATE_KEY = os.environ.get("GROOM_LIVENESS_STATE_KEY", "consolidated/groom_liveness/alerted.json")
+# Repo the groom files its digest / failure issues into.
+DIGEST_REPO = os.environ.get("GROOM_DIGEST_REPO", "nousergon/alpha-engine-config")
+DIGEST_LABEL = os.environ.get("GROOM_DIGEST_LABEL", "groom-digest")
+# Shared fine-grained PAT (SecureString) — same param the Fleet-SF Watch uses;
+# needs `issues:read` on DIGEST_REPO. Read at probe time only, never logged.
+GITHUB_PAT_SSM_PARAM = os.environ.get(
+    "GITHUB_PAT_SSM_PARAM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+# A run's worst-case wall clock = the spot box hard-timeout watchdog
+# (groom_spot_bootstrap.sh MAX_RUNTIME_SECONDS, 360 min) + slack for box boot +
+# report latency. A trigger is only checked once now >= T + CEILING + MARGIN, so
+# a still-legitimately-running groom never false-alarms.
+CEILING_MIN = int(os.environ.get("GROOM_CEILING_MIN", "360"))
+MARGIN_MIN = int(os.environ.get("GROOM_MARGIN_MIN", "45"))
+# How far back to enumerate triggers. Must exceed the longest inter-groom gap +
+# CEILING + MARGIN so a single silent death (otherwise masked by the next
+# successful run's digest) is still attributed to its own trigger window.
+LOOKBACK_HOURS = int(os.environ.get("GROOM_LOOKBACK_HOURS", "30"))
+_PAT_TIMEOUT_SEC = 15
+
+# Groom schedule (UTC), MIRRORS the dispatcher's EventBridge Scheduler crons
+# (scheduled-groom-dispatcher/deploy.sh SCHED_CRONS). `dows` are Python weekday
+# ordinals: Mon=0 … Sun=6. Override via the GROOM_SCHEDULE env (JSON list of
+# {hour, minute, dows}) if the dispatcher cadence changes — keep the two in sync.
+#   cron(0 7 ? * SUN-FRI *) → 07:00 on Sun(6),Mon(0)..Fri(4)
+#   cron(0 23 * * ? *)      → 23:00 daily
+_DEFAULT_SCHEDULE = [
+    {"hour": 7, "minute": 0, "dows": [6, 0, 1, 2, 3, 4], "label": "07:00 Sun-Fri"},
+    {"hour": 23, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "23:00 daily"},
+]
+
+
+def _schedule() -> list[dict]:
+    raw = os.environ.get("GROOM_SCHEDULE")
+    if not raw:
+        return _DEFAULT_SCHEDULE
+    try:
+        sched = json.loads(raw)
+        assert isinstance(sched, list) and sched
+        return sched
+    except (ValueError, AssertionError) as exc:
+        logger.warning("bad GROOM_SCHEDULE env (%s); using default", exc)
+        return _DEFAULT_SCHEDULE
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _expected_triggers(now: datetime) -> list[dict]:
+    """Enumerate every scheduled groom trigger in the lookback window that is now
+    MATURE (had CEILING+MARGIN minutes to finish). Each → {at, label}."""
+    horizon = now - timedelta(hours=LOOKBACK_HOURS)
+    mature_before = now - timedelta(minutes=CEILING_MIN + MARGIN_MIN)
+    out: list[dict] = []
+    # Walk each calendar date in [horizon-1d, now] so a trigger near the window
+    # edge isn't dropped, then filter to [horizon, mature_before].
+    day = (horizon - timedelta(days=1)).date()
+    last = now.date()
+    while day <= last:
+        for entry in _schedule():
+            if day.weekday() not in set(entry["dows"]):
+                continue
+            t = datetime(
+                day.year, day.month, day.day,
+                int(entry["hour"]), int(entry["minute"]),
+                tzinfo=timezone.utc,
+            )
+            if horizon <= t <= mature_before:
+                out.append({"at": t, "label": entry.get("label", f"{entry['hour']:02d}:{entry['minute']:02d}")})
+        day += timedelta(days=1)
+    out.sort(key=lambda d: d["at"])
+    return out
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=REGION)
+
+
+def _load_alerted(s3, now: datetime) -> set[str]:
+    """ISO trigger-timestamps already alerted (pruned to the lookback window).
+    A missing object is the expected first-run case, NOT an error → empty set."""
+    horizon = now - timedelta(hours=LOOKBACK_HOURS)
+    try:
+        obj = s3.get_object(Bucket=WATCH_BUCKET, Key=STATE_KEY)
+        data = json.loads(obj["Body"].read())
+        items = data.get("alerted", []) if isinstance(data, dict) else []
+    except Exception as exc:  # noqa: BLE001 — absence expected; bad blob recoverable
+        code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+        if code not in {"NoSuchKey", "404", "403"}:
+            logger.warning("could not read liveness state %s: %s", STATE_KEY, exc)
+        items = []
+    out: set[str] = set()
+    for iso in items:
+        try:
+            if datetime.fromisoformat(iso) >= horizon:
+                out.add(iso)
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def _save_alerted(s3, alerted: set[str]) -> None:
+    """Persist the pruned alerted-set. Best-effort: a write failure only risks a
+    duplicate alert next run (logged), never a missed finding — so it does NOT
+    raise (the finding already surfaced via Telegram + the structured return)."""
+    try:
+        s3.put_object(
+            Bucket=WATCH_BUCKET,
+            Key=STATE_KEY,
+            Body=json.dumps({"alerted": sorted(alerted)}, indent=2).encode("utf-8"),
+            ContentType="application/json",
+        )
+    except Exception as exc:  # noqa: BLE001 — dedup state; failure only risks a dup ping
+        logger.warning("could not persist liveness state %s: %s", STATE_KEY, exc)
+
+
+def _get_github_pat() -> str:
+    ssm = boto3.client("ssm", region_name=REGION)
+    resp = ssm.get_parameter(Name=GITHUB_PAT_SSM_PARAM, WithDecryption=True)
+    return resp["Parameter"]["Value"]
+
+
+def _fetch_digest_timestamps(pat: str) -> list[datetime]:
+    """Created-at timestamps of recent ``groom-digest``-labeled issues (success
+    digests AND loud-failure issues both carry the label). PRIMARY input — RAISES
+    on error (fail-loud)."""
+    url = (
+        f"https://api.github.com/repos/{DIGEST_REPO}/issues"
+        f"?labels={DIGEST_LABEL}&state=all&sort=created&direction=desc&per_page=50"
+    )
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {pat}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "groom-liveness-probe",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=_PAT_TIMEOUT_SEC) as resp:
+        issues = json.loads(resp.read())
+    stamps: list[datetime] = []
+    for it in issues:
+        created = it.get("created_at")
+        if not created:
+            continue
+        stamps.append(datetime.fromisoformat(created.replace("Z", "+00:00")))
+    return stamps
+
+
+def _missed(triggers: list[dict], stamps: list[datetime]) -> list[dict]:
+    """A trigger is a MISS iff no digest issue was created inside its run window
+    [T, T + CEILING + MARGIN]. Windows for the default schedule don't overlap, so
+    attribution is 1:1."""
+    window = timedelta(minutes=CEILING_MIN + MARGIN_MIN)
+    misses: list[dict] = []
+    for trig in triggers:
+        t = trig["at"]
+        if not any(t <= s <= t + window for s in stamps):
+            misses.append(trig)
+    return misses
+
+
+def _alert(misses: list[dict]) -> bool:
+    """LOUD Telegram alert — the surface the groom's own self-report can't reach.
+    Best-effort: failure is logged + returned, does not raise (the finding is in
+    the structured return)."""
+    lines = [
+        "\U0001f6f0️ *Groom Liveness Probe — SILENT FAILURE*",
+        f"{len(misses)} scheduled groom run(s) filed NO terminal report "
+        f"(no `{DIGEST_LABEL}` issue in-window):",
+    ]
+    for m in misses:
+        lines.append(f"• {m['label']} @ {m['at'].strftime('%Y-%m-%d %H:%M')}Z")
+    lines.append(
+        "_Box likely died silently (spot reclaim / OOM / pre-trap crash) or was "
+        "never dispatched (schedule/dispatcher broken). Check the "
+        "scheduled-groom-dispatcher logs + SSM command history._"
+    )
+    try:
+        return bool(send_message("\n".join(lines), disable_notification=False))
+    except Exception as exc:  # noqa: BLE001 — delivery surface; finding still returned
+        logger.warning("liveness alert Telegram send failed (non-fatal): %s", exc)
+        return False
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Scheduled (EventBridge) entrypoint. Returns a structured result; raises on
+    a PRIMARY-input (GitHub/SSM) failure so the check can never silently no-op."""
+    now = _now()
+    triggers = _expected_triggers(now)
+    logger.info("groom liveness probe: %d mature trigger(s) in last %dh", len(triggers), LOOKBACK_HOURS)
+    if not triggers:
+        return {"checked": 0, "missed": 0, "alerted": False, "reason": "no mature triggers in window"}
+
+    pat = _get_github_pat()
+    stamps = _fetch_digest_timestamps(pat)  # PRIMARY — fail-loud
+    misses = _missed(triggers, stamps)
+
+    s3 = _s3_client()
+    already = _load_alerted(s3, now)
+    new_misses = [m for m in misses if m["at"].isoformat() not in already]
+
+    alerted = False
+    if new_misses:
+        logger.warning(
+            "groom liveness: %d NEW scheduled run(s) with NO terminal report (of %d mature): %s",
+            len(new_misses), len(triggers), [m["at"].isoformat() for m in new_misses],
+        )
+        alerted = _alert(new_misses)
+        # Record only on a successful alert so a delivery outage retries next run.
+        if alerted:
+            already |= {m["at"].isoformat() for m in new_misses}
+            _save_alerted(s3, already)
+    elif misses:
+        logger.info("groom liveness: %d miss(es) already alerted — suppressed", len(misses))
+    else:
+        logger.info("groom liveness: all %d scheduled run(s) reported a terminal digest", len(triggers))
+
+    return {
+        "checked": len(triggers),
+        "missed": len(misses),
+        "new_missed": len(new_misses),
+        "missed_triggers": [m["at"].isoformat() for m in new_misses],
+        "digests_seen": len(stamps),
+        "alerted": alerted,
+    }

--- a/infrastructure/lambdas/groom-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/groom-liveness-probe/requirements.txt
@@ -1,0 +1,6 @@
+# Only the stable `telegram.send_message` primitive is used here — no extras.
+# Mirrors the sibling saturday-sf-watch-dispatcher pin (same Fleet-Watch family);
+# the lambda-dir requirements are NOT lockstep-bound to the repo-root pin
+# (tests/test_lib_pin_lockstep.py scans only requirements.txt / Dockerfile /
+# requirements-daily-news.txt), so a recent telegram-stable pin is sufficient.
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -1,0 +1,170 @@
+"""Unit tests for the groom-liveness-probe handler.
+
+Cover the load-bearing logic with no AWS/GitHub I/O: trigger enumeration
+(maturity + day-of-week filtering), per-trigger miss attribution, S3 dedup
+suppression, and the fail-loud contract on the PRIMARY input.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+# Stub alpha_engine_lib.telegram before importing index (the real lib isn't on the
+# test path; the probe only uses send_message).
+_ael = types.ModuleType("alpha_engine_lib")
+_tg = types.ModuleType("alpha_engine_lib.telegram")
+_tg.send_message = lambda *a, **k: True  # type: ignore[attr-defined]
+_ael.telegram = _tg  # type: ignore[attr-defined]
+sys.modules.setdefault("alpha_engine_lib", _ael)
+sys.modules.setdefault("alpha_engine_lib.telegram", _tg)
+
+import index  # noqa: E402
+
+UTC = timezone.utc
+
+
+def _dt(y, mo, d, h, mi=0):
+    return datetime(y, mo, d, h, mi, tzinfo=UTC)
+
+
+# ---- _expected_triggers ----------------------------------------------------
+
+
+def test_only_mature_triggers_returned(monkeypatch):
+    """A trigger younger than CEILING+MARGIN is NOT yet checkable."""
+    monkeypatch.setattr(index, "CEILING_MIN", 360)
+    monkeypatch.setattr(index, "MARGIN_MIN", 45)
+    monkeypatch.setattr(index, "LOOKBACK_HOURS", 30)
+    # Tue 14:00 UTC. The 07:00 Tue trigger matured (7h ago); a hypothetical recent
+    # one would not. 23:00 Mon (prev day) also mature.
+    now = _dt(2026, 6, 30, 14, 0)  # 2026-06-30 is a Tuesday
+    trigs = index._expected_triggers(now)
+    ats = {t["at"] for t in trigs}
+    assert _dt(2026, 6, 30, 7, 0) in ats   # 07:00 Tue, matured
+    assert _dt(2026, 6, 29, 23, 0) in ats  # 23:00 Mon, matured
+    # Nothing in the immature zone (now - 6.75h .. now).
+    assert all(t["at"] <= now - timedelta(minutes=405) for t in trigs)
+
+
+def test_saturday_0700_excluded(monkeypatch):
+    """The 07:00 schedule is Sun-Fri — Saturday must not produce a 07:00 trigger."""
+    monkeypatch.setattr(index, "LOOKBACK_HOURS", 12)
+    # Sat 2026-06-27 18:00 UTC → the only mature trigger in 12h is... 07:00 Sat is
+    # excluded; 23:00 Fri is >12h before. So expect no 07:00-Sat trigger.
+    now = _dt(2026, 6, 27, 18, 0)  # Saturday
+    trigs = index._expected_triggers(now)
+    assert _dt(2026, 6, 27, 7, 0) not in {t["at"] for t in trigs}
+
+
+# ---- _missed ---------------------------------------------------------------
+
+
+def test_trigger_with_digest_in_window_is_not_missed(monkeypatch):
+    monkeypatch.setattr(index, "CEILING_MIN", 360)
+    monkeypatch.setattr(index, "MARGIN_MIN", 45)
+    trig = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
+    # Digest filed 6 min into the run → inside [23:00, 05:45].
+    stamps = [_dt(2026, 6, 29, 23, 6)]
+    assert index._missed([trig], stamps) == []
+
+
+def test_trigger_with_no_digest_is_missed(monkeypatch):
+    monkeypatch.setattr(index, "CEILING_MIN", 360)
+    monkeypatch.setattr(index, "MARGIN_MIN", 45)
+    trig = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
+    # Only digest is from a DIFFERENT run window (the next morning's groom).
+    stamps = [_dt(2026, 6, 30, 7, 10)]
+    assert [m["at"] for m in index._missed([trig], stamps)] == [trig["at"]]
+
+
+def test_single_silent_death_not_masked_by_later_success(monkeypatch):
+    """The key property: a missed 23:00 run is still flagged even though the next
+    07:00 run filed a digest (per-trigger windows, not latest-age)."""
+    monkeypatch.setattr(index, "CEILING_MIN", 360)
+    monkeypatch.setattr(index, "MARGIN_MIN", 45)
+    t_dead = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
+    t_ok = {"at": _dt(2026, 6, 30, 7, 0), "label": "07:00 Sun-Fri"}
+    stamps = [_dt(2026, 6, 30, 7, 8)]  # only the 07:00 run reported
+    misses = index._missed([t_dead, t_ok], stamps)
+    assert [m["at"] for m in misses] == [t_dead["at"]]
+
+
+# ---- handler (dedup + fail-loud) -------------------------------------------
+
+
+class _FakeS3:
+    def __init__(self, alerted=None):
+        self._alerted = alerted or []
+        self.put_calls = []
+
+    def get_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg names
+        import io
+
+        body = index.json.dumps({"alerted": self._alerted}).encode()
+        return {"Body": io.BytesIO(body)}
+
+    def put_object(self, Bucket, Key, Body, ContentType):  # noqa: N803
+        self.put_calls.append(index.json.loads(Body))
+
+
+def _wire(monkeypatch, *, triggers, stamps, s3, sent=True):
+    monkeypatch.setattr(index, "_expected_triggers", lambda now: triggers)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "pat")
+    monkeypatch.setattr(index, "_fetch_digest_timestamps", lambda pat: stamps)
+    monkeypatch.setattr(index, "_s3_client", lambda: s3)
+    sends = []
+    monkeypatch.setattr(index, "send_message", lambda *a, **k: sends.append(a) or sent)
+    return sends
+
+
+def test_handler_alerts_new_miss_and_records_state(monkeypatch):
+    trig = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
+    s3 = _FakeS3(alerted=[])
+    sends = _wire(monkeypatch, triggers=[trig], stamps=[], s3=s3)
+    out = index.handler({}, None)
+    assert out["new_missed"] == 1 and out["alerted"] is True
+    assert len(sends) == 1
+    # State persisted so the next run suppresses it.
+    assert s3.put_calls and trig["at"].isoformat() in s3.put_calls[-1]["alerted"]
+
+
+def test_handler_suppresses_already_alerted_miss(monkeypatch):
+    trig = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
+    s3 = _FakeS3(alerted=[trig["at"].isoformat()])
+    sends = _wire(monkeypatch, triggers=[trig], stamps=[], s3=s3)
+    out = index.handler({}, None)
+    assert out["missed"] == 1 and out["new_missed"] == 0 and out["alerted"] is False
+    assert sends == []  # no duplicate ping
+
+
+def test_handler_all_reported_no_alert(monkeypatch):
+    trig = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
+    s3 = _FakeS3(alerted=[])
+    sends = _wire(monkeypatch, triggers=[trig], stamps=[_dt(2026, 6, 29, 23, 5)], s3=s3)
+    out = index.handler({}, None)
+    assert out["missed"] == 0 and out["alerted"] is False and sends == []
+
+
+def test_handler_fail_loud_on_github_error(monkeypatch):
+    """The PRIMARY input (digest fetch) RAISES — a silently-skipped check is the
+    exact failure this guards against."""
+    trig = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
+    monkeypatch.setattr(index, "_expected_triggers", lambda now: [trig])
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "pat")
+
+    def _boom(pat):
+        raise RuntimeError("github 500")
+
+    monkeypatch.setattr(index, "_fetch_digest_timestamps", _boom)
+    with pytest.raises(RuntimeError):
+        index.handler({}, None)
+
+
+def test_handler_no_mature_triggers_short_circuits(monkeypatch):
+    monkeypatch.setattr(index, "_expected_triggers", lambda now: [])
+    out = index.handler({}, None)
+    assert out["checked"] == 0 and out["alerted"] is False


### PR DESCRIPTION
## Why

The EC2-spot backlog groom (config#1432) self-reports its terminal state (a `groom-digest` issue + Telegram ping) **only when the box lives long enough to run `groom_run.sh`'s reporting trap**. The **silent** modes file nothing and nothing notices:

- spot reclaim mid-run
- OOM / kernel panic before the trap installs
- a lost / failed SSM command
- the `scheduled-groom-dispatcher` Lambda erroring
- a broken / disabled EventBridge schedule (the 2026-06-29 dead-trigger class)

This is the same gap the Fleet-SF Watch closes for the three Step Functions — but the groom is **not** an SF, so it gets no EventBridge terminal-failure event for the existing watcher to hang off.

## What

`infrastructure/lambdas/groom-liveness-probe/` — a schedule-aware external watchdog (EventBridge Scheduler, 2×/day):

1. Enumerate scheduled groom triggers (07:00 Sun-Fri, 23:00 daily; mirrors the dispatcher crons) that have had `CEILING+MARGIN` to finish.
2. Fetch recent `groom-digest`-labeled issues from `nousergon/alpha-engine-config` (success digests **and** loud-failure issues both carry the label).
3. For each trigger, assert a digest landed inside its run window `[T, T+CEILING+MARGIN]`. No digest → **LOUD Telegram alert**. **Per-trigger windows** so a single silent death isn't masked by the next successful run.
4. **S3 dedup state** suppresses re-pinging a standing miss; generous lookback + dedup = tolerant to schedule/ceiling changes (no fragile probe-time tuning).

**Fail-loud:** the digest fetch is the PRIMARY input → GitHub/SSM error RAISES (a silently-skipped liveness check is the exact failure this guards). Telegram send + dedup-state write are best-effort.

Reuses the Fleet-Watch substrate: same SSM PAT param, `alpha_engine_lib.telegram`, operator-gated deploy mirroring `scheduled-groom-dispatcher` (zero live effect until `--bootstrap`).

## This is the "probe now" half

The Step-Function-wrap that would let the **existing** Fleet-SF Watch cover the groom natively is the tracked **"SF later"** follow-up (filed separately).

## Tests / verification

`test_handler.py` — 10 tests: trigger maturity + DOW filtering, per-trigger miss attribution, the single-silent-death-not-masked property, S3 dedup suppression, fail-loud-on-GitHub-error. **Local: 10 passed**, lambda-dir guard tests (lockstep + dockerfile-copies) green, ruff clean.

⚠️ Deploy is operator-gated (`deploy.sh --bootstrap`) — merging has no live effect. Recommend a CloudWatch alarm on the function `Errors` metric (the fail-loud contract assumes one). Related: companion fix for the root cause that first surfaced this gap — alpha-engine-config#1471 (groom was 100% DOA running as root).