### PR TITLE
[P1/mid] test-date brittleness: lift daily_append 'today' anchor to a shared fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ would be silently no-op'd by a live SSM read. See
 
 import os
 import sys
+from datetime import datetime, timezone
 
 import pytest
 
@@ -43,3 +44,51 @@ def _isolate_secrets_from_ssm(monkeypatch):
     clear_cache()
     yield
     clear_cache()
+
+
+def recent_trading_day_str() -> str:
+    """Most recent NYSE trading day as of now, ISO ``YYYY-MM-DD``.
+
+    Shared chokepoint for date-driven ``daily_append`` tests. ``daily_append``
+    enforces an NYSE-trading-day gate (config#1572: "refusing to append a
+    phantom session") — a raw ``datetime.now()`` fed straight into
+    ``date_str`` detonates every weekend and market holiday (surfaced
+    2026-07-03, the observed Independence Day holiday: 7 tests red on
+    ``main`` with "is not an NYSE trading day"). Anchoring to the most
+    recent *trading* day keeps the date a valid session (passes the gate)
+    AND within the freshness threshold (staleness is 0 trading days — the
+    last row IS this date), so it neither rots (the 2026-05-04
+    hardcoded-date failure) nor trips the phantom-session guard.
+
+    Originally a test-local helper in
+    ``tests/test_daily_append_skip_if_exists.py`` (PR #599); promoted here
+    so any new date-driven ``daily_append`` test has a single discoverable
+    chokepoint instead of hand-rolling ``datetime.now()`` again (config#1630).
+
+    Do NOT use this for the intentionally hardcoded scenario tests
+    (``test_daily_append_writer_lock.py``, ``test_daily_append_macro_monotonic.py``,
+    ``test_daily_append_missing_from_closes.py``,
+    ``test_daily_append_trading_day_gate.py``) — those pin specific
+    historical/holiday dates on purpose to exercise fixed scenarios, and
+    migrating them to a live anchor would destroy what they assert.
+    """
+    from nousergon_lib.trading_calendar import is_trading_day, previous_trading_day
+
+    d = datetime.now(timezone.utc).date()
+    if not is_trading_day(d):
+        d = previous_trading_day(d)
+    return d.isoformat()
+
+
+@pytest.fixture
+def recent_trading_day() -> str:
+    """Pytest fixture wrapping :func:`recent_trading_day_str`.
+
+    Returns the most recent NYSE trading day as an ISO ``YYYY-MM-DD``
+    string — a valid ``daily_append(date_str=...)`` anchor on any day the
+    suite runs (weekday, weekend, or market holiday). Prefer this fixture
+    for new tests; call the module-level function directly only when a
+    fixture isn't ergonomic (e.g. inside a helper that isn't itself a
+    test function).
+    """
+    return recent_trading_day_str()

