### PR TITLE
[P1/high] fix(eod-sf): hoist executor-deploy refresh to a single top-of-pipeline chokepoint (config#1549)

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -157,14 +157,14 @@
     },
     "SSMReadyChoice": {
       "Type": "Choice",
-      "Comment": "PingStatus=Online → CheckSkipPostMarketData (enter the per-task rerun gates). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail to HandleFailure when the budget is exhausted (per feedback_no_silent_fails — the agent not registering after 3 min is a real boot problem, not just timing; HandleFailure notifies + ForceStopInstance releases the box). This NEVER silently skips EOD reconcile — an unreachable box fails the execution loud.",
+      "Comment": "PingStatus=Online → CheckSkipRefreshExecutorDeploy (enter the per-task rerun gates; the FIRST gate now hoists the executor-checkout refresh to the top of the pipeline per config#1549, so the entire EOD run — postmarket → arctic → snapshot → reconcile — executes latest origin/main by construction). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail to HandleFailure when the budget is exhausted (per feedback_no_silent_fails — the agent not registering after 3 min is a real boot problem, not just timing; HandleFailure notifies + ForceStopInstance releases the box). This NEVER silently skips EOD reconcile — an unreachable box fails the execution loud.",
       "Choices": [
         {
           "And": [
             {"Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus", "IsPresent": true},
             {"Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus", "StringEquals": "Online"}
           ],
-          "Next": "CheckSkipPostMarketData"
+          "Next": "CheckSkipRefreshExecutorDeploy"
         },
         {
           "Variable": "$.ssm_poll.attempts",
@@ -581,13 +581,13 @@
     },
     "EODReconcile": {
       "Type": "Task",
-      "Comment": "Run EOD reconciliation on trading EC2 \u2014 reads closes from ArcticDB + state from S3 snapshot (no live IB), computes P&L, sends email. pipefail surfaces python crashes that tee would otherwise mask. Refreshes the executor checkout to origin/main via the canonical boot-pull.sh BEFORE running eod_reconcile.py: the trading instance boot-pulls once each morning (boot-pull.service, ~6:10 AM PT), but executor PRs that merge during the trading day leave the checkout stale by EOD, so eod_reconcile.py's ExecutorPreflight deploy-drift guard hard-fails (2026-06-30 incident: 3 executor PRs merged 08:07\u201308:54 PT after the morning boot-pull; EOD refused on b7e52b1 vs main@8c3014e). Refreshing here makes reconcile run latest main by construction. boot-pull is run as ec2-user (matching boot-pull.service User=ec2-user + the ec2-user-owned checkout / ~/.netrc); the root-side eod_reconcile.py already reads HEAD via a safe.directory workaround. FAIL-LOUD PRESERVED: the drift guard remains the authoritative gate \u2014 if boot-pull fails (auth/network), the checkout stays stale and eod_reconcile.py hard-fails with its actionable message (the `|| echo` only surfaces a breadcrumb; it does not swallow \u2014 the guard downstream is loud).",
+      "Comment": "Run EOD reconciliation on trading EC2 \u2014 reads closes from ArcticDB + state from S3 snapshot (no live IB), computes P&L, sends email. pipefail surfaces python crashes that tee would otherwise mask. Deploy-freshness is guaranteed UPSTREAM by the top-of-pipeline RefreshExecutorDeploy chokepoint (config#1549) \u2014 the whole EOD run executes latest origin/main by construction, so nousergon-data#574's per-step boot-pull is no longer carried here. eod_reconcile.py's ExecutorPreflight deploy-drift guard remains the authoritative fail-loud gate. (executionTimeout left at 600s from #574 \u2014 a safe upper bound; harmless without the inline refresh.)",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -o pipefail', 'cd /home/ec2-user/alpha-engine', 'sudo -u ec2-user -H bash /home/ec2-user/alpha-engine/infrastructure/boot-pull.sh > /var/log/eod-bootpull.log 2>&1 || echo \"[eod-preflight] boot-pull deploy refresh returned non-zero; eod_reconcile deploy-drift guard will surface any staleness LOUD\"', 'set -a && source /home/ec2-user/.alpha-engine.env && set +a', 'export ALPHA_ENGINE_DEPLOYED=1', 'export FLOW_DOCTOR_ENABLED=1', 'source .venv/bin/activate', States.Format('python -m krepis.ssm_log_capture run --slug eod --log /var/log/eod.log -- python executor/eod_reconcile.py --date {}', $.run_date))",
+          "commands.$": "States.Array('set -o pipefail', 'cd /home/ec2-user/alpha-engine', 'set -a && source /home/ec2-user/.alpha-engine.env && set +a', 'export ALPHA_ENGINE_DEPLOYED=1', 'export FLOW_DOCTOR_ENABLED=1', 'source .venv/bin/activate', States.Format('python -m krepis.ssm_log_capture run --slug eod --log /var/log/eod.log -- python executor/eod_reconcile.py --date {}', $.run_date))",
           "executionTimeout": [
             "600"
           ]
@@ -774,6 +774,152 @@
       },
       "ResultPath": "$.substrate_check_poll",
       "Next": "StopTradingInstance"
+    },
+    "CheckSkipRefreshExecutorDeploy": {
+      "Type": "Choice",
+      "Comment": "Per-task rerun gate (L4607) for the top-of-pipeline executor-deploy refresh (config#1549). Input {\"skip_refresh_executor_deploy\": true} routes past RefreshExecutorDeploy to the first work gate (CheckSkipPostMarketData); missing flag = run as normal. This is the FIRST gate the SSM-ready path enters \u2014 hoisting the refresh here (out of the per-step EODReconcile refresh added in nousergon-data#574) means the ENTIRE EOD run (PostMarketData \u2192 PostMarketArcticAppend \u2192 CaptureSnapshot \u2192 EODReconcile) executes latest origin/main by construction, closing the silent-stale-code exposure on the non-drift-guarded work steps. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_refresh_executor_deploy",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_refresh_executor_deploy",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "CheckSkipPostMarketData"
+        }
+      ],
+      "Default": "RefreshExecutorDeploy"
+    },
+    "RefreshExecutorDeploy": {
+      "Type": "Task",
+      "Comment": "Hoisted deploy-drift chokepoint (config#1549). Refreshes the trading instance's crucible-executor checkout to origin/main via the canonical boot-pull.sh ONCE at the top of the EOD pipeline, before any work step runs. The trading instance boot-pulls once each morning (boot-pull.service, ~6:10 AM PT), but executor PRs that merge during the trading day leave the checkout stale by EOD (2026-06-30 incident: 3 executor PRs merged 08:07\u201308:54 PT after the morning boot-pull). nousergon-data#574 patched only the EODReconcile step (the one work step carrying a drift guard); the earlier PostMarketData / PostMarketArcticAppend / CaptureSnapshot steps had no guard and would run stale intraday code silently. Refreshing here makes the whole run execute latest main by construction. FAIL-LOUD: boot-pull runs WITHOUT a `|| echo` swallow, so a failed refresh (auth/network/dep-install) surfaces as a non-zero SSM status \u2192 HandleFailure \u2192 ForceStopInstance BEFORE any stale-code work step runs (stronger than #574, whose swallow relied on the downstream reconcile guard). boot-pull runs as ec2-user (matching boot-pull.service User=ec2-user + the ec2-user-owned checkout / ~/.netrc); a root git fetch/reset would trip git's dubious-ownership guard (CVE-2022-24765).",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -o pipefail",
+            "cd /home/ec2-user/alpha-engine",
+            "sudo -u ec2-user -H bash /home/ec2-user/alpha-engine/infrastructure/boot-pull.sh > /var/log/eod-bootpull.log 2>&1"
+          ],
+          "executionTimeout": [
+            "600"
+          ]
+        },
+        "TimeoutSeconds": 600
+      },
+      "TimeoutSeconds": 660,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.TaskFailed"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-loud: a failed executor-deploy refresh must halt EOD before any work step runs stale code. Don't paper over it \u2014 the whole point of the hoist is that non-guarded steps never run stale.",
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.refresh_executor_deploy_result",
+      "Next": "WaitForRefreshExecutorDeploy"
+    },
+    "WaitForRefreshExecutorDeploy": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.refresh_executor_deploy_result.Command.CommandId",
+        "InstanceId.$": "$.trading_instance_id[0]"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "CommandId.$": "$.CommandId",
+        "InstanceId.$": "$.InstanceId"
+      },
+      "ResultPath": "$.refresh_executor_deploy_poll",
+      "Next": "CheckRefreshExecutorDeployStatus"
+    },
+    "CheckRefreshExecutorDeployStatus": {
+      "Type": "Choice",
+      "Comment": "Default routes to HandleFailure so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed \u2014 a stale checkout must never reach the work steps.",
+      "Choices": [
+        {
+          "Variable": "$.refresh_executor_deploy_poll.Status",
+          "StringEquals": "Success",
+          "Next": "CheckSkipPostMarketData"
+        },
+        {
+          "Variable": "$.refresh_executor_deploy_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "RefreshExecutorDeployWait"
+        },
+        {
+          "Variable": "$.refresh_executor_deploy_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "RefreshExecutorDeployWait"
+        },
+        {
+          "Variable": "$.refresh_executor_deploy_poll.Status",
+          "StringEquals": "Delayed",
+          "Next": "RefreshExecutorDeployWait"
+        }
+      ],
+      "Default": "RefreshExecutorDeployStatusError"
+    },
+    "RefreshExecutorDeployWait": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "WaitForRefreshExecutorDeploy"
+    },
+    "RefreshExecutorDeployStatusError": {
+      "Type": "Pass",
+      "Comment": "Choice Default path \u2014 synthesize $.error from poll result so HandleFailure's JsonToString($.error) has something to stringify.",
+      "Parameters": {
+        "source": "refresh_executor_deploy_status",
+        "status.$": "$.refresh_executor_deploy_poll.Status",
+        "status_details.$": "$.refresh_executor_deploy_poll.StatusDetails",
+        "response_code.$": "$.refresh_executor_deploy_poll.ResponseCode",
+        "command_id.$": "$.refresh_executor_deploy_poll.CommandId",
+        "instance_id.$": "$.refresh_executor_deploy_poll.InstanceId"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
     },
     "CheckSkipPostMarketData": {
       "Type": "Choice",

--- a/tests/test_sf_eod_deploy_refresh_wiring.py
+++ b/tests/test_sf_eod_deploy_refresh_wiring.py
@@ -1,4 +1,5 @@
-"""Pins the EOD-SF deploy-refresh-before-reconcile invariant.
+"""Pins the EOD-SF executor-deploy-refresh invariant — HOISTED to a single
+top-of-pipeline chokepoint (config#1549).
 
 Incident (2026-06-30 EOD, run for 2026-06-30 executed 2026-07-01): the
 ``ne-postclose-trading-pipeline`` EOD reconcile hard-failed at
@@ -12,36 +13,57 @@ so the checkout only refreshes once per day at boot; any executor PR that
 merges during the trading day leaves EOD reconcile on stale code and the
 (correct, fail-loud) drift guard refuses to reconcile NAV.
 
-Root-cause fix at the correct layer: the EOD pipeline must bring the
-executor checkout to ``origin/main`` **before** the drift-guarded
-``eod_reconcile.py``, using the canonical, tested refresh path
-(``infrastructure/boot-pull.sh`` — the same script ``boot-pull.service``
-runs, and the exact recovery the drift-guard message itself prescribes).
-This makes EOD reconcile run latest ``main`` by construction and closes
-the intraday-merge window structurally.
+The 2026-06-30 same-day recovery (nousergon-data#574) patched ONLY the
+``EODReconcile`` step (the one work step that happens to carry a drift
+guard). But the broader class is that the EOD pipeline refreshes the
+executor/data code only once per day at morning boot, so EVERY EOD step —
+``PostMarketData`` / ``PostMarketArcticAppend`` / ``CaptureSnapshot``,
+which run BEFORE the reconcile and have NO drift guard — executed stale
+intraday code *silently* (no fail-loud surface), and a stale-code snapshot
+that a fresh-code reconcile then reads is a latent cross-version
+consistency risk.
 
-Two load-bearing details this test pins so the fix cannot silently rot:
+Root-cause fix at the correct layer (config#1549): hoist the refresh out
+of the reconcile step into a single ``RefreshExecutorDeploy`` SSM state at
+the TOP of the pipeline — right after the SSM-readiness gate, before the
+first work gate ``CheckSkipPostMarketData`` — invoking the canonical,
+tested ``infrastructure/boot-pull.sh`` ONCE (as ``ec2-user``) so the
+*entire* EOD run (postmarket → arctic → snapshot → reconcile) executes on
+latest ``origin/main`` by construction. #574's per-step refresh is removed
+from ``EODReconcile`` (the top-level step subsumes it). This lifts the
+invariant "EOD runs latest main" to one chokepoint instead of N per-step
+patches, and closes the silent-stale-code exposure on the non-guarded
+steps.
 
-1. The refresh must run **as ``ec2-user``** (``sudo -u ec2-user``). SSM
+Load-bearing details this test pins so the fix cannot silently rot:
+
+1. The refresh lives in its OWN ``RefreshExecutorDeploy`` state (not
+   inline in ``EODReconcile``), wired via the async
+   send → ``WaitFor…`` → ``Check…Status`` triplet like every other EOD
+   SSM work step, and gated by ``CheckSkipRefreshExecutorDeploy`` for
+   per-task rerunnability.
+
+2. The refresh runs **as ``ec2-user``** (``sudo -u ec2-user``). SSM
    ``AWS-RunShellScript`` runs as root, but ``boot-pull.service`` is
    ``User=ec2-user`` and the checkout + ``~/.netrc`` are ec2-user-owned;
    boot-pull.sh has no ``safe.directory``/``sudo`` shim, so a root
    invocation would trip git's dubious-ownership guard (CVE-2022-24765).
 
-2. The refresh must appear **before** ``eod_reconcile.py`` in the command
-   array — refreshing after the reconcile would be pointless.
+3. It runs **before** any work step (topologically upstream of
+   ``PostMarketData``), and ``EODReconcile`` no longer carries an inline
+   boot-pull.
 
-FAIL-LOUD is preserved and asserted elsewhere: the drift guard remains the
-authoritative gate; this step only removes the *false-positive* staleness
-that an intraday merge injects. If boot-pull itself fails, the checkout
-stays stale and ``eod_reconcile.py`` hard-fails LOUD — this test does not
-weaken that.
+4. **FAIL-LOUD is strengthened**: because the non-guarded work steps now
+   depend on this refresh having succeeded, ``RefreshExecutorDeploy`` must
+   NOT swallow a boot-pull failure with ``|| echo`` — a failed refresh
+   surfaces as a non-zero SSM status → HandleFailure → ForceStopInstance
+   BEFORE any stale-code work step runs. (The drift guard in
+   ``eod_reconcile.py`` remains the authoritative gate downstream.)
 """
 
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 
 import pytest
@@ -49,47 +71,45 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_eod.json"
 
-# 2026-07-01 (EOD run_date-threading fix): EODReconcile's Parameters.commands
-# moved from a plain JSON array to a `commands.$ States.Array(...)` intrinsic
-# expression (needed to splice $.run_date via States.Format — see
-# test_sf_ssm_pipefail_wiring.py's _LIB_CLI_RE docstring for why the inline
-# bash-trap form can't live in a commands.$ context). None of this file's
-# assertions check exact list equality — only substring/ordering checks — so
-# extracting each single-quoted literal argument (the plain setup lines AND
-# the States.Format(...) template string, which still contains the
-# boot-pull.sh / eod_reconcile.py substrings these tests key off) preserves
-# every check unchanged.
-_QUOTED_ARG_RE = re.compile(r"'([^']*)'")
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
 
 
 @pytest.fixture(scope="module")
-def eod_commands() -> list[str]:
-    doc = json.loads(_SF_PATH.read_text())
-    params = doc["States"]["EODReconcile"]["Parameters"]["Parameters"]
-    if "commands" in params:
-        return params["commands"]
-    return _QUOTED_ARG_RE.findall(params["commands.$"])
+def refresh_commands(states) -> list[str]:
+    # RefreshExecutorDeploy uses a plain `commands` JSON array (no $.run_date
+    # splice needed, unlike EODReconcile's States.Array/States.Format form).
+    return states["RefreshExecutorDeploy"]["Parameters"]["Parameters"]["commands"]
 
 
 def _index_of(cmds: list[str], needle: str) -> int:
     return next((i for i, c in enumerate(cmds) if needle in c), -1)
 
 
-class TestDeployRefreshBeforeReconcile:
-    def test_boot_pull_refresh_present(self, eod_commands):
-        idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
+class TestRefreshHoistedToChokepoint:
+    def test_refresh_state_exists(self, states):
+        assert "RefreshExecutorDeploy" in states, (
+            "config#1549: the executor-deploy refresh must be a dedicated "
+            "top-of-pipeline RefreshExecutorDeploy state, not inline in "
+            "EODReconcile."
+        )
+        st = states["RefreshExecutorDeploy"]
+        assert "ssm:sendCommand" in st["Resource"]
+
+    def test_boot_pull_refresh_present(self, refresh_commands):
+        idx = _index_of(refresh_commands, "infrastructure/boot-pull.sh")
         assert idx != -1, (
-            "EODReconcile must refresh the executor checkout via "
-            "infrastructure/boot-pull.sh before running eod_reconcile.py — "
-            "otherwise an executor PR merged during the trading day leaves "
-            "the checkout stale and the deploy-drift guard hard-fails "
-            "(2026-06-30 incident)."
+            "RefreshExecutorDeploy must refresh the executor checkout via "
+            "infrastructure/boot-pull.sh so the whole EOD run executes latest "
+            "origin/main (2026-06-30 intraday-merge incident)."
         )
 
-    def test_refresh_runs_as_ec2_user(self, eod_commands):
-        idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
+    def test_refresh_runs_as_ec2_user(self, refresh_commands):
+        idx = _index_of(refresh_commands, "infrastructure/boot-pull.sh")
         assert idx != -1
-        line = eod_commands[idx]
+        line = refresh_commands[idx]
         assert "sudo -u ec2-user" in line, (
             "boot-pull.sh must run as ec2-user (matching boot-pull.service "
             "User=ec2-user and the ec2-user-owned checkout/~/.netrc). SSM "
@@ -97,24 +117,53 @@ class TestDeployRefreshBeforeReconcile:
             "checkout trips git's dubious-ownership guard (CVE-2022-24765)."
         )
 
-    def test_refresh_precedes_reconcile(self, eod_commands):
-        refresh_idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
-        reconcile_idx = _index_of(eod_commands, "executor/eod_reconcile.py")
-        assert refresh_idx != -1 and reconcile_idx != -1
-        assert refresh_idx < reconcile_idx, (
-            "The deploy refresh must run BEFORE eod_reconcile.py — "
-            "refreshing after the reconcile is a no-op."
+    def test_pipefail_first(self, refresh_commands):
+        assert refresh_commands[0].startswith("set ") and "pipefail" in refresh_commands[0]
+
+    def test_refresh_is_fail_loud_not_swallowed(self, refresh_commands):
+        # The whole point of the hoist is that non-drift-guarded work steps
+        # depend on the refresh having succeeded — so a failed boot-pull must
+        # NOT be swallowed with `|| echo` (as #574's inline form did, relying
+        # on the downstream reconcile guard). It must propagate a non-zero exit.
+        idx = _index_of(refresh_commands, "infrastructure/boot-pull.sh")
+        assert "|| echo" not in refresh_commands[idx] and "|| true" not in refresh_commands[idx], (
+            "RefreshExecutorDeploy must fail loud on a boot-pull failure — "
+            "swallowing it would let PostMarketData/ArcticAppend/Snapshot run "
+            "stale code silently, the exact exposure config#1549 closes."
         )
 
-    def test_pipefail_still_first(self, eod_commands):
-        # The refresh insertion must not displace `set -o pipefail` from
-        # the first slot (test_sf_ssm_pipefail_wiring pins this too; belt
-        # and suspenders so the two invariants can't drift apart).
-        assert eod_commands[0].startswith("set ") and "pipefail" in eod_commands[0]
+    def test_refresh_does_not_swallow_via_tee(self, refresh_commands):
+        idx = _index_of(refresh_commands, "infrastructure/boot-pull.sh")
+        assert "| tee " not in refresh_commands[idx]
 
-    def test_refresh_does_not_swallow_via_tee(self, eod_commands):
-        # The refresh line must not introduce a competing `| tee` work
-        # line (that would confuse the S3-log-ship guard, which keys off
-        # the first tee'd logfile). It writes to its own file via `>`.
-        idx = _index_of(eod_commands, "infrastructure/boot-pull.sh")
-        assert "| tee " not in eod_commands[idx]
+    def test_refresh_runs_before_any_work_step(self, states):
+        # RefreshExecutorDeploy (via its Check…Status Success edge) enters the
+        # first work gate CheckSkipPostMarketData; and the SSM-readiness gate
+        # enters the refresh gate first. So the refresh is topologically
+        # upstream of every work step.
+        succ = [c["Next"] for c in states["CheckRefreshExecutorDeployStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["CheckSkipPostMarketData"]
+        online = [c["Next"] for c in states["SSMReadyChoice"]["Choices"]
+                  if any(x.get("StringEquals") == "Online" for x in c.get("And", []))]
+        assert online == ["CheckSkipRefreshExecutorDeploy"]
+
+
+class TestReconcileNoLongerCarriesInlineRefresh:
+    """#574's per-step boot-pull is removed from EODReconcile — the top-level
+    RefreshExecutorDeploy chokepoint subsumes it (config#1549)."""
+
+    def test_eod_reconcile_has_no_inline_boot_pull(self, states):
+        params = states["EODReconcile"]["Parameters"]["Parameters"]
+        # EODReconcile uses commands.$ (States.Array/States.Format for $.run_date).
+        blob = params.get("commands.$") or json.dumps(params.get("commands", []))
+        assert "boot-pull.sh" not in blob, (
+            "EODReconcile must NOT carry an inline boot-pull refresh — it is "
+            "hoisted to RefreshExecutorDeploy at the top of the pipeline "
+            "(config#1549). Leaving both would double-refresh."
+        )
+
+    def test_eod_reconcile_still_runs_reconcile(self, states):
+        params = states["EODReconcile"]["Parameters"]["Parameters"]
+        blob = params.get("commands.$") or json.dumps(params.get("commands", []))
+        assert "executor/eod_reconcile.py" in blob

--- a/tests/test_sf_eod_instance_start_wiring.py
+++ b/tests/test_sf_eod_instance_start_wiring.py
@@ -99,7 +99,10 @@ class TestSSMReadyChoiceFailLoud:
         assert variables == {
             "$.ssm_describe_result.InstanceInformationList[0].PingStatus"
         }
-        assert cond["Next"] == "CheckSkipPostMarketData"
+        # config#1549: the first gate is now CheckSkipRefreshExecutorDeploy —
+        # the hoisted top-of-pipeline executor-deploy refresh — which converges
+        # on CheckSkipPostMarketData (the first work gate) on skip/success.
+        assert cond["Next"] == "CheckSkipRefreshExecutorDeploy"
 
     def test_budget_exhaustion_hard_fails(self, states):
         ch = states["SSMReadyChoice"]
@@ -154,5 +157,8 @@ class TestAllEntryPathsEnsureRunning:
         # The readiness gate is the ONLY edge from the start block into the work
         # chain; its Online target must be a non-sendCommand gate (the skip
         # gate), proving the box is confirmed ready before any sendCommand.
-        assert online_next == ["CheckSkipPostMarketData"]
-        assert "sendCommand" not in str(states["CheckSkipPostMarketData"].get("Resource", ""))
+        # config#1549: the readiness gate now lands on CheckSkipRefreshExecutorDeploy
+        # (the hoisted deploy-refresh gate), still a Choice gate — proving the box
+        # is confirmed SSM-Online before RefreshExecutorDeploy's sendCommand fires.
+        assert online_next == ["CheckSkipRefreshExecutorDeploy"]
+        assert "sendCommand" not in str(states["CheckSkipRefreshExecutorDeploy"].get("Resource", ""))

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -26,6 +26,10 @@ _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_eod.json"
 # daily_append, mirroring the weekday MorningArcticAppend split L4608) — it gets
 # its own skip-gate so a recovery rerun can skip whichever half already completed.
 _CHAIN = [
+    # config#1549 — the hoisted top-of-pipeline executor-deploy refresh gate runs
+    # FIRST (right after the SSM-readiness gate), so the entire EOD run executes
+    # latest origin/main by construction. Skipping it resumes at the first work gate.
+    ("CheckSkipRefreshExecutorDeploy", "RefreshExecutorDeploy", "skip_refresh_executor_deploy", "CheckSkipPostMarketData"),
     ("CheckSkipPostMarketData", "PostMarketData", "skip_post_market_data", "CheckSkipPostMarketArcticAppend"),
     ("CheckSkipPostMarketArcticAppend", "PostMarketArcticAppend", "skip_post_market_arctic_append", "CheckSkipCaptureSnapshot"),
     ("CheckSkipCaptureSnapshot", "CaptureSnapshot", "skip_capture_snapshot", "CheckSkipEODReconcile"),
@@ -63,10 +67,19 @@ class TestEntryEdgesRouteThroughGates:
         failopen = [c["Next"] for c in states["AcquireMutex"]["Catch"]
                     if "States.ALL" in c["ErrorEquals"]]
         assert failopen == ["StartTradingInstance"]
-        # The ensure-running block's SSM-ready path must land on the first gate.
+        # The ensure-running block's SSM-ready path must land on the first gate,
+        # which is now the hoisted deploy-refresh gate (config#1549).
         online = [c["Next"] for c in states["SSMReadyChoice"]["Choices"]
                   if any(x.get("StringEquals") == "Online" for x in c.get("And", []))]
-        assert online == ["CheckSkipPostMarketData"]
+        assert online == ["CheckSkipRefreshExecutorDeploy"]
+
+    def test_refresh_success_enters_post_market_gate(self, states):
+        # config#1549: after the deploy refresh succeeds, control enters the
+        # first work gate (CheckSkipPostMarketData) — the whole run now executes
+        # on latest origin/main.
+        succ = [c["Next"] for c in states["CheckRefreshExecutorDeployStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["CheckSkipPostMarketData"]
 
     def test_post_market_success_enters_arctic_append_gate(self, states):
         succ = [c["Next"] for c in states["CheckPostMarketStatus"]["Choices"]
@@ -92,7 +105,7 @@ class TestEntryEdgesRouteThroughGates:
 class TestPaths:
     def _walk(self, states, skip_flags):
         gates = {c[0] for c in _CHAIN}
-        order, seen, cur = [], set(), "CheckSkipPostMarketData"
+        order, seen, cur = [], set(), "CheckSkipRefreshExecutorDeploy"
         while cur and cur in states and cur not in seen:
             seen.add(cur)
             st = states[cur]
@@ -124,14 +137,24 @@ class TestPaths:
         # Cost-guard cleanup must ALWAYS run.
         assert order == ["StopTradingInstance"]
 
+    def test_skip_refresh_resumes_at_post_market_data(self, states):
+        # config#1549: skipping only the deploy refresh (e.g. an operator rerun
+        # on a box already known fresh) resumes at the first work task.
+        order = self._walk(states, skip_flags={"skip_refresh_executor_deploy"})
+        assert "RefreshExecutorDeploy" not in order
+        assert order[0] == "PostMarketData"
+        assert order[-1] == "StopTradingInstance"
+
     def test_skip_post_market_resumes_at_arctic_append(self, states):
-        order = self._walk(states, skip_flags={"skip_post_market_data"})
+        # Also skip the leading refresh gate so the walk starts cleanly at the
+        # PostMarket portion under test (config#1549 added the refresh gate first).
+        order = self._walk(states, skip_flags={"skip_refresh_executor_deploy", "skip_post_market_data"})
         assert "PostMarketData" not in order
         assert order[0] == "PostMarketArcticAppend"
         assert order[-1] == "StopTradingInstance"
 
     def test_skip_post_market_and_arctic_append_resumes_at_snapshot(self, states):
-        order = self._walk(states, skip_flags={"skip_post_market_data", "skip_post_market_arctic_append"})
+        order = self._walk(states, skip_flags={"skip_refresh_executor_deploy", "skip_post_market_data", "skip_post_market_arctic_append"})
         assert "PostMarketData" not in order
         assert "PostMarketArcticAppend" not in order
         assert order[0] == "CaptureSnapshot"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -468,6 +468,16 @@ class TestEODSFTopLevelFieldsClosed:
             "ec2_start_result",
             "ssm_describe_result",
             "ssm_poll",
+            # config#1549 — top-of-pipeline executor-deploy refresh chokepoint.
+            # CheckSkipRefreshExecutorDeploy reads $.skip_refresh_executor_deploy
+            # (optional rerun flag); RefreshExecutorDeploy emits
+            # $.refresh_executor_deploy_result (sendCommand) and its poll emits
+            # $.refresh_executor_deploy_poll (getCommandInvocation, trimmed by
+            # ResultSelector). Hoists nousergon-data#574's per-step boot-pull to
+            # a single chokepoint so the whole EOD run executes latest main.
+            "skip_refresh_executor_deploy",
+            "refresh_executor_deploy_result",
+            "refresh_executor_deploy_poll",
         }
     )
 


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** high

Closes nousergon/alpha-engine-config#1549

## Problem (the class, not the symptom site)
The EOD pipeline (`ne-postclose-trading-pipeline`) refreshes the long-lived trading instance's executor/data checkout only **once per day at morning boot** (`boot-pull.service`, ~6:10 AM PT). Any executor PR merged during the trading day leaves EOD steps on stale code. The 2026-06-30 incident: 3 executor PRs merged 08:07–08:54 PT after the morning boot-pull, so `eod_reconcile.py`'s `ExecutorPreflight.check_deploy_drift` hard-failed (checkout `b7e52b1` vs `origin/main@8c3014e`).

nousergon-data#574 (merged) patched **only** `EODReconcile` — the one work step that happens to carry a drift guard. But the earlier steps — `PostMarketData` (`weekly_collector.py`), `PostMarketArcticAppend`, `CaptureSnapshot` — run *before* the reconcile and have **no drift guard**, so they executed stale intraday code **silently**. A stale-code snapshot that a fresh-code reconcile then reads is a latent cross-version-consistency risk.

## Fix (the named structural chokepoint)
Hoist the refresh into a single **`RefreshExecutorDeploy`** SSM state at the **top** of the pipeline — right after the SSM-readiness gate, before the first work gate `CheckSkipPostMarketData` — invoking the canonical `infrastructure/boot-pull.sh` **once** (as `ec2-user`) so the *entire* EOD run (postmarket → arctic → snapshot → reconcile) executes on latest `origin/main` **by construction**.

- New `RefreshExecutorDeploy` (+ `WaitForRefreshExecutorDeploy` / `CheckRefreshExecutorDeployStatus` / `RefreshExecutorDeployWait` / `RefreshExecutorDeployStatusError`) mirrors the existing async **send → wait → check** SSM triplet verbatim, so it satisfies the poll-ResultSelector (drops stdout, keeps Status + the `*StatusError` fields), the `Ssm.InvocationDoesNotExist(Exception)` dual-form retry, and the `set -o pipefail`-first registries in lockstep.
- New `CheckSkipRefreshExecutorDeploy` per-task rerun gate (`skip_refresh_executor_deploy`), matching the L4607 skip-gate structure.
- The SSM-readiness `Online` edge now lands on `CheckSkipRefreshExecutorDeploy` (was `CheckSkipPostMarketData`).
- **#574's per-step boot-pull is removed** from `EODReconcile` (the top-level step subsumes it). `EODReconcile`'s executionTimeout is left at #574's 600s — a harmless upper bound now that the inline refresh is gone.

## Fail-loud is *strengthened* vs #574
Because the non-guarded work steps now depend on the refresh having succeeded, `RefreshExecutorDeploy` does **not** swallow a boot-pull failure with `|| echo` (as #574's inline form did, relying on the downstream reconcile guard). A failed refresh surfaces as a non-zero SSM status → `HandleFailure` → `ForceStopInstance` **before any stale-code work step runs**. `eod_reconcile.py`'s drift guard remains the authoritative gate downstream. Runs as `ec2-user` (CVE-2022-24765 dubious-ownership guard).

## Tests
- `test_sf_eod_deploy_refresh_wiring.py` **repointed** from the inline-`EODReconcile` invariant to the hoisted `RefreshExecutorDeploy` state, plus new assertions: fail-loud (no `|| echo`/`|| true` swallow), runs-before-any-work-step, and `EODReconcile`-carries-no-inline-boot-pull.
- Updated the skip-gate chain registry + walk (`test_sf_eod_skipgate_wiring.py`), the SSM-readiness entry-edge (`test_sf_eod_instance_start_wiring.py`), and the EOD top-level `$.<field>` closed registry (`test_sf_payload_uniqueness.py`) with the 3 new fields.

**Validation:** full EOD + cross-SF wiring suite green locally — `699 passed, 5 skipped` (skips are env-gated, unrelated; `test_sf_preflight.py` needs `pandas`, not installed on the groom box — it exercises preflight logic, not EOD SF structure, so it is unaffected by this topology change). No `.github/workflows/*` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)