### PR TITLE
fix(eod-sf): skip flags honored only for pipeline_role=operator-replay (config#1614)

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -91,14 +91,16 @@
     },
     "StartTradingInstance": {
       "Type": "Task",
-      "Comment": "Re-runnability guard (2026-06-30 incident). Ensure the long-lived trading instance is running + SSM-registered BEFORE any EOD ssm:sendCommand. The normal daemon-shutdown-triggered run enters with the box already up, but EOD's OWN terminal StopTradingInstance and failure-path ForceStopInstance both STOP it — so any operator recovery rerun after a prior failure lands on a stopped instance and the first sendCommand dies with Ssm.InvalidInstanceIdException (observed 2026-06-30 rerun watch-rerun-2026-06-30-1: EODReconcile sendCommand → 'Instances not in a valid state', instance i-018eb3307a21329bf stopped by the prior run's ForceStopInstance). ec2:startInstances is a no-op if already running, so this is safe on the normal path and makes the EOD pipeline idempotently re-runnable. Mirrors the daily/preopen StartExecutorEC2 → SSM-readiness poll (config#1430, the same InvalidInstanceIdException class on cold-boot).",
+      "Comment": "Re-runnability guard (2026-06-30 incident). Ensure the long-lived trading instance is running + SSM-registered BEFORE any EOD ssm:sendCommand. The normal daemon-shutdown-triggered run enters with the box already up, but EOD's OWN terminal StopTradingInstance and failure-path ForceStopInstance both STOP it \u2014 so any operator recovery rerun after a prior failure lands on a stopped instance and the first sendCommand dies with Ssm.InvalidInstanceIdException (observed 2026-06-30 rerun watch-rerun-2026-06-30-1: EODReconcile sendCommand \u2192 'Instances not in a valid state', instance i-018eb3307a21329bf stopped by the prior run's ForceStopInstance). ec2:startInstances is a no-op if already running, so this is safe on the normal path and makes the EOD pipeline idempotently re-runnable. Mirrors the daily/preopen StartExecutorEC2 \u2192 SSM-readiness poll (config#1430, the same InvalidInstanceIdException class on cold-boot).",
       "Resource": "arn:aws:states:::aws-sdk:ec2:startInstances",
       "Parameters": {
         "InstanceIds.$": "$.trading_instance_id"
       },
       "Retry": [
         {
-          "ErrorEquals": ["States.TaskFailed"],
+          "ErrorEquals": [
+            "States.TaskFailed"
+          ],
           "MaxAttempts": 2,
           "IntervalSeconds": 30,
           "BackoffRate": 1.0
@@ -106,7 +108,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -116,14 +120,16 @@
     },
     "WaitForInstanceReady": {
       "Type": "Wait",
-      "Comment": "Initial settle before polling for SSM-agent registration. EC2 stopped→running takes ~15-25s; polling describeInstanceInformation any earlier just burns API calls.",
+      "Comment": "Initial settle before polling for SSM-agent registration. EC2 stopped\u2192running takes ~15-25s; polling describeInstanceInformation any earlier just burns API calls.",
       "Seconds": 15,
       "Next": "InitSSMPollCounter"
     },
     "InitSSMPollCounter": {
       "Type": "Pass",
       "Comment": "Initialize attempts counter for the SSM-readiness poll loop.",
-      "Result": {"attempts": 0},
+      "Result": {
+        "attempts": 0
+      },
       "ResultPath": "$.ssm_poll",
       "Next": "DescribeInstanceInfo"
     },
@@ -133,13 +139,19 @@
       "Resource": "arn:aws:states:::aws-sdk:ssm:describeInstanceInformation",
       "Parameters": {
         "Filters": [
-          {"Key": "InstanceIds", "Values.$": "$.trading_instance_id"}
+          {
+            "Key": "InstanceIds",
+            "Values.$": "$.trading_instance_id"
+          }
         ]
       },
       "TimeoutSeconds": 15,
       "Retry": [
         {
-          "ErrorEquals": ["Ssm.SdkClientException", "States.Timeout"],
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
           "MaxAttempts": 2,
           "IntervalSeconds": 5,
           "BackoffRate": 1.5
@@ -147,7 +159,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -157,12 +171,18 @@
     },
     "SSMReadyChoice": {
       "Type": "Choice",
-      "Comment": "PingStatus=Online → CheckSkipRefreshExecutorDeploy (enter the per-task rerun gates; the FIRST gate now hoists the executor-checkout refresh to the top of the pipeline per config#1549, so the entire EOD run — postmarket → arctic → snapshot → reconcile — executes latest origin/main by construction). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail to HandleFailure when the budget is exhausted (per feedback_no_silent_fails — the agent not registering after 3 min is a real boot problem, not just timing; HandleFailure notifies + ForceStopInstance releases the box). This NEVER silently skips EOD reconcile — an unreachable box fails the execution loud.",
+      "Comment": "PingStatus=Online \u2192 CheckSkipRefreshExecutorDeploy (enter the per-task rerun gates; the FIRST gate now hoists the executor-checkout refresh to the top of the pipeline per config#1549, so the entire EOD run \u2014 postmarket \u2192 arctic \u2192 snapshot \u2192 reconcile \u2014 executes latest origin/main by construction). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail to HandleFailure when the budget is exhausted (per feedback_no_silent_fails \u2014 the agent not registering after 3 min is a real boot problem, not just timing; HandleFailure notifies + ForceStopInstance releases the box). This NEVER silently skips EOD reconcile \u2014 an unreachable box fails the execution loud.",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus", "IsPresent": true},
-            {"Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus", "StringEquals": "Online"}
+            {
+              "Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.ssm_describe_result.InstanceInformationList[0].PingStatus",
+              "StringEquals": "Online"
+            }
           ],
           "Next": "CheckSkipRefreshExecutorDeploy"
         },
@@ -181,7 +201,9 @@
     },
     "IncrementSSMPoll": {
       "Type": "Pass",
-      "Parameters": {"attempts.$": "States.MathAdd($.ssm_poll.attempts, 1)"},
+      "Parameters": {
+        "attempts.$": "States.MathAdd($.ssm_poll.attempts, 1)"
+      },
       "ResultPath": "$.ssm_poll",
       "Next": "DescribeInstanceInfo"
     },
@@ -322,6 +344,14 @@
       "Choices": [
         {
           "And": [
+            {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "operator-replay"
+            },
             {
               "Variable": "$.skip_post_market_arctic_append",
               "IsPresent": true
@@ -782,6 +812,14 @@
         {
           "And": [
             {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "operator-replay"
+            },
+            {
               "Variable": "$.skip_refresh_executor_deploy",
               "IsPresent": true
             },
@@ -928,6 +966,14 @@
         {
           "And": [
             {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "operator-replay"
+            },
+            {
               "Variable": "$.skip_post_market_data",
               "IsPresent": true
             },
@@ -947,6 +993,14 @@
       "Choices": [
         {
           "And": [
+            {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "operator-replay"
+            },
             {
               "Variable": "$.skip_capture_snapshot",
               "IsPresent": true
@@ -968,6 +1022,14 @@
         {
           "And": [
             {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "operator-replay"
+            },
+            {
               "Variable": "$.skip_eod_reconcile",
               "IsPresent": true
             },
@@ -987,6 +1049,14 @@
       "Choices": [
         {
           "And": [
+            {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "operator-replay"
+            },
             {
               "Variable": "$.skip_daily_substrate_health_check",
               "IsPresent": true

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -7,6 +7,14 @@ CaptureSnapshot from scratch. This adds a skip-gate before each EOD work task
 so an operator rerun passing `{"skip_<task>": true}` resumes at the first
 incomplete task. Mirrors the weekday SF gates (L4606) and the Saturday SF.
 
+config#1614 (2026-07-02): skip flags are honored ONLY when the execution
+input carries `pipeline_role == "operator-replay"`. On any other role (the
+daemon's `eod`, `daily`, absent, etc.) the flags are structurally INERT and
+every task runs — closing the 2026-06-30 forced-green vector where a
+recovery rerun passed `skip_capture_snapshot=true` on a live-role input and
+silently bypassed the CaptureSnapshot axis guard (config#1610). Skips are
+ignored, not fatal: the downstream fail-loud guards stay the enforcement.
+
 The final cost-guard `StopTradingInstance` is intentionally NOT skip-gated — it
 must always run to release the trading EC2.
 """
@@ -48,9 +56,16 @@ class TestGatePresenceAndShape:
     def test_gate_exists_and_shaped(self, states, gate, task, flag, nxt):
         assert gate in states and states[gate]["Type"] == "Choice"
         c = states[gate]["Choices"][0]
-        assert {cond["Variable"] for cond in c["And"]} == {f"$.{flag}"}
-        assert any(cond.get("IsPresent") is True for cond in c["And"])
-        assert any(cond.get("BooleanEquals") is True for cond in c["And"])
+        # config#1614: every skip gate requires BOTH the flag AND the
+        # operator-replay pipeline_role — a skip flag on a live-role input
+        # is inert.
+        assert {cond["Variable"] for cond in c["And"]} == {f"$.{flag}", "$.pipeline_role"}
+        flag_conds = [x for x in c["And"] if x["Variable"] == f"$.{flag}"]
+        role_conds = [x for x in c["And"] if x["Variable"] == "$.pipeline_role"]
+        assert any(x.get("IsPresent") is True for x in flag_conds)
+        assert any(x.get("BooleanEquals") is True for x in flag_conds)
+        assert any(x.get("IsPresent") is True for x in role_conds)
+        assert any(x.get("StringEquals") == "operator-replay" for x in role_conds)
         assert c["Next"] == nxt
         assert states[gate]["Default"] == task
 
@@ -103,7 +118,10 @@ class TestEntryEdgesRouteThroughGates:
 
 
 class TestPaths:
-    def _walk(self, states, skip_flags):
+    def _walk(self, states, skip_flags, pipeline_role="operator-replay"):
+        """Simulate the gate chain. Mirrors ASL Choice semantics: the skip
+        branch is taken only when the flag is set AND pipeline_role ==
+        "operator-replay" (config#1614)."""
         gates = {c[0] for c in _CHAIN}
         order, seen, cur = [], set(), "CheckSkipRefreshExecutorDeploy"
         while cur and cur in states and cur not in seen:
@@ -111,7 +129,8 @@ class TestPaths:
             st = states[cur]
             if cur in gates:
                 flag = next(c[2] for c in _CHAIN if c[0] == cur)
-                cur = st["Choices"][0]["Next"] if flag in skip_flags else st["Default"]
+                skip_taken = flag in skip_flags and pipeline_role == "operator-replay"
+                cur = st["Choices"][0]["Next"] if skip_taken else st["Default"]
                 continue
             order.append(cur)
             if st.get("End") or st["Type"] in ("Succeed", "Fail"):
@@ -159,3 +178,30 @@ class TestPaths:
         assert "PostMarketArcticAppend" not in order
         assert order[0] == "CaptureSnapshot"
         assert order[-1] == "StopTradingInstance"
+
+
+class TestSkipFlagsInertOutsideOperatorReplay:
+    """config#1614 closes-when: a skip flag on a non-operator-replay input is
+    structurally ignored — the 2026-06-30 skip_capture_snapshot forced-green
+    vector no longer exists for live/daemon/watch-initiated runs."""
+
+    def test_all_skips_inert_on_live_eod_role(self, states):
+        order = self._walk(states, skip_flags={c[2] for c in _CHAIN}, pipeline_role="eod")
+        for task in (c[1] for c in _CHAIN):
+            assert task in order, f"{task} was skipped despite non-replay role"
+        assert order[-1] == "StopTradingInstance"
+
+    def test_all_skips_inert_when_role_absent(self, states):
+        order = self._walk(states, skip_flags={c[2] for c in _CHAIN}, pipeline_role=None)
+        for task in (c[1] for c in _CHAIN):
+            assert task in order, f"{task} was skipped despite absent role"
+
+    def test_operator_replay_still_honors_skips(self, states):
+        order = self._walk(
+            states,
+            skip_flags={c[2] for c in _CHAIN},
+            pipeline_role="operator-replay",
+        )
+        assert order == ["StopTradingInstance"]
+
+    _walk = TestPaths._walk


### PR DESCRIPTION
## Why

config#1614 / config#1610: the 6/30 EOD recovery forced a green run by passing `skip_capture_snapshot=true` on a live-role input, bypassing the CaptureSnapshot axis guard and silently mis-joining the reconcile. The charter forbids it in prose — this makes it structural.

## What

All six `CheckSkip*` gates in `ne-postclose-trading-pipeline` now require `pipeline_role == "operator-replay"` in addition to the flag. Any other role (`eod`, `daily`, absent) ignores the flags — states run normally, downstream fail-loud guards (snapshot + reconcile axis guards, crucible-executor#322) stay the enforcement. Operator replays keep full resume semantics.

## Tests

`test_sf_eod_skipgate_wiring.py`: gate-shape pins the role conjunct; new `TestSkipFlagsInertOutsideOperatorReplay` covers all-skips-inert on `eod`/absent roles + operator-replay unchanged. Full `step_function_eod.json` test set: **218 passed** locally.

## Deploy

`deploy-infrastructure.yml` applies the definition on merge. EOD SF doesn't run again until Mon 7/6 post-close — safe to merge any time this weekend.

## Sequencing (trip-readiness for 7/9–7/10)

This is gate #2 for config#1616 (flip weekday+EOD watch to autonomous merge). Gate #1 is Monday 7/6's live EOD validation (config#1610 closes-when #2). Both green → flip Tuesday 7/7 → Wednesday 7/8 is a full autonomous rehearsal day with Brian present → Thursday/Friday unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)