### PR TITLE
feat(groom): bounded auto-relaunch on EC2 spot interruption mid-run

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -40,6 +40,7 @@ import logging
 import os
 import re
 import time
+import uuid
 
 import boto3
 from nousergon_lib import ec2_spot
@@ -124,6 +125,16 @@ def _resolve_model(event: dict) -> str:
     return m
 
 
+def _resolve_force_on_demand(event: dict) -> bool:
+    """config#1645: set by the dispatch Step Function's relaunch loop on the
+    final bounded retry after repeated spot-interruption (mid-run box death,
+    not a launch-time capacity error — see _launch_instance) — forces this
+    attempt onto on-demand so a bad spot-capacity window still guarantees
+    completion rather than retrying on the same flaky market indefinitely.
+    Not set by any of the 3 live schedules' own EventBridge Scheduler input."""
+    return bool(event.get("force_on_demand", False))
+
+
 def _resolve_soft_limit_min(event: dict) -> int | None:
     """Optional bounded-test override — NOT set by any of the 3 live schedules
     (their SCHED_INPUTS carry no such key), only by a manual `aws lambda invoke`
@@ -144,7 +155,7 @@ def _resolve_soft_limit_min(event: dict) -> int | None:
 
 
 def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: str,
-                       soft_limit_min: int | None = None) -> str:
+                       run_token: str, soft_limit_min: int | None = None) -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec bootstrap.
 
     Runs as root on the box. The heavy, version-controlled logic lives in the
@@ -174,12 +185,16 @@ git clone --depth 1 --branch {GROOM_BRANCH} \
 cd /home/ec2-user/alpha-engine-config
 export GROOM_MODEL={model}
 export GROOM_ISSUE_FILTER={issue_filter}
+export GROOM_RUN_TOKEN={run_token}
 exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"{soft_limit_flag}
 """
 
 
-def _launch_instance() -> tuple[str, str]:
-    """Launch the groom box; spot first, on-demand fallback on capacity exhaustion."""
+def _launch_instance(force_on_demand: bool = False) -> tuple[str, str]:
+    """Launch the groom box; spot first, on-demand fallback on capacity exhaustion
+    OR when force_on_demand (config#1645: the dispatch SF's last bounded relaunch
+    attempt after repeated mid-run spot interruption — skip straight to on-demand
+    rather than trying the same flaky spot market a third time)."""
     common = dict(
         image_id=AMI_ID,
         key_name=KEY_NAME,
@@ -190,6 +205,10 @@ def _launch_instance() -> tuple[str, str]:
         tag_name="alpha-engine-groom-spot",
         region=REGION,
     )
+    if force_on_demand:
+        logger.warning("force_on_demand set (config#1645 relaunch escalation) — launching ON-DEMAND")
+        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=False, **common)
+        return iid, "on-demand"
     try:
         iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=True, **common)
         return iid, "spot"
@@ -223,15 +242,15 @@ def _wait_ssm_online(instance_id: str) -> None:
 
 
 def _send_bootstrap(instance_id: str, run_mode: str, run_url: str, model: str, issue_filter: str,
-                    soft_limit_min: int | None = None) -> str:
+                    run_token: str, soft_limit_min: int | None = None) -> str:
     """Fire the async, detached SSM command that runs the groom + self-terminates."""
     ssm = boto3.client("ssm", region_name=REGION)
     resp = ssm.send_command(
         InstanceIds=[instance_id],
         DocumentName="AWS-RunShellScript",
-        Comment=f"backlog groom ({run_mode}, {model}, {issue_filter}) — config#1432/#1495",
+        Comment=f"backlog groom ({run_mode}, {model}, {issue_filter}) — config#1432/#1495/#1645",
         Parameters={
-            "commands": [_bootstrap_command(run_mode, run_url, model, issue_filter, soft_limit_min)],
+            "commands": [_bootstrap_command(run_mode, run_url, model, issue_filter, run_token, soft_limit_min)],
             # Execution timeout (NOT the start timeout) — without this SSM kills the
             # command at the 3600s default, guillotining a multi-hour groom.
             "executionTimeout": [str(MAX_RUNTIME_SECONDS)],
@@ -262,13 +281,18 @@ def _terminate_instance(instance_id: str) -> None:
 
 
 def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_filter: str,
-                       soft_limit_min: int | None = None) -> dict:
+                       soft_limit_min: int | None = None, force_on_demand: bool = False) -> dict:
     """Launch + bootstrap the groom box. Fail-loud — any error RAISES."""
     if not DISPATCH_ENABLED:
         logger.warning("GROOM_DISPATCH_ENABLED=false — groom spot NOT launched")
         return {"launched": False, "reason": "disabled"}
 
