### PR TITLE
feat(groom): wrap groom dispatch in a Step Function for native Fleet-SF Watch coverage

### DIFF
--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -66,7 +66,8 @@ echo "==> Stamping Step Function definitions with git SHA..."
 SAT_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
 DAILY_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
 EOD_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
-trap "rm -f '$SAT_STAMPED' '$DAILY_STAMPED' '$EOD_STAMPED'" EXIT
+GROOM_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
+trap "rm -f '$SAT_STAMPED' '$DAILY_STAMPED' '$EOD_STAMPED' '$GROOM_STAMPED'" EXIT
 python3 -c "
 import json, sys
 path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -98,12 +99,23 @@ if orig.startswith('[git:'):
 d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
 json.dump(d, open(path_out, 'w'), indent=2)
 " "$SCRIPT_DIR/step_function_eod.json" "$EOD_STAMPED" "$GIT_SHA"
+python3 -c "
+import json, sys
+path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(path_in))
+orig = d.get('Comment', '')
+if orig.startswith('[git:'):
+    orig = orig.split(' ', 1)[1] if ' ' in orig else ''
+d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
+json.dump(d, open(path_out, 'w'), indent=2)
+" "$SCRIPT_DIR/step_function_groom.json" "$GROOM_STAMPED" "$GIT_SHA"
 
 echo ""
 echo "==> Uploading Step Function definitions to S3..."
 aws s3 cp "$SAT_STAMPED" "s3://$BUCKET/infrastructure/step_function.json" --quiet
 aws s3 cp "$DAILY_STAMPED" "s3://$BUCKET/infrastructure/step_function_daily.json" --quiet
 aws s3 cp "$EOD_STAMPED" "s3://$BUCKET/infrastructure/step_function_eod.json" --quiet
+aws s3 cp "$GROOM_STAMPED" "s3://$BUCKET/infrastructure/step_function_groom.json" --quiet
 echo "  Uploaded to s3://$BUCKET/infrastructure/"
 
 # ── 3. Update Step Function definitions (existence-aware) ────────────────────
@@ -122,6 +134,7 @@ echo "==> Updating Step Function definitions..."
 SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"
 DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline"
 EOD_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
+GROOM_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-pipeline"
 # Shared SF execution role (the CFN StepFunctionsRoleArn default; all three
 # orchestration SFs run under it). Used only for the EOD create-if-absent path.
 SF_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-step-functions-role"
@@ -165,6 +178,7 @@ update_or_create() {
 update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline"
 update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline"
 update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post-close trading pipeline"
+update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-pipeline" "Backlog groom pipeline"
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────
 echo ""

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -131,8 +131,9 @@ if $BOOTSTRAP; then
     echo "  Lambda exists, code will be updated in step 3"
   fi
 
-  # EventBridge rule: terminal-failure statuses of ANY of the three fleet SFs.
-  # One rule, one target — keep the ARN list in lockstep with index.PIPELINES.
+  # EventBridge rule: terminal-failure statuses of ANY of the four registered
+  # SFs (3 trading pipelines + the groom dispatch SF, config#1472). One rule,
+  # one target — keep the ARN list in lockstep with index.PIPELINES.
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   EVENT_PATTERN=$(cat <<EOF
 {
@@ -143,7 +144,8 @@ if $BOOTSTRAP; then
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-dispatch"
     ],
     "status": ["FAILED", "TIMED_OUT", "ABORTED"]
   }
@@ -153,7 +155,7 @@ EOF
   run aws events put-rule \
     --name "${RULE_NAME}" \
     --event-pattern "${EVENT_PATTERN}" \
-    --description "Fleet SF (saturday/weekday/eod) terminal failure → sf-watch-dispatcher" \
+    --description "Fleet SF (saturday/weekday/eod/groom) terminal failure → sf-watch-dispatcher" \
     --region "${REGION}" \
     --query 'RuleArn' --output text
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -37,7 +37,8 @@
         "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*",
         "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:*",
         "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*"
+        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-groom-dispatch:*"
       ]
     },
     {

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -110,6 +110,26 @@ PIPELINES: dict[str, dict[str, str]] = {
         "watch_prefix": "consolidated/eod_sf_watch",
         "dispatch_event_type": "eod-sf-failure",
     },
+    # Backlog groom dispatch (config#1472) — wraps the EC2-spot-via-SSM groom
+    # dispatch in a Step Function purely for uniform observability (watch-log
+    # artifact + silent Telegram record), replacing the bespoke external
+    # liveness-probe Lambda (data#556). `dispatch_event_type` is DELIBERATELY
+    # given a distinct, not-yet-wired type: `.github/workflows/sf-watch.yml`'s
+    # `types:` allowlist does NOT include it, so a groom failure gets full
+    # watch-log + Telegram coverage but the repository_dispatch call (if
+    # AGENT_DISPATCH_ENABLED) lands as a safe no-op — no workflow listens for
+    # it yet. Groom failures are almost always operational (spot capacity, SSM
+    # misfire) rather than a code defect, so wiring it into the SAME
+    # code-fix-via-PR resilience-agent charter the trading pipelines use needs
+    # its own deliberate autonomy-posture decision first (mirrors the still-open
+    # weekday/EOD soak-exit decision in config#1408) — tracked separately, not
+    # bundled into this SF-wrap.
+    "alpha-engine-groom-dispatch": {
+        "cadence_slug": "groom",
+        "label": "Backlog Groom",
+        "watch_prefix": "consolidated/groom_sf_watch",
+        "dispatch_event_type": "groom-sf-failure",
+    },
 }
 SCHEMA_VERSION = 1
 _CAUSE_MAX_CHARS = 600

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
-# deploy.sh — Create or update the alpha-engine-scheduled-groom-dispatcher Lambda
-# and wire its EventBridge Scheduler rules (config#1322, #1432).
+# deploy.sh — Create or update the alpha-engine-scheduled-groom-dispatcher Lambda,
+# the alpha-engine-groom-dispatch Step Function that wraps it, and wire the
+# EventBridge Scheduler rules to start SF executions (config#1322, #1432, #1472).
 #
