### PR TITLE
fix(eod-sf): start + SSM-ready the trading instance before EOD sendCommands (re-runnability)

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -21,7 +21,7 @@
           "Next": "AcquireMutex"
         }
       ],
-      "Default": "CheckSkipPostMarketData"
+      "Default": "StartTradingInstance"
     },
     "AcquireMutex": {
       "Type": "Task",
@@ -50,17 +50,113 @@
         {
           "ErrorEquals": ["States.ALL"],
           "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block the EOD reconcile + instance-stop path. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability' carve-out, the primary deliverable (reconcile + stop trading EC2) survives a mutex-side failure. The error is captured in $.mutex_error for forensic review.",
-          "Next": "CheckSkipPostMarketData",
+          "Next": "StartTradingInstance",
           "ResultPath": "$.mutex_error"
         }
       ],
       "ResultPath": "$.mutex_result",
-      "Next": "CheckSkipPostMarketData"
+      "Next": "StartTradingInstance"
     },
     "MutexConflict": {
       "Type": "Fail",
       "Error": "MutexConflict",
       "Cause": "L274: another EOD execution with the same pipeline_role + start-minute already holds the mutex. Cost-guard note: the EOD SF's HandleFailure → ForceStopInstance chain is unreachable from a Fail state, but a duplicate EOD execution by definition means another EOD execution IS running the cost-guard path; the trading instance still gets stopped."
+    },
+    "StartTradingInstance": {
+      "Type": "Task",
+      "Comment": "Re-runnability guard (2026-06-30 incident). Ensure the long-lived trading instance is running + SSM-registered BEFORE any EOD ssm:sendCommand. The normal daemon-shutdown-triggered run enters with the box already up, but EOD's OWN terminal StopTradingInstance and failure-path ForceStopInstance both STOP it — so any operator recovery rerun after a prior failure lands on a stopped instance and the first sendCommand dies with Ssm.InvalidInstanceIdException (observed 2026-06-30 rerun watch-rerun-2026-06-30-1: EODReconcile sendCommand → 'Instances not in a valid state', instance i-018eb3307a21329bf stopped by the prior run's ForceStopInstance). ec2:startInstances is a no-op if already running, so this is safe on the normal path and makes the EOD pipeline idempotently re-runnable. Mirrors the daily/preopen StartExecutorEC2 → SSM-readiness poll (config#1430, the same InvalidInstanceIdException class on cold-boot).",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:startInstances",
+      "Parameters": {
+        "InstanceIds.$": "$.trading_instance_id"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.ec2_start_result",
+      "Next": "WaitForInstanceReady"
+    },
+    "WaitForInstanceReady": {
+      "Type": "Wait",
+      "Comment": "Initial settle before polling for SSM-agent registration. EC2 stopped→running takes ~15-25s; polling describeInstanceInformation any earlier just burns API calls.",
+      "Seconds": 15,
+      "Next": "InitSSMPollCounter"
+    },
+    "InitSSMPollCounter": {
+      "Type": "Pass",
+      "Comment": "Initialize attempts counter for the SSM-readiness poll loop.",
+      "Result": {"attempts": 0},
+      "ResultPath": "$.ssm_poll",
+      "Next": "DescribeInstanceInfo"
+    },
+    "DescribeInstanceInfo": {
+      "Type": "Task",
+      "Comment": "Poll SSM-agent registration on the trading instance until PingStatus=Online, so the first EOD ssm:sendCommand never fires against a stopped / not-yet-registered box (the Ssm.InvalidInstanceIdException failure mode). Mirrors the daily SF DescribeInstanceInfo (config#1430).",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:describeInstanceInformation",
+      "Parameters": {
+        "Filters": [
+          {"Key": "InstanceIds", "Values.$": "$.trading_instance_id"}
+        ]
+      },
+      "TimeoutSeconds": 15,
+      "Retry": [
+        {
+          "ErrorEquals": ["Ssm.SdkClientException", "States.Timeout"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.ssm_describe_result",
+      "Next": "SSMReadyChoice"
+    },
+    "SSMReadyChoice": {
+      "Type": "Choice",
+      "Comment": "PingStatus=Online → CheckSkipPostMarketData (enter the per-task rerun gates). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail to HandleFailure when the budget is exhausted (per feedback_no_silent_fails — the agent not registering after 3 min is a real boot problem, not just timing; HandleFailure notifies + ForceStopInstance releases the box). This NEVER silently skips EOD reconcile — an unreachable box fails the execution loud.",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus", "IsPresent": true},
+            {"Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus", "StringEquals": "Online"}
+          ],
+          "Next": "CheckSkipPostMarketData"
+        },
+        {
+          "Variable": "$.ssm_poll.attempts",
+          "NumericGreaterThanEquals": 12,
+          "Next": "HandleFailure"
+        }
+      ],
+      "Default": "WaitSSMPoll"
+    },
+    "WaitSSMPoll": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "IncrementSSMPoll"
+    },
+    "IncrementSSMPoll": {
+      "Type": "Pass",
+      "Parameters": {"attempts.$": "States.MathAdd($.ssm_poll.attempts, 1)"},
+      "ResultPath": "$.ssm_poll",
+      "Next": "DescribeInstanceInfo"
     },
     "PostMarketData": {
       "Type": "Task",

--- a/tests/test_sf_eod_instance_start_wiring.py
+++ b/tests/test_sf_eod_instance_start_wiring.py
@@ -1,0 +1,158 @@
+"""Pins the EOD SF re-runnability guard: the trading instance is started +
+SSM-registered BEFORE any post-market ssm:sendCommand.
+
+Origin — 2026-06-30 incident. `ne-postclose-trading-pipeline` failed at
+`EODReconcile` (deploy-drift guard, fixed in nousergon-data#574). The operator
+recovery rerun (`watch-rerun-2026-06-30-1`, with the correct skip flags) then
+died at the EODReconcile `ssm:sendCommand` with
+`Ssm.InvalidInstanceIdException: Instances not in a valid state` — because the
+trading instance `i-018eb3307a21329bf` was **stopped** by the *prior* run's
+terminal `ForceStopInstance`. The EOD SF assumed the daemon-shutdown trigger
+left the box running, but BOTH its success path (`StopTradingInstance`) and its
+failure path (`ForceStopInstance`) stop it, so *every* recovery rerun landed on
+a stopped instance and could never reach reconcile.
+
+Fix (this guard's target): insert a `StartTradingInstance` (`ec2:startInstances`,
+no-op if already running) → SSM-readiness poll (`describeInstanceInformation`
+until `PingStatus=Online`, bounded ~3 min, hard-fail to `HandleFailure` on
+budget exhaustion) block at the single post-mutex chokepoint, so all three
+entry paths ensure the box is up before the first SSM step. Mirrors the
+daily/preopen SF `StartExecutorEC2` → `SSMReadyChoice` pattern (config#1430,
+the same InvalidInstanceIdException-on-cold-box class).
+
+This test is the chokepoint that keeps the EOD SF re-runnable: it fails loudly
+if a future edit removes the start/poll block or reroutes the mutex paths past
+it (which would re-open the exact 2026-06-30 rerun failure).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_SF_PATH = Path(__file__).resolve().parent.parent / "infrastructure" / "step_function_eod.json"
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    return sf["States"]
+
+
+class TestEnsureRunningBlockShape:
+    def test_start_instance_state_shape(self, states):
+        st = states["StartTradingInstance"]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:ec2:startInstances"
+        # startInstances on the same instance-id list the SSM steps target — no
+        # hardcoded id, so it tracks $.trading_instance_id from the trigger.
+        assert st["Parameters"]["InstanceIds.$"] == "$.trading_instance_id"
+        # A start failure must fail the run, not silently proceed to a
+        # sendCommand against a down box.
+        catch_all = [c["Next"] for c in st.get("Catch", [])
+                     if "States.ALL" in c["ErrorEquals"]]
+        assert catch_all == ["HandleFailure"]
+        assert st["Next"] == "WaitForInstanceReady"
+
+    def test_describe_instance_info_polls_ssm_registration(self, states):
+        st = states["DescribeInstanceInfo"]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:ssm:describeInstanceInformation"
+        # Filter on the same instance-id list.
+        flt = st["Parameters"]["Filters"][0]
+        assert flt["Key"] == "InstanceIds"
+        assert flt["Values.$"] == "$.trading_instance_id"
+        catch_all = [c["Next"] for c in st.get("Catch", [])
+                     if "States.ALL" in c["ErrorEquals"]]
+        assert catch_all == ["HandleFailure"]
+
+    def test_poll_loop_increments_bounded_counter(self, states):
+        assert states["InitSSMPollCounter"]["Result"] == {"attempts": 0}
+        assert states["InitSSMPollCounter"]["ResultPath"] == "$.ssm_poll"
+        inc = states["IncrementSSMPoll"]
+        assert inc["Parameters"]["attempts.$"] == "States.MathAdd($.ssm_poll.attempts, 1)"
+        assert inc["ResultPath"] == "$.ssm_poll"
+        assert inc["Next"] == "DescribeInstanceInfo"
+        assert states["WaitSSMPoll"]["Type"] == "Wait"
+        assert states["WaitSSMPoll"]["Next"] == "IncrementSSMPoll"
+
+
+class TestSSMReadyChoiceFailLoud:
+    """The readiness gate must (a) advance to real work only when Online and
+    (b) HARD-FAIL on budget exhaustion — never silently skip EOD reconcile."""
+
+    def test_online_advances_to_first_work_gate(self, states):
+        ch = states["SSMReadyChoice"]
+        online = [c for c in ch["Choices"]
+                  if c.get("StringEquals") == "Online"
+                  or any(x.get("StringEquals") == "Online" for x in c.get("And", []))]
+        assert len(online) == 1
+        # The Online branch keys off PingStatus and lands on the rerun-gate chain.
+        cond = online[0]
+        variables = {x["Variable"] for x in cond["And"]}
+        assert variables == {
+            "$.ssm_describe_result.InstanceInformationList[0].PingStatus"
+        }
+        assert cond["Next"] == "CheckSkipPostMarketData"
+
+    def test_budget_exhaustion_hard_fails(self, states):
+        ch = states["SSMReadyChoice"]
+        budget = [c for c in ch["Choices"]
+                  if c.get("Variable") == "$.ssm_poll.attempts"]
+        assert len(budget) == 1, "no bounded-attempts branch on the readiness poll"
+        # Exhausted budget must route to the fail-loud handler, NOT to the work
+        # chain (that would run EOD against a possibly-down box, or skip it).
+        assert budget[0]["Next"] == "HandleFailure"
+        assert budget[0].get("NumericGreaterThanEquals", 0) >= 1
+        # And the default keeps looping (waits), it does not fall through to work.
+        assert ch["Default"] == "WaitSSMPoll"
+
+    def test_handle_failure_still_releases_the_instance(self, states):
+        # Fail-loud on an unready box must still hit the ForceStopInstance
+        # cost-guard so we never leak a running trading box on a failed EOD.
+        assert states["HandleFailure"]["Next"] == "ForceStopInstance"
+        assert states["ForceStopInstance"]["Resource"] == "arn:aws:states:::aws-sdk:ec2:stopInstances"
+
+
+class TestAllEntryPathsEnsureRunning:
+    """Every post-mutex entry must pass through StartTradingInstance so no
+    ssm:sendCommand can fire before the box is confirmed SSM-Online."""
+
+    def test_three_mutex_edges_route_to_start(self, states):
+        assert states["CheckMutexRole"]["Default"] == "StartTradingInstance"
+        assert states["AcquireMutex"]["Next"] == "StartTradingInstance"
+        failopen = [c["Next"] for c in states["AcquireMutex"]["Catch"]
+                    if "States.ALL" in c["ErrorEquals"]]
+        assert failopen == ["StartTradingInstance"]
+
+    def test_start_block_reaches_first_sendcommand_only_via_readiness(self, states):
+        """Static reachability: from StartTradingInstance, no ssm:sendCommand is
+        reachable without first passing SSMReadyChoice's Online branch."""
+        # Walk forward from StartTradingInstance following ONLY the non-failure
+        # edges; assert the first sendCommand state is preceded by SSMReadyChoice.
+        def send_command_states() -> set:
+            return {n for n, st in states.items()
+                    if "ssm:sendCommand" in str(st.get("Resource", ""))}
+
+        sends = send_command_states()
+        assert sends, "no ssm:sendCommand states found — fixture broken"
+
+        # BFS from StartTradingInstance over Next/Default/Choice edges (skip
+        # Catch→HandleFailure error edges). Any sendCommand reached must have
+        # SSMReadyChoice on every path — enforced simply by requiring the
+        # readiness gate to be the sole non-error successor bridge.
+        assert "SSMReadyChoice" in states
+        online_next = [c["Next"] for c in states["SSMReadyChoice"]["Choices"]
+                       if c.get("StringEquals") == "Online"
+                       or any(x.get("StringEquals") == "Online" for x in c.get("And", []))]
+        # The readiness gate is the ONLY edge from the start block into the work
+        # chain; its Online target must be a non-sendCommand gate (the skip
+        # gate), proving the box is confirmed ready before any sendCommand.
+        assert online_next == ["CheckSkipPostMarketData"]
+        assert "sendCommand" not in str(states["CheckSkipPostMarketData"].get("Resource", ""))

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -52,13 +52,21 @@ class TestGatePresenceAndShape:
 
 
 class TestEntryEdgesRouteThroughGates:
-    def test_mutex_paths_enter_post_market_gate(self, states):
-        # All three entries to PostMarketData now go through the gate.
-        assert states["CheckMutexRole"]["Default"] == "CheckSkipPostMarketData"
-        assert states["AcquireMutex"]["Next"] == "CheckSkipPostMarketData"
+    def test_mutex_paths_enter_instance_start_then_post_market_gate(self, states):
+        # 2026-06-30: all three post-mutex entries now go through the
+        # StartTradingInstance re-runnability guard first, which — once the box
+        # is SSM-Online — converges on the CheckSkipPostMarketData rerun-gate
+        # chain. (The ensure-running block is pinned in detail by
+        # test_sf_eod_instance_start_wiring.py.)
+        assert states["CheckMutexRole"]["Default"] == "StartTradingInstance"
+        assert states["AcquireMutex"]["Next"] == "StartTradingInstance"
         failopen = [c["Next"] for c in states["AcquireMutex"]["Catch"]
                     if "States.ALL" in c["ErrorEquals"]]
-        assert failopen == ["CheckSkipPostMarketData"]
+        assert failopen == ["StartTradingInstance"]
+        # The ensure-running block's SSM-ready path must land on the first gate.
+        online = [c["Next"] for c in states["SSMReadyChoice"]["Choices"]
+                  if any(x.get("StringEquals") == "Online" for x in c.get("And", []))]
+        assert online == ["CheckSkipPostMarketData"]
 
     def test_post_market_success_enters_arctic_append_gate(self, states):
         succ = [c["Next"] for c in states["CheckPostMarketStatus"]["Choices"]

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -77,11 +77,14 @@ CADENCE_ROLES = {"daily", "weekly", "eod", "shell-run"}
 FORMER_FIRST_STATE_BY_SF = {
     "saturday": ("step_function.json", "CheckShellRun"),
     "weekday": ("step_function_daily.json", "DeployDriftCheck"),
-    # L4607: the EOD SF's first post-mutex state is now the per-task rerun
-    # gate CheckSkipPostMarketData (whose Default runs PostMarketData), not
-    # PostMarketData directly. The mutex still routes to the pipeline's first
-    # work state — that state is just the skip-gate now.
-    "eod": ("step_function_eod.json", "CheckSkipPostMarketData"),
+    # 2026-06-30: the EOD SF's first post-mutex state is now the re-runnability
+    # guard StartTradingInstance (ec2:startInstances → SSM-readiness poll), which
+    # then flows into the CheckSkipPostMarketData rerun-gate chain. Inserted
+    # because an operator recovery rerun landed on a stopped instance (the prior
+    # run's ForceStopInstance) and the first ssm:sendCommand died with
+    # Ssm.InvalidInstanceIdException. The mutex still routes to the pipeline's
+    # first post-mutex work state — that state is just the ensure-running gate now.
+    "eod": ("step_function_eod.json", "StartTradingInstance"),
 }
 
 

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -458,6 +458,16 @@ class TestEODSFTopLevelFieldsClosed:
             "skip_capture_snapshot",
             "skip_eod_reconcile",
             "skip_daily_substrate_health_check",
+            # StartTradingInstance re-runnability guard (2026-06-30) —
+            # ec2:startInstances emits $.ec2_start_result; the SSM-readiness
+            # poll emits $.ssm_describe_result (describeInstanceInformation) and
+            # $.ssm_poll (bounded attempts counter). Ensures the box is up +
+            # SSM-Online before the first sendCommand, so an operator recovery
+            # rerun after the prior run's ForceStopInstance no longer dies with
+            # Ssm.InvalidInstanceIdException.
+            "ec2_start_result",
+            "ssm_describe_result",
+            "ssm_poll",
         }
     )
 


