### PR TITLE
feat(groom): drop Saturday skip — uniform 3x/day, 7 days, no exceptions

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/README.md
+++ b/infrastructure/lambdas/groom-liveness-probe/README.md
@@ -18,7 +18,7 @@ Schedule-aware, per-trigger accounting:
 1. Enumerate every scheduled groom trigger in the last `GROOM_LOOKBACK_HOURS`
    that has had `GROOM_CEILING_MIN + GROOM_MARGIN_MIN` to finish (so a still-running
    groom never false-alarms). The schedule mirrors the dispatcher's crons
-   (07:00 Sun-Fri, 23:00 daily) and is overridable via `GROOM_SCHEDULE` (JSON).
+   (07:00 daily, 23:00 daily) and is overridable via `GROOM_SCHEDULE` (JSON).
 2. Fetch recent `groom-digest`-labeled issues from `nousergon/alpha-engine-config`
    (success digests **and** loud-failure issues both carry the label).
 3. For each trigger, assert a digest was created inside its run window

--- a/infrastructure/lambdas/groom-liveness-probe/index.py
+++ b/infrastructure/lambdas/groom-liveness-probe/index.py
@@ -77,10 +77,12 @@ _PAT_TIMEOUT_SEC = 15
 # (scheduled-groom-dispatcher/deploy.sh SCHED_CRONS). `dows` are Python weekday
 # ordinals: Mon=0 … Sun=6. Override via the GROOM_SCHEDULE env (JSON list of
 # {hour, minute, dows}) if the dispatcher cadence changes — keep the two in sync.
-#   cron(0 7 ? * SUN-FRI *) → 07:00 on Sun(6),Mon(0)..Fri(4)
-#   cron(0 23 * * ? *)      → 23:00 daily
+# Uniform 3x/day, all 7 days, since 2026-07-02 (the 07:00 Sat-skip was dropped —
+# no real contention with the weekly SF; see scheduled-groom-dispatcher/README.md).
+#   cron(0 7 * * ? *)  → 07:00 daily
+#   cron(0 23 * * ? *) → 23:00 daily
 _DEFAULT_SCHEDULE = [
-    {"hour": 7, "minute": 0, "dows": [6, 0, 1, 2, 3, 4], "label": "07:00 Sun-Fri"},
+    {"hour": 7, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "07:00 daily"},
     {"hour": 23, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "23:00 daily"},
 ]
 

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -50,14 +50,17 @@ def test_only_mature_triggers_returned(monkeypatch):
     assert all(t["at"] <= now - timedelta(minutes=405) for t in trigs)
 
 
-def test_saturday_0700_excluded(monkeypatch):
-    """The 07:00 schedule is Sun-Fri — Saturday must not produce a 07:00 trigger."""
+def test_saturday_0700_included(monkeypatch):
+    """Uniform 3x/day, all 7 days (2026-07-02, no exceptions) — Saturday MUST
+    produce a 07:00 trigger like every other day (the old Sun-Fri Sat-skip was
+    removed; see scheduled-groom-dispatcher/README.md)."""
+    monkeypatch.setattr(index, "CEILING_MIN", 360)
+    monkeypatch.setattr(index, "MARGIN_MIN", 45)
     monkeypatch.setattr(index, "LOOKBACK_HOURS", 12)
-    # Sat 2026-06-27 18:00 UTC → the only mature trigger in 12h is... 07:00 Sat is
-    # excluded; 23:00 Fri is >12h before. So expect no 07:00-Sat trigger.
+    # Sat 2026-06-27 18:00 UTC → 07:00 Sat matured (11h ago, > CEILING+MARGIN).
     now = _dt(2026, 6, 27, 18, 0)  # Saturday
     trigs = index._expected_triggers(now)
-    assert _dt(2026, 6, 27, 7, 0) not in {t["at"] for t in trigs}
+    assert _dt(2026, 6, 27, 7, 0) in {t["at"] for t in trigs}
 
 
 # ---- _missed ---------------------------------------------------------------
