### PR TITLE
feat(signal_returns): dual-write long-format score_performance_outcomes (config#1483 Phase 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.77.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/collectors/signal_returns.py
+++ b/collectors/signal_returns.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-from datetime import date
+from datetime import date, datetime, timezone
 
 import boto3
 import pandas as pd
@@ -81,6 +81,14 @@ def collect(
 
     # Step 2: Backfill score_performance returns via universe_returns JOIN
     results["backfill_score_returns"] = _backfill_score_returns(db_path, dry_run)
+
+    # Step 2c: Phase-2 dual-write of the long-format score_performance_outcomes
+    # table (EPIC config#1483). Emits one row per (signal, score_date, horizon)
+    # for the canonical HorizonPolicy horizons, sourced from universe_returns
+    # decimals + validated against the nousergon_lib outcome_record contract.
+    # ADDITIVE + SECONDARY during the >=1-week dual-write soak — the wide
+    # score_performance columns (Step 2) stay primary until the Phase-4 cutover.
+    results["backfill_outcome_records"] = _backfill_outcome_records(db_path, dry_run)
 
     # Step 2b: Drift gate — emit canonical-context coverage as a CW gauge
     # so an alarm fires if the producer ever regresses (e.g. signals.json
@@ -532,6 +540,207 @@ def _backfill_score_returns(db_path: str, dry_run: bool) -> dict:
 
     except Exception as e:
         logger.error("backfill_score_returns failed: %s", e)
+        return {"status": "error", "error": str(e), "rows_written": 0}
+
+
+# ── Step 2c: Long-format outcome dual-write (EPIC config#1483 Phase 2) ─────────
+
+
+def _ensure_score_performance_outcomes_schema(conn) -> None:
+    """Create the long-format ``score_performance_outcomes`` table if absent.
+
+    The config#1483 root-cause fix for the wide horizon-suffixed columns: one
+    row per (signal, score_date, horizon_days) so a horizon change is a DATA
+    change, not a fleet-wide column rename. Field names + semantics mirror
+    ``nousergon_lib.contracts`` ``outcome_record`` (v1) and
+    ``nousergon_lib.quant.horizons.OutcomeColumns``. Self-creating (IF NOT
+    EXISTS) so this producer is Phase-2-self-sufficient; the authoritative
+    research-side migration + consumer reads land in Phase 3. Returns/spy
+    stored as DECIMALS (matching the universe_returns source + log_alpha),
+    NOT the legacy percent quirk of the wide columns.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS score_performance_outcomes (
+            id             INTEGER PRIMARY KEY,
+            signal_id      TEXT NOT NULL,
+            symbol         TEXT NOT NULL,
+            score_date     TEXT NOT NULL,
+            horizon_days   INTEGER NOT NULL,
+            beat_spy       INTEGER,
+            stock_return   REAL,
+            spy_return     REAL,
+            log_alpha      REAL,
+            is_primary     INTEGER NOT NULL,
+            resolved_at    TEXT NOT NULL,
+            schema_version INTEGER NOT NULL DEFAULT 1,
+            UNIQUE(signal_id, horizon_days)
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_spo_horizon ON score_performance_outcomes(horizon_days)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_spo_score_date ON score_performance_outcomes(score_date)"
+    )
+    conn.commit()
+
+
+def _backfill_outcome_records(
+    db_path: str, dry_run: bool, resolved_at: str | None = None, policy=None,
+) -> dict:
+    """Dual-write the long-format ``score_performance_outcomes`` rows alongside
+    the wide ``score_performance`` columns (EPIC config#1483 Phase 2).
+
+    For each canonical ``HorizonPolicy`` horizon (primary 21d + diagnostics),
+    reads the DECIMAL forward returns straight from ``universe_returns`` (the
+    same JOIN Step 2 uses, before its percent conversion), derives the
+    long-format record, VALIDATES it against the ``outcome_record`` contract
+    (fail-loud on a shape/label violation), and idempotently inserts it. The
+    canonical primary horizon carries the log-domain ``log_alpha``; diagnostic
+    horizons carry ``log_alpha = NULL`` (no canonical alpha at a non-primary
+    horizon — the contract's if/then permits null only when ``is_primary`` is
+    False). Legacy 10d/30d horizons are deliberately NOT carried into the
+    canonical store — only the policy horizons.
+
+    ``resolved_at``/``policy`` are injectable for deterministic tests.
+    """
+    from nousergon_lib.contracts import validate
+    from nousergon_lib.quant.horizons import DEFAULT_POLICY
+
+    policy = policy or DEFAULT_POLICY
+    resolved_at = resolved_at or datetime.now(timezone.utc).isoformat()
+
+    try:
+        conn = sqlite3.connect(db_path)
+        _ensure_score_performance_outcomes_schema(conn)
+
+        ur_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(universe_returns)").fetchall()
+        }
+        has_log = {"log_return_21d", "log_spy_return_21d"} <= ur_cols
+        written = 0
+
+        for h in policy.all_horizons:
+            hcol = f"{h}d"
+            need = {f"return_{hcol}", f"spy_return_{hcol}", f"beat_spy_{hcol}"}
+            if not need <= ur_cols:
+                # A policy horizon whose universe_returns columns don't exist
+                # yet (e.g. a newly-added diagnostic horizon before its data
+                # collector ships). Skip + WARN — graceful-empty, detectable.
+                logger.warning(
+                    "score_performance_outcomes: universe_returns lacks %s — "
+                    "skipping horizon %dd",
+                    sorted(need - ur_cols), h,
+                )
+                continue
+
+            is_primary = policy.is_primary(h)
+            log_select = (
+                ", ur.log_return_21d, ur.log_spy_return_21d"
+                if (is_primary and has_log)
+                else ""
+            )
+            rows = conn.execute(
+                f"""
+                SELECT sp.symbol, sp.score_date,
+                       ur.return_{hcol}, ur.spy_return_{hcol}, ur.beat_spy_{hcol}{log_select}
+                FROM score_performance sp
+                JOIN universe_returns ur
+                  ON ur.ticker = sp.symbol AND ur.eval_date = sp.score_date
+                WHERE ur.return_{hcol} IS NOT NULL
+                """
+            ).fetchall()
+
+            for row in rows:
+                symbol, score_date, stock_return, spy_return, beat_spy = row[:5]
+                # A resolved record requires both legs; a missing spy leg means
+                # the outcome isn't fully resolved yet — skip (re-picked up on a
+                # later run once universe_returns has it).
+                if stock_return is None or spy_return is None:
+                    continue
+
+                log_alpha = None
+                if is_primary and has_log:
+                    lr, lsr = row[5], row[6]
+                    if lr is not None:
+                        log_alpha = round(lr - (lsr if lsr is not None else 0.0), 6)
+                if is_primary and log_alpha is None:
+                    # The primary row MUST carry the canonical label; writing a
+                    # null-alpha primary would violate the contract. Skip + WARN
+                    # rather than fabricate — the row lands once the log columns
+                    # resolve. (Post-#197 universe_returns always has them.)
+                    logger.warning(
+                        "score_performance_outcomes: canonical log_alpha "
+                        "unavailable for primary %dd row %s@%s — skipping",
+                        h, symbol, score_date,
+                    )
+                    continue
+
+                # beat_spy: prefer the stored flag; derive from the decimal
+                # legs when null (mirrors Step 2's beat_spy repair), never
+                # fabricate.
+                beat = bool(beat_spy) if beat_spy is not None else (stock_return > spy_return)
+
+                record = {
+                    "schema_version": 1,
+                    "signal_id": f"{symbol}:{score_date}",
+                    "score_date": score_date,
+                    "horizon_days": int(h),
+                    "beat_spy": beat,
+                    "stock_return": float(stock_return),
+                    "spy_return": float(spy_return),
+                    "log_alpha": float(log_alpha) if log_alpha is not None else None,
+                    "resolved_at": resolved_at,
+                    "is_primary": is_primary,
+                }
+                # Fail-loud on a contract violation — a malformed record is a
+                # producer bug (caught by the step-level except → status:error,
+                # which surfaces as collect() status:partial, NOT a silent skip).
+                validate("outcome_record", record)
+
+                if not dry_run:
+                    conn.execute(
+                        """
+                        INSERT OR IGNORE INTO score_performance_outcomes
+                            (signal_id, symbol, score_date, horizon_days, beat_spy,
+                             stock_return, spy_return, log_alpha, is_primary,
+                             resolved_at, schema_version)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            record["signal_id"], symbol, score_date, int(h),
+                            1 if beat else 0,
+                            record["stock_return"], record["spy_return"],
+                            record["log_alpha"],
+                            1 if is_primary else 0,
+                            resolved_at, 1,
+                        ),
+                    )
+                written += 1
+
+        if not dry_run:
+            conn.commit()
+        conn.close()
+
+        if written:
+            logger.info(
+                "Dual-wrote %d long-format score_performance_outcomes rows "
+                "(config#1483 Phase 2)", written,
+            )
+        return {"status": "ok", "rows_written": written}
+
+    except Exception as e:
+        # no-silent-fails carve-out (~/Development/CLAUDE.md): (a) failure mode =
+        # the NEW long-format dual-write (schema / contract / JOIN bug); (b) the
+        # primary deliverable — the wide score_performance columns (Step 2,
+        # already committed) — survives, and the live eval system reads THOSE,
+        # not this table, during the soak; (c) recording surface = this ERROR
+        # log + status:error in the returned dict, which bubbles to collect()'s
+        # has_errors → overall status:partial. At the Phase-4 cutover this store
+        # becomes primary and this handler flips to fail-loud (re-raise).
+        logger.error("backfill_outcome_records failed: %s", e)
         return {"status": "error", "error": str(e), "rows_written": 0}
 
 

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0
 anyio>=4.0
 tenacity>=8.0
 pyyaml>=6.0
-nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0
+nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.77.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.70.0
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.77.0
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via alpha_engine_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_signal_returns_outcome_records.py
+++ b/tests/test_signal_returns_outcome_records.py
@@ -1,0 +1,205 @@
+"""signal_returns long-format outcome dual-write (EPIC config#1483 Phase 2).
+
+Covers ``_backfill_outcome_records`` + ``_ensure_score_performance_outcomes_schema``:
+  - creates the long-format score_performance_outcomes table (self-sufficient)
+  - dual-writes one row per (signal, score_date, HorizonPolicy horizon) from
+    the universe_returns DECIMAL source (not the wide percent columns)
+  - every emitted record validates against the nousergon_lib outcome_record
+    contract (v1); the canonical primary (21d) carries a non-null log_alpha,
+    diagnostics (5d) carry null
+  - legacy 10d/30d horizons are NOT carried into the canonical store
+  - idempotent re-runs; dry-run writes nothing; graceful skip on absent columns
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from collectors.signal_returns import (
+    _backfill_outcome_records,
+    _ensure_score_performance_outcomes_schema,
+)
+from nousergon_lib.contracts import conformance_errors
+from nousergon_lib.quant.horizons import DEFAULT_POLICY
+
+_RESOLVED_AT = "2026-07-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def tmp_db():
+    with tempfile.TemporaryDirectory() as d:
+        yield str(Path(d) / "research.db")
+
+
+def _seed(db: str, *, with_log=True, with_5d=True, symbol="AAPL", score_date="2026-03-02"):
+    """Seed a score_performance row + its resolved universe_returns row."""
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE score_performance (
+                id INTEGER PRIMARY KEY, symbol TEXT NOT NULL, score_date TEXT NOT NULL,
+                score REAL NOT NULL, price_on_date REAL, UNIQUE(symbol, score_date)
+            )
+            """
+        )
+        cols = [
+            "id INTEGER PRIMARY KEY AUTOINCREMENT", "ticker TEXT", "eval_date TEXT",
+            "return_21d REAL", "spy_return_21d REAL", "beat_spy_21d INTEGER",
+        ]
+        if with_5d:
+            cols += ["return_5d REAL", "spy_return_5d REAL", "beat_spy_5d INTEGER"]
+        if with_log:
+            cols += ["log_return_21d REAL", "log_spy_return_21d REAL"]
+        conn.execute(f"CREATE TABLE universe_returns ({', '.join(cols)}, UNIQUE(ticker, eval_date))")
+        conn.execute(
+            "INSERT INTO score_performance (symbol, score_date, score, price_on_date) VALUES (?,?,?,?)",
+            (symbol, score_date, 80.0, 100.0),
+        )
+        ur_cols = ["ticker", "eval_date", "return_21d", "spy_return_21d", "beat_spy_21d"]
+        ur_vals = [symbol, score_date, 0.043, 0.021, 1]
+        if with_5d:
+            ur_cols += ["return_5d", "spy_return_5d", "beat_spy_5d"]
+            ur_vals += [0.011, 0.008, 1]
+        if with_log:
+            ur_cols += ["log_return_21d", "log_spy_return_21d"]
+            ur_vals += [0.0421, 0.0208]
+        conn.execute(
+            f"INSERT INTO universe_returns ({', '.join(ur_cols)}) VALUES ({', '.join('?' * len(ur_vals))})",
+            ur_vals,
+        )
+        conn.commit()
+
+
+def _fetch(db: str):
+    with sqlite3.connect(db) as conn:
+        conn.row_factory = sqlite3.Row
+        return {
+            (r["horizon_days"]): dict(r)
+            for r in conn.execute("SELECT * FROM score_performance_outcomes").fetchall()
+        }
+
+
+class TestSchemaEnsure:
+    def test_creates_table(self, tmp_db):
+        with sqlite3.connect(tmp_db) as conn:
+            _ensure_score_performance_outcomes_schema(conn)
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(score_performance_outcomes)")}
+        assert {"signal_id", "horizon_days", "log_alpha", "is_primary", "resolved_at"} <= cols
+
+    def test_idempotent(self, tmp_db):
+        with sqlite3.connect(tmp_db) as conn:
+            _ensure_score_performance_outcomes_schema(conn)
+            _ensure_score_performance_outcomes_schema(conn)  # no raise
+
+
+class TestDualWrite:
+    def test_writes_primary_and_diagnostic_rows(self, tmp_db):
+        _seed(tmp_db)
+        res = _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        assert res["status"] == "ok"
+        rows = _fetch(tmp_db)
+        # Policy default = primary 21 + diagnostic 5
+        assert set(rows) == set(DEFAULT_POLICY.all_horizons) == {21, 5}
+
+    def test_primary_row_carries_canonical_log_alpha(self, tmp_db):
+        _seed(tmp_db)
+        _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        primary = _fetch(tmp_db)[21]
+        assert primary["is_primary"] == 1
+        # log_alpha = log_return_21d - log_spy_return_21d
+        assert primary["log_alpha"] == pytest.approx(0.0421 - 0.0208, abs=1e-6)
+        # decimals, not percent
+        assert primary["stock_return"] == pytest.approx(0.043)
+        assert primary["spy_return"] == pytest.approx(0.021)
+        assert primary["beat_spy"] == 1
+
+    def test_diagnostic_row_has_null_log_alpha(self, tmp_db):
+        _seed(tmp_db)
+        _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        diag = _fetch(tmp_db)[5]
+        assert diag["is_primary"] == 0
+        assert diag["log_alpha"] is None
+        assert diag["stock_return"] == pytest.approx(0.011)
+
+    def test_every_row_conforms_to_contract(self, tmp_db):
+        _seed(tmp_db)
+        _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        with sqlite3.connect(tmp_db) as conn:
+            conn.row_factory = sqlite3.Row
+            for r in conn.execute("SELECT * FROM score_performance_outcomes"):
+                record = {
+                    "schema_version": r["schema_version"],
+                    "signal_id": r["signal_id"],
+                    "score_date": r["score_date"],
+                    "horizon_days": r["horizon_days"],
+                    "beat_spy": bool(r["beat_spy"]),
+                    "stock_return": r["stock_return"],
+                    "spy_return": r["spy_return"],
+                    "log_alpha": r["log_alpha"],
+                    "resolved_at": r["resolved_at"],
+                    "is_primary": bool(r["is_primary"]),
+                }
+                assert conformance_errors("outcome_record", record) == []
+
+    def test_legacy_horizons_not_written(self, tmp_db):
+        # 10d/30d are legacy — the canonical store must not carry them even if
+        # universe_returns has those columns.
+        _seed(tmp_db)
+        with sqlite3.connect(tmp_db) as conn:
+            conn.execute("ALTER TABLE universe_returns ADD COLUMN return_10d REAL")
+            conn.execute("ALTER TABLE universe_returns ADD COLUMN spy_return_10d REAL")
+            conn.execute("ALTER TABLE universe_returns ADD COLUMN beat_spy_10d INTEGER")
+            conn.execute("UPDATE universe_returns SET return_10d=0.02, spy_return_10d=0.01, beat_spy_10d=1")
+            conn.commit()
+        _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        assert 10 not in _fetch(tmp_db)
+
+    def test_idempotent_rerun(self, tmp_db):
+        _seed(tmp_db)
+        _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        _backfill_outcome_records(tmp_db, dry_run=False, resolved_at="2026-07-09T00:00:00+00:00")
+        rows = _fetch(tmp_db)
+        assert len(rows) == 2  # not duplicated
+        # first-write resolved_at preserved (INSERT OR IGNORE)
+        assert rows[21]["resolved_at"] == _RESOLVED_AT
+
+    def test_dry_run_writes_nothing(self, tmp_db):
+        _seed(tmp_db)
+        res = _backfill_outcome_records(tmp_db, dry_run=True, resolved_at=_RESOLVED_AT)
+        assert res["status"] == "ok"
+        assert _fetch(tmp_db) == {}
+
+    def test_primary_skipped_when_log_columns_absent(self, tmp_db):
+        # No log columns → primary can't carry canonical alpha → skip primary,
+        # still write the diagnostic (which needs no log_alpha).
+        _seed(tmp_db, with_log=False)
+        _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        rows = _fetch(tmp_db)
+        assert 21 not in rows
+        assert 5 in rows
+
+    def test_unresolved_row_skipped(self, tmp_db):
+        # score_performance row with no matching universe_returns → nothing written.
+        with sqlite3.connect(tmp_db) as conn:
+            conn.execute(
+                """
+                CREATE TABLE score_performance (
+                    id INTEGER PRIMARY KEY, symbol TEXT, score_date TEXT,
+                    score REAL, price_on_date REAL, UNIQUE(symbol, score_date)
+                )
+                """
+            )
+            conn.execute(
+                "CREATE TABLE universe_returns (id INTEGER PRIMARY KEY, ticker TEXT, eval_date TEXT, "
+                "return_21d REAL, spy_return_21d REAL, beat_spy_21d INTEGER, return_5d REAL, "
+                "spy_return_5d REAL, beat_spy_5d INTEGER, log_return_21d REAL, log_spy_return_21d REAL, "
+                "UNIQUE(ticker, eval_date))"
+            )
+            conn.execute("INSERT INTO score_performance (symbol, score_date, score, price_on_date) VALUES ('AAPL','2026-03-02',80,100)")
+            conn.commit()
+        res = _backfill_outcome_records(tmp_db, dry_run=False, resolved_at=_RESOLVED_AT)
+        assert res["status"] == "ok"
+        assert _fetch(tmp_db) == {}


