### PR TITLE
fix(iam): grant github-actions-lambda-deploy ECR push on replay-counterfactual/concordance

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -26,7 +26,9 @@
         "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-predictor",
         "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-data-collector",
         "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-health-check",
-        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-evaluator"
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-evaluator",
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-replay-counterfactual",
+        "arn:aws:ecr:us-east-1:711398986525:repository/alpha-engine-replay-concordance"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Extends the `github-actions-lambda-deploy` OIDC role's codified `ECRPush` statement (`infrastructure/iam/github-actions-lambda-deploy.json`) with the 2 backtester replay-Lambda ECR repo ARNs: `alpha-engine-replay-counterfactual` and `alpha-engine-replay-concordance`.
- The role already has `lambda:*` on both functions via the `alpha-engine-*` wildcard in `LambdaUpdate`/`LambdaInvokeCanary` — only the ECR push grant was missing. Without this, any GitHub Actions deploy job for either replay Lambda 403s on `ecr:PutImage`.
- This is the IAM prerequisite for `nousergon/alpha-engine-config#1209` (extend crucible-backtester's image-Lambda auto-deploy from health-check-only to all 3 backtester image Lambdas).

## Important — code lands here, live apply is a separate operator step
Per this directory's own convention (documented in `infrastructure/iam/README.md`, and mirrored by `alpha-engine-config`'s `iam/alpha-engine-dashboard-role/alpha-engine-dashboard-passrole-executor.json`), this PR codifies the **intended** grant; it does not itself change the live AWS role. An operator with `iam:PutRolePolicy` needs to run:

```
./infrastructure/iam/apply.sh github-actions-lambda-deploy
```

**Until that apply runs:**
- `iam-drift-check.yml` (which this PR will trigger, since it touches `infrastructure/iam/**`) will correctly report drift on this file vs. live AWS — this is expected, not a bug in this PR, and mirrors the existing dashboard-passrole precedent of merging codified-but-unapplied IAM.
- Any deploy workflow added for the 2 replay Lambdas will still 403 on `ecr:PutImage` until the apply runs.

## Test plan
- [x] `python3 -c "import json; json.load(open('infrastructure/iam/github-actions-lambda-deploy.json'))"` — valid JSON
- [x] Diff is additive-only (2 new ARNs in the `ECRPush` statement's `Resource` list); no existing statements touched
- [ ] Operator: run `./infrastructure/iam/apply.sh github-actions-lambda-deploy`, then re-run `iam-drift-check.yml` to confirm clean
- [ ] Operator/downstream: once applied, the crucible-backtester `deploy.yml` matrix (config#1209, blocked separately on `workflow` PAT scope) can deploy the 2 replay Lambdas without 403

Closes the IAM-blocker half of `nousergon/alpha-engine-config#1209`.