### PR TITLE
fix(spot-launch): fail loud when ec2_spot launch exits 0 without an instance id (config#1646)

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -354,7 +354,16 @@ if [ "$ec2_spot_rc" -ne 0 ] || [ -z "$INSTANCE_ID" ]; then
     if [ "$ec2_spot_rc" -eq 64 ]; then
         echo "ERROR: capacity exhausted across all instance_type × subnet combinations. Wait + retry, or expand the lists." >&2
     fi
-    exit "${ec2_spot_rc:-1}"
+    if [ "$ec2_spot_rc" -eq 0 ]; then
+      # rc=0 with an EMPTY instance id = the launch layer produced nothing
+      # (e.g. the guard-less `-m nousergon_lib.ec2_spot` shim no-op,
+      # config#1646). `${ec2_spot_rc:-1}` defaults only when UNSET — a
+      # captured 0 passed through and the SF recorded a silent success
+      # on 2026-07-03. An empty id must always fail loud.
+      echo "ERROR: ec2_spot launch exited 0 without an instance id — failing loud (config#1646)" >&2
+      ec2_spot_rc=1
+    fi
+    exit "$ec2_spot_rc"
 fi
 
 echo "  Instance ID: $INSTANCE_ID"

--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -170,7 +170,16 @@ if [ "$ec2_spot_rc" -ne 0 ] || [ -z "$INSTANCE_ID" ]; then
     if [ "$ec2_spot_rc" -eq 64 ]; then
         echo "ERROR: capacity exhausted across all instance_type × subnet combinations. Wait + retry, or expand the lists." >&2
     fi
-    exit "${ec2_spot_rc:-1}"
+    if [ "$ec2_spot_rc" -eq 0 ]; then
+      # rc=0 with an EMPTY instance id = the launch layer produced nothing
+      # (e.g. the guard-less `-m nousergon_lib.ec2_spot` shim no-op,
+      # config#1646). `${ec2_spot_rc:-1}` defaults only when UNSET — a
+      # captured 0 passed through and the SF recorded a silent success
+      # on 2026-07-03. An empty id must always fail loud.
+      echo "ERROR: ec2_spot launch exited 0 without an instance id — failing loud (config#1646)" >&2
+      ec2_spot_rc=1
+    fi
+    exit "$ec2_spot_rc"
 fi
 
 echo "  Instance ID: $INSTANCE_ID"


### PR DESCRIPTION
## Hardening from config#1646 (2026-07-03 weekly-SF silent no-op)

During the recovery rerun, the spot launchers hit the guard-less `-m nousergon_lib.ec2_spot` shim (silent exit-0 no-op with empty stdout). The existing guard caught the empty `INSTANCE_ID` — but then ran `exit "${ec2_spot_rc:-1}"`, and `:-1` defaults only when UNSET: the captured **0** passed through, the launcher exited 0, and the SF recorded another silent success.

This change makes an empty instance id ALWAYS exit nonzero (with an explicit ERROR line), regardless of the launch layer's exit code — per the fail-loud rule: an SSM workload state must never report success without having produced its work.

The shim itself now delegates (nousergon/nousergon-lib#155, 0.81.1, hot-installed on the box), and the SF wrapper migrated to krepis (nousergon/nousergon-data#602) — this PR closes the remaining swallow at the launcher layer.

Not rerun-blocking (recovery attempt 2 runs with the fixed shim); left open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