@@ -87,7 +90,7 @@ def test_single_silent_death_not_masked_by_later_success(monkeypatch):
     monkeypatch.setattr(index, "CEILING_MIN", 360)
     monkeypatch.setattr(index, "MARGIN_MIN", 45)
     t_dead = {"at": _dt(2026, 6, 29, 23, 0), "label": "23:00 daily"}
-    t_ok = {"at": _dt(2026, 6, 30, 7, 0), "label": "07:00 Sun-Fri"}
+    t_ok = {"at": _dt(2026, 6, 30, 7, 0), "label": "07:00 daily"}
     stamps = [_dt(2026, 6, 30, 7, 8)]  # only the 07:00 run reported
     misses = index._missed([t_dead, t_ok], stamps)
     assert [m["at"] for m in misses] == [t_dead["at"]]
@@ -111,7 +114,16 @@ class _FakeS3:
         self.put_calls.append(index.json.loads(Body))
 
 
-def _wire(monkeypatch, *, triggers, stamps, s3, sent=True):
+def _wire(monkeypatch, *, triggers, stamps, s3, sent=True, now=_dt(2026, 6, 30, 0, 0)):
+    # Freeze _now() — handler()'s _load_alerted() prunes the alerted-set to
+    # [now - LOOKBACK_HOURS, now], so leaving _now() on the REAL wall clock while
+    # every test hardcodes a 2026-06-29-ish trigger date makes the suite flaky-by
+    # -design: it silently breaks the moment real time drifts far enough past the
+    # hardcoded dates to prune them out of the lookback window (caught 2026-07-02
+    # — test_handler_suppresses_already_alerted_miss started failing with no code
+    # change, purely from elapsed wall-clock time). Default `now` sits ~1h after
+    # the trigger dates the other tests share.
+    monkeypatch.setattr(index, "_now", lambda: now)
     monkeypatch.setattr(index, "_expected_triggers", lambda now: triggers)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "pat")
     monkeypatch.setattr(index, "_fetch_digest_timestamps", lambda pat: stamps)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -21,7 +21,7 @@ then self-terminates (~$2/mo).
 
 ```
 EventBridge Scheduler rules (UTC, cron)                    THIS Lambda
-  alpha-engine-scheduled-groom-0700-sunfri          ─┐      1. nousergon_lib.ec2_spot.launch()
+  alpha-engine-scheduled-groom-0700-daily           ─┐      1. nousergon_lib.ec2_spot.launch()
   alpha-engine-scheduled-groom-2300-daily           ─┼───▶     (spot; on-demand fallback)
   alpha-engine-scheduled-groom-1500-daily-opus-high ─┘      2. wait instance running + SSM Online
                                                              3. async ssm send-command (detached):
@@ -45,8 +45,8 @@ flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 
 | Scheduler rule | Expression (UTC) | PT | Day mask | run_mode | model | issue_filter |
 |---|---|---|---|---|---|---|
-| `…-0700-sunfri` | `cron(0 7 ? * SUN-FRI *)` | 12am | Sun–Fri (skips Sat) | full | claude-sonnet-5 | default |
-| `…-2300-daily` | `cron(0 23 * * ? *)` | 4pm | daily incl. Sat | full | claude-sonnet-5 | default |
+| `…-0700-daily` | `cron(0 7 * * ? *)` | 12am | daily (all 7) | full | claude-sonnet-5 | default |
+| `…-2300-daily` | `cron(0 23 * * ? *)` | 4pm | daily (all 7) | full | claude-sonnet-5 | default |
 | `…-1500-daily-opus-high` | `cron(0 15 * * ? *)` | 8am | daily (all 7) | full | claude-opus-4-8 | high-only |
 
 > **Reduced 3→2/day on 2026-06-29** (usage pacing): the former
@@ -64,14 +64,25 @@ flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 > difficulty) gets relabeled `complexity:ultra`, which permanently exits ALL
 > automated grooming (both this schedule and the two Sonnet ones).
 
-The Sat-skip rationale is carried verbatim from `backlog-groom.yml`: the
-`…-0700-sunfri` rule avoids colliding with the 09:00-UTC Crucible Saturday
-pipeline; the daily 23:00 rule runs every day (Brian wants the Sat 4pm-PT groom
-retained).
+> **Sat-skip removed 2026-07-02, uniform 3x/day/7-days, no exceptions.** The
+> former `…-0700-sunfri` rule (`cron(0 7 ? * SUN-FRI *)`) skipped Saturday to
+> "avoid colliding with the 09:00-UTC Crucible Saturday pipeline" — a rationale
+> carried verbatim from the original `backlog-groom.yml` GHA cron comment with
+> no incident or postmortem behind it. Investigated and found no real
+> contention: the groom draws from the Claude **Max-plan** OAuth token
+> (`CLAUDE_CODE_OAUTH_TOKEN`); the weekly SF's Research/Predictor agents call
+> the Anthropic API directly via a separate pay-as-you-go `ANTHROPIC_API_KEY` —
+> disjoint quota pools. EC2 spot capacity is also disjoint: the groom uses
+> `t3/t3a/t2.medium`; the weekly SF's data/RAG/training stages use
+> `c5/m5/c6i/c5a.large` and `r5/r5a/r6i/m5.large`. Renamed `…-0700-sunfri` →
+> `…-0700-daily`; `deploy.sh --bootstrap` creates the new rule and PRUNES the
+> old one automatically (§ prune reconciliation). This also means the groom
+> cadence no longer needs to track which day the weekly SF lands on (e.g. the
+> holiday-aware Friday shift, `weekly-schedule-adjuster` #578) — it's simply
+> uniform every day now.
 
 EventBridge Scheduler cron uses 6 fields `cron(min hour day-of-month month
-day-of-week year)` with `?` for an unspecified day field and `SUN-FRI` for the
-day-of-week mask.
+day-of-week year)` with `?` for an unspecified day field.
 
 ## Schedule-input routing
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -23,13 +23,21 @@
 # Lambda) + ssm:GetCommandInvocation (to poll) + sns:Publish (to alert on
 # failure) — it never touches secrets or launches anything itself.
 #
