### PR TITLE
[P2/unlabeled] fix(infra): add EOD-pipeline MutexConflict alarm (config#1416)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -629,10 +629,11 @@ Resources:
   # TreatMissingData=notBreaching covers the zero-conflict steady state, where no
   # match -> no data point -> alarm OK.)
   #
-  # EOD (ne-postclose-trading-pipeline) is intentionally NOT covered here: it is
-  # script-managed (update_eod_pipeline_sf.sh, logging still OFF) and is
-  # daemon-shutdown-triggered (single event), not cron-double-fire-prone. EOD
-  # coverage is tracked as a separate follow-up.
+  # EOD (ne-postclose-trading-pipeline) is now covered too — see the
+  # PostcloseTradingMutexConflict* resources below (config#1416). It is still
+  # script-managed (update_eod_pipeline_sf.sh + deploy-infrastructure.sh), so
+  # unlike the two SFs above, its log group is deliberately NOT a CFN
+  # resource — see the comment on that section for why.
   WeeklyFreshnessMutexConflictMetricFilter:
     Type: AWS::Logs::MetricFilter
     DependsOn: WeeklyFreshnessLogGroup
@@ -684,6 +685,48 @@ Resources:
         duplicate-trigger source.
       Namespace: AlphaEngine/StepFunctions
       MetricName: PreopenTradingMutexConflictFails
+      Statistic: Sum
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlertsTopic
+
+  # --------------------------------------------------------------------------
+  # EOD (ne-postclose-trading-pipeline) MutexConflict alarm (config#1416)
+  # --------------------------------------------------------------------------
+  # EOD is script-managed (infrastructure/update_eod_pipeline_sf.sh +
+  # deploy-infrastructure.sh's update_or_create()), not a CFN
+  # AWS::StepFunctions::StateMachine resource, so — unlike the weekly/preopen
+  # pair above — its log group is NOT a CFN resource: the scripts create it
+  # idempotently (create-log-group + put-retention-policy) before setting
+  # LoggingConfiguration on the state machine. CFN owns only the filter +
+  # alarm below, which read the log group by its literal name. This ordering
+  # is deliberate: the scripts' state-machine update (deploy-infrastructure.sh
+  # step 3) runs BEFORE this stack's deploy (step 4), so a CFN-owned log group
+  # would not exist yet on first deploy.
+  PostcloseTradingMutexConflictMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/stepfunctions/ne-postclose-trading-pipeline
+      FilterPattern: '"MutexConflict"'
+      MetricTransformations:
+        - MetricNamespace: AlphaEngine/StepFunctions
+          MetricName: PostcloseTradingMutexConflictFails
+          MetricValue: '1'
+
+  PostcloseTradingMutexConflictAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ne-postclose-trading-mutex-conflict
+      AlarmDescription: >-
+        L274 MutexConflict Fail on the post-close (EOD) pipeline
+        (duplicate-trigger guard fired). First occurrence = investigate the
+        duplicate-trigger source.
+      Namespace: AlphaEngine/StepFunctions
+      MetricName: PostcloseTradingMutexConflictFails
       Statistic: Sum
       Period: 86400
       EvaluationPeriods: 1

--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -163,21 +163,43 @@ update_or_defer_to_cfn() {
     fi
 }
 
-# Standalone SF (not in CFN — EOD): update if present, else create.
+# Standalone SF (not in CFN — EOD, groom): update if present, else create.
+# An optional 5th arg is a JSON LoggingConfiguration string — only EOD passes
+# one (config#1416); groom's call omits it, preserving its current
+# no-logging behavior exactly.
 update_or_create() {
-    local arn="$1" stamped="$2" name="$3" label="$4"
+    local arn="$1" stamped="$2" name="$3" label="$4" logging="${5:-}"
+    local logging_args=()
+    if [ -n "$logging" ]; then
+        logging_args=(--logging-configuration "$logging")
+    fi
     if sf_exists "$arn"; then
-        aws stepfunctions update-state-machine --state-machine-arn "$arn" --definition "file://$stamped" --query "updateDate" --output text
+        aws stepfunctions update-state-machine --state-machine-arn "$arn" --definition "file://$stamped" "${logging_args[@]}" --query "updateDate" --output text
         echo "  $label updated."
     else
-        aws stepfunctions create-state-machine --name "$name" --definition "file://$stamped" --role-arn "$SF_ROLE_ARN" --query "stateMachineArn" --output text
+        aws stepfunctions create-state-machine --name "$name" --definition "file://$stamped" --role-arn "$SF_ROLE_ARN" "${logging_args[@]}" --query "stateMachineArn" --output text
         echo "  $label created (was absent — rename cutover)."
     fi
 }
 
+# config#1416: EOD execution-log group + LoggingConfiguration, mirroring the
+# weekly/preopen pair (config#729/#537). Deliberately NOT a CFN-owned log
+# group — this script (and update_eod_pipeline_sf.sh) creates it idempotently
+# BEFORE this step's update_or_create() call, since this step (3) runs before
+# the CFN stack deploy (step 4) below; a CFN-owned log group would not exist
+# yet on the very first deploy after this change merges. CFN owns only the
+# metric-filter + alarm that read this log group by its literal name (see
+# alpha-engine-orchestration.yaml).
+EOD_LOG_GROUP_NAME="/aws/stepfunctions/ne-postclose-trading-pipeline"
+EOD_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${EOD_LOG_GROUP_NAME}:*"
+echo "  Ensuring EOD log group exists (idempotent)..."
+aws logs create-log-group --log-group-name "$EOD_LOG_GROUP_NAME" --region "$REGION" 2>/dev/null || true
+aws logs put-retention-policy --log-group-name "$EOD_LOG_GROUP_NAME" --retention-in-days 30 --region "$REGION"
+EOD_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"'"$EOD_LOG_GROUP_ARN"'"}}]}'
+
 update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline"
 update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline"
