### PR TITLE
feat(infra): weekly-schedule-adjuster — holiday-aware weekly-SF run day

### DIFF
--- a/infrastructure/lambdas/weekly-schedule-adjuster/README.md
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/README.md
@@ -1,0 +1,72 @@
+# alpha-engine-weekly-schedule-adjuster
+
+Holds the weekly research Step Function (`ne-weekly-freshness-pipeline`) to the
+**day after the last NYSE trading day of the week**, so a trailing market
+holiday shifts the run *earlier* (never later).
+
+- **Normal weeks** → the run day is Saturday, and the CFN-owned
+  `alpha-engine-saturday` cron fires it as always. The adjuster does nothing but
+  ensure that cron is enabled + reap any spent one-shot.
+- **Trailing-holiday weeks** (Good Friday; a Friday-observed July‑4 / Christmas)
+  → the last trading day is Thursday, so the run shifts to **Friday**. The
+  adjuster disables `alpha-engine-saturday` for that week and stands up a
+  one-shot EventBridge rule (`alpha-engine-weekly-oneshot-YYYYMMDD`) that fires
+  the weekly SF once on the run day with a **byte-identical weekly input**.
+
+## Why a reconciler, not a daily gate
+
+The research inputs are trading-day-gated — they freeze at the last close, so
+running *later* in a market-closed weekend buys no freshness. Run as early as
+the last trading day's data has settled (T+1): Saturday normally, Friday on a
+trailing-holiday week.
+
+Crucially the reconciler is **fail-safe**: `alpha-engine-saturday` is the
+untouched baseline. If this Lambda never runs or errors, that cron stays in
+whatever state it was — a normal week leaves it ENABLED, so the weekly run still
+happens Saturday. **A broken adjuster degrades to the normal Saturday run, never
+a missed run.** (A daily "should I run today?" gate has the opposite, dangerous
+failure mode: a broken gate misses the week.) On the holiday branch the one-shot
+is created *before* the Saturday cron is disabled, so a mid-run failure also
+leaves Saturday firing.
+
+## Trigger
+
+Weekly EventBridge tick — **Wed 06:00 UTC** (`cron(0 6 ? * WED *)`), mid-week so
+a holiday shift is in place days before the weekend. Idempotent: safe to run any
+number of times per week.
+
+## Deploy (operator-run, outside CloudFormation)
+
+```bash
+bash infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh --dry-run    # preview
+bash infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh --bootstrap  # first-time: role + fn + weekly tick
+bash infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh              # code update only
+```
+
+After the first `--bootstrap`, verify on the next Wednesday via CloudWatch Logs
+(`/aws/lambda/alpha-engine-weekly-schedule-adjuster`): a normal week logs
+`acted=normal`; the next holiday week logs `acted=holiday_shift` with the
+one-shot name.
+
+## IAM (`iam-policy.json`)
+
+- `events:EnableRule`/`DisableRule` on `alpha-engine-saturday` only.
+- `events:PutRule`/`PutTargets`/`RemoveTargets`/`DeleteRule` on
+  `alpha-engine-weekly-oneshot-*` only.
+- `events:ListRules`/`ListTargetsByRule`/`DescribeRule` (read, reconcile).
+- `iam:PassRole` on `alpha-engine-eventbridge-sfn-role` (attached to the
+  one-shot's SF target), constrained to `events.amazonaws.com`.
+
+## Relationship to `run_weekly_offcycle.sh`
+
+This Lambda automates, on the NYSE calendar, exactly what
+`run_weekly_offcycle.sh` does by hand (disable the Saturday cron + schedule a
+run + restore). The offcycle script remains the manual break-glass path.
+
+## Interaction note
+
+`alpha-engine-saturday` is CFN-owned (`alpha-engine-orchestration.yaml`,
+`State: ENABLED`). If that stack redeploys mid-holiday-week it will re-enable the
+cron, which would double-fire alongside the one-shot (mutex-protected, low
+probability over a holiday weekend). The next Wednesday reconcile re-asserts the
+correct state regardless.

--- a/infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-weekly-schedule-adjuster Lambda
+# and its weekly EventBridge tick.
+#
+# The Lambda runs mid-week (Wed 06:00 UTC) and reconciles the LIVE weekly-run
+# schedule to the NYSE calendar for the current week's weekend: normal weeks
+# leave the CFN-owned alpha-engine-saturday cron ENABLED; trailing-holiday
+# weeks (Good Friday; Friday-observed July-4/Christmas) DISABLE it and stand up
+# a one-shot rule on the earlier run day (the day after the week's last trading
+# session). Fail-safe: a broken adjuster degrades to the normal Saturday run,
+# never a missed run (see index.py header).
+#
+# Managed OUTSIDE CloudFormation — same rationale as the sibling event Lambdas
+# (eod-success-friday-shell-trigger, sf-telegram-notifier, spot-orphan-reaper):
+# keeps the github-actions-lambda-deploy OIDC role's blast radius narrow.
+#
+# Usage:
+#   bash infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh             # update code only
+#   bash infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh --bootstrap # first-time create + wire the weekly tick
+#   bash infrastructure/lambdas/weekly-schedule-adjuster/deploy.sh --dry-run   # show actions, do not apply
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-weekly-schedule-adjuster"
+ROLE_NAME="alpha-engine-weekly-schedule-adjuster-role"
+POLICY_NAME="alpha-engine-weekly-schedule-adjuster-policy"
+RULE_NAME="alpha-engine-weekly-schedule-adjuster"
+# Wednesday 06:00 UTC — mid-week, well before the Fri/Sat weekend run so a
+# holiday-shift is in place with days to spare.
+SCHEDULE_EXPR="cron(0 6 ? * WED *)"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+
+# ----- 0. Validate handler + run unit tests ---------------------------------
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
+      --zip-file "fileb://${ZIP}" --timeout 60 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  echo "  Creating weekly EventBridge tick: ${RULE_NAME} (${SCHEDULE_EXPR})"
+  run aws events put-rule --name "${RULE_NAME}" --schedule-expression "${SCHEDULE_EXPR}" \
+    --state ENABLED --description "Weekly reconcile of the holiday-shifted weekly-SF run day" \
+    --region "${REGION}" --query 'RuleArn' --output text
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" --action lambda:InvokeFunction \
+    --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code (always, idempotent) -------------------------
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"; fi
+echo "✓ Code deployed."

--- a/infrastructure/lambdas/weekly-schedule-adjuster/iam-policy.json
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/iam-policy.json
@@ -1,0 +1,47 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-weekly-schedule-adjuster:*"
+    },
+    {
+      "Sid": "ListRulesForReconcile",
+      "Effect": "Allow",
+      "Action": ["events:ListRules", "events:ListTargetsByRule", "events:DescribeRule"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ToggleSaturdayCron",
+      "Effect": "Allow",
+      "Action": ["events:EnableRule", "events:DisableRule"],
+      "Resource": "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-saturday"
+    },
+    {
+      "Sid": "ManageWeeklyOneShots",
+      "Effect": "Allow",
+      "Action": [
+        "events:PutRule",
+        "events:PutTargets",
+        "events:RemoveTargets",
+        "events:DeleteRule"
+      ],
+      "Resource": "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-weekly-oneshot-*"
+    },
+    {
+      "Sid": "PassSfnTargetRoleToOneShot",
+      "Effect": "Allow",
+      "Action": ["iam:PassRole"],
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-eventbridge-sfn-role",
+      "Condition": {
+        "StringEquals": {"iam:PassedToService": "events.amazonaws.com"}
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/weekly-schedule-adjuster/index.py
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/index.py
@@ -1,0 +1,226 @@
+"""alpha-engine-weekly-schedule-adjuster — hold the weekly research SF to the
+day AFTER the last NYSE trading day of the week.
+
+Normal weeks -> the Saturday cron (``alpha-engine-saturday``) fires as always.
+Trailing-holiday weeks (Good Friday; a Friday-observed July-4 / Christmas) ->
+the week's last trading day is Thursday, so the run shifts ONE DAY EARLIER to
+Friday: this reconciler disables the Saturday cron for that week and stands up
+a one-shot rule on the run day (byte-identical weekly input). Rationale: the
+research inputs are trading-day-gated (frozen at the last close), so running
+later in a market-closed weekend gains no freshness — run as early as the last
+trading day's data has settled (T+1), which is Saturday normally and Friday on
+a trailing-holiday week.
+
+WEEKLY RECONCILER, not a daily gate. Runs mid-week (Wed) and reconciles the
+LIVE schedule to the calendar for the CURRENT week's weekend:
+
+  * ``run_day == Saturday``  -> ensure Saturday cron ENABLED + drop stale one-shots
+  * ``run_day  < Saturday``  -> ensure Saturday cron DISABLED + one-shot on run_day
+
+FAIL-SAFE (the whole point of a reconciler over a gate): the Saturday cron is
+the UNTOUCHED baseline. If this Lambda never runs, or errors, the Saturday cron
+stays in whatever state it was — a normal week leaves it ENABLED, so the weekly
+run STILL happens Saturday. A broken adjuster degrades to the normal Saturday
+run, NEVER to a missed run. (A daily gate has the opposite failure mode: a
+broken gate = missed run.) On the holiday branch the one-shot is created BEFORE
+the Saturday cron is disabled, so a mid-run failure also leaves Saturday firing.
+
+Managed OUTSIDE CloudFormation (operator-deployed via deploy.sh) — same
+rationale as the sibling event Lambdas (eod-success-friday-shell-trigger,
+sf-telegram-notifier, spot-orphan-reaper): keeps the github-actions-lambda-deploy
+OIDC role's blast radius narrow.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime, timedelta, timezone
+
+import boto3
+
+from nousergon_lib.trading_calendar import is_trading_day
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
+
+SATURDAY_RULE = "alpha-engine-saturday"          # the normal weekly cron (CFN-owned)
+ONESHOT_PREFIX = "alpha-engine-weekly-oneshot-"  # <prefix>YYYYMMDD, created per holiday week
+SATURDAY_WEEKDAY = 5                              # date.weekday(): Mon=0 .. Sat=5
+
+WEEKLY_SF_ARN = (
+    f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"
+)
+SFN_TARGET_ROLE_ARN = os.environ.get(
+    "SFN_TARGET_ROLE_ARN",
+    f"arn:aws:iam::{ACCOUNT_ID}:role/alpha-engine-eventbridge-sfn-role",
+)
+TRADING_EC2_INSTANCE_ID = os.environ.get("TRADING_EC2_INSTANCE_ID", "i-09b539c844515d549")
+SNS_TOPIC_ARN = os.environ.get(
+    "SNS_TOPIC_ARN", f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts"
+)
+
+
+# ---------------------------------------------------------------------------
+# Calendar
+# ---------------------------------------------------------------------------
+def weekly_run_day(d: date) -> date:
+    """The day AFTER the last NYSE trading day of d's Mon–Sun week.
+
+    Walks back from Sunday to the week's last trading session, then +1 calendar
+    day. Normal weeks -> Saturday; a Friday-holiday week -> Friday; a
+    (hypothetical) Thu+Fri closure -> Thursday.
+    """
+    sunday = d + timedelta(days=6 - d.weekday())
+    probe = sunday
+    while not is_trading_day(probe):
+        probe -= timedelta(days=1)
+    return probe + timedelta(days=1)
+
+
+def _oneshot_name(run_day: date) -> str:
+    return f"{ONESHOT_PREFIX}{run_day.strftime('%Y%m%d')}"
+
+
+def _weekly_input() -> str:
+    # byte-shape identical to the Saturday cron's target Input
+    return (
+        "{\n"
+        f'  "ec2_instance_id": ["{TRADING_EC2_INSTANCE_ID}"],\n'
+        f'  "sns_topic_arn": "{SNS_TOPIC_ARN}",\n'
+        '  "pipeline_role": "weekly"\n'
+        "}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# EventBridge reconciliation helpers (idempotent)
+# ---------------------------------------------------------------------------
+def _rule_state(events, name: str) -> str | None:
+    try:
+        return events.describe_rule(Name=name)["State"]
+    except events.exceptions.ResourceNotFoundException:
+        return None
+
+
+def _ensure_saturday(events, *, enabled: bool) -> str:
+    state = _rule_state(events, SATURDAY_RULE)
+    want = "ENABLED" if enabled else "DISABLED"
+    if state is None:
+        # The CFN-owned rule is missing — do NOT create it here (CFN is SoT).
+        logger.warning("%s not found — cannot reconcile state to %s", SATURDAY_RULE, want)
+        return "missing"
+    if state == want:
+        return "already_" + want.lower()
+    if enabled:
+        events.enable_rule(Name=SATURDAY_RULE)
+    else:
+        events.disable_rule(Name=SATURDAY_RULE)
+    logger.info("%s: %s -> %s", SATURDAY_RULE, state, want)
+    return want.lower()
+
+
+def _ensure_oneshot(events, run_day: date) -> str:
+    """Create/refresh a one-shot rule that fires the weekly SF once on run_day."""
+    name = _oneshot_name(run_day)
+    # specific-date cron: cron(min hour day month ? year) fires exactly once
+    expr = f"cron(0 9 {run_day.day} {run_day.month} ? {run_day.year})"
+    events.put_rule(
+        Name=name,
+        ScheduleExpression=expr,
+        State="ENABLED",
+        Description=(
+            f"One-shot weekly SF on {run_day.isoformat()} 09:00 UTC "
+            f"(day after last trading day; {SATURDAY_RULE} suppressed this week). "
+            "Auto-managed by alpha-engine-weekly-schedule-adjuster; reaped after firing."
+        ),
+    )
+    events.put_targets(
+        Rule=name,
+        Targets=[
+            {
+                "Id": "weekly-oneshot",
+                "Arn": WEEKLY_SF_ARN,
+                "RoleArn": SFN_TARGET_ROLE_ARN,
+                "Input": _weekly_input(),
+            }
+        ],
+    )
+    logger.info("one-shot ready: %s (%s)", name, expr)
+    return name
+
+
+def _drop_stale_oneshots(events, today: date, keep: str | None) -> list[str]:
+    """Delete adjuster-created one-shot rules whose run date is strictly past."""
+    dropped: list[str] = []
+    paginator = events.get_paginator("list_rules")
+    for page in paginator.paginate(NamePrefix=ONESHOT_PREFIX):
+        for rule in page.get("Rules", []):
+            name = rule["Name"]
+            if name == keep:
+                continue
+            try:
+                run_day = datetime.strptime(name[len(ONESHOT_PREFIX):], "%Y%m%d").date()
+            except ValueError:
+                continue  # unrecognized suffix — leave it alone
+            if run_day >= today:
+                continue  # future/today one-shot (another holiday week) — keep
+            # remove targets then delete the rule
+            tids = [t["Id"] for t in events.list_targets_by_rule(Rule=name).get("Targets", [])]
+            if tids:
+                events.remove_targets(Rule=name, Ids=tids)
+            events.delete_rule(Name=name)
+            dropped.append(name)
+            logger.info("reaped stale one-shot: %s (ran %s)", name, run_day.isoformat())
+    return dropped
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+def _today(event: dict) -> date:
+    # EventBridge scheduled events carry ISO "time"; fall back to wall clock.
+    t = (event or {}).get("time")
+    if t:
+        return datetime.fromisoformat(t.replace("Z", "+00:00")).astimezone(timezone.utc).date()
+    return datetime.now(timezone.utc).date()
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    events = boto3.client("events", region_name=REGION)
+    today = _today(event)
+    run_day = weekly_run_day(today)
+
+    if run_day < today:
+        # Reconciler ran after this week's run day already passed — leave the
+        # baseline alone, just reap anything stale. (Shouldn't happen on a Wed tick.)
+        dropped = _drop_stale_oneshots(events, today, keep=None)
+        return {"acted": "past", "run_day": run_day.isoformat(), "reaped": dropped}
+
+    if run_day.weekday() == SATURDAY_WEEKDAY:
+        # Normal week — the CFN Saturday cron owns it. Ensure it's enabled
+        # (heals a prior holiday week's disable) and clean up spent one-shots.
+        sat = _ensure_saturday(events, enabled=True)
+        dropped = _drop_stale_oneshots(events, today, keep=None)
+        return {
+            "acted": "normal", "run_day": run_day.isoformat(),
+            "saturday": sat, "reaped": dropped,
+        }
+
+    # Trailing-holiday week — shift earlier. One-shot FIRST (fail-safe), then
+    # suppress the Saturday cron.
+    name = _ensure_oneshot(events, run_day)
+    sat = _ensure_saturday(events, enabled=False)
+    dropped = _drop_stale_oneshots(events, today, keep=name)
+    logger.info(
+        "HOLIDAY-SHIFT week: weekly SF -> %s (%s); %s disabled",
+        run_day.isoformat(), name, SATURDAY_RULE,
+    )
+    return {
+        "acted": "holiday_shift", "run_day": run_day.isoformat(),
+        "oneshot": name, "saturday": sat, "reaped": dropped,
+    }

--- a/infrastructure/lambdas/weekly-schedule-adjuster/requirements.txt
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/requirements.txt
@@ -1,0 +1,5 @@
+# Only nousergon_lib.trading_calendar (is_trading_day) is needed. Pinned to
+# alpha-engine-data's main lib pin so the NYSE-holiday calendar the adjuster
+# reasons over matches the rest of the fleet (avoids a divergent holiday set
+# deciding when the weekly run fires).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.77.0

--- a/infrastructure/lambdas/weekly-schedule-adjuster/test_handler.py
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/test_handler.py
@@ -1,0 +1,179 @@
+"""Unit tests for weekly-schedule-adjuster index.handler.
+
+Stubs ``nousergon_lib.trading_calendar.is_trading_day`` with a small NYSE
+calendar (July 2026 incl. the Fri 7/3 July-4-observed holiday) and a fake
+EventBridge client, so tests assert the reconcile decision + the exact
+enable/disable/one-shot actions without AWS or the lib.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+# NYSE calendar stub: 2026 weekdays are trading days EXCEPT the holidays below.
+_HOLIDAYS = {date(2026, 7, 3), date(2026, 12, 25), date(2026, 4, 3)}  # Jul4-obs, Xmas, Good Fri
+
+
+def _is_trading_day(d: date) -> bool:
+    return d.weekday() < 5 and d not in _HOLIDAYS
+
+
+_lib = types.ModuleType("nousergon_lib")
+_tc = types.ModuleType("nousergon_lib.trading_calendar")
+_tc.is_trading_day = _is_trading_day
+_lib.trading_calendar = _tc
+sys.modules.setdefault("nousergon_lib", _lib)
+sys.modules.setdefault("nousergon_lib.trading_calendar", _tc)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+
+class _FakeExc(Exception):
+    pass
+
+
+class _FakeEvents:
+    """Captures EventBridge calls; models alpha-engine-saturday + one-shots."""
+
+    class exceptions:  # noqa: N801 — mirror boto3 client.exceptions
+        ResourceNotFoundException = _FakeExc
+
+    def __init__(self, saturday_state="ENABLED", existing_oneshots=None):
+        self.saturday_state = saturday_state
+        self.rules = dict(existing_oneshots or {})  # name -> {"targets": [...]}
+        self.calls: list[tuple] = []
+
+    def describe_rule(self, Name):
+        self.calls.append(("describe", Name))
+        if Name == "alpha-engine-saturday":
+            return {"State": self.saturday_state}
+        if Name in self.rules:
+            return {"State": "ENABLED"}
+        raise self.exceptions.ResourceNotFoundException(Name)
+
+    def enable_rule(self, Name):
+        self.calls.append(("enable", Name)); self.saturday_state = "ENABLED"
+
+    def disable_rule(self, Name):
+        self.calls.append(("disable", Name)); self.saturday_state = "DISABLED"
+
+    def put_rule(self, Name, ScheduleExpression, State, Description):
+        self.calls.append(("put_rule", Name, ScheduleExpression))
+        self.rules.setdefault(Name, {"targets": []})
+
+    def put_targets(self, Rule, Targets):
+        self.calls.append(("put_targets", Rule, Targets[0]["Arn"], Targets[0]["RoleArn"]))
+        self.rules.setdefault(Rule, {})["targets"] = Targets
+
+    def list_targets_by_rule(self, Rule):
+        return {"Targets": self.rules.get(Rule, {}).get("targets", [])}
+
+    def remove_targets(self, Rule, Ids):
+        self.calls.append(("remove_targets", Rule))
+
+    def delete_rule(self, Name):
+        self.calls.append(("delete_rule", Name)); self.rules.pop(Name, None)
+
+    def get_paginator(self, _op):
+        rules = [{"Name": n} for n in self.rules if n.startswith(index.ONESHOT_PREFIX)]
+        fake = self
+
+        class _P:
+            def paginate(self, NamePrefix):
+                return [{"Rules": [r for r in rules if r["Name"].startswith(NamePrefix)]}]
+
+        return _P()
+
+
+@pytest.fixture
+def patch_client(monkeypatch):
+    holder = {}
+
+    def _factory(state="ENABLED", oneshots=None):
+        holder["c"] = _FakeEvents(state, oneshots)
+        monkeypatch.setattr(index.boto3, "client", lambda *a, **k: holder["c"])
+        return holder["c"]
+
+    return _factory
+
+
+def _ev(d: date) -> dict:
+    return {"time": f"{d.isoformat()}T06:00:00Z"}
+
+
+# --- calendar ---------------------------------------------------------------
+
+def test_weekly_run_day_normal_week_is_saturday():
+    # Wed 2026-07-08 -> last trading Fri 7/10 -> run Sat 7/11
+    assert index.weekly_run_day(date(2026, 7, 8)) == date(2026, 7, 11)
+
+
+def test_weekly_run_day_july4_week_is_friday():
+    # Wed 2026-07-01 -> Fri 7/3 holiday, last trading Thu 7/2 -> run Fri 7/3
+    assert index.weekly_run_day(date(2026, 7, 1)) == date(2026, 7, 3)
+
+
+def test_weekly_run_day_good_friday_and_christmas():
+    assert index.weekly_run_day(date(2026, 3, 31)) == date(2026, 4, 3)   # Good Friday
+    assert index.weekly_run_day(date(2026, 12, 23)) == date(2026, 12, 25)  # Christmas Fri
+
+
+# --- normal week ------------------------------------------------------------
+
+def test_normal_week_enables_saturday_no_oneshot(patch_client):
+    c = patch_client(state="ENABLED")
+    out = index.handler(_ev(date(2026, 7, 8)), None)
+    assert out["acted"] == "normal"
+    assert not any(k == "put_rule" for k in (call[0] for call in c.calls))
+    assert not any(k == "disable" for k in (call[0] for call in c.calls))
+
+
+def test_normal_week_heals_prior_disable(patch_client):
+    c = patch_client(state="DISABLED")  # left disabled by a prior holiday week
+    out = index.handler(_ev(date(2026, 7, 8)), None)
+    assert out["saturday"] == "enabled"
+    assert ("enable", "alpha-engine-saturday") in c.calls
+
+
+# --- holiday week -----------------------------------------------------------
+
+def test_holiday_week_creates_oneshot_then_disables_saturday(patch_client):
+    c = patch_client(state="ENABLED")
+    out = index.handler(_ev(date(2026, 7, 1)), None)
+    assert out["acted"] == "holiday_shift"
+    assert out["oneshot"] == "alpha-engine-weekly-oneshot-20260703"
+    kinds = [call[0] for call in c.calls]
+    # one-shot rule + target created BEFORE the Saturday disable (fail-safe order)
+    assert kinds.index("put_rule") < kinds.index("disable")
+    assert kinds.index("put_targets") < kinds.index("disable")
+    # one-shot targets the weekly SF via the sfn target role
+    pt = next(call for call in c.calls if call[0] == "put_targets")
+    assert pt[2].endswith("ne-weekly-freshness-pipeline")
+    assert pt[3].endswith("alpha-engine-eventbridge-sfn-role")
+
+
+def test_holiday_week_idempotent(patch_client):
+    # already adjusted: Saturday disabled + one-shot present -> no state churn
+    c = patch_client(state="DISABLED", oneshots={"alpha-engine-weekly-oneshot-20260703": {"targets": []}})
+    out = index.handler(_ev(date(2026, 7, 1)), None)
+    assert out["acted"] == "holiday_shift"
+    assert out["saturday"] == "already_disabled"  # no redundant disable call
+
+
+def test_normal_week_reaps_stale_oneshot(patch_client):
+    c = patch_client(state="ENABLED", oneshots={"alpha-engine-weekly-oneshot-20260703": {"targets": [{"Id": "x"}]}})
+    out = index.handler(_ev(date(2026, 7, 8)), None)  # after 7/3
+    assert "alpha-engine-weekly-oneshot-20260703" in out["reaped"]
+    assert ("delete_rule", "alpha-engine-weekly-oneshot-20260703") in c.calls
+
+
+def test_weekly_input_shape_matches_cron():
+    inp = index._weekly_input()
+    assert '"pipeline_role": "weekly"' in inp
+    assert '"ec2_instance_id": ["i-09b539c844515d549"]' in inp


### PR DESCRIPTION
## What
A small weekly **reconciler** Lambda that holds the weekly research SF to the **day after the last NYSE trading day of the week** — so a trailing market holiday shifts the run *earlier*, never later. (Automates on the calendar exactly what `run_weekly_offcycle.sh` does by hand.)

- **Normal weeks:** the CFN-owned `alpha-engine-saturday` cron fires Saturday as always; the adjuster just ensures it's enabled + reaps spent one-shots.
- **Trailing-holiday weeks** (Good Friday; a Fri-observed July-4/Christmas): last trading day is Thursday → it **disables** the Saturday cron and stands up a one-shot rule on **Friday** with byte-identical weekly input.

## Why a reconciler, not a daily gate (the key design point)
The research inputs are trading-day-gated (frozen at the last close), so running *later* in a market-closed weekend gains no freshness — run as early as the last close's data has settled (Sat normally, Fri on a holiday week). And critically it's **fail-safe**: `alpha-engine-saturday` is the untouched baseline, so **a broken adjuster degrades to the normal Saturday run, never a missed run** (a daily "should I run today?" gate has the opposite, dangerous failure mode). The holiday branch creates the one-shot *before* disabling Saturday, so a mid-run failure also leaves Saturday firing.

## Deploy / blast radius
Operator-deployed **outside CloudFormation** (mirrors `eod-success-friday-shell-trigger`, `sf-telegram-notifier`) to keep the OIDC deploy role narrow. **Merging this PR does NOT deploy it** — run `deploy.sh --bootstrap` to go live. **Not urgent:** next holiday-shift week is ~Christmas 2026; this Friday's 7/3 run is already set up manually (temp one-shot + Saturday-cron suppression + auto-re-enable).

## Tests
`test_handler.py` (9): `weekly_run_day` for July-4 / Good-Friday / Christmas / normal weeks; normal-week enables Saturday + no one-shot; holiday-week one-shot-before-disable (fail-safe order) targeting the weekly SF via the sfn role; idempotent; stale-one-shot reap; input shape. All pass. Run by `deploy.sh` (repo convention for operator Lambdas; outside pytest `tests/` so CI is unaffected).

## IAM (scoped)
`EnableRule`/`DisableRule` on `alpha-engine-saturday` only · `PutRule`/`PutTargets`/`RemoveTargets`/`DeleteRule` on `alpha-engine-weekly-oneshot-*` only · read-only reconcile · `PassRole` on `alpha-engine-eventbridge-sfn-role` constrained to `events.amazonaws.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)