### PR TITLE
fix(deploy): fix silently-dead canary-rollback alert (config#1545)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,21 +58,28 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       # The deploy.sh canary-rollback path publishes a dedup-keyed alert via
-      # `python3 -m alpha_engine_lib.alerts publish` (deploy.sh:153) so a
-      # rolled-back deploy isn't silent on the alert channel beyond the GHA
-      # red-icon. Without alpha-engine-lib installed in the runner Python,
-      # the alerts call fails with ModuleNotFoundError and the alert never
-      # publishes — the recurring failure mode L221 retrofit was designed
-      # to fix. Pinned to the same v0.26.0 ref as requirements.txt:18 so the
-      # CI alert path and the Lambda runtime path share a single source of
-      # truth on the lib version. No extras needed (alerts uses boto3/SNS,
-      # which is preinstalled on ubuntu-latest).
+      # `python3 -m krepis.alerts publish` so a rolled-back deploy isn't
+      # silent on the alert channel beyond the GHA red-icon. Without krepis
+      # installed in the runner Python, the alerts call fails with
+      # ModuleNotFoundError and the alert never publishes — the recurring
+      # failure mode L221 retrofit was designed to fix.
+      #
+      # FIXED 2026-07-01 (config#1545): this step previously installed the
+      # stale `alpha-engine-lib @ ...@v0.26.0` ref, which provides the
+      # `alpha_engine_lib` import name — but deploy.sh calls `krepis.alerts`
+      # (migrated from `nousergon_lib.alerts` at config#1339). Neither name
+      # matched what was actually installed, so this alert path had been
+      # silently dead (ModuleNotFoundError swallowed by `|| true`) since the
+      # nousergon_lib migration landed — the exact L221 failure mode this
+      # step exists to prevent. Pin matches requirements.txt's `krepis>=0.6.0`
+      # floor. No extras needed (alerts uses boto3/SNS, preinstalled on
+      # ubuntu-latest).
       - name: Set up Python for canary-rollback alert publish
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install alpha-engine-lib for deploy.sh alerts call
-        run: pip install "alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.26.0"
+      - name: Install krepis for deploy.sh alerts call
+        run: pip install "krepis>=0.6.0"
 
       - name: Deploy Phase 2 Lambda (alpha-engine-data-collector)
         working-directory: alpha-engine-data

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -153,7 +153,13 @@ if [ "$CANARY_STATUS" != "OK" ] && [ "$CANARY_STATUS" != "SKIPPED" ]; then
   # alert per (Lambda, version) — lib v0.24.0 substrate (L221
   # retrofit 2026-05-22). Best-effort; trailing || true never
   # overrides the deploy's exit 1.
-  python3 -m nousergon_lib.alerts publish \
+  # Target is krepis.alerts (config#1339/config#1545): alerts relocated to
+  # krepis at nousergon-lib v0.66.0, and the runner-side install this call
+  # depends on had drifted to a stale alpha-engine-lib@v0.26.0 pin whose
+  # import name (alpha_engine_lib) never matched this nousergon_lib call —
+  # the exact L221 alert this comment describes had been silently dead
+  # (ModuleNotFoundError swallowed by || true) since that pin went stale.
+  python3 -m krepis.alerts publish \
     --severity error \
     --source "alpha-engine-data/infrastructure/deploy.sh" \
     --dedup-key "canary-fail-${FUNCTION_NAME}-v${VERSION}" \


### PR DESCRIPTION
## Summary
- Found while auditing config#1545 (the crucible-predictor/crucible-evaluator `krepis.aws invoke-canary` `ModuleNotFoundError` incident, 2026-07-01) for other bare-GHA-runner project-package invocations.
- `deploy.sh`'s canary-rollback alert (the L221 independent-channel alert built after the #274 "10 silent rollbacks" retrospective) calls `python3 -m nousergon_lib.alerts publish`, but `deploy.yml`'s runner-side install step still installed the stale `alpha-engine-lib @ ...@v0.26.0` ref — providing the OLD `alpha_engine_lib` import name, which matches neither `nousergon_lib` nor the call actually made. Since the call is wrapped in `|| true` (best-effort, by design — it must never override the canary's own `exit 1`), this failure was completely silent: no CI red, no alert, nothing. The exact alerting this repo built to prevent silent rollbacks had itself gone silently dark.
- Fix: convert the call to `python3 -m krepis.alerts publish` (the CLI alpha-engine-research/predictor/evaluator have all converged on) and install `krepis>=0.6.0` on the runner (matches `requirements.txt`'s existing floor) instead of the stale pin.

## Test plan
- [x] `bash -n infrastructure/deploy.sh` — syntax check passes
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — valid YAML
- [x] No test in `tests/` references this alert call or the old/new lib pin (grepped, confirmed)
- [ ] CI green on this PR's push
- [ ] Next canary rollback on `main` (if any) actually publishes to the alert channel — not directly testable pre-merge since it only fires on canary failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)