### PR TITLE
feat(groom): code-only auto-deploy on merge + track missed Opus schedule (config#1571)

### DIFF
--- a/.github/workflows/deploy-groom-liveness-probe.yml
+++ b/.github/workflows/deploy-groom-liveness-probe.yml
@@ -1,0 +1,86 @@
+name: Deploy groom-liveness-probe
+
+# Auto-deploy the alpha-engine-groom-liveness-probe Lambda CODE on merge to
+# main. Same pattern as deploy-scheduled-groom-dispatcher.yml /
+# deploy-freshness-monitor.yml: this script's default/flagless run is already
+# code-only (no aws iam/scheduler writes happen unless --bootstrap is passed),
+# so no new script flag was needed to make this safe.
+#
+# A change to SCHED_NAMES/SCHED_CRONS (the two liveness-check cadences, or a
+# future 3rd entry) still requires an operator to run `deploy.sh --bootstrap`
+# by hand, for the same reason as the dispatcher: the github-actions-lambda-
+# deploy OIDC role deliberately lacks iam:CreateRole / iam:PutRolePolicy
+# (fleet-wide policy, infrastructure/iam/README.md). A code change to
+# GROOM_SCHEDULE's _DEFAULT_SCHEDULE (e.g. config#1571's 15:00 entry) IS a
+# code-only change — it auto-deploys via this workflow — but the underlying
+# EventBridge Scheduler cadence for the PROBE ITSELF (when it invokes, not
+# what it checks for) only changes via SCHED_CRONS + --bootstrap.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/groom-liveness-probe/**'
+      - '.github/workflows/deploy-groom-liveness-probe.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-groom-liveness-probe-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy groom-liveness-probe Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy groom-liveness-probe (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/groom-liveness-probe/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-groom-liveness-probe \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-groom-liveness-probe.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/.github/workflows/deploy-scheduled-groom-dispatcher.yml
+++ b/.github/workflows/deploy-scheduled-groom-dispatcher.yml
@@ -1,0 +1,92 @@
+name: Deploy scheduled-groom-dispatcher
+
+# Auto-deploy the alpha-engine-scheduled-groom-dispatcher Lambda CODE on merge
+# to main. Mirrors deploy-freshness-monitor.yml — same gap, same fix: the
+# dispatcher was previously operator-deployed only end-to-end (code AND
+# schedule/IAM bundled behind --bootstrap), so a merged code fix sat inert
+# until someone remembered to run deploy.sh by hand. This closes that gap for
+# the CODE path only.
+#
+# Separation of concerns: this deploys CODE only (deploy.sh with NO flag —
+# unlike freshness-monitor, this script's default/flagless run IS already
+# code-only; --bootstrap is what ADDS the IAM-role-creation + EventBridge
+# Scheduler wiring, not the reverse, so no new script flag was needed here).
+# A change to SCHED_NAMES/SCHED_CRONS/SCHED_INPUTS (a schedule/cadence change)
+# still requires an operator to run `deploy.sh --bootstrap` by hand — the
+# github-actions-lambda-deploy OIDC role deliberately has no iam:CreateRole /
+# iam:PutRolePolicy (fleet-wide policy after 4 IAM-clobber incidents in 2
+# months traced to auto-applied IAM writes; see infrastructure/iam/README.md).
+# It DOES already have scheduler:Create/Update/DeleteSchedule + a scoped
+# iam:PassRole — a future refinement could split deploy.sh's --bootstrap into
+# an IAM-role-creation step (still operator-only) and a schedule-rules-only
+# step (auto-deployable), but that needs a deliberate script redesign +
+# live-AWS validation, not bundled into this workflow-only change.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/scheduled-groom-dispatcher/**'
+      - '.github/workflows/deploy-scheduled-groom-dispatcher.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-scheduled-groom-dispatcher-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy scheduled-groom-dispatcher Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy scheduled-groom-dispatcher (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-scheduled-groom-dispatcher \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-scheduled-groom-dispatcher.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/infrastructure/lambdas/groom-liveness-probe/README.md
+++ b/infrastructure/lambdas/groom-liveness-probe/README.md
@@ -18,7 +18,8 @@ Schedule-aware, per-trigger accounting:
 1. Enumerate every scheduled groom trigger in the last `GROOM_LOOKBACK_HOURS`
    that has had `GROOM_CEILING_MIN + GROOM_MARGIN_MIN` to finish (so a still-running
    groom never false-alarms). The schedule mirrors the dispatcher's crons
-   (07:00 daily, 23:00 daily) and is overridable via `GROOM_SCHEDULE` (JSON).
+   (07:00 daily, 15:00 daily Opus high-only, 23:00 daily) and is overridable via
+   `GROOM_SCHEDULE` (JSON).
 2. Fetch recent `groom-digest`-labeled issues from `nousergon/alpha-engine-config`
    (success digests **and** loud-failure issues both carry the label).
 3. For each trigger, assert a digest was created inside its run window
@@ -43,16 +44,26 @@ terminal-failure event for the existing watcher to hang off. Wrapping the groom
 dispatch in a Step Function so the existing Fleet-SF Watch covers it natively is
 the tracked **"SF later"** follow-up; this Lambda is the **"probe now"** half.
 
-## Deploy (operator-gated, outside CloudFormation)
+## Deploy
+
+**Code: auto-deploys on merge to main** (2026-07-02) via
+`.github/workflows/deploy-groom-liveness-probe.yml` — no operator action
+needed for a code-only PR (e.g. adding a schedule entry to `_DEFAULT_SCHEDULE`,
+per config#1571).
+
+**Cadence / IAM: still operator-gated, outside CloudFormation** — the CI OIDC
+role deliberately cannot create/modify IAM roles (fleet-wide policy). Run by
+hand:
 
 ```
 bash deploy.sh --dry-run     # show actions
-bash deploy.sh --bootstrap   # first-time: create role + Lambda + 2 Scheduler rules
-bash deploy.sh               # update code only
+bash deploy.sh --bootstrap   # first-time / cadence change: create role + Lambda + 2 Scheduler rules
+bash deploy.sh               # update code only (same command CI runs)
 bash deploy.sh --smoke       # invoke once (read-only; pings only on a REAL miss)
 ```
 
-Merging the PR has **zero** live effect until an operator runs `--bootstrap`.
+A PR that changes `SCHED_CRONS` (this probe's own invocation cadence) or
+`iam-policy.json` has zero live effect until an operator runs `--bootstrap`.
 Recommend wiring a CloudWatch alarm on this function's `Errors` metric (the
 fail-loud contract assumes one).
 

--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -21,14 +21,23 @@
 # (groom hard-ceiling 360 min + slack). Per-trigger windows + S3 dedup make the
 # exact times non-load-bearing (generous LOOKBACK tolerates schedule drift):
 #   06:30 daily   cron(30 6 * * ? *)   # after the 23:00 groom matures (~05:45)
-#   14:30 daily   cron(30 14 * * ? *)  # after the 07:00 Sun-Fri groom matures (~13:45)
+#   14:30 daily   cron(30 14 * * ? *)  # after the 07:00 groom matures (~13:45; the
+#                                      #   07:00 groom runs daily since 2026-07-02 —
+#                                      #   the old "Sun-Fri" framing is gone)
 #
 # Managed OUTSIDE CloudFormation — mirrors the sibling dispatchers (narrow OIDC
-# blast radius, operator-deployed only). Merging the PR has ZERO live effect
-# until an operator runs this with --bootstrap.
+# blast radius: the CI role deliberately lacks iam:CreateRole/iam:PutRolePolicy,
+# fleet-wide policy after 4 IAM-clobber incidents — infrastructure/iam/README.md).
+#
+# CODE auto-deploys on merge to main via
+# `.github/workflows/deploy-groom-liveness-probe.yml` (path-filtered to this
+# directory), which runs this script with NO flags (the default/flagless run
+# is already code-only). A SCHED_CRONS change (this probe's OWN invocation
+# cadence) still needs an operator to run `--bootstrap` by hand — merging
+# alone has ZERO live effect on it.
 #
 # Usage:
-#   bash .../groom-liveness-probe/deploy.sh             # update code only
+#   bash .../groom-liveness-probe/deploy.sh             # update code only (same command CI runs)
 #   bash .../groom-liveness-probe/deploy.sh --bootstrap # first-time create + wire schedules
 #   bash .../groom-liveness-probe/deploy.sh --dry-run   # show actions, do not apply
 #   bash .../groom-liveness-probe/deploy.sh --smoke     # invoke once (read-only check; pings only on a real miss)

--- a/infrastructure/lambdas/groom-liveness-probe/index.py
+++ b/infrastructure/lambdas/groom-liveness-probe/index.py
@@ -79,10 +79,23 @@ _PAT_TIMEOUT_SEC = 15
 # {hour, minute, dows}) if the dispatcher cadence changes — keep the two in sync.
 # Uniform 3x/day, all 7 days, since 2026-07-02 (the 07:00 Sat-skip was dropped —
 # no real contention with the weekly SF; see scheduled-groom-dispatcher/README.md).
+# The 15:00 entry (config#1571) was ADDED 2026-07-02 — the dispatcher's Opus/
+# complexity:high-only schedule existed since 2026-07-01 (config#1495 follow-up)
+# but this probe never tracked it, a blind spot for that schedule's silent
+# failures. No special-casing needed for its "empty complexity:high queue"
+# clean-stop case: groom_driver.py files a groom-digest issue even on a
+# total==0 clean shutdown, so _missed()'s presence-in-window check (it never
+# inspects digest CONTENT) already treats that correctly as "not missed."
 #   cron(0 7 * * ? *)  → 07:00 daily
+#   cron(0 15 * * ? *) → 15:00 daily (Opus, complexity:high only)
 #   cron(0 23 * * ? *) → 23:00 daily
+# The three windows [T, T+CEILING+MARGIN] never overlap at the default
+# CEILING_MIN=360/MARGIN_MIN=45 (6h45m): 07:00+6:45=13:45 (< 15:00),
+# 15:00+6:45=21:45 (< 23:00), 23:00+6:45=05:45 next day (< 07:00) — so
+# per-trigger attribution stays 1:1 (see _missed's docstring).
 _DEFAULT_SCHEDULE = [
     {"hour": 7, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "07:00 daily"},
+    {"hour": 15, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "15:00 daily (Opus high-only)"},
     {"hour": 23, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "23:00 daily"},
 ]
 

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -63,6 +63,36 @@ def test_saturday_0700_included(monkeypatch):
     assert _dt(2026, 6, 27, 7, 0) in {t["at"] for t in trigs}
 
 
+def test_1500_opus_schedule_included(monkeypatch):
+    """config#1571: the 15:00 UTC Opus/complexity:high schedule must be tracked
+    too, not just the two Sonnet schedules — its silent death was previously
+    invisible to this probe (the schedule existed since 2026-07-01, config#1495
+    follow-up, but was never added here)."""
+    monkeypatch.setattr(index, "CEILING_MIN", 360)
+    monkeypatch.setattr(index, "MARGIN_MIN", 45)
+    monkeypatch.setattr(index, "LOOKBACK_HOURS", 30)
+    # Wed 2026-07-01 22:00 UTC -> 15:00 Wed matured (7h ago).
+    now = _dt(2026, 7, 1, 22, 0)
+    trigs = index._expected_triggers(now)
+    assert _dt(2026, 7, 1, 15, 0) in {t["at"] for t in trigs}
+
+
+def test_three_daily_triggers_dont_overlap_in_one_day(monkeypatch):
+    """The three windows [T, T+CEILING+MARGIN] must stay disjoint so per-trigger
+    attribution remains 1:1 (see _missed's docstring) now that a 3rd schedule
+    shares the day with the original two."""
+    monkeypatch.setattr(index, "CEILING_MIN", 360)
+    monkeypatch.setattr(index, "MARGIN_MIN", 45)
+    monkeypatch.setattr(index, "LOOKBACK_HOURS", 24)
+    now = _dt(2026, 7, 2, 6, 0)
+    trigs = index._expected_triggers(now)
+    ats = sorted(t["at"] for t in trigs)
+    assert len(ats) == 3
+    window = timedelta(minutes=360 + 45)
+    for a, b in zip(ats, ats[1:]):
+        assert a + window <= b, f"{a} window overlaps {b}"
+
+
 # ---- _missed ---------------------------------------------------------------
 
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -13,9 +13,13 @@ then self-terminates (~$2/mo).
 > **Status: LIVE** (cutover 2026-06-30, config#1432). This is the sole scheduler
 > for the backlog groom — the GHA `schedule:` crons in `backlog-groom.yml` have
 > been REMOVED; that workflow now runs only on `workflow_dispatch` (manual
-> escape hatch). Any code change here needs `deploy.sh` (code-only, or
-> `--bootstrap` when a schedule/IAM changes) run by an operator with AWS creds
-> before it has live effect — merging the PR alone does not deploy it.
+> escape hatch). **CODE auto-deploys on merge to main** (2026-07-02) via
+> `.github/workflows/deploy-scheduled-groom-dispatcher.yml`. A **schedule or
+> IAM change** (`SCHED_NAMES`/`SCHED_CRONS`/`SCHED_INPUTS`, `iam-policy.json`,
+> `step_function_groom.json`, `sf-execution-iam-policy.json`) still has ZERO
+> live effect until an operator runs `deploy.sh --bootstrap` by hand — the CI
+> OIDC role deliberately cannot create/modify IAM roles (see `deploy.sh`'s
+> header comment).
 
 ## How it fits
 
@@ -112,19 +116,30 @@ but injection protection is cheap).
   group; the Scheduler execution role can `lambda:InvokeFunction` this function
   only.
 
-## Deploy (operator-managed, outside CloudFormation)
+## Deploy
+
+**Code: auto-deploys on merge to main** via
+`.github/workflows/deploy-scheduled-groom-dispatcher.yml` (path-filtered to
+this directory) — no operator action needed for a code-only PR.
+
+**Schedule / IAM: still operator-managed, outside CloudFormation** — the CI
+OIDC role deliberately cannot create/modify IAM roles (fleet-wide policy, see
+`deploy.sh`'s header). Run by hand:
 
 ```bash
 bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap  # roles + lambda + schedules (creates/updates from SCHED_NAMES; prunes orphaned rules)
-bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh              # update code only
+bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh              # update code only (same command CI runs)
 bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --dry-run    # preview
 bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --smoke      # ⚠ fires a REAL groom run
 ```
 
-Merging the PR has **zero live effect** until an operator runs `--bootstrap`.
-`--smoke` invokes the Lambda with a synthetic schedule event and (since
-`GROOM_DISPATCH_ENABLED` defaults on) **triggers an actual groom run** — use
-intentionally.
+A PR that touches `SCHED_NAMES`/`SCHED_CRONS`/`SCHED_INPUTS`, `iam-policy.json`,
+`step_function_groom.json`, or `sf-execution-iam-policy.json` has **zero live
+effect on the schedule/IAM** once merged until an operator runs `--bootstrap`
+— CI will still auto-deploy the CODE, but the cron/IAM change itself sits
+inert until then. `--smoke` invokes the Lambda with a synthetic schedule event
+and (since `GROOM_DISPATCH_ENABLED` defaults on) **triggers an actual groom
+run** — use intentionally.
 
 ## Validating a new/changed schedule
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -45,16 +45,28 @@
 # (deleted) on deploy, so removing a cadence here removes it live too.
 #
 # Managed OUTSIDE CloudFormation — same rationale as the sibling dispatchers
-# (keeps the github-actions-lambda-deploy OIDC role's blast radius narrow;
-# operator-deployed only). Merging the PR has ZERO live effect until an operator
-# runs this with --bootstrap. CUTOVER (config#1432): after a manual --smoke spot
-# run validates end-to-end, deploy this AND disable the GHA `schedule:` crons in
-# backlog-groom.yml together (so there is no double-groom and no gap). NOTE:
-# --smoke fires a REAL groom on a REAL spot box.
+# (keeps the github-actions-lambda-deploy OIDC role's blast radius narrow: it
+# deliberately lacks iam:CreateRole/iam:PutRolePolicy, a fleet-wide policy
+# after 4 IAM-clobber incidents in 2 months — see infrastructure/iam/README.md).
+#
+# CODE auto-deploys on merge to main via
+# `.github/workflows/deploy-scheduled-groom-dispatcher.yml` (path-filtered to
+# `infrastructure/lambdas/scheduled-groom-dispatcher/**`), which runs this
+# script with NO flags (this script's default/flagless run is already
+# code-only — --bootstrap is what ADDS IAM-role-creation + EventBridge
+# Scheduler wiring on top, not the reverse) under the github-actions-lambda-
+# deploy OIDC role (LambdaUpdate grant on `alpha-engine-*`, no IAM-role-create).
+# A SCHED_NAMES/SCHED_CRONS/SCHED_INPUTS change (a schedule/cadence change,
+# e.g. this file's own 2026-07-02 Sat-skip removal) still needs an operator to
+# run `--bootstrap` by hand — merging alone has ZERO effect on the live
+# EventBridge Scheduler rule. CUTOVER (config#1432, historical): after a
+# manual --smoke spot run validates end-to-end, deploy this AND disable the
+# GHA `schedule:` crons in backlog-groom.yml together (so there is no
+# double-groom and no gap). NOTE: --smoke fires a REAL groom on a REAL spot box.
 #
 # Usage:
-#   bash .../scheduled-groom-dispatcher/deploy.sh             # update code only
-#   bash .../scheduled-groom-dispatcher/deploy.sh --bootstrap # first-time create + wire EventBridge Scheduler
+#   bash .../scheduled-groom-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../scheduled-groom-dispatcher/deploy.sh --bootstrap # operator-only: create/update IAM roles + wire EventBridge Scheduler
 #   bash .../scheduled-groom-dispatcher/deploy.sh --dry-run   # show actions, do not apply
 #   bash .../scheduled-groom-dispatcher/deploy.sh --smoke     # invoke once with a synthetic schedule event (⚠ fires a REAL groom)
 


### PR DESCRIPTION
Brian: "why don't we autodeploy this on merge? ... i always want to set up an auto deploy, its too easy to forget post deploy commands."

## Why it wasn't auto-deployed

The `github-actions-lambda-deploy` OIDC role deliberately lacks `iam:CreateRole`/`iam:PutRolePolicy` — a **fleet-wide policy**, not a local choice, after 4 IAM-clobber incidents in 2 months (`infrastructure/iam/README.md`). `deploy.sh --bootstrap` needs both to create IAM roles, so it was never safe to run under CI. But both scripts' **default/flagless run was already code-only** (no `aws iam`/`scheduler` writes happen unless `--bootstrap` is passed) — so no script changes were needed, just the missing CI wiring.

## Fix — mirrors the existing `deploy-freshness-monitor.yml` precedent exactly

- `.github/workflows/deploy-scheduled-groom-dispatcher.yml` — auto-deploys on push to main touching `infrastructure/lambdas/scheduled-groom-dispatcher/**`, runs `deploy.sh` with no flags. No new IAM grant needed — `LambdaUpdate` already covers `arn:...:function:alpha-engine-*`.
- `.github/workflows/deploy-groom-liveness-probe.yml` — same pattern for the liveness probe.

**A schedule/IAM change** (`SCHED_NAMES`/`SCHED_CRONS`/`SCHED_INPUTS`, `iam-policy.json`, `step_function_groom.json`) still needs an operator to run `deploy.sh --bootstrap` by hand — CI auto-deploys the code, but the cron/IAM mutation itself sits inert until then. Documented in both READMEs and both `deploy.sh` headers so this doesn't surprise anyone again.

## Also fixes config#1571 (found in the prior session, in the same area)

`groom-liveness-probe`'s `_DEFAULT_SCHEDULE` never tracked the 15:00 UTC Opus/`complexity:high` schedule (added 2026-07-01, config#1495 follow-up) — a silent death on that schedule was invisible to the probe. Added the 3rd entry, verified the three trigger windows stay non-overlapping (the `_missed()` 1:1-attribution invariant), added test coverage.

## Test plan
- [x] `scheduled-groom-dispatcher/test_handler.py` — 14/14 passed.
- [x] `groom-liveness-probe/test_handler.py` — 12/12 passed.
- [x] `ruff check` clean, `bash -n` clean on both `deploy.sh`, both workflow YAMLs parse.

## Note on branch history

This replaces `feat/groom-uniform-3x-7day` (nousergon-data#586, the Saturday-skip-removal PR) as the branch base — #586 merged mid-session while this follow-up was in flight. Rebased cleanly onto the fresh `main` with zero conflicts (verified — #586's changes are already in `main` unchanged); this PR only carries the NEW auto-deploy + config#1571 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)