### PR TITLE
fix(saturday-sf): normalize $.error on LibPinDriftGate path so HandleFailure fails loud, not States.Runtime

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -97,15 +97,26 @@
     },
     "LibPinDriftGate": {
       "Type": "Choice",
-      "Comment": "Hard-fail when the lib-pin probe reports has_drift=true (a confirmed co-install parity break or below-floor regression). Surfaces cross-repo pin drift loudly before the SF spends on any spot launch.",
+      "Comment": "Hard-fail when the lib-pin probe reports has_drift=true (a confirmed co-install parity break or below-floor regression). Surfaces cross-repo pin drift loudly before the SF spends on any spot launch. Routes via ExtractLibPinDriftError (NOT straight to HandleFailure): a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — jumping here directly made HandleFailure itself die with States.Runtime ('$.error could not be found', 2026-07-03 offcycle-shell), swallowing the drift reason behind an opaque meta-error. Mirrors the existing Extract*Error normalizer convention.",
       "Choices": [
         {
           "Variable": "$.libpin_drift_result.Payload.has_drift",
           "BooleanEquals": true,
-          "Next": "HandleFailure"
+          "Next": "ExtractLibPinDriftError"
         }
       ],
       "Default": "CheckMutexRole"
+    },
+    "ExtractLibPinDriftError": {
+      "Type": "Pass",
+      "Comment": "Normalize a confirmed lib-pin drift (LibPinDriftGate has_drift==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) — it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the drift offenders (2026-07-03 offcycle-shell). Carries the whole probe Payload (reason/offenders/pins/parity_ok/floor_ok/min_lib_version) so the FAILED SNS alert names the exact cross-repo pin mismatch a human must resolve. References only $.libpin_drift_result.Payload — guaranteed present because the gate already dereferenced Payload.has_drift to route here — so this normalizer cannot itself raise a missing-field States.Runtime. Mirrors the existing Extract*Error → HandleFailure convention; no new error channel. FAIL-LOUD PRESERVED: still → HandleFailure → FailExecution (the pipeline still hard-fails on real drift by design).",
+      "Parameters": {
+        "phase": "LibPinDriftGate",
+        "source": "LibPinDriftGate.has_drift",
+        "drift.$": "$.libpin_drift_result.Payload"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
     },
     "CheckMutexRole": {
       "Type": "Choice",

--- a/tests/test_sf_lib_pin_drift_wiring.py
+++ b/tests/test_sf_lib_pin_drift_wiring.py
@@ -83,9 +83,60 @@ def test_gate_halts_only_on_confirmed_drift(states):
     c = gate["Choices"][0]
     assert c["Variable"] == "$.libpin_drift_result.Payload.has_drift"
     assert c["BooleanEquals"] is True
-    assert c["Next"] == "HandleFailure"
+    # Confirmed drift halts, but routes through the $.error normalizer FIRST
+    # (not straight to HandleFailure) — see test_drift_halt_normalizes_error.
+    assert c["Next"] == "ExtractLibPinDriftError"
     # No drift → proceed into the pipeline.
     assert gate["Default"] == "CheckMutexRole"
+
+
+def test_drift_halt_normalizes_error_before_handle_failure(states):
+    """The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) —
+    its transition does NOT populate $.error. HandleFailure's Message calls
+    States.JsonToString($.error), so a direct Choice→HandleFailure jump killed
+    the SF with an opaque States.Runtime ('$.error could not be found') that
+    swallowed the drift reason (2026-07-03 offcycle-shell). The drift path must
+    first hit an Extract*Error normalizer that writes $.error, matching every
+    other HandleFailure entry."""
+    norm = states["ExtractLibPinDriftError"]
+    assert norm["Type"] == "Pass"
+    assert norm["ResultPath"] == "$.error"
+    assert norm["Next"] == "HandleFailure"
+    # References only the whole probe Payload — guaranteed present because the
+    # gate already dereferenced Payload.has_drift to route here — so the
+    # normalizer cannot itself raise a missing-field States.Runtime.
+    assert norm["Parameters"]["drift.$"] == "$.libpin_drift_result.Payload"
+
+
+def test_every_handle_failure_entry_populates_error(states):
+    """CHOKEPOINT for the whole failure class (2026-07-03): HandleFailure's
+    Message template hard-requires $.error via States.JsonToString($.error), so
+    EVERY transition that lands on HandleFailure must guarantee $.error is set —
+    either a Task Catch with ResultPath '$.error', or a Pass normalizer with
+    ResultPath '$.error'. A future soft-path/Choice that jumps straight to
+    HandleFailure (as LibPinDriftGate once did) would re-introduce the opaque
+    States.Runtime meta-crash; this test fails loudly if any such path appears."""
+    offenders = []
+    for name, st in states.items():
+        # Catch-based entries.
+        for cat in st.get("Catch", []):
+            if cat.get("Next") == "HandleFailure" and cat.get("ResultPath") != "$.error":
+                offenders.append(f"{name} Catch ResultPath={cat.get('ResultPath')!r}")
+        # State-transition entries (Next / Default / Choice).
+        transitions = [st.get("Next"), st.get("Default")]
+        transitions += [c.get("Next") for c in st.get("Choices", [])]
+        if "HandleFailure" in transitions:
+            # The source state must itself write $.error before handing off —
+            # i.e. be a Pass normalizer with ResultPath '$.error'.
+            if not (st.get("Type") == "Pass" and st.get("ResultPath") == "$.error"):
+                offenders.append(
+                    f"{name} (Type={st.get('Type')}) transitions to HandleFailure "
+                    f"without setting $.error (ResultPath={st.get('ResultPath')!r})"
+                )
+    assert not offenders, (
+        "State(s) reach HandleFailure without populating $.error — "
+        "HandleFailure will die with States.Runtime: " + "; ".join(offenders)
+    )
 
 
 def test_gate_runs_before_any_spot_launch(sf, states):


### PR DESCRIPTION
## Root cause

The Saturday SF (`ne-weekly-freshness-pipeline`) `offcycle-shell-20260703-005835` execution terminated **FAILED** at `HandleFailure` with:

> `States.Runtime`: … `States.JsonToString($.error)` … The JsonPath argument for the field `$.error` could not be found in the input …

`LibPinDriftCheck` correctly detected a **genuine** co-install parity break (`crucible-backtester=v0.77.1 != crucible-predictor=v0.78.0`, `has_drift=true`). `LibPinDriftGate` — a **Choice** — then routed straight to `HandleFailure`. But `HandleFailure`'s SNS `Message` is `States.Format('… Error: {} …', $.pipeline_label, States.JsonToString($.error))`, and **a Choice transition never populates `$.error`** the way a Task `Catch` with `ResultPath: $.error` does. So the failure *annunciator itself* crashed with `States.Runtime`, and the SF died with an opaque meta-error that **swallowed the real drift reason**.

Every other entry into `HandleFailure` already sets `$.error` — via a Task `Catch` (`ResultPath: $.error`) or an `Extract*Error` Pass normalizer. `LibPinDriftGate` was the **only** path that skipped it.

## The fix (correct layer, no band-aid, no swallow)

Route the drift-halt through a new **`ExtractLibPinDriftError`** Pass normalizer that writes the whole probe Payload into `$.error` before `HandleFailure` — mirroring the established `Extract*Error → HandleFailure` convention. It references only `$.libpin_drift_result.Payload` (guaranteed present, since the gate already dereferenced `Payload.has_drift` to route here), so the normalizer itself cannot raise a missing-field `States.Runtime`.

**Fail-loud preserved.** This does *not* make the failure quieter: the pipeline still hard-fails on real drift (`→ HandleFailure → FailExecution`). The change only ensures the drift **reason is surfaced** in the SNS alert instead of being hidden behind the meta-crash. The `LibPinDriftGate` hard-fail-on-drift semantics are unchanged.

## Guard / test that now covers this failure class

- `test_gate_halts_only_on_confirmed_drift` — updated for the new routing (`Choice → ExtractLibPinDriftError`).
- `test_drift_halt_normalizes_error_before_handle_failure` — pins the new normalizer (Pass, `ResultPath=$.error`, `Next=HandleFailure`, references the whole Payload).
- **`test_every_handle_failure_entry_populates_error`** — a **class chokepoint**: asserts *every* transition into `HandleFailure` (Catch or state-transition) guarantees `$.error` is set. Any future soft-path/Choice that jumps straight to `HandleFailure` (as `LibPinDriftGate` once did) fails this test loudly, preventing regression of the whole meta-crash class.

## Fail-loud rationale (error-handling touched)

The only error-handling change is that the drift path now *sets* `$.error` before the existing loud-fail path — it adds information to a failure, never suppresses one. No Catch/Retry was added to "pass" a failing step; no fatal step was made non-fatal; no skip-gate was widened.

## Note — the underlying drift is real and needs a human lockstep decision

This PR fixes the **annunciator**, not the drift. The `v0.77.1` vs `v0.78.0` co-install parity break between `crucible-backtester` and `crucible-predictor` is a genuine cross-repo lib-pin lockstep condition that the (now-fixed) preflight will keep surfacing loudly until a human resolves which pin is authoritative. Escalated separately; **not** auto-resolved here (deciding the authoritative pin is a load-bearing lockstep decision, out of scope for the failed step). The Saturday→Monday buffer applies.

Validation: `tests/test_sf_lib_pin_drift_wiring.py` + the full SF-definition wiring suite (364 tests) pass locally; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)