### PR DESCRIPTION
> **PROPOSE-ONLY / DRAFT** — opened by Fleet-SF Watch for the 2026-06-30 EOD
> recovery failure. The `eod` kill-switch
> (`/alpha-engine/eod_sf_watch/autonomous_merge_enabled`) is `false` (EOD soak),
> so this is **not** auto-merged and the SF was **not** rerun. Needs Brian's
> review + the operational recovery below.

## (a) Root cause
`ne-postclose-trading-pipeline` recovery rerun `watch-rerun-2026-06-30-1` failed at
`EODReconcile → HandleFailure → ForceStopInstance → FailExecution`. The true failure
is at the `EODReconcile` `ssm:sendCommand`:

```
Ssm.InvalidInstanceIdException: Instances not in a valid state for account
```

`force_stop_result` in the failure input shows `i-018eb3307a21329bf` was already
`stopped`. This is a **re-runnability defect**, not a transient:

- The EOD SF is a chain of `ssm:sendCommand`s to the long-lived trading instance.
- It has **no "start instance" step** — it assumes the `daemon_shutdown` trigger
  left the box running.
- But **both** its terminal path (`StopTradingInstance`) **and** its failure path
  (`ForceStopInstance`) **stop** the instance.
- So after *any* failure, the box is stopped, and **every** operator recovery
  rerun deterministically dies at the first `sendCommand` — exactly what happened
  here (the prior drift-guard failure's `ForceStopInstance` stopped the box; the
  rerun 3 min later couldn't reach it).

Reconcile never ran in either the original run (drift preflight, #574) or this
rerun (stopped box) → **no NAV was written for 2026-06-30, no double-reconcile risk.**

This is the **same InvalidInstanceIdException-on-not-ready-box class** the
daily/preopen SF already solved in config#1430 (2026-05-05 cold-boot race) — the
invariant "ensure the box is SSM-Online before the first sendCommand" was never
ported to EOD.

## (b) The fix and why it is correct at this layer
Insert a **`StartTradingInstance`** (`ec2:startInstances`, no-op if already
running) → **SSM-readiness poll** (`describeInstanceInformation` until
`PingStatus=Online`, bounded to ~3 min, hard-fail to `HandleFailure` on budget
exhaustion) block at the **single post-mutex chokepoint**. All three mutex entry
edges (`CheckMutexRole.Default`, `AcquireMutex.Next`, `AcquireMutex` fail-open
catch) now route through it before any SSM step. This:

- Mirrors the **daily/preopen** SF `StartExecutorEC2 → WaitForInstanceReady →
  DescribeInstanceInfo → SSMReadyChoice` pattern verbatim (institutional
  consistency; config#1430).
- Is safe on the **normal** path: starting an already-running box is a no-op, and
  the readiness poll passes on the first attempt.
- Makes the pipeline **idempotently re-runnable**: a recovery rerun now starts the
  box itself; no manual instance start required.
- Needs **no IAM change** — the SF role already grants `ec2:StartInstances` (on the
  trading-instance ARN) + `ssm:DescribeInstanceInformation`.
- Needs **no lib release / venv redeploy** — it is a pure SF-definition change.

## (c) Guard that now covers this failure class
`tests/test_sf_eod_instance_start_wiring.py` (new) pins: the start/poll block
shape; that **all three** post-mutex entries route through `StartTradingInstance`;
that the readiness gate advances to real work **only** when `PingStatus=Online`;
and that budget exhaustion **hard-fails** (never silently skips reconcile). Updated
`test_sf_mutex_wiring.py` + `test_sf_eod_skipgate_wiring.py` for the new
convergence, and registered the 3 new `$.` ResultPaths in the closed namespace
guard (`test_sf_payload_uniqueness.py`).

## (d) Fail-loud rationale
The readiness poll's budget-exhaustion branch routes to `HandleFailure` (→ SNS +
`ForceStopInstance` → `FailExecution`), **not** to the work chain. An instance that
never registers within ~3 min is a real boot problem and fails the execution loud;
nothing is swallowed or made quieter.

## Operational recovery (for Brian — after merge + deploy)
1. Merge this PR; wait for `deploy-infrastructure.yml` to land the updated live
   `ne-postclose-trading-pipeline` definition.
2. Start a **fresh** execution (NOT `redrive`) with the same skip set the operator
   already used (the 3 data steps completed in the original run; reconcile never
   ran, so it is a first reconcile — no double-reconcile):

   ```
   aws stepfunctions start-execution \
     --state-machine-arn arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline \
     --name watch-rerun-2026-06-30-2 \
     --input '{"trading_instance_id":["i-018eb3307a21329bf"],"ec2_instance_id":["i-09b539c844515d549"],"sns_topic_arn":"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts","run_date":"2026-06-30","triggered_by":"operator_recovery","pipeline_role":"operator-replay","skip_post_market_data":true,"skip_post_market_arctic_append":true,"skip_capture_snapshot":true}'
   ```

   With this fix deployed, the SF starts the box itself — no manual `boot-pull` /
   instance-start needed. (The #574 deploy-drift refresh still runs inside
   `EODReconcile`, so the box also lands on fresh executor code.)

## Residual class
Filed as a follow-up: lift "ensure the trading box is SSM-Online before the first
sendCommand" to a **generic cross-SF guard** so a future/other SF can't re-open the
class at site N+1 (this PR ports it to EOD concretely + adds an EOD-specific guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
