### PR TITLE
fix(infra): reconcile EventBridge SF-status rules on every deploy, not just --bootstrap

### DIFF
--- a/infrastructure/lambdas/friday-shell-run-report/deploy.sh
+++ b/infrastructure/lambdas/friday-shell-run-report/deploy.sh
@@ -95,11 +95,20 @@ if $BOOTSTRAP; then
   else
     echo "  Lambda exists, code will be updated in step 3"
   fi
+fi
 
-  # EventBridge rule: Saturday SF terminal transitions (SUCCEEDED/FAILED/TIMED_OUT/ABORTED).
-  # The handler no-ops on non-shell-run executions, so no input-content filter is needed.
-  echo "  Creating EventBridge rule: ${RULE_NAME}"
-  EVENT_PATTERN=$(cat <<EOF
+# ----- 2b. Reconcile EventBridge rule (ALWAYS — not bootstrap-gated) --------
+#
+# config#1453/config#1460: a rename that changes an SF ARN must be picked up
+# by a PLAIN `deploy.sh` run, not just the first-time `--bootstrap` (this
+# rule was one of the two EventBridge triggers the ne-* rename silently
+# dropped). put-rule/put-targets/add-permission are idempotent create-or-
+# update calls, so reconciling on every deploy converges the live rule to
+# source with no bootstrap dependency. Requires the Lambda to already exist
+# (i.e. `--bootstrap` has run at least once).
+# The handler no-ops on non-shell-run executions, so no input-content filter is needed.
+echo "Reconciling EventBridge rule: ${RULE_NAME}"
+EVENT_PATTERN=$(cat <<EOF
 {
   "source": ["aws.states"],
   "detail-type": ["Step Functions Execution Status Change"],
@@ -110,18 +119,17 @@ if $BOOTSTRAP; then
 }
 EOF
 )
-  run aws events put-rule --name "${RULE_NAME}" --event-pattern "${EVENT_PATTERN}" \
-    --description "Consolidated Friday shell-run report on Saturday SF terminal (Lambda shell-run-guards)" \
-    --region "${REGION}" --query 'RuleArn' --output text
+run aws events put-rule --name "${RULE_NAME}" --event-pattern "${EVENT_PATTERN}" \
+  --description "Consolidated Friday shell-run report on Saturday SF terminal (Lambda shell-run-guards)" \
+  --region "${REGION}" --query 'RuleArn' --output text
 
-  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
-  run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
 
-  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
-    --statement-id "eventbridge-${RULE_NAME}" --action lambda:InvokeFunction \
-    --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
-fi
+RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
+  --statement-id "eventbridge-${RULE_NAME}" --action lambda:InvokeFunction \
+  --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
@@ -123,10 +123,19 @@ if $BOOTSTRAP; then
   else
     echo "  Lambda exists, code will be updated in step 3"
   fi
+fi
 
-  # EventBridge rule: Saturday SF SUCCEEDED ONLY.
-  echo "  Creating EventBridge rule: ${RULE_NAME}"
-  EVENT_PATTERN=$(cat <<EOF
+# ----- 2b. Reconcile EventBridge rule (ALWAYS — not bootstrap-gated) --------
+#
+# config#1453/config#1460: a rename that changes an SF ARN must be picked up
+# by a PLAIN `deploy.sh` run, not just the first-time `--bootstrap` (this
+# rule was one of the two EventBridge triggers the ne-* rename silently
+# dropped). put-rule/put-targets/add-permission are idempotent create-or-
+# update calls, so reconciling on every deploy converges the live rule to
+# source with no bootstrap dependency. Requires the Lambda to already exist
+# (i.e. `--bootstrap` has run at least once).
+echo "Reconciling EventBridge rule: ${RULE_NAME}"
+EVENT_PATTERN=$(cat <<EOF
 {
   "source": ["aws.states"],
   "detail-type": ["Step Functions Execution Status Change"],
@@ -139,28 +148,27 @@ if $BOOTSTRAP; then
 }
 EOF
 )
-  run aws events put-rule \
-    --name "${RULE_NAME}" \
-    --event-pattern "${EVENT_PATTERN}" \
-    --description "Saturday SF SUCCEEDED → backlog groom (repository_dispatch via groom dispatcher)" \
-    --region "${REGION}" \
-    --query 'RuleArn' --output text
+run aws events put-rule \
+  --name "${RULE_NAME}" \
+  --event-pattern "${EVENT_PATTERN}" \
+  --description "Saturday SF SUCCEEDED → backlog groom (repository_dispatch via groom dispatcher)" \
+  --region "${REGION}" \
+  --query 'RuleArn' --output text
 
-  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
-  run aws events put-targets \
-    --rule "${RULE_NAME}" \
-    --targets "Id=1,Arn=${FN_ARN}" \
-    --region "${REGION}"
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+run aws events put-targets \
+  --rule "${RULE_NAME}" \
+  --targets "Id=1,Arn=${FN_ARN}" \
+  --region "${REGION}"
 
-  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
-    --function-name "${FUNCTION_NAME}" \
-    --statement-id "eventbridge-${RULE_NAME}" \
-    --action lambda:InvokeFunction \
-    --principal events.amazonaws.com \
-    --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
-fi
+RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+run aws lambda add-permission \
+  --function-name "${FUNCTION_NAME}" \
+  --statement-id "eventbridge-${RULE_NAME}" \
+  --action lambda:InvokeFunction \
+  --principal events.amazonaws.com \
+  --source-arn "${RULE_ARN}" \
+  --region "${REGION}" 2>/dev/null || true
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -123,10 +123,19 @@ if $BOOTSTRAP; then
   else
     echo "  Lambda exists, code will be updated in step 3"
   fi
+fi
 
-  # EventBridge rule: Step Functions Execution Status Change for the 3 alpha-engine SFs
-  echo "  Creating EventBridge rule: ${RULE_NAME}"
-  EVENT_PATTERN=$(cat <<EOF
+# ----- 2b. Reconcile EventBridge rule (ALWAYS — not bootstrap-gated) --------
+#
+# config#1453: a rename that changes an SF ARN (or the rule's status/source
+# filter) must be picked up by a PLAIN `deploy.sh` run, not just the
+# first-time `--bootstrap`. put-rule/put-targets/add-permission are all
+# idempotent create-or-update calls, so running this block on every deploy
+# converges the live rule to source with no bootstrap dependency. Requires
+# the Lambda to already exist (i.e. `--bootstrap` has run at least once).
+
+echo "Reconciling EventBridge rule: ${RULE_NAME}"
+EVENT_PATTERN=$(cat <<EOF
 {
   "source": ["aws.states"],
   "detail-type": ["Step Functions Execution Status Change"],
@@ -141,28 +150,27 @@ if $BOOTSTRAP; then
 }
 EOF
 )
-  run aws events put-rule \
-    --name "${RULE_NAME}" \
-    --event-pattern "${EVENT_PATTERN}" \
-    --description "Fan SF status changes to alpha-engine-sf-telegram-notifier" \
-    --region "${REGION}" \
-    --query 'RuleArn' --output text
+run aws events put-rule \
+  --name "${RULE_NAME}" \
+  --event-pattern "${EVENT_PATTERN}" \
+  --description "Fan SF status changes to alpha-engine-sf-telegram-notifier" \
+  --region "${REGION}" \
+  --query 'RuleArn' --output text
 
-  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
-  run aws events put-targets \
-    --rule "${RULE_NAME}" \
-    --targets "Id=1,Arn=${FN_ARN}" \
-    --region "${REGION}"
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+run aws events put-targets \
+  --rule "${RULE_NAME}" \
+  --targets "Id=1,Arn=${FN_ARN}" \
+  --region "${REGION}"
 
-  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
-    --function-name "${FUNCTION_NAME}" \
-    --statement-id "eventbridge-${RULE_NAME}" \
-    --action lambda:InvokeFunction \
-    --principal events.amazonaws.com \
-    --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
-fi
+RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+run aws lambda add-permission \
+  --function-name "${FUNCTION_NAME}" \
+  --statement-id "eventbridge-${RULE_NAME}" \
+  --action lambda:InvokeFunction \
+  --principal events.amazonaws.com \
+  --source-arn "${RULE_ARN}" \
+  --region "${REGION}" 2>/dev/null || true
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 


### PR DESCRIPTION
## Why
The ne-* SF rename (config#1381) silently orphaned three EventBridge rules — sf-telegram-notifier's sf-status-change (config#1453), friday-shell-run-report, and saturday-succeeded-groom (both config#1460) — because each `deploy.sh` gated its `put-rule`/`put-targets`/`add-permission` reconcile behind `--bootstrap`. A plain `deploy.sh` redeploy only updates Lambda code, never the EventBridge event pattern, so the rules kept matching the deleted old SF ARNs until someone noticed and manually re-ran `--bootstrap`.

All three were already fixed **live** this session (documented in config#1453/config#1460), but the systemic trap remained undocumented and unfixed in code — the next SF rename hits the exact same silent-drop bug.

## Fix
`put-rule` / `put-targets` / `add-permission` are all idempotent create-or-update calls. Moved them out of the `--bootstrap`-only block into an always-run "2b. Reconcile EventBridge rule" step in all three `deploy.sh` scripts:
- `infrastructure/lambdas/sf-telegram-notifier/deploy.sh`
- `infrastructure/lambdas/friday-shell-run-report/deploy.sh`
- `infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh`

`--bootstrap` still existence-guards the one-time IAM role + Lambda function creation only.

## Test plan
- [x] `bash -n` syntax check on all 3 modified scripts.
- [x] Handler unit tests pass for all 3 (`test_handler.py`: 20 / 5 / 4 passed).
- [x] `deploy.sh --dry-run` (no `--bootstrap`) against all 3 — confirmed the reconcile step (`put-rule`/`put-targets`/`add-permission`) now fires on a plain run, where previously it was skipped entirely without `--bootstrap`.

Addresses the systemic-fix section of #1453 and #1460 (tracked in `nousergon/alpha-engine-config`); contributes to the drift-guard EPIC #1464.