-update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post-close trading pipeline"
+update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post-close trading pipeline" "$EOD_LOGGING_CONFIG"
 update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-pipeline" "Backlog groom pipeline"
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────

--- a/infrastructure/update_eod_pipeline_sf.sh
+++ b/infrastructure/update_eod_pipeline_sf.sh
@@ -18,6 +18,13 @@
 # Idempotent: re-running with the same definition is a no-op (AWS only
 # bumps the revision when the definition actually changes).
 #
+# config#1416: also ensures the EOD execution-log group exists (idempotent
+# create-log-group + put-retention-policy) and enables ERROR-level
+# LoggingConfiguration on the state machine, mirroring the weekly/preopen
+# pair (config#729/#537) so the same MutexConflict metric-filter + alarm
+# pattern has a log group to read. Unlike those two, this log group is NOT
+# a CloudFormation resource — see the CFN template comment for why.
+#
 # Usage:
 #   ./infrastructure/update_eod_pipeline_sf.sh
 
@@ -44,12 +51,20 @@ fi
 # Validate JSON before sending it to AWS.
 python3 -c "import json,sys; json.load(open(sys.argv[1])); print('  Definition: JSON valid')" "$DEFN_FILE"
 
+LOG_GROUP_NAME="/aws/stepfunctions/ne-postclose-trading-pipeline"
+LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${LOG_GROUP_NAME}:*"
+
+echo "  Ensuring EOD log group exists (idempotent)..."
+aws logs create-log-group --log-group-name "$LOG_GROUP_NAME" --region "$REGION" 2>/dev/null || true
+aws logs put-retention-policy --log-group-name "$LOG_GROUP_NAME" --retention-in-days 30 --region "$REGION"
+
 aws stepfunctions update-state-machine \
     --state-machine-arn "$SM_ARN" \
     --definition "file://$DEFN_FILE" \
+    --logging-configuration '{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"'"$LOG_GROUP_ARN"'"}}]}' \
     --region "$REGION" > /dev/null
 
