### PR TITLE
feat(sf-watch): external liveness probe for Fleet-SF Watch's own wiring

### DIFF
--- a/infrastructure/lambdas/sf-watch-liveness-probe/README.md
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/README.md
@@ -1,0 +1,57 @@
+# alpha-engine-sf-watch-liveness-probe
+
+External wiring-integrity check for Fleet-SF Watch itself (`saturday-sf-watch-dispatcher`).
+
+Fleet-SF Watch is event-driven: it only fires when a registered pipeline's
+Step Function reaches a terminal FAILED/TIMED_OUT/ABORTED status via its
+EventBridge rule. That means there's no natural "session" to report a
+begin/end for — and, critically, **nothing notices if the watcher's own
+wiring silently breaks**. That's exactly what happened on 2026-06-29: the
+EventBridge rule pointed at a deleted SF ARN for an unknown period before a
+real failure exposed it, and the Lambda's own `Errors` metric stayed at zero
+the whole time — it simply never got invoked. A "0 errors" signal looked
+healthy while the watcher was completely dead.
+
+## How it works
+
+Read-only, schedule-aware config-drift check:
+
+1. The EventBridge rule (`alpha-engine-saturday-sf-watch-failed`) exists, is
+   `ENABLED`, and targets the expected dispatcher Lambda.
+2. The rule's registered `stateMachineArn` list matches
+   `EXPECTED_PIPELINE_NAMES` (kept in lockstep with the dispatcher's own
+   `PIPELINES` registry — cross-checked by a test).
+3. Every expected pipeline's Step Function actually **exists** — the exact
+   2026-06-29 dead-ARN class, caught directly instead of waiting for a real
+   failure to expose it.
+4. The target dispatcher Lambda is `Active` with a successful last code
+   update.
+
+Silent-unless-broken (mirrors the groom-liveness-probe's philosophy, one
+layer up): a clean check logs and returns, no Telegram noise. Any problem
+fires a LOUD alert, deduplicated by the **content** of the problem set (a
+hash, not a timestamp) — a standing issue doesn't re-ping every run, and the
+alert state clears automatically once the check is clean again.
+
+**Fail-loud:** every AWS describe/list call is the PRIMARY input — an error
+code other than the specific "doesn't exist" ones being checked for RAISES,
+surfacing via the Lambda error metric + a CW alarm rather than silently
+skipping the one check that verifies nothing else is silently broken. The
+Telegram send and dedup-state write are best-effort.
+
+## Deploy (operator-gated, outside CloudFormation)
+
+```
+bash deploy.sh --dry-run     # show actions
+bash deploy.sh --bootstrap   # first-time: create role + Lambda + 2 Scheduler rules
+bash deploy.sh               # update code only
+bash deploy.sh --smoke       # invoke once (read-only; pings only on a REAL problem)
+```
+
+Merging the PR has **zero** live effect until an operator runs `--bootstrap`.
+Recommend wiring a CloudWatch alarm on this function's `Errors` metric (the
+fail-loud contract assumes one).
+
+Cadence (UTC): `cron(45 6 * * ? *)` and `cron(45 14 * * ? *)` — offset 15 min
+from the groom-liveness-probe's cadence purely to avoid simultaneous
+invocation; this check isn't tied to any pipeline's own schedule.

