### PR TITLE
[P1/mid] fix(infra): sync RationaleClustering SF TimeoutSeconds to Lambda's 900s budget (config#1650)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1316,7 +1316,7 @@
                   "dry_run_llm.$": "$.research_dry"
                 }
               },
-              "TimeoutSeconds": 600,
+              "TimeoutSeconds": 900,
               "Retry": [
                 {
                   "ErrorEquals": [

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -576,7 +576,13 @@ class TestRationaleClustering:
         assert payload["end_time_iso.$"] == "$$.Execution.StartTime"
 
     def test_timeout_matches_lambda_cap(self, states):
-        assert states["RationaleClustering"]["TimeoutSeconds"] == 600
+        # Clustering Lambda is configured with timeout=900s (the AWS
+        # Lambda ceiling — alpha-engine-research infrastructure/deploy.sh,
+        # bumped 600s -> 900s to absorb corpus growth) — SF state
+        # TimeoutSeconds must equal that ceiling, else the SF kills the
+        # lambda:invoke wait independently of (and before) the Lambda's
+        # own configured timeout (config#1650).
+        assert states["RationaleClustering"]["TimeoutSeconds"] == 900
 
     def test_success_continues_to_concordance_gate(self, states):
         # Clustering converges to CheckSkipReplayConcordance (the gate


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

Refs #1650

## Root cause

`crucible-research`#228 (2026-05-24) bumped the `RationaleClustering` Lambda's own AWS timeout from 600s to 900s (the AWS Lambda ceiling, "to absorb corpus growth" per that PR's commit message — confirmed still current live in `crucible-research/infrastructure/deploy.sh`'s `deploy_rationale_clustering()`, `--timeout 900`). This repo's `infrastructure/step_function.json` — the live trading Step Function definition — was never updated to match; the `RationaleClustering` Task state's `TimeoutSeconds` stayed at `600`.

A Step Function Task's `TimeoutSeconds` is an **independent** ceiling on how long the state machine waits for the `lambda:invoke` response — separate from the Lambda's own configured timeout. So the SF was killing the wait at 600s regardless of the Lambda having 900s of budget to work with. This is the concrete, mechanical explanation for the "chronic `RationaleClustering` timeout" symptom in config#1650. It's fail-soft (the state's `Catch` routes to `CheckSkipReplayConcordance` on `States.ALL`, so it hasn't caused a pipeline outage), but it fires recurringly and pollutes flow-doctor/alerting.

## Fix

One-line change: `infrastructure/step_function.json`, `RationaleClustering` Task state, `TimeoutSeconds`: `600` → `900`.

This matches the repo's existing convention for every other direct `lambda:invoke` Task state in this file — `Research` (900), `EvalJudgeProcess` (900), `EvalRollingMean` (300), `ReplayConcordance` (900) — each sets `TimeoutSeconds` to exactly match its target Lambda's configured AWS timeout (verified live against `crucible-research/infrastructure/deploy.sh` for each). No margin/buffer is added on top for this class of state (that pattern only appears for the separate "shell-runner" Lambda states, which carry their own internal timeout in the payload plus a 60s outer-invoke buffer — not applicable here).

## Test

`tests/test_sf_eval_judge_wiring.py::TestRationaleClustering::test_timeout_matches_lambda_cap` is the existing lockstep/drift assertion for this exact value; it hard-coded `600` and is updated to `900` with a comment explaining the lockstep-with-Lambda-config convention and pointing at config#1650.

Full suite green locally: `pytest tests/` → 2570 passed, 12 skipped (pre-existing skips, unrelated to this change). Scoped SF-wiring subset (`pytest tests/ -k "sf_ or step_function"`) → 739 passed, 5 skipped.

## Deployment

No `.github/workflows/*` changes needed or made — `.github/workflows/deploy-infrastructure.yml` restamps the SF definition (`aws stepfunctions update-state-machine`) on every push to `main`, unconditionally (no path filter), so merging this PR is sufficient to apply the fix. Nothing here needs manual apply.

## Scope note

This addresses part 3 of the 3-part config#1650 issue only (the `RationaleClustering` SF/Lambda timeout drift). The other two parts are separately dispositioned — not closed by this PR.