### PR TITLE
fix(corporate-actions): price-evidence gate blocks phantom split factors (config#1455)

### DIFF
--- a/builders/migrate_universe_crsp_basis.py
+++ b/builders/migrate_universe_crsp_basis.py
@@ -205,6 +205,14 @@ class TickerOutcome:
     error: str | None = None
     written: bool = False
     new_df: pd.DataFrame | None = field(default=None, repr=False)
+    # Splits the feed reported but ``corporate_actions.apply`` declined to
+    # apply because the raw close shows no corroborating price move
+    # (config#1455 price-evidence gate) — human-readable ``"TICKER ratio
+    # (ex_date)"`` strings. Surfaced explicitly in the audit report so an
+    # out-of-tol reconciliation residual caused by a feed-reported-but-
+    # unconfirmed split is diagnosed as exactly that, not a generic
+    # "missing/doubled/mis-ratio'd" guess.
+    unconfirmed_splits: list[str] = field(default_factory=list)
 
 
 # ── raw price fetch (yfinance auto_adjust=False) ──────────────────────────────
@@ -687,9 +695,23 @@ def migrate_universe_crsp_basis(
             split_actions = ca.get_splits(ticker, client=client)
             dividend_actions = ca.get_dividends(ticker, client=client)
 
-            new_df, _applied = reconstruct_basis(
+            new_df, applied = reconstruct_basis(
                 ticker, raw_df, split_actions, dividend_actions,
             )
+            unconfirmed_splits = [
+                f"{ticker} {a.human()} ({a.ex_date})"
+                for a in split_actions
+                if any(
+                    r.get("action_id") == a.action_id and r.get("status") == "unconfirmed"
+                    for r in applied
+                )
+            ]
+            if unconfirmed_splits:
+                log.warning(
+                    "%s: %d feed-reported split(s) NOT applied — no "
+                    "corroborating price move (config#1455): %s",
+                    ticker, len(unconfirmed_splits), unconfirmed_splits,
+                )
 
             rec = reconcile_total_return(
                 ticker,
@@ -708,6 +730,7 @@ def migrate_universe_crsp_basis(
                 n_rows=len(new_df),
                 n_splits=len(split_actions),
                 n_dividends=len(dividend_actions),
+                unconfirmed_splits=unconfirmed_splits,
             )
 
             if apply:
@@ -742,6 +765,7 @@ def migrate_universe_crsp_basis(
     errors: list[dict] = []
     no_old_close: list[str] = []
     fetch_empty: list[str] = []
+    unconfirmed_splits: list[str] = []
     written = 0
 
     for o in outcomes:
@@ -754,6 +778,8 @@ def migrate_universe_crsp_basis(
         elif o.outcome == "error":
             errors.append({"ticker": o.ticker, "error": o.error})
             log.error("CRSP migration error for %s: %s", o.ticker, o.error)
+        if o.unconfirmed_splits:
+            unconfirmed_splits.extend(o.unconfirmed_splits)
 
     # ── WRITE scratch (apply) — only after all reconciliations computed ───────
     if apply:
@@ -809,6 +835,7 @@ def migrate_universe_crsp_basis(
         "no_old_close_count": len(no_old_close),
         "fetch_empty_count": len(fetch_empty),
         "errors_count": len(errors),
+        "unconfirmed_splits_count": len(unconfirmed_splits),
         "written_count": written,
         "elapsed_seconds": round(elapsed, 1),
         "workers": workers,
@@ -816,6 +843,15 @@ def migrate_universe_crsp_basis(
         "unexplained": [r.to_dict() for r in unexplained],
         "no_old_close": no_old_close,
         "fetch_empty": fetch_empty,
+        # Feed-reported splits corporate_actions.apply declined to apply (no
+        # corroborating price move — config#1455). NOT applied to Close/
+        # total_return_close for these tickers, so an out-of-tol residual on
+        # one of these names is diagnosed as exactly this, not a generic
+        # "missing/doubled/mis-ratio'd" guess. Still counted in the ticker's
+        # n_splits; does NOT by itself fail the run (the reconciliation gate
+        # is the actual pass/fail signal — a name whose feed-reported split
+        # was correctly withheld may still reconcile within_tol).
+        "unconfirmed_splits": unconfirmed_splits,
         "errors": errors,
         "known_divergence_tickers": sorted(known_divergence_tickers),
     }
@@ -826,11 +862,11 @@ def migrate_universe_crsp_basis(
     log.info(
         "migrate_universe_crsp_basis: applied=%s reconcile_start=%s targets=%d "
         "reconciled=%d within_tol=%d out_of_tol=%d no_overlap=%d unexplained=%d "
-        "errors=%d written=%d in_window_dates=%d excluded_pre_window_dates=%d "
-        "elapsed=%.1fs",
+        "errors=%d unconfirmed_splits=%d written=%d in_window_dates=%d "
+        "excluded_pre_window_dates=%d elapsed=%.1fs",
         apply, reconcile_start, len(targets), len(records), len(within_tol),
-        len(out_of_tol), len(no_overlap), len(unexplained), len(errors), written,
-        total_in_window, total_excluded, elapsed,
+        len(out_of_tol), len(no_overlap), len(unexplained), len(errors),
+        len(unconfirmed_splits), written, total_in_window, total_excluded, elapsed,
     )
 
     # ── FAIL LOUD ─────────────────────────────────────────────────────────────

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -311,15 +311,30 @@ class CorporateAction:
 
     # ── human description ────────────────────────────────────────────────
     def human(self) -> str:
-        """A human-readable one-liner, e.g. '1-for-2 reverse split'."""
+        """A human-readable one-liner, e.g. '1-for-2 reverse split'.
+
+        Uses the EXACT ``split_from``/``split_to`` ratio, not a floor-divided
+        approximation: a non-clean-integer ratio (e.g. polygon's ``1000:1061``
+        stock-dividend-style "split", ~1.061x) previously floor-divided to
+        ``1061 // 1000 == 1`` and printed as the misleading, no-op-looking
+        "1-for-1 forward split" — which derailed the config#1455 investigation
+        (the diagnostic label made a real ~6.1% action look like garbage data).
+        A clean integer ratio (the common case, e.g. 4:1) still prints as
+        before; anything else prints the raw ``split_from:split_to`` ratio so
+        the reader sees the true numbers rather than a rounded lie.
+        """
         if self.type == _TYPE_SPLIT and self.split_from and self.split_to:
             if self.split_to >= self.split_from:
                 # forward N-for-1 (split_from=1, split_to=N)
-                n = self.split_to // self.split_from
-                return f"{n}-for-1 forward split"
+                if self.split_to % self.split_from == 0:
+                    n = self.split_to // self.split_from
+                    return f"{n}-for-1 forward split"
+                return f"{self.split_to}-for-{self.split_from} forward split"
             # reverse 1-for-N (split_from=N, split_to=1)
-            n = self.split_from // self.split_to
-            return f"1-for-{n} reverse split"
+            if self.split_from % self.split_to == 0:
+                n = self.split_from // self.split_to
+                return f"1-for-{n} reverse split"
+            return f"{self.split_to}-for-{self.split_from} reverse split"
         if self.type == _TYPE_DIVIDEND:
             return f"dividend {self.cash_amount} ({self.dividend_kind})"
         if self.type == _TYPE_RENAME:
@@ -363,6 +378,94 @@ def expected_factor(action: CorporateAction) -> float:
         f"expected_factor not implemented for action type {action.type!r} "
         "(only splits implemented this PR)"
     )
+
+
+# Relative tolerance for the price-evidence boundary-ratio check
+# (``has_price_evidence``): splits are integer-ish ratios (factor <= 0.5 or
+# >= 2 for anything that would ever be reported as a split), so the observed
+# close[d]/close[d-1] boundary ratio at a REAL split sits close to
+# 1/expected_factor; a generous 15% band absorbs ordinary multi-day price
+# drift around the ex_date without confusing a real split with a coincident
+# earnings-move noop. Mirrors ``features.compute._AUDIT_FACTOR_REL_TOL`` (the
+# existing post-condition audit's tolerance) — same discipline, applied as a
+# PRE-condition here so a phantom action never reaches the price level.
+_PRICE_EVIDENCE_REL_TOL = 0.15
+
+# Window (calendar days) around ex_date searched for the boundary-ratio price
+# evidence — mirrors ``features.compute._AUDIT_EX_DATE_WINDOW_DAYS`` (a split
+# can print 1-2 sessions late/early relative to the polygon execution_date on
+# a thin feed).
+_PRICE_EVIDENCE_EX_DATE_WINDOW_DAYS = 4
+
+
+def has_price_evidence(
+    close: pd.Series,
+    action: CorporateAction,
+    *,
+    rel_tol: float = _PRICE_EVIDENCE_REL_TOL,
+    window_days: int = _PRICE_EVIDENCE_EX_DATE_WINDOW_DAYS,
+) -> bool:
+    """Does the RAW (unadjusted) ``close`` series actually show a price move
+    corroborating ``action`` (a split) around its ``ex_date``?
+
+    A corporate-action FEED can report a split that never happened in the real
+    market (a premature/erroneous/duplicate feed entry — observed live:
+    polygon returning ``execution_date`` in the past with no matching price
+    discontinuity, config#1455). Blindly trusting every feed event and
+    dividing/multiplying the ENTIRE pre-ex_date history by its factor bakes a
+    fictitious jump into the adjusted series — the mirror-image corruption of
+    the un-flattened-known-split case ``audit_action_jumps`` already catches
+    (PR3 §3): there, a REAL split's factor is missing from the series; here, a
+    FAKE split's factor gets baked in. Both are "trust polygon's stated
+    factor without checking the market agrees."
+
+    Looks for at least one adjacent trading-day pair straddling ``ex_date``
+    (within ``window_days``) on the RAW, UNADJUSTED close whose ratio
+    ``close[d]/close[d-1]`` is within ``rel_tol`` of ``expected_factor(action)``
+    (the boundary ratio a real split of this size prints on unadjusted prices —
+    ``expected_factor`` is exactly the multiplier that brings a PRE-ex_date raw
+    price onto the POST-ex_date scale, so the same multiplier is what the raw
+    series' own pre→post boundary ratio shows: e.g. a reverse 1-for-3 split,
+    ``expected_factor=3.0``, triples the raw price at the boundary; a forward
+    4-for-1 split, ``expected_factor=0.25``, quarters it). Returns ``True`` on
+    ANY matching boundary in the window (a split can print 1-2 sessions
+    late/early on a thin feed) or if ``close`` doesn't cover the window at all
+    (can't disprove it — degrades to trusting the feed, the PRE-existing
+    behavior, rather than blocking on missing data). Returns ``False`` only
+    when the window IS covered and NO boundary pair matches — the confident
+    "this action has no price corroboration" case.
+    """
+    if action.type != _TYPE_SPLIT:
+        return True  # only splits mutate the price level; nothing to check
+    expected = expected_factor(action)
+    if expected <= 0:
+        return True  # malformed ratio — expected_factor already guards this
+    # Boundary ratio close[d]/close[d-1] for d the first row on/after ex_date,
+    # on UNADJUSTED prices, IS expected_factor (see docstring).
+    target_ratio = expected
+
+    if close is None or close.empty:
+        return True  # no series to check against — can't disprove, don't block
+
+    idx = close.index if isinstance(close.index, pd.DatetimeIndex) else pd.to_datetime(close.index)
+    s = pd.Series(close.to_numpy(dtype="float64"), index=idx).sort_index()
+    s = s[s > 0]  # a non-positive close can't form a meaningful ratio
+    if s.empty:
+        return True
+
+    ex = pd.Timestamp(action.ex_date).normalize()
+    lo = ex - pd.Timedelta(days=window_days)
+    hi = ex + pd.Timedelta(days=window_days)
+    window = s[(s.index >= lo) & (s.index <= hi)]
+    if len(window) < 2:
+        # Window not covered by this series (e.g. ticker's history starts
+        # after ex_date, or a sparse feed) — can't disprove, don't block.
+        return True
+
+    ratios = (window / window.shift(1)).dropna()
+    if ratios.empty:
+        return True
+    return bool((ratios.sub(target_ratio).abs() <= rel_tol * target_ratio).any())
 
 
 # ── dividends: total-return factor MATH (CRSP/Barra basis) ───────────────────
@@ -509,8 +612,12 @@ def apply(
 
     Returns ``(restated_df, applied_results)`` where each ``applied_result`` is
     ``{"action_id", "store", "n_rows_adjusted", "factor", "status"}`` and
-    ``status`` is ``"applied"`` (restated this call) or ``"noop"`` (already
-    applied per the registry — not re-adjusted).
+    ``status`` is ``"applied"`` (restated this call), ``"noop"`` (already
+    applied per the registry — not re-adjusted), or ``"unconfirmed"`` (the feed
+    reported the action but the raw close shows NO corroborating price move
+    around ``ex_date`` — NOT applied, config#1455 price-evidence gate; never
+    marks the registry, so it is re-checked every call rather than remembered
+    as permanently skipped).
     """
     applied_results: list[dict] = []
     if df is None or getattr(df, "empty", True) or not actions:
@@ -551,6 +658,7 @@ def apply(
         return df, applied_results
 
     idx = df.index if isinstance(df.index, pd.DatetimeIndex) else pd.to_datetime(df.index)
+    raw_close = df["Close"] if "Close" in df.columns else None
 
     events_to_apply: list[CorporateAction] = []
     for a in split_actions:
@@ -564,6 +672,33 @@ def apply(
                 "factor": factor,
                 "status": "noop",
             })
+            continue
+        # PRICE-EVIDENCE gate (config#1455): a feed can report a split that
+        # never happened in the real market (observed live: polygon returning
+        # a past execution_date with no matching price discontinuity — the
+        # mirror-image of the un-flattened-KNOWN-split corruption
+        # ``audit_action_jumps`` catches post-hoc). Check BEFORE restating so
+        # a phantom factor never reaches the price level: an action with no
+        # corroborating boundary move on the raw close is NOT applied here —
+        # it is surfaced as ``status="unconfirmed"`` (loud, visible, never
+        # silently dropped) so the caller can WARN/notify rather than bake in
+        # a fictitious jump. Never marks the registry (an unconfirmed action
+        # must be re-checked every run, not remembered as skipped).
+        if not has_price_evidence(raw_close, a):
+            applied_results.append({
+                "action_id": a.action_id,
+                "store": store,
+                "n_rows_adjusted": 0,
+                "factor": factor,
+                "status": "unconfirmed",
+            })
+            log.warning(
+                "corporate_actions.apply: %s %s (%s) has NO corroborating "
+                "price move on the raw close within the ex_date window — "
+                "NOT applying (feed-reported split with no market evidence, "
+                "config#1455); action_id=%s",
+                a.ticker, a.human(), store, a.action_id,
+            )
             continue
         events_to_apply.append(a)
 

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -135,6 +135,17 @@ class TestExpectedFactor:
             == "10-for-1 forward split"
         )
 
+    def test_human_description_non_clean_ratio_not_floor_divided(self):
+        """config#1455: a non-integer ratio (e.g. polygon's 1000:1061
+        stock-dividend-style 'split') previously floor-divided to 1061//1000==1
+        and printed as the misleading, no-op-looking '1-for-1 forward split' —
+        derailing the investigation into whether the action was real. It must
+        print the EXACT ratio instead of a rounded lie."""
+        a = ca.CorporateAction.from_split("HON", "2025-10-30", 1000, 1061)
+        assert a.human() == "1061-for-1000 forward split"
+        b = ca.CorporateAction.from_split("DD", "2025-11-03", 100, 239)
+        assert b.human() == "239-for-100 forward split"
+
 
 class TestDetectSplits:
     def _fake_client(self, events):
@@ -265,3 +276,93 @@ class TestApply:
         assert out is df and res == []
         out2, res2 = ca.apply(pd.DataFrame(), [ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)], store=self._STORE)
         assert res2 == []
+
+    def test_phantom_split_is_unconfirmed_not_applied(self):
+        """config#1455 root cause: a feed can report a split (execution_date
+        in the past, real ratio) that never happened in the real market — the
+        raw close shows NO boundary discontinuity. ``apply`` must NOT bake
+        that factor into Close; it must report ``status="unconfirmed"`` and
+        leave the frame untouched for that action."""
+        df = _unfolded_reverse_split_frame()  # flat ~$48 the whole way through
+        # A 10-for-1 forward split with NO corresponding ~10x price drop
+        # anywhere in the (flat) series — exactly the live KLAC 2026-06-12
+        # case (config#1455 audit evidence).
+        phantom = ca.CorporateAction.from_split("KLAC", "2026-06-15", 1, 10)
+
+        out, results = ca.apply(df, [phantom], store=self._STORE, registry=None)
+
+        pd.testing.assert_frame_equal(out, df)  # untouched — factor NOT applied
+        assert len(results) == 1
+        assert results[0]["status"] == "unconfirmed"
+        assert results[0]["action_id"] == phantom.action_id
+        assert results[0]["n_rows_adjusted"] == 0
+
+    def test_confirmed_and_phantom_splits_partition_independently(self):
+        """One real (price-corroborated) split and one phantom split in the
+        SAME call: the real one restates normally, the phantom one is
+        withheld — each action's fate is independent."""
+        df = _unfolded_reverse_split_frame()  # real ~3x jump at 2026-06-24
+        real = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+        phantom = ca.CorporateAction.from_split("DD", "2026-06-24", 1, 10)
+
+        out, results = ca.apply(df, [real, phantom], store=self._STORE, registry=None)
+
+        by_id = {r["action_id"]: r for r in results}
+        assert by_id[real.action_id]["status"] == "applied"
+        assert by_id[phantom.action_id]["status"] == "unconfirmed"
+        # The real split's restatement still lands (boundary jump flattened).
+        assert out["Close"].pct_change().abs().max() < 0.45
+
+    def test_unconfirmed_split_does_not_mark_registry(self):
+        """An unconfirmed action must be re-checked every run, not remembered
+        as permanently skipped — so it must NOT durably mark the registry."""
+        reg = _registry()
+        df = _unfolded_reverse_split_frame()
+        phantom = ca.CorporateAction.from_split("KLAC", "2026-06-15", 1, 10)
+
+        _out, results = ca.apply(df, [phantom], store=self._STORE, registry=reg, run_id="r1")
+        assert results[0]["status"] == "unconfirmed"
+        assert reg.is_applied(self._STORE, phantom.action_id) is False
+
+
+class TestHasPriceEvidence:
+    def test_real_reverse_split_confirmed(self):
+        df = _unfolded_reverse_split_frame()  # genuine ~3x jump at 2026-06-24
+        action = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+        assert ca.has_price_evidence(df["Close"], action) is True
+
+    def test_phantom_split_not_confirmed(self):
+        df = _unfolded_reverse_split_frame()  # flat through the claimed date
+        action = ca.CorporateAction.from_split("KLAC", "2026-06-15", 1, 10)
+        assert ca.has_price_evidence(df["Close"], action) is False
+
+    def test_forward_split_boundary_ratio_direction(self):
+        """A forward N-for-1 split's raw boundary ratio close[post]/close[pre]
+        is expected_factor directly (< 1, price DROPS at the split) — not its
+        reciprocal. Regression guard for the ratio-direction bug caught in
+        development (inverted target_ratio made every real split look
+        unconfirmed)."""
+        idx = pd.bdate_range("2026-01-01", "2026-02-01")
+        pre = idx < pd.Timestamp("2026-01-20")
+        close = pd.Series(np.where(pre, 100.0, 25.0), index=idx)  # clean 4:1 drop
+        action = ca.CorporateAction.from_split("X", "2026-01-20", 1, 4)
+        assert ca.has_price_evidence(close, action) is True
+
+    def test_no_window_coverage_degrades_to_true(self):
+        """A series that doesn't cover the ex_date window can't disprove the
+        action — degrades to trusting the feed (pre-existing behavior) rather
+        than blocking on missing data."""
+        idx = pd.bdate_range("2020-01-01", "2020-01-10")
+        close = pd.Series(100.0, index=idx)
+        action = ca.CorporateAction.from_split("X", "2026-06-15", 1, 10)
+        assert ca.has_price_evidence(close, action) is True
+
+    def test_empty_series_degrades_to_true(self):
+        action = ca.CorporateAction.from_split("X", "2026-06-15", 1, 10)
+        assert ca.has_price_evidence(pd.Series(dtype="float64"), action) is True
+
+    def test_dividend_and_rename_always_true(self):
+        """Only splits mutate the price level; has_price_evidence is a no-op
+        gate for other action types (apply() rejects them independently)."""
+        div = ca.CorporateAction(type="dividend", ticker="X", ex_date="2026-01-01", cash_amount=0.5)
+        assert ca.has_price_evidence(pd.Series([1.0]), div) is True

--- a/tests/test_migrate_universe_crsp_basis.py
+++ b/tests/test_migrate_universe_crsp_basis.py
@@ -345,6 +345,44 @@ def test_orchestration_known_divergence_does_not_fail(monkeypatch):
     assert result["unexplained_count"] == 0
 
 
+def test_orchestration_phantom_split_surfaced_not_applied(monkeypatch):
+    """config#1455 root cause: a feed-reported split with NO corroborating
+    price move (e.g. live polygon returning a past execution_date for KLAC/
+    HON/DD with no matching market discontinuity) must NOT be baked into
+    Close/total_return_close, and must be surfaced in the audit report as
+    ``unconfirmed_splits`` — not silently applied, and not misdiagnosed as a
+    generic reconciliation residual."""
+    idx = pd.bdate_range("2026-06-01", periods=6)
+    # Flat raw series — NO real split anywhere in it.
+    raw = pd.DataFrame({"Close": [50.0] * 6, "Volume": [1e6] * 6}, index=idx)
+    raw_frames = {"X": raw}
+    old_closes = {"X": pd.Series([50.0] * 6, index=idx)}  # matches raw exactly
+    # Feed reports a 10-for-1 split that never happened (phantom, config#1455).
+    client = _FakePolygon(
+        splits={"X": [{"execution_date": idx[3].strftime("%Y-%m-%d"),
+                       "split_from": 1, "split_to": 10}]},
+        dividends={"X": []},
+    )
+    _patch_orchestration(monkeypatch, old_closes=old_closes)
+
+    result = m.migrate_universe_crsp_basis(
+        apply=False,
+        raw_fetch=lambda t: raw_frames[t],
+        client=client,
+        rel_tol=0.02,
+        workers=1,
+    )
+    # The phantom split was NOT applied — reconstruction stays flat $50,
+    # matching old_close exactly, so the ticker reconciles clean (the gate's
+    # job: correctly WITHHOLDING an unconfirmed action lets a clean name pass
+    # instead of false-failing on a fictitious 10x factor).
+    assert result["status"] == "ok"
+    assert result["within_tol_count"] == 1
+    assert result["unexplained_count"] == 0
+    assert result["unconfirmed_splits_count"] == 1
+    assert result["unconfirmed_splits"] == ["X 10-for-1 forward split (2026-06-04)"]
+
+
 def test_orchestration_apply_writes_scratch_lib_only(monkeypatch, tmp_path):
     """Apply path: the reconstructed series is written to a REAL (LMDB) scratch
     library, and the live universe lib is never written."""


### PR DESCRIPTION
## Summary

Root-causes config#1455 (CRSP reconciliation gate systematically false-fails on split/spinoff names). This is a root-cause fix, not the reconciliation-methodology workaround originally hypothesized in the issue.

**What the investigation found (live polygon + yfinance data, 2026-06-30/07-01):** `corporate_actions.get_splits`/`apply` blindly trusts every polygon split event and multiplicatively bakes it into the price level, with **zero corroboration against the actual observed price series**. Confirmed live:

- **KLAC**: polygon reports a 10-for-1 split executed 2026-06-12 (19 days in the past at time of investigation); yfinance raw unadjusted price shows continuous $190-300 trading through 2026-06-30 with no split-sized move anywhere near that date — the split never happened. Baking its 0.1x factor into history produced the reported ~100% reconciliation deviation.
- **HON**: polygon's `1000:1061` "split" (2025-10-30) is real (confirmed by price evidence, a small stock-dividend-style action); its `2:1` "split" (2026-06-29) has NO corresponding price move — phantom, matches the reported ~100% HON deviation.
- **DD**: polygon's 2019 "3-for-1 reverse split" and 2025 "239-for-100 forward split" are also not corroborated by raw price action (DD's real 2019 move was the DowDuPont/Dow/Corteva spinoff, not a clean multiplicative split) — matches the reported ~210%-570% DD deviation.

**Bonus find:** `CorporateAction.human()` floor-divided non-integer ratios (`1061 // 1000 == 1`), so HON's real ~6.1% action displayed as the misleading no-op-looking "1-for-1 forward split" during the original investigation — this directly derailed the earlier root-cause attempt. Fixed to print the exact ratio.

## Fix

`corporate_actions/__init__.py`:
- `has_price_evidence(close, action)`: checks the RAW close series for a boundary-ratio move matching `expected_factor(action)` within tolerance around `ex_date` — the mirror-image of the existing `audit_action_jumps` post-condition (which catches a REAL split's factor missing from a series; this catches a FAKE split's factor about to be baked in).
- `apply()` now gates every split through `has_price_evidence` BEFORE restating: an unconfirmed action gets `status="unconfirmed"` (loud, WARN-logged, visible in the return value) and is NOT applied — never marks the registry, so it's re-checked every run rather than permanently remembered as skipped. Other confirmed actions in the same call still apply normally (independent per-action).
- `human()`: prints the exact ratio when it doesn't reduce to a clean small integer, instead of floor-dividing to a misleading label.

`apply()` is the shared chokepoint for `builders/daily_append.py`, `builders/backfill.py` (via `features/compute.py`), and the PR7 CRSP migration script — so this closes the same corruption vector in the **live daily-sync path**, not just the offline migration.

`builders/migrate_universe_crsp_basis.py`: threads unconfirmed splits through to the audit report (new `unconfirmed_splits` / `unconfirmed_splits_count` fields) so an out-of-tol residual caused by a withheld phantom split is diagnosed as exactly that.

## Out of scope (unchanged)

Does NOT implement a first-class spinoff type (DD's real 2019 action was a spinoff, not a clean split) — explicitly out of scope per config#1455's own "To do" item 3. This fix's job is to stop applying a wrong multiplicative factor to a spinoff-mischaracterized-as-split, which it does (withholds it, same as a phantom).

## Test plan

- [x] `pytest tests/` — **2449 passed, 10 skipped** (11 new tests: gate behavior, `human()` fix, orchestration-level surfacing)
- [x] Verified live against real KLAC/HON/DD/JNJ data via yfinance+polygon: phantom splits now correctly withheld, `Close` matches the raw series (previously corrupted by the fake factor)
- [x] `python -m corporate_actions` / `python -m builders.migrate_universe_crsp_basis` import cleanly

Closes config#1455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)