-# Each Scheduler rule fires THIS Lambda on cadence; the Lambda LAUNCHES A
-# DEDICATED EC2 SPOT BOX (nousergon_lib.ec2_spot, on-demand fallback) and fires an
-# async SSM command that clones nousergon/alpha-engine-config and runs the SAME
-# scripts/groom_run.sh entrypoint the GHA workflow uses, then self-terminates.
-# This moves the heavy ~hours-long groom OFF the org's 2,000 included PRIVATE-repo
-# GHA Actions minutes (config#1432; was: a repository_dispatch into backlog-groom.yml).
-# EventBridge Scheduler conventions (scheduler.amazonaws.com role, cron()
-# expression, flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
+# Each Scheduler rule now starts an execution of the alpha-engine-groom-dispatch
+# STEP FUNCTION (config#1472 — was: directly invoking the Lambda). The SF's sole
+# job is orchestration/observability: invoke this Lambda (UNCHANGED — it still
+# launches the spot box + fires the async SSM command exactly as before), then
+# poll the SSM command to a real terminal status so the SF's own execution
+# status (SUCCEEDED/FAILED) is truthful — which is what plugs the groom into the
+# EXISTING Fleet-SF Watch resilience/observability agent (the same mechanism
+# that already watches the Saturday/weekday/EOD pipelines), instead of the
+# bespoke external liveness-probe Lambda (nousergon-data#556). The heavy
+# grooming logic is completely unchanged — nothing about scripts/groom_run.sh
+# or the spot box's own self-termination changes.
 #
 # IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole (the
 # executor role) + ssm:SendCommand. The BOX reads all secrets itself from SSM via
 # its instance profile (alpha-engine-executor-role → ssm:GetParameter on
-# /alpha-engine/*), so the Lambda needs NO secret access.
+# /alpha-engine/*), so the Lambda needs NO secret access. The SF's OWN execution
+# role (sf-execution-iam-policy.json) needs only lambda:InvokeFunction (on this
+# Lambda) + ssm:GetCommandInvocation (to poll) + sns:Publish (to alert on
+# failure) — it never touches secrets or launches anything itself.
 #
 # Cadence (UTC, mirrors the GHA crons exactly). Reduced 3->2/day on 2026-06-29
 # (the 15:00 UTC / 8am-PT run was dropped per usage pacing); a 3rd schedule was
