### PR TITLE
fix(adjuster): vendor NYSE calendar — nousergon_lib can't be bundled into a Lambda zip

### DIFF
--- a/infrastructure/lambdas/weekly-schedule-adjuster/index.py
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/index.py
@@ -40,7 +40,40 @@ from datetime import date, datetime, timedelta, timezone
 
 import boto3
 
-from nousergon_lib.trading_calendar import is_trading_day
+# Vendored NYSE trading calendar. The Lambda needs ONLY "is this date an NYSE
+# session?", and the canonical ``nousergon_lib`` is now mypyc/pydantic-compiled
+# (platform-specific ``.so``), so it cannot be bundled into a Lambda zip from a
+# dev Mac (linux/py3.12 mismatch — the built wheels are darwin/py3.14). We vendor
+# the static NYSE holiday set (through 2030, verbatim from
+# ``nousergon_lib.trading_calendar.NYSE_HOLIDAYS``) + a pure-Python session check.
+# test_handler.py::test_vendored_holidays_match_lib asserts this stays in
+# lockstep with the lib (drift guard), so the copy can't silently diverge.
+_NYSE_HOLIDAYS = frozenset({
+    date(2026, 1, 1), date(2026, 1, 19), date(2026, 2, 16), date(2026, 4, 3),
+    date(2026, 5, 25), date(2026, 6, 19), date(2026, 7, 3), date(2026, 9, 7),
+    date(2026, 11, 26), date(2026, 12, 25),
+    date(2027, 1, 1), date(2027, 1, 18), date(2027, 2, 15), date(2027, 3, 26),
+    date(2027, 5, 31), date(2027, 6, 18), date(2027, 7, 5), date(2027, 9, 6),
+    date(2027, 11, 25), date(2027, 12, 24),
+    date(2028, 1, 17), date(2028, 2, 21), date(2028, 4, 14), date(2028, 5, 29),
+    date(2028, 6, 19), date(2028, 7, 4), date(2028, 9, 4), date(2028, 11, 23),
+    date(2028, 12, 25),
+    date(2029, 1, 1), date(2029, 1, 15), date(2029, 2, 19), date(2029, 3, 30),
+    date(2029, 5, 28), date(2029, 6, 19), date(2029, 7, 4), date(2029, 9, 3),
+    date(2029, 11, 22), date(2029, 12, 25),
+    date(2030, 1, 1), date(2030, 1, 21), date(2030, 2, 18), date(2030, 4, 19),
+    date(2030, 5, 27), date(2030, 6, 19), date(2030, 7, 4), date(2030, 9, 2),
+    date(2030, 11, 28), date(2030, 12, 25),
+})
+
+
+def is_trading_day(d: date) -> bool:
+    """NYSE session? A weekday that is not a holiday. (Early-close half-days
+    count as sessions — correct for 'last trading day of the week'.) The holiday
+    set covers through 2030; extend it (and the drift-guard test) before then.
+    """
+    return d.weekday() < 5 and d not in _NYSE_HOLIDAYS
+
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))

--- a/infrastructure/lambdas/weekly-schedule-adjuster/requirements.txt
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/requirements.txt
@@ -1,5 +1,5 @@
-# Only nousergon_lib.trading_calendar (is_trading_day) is needed. Pinned to
-# alpha-engine-data's main lib pin so the NYSE-holiday calendar the adjuster
-# reasons over matches the rest of the fleet (avoids a divergent holiday set
-# deciding when the weekly run fires).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.77.0
+# No external runtime deps. boto3 is provided by the Lambda runtime, and the
+# NYSE trading calendar is VENDORED into index.py (a pure-Python holiday set +
+# session check) — the canonical nousergon_lib is mypyc/pydantic-compiled and
+# its platform-specific .so wheels cannot be bundled into a Lambda zip from a
+# dev Mac. test_handler.py drift-guards the vendored set against the lib.