-echo "  State machine: definition updated"
+echo "  State machine: definition updated (execution logging: ERROR level, enabled)"
 echo ""
 echo "=== EOD Pipeline SF Update Complete ==="
 echo ""

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -594,3 +594,156 @@ class TestCfnMutexConflictAlarms:
         assert "!Ref AlertsTopic" in block, (
             "the weekly-freshness mutex-conflict alarm must page AlertsTopic"
         )
+
+
+class TestCfnEodMutexConflictAlarm:
+    """EOD (ne-postclose-trading-pipeline) MutexConflict coverage (config#1416).
+
+    EOD is script-managed (update_eod_pipeline_sf.sh + deploy-infrastructure.sh's
+    update_or_create()), not a CFN AWS::StepFunctions::StateMachine resource. Per
+    the design note in alpha-engine-orchestration.yaml, this means EOD's log
+    group is deliberately NOT a CFN resource (unlike the weekly/preopen pair in
+    TestCfnMutexConflictAlarms) — the scripts create it idempotently, out of
+    band, before setting LoggingConfiguration on the state machine. Only the
+    metric-filter + alarm (which read the log group by literal name) are CFN
+    resources. These tests pin that shape so a future "cleanup" doesn't
+    "fix" the asymmetry by adding a CFN LogGroup for EOD, which would break
+    deploy ordering (see the CFN comment + PR description for the full
+    reasoning).
+    """
+
+    EOD_LOG_GROUP_NAME = "/aws/stepfunctions/ne-postclose-trading-pipeline"
+
+    @pytest.fixture(scope="class")
+    def cfn_text(self) -> str:
+        return CFN_PATH.read_text()
+
+    def test_metric_filter_present(self, cfn_text):
+        assert "PostcloseTradingMutexConflictMetricFilter:" in cfn_text, (
+            "missing AWS::Logs::MetricFilter resource for the EOD pipeline "
+            "(config#1416)"
+        )
+        assert "PostcloseTradingMutexConflictFails" in cfn_text, (
+            "EOD metric filter must emit a dedicated "
+            "PostcloseTradingMutexConflictFails metric"
+        )
+
+    def test_alarm_present(self, cfn_text):
+        assert "PostcloseTradingMutexConflictAlarm:" in cfn_text, (
+            "missing CloudWatch alarm resource for the EOD pipeline "
+            "(config#1416)"
+        )
+        assert "ne-postclose-trading-mutex-conflict" in cfn_text, (
+            "missing the ne-postclose-trading-mutex-conflict AlarmName"
+        )
+
+    def test_metric_filter_log_group_name_matches_script_managed_group(
+        self, cfn_text
+    ):
+        anchor = cfn_text.index("PostcloseTradingMutexConflictMetricFilter:")
+        block = cfn_text[anchor : anchor + 500]
+        assert f"LogGroupName: {self.EOD_LOG_GROUP_NAME}" in block, (
+            "EOD metric filter LogGroupName must match the literal log group "
+            "name the scripts create (update_eod_pipeline_sf.sh / "
+            "deploy-infrastructure.sh) — /aws/stepfunctions/"
+            "ne-postclose-trading-pipeline"
+        )
+
+    def test_metric_filter_has_no_dimensions_or_default_value(self, cfn_text):
+        mf_start = cfn_text.index("PostcloseTradingMutexConflictMetricFilter")
+        mf_region = cfn_text[
+            mf_start : cfn_text.index("PostcloseTradingMutexConflictAlarm")
+        ]
+        assert "Dimensions" not in mf_region, (
+            "EOD MutexConflict metric filter must NOT set Dimensions — same "
+            "invariant as the weekly/preopen pair (config#729)"
+        )
+        assert "DefaultValue" not in mf_region, (
+            "EOD MutexConflict metric filter must NOT set DefaultValue"
+        )
+
+    def test_alarm_routes_to_alerts_topic(self, cfn_text):
+        anchor = cfn_text.index("PostcloseTradingMutexConflictAlarm:")
+        block = cfn_text[anchor : anchor + 900]
+        assert "!Ref AlertsTopic" in block, (
+            "the postclose-trading mutex-conflict alarm must page AlertsTopic"
+        )
+
+    def test_eod_log_group_is_not_a_cfn_resource(self, cfn_text):
+        # Regression guard: unlike WeeklyFreshnessLogGroup / PreopenTradingLogGroup,
+        # EOD's log group must NOT become a CFN AWS::Logs::LogGroup resource.
+        # Reasoning (config#1416): deploy-infrastructure.sh runs the
+        # script-managed state-machine update (step 3, update_or_create()) BEFORE
+        # the CFN stack deploy (step 4). If EOD's log group were CFN-owned, the
+        # first deploy after this change would try to set LoggingConfiguration
+        # in step 3 pointing at a log group CFN hasn't created yet (step 4 hasn't
+        # run) -> ResourceNotFoundException. The scripts create the log group
+        # idempotently out of band instead; CFN owns only the filter + alarm.
+        assert "PostcloseTradingLogGroup" not in cfn_text, (
+            "EOD's log group must NOT be a CFN resource (no "
+            "PostcloseTradingLogGroup) — it is created idempotently by "
+            "update_eod_pipeline_sf.sh / deploy-infrastructure.sh instead. "
+            "See config#1416: a CFN-owned log group here would break deploy "
+            "ordering (script step runs before the CFN stack deploy step)."
+        )
+
+
+class TestEodLoggingScriptWiring:
+    """Text-contains checks over the two shell scripts that manage the
+    script-managed EOD state machine (config#1416). This repo has no
+    bash-execution test harness, so — same style as the CFN raw-text tests
+    above — these pin the presence of the AWS CLI flags/calls that enable EOD
+    execution logging, without actually invoking AWS.
+    """
+
+    @pytest.fixture(scope="class")
+    def update_eod_script_text(self) -> str:
+        return (INFRA / "update_eod_pipeline_sf.sh").read_text()
+
+    @pytest.fixture(scope="class")
+    def deploy_infra_script_text(self) -> str:
+        return (INFRA / "deploy-infrastructure.sh").read_text()
+
+    def test_update_eod_script_enables_logging(self, update_eod_script_text):
+        assert "--logging-configuration" in update_eod_script_text, (
+            "update_eod_pipeline_sf.sh must pass --logging-configuration to "
+            "update-state-machine so the manual-fallback path also enables "
+            "EOD execution logging (config#1416)"
+        )
+        assert "create-log-group" in update_eod_script_text, (
+            "update_eod_pipeline_sf.sh must idempotently ensure the EOD log "
+            "group exists (create-log-group) before enabling logging"
+        )
+        assert "put-retention-policy" in update_eod_script_text, (
+            "update_eod_pipeline_sf.sh must set retention on the EOD log group"
+        )
+
+    def test_deploy_infra_script_enables_logging_for_eod_only(
+        self, deploy_infra_script_text
+    ):
+        assert "create-log-group" in deploy_infra_script_text, (
+            "deploy-infrastructure.sh must idempotently ensure the EOD log "
+            "group exists before the update_or_create() call for EOD "
+            "(config#1416)"
+        )
+
+        eod_call_line = next(
+            line
+            for line in deploy_infra_script_text.splitlines()
+            if "update_or_create" in line and "$EOD_ARN" in line
+        )
+        groom_call_line = next(
+            line
+            for line in deploy_infra_script_text.splitlines()
+            if "update_or_create" in line and "$GROOM_ARN" in line
+        )
+
+        assert "EOD_LOGGING_CONFIG" in eod_call_line, (
+            "the update_or_create() call site for $EOD_ARN must pass the "
+            "logging-configuration variable as its 5th argument (config#1416)"
+        )
+        assert "EOD_LOGGING_CONFIG" not in groom_call_line, (
+            "the update_or_create() call site for $GROOM_ARN must NOT pass "
+            "any logging-configuration argument — groom's behavior must be "
+            "unchanged by config#1416"
+        )


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** unlabeled