-    instance_id, market = _launch_instance()
+    # config#1645: a fresh token per launch ATTEMPT (not per schedule) — the
+    # dispatch Step Function's relaunch loop calls this Lambda again with a new
+    # execution, so each attempt gets its own S3 completion-marker key. A dead
+    # box's stale marker (if any) can never be mistaken for THIS attempt's.
+    run_token = uuid.uuid4().hex
+    instance_id, market = _launch_instance(force_on_demand=force_on_demand)
     logger.info("launched groom box %s (%s)", instance_id, market)
     # Once the box is up, ANY failure before the bootstrap command is delivered
     # would orphan it (no watchdog/trap yet). Terminate-on-error so a slow
@@ -285,12 +309,15 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
             f"https://{REGION}.console.aws.amazon.com/cloudwatch/home?region={REGION}"
             f"#logsV2:log-groups (log group {CW_LOG_GROUP}, instance {instance_id})"
         )
-        command_id = _send_bootstrap(instance_id, run_mode, run_url, model, issue_filter, soft_limit_min)
+        command_id = _send_bootstrap(
+            instance_id, run_mode, run_url, model, issue_filter, run_token, soft_limit_min
+        )
     except Exception:
         _terminate_instance(instance_id)
         raise
     logger.info(
-        "groom dispatched: instance=%s market=%s command=%s run_mode=%s model=%s issue_filter=%s schedule=%s",
+        "groom dispatched: instance=%s market=%s command=%s run_mode=%s model=%s issue_filter=%s "
+        "schedule=%s run_token=%s",
         instance_id,
         market,
         command_id,
@@ -298,6 +325,7 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         model,
         issue_filter,
         schedule_label,
+        run_token,
     )
     return {
         "launched": True,
@@ -307,6 +335,7 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         "run_mode": run_mode,
         "model": model,
         "issue_filter": issue_filter,
+        "run_token": run_token,
     }
 
 
