### PR TITLE
feat(sf): judge the week's thinktank captures in the Saturday eval batch (config#1579 P2)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1049,7 +1049,8 @@
                 "Payload": {
                   "force_sonnet_pass": true,
                   "date.$": "$.eval_cadence.eval_date",
-                  "dry_run_llm.$": "$.research_dry"
+                  "dry_run_llm.$": "$.research_dry",
+                  "capture_lookback_days": 6
                 }
               },
               "TimeoutSeconds": 300,
@@ -1086,7 +1087,8 @@
                 "Payload": {
                   "force_sonnet_pass": false,
                   "date.$": "$.eval_cadence.eval_date",
-                  "dry_run_llm.$": "$.research_dry"
+                  "dry_run_llm.$": "$.research_dry",
+                  "capture_lookback_days": 6
                 }
               },
               "TimeoutSeconds": 300,

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -79,10 +79,10 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     "Research": frozenset({"dry_run_llm.$", "force", "weekly_run", "skip_dry_run_gate"}),
     "DataPhase2": frozenset({"dry_run.$", "phase"}),
     "EvalJudgeSubmitFirstSaturday": frozenset(
-        {"date.$", "dry_run_llm.$", "force_sonnet_pass"}
+        {"date.$", "dry_run_llm.$", "force_sonnet_pass", "capture_lookback_days"}
     ),
     "EvalJudgeSubmitWeekly": frozenset(
-        {"date.$", "dry_run_llm.$", "force_sonnet_pass"}
+        {"date.$", "dry_run_llm.$", "force_sonnet_pass", "capture_lookback_days"}
     ),
     "EvalJudgePoll": frozenset(
         {"batch_id.$", "dry_run_llm.$", "max_wait_seconds", "submit_iso.$"}


### PR DESCRIPTION
Adds `"capture_lookback_days": 6` to both `EvalJudgeSubmit*` state payloads. The submit handler (crucible-research PR, branch `feat/thinktank-eval-corpus-wiring`) expands it to `extra_dates` = Sun–Fri, so the week's daily think-tank DecisionArtifacts are judged in the SAME Saturday batch as the weekly graph's — no parallel Submit/Poll/Process chain, no re-judging (graph artifacts only exist in Saturday partitions, outside a 6-day lookback), unmapped agent_ids in weekday partitions skip cleanly as today.

**Merge order:** the crucible-research handler PR must merge + its submit Lambda redeploy (automatic on research main push) BEFORE this — an older handler simply ignores the unknown payload key, so mis-ordering is safe-degraded (fail-soft to current behavior), but the intended coupling is research-first.

SF auto-deploys on merge via `deploy-infrastructure.yml` — no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)