## Summary

PR #537 (merged) restored execution logging + a MutexConflict CloudWatch
alarm for the two CFN-managed step functions (`ne-weekly-freshness-pipeline`,
`ne-preopen-trading-pipeline`) but explicitly deferred the EOD pipeline
(`ne-postclose-trading-pipeline`) because it is **not** a CFN-managed
resource — it's created/updated purely by scripts. This PR closes that gap.

- `infrastructure/update_eod_pipeline_sf.sh` (manual fallback) and
  `infrastructure/deploy-infrastructure.sh`'s `update_or_create()` (the
  auto-deploy-on-merge path) now idempotently ensure the EOD execution log
  group exists (`create-log-group` + `put-retention-policy`, both tolerate
  already-exists) and enable `ERROR`-level `LoggingConfiguration` on the
  state machine, mirroring the weekly/preopen pair.
- `update_or_create()` gained an optional 5th arg (a JSON
  `LoggingConfiguration` string) so only the EOD call site enables logging —
  the backlog-groom pipeline (`GROOM_ARN`), which shares this helper, is
  unaffected.
- `infrastructure/cloudformation/alpha-engine-orchestration.yaml` gets a new
  `PostcloseTradingMutexConflictMetricFilter` + `PostcloseTradingMutexConflictAlarm`
  pair, matching the shape/naming convention of the existing
  `WeeklyFreshnessMutexConflict*` / `PreopenTradingMutexConflict*` resources.

