### PR TITLE
feat(groom): route the 8am PT scheduled-groom to Opus/complexity:high

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -10,24 +10,26 @@ private `alpha-engine-config` repo). The box runs the SAME
 `scripts/groom_run.sh` entrypoint the GHA workflow uses (single source of truth),
 then self-terminates (~$2/mo).
 
-> **Status: UNVALIDATED.** This is the IaC + handler only. It has **zero live
-> effect** until an operator runs `deploy.sh --bootstrap`. **Cutover** (config#1432):
-> after a manual `--smoke` spot run validates end-to-end, deploy this AND disable
-> the GHA `schedule:` crons in `backlog-groom.yml` together — so there is no
-> double-groom and no gap. `workflow_dispatch` stays as the manual escape hatch.
+> **Status: LIVE** (cutover 2026-06-30, config#1432). This is the sole scheduler
+> for the backlog groom — the GHA `schedule:` crons in `backlog-groom.yml` have
+> been REMOVED; that workflow now runs only on `workflow_dispatch` (manual
+> escape hatch). Any code change here needs `deploy.sh` (code-only, or
+> `--bootstrap` when a schedule/IAM changes) run by an operator with AWS creds
+> before it has live effect — merging the PR alone does not deploy it.
 
 ## How it fits
 
 ```
-EventBridge Scheduler rules (UTC, cron)            THIS Lambda
-  alpha-engine-scheduled-groom-0700-sunfri  ─┐      1. nousergon_lib.ec2_spot.launch()
-  alpha-engine-scheduled-groom-2300-daily   ─┴────▶    (spot; on-demand fallback)
-                                                    2. wait instance running + SSM Online
-                                                    3. async ssm send-command (detached):
-                                                          │
-                                                          ▼
+EventBridge Scheduler rules (UTC, cron)                    THIS Lambda
+  alpha-engine-scheduled-groom-0700-sunfri          ─┐      1. nousergon_lib.ec2_spot.launch()
+  alpha-engine-scheduled-groom-2300-daily           ─┼───▶     (spot; on-demand fallback)
+  alpha-engine-scheduled-groom-1500-daily-opus-high ─┘      2. wait instance running + SSM Online
+                                                             3. async ssm send-command (detached):
+                                                                   │
+                                                                   ▼
    EC2 spot box (AL2023, alpha-engine-executor-profile)
      prelude: read PAT (SSM) → clone alpha-engine-config
+       → export GROOM_MODEL / GROOM_ISSUE_FILTER (from the schedule's event)
        → infrastructure/groom_spot_bootstrap.sh --mode <full|sweep>
          → scripts/groom_run.sh  (budget gate → driver/sweep → digest-verify)
      → shutdown -h now (InstanceInitiatedShutdownBehavior=terminate)
@@ -39,17 +41,28 @@ credential, and this Lambda needs no secret access. The EventBridge Scheduler co
 (`scheduler.amazonaws.com` execution role, `cron()` expression, OFF
 flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 
-## Cadence — one-for-one with the GHA crons it replaces
+## Cadence
 
-| Scheduler rule | Expression (UTC) | GHA cron replaced | PT | Day mask | run_mode |
-|---|---|---|---|---|---|
-| `…-0700-sunfri` | `cron(0 7 ? * SUN-FRI *)` | `0 7 * * 0-5` | 12am | Sun–Fri (skips Sat) | full |
-| `…-2300-daily` | `cron(0 23 * * ? *)` | `0 23 * * *` | 4pm | daily incl. Sat | full |
+| Scheduler rule | Expression (UTC) | PT | Day mask | run_mode | model | issue_filter |
+|---|---|---|---|---|---|---|
+| `…-0700-sunfri` | `cron(0 7 ? * SUN-FRI *)` | 12am | Sun–Fri (skips Sat) | full | claude-sonnet-5 | default |
+| `…-2300-daily` | `cron(0 23 * * ? *)` | 4pm | daily incl. Sat | full | claude-sonnet-5 | default |
+| `…-1500-daily-opus-high` | `cron(0 15 * * ? *)` | 8am | daily (all 7) | full | claude-opus-4-8 | high-only |
 
 > **Reduced 3→2/day on 2026-06-29** (usage pacing): the former
-> `…-1500-sunfri` rule (`cron(0 15 ? * SUN-FRI *)`, 8am PT) was dropped.
-> `deploy.sh` step 2e prunes it from live on the next `--bootstrap`; the matching
-> `0 15 * * 0-5` GHA cron is removed in the same change.
+> `…-1500-sunfri` rule (`cron(0 15 ? * SUN-FRI *)`, 8am PT, Sonnet/default) was
+> dropped. **Re-added 2026-07-01** at the same 15:00 UTC slot (config#1495
+> follow-up) as a DIFFERENT tier, not a reinstatement: `…-1500-daily-opus-high`
+> runs **Opus** against **`complexity:high` issues only** — the queue the two
+> Sonnet schedules above explicitly exclude. It shares the SAME weekly Max-quota
+> reserve-for-interactive budget gate (`scripts/groom_budget.py`) as the Sonnet
+> schedules — it competes for the same pool, not a separate one — and shuts
+> down immediately/cleanly if the `complexity:high` queue is empty (a
+> `total == 0` clean stop, never a floor-breach false-positive; see
+> `scripts/groom_driver.py`). An issue an Opus chunk judges to need Brian's own
+> judgment (a genuine, irreducible product/architecture fork — not mere
+> difficulty) gets relabeled `complexity:ultra`, which permanently exits ALL
+> automated grooming (both this schedule and the two Sonnet ones).
 
 The Sat-skip rationale is carried verbatim from `backlog-groom.yml`: the
 `…-0700-sunfri` rule avoids colliding with the 09:00-UTC Crucible Saturday
@@ -60,14 +73,20 @@ EventBridge Scheduler cron uses 6 fields `cron(min hour day-of-month month
 day-of-week year)` with `?` for an unspecified day field and `SUN-FRI` for the
 day-of-week mask.
 
-## Run-mode routing
+## Schedule-input routing
 
-Each schedule passes a JSON input `{"run_mode": "...", "schedule": "..."}`. The
-Lambda forwards `run_mode` into `client_payload` (also as `phase` for
-forward-compat); `backlog-groom.yml`'s run-mode step reads
-`github.event.client_payload.run_mode` to route `full` vs `sweep`. Both
-current rules are `full` (the drain-phase default). An unknown/missing run_mode
-degrades to `full`.
+Each schedule passes a JSON input, e.g. `{"run_mode": "full", "model":
+"claude-opus-4-8", "issue_filter": "high-only", "schedule": "0 15 * * *"}`.
+The Lambda resolves each field (unknown/missing values degrade to a safe
+default — `full` / `claude-sonnet-5` / `default`) and exports `GROOM_MODEL` +
+`GROOM_ISSUE_FILTER` in the SSM bootstrap prelude ahead of invoking
+`groom_spot_bootstrap.sh --mode <run_mode>`, which forwards them into
+`scripts/groom_run.sh` → `scripts/groom_driver.py` (`--issue-filter` selects
+the Sonnet default queue vs. the Opus `complexity:high`-only queue; `--model`
+is passed straight to the `claude -p` invocation). `model` is validated against
+a conservative allowlist regex before being embedded in the shell command
+(defense-in-depth — the event is Lambda-config-controlled, not raw user input,
+but injection protection is cheap).
 
 ## Contract & safety
 
@@ -96,32 +115,19 @@ Merging the PR has **zero live effect** until an operator runs `--bootstrap`.
 `GROOM_DISPATCH_ENABLED` defaults on) **triggers an actual groom run** — use
 intentionally.
 
-## Validation — apply + on-time-firing soak (REQUIRED before removing GHA crons)
+## Validating a new/changed schedule
 
-1. **Prereq**: the `alpha-engine-config` PR adding the `scheduled-groom`
-   dispatch type + run-mode routing must be merged (cross-linked below).
-2. **Apply**: `bash …/deploy.sh --bootstrap` (operator with AWS creds).
-3. **Verify wiring**: `aws scheduler list-schedules --name-prefix
-   alpha-engine-scheduled-groom --region us-east-1` shows both; `--smoke`
-   produces a backlog-groom run in alpha-engine-config Actions.
-4. **Soak (multi-day)**: confirm each rule fires **on time** for a week — compare
-   the EventBridge/Lambda CloudWatch invocation timestamps against the cron and
-   confirm a matching `repository_dispatch` (`scheduled-groom`) backlog-groom run
-   appears within a minute. Watch the Lambda `Errors` metric stays at 0.
-5. **Cut over**: only after the soak confirms reliable on-time firing, remove the
-   remaining `schedule:` crons from `backlog-groom.yml` (a follow-up PR), leaving
-   EventBridge as the sole scheduler. Until then both run (the workflow's
-   `concurrency` group serialises any rare overlap, so the belt-and-suspenders
-   window is harmless).
-
-## Prerequisite in alpha-engine-config
-
-`backlog-groom.yml` must listen for the trigger and honor the run-mode:
-
-```yaml
-on:
-  repository_dispatch:
-    types: [saturday-sf-success-groom, scheduled-groom]
-```
-
-(the run-mode step reads `github.event.client_payload.run_mode`).
+1. **Apply**: `bash …/deploy.sh --bootstrap` (operator with AWS creds) — creates/
+   updates the 3 Scheduler rules from `SCHED_NAMES`/`SCHED_CRONS`/`SCHED_INPUTS`
+   and prunes any live rule under the prefix no longer listed there.
+2. **Verify wiring**: `aws scheduler list-schedules --name-prefix
+   alpha-engine-scheduled-groom --region us-east-1` shows all 3.
+3. **Bounded manual test**: `aws lambda invoke` with the target schedule's JSON
+   input (see the Cadence table) to fire an on-demand run without waiting for
+   the cron; add `"soft_limit_min"` handling is NOT read by the Lambda itself —
+   cap a manual box's runtime by SSH/SSM-exporting `SOFT_LIMIT_MIN` before
+   `groom_spot_bootstrap.sh --soft-limit-min <n>` runs, or invoke the bootstrap
+   script directly with that flag on a manually launched box.
+4. **Soak**: confirm the rule fires on time and produces (or, for `high-only`,
+   cleanly no-ops on) a `groom-digest` issue in `alpha-engine-config`; watch the
+   Lambda `Errors` metric stays at 0.

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -17,9 +17,13 @@
 # /alpha-engine/*), so the Lambda needs NO secret access.
 #
 # Cadence (UTC, mirrors the GHA crons exactly). Reduced 3->2/day on 2026-06-29
-# (the 15:00 UTC / 8am-PT run was dropped per usage pacing):
-#   07:00 Sun-Fri   cron(0 7 ? * SUN-FRI *)   FULL   # 12am PT, skips Sat
-#   23:00 daily     cron(0 23 * * ? *)        FULL   # 4pm PT, every day incl. Sat
+# (the 15:00 UTC / 8am-PT run was dropped per usage pacing); a 3rd schedule was
+# re-added 2026-07-01 (config#1495 follow-up) at the SAME 15:00 UTC slot, now
+# running a DIFFERENT tier — Opus, complexity:high ONLY — not a reinstatement
+# of the old Sonnet drain-phase run:
+#   07:00 Sun-Fri   cron(0 7 ? * SUN-FRI *)   FULL   Sonnet, default queue   # 12am PT, skips Sat
+#   23:00 daily     cron(0 23 * * ? *)        FULL   Sonnet, default queue  # 4pm PT, every day incl. Sat
+#   15:00 daily     cron(0 15 * * ? *)        FULL   Opus,   high-only      # 8am PT, every day
 #
 # SCHED_NAMES is the source of truth: any live scheduler rule under the
 # alpha-engine-scheduled-groom- prefix that is NOT in SCHED_NAMES is PRUNED
@@ -56,19 +60,25 @@ ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
 SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
 
-# Schedule definitions: name | cron expression (UTC) | JSON input (run_mode + label).
-# Mirrors backlog-groom.yml's `schedule:` crons one-for-one.
+# Schedule definitions: name | cron expression (UTC) | JSON input (run_mode +
+# label, plus model/issue_filter for the Opus high-tier schedule). The two
+# Sonnet schedules omit model/issue_filter — the Lambda defaults them to
+# claude-sonnet-5 / "default" (the pre-existing mid-tier queue), so this is not
+# a behavior change for them.
 SCHED_NAMES=(
   "alpha-engine-scheduled-groom-0700-sunfri"
   "alpha-engine-scheduled-groom-2300-daily"
+  "alpha-engine-scheduled-groom-1500-daily-opus-high"
 )
 SCHED_CRONS=(
   "cron(0 7 ? * SUN-FRI *)"
   "cron(0 23 * * ? *)"
+  "cron(0 15 * * ? *)"
 )
 SCHED_INPUTS=(
   '{"run_mode":"full","schedule":"0 7 * * 0-5"}'
   '{"run_mode":"full","schedule":"0 23 * * *"}'
+  '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","schedule":"0 15 * * *"}'
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2d).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 
 import boto3
@@ -87,6 +88,13 @@ CW_LOG_GROUP = os.environ.get("GROOM_CW_LOG_GROUP", "/alpha-engine/groom-spot")
 
 _VALID_RUN_MODES = {"full", "sweep"}
 _DEFAULT_RUN_MODE = "full"
+_VALID_ISSUE_FILTERS = {"default", "high-only"}
+_DEFAULT_ISSUE_FILTER = "default"
+_DEFAULT_MODEL = "claude-sonnet-5"
+# Defense-in-depth allowlist for the model id (embedded verbatim into the SSM
+# shell command below) — model ids are Lambda-config-controlled, not raw user
+# input, but this is cheap and rules out shell-metacharacter injection outright.
+_MODEL_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 
 
 def _resolve_run_mode(event: dict) -> str:
@@ -98,7 +106,25 @@ def _resolve_run_mode(event: dict) -> str:
     return rm
 
 
-def _bootstrap_command(run_mode: str, run_url: str) -> str:
+def _resolve_issue_filter(event: dict) -> str:
+    """Pull issue_filter from the schedule input; unknown/missing → default (Sonnet queue)."""
+    f = str(event.get("issue_filter") or _DEFAULT_ISSUE_FILTER).strip().lower()
+    if f not in _VALID_ISSUE_FILTERS:
+        logger.warning("unknown issue_filter %r — defaulting to %s", f, _DEFAULT_ISSUE_FILTER)
+        f = _DEFAULT_ISSUE_FILTER
+    return f
+
+
+def _resolve_model(event: dict) -> str:
+    """Pull model from the schedule input; missing/malformed → default (Sonnet 5)."""
+    m = str(event.get("model") or _DEFAULT_MODEL).strip()
+    if not _MODEL_RE.match(m):
+        logger.warning("malformed model %r — defaulting to %s", m, _DEFAULT_MODEL)
+        m = _DEFAULT_MODEL
+    return m
+
+
+def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: str) -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec bootstrap.
 
     Runs as root on the box. The heavy, version-controlled logic lives in the
@@ -125,6 +151,8 @@ git clone --depth 1 --branch {GROOM_BRANCH} \
   "https://x-access-token:${{PAT}}@github.com/{GROOM_REPO}.git" \
   /home/ec2-user/alpha-engine-config || fail "clone failed"
 cd /home/ec2-user/alpha-engine-config
+export GROOM_MODEL={model}
+export GROOM_ISSUE_FILTER={issue_filter}
 exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"
 """
 
@@ -173,15 +201,15 @@ def _wait_ssm_online(instance_id: str) -> None:
     )
 
 
-def _send_bootstrap(instance_id: str, run_mode: str, run_url: str) -> str:
+def _send_bootstrap(instance_id: str, run_mode: str, run_url: str, model: str, issue_filter: str) -> str:
     """Fire the async, detached SSM command that runs the groom + self-terminates."""
     ssm = boto3.client("ssm", region_name=REGION)
     resp = ssm.send_command(
         InstanceIds=[instance_id],
         DocumentName="AWS-RunShellScript",
-        Comment=f"backlog groom ({run_mode}) — config#1432",
+        Comment=f"backlog groom ({run_mode}, {model}, {issue_filter}) — config#1432/#1495",
         Parameters={
-            "commands": [_bootstrap_command(run_mode, run_url)],
+            "commands": [_bootstrap_command(run_mode, run_url, model, issue_filter)],
             # Execution timeout (NOT the start timeout) — without this SSM kills the
             # command at the 3600s default, guillotining a multi-hour groom.
             "executionTimeout": [str(MAX_RUNTIME_SECONDS)],
@@ -211,7 +239,7 @@ def _terminate_instance(instance_id: str) -> None:
         )
 
 
-def _launch_groom_spot(run_mode: str, schedule_label: str) -> dict:
+def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_filter: str) -> dict:
     """Launch + bootstrap the groom box. Fail-loud — any error RAISES."""
     if not DISPATCH_ENABLED:
         logger.warning("GROOM_DISPATCH_ENABLED=false — groom spot NOT launched")
@@ -234,16 +262,18 @@ def _launch_groom_spot(run_mode: str, schedule_label: str) -> dict:
             f"https://{REGION}.console.aws.amazon.com/cloudwatch/home?region={REGION}"
             f"#logsV2:log-groups (log group {CW_LOG_GROUP}, instance {instance_id})"
         )
-        command_id = _send_bootstrap(instance_id, run_mode, run_url)
+        command_id = _send_bootstrap(instance_id, run_mode, run_url, model, issue_filter)
     except Exception:
         _terminate_instance(instance_id)
         raise
     logger.info(
-        "groom dispatched: instance=%s market=%s command=%s run_mode=%s schedule=%s",
+        "groom dispatched: instance=%s market=%s command=%s run_mode=%s model=%s issue_filter=%s schedule=%s",
         instance_id,
         market,
         command_id,
         run_mode,
+        model,
+        issue_filter,
         schedule_label,
     )
     return {
@@ -252,17 +282,25 @@ def _launch_groom_spot(run_mode: str, schedule_label: str) -> dict:
         "market": market,
         "command_id": command_id,
         "run_mode": run_mode,
+        "model": model,
+        "issue_filter": issue_filter,
     }
 
 
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge Scheduler handler — launches the groom spot box on cadence.
 
-    `event` is the schedule's JSON input, e.g. {"run_mode": "full", "schedule": "0 23 * * *"}.
+    `event` is the schedule's JSON input, e.g. {"run_mode": "full", "model":
+    "claude-opus-4-8", "issue_filter": "high-only", "schedule": "0 15 * * *"}.
+    `model`/`issue_filter` default to the Sonnet mid-tier queue when absent
+    (the two pre-existing Sonnet schedules don't set them).
     """
     event = event or {}
     run_mode = _resolve_run_mode(event)
+    model = _resolve_model(event)
+    issue_filter = _resolve_issue_filter(event)
     schedule_label = str(event.get("schedule") or "unknown")
-    logger.info("scheduled groom trigger: run_mode=%s schedule=%s", run_mode, schedule_label)
-    result = _launch_groom_spot(run_mode, schedule_label)
+    logger.info("scheduled groom trigger: run_mode=%s model=%s issue_filter=%s schedule=%s",
+                run_mode, model, issue_filter, schedule_label)
+    result = _launch_groom_spot(run_mode, schedule_label, model, issue_filter)
     return {"groom": result}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -154,6 +154,54 @@ def test_sweep_run_mode_is_forwarded(monkeypatch):
     assert "--mode sweep" in idx._test_ssm.sent[0]["Parameters"]["commands"][0]
 
 
+def test_high_only_schedule_forwards_model_and_issue_filter(monkeypatch):
+    # The 3rd (Opus, 8am PT) schedule's event carries model + issue_filter —
+    # these must reach the box as exported env vars ahead of the bootstrap exec.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler(
+        {"run_mode": "full", "model": "claude-opus-4-8", "issue_filter": "high-only",
+         "schedule": "0 15 * * *"},
+        None,
+    )
+    g = out["groom"]
+    assert g["model"] == "claude-opus-4-8"
+    assert g["issue_filter"] == "high-only"
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "export GROOM_MODEL=claude-opus-4-8" in cmd
+    assert "export GROOM_ISSUE_FILTER=high-only" in cmd
+    assert cmd.index("export GROOM_MODEL") < cmd.index("groom_spot_bootstrap.sh")
+
+
+def test_missing_model_and_issue_filter_default_to_sonnet_queue(monkeypatch):
+    # The 2 pre-existing Sonnet schedules don't set model/issue_filter — must
+    # default exactly like before this feature (no behavior change for them).
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    g = out["groom"]
+    assert g["model"] == "claude-sonnet-5"
+    assert g["issue_filter"] == "default"
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "export GROOM_MODEL=claude-sonnet-5" in cmd
+    assert "export GROOM_ISSUE_FILTER=default" in cmd
+
+
+def test_unknown_issue_filter_falls_back_to_default(monkeypatch):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"run_mode": "full", "issue_filter": "bogus"}, None)
+    assert out["groom"]["issue_filter"] == "default"
+
+
+def test_malformed_model_falls_back_to_default(monkeypatch):
+    # A model string with shell metacharacters must be rejected outright rather
+    # than embedded into the SSM command (defense-in-depth allowlist).
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"run_mode": "full", "model": "claude; rm -rf /"}, None)
+    assert out["groom"]["model"] == "claude-sonnet-5"
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "claude; rm -rf /" not in cmd
+    assert "export GROOM_MODEL=claude-sonnet-5" in cmd
+
+
 def test_disabled_flag_short_circuits(monkeypatch):
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "false"})
     out = idx.handler({"run_mode": "full"}, None)


### PR DESCRIPTION
## Summary
- Re-adds the 15:00 UTC (8am PT) scheduled-groom slot dropped 2026-06-29 for usage pacing — but as a distinct tier, not a reinstatement: `alpha-engine-scheduled-groom-1500-daily-opus-high` runs **Opus** against the **`complexity:high`-only** queue the two existing Sonnet schedules explicitly exclude.
- `index.py`: resolves `model`/`issue_filter` from the EventBridge Scheduler event (default `claude-sonnet-5`/`default` — the 2 existing Sonnet schedules are unaffected), exports `GROOM_MODEL`/`GROOM_ISSUE_FILTER` in the SSM bootstrap prelude ahead of the `groom_spot_bootstrap.sh` exec. `model` is validated against an allowlist regex before shell embedding (defense-in-depth).
- `deploy.sh`: adds the 3rd `SCHED_NAMES`/`SCHED_CRONS`/`SCHED_INPUTS` entry — `cron(0 15 * * ? *)`, daily including Saturday (unlike the old Sun-Fri-only 0700 slot).
- `README.md`: corrects several claims left stale since the 2026-06-30 spot cutover (the doc still described the pre-cutover `repository_dispatch`-into-GHA design) alongside the new cadence table.

Companion PR (driver-side filter/prompt): nousergon/alpha-engine-config#1503

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` — 11 passed (7 pre-existing + 4 new: model/issue_filter forwarding, defaults preserved for the 2 existing schedules, malformed-model rejection)
- [x] `bash deploy.sh --dry-run --bootstrap` — previewed the exact AWS calls (2 schedule updates unchanged, 1 new schedule create, no prune) with no live mutation
- [ ] Live `--bootstrap` apply + bounded (1hr) manual invoke against the real `complexity:high` queue — will run after review, report results