### PR TITLE
fix(eod-sf): refresh executor checkout to origin/main before drift-guarded reconcile

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -391,7 +391,7 @@
     },
     "EODReconcile": {
       "Type": "Task",
-      "Comment": "Run EOD reconciliation on trading EC2 — reads closes from ArcticDB + state from S3 snapshot (no live IB), computes P&L, sends email. pipefail surfaces python crashes that tee would otherwise mask.",
+      "Comment": "Run EOD reconciliation on trading EC2 — reads closes from ArcticDB + state from S3 snapshot (no live IB), computes P&L, sends email. pipefail surfaces python crashes that tee would otherwise mask. Refreshes the executor checkout to origin/main via the canonical boot-pull.sh BEFORE running eod_reconcile.py: the trading instance boot-pulls once each morning (boot-pull.service, ~6:10 AM PT), but executor PRs that merge during the trading day leave the checkout stale by EOD, so eod_reconcile.py's ExecutorPreflight deploy-drift guard hard-fails (2026-06-30 incident: 3 executor PRs merged 08:07–08:54 PT after the morning boot-pull; EOD refused on b7e52b1 vs main@8c3014e). Refreshing here makes reconcile run latest main by construction. boot-pull is run as ec2-user (matching boot-pull.service User=ec2-user + the ec2-user-owned checkout / ~/.netrc); the root-side eod_reconcile.py already reads HEAD via a safe.directory workaround. FAIL-LOUD PRESERVED: the drift guard remains the authoritative gate — if boot-pull fails (auth/network), the checkout stays stale and eod_reconcile.py hard-fails with its actionable message (the `|| echo` only surfaces a breadcrumb; it does not swallow — the guard downstream is loud).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -400,6 +400,7 @@
           "commands": [
             "set -o pipefail",
             "cd /home/ec2-user/alpha-engine",
+            "sudo -u ec2-user -H bash /home/ec2-user/alpha-engine/infrastructure/boot-pull.sh > /var/log/eod-bootpull.log 2>&1 || echo '[eod-preflight] boot-pull deploy refresh returned non-zero; eod_reconcile deploy-drift guard will surface any staleness LOUD'",
             "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "export ALPHA_ENGINE_DEPLOYED=1",
             "export FLOW_DOCTOR_ENABLED=1",
@@ -407,11 +408,11 @@
             "trap 'aws s3 cp /var/log/eod.log \"s3://alpha-engine-research/_ssm_logs/eod/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python executor/eod_reconcile.py 2>&1 | tee /var/log/eod.log"
           ],
-          "executionTimeout": ["120"]
+          "executionTimeout": ["600"]
         },
-        "TimeoutSeconds": 120
+        "TimeoutSeconds": 600
       },
