### PR TITLE
deploy: canary → krepis.aws invoke-canary CLI; krepis>=0.7.0 (Part of #1494)

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -108,15 +108,42 @@ aws lambda create-alias \
   --region "$REGION"
 echo "  Alias 'live' -> version $VERSION"
 
-# Canary
+# Canary — POST-promotion (the 'live' alias already moved to $VERSION above).
+#
+# Invoke via the shared ``krepis.aws invoke-canary`` CLI (config#1494, published
+# in krepis 0.7.0) instead of a bare ``aws lambda invoke``. The CLI retries ONLY
+# on the throttle/concurrency signal (TooManyRequestsException /
+# ReservedFunctionConcurrentInvocationLimitExceeded) with bounded backoff+jitter,
+# writes the response payload to --out, prints the invoke metadata JSON to stdout,
+# exits 0 on invoke-API success and 1 on a non-throttle boto error or throttle
+# exhaustion. boto3 path — no ``--cli-binary-format``/base64.
 echo "  Running canary (dry_run=true)..."
 CANARY_OUT=$(mktemp)
-aws lambda invoke \
-  --function-name "${FUNCTION_NAME}:live" \
-  --payload '{"phase": 2, "dry_run": true}' \
-  --cli-binary-format raw-in-base64-out \
-  --region "$REGION" \
-  "$CANARY_OUT" > /dev/null
+if ! python3 -m krepis.aws invoke-canary \
+    --function-name "${FUNCTION_NAME}:live" \
+    --payload '{"phase": 2, "dry_run": true}' \
+    --out "$CANARY_OUT" \
+    --region "$REGION" \
+    --max-attempts 6 \
+    --label "${FUNCTION_NAME}-canary" > /dev/null; then
+  # The invoke API never returned a payload — either a non-throttle error, or
+  # the reserved-concurrency slot stayed busy past the bounded retry window.
+  # The deploy itself SUCCEEDED (the live alias already moved to $VERSION); a
+  # never-run smoke test is NOT a canary failure, so do NOT roll back —
+  # reverting a healthy deploy because we couldn't get a test slot would be the
+  # wrong action. Surface loud (fail the job) + alert so an operator confirms
+  # the live version by hand. Distinct dedup-key from the bad-STATUS rollback
+  # path below.
+  rm -f "$CANARY_OUT"
+  echo "  ERROR: canary could not be invoked (slot contention or invoke error) — deploy left LIVE on v${VERSION}, NOT rolled back."
+  python3 -m krepis.alerts publish \
+    --severity error \
+    --source "alpha-engine-data/infrastructure/deploy.sh" \
+    --dedup-key "canary-uninvokable-${FUNCTION_NAME}-v${VERSION}" \
+    --message "Canary could NOT be invoked for ${FUNCTION_NAME} v${VERSION} (throttle/concurrency or invoke error, retries exhausted). Live alias LEFT on v${VERSION} — deploy succeeded, NOT rolled back. Verify the live version manually." \
+    || true
+  exit 1
+fi
 
 CANARY_STATUS=$(python3 -c "
 import json, sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,10 @@ nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nouse
 # directly (not via a nousergon-lib bump, which would drag the in-flight,
 # 7/3-cutover SF-rename refs in lib 0.74.0 into this repo). Floor guarantees
 # the upgrade even on a non-fresh venv.
-krepis>=0.6.0
+#
+# Bumped to >=0.7.0 (config#1494): deploy.sh's canary now CALLS the
+# ``krepis.aws invoke-canary`` CLI (0.7.0 ships it) instead of a bare
+# ``aws lambda invoke``. The invoke is now LOAD-BEARING, so krepis must be
+# importable in the deploy environment — this floor makes it a hard
+# runtime/deploy dependency.
+krepis>=0.7.0


### PR DESCRIPTION
## What

Convert the top-level canary in `infrastructure/deploy.sh` to CALL the shared `python3 -m krepis.aws invoke-canary` CLI (published in **krepis 0.7.0**) instead of a bare `aws lambda invoke`. Bump the krepis floor `>=0.6.0` → `>=0.7.0`.

Part of nousergon/alpha-engine-config#1494 (4 repos; the aggregate closes when the last of the 4 merges).
Closes nousergon/alpha-engine-config#1494

## Files changed
- `infrastructure/deploy.sh` — canary now runs `python3 -m krepis.aws invoke-canary --function-name ${FUNCTION_NAME}:live --payload '{"phase": 2, "dry_run": true}' --out "$CANARY_OUT" --region "$REGION" --max-attempts 6 --label ...`. boto3 path — the `--cli-binary-format raw-in-base64-out` flag is gone. Added the uninvokable path (below).
- `requirements.txt` — `krepis>=0.6.0` → `krepis>=0.7.0` (comment updated). Pin survives the Dockerfile grep filter into the Lambda image; no literal krepis Dockerfile pin.

## Semantics preserved (POST-promotion)
The `live` alias is already moved to `$VERSION` before the canary fires.
- **NEW — CLI exit ≠ 0 (uninvokable: non-throttle error or throttle exhaustion):** do NOT roll back (a never-run smoke test is not a canary failure), emit `krepis.alerts` dedup key `canary-uninvokable-${FUNCTION_NAME}-v${VERSION}`, `exit 1`. Mirrors crucible-research's no-rollback-on-uninvokable path.
- **UNCHANGED — CLI exit 0 but bad `status`:** roll the alias back to `PREV_VERSION` + `nousergon_lib.alerts` dedup key `canary-fail-...`, `exit 1`.

The pin-lockstep guard (`test_lib_pin_lockstep.py`) locks **nousergon-lib** across requirements.txt / Dockerfile / requirements-daily-news.txt — the krepis bump does not touch it.

## Tests run
- `bash -n infrastructure/deploy.sh` → **OK**
- `python3 -m krepis.aws invoke-canary --help` (krepis 0.7.0 from PyPI) → **OK**
- `grep -rn _invoke_lambda_with_throttle_retry infrastructure/deploy.sh` → **empty** (no inline helper existed; bare invoke replaced)
- `pytest tests/test_flow_doctor_wiring.py tests/test_lib_pin_lockstep.py tests/test_sf_lib_pin_drift_wiring.py` → **21 passed, 3 skipped**

## Unvalidated part (needs live AWS)
The deploy.sh canary invokes a real AWS Lambda — not runnable here. **Brian's one command:** the next `main` **Deploy** run must be green, i.e. `bash infrastructure/deploy.sh` in a deploy context completes and the canary passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)