### PR TITLE
[P3/high] fix(infra): route changelog-mirror smoke alert through krepis.alerts (config#1339)

### DIFF
--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -172,14 +172,25 @@ SMOKE_ARG="${1:-}"
 if [[ "${SMOKE_ARG}" == "--smoke" ]]; then
   echo "Smoke-testing via alerts.publish (SNS-only, severity=info)..."
   TS=$(date -u +%s)
-  # Resolve Python with alpha_engine_lib installed — prefer repo-local
+  # Resolve Python with the alerts CLI installed — prefer repo-local
   # .venv, fall back to system python3 (mirrors the alpha-engine
   # health_checker.sh pattern).
   _alert_python="python3"
   if [ -x "$(dirname "$0")/../../../.venv/bin/python" ]; then
     _alert_python="$(dirname "$0")/../../../.venv/bin/python"
   fi
-  "$_alert_python" -m nousergon_lib.alerts publish \
+  # Invoke the alerts CLI via ``krepis.alerts`` (config#1339), matching this
+  # repo's own infrastructure/deploy.sh. The alerts module relocated to
+  # ``krepis`` (MIT) at nousergon-lib v0.66.0; ``nousergon_lib.alerts`` and
+  # ``alpha_engine_lib.alerts`` are now re-export/alias shims. Running a shim
+  # under runpy (``python -m <shim>.alerts``) was a SILENT exit-0 no-op on any
+  # pin < v0.81.1 — the shim fell off its end before the target's __main__
+  # guard fired (the config#1646 incident: a weekly SF reported SUCCESS while
+  # running zero workloads). This repo pins nousergon-lib v0.77.0 (< 0.81.1),
+  # so the shim path here would no-op; ``krepis`` is a hard transitive dep
+  # (requirements.txt floors ``krepis>=0.6.0``), so ``-m krepis.alerts`` runs
+  # the real CLI under runpy regardless of the lib pin.
+  "$_alert_python" -m krepis.alerts publish \
     --severity info \
     --no-telegram \
     --source alpha-engine-data/changelog-incident-mirror/deploy.sh \

--- a/tests/test_infra_alerts_uses_krepis.py
+++ b/tests/test_infra_alerts_uses_krepis.py
@@ -1,0 +1,65 @@
+"""Chokepoint: infrastructure ``*.sh`` alert invocations must use ``krepis.alerts``.
+
+The alerts CLI relocated from ``alpha_engine_lib.alerts`` (pre-rename) →
+``nousergon_lib.alerts`` (v0.60.0 rename) → ``krepis.alerts`` (v0.66.0 MIT
+rebase). Both older names are now shims, and invoking a shim under runpy
+(``python -m <shim>.alerts``) is broken in two distinct ways:
+
+  * ``python -m alpha_engine_lib.alerts`` — the alias shim's ``_AliasLoader``
+    has no ``get_code``, so runpy raises ``AttributeError`` and the process
+    dies (crashes, or is swallowed by a ``|| echo`` degrade → no alert).
+  * ``python -m nousergon_lib.alerts`` — a re-export shim; on any nousergon-lib
+    pin < v0.81.1 it fell off its end with exit 0 before the target's
+    ``__main__`` guard fired, i.e. a SILENT no-op (the config#1646 incident: a
+    weekly Step Function reported SUCCESS while running zero workloads). This
+    repo pins nousergon-lib v0.77.0, so that path no-ops here today.
+
+The robust, pin-independent entrypoint is ``python -m krepis.alerts`` — ``krepis``
+is a hard transitive dep (``requirements.txt`` floors ``krepis>=0.6.0``), so the
+real CLI runs under runpy regardless of the nousergon-lib pin. This guard fails
+loud at PR time if any box-executed ``infrastructure/`` script re-introduces a
+shim-name ``-m ...alerts`` runpy invocation. Tracks config#1339.
+
+Shape mirrors the repo's forbidden-phrase chokepoint tests (e.g.
+``test_spot_data_weekly_ssm_transport.py``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_INFRA = _REPO_ROOT / "infrastructure"
+
+# A runpy invocation of the alerts CLI under a SHIM name (``python``/``python3``/
+# ``$VAR`` before ``-m`` tolerated). Bare imports and prose mentions are fine —
+# only the ``-m`` runpy entrypoint is broken for the shim names.
+_SHIM_ALERTS_RE = re.compile(r"-m\s+(?:alpha_engine_lib|nousergon_lib)\.alerts\b")
+
+
+def _iter_infra_scripts():
+    """Shell scripts under infrastructure/ — the scripts SSM/systemd/deploy
+    flows execute on the box, the only place a runpy shim invocation does harm."""
+    if not _INFRA.is_dir():
+        return
+    yield from _INFRA.rglob("*.sh")
+
+
+def test_infra_alert_invocations_use_krepis():
+    violations: list[tuple[str, int, str]] = []
+    for path in _iter_infra_scripts():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if line.lstrip().startswith("#"):  # historical-context prose is fine
+                continue
+            if _SHIM_ALERTS_RE.search(line):
+                violations.append(
+                    (str(path.relative_to(_REPO_ROOT)), lineno, line.strip())
+                )
+    assert not violations, (
+        "Found `python -m {alpha_engine_lib,nousergon_lib}.alerts` runpy "
+        "invocation(s) in infrastructure scripts. The alias shim crashes under "
+        "runpy and the re-export shim silently no-ops on nousergon-lib < "
+        "v0.81.1. Use the pin-independent `-m krepis.alerts` (config#1339):\n"
+        + "\n".join(f"  {p}:{ln}  {src}" for p, ln, src in violations)
+    )


### PR DESCRIPTION
**Priority:** P3 · **Complexity:** high

Part of nousergon/alpha-engine-config#1339 (migrate fleet alerts off the alias/re-export shims).

## Problem
`infrastructure/lambdas/changelog-incident-mirror/deploy.sh` (the `--smoke` deploy check) invoked the alerts CLI via `python -m nousergon_lib.alerts`. That module is a **re-export shim** for `krepis.alerts` (relocated at nousergon-lib v0.66.0). Running a shim under runpy was a **silent exit-0 no-op** on any nousergon-lib pin `< v0.81.1`: the shim fell off its end before the target `krepis.alerts` `__main__` guard could fire (the config#1646 incident — a weekly Step Function reported SUCCESS while running zero workloads). This repo pins **nousergon-lib v0.77.0**, so the smoke alert here silently no-ops today.

## Fix (root cause, pin-independent)
Route the invocation through `python -m krepis.alerts`, matching this repo own `infrastructure/deploy.sh:162`. `krepis` is a hard transitive dep (`requirements.txt` floors `krepis>=0.6.0`), so the real CLI runs under runpy **regardless of the nousergon-lib pin**. Also refreshes the now-stale `alpha_engine_lib`-era comment.

## Drift guard
Adds `tests/test_infra_alerts_uses_krepis.py` — a forbidden-phrase chokepoint (mirrors the repo `*_ssm_transport.py` guards) that fails loud if any `infrastructure/*.sh` re-introduces a shim-name (`alpha_engine_lib`/`nousergon_lib`) `-m ...alerts` runpy invocation. This is the missing automated guard that let `deploy.sh` migrate to krepis while this smoke path was left behind.

## Validation
- `pytest tests/test_infra_alerts_uses_krepis.py` green (verified non-vacuous: regex catches both shim forms, passes `krepis.alerts`).
- `ruff check` clean on the new test.
- Confirmed no remaining shim `-m ...alerts` invocation in `infrastructure/`.

Refs nousergon/alpha-engine-config#1339