### PR TITLE
fix(tests): anchor daily_append date tests to most-recent NYSE trading day (config#1572)

### DIFF
--- a/tests/test_daily_append_skip_if_exists.py
+++ b/tests/test_daily_append_skip_if_exists.py
@@ -53,6 +53,27 @@ def _disable_factor_momentum_daily(monkeypatch):
     monkeypatch.setenv("FACTOR_MOMENTUM_DAILY_ENABLED", "false")
 
 
+def _recent_trading_day_str() -> str:
+    """Most recent NYSE trading day as of now, ISO ``YYYY-MM-DD``.
+
+    These tests feed the resolved date straight into ``daily_append`` as
+    ``date_str``, which enforces an NYSE-trading-day gate (config#1572) —
+    a raw ``datetime.now()`` detonates every weekend and market holiday
+    (surfaced 2026-07-03, the observed Independence Day holiday: 7 tests
+    red on ``main`` with "is not an NYSE trading day"). Anchoring to the
+    most recent *trading* day keeps the date a valid session (passes the
+    gate) AND within the freshness threshold (staleness is 0 trading days
+    — the last row IS this date), so it neither rots (the 2026-05-04
+    hardcoded-date failure) nor trips the phantom-session guard.
+    """
+    from nousergon_lib.trading_calendar import is_trading_day, previous_trading_day
+
+    d = datetime.now(timezone.utc).date()
+    if not is_trading_day(d):
+        d = previous_trading_day(d)
+    return d.isoformat()
+
+
 def _stub_closes(tickers: list[str]) -> dict:
     """Minimal daily_closes shape: per-ticker {Open,High,Low,Close,Volume,VWAP}."""
     return {
@@ -173,11 +194,11 @@ def test_skip_if_exists_true_skips_when_today_in_hist(monkeypatch):
     spend, just a microsecond ``today_ts in hist.index`` check."""
     from builders.daily_append import daily_append
 
-    # Use real "now" so the daily_append freshness scan (5d threshold
-    # against datetime.now(timezone.utc)) doesn't trip as the calendar
-    # advances. Hardcoded dates rot — the 2026-05-04 CI breakage
-    # surfaced because "2026-04-28" had aged 6d past the threshold.
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # Anchor to the most recent NYSE *trading* day (see
+    # _recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
+    # and detonates the config#1572 phantom-session gate on weekends and
+    # market holidays (2026-07-03). The trading-day anchor dodges both.
+    today_str = _recent_trading_day_str()
     universe = ["AAPL", "MSFT", "GOOGL"]
     _, _, write_calls = _patch_targets(
         monkeypatch,
@@ -208,11 +229,11 @@ def test_skip_if_exists_true_writes_when_today_missing(monkeypatch):
     silent-skip bug for tickers with genuinely-missing today rows."""
     from builders.daily_append import daily_append
 
-    # Use real "now" so the daily_append freshness scan (5d threshold
-    # against datetime.now(timezone.utc)) doesn't trip as the calendar
-    # advances. Hardcoded dates rot — the 2026-05-04 CI breakage
-    # surfaced because "2026-04-28" had aged 6d past the threshold.
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # Anchor to the most recent NYSE *trading* day (see
+    # _recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
+    # and detonates the config#1572 phantom-session gate on weekends and
+    # market holidays (2026-07-03). The trading-day anchor dodges both.
+    today_str = _recent_trading_day_str()
     universe = ["AAPL", "MSFT"]
     _, _, write_calls = _patch_targets(
         monkeypatch,
@@ -238,11 +259,11 @@ def test_skip_if_exists_false_writes_even_when_today_in_hist(monkeypatch):
     that the 2026-04-18 commit introduced for the polygon-label incident."""
     from builders.daily_append import daily_append
 
-    # Use real "now" so the daily_append freshness scan (5d threshold
-    # against datetime.now(timezone.utc)) doesn't trip as the calendar
-    # advances. Hardcoded dates rot — the 2026-05-04 CI breakage
-    # surfaced because "2026-04-28" had aged 6d past the threshold.
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # Anchor to the most recent NYSE *trading* day (see
+    # _recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
+    # and detonates the config#1572 phantom-session gate on weekends and
+    # market holidays (2026-07-03). The trading-day anchor dodges both.
+    today_str = _recent_trading_day_str()
     universe = ["AAPL", "MSFT"]
     _, _, write_calls = _patch_targets(
         monkeypatch,

--- a/tests/test_daily_append_universe_chunking.py
+++ b/tests/test_daily_append_universe_chunking.py
@@ -27,13 +27,15 @@ These tests pin:
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 
-from tests.test_daily_append_skip_if_exists import _patch_targets
+from tests.test_daily_append_skip_if_exists import (
+    _patch_targets,
+    _recent_trading_day_str,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -60,7 +62,7 @@ def test_universe_pass_chunks_read_batch_calls(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today_str = _recent_trading_day_str()
     # 4 universe + XLRE leak + SPY universe-extra = 6 → 3 chunks at K=2
     universe = ["AAPL", "MSFT", "GOOGL", "AMZN"]
     universe_lib, _, _ = _patch_targets(
@@ -97,7 +99,7 @@ def test_universe_pass_chunks_write_batches_too(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today_str = _recent_trading_day_str()
     # 3 universe + XLRE leak + SPY universe-extra = 5 effective → 3 chunks at K=2
     universe = ["AAPL", "MSFT", "GOOGL"]
     universe_lib, _, _ = _patch_targets(
@@ -128,7 +130,7 @@ def test_universe_pass_gc_collect_called_between_chunks(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today_str = _recent_trading_day_str()
     universe = ["AAPL", "MSFT", "GOOGL", "AMZN", "META"]  # 5 → 3 chunks
     _patch_targets(
         monkeypatch,
@@ -158,7 +160,7 @@ def test_universe_pass_n_ok_accumulates_across_chunks(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today_str = _recent_trading_day_str()
     universe = ["AAPL", "MSFT", "GOOGL", "AMZN", "META", "NVDA"]  # 6 → 3 chunks
     _patch_targets(
         monkeypatch,


### PR DESCRIPTION
## Root cause
`main` went red (run [28631222064]($CI_RUN_URL), 7 failures) on **2026-07-03**, the observed Independence Day holiday (July 4 falls on Saturday; NYSE closed). `tests/test_daily_append_skip_if_exists.py` (3) and `tests/test_daily_append_universe_chunking.py` (4) built their date via `datetime.now(timezone.utc)` and fed it straight into `daily_append(date_str=...)`, which enforces an NYSE-trading-day gate (**config#1572** — "refusing to append a phantom session to the universe"). Real "now" is not guaranteed to be a trading day, so these tests are a **latent time-bomb that detonates every weekend and market holiday**.

The tests originally used raw "now" to dodge a *different* guard — the universe-freshness scan, which trips on rotted hardcoded dates (the 2026-05-04 breakage). Both guards actually want the same input the tests never supplied: a **recent trading day**.

## The fix (correct layer: test data, not production logic)
A shared `_recent_trading_day_str()` helper resolves the most recent NYSE trading day as of now — today if it's a session, else `previous_trading_day(today)` (via `nousergon_lib.trading_calendar`, the real path, not the deprecated `alpha_engine_lib` alias). The resolved date is:
- a **valid session** → passes the config#1572 phantom-session gate, and
- **0 trading-days stale** (the last hist row IS this date) → passes the freshness scan,

in every case — weekday, weekend, or holiday. It neither rots nor phantoms.

## Guard that now covers this class
The 7 tests themselves are the regression guard: they exercise `daily_append` with a real resolved date on every CI run (including holidays), and the trading-day anchor guarantees a valid session year-round.

## Fail-loud rationale
The **config#1572 production guard is correct and untouched** — this is NOT a fail-loud swallow. The guard stays fully armed; the test merely feeds it the valid trading date that a real invocation always would. No test was skipped, xfailed, or weakened.

## Validation
`pytest tests/ -k daily_append` → **169 passed** locally (the 7 formerly-red tests now green). Confirmed `is_trading_day(2026-07-03) == False`, `previous_trading_day(2026-07-03) == 2026-07-02`.

🤖 Fleet CI Watch — autonomous resilience agent (ask-forgiveness; Brian reviews after).