### PR TITLE
test(metron-drift-guard): cover fund-proxy ETFs alongside risk/sector

### DIFF
--- a/tests/test_metron_etf_drift_guard.py
+++ b/tests/test_metron_etf_drift_guard.py
@@ -1,5 +1,5 @@
-"""Cross-package drift guard: producer ``RISK_FACTOR_ETFS`` vs metron's risk/sector
-constants (metron-ops#85, a #43 follow-up).
+"""Cross-package drift guard: producer ``RISK_FACTOR_ETFS`` / ``FUND_PROXY_ETFS`` vs
+metron's risk/sector constants + fund-proxy map (metron-ops#85/#112, #43 follow-ups).
 
 The analytics reference ETFs are hand-maintained in two places that MUST stay in sync:
 
@@ -13,6 +13,12 @@ If metron adds/changes a factor or sector ETF and the producer list doesn't foll
 spine silently stops emitting that ETF's close_history → it silently drops from
 Risk/Attribution (the exact metron-ops#43 failure class, re-introduced quietly). This
 lifts that invariant to a CI chokepoint.
+
+The same failure class applies to the late-striking mutual-fund same-day NAV ESTIMATE
+(metron-ops#112): the producer's ``FUND_PROXY_ETFS`` here must cover every proxy ETF
+metron's ``api.services.fund_proxy.PROXY_ETFS`` can resolve a fund to, or the spine has
+no close_history / intraday ``fund_proxies`` quotes for it and the estimate silently
+never computes.
 
 Cross-package: metron + nousergon-data are co-installed on the box
 (``pip install -e ../metron -e .`` per DEPLOY.md), so this can import metron's constants
@@ -63,4 +69,41 @@ def test_risk_factor_etfs_has_no_duplicates():
     set comparison (and pointlessly re-request the same close-history)."""
     assert len(mmd.RISK_FACTOR_ETFS) == len(set(mmd.RISK_FACTOR_ETFS)), (
         f"duplicate symbol(s) in RISK_FACTOR_ETFS: {mmd.RISK_FACTOR_ETFS}"
+    )
+
+
+def test_fund_proxy_etfs_cover_metrons_fund_proxy_module():
+    """metron-ops#112: metron's ``fund_proxy.PROXY_ETFS`` (the tracking-proxy ETFs the
+    same-day mutual-fund NAV ESTIMATE can resolve to — see ``api/services/fund_proxy.py``)
+    must be a SUBSET of the producer's ``FUND_PROXY_ETFS`` (here). If metron adds a fund
+    proxy the producer doesn't publish close_history/intraday quotes for, the spine
+    silently has no data for it and the estimate can never compute — the same
+    metron-ops#43 failure class this module already guards for the risk/sector ETFs.
+
+    Subset (``<=``), not equality: ``PROXY_ETFS`` also folds in ``DEFAULT_PROXY`` (the
+    broad-market fallback for an unmapped fund), which is already published via SPY —
+    the producer is free to publish MORE proxies than metron currently maps to a fund."""
+    fund_proxy = pytest.importorskip(
+        "api.services.fund_proxy",
+        reason="metron not co-installed (data-repo CI); drift guard runs on the box / when metron is installed",
+    )
+
+    metron_proxy_etfs = set(fund_proxy.PROXY_ETFS)
+    producer_etfs = set(mmd.FUND_PROXY_ETFS)
+
+    missing_from_producer = metron_proxy_etfs - producer_etfs
+
+    assert metron_proxy_etfs <= producer_etfs, (
+        "fund_proxy.PROXY_ETFS drifted ahead of FUND_PROXY_ETFS — the spine won't publish "
+        "close_history / intraday fund_proxies quotes for a proxy metron now resolves to "
+        "(metron-ops#43/#112 failure class). "
+        f"Add to FUND_PROXY_ETFS: {sorted(missing_from_producer)}."
+    )
+
+
+def test_fund_proxy_etfs_has_no_duplicates():
+    """Mirrors ``test_risk_factor_etfs_has_no_duplicates`` for the fund-proxy list — a dup
+    would mask a real drift in the subset comparison above."""
+    assert len(mmd.FUND_PROXY_ETFS) == len(set(mmd.FUND_PROXY_ETFS)), (
+        f"duplicate symbol(s) in FUND_PROXY_ETFS: {mmd.FUND_PROXY_ETFS}"
     )


### PR DESCRIPTION
## Summary

Ref nousergon/metron-ops#112

Metron's mutual-fund same-day NAV estimate (metron-ops#112, mechanism B)
resolves each held fund to a tracking-proxy ETF via
`api.services.fund_proxy.FUND_PROXY` / `PROXY_ETFS` (SPY, IXUS). This
producer already publishes `FUND_PROXY_ETFS = ["SPY", "IXUS"]`
(`collectors/metron_market_data.py:77`) — both close_history and the
intraday `fund_proxies` quote map metron reads from — but nothing enforced
that metron's proxy set stays a SUBSET of what's published. If metron adds a
proxy the producer doesn't publish, the spine silently has no data for it and
the estimate can never compute (the same metron-ops#43 failure class the
existing `RISK_FACTOR_ETFS` drift guard already catches for the factor/sector
ETFs).

This PR extends `tests/test_metron_etf_drift_guard.py` with two new tests,
mirroring the existing test's exact `importorskip`/subset-check pattern and
docstring style:
- `test_fund_proxy_etfs_cover_metrons_fund_proxy_module` — asserts
  `set(fund_proxy.PROXY_ETFS) <= set(mmd.FUND_PROXY_ETFS)` (subset, not
  equality — `PROXY_ETFS` folds in `DEFAULT_PROXY`, already covered by SPY).
- `test_fund_proxy_etfs_has_no_duplicates` — mirrors the existing
  `RISK_FACTOR_ETFS` no-duplicates test for `FUND_PROXY_ETFS`.

The module docstring is updated to describe both guards now covered.

## Test plan

Set up a python3.12 venv (`.venv312`), installed this repo's
`requirements.txt` (including the git-sourced `nousergon-lib` dependency),
then `pip install -e /tmp/runner_temp/metron` (metron's `api` +
`portfolio_analytics` packages) into the SAME venv so the drift guard's
`importorskip` actually resolves and the comparison runs for real (not
skipped):

```
pytest tests/test_metron_etf_drift_guard.py tests/test_metron_market_data.py -v
  → 36 passed (0 skipped) — includes both new tests actually executing
    the real PROXY_ETFS <= FUND_PROXY_ETFS comparison, not the importorskip path.

pytest tests/ -q
  → 2440 passed, 3 failed, 7 skipped
```
The 3 failures (`test_freshness_uses_trading_days.py::test_no_calendar_days_in_freshness_functions`,
`test_no_secret_environ_reads.py::test_no_secret_environ_reads`,
`test_wave4_slim_arctic_parity.py::test_no_functional_slim_surface_in_production`)
are pre-existing on `origin/main` unmodified (verified via `git stash`) —
unrelated to this change and unaffected by co-installing metron.

- [x] `pytest tests/test_metron_etf_drift_guard.py tests/test_metron_market_data.py -v` with metron co-installed — both new tests run for real, not skipped
- [x] `pytest tests/ -q` full suite
- [x] Confirmed the 3 pre-existing failures reproduce identically on unmodified `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)