### PR TITLE
fix(saturday-sf): migrate ssm_log_capture callers to krepis (canonical) + execute-the-wrapper CI guard (config#1646)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -262,7 +262,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only{}',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only{}',$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -423,7 +423,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only{}',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only{}',$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -627,7 +627,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$.preflight_args))",
                   "executionTimeout": [
                     "3600"
                   ]
@@ -1601,7 +1601,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only{}',$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -1869,7 +1869,7 @@
                       "DocumentName": "AWS-RunShellScript",
                       "InstanceIds.$": "$.ec2_instance_id",
                       "Parameters": {
-                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
+                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
                         "executionTimeout": [
                           "5400"
                         ]
@@ -2008,7 +2008,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_train.sh --model-zoo-select{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_train.sh --model-zoo-select{}',$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2247,7 +2247,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -2370,7 +2370,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -2493,7 +2493,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -2616,7 +2616,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -2739,7 +2739,7 @@
           "executionTimeout": [
             "3600"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity{}',$.preflight_args))"
         },
         "TimeoutSeconds": 3600
       },

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -6,7 +6,7 @@
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator"
   ],
   "DataPhase1": [
     "set -eo pipefail",
@@ -15,7 +15,7 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
   ],
   "DriftDetection": [
     "set -eo pipefail",
@@ -23,7 +23,7 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug drift-detection --log /var/log/drift-detection.log -- bash infrastructure/spot_drift_detection.sh"
   ],
   "Evaluator": [
     "set -eo pipefail",
@@ -32,7 +32,7 @@
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
   ],
   "MorningEnrich": [
     "set -eo pipefail",
@@ -41,7 +41,7 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
   ],
   "Parity": [
     "set -eo pipefail",
@@ -50,7 +50,7 @@
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator"
   ],
   "PortfolioOptimizerBacktest": [
     "set -eo pipefail",
@@ -59,7 +59,7 @@
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator"
   ],
   "PredictorBacktest": [
     "set -eo pipefail",
@@ -68,7 +68,7 @@
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator"
   ],
   "PredictorTraining": [
     "set -eo pipefail",
@@ -80,7 +80,7 @@
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export ALPHA_ENGINE_EXPERIMENT_ID=reference",
     "export PREDICTOR_DEFER_TRAINING_EMAIL=1",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
   ],
   "RAGIngestion": [
     "set -eo pipefail",
@@ -88,6 +88,6 @@
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m nousergon_lib.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
   ]
 }

--- a/tests/test_sf_backtest_parity_split_wiring.py
+++ b/tests/test_sf_backtest_parity_split_wiring.py
@@ -342,7 +342,7 @@ class TestSsmCommandShape:
         """
         cmds = self._commands(states, "Parity")
         work = next(
-            c for c in cmds if "nousergon_lib.ssm_log_capture run" in c
+            c for c in cmds if "krepis.ssm_log_capture run" in c
         )
         assert "--slug parity" in work
         assert "--log /var/log/parity.log" in work

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -334,10 +334,18 @@ def orig_spot_cmds() -> dict:
       `'trap \\'aws s3 cp ...\\' EXIT'` inside `commands.$ States.Array`
       (ASL doesn't unescape `\\'` in arg strings — caught by the
       Friday-PM dry-pass). The baseline now reflects the lib-CLI form:
-      `python -m nousergon_lib.ssm_log_capture run --slug X
+      `python -m krepis.ssm_log_capture run --slug X
       --log Y -- bash <launcher>`. The keystone's byte-identicality
       proof against the new baseline still holds (the absent path runs
       the same lib-CLI invocation with `preflight_args=""`).
+    - **Regenerated 2026-07-03** as part of the `nousergon_lib.ssm_log_capture`
+      → `krepis.ssm_log_capture` caller migration (config#1646). The
+      `nousergon_lib` path became a guard-less re-export shim at lib
+      v0.66.0: under `python -m` it exits 0 WITHOUT executing the inner
+      command — the 2026-07-03 weekly ran zero EC2 workloads while
+      reporting SUCCESS. `krepis.ssm_log_capture` is the canonical
+      executable path; `test_ssm_log_capture_wrapper_executes.py` now
+      proves executability (not just importability) in CI.
 
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
@@ -652,7 +660,7 @@ class TestByteIdenticalAbsentPath:
             ``{token} --preflight-only 2>&1 | tee {log}``
         to
             ``/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m
-              nousergon_lib.ssm_log_capture run --slug X --log Y --
+              krepis.ssm_log_capture run --slug X --log Y --
               {token} --preflight-only``
         as part of the inline-trap-to-lib-CLI lift (alpha-engine-lib PR #57).
         The lib CLI internalizes tee + S3-ship; --preflight-only still
@@ -667,7 +675,7 @@ class TestByteIdenticalAbsentPath:
         final = cmds[-1]
         expected = (
             "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python "
-            "-m nousergon_lib.ssm_log_capture run "
+            "-m krepis.ssm_log_capture run "
             f"--slug {slug} --log {log} -- "
             f"{token} --preflight-only"
         )

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -238,7 +238,7 @@ class TestSsmCommandShape:
 
     def test_morning_enrich_log_capture_via_lib_cli(self, states):
         """The trap-and-log-ship invariant is now satisfied by the
