### PR TITLE
[P2/low] fix(sf-watch): code-fence S3 watch-log path in Telegram receipt

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -340,10 +340,10 @@ def _notify(record: dict, key: str, pipeline_name: str) -> bool:
         f"{label}: {record['status']}",
     ]
     if record.get("failed_state"):
-        lines.append(f"Failed state: {record['failed_state']}")
+        lines.append(f"Failed state: `{record['failed_state']}`")
     if record.get("cause"):
-        lines.append(f"Cause: {record['cause']}")
-    lines.append(f"Watch log: s3://{WATCH_BUCKET}/{key}")
+        lines.append(f"Cause: `{record['cause']}`")
+    lines.append(f"Watch log: `s3://{WATCH_BUCKET}/{key}`")
     if will_dispatch:
         footer = "_autonomous fix ACTIVE — resilience agent dispatched (diagnose→fix→merge→rerun)_"
     elif AGENT_DISPATCH_ENABLED and not has_listener:

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -137,9 +137,21 @@ def test_telegram_is_silent_and_records_artifact_location():
     assert kwargs["disable_notification"] is True  # notifier already buzzed loud
     assert "Fleet-SF Watch — OBSERVE" in text
     assert "Weekly Freshness SF: FAILED" in text  # pipeline-aware label
-    assert "Failed state: RAGIngestion" in text
+    assert "Failed state: `RAGIngestion`" in text
     assert "consolidated/saturday_sf_watch/2023-11-14.json" in text
     assert "observe-only" in text
+
+
+def test_watch_log_path_is_code_fenced():
+    """config#1584: underscored S3 keys must survive Telegram legacy Markdown
+    (which treats bare ``_`` as italic delimiters) — wrap in backticks."""
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        index.handler(_event("FAILED"), None)
+    text = _telegram_mod.send_message.call_args.args[0]
+    assert "`s3://alpha-engine-research/consolidated/saturday_sf_watch/2023-11-14.json`" in text
+    assert "Failed state: `RAGIngestion`" in text
+    assert "Cause: `States.TaskFailed: RAGIngestion failed`" in text
 
 
 def test_run_date_prefers_input_run_date():


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** low

Fixes the Fleet-SF Watch Telegram receipt rendering underscored S3 keys (e.g. `consolidated/groom_sf_watch/2026-07-02.json`) with underscores swallowed/italicized by Telegram's legacy Markdown parse mode, corrupting the human-facing path so a copy/transcribe 404s.

`_notify` in `infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py` now wraps the S3 URI and the `failed_state`/`cause` interpolations in backtick code spans, which render literally and are copy-pasteable under both legacy Markdown and MarkdownV2 — confirmed the lib helper (`krepis.telegram.send_message`, re-exported via `nousergon_lib.telegram`) uses `parse_mode="Markdown"` (legacy), where inline code spans need no additional escaping.

Added `test_watch_log_path_is_code_fenced` and updated the pre-existing assertion in `test_telegram_is_silent_and_records_artifact_location` to match. Full suite green (28/28).

Deploy: `deploy-infrastructure.yml` has no path filter and restamps on every main push, so this auto-deploys — no manual `deploy.sh` step needed.

Closes #1584