@@ -49,15 +56,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-scheduled-groom-dispatcher"
 ROLE_NAME="alpha-engine-scheduled-groom-dispatcher-role"
 POLICY_NAME="alpha-engine-scheduled-groom-dispatcher-policy"
+# The Step Function that wraps the Lambda (config#1472). "dispatch" (not
+# "-pipeline") to distinguish it from the fleet's trading-orchestration SFs
+# while still reading clearly as the dispatch mechanism.
+SF_NAME="alpha-engine-groom-dispatch"
+SF_ROLE_NAME="alpha-engine-groom-sf-role"
+SF_POLICY_NAME="alpha-engine-groom-sf-policy"
+SF_DEFINITION_FILE="${SCRIPT_DIR}/../../step_function_groom.json"
 # EventBridge Scheduler execution role (assumed by scheduler.amazonaws.com to
-# invoke the Lambda). Single-target blast radius: lambda:InvokeFunction on this
-# function only.
+# START THE SF). Single-target blast radius: states:StartExecution on this SF
+# only (config#1472 — was lambda:InvokeFunction directly on the Lambda).
 SCHED_ROLE_NAME="alpha-engine-scheduled-groom-dispatcher-scheduler-role"
-SCHED_POLICY_NAME="invoke-scheduled-groom-dispatcher"
+SCHED_POLICY_NAME="start-execution-groom-dispatch"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 
 FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+SF_ARN="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:${SF_NAME}"
+SF_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SF_ROLE_NAME}"
 SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
 
 # Schedule definitions: name | cron expression (UTC) | JSON input (run_mode +
@@ -80,7 +96,7 @@ SCHED_INPUTS=(
   '{"run_mode":"full","schedule":"0 23 * * *"}'
   '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","schedule":"0 15 * * *"}'
 )
-# Prefix used to discover live rules for prune reconciliation (see step 2d).
+# Prefix used to discover live rules for prune reconciliation (see step 2f).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"
 
 DRY_RUN=false
@@ -181,23 +197,67 @@ if $BOOTSTRAP; then
     echo "  Lambda exists, code will be updated in step 3"
   fi
 
-  # --- 2c. EventBridge Scheduler execution role (invoke this Lambda only) ---
+  # --- 2c. The groom-dispatch Step Function (config#1472) ---
+  SF_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"states.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${SF_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating SF execution role: ${SF_ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${SF_ROLE_NAME}" \
+      --assume-role-policy-document "${SF_TRUST}" \
+      --description "Execution role for ${SF_NAME} — invokes the groom Lambda + polls SSM (config#1472)" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  SF execution role exists: ${SF_ROLE_NAME}"
+  fi
+  echo "  Applying SF policy: ${SF_POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${SF_ROLE_NAME}" \
+    --policy-name "${SF_POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/sf-execution-iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for SF role propagation..."
+    sleep 10
+  fi
+
+  if ! aws stepfunctions describe-state-machine --state-machine-arn "${SF_ARN}" \
+      --query 'name' --output text >/dev/null 2>&1; then
+    echo "  Creating Step Function: ${SF_NAME}"
+    run aws stepfunctions create-state-machine \
+      --name "${SF_NAME}" \
+      --definition "file://${SF_DEFINITION_FILE}" \
+      --role-arn "${SF_ROLE_ARN}" \
+      --type STANDARD \
+      --logging-configuration "level=ERROR,includeExecutionData=false,destinations=[{cloudWatchLogsLogGroup={logGroupArn=arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws/vendedlogs/states/${SF_NAME}:*}}]" \
+      --region "${REGION}" \
+      --query 'stateMachineArn' --output text
+  else
+    echo "  Step Function exists, updating definition: ${SF_NAME}"
+    run aws stepfunctions update-state-machine \
+      --state-machine-arn "${SF_ARN}" \
+      --definition "file://${SF_DEFINITION_FILE}" \
+      --role-arn "${SF_ROLE_ARN}" \
+      --region "${REGION}" \
+      --query 'updateDate' --output text
+  fi
+
+  # --- 2d. EventBridge Scheduler execution role (start THIS SF only) ---
   SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   if ! aws iam get-role --role-name "${SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
     echo "  Creating Scheduler execution role: ${SCHED_ROLE_NAME}"
     run aws iam create-role \
       --role-name "${SCHED_ROLE_NAME}" \
       --assume-role-policy-document "${SCHED_TRUST}" \