@@ -318,14 +347,20 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     `model`/`issue_filter` default to the Sonnet mid-tier queue when absent
     (the two pre-existing Sonnet schedules don't set them). `soft_limit_min` is
     a manual-invoke-ONLY bounded-test override — no live schedule sets it.
+    `force_on_demand` (config#1645) is set only by the dispatch Step Function's
+    own relaunch loop on its final bounded retry — no live schedule sets it.
     """
     event = event or {}
     run_mode = _resolve_run_mode(event)
     model = _resolve_model(event)
     issue_filter = _resolve_issue_filter(event)
     soft_limit_min = _resolve_soft_limit_min(event)
+    force_on_demand = _resolve_force_on_demand(event)
     schedule_label = str(event.get("schedule") or "unknown")
-    logger.info("scheduled groom trigger: run_mode=%s model=%s issue_filter=%s soft_limit_min=%s schedule=%s",
-                run_mode, model, issue_filter, soft_limit_min, schedule_label)
-    result = _launch_groom_spot(run_mode, schedule_label, model, issue_filter, soft_limit_min)
+    logger.info(
+        "scheduled groom trigger: run_mode=%s model=%s issue_filter=%s soft_limit_min=%s "
+        "force_on_demand=%s schedule=%s",
+        run_mode, model, issue_filter, soft_limit_min, force_on_demand, schedule_label,
+    )
+    result = _launch_groom_spot(run_mode, schedule_label, model, issue_filter, soft_limit_min, force_on_demand)
     return {"groom": result}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/sf-execution-iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/sf-execution-iam-policy.json
@@ -20,6 +20,12 @@
       "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
     },
     {
+      "Sid": "CheckGroomRunCompletionMarker",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/groom/_control/completed/*"
+    },
+    {
       "Sid": "Logs",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -244,6 +244,57 @@ def test_launch_failure_raises(monkeypatch):
         idx.handler({"run_mode": "full"}, None)
 
 
+def test_run_token_generated_and_exported_and_returned(monkeypatch):
+    # config#1645: the dispatch Step Function's completion-marker check needs a
+    # per-attempt token that reaches the box (as GROOM_RUN_TOKEN) AND comes back
+    # in the Lambda's own response (so the SF can build the S3 key to check).
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    g = out["groom"]
+    assert "run_token" in g and g["run_token"], "run_token missing from the Lambda's response"
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert f"export GROOM_RUN_TOKEN={g['run_token']}" in cmd
+    assert cmd.index("export GROOM_RUN_TOKEN") < cmd.index("groom_spot_bootstrap.sh")
+
+
+def test_run_token_differs_across_invocations(monkeypatch):
+    # Each SF relaunch attempt calls the Lambda again — a stale token reused
+    # across attempts would let a dead attempt's (absent) marker be confused
+    # with a fresh attempt's, defeating the whole relaunch-detection mechanism.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out1 = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    out2 = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    assert out1["groom"]["run_token"] != out2["groom"]["run_token"]
+
+
+def test_force_on_demand_skips_spot_entirely(monkeypatch):
+    # config#1645: the SF's final bounded relaunch attempt after repeated
+    # mid-run spot interruption sets force_on_demand — must go straight to
+    # on-demand, not attempt (and possibly lose to) spot a third time.
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        return "i-forced"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"run_mode": "full", "force_on_demand": True}, None)
+    assert out["groom"]["market"] == "on-demand"
+    assert seen == [False], "force_on_demand must skip the spot attempt outright"
+
+
+def test_force_on_demand_absent_by_default(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        return "i-normal"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    idx.handler({"run_mode": "full"}, None)
+    assert seen == [True], "the 2 pre-existing schedules' behavior must be unchanged"
+
+
 def test_post_launch_failure_terminates_instance_no_orphan(monkeypatch):
     # If the box launches but a later step (SSM-online / SendCommand) fails, the
     # box would orphan (no bootstrap → no watchdog/trap). The dispatcher must

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -1,14 +1,25 @@
 {
-  "Comment": "Backlog groom dispatch (config#1472) — wraps the EventBridge Scheduler -> Lambda -> EC2-spot-via-SSM dispatch chain in a Step Function so the fleet's existing Fleet-SF Watch resilience/observability agent covers groom runs the SAME way it covers the Saturday/weekday/EOD pipelines, instead of via a bespoke external liveness-probe Lambda. The heavy grooming logic is UNCHANGED — this SF only orchestrates: invoke the existing alpha-engine-scheduled-groom-dispatcher Lambda (launches the spot box + fires the async SSM command, exactly as it already does), then poll the SSM command to a terminal state so the SF's OWN execution status (SUCCEEDED/FAILED) is truthful. The spot box still self-terminates on its own EXIT trap regardless of what this SF observes — this adds observability, it does not change the dispatch mechanism.",
-  "StartAt": "LaunchGroomSpot",
+  "Comment": "Backlog groom dispatch (config#1472) — wraps the EventBridge Scheduler -> Lambda -> EC2-spot-via-SSM dispatch chain in a Step Function so the fleet's existing Fleet-SF Watch resilience/observability agent covers groom runs the SAME way it covers the Saturday/weekday/EOD pipelines, instead of via a bespoke external liveness-probe Lambda. The heavy grooming logic is UNCHANGED — this SF only orchestrates: invoke the existing alpha-engine-scheduled-groom-dispatcher Lambda (launches the spot box + fires the async SSM command, exactly as it already does), then poll the SSM command to a terminal state so the SF's OWN execution status (SUCCEEDED/FAILED) is truthful. The spot box still self-terminates on its own EXIT trap regardless of what this SF observes — this adds observability, it does not change the dispatch mechanism. config#1645 adds bounded auto-relaunch: live audit (2026-07-03) found 5-of-6 recent groom-dispatch failures were SSM StatusDetails=Undeliverable — the underlying EC2 spot box was reclaimed mid-run, not a Lambda/app-level error, and every prior run simply gave up after one dead box. Since groom_driver.py re-derives its issue queue from live GitHub state each launch, a relaunch is naturally resumable (no checkpointing needed) — so on a non-Success SSM status this SF now checks an S3 completion marker (written by groom_run.sh's own exit paths) to distinguish 'the box died before the script finished' (marker absent -> safe, bounded relaunch, escalating to on-demand on the final attempt) from 'the script reached its own terminal state' (marker present -> a genuine app-level outcome already self-alerted via Telegram/GH issue -> fail the SF cleanly, no relaunch, no duplicate alert). This also incidentally hardens the pre-existing SSM shutdown/status-report race documented in groom_spot_bootstrap.sh's finish() trap: that race can make a genuinely successful run report Failed/Undeliverable, and this SF used to propagate that false status straight to Fleet-SF-Watch; now such a case is recognized as marker-present-so-don't-relaunch instead of triggering an unnecessary retry.",
+  "StartAt": "InitRunState",
   "States": {
+    "InitRunState": {
+      "Type": "Pass",
+      "Comment": "Seed the bounded-relaunch counters. The EventBridge Scheduler's 3 live inputs (and the saturday-sf-success-groom repository_dispatch) carry only run_mode/model/issue_filter/schedule/soft_limit_min — this always starts a fresh loop at retry_count=0. `fod` (force_on_demand, boxed in its own object) is a SEPARATE top-level field from schedInput, not nested into it directly — States.JsonMerge's arguments must be real JSONPaths (a literal object argument fails ASL schema validation), so LaunchGroomSpot merges $.schedInput with $.fod at invoke time instead of this state trying to inject the field inline.",
+      "Parameters": {
+        "schedInput.$": "$",
+        "retry_count": 0,
+        "max_retries": 2,
+        "fod": {"force_on_demand": false}
+      },
+      "Next": "LaunchGroomSpot"
+    },
     "LaunchGroomSpot": {
       "Type": "Task",
-      "Comment": "Invoke the EXISTING scheduled-groom-dispatcher Lambda unchanged — it launches the spot box (or on-demand on capacity exhaustion), waits for SSM Online, and fires the async detached SSM RunShellScript command, returning {launched, instance_id, command_id, market, run_mode, model, issue_filter} (or {launched:false, reason:'disabled'} under the GROOM_DISPATCH_ENABLED kill-switch). The execution input IS the same JSON payload the EventBridge Scheduler rule used to pass directly to the Lambda (run_mode/model/issue_filter/schedule) — this SF is a pass-through wrapper, not a redesign of the payload contract.",
+      "Comment": "Invoke the EXISTING scheduled-groom-dispatcher Lambda unchanged apart from config#1645's force_on_demand passthrough — it launches the spot box (or on-demand on capacity exhaustion, or unconditionally on-demand when force_on_demand is set), waits for SSM Online, and fires the async detached SSM RunShellScript command, returning {launched, instance_id, command_id, market, run_mode, model, issue_filter, run_token} (or {launched:false, reason:'disabled'} under the GROOM_DISPATCH_ENABLED kill-switch). The Payload is $.schedInput (the original EventBridge Scheduler input, unchanged) merged with $.fod (only ever {force_on_demand: true|false}) — this SF is a pass-through wrapper, not a redesign of the payload contract.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
-        "Payload.$": "$"
+        "Payload.$": "States.JsonMerge($.schedInput, $.fod, false)"
       },
       "TimeoutSeconds": 360,
       "Retry": [
@@ -22,7 +33,7 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Comment": "A launch failure (spot+on-demand exhaustion, SSM send failure, etc.) — the Lambda itself already terminates any partially-launched box before re-raising, so no cleanup needed here.",
+          "Comment": "A launch failure (spot+on-demand exhaustion, SSM send failure, etc.) — the Lambda itself already terminates any partially-launched box before re-raising, so no cleanup needed here. Not retried by this SF: an exhausted-on-demand launch failure is a genuine capacity/IAM problem, not the mid-run-interruption case config#1645 handles.",
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -77,30 +88,130 @@
     },
     "CheckGroomStatus": {
       "Type": "Choice",
-      "Comment": "Default routes to GroomStatusError so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed — mirrors CheckPostMarketStatus/CheckEODStatus.",
+      "Comment": "Default (config#1645) routes to CheckCompletionMarker rather than straight to failure — any non-Success/InProgress/Pending/Delayed SSM status (Failed, Cancelled, TimedOut, Undeliverable, ...) might mean 'the box died mid-run', which is potentially recoverable via relaunch, not necessarily a genuine failure.",
       "Choices": [
         {"Variable": "$.groomPoll.Status", "StringEquals": "Success", "Next": "GroomSucceeded"},
         {"Variable": "$.groomPoll.Status", "StringEquals": "InProgress", "Next": "GroomWait"},
         {"Variable": "$.groomPoll.Status", "StringEquals": "Pending", "Next": "GroomWait"},
         {"Variable": "$.groomPoll.Status", "StringEquals": "Delayed", "Next": "GroomWait"}
       ],
-      "Default": "GroomStatusError"
+      "Default": "CheckCompletionMarker"
     },
     "GroomWait": {
       "Type": "Wait",
       "Seconds": 15,
       "Next": "PollGroomCommand"
     },
+    "CheckCompletionMarker": {
+      "Type": "Task",
+      "Comment": "config#1645: groom_run.sh writes s3://alpha-engine-research/groom/_control/completed/<run_token>.json as the LAST action of every one of its own exit paths (budget-skip / clean success / classified failure). Its existence — regardless of what SSM's own status says — is the authoritative signal that the script reached its own terminal state (and, on a real failure, already self-alerted via Telegram/GH issue). Absence means the box disappeared before the script ever finished: safe and correct to relaunch, since groom_driver.py re-derives its issue queue from live GitHub state each launch (no checkpointing needed).",
+      "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
+      "Parameters": {
+        "Bucket": "alpha-engine-research",
+        "Key.$": "States.Format('groom/_control/completed/{}.json', $.groomLaunch.Payload.groom.run_token)"
+      },
+      "ResultPath": "$.markerCheck",
+      "Next": "GroomStatusError",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "Marker missing (NoSuchKey) OR any other S3 error — conservatively treated the same way: the box's own script never confirmed it finished, so this is the mid-run-death case config#1645 exists to recover from.",
+          "Next": "CheckRetryBudget",
+          "ResultPath": "$.markerCheckError"
+        }
+      ]
+    },
+    "CheckRetryBudget": {
+      "Type": "Choice",
+      "Comment": "config#1645: marker is absent (box died mid-run) — relaunch if attempts remain, else give up and alert. Bounded to max_retries (2, i.e. up to 3 total launch attempts per scheduled cycle) so a genuinely bad AWS day can't spot-cycle indefinitely.",
+      "Choices": [
+        {
+          "Variable": "$.retry_count",
+          "NumericLessThanPath": "$.max_retries",
+          "Next": "PrepRelaunch"
+        }
+      ],
+      "Default": "GroomRetriesExhausted"
+    },
+    "PrepRelaunch": {
+      "Type": "Pass",
+      "Comment": "config#1645: bump the counter for the next attempt (each relaunch calls the Lambda fresh, which mints its own new run_token — the old attempt's absent marker is never confused with the new attempt's).",
+      "Parameters": {
+        "schedInput.$": "$.schedInput",
+        "retry_count.$": "States.MathAdd($.retry_count, 1)",
+        "max_retries.$": "$.max_retries",
+        "fod.$": "$.fod"
+      },
+      "Next": "CheckForceOnDemand"
+    },
+    "CheckForceOnDemand": {
+      "Type": "Choice",
+      "Comment": "config#1645: if this relaunch is the LAST allowed attempt (retry_count now equals max_retries), force on-demand so a bad spot-capacity window still guarantees completion instead of trying the same flaky market a third time.",
+      "Choices": [
+        {
+          "Variable": "$.retry_count",
+          "NumericEqualsPath": "$.max_retries",
+          "Next": "SetForceOnDemand"
+        }
+      ],
+      "Default": "NotifyRelaunch"
+    },
+    "SetForceOnDemand": {
+      "Type": "Pass",
+      "Parameters": {
+        "schedInput.$": "$.schedInput",
+        "retry_count.$": "$.retry_count",
+        "max_retries.$": "$.max_retries",
+        "fod": {"force_on_demand": true}
+      },
+      "Next": "NotifyRelaunch"
+    },
+    "NotifyRelaunch": {
+      "Type": "Task",
+      "Comment": "config#1645: best-effort WARNING-level ping (distinct from HandleFailure's FAILED alert) so a spot interruption is visible in real time instead of only discoverable after the fact via CloudWatch log archaeology. Never blocks the relaunch on a publish failure.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine Backlog Groom — spot interrupted, auto-relaunching",
+        "Message.$": "States.Format('Backlog groom box appears to have been reclaimed mid-run (SSM status={}, no completion marker). Relaunching automatically: attempt {} of {}, force_on_demand={}.', $.groomPoll.Status, $.retry_count, $.max_retries, $.fod.force_on_demand)"
+      },
+      "ResultPath": "$.relaunch_notify",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "LaunchGroomSpot",
+          "ResultPath": "$.relaunch_notify_error"
+        }
+      ],
+      "Next": "LaunchGroomSpot"
+    },
     "GroomStatusError": {
       "Type": "Pass",
-      "Comment": "Choice Default path — synthesize $.error from the poll result so HandleFailure's JsonToString($.error) has something to stringify. Covers Failed/Cancelled/TimedOut and any status not explicitly modeled above.",
+      "Comment": "Reached when the completion marker EXISTS despite a non-Success SSM status — groom_run.sh reached its own terminal state (a genuine app-level outcome, already self-alerted via Telegram/GH issue) OR this is the pre-existing SSM shutdown/status-report race (config#1472) where the run actually succeeded. Either way: no relaunch. This SF still reports FAILED for Fleet-SF-Watch visibility (accurate enough — the rare race-condition false-negative is a pre-existing, separately-tracked residual, not newly introduced here).",
       "Parameters": {
         "source": "groom_status",
+        "reason": "marker_present_no_relaunch",
         "status.$": "$.groomPoll.Status",
         "status_details.$": "$.groomPoll.StatusDetails",
         "response_code.$": "$.groomPoll.ResponseCode",
         "command_id.$": "$.groomPoll.CommandId",
         "instance_id.$": "$.groomPoll.InstanceId"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "GroomRetriesExhausted": {
+      "Type": "Pass",
+      "Comment": "config#1645: the completion marker was absent on every attempt (box died mid-run each time) and the bounded relaunch budget (including the forced-on-demand final attempt) is spent — a genuine escalation, not a routine spot hiccup.",
+      "Parameters": {
+        "source": "groom_status",
+        "reason": "spot_interruption_retries_exhausted",
+        "status.$": "$.groomPoll.Status",
+        "status_details.$": "$.groomPoll.StatusDetails",
+        "retry_count.$": "$.retry_count",
+        "max_retries.$": "$.max_retries",
+        "command_id.$": "$.groomLaunch.Payload.groom.command_id",
+        "instance_id.$": "$.groomLaunch.Payload.groom.instance_id"
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"


### PR DESCRIPTION
## Summary
- config#1645. Companion to `nousergon/alpha-engine-config#1647` (the completion-marker write).
- The groom dispatch Step Function (`step_function_groom.json`) now checks an S3 completion marker before treating a non-Success SSM command status as a hard failure. Marker absent → the box died mid-run before the script ever finished → bounded relaunch (up to 2, i.e. 3 total attempts), final attempt forced onto **on-demand** so a bad spot-capacity window still guarantees completion. Marker present → a genuine, already-self-alerted app outcome (or the pre-existing SSM shutdown-race false-negative) → fail cleanly, no relaunch, no duplicate alert.
- `index.py`: generates a `run_token` per launch attempt, threads it to the box as `GROOM_RUN_TOKEN`, accepts `force_on_demand` (SF-only, no live schedule sets it) to skip straight to on-demand.
- `sf-execution-iam-policy.json`: adds `s3:GetObject` scoped to `groom/_control/completed/*`.
- A best-effort SNS ping fires on each relaunch (distinct WARNING subject from the FAILED alert) so an interruption is visible in real time.

## Why
Live audit (2026-07-03) found 5-of-6 recent groom-dispatch SF failures were `SSM StatusDetails=Undeliverable` — genuine mid-run spot reclaims, not the already-fixed SSM shutdown/status-report race (config#1472, which shows the `[groom-bootstrap] exit rc=...` line before dying; these did not). Since `groom_driver.py` re-derives its issue queue from live GitHub state on every launch, a relaunch is naturally resumable with zero checkpointing.

## Test plan
- [x] `aws stepfunctions validate-state-machine-definition` on the new ASL — `"result": "OK"`, zero diagnostics.
- [x] `python3 -m json.tool` on the ASL + updated IAM policy — valid JSON.
- [x] `python3 -m pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py -q` — 18 passed (4 new: run_token generated/exported/returned, run_token differs across invocations, force_on_demand skips spot, force_on_demand absent by default preserves existing behavior for the 2 live Sonnet schedules).
- [x] `python3 -m pytest tests/test_deploy_infrastructure_sf_coverage.py tests/test_sf_payload_uniqueness.py tests/test_sf_invocationdoesnotexist_retry.py tests/test_sf_iam_lambda_grants.py -q` — 49 passed, 1 skipped (repo-wide SF wiring/coverage guards unaffected).

## Deploy note
This changes a **live production Step Function definition + IAM policy** — per this repo's convention, `deploy.sh --bootstrap` is an **operator-only** step (not auto-deployed on merge). After merge, the ASL/IAM changes have zero live effect until someone explicitly runs `infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap`. Flagging this explicitly rather than running it myself, since it touches production automation (3x/day groom cadence, unattended) and adds a new on-demand-fallback cost path (trivial — a t3.medium on-demand vs spot, only on the rare final relaunch attempt — but still a live-cost-behavior change worth a human's go-ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)