### PR TITLE
fix(groom): install pytest into a temp target in deploy.sh — unbreak the auto-deploy workflows

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -82,22 +82,33 @@ run() {
   if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
 }
 
-# ----- 0. Validate handler + run unit tests ----------------------------------
+# ----- 0. Validate handler syntax --------------------------------------------
 
 python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
-
-if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Running handler unit tests..."
-  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
-fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
 PKG=$(mktemp -d)
-trap "rm -rf '$PKG'" EXIT
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 
 echo "Installing deps into ${PKG} (pip install -t)..."
 python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+
+# ----- 1a. Preflight handler unit tests with runtime deps available ---------
+# Mirrors freshness-monitor/deploy.sh: runs AFTER step 1's pip install so the
+# test's imports resolve against the exact deps being shipped, and pytest is
+# never assumed on the caller's bare python (a bare setup-python in CI has no
+# pytest — the 2026-07-02 first-run failure of the auto-deploy workflows).
+# pytest installs into $TEST_DEPS, separate from $PKG, so it doesn't get
+# bundled into the Lambda zip.
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Installing pytest into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
+  echo "Running handler unit tests (PYTHONPATH=${PKG}:${TEST_DEPS})..."
+  PYTHONPATH="${PKG}:${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 ZIP="${PKG}/function.zip"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -139,7 +139,7 @@ run() {
   fi
 }
 
-# ----- 0. Validate handler + run unit tests ----------------------------------
+# ----- 0. Validate handler syntax --------------------------------------------
 
 python3 -c "
 import ast
@@ -148,15 +148,11 @@ ast.parse(src)
 print('index.py syntax OK')
 "
 
-if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Running handler unit tests..."
-  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
-fi
-
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
 PKG=$(mktemp -d)
-trap "rm -rf '$PKG'" EXIT
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 
 echo "Installing deps into ${PKG} (pip install -t)..."
 python3 -m pip install \
@@ -164,6 +160,21 @@ python3 -m pip install \
   --target "${PKG}" \
   --upgrade \
   -r "${SCRIPT_DIR}/requirements.txt"
+
+# ----- 1a. Preflight handler unit tests with runtime deps available ---------
+# Mirrors freshness-monitor/deploy.sh: runs AFTER step 1's pip install so the
+# test's imports resolve against the exact deps being shipped, and pytest is
+# never assumed on the caller's bare python (a bare setup-python in CI has no
+# pytest — the 2026-07-02 first-run failure of the auto-deploy workflows).
+# pytest installs into $TEST_DEPS, separate from $PKG, so it doesn't get
+# bundled into the Lambda zip.
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Installing pytest into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
+  echo "Running handler unit tests (PYTHONPATH=${PKG}:${TEST_DEPS})..."
+  PYTHONPATH="${PKG}:${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 ZIP="${PKG}/function.zip"


### PR DESCRIPTION
## Problem

Both code-only auto-deploy workflows shipped in #587 (`deploy-groom-liveness-probe.yml`, `deploy-scheduled-groom-dispatcher.yml`) went **red on their first push-to-main run** (commit 860a3df, 2026-07-02 13:57 UTC):

```
Running handler unit tests...
python3: No module named pytest
##[error]Process completed with exit code 1
```

Both `deploy.sh` scripts ran `python3 -m pytest test_handler.py` against the caller's bare python. On operator machines pytest happens to be installed globally, so manual runs always worked; the GHA runner's bare `setup-python@v5` has no pytest, so the very first CI trip died — **before packaging**, so the #587 Lambda code (including the config#1571 missed-15:00-Opus-schedule tracking) never deployed and is still not live.

## Fix

Mirror the existing institutional pattern in `infrastructure/lambdas/freshness-monitor/deploy.sh` (§1a) in both scripts, rather than patching the workflows with an ad-hoc `pip install pytest` step:

- Handler unit tests now run **after** the runtime-deps `pip install --target $PKG`, with `PYTHONPATH=$PKG:$TEST_DEPS` — so tests import against the exact deps being shipped.
- pytest installs into a separate `$TEST_DEPS` mktemp target, so it is never assumed on the caller's python and never bundled into the Lambda zip.

Fixing this in `deploy.sh` (not the workflows) makes the scripts self-contained for every caller — CI, operator laptop, future workflows.

## Verification

- `bash infrastructure/lambdas/groom-liveness-probe/deploy.sh --dry-run` — clean: syntax OK, deps install, **12 handler tests pass**, package builds, AWS call stays behind the dry-run wrapper.
- `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --dry-run` — clean: **14 handler tests pass**, same.
- Full repo suite with the repo venv: **2505 passed, 8 skipped**.

## On merge

Both deploy workflows are path-filtered on `infrastructure/lambdas/<name>/**`, so merging this PR re-triggers them and ships the still-undeployed #587 code to both Lambdas — no manual re-run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)