-      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} on the groom cadence" \
+      --description "EventBridge Scheduler role: start ${SF_NAME} on the groom cadence" \
       --query 'Role.RoleName' --output text
   else
     echo "  Scheduler execution role exists: ${SCHED_ROLE_NAME}"
   fi
   SCHED_INVOKE_POLICY=$(cat <<EOF
-{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["lambda:InvokeFunction"],"Resource":"${FN_ARN}"}]}
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["states:StartExecution"],"Resource":"${SF_ARN}"}]}
 EOF
 )
-  echo "  Applying Scheduler invoke policy: ${SCHED_POLICY_NAME}"
+  echo "  Applying Scheduler start-execution policy: ${SCHED_POLICY_NAME}"
   run aws iam put-role-policy \
     --role-name "${SCHED_ROLE_NAME}" \
     --policy-name "${SCHED_POLICY_NAME}" \
@@ -208,13 +268,13 @@ EOF
     sleep 10
   fi
 
-  # --- 2d. The EventBridge Scheduler rules ---
+  # --- 2e. The EventBridge Scheduler rules (target = SF, not the Lambda) ---
   for i in "${!SCHED_NAMES[@]}"; do
     name="${SCHED_NAMES[$i]}"
     cron="${SCHED_CRONS[$i]}"
     input="${SCHED_INPUTS[$i]}"
     target=$(cat <<EOF
-{"Arn":"${FN_ARN}","RoleArn":"${SCHED_ROLE_ARN}","Input":"$(printf '%s' "$input" | sed 's/"/\\"/g')"}
+{"Arn":"${SF_ARN}","RoleArn":"${SCHED_ROLE_ARN}","Input":"$(printf '%s' "$input" | sed 's/"/\\"/g')"}
 EOF
 )
     if aws scheduler get-schedule --name "${name}" --region "${REGION}" \
@@ -247,7 +307,7 @@ EOF
     fi
   done
 
-  # --- 2e. Prune reconciliation: delete any live rule under SCHED_PREFIX that is
+  # --- 2f. Prune reconciliation: delete any live rule under SCHED_PREFIX that is
   # no longer in SCHED_NAMES (so dropping a cadence above removes it live too,
   # rather than silently orphaning a still-firing schedule). Added 2026-06-29
   # alongside the 3->2/day reduction (the 1500-sunfri rule is the first prunee).
@@ -288,18 +348,21 @@ fi
 
 echo "✓ Code deployed."
 
-# ----- 4. Smoke (synthetic schedule event) ----------------------------------
+# ----- 4. Smoke (synthetic schedule event, via the SF — the real live path) --
 
 if $SMOKE; then
   echo ""
-  echo "Smoke-testing via direct invoke (synthetic schedule event, run_mode=full)..."
-  RESP=$(mktemp)
-  aws lambda invoke \
-    --function-name "${FUNCTION_NAME}" \
-    --cli-binary-format raw-in-base64-out \
-    --payload '{"run_mode":"full","schedule":"smoke-test"}' \
+  echo "Smoke-testing via SF start-execution (synthetic schedule event, run_mode=full)..."
+  echo "⚠ this starts a REAL execution of ${SF_NAME}, which invokes the Lambda and fires a REAL groom."
+  EXEC_ARN=$(aws stepfunctions start-execution \
+    --state-machine-arn "${SF_ARN}" \
+    --input '{"run_mode":"full","schedule":"smoke-test"}' \
     --region "${REGION}" \
-    "${RESP}" >/dev/null
+    --query 'executionArn' --output text)
+  echo "Started execution: ${EXEC_ARN}"
+  echo "(async — poll with: aws stepfunctions describe-execution --execution-arn ${EXEC_ARN} --region ${REGION})"
+  RESP=$(mktemp)
+  echo "{\"executionArn\": \"${EXEC_ARN}\"}" > "${RESP}"
   cat "${RESP}"
   echo ""
   rm -f "${RESP}"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/sf-execution-iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/sf-execution-iam-policy.json
