### PR TITLE
fix(groom-dispatcher): 300s timeout + terminate box on post-launch error (no orphan) — config#1477

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -162,7 +162,7 @@ if $BOOTSTRAP; then
       --role "${ROLE_ARN}" \
       --handler index.handler \
       --zip-file "fileb://${ZIP}" \
-      --timeout 30 \
+      --timeout 300 \
       --memory-size 256 \
       --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true}' \
       --region "${REGION}" \

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -39,6 +39,15 @@
         "ssm:DescribeInstanceInformation"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "TerminateGroomSpotOnError",
+      "Effect": "Allow",
+      "Action": ["ec2:TerminateInstances"],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": { "ec2:ResourceTag/Name": "alpha-engine-groom-spot" }
+      }
     }
   ]
 }

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -195,6 +195,22 @@ def _send_bootstrap(instance_id: str, run_mode: str, run_url: str) -> str:
     return resp["Command"]["CommandId"]
 
 
+def _terminate_instance(instance_id: str) -> None:
+    """Best-effort terminate of a just-launched box whose post-launch steps
+    failed. Without this the box orphans: it received no bootstrap, so neither
+    the in-script watchdog nor the EXIT trap (both armed BY the bootstrap) is
+    running to tear it down — it idles until manually killed. Never masks the
+    original error (logged, not raised)."""
+    try:
+        boto3.client("ec2", region_name=REGION).terminate_instances(InstanceIds=[instance_id])
+        logger.warning("terminated groom box %s after post-launch failure (no orphan)", instance_id)
+    except Exception as exc:  # noqa: BLE001 — cleanup; the original error re-raises below
+        logger.error(
+            "FAILED to terminate %s after a post-launch error (%s) — MANUAL cleanup needed",
+            instance_id, exc,
+        )
+
+
 def _launch_groom_spot(run_mode: str, schedule_label: str) -> dict:
     """Launch + bootstrap the groom box. Fail-loud — any error RAISES."""
     if not DISPATCH_ENABLED:
@@ -203,16 +219,25 @@ def _launch_groom_spot(run_mode: str, schedule_label: str) -> dict:
 
     instance_id, market = _launch_instance()
     logger.info("launched groom box %s (%s)", instance_id, market)
