### PR TITLE
fix(reaper): single global cap, delete per-workload budget table (config#1492)

### DIFF
--- a/infrastructure/lambdas/spot-orphan-reaper/README.md
+++ b/infrastructure/lambdas/spot-orphan-reaper/README.md
@@ -1,40 +1,62 @@
 # alpha-engine-spot-orphan-reaper
 
 Hourly backstop Lambda that terminates orphan `alpha-engine-*` tagged spot
-instances. Backs up the spot-side `systemd-run` watchdog installed by each
-of the four spot launcher scripts:
+instances whose on-box watchdog failed to arm.
 
-| Launcher                              | Tag prefix                  | Budget (s) |
-|---------------------------------------|-----------------------------|-----------:|
-| `spot_data_weekly.sh`                 | `alpha-engine-data-weekly-` |       5400 |
-| `spot_drift_detection.sh`             | `alpha-engine-drift-`       |       1800 |
-| `spot_train.sh` (predictor)           | `alpha-engine-gbm-train-`   |       5400 |
-| `spot_backtest.sh`                    | `alpha-engine-backtest-`    |       7200 |
+## One number, zero per-workload config (config#1492)
 
-Plus a default `7200` budget for unrecognised `alpha-engine-*` tags so a new
-launcher added without updating the table fails safe.
+Every alpha-engine spot box self-terminates via its own `systemd-run ... shutdown
+-h now` watchdog (+ `InstanceInitiatedShutdownBehavior=terminate`). This reaper is
+**only a backstop** for the box whose watchdog never installed. A backstop does
+not need per-workload precision — it enforces one invariant:
 
-Each tagged instance whose `LaunchTime` is older than `(budget + 1800s grace)`
-is terminated. The grace buffer (default 30 minutes via `GRACE_SECONDS`)
-covers the gap between launcher MAX_RUNTIME_SECONDS and the reaper's
-hourly cron firing cadence — workloads that legitimately push their budget
-get one extra hour before the reaper fires.
+> no alpha-engine spot box should ever outlive the **longest watchdog in the
+> fleet** (plus a grace window).
+
+So there is deliberately **no per-tag budget table**. Any running `alpha-engine-*`
+spot older than `MAX_SPOT_BUDGET_SECONDS + GRACE_SECONDS` is terminated:
+
+| Env var                   | Default   | Meaning                                                        |
+|---------------------------|-----------|---------------------------------------------------------------|
+| `MAX_SPOT_BUDGET_SECONDS` | `21600` (6h) | Longest on-box watchdog in the fleet (backlog groom).      |
+| `GRACE_SECONDS`           | `1800` (30m) | Gap between a watchdog firing and the hourly scan noticing. |
+
+Effective reap threshold = **6.5h**.
+
+### Why no table
+
+The previous design kept a `TAG_BUDGETS` dict mapping each launcher's tag prefix
+to its `MAX_RUNTIME_SECONDS`. That dict lived in **this repo** but had to stay in
+lockstep with launcher budgets defined in **other repos**. On 2026-07-01 the
+groom-on-spot migration (config#1432) added `alpha-engine-groom-spot` (6h
+watchdog) without adding a table row, so the reaper's 2h default killed a **live
+groom mid-run at 2.5h** (config#1492).
+
+A single global cap cannot drift out of lockstep with anything:
+
+- **Adding a new spot workload touches only its own launcher.** The reaper needs
+  no change as long as that workload's watchdog ≤ `MAX_SPOT_BUDGET_SECONDS`.
+- The cap moves **only** when a workload legitimately needs a *longer* watchdog
+  than any today — a rare, deliberate act — and the failure mode if forgotten is
+  **loud** (the box is reaped at the cap and logged), never a silent mis-kill at a
+  wrong per-workload guess.
+
+Trade-off accepted: a genuinely orphaned *short* workload (e.g. a 30-min drift
+box whose watchdog failed) lingers up to 6.5h before the backstop fires instead of
+~1h. That is pennies of spot on a rare event — the correct trade for a backstop.
 
 ## Defense in depth
 
-The reaper is **Layer 2** of the orphan-prevention stack. Layers:
-
-1. **Spot-side watchdog** (in each launcher): `systemd-run --on-active=$MAX_RUNTIME_SECONDS` fires `shutdown -h now`. Combined with `InstanceInitiatedShutdownBehavior=terminate` (also set by each launcher) this terminates the instance. Fires regardless of dispatcher state.
-2. **This Lambda**: hourly scan + termination for the case where the watchdog itself never installed (dispatcher SSM cancelled before reaching the `systemd-run` step, package manager interrupted bootstrap, AMI issue, etc.).
-3. **CloudWatch billing alarm** (`AlphaEngine-Monthly` budget, $50/month): catches anything the other two missed and signals via SNS.
+1. **Spot-side watchdog** (in each launcher): `systemd-run --on-active=$MAX_RUNTIME_SECONDS` fires `shutdown -h now`. With `InstanceInitiatedShutdownBehavior=terminate` this terminates the instance. Fires regardless of dispatcher state — the primary teardown.
+2. **This Lambda**: hourly scan + termination for the case where the watchdog itself never installed (dispatcher SSM cancelled before the `systemd-run` step, package-manager-interrupted bootstrap, AMI issue, etc.).
+3. **CloudWatch billing alarm** (`AlphaEngine-Monthly` budget, $50/month): catches anything the other two missed, signals via SNS.
 
 ## CloudWatch metric
 
-`AlphaEngine/Infra/spot_orphans_terminated` (Count, sum) with `tag_prefix`
-dimension. Zero is the expected steady-state; any non-zero value is a
-process-quality signal worth investigating (most likely cause: a launcher
-shipped without the watchdog install step, or the budget table here is
-stale).
+`AlphaEngine/Infra/spot_orphans_terminated` (Count, sum) with a `name` dimension
+(the terminated box's `Name` tag). Zero is the expected steady-state; any non-zero
+value is a process-quality signal worth investigating — the most likely cause is a
+launcher that shipped without arming its watchdog.
 
 ## Deploying
 
@@ -42,7 +64,7 @@ stale).
 # First-time: create role, policy, Lambda, EventBridge rule + permission
 bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --bootstrap
 
-# Subsequent code-only updates
+# Subsequent updates — pushes code AND converges the canonical env
 bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh
 
 # Smoke (flips DRY_RUN=true, invokes once, prints scan output, flips back)
@@ -52,22 +74,27 @@ bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --smoke
 bash infrastructure/lambdas/spot-orphan-reaper/deploy.sh --dry-run
 ```
 
-Managed outside CloudFormation by deliberate choice — same rationale as
-the `changelog-cloudwatch-mirror` Lambda: this function has destructive
-`ec2:TerminateInstances` permission so the `github-actions-lambda-deploy`
-OIDC role's blast radius stays narrow.
+Every deploy converges the function env to the canonical `PROD_ENV` defined once
+in `deploy.sh` (create sets it; `update-function-code` does not touch env, so the
+explicit `update-function-configuration` is what lands `MAX_SPOT_BUDGET_SECONDS`
+on an already-created reaper).
+
+Managed outside CloudFormation by deliberate choice — same rationale as the
+`changelog-cloudwatch-mirror` Lambda: this function has destructive
+`ec2:TerminateInstances` permission, so the `github-actions-lambda-deploy` OIDC
+role's blast radius stays narrow.
 
 ## IAM
 
 The role's inline policy (`iam-policy.json`):
 
 - `ec2:DescribeInstances *` — global read for the scan
-- `ec2:TerminateInstances` scoped to instances with `tag:Name` matching `alpha-engine-*` — defence in depth so even with a buggy reaper run it cannot terminate anything outside the alpha-engine tag prefix
+- `ec2:TerminateInstances` scoped to instances with `tag:Name` matching `alpha-engine-*` — defence in depth so even a buggy reaper run cannot terminate anything outside the alpha-engine tag prefix
 - `cloudwatch:PutMetricData` scoped to namespace `AlphaEngine/Infra`
 - Standard Lambda logging perms
 
-## Updating budgets
+## Changing the cap
 
-When a launcher's `MAX_RUNTIME_SECONDS` default changes, update the
-`TAG_BUDGETS` dict in `index.py` in the same commit. Out-of-sync values
-will cause the reaper to terminate live workloads.
+Bump `MAX_SPOT_BUDGET_SECONDS` (in `deploy.sh`'s `PROD_ENV`/`SMOKE_ENV`) **only**
+when some spot workload legitimately needs a watchdog longer than the current 6h.
+It is one number in one place — never a per-workload table.

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -27,6 +27,12 @@ RULE_NAME="alpha-engine-spot-orphan-reaper-hourly"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 
+# Canonical function env — defined ONCE so the create / update / smoke paths can
+# never drift out of lockstep. MAX_SPOT_BUDGET_SECONDS is the single global reap
+# cap (longest fleet watchdog; see index.py docstring); GRACE covers scan cadence.
+PROD_ENV='Variables={MAX_SPOT_BUDGET_SECONDS=21600,GRACE_SECONDS=1800,DRY_RUN=false}'
+SMOKE_ENV='Variables={MAX_SPOT_BUDGET_SECONDS=21600,GRACE_SECONDS=1800,DRY_RUN=true}'
+
 DRY_RUN=false
 BOOTSTRAP=false
 SMOKE=false
@@ -106,7 +112,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 60 \
       --memory-size 128 \
-      --environment 'Variables={GRACE_SECONDS=1800,DRY_RUN=false}' \
+      --environment "${PROD_ENV}" \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   fi
@@ -162,6 +168,20 @@ fi
 
 echo "✓ Code deployed."
 
+# Converge function env on EVERY deploy. `update-function-code` does not touch
+# env, so an existing function would otherwise keep whatever env it had — this is
+# how MAX_SPOT_BUDGET_SECONDS lands on an already-created reaper (and how any
+# interim env override gets reset to the canonical value).
+if ! $DRY_RUN; then
+  aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment "${PROD_ENV}" \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text > /dev/null
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+  echo "✓ Env converged: ${PROD_ENV}"
+fi
+
 # ----- 3. Smoke (dry-run scan) ----------------------------------------------
 
 if $SMOKE; then
@@ -172,7 +192,7 @@ if $SMOKE; then
   # Override DRY_RUN at the env layer for the smoke invoke
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
-    --environment 'Variables={GRACE_SECONDS=1800,DRY_RUN=true}' \
+    --environment "${SMOKE_ENV}" \
     --region "${REGION}" \
     --query 'LastUpdateStatus' --output text > /dev/null
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
@@ -185,10 +205,10 @@ if $SMOKE; then
   cat "${RESP}"
   echo ""
 
-  # Restore production DRY_RUN=false
+  # Restore production env (DRY_RUN=false)
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
-    --environment 'Variables={GRACE_SECONDS=1800,DRY_RUN=false}' \
+    --environment "${PROD_ENV}" \
     --region "${REGION}" \
     --query 'LastUpdateStatus' --output text > /dev/null
 fi

--- a/infrastructure/lambdas/spot-orphan-reaper/index.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/index.py
@@ -1,21 +1,42 @@
 """alpha-engine-spot-orphan-reaper — terminate orphan alpha-engine spot instances.
 
-Backstop for the spot-side watchdog installed by the four spot launcher
-scripts (data_weekly / drift_detection / train / backtest). The watchdog
-fires `shutdown -h now` after MAX_RUNTIME_SECONDS, which combined with
-`InstanceInitiatedShutdownBehavior=terminate` (also set by the launchers)
-terminates the spot. This Lambda catches the residual case where the
-watchdog itself never installed — dispatcher SSM cancelled before reaching
-the `systemd-run` step, package manager interrupted bootstrap, etc.
+Backstop for the spot-side watchdog every spot launcher installs (`systemd-run
+... shutdown -h now` after that workload's MAX_RUNTIME_SECONDS, combined with
+`InstanceInitiatedShutdownBehavior=terminate`). This Lambda catches the residual
+case where the watchdog itself never installed — dispatcher SSM cancelled before
+reaching the `systemd-run` step, package manager interrupted bootstrap, etc.
 
-Hourly EventBridge cron scans `alpha-engine-*` tagged spot instances. Any
-instance whose `LaunchTime` exceeds the per-tag-prefix budget plus a 30
-minute grace window is terminated. Emits CloudWatch custom metric
-`AlphaEngine/Infra/spot_orphans_terminated` (sum) with `tag_prefix`
-dimension for trend observation.
+DESIGN — one number, zero per-workload config (2026-07-01, config#1492).
+Every alpha-engine spot box self-terminates via its own on-box watchdog; this
+reaper is ONLY a backstop for the box whose watchdog failed to arm. A backstop
+does not need per-workload precision — it needs a single invariant:
 
-Budgets mirror MAX_RUNTIME_SECONDS in each launcher; grace covers the
-gap between launcher budget and reaper firing cadence.
+    no alpha-engine spot box should ever outlive the LONGEST watchdog in the
+    fleet (plus a grace window).
+
+So there is deliberately NO per-tag budget table. The previous table
+(`TAG_BUDGETS`) had to be kept in lockstep with each launcher's MAX_RUNTIME_SECONDS
+in a DIFFERENT repo; on 2026-07-01 the groom-on-spot migration (config#1432) added
+`alpha-engine-groom-spot` (6h watchdog) without a table row, so the reaper's 2h
+default killed a live groom mid-run at 2.5h (config#1492). A single global cap
+above the longest watchdog cannot drift out of lockstep with anything:
+
+  - Adding a new spot workload touches ONLY its own launcher. The reaper needs no
+    change as long as the workload's watchdog <= MAX_SPOT_BUDGET_SECONDS.
+  - The only time this constant moves is when a workload legitimately needs a
+    LONGER watchdog than any today — a rare, deliberate act, and the failure mode
+    if forgotten is LOUD (the box is reaped at the cap and logged), never a silent
+    mis-kill at a wrong per-workload guess.
+
+Cap sizing: MAX_SPOT_BUDGET_SECONDS defaults to 21600 (6h) — the longest fleet
+watchdog (backlog groom, groom_spot_bootstrap.sh). GRACE_SECONDS (default 1800)
+covers the gap between that watchdog firing and the reaper's hourly cadence, so
+the effective reap threshold is 6.5h. Both are env-overridable.
+
+Hourly EventBridge cron scans running `alpha-engine-*` spot instances and
+terminates any older than the threshold. Emits CloudWatch custom metric
+`AlphaEngine/Infra/spot_orphans_terminated` (sum) with a `name` dimension (the
+box's Name tag) purely for observability — it does NOT feed the reap decision.
 """
 
 from __future__ import annotations
@@ -30,35 +51,15 @@ logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
+# The longest on-box watchdog in the fleet. Keep >= the largest launcher
+# MAX_RUNTIME_SECONDS (today: backlog groom = 21600s / 6h). This is the ONLY
+# number that ties the reaper to the workloads, and it is a single ceiling, not a
+# per-workload table — see the module docstring.
+MAX_SPOT_BUDGET_SECONDS = int(os.environ.get("MAX_SPOT_BUDGET_SECONDS", "21600"))
+# Grace between a watchdog firing and the reaper's hourly scan noticing.
 GRACE_SECONDS = int(os.environ.get("GRACE_SECONDS", "1800"))
+REAP_AFTER_SECONDS = MAX_SPOT_BUDGET_SECONDS + GRACE_SECONDS
 DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
-
-# Tag-prefix → MAX_RUNTIME_SECONDS. Must stay in lockstep with the launcher
-# scripts' MAX_RUNTIME_SECONDS defaults; if a launcher's budget changes
-# without updating this table the orphan reaper will terminate live workloads.
-TAG_BUDGETS: dict[str, int] = {
-    "alpha-engine-data-weekly-": 5400,    # spot_data_weekly.sh
-    "alpha-engine-drift-": 1800,          # spot_drift_detection.sh
-    "alpha-engine-gbm-train-": 5400,      # spot_train.sh
-    "alpha-engine-backtest-": 7200,       # spot_backtest.sh
-}
-DEFAULT_BUDGET_SECONDS = 7200  # for unrecognised alpha-engine-* tags
-
-
-def _budget_for_name(name: str) -> int:
-    """Return the runtime budget for a spot tagged with this Name value."""
-    for prefix, budget in TAG_BUDGETS.items():
-        if name.startswith(prefix):
-            return budget
-    return DEFAULT_BUDGET_SECONDS
-
-
-def _matched_prefix(name: str) -> str:
-    """Return the matched tag prefix, or 'alpha-engine-other-' for the default branch."""
-    for prefix in TAG_BUDGETS:
-        if name.startswith(prefix):
-            return prefix
-    return "alpha-engine-other-"
 
 
 def _scan_spot_instances(ec2) -> list[dict]:
@@ -84,7 +85,7 @@ def _scan_spot_instances(ec2) -> list[dict]:
     return out
 
 
-def _emit_metric(cw, tag_prefix: str, count: int) -> None:
+def _emit_metric(cw, name: str, count: int) -> None:
     """Emit one CloudWatch metric data point per terminated instance group."""
     if count == 0:
         return
@@ -93,13 +94,13 @@ def _emit_metric(cw, tag_prefix: str, count: int) -> None:
             Namespace="AlphaEngine/Infra",
             MetricData=[{
                 "MetricName": "spot_orphans_terminated",
-                "Dimensions": [{"Name": "tag_prefix", "Value": tag_prefix}],
+                "Dimensions": [{"Name": "name", "Value": name}],
                 "Value": float(count),
                 "Unit": "Count",
             }],
         )
     except Exception as exc:
-        logger.warning("CloudWatch put_metric_data failed for %s: %s", tag_prefix, exc)
+        logger.warning("CloudWatch put_metric_data failed for %s: %s", name, exc)
 
 
 def handler(event: dict, context) -> dict:
@@ -110,17 +111,19 @@ def handler(event: dict, context) -> dict:
     ec2 = boto3.client("ec2", region_name=REGION)
     cw = boto3.client("cloudwatch", region_name=REGION)
     now = datetime.now(timezone.utc)
+    threshold = timedelta(seconds=REAP_AFTER_SECONDS)
 
     instances = _scan_spot_instances(ec2)
-    logger.info("Scanned %d running alpha-engine spot instances", len(instances))
+    logger.info(
+        "Scanned %d running alpha-engine spot instances (reap threshold=%ds)",
+        len(instances), REAP_AFTER_SECONDS,
+    )
 
     orphans: list[dict] = []
     terminated: list[str] = []
-    per_prefix_terminated: dict[str, int] = {}
+    per_name_terminated: dict[str, int] = {}
 
     for inst in instances:
-        budget = _budget_for_name(inst["name"])
-        threshold = timedelta(seconds=budget + GRACE_SECONDS)
         age = now - inst["launch_time"]
         if age <= threshold:
             continue
@@ -128,38 +131,38 @@ def handler(event: dict, context) -> dict:
             "instance_id": inst["instance_id"],
             "name": inst["name"],
             "age_seconds": int(age.total_seconds()),
-            "budget_seconds": budget,
-            "grace_seconds": GRACE_SECONDS,
+            "reap_after_seconds": REAP_AFTER_SECONDS,
             "instance_type": inst["instance_type"],
         })
-        prefix = _matched_prefix(inst["name"])
         if DRY_RUN:
             logger.warning(
-                "DRY_RUN orphan %s (%s, age=%ds, budget=%ds): would terminate",
-                inst["instance_id"], inst["name"], int(age.total_seconds()), budget,
+                "DRY_RUN orphan %s (%s, age=%ds, reap_after=%ds): would terminate",
+                inst["instance_id"], inst["name"], int(age.total_seconds()),
+                REAP_AFTER_SECONDS,
             )
             continue
         try:
             ec2.terminate_instances(InstanceIds=[inst["instance_id"]])
             terminated.append(inst["instance_id"])
-            per_prefix_terminated[prefix] = per_prefix_terminated.get(prefix, 0) + 1
+            per_name_terminated[inst["name"]] = per_name_terminated.get(inst["name"], 0) + 1
             logger.warning(
-                "Terminated orphan %s (%s, age=%ds, budget=%ds, type=%s)",
+                "Terminated orphan %s (%s, age=%ds, reap_after=%ds, type=%s)",
                 inst["instance_id"], inst["name"], int(age.total_seconds()),
-                budget, inst["instance_type"],
+                REAP_AFTER_SECONDS, inst["instance_type"],
             )
         except Exception as exc:
             logger.error(
                 "terminate_instances failed for %s: %s", inst["instance_id"], exc,
             )
 
-    for prefix, count in per_prefix_terminated.items():
-        _emit_metric(cw, prefix, count)
+    for name, count in per_name_terminated.items():
+        _emit_metric(cw, name, count)
 
     return {
         "scanned": len(instances),
         "orphans_detected": len(orphans),
         "terminated": terminated,
         "dry_run": DRY_RUN,
+        "reap_after_seconds": REAP_AFTER_SECONDS,
         "orphan_detail": orphans,
     }

--- a/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
@@ -1,8 +1,10 @@
 """Unit tests for the alpha-engine-spot-orphan-reaper Lambda handler.
 
-Mocks boto3 EC2 + CloudWatch clients so tests run without AWS calls.
-Locks the budget table, age-threshold + grace math, dry-run semantics,
-and partial-failure resilience.
+Mocks boto3 EC2 + CloudWatch clients so tests run without AWS calls. Locks the
+single-global-cap semantics (config#1492): no per-workload budget table — every
+alpha-engine spot is reaped only after the one fleet-wide threshold
+(MAX_SPOT_BUDGET_SECONDS + GRACE_SECONDS). Includes the exact regression that
+motivated the redesign: a live 6h groom box must NOT be reaped at 2.5–3h.
 """
 
 from __future__ import annotations
@@ -19,11 +21,15 @@ import pytest
 SCRIPT_DIR = Path(__file__).parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
+# Default threshold = MAX_SPOT_BUDGET_SECONDS (21600) + GRACE_SECONDS (1800) = 23400s.
+THRESHOLD = 23400
+
 
 @pytest.fixture
 def index_module(monkeypatch):
     """Reload the handler module with the test env so module-level vars resolve."""
     monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("MAX_SPOT_BUDGET_SECONDS", "21600")
     monkeypatch.setenv("GRACE_SECONDS", "1800")
     monkeypatch.setenv("DRY_RUN", "false")
     if "index" in sys.modules:
@@ -49,93 +55,82 @@ def _describe_instances_paginator(spots: list[dict]):
     return paginator
 
 
-class TestBudgetTable:
-    def test_data_weekly_budget(self, index_module):
-        assert index_module._budget_for_name("alpha-engine-data-weekly-20260511") == 5400
+def _run(index_module, spots):
+    ec2 = MagicMock()
+    ec2.get_paginator.return_value = _describe_instances_paginator(spots)
+    cw = MagicMock()
+    with patch.object(index_module.boto3, "client",
+                      side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+        out = index_module.handler({}, None)
+    return out, ec2, cw
 
-    def test_drift_budget(self, index_module):
-        assert index_module._budget_for_name("alpha-engine-drift-20260511") == 1800
 
-    def test_train_budget(self, index_module):
-        assert index_module._budget_for_name("alpha-engine-gbm-train-20260511") == 5400
+class TestThresholdConfig:
+    def test_threshold_is_budget_plus_grace(self, index_module):
+        assert index_module.REAP_AFTER_SECONDS == THRESHOLD
 
-    def test_backtest_budget(self, index_module):
-        assert index_module._budget_for_name("alpha-engine-backtest-20260511") == 7200
-
-    def test_unknown_falls_to_default(self, index_module):
-        assert index_module._budget_for_name("alpha-engine-mystery-20260511") == 7200
-
-    def test_matched_prefix(self, index_module):
-        assert index_module._matched_prefix("alpha-engine-backtest-20260511") == "alpha-engine-backtest-"
-        assert index_module._matched_prefix("alpha-engine-novel-20260511") == "alpha-engine-other-"
+    def test_threshold_overridable_via_env(self, monkeypatch):
+        # A workload that legitimately needs a longer watchdog bumps ONE number.
+        monkeypatch.setenv("MAX_SPOT_BUDGET_SECONDS", "28800")  # 8h
+        monkeypatch.setenv("GRACE_SECONDS", "1800")
+        if "index" in sys.modules:
+            del sys.modules["index"]
+        mod = importlib.import_module("index")
+        assert mod.REAP_AFTER_SECONDS == 30600
 
 
 class TestHandler:
+    def test_live_groom_at_3h_is_not_reaped(self, index_module):
+        # REGRESSION (config#1492): the 6h groom box was killed at 2.5h by the old
+        # per-workload default. Under the single cap a 3h-old groom is safe.
+        spots = [_spot("i-groom", "alpha-engine-groom-spot", age_seconds=10800)]
+        out, ec2, _ = _run(index_module, spots)
+        assert out["orphans_detected"] == 0
+        ec2.terminate_instances.assert_not_called()
+
+    def test_orphaned_groom_past_threshold_is_reaped(self, index_module):
+        # A groom box that outlived its own 6h watchdog + grace is a genuine orphan.
+        spots = [_spot("i-groom", "alpha-engine-groom-spot", age_seconds=THRESHOLD + 600)]
+        out, ec2, cw = _run(index_module, spots)
+        assert out["orphans_detected"] == 1
+        assert out["terminated"] == ["i-groom"]
+        ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-groom"])
+        cw.put_metric_data.assert_called_once()
+
     def test_no_orphans_when_all_young(self, index_module):
-        # Both spots are well within budget — none should be terminated.
         spots = [
             _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=600),
-            _spot("i-0002", "alpha-engine-data-weekly-20260511", age_seconds=900),
+            _spot("i-0002", "alpha-engine-data-weekly-20260511", age_seconds=7800),
         ]
-        ec2 = MagicMock()
-        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
-        cw = MagicMock()
-
-        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
-            out = index_module.handler({}, None)
-
+        out, ec2, cw = _run(index_module, spots)
         assert out["scanned"] == 2
         assert out["orphans_detected"] == 0
         assert out["terminated"] == []
         ec2.terminate_instances.assert_not_called()
         cw.put_metric_data.assert_not_called()
 
-    def test_terminates_orphan_past_budget_plus_grace(self, index_module):
-        # backtest budget=7200, grace=1800 → threshold 9000s; spot age 10000s → orphan
-        spots = [
-            _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=10000),
-            _spot("i-0002", "alpha-engine-drift-20260511", age_seconds=600),  # young
-        ]
-        ec2 = MagicMock()
-        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
-        cw = MagicMock()
-
-        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
-            out = index_module.handler({}, None)
-
-        assert out["scanned"] == 2
-        assert out["orphans_detected"] == 1
-        assert out["terminated"] == ["i-0001"]
-        ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-0001"])
-        cw.put_metric_data.assert_called_once()
-
-    def test_grace_buffer_protects_just_over_budget(self, index_module):
-        # backtest budget=7200; spot 7800s old (over budget, within grace) → NOT orphan
-        spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=7800)]
-        ec2 = MagicMock()
-        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
-        cw = MagicMock()
-
-        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
-            out = index_module.handler({}, None)
-
+    def test_boundary_just_under_threshold_is_safe(self, index_module):
+        spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD - 60)]
+        out, ec2, _ = _run(index_module, spots)
         assert out["orphans_detected"] == 0
         ec2.terminate_instances.assert_not_called()
 
+    def test_boundary_just_over_threshold_is_reaped(self, index_module):
+        spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD + 60)]
+        out, ec2, _ = _run(index_module, spots)
+        assert out["orphans_detected"] == 1
+        assert out["terminated"] == ["i-0001"]
+
     def test_dry_run_does_not_terminate(self, monkeypatch):
+        monkeypatch.setenv("MAX_SPOT_BUDGET_SECONDS", "21600")
+        monkeypatch.setenv("GRACE_SECONDS", "1800")
         monkeypatch.setenv("DRY_RUN", "true")
         if "index" in sys.modules:
             del sys.modules["index"]
         index_module = importlib.import_module("index")
 
-        spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=10000)]
-        ec2 = MagicMock()
-        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
-        cw = MagicMock()
-
-        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
-            out = index_module.handler({}, None)
-
+        spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD + 600)]
+        out, ec2, _ = _run(index_module, spots)
         assert out["dry_run"] is True
         assert out["orphans_detected"] == 1
         assert out["terminated"] == []
@@ -143,22 +138,20 @@ class TestHandler:
 
     def test_terminate_failure_is_logged_but_does_not_crash(self, index_module):
         spots = [
-            _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=10000),
-            _spot("i-0002", "alpha-engine-backtest-20260511", age_seconds=11000),
+            _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD + 600),
+            _spot("i-0002", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD + 1600),
         ]
         ec2 = MagicMock()
         ec2.get_paginator.return_value = _describe_instances_paginator(spots)
-        # First terminate raises; second succeeds — verify we continue past the first
         ec2.terminate_instances.side_effect = [
             Exception("simulated AWS error"),
             {"TerminatingInstances": [{"InstanceId": "i-0002"}]},
         ]
         cw = MagicMock()
-
-        with patch.object(index_module.boto3, "client", side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+        with patch.object(index_module.boto3, "client",
+                          side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
             out = index_module.handler({}, None)
 
         assert out["orphans_detected"] == 2
-        # Only the second succeeds; first's failure does not abort the loop
         assert out["terminated"] == ["i-0002"]
         assert ec2.terminate_instances.call_count == 2


### PR DESCRIPTION
## What & why

The `alpha-engine-spot-orphan-reaper` **terminated a live backlog groom mid-run** on 2026-07-01 (03:15 PT), ~3h into a 6h-budget run — killing the run that had opened PRs #1490/#1491 before it finalized its digest (#1489 frozen at `RUN IN PROGRESS`) or fired its terminal Telegram ping. That "botched notification" was a *symptom*; the box was killed out from under the run.

**Root cause:** the reaper held a per-workload `TAG_BUDGETS` table (in this repo) that had to be kept in lockstep with each launcher's `MAX_RUNTIME_SECONDS` (defined in *other* repos). The groom-on-spot migration (config#1432, 6/30) added `alpha-engine-groom-spot` (6h watchdog) without a table row → the reaper's **2h default + 30m grace = 2.5h** killed it. This is the exact "will terminate live workloads" failure the old code's own comment warned about.

## The fix — delete the table

A backstop doesn't need per-workload precision (every box self-terminates via its own on-box watchdog). It needs **one invariant**: *no alpha-engine spot should outlive the longest watchdog in the fleet.*

- One global cap: `MAX_SPOT_BUDGET_SECONDS` (21600 / 6h, the groom) `+ GRACE_SECONDS` (1800) = **6.5h**.
- **Adding a new spot workload now touches only its own launcher.** The reaper never needs editing again unless a workload legitimately needs a watchdog >6.5h — then it's one number in one file with a loud failure mode, never a silent mis-kill.
- Accepted trade-off: a genuinely-orphaned *short* box lingers up to 6.5h instead of ~1h before the backstop fires. Pennies of spot on a rare event.

## Changes
- `index.py` — remove `TAG_BUDGETS`/`_budget_for_name`/`_matched_prefix`; single-threshold reap; metric dim now `name` (observability only).
- `test_handler.py` — locks the regression (**live groom @3h NOT reaped; orphan @>6.5h reaped**) + boundary / env-override / dry-run / partial-failure. **9 passed.**
- `deploy.sh` — canonical `PROD_ENV`/`SMOKE_ENV` defined **once** (kills the 4-copy env drift); env converged on every deploy so an existing fn actually picks up `MAX_SPOT_BUDGET_SECONDS`.
- `README.md` — documents the one-number design.

## Rollout / deploy notes
- **Interim guard already live:** bumped the running reaper's `GRACE_SECONDS` 1800→18000 so tonight's 00:01 groom is protected *before* this merges. The redeploy's env-converge resets it to the canonical 1800.
- **After merge this Lambda needs `deploy.sh` run** (managed outside CFN by design — it holds `ec2:TerminateInstances`, kept off the OIDC deploy role). I can run it once you merge.

Closes the recurrence in config#1492.
