### PR TITLE
fix(groom): install pytest (+boto3) before deploy.sh's test step — CI auto-deploy was red

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -82,19 +82,37 @@ run() {
   if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
 }
 
-# ----- 0. Validate handler + run unit tests ----------------------------------
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+# PKG and TEST_DEPS are both created up front (mirrors freshness-monitor/
+# deploy.sh) so ONE trap covers both — a pytest-install failure below still
+# cleans up.
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 
 python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
 
+# ----- 0b. Preflight handler unit tests --------------------------------------
+# Only alpha_engine_lib.telegram is stubbed in sys.modules (see
+# test_handler.py's header) — `index.py`'s `import boto3` is REAL, and
+# requirements.txt deliberately omits boto3 (provided by the Lambda runtime
+# at deploy time, per its own comment), so pytest's `import index` needs it
+# installed explicitly here. Installed into a scratch TEST_DEPS dir — NOT the
+# caller's global site-packages, not bundled into the Lambda zip (mirrors
+# freshness-monitor/deploy.sh). 2026-07-02: the CI auto-deploy workflow's
+# FIRST real run failed here with "No module named pytest" — this script had
+# only ever been run from an operator's laptop before, where pytest/boto3
+# happened to already be installed as dev/tooling dependencies; the gap was
+# invisible until CI actually exercised this path.
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Installing pytest + boto3 into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest boto3
   echo "Running handler unit tests..."
-  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
-
-PKG=$(mktemp -d)
-trap "rm -rf '$PKG'" EXIT
 
 echo "Installing deps into ${PKG} (pip install -t)..."
 python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -139,7 +139,14 @@ run() {
   fi
 }
 
-# ----- 0. Validate handler + run unit tests ----------------------------------
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+# PKG and TEST_DEPS are both created up front (mirrors freshness-monitor/
+# deploy.sh) so ONE trap covers both — a pytest-install failure below still
+# cleans up.
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 
 python3 -c "
 import ast
@@ -148,15 +155,24 @@ ast.parse(src)
 print('index.py syntax OK')
 "
 
+# ----- 0b. Preflight handler unit tests --------------------------------------
+# Hermetic (boto3/nousergon_lib are stubbed in sys.modules before `import
+# index` — see test_handler.py's header), so only pytest itself needs to be
+# resolvable here, not the runtime deps. Installed into a scratch TEST_DEPS
+# dir — NOT the caller's global site-packages, not bundled into the Lambda
+# zip — so this works on a bare CI runner (2026-07-02: the CI auto-deploy
+# workflow's FIRST real run failed here with "No module named pytest" — this
+# script had only ever been run from an operator's laptop before, where
+# pytest happened to already be installed as a dev dependency; the gap was
+# invisible until CI actually exercised this path).
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Installing pytest into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
   echo "Running handler unit tests..."
-  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
-
-PKG=$(mktemp -d)
-trap "rm -rf '$PKG'" EXIT
 
 echo "Installing deps into ${PKG} (pip install -t)..."
 python3 -m pip install \


### PR DESCRIPTION
Both new code-only auto-deploy workflows (#587) failed on their **first real run** after merge:

```
/opt/hostedtoolcache/Python/3.12.13/x64/bin/python3: No module named pytest
```

## Root cause

`deploy.sh`'s step 0 has always run `python3 -m pytest test_handler.py` assuming pytest is already importable — true every time this script had only ever been run from an operator's laptop (pytest happened to already be installed as a dev dependency), never true on a bare GHA runner (only `actions/setup-python`, no pytest). The gap predates this session's PRs but was invisible until CI actually exercised the path for the first time.

`groom-liveness-probe` had a second, related gap: its `test_handler.py` only stubs `alpha_engine_lib.telegram` in `sys.modules`, not `boto3` — `index.py`'s `import boto3` is REAL, and `requirements.txt` deliberately omits boto3 ("provided by the Lambda runtime"), so pytest's `import index` needs it installed explicitly for the test run too.

## Fix

Mirrors the existing `deploy-freshness-monitor.yml`/`deploy.sh` precedent exactly: create `PKG` + `TEST_DEPS` scratch dirs up front with one combined `EXIT` trap, install `pytest` (+`boto3` for the liveness probe) into `TEST_DEPS` via `pip install --target` (not the caller's global site-packages, not bundled into the Lambda zip), run tests with `PYTHONPATH=TEST_DEPS`.

## Also applied live (explicitly authorized)

Ran the actual `scheduled-groom-dispatcher/deploy.sh --bootstrap` for real against production AWS to complete #586's pending schedule change (the Saturday-skip removal had been merged but not yet applied — this was the reason CI's first run surfaced the pytest gap in the first place, since it also runs the `--bootstrap` code path via the still-manual operator command). Confirmed live:
- `alpha-engine-scheduled-groom-0700-daily` exists at `cron(0 7 * * ? *)`
- `alpha-engine-scheduled-groom-0700-sunfri` is gone (pruned)

## Test plan
- [x] Full `--dry-run` for both scripts, end to end (syntax → pytest install → tests → package → zip → dry-run deploy call) — clean.
- [x] Full `--bootstrap --dry-run` for the dispatcher — confirmed exact expected plan before running for real.
- [x] `ruff check` clean, `bash -n` clean on both scripts.
- [x] Real `--bootstrap` run verified against live AWS state (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)