-# Cadence (UTC, mirrors the GHA crons exactly). Reduced 3->2/day on 2026-06-29
-# (the 15:00 UTC / 8am-PT run was dropped per usage pacing); a 3rd schedule was
-# re-added 2026-07-01 (config#1495 follow-up) at the SAME 15:00 UTC slot, now
-# running a DIFFERENT tier — Opus, complexity:high ONLY — not a reinstatement
-# of the old Sonnet drain-phase run:
-#   07:00 Sun-Fri   cron(0 7 ? * SUN-FRI *)   FULL   Sonnet, default queue   # 12am PT, skips Sat
-#   23:00 daily     cron(0 23 * * ? *)        FULL   Sonnet, default queue  # 4pm PT, every day incl. Sat
+# Cadence (UTC). Reduced 3->2/day on 2026-06-29 (the 15:00 UTC / 8am-PT run was
+# dropped per usage pacing); a 3rd schedule was re-added 2026-07-01 (config#1495
+# follow-up) at the SAME 15:00 UTC slot, now running a DIFFERENT tier — Opus,
+# complexity:high ONLY — not a reinstatement of the old Sonnet drain-phase run.
+# UNIFORM 3x/day, all 7 days, since 2026-07-02: the Sat-skip on the 07:00 slot
+# (originally "avoid colliding with the 09:00 UTC Saturday pipeline") was never
+# evidence-based — investigated and confirmed the groom and the weekly SF share
+# NEITHER the Claude Max quota (groom = Max-plan OAuth token; weekly SF Research/
+# Predictor = separate pay-as-you-go ANTHROPIC_API_KEY) NOR EC2 spot capacity
+# (disjoint instance families: groom t3/t3a/t2.medium vs weekly-SF c5/m5/c6i/c5a/
+# r5/r5a/r6i.large). No exceptions kept — the weekly SF can also now land on any
+# day (e.g. Friday, per the holiday-aware weekly-schedule-adjuster, #578) without
+# the groom cadence needing to track it.
+#   07:00 daily     cron(0 7 * * ? *)         FULL   Sonnet, default queue  # 12am PT, every day
+#   23:00 daily     cron(0 23 * * ? *)        FULL   Sonnet, default queue  # 4pm PT, every day
 #   15:00 daily     cron(0 15 * * ? *)        FULL   Opus,   high-only      # 8am PT, every day
 #
 # SCHED_NAMES is the source of truth: any live scheduler rule under the