-      "TimeoutSeconds": 180,
+      "TimeoutSeconds": 660,
       "Retry": [
         {
           "ErrorEquals": ["States.TaskFailed"],

--- a/tests/test_sf_eod_deploy_refresh_wiring.py
+++ b/tests/test_sf_eod_deploy_refresh_wiring.py
@@ -1,0 +1,104 @@
+"""Pins the EOD-SF deploy-refresh-before-reconcile invariant.
+
+Incident (2026-06-30 EOD, run for 2026-06-30 executed 2026-07-01): the
+``ne-postclose-trading-pipeline`` EOD reconcile hard-failed at
+``executor/preflight.py::check_deploy_drift`` — the trading instance's
+crucible-executor checkout was on ``b7e52b1`` (what the ~6:10 AM PT
+``boot-pull.service`` correctly pulled) while ``origin/main`` had advanced
+to ``8c3014e``. Three executor PRs (#319/#317/#318) merged 08:07–08:54 PT,
+*hours after* the morning boot-pull. The trading instance is long-lived
+(boots in the morning, trades all day, EOD-reconciles on the same box),
+so the checkout only refreshes once per day at boot; any executor PR that
+merges during the trading day leaves EOD reconcile on stale code and the
+(correct, fail-loud) drift guard refuses to reconcile NAV.
+
+Root-cause fix at the correct layer: the EOD pipeline must bring the
+executor checkout to ``origin/main`` **before** the drift-guarded
+``eod_reconcile.py``, using the canonical, tested refresh path
+(``infrastructure/boot-pull.sh`` — the same script ``boot-pull.service``
+runs, and the exact recovery the drift-guard message itself prescribes).
+This makes EOD reconcile run latest ``main`` by construction and closes
+the intraday-merge window structurally.
+
+Two load-bearing details this test pins so the fix cannot silently rot:
+
+1. The refresh must run **as ``ec2-user``** (``sudo -u ec2-user``). SSM
+   ``AWS-RunShellScript`` runs as root, but ``boot-pull.service`` is
+   ``User=ec2-user`` and the checkout + ``~/.netrc`` are ec2-user-owned;
+   boot-pull.sh has no ``safe.directory``/``sudo`` shim, so a root
+   invocation would trip git's dubious-ownership guard (CVE-2022-24765).
+
+2. The refresh must appear **before** ``eod_reconcile.py`` in the command
+   array — refreshing after the reconcile would be pointless.
+
+FAIL-LOUD is preserved and asserted elsewhere: the drift guard remains the
+authoritative gate; this step only removes the *false-positive* staleness
+that an intraday merge injects. If boot-pull itself fails, the checkout
+stays stale and ``eod_reconcile.py`` hard-fails LOUD — this test does not
+weaken that.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_eod.json"
+
+
+@pytest.fixture(scope="module")
+def eod_commands() -> list[str]:
+    doc = json.loads(_SF_PATH.read_text())
+    return doc["States"]["EODReconcile"]["Parameters"]["Parameters"]["commands"]
+
+
+def _index_of(cmds: list[str], needle: str) -> int:
+    return next((i for i, c in enumerate(cmds) if needle in c), -1)
+
+
+class TestDeployRefreshBeforeReconcile:
+    def test_boot_pull_refresh_present(self, eod_commands):
+        idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
+        assert idx != -1, (
+            "EODReconcile must refresh the executor checkout via "
+            "infrastructure/boot-pull.sh before running eod_reconcile.py — "
+            "otherwise an executor PR merged during the trading day leaves "
+            "the checkout stale and the deploy-drift guard hard-fails "
+            "(2026-06-30 incident)."
+        )
+
+    def test_refresh_runs_as_ec2_user(self, eod_commands):
+        idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
+        assert idx != -1
+        line = eod_commands[idx]
+        assert "sudo -u ec2-user" in line, (
+            "boot-pull.sh must run as ec2-user (matching boot-pull.service "
+            "User=ec2-user and the ec2-user-owned checkout/~/.netrc). SSM "
+            "runs as root; a root git fetch/reset on the ec2-user-owned "
+            "checkout trips git's dubious-ownership guard (CVE-2022-24765)."
+        )
+
+    def test_refresh_precedes_reconcile(self, eod_commands):
+        refresh_idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
+        reconcile_idx = _index_of(eod_commands, "executor/eod_reconcile.py")
+        assert refresh_idx != -1 and reconcile_idx != -1
+        assert refresh_idx < reconcile_idx, (
+            "The deploy refresh must run BEFORE eod_reconcile.py — "
+            "refreshing after the reconcile is a no-op."
+        )
+
+    def test_pipefail_still_first(self, eod_commands):
+        # The refresh insertion must not displace `set -o pipefail` from
+        # the first slot (test_sf_ssm_pipefail_wiring pins this too; belt
+        # and suspenders so the two invariants can't drift apart).
+        assert eod_commands[0].startswith("set ") and "pipefail" in eod_commands[0]
+
+    def test_refresh_does_not_swallow_via_tee(self, eod_commands):
+        # The refresh line must not introduce a competing `| tee` work
+        # line (that would confuse the S3-log-ship guard, which keys off
+        # the first tee'd logfile). It writes to its own file via `>`.
+        idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
+        assert "| tee " not in eod_commands[idx]


### PR DESCRIPTION
> **PROPOSE-ONLY / DRAFT** — opened by Fleet-SF Watch for the 2026-06-30 EOD failure.
> The `eod` kill-switch (`/alpha-engine/eod_sf_watch/autonomous_merge_enabled`) is `false`
> (EOD soak), so this is **not** auto-merged and the SF was **not** rerun. Needs Brian's review + the
> operational recovery below.

## (a) Root cause
`ne-postclose-trading-pipeline` (run_date 2026-06-30, executed 2026-07-01 20:15Z) failed at
`FailExecution`, but the **true** failure is upstream at `EODReconcile → CheckEODStatus → EODStatusError`:
`executor/eod_reconcile.py` hard-failed in `ExecutorPreflight.check_deploy_drift`:

```
RuntimeError: Deploy drift: executor checkout at /home/ec2-user/alpha-engine is on b7e52b1869e2
but nousergon/crucible-executor@main is now at 8c3014e9b6e1. boot-pull.service did not advance
the checkout ... Refusing to proceed — running stale code on new signals is how 2026-04-20 happened.
```

The guard is **correct and fail-loud** — it refused to reconcile NAV on stale code. Reconcile never
ran (died at preflight) → **no NAV was written, no double-reconcile risk.**

**Why the checkout was stale (not a boot-pull failure):**
- Instance checkout: `b7e52b1` (#316, merged **06-30 15:43 PT**) — exactly what the **07-01 6:10 AM PT**
  `boot-pull.service` pulled.
- `origin/main` = `8c3014e`, because `#319`/`#317`/`#318` merged **07-01 08:07–08:54 PT** — *2+ hours
  after* the morning boot-pull.

The long-lived trading instance boots once each morning, pulls executor code, trades all day, and
EOD-reconciles on the same box. The EOD pipeline has **no code-refresh step**, so *any* executor PR
that merges during the trading day leaves EOD reconcile on stale code and the drift guard (correctly)
refuses. This is a structural orchestration gap, not a transient and not a boot-pull defect.

## (b) The fix and why it is correct at this layer
The EOD pipeline now refreshes the executor checkout to `origin/main` via the **canonical
`infrastructure/boot-pull.sh`** — the same script `boot-pull.service` runs and the exact recovery the
drift-guard message prescribes — **before** the drift-guarded `eod_reconcile.py`. EOD reconcile now
runs latest `main` by construction, closing the intraday-merge window structurally rather than
patching a symptom or loosening the guard.

- Invoked **as `ec2-user`** (`sudo -u ec2-user -H`): SSM `AWS-RunShellScript` runs as **root**, but
  `boot-pull.service` is `User=ec2-user` and the checkout + `~/.netrc` are ec2-user-owned; boot-pull.sh
  has no `safe.directory` shim, so a root `git fetch/reset` would trip git's dubious-ownership guard
  (CVE-2022-24765). The root-side `eod_reconcile.py` already reads HEAD via its own `safe.directory`
  workaround, so it still validates correctly.
- `executionTimeout` 120→600s (SF `TimeoutSeconds` 180→660) to cover the pull.
- Smallest change on the correct layer: the refresh lives in the EODReconcile step (where freshness is
  required and the guard lives). PostMarket/Snapshot have no drift guard; refreshing the whole pipeline
  is a broader, riskier change tracked separately (see residual follow-up).

## (c) Guard that now covers this class
`tests/test_sf_eod_deploy_refresh_wiring.py` — pins that `EODReconcile` runs `boot-pull.sh` (as
`ec2-user`) **before** `eod_reconcile.py`, and that the refresh doesn't displace `pipefail` or
introduce a competing `| tee` work line. Passing locally alongside the full SF-definition guard set
(pipefail / skipgate / payload-uniqueness / poll-resultselector / invocationdoesnotexist-retry /
mutex / substrate — 169 pure-JSON guards green).

## (d) Fail-loud rationale (error-handling touched)
The drift guard **remains the authoritative gate**. This change removes only the *false-positive*
staleness an intraday merge injects; it does **not** wrap, catch, retry-to-pass, or widen any failure.
If boot-pull itself fails (auth/network), the checkout stays stale and `eod_reconcile.py` hard-fails
LOUD with its actionable message. The trailing `|| echo` surfaces a breadcrumb in SSM stdout — it is
non-fatal (boot-pull is not the exit-code-determining last command) and it does **not** swallow: the
downstream drift guard is the loud backstop.

## Operational recovery (Brian — needs SSM to the trading instance; the watch role cannot)
A naive SF rerun will **fail identically** — the instance is still on `b7e52b1` and nothing has
advanced it. To recover **before** this fix deploys:
1. On `i-018eb3307a21329bf`: `sudo -u ec2-user bash /home/ec2-user/alpha-engine/infrastructure/boot-pull.sh`
   (or `git -C /home/ec2-user/alpha-engine fetch && git -C ... reset --hard origin/main` + `pip install`).
2. Rerun EOD from `EODReconcile` with the already-completed states skipped (idempotent — no re-reconcile):
   ```json
   {"trading_instance_id":["i-018eb3307a21329bf"],"ec2_instance_id":["i-09b539c844515d549"],
    "sns_topic_arn":"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts","run_date":"2026-06-30",
    "triggered_by":"watch_recovery","pipeline_role":"eod",
    "skip_post_market_data":true,"skip_post_market_arctic_append":true,"skip_capture_snapshot":true}
   ```
   `start-execution` on `arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline`
   (a FRESH execution with skip flags — **not** `redrive-execution`).

Once this PR deploys, the refresh is automatic and the rerun would succeed without step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)