### PR TITLE
fix(corporate-actions): market-corroborated factor orientation + exactly-once mark discipline + splice basis-guard

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -769,9 +769,203 @@ def _ensure_history_restated(
         universe_lib.write(
             ticker, to_arctic_canonical(restated), prune_previous_versions=True,
         )
+    # Mark ONLY actions apply() actually folded in (status == "applied") —
+    # marking an unconfirmed/ambiguous refusal poisons the exactly-once
+    # contract (the 2026-07-01 incident: HON/DD marked applied on refused
+    # applies, permanently freezing their un-restated histories behind the
+    # marker). A refused action stays pending and re-checks every run.
+    applied_ids = {r["action_id"] for r in applied if r["status"] == "applied"}
     for a in pending:
-        registry.mark_applied(a, _ca.STORE_ARCTICDB_UNIVERSE, run_id=run_id)
+        if a.action_id in applied_ids:
+            registry.mark_applied(a, _ca.STORE_ARCTICDB_UNIVERSE, run_id=run_id)
+        else:
+            log.warning(
+                "daily_append basis-consistency: %s action %s NOT marked "
+                "applied (apply() refused it) — will re-check next run",
+                ticker, a.action_id,
+            )
     return restated if n_changed else hist
+
+
+# An incoming-row-vs-prior-stored-close ratio at or beyond this multiple (or
+# its reciprocal) engages the splice basis-guard's checks. Genuine market
+# moves overlap the split-ratio zone (2026 scan: CAR −48%, KD −55% are real),
+# so crossing this threshold is a TRIGGER for the deterministic tests
+# (registered-action match, same-date stored-row disagreement), never a
+# refusal by magnitude alone.
+_SPLICE_GUARD_SOFT_RATIO = 1.5
+# Tolerance for matching the observed splice ratio to a registered action's
+# factor (mirrors corporate_actions._PRICE_EVIDENCE_REL_TOL).
+_SPLICE_GUARD_REL_TOL = 0.15
+# Operator escape hatch for a GENUINE ≥90% market move the guard would
+# otherwise refuse: comma-separated TICKER:YYYY-MM-DD entries.
+_SPLICE_GUARD_ALLOW_ENV = "DAILY_APPEND_SPLICE_GUARD_ALLOW"
+# Price fields scaled by a split factor (volume scales inversely).
+_SPLICE_PRICE_FIELDS = ("Open", "High", "Low", "Close", "VWAP")
+
+
+def _splice_basis_guard(
+    ticker: str,
+    bar,
+    hist: pd.DataFrame,
+    today_ts,
+    actions: list,
+    registry,
+):
+    """Refuse — or deterministically restate — an incoming daily row whose
+    close sits on a different adjusted basis than the stored history.
+
+    The discriminator between a basis mismatch and a genuine market move
+    (calibrated on the 2026 universe scan: STRL +52%, CAR −48%, KD −55% are
+    all REAL single-day moves that overlap the 2:1-split ratio zone, so
+    magnitude alone cannot refuse):
+
+      * A registered split with ``ex_date > row_date`` already applied to the
+        store explains a ``1/factor`` gap exactly → the row arrived on the
+        pre-action basis (polygon restates its aggregates only once the ex
+        date lands — the CRWD 2026-06-30 case). Deterministic: restate it.
+      * A split-like disagreement with an ALREADY-STORED row for the SAME
+        date whose value coheres with its own neighbors is NEVER a market
+        move (same date, same market — the HON 2026-06-26 case: incoming
+        464.42 vs stored 232.21 on a series whose 06-25 was 231.24) →
+        refuse the overwrite, keep the stored row.
+      * A pure append (no stored same-date row) with an unexplained
+        split-like ratio can be a genuine crash/pop → WRITE it, but at
+        ERROR severity so the flow-doctor pages the same day (if it was a
+        missed corporate action, the registry detection + restatement path
+        heals it as soon as a record lands; if it never lands, the page is
+        the operator's cue).
+
+    Returns ``(bar, verdict)`` with verdict ``"ok"`` / ``"restated"`` /
+    ``"refused"``. Fail-open on missing inputs (no prior close / NaN bar
+    close): the guard protects against DISCONTINUITY; absence of evidence is
+    not one. ``DAILY_APPEND_SPLICE_GUARD_ALLOW=TICKER:YYYY-MM-DD`` force-writes
+    through a refusal.
+    """
+    import corporate_actions as _ca
+
+    try:
+        bar_close = float(bar["Close"])
+    except Exception:  # noqa: BLE001 - NaN/absent close is handled upstream
+        return bar, "ok"
+    if hist is None or hist.empty or "Close" not in hist.columns:
+        return bar, "ok"
+    prior = hist.loc[hist.index < today_ts, "Close"].dropna()
+    if prior.empty or not np.isfinite(bar_close) or bar_close <= 0:
+        return bar, "ok"
+    prior_close = float(prior.iloc[-1])
+    if prior_close <= 0:
+        return bar, "ok"
+
+    ratio = bar_close / prior_close
+    if 1.0 / _SPLICE_GUARD_SOFT_RATIO < ratio < _SPLICE_GUARD_SOFT_RATIO:
+        return bar, "ok"
+
+    # A registered split whose ex_date is AFTER this row's date and which is
+    # already folded into the stored history explains the gap exactly: the
+    # incoming row is pre-action basis, the store is post-action basis, and
+    # the observed ratio is 1/factor. Restate the row by the action's factor.
+    for a in actions:
+        if getattr(a, "type", None) != "split":
+            continue
+        try:
+            ex_ts = pd.Timestamp(a.ex_date).normalize()
+            factor = _ca.expected_factor(a)
+        except Exception:  # noqa: BLE001 - malformed action, can't explain
+            continue
+        if factor <= 0 or ex_ts <= today_ts:
+            continue
+        if registry is not None and not registry.is_applied(
+            _ca.STORE_ARCTICDB_UNIVERSE, a.action_id
+        ):
+            continue
+        expected_gap = 1.0 / factor
+        if abs(ratio - expected_gap) <= _SPLICE_GUARD_REL_TOL * expected_gap:
+            restated_bar = bar.copy()
+            for fld in _SPLICE_PRICE_FIELDS:
+                try:
+                    val = float(restated_bar[fld])
+                except Exception:  # noqa: BLE001 - absent/NaN field, skip
+                    continue
+                if np.isfinite(val):
+                    restated_bar[fld] = val * factor
+            try:
+                vol = float(restated_bar["Volume"])
+                if np.isfinite(vol):
+                    restated_bar["Volume"] = round(vol / factor)
+            except Exception:  # noqa: BLE001 - absent/NaN volume, skip
+                pass
+            log.warning(
+                "daily_append splice basis-guard: %s @ %s row arrived on the "
+                "PRE-action basis (ratio %.4f vs stored history; registered "
+                "%s, ex %s, already applied to the store) — restated the "
+                "incoming row by factor %.6g before splice",
+                ticker, today_ts.date(), ratio, a.human(), a.ex_date, factor,
+            )
+            return restated_bar, "restated"
+
+    allow = {
+        entry.strip()
+        for entry in os.environ.get(_SPLICE_GUARD_ALLOW_ENV, "").split(",")
+        if entry.strip()
+    }
+    allowlisted = f"{ticker}:{today_ts.date()}" in allow
+
+    # Same-date disagreement test: an on-basis stored row for THIS date that
+    # coheres with its own prior neighbor cannot be re-printed a split-like
+    # factor away by the same market — the incoming row is off-basis.
+    stored_same = None
+    if today_ts in hist.index:
+        try:
+            v = float(hist.loc[today_ts, "Close"])
+            if np.isfinite(v) and v > 0:
+                stored_same = v
+        except Exception:  # noqa: BLE001 - malformed stored cell, no verdict
+            stored_same = None
+    if stored_same is not None:
+        same_ratio = bar_close / stored_same
+        stored_coheres = (
+            1.0 / _SPLICE_GUARD_SOFT_RATIO
+            < stored_same / prior_close
+            < _SPLICE_GUARD_SOFT_RATIO
+        )
+        if (
+            not (1.0 / _SPLICE_GUARD_SOFT_RATIO < same_ratio < _SPLICE_GUARD_SOFT_RATIO)
+            and stored_coheres
+        ):
+            if allowlisted:
+                log.warning(
+                    "daily_append splice basis-guard: %s @ %s same-date "
+                    "disagreement (incoming %.4f vs stored %.4f) is "
+                    "operator-allowlisted via %s — overwriting",
+                    ticker, today_ts.date(), bar_close, stored_same,
+                    _SPLICE_GUARD_ALLOW_ENV,
+                )
+                return bar, "ok"
+            log.error(
+                "daily_append splice basis-guard: REFUSING %s @ %s — incoming "
+                "close %.4f disagrees with the ALREADY-STORED close %.4f for "
+                "the SAME date by a split-like factor (%.4f) while the stored "
+                "row coheres with its neighbors. Same-date same-market "
+                "disagreement is a basis mismatch, never a move (2026-06-26 "
+                "HON incident class) — keeping the stored row. Force with "
+                "%s=%s:%s",
+                ticker, today_ts.date(), bar_close, stored_same, same_ratio,
+                _SPLICE_GUARD_ALLOW_ENV, ticker, today_ts.date(),
+            )
+            return bar, "refused"
+
+    # Pure append with an unexplained split-like ratio: can be a genuine
+    # crash/pop (CAR −48%, KD −55% verified real) — write it, page loudly.
+    log.error(
+        "daily_append splice basis-guard: %s @ %s incoming close %.4f vs "
+        "prior stored close %.4f (ratio %.4f) is split-like and NO registered "
+        "corporate action explains it. Writing (a genuine move is possible), "
+        "but if a corporate-action record lands later the restatement path "
+        "must flatten this boundary — verify the split calendar",
+        ticker, today_ts.date(), bar_close, prior_close, ratio,
+    )
+    return bar, "ok"
 
 
 def daily_append(
@@ -1396,6 +1590,26 @@ def _daily_append_impl(
                             "backfill audit remains the correctness gate",
                             ticker, exc,
                         )
+
+                # ── splice basis-guard (2026-07-02 incident) ────────────────
+                # The incoming row and the stored history can sit on DIFFERENT
+                # adjusted bases around a corporate action: polygon serves the
+                # pre-action basis until the ex date lands (CRWD 6/30 spliced
+                # raw at 763.14 onto a ×0.25-restated series), and an old-basis
+                # parquet row can land on a freshly-rebuilt clean series (HON
+                # 6/26 = 464.42 onto the new-basis history — the discontinuity
+                # that later fed FALSE price evidence to an inverted feed
+                # record). Never splice a split-like discontinuity raw: restate
+                # the incoming row when a registered action deterministically
+                # explains the basis gap, refuse it (loud) otherwise.
+                bar, splice_verdict = _splice_basis_guard(
+                    ticker, bar, hist, today_ts,
+                    splits_by_ticker.get(ticker, []), ca_registry,
+                )
+                if splice_verdict == "refused":
+                    n_quality_blocked += 1
+                    quality_blocked_details.append((ticker, "splice_basis_guard"))
+                    continue
 
                 new_row_data = {col: bar.get(col, np.nan) for col in OHLCV_COLS}
                 # Carry per-row provenance through to the ArcticDB write. Source

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -656,6 +656,7 @@ def collect(
     fallback_source: str = "yfinance",
     registry=_REGISTRY_UNSET,
     _emit_ca_email: bool = True,
+    _defer_unexplained_errors: bool = False,
 ) -> dict:
     """
     Fetch OHLCV for all tickers and write to S3.
@@ -1163,9 +1164,11 @@ def collect(
 
     # Discrepancy logging (polygon_only mode, when overwriting an existing parquet)
     explained_actions: list = []
+    unexplained_discrepancies: list = []
     if existing_close_for_discrepancy and polygon_count > 0:
-        explained_actions = _log_close_discrepancies(
+        explained_actions, unexplained_discrepancies = _log_close_discrepancies(
             closes_df, existing_close_for_discrepancy, run_date, registry=registry,
+            defer_unexplained=_defer_unexplained_errors,
         )
 
     # ONE informational email per run for confirmed corporate-action
@@ -1185,6 +1188,7 @@ def collect(
             "yfinance": yfinance_count,
             "source": source,
             "corporate_actions": explained_actions,
+            "unexplained_discrepancies": unexplained_discrepancies,
         }
 
     # ── Step 4: Write to S3 ──────────────────────────────────────────────────
@@ -1210,6 +1214,7 @@ def collect(
             "yfinance": yfinance_count,
             "source": source,
             "corporate_actions": explained_actions,
+            "unexplained_discrepancies": unexplained_discrepancies,
         }
     except Exception as e:
         logger.error("Failed to write daily closes: %s", e)
@@ -1398,6 +1403,7 @@ def _collect_window(
         "skipped_dates": [],
         "backfill_failed_dates": [],
         "corporate_actions": [],
+        "unexplained_discrepancies": [],
     }
     # Iterate oldest → newest so the most recent date's parquet is the
     # last one written. Matches the operator mental model "the latest
@@ -1417,6 +1423,7 @@ def _collect_window(
                 split_touched_dates=split_touched_dates,  # config#717
                 registry=registry,  # config#1431: one registry per window
                 _emit_ca_email=False,  # email sent ONCE at window level below
+                _defer_unexplained_errors=True,  # aggregated ONCE below (2026-07-02)
                 equities_source=equities_source,
                 index_source=index_source,
                 fallback_source=fallback_source,
@@ -1446,12 +1453,26 @@ def _collect_window(
         # the window for the single informational email sent below.
         if result.get("corporate_actions"):
             aggregate["corporate_actions"].extend(result["corporate_actions"])
+        if result.get("unexplained_discrepancies"):
+            aggregate["unexplained_discrepancies"].extend(
+                result["unexplained_discrepancies"]
+            )
 
     # config#1431: ONE informational email per window run for confirmed
     # corporate-action restatements (deduped by action_id in the email layer).
     # Skipped in dry_run (registry is None → no explained actions accumulate).
     if not dry_run and aggregate["corporate_actions"]:
         _send_corporate_action_email(aggregate["corporate_actions"], target_date)
+
+    # 2026-07-02: window-level roll-up of the UNEXPLAINED >5% overwrites the
+    # per-date calls deferred. A corporate-action restatement touches every
+    # window date with ONE uniform ratio — six per-date ERROR emails for one
+    # HON event was misrouting. Uniform-ratio groups (≥2 dates, same ticker,
+    # ratio agreeing within tolerance) page ONCE with the inferred factor;
+    # singletons keep the original per-date ERROR semantics.
+    _emit_window_unexplained_discrepancies(
+        aggregate["unexplained_discrepancies"], target_date,
+    )
 
     # ── Fatality is TARGET-driven, not "any per-date error" ─────────────
     _target = aggregate["per_date"].get(target_date)
@@ -1662,13 +1683,65 @@ def _split_ratio_hint(prior: float, new: float) -> str:
     return ""
 
 
+# Two window dates' unexplained overwrite ratios "agree" (same corporate-action
+# restatement) when they differ by less than this relative tolerance.
+_UNIFORM_RATIO_REL_TOL = 0.02
+
+
+def _emit_window_unexplained_discrepancies(rows: list, target_date: str) -> None:
+    """Window-level roll-up of unexplained >5% overwrite discrepancies.
+
+    Groups rows by ticker; a group whose ratios all agree within
+    ``_UNIFORM_RATIO_REL_TOL`` across ≥2 dates is ONE event (a corporate-action
+    restatement sweeping the window — the 2026-07-02 HON case produced six
+    per-date ERROR emails for one 2:1 separation) and pages ONCE with the
+    inferred factor. Non-uniform groups and singletons page per row, preserving
+    the original per-date ERROR semantics.
+    """
+    if not rows:
+        return
+    by_ticker: dict[str, list] = {}
+    for r in rows:
+        by_ticker.setdefault(r["ticker"], []).append(r)
+    for ticker, group in sorted(by_ticker.items()):
+        ratios = [g["ratio"] for g in group]
+        mean_ratio = sum(ratios) / len(ratios)
+        uniform = len(group) >= 2 and all(
+            abs(r - mean_ratio) <= _UNIFORM_RATIO_REL_TOL * mean_ratio
+            for r in ratios
+        )
+        if uniform:
+            dates = ", ".join(sorted(g["date"] for g in group))
+            logger.error(
+                "polygon_only OVERWRITE %s: UNIFORM ×%.4f restatement across "
+                "%d window date(s) [%s]%s — one event, consistent with a "
+                "corporate action restating adjusted history that has NO "
+                "matching registry/feed record (or an inverted one); check "
+                "the split calendar and the corporate-action registry before "
+                "downstream consumers re-read",
+                ticker, mean_ratio, len(group), dates,
+                _split_ratio_hint(group[0]["prior"], group[0]["new"]),
+            )
+        else:
+            for g in group:
+                pct = abs(g["new"] - g["prior"]) / g["prior"] * 100
+                logger.error(
+                    "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f "
+                    "(%.2f%% diff vs prior parquet)%s — investigate before "
+                    "downstream consumers re-read",
+                    g["ticker"], g["date"], g["prior"], g["new"], pct,
+                    _split_ratio_hint(g["prior"], g["new"]),
+                )
+
+
 def _log_close_discrepancies(
     new_df: pd.DataFrame,
     prior_close: dict[str, float],
     run_date: str,
     *,
     registry=None,
-) -> list:
+    defer_unexplained: bool = False,
+) -> "tuple[list, list]":
     """Log per-ticker Close discrepancy when polygon overwrites yfinance.
 
     A small drift (<1%) is normal — different feeds, slight tick-time offsets,
@@ -1696,9 +1769,19 @@ def _log_close_discrepancies(
     ERROR filter (fixing the HON 1-for-2 reverse-split false-ERROR). The
     authoritative registry takes precedence over the secondary
     ``_split_ratio_hint`` text heuristic (which stays, now only annotating the
-    UNEXPLAINED ERROR branch). Returns the list of explained
-    ``CorporateAction``s seen this run (for the run's one informational email);
-    deduped at the email layer.
+    UNEXPLAINED ERROR branch).
+
+    2026-07-02 (six-ERROR-email incident): with ``defer_unexplained=True`` the
+    unexplained >5% rows are NOT logged at ERROR here — they are returned for
+    the WINDOW caller to aggregate (a corporate-action restatement touches
+    every window date with ONE uniform ratio; six per-date ERROR emails for
+    one event is misrouting, and a genuinely unexplained uniform-ratio group
+    should page ONCE with the inferred factor). Per-date WARN still records
+    each row (``feedback_no_silent_fails`` — the surface stays, severity moves
+    to the aggregate).
+
+    Returns ``(explained_actions, unexplained_rows)`` where each unexplained
+    row is ``{"ticker", "date", "prior", "new", "ratio"}``.
     """
     n_compared = 0
     n_warn = 0
@@ -1706,6 +1789,7 @@ def _log_close_discrepancies(
     n_restatement = 0
     n_corporate_action = 0
     explained_actions: list = []
+    unexplained_rows: list = []
     biggest: tuple[str, float] = ("", 0.0)
     for ticker in new_df.index:
         prior = prior_close.get(str(ticker))
@@ -1747,12 +1831,31 @@ def _log_close_discrepancies(
             n_corporate_action += 1
             explained_actions.append(action)
         elif pct_diff > _DISCREPANCY_ERROR_PCT:
-            logger.error(
-                "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f (%.2f%% diff vs prior parquet)%s — "
-                "investigate before downstream consumers re-read",
-                ticker, run_date, prior, float(new_close), pct_diff * 100,
-                _split_ratio_hint(prior, float(new_close)),
-            )
+            unexplained_rows.append({
+                "ticker": str(ticker),
+                "date": run_date,
+                "prior": float(prior),
+                "new": float(new_close),
+                "ratio": float(new_close) / float(prior),
+            })
+            if defer_unexplained:
+                # Window caller aggregates uniform-ratio groups into ONE
+                # ERROR; the per-row surface stays at WARN so nothing is
+                # silently dropped (feedback_no_silent_fails).
+                logger.warning(
+                    "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f "
+                    "(%.2f%% diff vs prior parquet)%s — deferred to the "
+                    "window-level unexplained-discrepancy aggregation",
+                    ticker, run_date, prior, float(new_close), pct_diff * 100,
+                    _split_ratio_hint(prior, float(new_close)),
+                )
+            else:
+                logger.error(
+                    "polygon_only OVERWRITE %s @ %s: Close %.4f → %.4f (%.2f%% diff vs prior parquet)%s — "
+                    "investigate before downstream consumers re-read",
+                    ticker, run_date, prior, float(new_close), pct_diff * 100,
+                    _split_ratio_hint(prior, float(new_close)),
+                )
             n_error += 1
         elif pct_diff > _DISCREPANCY_WARN_PCT:
             logger.warning(
@@ -1768,7 +1871,7 @@ def _log_close_discrepancies(
         run_date, n_compared, n_warn, n_error, n_restatement, n_corporate_action,
         biggest[0] or "n/a", biggest[1] * 100,
     )
-    return explained_actions
+    return explained_actions, unexplained_rows
 
 
 def _fred_record(store_ticker: str, date_str: str, close: float) -> dict:

--- a/corporate_actions/__init__.py
+++ b/corporate_actions/__init__.py
@@ -141,6 +141,18 @@ class CorporateActionAuditError(RuntimeError):
     """
 
 
+def _normalize_ratio_field(value):
+    """Normalize a split-ratio field: integral → int (id-stable), else float.
+
+    Raises ``ValueError`` on non-positive/non-numeric input — a malformed
+    ratio must fail loud at construction, never become a silent 1:1 no-op.
+    """
+    f = float(value)
+    if not (f > 0) or f != f:
+        raise ValueError(f"split ratio field must be a positive number, got {value!r}")
+    return int(f) if f.is_integer() else f
+
+
 @dataclass(frozen=True)
 class CorporateAction:
     """An immutable, content-addressed corporate-action record.
@@ -156,9 +168,11 @@ class CorporateAction:
     type: str  # "split" | "dividend" | "rename"
     ticker: str
     ex_date: str  # YYYY-MM-DD; the adjustment applies to rows STRICTLY BEFORE this
-    # split fields
-    split_from: int | None = None
-    split_to: int | None = None
+    # split fields — fractional for spinoff-style records (1000:1061, 1:1.2);
+    # integral values are normalized to int so content-addressed ids are
+    # stable across int/float construction paths.
+    split_from: int | float | None = None
+    split_to: int | float | None = None
     # dividend fields (detected by detect_dividends, recorded CRSP-separate)
     cash_amount: float | None = None
     dividend_kind: str | None = None
@@ -196,19 +210,26 @@ class CorporateAction:
         cls,
         ticker: str,
         ex_date: str,
-        split_from: int,
-        split_to: int,
+        split_from: "int | float",
+        split_to: "int | float",
         *,
         source: str = "polygon",
         raw: dict | None = None,
     ) -> "CorporateAction":
-        """Build a split action; ``action_id`` is derived deterministically."""
+        """Build a split action; ``action_id`` is derived deterministically.
+
+        Ratio fields accept FRACTIONAL values (polygon's spinoff-style
+        ``1000:1061`` / ``1:1.2`` records — an ``int()`` cast here silently
+        truncated those factors before 2026-07-02); integral values normalize
+        to ``int`` so the content-addressed id is unchanged for the dominant
+        integer-ratio case.
+        """
         return cls(
             type=_TYPE_SPLIT,
             ticker=str(ticker),
             ex_date=str(ex_date),
-            split_from=int(split_from),
-            split_to=int(split_to),
+            split_from=_normalize_ratio_field(split_from),
+            split_to=_normalize_ratio_field(split_to),
             source=source,
             raw=dict(raw or {}),
         )
@@ -397,6 +418,104 @@ _PRICE_EVIDENCE_REL_TOL = 0.15
 # a thin feed).
 _PRICE_EVIDENCE_EX_DATE_WINDOW_DAYS = 4
 
+# A factor must sit at least this far (multiplicatively) from 1.0 for the
+# direct-vs-inverse orientation test to be discriminable from ordinary daily
+# drift: 1.45 keeps every real split ratio (3:2 = 1.5 and up) in scope while
+# excluding the near-1 spinoff-adjustment records (1000:1061 ≈ 1.061) whose
+# stated factor, inverse, and market noise share one tolerance band.
+_ORIENTATION_MIN_SEPARATION = 1.45
+
+
+def price_evidence_orientation(
+    close: pd.Series,
+    action: CorporateAction,
+    *,
+    rel_tol: float = _PRICE_EVIDENCE_REL_TOL,
+    window_days: int = _PRICE_EVIDENCE_EX_DATE_WINDOW_DAYS,
+) -> str:
+    """Classify what the RAW ``close`` series says about ``action``'s factor
+    DIRECTION around its ``ex_date``.
+
+    A corporate-action FEED can report a split that never happened (config#1455
+    phantom class) — or, observed live 2026-07-01/02, report a REAL split with
+    the ``split_from``/``split_to`` ratio INVERTED (polygon published HON's
+    forward 1:2 as ``2:1`` — then deleted the record upstream — and DD's
+    forward 1:3 as ``3:1``; blindly applying the stated factor multiplied both
+    tickers' full pre-ex histories instead of dividing them). The market's own
+    boundary move is ground truth for the DIRECTION polygon's adjusted
+    aggregates actually applied, so the factor we fold into a price store must
+    be corroborated against it, not trusted from the feed's field ordering.
+
+    Looks at every adjacent trading-day pair in ±``window_days`` of ``ex_date``
+    on the RAW close (a real split prints its factor as the boundary ratio
+    ``close[d]/close[d-1]``) and returns one of:
+
+      * ``"direct"``    — a boundary matches ``expected_factor(action)`` and
+        none matches its inverse: the feed's orientation is market-confirmed.
+      * ``"inverse"``   — a boundary matches ``1/expected_factor`` and none
+        matches the stated factor: the feed record is inverted; the
+        market-corrected factor is ``1/expected_factor``.
+      * ``"ambiguous"`` — boundaries match BOTH orientations (seen when a
+        prior basis-splice corruption fabricates the direct ratio while the
+        real move prints the inverse — the HON 2026-07-01 series). Nothing
+        can be trusted here; the caller must refuse.
+      * ``"none"``      — the window is covered but no boundary matches
+        either orientation (the phantom-split case).
+      * ``"uncovered"`` — the series doesn't cover the window (< 2 rows), so
+        the market can neither confirm nor refute.
+
+    Non-split actions return ``"direct"`` (nothing to check — only splits
+    mutate the price level) as does a malformed factor (``expected_factor``
+    guards those upstream).
+    """
+    if action.type != _TYPE_SPLIT:
+        return "direct"  # only splits mutate the price level; nothing to check
+    expected = expected_factor(action)
+    if expected <= 0:
+        return "direct"  # malformed ratio — expected_factor already guards this
+
+    if close is None or close.empty:
+        return "uncovered"
+
+    idx = close.index if isinstance(close.index, pd.DatetimeIndex) else pd.to_datetime(close.index)
+    s = pd.Series(close.to_numpy(dtype="float64"), index=idx).sort_index()
+    s = s[s > 0]  # a non-positive close can't form a meaningful ratio
+    if s.empty:
+        return "uncovered"
+
+    ex = pd.Timestamp(action.ex_date).normalize()
+    lo = ex - pd.Timedelta(days=window_days)
+    hi = ex + pd.Timedelta(days=window_days)
+    window = s[(s.index >= lo) & (s.index <= hi)]
+    if len(window) < 2:
+        # Window not covered by this series (e.g. ticker's history starts
+        # after ex_date, or a sparse feed).
+        return "uncovered"
+
+    ratios = (window / window.shift(1)).dropna()
+    if ratios.empty:
+        return "uncovered"
+
+    direct_hit = bool((ratios.sub(expected).abs() <= rel_tol * expected).any())
+
+    # Orientation is only DISCRIMINABLE when the factor sits well away from
+    # 1.0 — for a near-1 factor (polygon's 1000:1061 spinoff-style records)
+    # the stated factor, its inverse, and ordinary daily drift all fall inside
+    # one tolerance band, so inverse/ambiguous verdicts would be noise. Those
+    # factors keep the legacy direct-only semantics.
+    if 1.0 / _ORIENTATION_MIN_SEPARATION < expected < _ORIENTATION_MIN_SEPARATION:
+        return "direct" if direct_hit else "none"
+
+    inverse = 1.0 / expected
+    inverse_hit = bool((ratios.sub(inverse).abs() <= rel_tol * inverse).any())
+    if direct_hit and inverse_hit:
+        return "ambiguous"
+    if direct_hit:
+        return "direct"
+    if inverse_hit:
+        return "inverse"
+    return "none"
+
 
 def has_price_evidence(
     close: pd.Series,
@@ -405,67 +524,17 @@ def has_price_evidence(
     rel_tol: float = _PRICE_EVIDENCE_REL_TOL,
     window_days: int = _PRICE_EVIDENCE_EX_DATE_WINDOW_DAYS,
 ) -> bool:
-    """Does the RAW (unadjusted) ``close`` series actually show a price move
-    corroborating ``action`` (a split) around its ``ex_date``?
-
-    A corporate-action FEED can report a split that never happened in the real
-    market (a premature/erroneous/duplicate feed entry — observed live:
-    polygon returning ``execution_date`` in the past with no matching price
-    discontinuity, config#1455). Blindly trusting every feed event and
-    dividing/multiplying the ENTIRE pre-ex_date history by its factor bakes a
-    fictitious jump into the adjusted series — the mirror-image corruption of
-    the un-flattened-known-split case ``audit_action_jumps`` already catches
-    (PR3 §3): there, a REAL split's factor is missing from the series; here, a
-    FAKE split's factor gets baked in. Both are "trust polygon's stated
-    factor without checking the market agrees."
-
-    Looks for at least one adjacent trading-day pair straddling ``ex_date``
-    (within ``window_days``) on the RAW, UNADJUSTED close whose ratio
-    ``close[d]/close[d-1]`` is within ``rel_tol`` of ``expected_factor(action)``
-    (the boundary ratio a real split of this size prints on unadjusted prices —
-    ``expected_factor`` is exactly the multiplier that brings a PRE-ex_date raw
-    price onto the POST-ex_date scale, so the same multiplier is what the raw
-    series' own pre→post boundary ratio shows: e.g. a reverse 1-for-3 split,
-    ``expected_factor=3.0``, triples the raw price at the boundary; a forward
-    4-for-1 split, ``expected_factor=0.25``, quarters it). Returns ``True`` on
-    ANY matching boundary in the window (a split can print 1-2 sessions
-    late/early on a thin feed) or if ``close`` doesn't cover the window at all
-    (can't disprove it — degrades to trusting the feed, the PRE-existing
-    behavior, rather than blocking on missing data). Returns ``False`` only
-    when the window IS covered and NO boundary pair matches — the confident
-    "this action has no price corroboration" case.
+    """Back-compat wrapper over :func:`price_evidence_orientation` — True iff
+    the market confirms the action's STATED orientation. Note the semantic
+    tightening (2026-07-02): an uncovered window now returns ``False`` (do not
+    mutate a price level on zero corroboration) where it previously trusted
+    the feed — the inverted-record incident showed feed trust without market
+    evidence is how full-history corruption happens. With no pre-ex rows in
+    frame there is nothing to restate anyway, so the safe answer costs nothing.
     """
-    if action.type != _TYPE_SPLIT:
-        return True  # only splits mutate the price level; nothing to check
-    expected = expected_factor(action)
-    if expected <= 0:
-        return True  # malformed ratio — expected_factor already guards this
-    # Boundary ratio close[d]/close[d-1] for d the first row on/after ex_date,
-    # on UNADJUSTED prices, IS expected_factor (see docstring).
-    target_ratio = expected
-
-    if close is None or close.empty:
-        return True  # no series to check against — can't disprove, don't block
-
-    idx = close.index if isinstance(close.index, pd.DatetimeIndex) else pd.to_datetime(close.index)
-    s = pd.Series(close.to_numpy(dtype="float64"), index=idx).sort_index()
-    s = s[s > 0]  # a non-positive close can't form a meaningful ratio
-    if s.empty:
-        return True
-
-    ex = pd.Timestamp(action.ex_date).normalize()
-    lo = ex - pd.Timedelta(days=window_days)
-    hi = ex + pd.Timedelta(days=window_days)
-    window = s[(s.index >= lo) & (s.index <= hi)]
-    if len(window) < 2:
-        # Window not covered by this series (e.g. ticker's history starts
-        # after ex_date, or a sparse feed) — can't disprove, don't block.
-        return True
-
-    ratios = (window / window.shift(1)).dropna()
-    if ratios.empty:
-        return True
-    return bool((ratios.sub(target_ratio).abs() <= rel_tol * target_ratio).any())
+    return price_evidence_orientation(
+        close, action, rel_tol=rel_tol, window_days=window_days,
+    ) == "direct"
 
 
 # ── dividends: total-return factor MATH (CRSP/Barra basis) ───────────────────
@@ -660,9 +729,17 @@ def apply(
     idx = df.index if isinstance(df.index, pd.DatetimeIndex) else pd.to_datetime(df.index)
     raw_close = df["Close"] if "Close" in df.columns else None
 
-    events_to_apply: list[CorporateAction] = []
+    # (action, effective_factor, orientation_corrected) triples cleared to
+    # restate. ``effective_factor`` is the MARKET-CORROBORATED multiplier for
+    # pre-ex rows — equal to the feed's ``expected_factor`` when the market
+    # confirms the stated orientation, and its inverse when the market shows
+    # the feed record is inverted (observed live 2026-07-01/02: polygon
+    # published HON's forward 1:2 as ``2:1`` and DD's forward 1:3 as ``3:1``,
+    # which — applied as stated — multiplied both full histories instead of
+    # dividing them).
+    events_to_apply: list[tuple[CorporateAction, float, bool]] = []
     for a in split_actions:
-        factor = expected_factor(a)  # == split_from / split_to (authoritative)
+        factor = expected_factor(a)  # == split_from / split_to (as stated by feed)
         # Exactly-once: skip an action already folded into this store.
         if registry is not None and registry.is_applied(store, a.action_id):
             applied_results.append({
@@ -673,56 +750,117 @@ def apply(
                 "status": "noop",
             })
             continue
-        # PRICE-EVIDENCE gate (config#1455): a feed can report a split that
-        # never happened in the real market (observed live: polygon returning
-        # a past execution_date with no matching price discontinuity — the
-        # mirror-image of the un-flattened-KNOWN-split corruption
-        # ``audit_action_jumps`` catches post-hoc). Check BEFORE restating so
-        # a phantom factor never reaches the price level: an action with no
-        # corroborating boundary move on the raw close is NOT applied here —
-        # it is surfaced as ``status="unconfirmed"`` (loud, visible, never
-        # silently dropped) so the caller can WARN/notify rather than bake in
-        # a fictitious jump. Never marks the registry (an unconfirmed action
-        # must be re-checked every run, not remembered as skipped).
-        if not has_price_evidence(raw_close, a):
+        # PRICE-EVIDENCE + ORIENTATION gate (config#1455 + 2026-07-02
+        # inverted-record incident): the market's own boundary move is the
+        # ground truth for BOTH whether the action is real (phantom check) and
+        # which DIRECTION its factor applies (orientation check). The stated
+        # factor reaches the price level only when the raw close corroborates
+        # it; an unambiguous inverse match applies the market-corrected
+        # 1/factor (loud WARN + flagged in the result); ambiguous/none/
+        # uncovered never mutate the store and never mark the registry (an
+        # unresolved action must be re-checked every run, not remembered as
+        # skipped).
+        orientation = price_evidence_orientation(raw_close, a)
+        if orientation == "direct":
+            events_to_apply.append((a, factor, False))
+        elif orientation == "inverse":
+            corrected = 1.0 / factor
+            applied_note = (
+                "corporate_actions.apply: %s %s (%s) — feed record is "
+                "INVERTED: raw close boundary matches 1/factor=%.6g, not the "
+                "stated factor %.6g. Applying the MARKET-CORRECTED factor "
+                "(orientation_corrected=True); action_id=%s"
+            )
+            log.warning(
+                applied_note, a.ticker, a.human(), store, corrected, factor,
+                a.action_id,
+            )
+            events_to_apply.append((a, corrected, True))
+        else:
             applied_results.append({
                 "action_id": a.action_id,
                 "store": store,
                 "n_rows_adjusted": 0,
                 "factor": factor,
-                "status": "unconfirmed",
+                "status": (
+                    "ambiguous_evidence" if orientation == "ambiguous"
+                    else "unconfirmed"
+                ),
             })
-            log.warning(
-                "corporate_actions.apply: %s %s (%s) has NO corroborating "
-                "price move on the raw close within the ex_date window — "
-                "NOT applying (feed-reported split with no market evidence, "
-                "config#1455); action_id=%s",
-                a.ticker, a.human(), store, a.action_id,
-            )
+            if orientation == "ambiguous":
+                log.error(
+                    "corporate_actions.apply: %s %s (%s) — raw close matches "
+                    "BOTH the stated factor and its inverse around ex_date "
+                    "(a prior basis-splice corruption can fabricate the "
+                    "stated-direction ratio). REFUSING to restate — resolve "
+                    "the series basis first; action_id=%s",
+                    a.ticker, a.human(), store, a.action_id,
+                )
+            else:
+                log.warning(
+                    "corporate_actions.apply: %s %s (%s) has NO corroborating "
+                    "price move on the raw close within the ex_date window "
+                    "(orientation=%s) — NOT applying (feed-reported split "
+                    "with no market evidence, config#1455); action_id=%s",
+                    a.ticker, a.human(), store, orientation, a.action_id,
+                )
             continue
-        events_to_apply.append(a)
 
     if not events_to_apply:
         return df, applied_results
 
+    # Feed ``restate_series_for_splits`` the MARKET-CORROBORATED factor: for an
+    # orientation-corrected action the from/to pair is swapped so the shared
+    # factor convention (multiply pre-ex rows by split_from/split_to) yields
+    # the corrected multiplier.
     events = [
         {
             "execution_date": a.ex_date,
-            "split_from": a.split_from,
-            "split_to": a.split_to,
+            "split_from": a.split_to if corrected_flag else a.split_from,
+            "split_to": a.split_from if corrected_flag else a.split_to,
         }
-        for a in events_to_apply
+        for a, _eff, corrected_flag in events_to_apply
     ]
     restated = restate_series_for_splits(df, events)
 
-    for a in events_to_apply:
+    # POST-RESTATE boundary audit (2026-07-02): on the OUTPUT frame, no
+    # boundary pair around any applied ex_date may still print the applied
+    # factor or its inverse — a residual means the restatement went the wrong
+    # direction or double-applied (the corruption this function exists to
+    # prevent). Fail loud BEFORE the caller writes. Near-1 factors are exempt
+    # (a correctly-flattened ~1.0 boundary is indistinguishable from a near-1
+    # factor within tolerance, so the audit would false-fail).
+    if "Close" in restated.columns:
+        for a, eff, _corrected_flag in events_to_apply:
+            stated = expected_factor(a)
+            if 1.0 / _ORIENTATION_MIN_SEPARATION < stated < _ORIENTATION_MIN_SEPARATION:
+                continue
+            residual = price_evidence_orientation(
+                restated["Close"],
+                CorporateAction.from_split(
+                    a.ticker, a.ex_date, a.split_from, a.split_to,
+                    source=a.source, raw=a.raw,
+                ),
+            )
+            if residual in ("direct", "inverse", "ambiguous"):
+                raise CorporateActionAuditError(
+                    f"corporate_actions.apply: post-restate residual boundary "
+                    f"for {a.ticker} {a.human()} (store={store}, "
+                    f"orientation={residual}, effective_factor={eff:.6g}, "
+                    f"action_id={a.action_id}) — restatement did not flatten "
+                    f"the ex_date boundary; refusing so the caller does not "
+                    f"persist a corrupted series"
+                )
+
+    for a, eff, corrected_flag in events_to_apply:
         ex = pd.Timestamp(a.ex_date).normalize()
         n_rows_adjusted = int((idx < ex).sum())
         applied_results.append({
             "action_id": a.action_id,
             "store": store,
             "n_rows_adjusted": n_rows_adjusted,
-            "factor": expected_factor(a),
+            "factor": eff,
+            "orientation_corrected": corrected_flag,
             "status": "applied",
         })
         if registry is not None:
@@ -839,9 +977,20 @@ def _sync_arcticdb_universe(
     )
     if any(r["n_rows_adjusted"] > 0 for r in applied_math):
         lib.write(ticker, to_arctic_canonical(restated), prune_previous_versions=True)
+    # Mark ONLY actions apply() actually folded in (status == "applied").
+    # Marking an unconfirmed/ambiguous refusal would poison the exactly-once
+    # contract: the marker permanently blocks the restatement it falsely
+    # claims happened (2026-07-01 incident — HON/DD were marked applied on a
+    # refused/corrupted apply and their un-restated histories were frozen
+    # behind the marker). A refused action stays pending and is re-checked
+    # every run — loud, never silently dropped.
     if registry is not None:
+        applied_ids = {
+            r["action_id"] for r in applied_math if r["status"] == "applied"
+        }
         for a in pending:
-            registry.mark_applied(a, STORE_ARCTICDB_UNIVERSE, run_id=run_id)
+            if a.action_id in applied_ids:
+                registry.mark_applied(a, STORE_ARCTICDB_UNIVERSE, run_id=run_id)
     for r in applied_math:
         r = dict(r)
         r["ticker"] = ticker

--- a/corporate_actions/registry.py
+++ b/corporate_actions/registry.py
@@ -268,18 +268,26 @@ class CorporateActionRegistry:
         close jump from ``prior`` to ``new`` on ``date`` for ``ticker``, or None.
 
         A match requires BOTH:
-          1. the observed multiplicative factor ``new/prior`` equals the action's
-             :func:`corporate_actions.expected_factor` within ``_SPLIT_RATIO_TOL``
-             (a split restates by the EXACT factor), and
+          1. the observed multiplicative factor ``new/prior`` equals the
+             action's :func:`corporate_actions.expected_factor` — OR its
+             INVERSE — within ``_SPLIT_RATIO_TOL`` (a split restates by the
+             EXACT factor; the inverse match covers a feed record published
+             with the from/to ratio inverted, observed live 2026-06/07 on
+             polygon's HON ``2:1`` and DD ``3:1`` records — the restatement
+             the overwrite performs is still that action's, so the ERROR
+             storm it caused was misclassification, not signal), and
           2. the action's ``ex_date`` is plausibly near ``date`` — on/after
              ``date`` (a split restates dates strictly before its ex date), with
              a few days of early leniency and a bounded look-ahead.
 
-        Only split actions are classified this PR. Matches against the splits
-        DETECTED THIS SESSION (``_session_actions``, recorded via
-        record_detected) — sufficient and authoritative for the live run, and
-        free of any S3 list. Returns the matching action (the first, by ex_date)
-        or None.
+        Only split actions are classified. Matches against the splits detected
+        THIS SESSION (``_session_actions``) first, then the PERSISTED registry
+        (``_ensure_loaded`` — one lazy S3 list per registry instance): a window
+        that re-touches a date restated days earlier must still classify the
+        overwrite as that action's expected restatement (2026-07-02: six
+        per-date ERROR emails for HON's already-registered separation because
+        only session-scope was consulted). Returns the matching action (the
+        first, by ex_date) or None.
         """
         from corporate_actions import expected_factor
 
@@ -291,9 +299,19 @@ class CorporateActionRegistry:
         except Exception:
             return None
 
+        known: dict = {}
+        try:
+            known.update(self._ensure_loaded())
+        except Exception as exc:  # noqa: BLE001 - degrade to session-only scope
+            log.warning(
+                "corporate_actions registry: persisted-action load failed (%s) "
+                "— explains_discrepancy degrades to session-detected scope",
+                exc,
+            )
+        known.update(self._session_actions)  # session wins on id collision
         candidates = [
             a
-            for a in self._session_actions.values()
+            for a in known.values()
             if a.type == "split" and a.ticker == str(ticker)
         ]
         # Evaluate by ex_date ascending so the earliest plausible action wins.
@@ -315,5 +333,8 @@ class CorporateActionRegistry:
             if expected <= 0:
                 continue
             if abs(observed - expected) / expected <= _SPLIT_RATIO_TOL:
+                return action
+            inverse = 1.0 / expected
+            if abs(observed - inverse) / inverse <= _SPLIT_RATIO_TOL:
                 return action
         return None

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -78,6 +78,53 @@ class PolygonForbiddenError(Exception):
     """
 
 
+def _split_ratio_num(value):
+    """Parse one polygon split-ratio field, preserving fractional factors.
+
+    Polygon publishes FRACTIONAL ``split_from``/``split_to`` for spinoff-style
+    adjustments (``1000:1061``, ``1:1.0517…``; live 2026-06: CCBC ``1:1.2``,
+    NRWRF ``20.625:21.625``). The pre-2026-07-02 ``int()`` cast silently
+    truncated those (``1.2 → 1``, corrupting the registry's expected factor)
+    and raised on numeric strings, degrading the WHOLE window's split
+    detection to empty. Integral values normalize to ``int`` so the
+    content-addressed action id derivation is unchanged for the (dominant)
+    integer-ratio case. Returns ``None`` for a malformed/non-positive value.
+    """
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not (f > 0) or f != f or f in (float("inf"), float("-inf")):
+        return None
+    return int(f) if float(f).is_integer() else f
+
+
+def _parse_split_row(r: dict, *, require_ticker: bool = False):
+    """Parse one ``/v3/reference/splits`` result row; ``None`` + WARN if
+    malformed (per-row skip — one bad row must not degrade the whole window's
+    split detection to empty, which is what a raised cast did before
+    2026-07-02)."""
+    exec_date = r.get("execution_date")
+    sf = _split_ratio_num(r.get("split_from"))
+    st = _split_ratio_num(r.get("split_to"))
+    ticker = r.get("ticker")
+    if not exec_date or sf is None or st is None or (require_ticker and not ticker):
+        logger.warning(
+            "polygon splits: skipping malformed record (execution_date=%r, "
+            "split_from=%r, split_to=%r, ticker=%r)",
+            exec_date, r.get("split_from"), r.get("split_to"), ticker,
+        )
+        return None
+    row = {
+        "execution_date": str(exec_date),
+        "split_from": sf,
+        "split_to": st,
+    }
+    if ticker:
+        row["ticker"] = str(ticker)
+    return row
+
+
 class PolygonClient:
     """Rate-limited polygon.io REST client with dividend adjustment."""
 
@@ -284,12 +331,17 @@ class PolygonClient:
         split lands.
 
         Returns a list of ``{"execution_date": "YYYY-MM-DD",
-        "split_from": int, "split_to": int}`` sorted ascending by date. A
-        forward N-for-1 split is ``split_from=1, split_to=N`` (one old share
-        becomes N new shares → adjusted price divides by N); a reverse 1-for-N
-        split is ``split_from=N, split_to=1``. The per-event multiplicative
-        factor applied to prices BEFORE the execution date is
-        ``split_from / split_to``.
+        "split_from": int|float, "split_to": int|float}`` sorted ascending by
+        date. A forward N-for-1 split is ``split_from=1, split_to=N`` (one old
+        share becomes N new shares → adjusted price divides by N); a reverse
+        1-for-N split is ``split_from=N, split_to=1``. The per-event
+        multiplicative factor applied to prices BEFORE the execution date is
+        ``split_from / split_to``. Ratio fields are FRACTIONAL when polygon
+        publishes them so (spinoff-style records like ``1000:1061`` or
+        ``1:1.0517…``; live examples 2026-06: CCBC ``1:1.2``, NRWRF
+        ``20.625:21.625``) — ``int()`` truncation silently corrupted those
+        factors before 2026-07-02. Integral values normalize to ``int`` so
+        content-addressed action ids stay stable.
         """
         results: list[dict] = []
         try:
@@ -300,18 +352,11 @@ class PolygonClient:
         except PolygonForbiddenError:
             return []
         for r in data.get("results", []) or []:
-            exec_date = r.get("execution_date")
-            sf = r.get("split_from")
-            st = r.get("split_to")
-            if not exec_date or not sf or not st:
-                continue
-            results.append(
-                {
-                    "execution_date": str(exec_date),
-                    "split_from": int(sf),
-                    "split_to": int(st),
-                }
-            )
+            row = _parse_split_row(r)
+            if row is not None:
+                results.append(
+                    {k: row[k] for k in ("execution_date", "split_from", "split_to")}
+                )
         results.sort(key=lambda r: r["execution_date"])
         return results
 
@@ -349,20 +394,9 @@ class PolygonClient:
         except PolygonForbiddenError:
             return []
         for r in data.get("results", []) or []:
-            exec_date = r.get("execution_date")
-            sf = r.get("split_from")
-            st = r.get("split_to")
-            ticker = r.get("ticker")
-            if not exec_date or not sf or not st or not ticker:
-                continue
-            results.append(
-                {
-                    "ticker": str(ticker),
-                    "execution_date": str(exec_date),
-                    "split_from": int(sf),
-                    "split_to": int(st),
-                }
-            )
+            row = _parse_split_row(r, require_ticker=True)
+            if row is not None:
+                results.append(row)
         results.sort(key=lambda r: r["execution_date"])
         return results
 

--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -348,18 +348,21 @@ class TestHasPriceEvidence:
         action = ca.CorporateAction.from_split("X", "2026-01-20", 1, 4)
         assert ca.has_price_evidence(close, action) is True
 
-    def test_no_window_coverage_degrades_to_true(self):
-        """A series that doesn't cover the ex_date window can't disprove the
-        action — degrades to trusting the feed (pre-existing behavior) rather
-        than blocking on missing data."""
+    def test_no_window_coverage_is_uncovered_not_trusted(self):
+        """A series that doesn't cover the ex_date window can neither confirm
+        nor refute the action. Semantics TIGHTENED 2026-07-02 (inverted-record
+        incident): a price-level mutation now requires positive market
+        corroboration, so uncovered -> not applied (with no pre-ex rows in
+        frame there is nothing to restate anyway - the safe answer is free)."""
         idx = pd.bdate_range("2020-01-01", "2020-01-10")
         close = pd.Series(100.0, index=idx)
         action = ca.CorporateAction.from_split("X", "2026-06-15", 1, 10)
-        assert ca.has_price_evidence(close, action) is True
+        assert ca.price_evidence_orientation(close, action) == "uncovered"
+        assert ca.has_price_evidence(close, action) is False
 
-    def test_empty_series_degrades_to_true(self):
+    def test_empty_series_is_uncovered_not_trusted(self):
         action = ca.CorporateAction.from_split("X", "2026-06-15", 1, 10)
-        assert ca.has_price_evidence(pd.Series(dtype="float64"), action) is True
+        assert ca.has_price_evidence(pd.Series(dtype="float64"), action) is False
 
     def test_dividend_and_rename_always_true(self):
         """Only splits mutate the price level; has_price_evidence is a no-op

--- a/tests/test_corporate_actions_orientation.py
+++ b/tests/test_corporate_actions_orientation.py
@@ -1,0 +1,254 @@
+"""2026-07-02 inverted-feed-record incident class — regression coverage.
+
+The incident (Honeywell separation + DuPont split, 2026-06/07):
+
+  * polygon published BOTH mega-cap June 2026 split records with the
+    ``split_from``/``split_to`` ratio INVERTED (HON's forward 1:2 as ``2:1``
+    — a record it later deleted upstream — and DD's forward 1:3 as ``3:1``),
+    while its adjusted aggregates restated the histories in the true
+    (dividing) direction;
+  * ``apply()`` trusted the stated orientation, and — corroborated by a
+    prior splice-corruption boundary — multiplied HON's full pre-ex history
+    ×2 (DD ×3) in the ArcticDB training store;
+  * ``_ensure_history_restated`` / ``_sync_arcticdb_universe`` then marked
+    even REFUSED actions as applied, permanently freezing the corruption
+    behind the exactly-once marker;
+  * fractional polygon ratio fields (CCBC ``1:1.2``, NRWRF
+    ``20.625:21.625``) were silently int-truncated on ingest;
+  * the discrepancy classifier consulted only session-detected actions and
+    only the stated orientation, so the (registered!) event still paged six
+    per-date ERROR emails when later windows re-touched restated dates.
+
+Each test here pins the corrected behavior for one of those legs.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+import corporate_actions as ca
+from corporate_actions import CorporateActionRegistry
+
+
+class _FakeS3:
+    """Minimal in-memory S3 double for seeding a CorporateActionRegistry."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"fake"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _registry() -> CorporateActionRegistry:
+    return CorporateActionRegistry(_FakeS3(), "test-bucket")
+
+
+def _series(values_by_date: dict[str, float]) -> pd.Series:
+    idx = pd.to_datetime(list(values_by_date))
+    return pd.Series(list(values_by_date.values()), index=idx).sort_index()
+
+
+def _frame(values_by_date: dict[str, float]) -> pd.DataFrame:
+    close = _series(values_by_date)
+    return pd.DataFrame(
+        {
+            "Open": close.values,
+            "High": close.values,
+            "Low": close.values,
+            "Close": close.values,
+            "Volume": 1_000_000.0,
+            "VWAP": close.values,
+        },
+        index=close.index,
+    )
+
+
+def _dd_like_frame() -> pd.DataFrame:
+    """A clean pre-split series with the genuine forward-split drop at the ex
+    date — what the raw market actually printed for DD's 1:3 on 2026-06-24."""
+    dates = pd.bdate_range("2026-05-15", "2026-06-30")
+    vals = np.where(dates < pd.Timestamp("2026-06-24"), 420.0, 140.0)
+    return pd.DataFrame(
+        {
+            "Open": vals, "High": vals, "Low": vals, "Close": vals,
+            "Volume": 1_000_000.0, "VWAP": vals,
+        },
+        index=dates,
+    )
+
+
+class TestOrientationClassification:
+    def test_inverted_record_classified_inverse(self):
+        # Feed says 3:1 (reverse, price should TRIPLE); market halved-by-3.
+        inverted = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+        df = _dd_like_frame()
+        assert ca.price_evidence_orientation(df["Close"], inverted) == "inverse"
+
+    def test_correct_record_classified_direct(self):
+        correct = ca.CorporateAction.from_split("DD", "2026-06-24", 1, 3)
+        df = _dd_like_frame()
+        assert ca.price_evidence_orientation(df["Close"], correct) == "direct"
+
+    def test_splice_corrupted_series_classified_ambiguous(self):
+        # The HON 2026-07-01 shape: clean new-basis series EXCEPT one raw
+        # old-basis spliced row right before the ex date — the splice prints
+        # the stated-direction ratio while the real move prints the inverse.
+        vals = {
+            "2026-06-24": 227.42,
+            "2026-06-25": 231.24,
+            "2026-06-26": 464.42,  # old-basis splice row
+            "2026-06-29": 227.80,
+            "2026-06-30": 223.90,
+        }
+        inverted = ca.CorporateAction.from_split("HON", "2026-06-29", 2, 1)
+        assert (
+            ca.price_evidence_orientation(_series(vals), inverted) == "ambiguous"
+        )
+
+    def test_near_one_factor_keeps_legacy_direct_semantics(self):
+        # 1000:1061 spinoff-style record: direction is not discriminable from
+        # daily noise — never returns inverse/ambiguous.
+        action = ca.CorporateAction.from_split("HON", "2025-10-30", 1000, 1061)
+        vals = {d.strftime("%Y-%m-%d"): 100.0 for d in pd.bdate_range("2025-10-20", "2025-11-05")}
+        orientation = ca.price_evidence_orientation(_series(vals), action)
+        assert orientation in ("direct", "none")
+
+
+class TestApplyOrientation:
+    _STORE = ca.STORE_ARCTICDB_UNIVERSE
+
+    def test_inverted_record_applies_market_corrected_factor(self):
+        inverted = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+        df = _dd_like_frame()
+        out, results = ca.apply(df, [inverted], store=self._STORE, registry=None)
+        (res,) = results
+        assert res["status"] == "applied"
+        assert res["orientation_corrected"] is True
+        assert res["factor"] == pytest.approx(1 / 3)
+        # Pre-ex history DIVIDED (onto the post-split scale), never multiplied.
+        assert out.loc["2026-06-23", "Close"] == pytest.approx(140.0)
+        assert out.loc["2026-06-24", "Close"] == pytest.approx(140.0)
+        # Boundary flattened — no residual split-like jump.
+        assert out["Close"].pct_change().abs().max() < 0.33
+
+    def test_ambiguous_evidence_refuses_and_never_marks(self):
+        reg = _registry()
+        vals = {
+            "2026-06-24": 227.42,
+            "2026-06-25": 231.24,
+            "2026-06-26": 464.42,
+            "2026-06-29": 227.80,
+            "2026-06-30": 223.90,
+        }
+        inverted = ca.CorporateAction.from_split("HON", "2026-06-29", 2, 1)
+        df = _frame(vals)
+        out, results = ca.apply(df, [inverted], store=self._STORE, registry=reg)
+        (res,) = results
+        assert res["status"] == "ambiguous_evidence"
+        assert res["n_rows_adjusted"] == 0
+        assert reg.is_applied(self._STORE, inverted.action_id) is False
+        # Frame untouched.
+        assert out.loc["2026-06-25", "Close"] == pytest.approx(231.24)
+
+
+class TestFractionalRatios:
+    def test_fractional_split_factor_survives_construction(self):
+        action = ca.CorporateAction.from_split("CCBC", "2026-06-18", 1, 1.2)
+        assert action.split_to == pytest.approx(1.2)
+        assert ca.expected_factor(action) == pytest.approx(1 / 1.2)
+
+    def test_integral_float_normalizes_to_int_for_id_stability(self):
+        a_int = ca.CorporateAction.from_split("X", "2026-01-02", 1, 2)
+        a_float = ca.CorporateAction.from_split("X", "2026-01-02", 1.0, 2.0)
+        assert a_int.action_id == a_float.action_id
+        assert isinstance(a_float.split_from, int)
+
+    def test_malformed_ratio_fails_loud(self):
+        with pytest.raises(ValueError):
+            ca.CorporateAction.from_split("X", "2026-01-02", 0, 2)
+        with pytest.raises(ValueError):
+            ca.CorporateAction.from_split("X", "2026-01-02", "abc", 2)
+
+
+class TestExplainsDiscrepancyUpgrades:
+    def test_inverse_ratio_of_registered_action_explains(self):
+        # DD's registry record is the upstream-inverted 3:1; the overwrite the
+        # window observes is the TRUE restatement ratio ~1/3. Must classify as
+        # that action's restatement (WARN), not page an unexplained ERROR.
+        reg = _registry()
+        inverted = ca.CorporateAction.from_split("DD", "2026-06-24", 3, 1)
+        reg.record_detected(inverted, run_id="r")
+        action = reg.explains_discrepancy("DD", "2026-06-20", 420.03, 140.01)
+        assert action is not None
+        assert action.action_id == inverted.action_id
+
+    def test_persisted_actions_consulted_without_session_detection(self):
+        # A FRESH registry instance over the same S3 (new session, no
+        # record_detected calls) must still explain via the persisted record —
+        # the 2026-07-02 six-email storm was session-scope-only matching.
+        s3 = _FakeS3()
+        first = CorporateActionRegistry(s3, "test-bucket")
+        recorded = ca.CorporateAction.from_split("HON", "2026-06-29", 1, 2)
+        first.record_detected(recorded, run_id="r1")
+
+        fresh = CorporateActionRegistry(s3, "test-bucket")
+        action = fresh.explains_discrepancy("HON", "2026-06-26", 464.42, 232.21)
+        assert action is not None
+        assert action.action_id == recorded.action_id
+
+
+class TestMarkOnlyAppliedDiscipline:
+    def test_sync_arcticdb_universe_does_not_mark_refused_action(self, monkeypatch):
+        # A phantom action (no market evidence in the symbol's series) must
+        # stay UNMARKED after the sync leg — marking it froze HON/DD's
+        # un-restated histories behind the exactly-once contract on 2026-07-01.
+        reg = _registry()
+        phantom = ca.CorporateAction.from_split("HON", "2026-06-29", 1, 2)
+
+        flat = _frame(
+            {d.strftime("%Y-%m-%d"): 100.0
+             for d in pd.bdate_range("2026-06-20", "2026-07-01")}
+        )
+
+        class _FakeLib:
+            def read(self, _symbol):
+                class _R:
+                    data = flat
+                return _R()
+
+            def write(self, *a, **k):
+                raise AssertionError("refused action must not trigger a write")
+
+        monkeypatch.setattr(
+            "store.arctic_store.get_universe_lib", lambda bucket: _FakeLib()
+        )
+        monkeypatch.setattr(
+            "store.arctic_store.to_arctic_canonical", lambda df: df
+        )
+        results = ca._sync_arcticdb_universe(
+            "test-bucket", "HON", [phantom], reg, run_id="r"
+        )
+        (res,) = results
+        assert res["status"] == "unconfirmed"
+        assert reg.is_applied(ca.STORE_ARCTICDB_UNIVERSE, phantom.action_id) is False

--- a/tests/test_daily_append_splice_guard.py
+++ b/tests/test_daily_append_splice_guard.py
@@ -1,0 +1,153 @@
+"""Splice basis-guard on daily_append's incoming row (2026-07-02 incident).
+
+Two verified live corruptions motivated the guard:
+
+  * HON 2026-06-26 — a raw old-basis parquet row (464.42) overwrote the
+    already-stored new-basis row (232.21) on a series whose neighbors were
+    ~231: a same-date, same-market split-like disagreement that is never a
+    price move. That planted the boundary which later corroborated polygon's
+    inverted 2:1 record into a full-history ×2.
+  * CRWD 2026-06-30 — the incoming row arrived on the PRE-split basis
+    (763.14) while the stored history was already ×0.25-restated for the
+    registered 1:4 (ex 2026-07-02): deterministic gap of exactly 1/factor,
+    healed by restating the row, never by splicing it raw.
+
+Calibration constraint (2026 universe scan): CAR −48% and KD −55% are
+GENUINE single-day moves that overlap the 2:1 ratio zone, so a pure append
+with an unexplained split-like ratio must WRITE (with an ERROR page), not
+refuse — magnitude alone cannot refuse.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pandas as pd
+import pytest
+from botocore.exceptions import ClientError
+
+import corporate_actions as ca
+from corporate_actions import CorporateActionRegistry
+from builders.daily_append import _splice_basis_guard
+
+
+class _FakeS3:
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def head_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        return {"ContentLength": len(self.store[Key])}
+
+    def get_object(self, *, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {"ETag": '"fake"'}
+
+    def list_objects_v2(self, *, Bucket, Prefix, ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+
+def _hist(values_by_date: dict[str, float]) -> pd.DataFrame:
+    idx = pd.to_datetime(list(values_by_date))
+    vals = list(values_by_date.values())
+    return pd.DataFrame({"Close": vals}, index=idx).sort_index()
+
+
+def _bar(close: float, volume: float = 1_000_000.0) -> pd.Series:
+    return pd.Series(
+        {"Open": close, "High": close, "Low": close, "Close": close,
+         "Volume": volume, "VWAP": close}
+    )
+
+
+class TestSpliceBasisGuard:
+    def test_normal_move_passes_untouched(self):
+        hist = _hist({"2026-06-26": 100.0, "2026-06-29": 101.0})
+        bar = _bar(102.5)
+        out, verdict = _splice_basis_guard(
+            "X", bar, hist, pd.Timestamp("2026-06-30"), [], None
+        )
+        assert verdict == "ok"
+        assert out is bar
+
+    def test_pre_action_basis_row_restated_by_applied_future_ex_action(self):
+        # CRWD case: stored history already ×0.25-restated for the registered
+        # 1:4 (ex 2026-07-02); incoming 2026-06-30 row arrives pre-split.
+        reg = CorporateActionRegistry(_FakeS3(), "b")
+        action = ca.CorporateAction.from_split("CRWD", "2026-07-02", 1, 4)
+        reg.record_detected(action, run_id="r")
+        reg.mark_applied(action, ca.STORE_ARCTICDB_UNIVERSE, run_id="r")
+
+        hist = _hist({"2026-06-26": 175.27, "2026-06-29": 185.73})
+        bar = _bar(763.14, volume=3_687_971)
+        out, verdict = _splice_basis_guard(
+            "CRWD", bar, hist, pd.Timestamp("2026-06-30"), [action], reg
+        )
+        assert verdict == "restated"
+        assert float(out["Close"]) == pytest.approx(763.14 * 0.25)
+        assert float(out["Volume"]) == pytest.approx(3_687_971 / 0.25, rel=1e-6)
+
+    def test_unapplied_future_ex_action_does_not_restate(self):
+        # The store is NOT yet on the post-action scale — a 1/factor gap is
+        # then expected pre-basis continuity, not a mismatch to correct.
+        reg = CorporateActionRegistry(_FakeS3(), "b")
+        action = ca.CorporateAction.from_split("CRWD", "2026-07-02", 1, 4)
+        reg.record_detected(action, run_id="r")  # detected, NOT applied
+
+        hist = _hist({"2026-06-26": 701.09, "2026-06-29": 742.91})
+        bar = _bar(763.14)
+        out, verdict = _splice_basis_guard(
+            "CRWD", bar, hist, pd.Timestamp("2026-06-30"), [action], reg
+        )
+        assert verdict == "ok"
+        assert float(out["Close"]) == pytest.approx(763.14)
+
+    def test_same_date_split_like_disagreement_refused(self, caplog):
+        # HON case: stored 2026-06-26 row (232.21) coheres with its neighbor
+        # (231.24); incoming claims 464.42 for the SAME date — basis mismatch.
+        hist = _hist({"2026-06-25": 231.24, "2026-06-26": 232.21})
+        bar = _bar(464.42)
+        with caplog.at_level(logging.ERROR):
+            _out, verdict = _splice_basis_guard(
+                "HON", bar, hist, pd.Timestamp("2026-06-26"), [], None
+            )
+        assert verdict == "refused"
+        assert any("REFUSING HON" in r.message for r in caplog.records)
+
+    def test_same_date_refusal_operator_allowlist_overrides(self, monkeypatch):
+        hist = _hist({"2026-06-25": 231.24, "2026-06-26": 232.21})
+        bar = _bar(464.42)
+        monkeypatch.setenv(
+            "DAILY_APPEND_SPLICE_GUARD_ALLOW", "HON:2026-06-26"
+        )
+        _out, verdict = _splice_basis_guard(
+            "HON", bar, hist, pd.Timestamp("2026-06-26"), [], None
+        )
+        assert verdict == "ok"
+
+    def test_pure_append_genuine_crash_writes_with_error_page(self, caplog):
+        # KD −55% (2026-02-09, verified genuine): no stored same-date row, no
+        # registered action — must WRITE the row, paging at ERROR severity.
+        hist = _hist({"2026-02-05": 22.07, "2026-02-06": 23.49})
+        bar = _bar(10.59)
+        with caplog.at_level(logging.ERROR):
+            out, verdict = _splice_basis_guard(
+                "KD", bar, hist, pd.Timestamp("2026-02-09"), [], None
+            )
+        assert verdict == "ok"
+        assert float(out["Close"]) == pytest.approx(10.59)
+        assert any("NO registered corporate action" in r.message for r in caplog.records)
+
+    def test_missing_prior_close_fails_open(self):
+        out, verdict = _splice_basis_guard(
+            "NEW", _bar(50.0), pd.DataFrame(), pd.Timestamp("2026-06-30"), [], None
+        )
+        assert verdict == "ok"

--- a/tests/test_daily_closes_split_hint.py
+++ b/tests/test_daily_closes_split_hint.py
@@ -115,7 +115,7 @@ class TestRegistryReclassifiesConfirmedSplit:
         new_df = pd.DataFrame({"Close": [458.98]}, index=["HON"])
         reg = _registry_with_hon_reverse_split()
         with caplog.at_level(logging.DEBUG):
-            explained = daily_closes._log_close_discrepancies(
+            explained, _unexplained = daily_closes._log_close_discrepancies(
                 new_df, {"HON": 229.49}, "2026-06-25", registry=reg
             )
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
@@ -128,7 +128,7 @@ class TestRegistryReclassifiesConfirmedSplit:
     def test_registry_none_still_errors(self, caplog):
         new_df = pd.DataFrame({"Close": [458.98]}, index=["HON"])
         with caplog.at_level(logging.DEBUG):
-            explained = daily_closes._log_close_discrepancies(
+            explained, _unexplained = daily_closes._log_close_discrepancies(
                 new_df, {"HON": 229.49}, "2026-06-25", registry=None
             )
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
@@ -142,7 +142,7 @@ class TestRegistryReclassifiesConfirmedSplit:
         new_df = pd.DataFrame({"Close": [200.0]}, index=["MMM"])
         reg = _registry_with_hon_reverse_split()
         with caplog.at_level(logging.DEBUG):
-            explained = daily_closes._log_close_discrepancies(
+            explained, _unexplained = daily_closes._log_close_discrepancies(
                 new_df, {"MMM": 100.0}, "2026-06-25", registry=reg
             )
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]

--- a/tests/test_daily_closes_window_discrepancy_rollup.py
+++ b/tests/test_daily_closes_window_discrepancy_rollup.py
@@ -1,0 +1,82 @@
+"""Window-level roll-up of unexplained overwrite discrepancies (2026-07-02).
+
+One corporate action restating adjusted history touches EVERY window date with
+one uniform ratio — the HON separation paged six per-date ERROR emails for a
+single 2:1 event. The window roll-up pages ONCE per uniform-ratio group and
+preserves per-date ERROR semantics for non-uniform rows (a genuine per-date
+data-quality anomaly must stay loud on its own date).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+from collectors import daily_closes
+
+
+def _row(ticker: str, date: str, prior: float, new: float) -> dict:
+    return {
+        "ticker": ticker, "date": date, "prior": prior, "new": new,
+        "ratio": new / prior,
+    }
+
+
+class TestWindowUnexplainedRollup:
+    def test_uniform_ratio_group_pages_once(self, caplog):
+        rows = [
+            _row("HON", "2026-06-23", 444.74, 222.37),
+            _row("HON", "2026-06-24", 454.84, 227.42),
+            _row("HON", "2026-06-25", 462.48, 231.24),
+            _row("HON", "2026-06-26", 464.42, 232.21),
+            _row("HON", "2026-06-29", 455.60, 227.80),
+            _row("HON", "2026-06-30", 447.80, 223.90),
+        ]
+        with caplog.at_level(logging.ERROR):
+            daily_closes._emit_window_unexplained_discrepancies(rows, "2026-07-01")
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1  # ONE page for six restated dates
+        assert "UNIFORM" in errors[0].message
+        assert "6 window date(s)" in errors[0].message
+        assert "2:1" in errors[0].message  # split-ratio hint carried through
+
+    def test_non_uniform_rows_keep_per_date_errors(self, caplog):
+        rows = [
+            _row("MMM", "2026-06-24", 100.0, 210.0),
+            _row("MMM", "2026-06-26", 100.0, 55.0),
+        ]
+        with caplog.at_level(logging.ERROR):
+            daily_closes._emit_window_unexplained_discrepancies(rows, "2026-07-01")
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 2
+        assert all("polygon_only OVERWRITE MMM @" in r.message for r in errors)
+
+    def test_singleton_keeps_per_date_error(self, caplog):
+        rows = [_row("XYZ", "2026-06-24", 100.0, 55.0)]
+        with caplog.at_level(logging.ERROR):
+            daily_closes._emit_window_unexplained_discrepancies(rows, "2026-07-01")
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "OVERWRITE XYZ @ 2026-06-24" in errors[0].message
+
+    def test_empty_rows_no_logging(self, caplog):
+        with caplog.at_level(logging.DEBUG):
+            daily_closes._emit_window_unexplained_discrepancies([], "2026-07-01")
+        assert caplog.records == []
+
+    def test_deferred_per_date_rows_log_warn_not_error(self, caplog):
+        # The per-date call under a window defers: the row surface stays (WARN)
+        # while the ERROR moves to the aggregate.
+        new_df = pd.DataFrame({"Close": [232.21]}, index=["HON"])
+        with caplog.at_level(logging.DEBUG):
+            explained, unexplained = daily_closes._log_close_discrepancies(
+                new_df, {"HON": 464.42}, "2026-06-26", defer_unexplained=True,
+            )
+        assert explained == []
+        assert len(unexplained) == 1
+        assert unexplained[0]["ticker"] == "HON"
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert errors == []
+        assert any("deferred to the window-level" in r.message for r in warns)

--- a/tests/test_polygon_client.py
+++ b/tests/test_polygon_client.py
@@ -339,3 +339,60 @@ def test_get_ticker_events_empty_results_object():
     client = _make_client()
     with patch.object(client, "_get", return_value={"status": "OK"}):
         assert client.get_ticker_events("FB") == []
+
+
+# ── fractional split-ratio fields (2026-07-02 incident class) ────────────────
+#
+# Polygon publishes FRACTIONAL split_from/split_to for spinoff-style records
+# (live 2026-06: CCBC 1:1.2, NRWRF 20.625:21.625, CFRLF 1:1.0517…). The old
+# int() cast silently truncated them (1.2 → 1: a corrupted no-op factor) and
+# raised on malformed rows, degrading the WHOLE window's split detection to
+# empty. Rows now parse fractionally; malformed rows skip per-row with a WARN.
+
+
+def test_get_recent_splits_preserves_fractional_ratios():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ticker": "CCBC", "execution_date": "2026-06-18",
+             "split_from": 1, "split_to": 1.2},
+            {"ticker": "NRWRF", "execution_date": "2026-06-18",
+             "split_from": 20.625, "split_to": 21.625},
+        ]
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_recent_splits("2026-06-15", "2026-06-20")
+    assert out[0]["split_to"] == pytest.approx(1.2)
+    assert out[1]["split_from"] == pytest.approx(20.625)
+    # Integral values stay int (content-addressed action-id stability).
+    assert isinstance(out[0]["split_from"], int)
+
+
+def test_get_recent_splits_skips_malformed_row_keeps_rest():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ticker": "BAD", "execution_date": "2026-06-18",
+             "split_from": "not-a-number", "split_to": 1},
+            {"ticker": "GOOD", "execution_date": "2026-06-18",
+             "split_from": 1, "split_to": 2},
+        ]
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_recent_splits("2026-06-15", "2026-06-20")
+    assert [r["ticker"] for r in out] == ["GOOD"]
+
+
+def test_get_splits_preserves_fractional_ratios():
+    client = _make_client()
+    resp = {
+        "results": [
+            {"ticker": "HON", "execution_date": "2025-10-30",
+             "split_from": 1000, "split_to": 1061},
+        ]
+    }
+    with patch.object(client, "_get", return_value=resp):
+        out = client.get_splits("HON")
+    assert out == [
+        {"execution_date": "2025-10-30", "split_from": 1000, "split_to": 1061},
+    ]


### PR DESCRIPTION
## Incident (2026-07-02)

Six Flow-Doctor ERROR emails this morning — `polygon_only OVERWRITE HON` across six window dates — turned out to be the visible tip of a compound corporate-actions failure:

1. **Upstream:** polygon published BOTH mega-cap June split records with the from/to ratio **inverted** (HON `2:1` for the true forward 1:2 — a record polygon later **deleted**; DD `3:1` for the true 1:3), while its adjusted aggregates restated in the true (dividing) direction.
2. `apply()` trusted the stated orientation → **HON's full pre-6/29 ArcticDB history ×2, DD's pre-6/24 ×3** in the predictor training store.
3. The evidence gate was corroborated by a prior **raw splice row** (HON 6/26 = 464.42 written onto a clean new-basis series) — corruption from one defect validating another.
4. `_ensure_history_restated` / `_sync_arcticdb_universe` marked even **refused** actions as applied → the exactly-once marker froze the un-restated/corrupted state permanently.
5. Fractional polygon ratio fields (`CCBC 1:1.2`, `NRWRF 20.625:21.625`) were silently **int-truncated** on ingest.
6. The discrepancy classifier consulted only session-detected actions in the stated orientation → the registered event still paged 6× per-date ERRORs.

## Hardening (this PR)

- **`price_evidence_orientation()`** — the market's own boundary move is ground truth for factor *direction*: `direct` / `inverse` / `ambiguous` / `none` / `uncovered`. `apply()` applies the market-corrected `1/factor` on an unambiguous inverse (loud WARN + `orientation_corrected` result flag), **refuses** ambiguous evidence, and no longer trusts an uncovered window (positive corroboration required before mutating a price level). A **post-restate boundary audit** raises before any caller writes a residual factor.
- **Mark-only-applied discipline** in `_ensure_history_restated` + `_sync_arcticdb_universe` — refused actions stay pending and re-check every run.
- **Splice basis-guard** in `daily_append`: pre-action-basis rows for a registered already-applied future-ex split are deterministically restated (CRWD 6/30 case); same-date split-like disagreement with a cohering stored row is refused (HON 6/26 case); pure-append unexplained split-like ratios **write but page at ERROR** — calibrated on the 2026 universe scan where CAR −48% and KD −55% are genuine single-day moves overlapping the 2:1 zone (magnitude alone cannot refuse). Operator escape hatch: `DAILY_APPEND_SPLICE_GUARD_ALLOW=TICKER:YYYY-MM-DD`.
- **Fractional split ratios** preserved end-to-end; malformed feed rows skip per-row with WARN instead of degrading the whole window's detection to empty.
- **`explains_discrepancy`** consults persisted registry actions (not just session-detected) and matches either orientation.
- **Window-level roll-up** of unexplained >5% overwrites: a uniform-ratio group (one corporate-action restatement sweeping the window) pages ONCE with the inferred factor; non-uniform rows keep per-date ERRORs. Per-row WARN surface retained (no silent drops).

## Data remediation (already executed operator-side, verified)

- HON + DD ArcticDB: full single-ticker rebuilds via `builders.backfill --ticker` — **0 residual >33% moves across 10y** for both.
- CRWD: surgical 6/30 OHLCV row fix (763.14 → 190.785 basis); features for its 6/30–7/1 rows heal at Saturday's organic backfill.
- Archive parquets: 6/12, 6/15, 6/16, 6/17 re-fetched to current polygon basis; CRWD/MLI rows in the phantom 6/19 parquet restated by their split factors.
- Corrected registry records written (`8b2a092f2a0c743e` HON 1:2, `d33c1022d713f6ad` DD 1:3, `source=operator_correction`, `raw.corrects_action_id` provenance) + `arcticdb_universe` applied markers. The two inverted records remain in the registry as superseded evidence (CRSP-style supersede-not-delete; they are inert behind their applied markers and the corrected records).
- Universe-wide scan (901 symbols, 2026 dates): no other basis corruption; STRL/CAR/KD hits verified as genuine market moves via yfinance.

## Behavior changes to note in review

- `has_price_evidence` on an **uncovered** window now returns False (was: trust the feed). With no pre-ex rows in frame there is nothing to restate, so the safe answer is free.
- `_log_close_discrepancies` returns a tuple `(explained, unexplained)`.
- New apply() result status `ambiguous_evidence`.

Suite: **2,526 passed + 30 new regression tests**, ruff clean on changed files (repo-preexisting findings untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)