### PR TITLE
feat(sf-watch): flip groom to has_listener=True — wired into resilience-agent charter

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -117,25 +117,21 @@ PIPELINES: dict[str, dict[str, object]] = {
     # Backlog groom dispatch (config#1472) — wraps the EC2-spot-via-SSM groom
     # dispatch in a Step Function purely for uniform observability (watch-log
     # artifact + silent Telegram record), replacing the bespoke external
-    # liveness-probe Lambda (data#556). `has_listener=False` (config#1535):
-    # `.github/workflows/sf-watch.yml`'s `types:` allowlist does NOT include
-    # `dispatch_event_type` below, so a groom failure gets full watch-log +
-    # Telegram coverage, but NO repository_dispatch fires and the notification
-    # copy says so honestly — it must NOT claim "autonomous fix ACTIVE" when no
-    # workflow is listening (config#1535, the exact bug this field fixes).
-    # Groom failures are almost always operational (spot capacity, SSM
-    # misfire) rather than a code defect, so wiring this into the SAME
-    # code-fix-via-PR resilience-agent charter the trading pipelines use needs
-    # its own deliberate autonomy-posture decision first (mirrors the still-open
-    # weekday/EOD soak-exit decision in config#1408) — tracked separately, not
-    # bundled into this SF-wrap. Flip to True ONLY once `groom-sf-failure` is
-    # actually added to sf-watch.yml's `types:` list.
+    # liveness-probe Lambda (data#556). `has_listener=True` (2026-07-01 follow-
+    # up to config#1535): `groom-sf-failure` is now in sf-watch.yml's `types:`
+    # allowlist and the charter (.github/sf-watch-prompt.md) has a dedicated
+    # groom guardrail (STEP 2.5 case 4) — classify-first (most groom failures
+    # are transient infra, not a code defect), plain rerun (no skip-flags, the
+    # groom SF has no multi-stage idempotency concern). Its kill-switch
+    # (/alpha-engine/groom_sf_watch/autonomous_merge_enabled) defaults `true`
+    # from day one — lower stakes than any trading pipeline since it touches no
+    # live capital, unlike weekday/EOD which soak PROPOSE-ONLY (config#1408).
     "alpha-engine-groom-dispatch": {
         "cadence_slug": "groom",
         "label": "Backlog Groom",
         "watch_prefix": "consolidated/groom_sf_watch",
         "dispatch_event_type": "groom-sf-failure",
-        "has_listener": False,
+        "has_listener": True,
     },
 }
 SCHEMA_VERSION = 1

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -367,11 +367,73 @@ def test_pat_never_appears_in_result(monkeypatch):
     assert "ghp_SECRET_TOKEN" not in json.dumps(result)
 
 