-        nousergon_lib.ssm_log_capture Python CLI (lib v0.25.0), not
+        krepis.ssm_log_capture Python CLI (lib v0.25.0), not
         by an inline `trap 'aws s3 cp ...' EXIT` line. The 2026-05-22
         Friday-PM dry-pass caught the prior inline-trap form failing
         under ASL States.Array escape semantics (`\\'` not unescaped to
@@ -251,7 +251,7 @@ class TestSsmCommandShape:
         work_idx = next(
             i
             for i, c in enumerate(cmds)
-            if "nousergon_lib.ssm_log_capture run" in c
+            if "krepis.ssm_log_capture run" in c
         )
         work = cmds[work_idx]
         # Right slug and log path

--- a/tests/test_sf_ssm_pipefail_wiring.py
+++ b/tests/test_sf_ssm_pipefail_wiring.py
@@ -27,8 +27,8 @@ Three rules pinned here:
        "s3://..." --only-show-errors || true' EXIT` BEFORE a
        `| tee /var/log/X.log` work line. Used by states whose
        `commands` is a plain JSON array.
-   (b) **`nousergon_lib.ssm_log_capture` CLI** — a single
-       `python -m nousergon_lib.ssm_log_capture run --slug X
+   (b) **`krepis.ssm_log_capture` CLI** — a single
+       `python -m krepis.ssm_log_capture run --slug X
        --log /var/log/X.log -- bash <launcher> ...` invocation that
        internalizes both the trap and the tee. Used by states whose
        `commands.$` is a `States.Array(...)` (the ASL escape surface
@@ -177,7 +177,7 @@ def test_weekday_sf_ssm_blocks_export_flow_doctor_enabled() -> None:
 
 _TEE_WORK_RE = re.compile(r"\| tee (?:-a )?(/var/log/[\w.-]+\.log)")
 # Accepts all three historical/current import names for the same module:
-# alpha_engine_lib.ssm_log_capture (original) -> nousergon_lib.ssm_log_capture
+# alpha_engine_lib.ssm_log_capture (original) -> krepis.ssm_log_capture
 # (rename shim) -> krepis.ssm_log_capture (v0.66.0 MIT lift, the current
 # canonical path). This regex was stale at only the FIRST name until
 # 2026-07-01 (config#1552-adjacent EOD date-thread fix) — genuinely never
@@ -203,8 +203,8 @@ def test_long_ssm_steps_ship_log_to_s3(sf_path: Path) -> None:
 
     (a) **Inline bash trap** before `| tee /var/log/X.log` work line —
         original form, plain `commands` JSON arrays only.
-    (b) **`nousergon_lib.ssm_log_capture` CLI** — single
-        `python -m nousergon_lib.ssm_log_capture run --slug X
+    (b) **`krepis.ssm_log_capture` CLI** — single
+        `python -m krepis.ssm_log_capture run --slug X
         --log /var/log/X.log -- bash <launcher>` line; internalizes the
         trap. Required form for `commands.$ States.Array(...)` states
         (ASL doesn't unescape `\\'` in arg strings; the inline-trap
@@ -275,7 +275,7 @@ def test_long_ssm_steps_ship_log_to_s3(sf_path: Path) -> None:
         "\\\"s3://alpha-engine-research/_ssm_logs/<slug>/...\\\" "
         "--only-show-errors || true' EXIT\"` immediately before the "
         "`| tee` work line (only works in plain `commands` arrays), "
-        "OR switch the work line to `python -m nousergon_lib.ssm_log_capture "
+        "OR switch the work line to `python -m krepis.ssm_log_capture "
         "run --slug X --log /var/log/X.log -- bash <launcher>` (required "
         "for `commands.$ States.Array(...)` states). See 2026-05-22 "
         "Friday-PM dry-pass + alpha-engine-lib PR #57."

--- a/tests/test_ssm_log_capture_wrapper_executes.py
+++ b/tests/test_ssm_log_capture_wrapper_executes.py
@@ -1,0 +1,133 @@
+"""The SF's ssm_log_capture wrapper must EXECUTE, not merely import.
+
+Bug class this guards (config#1646, 2026-07-03): the weekly SF wraps every
+EC2 workload as ``python -m <module> run --slug X --log Y -- bash <launcher>``.
+At lib v0.66.0 ``nousergon_lib.ssm_log_capture`` became a re-export shim
+(``import krepis.ssm_log_capture as _mod; sys.modules[__name__] = _mod``)
+with no ``if __name__ == "__main__"`` block. Under ``python -m`` (runpy) the
+shim imports, rebinds, falls off the end — **exit 0, the inner command never
+runs, no log, no error**. All 11 SSM workload states became instant silent
+"successes": no predictor training, no backtester, no evaluator, no emails —
+while the SF (and the Friday-shell preflight, 107/107 "pass") reported green.
+
+String-pinning wiring tests provably cannot catch this: the module was
+importable, its public surface resolved — it just wasn't *executable*. The
+only structural guard is to RUN the exact module path the SF invokes with a
+sentinel inner command and assert (a) the sentinel executed, (b) the log file
+was written, (c) the inner exit code propagates. That is what this test does.
+
+The module paths under test are extracted from ``infrastructure/
+step_function.json`` itself (chokepoint: a future caller migration is
+automatically covered — whatever path the SF names must execute here).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SF_PATHS = [
+    _REPO_ROOT / "infrastructure" / "step_function.json",
+    _REPO_ROOT / "infrastructure" / "step_function_daily.json",
+    _REPO_ROOT / "infrastructure" / "step_function_eod.json",
+    _REPO_ROOT / "infrastructure" / "step_function_groom.json",
+]
+
+# `python -m <module> run --slug ...` as embedded in SF command strings.
+_WRAPPER_RE = re.compile(r"-m\s+([\w.]+\.ssm_log_capture)\s+run\b")
+
+
+def _wrapper_modules() -> set[str]:
+    """Every ssm_log_capture module path any SF definition invokes via -m."""
+    modules: set[str] = set()
+    for sf_path in _SF_PATHS:
+        if not sf_path.exists():
+            continue
+        modules.update(_WRAPPER_RE.findall(sf_path.read_text()))
+    return modules
+
+
+def test_sf_definitions_reference_at_least_one_wrapper():
+    """Sanity: extraction must find the wrapper — an empty set would make the
+    executability tests below vacuously pass (the silent-no-op of tests)."""
+    assert _wrapper_modules(), (
+        "No `-m <module>.ssm_log_capture run` invocations found in any SF "
+        "definition — either the wrapper was removed (update this test's "
+        "extraction) or the regex went stale."
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_wrapper_modules()))
+def test_wrapper_module_executes_inner_command(module, tmp_path):
+    """`python -m <module> run ... -- <cmd>` must actually run <cmd>.
+
+    A guard-less shim exits 0 here with no output and no log file — the
+    exact 2026-07-03 failure mode — and this test fails on all three
+    assertions.
+    """
+    log = tmp_path / "wrapper.log"
+    sentinel = "SENTINEL_WRAPPER_EXECUTED_1646"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            module,
+            "run",
+            "--slug",
+            "wrapper-execute-test",
+            "--log",
+            str(log),
+            "--",
+            sys.executable,
+            "-c",
+            f"print('{sentinel}')",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert sentinel in proc.stdout, (
+        f"`python -m {module} run -- <cmd>` did NOT execute the inner "
+        f"command (stdout={proc.stdout!r}, stderr tail="
+        f"{proc.stderr[-300:]!r}). If {module} is a re-export shim it needs "
+        "an `if __name__ == '__main__':` delegate — this is the config#1646 "
+        "silent-no-op bug class."
+    )
+    assert log.exists() and sentinel in log.read_text(), (
+        f"wrapper ran but did not tee the inner output to --log ({log})"
+    )
+    assert proc.returncode == 0
+
+
+@pytest.mark.parametrize("module", sorted(_wrapper_modules()))
+def test_wrapper_module_propagates_inner_exit_code(module, tmp_path):
+    """A failing workload must fail the SSM command — rc must propagate."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            module,
+            "run",
+            "--slug",
+            "wrapper-execute-test",
+            "--log",
+            str(tmp_path / "wrapper.log"),
+            "--",
+            sys.executable,
+            "-c",
+            "raise SystemExit(7)",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 7, (
+        f"inner exit code not propagated (got {proc.returncode}) — a "
+        "workload failure would be reported to the SF as success"
+    )


### PR DESCRIPTION
## Fixes the 2026-07-03 silent no-op weekly run (config#1646)

The holiday-shifted weekly SF reported SUCCESS but ran **zero EC2 workloads**: every spot command is wrapped as `python -m nousergon_lib.ssm_log_capture run … -- bash <launcher>`, and since lib v0.66.0 that module is a re-export shim with no `__main__` guard — under `python -m` it exits 0 without executing the inner command. No predictor training, model-zoo, backtester, parity, evaluator, morning-enrich, RAG, or data-weekly work ran; none of their emails sent. Armed 2026-07-03 01:02 UTC when the dashboard box venv picked up nousergon-lib 0.81.0.

## Change

- `infrastructure/step_function.json`: all 11 wrapper callers → **`krepis.ssm_log_capture`** (the canonical executable path per the v0.66.0 relocation). Verified on the box (krepis 0.5.0, dashboard venv): inner command runs, log tees, exit codes propagate.
- Wiring tests + frozen `sf_prekeystone_spot_commands.json` baseline regenerated in lockstep (fixture history documents the regeneration; `test_sf_ssm_pipefail_wiring`'s match regex already accepted the krepis form as canonical).
- **New `tests/test_ssm_log_capture_wrapper_executes.py`** — the structural guard this bug class demands: extracts every `-m <module>.ssm_log_capture run` path from all SF definitions (chokepoint — future migrations auto-covered) and proves via subprocess that the wrapper (a) executes a sentinel inner command, (b) tees it to `--log`, (c) propagates the inner exit code. String-pinning wiring tests provably cannot catch importable-but-not-executable; verified this test FAILS against the broken `nousergon_lib` path.

## Companion

nousergon/nousergon-lib#155 adds the `__main__` delegate to the shims themselves (closes the class for any other `-m nousergon_lib.*` caller).

## Tests

Full suite: **2573 passed, 8 skipped** locally.

## Deploy

Merge auto-deploys the SF via `deploy-infrastructure.yml`. Recovery rerun of the weekly (from MorningEnrich/DataPhase1 through Evaluator, trading_day 2026-07-02) follows the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)