## Why EOD's log group is NOT a CFN resource (the likely first review question)

Unlike the weekly/preopen pair, **EOD's log group is deliberately NOT a CFN
`AWS::Logs::LogGroup` resource.** This is not an oversight — it's required by
deploy ordering:

`deploy-infrastructure.sh` runs the script-managed state-machine update (step
3, `update_or_create()`) **before** the CFN stack deploy (step 4). If the EOD
log group were CFN-owned, the very first deploy after this PR merges would
try to set `LoggingConfiguration` on the EOD state machine in step 3, pointing
at a log group CFN hasn't created yet (step 4 hasn't run) →
`ResourceNotFoundException`. It would also risk a name collision if CFN later
tried to *create* a log group the scripts had already created out-of-band.

So: the EOD log group is created/retention-configured **idempotently by the
scripts themselves**, and CFN owns only the `MetricFilter` + `Alarm`, which
read that log group by its literal name (no CFN `LogGroup` resource, no
`DependsOn`). Both the script and the CFN template carry comments explaining
this asymmetry so it doesn't read as inconsistent with the weekly/preopen
pattern.

## Testing

- `tests/test_sf_mutex_wiring.py` gains:
  - `TestCfnEodMutexConflictAlarm` — pins the new metric filter + alarm
    resource names/properties, the no-`Dimensions`/`DefaultValue` invariant,
    the literal log-group name, and (regression guard) that no
    `PostcloseTradingLogGroup` CFN resource exists.
  - `TestEodLoggingScriptWiring` — text-contains checks confirming both shell
    scripts reference `--logging-configuration` / `create-log-group`, and
    that the `update_or_create` call site for `$EOD_ARN` passes the logging
    config while the `$GROOM_ARN` call site does not.
- Full `pytest tests/` run: 2500 passed, 11 skipped (pre-existing skips,
  unrelated to this change).
- `aws cloudformation validate-template` was not permitted for this
  runner's role (`AccessDenied`); instead validated the template by parsing
  it with a CFN-intrinsic-tag-tolerant YAML loader and confirming the new
  resources parse with the expected `Type`s and that no
  `PostcloseTradingLogGroup` resource was introduced. `bash -n` syntax-checked
  both modified shell scripts.

Closes nousergon/alpha-engine-config#1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)