### PR DESCRIPTION
## Summary

**EPIC config#1483 Phase 2 — the producer half.** Dual-writes the long-format `score_performance_outcomes` rows alongside the existing wide horizon-suffixed `score_performance` columns, so a future horizon change becomes a **data** change rather than the fleet-wide column rename that caused the config#1456 silent starvation.

Builds on the Phase-1 lib chokepoint (nousergon-lib#147, merged): consumes `nousergon_lib.quant.horizons` (`HorizonPolicy`, primary 21d + diagnostic 5d) + validates every emitted row against `nousergon_lib.contracts` `outcome_record` (v1).

**Fully additive, contained blast radius:** a brand-new self-creating table; the wide columns are untouched. The live eval system reads the wide columns, so even a bug in this path can't corrupt production during the soak.

## What it does (`collectors/signal_returns.py`)
- **New Step 2c** (`_backfill_outcome_records`, after the wide backfill): per canonical `HorizonPolicy` horizon, reads the **decimal** forward returns straight from `universe_returns` (the same JOIN Step 2 uses, *before* its `*100` percent conversion), derives the long-format record, `validate()`s it against the contract, and idempotently inserts (`INSERT OR IGNORE`, keyed `signal_id`+`horizon_days`).
- New `score_performance_outcomes` table, self-creating (`CREATE TABLE IF NOT EXISTS`) so this producer is Phase-2-self-sufficient.
- Primary (21d) carries the log-domain `log_alpha`; diagnostic (5d) carries `log_alpha=NULL` (contract `if/then` permits null only when `is_primary` is False). Primary rows whose log columns are absent are **skipped + WARNed**, never written null-alpha.
- Legacy 10d/30d are **not** carried into the canonical store — only policy horizons.

## Design decisions (SOTA calls — flagging for review)
1. **Units = decimals** (0.043), matching the `universe_returns` source + `log_alpha`, **not** the legacy percent quirk (4.3) of the wide columns. A new canonical store shouldn't inherit a display quirk; Phase-3 consumers are written fresh against it. → if you'd rather have column-for-column value parity with the wide columns during migration, say so and I'll switch.
2. **Fail-soft during the soak**: the dual-write is additive + **secondary** during the ≥1-week window (per your ratified dual-write decision). Its `except` logs ERROR + returns `status:error` (→ `collect()` `status:partial`) rather than breaking the primary wide production. Inline carve-out comment names the failure mode + recording surface per the no-silent-fails rule. **At the Phase-4 cutover this store becomes primary and the handler flips to fail-loud** (re-raise).

## Repin
`nousergon-lib v0.70.0 → v0.77.0` across the 3 lockstep files (`requirements.txt` + `Dockerfile` + `requirements-daily-news.txt`) for the new `quant.horizons` + `contracts.outcome_record` surface.

## Test plan
- [x] `tests/test_signal_returns_outcome_records.py` (11): schema; primary+diagnostic write; decimals; **every emitted row conforms to the `outcome_record` contract**; legacy horizons excluded; idempotent re-run; dry-run; primary-skip on absent log columns; unresolved-row skip
- [x] `test_lib_pin_lockstep` + `test_flow_doctor_wiring` green (repin clears both)
- [x] Full data suite green: **2486 passed, 4 skipped**

## Sequencing / next
- **Phase 3** (separate, human-gated): consumers migrate to read the long-format via the `HorizonPolicy` filter (predictor calibrator, backtester optimizers, research scorecard, dashboard, evaluator) + the authoritative research-side `archive/schema.py` migration + the suffix burn-down guard v2.
- **Phase 4**: retire the wide columns; flip this dual-write to fail-loud; the acceptance test (add a diagnostic horizon via config, zero code change end-to-end).
- Soak: ≥1 week of dual-write per the ratified S3-contract-safety decision before Phase 3 consumer cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)