### PR TITLE
[P3/none] fix(daily_closes): unify preservation mechanisms onto priority-waterfall

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -689,7 +689,12 @@ def collect(
                 ``source ∈ {"yfinance", "polygon"}`` AND ``Close`` is not
                 null), and skips fetching those tickers from yfinance.
                 Existing canonical rows are then merged into the output
-                parquet. Implements the source-precedence-ladder skip-set
+                parquet via ``_coalesce_by_source_priority`` (config#720 —
+                the same source-priority-waterfall primitive every mode
+                uses; a fresh yfinance/auto fetch is equal-or-higher
+                priority than a canonical prior row of the same tier, so it
+                always wins the merge, matching the pre-#720 behavior).
+                Implements the source-precedence-ladder skip-set
                 semantic from the windowed-data-reconciliation arc:
 
                   - ``yfinance_only`` mode: skips canonical tickers (any
@@ -823,17 +828,22 @@ def collect(
     # Skip-on-exists short-circuit (yfinance_only + auto only) returns inside
     # the live branch since dry_run by definition isn't going to write.
     existing_close_for_discrepancy: dict[str, float] | None = None
-    # Full prior-parquet rows (with ``source``), used by the polygon_only
-    # source-priority coalesce so a transient live-fetch gap retains the prior
+    # Full prior-parquet rows (with ``source``) fed to the single
+    # ``_coalesce_by_source_priority`` merge (config#720: the one preservation
+    # primitive for every mode) so a transient live-fetch gap retains the prior
     # value instead of blanking it. Empty unless an existing parquet is read.
+    #
+    # ``polygon_only`` populates this with EVERY prior row (any source) — the
+    # coalesce's own priority waterfall decides retain/overwrite/downgrade-block.
+    # ``yfinance_only``/``auto`` + ``skip_if_canonical=True`` populate it with
+    # only the rows already carrying an authoritative source (yfinance/polygon)
+    # and a non-null Close — mirrors the pre-config#720 ``canonical_existing_rows``
+    # filter exactly, so those modes' coalesce input (and therefore output) is
+    # unchanged; yfinance/auto's own fresh fetch is equal-or-higher priority
+    # than a canonical prior row of the same tier, so it naturally lands in the
+    # coalesce's "restatement wins"/"new_only" branches — the "equal-priority
+    # case" the consolidation issue (config#720) describes.
     existing_rows_for_merge: list[dict] = []
-    # When skip_if_canonical=True, ``canonical_existing_rows`` carries
-    # the records dicts for tickers in the existing parquet that already
-    # have an authoritative source (yfinance / polygon) and a non-null
-    # Close. They get merged into the output records before write so
-    # the parquet preserves prior canonical state across the window
-    # scan. Empty when skip_if_canonical=False (legacy overwrite path).
-    canonical_existing_rows: list[dict] = []
     canonical_skip_set: set[str] = set()
     from botocore.exceptions import ClientError
     head = None
@@ -915,11 +925,13 @@ def collect(
                     exc,
                 )
         elif skip_if_canonical:
-            # yfinance_only / auto + skip_if_canonical=True: read the
-            # full parquet, extract canonical rows so they survive into
-            # the merged output. Bypass the post-close-skip short-circuit
-            # below — the whole point of windowed reconciliation is to
-            # fill NaN cells in older dates that legacy logic would skip.
+            # yfinance_only / auto + skip_if_canonical=True: read the full
+            # parquet, extract canonical rows so they survive into the merged
+            # output via the shared ``_coalesce_by_source_priority`` step
+            # below (config#720 — same primitive polygon_only uses). Bypass
+            # the post-close-skip short-circuit below — the whole point of
+            # windowed reconciliation is to fill NaN cells in older dates
+            # that legacy logic would skip.
             try:
                 obj = s3.get_object(Bucket=bucket, Key=key)
                 existing_df = pd.read_parquet(
@@ -937,7 +949,7 @@ def collect(
                             canonical_skip_set.add(str(t))
                             preserved = {"ticker": str(t)}
                             preserved.update(row.to_dict())
-                            canonical_existing_rows.append(preserved)
+                            existing_rows_for_merge.append(preserved)
                 logger.info(
                     "[skip_if_canonical] %s: %d existing canonical "
                     "tickers will be preserved; yfinance fetch reduced "
@@ -956,7 +968,7 @@ def collect(
                     run_date, exc,
                 )
                 canonical_skip_set = set()
-                canonical_existing_rows = []
+                existing_rows_for_merge = []
         elif not dry_run and _is_post_close_write(last_modified, run_date):
             logger.info(
                 "Daily closes already exist for %s (post-close at %s, source=%s) — skipping",
@@ -1051,8 +1063,8 @@ def collect(
     missing = [t for t in tickers if t.lstrip("^") not in captured_tickers]
     # When skip_if_canonical=True (yfinance_only / auto window mode), drop
     # tickers that already have an authoritative source in the existing
-    # parquet — those rows will be merged from ``canonical_existing_rows``
-    # before write, so refetching them would just churn API budget.
+    # parquet — those rows will be merged back via the source-priority
+    # coalesce below, so refetching them would just churn API budget.
     if canonical_skip_set:
         before = len(missing)
         missing = [t for t in missing if t.lstrip("^") not in canonical_skip_set]
@@ -1082,22 +1094,37 @@ def collect(
                 records, missing, run_date,
             )
 
+    # ── Source-priority coalesce (yfinance_only / auto) — config#720 ─────────
     # Merge preserved canonical rows from the existing parquet into the
-    # records list. These are tickers we deliberately skipped fetching
-    # — they survive into the output unchanged. Polygon-only mode has
-    # ``canonical_existing_rows`` empty by construction (skip flag
-    # ignored per option (a)), so the legacy overwrite path is preserved.
-    if canonical_existing_rows:
-        already_captured = {r["ticker"] for r in records}
-        merged_in = 0
-        for row in canonical_existing_rows:
-            if row["ticker"] not in already_captured:
-                records.append(row)
-                merged_in += 1
+    # records list via the SAME ``_coalesce_by_source_priority`` primitive
+    # ``polygon_only`` uses below (config#720: unify the two preservation
+    # mechanisms). ``existing_rows_for_merge`` here holds only the rows
+    # already carrying an authoritative source (yfinance/polygon) + non-null
+    # Close (populated above, identical filter to the pre-#720
+    # ``canonical_existing_rows``), and yfinance/auto's own fresh fetch is
+    # equal-or-higher priority than a canonical prior row of the same
+    # tier — so this fresh fetch always lands in the coalesce's
+    # "restatement wins" / "new_only" branches, the "equal-priority case"
+    # the consolidation subsumes; a ticker this run couldn't (re)capture
+    # retains its prior canonical row exactly as before.
+    #
+    # Deliberately runs BEFORE the coverage gate below (unlike the
+    # polygon_only coalesce, which runs after) — preserved canonical rows
+    # must count toward the coverage denominator here, matching the
+    # documented ``skip_if_canonical`` contract ("coverage gate evaluates
+    # the merged-output denominator"). polygon_only has
+    # ``existing_rows_for_merge`` empty at this point (only populated in its
+    # own branch above), so this is a no-op for that mode.
+    if source != "polygon_only" and existing_rows_for_merge:
+        records, canon_merge_stats = _coalesce_by_source_priority(
+            records, existing_rows_for_merge, run_date,
+        )
         logger.info(
-            "[skip_if_canonical] %s: merged %d preserved canonical rows "
-            "into output records",
-            run_date, merged_in,
+            "[skip_if_canonical] %s: coalesce retained %d preserved canonical "
+            "row(s), overwrote %d, new %d (total %d)",
+            run_date, canon_merge_stats["retained"],
+            canon_merge_stats["overwritten"], canon_merge_stats["new_only"],
+            len(records),
         )
 
     # ── Coverage gates — per-mode hard-fails ─────────────────────────────────
@@ -1134,8 +1161,10 @@ def collect(
     # while polygon restatements still win and a lower-tier fresh value can't
     # downgrade a higher-tier existing cell. Runs AFTER the coverage gate, so a
     # genuine polygon outage still hard-fails on the FRESH fetch before any
-    # retained rows could mask it. (yfinance_only / auto preserve prior state
-    # via ``canonical_existing_rows`` above, so the coalesce is polygon_only.)
+    # retained rows could mask it. (yfinance_only / auto already ran the SAME
+    # ``_coalesce_by_source_priority`` primitive above, before the coverage
+    # gate — config#720 unified both modes onto this one function; only the
+    # gate-ordering and the existing-rows population differ per mode.)
     if source == "polygon_only" and existing_rows_for_merge:
         records, merge_stats = _coalesce_by_source_priority(
             records, existing_rows_for_merge, run_date,

--- a/tests/test_daily_closes_source_priority_merge.py
+++ b/tests/test_daily_closes_source_priority_merge.py
@@ -1,6 +1,6 @@
 """Tests for the source-priority coalesce merge on
 ``collectors.daily_closes._coalesce_by_source_priority`` and its wiring into
-``collect(source="polygon_only")``.
+``collect(source="polygon_only")`` **and** ``collect(source="yfinance_only"/"auto")``.
 
 Background (incident 2026-06-01):
 
@@ -20,14 +20,27 @@ authoritative source, else the prior datapoint is retained").
 The fix is an institutional source-of-record waterfall (``_SOURCE_PRIORITY``):
 a cell is replaced only by an equal-or-higher-priority source; lower or missing
 never clobbers higher-quality existing data. These tests lock the contract.
+
+config#720 (unification): ``yfinance_only``/``auto`` + ``skip_if_canonical=True``
+used to preserve prior canonical rows via a separate, older
+``canonical_existing_rows`` skip-and-merge mechanism. That mechanism has been
+removed — those modes now route through this SAME ``_coalesce_by_source_priority``
+primitive (their own fresh fetch is equal-or-higher priority than a canonical
+prior row of the same tier, so it lands in the "restatement wins"/"new_only"
+branches — the equal-priority special case the consolidation subsumes).
+``TestUnifiedCoalesceWiringYfinanceAuto`` below locks that wiring.
 """
 
 from __future__ import annotations
 
+import io
 import math
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
+from collectors import daily_closes
 from collectors.daily_closes import _coalesce_by_source_priority
 
 
@@ -180,3 +193,143 @@ def test_mixed_scenario_stats():
         "overwritten": 1,
         "new_only": 1,
     }
+
+
+# ── config#720: yfinance_only / auto now route through the SAME primitive ───
+
+
+def _existing_parquet_with_sources(rows: dict[str, dict]) -> MagicMock:
+    """Minimal S3 mock: head_object + get_object return a parquet with the
+    given per-ticker ``source``/``Close`` fields (mirrors the fixture in
+    test_daily_closes_skip_if_canonical.py)."""
+    s3 = MagicMock()
+    s3.head_object.return_value = {
+        "LastModified": datetime(2026, 5, 7, 21, 0, 0, tzinfo=timezone.utc),
+        "ContentLength": 123,
+        "ContentType": "application/octet-stream",
+    }
+    df_rows = []
+    for ticker, fields in rows.items():
+        df_rows.append({
+            "Open": fields.get("Open", 100.0),
+            "High": fields.get("High", 100.0),
+            "Low": fields.get("Low", 100.0),
+            "Close": fields.get("Close", 100.0),
+            "Adj_Close": fields.get("Adj_Close", 100.0),
+            "Volume": fields.get("Volume", 0),
+            "VWAP": fields.get("VWAP"),
+            "source": fields.get("source"),
+        })
+    df = pd.DataFrame(df_rows, index=pd.Index(list(rows.keys()), name="ticker"))
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy", index=True)
+    body_bytes = buf.getvalue()
+    s3.get_object.side_effect = lambda *a, **k: {"Body": MagicMock(read=lambda: body_bytes)}
+    s3.put_object.return_value = {"ETag": '"abc"'}
+    return s3
+
+
+class TestUnifiedCoalesceWiringYfinanceAuto:
+    """config#720: the ``canonical_existing_rows`` skip-and-merge mechanism is
+    gone — ``yfinance_only``/``auto`` + ``skip_if_canonical=True`` now call
+    ``_coalesce_by_source_priority`` directly, same as ``polygon_only``."""
+
+    def test_yfinance_only_calls_coalesce_by_source_priority(self):
+        s3 = _existing_parquet_with_sources({
+            "AAPL": {"Close": 150.0, "source": "yfinance"},
+        })
+
+        def _yf_side(missing, run_date, records):
+            for t in missing:
+                records.append({
+                    "ticker": t.lstrip("^"), "date": run_date,
+                    "Open": 1.0, "High": 1.0, "Low": 1.0, "Close": 1.0,
+                    "Adj_Close": 1.0, "Volume": 1, "VWAP": None,
+                    "source": "yfinance",
+                })
+            return len(missing)
+
+        with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+                patch.object(daily_closes, "_fetch_polygon_closes", return_value=0), \
+                patch.object(daily_closes, "_fetch_yfinance_closes", side_effect=_yf_side), \
+                patch.object(daily_closes, "_fetch_fred_closes", return_value=0), \
+                patch.object(
+                    daily_closes, "_coalesce_by_source_priority",
+                    wraps=daily_closes._coalesce_by_source_priority,
+                ) as coalesce_spy:
+            result = daily_closes.collect(
+                bucket="b", tickers=["AAPL", "MSFT"],
+                run_date="2026-05-08",
+                source="yfinance_only", skip_if_canonical=True,
+            )
+        coalesce_spy.assert_called_once()
+        assert result.get("status") == "ok"
+        out_df = pd.read_parquet(
+            io.BytesIO(s3.put_object.call_args.kwargs["Body"]), engine="pyarrow",
+        )
+        assert out_df.loc["AAPL", "Close"] == 150.0  # preserved via coalesce
+        assert out_df.loc["MSFT", "Close"] == 1.0    # freshly fetched
+
+    def test_auto_mode_calls_coalesce_by_source_priority(self):
+        s3 = _existing_parquet_with_sources({
+            "AAPL": {"Close": 150.0, "source": "polygon"},
+        })
+
+        with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+                patch.object(daily_closes, "_fetch_polygon_closes", return_value=0), \
+                patch.object(daily_closes, "_fetch_yfinance_closes", return_value=0), \
+                patch.object(daily_closes, "_fetch_fred_closes", return_value=0), \
+                patch.object(
+                    daily_closes, "_coalesce_by_source_priority",
+                    wraps=daily_closes._coalesce_by_source_priority,
+                ) as coalesce_spy:
+            result = daily_closes.collect(
+                bucket="b", tickers=["AAPL"],
+                run_date="2026-05-08",
+                source="auto", skip_if_canonical=True,
+            )
+        coalesce_spy.assert_called_once()
+        assert result.get("status") == "ok"
+        out_df = pd.read_parquet(
+            io.BytesIO(s3.put_object.call_args.kwargs["Body"]), engine="pyarrow",
+        )
+        assert out_df.loc["AAPL", "Close"] == 150.0  # retained, not blanked
+
+    def test_polygon_only_coalesce_call_unaffected_by_yfinance_wiring(self):
+        """Sanity: polygon_only's own coalesce call site is untouched — the
+        shared function is called exactly once, with polygon_only's full
+        existing-rows set (not the yfinance-side canonical-only set)."""
+        s3 = _existing_parquet_with_sources({
+            "AAPL": {"Close": 150.0, "source": "polygon"},
+            "TNX": {"Close": 4.5, "source": "fred"},
+        })
+
+        def _polygon_side(tickers, run_date, records, source):
+            # Simulate AAPL refresh, TNX (FRED-only) not present this run.
+            records.append({
+                "ticker": "AAPL", "date": run_date, "Open": 151.0, "High": 151.0,
+                "Low": 151.0, "Close": 151.0, "Adj_Close": 151.0, "Volume": 1,
+                "VWAP": 150.5, "source": "polygon",
+            })
+            return 1
+
+        with patch("collectors.daily_closes.boto3.client", return_value=s3), \
+                patch.object(daily_closes, "_fetch_polygon_closes", side_effect=_polygon_side), \
+                patch.object(daily_closes, "_fetch_yfinance_closes", return_value=0), \
+                patch.object(daily_closes, "_fetch_fred_closes", return_value=0), \
+                patch.object(
+                    daily_closes, "_coalesce_by_source_priority",
+                    wraps=daily_closes._coalesce_by_source_priority,
+                ) as coalesce_spy:
+            result = daily_closes.collect(
+                bucket="b", tickers=["AAPL", "^TNX"],
+                run_date="2026-05-08",
+                source="polygon_only",
+            )
+        coalesce_spy.assert_called_once()
+        assert result.get("status") == "ok"
+        out_df = pd.read_parquet(
+            io.BytesIO(s3.put_object.call_args.kwargs["Body"]), engine="pyarrow",
+        )
+        assert out_df.loc["AAPL", "Close"] == 151.0  # fresh polygon wins
+        assert out_df.loc["TNX", "Close"] == 4.5     # retained (FRED absent this run)


### PR DESCRIPTION
**Priority:** P3 · **Complexity:** none

## Summary

- `collectors/daily_closes.py` had two parallel mechanisms implementing the same "don't let missing/refused data blank out previously-good values" invariant: `polygon_only` used `_coalesce_by_source_priority` (added after the 2026-06-01 FRED-429/TNX-blank incident, PR #354); `yfinance_only`/`auto` + `skip_if_canonical=True` used an older, separate `canonical_existing_rows` skip-and-merge.
- This consolidates both onto `_coalesce_by_source_priority`. `yfinance_only`/`auto`'s own fresh fetch is equal-or-higher priority than a canonical prior row of the same tier, so it naturally lands in the coalesce's "restatement wins"/"new_only" branches — the equal-priority special case the coalesce was already designed to handle. `canonical_existing_rows` is removed entirely.
- Call-site ordering is preserved per mode: the `yfinance_only`/`auto` coalesce call stays **before** the coverage gate (preserved rows count toward the coverage denominator — matches the documented `skip_if_canonical` contract); `polygon_only`'s stays **after** (so a genuine polygon outage isn't masked by retained rows).
- No externally-observable behavior change intended for either mode — this is an internal consolidation, not a behavior change. (Confirmed via full test suite + new wiring tests below; see also the "known pre-existing gap, left alone" note.)

## Known pre-existing gap, left alone

While tracing through the two mechanisms I found `yfinance_only`/`auto` + `skip_if_canonical` never treated FRED-sourced rows (e.g. prior TNX/VIX/IRX/VIX3M values) as "canonical" — only `source ∈ {"yfinance","polygon"}` counted. Combined with FRED (Step 2) always being retried unconditionally each run, a FRED miss on a macro ticker in `yfinance_only`/`auto` mode today silently drops that ticker from the output parquet rather than retaining the prior value (unlike `polygon_only`, which is protected by the coalesce). I deliberately did **not** fix this as part of the consolidation — the task was scoped as "no behavior change," and expanding retain-on-empty coverage to FRED-sourced rows in `yfinance_only`/`auto` would be a real (probably good) behavior change, better done as its own deliberate follow-up with its own test coverage and incident-reasoning writeup, not smuggled into an internal refactor. Flagging here for visibility.

## Test plan

- [x] `pytest tests/` — full suite: 2498 passed, 8 skipped, 0 failed (baseline pre-refactor: 2495 passed, 8 skipped).
- [x] `pytest tests/test_daily_closes_source_priority_merge.py tests/test_daily_closes_skip_if_canonical.py tests/test_daily_closes_coalesce_hardening.py tests/test_daily_closes_window_days.py tests/test_daily_closes_source_modes.py -q` — all green.
- [x] Added `TestUnifiedCoalesceWiringYfinanceAuto` to `tests/test_daily_closes_source_priority_merge.py`: asserts `yfinance_only` and `auto` modes now call `_coalesce_by_source_priority` (via a `wraps=` spy), and that `polygon_only`'s own call site is unaffected.

Closes nousergon/alpha-engine-config#720

🤖 Generated with [Claude Code](https://claude.com/claude-code)