--- a/infrastructure/lambdas/sf-watch-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/deploy.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-sf-watch-liveness-probe Lambda
+# and wire its EventBridge Scheduler rules.
+#
+# WHY: Fleet-SF Watch (saturday-sf-watch-dispatcher) is event-driven — it only
+# fires when a registered pipeline's SF reaches a terminal FAILED/TIMED_OUT/
+# ABORTED status via its EventBridge rule. Nothing notices if the WATCHER's own
+# wiring silently breaks — exactly what happened 2026-06-29: the rule pointed
+# at a deleted SF ARN for an unknown period, and the Lambda's own Errors metric
+# stayed at zero the whole time (it simply never got invoked). This probe is
+# the external watchdog FOR the watchdog: read-only, schedule-aware, asserts
+# the rule/registry/target-Lambda wiring is intact, and LOUD-pings Telegram
+# only when something's actually broken (silent-unless-broken, mirroring the
+# groom-liveness-probe's philosophy one layer up).
+#
+# IAM (iam-policy.json): logs + ssm:GetParameter (Telegram creds) +
+# events:DescribeRule/ListTargetsByRule + states:DescribeStateMachine (scoped to
+# the 5 registered pipeline ARNs) + lambda:GetFunctionConfiguration (scoped to
+# the dispatcher) + s3 Get/Put on the dedup state key. Entirely read-only — no
+# launch/send/write-anywhere-else permissions.
+#
+# Cadence (UTC): twice daily, offset 15 min from the groom-liveness-probe's own
+# cadence (06:30/14:30) purely to avoid simultaneous invocation, not for any
+# functional reason — this is a config-drift check, not tied to any pipeline's
+# own schedule:
+#   06:45 daily   cron(45 6 * * ? *)
+#   14:45 daily   cron(45 14 * * ? *)
+#
+# Managed OUTSIDE CloudFormation — mirrors the sibling dispatchers/probes
+# (narrow OIDC blast radius, operator-deployed only). Merging the PR has ZERO
+# live effect until an operator runs this with --bootstrap.
+#
+# Usage:
+#   bash .../sf-watch-liveness-probe/deploy.sh             # update code only
+#   bash .../sf-watch-liveness-probe/deploy.sh --bootstrap # first-time create + wire schedules
+#   bash .../sf-watch-liveness-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../sf-watch-liveness-probe/deploy.sh --smoke     # invoke once (read-only check; pings only on a real problem)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-sf-watch-liveness-probe"
+ROLE_NAME="alpha-engine-sf-watch-liveness-probe-role"
+POLICY_NAME="alpha-engine-sf-watch-liveness-probe-policy"
+SCHED_ROLE_NAME="alpha-engine-sf-watch-liveness-probe-scheduler-role"
+SCHED_POLICY_NAME="invoke-sf-watch-liveness-probe"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
+
+SCHED_NAMES=(
+  "alpha-engine-sf-watch-liveness-0645-daily"
+  "alpha-engine-sf-watch-liveness-1445-daily"
+)
+SCHED_CRONS=(
+  "cron(45 6 * * ? *)"
+  "cron(45 14 * * ? *)"
+)
+SCHED_PREFIX="alpha-engine-sf-watch-liveness-"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
+      --zip-file "fileb://${ZIP}" --timeout 30 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} on the liveness cadence" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${SCHED_ROLE_NAME}"
+  fi
+  SCHED_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"lambda:InvokeFunction\"],\"Resource\":\"${FN_ARN}\"}]}"
+  echo "  Applying Scheduler invoke policy: ${SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${SCHED_ROLE_NAME}" --policy-name "${SCHED_POLICY_NAME}" \
+    --policy-document "${SCHED_INVOKE_POLICY}"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  for i in "${!SCHED_NAMES[@]}"; do
+    name="${SCHED_NAMES[$i]}"
+    cron="${SCHED_CRONS[$i]}"
+    target="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${SCHED_ROLE_ARN}\",\"Input\":\"{}\"}"
+    if aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+      echo "  Updating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler update-schedule --name "${name}" --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
+    else
+      echo "  Creating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler create-schedule --name "${name}" --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
+    fi
+    if ! $DRY_RUN; then
+      aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+        || { echo "ERROR: Scheduler rule ${name} not found after create/update" >&2; exit 1; }
+    fi
+  done
+
+  # Prune reconciliation: delete any live rule under SCHED_PREFIX not in SCHED_NAMES.
+  echo "  Pruning orphaned Scheduler rules under prefix ${SCHED_PREFIX}..."
+  LIVE_RULES=$(aws scheduler list-schedules --name-prefix "${SCHED_PREFIX}" --region "${REGION}" --query 'Schedules[].Name' --output text 2>/dev/null || echo "")
+  for live in ${LIVE_RULES}; do
+    keep=false
+    for want in "${SCHED_NAMES[@]}"; do [ "${live}" = "${want}" ] && { keep=true; break; }; done
+    if ! $keep; then
+      echo "    Deleting orphaned Scheduler rule: ${live}"
+      run aws scheduler delete-schedule --name "${live}" --region "${REGION}"
+    fi
+  done
+fi
+
+# ----- 3. Update function code (always, idempotent) -------------------------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (synthetic invoke; read-only — only pings on a REAL problem) -
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (read-only wiring check)..."
+  RESP=$(mktemp)
+  aws lambda invoke --function-name "${FUNCTION_NAME}" --cli-binary-format raw-in-base64-out \
+    --payload '{}' --region "${REGION}" "${RESP}" >/dev/null
+  cat "${RESP}"; echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
@@ -1,0 +1,54 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-sf-watch-liveness-probe:*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    },
+    {
+      "Sid": "ReadEventBridgeRule",
+      "Effect": "Allow",
+      "Action": ["events:DescribeRule", "events:ListTargetsByRule"],
+      "Resource": "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-saturday-sf-watch-failed"
+    },
+    {
+      "Sid": "ReadRegisteredStateMachines",
+      "Effect": "Allow",
+      "Action": ["states:DescribeStateMachine"],
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-groom-dispatch"
+      ]
+    },
+    {
+      "Sid": "ReadDispatcherLambdaHealth",
+      "Effect": "Allow",
+      "Action": ["lambda:GetFunctionConfiguration"],
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-saturday-sf-watch-dispatcher"
+    },
+    {
+      "Sid": "LivenessDedupState",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/sf_watch_liveness/*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -1,0 +1,250 @@
+"""alpha-engine-sf-watch-liveness-probe — external wiring-integrity check for
+Fleet-SF Watch itself.
+
+Fleet-SF Watch (saturday-sf-watch-dispatcher) is event-driven: it only fires
+when a registered pipeline's Step Function reaches a terminal FAILED/TIMED_OUT
+/ABORTED status via its EventBridge rule. That means there is no natural
+"session" to report a begin/end for — and, critically, NOTHING notices if the
+watcher's own wiring silently breaks. That is exactly what happened on
+2026-06-29: the EventBridge rule pointed at a deleted SF ARN for an unknown
+period before a real failure exposed it, and the Lambda's own Errors metric
+stayed at zero the whole time — it simply never got invoked. A "0 errors"
+health signal looked fine while the watcher was completely dead.
+
+This probe is the external watchdog FOR the watchdog — mirrors the groom
+liveness probe's philosophy (an external observer of a producer that cannot be
+trusted to report its own death), applied one layer up. It runs on a schedule
+and asserts, read-only:
+
+  1. The EventBridge rule exists, is ENABLED, and targets the expected Lambda.
+  2. The rule's registered stateMachineArn list matches EXPECTED_PIPELINE_NAMES
+     below (keep in lockstep with saturday-sf-watch-dispatcher/index.py's
+     PIPELINES dict AND that dispatcher's own deploy.sh EVENT_PATTERN — a
+     regression test cross-checks this file against deploy.sh, mirroring
+     test_registry_and_eventbridge_rule_are_in_lockstep in that Lambda's own
+     tests).
+  3. Every expected SF ARN's state machine actually EXISTS — catches the exact
+     2026-06-29 dead-ARN class directly, instead of waiting for a real failure
+     to expose it.
+  4. The target Lambda is Active with a successful last code update.
+
+Silent-unless-broken (mirrors the groom probe and Fleet-SF Watch's own
+failure-driven design): a clean check logs and returns, no Telegram noise. Any
+problem fires a LOUD alert, deduplicated by the CONTENT of the problem set
+(a hash), not a timestamp — so a standing issue doesn't re-ping every run, and
+the alert state clears automatically the moment the check is clean again.
+
+**Fail-loud (CLAUDE.md no-silent-fails).** Every AWS describe/list call here is
+the PRIMARY input: an UNEXPECTED API error (anything other than the specific
+"this resource doesn't exist" codes we're explicitly checking for) RAISES, so a
+broken probe surfaces via the Lambda error metric + CW alarm rather than
+silently skipping the one check that verifies nothing else is silently broken.
+The Telegram alert itself is a secondary delivery surface: its own failure is
+logged + returned, not raised.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import boto3
+
+from alpha_engine_lib.telegram import send_message
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
+
+RULE_NAME = os.environ.get("SF_WATCH_RULE_NAME", "alpha-engine-saturday-sf-watch-failed")
+EXPECTED_TARGET_FUNCTION = os.environ.get(
+    "SF_WATCH_FUNCTION_NAME", "alpha-engine-saturday-sf-watch-dispatcher"
+)
+# MUST stay in lockstep with saturday-sf-watch-dispatcher/index.py's PIPELINES
+# dict AND that dispatcher's own deploy.sh EVENT_PATTERN (test_handler.py cross-
+# checks this list against deploy.sh's literal ARNs, mirroring the sibling
+# lockstep guard already in saturday-sf-watch-dispatcher/test_handler.py).
+EXPECTED_PIPELINE_NAMES = [
+    "ne-weekly-freshness-pipeline",
+    "ne-preopen-trading-pipeline",
+    "ne-postclose-trading-pipeline",
+    "alpha-engine-eod-pipeline",  # transitional alias, config#1408 / re-exam 2026-07-03
+    "alpha-engine-groom-dispatch",  # config#1472
+]
+
+WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
+STATE_KEY = os.environ.get("SF_WATCH_LIVENESS_STATE_KEY", "consolidated/sf_watch_liveness/alerted.json")
+
+
+def _error_code(exc: Exception) -> str:
+    return str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+
+
+def _events_client():
+    return boto3.client("events", region_name=REGION)
+
+
+def _sfn_client():
+    return boto3.client("stepfunctions", region_name=REGION)
+
+
+def _lambda_client():
+    return boto3.client("lambda", region_name=REGION)
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=REGION)
+
+
+def _check_rule() -> list[str]:
+    """Rule existence/state/target. Fail-loud on any error code OTHER than the
+    specific "does not exist" one we're explicitly checking for."""
+    problems: list[str] = []
+    events = _events_client()
+    try:
+        rule = events.describe_rule(Name=RULE_NAME)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) == "ResourceNotFoundException":
+            return [f"EventBridge rule '{RULE_NAME}' does NOT EXIST"]
+        raise
+
+    if rule.get("State") != "ENABLED":
+        problems.append(f"EventBridge rule '{RULE_NAME}' is {rule.get('State')}, not ENABLED")
+
+    targets = events.list_targets_by_rule(Rule=RULE_NAME).get("Targets", [])
+    target_arns = {t.get("Arn", "") for t in targets}
+    expected_fn_arn = f"arn:aws:lambda:{REGION}:{ACCOUNT_ID}:function:{EXPECTED_TARGET_FUNCTION}"
+    if expected_fn_arn not in target_arns:
+        problems.append(
+            f"rule '{RULE_NAME}' does not target {EXPECTED_TARGET_FUNCTION} "
+            f"(targets: {sorted(target_arns) or 'NONE'})"
+        )
+
+    pattern = json.loads(rule.get("EventPattern", "{}"))
+    registered = set(pattern.get("detail", {}).get("stateMachineArn", []))
+    registered_names = {arn.rsplit(":", 1)[-1] for arn in registered}
+    expected_names = set(EXPECTED_PIPELINE_NAMES)
+    missing = expected_names - registered_names
+    extra = registered_names - expected_names
+    if missing:
+        problems.append(f"rule is MISSING expected pipeline(s): {sorted(missing)}")
+    if extra:
+        problems.append(f"rule has UNEXPECTED extra pipeline(s) not in the registry: {sorted(extra)}")
+    return problems
+
+
+def _check_state_machines_exist() -> list[str]:
+    """Each expected pipeline's SF must actually exist — the exact 2026-06-29
+    dead-ARN bug class, caught directly instead of waiting for a real failure."""
+    problems: list[str] = []
+    sfn = _sfn_client()
+    for name in EXPECTED_PIPELINE_NAMES:
+        arn = f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{name}"
+        try:
+            sfn.describe_state_machine(stateMachineArn=arn)
+        except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+            if _error_code(exc) == "StateMachineDoesNotExist":
+                problems.append(f"registered pipeline '{name}' has NO live Step Function (dead ARN)")
+            else:
+                raise
+    return problems
+
+
+def _check_lambda_healthy() -> list[str]:
+    problems: list[str] = []
+    lam = _lambda_client()
+    try:
+        cfg = lam.get_function_configuration(FunctionName=EXPECTED_TARGET_FUNCTION)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) == "ResourceNotFoundException":
+            return [f"target Lambda '{EXPECTED_TARGET_FUNCTION}' does NOT EXIST"]
+        raise
+    if cfg.get("State") != "Active":
+        problems.append(f"target Lambda '{EXPECTED_TARGET_FUNCTION}' state={cfg.get('State')}, not Active")
+    if cfg.get("LastUpdateStatus") != "Successful":
+        problems.append(
+            f"target Lambda '{EXPECTED_TARGET_FUNCTION}' LastUpdateStatus={cfg.get('LastUpdateStatus')}"
+        )
+    return problems
+
+
+def _problem_fingerprint(problems: list[str]) -> str:
+    return hashlib.sha256("\n".join(sorted(problems)).encode()).hexdigest()[:16]
+
+
+def _load_alerted_fingerprint(s3) -> str | None:
+    """None means either 'no state yet' or 'currently healthy' — both treated
+    the same way (nothing to suppress against)."""
+    try:
+        obj = s3.get_object(Bucket=WATCH_BUCKET, Key=STATE_KEY)
+        return json.loads(obj["Body"].read()).get("fingerprint")
+    except Exception as exc:  # noqa: BLE001 — absence expected; bad blob recoverable
+        if _error_code(exc) not in {"NoSuchKey", "404", "403", ""}:
+            logger.warning("could not read sf-watch liveness state %s: %s", STATE_KEY, exc)
+        return None
+
+
+def _save_alerted_fingerprint(s3, fingerprint: str | None) -> None:
+    """Best-effort: a write failure only risks a duplicate/missed-clear ping
+    next run (logged), never a missed finding — so it does NOT raise."""
+    try:
+        s3.put_object(
+            Bucket=WATCH_BUCKET,
+            Key=STATE_KEY,
+            Body=json.dumps(
+                {"fingerprint": fingerprint, "updated_at": datetime.now(timezone.utc).isoformat()},
+                indent=2,
+            ).encode("utf-8"),
+            ContentType="application/json",
+        )
+    except Exception as exc:  # noqa: BLE001 — dedup state; failure only risks a dup ping
+        logger.warning("could not persist sf-watch liveness state %s: %s", STATE_KEY, exc)
+
+
+def _alert(problems: list[str]) -> bool:
+    lines = [
+        "\U0001f6f0️ *Fleet-SF Watch Liveness Probe — WIRING PROBLEM*",
+        f"{len(problems)} issue(s) found with the Fleet-SF Watch trigger itself "
+        "(NOT a pipeline failure — the WATCHER's own wiring):",
+    ]
+    for p in problems:
+        lines.append(f"• {p}")
+    lines.append(
+        "_Fleet-SF Watch may not catch a real pipeline failure right now. "
+        "Check the EventBridge rule + saturday-sf-watch-dispatcher Lambda._"
+    )
+    try:
+        return bool(send_message("\n".join(lines), disable_notification=False))
+    except Exception as exc:  # noqa: BLE001 — delivery surface; finding still returned
+        logger.warning("sf-watch liveness alert Telegram send failed (non-fatal): %s", exc)
+        return False
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Scheduled (EventBridge) entrypoint. Read-only; raises on an unexpected
+    AWS API failure so the check can never silently no-op."""
+    problems = _check_rule() + _check_state_machines_exist() + _check_lambda_healthy()
+    fingerprint = _problem_fingerprint(problems) if problems else None
+
+    s3 = _s3_client()
+    already = _load_alerted_fingerprint(s3)
+
+    alerted = False
+    if problems and fingerprint != already:
+        logger.warning("sf-watch liveness: %d NEW problem(s): %s", len(problems), problems)
+        alerted = _alert(problems)
+        if alerted:
+            _save_alerted_fingerprint(s3, fingerprint)
+    elif problems:
+        logger.info("sf-watch liveness: %d problem(s), unchanged since last alert — suppressed", len(problems))
+    else:
+        logger.info("sf-watch liveness: all checks clean")
+        if already is not None:
+            _save_alerted_fingerprint(s3, None)  # clear dedup state now that it's healthy again
+
+    return {"problems": problems, "alerted": alerted, "clean": not problems}

--- a/infrastructure/lambdas/sf-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/requirements.txt
@@ -1,0 +1,6 @@
+# Only the stable `telegram.send_message` primitive is used here — no extras.
+# Mirrors the sibling groom-liveness-probe / saturday-sf-watch-dispatcher pins
+# (same Fleet-Watch family); this lambda-dir pin is NOT lockstep-bound to the
+# repo-root pin (tests/test_lib_pin_lockstep.py scans only requirements.txt /
+# Dockerfile / requirements-daily-news.txt at the repo root).
+alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4

--- a/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
@@ -1,0 +1,266 @@
+"""Unit tests for sf-watch-liveness-probe index.handler.
+
+Stubs alpha_engine_lib.telegram.send_message (no live Telegram) and mocks
+boto3 events/stepfunctions/lambda/s3 clients. Asserts: a clean environment
+alerts nothing, each individual wiring problem is detected, problems are
+deduplicated by content (not re-alerted every run), and the dedup state
+clears once the environment goes clean again.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_lib_pkg = types.ModuleType("alpha_engine_lib")
+_telegram_mod = types.ModuleType("alpha_engine_lib.telegram")
+_telegram_mod.send_message = MagicMock(return_value=True)
+_lib_pkg.telegram = _telegram_mod
+sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
+sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+REGION = "us-east-1"
+ACCOUNT_ID = "711398986525"
+RULE_ARN_PATTERN = "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-saturday-sf-watch-failed"
+
+
+class FakeClientError(Exception):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+def _healthy_event_pattern() -> str:
+    return json.dumps({
+        "source": ["aws.states"],
+        "detail-type": ["Step Functions Execution Status Change"],
+        "detail": {
+            "stateMachineArn": [
+                f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{name}"
+                for name in index.EXPECTED_PIPELINE_NAMES
+            ],
+            "status": ["FAILED", "TIMED_OUT", "ABORTED"],
+        },
+    })
+
+
+def _make_events_client(*, rule_missing=False, state="ENABLED", pattern=None, no_target=False):
+    events = MagicMock()
+    if rule_missing:
+        events.describe_rule.side_effect = FakeClientError("ResourceNotFoundException")
+        return events
+    events.describe_rule.return_value = {
+        "State": state,
+        "EventPattern": pattern if pattern is not None else _healthy_event_pattern(),
+    }
+    fn_arn = f"arn:aws:lambda:{REGION}:{ACCOUNT_ID}:function:{index.EXPECTED_TARGET_FUNCTION}"
+    events.list_targets_by_rule.return_value = {
+        "Targets": [] if no_target else [{"Arn": fn_arn}]
+    }
+    return events
+
+
+def _make_sfn_client(*, missing_names=()):
+    sfn = MagicMock()
+
+    def describe(stateMachineArn):  # noqa: N803 — boto3 kwarg name
+        name = stateMachineArn.rsplit(":", 1)[-1]
+        if name in missing_names:
+            raise FakeClientError("StateMachineDoesNotExist")
+        return {"name": name, "status": "ACTIVE"}
+
+    sfn.describe_state_machine.side_effect = describe
+    return sfn
+
+
+def _make_lambda_client(*, missing=False, state="Active", last_update="Successful"):
+    lam = MagicMock()
+    if missing:
+        lam.get_function_configuration.side_effect = FakeClientError("ResourceNotFoundException")
+    else:
+        lam.get_function_configuration.return_value = {"State": state, "LastUpdateStatus": last_update}
+    return lam
+
+
+def _make_s3_client(*, existing_fingerprint=None):
+    s3 = MagicMock()
+    if existing_fingerprint is None:
+        s3.get_object.side_effect = FakeClientError("NoSuchKey")
+    else:
+        body = MagicMock()
+        body.read.return_value = json.dumps({"fingerprint": existing_fingerprint}).encode()
+        s3.get_object.return_value = {"Body": body}
+    return s3
+
+
+def _clients_factory(events, sfn, lam, s3):
+    def factory(name, region_name=None):
+        return {"events": events, "stepfunctions": sfn, "lambda": lam, "s3": s3}[name]
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def reset_telegram():
+    _telegram_mod.send_message.reset_mock()
+    _telegram_mod.send_message.return_value = True
+    yield
+
+
+def test_all_clean_alerts_nothing():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert result == {"problems": [], "alerted": False, "clean": True}
+    _telegram_mod.send_message.assert_not_called()
+
+
+def test_dead_rule_alerts():
+    events = _make_events_client(rule_missing=True)
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any("does NOT EXIST" in p for p in result["problems"])
+    assert result["alerted"] is True
+    _telegram_mod.send_message.assert_called_once()
+
+
+def test_disabled_rule_alerts():
+    events = _make_events_client(state="DISABLED")
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any("not ENABLED" in p for p in result["problems"])
+
+
+def test_wrong_target_alerts():
+    events = _make_events_client(no_target=True)
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any("does not target" in p for p in result["problems"])
+
+
+def test_missing_pipeline_arn_in_rule_alerts():
+    """The exact 2026-06-29 bug class: a registered pipeline dropped from the
+    rule's own EventPattern (e.g. after a rename)."""
+    incomplete = json.dumps({
+        "detail": {
+            "stateMachineArn": [
+                f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{name}"
+                for name in index.EXPECTED_PIPELINE_NAMES
+                if name != "alpha-engine-groom-dispatch"
+            ]
+        }
+    })
+    events = _make_events_client(pattern=incomplete)
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any("MISSING expected pipeline" in p and "alpha-engine-groom-dispatch" in p for p in result["problems"])
+
+
+def test_dead_state_machine_arn_alerts():
+    """The exact 2026-06-29 bug class: registered in the rule, but the SF
+    itself no longer exists (deleted/renamed)."""
+    events = _make_events_client()
+    sfn = _make_sfn_client(missing_names={"alpha-engine-eod-pipeline"})
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any("NO live Step Function" in p and "alpha-engine-eod-pipeline" in p for p in result["problems"])
+
+
+def test_unhealthy_lambda_alerts():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client(state="Failed")
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any("not Active" in p for p in result["problems"])
+
+
+def test_repeat_problem_is_suppressed_not_realerted():
+    events = _make_events_client(rule_missing=True)
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    fingerprint = index._problem_fingerprint([f"EventBridge rule '{index.RULE_NAME}' does NOT EXIST"])
+    s3 = _make_s3_client(existing_fingerprint=fingerprint)
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert result["alerted"] is False  # same problem as last time — suppressed
+    _telegram_mod.send_message.assert_not_called()
+
+
+def test_dedup_state_cleared_once_healthy_again():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client(existing_fingerprint="stale-fingerprint-from-a-past-problem")
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        index.handler({}, None)
+    s3.put_object.assert_called_once()
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    assert written["fingerprint"] is None
+
+
+def _sibling_dispatcher_pipeline_names() -> set[str]:
+    """Parse the SF names registered in the sibling saturday-sf-watch-dispatcher
+    Lambda's own PIPELINES dict — the source of truth this probe must mirror."""
+    import re
+
+    path = Path(__file__).parent.parent / "saturday-sf-watch-dispatcher" / "index.py"
+    text = path.read_text()
+    start = text.index("PIPELINES: dict")
+    end = text.index("\n}\n", start)
+    block = text[start:end]
+    return set(re.findall(r'^\s*"([\w.-]+)":\s*\{', block, re.M))
+
+
+def test_expected_pipeline_names_in_lockstep_with_dispatcher_registry():
+    """REGRESSION GUARD: this probe's EXPECTED_PIPELINE_NAMES must exactly match
+    the sibling saturday-sf-watch-dispatcher's own PIPELINES registry — drift
+    here would mean the liveness probe silently checks a stale set of pipelines
+    (missing a newly-added one, or false-alarming on a removed one), which is
+    the exact class of silent drift this probe exists to catch elsewhere."""
+    sibling = _sibling_dispatcher_pipeline_names()
+    mine = set(index.EXPECTED_PIPELINE_NAMES)
+    assert mine == sibling, (
+        f"EXPECTED_PIPELINE_NAMES drifted from saturday-sf-watch-dispatcher's "
+        f"PIPELINES registry — only-here: {sorted(mine - sibling)}, "
+        f"only-there: {sorted(sibling - mine)}"
+    )
+
+
+def test_unexpected_error_is_not_swallowed():
+    """An error code OTHER than the specific 'does not exist' ones must
+    propagate — a broken probe should surface via the Lambda error metric,
+    not silently report 'all clean'."""
+    events = MagicMock()
+    events.describe_rule.side_effect = FakeClientError("ThrottlingException")
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        with pytest.raises(FakeClientError):
+            index.handler({}, None)


### PR DESCRIPTION
## Summary
Answers Brian's question: "how do we know the SF fleet is running properly? should we get a Telegram notification that SF fleet begins/ends/fails?"

Fleet-SF Watch (`saturday-sf-watch-dispatcher`) is event-driven — it only fires when a registered pipeline's SF reaches a terminal FAILED/TIMED_OUT/ABORTED status via EventBridge. There's no session to report a begin/end for, but more importantly: nothing currently notices if the **watcher's own wiring** silently breaks. That's exactly what happened on 2026-06-29 — the EventBridge rule pointed at a deleted SF ARN for an unknown period, and the Lambda's own `Errors` metric stayed at zero the whole time (it just never got invoked). A healthy-looking metric masked total silent death.

New `alpha-engine-sf-watch-liveness-probe` Lambda, mirroring the existing `groom-liveness-probe`'s silent-unless-broken pattern one layer up:
- EventBridge rule exists / `ENABLED` / targets the right Lambda
- Rule's registered `stateMachineArn` list matches the dispatcher's own `PIPELINES` registry (lockstep-tested against the sibling Lambda's source)
- Every registered pipeline's Step Function actually exists — the exact 2026-06-29 dead-ARN class, caught directly
- Dispatcher Lambda is `Active` + last update `Successful`
- Telegram alert ONLY on a genuine problem, deduplicated by content hash (not timestamp) so a standing issue doesn't re-ping every run — clears automatically once healthy again
- Fail-loud: any AWS error other than the specific "doesn't exist" codes propagates, so a broken probe surfaces via its own error metric instead of silently reporting clean

Twice-daily cadence (06:45/14:45 UTC), offset from groom-liveness-probe's schedule to avoid simultaneous invocation — not tied to any pipeline's own schedule.

## Test plan
- [x] `pytest infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py` — 11 passed: clean-environment no-alert, each individual wiring problem (dead rule, disabled rule, wrong target, missing/extra pipeline in rule pattern, dead SF ARN, unhealthy Lambda), dedup-suppression, dedup-clears-once-healthy, unexpected-error-propagates, and the cross-Lambda registry lockstep guard
- [ ] Live smoke test after merge: `bash deploy.sh --bootstrap` then `--smoke` to confirm a clean read against the real live wiring