-def test_groom_failure_never_dispatches_even_when_globally_enabled(monkeypatch):
-    """config#1535 regression guard: groom has has_listener=False, so even with
-    the global AGENT_DISPATCH_ENABLED kill-switch on, no repository_dispatch
-    fires for it — no workflow listens for `groom-sf-failure` yet, so firing
-    one would be a wasted call misrepresented as real remediation."""
+def test_groom_failure_dispatches_when_enabled(monkeypatch):
+    """2026-07-01 (config#1535 follow-up): groom flipped to has_listener=True
+    once `groom-sf-failure` was added to sf-watch.yml's `types:` allowlist and
+    the charter gained a dedicated groom guardrail — it now dispatches exactly
+    like the trading pipelines when the global flag is on."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    sent = {}
+
+    def fake_urlopen(req, timeout=None):
+        sent["data"] = json.loads(req.data)
+        return _FakeResp()
+
+    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
+    assert result["agent_dispatch"] == {
+        "dispatched": True, "status_code": 204, "event_type": "groom-sf-failure",
+    }
+    assert result["action"] == "dispatched"
+    assert sent["data"]["event_type"] == "groom-sf-failure"
+    assert sent["data"]["client_payload"]["cadence_slug"] == "groom"
+
+
+def test_groom_telegram_claims_autonomous_fix_when_dispatched(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
+    text = _telegram_mod.send_message.call_args.args[0]
+    assert "Fleet-SF Watch — AUTO-FIX" in text
+    assert "Backlog Groom SF: FAILED" in text
+    assert "autonomous fix ACTIVE" in text
+
+
+def test_groom_watch_log_records_has_listener_true(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, _, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    event = written["events"][-1]
+    assert event["has_listener"] is True
+    assert event["action"] == "dispatch"
+    assert event["agent_dispatch_enabled"] is True
+
+
+def test_no_listener_pipeline_never_dispatches_even_when_globally_enabled(monkeypatch):
+    """Regression guard for the has_listener MECHANISM itself (config#1535):
+    a pipeline registered with has_listener=False must never fire a
+    repository_dispatch nor claim "autonomous fix ACTIVE", regardless of the
+    global kill-switch — exercised here via a synthetic entry now that groom
+    (the original motivating case) has flipped to True."""
+    fake_pipelines = dict(index.PIPELINES)
+    fake_pipelines["some-other-pipeline"] = {
+        "cadence_slug": "other",
+        "label": "Some Other Pipeline",
+        "watch_prefix": "consolidated/other_sf_watch",
+        "dispatch_event_type": "other-sf-failure",
+        "has_listener": False,
+    }
+    monkeypatch.setattr(index, "PIPELINES", fake_pipelines)
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
     fired = {"called": False}
@@ -383,41 +445,14 @@ def test_groom_failure_never_dispatches_even_when_globally_enabled(monkeypatch):
     monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
     factory, _, _ = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
-        result = index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
+        result = index.handler(_event("FAILED", sm_arn=UNREGISTERED_ARN), None)
     assert result["agent_dispatch"] == {"dispatched": False, "reason": "no_listener"}
     assert result["action"] == "observe"
-    assert fired["called"] is False  # no HTTP call attempted at all
-
-
-def test_groom_telegram_never_claims_autonomous_fix(monkeypatch):
-    """The Telegram receipt must say 'observe-only for this pipeline', never
-    'autonomous fix ACTIVE', even with the global flag on — the 2026-07-01
-    bug this fixes was exactly this false claim for groom."""
-    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
-    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
-    factory, _, _ = _make_clients()
-    with patch("index.boto3.client", side_effect=factory):
-        index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
+    assert fired["called"] is False
     text = _telegram_mod.send_message.call_args.args[0]
     assert "Fleet-SF Watch — OBSERVE" in text
-    assert "Backlog Groom SF: FAILED" in text
     assert "autonomous fix ACTIVE" not in text
     assert "observe-only for this pipeline" in text
-
-
-def test_groom_watch_log_records_has_listener_false(monkeypatch):
-    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
-    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
-    factory, _, s3 = _make_clients()
-    with patch("index.boto3.client", side_effect=factory):
-        index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
-    written = json.loads(s3.put_object.call_args.kwargs["Body"])
-    event = written["events"][-1]
-    assert event["has_listener"] is False
-    assert event["action"] == "observe"
-    assert event["agent_dispatch_enabled"] is True  # global flag recorded as-is, for audit
 
 
 def test_saturday_still_dispatches_normally_alongside_groom_fix(monkeypatch):


### PR DESCRIPTION
## Summary
Companion to `alpha-engine-config#1546` (adds `groom-sf-failure` to `sf-watch.yml`'s `types:` allowlist + a dedicated charter guardrail for groom's simpler, lower-stakes failure mode).

Flips `alpha-engine-groom-dispatch`'s `has_listener` from `False` to `True` in the `PIPELINES` registry — groom SF failures now fire a real `repository_dispatch` and get the same diagnose→fix→merge→rerun treatment as the trading pipelines, gated by the new `/alpha-engine/groom_sf_watch/autonomous_merge_enabled` kill-switch (created live, default `true` — lower stakes than trading since no live capital is touched).

## Test plan
- [x] `pytest infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py` — 27 passed. Replaced the 3 "groom never dispatches" tests (now stale — groom DOES dispatch) with: groom dispatches when enabled, Telegram claims AUTO-FIX correctly, watch-log records `has_listener=true`/`action=dispatch`. Added a new test preserving regression coverage of the `has_listener=False` code path itself via a synthetic pipeline entry (so that mechanism stays tested now that groom is no longer the example).
- [x] `pytest infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py` — 11 passed, unaffected (only checks pipeline names, not `has_listener`)