### PR TITLE
fix(calendar): NYSE-holiday gates at collect/append chokepoints + phantom-day purge tool (config#1572)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -1081,6 +1081,23 @@ def _daily_append_impl(
         from dates import default_run_date  # config#1014: trading-day axis
 
         date_str = default_run_date()
+
+    # NYSE-calendar gate (config#1572): appending a row for a non-trading day
+    # plants a phantom session in the ArcticDB training store (2026-06-19
+    # Juneteenth entered universe-wide via a fabricated daily-closes parquet).
+    # A non-trading date_str is always a caller error — fail loud, same
+    # calendar source of truth as the Step Function's CheckTradingDay gate.
+    from datetime import date as _date
+
+    from alpha_engine_lib.trading_calendar import is_trading_day as _is_td
+
+    if not _is_td(_date.fromisoformat(date_str)):
+        raise ValueError(
+            f"daily_append: date_str={date_str} is not an NYSE trading day — "
+            f"refusing to append a phantom session to the universe "
+            f"(config#1572)."
+        )
+
     today_ts = pd.Timestamp(date_str)
     t0 = time.time()
 

--- a/builders/purge_phantom_day.py
+++ b/builders/purge_phantom_day.py
@@ -1,0 +1,154 @@
+"""purge_phantom_day — remove a fabricated non-trading-day row fleet-wide.
+
+config#1572: 2026-06-19 (Juneteenth, NYSE closed) entered the daily-closes
+archive as a fabricated 924-row yfinance-sourced parquet — the weekday-only
+window enumeration in ``collectors.daily_closes._previous_business_days``
+included the holiday, the yfinance batch returned data anyway, and the
+Saturday backfill's daily delta then propagated a 2026-06-19 row into every
+ArcticDB universe/macro symbol. A phantom session distorts every
+rolling-window feature that crosses it and, around a corporate action, can
+carry a wrong-basis value that later corroborates a bad restatement (the
+2026-07-02 HON incident chain).
+
+This is the one-shot inverse: for a NAMED non-trading date, drop that row
+from every universe + macro symbol and delete the staging parquet. Dry-run by
+default; ``--apply`` performs the writes. Symbols without the row are
+untouched (no rewrite, no version churn).
+
+Usage (Mac: import arcticdb before boto3 — see the CRSP recipe):
+    python -c "import arcticdb; import sys; \
+        sys.argv=['p','--date','2026-06-19','--apply']; \
+        from builders.purge_phantom_day import main; main()"
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date as _date
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+DEFAULT_BUCKET = "alpha-engine-research"
+_PARQUET_KEY_TEMPLATE = "staging/daily_closes/{date}.parquet"
+
+
+def _purge_library(lib, target_ts: pd.Timestamp, apply: bool) -> dict:
+    """Drop ``target_ts``'s row from every symbol in ``lib`` that has it.
+
+    Full-series read → drop → write (with prune) per affected symbol —
+    ArcticDB's update() cannot delete a row, so the rewrite is the correct
+    primitive (same one daily_append's backfill branch uses). Returns
+    ``{"affected": [...], "clean": int, "errors": [(symbol, err), ...]}``.
+    """
+    affected: list[str] = []
+    errors: list[tuple[str, str]] = []
+    clean = 0
+    symbols = lib.list_symbols()
+    for i, symbol in enumerate(symbols):
+        try:
+            df = lib.read(symbol).data
+            if target_ts not in df.index:
+                clean += 1
+                continue
+            affected.append(symbol)
+            if apply:
+                out = df.drop(index=target_ts)
+                lib.write(symbol, out, prune_previous_versions=True)
+        except Exception as exc:  # noqa: BLE001 - collected + raised at exit
+            errors.append((symbol, str(exc)))
+            log.error("purge_phantom_day: %s failed: %s", symbol, exc)
+        if (i + 1) % 100 == 0:
+            log.info(
+                "purge_phantom_day: %d/%d symbols scanned (%d affected so far)",
+                i + 1, len(symbols), len(affected),
+            )
+    return {"affected": affected, "clean": clean, "errors": errors}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Remove a fabricated non-trading-day row from ArcticDB + the archive"
+    )
+    parser.add_argument("--date", required=True, help="YYYY-MM-DD (must be a NON-trading day)")
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Perform the writes/deletes (default: dry-run report only)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    from alpha_engine_lib.trading_calendar import is_trading_day
+
+    target = _date.fromisoformat(args.date)
+    # Inverse sanity gate: purging a REAL session would destroy good data.
+    if is_trading_day(target):
+        raise SystemExit(
+            f"{args.date} IS an NYSE trading day — refusing to purge a real "
+            f"session. This tool only removes fabricated non-trading-day rows "
+            f"(config#1572)."
+        )
+
+    import boto3
+
+    from store.arctic_store import get_macro_lib, get_universe_lib
+
+    target_ts = pd.Timestamp(args.date)
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    log.info("purge_phantom_day %s: date=%s bucket=%s", mode, args.date, args.bucket)
+
+    results = {}
+    for name, lib in (
+        ("universe", get_universe_lib(args.bucket)),
+        ("macro", get_macro_lib(args.bucket)),
+    ):
+        res = _purge_library(lib, target_ts, apply=args.apply)
+        results[name] = res
+        log.info(
+            "purge_phantom_day %s [%s]: %d affected, %d clean, %d errors%s",
+            mode, name, len(res["affected"]), res["clean"], len(res["errors"]),
+            "" if args.apply or not res["affected"] else
+            f" — would purge: {', '.join(res['affected'][:8])}"
+            f"{'…' if len(res['affected']) > 8 else ''}",
+        )
+
+    key = _PARQUET_KEY_TEMPLATE.format(date=args.date)
+    s3 = boto3.client("s3")
+    try:
+        s3.head_object(Bucket=args.bucket, Key=key)
+        parquet_exists = True
+    except Exception:  # noqa: BLE001 - 404 ⇒ nothing to delete
+        parquet_exists = False
+    if parquet_exists and args.apply:
+        s3.delete_object(Bucket=args.bucket, Key=key)
+        log.info("purge_phantom_day: deleted s3://%s/%s", args.bucket, key)
+    elif parquet_exists:
+        log.info("purge_phantom_day DRY-RUN: would delete s3://%s/%s", args.bucket, key)
+    else:
+        log.info("purge_phantom_day: no parquet at s3://%s/%s", args.bucket, key)
+
+    all_errors = [e for res in results.values() for e in res["errors"]]
+    if all_errors:
+        raise SystemExit(
+            f"purge_phantom_day: {len(all_errors)} symbol(s) failed — re-run "
+            f"to converge (idempotent); first: {all_errors[0]}"
+        )
+    total_affected = sum(len(res["affected"]) for res in results.values())
+    print(
+        f"purge_phantom_day {mode} complete: {total_affected} symbol row(s) "
+        f"{'purged' if args.apply else 'would be purged'} for {args.date}; "
+        f"parquet {'deleted' if (parquet_exists and args.apply) else ('present (dry-run)' if parquet_exists else 'absent')}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -317,8 +317,8 @@ def _polygon_symbol(store_ticker: str) -> str:
 
 
 def _previous_business_days(run_date: str, n: int) -> list[str]:
-    """Return ``n`` business days ending on ``run_date`` (inclusive),
-    newest first. ``n=1`` returns the most-recent business day at or
+    """Return ``n`` NYSE TRADING days ending at-or-before ``run_date``,
+    newest first. ``n=1`` returns the most-recent trading day at or
     before ``run_date``.
 
     Used by :func:`collect` in window-scan mode to enumerate the dates
@@ -326,23 +326,47 @@ def _previous_business_days(run_date: str, n: int) -> list[str]:
     by the caller — one ``grouped-daily`` call per date in the returned
     list, total ``n`` polygon calls regardless of universe size.
 
-    Saturday / Sunday ``run_date`` walks back to the prior Friday before
-    starting the window, so a Sat SF firing at 02:00 PT doesn't burn a
-    slot on a non-trading day. NYSE holiday handling lives downstream —
-    holidays return zero rows from polygon and an empty yfinance batch,
-    which the per-date skip logic handles gracefully.
+    HOLIDAY-AWARE since 2026-07-02 (config#1572): this helper was
+    weekday-only, on the documented assumption that "holidays return zero
+    rows from polygon and an empty yfinance batch" downstream. That
+    assumption was FALSE in practice — the first post-Juneteenth
+    yfinance-mode window enumerated 2026-06-19, the batch fetch returned
+    data anyway, and a fabricated 924-row parquet for a closed market day
+    entered the archive (and, via the Saturday backfill delta, the
+    ArcticDB training store universe-wide). Non-trading days must never be
+    enumerated for collection; ``alpha_engine_lib.trading_calendar`` is
+    the same source of truth the Step Function's CheckTradingDay gate uses.
     """
+    from alpha_engine_lib.trading_calendar import is_trading_day
+
     if n < 1:
         raise ValueError(f"window n must be >= 1, got {n}")
     cur = datetime.strptime(run_date, "%Y-%m-%d").date()
-    # Normalize the starting point to a business day.
-    while cur.weekday() >= 5:  # Sat=5, Sun=6
+    # Runaway guard: a broken calendar must fail loud, not spin backwards.
+    max_steps = n * 3 + 30
+    steps = 0
+    # Normalize the starting point to a trading day.
+    while not is_trading_day(cur):
         cur = cur - timedelta(days=1)
+        steps += 1
+        if steps > max_steps:
+            raise RuntimeError(
+                f"_previous_business_days: no trading day within {max_steps} "
+                f"calendar days before {run_date} — trading_calendar appears broken"
+            )
     dates: list[str] = [cur.isoformat()]
     for _ in range(n - 1):
         cur = cur - timedelta(days=1)
-        while cur.weekday() >= 5:
+        steps += 1
+        while not is_trading_day(cur):
             cur = cur - timedelta(days=1)
+            steps += 1
+            if steps > max_steps:
+                raise RuntimeError(
+                    f"_previous_business_days: exhausted {max_steps} steps "
+                    f"walking {n} trading days back from {run_date} — "
+                    f"trading_calendar appears broken"
+                )
         dates.append(cur.isoformat())
     return dates
 
@@ -765,6 +789,26 @@ def collect(
         from dates import default_run_date  # config#1014: trading-day axis
 
         run_date = default_run_date()
+
+    # NYSE-calendar gate (config#1572): a daily-closes parquet for a
+    # non-trading day is fabricated data by definition — polygon and yfinance
+    # have no session to serve, and whatever a batch fetch returns anyway gets
+    # persisted as a phantom day (2026-06-19 Juneteenth: 924 fabricated
+    # yfinance rows entered the archive and, via the Saturday backfill delta,
+    # the ArcticDB training store universe-wide). Window mode normalizes its
+    # anchor to a trading day (weekend/holiday SF fire-times are legitimate);
+    # a SINGLE-date call for a non-trading day is always a caller error and
+    # fails loud.
+    from alpha_engine_lib.trading_calendar import is_trading_day as _is_td
+
+    _run_dt = datetime.strptime(run_date, "%Y-%m-%d").date()
+    if window_days == 1 and not _is_td(_run_dt):
+        raise ValueError(
+            f"collect: run_date={run_date} is not an NYSE trading day — "
+            f"refusing to write a phantom daily-closes parquet (config#1572). "
+            f"If polygon/NYSE calendars diverged, fix "
+            f"alpha_engine_lib.trading_calendar, not this guard."
+        )
 
     if window_days > 1:
         return _collect_window(

--- a/tests/test_daily_append_trading_day_gate.py
+++ b/tests/test_daily_append_trading_day_gate.py
@@ -1,0 +1,32 @@
+"""daily_append NYSE-calendar gate + purge_phantom_day sanity gate (config#1572)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestDailyAppendRefusesNonTradingDay:
+    def test_holiday_date_raises(self):
+        from builders.daily_append import daily_append
+
+        with pytest.raises(ValueError, match="not an NYSE trading day"):
+            daily_append(date_str="2026-06-19")
+
+    def test_weekend_date_raises(self):
+        from builders.daily_append import daily_append
+
+        with pytest.raises(ValueError, match="not an NYSE trading day"):
+            daily_append(date_str="2026-07-05")
+
+
+class TestPurgeRefusesRealSession:
+    def test_trading_day_refused(self, monkeypatch):
+        import sys
+
+        from builders import purge_phantom_day
+
+        monkeypatch.setattr(
+            sys, "argv", ["purge", "--date", "2026-07-01", "--apply"],
+        )
+        with pytest.raises(SystemExit, match="IS an NYSE trading day"):
+            purge_phantom_day.main()

--- a/tests/test_daily_closes_window_days.py
+++ b/tests/test_daily_closes_window_days.py
@@ -406,3 +406,48 @@ class TestWindowOrchestration:
         assert captured == ["2026-05-06", "2026-05-07", "2026-05-08"]
         assert result["status"] == "ok"
         assert result["backfill_failed_dates"] == []
+
+
+# ── NYSE-holiday awareness (config#1572, 2026-07-02) ─────────────────────────
+#
+# _previous_business_days was weekday-only; the first post-Juneteenth
+# yfinance-mode window enumerated 2026-06-19 (a closed market day), the batch
+# fetch returned data anyway, and a fabricated 924-row parquet entered the
+# archive — then ArcticDB universe-wide via the Saturday backfill delta.
+
+
+class TestPreviousBusinessDaysHolidayAware:
+    def test_window_skips_juneteenth(self):
+        # Monday 6/22 walking back 3 trading days must skip Fri 6/19
+        # (Juneteenth 2026): 6/22 → 6/18 → 6/17.
+        assert daily_closes._previous_business_days("2026-06-22", n=3) == [
+            "2026-06-22", "2026-06-18", "2026-06-17",
+        ]
+
+    def test_holiday_run_date_normalizes_to_prior_trading_day(self):
+        # Friday 7/3 (Independence Day observed) anchors to Thu 7/2.
+        assert daily_closes._previous_business_days("2026-07-03", n=2) == [
+            "2026-07-02", "2026-07-01",
+        ]
+
+    def test_holiday_weekend_combo(self):
+        # Monday 7/6: back 2 trading days crosses the 7/3 holiday + weekend.
+        assert daily_closes._previous_business_days("2026-07-06", n=2) == [
+            "2026-07-06", "2026-07-02",
+        ]
+
+
+class TestCollectRefusesNonTradingDay:
+    def test_single_date_holiday_raises(self):
+        with pytest.raises(ValueError, match="not an NYSE trading day"):
+            daily_closes.collect(
+                "test-bucket", ["AAPL"], run_date="2026-06-19",
+                source="polygon_only",
+            )
+
+    def test_single_date_weekend_raises(self):
+        with pytest.raises(ValueError, match="not an NYSE trading day"):
+            daily_closes.collect(
+                "test-bucket", ["AAPL"], run_date="2026-07-04",
+                source="yfinance_only",
+            )


### PR DESCRIPTION
Closes the phantom-trading-day class from config#1572 (found during today's corporate-actions incident, nousergon-data#588).

## Root cause — pinned

`_previous_business_days` (the window-reconciliation date enumerator in `collectors/daily_closes.py`) was **weekday-only**, with a docstring explicitly assuming holidays self-handle downstream ("zero rows from polygon and an empty yfinance batch"). That assumption failed live: **yfinance was serving 2026-06-19 (Juneteenth) bars during the week after the holiday** — it has since removed them, the same vendor-data-mutation class as polygon's deleted HON split record — so the first post-holiday yfinance-mode reconciliation window persisted a fabricated 924-row parquet. The Saturday 6/27 cache refresh + backfill delta then propagated a 6/19 row into every ArcticDB universe symbol. Every other path (SF `CheckTradingDay`, gap-heal detection via `trading_calendar.previous_trading_day`, morning `_previous_trading_day`) was already calendar-aware; this one helper was the hole. (EOD SF execution history confirms no 6/19 run — the SF layer respected the holiday.)

## Fix

- `_previous_business_days` now enumerates **NYSE trading days** via `alpha_engine_lib.trading_calendar` — the same source of truth as `CheckTradingDay` — with a fail-loud runaway guard.
- `collect()` refuses a single-date `run_date` that isn't a trading day (window mode still normalizes weekend/holiday anchors — SF fire-times are legitimate).
- `daily_append()` refuses a non-trading `date_str`.
- New `builders/purge_phantom_day.py`: one-shot fleet-wide removal of a named non-trading day (universe + macro ArcticDB rows + staging parquet). Dry-run default; **refuses to purge a real trading day** (inverse sanity gate).

## Timing

Next holiday is **tomorrow, 2026-07-03**. `CheckTradingDay` halts the SFs tomorrow regardless; the exposure is **Monday 7/6's first post-holiday reconciliation window** — this needs to be merged (box pulls at Monday MorningEnrich) before then. The 6/19 purge run + verification is being executed operator-side and reported on config#1572.

Suite: 2,540 passed (+5 new: holiday window enumeration, collect/append gates, purge sanity gate). Ruff: zero new findings vs main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)