--- a/tests/test_daily_append_no_raw_now_date_str.py
+++ b/tests/test_daily_append_no_raw_now_date_str.py
@@ -1,0 +1,194 @@
+"""AST-walk regression pin: no raw ``now()``/``today()`` fed into
+``daily_append(date_str=...)``.
+
+Closes the recurring "test-date brittleness" defect class (config#1630).
+Date-driven ``daily_append`` tests each hand-rolled their own "today"
+date, and the two production guards — the config#1572 NYSE-trading-day
+gate **and** the universe-freshness scan — leave only a narrow valid
+window (a *recent trading day*). Ad-hoc dates kept falling outside it:
+
+  - 2026-05-04 — a hardcoded ``2026-04-28`` rotted 6d past the freshness
+    threshold.
+  - 2026-06-22 — Juneteenth (Fri 2026-06-19 holiday) ordering.
+  - 2026-07-03 — raw ``datetime.now()`` landed on the observed
+    Independence Day holiday (NYSE closed); 7 tests red on ``main``.
+
+PR #599 fixed the third incident by anchoring
+``test_daily_append_skip_if_exists.py`` /
+``test_daily_append_universe_chunking.py`` to
+``_recent_trading_day_str()`` (most recent NYSE *trading* day). Config#1630
+promoted that helper to ``tests/conftest.py`` as the shared
+``recent_trading_day_str()`` util + ``recent_trading_day`` fixture — the
+one discoverable chokepoint for "give me a valid daily_append date".
+
+This test is the fail-loud guard that keeps the next author from
+re-introducing the class: it walks every test module and rejects any
+``daily_append(date_str=...)`` (or positional first-arg) call site whose
+value is built from a bare ``datetime.now(...)`` / ``dt.now(...)`` /
+``date.today()`` / ``datetime.today()`` expression, instead of the
+shared fixture/util.
+
+Explicitly whitelisted (do NOT flag): the intentionally hardcoded
+scenario tests, which pin specific historical/holiday dates on purpose
+and would be broken by migrating to a live anchor:
+
+  - ``test_daily_append_writer_lock.py`` (``2026-05-27``, Memorial-Day race)
+  - ``test_daily_append_macro_monotonic.py`` (``2026-06-18``, Juneteenth ordering)
+  - ``test_daily_append_missing_from_closes.py`` (``2026-04-28``)
+  - ``test_daily_append_trading_day_gate.py`` (holiday dates that MUST raise)
+
+Also whitelisted: ``tests/conftest.py`` itself, which legitimately calls
+``datetime.now(timezone.utc)`` inside ``recent_trading_day_str()`` — the
+one place the raw "now" call is supposed to live.
+
+Only ``daily_append(date_str=...)`` call sites are in scope. Other uses
+of ``datetime.now()`` / ``date.today()`` elsewhere in a test file (e.g.
+stubbing an unrelated mock's index) are unaffected — see
+``test_daily_append_missing_from_closes.py``'s ``today_row`` stub, which
+uses ``datetime.now(timezone.utc).date()`` for a ``.tail()`` mock return
+value, not as a ``daily_append`` argument, and is correctly NOT flagged.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+TESTS_DIR = pathlib.Path(__file__).resolve().parent
+
+# Files that intentionally hardcode specific historical/holiday dates for
+# fixed scenarios (config#1630 "explicitly out of scope"). A raw
+# datetime.now()/date.today() call feeding daily_append(date_str=...)
+# in one of these would still be a real bug, but the file's *purpose* is
+# to pin exact dates, so we allowlist by filename rather than trying to
+# distinguish "the deliberate hardcoded date" from "an accidental raw
+# now()" within them.
+FILES_ALLOWED_RAW_NOW = frozenset({
+    "test_daily_append_writer_lock.py",
+    "test_daily_append_macro_monotonic.py",
+    "test_daily_append_missing_from_closes.py",
+    "test_daily_append_trading_day_gate.py",
+})
+
+# The one legitimate call site for a raw now()/today() call: the shared
+# anchor helper itself.
+FILES_ALLOWED_RAW_NOW |= {"conftest.py"}
+
+_NOW_TODAY_ATTRS = {
+    ("datetime", "now"),
+    ("dt", "now"),
+    ("date", "today"),
+    ("datetime", "today"),
+}
+
+
+def _root_name(node: ast.AST) -> str | None:
+    """Innermost ``Name`` id of a (possibly chained) attribute/call
+    expression, e.g. ``datetime`` in ``datetime.now(timezone.utc).date()``."""
+    while isinstance(node, (ast.Attribute, ast.Call)):
+        node = node.func if isinstance(node, ast.Call) else node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _contains_raw_now_call(expr: ast.AST) -> bool:
+    """True if ``expr`` (a date_str argument expression) is built from a
+    bare ``datetime.now(...)``/``date.today()``-style call anywhere in
+    its subtree — e.g. ``datetime.now(timezone.utc).date().isoformat()``.
+    """
+    for node in ast.walk(expr):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        root = _root_name(func.value)
+        if root is not None and (root, func.attr) in _NOW_TODAY_ATTRS:
+            return True
+    return False
+
+
+def _daily_append_date_str_violations(path: pathlib.Path) -> list[tuple[int, str]]:
+    """(lineno, source_line) for every ``daily_append(date_str=<raw now>)``
+    (or positional first-arg) call site in ``path``."""
+    try:
+        source = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else (
+            func.attr if isinstance(func, ast.Attribute) else None
+        )
+        if name != "daily_append":
+            continue
+
+        date_expr: ast.AST | None = None
+        for kw in node.keywords:
+            if kw.arg == "date_str":
+                date_expr = kw.value
+                break
+        if date_expr is None and node.args:
+            # date_str is daily_append's first positional parameter.
+            date_expr = node.args[0]
+        if date_expr is None:
+            continue
+
+        if _contains_raw_now_call(date_expr):
+            lineno = node.lineno
+            src = source_lines[lineno - 1] if lineno - 1 < len(source_lines) else ""
+            violations.append((lineno, src.strip()))
+
+    return violations
+
+
+def _test_files() -> list[pathlib.Path]:
+    return sorted(TESTS_DIR.glob("*.py"))
+
+
+def test_no_raw_now_date_str():
+    """``daily_append(date_str=...)`` must never be fed a bare
+    ``datetime.now(...)``/``date.today()`` expression directly. Use the
+    shared ``tests/conftest.py`` ``recent_trading_day_str()`` util (or
+    the ``recent_trading_day`` fixture) instead — it resolves to the
+    most recent NYSE *trading* day, which is valid on every weekday,
+    weekend, and market holiday. A raw "now" is not guaranteed to be a
+    trading day and will intermittently fail the config#1572
+    phantom-session gate (config#1630).
+
+    The intentionally hardcoded scenario-test files are exempt — see
+    ``FILES_ALLOWED_RAW_NOW`` and this module's docstring.
+    """
+    all_violations: list[str] = []
+    for path in _test_files():
+        if path.name in FILES_ALLOWED_RAW_NOW:
+            continue
+        for lineno, src in _daily_append_date_str_violations(path):
+            all_violations.append(f"  {path.name}:{lineno}: {src}")
+
+    assert not all_violations, (
+        "Raw datetime.now()/date.today() fed into daily_append(date_str=...) "
+        "found in test file(s) not on the intentional-hardcoded-date "
+        "allowlist. Use tests/conftest.py's recent_trading_day_str() "
+        "(or the recent_trading_day fixture) instead — see config#1630.\n"
+        + "\n".join(all_violations)
+    )
+
+
+def test_allowlisted_files_exist_or_are_conftest():
+    """Keeps FILES_ALLOWED_RAW_NOW honest: every entry must be either the
+    shared conftest (which legitimately defines the raw now() call) or
+    an actual test file in tests/. Guards against typos silently
+    widening (or narrowing) the allowlist."""
+    for name in FILES_ALLOWED_RAW_NOW:
+        assert (TESTS_DIR / name).exists(), (
+            f"FILES_ALLOWED_RAW_NOW entry {name!r} does not exist in tests/"
+        )

--- a/tests/test_daily_append_skip_if_exists.py
+++ b/tests/test_daily_append_skip_if_exists.py
@@ -32,12 +32,18 @@ These tests lock the contract:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+
+# Shared "today" anchor (config#1630): promoted out of this module into
+# tests/conftest.py so every date-driven daily_append test — not just the
+# two originally cross-importing this file — has one discoverable
+# chokepoint. See conftest.recent_trading_day_str's docstring for the
+# incident history (2026-05-04, 2026-06-22, 2026-07-03).
+from tests.conftest import recent_trading_day_str
 
 
 _DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
@@ -51,27 +57,6 @@ def _disable_factor_momentum_daily(monkeypatch):
     # assertions here. The pass has its own tests (test_factor_momentum.py +
     # test_daily_append_factor_momentum.py).
     monkeypatch.setenv("FACTOR_MOMENTUM_DAILY_ENABLED", "false")
-
-
-def _recent_trading_day_str() -> str:
-    """Most recent NYSE trading day as of now, ISO ``YYYY-MM-DD``.
-
-    These tests feed the resolved date straight into ``daily_append`` as
-    ``date_str``, which enforces an NYSE-trading-day gate (config#1572) —
-    a raw ``datetime.now()`` detonates every weekend and market holiday
-    (surfaced 2026-07-03, the observed Independence Day holiday: 7 tests
-    red on ``main`` with "is not an NYSE trading day"). Anchoring to the
-    most recent *trading* day keeps the date a valid session (passes the
-    gate) AND within the freshness threshold (staleness is 0 trading days
-    — the last row IS this date), so it neither rots (the 2026-05-04
-    hardcoded-date failure) nor trips the phantom-session guard.
-    """
-    from nousergon_lib.trading_calendar import is_trading_day, previous_trading_day
-
-    d = datetime.now(timezone.utc).date()
-    if not is_trading_day(d):
-        d = previous_trading_day(d)
-    return d.isoformat()
 
 
 def _stub_closes(tickers: list[str]) -> dict:
@@ -195,10 +180,10 @@ def test_skip_if_exists_true_skips_when_today_in_hist(monkeypatch):
     from builders.daily_append import daily_append
 
     # Anchor to the most recent NYSE *trading* day (see
-    # _recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
+    # conftest.recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
     # and detonates the config#1572 phantom-session gate on weekends and
     # market holidays (2026-07-03). The trading-day anchor dodges both.
-    today_str = _recent_trading_day_str()
+    today_str = recent_trading_day_str()
     universe = ["AAPL", "MSFT", "GOOGL"]
     _, _, write_calls = _patch_targets(
         monkeypatch,
@@ -230,10 +215,10 @@ def test_skip_if_exists_true_writes_when_today_missing(monkeypatch):
     from builders.daily_append import daily_append
 
     # Anchor to the most recent NYSE *trading* day (see
-    # _recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
+    # conftest.recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
     # and detonates the config#1572 phantom-session gate on weekends and
     # market holidays (2026-07-03). The trading-day anchor dodges both.
-    today_str = _recent_trading_day_str()
+    today_str = recent_trading_day_str()
     universe = ["AAPL", "MSFT"]
     _, _, write_calls = _patch_targets(
         monkeypatch,
@@ -260,10 +245,10 @@ def test_skip_if_exists_false_writes_even_when_today_in_hist(monkeypatch):
     from builders.daily_append import daily_append
 
     # Anchor to the most recent NYSE *trading* day (see
-    # _recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
+    # conftest.recent_trading_day_str): raw "now" rots when hardcoded (2026-05-04)
     # and detonates the config#1572 phantom-session gate on weekends and
     # market holidays (2026-07-03). The trading-day anchor dodges both.
-    today_str = _recent_trading_day_str()
+    today_str = recent_trading_day_str()
     universe = ["AAPL", "MSFT"]
     _, _, write_calls = _patch_targets(
         monkeypatch,

--- a/tests/test_daily_append_universe_chunking.py
+++ b/tests/test_daily_append_universe_chunking.py
@@ -32,10 +32,12 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from tests.test_daily_append_skip_if_exists import (
-    _patch_targets,
-    _recent_trading_day_str,
-)
+from tests.test_daily_append_skip_if_exists import _patch_targets
+
+# Shared "today" anchor (config#1630) — see tests/conftest.py's
+# recent_trading_day_str docstring for the incident history
+# (2026-05-04, 2026-06-22, 2026-07-03).
+from tests.conftest import recent_trading_day_str
 
 
 @pytest.fixture(autouse=True)
@@ -62,7 +64,7 @@ def test_universe_pass_chunks_read_batch_calls(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = _recent_trading_day_str()
+    today_str = recent_trading_day_str()
     # 4 universe + XLRE leak + SPY universe-extra = 6 → 3 chunks at K=2
     universe = ["AAPL", "MSFT", "GOOGL", "AMZN"]
     universe_lib, _, _ = _patch_targets(
@@ -99,7 +101,7 @@ def test_universe_pass_chunks_write_batches_too(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = _recent_trading_day_str()
+    today_str = recent_trading_day_str()
     # 3 universe + XLRE leak + SPY universe-extra = 5 effective → 3 chunks at K=2
     universe = ["AAPL", "MSFT", "GOOGL"]
     universe_lib, _, _ = _patch_targets(
@@ -130,7 +132,7 @@ def test_universe_pass_gc_collect_called_between_chunks(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = _recent_trading_day_str()
+    today_str = recent_trading_day_str()
     universe = ["AAPL", "MSFT", "GOOGL", "AMZN", "META"]  # 5 → 3 chunks
     _patch_targets(
         monkeypatch,
@@ -160,7 +162,7 @@ def test_universe_pass_n_ok_accumulates_across_chunks(monkeypatch):
 
     monkeypatch.setattr(_da, "UNIVERSE_CHUNK_SIZE", 2)
 
-    today_str = _recent_trading_day_str()
+    today_str = recent_trading_day_str()
     universe = ["AAPL", "MSFT", "GOOGL", "AMZN", "META", "NVDA"]  # 6 → 3 chunks
     _patch_targets(
         monkeypatch,


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

Closes nousergon/alpha-engine-config#1630

## Problem

`test_daily_append_skip_if_exists.py` and `test_daily_append_universe_chunking.py` each fed `daily_append(date_str=...)` via a test-local `_recent_trading_day_str()` helper (added in #599 to fix the 2026-07-03 Independence Day CI break — 7 tests red with `ValueError: date_str=2026-07-03 is not an NYSE trading day`, config#1572's phantom-session gate).

That helper fixed the two red files at the correct layer (anchor to the most recent NYSE *trading* day, not raw `datetime.now()`), but it lived inside one test module with no shared, discoverable chokepoint. The next author who needs "today" as a valid `daily_append` date would just hand-roll `datetime.now()` again and reopen the same defect class — which has already recurred three times (2026-05-04 rotted hardcoded date, 2026-06-22 Juneteenth ordering, 2026-07-03 raw-now-on-holiday).

## Fix

1. Promoted `_recent_trading_day_str()` from `tests/test_daily_append_skip_if_exists.py` into `tests/conftest.py` as a shared `recent_trading_day_str()` util **and** a `recent_trading_day` pytest fixture (ISO `YYYY-MM-DD`). Repointed both existing call sites (`test_daily_append_skip_if_exists.py`, `test_daily_append_universe_chunking.py`) at the shared symbol — `test_daily_append_universe_chunking.py` now imports it directly from `tests.conftest` instead of cross-importing it from the sibling test module.
2. Added `tests/test_daily_append_no_raw_now_date_str.py`, a collection-time AST-walk guard test (mirrors the existing `test_freshness_uses_trading_days.py` / `test_dockerfile_copies_match_deployed_imports.py` pattern) that walks every file in `tests/` and fails if any `daily_append(date_str=...)` call site is built from a bare `datetime.now(...)`/`date.today()` expression, outside an explicit allowlist.
3. Audited `tests/` for the same brittleness pattern: no other test files call `daily_append(date_str=...)` with a raw now/today expression. `test_daily_append_missing_from_closes.py` does use `datetime.now(timezone.utc).date()`, but only to build an unrelated mock's `.tail()` return value, not as a `daily_append` argument — confirmed the new guard does *not* false-positive on it.

## Explicitly out of scope (untouched, per the issue)

The intentionally hardcoded scenario tests — `test_daily_append_writer_lock.py` (`2026-05-27`, Memorial-Day race), `test_daily_append_macro_monotonic.py` (`2026-06-18`, Juneteenth ordering), `test_daily_append_missing_from_closes.py` (`2026-04-28`), `test_daily_append_trading_day_gate.py` (holiday dates that MUST raise) — these pin specific historical dates on purpose. They're on the guard test's allowlist so the meta-test doesn't fight them.

## Test plan

- [x] `pip install -r requirements.txt && pip install pytest` (nousergon-lib v0.77.0 + arcticdb installed cleanly)
- [x] `pytest tests/test_daily_append_skip_if_exists.py tests/test_daily_append_universe_chunking.py -v` — 12 passed
- [x] `pytest tests/test_daily_append_no_raw_now_date_str.py -v` — 2 passed; manually verified the guard actually fails by temporarily injecting a `daily_append(date_str=datetime.now(timezone.utc).date().isoformat())` violation into a scratch test file, confirmed it fails, then removed the scratch file
- [x] Full suite: `pytest tests/ -q` → **2566 passed, 12 skipped, 0 failed** (skips are pre-existing environment-gated tests — metron co-install, IAM/SF wiring, integration e2e — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)