@@ -1,0 +1,38 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "InvokeGroomDispatcherLambda",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-scheduled-groom-dispatcher"
+    },
+    {
+      "Sid": "PollGroomSsmCommand",
+      "Effect": "Allow",
+      "Action": "ssm:GetCommandInvocation",
+      "Resource": "*"
+    },
+    {
+      "Sid": "AlertOnFailure",
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    },
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:UpdateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:PutResourcePolicy",
+        "logs:DescribeResourcePolicies",
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -1,0 +1,141 @@
+{
+  "Comment": "Backlog groom dispatch (config#1472) — wraps the EventBridge Scheduler -> Lambda -> EC2-spot-via-SSM dispatch chain in a Step Function so the fleet's existing Fleet-SF Watch resilience/observability agent covers groom runs the SAME way it covers the Saturday/weekday/EOD pipelines, instead of via a bespoke external liveness-probe Lambda. The heavy grooming logic is UNCHANGED — this SF only orchestrates: invoke the existing alpha-engine-scheduled-groom-dispatcher Lambda (launches the spot box + fires the async SSM command, exactly as it already does), then poll the SSM command to a terminal state so the SF's OWN execution status (SUCCEEDED/FAILED) is truthful. The spot box still self-terminates on its own EXIT trap regardless of what this SF observes — this adds observability, it does not change the dispatch mechanism.",
+  "StartAt": "LaunchGroomSpot",
+  "States": {
+    "LaunchGroomSpot": {
+      "Type": "Task",
+      "Comment": "Invoke the EXISTING scheduled-groom-dispatcher Lambda unchanged — it launches the spot box (or on-demand on capacity exhaustion), waits for SSM Online, and fires the async detached SSM RunShellScript command, returning {launched, instance_id, command_id, market, run_mode, model, issue_filter} (or {launched:false, reason:'disabled'} under the GROOM_DISPATCH_ENABLED kill-switch). The execution input IS the same JSON payload the EventBridge Scheduler rule used to pass directly to the Lambda (run_mode/model/issue_filter/schedule) — this SF is a pass-through wrapper, not a redesign of the payload contract.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
+        "Payload.$": "$"
+      },
+      "TimeoutSeconds": 360,
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "A launch failure (spot+on-demand exhaustion, SSM send failure, etc.) — the Lambda itself already terminates any partially-launched box before re-raising, so no cleanup needed here.",
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.groomLaunch",
+      "Next": "CheckLaunched"
+    },
+    "CheckLaunched": {
+      "Type": "Choice",
+      "Comment": "GROOM_DISPATCH_ENABLED=false is an intentional kill-switch skip, not a failure — route to a clean Succeed rather than polling a box that was never launched.",
+      "Choices": [
+        {
+          "Variable": "$.groomLaunch.Payload.groom.launched",
+          "BooleanEquals": true,
+          "Next": "PollGroomCommand"
+        }
+      ],
+      "Default": "GroomSkipped"
+    },
+    "PollGroomCommand": {
+      "Type": "Task",
+      "Comment": "Poll the async SSM command to a terminal state. No attempt-cap/counter here (mirrors the fleet's existing poll-loop convention, e.g. step_function_eod.json's PostMarketData/WaitForPostMarketData) — the underlying command is itself bounded by groom_spot_bootstrap.sh's own hard watchdog (MAX_RUNTIME_SECONDS, default 21600s/6h) plus the spot-orphan-reaper's 6.5h fleet cap, so this loop always resolves to a terminal SSM status without needing its own ceiling.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.groomLaunch.Payload.groom.command_id",
+        "InstanceId.$": "$.groomLaunch.Payload.groom.instance_id"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.InvocationDoesNotExistException", "Ssm.InvocationDoesNotExist"],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "CommandId.$": "$.CommandId",
+        "InstanceId.$": "$.InstanceId"
+      },
+      "ResultPath": "$.groomPoll",
+      "Next": "CheckGroomStatus"
+    },
+    "CheckGroomStatus": {
+      "Type": "Choice",
+      "Comment": "Default routes to GroomStatusError so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed — mirrors CheckPostMarketStatus/CheckEODStatus.",
+      "Choices": [
+        {"Variable": "$.groomPoll.Status", "StringEquals": "Success", "Next": "GroomSucceeded"},
+        {"Variable": "$.groomPoll.Status", "StringEquals": "InProgress", "Next": "GroomWait"},
+        {"Variable": "$.groomPoll.Status", "StringEquals": "Pending", "Next": "GroomWait"},
+        {"Variable": "$.groomPoll.Status", "StringEquals": "Delayed", "Next": "GroomWait"}
+      ],
+      "Default": "GroomStatusError"
+    },
+    "GroomWait": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "PollGroomCommand"
+    },
+    "GroomStatusError": {
+      "Type": "Pass",
+      "Comment": "Choice Default path — synthesize $.error from the poll result so HandleFailure's JsonToString($.error) has something to stringify. Covers Failed/Cancelled/TimedOut and any status not explicitly modeled above.",
+      "Parameters": {
+        "source": "groom_status",
+        "status.$": "$.groomPoll.Status",
+        "status_details.$": "$.groomPoll.StatusDetails",
+        "response_code.$": "$.groomPoll.ResponseCode",
+        "command_id.$": "$.groomPoll.CommandId",
+        "instance_id.$": "$.groomPoll.InstanceId"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "HandleFailure": {
+      "Type": "Task",
+      "Comment": "Failure alert via SNS (same topic the fleet SFs already use). No force-stop step is needed here — unlike the persistent trading instance the EOD SF guards, the groom spot box tears itself down via groom_spot_bootstrap.sh's own EXIT trap regardless of what this SF observes; there is no idle-cost risk to guard against.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine Backlog Groom — FAILED",
+        "Message.$": "States.Format('Backlog groom dispatch failed. Error: {}', States.JsonToString($.error))"
+      },
+      "ResultPath": "$.failure_notify",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Defense-in-depth: an SNS publish failure must not block the SF from reaching its own FAILED terminal state (which is what Fleet-SF Watch's EventBridge pattern actually listens for).",
+          "Next": "FailExecution",
+          "ResultPath": "$.failure_notify_error"
+        }
+      ],
+      "Next": "FailExecution"
+    },
+    "FailExecution": {
+      "Type": "Fail",
+      "Error": "GroomDispatchFailure",
+      "Cause": "Backlog groom dispatch failed — see the SNS alert / groom-spot CloudWatch log group for detail."
+    },
+    "GroomSucceeded": {
+      "Type": "Succeed"
+    },
+    "GroomSkipped": {
+      "Type": "Succeed",
+      "Comment": "GROOM_DISPATCH_ENABLED=false kill-switch — intentional no-op, not a failure."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Closes the "SF later" half of `alpha-engine-config#1472`. EventBridge Scheduler now starts an execution of a new `alpha-engine-groom-dispatch` Step Function instead of invoking the dispatcher Lambda directly. The SF's only job is orchestration/observability — invoke the existing Lambda (unchanged), poll the async SSM command to a real terminal status — so the SF's own execution status is truthful and the fleet's existing Fleet-SF Watch resilience/observability agent covers groom the same way it already covers the Saturday/weekday/EOD pipelines.

- **New:** `infrastructure/step_function_groom.json` — mirrors the fleet's existing SSM-poll-loop convention (no invented attempt-cap; relies on the box's own 6h watchdog + the spot-orphan-reaper's 6.5h cap to always resolve to a terminal SSM status).
- **New:** `scheduled-groom-dispatcher/sf-execution-iam-policy.json` — the SF's execution role (invoke Lambda + poll SSM + alert via SNS).
- `scheduled-groom-dispatcher/deploy.sh` — bootstraps the SF + its role; retargets the 3 EventBridge Scheduler rules (and the Scheduler's own role policy) from `lambda:InvokeFunction` to `states:StartExecution` on the new SF.
- `saturday-sf-watch-dispatcher/` — registers the groom SF as a 4th pipeline (mirrors exactly how the transitional EOD alias was added for `config#1408`). **Deliberately does not** wire `groom-sf-failure` into `sf-watch.yml`'s dispatch types yet — groom failures are usually operational (spot/SSM), not code defects, so routing them into the code-fix-via-PR resilience charter needs its own autonomy decision, tracked separately. Groom still gets full watch-log + Telegram observability regardless.

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` — 11 passed (unchanged — the Lambda's own logic isn't touched)
- [x] `pytest infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py` — 22 passed, including the registry/EventBridge-rule lockstep regression guard
- [x] `bash deploy.sh --dry-run --bootstrap` in both dispatcher directories — previewed the exact AWS calls (SF create, IAM roles, Scheduler retarget, EventBridge rule update) with no live mutation
- [ ] Live `--bootstrap` apply + a smoke execution — will run after review, report results