### PR TITLE
[P2/high] fix(nousergon-data): re-point daily_news held-ticker union to metron holdings snapshot

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -4,20 +4,28 @@ Mirrors the Saturday ``run_news_pipeline`` chain (news aggregator →
 ``NewsNLPPipeline`` → ``aggregate_and_write``) but on a WEEKDAY cadence over a
 small, high-value universe:
 
-    robodashboard holdings  ∪  alpha-engine signals universe (tracked + recs)
+    Metron held tickers  ∪  alpha-engine signals universe (tracked + recs)
 
 and writes to a SEPARATE eval-artifact prefix (``data/news_aggregates_daily/``)
-with a ``latest.json`` sidecar, so the robodashboard morning brief gets a stable
-pointer to the freshest pull without knowing the trading day. The Saturday
+with a ``latest.json`` sidecar, so the morning brief gets a stable pointer to the
+freshest pull without knowing the trading day. The Saturday
 ``data/news_aggregates/`` artifact (full signals universe, 168h, RAG-ingested)
 is untouched — this is an additive daily companion.
+
+The held-ticker source is Metron's nightly ``metron/holdings_universe.json``
+(config#1506) — the successor to the retired ``robodashboard/holdings_universe.json``
+(nousergon/metron-ops#119). Same symbols-only ``{"tickers": [...]}`` shape; Metron
+publishes it on its ``daily-refresh`` (metron-refresh.timer, 21:30 UTC among the
+post-close window), so this union re-sources Brian's held names that robodashboard's
+retired producer used to feed. Still fail-soft: a missing/unreadable holdings file
+degrades to AE's own signal universe rather than aborting the pull.
 
 Deterministic: APIs (Polygon/GDELT/Yahoo) + dictionary NLP (Loughran-McDonald +
 rule-based events). No LLM, no API spend — honors
 ``[[preference_llm_calls_confined_to_research_module]]``.
 
 Why a small universe (vs. all ~900 constituents): the only daily consumers are
-robodashboard's brief (the held names) and AE's own tracked set — and Polygon's
+the morning brief (the held names) and AE's own tracked set — and Polygon's
 free tier is 5 req/min, so a per-ticker pull over 900 names is infeasible in any
 morning window. The full universe stays on the weekly Saturday cadence.
 
@@ -51,20 +59,31 @@ logger = logging.getLogger(__name__)
 DAILY_PREFIX = "data/news_aggregates_daily"
 ARTICLES_PREFIX = "data/news_articles_daily"
 DIGEST_PREFIX = "data/news_digest_daily"
-HOLDINGS_UNIVERSE_KEY = "robodashboard/holdings_universe.json"
+# Metron's nightly held-ticker snapshot — the robodashboard successor (config#1506,
+# nousergon/metron-ops#119). Same symbols-only ``{"tickers": [...]}`` shape the retired
+# robodashboard/holdings_universe.json had; published by Metron's daily-refresh (see
+# metron api/services/data_spine.py::publish_holdings_universe). This is the SAME S3
+# object collectors/metron_market_data.py reads for its yf-priced universe — the
+# ``tickers`` slice is the news-universe view of that same held set.
+HOLDINGS_UNIVERSE_KEY = "metron/holdings_universe.json"
 DEFAULT_LOOKBACK_HOURS = 24
 DEFAULT_BUCKET = "alpha-engine-research"
 
 
 def _load_holdings_universe(bucket: str, s3_client: Any) -> list[str]:
-    """Read robodashboard's published held-ticker symbols (fail-soft → [])."""
+    """Read Metron's published held-ticker symbols (fail-soft → []).
+
+    Reads the symbols-only ``tickers`` slice of ``metron/holdings_universe.json``
+    (config#1506) — the robodashboard successor. Same ``{"tickers": [...]}`` contract
+    the retired ``robodashboard/holdings_universe.json`` had, so the parse is unchanged.
+    """
     try:
         obj = s3_client.get_object(Bucket=bucket, Key=HOLDINGS_UNIVERSE_KEY)
         data = json.loads(obj["Body"].read())
         tickers = [
             str(t).strip().upper() for t in data.get("tickers", []) if str(t).strip()
         ]
-        logger.info("[daily_news] loaded %d robodashboard holdings tickers", len(tickers))
+        logger.info("[daily_news] loaded %d Metron holdings tickers", len(tickers))
         return tickers
     except Exception as e:  # missing object, no creds, parse error, etc.
         logger.warning(
@@ -75,7 +94,7 @@ def _load_holdings_universe(bucket: str, s3_client: Any) -> list[str]:
 
 
 def assemble_universe(bucket: str, s3_client: Any) -> list[str]:
-    """Union robodashboard holdings ∪ AE signals universe (tracked + recs).
+    """Union Metron held tickers ∪ AE signals universe (tracked + recs).
 
     Each slice is fail-soft: a missing holdings file or signals.json degrades
     to whatever is available rather than aborting the pull.

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -16,7 +16,13 @@ from collectors import daily_news
 
 
 def _mock_s3(holdings=None, signals_universe=None):
-    """S3 mock serving the holdings_universe.json key and a signals.json."""
+    """S3 mock serving the Metron holdings_universe.json key and a signals.json.
+
+    The holdings object mirrors Metron's REAL published payload
+    (``metron/holdings_universe.json`` — config#1506): the symbols-only ``tickers``
+    slice the union consumes, alongside the ``holdings``/``currencies`` fields the
+    market-data producer reads. daily_news must read ONLY ``tickers`` and ignore the rest.
+    """
     s3 = MagicMock()
     s3.list_objects_v2.return_value = {
         "CommonPrefixes": [{"Prefix": "signals/2026-06-05/"}],
@@ -26,7 +32,16 @@ def _mock_s3(holdings=None, signals_universe=None):
         if Key == daily_news.HOLDINGS_UNIVERSE_KEY:
             if holdings is None:
                 raise RuntimeError("NoSuchKey")
-            return {"Body": BytesIO(json.dumps({"tickers": holdings}).encode())}
+            payload = {
+                "schema_version": 2,
+                "as_of": "2026-07-02",
+                "source": "metron",
+                # Full Metron shape — daily_news must pick out `tickers` and ignore these.
+                "holdings": [{"yf_symbol": t, "currency": "USD"} for t in holdings],
+                "currencies": [],
+                "tickers": holdings,
+            }
+            return {"Body": BytesIO(json.dumps(payload).encode())}
         if Key.endswith("signals.json"):
             uni = [{"ticker": t} for t in (signals_universe or [])]
             return {"Body": BytesIO(json.dumps({"universe": uni}).encode())}
@@ -36,9 +51,22 @@ def _mock_s3(holdings=None, signals_universe=None):
     return s3
 
 
+def test_holdings_universe_key_points_at_metron():
+    # config#1506: the held-ticker source is Metron's snapshot, NOT the retired
+    # robodashboard producer (nousergon/metron-ops#119).
+    assert daily_news.HOLDINGS_UNIVERSE_KEY == "metron/holdings_universe.json"
+
+
 def test_assemble_universe_unions_dedupes_sorts():
     s3 = _mock_s3(holdings=["AAPL", "tsla"], signals_universe=["AAPL", "MSFT"])
     assert daily_news.assemble_universe("b", s3) == ["AAPL", "MSFT", "TSLA"]
+
+
+def test_load_holdings_reads_tickers_slice_of_metron_payload():
+    # daily_news consumes ONLY the symbols-only `tickers` slice of Metron's payload —
+    # the `holdings`/`currencies` (yf-priced) fields are the market-data producer's view.
+    s3 = _mock_s3(holdings=["AAPL", "nvda"], signals_universe=[])
+    assert daily_news._load_holdings_universe("b", s3) == ["AAPL", "NVDA"]
 
 
 def test_assemble_universe_fail_soft_no_holdings():


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** high

Refs #1506 (auto-closed by the primary metron producer PR nousergon/metron#169)

## Problem
The weekday `RunDailyNews` step unions Brian's held tickers into the daily-news universe from `robodashboard/holdings_universe.json`. That producer was **retired** (nousergon/metron-ops#119), so the union silently degraded to AE's own signal set — held-but-not-AE-tracked tickers stopped appearing in the daily brief (fail-soft, `severity: warning`, so no alert fired).

## Fix
Re-point the union at **`metron/holdings_universe.json`** — Metron's nightly held-ticker snapshot (robodashboard's successor, published on its `daily-refresh` at 21:30 UTC via `metron-refresh.timer`). Metron's companion PR (nousergon/metron#169) adds a symbols-only `tickers` slice to that payload in the **same `{"tickers": [...]}` shape** the retired robodashboard file had, so the loader parse is unchanged.

This is the **same S3 object** `collectors/metron_market_data.py` already reads for its yf-priced universe — `daily_news` consumes the news-universe view (`tickers`) of that same held set, one object, two consumers.

- Union stays **fail-soft**: a missing/unreadable snapshot degrades to AE's signal universe, never aborts the pull.
- Docstrings/logs updated from robodashboard → Metron.

## Tests (green)
`tests/test_daily_news.py` — the S3 mock now serves Metron's **real** payload (`holdings`/`currencies`/`tickers`), and tests assert `daily_news` reads ONLY the `tickers` slice (ignoring the yf-priced fields). Added `test_holdings_universe_key_points_at_metron` and `test_load_holdings_reads_tickers_slice_of_metron_payload`.
```
$ python -m pytest tests/test_daily_news.py -q
18 passed
$ ruff check collectors/daily_news.py     # main change file
All checks passed!
```
(Pre-existing `E702` lint on unrelated `MagicMock(); ...` lines in the test file is untouched; this repo ships no ruff config gating it.)

## Companion PRs
- **Primary / producer (Closes #1506):** nousergon/metron#169 — adds the `tickers` slice.
- `alpha-engine-config`: re-add the `metron_holdings_universe` freshness row.
- `metron-ops`: DEPLOY.md — document the snapshot now feeds this union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)