--- a/infrastructure/lambdas/weekly-schedule-adjuster/test_handler.py
+++ b/infrastructure/lambdas/weekly-schedule-adjuster/test_handler.py
@@ -1,34 +1,19 @@
 """Unit tests for weekly-schedule-adjuster index.handler.
 
-Stubs ``nousergon_lib.trading_calendar.is_trading_day`` with a small NYSE
-calendar (July 2026 incl. the Fri 7/3 July-4-observed holiday) and a fake
-EventBridge client, so tests assert the reconcile decision + the exact
-enable/disable/one-shot actions without AWS or the lib.
+The NYSE calendar is VENDORED into index.py (pure Python), so these tests run
+directly against it — no lib stub. A fake EventBridge client captures the
+enable/disable/one-shot actions without AWS. ``test_vendored_holidays_match_lib``
+drift-guards the vendored set against the canonical ``nousergon_lib`` (skipped
+where the lib isn't importable).
 """
 
 from __future__ import annotations
 
 import sys
-import types
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
-
-# NYSE calendar stub: 2026 weekdays are trading days EXCEPT the holidays below.
-_HOLIDAYS = {date(2026, 7, 3), date(2026, 12, 25), date(2026, 4, 3)}  # Jul4-obs, Xmas, Good Fri
-
-
-def _is_trading_day(d: date) -> bool:
-    return d.weekday() < 5 and d not in _HOLIDAYS
-
-
-_lib = types.ModuleType("nousergon_lib")
-_tc = types.ModuleType("nousergon_lib.trading_calendar")
-_tc.is_trading_day = _is_trading_day
-_lib.trading_calendar = _tc
-sys.modules.setdefault("nousergon_lib", _lib)
-sys.modules.setdefault("nousergon_lib.trading_calendar", _tc)
 
 sys.path.insert(0, str(Path(__file__).parent))
 import index  # noqa: E402
@@ -177,3 +162,16 @@ def test_weekly_input_shape_matches_cron():
     inp = index._weekly_input()
     assert '"pipeline_role": "weekly"' in inp
     assert '"ec2_instance_id": ["i-09b539c844515d549"]' in inp
+
+
+# --- drift guard: vendored calendar must match the canonical lib -------------
+
+def test_vendored_holidays_match_lib():
+    tc = pytest.importorskip("nousergon_lib.trading_calendar")
+    lib_hol = {d for d in tc.NYSE_HOLIDAYS if 2026 <= d.year <= 2030}
+    assert index._NYSE_HOLIDAYS == lib_hol, "vendored NYSE holidays diverged from nousergon_lib"
+    # and the session predicate agrees day-for-day across the vendored range
+    d = date(2026, 1, 1)
+    while d <= date(2030, 12, 31):
+        assert index.is_trading_day(d) == tc.is_trading_day(d), d.isoformat()
+        d += timedelta(days=1)


### PR DESCRIPTION
## Why (deploy blocker)
Bootstrapping #578 surfaced a **packaging defect**: `nousergon_lib` is now **mypyc-compiled** and pulls **pydantic-core**, so `pip install -t` from a dev Mac bundles `cpython-314-darwin` `.so` wheels (5 of them, incl. the lib's own compiled module) that **cannot import on the Lambda runtime** (linux/py3.12). The merged handler would deploy a Lambda that **fails at import** — i.e. the automation silently wouldn't work.

## Fix
The adjuster needs exactly one stable thing — *is a date an NYSE session?* — so **vendor** the static NYSE holiday set (through 2030, **verbatim** from `nousergon_lib.trading_calendar.NYSE_HOLIDAYS`) + a pure-Python `is_trading_day` into `index.py`. Zero external runtime deps → the zip is pure-Python and deploys on any platform.

**Drift guard:** `test_vendored_holidays_match_lib` asserts the vendored set + the session predicate match the canonical lib **day-for-day across 2026–2030** (skips where the lib isn't importable), so the copy can't silently diverge. 10 tests pass (incl. the drift guard run against the live lib).

Unblocks the `deploy.sh --bootstrap` for #578. Not urgent (next holiday-shift week ≈ Christmas 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)