-    _wait_ssm_online(instance_id)
-    # IMPORTANT: this string is embedded in the prelude's bash double-quoted
-    # `--run-url "..."`, so it MUST NOT contain `$` — the AWS console's normal
-    # `$252F` log-group encoding would expand as positional params ($2, $5...)
-    # under `set -u` and abort the prelude. Keep it `$`-free.
-    run_url = (
-        f"https://{REGION}.console.aws.amazon.com/cloudwatch/home?region={REGION}"
-        f"#logsV2:log-groups (log group {CW_LOG_GROUP}, instance {instance_id})"
-    )
-    command_id = _send_bootstrap(instance_id, run_mode, run_url)
+    # Once the box is up, ANY failure before the bootstrap command is delivered
+    # would orphan it (no watchdog/trap yet). Terminate-on-error so a slow
+    # SSM-online, an SSM SendCommand error, etc. tears the box down instead of
+    # leaving it idling. (A hard Lambda-timeout KILL can't run this — that's why
+    # the function timeout is also sized well above the launch+online budget.)
+    try:
+        _wait_ssm_online(instance_id)
+        # IMPORTANT: this string is embedded in the prelude's bash double-quoted
+        # `--run-url "..."`, so it MUST NOT contain `$` — the AWS console's normal
+        # `$252F` log-group encoding would expand as positional params ($2, $5...)
+        # under `set -u` and abort the prelude. Keep it `$`-free.
+        run_url = (
+            f"https://{REGION}.console.aws.amazon.com/cloudwatch/home?region={REGION}"
+            f"#logsV2:log-groups (log group {CW_LOG_GROUP}, instance {instance_id})"
+        )
+        command_id = _send_bootstrap(instance_id, run_mode, run_url)
+    except Exception:
+        _terminate_instance(instance_id)
+        raise
     logger.info(
         "groom dispatched: instance=%s market=%s command=%s run_mode=%s schedule=%s",
         instance_id,

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -51,8 +51,15 @@ class _FakeWaiter:
 
 
 class _FakeEc2:
+    def __init__(self):
+        self.terminated = []
+
     def get_waiter(self, name):
         return _FakeWaiter()
+
+    def terminate_instances(self, InstanceIds):  # noqa: N803 — boto3 kwarg name
+        self.terminated.extend(InstanceIds)
+        return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
 
 
 class _FakeSsm:
@@ -71,7 +78,8 @@ def _load(monkeypatch, *, launch_impl=None, env=None):
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
     ssm = _FakeSsm()
-    clients = {"ec2": _FakeEc2(), "ssm": ssm}
+    ec2 = _FakeEc2()
+    clients = {"ec2": ec2, "ssm": ssm}
     if launch_impl is None:
         launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
     _install_stubs(launch_impl, clients)
@@ -79,6 +87,7 @@ def _load(monkeypatch, *, launch_impl=None, env=None):
 
     importlib.reload(index)
     index._test_ssm = ssm  # expose for assertions
+    index._test_ec2 = ec2
     return index
 
 
@@ -162,3 +171,23 @@ def test_launch_failure_raises(monkeypatch):
     idx = _load(monkeypatch, launch_impl=_boom, env={"GROOM_DISPATCH_ENABLED": "true"})
     with pytest.raises(_SpotLaunchError, match="RunInstances denied"):
         idx.handler({"run_mode": "full"}, None)
+
+
+def test_post_launch_failure_terminates_instance_no_orphan(monkeypatch):
+    # If the box launches but a later step (SSM-online / SendCommand) fails, the
+    # box would orphan (no bootstrap → no watchdog/trap). The dispatcher must
+    # terminate it before re-raising. Regression cover for the 2026-06-30 orphan.
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: "i-orphan",  # noqa: E731
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom_send(**kw):
+        raise RuntimeError("SSM SendCommand failed")
+
+    idx._test_ssm.send_command = _boom_send
+    with pytest.raises(RuntimeError, match="SendCommand failed"):
+        idx.handler({"run_mode": "full"}, None)
+    # The just-launched box was terminated (not orphaned) before the re-raise.
+    assert idx._test_ec2.terminated == ["i-orphan"]


### PR DESCRIPTION
## Root cause (config#1477, found 2026-06-30)

The `scheduled-groom-dispatcher`'s **30s Lambda timeout** was too tight for launch + SSM-online (scheduled runs squeaked by at 24–29s). An invoke timed out at 30s **while waiting for SSM-online** — the box had launched but no bootstrap command was ever sent, leaving an **orphaned idle instance** (the watchdog + EXIT trap are armed by the bootstrap, which never ran). EventBridge retries could compound orphans.

## Fix (two parts)

1. **`deploy.sh`**: create-function `--timeout 30 → 300` (well above the 180s SSM-online + 200s instance-running budgets). The **live function is already at 300s** (bumped manually to unblock); this codifies it so a recreate can't revert.
2. **`index.py`**: wrap the post-launch steps (SSM-online wait + SendCommand) in **terminate-on-error** — any catchable failure terminates the just-launched box before re-raising, so a slow/failed SSM step never orphans. `iam-policy.json` gains `ec2:TerminateInstances` scoped by the `Name=alpha-engine-groom-spot` resource tag. (A hard Lambda-timeout *kill* can't run cleanup — hence the timeout headroom too.)

## Tests

`test_handler.py` — new orphan-regression test (post-launch failure → instance terminated, not orphaned). **Local: 7 passed**, ruff clean, deploy.sh + IAM JSON valid.

## Deploy note

After merge this needs `deploy.sh --bootstrap` (re-applies the IAM inline policy incl. the new TerminateInstances + updates code). The live timeout is already 300s. Closes config#1477.