### PR TITLE
Union Metron's watchlist universe into load_metron_universe (fixes MU-not-recognized)

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -4,7 +4,7 @@
 system. Metron publishes its held-ticker universe to
 ``s3://<bucket>/metron/holdings_universe.json`` (yf_symbols + the non-USD currencies it
 holds) and its watchlist-only-ticker universe (tracked but never bought,
-metron-ops#42/#121) to ``s3://<bucket>/metron/watchlist_universe.json`` (metron-ops#131b)
+metron-ops#42/#121) to ``s3://<bucket>/metron/watchlist_universe.json`` (metron-ops#132)
 — ``load_metron_universe()`` reads and UNIONS both, so every producer below (and every
 Metron per-ticker consumer: fundamentals/technicals/analyst/sentiment/tearsheet) treats a
 watched-but-not-held ticker identically to a held one. This producer writes two artifacts
@@ -57,7 +57,7 @@ HOLDINGS_UNIVERSE_KEY = "metron/holdings_universe.json"
 # Metron also publishes a WATCHLIST-only-ticker universe (tracked but never bought,
 # metron-ops#42/#121) — unioned into load_metron_universe() below so a watchlist-only
 # ticker gets the SAME fundamentals/technicals/analyst/sentiment/price-history coverage a
-# held position does (metron-ops#131b: Brian added MU to his watchlist and it showed no
+# held position does (metron-ops#132: Brian added MU to his watchlist and it showed no
 # data — every per-ticker collector fetches strictly over the held union above, so a
 # never-held ticker was never in scope for any of them).
 WATCHLIST_UNIVERSE_KEY = "metron/watchlist_universe.json"
@@ -250,7 +250,7 @@ def _read_metron_universe_holdings(bucket: str, s3_client: Any, key: str) -> lis
 
 def load_metron_universe(bucket: str, s3_client: Any) -> tuple[list[dict], list[str]]:
     """Read Metron's published universe → ``(holdings, currencies)`` — the UNION of the
-    held-ticker universe and the watchlist-only-ticker universe (metron-ops#131b), so a
+    held-ticker universe and the watchlist-only-ticker universe (metron-ops#132), so a
     ticker Brian is only watching (never bought) gets the same per-ticker coverage a held
     position does everywhere this feeds: fundamentals/technicals/analyst/sentiment,
     close/FX history, and the valuation-medians benchmark set.

--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -1,19 +1,23 @@
-"""Metron market-data producer — EOD closes + FX for Metron's held-ticker universe.
+"""Metron market-data producer — EOD closes + FX for Metron's held + watchlist universe.
 
 `alpha-engine-data` is the single market-data ground truth for the whole Nous Ergon
 system. Metron publishes its held-ticker universe to
 ``s3://<bucket>/metron/holdings_universe.json`` (yf_symbols + the non-USD currencies it
-holds); this producer reads it and writes two artifacts the Metron app consumes — so
-Metron makes NO direct market-data API calls of its own:
+holds) and its watchlist-only-ticker universe (tracked but never bought,
+metron-ops#42/#121) to ``s3://<bucket>/metron/watchlist_universe.json`` (metron-ops#131b)
+— ``load_metron_universe()`` reads and UNIONS both, so every producer below (and every
+Metron per-ticker consumer: fundamentals/technicals/analyst/sentiment/tearsheet) treats a
+watched-but-not-held ticker identically to a held one. This producer writes two artifacts
+the Metron app consumes — so Metron makes NO direct market-data API calls of its own:
 
     market_data/eod_closes/{date}.json   + market_data/eod_closes/latest.json
     market_data/fx/{date}.json           + market_data/fx/latest.json
     market_data/fundamentals/latest.json   (daily — tearsheet multiples/ratios)
     market_data/intraday/latest.json       (every 5 min while NYSE open AND Metron in use)
 
-Closes cover the held union — including foreign listings (``1299.HK``, ``RMS.PA``), OTC
-(``GTBIF``), and funds (``FNILX``) that the ~903-name SP1500 constituent cache refuses.
-FX covers the held non-USD currencies (``{CCY}USD=X``).
+Closes cover the held+watchlist union — including foreign listings (``1299.HK``,
+``RMS.PA``), OTC (``GTBIF``), and funds (``FNILX``) that the ~903-name SP1500 constituent
+cache refuses. FX covers the held+watchlist non-USD currencies (``{CCY}USD=X``).
 
 Artifact schemas (versioned — Metron's consumer pins on ``schema_version``):
 
@@ -50,6 +54,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_BUCKET = "alpha-engine-research"
 # Metron publishes its held universe here (see metron api/services/data_spine.py).
 HOLDINGS_UNIVERSE_KEY = "metron/holdings_universe.json"
+# Metron also publishes a WATCHLIST-only-ticker universe (tracked but never bought,
+# metron-ops#42/#121) — unioned into load_metron_universe() below so a watchlist-only
+# ticker gets the SAME fundamentals/technicals/analyst/sentiment/price-history coverage a
+# held position does (metron-ops#131b: Brian added MU to his watchlist and it showed no
+# data — every per-ticker collector fetches strictly over the held union above, so a
+# never-held ticker was never in scope for any of them).
+WATCHLIST_UNIVERSE_KEY = "metron/watchlist_universe.json"
 CLOSES_PREFIX = "market_data/eod_closes/"
 FX_PREFIX = "market_data/fx/"
 # History artifacts (per-symbol / per-currency) — power Metron's Performance NAV
@@ -220,27 +231,47 @@ MediansUniverseSource = Callable[[], list[str]]
 # ── Universe read ───────────────────────────────────────────────────────────
 
 
-def load_metron_universe(bucket: str, s3_client: Any) -> tuple[list[dict], list[str]]:
-    """Read Metron's published held universe → ``(holdings, currencies)``.
-
-    ``holdings`` = ``[{"yf_symbol", "currency"}, …]``; ``currencies`` = distinct non-USD
-    currencies held. Fail-soft: a missing object / no creds / parse error → ``([], [])``
-    (logged) so the daily run proceeds rather than aborting."""
+def _read_metron_universe_holdings(bucket: str, s3_client: Any, key: str) -> list[dict]:
+    """Read one Metron universe artifact's ``holdings`` list. Fail-soft per artifact: a
+    missing object / no creds / parse error contributes nothing (logged) rather than
+    aborting the caller's union."""
     try:
-        obj = s3_client.get_object(Bucket=bucket, Key=HOLDINGS_UNIVERSE_KEY)
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
         data = json.loads(obj["Body"].read())
-        holdings = [
+        return [
             {"yf_symbol": str(h["yf_symbol"]).strip(), "currency": str(h.get("currency", "USD")).strip()}
             for h in data.get("holdings", [])
             if str(h.get("yf_symbol", "")).strip()
         ]
-        currencies = [str(c).strip().upper() for c in data.get("currencies", []) if str(c).strip()]
-        logger.info("[metron_market_data] universe: %d instruments, %d non-USD currencies",
-                    len(holdings), len(currencies))
-        return holdings, currencies
     except Exception as e:  # missing object, no creds, parse error, etc.
-        logger.warning("[metron_market_data] metron universe unavailable (%s) — empty pull", e)
-        return [], []
+        logger.warning("[metron_market_data] %s unavailable (%s) — no contribution", key, e)
+        return []
+
+
+def load_metron_universe(bucket: str, s3_client: Any) -> tuple[list[dict], list[str]]:
+    """Read Metron's published universe → ``(holdings, currencies)`` — the UNION of the
+    held-ticker universe and the watchlist-only-ticker universe (metron-ops#131b), so a
+    ticker Brian is only watching (never bought) gets the same per-ticker coverage a held
+    position does everywhere this feeds: fundamentals/technicals/analyst/sentiment,
+    close/FX history, and the valuation-medians benchmark set.
+
+    ``holdings`` = ``[{"yf_symbol", "currency"}, …]``, deduped by yf_symbol — a symbol in
+    BOTH universes keeps the held-universe currency (it's the economically authoritative
+    one for a real position). ``currencies`` = distinct non-USD currencies across both.
+    Fail-soft per artifact (see ``_read_metron_universe_holdings``): either missing / no
+    creds / parse error contributes nothing rather than aborting the daily run."""
+    watched = _read_metron_universe_holdings(bucket, s3_client, WATCHLIST_UNIVERSE_KEY)
+    held = _read_metron_universe_holdings(bucket, s3_client, HOLDINGS_UNIVERSE_KEY)
+    by_yf: dict[str, str] = {h["yf_symbol"]: h["currency"] for h in watched}
+    by_yf.update({h["yf_symbol"]: h["currency"] for h in held})  # held wins on conflict
+    holdings = [{"yf_symbol": yf, "currency": ccy} for yf, ccy in sorted(by_yf.items())]
+    currencies = sorted({ccy for ccy in by_yf.values() if ccy and ccy != "USD"})
+    watchlist_only = {h["yf_symbol"] for h in watched} - {h["yf_symbol"] for h in held}
+    logger.info(
+        "[metron_market_data] universe: %d instruments (%d held, %d watchlist-only), %d non-USD currencies",
+        len(holdings), len(held), len(watchlist_only), len(currencies),
+    )
+    return holdings, currencies
 
 
 # ── yfinance fetchers (default sources) ─────────────────────────────────────

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -16,10 +16,14 @@ from unittest.mock import MagicMock
 from collectors import metron_market_data as mmd
 
 
-def _universe_s3(universe: dict | None, heartbeat_ts: str | None = None) -> MagicMock:
-    """A MagicMock S3 whose get_object dispatches per key: the Metron universe JSON
-    (raises if None) and, when ``heartbeat_ts`` is given, a fresh UI-heartbeat object
-    (the intraday demand gate); any other key raises NoSuchKey."""
+def _universe_s3(
+    universe: dict | None, heartbeat_ts: str | None = None, watchlist: dict | None = None
+) -> MagicMock:
+    """A MagicMock S3 whose get_object dispatches per key: the Metron held-universe JSON
+    (raises if None), the Metron watchlist-universe JSON (raises if None — most tests don't
+    exercise the watchlist union, matching the artifact simply not existing yet) and, when
+    ``heartbeat_ts`` is given, a fresh UI-heartbeat object (the intraday demand gate); any
+    other key raises NoSuchKey."""
     s3 = MagicMock()
 
     def _get(Bucket, Key):
@@ -31,9 +35,15 @@ def _universe_s3(universe: dict | None, heartbeat_ts: str | None = None) -> Magi
             if heartbeat_ts is None:
                 raise Exception("NoSuchKey")
             return _body({"ts": heartbeat_ts})
-        if universe is None:
-            raise Exception("NoSuchKey")
-        return _body(universe)
+        if Key == mmd.WATCHLIST_UNIVERSE_KEY:
+            if watchlist is None:
+                raise Exception("NoSuchKey")
+            return _body(watchlist)
+        if Key == mmd.HOLDINGS_UNIVERSE_KEY:
+            if universe is None:
+                raise Exception("NoSuchKey")
+            return _body(universe)
+        raise Exception("NoSuchKey")
 
     s3.get_object.side_effect = _get
     return s3
@@ -127,6 +137,49 @@ def test_load_universe_parses_holdings_and_currencies():
     holdings, currencies = mmd.load_metron_universe("b", s3)
     assert {h["yf_symbol"] for h in holdings} == {"AAPL", "1299.HK"}
     assert currencies == ["HKD"]
+
+
+class TestWatchlistUniverseUnion:
+    """metron-ops#131b: a watchlist-only ticker (tracked but never bought) must get the
+    SAME per-ticker collector coverage a held position does — load_metron_universe unions
+    metron/holdings_universe.json with metron/watchlist_universe.json."""
+
+    def test_watchlist_only_symbol_is_unioned_in(self):
+        s3 = _universe_s3(_UNIVERSE, watchlist={
+            "schema_version": 1, "as_of": "2026-07-02", "source": "metron",
+            "holdings": [{"yf_symbol": "MU", "currency": "USD"}],
+            "currencies": [],
+        })
+        holdings, currencies = mmd.load_metron_universe("b", s3)
+        assert {h["yf_symbol"] for h in holdings} == {"AAPL", "1299.HK", "MU"}
+        assert currencies == ["HKD"]
+
+    def test_held_universe_currency_wins_on_conflict(self):
+        # AAPL watchlisted with a (bogus) non-USD currency — the held universe's USD must
+        # win, since that's the economically authoritative currency for a real position.
+        s3 = _universe_s3(_UNIVERSE, watchlist={
+            "holdings": [{"yf_symbol": "AAPL", "currency": "EUR"}], "currencies": ["EUR"],
+        })
+        holdings, currencies = mmd.load_metron_universe("b", s3)
+        aapl = next(h for h in holdings if h["yf_symbol"] == "AAPL")
+        assert aapl["currency"] == "USD"
+
+    def test_missing_watchlist_artifact_fails_soft_to_held_only(self):
+        # No watchlist artifact published yet (or the read fails) → the held universe alone,
+        # unchanged from the pre-union behavior — never aborts the run.
+        s3 = _universe_s3(_UNIVERSE)  # watchlist=None → NoSuchKey
+        holdings, currencies = mmd.load_metron_universe("b", s3)
+        assert {h["yf_symbol"] for h in holdings} == {"AAPL", "1299.HK"}
+        assert currencies == ["HKD"]
+
+    def test_missing_held_artifact_still_surfaces_watchlist_only_symbols(self):
+        # The held-universe read failing (e.g. transient S3 error) must not also blank out
+        # watchlist coverage — the two artifacts fail independently.
+        s3 = _universe_s3(None, watchlist={
+            "holdings": [{"yf_symbol": "MU", "currency": "USD"}], "currencies": [],
+        })
+        holdings, currencies = mmd.load_metron_universe("b", s3)
+        assert {h["yf_symbol"] for h in holdings} == {"MU"}
 
 
 class TestHistory:

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -140,7 +140,7 @@ def test_load_universe_parses_holdings_and_currencies():
 
 
 class TestWatchlistUniverseUnion:
-    """metron-ops#131b: a watchlist-only ticker (tracked but never bought) must get the
+    """metron-ops#132: a watchlist-only ticker (tracked but never bought) must get the
     SAME per-ticker collector coverage a held position does — load_metron_universe unions
     metron/holdings_universe.json with metron/watchlist_universe.json."""
 


### PR DESCRIPTION
## Summary
- Companion to nousergon/metron#172 — Metron now also publishes a watchlist-only-ticker universe artifact (`metron/watchlist_universe.json`), since every per-ticker collector here (`collect_fundamentals`, `collect_analyst`, `collect_sentiment`, `collect_technicals`/`collect_history`) previously fetched strictly over the held-position universe (`metron/holdings_universe.json`) — a watchlisted-but-never-bought ticker (Brian's MU report) was never in scope for any of them.
- `load_metron_universe()` now unions both artifacts, deduped by `yf_symbol` (held-universe currency wins on conflict — it's the economically authoritative one for a real position). Every call site (9 of them, per grep) inherits watchlist coverage automatically since they all go through this one function — no per-collector changes needed.
- Fail-soft per-artifact, independently: either missing/erroring contributes nothing rather than aborting the read of the other.

Fixes nousergon/metron-ops#132.

## Test plan
- [x] `TestWatchlistUniverseUnion` (4 new tests): watchlist-only symbol unioned in, held-universe currency wins on conflict, missing-watchlist-artifact fails soft to held-only (unchanged pre-union behavior), missing-held-artifact still surfaces watchlist-only symbols
- [x] Existing `load_metron_universe`/`collect*` tests unchanged and green (stricter per-key mock dispatch in `_universe_s3`, still backward-compatible)
- [x] Full `pytest tests/` green (2565 passed — 1 pre-existing unrelated failure in `test_load_config_experiment_package.py`, confirmed present on unmodified `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)