@@ -82,17 +90,17 @@ SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
 # claude-sonnet-5 / "default" (the pre-existing mid-tier queue), so this is not
 # a behavior change for them.
 SCHED_NAMES=(
-  "alpha-engine-scheduled-groom-0700-sunfri"
+  "alpha-engine-scheduled-groom-0700-daily"
   "alpha-engine-scheduled-groom-2300-daily"
   "alpha-engine-scheduled-groom-1500-daily-opus-high"
 )
 SCHED_CRONS=(
-  "cron(0 7 ? * SUN-FRI *)"
+  "cron(0 7 * * ? *)"
   "cron(0 23 * * ? *)"
   "cron(0 15 * * ? *)"
 )
 SCHED_INPUTS=(
-  '{"run_mode":"full","schedule":"0 7 * * 0-5"}'
+  '{"run_mode":"full","schedule":"0 7 * * *"}'
   '{"run_mode":"full","schedule":"0 23 * * *"}'
   '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","schedule":"0 15 * * *"}'
 )


### PR DESCRIPTION
Brian asked whether the groom's Saturday 07:00-slot skip is still needed now that the weekly SF is shifting days (holiday-aware Friday runs, #578), or whether the groom and weekly SF can just run in parallel unconditionally.

## Investigation

The Sat-skip rationale (`…-0700-sunfri` avoids colliding with the 09:00 UTC Saturday pipeline) is carried verbatim from the original `backlog-groom.yml` GHA cron comment — no incident or postmortem behind it, a precautionary design-time guess. Checked the two resources that would actually matter for contention:

- **Claude Max quota: not shared.** Groom runs on the Max-plan OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`); the weekly SF's Research/Predictor agents use a separate pay-as-you-go `ANTHROPIC_API_KEY`.
- **EC2 spot capacity: disjoint pools.** Groom: `t3/t3a/t2.medium`. Weekly SF: `c5/m5/c6i/c5a.large` (data/RAG) and `r5/r5a/r6i/m5.large` (training).

No real contention found — safe to collapse to a uniform 3x/day, 7-days-a-week cadence, no exceptions.

## Changes

- **`scheduled-groom-dispatcher/deploy.sh`**: `…-0700-sunfri` (`cron(0 7 ? * SUN-FRI *)`) renamed to `…-0700-daily` (`cron(0 7 * * ? *)`). The existing prune-reconciliation in `--bootstrap` deletes the old rule and creates the new one automatically — no manual cleanup step.
- **`groom-liveness-probe/index.py`**: the independent liveness watchdog mirrors the dispatcher's cadence in its own `_DEFAULT_SCHEDULE` (its comment literally says "keep the two in sync") — updated so it doesn't silently stop watching for a Saturday 07:00 run.
- **Fixed a pre-existing, unrelated test failure** surfaced while running the suite (per CLAUDE.md's zero-tolerance rule for known-broken tests): `test_handler_suppresses_already_alerted_miss` didn't freeze `index._now()`, so its dedup-pruning assertion silently broke as real wall-clock time drifted past its hardcoded trigger date. Fixed at the root — `_wire()` now freezes `_now()` for every handler-level test in the file, not a one-off patch.

## Test plan
- [x] `scheduled-groom-dispatcher/test_handler.py` — 14/14 passed.
- [x] `groom-liveness-probe/test_handler.py` — 10/10 passed (was 9/10 before the `_now()` fix — confirmed pre-existing on unmodified `main`, unrelated to this change).
- [x] `ruff check` clean, `bash -n` clean, `SCHED_INPUTS` JSON validated.

## Deploy note

Per this repo's own contract (both READMEs), **merging has ZERO live effect** until an operator runs:
```bash
bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap
bash infrastructure/lambdas/groom-liveness-probe/deploy.sh --bootstrap   # (or its own deploy step, if code-only suffices)
```
`--bootstrap` on the dispatcher creates `…-0700-daily` and prunes `…-0700-sunfri` in the same operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)