### PR TITLE
[P1/mid] feat(infra): EventBridge SF-ARN + LoggingConfiguration drift guards (config#1464)

### DIFF
--- a/infrastructure/eventbridge/README.md
+++ b/infrastructure/eventbridge/README.md
@@ -1,0 +1,44 @@
+# EventBridge SF-ARN drift guard (alpha-engine-config#1464)
+
+`check-drift.py` diffs the `stateMachineArn` values baked into each
+script-managed EventBridge rule's `EventPattern` against what's live on
+AWS. It's the CI backstop for the drift class that bit this repo on the
+2026-06-29 `ne-*` Step Function rename (config#1381): a rule whose
+`EventPattern` still matches the OLD SF name/ARN doesn't error — it just
+quietly stops firing.
+
+## Scope
+
+Covers EventBridge rules wired by `infrastructure/lambdas/*/deploy.sh`
+scripts (managed outside CloudFormation — see each `deploy.sh`'s header
+comment for why). This script discovers them by scanning for an
+`EVENT_PATTERN=$(cat <<EOF ... EOF)` heredoc keyed on `stateMachineArn`, so
+a new Lambda wiring this pattern is picked up automatically — no registry
+to maintain here.
+
+**Not covered:** the two CFN-managed cron rules (`SaturdayTrigger` /
+`WeekdayTrigger` in
+`infrastructure/cloudformation/alpha-engine-orchestration.yaml`). Those are
+reconciled on every push to `main` by `deploy-infrastructure.yml`, so they
+can't silently drift the way the script-managed rules did.
+
+## Usage
+
+```bash
+# Check every discovered rule
+./infrastructure/eventbridge/check-drift.py
+
+# Check one rule
+./infrastructure/eventbridge/check-drift.py --rule alpha-engine-sf-status-change
+```
+
+Requires AWS creds with `events:DescribeRule` on the target rules.
+
+## CI wiring
+
+Not yet wired into a workflow — the PR that added this script includes the
+intended `sf-drift-check.yml` diff in its description, marked as
+needs-manual-apply (the runner that authored it lacks the `workflow` OIDC
+scope to push workflow YAML directly). It also needs
+`events:DescribeRule` added to the `github-actions-iam-drift-check` OIDC
+role's policy (codified in `crucible-executor`, not this repo).

--- a/infrastructure/eventbridge/check-drift.py
+++ b/infrastructure/eventbridge/check-drift.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""check-drift.py — Diff codified EventBridge rule event-patterns (SF ARNs)
+against live AWS state.
+
+**Background (alpha-engine-config#1464).** The 2026-06-29 Step Function
+rename (config#1381: ``alpha-engine-{saturday,weekday}`` → ``ne-weekly-
+freshness-pipeline`` / ``ne-preopen-trading-pipeline``) silently orphaned
+several EventBridge rules that reference an SF ARN/name in their
+``EventPattern`` — they kept matching the OLD name, so they simply stopped
+firing (no error, no alert). The two CFN-managed cron rules
+(``SaturdayTrigger`` / ``WeekdayTrigger`` in
+``infrastructure/cloudformation/alpha-engine-orchestration.yaml``) are safe
+from this because ``deploy-infrastructure.yml`` reconciles them on every
+push to main. The bitten rules were all managed OUTSIDE CloudFormation by
+individual Lambda ``deploy.sh`` scripts under ``infrastructure/lambdas/*/``
+— those only reconcile the live rule when an OPERATOR manually re-runs
+``deploy.sh`` (some only on ``--bootstrap``, i.e. never again after first
+create). A source-level rename that isn't followed by a manual redeploy
+leaves live AWS silently stale. This script is the CI backstop: it doesn't
+require anyone to remember to redeploy, it just fails loudly when source and
+live disagree.
+
+**Source of truth.** Each ``infrastructure/lambdas/<name>/deploy.sh`` that
+wires an EventBridge rule off Step Functions status-change events embeds its
+own ``EVENT_PATTERN=$(cat <<EOF ... EOF)`` heredoc + ``RULE_NAME="..."``
+literal — those two are, by construction, the SAME values the script would
+push to AWS with ``aws events put-rule``. This script discovers every such
+deploy.sh (glob + regex, no hardcoded rule registry to keep in sync), fills
+in the two placeholders the heredoc uses (``${REGION}`` / ``${ACCOUNT_ID}``,
+using each script's own literal fallback defaults), and diffs the resulting
+JSON against ``aws events describe-rule --name <rule>``.
+
+Drift cases (all exit non-zero):
+  * Live rule's EventPattern differs from the codified heredoc
+    (content-drift) — reported with the specific stateMachineArn sets on
+    each side when that's where the difference is, since that's the
+    class of drift this guard exists to catch.
+  * Rule not found on AWS at all                (missing-in-aws)
+  * A discovered EVENT_PATTERN block isn't valid JSON once substituted
+    (source-error — the deploy.sh itself is broken)
+
+JSON is compared after normalization (sorted object keys, order-independent
+array comparison), so cosmetic differences (whitespace, array order) don't
+trip the check.
+
+Usage:
+  ./infrastructure/eventbridge/check-drift.py             # check every discovered rule
+  ./infrastructure/eventbridge/check-drift.py --rule NAME  # check one rule (by RULE_NAME)
+
+Requires AWS creds with events:DescribeRule on the target rules. Locally:
+any admin profile. In CI: intended to reuse the same OIDC role as
+``iam-drift-check.yml`` (``github-actions-iam-drift-check``), which will
+need `events:DescribeRule` added to its policy — see this repo's PR for
+config#1464 for the exact IAM diff (that role is codified in
+crucible-executor, not this repo).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+REPO_ROOT = SCRIPT_DIR.parent.parent
+LAMBDAS_DIR = REPO_ROOT / "infrastructure" / "lambdas"
+
+# Fallback defaults mirrored from each deploy.sh's own
+# `REGION="${AWS_REGION:-us-east-1}"` / `ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"`
+# lines — used ONLY to resolve the `${REGION}`/`${ACCOUNT_ID}` placeholders
+# inside a script's EVENT_PATTERN heredoc so it can be parsed as JSON and
+# compared. The live rule lookup itself always uses the ambient AWS CLI
+# region/credentials, not these constants.
+DEFAULT_REGION = "us-east-1"
+DEFAULT_ACCOUNT_ID = "711398986525"
+
+_EVENT_PATTERN_RE = re.compile(
+    r"EVENT_PATTERN=\$\(cat <<EOF\n(.*?)\nEOF\n\)", re.DOTALL
+)
+_RULE_NAME_RE = re.compile(r'^RULE_NAME="([^"]+)"', re.MULTILINE)
+
+
+def _discover_codified_rules() -> list[dict]:
+    """Scan every `infrastructure/lambdas/*/deploy.sh` for an EVENT_PATTERN
+    heredoc keyed on `stateMachineArn`. Returns one entry per rule found,
+    each either `{"rule_name", "source_file", "expected_pattern"}` or, if
+    the heredoc doesn't parse, `{"rule_name", "source_file", "error"}`.
+
+    Deliberately a scan, not a hardcoded table — mirrors
+    `infrastructure/iam/check-drift.py`'s glob-every-codified-file
+    philosophy, so a new Lambda wiring an SF-status EventBridge rule is
+    picked up automatically without editing this script.
+    """
+    rules: list[dict] = []
+    for deploy_sh in sorted(LAMBDAS_DIR.glob("*/deploy.sh")):
+        text = deploy_sh.read_text()
+        pattern_match = _EVENT_PATTERN_RE.search(text)
+        if not pattern_match:
+            continue
+        pattern_src = pattern_match.group(1)
+        if "stateMachineArn" not in pattern_src:
+            continue
+
+        rule_match = _RULE_NAME_RE.search(text)
+        if not rule_match:
+            rules.append({
+                "rule_name": f"<unknown in {deploy_sh.name}>",
+                "source_file": deploy_sh,
+                "error": (
+                    f"{deploy_sh} has an EVENT_PATTERN keyed on "
+                    f"stateMachineArn but no RULE_NAME=\"...\" literal — "
+                    f"can't determine which live rule to check"
+                ),
+            })
+            continue
+        rule_name = rule_match.group(1)
+
+        resolved = pattern_src.replace("${REGION}", DEFAULT_REGION).replace(
+            "${ACCOUNT_ID}", DEFAULT_ACCOUNT_ID
+        )
+        try:
+            expected_pattern = json.loads(resolved)
+        except json.JSONDecodeError as exc:
+            rules.append({
+                "rule_name": rule_name,
+                "source_file": deploy_sh,
+                "error": (
+                    f"EVENT_PATTERN in {deploy_sh} is not valid JSON after "
+                    f"substituting REGION/ACCOUNT_ID placeholders ({exc})"
+                ),
+            })
+            continue
+
+        rules.append({
+            "rule_name": rule_name,
+            "source_file": deploy_sh,
+            "expected_pattern": expected_pattern,
+        })
+    return rules
+
+
+def _aws_events(*args: str, allow_missing: bool = False) -> dict | list | str | None:
+    """Call `aws events ...` and return the parsed JSON output.
+
+    If `allow_missing` and the CLI fails with ResourceNotFoundException,
+    return None instead of aborting — the caller turns that into a
+    missing-in-aws drift finding rather than a hard failure, since "the
+    rule doesn't exist" is itself a legitimate (if extreme) drift case.
+    """
+    result = subprocess.run(
+        ["aws", "events", *args, "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        if allow_missing and "ResourceNotFoundException" in result.stderr:
+            return None
+        sys.stderr.write(
+            f"AWS CLI failed: aws events {' '.join(args)}\n"
+            f"stderr: {result.stderr}\n"
+        )
+        sys.exit(2)
+    return json.loads(result.stdout) if result.stdout.strip() else {}
+
+
+def _canonical(obj):
+    """Recursively sort dict keys and (order-independently) list elements
+    so cosmetic reordering doesn't register as drift."""
+    if isinstance(obj, dict):
+        return {k: _canonical(obj[k]) for k in sorted(obj)}
+    if isinstance(obj, list):
+        canon_items = [_canonical(v) for v in obj]
+        try:
+            return sorted(canon_items, key=lambda x: json.dumps(x, sort_keys=True))
+        except TypeError:
+            return canon_items
+    return obj
+
+
+def _canonical_json(obj) -> str:
+    return json.dumps(_canonical(obj), sort_keys=True, separators=(",", ":"))
+
+
+def _extract_state_machine_arns(pattern: dict) -> set[str]:
+    """Pull the `detail.stateMachineArn` allow-list out of an EventPattern.
+    Handles both list and bare-string shapes (AWS accepts either)."""
+    detail = pattern.get("detail", {}) if isinstance(pattern, dict) else {}
+    arns = detail.get("stateMachineArn", [])
+    if isinstance(arns, str):
+        return {arns}
+    if isinstance(arns, list):
+        return set(arns)
+    return set()
+
+
+def _check_rule(rule: dict) -> list[str]:
+    """Return list of drift findings for one codified rule. Empty means clean."""
+    rule_name = rule["rule_name"]
+
+    if "error" in rule:
+        return [f"{rule_name}: {rule['error']}"]
+
+    expected_pattern = rule["expected_pattern"]
+    source_rel = rule["source_file"].relative_to(REPO_ROOT)
+
+    desc = _aws_events("describe-rule", "--name", rule_name, allow_missing=True)
+    if desc is None:
+        return [
+            f"{rule_name}: codified in {source_rel} but rule not found on "
+            f"AWS (run that lambda's deploy.sh --bootstrap, or re-run "
+            f"deploy.sh if it was deleted out of band)"
+        ]
+
+    live_pattern_raw = desc.get("EventPattern")
+    if not live_pattern_raw:
+        return [
+            f"{rule_name}: live rule exists but has no EventPattern "
+            f"(codified in {source_rel} expects one keyed on stateMachineArn)"
+        ]
+
+    try:
+        live_pattern = json.loads(live_pattern_raw)
+    except json.JSONDecodeError as exc:
+        return [f"{rule_name}: live EventPattern is not valid JSON ({exc})"]
+
+    if _canonical_json(expected_pattern) == _canonical_json(live_pattern):
+        return []
+
+    expected_arns = _extract_state_machine_arns(expected_pattern)
+    live_arns = _extract_state_machine_arns(live_pattern)
+    if expected_arns != live_arns:
+        return [
+            f"{rule_name}: live EventPattern's stateMachineArn set differs "
+            f"from {source_rel} (content drift)\n"
+            f"      codified: {sorted(expected_arns)}\n"
+            f"      live:     {sorted(live_arns)}"
+        ]
+
+    return [
+        f"{rule_name}: live EventPattern differs from {source_rel} "
+        f"(stateMachineArn set matches; some other field — e.g. the "
+        f"status filter — has drifted)"
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rule", help="Check one rule by RULE_NAME (default: every discovered rule)"
+    )
+    args = parser.parse_args()
+
+    rules = _discover_codified_rules()
+
+    if args.rule:
+        rules = [r for r in rules if r["rule_name"] == args.rule]
+        if not rules:
+            sys.stderr.write(
+                f"ERROR: no codified EVENT_PATTERN found for rule "
+                f"'{args.rule}' under {LAMBDAS_DIR}/*/deploy.sh\n"
+            )
+            return 2
+
+    if not rules:
+        print(
+            f"No codified stateMachineArn-keyed EventBridge rules found "
+            f"under {LAMBDAS_DIR}/*/deploy.sh — nothing to check."
+        )
+        return 0
+
+    total_findings: list[str] = []
+    for rule in rules:
+        total_findings.extend(_check_rule(rule))
+
+    if total_findings:
+        print(f"EventBridge SF-ARN drift detected ({len(total_findings)} finding(s)):")
+        for f in total_findings:
+            print(f"  - {f}")
+        return 1
+
+    rule_names = ", ".join(r["rule_name"] for r in rules)
+    print(f"OK: no EventBridge SF-ARN drift for {rule_names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/step-functions/README.md
+++ b/infrastructure/step-functions/README.md
@@ -1,0 +1,52 @@
+# SF LoggingConfiguration drift guard (alpha-engine-config#1464)
+
+`check-drift.py` diffs each orchestrated Step Function's live
+`loggingConfiguration` against what's codified. This is the CI backstop
+for a specific, easy-to-miss failure mode: `LoggingConfiguration` survives
+a plain `update-state-machine --definition ...` call (that's a partial
+update), but is **dropped whenever the state machine is recreated** rather
+than updated — e.g. a CloudFormation replacement triggered by a
+`StateMachineName` change. The 2026-06-29 `ne-*` rename (config#1381) did
+exactly that to the two CFN-managed SFs, silently breaking the L274
+MutexConflict CloudWatch metric-filter chain (config#729) until a later PR
+noticed and restored it.
+
+## Scope + source of truth
+
+Source of truth is split across two files (this script parses both, no
+duplicated table to keep in sync):
+
+| State machine | Source of truth | Expected |
+|---|---|---|
+| `ne-weekly-freshness-pipeline` | `infrastructure/cloudformation/alpha-engine-orchestration.yaml` (`SaturdayPipeline`) | `level=ERROR`, `includeExecutionData=true` |
+| `ne-preopen-trading-pipeline` | same file (`WeekdayPipeline`) | `level=ERROR`, `includeExecutionData=true` |
+| `ne-postclose-trading-pipeline` | `infrastructure/deploy-infrastructure.sh` (`EOD_LOGGING_CONFIG`) | `level=ERROR`, `includeExecutionData=true` |
+| `alpha-engine-groom-pipeline` | same file (`update_or_create` call omits the logging arg, deliberately) | no logging (`level=OFF`) |
+
+The CFN template isn't parsed with a real YAML library — `!Ref`/`!GetAtt`/
+`!Sub` intrinsics aren't valid plain YAML, and this repo's existing test
+suite already made the same call (see
+`tests/test_deploy_step_function_eventbridge_input.py`: "CFN's intrinsic
+tags require a custom loader" → slice the text instead).
+
+## Usage
+
+```bash
+# Check every codified state machine
+./infrastructure/step-functions/check-drift.py
+
+# Check one
+./infrastructure/step-functions/check-drift.py --name ne-weekly-freshness-pipeline
+```
+
+Requires AWS creds with `states:DescribeStateMachine` on the target state
+machines.
+
+## CI wiring
+
+Not yet wired into a workflow — see
+`infrastructure/eventbridge/README.md`'s "CI wiring" note; the same
+`sf-drift-check.yml` draft (in the PR description for config#1464) runs
+both this and the EventBridge guard. Also needs
+`states:DescribeStateMachine` added to the `github-actions-iam-drift-check`
+OIDC role's policy (codified in `crucible-executor`).

--- a/infrastructure/step-functions/check-drift.py
+++ b/infrastructure/step-functions/check-drift.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""check-drift.py — Diff codified Step Function `LoggingConfiguration` against
+live AWS state.
+
+**Background (alpha-engine-config#1464).** `LoggingConfiguration` survives a
+plain `update-state-machine --definition ...` call (that's a partial update;
+an omitted `loggingConfiguration` is left unchanged) but is DROPPED whenever
+a Step Function gets recreated rather than updated — e.g. a CloudFormation
+replacement triggered by a `StateMachineName` change. The 2026-06-29 `ne-*`
+rename (config#1381) did exactly that: the two CFN-managed SFs
+(`ne-weekly-freshness-pipeline`, `ne-preopen-trading-pipeline`) came back
+with NO execution logging, silently breaking the L274 MutexConflict
+CloudWatch metric-filter chain (config#729) until a later PR restored the
+CFN `LoggingConfiguration` block. Nothing caught the gap in between — this
+script is the CI backstop.
+
+**Source of truth is split across two files** (this system's actual layout,
+not a hypothetical one):
+
+  * `infrastructure/cloudformation/alpha-engine-orchestration.yaml` —
+    declares `LoggingConfiguration` for the two CFN-owned state machines
+    (`SaturdayPipeline` / `ne-weekly-freshness-pipeline` and
+    `WeekdayPipeline` / `ne-preopen-trading-pipeline`). The CFN comment on
+    those resources spells out why this is safe from the deploy-vs-drift
+    trap: the deploy script's `update-state-machine` call passes only
+    `--definition`, so it never wipes this CFN-set config.
+  * `infrastructure/deploy-infrastructure.sh` — the EOD SF
+    (`ne-postclose-trading-pipeline`) is NOT in CloudFormation (script-
+    managed); its `EOD_LOGGING_CONFIG` literal there is the source of truth,
+    passed explicitly on every `update-state-machine` / `create-state-machine`
+    call. The backlog-groom SF (`alpha-engine-groom-pipeline`) is also
+    script-managed but its `update_or_create` call deliberately omits a
+    logging arg ("preserving its current no-logging behavior exactly", per
+    that script's comment) — so this guard's codified expectation for groom
+    is "no logging enabled", and it flags drift if that ever changes without
+    a matching source update.
+
+This script parses both files (regex-based textual extraction — CFN's
+`!Ref`/`!GetAtt`/`!Sub` intrinsics aren't valid YAML for a stock loader, and
+this repo's own test suite already made the same "slice the text, don't
+pretend to fully parse CFN" call — see
+`tests/test_deploy_step_function_eventbridge_input.py`) into one expected
+`LoggingConfiguration` per state machine, then diffs each against
+`aws stepfunctions describe-state-machine --query loggingConfiguration`.
+
+Drift cases (all exit non-zero):
+  * Live `level` differs from codified (e.g. ERROR expected, live OFF —
+    exactly the recreate-drops-logging bug class)
+  * Live `includeExecutionData` differs from codified
+  * Live log group name differs from codified (comparing just the
+    `log-group:<name>:` component, not full ARN, so this doesn't false-
+    positive on account/region differences between this script's parsing
+    defaults and the live account)
+  * A codified state machine isn't found on AWS at all (missing-in-aws)
+  * The source files don't parse the way this script expects (source-error)
+
+Usage:
+  ./infrastructure/step-functions/check-drift.py               # check every codified SF
+  ./infrastructure/step-functions/check-drift.py --name NAME   # check one (by SF name)
+
+Requires AWS creds with states:DescribeStateMachine on the target state
+machines. In CI: intended to reuse the same OIDC role as
+`iam-drift-check.yml` (`github-actions-iam-drift-check`), which will need
+`states:DescribeStateMachine` added to its policy — see this repo's PR for
+config#1464 for the exact IAM diff (that role is codified in
+crucible-executor, not this repo).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+REPO_ROOT = SCRIPT_DIR.parent.parent
+CFN_TEMPLATE = REPO_ROOT / "infrastructure" / "cloudformation" / "alpha-engine-orchestration.yaml"
+DEPLOY_INFRA_SH = REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh"
+
+# Fallback defaults used only to build the ARN this script queries AWS with
+# (mirrors infrastructure/eventbridge/check-drift.py's same constants).
+DEFAULT_REGION = "us-east-1"
+DEFAULT_ACCOUNT_ID = "711398986525"
+
+_TOP_LEVEL_KEY_RE = re.compile(r"^  ([A-Za-z0-9]+):\s*$", re.MULTILINE)
+
+
+def _cfn_resource_blocks(text: str) -> dict[str, str]:
+    """Split the CFN template body into {logical_id: block_text}, where
+    block_text runs from one top-level (2-space-indented) key to the next.
+    Deliberately not a YAML parser — see module docstring."""
+    matches = list(_TOP_LEVEL_KEY_RE.finditer(text))
+    blocks: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        blocks[m.group(1)] = text[start:end]
+    return blocks
+
+
+def _discover_expected_from_cfn() -> list[dict]:
+    """Extract expected LoggingConfiguration for the two CFN-owned SFs."""
+    if not CFN_TEMPLATE.is_file():
+        return [{
+            "sf_name": "<cfn-template-missing>",
+            "source_file": CFN_TEMPLATE,
+            "error": f"{CFN_TEMPLATE} not found",
+        }]
+
+    text = CFN_TEMPLATE.read_text()
+    blocks = _cfn_resource_blocks(text)
+    results: list[dict] = []
+
+    for logical_id, block in blocks.items():
+        if "Type: AWS::StepFunctions::StateMachine" not in block:
+            continue
+
+        name_match = re.search(r"StateMachineName:\s*(\S+)", block)
+        if not name_match:
+            results.append({
+                "sf_name": f"<{logical_id}>",
+                "source_file": CFN_TEMPLATE,
+                "error": f"{logical_id} in {CFN_TEMPLATE.name} has no StateMachineName",
+            })
+            continue
+        sf_name = name_match.group(1)
+
+        if "LoggingConfiguration:" not in block:
+            results.append({
+                "sf_name": sf_name,
+                "source_file": CFN_TEMPLATE,
+                "expected_level": "OFF",
+                "expected_include_execution_data": None,
+                "expected_log_group_name": None,
+            })
+            continue
+
+        logging_block = block.split("LoggingConfiguration:", 1)[1]
+        level_match = re.search(r"Level:\s*(\S+)", logging_block)
+        include_match = re.search(r"IncludeExecutionData:\s*(\S+)", logging_block)
+        getatt_match = re.search(r"LogGroupArn:\s*!GetAtt\s+(\w+)\.Arn", logging_block)
+
+        if not (level_match and include_match and getatt_match):
+            results.append({
+                "sf_name": sf_name,
+                "source_file": CFN_TEMPLATE,
+                "error": (
+                    f"{logical_id} in {CFN_TEMPLATE.name} has a "
+                    f"LoggingConfiguration block this script couldn't fully "
+                    f"parse (expected Level: / IncludeExecutionData: / "
+                    f"LogGroupArn: !GetAtt X.Arn)"
+                ),
+            })
+            continue
+
+        log_group_logical_id = getatt_match.group(1)
+        log_group_block = blocks.get(log_group_logical_id, "")
+        log_group_name_match = re.search(r"LogGroupName:\s*(\S+)", log_group_block)
+        if not log_group_name_match:
+            results.append({
+                "sf_name": sf_name,
+                "source_file": CFN_TEMPLATE,
+                "error": (
+                    f"{logical_id} references LogGroupArn !GetAtt "
+                    f"{log_group_logical_id}.Arn but {log_group_logical_id} "
+                    f"has no resolvable LogGroupName in {CFN_TEMPLATE.name}"
+                ),
+            })
+            continue
+
+        results.append({
+            "sf_name": sf_name,
+            "source_file": CFN_TEMPLATE,
+            "expected_level": level_match.group(1),
+            "expected_include_execution_data": include_match.group(1).lower() == "true",
+            "expected_log_group_name": log_group_name_match.group(1),
+        })
+
+    return results
+
+
+def _discover_expected_from_deploy_script() -> list[dict]:
+    """Extract expected LoggingConfiguration for the script-managed SFs
+    (EOD = explicit logging config; groom = deliberately no logging)."""
+    if not DEPLOY_INFRA_SH.is_file():
+        return [{
+            "sf_name": "<deploy-infrastructure-sh-missing>",
+            "source_file": DEPLOY_INFRA_SH,
+            "error": f"{DEPLOY_INFRA_SH} not found",
+        }]
+
+    text = DEPLOY_INFRA_SH.read_text()
+    results: list[dict] = []
+
+    # --- EOD: explicit LoggingConfiguration ---------------------------------
+    eod_arn_match = re.search(
+        r'EOD_ARN="arn:aws:states:\$REGION:\$\{ACCOUNT_ID\}:stateMachine:([\w-]+)"',
+        text,
+    )
+    eod_log_group_match = re.search(r'EOD_LOG_GROUP_NAME="([^"]+)"', text)
+    eod_config_match = re.search(r"EOD_LOGGING_CONFIG='(\{.*?\})'", text)
+
+    if eod_arn_match and eod_log_group_match and eod_config_match:
+        eod_name = eod_arn_match.group(1)
+        eod_log_group_name = eod_log_group_match.group(1)
+        # The logGroupArn value inside EOD_LOGGING_CONFIG is itself a shell
+        # variable substitution (`...logGroupArn":"'"$EOD_LOG_GROUP_ARN"'"}`),
+        # not a literal — pull level/includeExecutionData directly out of the
+        # literal JSON text, and trust EOD_LOG_GROUP_NAME (extracted above,
+        # itself a plain literal) for the log group name.
+        level_match = re.search(r'"level":"([^"]+)"', eod_config_match.group(1))
+        include_match = re.search(
+            r'"includeExecutionData":(true|false)', eod_config_match.group(1)
+        )
+        if level_match and include_match:
+            results.append({
+                "sf_name": eod_name,
+                "source_file": DEPLOY_INFRA_SH,
+                "expected_level": level_match.group(1),
+                "expected_include_execution_data": include_match.group(1) == "true",
+                "expected_log_group_name": eod_log_group_name,
+            })
+        else:
+            results.append({
+                "sf_name": eod_name,
+                "source_file": DEPLOY_INFRA_SH,
+                "error": (
+                    f"EOD_LOGGING_CONFIG in {DEPLOY_INFRA_SH.name} didn't "
+                    f"parse as expected (level/includeExecutionData)"
+                ),
+            })
+    else:
+        results.append({
+            "sf_name": "<eod-sf-unresolved>",
+            "source_file": DEPLOY_INFRA_SH,
+            "error": (
+                f"Couldn't find EOD_ARN / EOD_LOG_GROUP_NAME / "
+                f"EOD_LOGGING_CONFIG literals in {DEPLOY_INFRA_SH.name} — "
+                f"has the EOD deploy plumbing been refactored?"
+            ),
+        })
+
+    # --- Groom: deliberately no logging (update_or_create omits the arg) ---
+    groom_arn_match = re.search(
+        r'GROOM_ARN="arn:aws:states:\$REGION:\$\{ACCOUNT_ID\}:stateMachine:([\w-]+)"',
+        text,
+    )
+    groom_call_match = re.search(
+        r'update_or_create\s+"\$GROOM_ARN"\s+"\$GROOM_STAMPED"\s+"[\w-]+"\s+"[^"]+"\s*(".*")?\s*$',
+        text,
+        re.MULTILINE,
+    )
+    if groom_arn_match:
+        groom_name = groom_arn_match.group(1)
+        has_logging_arg = bool(groom_call_match and groom_call_match.group(1))
+        if has_logging_arg:
+            results.append({
+                "sf_name": groom_name,
+                "source_file": DEPLOY_INFRA_SH,
+                "error": (
+                    f"groom SF's update_or_create call in "
+                    f"{DEPLOY_INFRA_SH.name} now passes a logging arg — "
+                    f"this script's groom-has-no-logging assumption is "
+                    f"stale, update it rather than trusting this result"
+                ),
+            })
+        else:
+            results.append({
+                "sf_name": groom_name,
+                "source_file": DEPLOY_INFRA_SH,
+                "expected_level": "OFF",
+                "expected_include_execution_data": None,
+                "expected_log_group_name": None,
+            })
+
+    return results
+
+
+def _discover_expected_logging_configs() -> list[dict]:
+    return _discover_expected_from_cfn() + _discover_expected_from_deploy_script()
+
+
+def _aws_stepfunctions(*args: str, allow_missing: bool = False):
+    result = subprocess.run(
+        ["aws", "stepfunctions", *args, "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        if allow_missing and (
+            "StateMachineDoesNotExist" in result.stderr
+            or "ResourceNotFoundException" in result.stderr
+        ):
+            return None
+        sys.stderr.write(
+            f"AWS CLI failed: aws stepfunctions {' '.join(args)}\n"
+            f"stderr: {result.stderr}\n"
+        )
+        sys.exit(2)
+    return json.loads(result.stdout) if result.stdout.strip() else {}
+
+
+def _live_log_group_name(logging_config: dict) -> str | None:
+    destinations = logging_config.get("destinations") or []
+    if not destinations:
+        return None
+    arn = destinations[0].get("cloudWatchLogsLogGroup", {}).get("logGroupArn", "")
+    # arn:aws:logs:<region>:<account>:log-group:<name>:* — pull just <name>,
+    # so this comparison is immune to region/account differences between
+    # this script's DEFAULT_REGION/DEFAULT_ACCOUNT_ID and the live account.
+    m = re.search(r"log-group:(.+?):(\*|\d+)?$", arn)
+    return m.group(1) if m else arn or None
+
+
+def _check_sf(entry: dict) -> list[str]:
+    sf_name = entry["sf_name"]
+
+    if "error" in entry:
+        return [f"{sf_name}: {entry['error']}"]
+
+    source_rel = entry["source_file"].relative_to(REPO_ROOT)
+    arn = (
+        f"arn:aws:states:{DEFAULT_REGION}:{DEFAULT_ACCOUNT_ID}:"
+        f"stateMachine:{sf_name}"
+    )
+
+    desc = _aws_stepfunctions(
+        "describe-state-machine", "--state-machine-arn", arn, allow_missing=True
+    )
+    if desc is None:
+        return [
+            f"{sf_name}: codified in {source_rel} but state machine not "
+            f"found on AWS (has it been renamed/recreated without updating "
+            f"the source, or vice versa?)"
+        ]
+
+    live_logging = desc.get("loggingConfiguration", {}) or {}
+    live_level = live_logging.get("level", "OFF")
+    live_include = live_logging.get("includeExecutionData")
+    live_log_group = _live_log_group_name(live_logging)
+
+    findings: list[str] = []
+
+    expected_level = entry["expected_level"]
+    if live_level != expected_level:
+        findings.append(
+            f"{sf_name}: LoggingConfiguration.level drift — codified "
+            f"{source_rel} expects '{expected_level}', live is "
+            f"'{live_level}'"
+        )
+        # If level itself has drifted to OFF, the includeExecutionData /
+        # log-group comparisons below are meaningless (AWS omits them) —
+        # skip the noise and report just the one root-cause finding.
+        return findings
+
+    expected_include = entry["expected_include_execution_data"]
+    if expected_include is not None and live_include != expected_include:
+        findings.append(
+            f"{sf_name}: LoggingConfiguration.includeExecutionData drift — "
+            f"codified {source_rel} expects {expected_include}, live is "
+            f"{live_include}"
+        )
+
+    expected_log_group = entry["expected_log_group_name"]
+    if expected_log_group is not None and live_log_group != expected_log_group:
+        findings.append(
+            f"{sf_name}: LoggingConfiguration log group drift — codified "
+            f"{source_rel} expects '{expected_log_group}', live is "
+            f"'{live_log_group}'"
+        )
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--name", help="Check one state machine by name (default: every codified one)"
+    )
+    args = parser.parse_args()
+
+    entries = _discover_expected_logging_configs()
+
+    if args.name:
+        entries = [e for e in entries if e["sf_name"] == args.name]
+        if not entries:
+            sys.stderr.write(
+                f"ERROR: no codified LoggingConfiguration found for state "
+                f"machine '{args.name}'\n"
+            )
+            return 2
+
+    if not entries:
+        print("No codified state machines found — nothing to check.")
+        return 0
+
+    total_findings: list[str] = []
+    for entry in entries:
+        total_findings.extend(_check_sf(entry))
+
+    if total_findings:
+        print(f"SF LoggingConfiguration drift detected ({len(total_findings)} finding(s)):")
+        for f in total_findings:
+            print(f"  - {f}")
+        return 1
+
+    sf_names = ", ".join(e["sf_name"] for e in entries)
+    print(f"OK: no LoggingConfiguration drift for {sf_names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_eventbridge_check_drift.py
+++ b/tests/test_eventbridge_check_drift.py
@@ -1,0 +1,225 @@
+"""Tests for infrastructure/eventbridge/check-drift.py (alpha-engine-config#1464).
+
+Covers the EventBridge SF-ARN drift guard: discovery of codified
+`EVENT_PATTERN` heredocs from `infrastructure/lambdas/*/deploy.sh`, and the
+compare-against-live logic (mocked `aws events` CLI calls — no real AWS
+access; mirrors this repo's existing subprocess-mock convention, e.g.
+tests/test_artifact_registry_coverage.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "infrastructure" / "eventbridge" / "check-drift.py"
+
+
+@pytest.fixture(scope="module")
+def cd():
+    """Load check-drift.py as a module (hyphenated filename, not importable
+    via a normal `import` statement)."""
+    spec = importlib.util.spec_from_file_location("eventbridge_check_drift", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── Discovery against the real repo state ───────────────────────────────────
+
+
+def test_discovers_all_three_historically_bitten_rules(cd):
+    """The 3 rules named in config#1464 as historically orphaned by the
+    2026-06-29 ne-* rename must all be discovered from their deploy.sh."""
+    rules = cd._discover_codified_rules()
+    rule_names = {r["rule_name"] for r in rules}
+    assert "alpha-engine-sf-status-change" in rule_names  # sf-telegram-notifier
+    assert "alpha-engine-friday-shell-run-report" in rule_names
+    assert "alpha-engine-saturday-succeeded-groom" in rule_names  # saturday-sf-success-groom-dispatcher
+
+
+def test_discovered_rules_have_no_parse_errors(cd):
+    """Every discovered rule under today's repo state must parse cleanly —
+    a source-error here means a deploy.sh's EVENT_PATTERN heredoc changed
+    shape in a way this script's regex no longer handles."""
+    rules = cd._discover_codified_rules()
+    assert rules, "expected at least one codified EventBridge rule"
+    errors = [r for r in rules if "error" in r]
+    assert not errors, f"unexpected parse errors: {errors}"
+
+
+def test_discovered_pattern_references_expected_state_machine(cd):
+    rules = {r["rule_name"]: r for r in cd._discover_codified_rules()}
+    sf_status_change = rules["alpha-engine-sf-status-change"]
+    arns = cd._extract_state_machine_arns(sf_status_change["expected_pattern"])
+    assert any("ne-weekly-freshness-pipeline" in arn for arn in arns)
+
+
+# ── _canonical_json — order/whitespace-insensitive comparison ──────────────
+
+
+def test_canonical_json_ignores_array_order():
+    from_a = {"detail": {"stateMachineArn": ["a", "b"], "status": ["X", "Y"]}}
+    from_b = {"detail": {"status": ["Y", "X"], "stateMachineArn": ["b", "a"]}}
+    # Need module-level function; import via fixture pattern replicated here
+    # for a standalone unit test without the AWS-call surface.
+    spec = importlib.util.spec_from_file_location("eventbridge_check_drift2", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module._canonical_json(from_a) == module._canonical_json(from_b)
+
+
+def test_canonical_json_detects_real_difference(cd):
+    a = {"detail": {"stateMachineArn": ["a", "b"]}}
+    b = {"detail": {"stateMachineArn": ["a", "c"]}}
+    assert cd._canonical_json(a) != cd._canonical_json(b)
+
+
+# ── _check_rule — mocked AWS CLI ────────────────────────────────────────────
+
+
+def _fake_run(returncode=0, stdout="", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def test_check_rule_no_drift_when_live_matches_codified(cd):
+    rule = {
+        "rule_name": "alpha-engine-sf-status-change",
+        "source_file": _REPO_ROOT / "infrastructure" / "lambdas" / "sf-telegram-notifier" / "deploy.sh",
+        "expected_pattern": {
+            "source": ["aws.states"],
+            "detail-type": ["Step Functions Execution Status Change"],
+            "detail": {
+                "stateMachineArn": [
+                    "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+                ],
+                "status": ["SUCCEEDED"],
+            },
+        },
+    }
+    live_response = {
+        "Name": "alpha-engine-sf-status-change",
+        "EventPattern": json.dumps(rule["expected_pattern"]),
+    }
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live_response))):
+        findings = cd._check_rule(rule)
+    assert findings == []
+
+
+def test_check_rule_detects_stale_state_machine_arn(cd):
+    """The exact bug class this guard exists for: live rule still matches
+    the OLD (pre-rename) SF name/ARN."""
+    rule = {
+        "rule_name": "alpha-engine-sf-status-change",
+        "source_file": _REPO_ROOT / "infrastructure" / "lambdas" / "sf-telegram-notifier" / "deploy.sh",
+        "expected_pattern": {
+            "source": ["aws.states"],
+            "detail-type": ["Step Functions Execution Status Change"],
+            "detail": {
+                "stateMachineArn": [
+                    "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+                ],
+                "status": ["SUCCEEDED"],
+            },
+        },
+    }
+    stale_live = {
+        "source": ["aws.states"],
+        "detail-type": ["Step Functions Execution Status Change"],
+        "detail": {
+            "stateMachineArn": [
+                # Pre-rename ARN — the exact 2026-06-29 orphaning scenario.
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday",
+            ],
+            "status": ["SUCCEEDED"],
+        },
+    }
+    live_response = {"Name": "alpha-engine-sf-status-change", "EventPattern": json.dumps(stale_live)}
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live_response))):
+        findings = cd._check_rule(rule)
+    assert len(findings) == 1
+    assert "stateMachineArn set differs" in findings[0]
+    assert "alpha-engine-saturday" in findings[0]
+
+
+def test_check_rule_missing_rule_on_aws(cd):
+    rule = {
+        "rule_name": "alpha-engine-sf-status-change",
+        "source_file": _REPO_ROOT / "infrastructure" / "lambdas" / "sf-telegram-notifier" / "deploy.sh",
+        "expected_pattern": {"detail": {"stateMachineArn": ["x"]}},
+    }
+    with patch.object(
+        cd.subprocess,
+        "run",
+        return_value=_fake_run(254, "", "An error occurred (ResourceNotFoundException)"),
+    ):
+        findings = cd._check_rule(rule)
+    assert len(findings) == 1
+    assert "not found on AWS" in findings[0]
+
+
+def test_check_rule_reports_precomputed_error(cd):
+    rule = {"rule_name": "broken-rule", "source_file": Path("x"), "error": "boom"}
+    findings = cd._check_rule(rule)
+    assert findings == ["broken-rule: boom"]
+
+
+def test_check_rule_no_event_pattern_on_live_rule(cd):
+    rule = {
+        "rule_name": "alpha-engine-sf-status-change",
+        "source_file": _REPO_ROOT / "infrastructure" / "lambdas" / "sf-telegram-notifier" / "deploy.sh",
+        "expected_pattern": {"detail": {"stateMachineArn": ["x"]}},
+    }
+    live_response = {"Name": "alpha-engine-sf-status-change", "ScheduleExpression": "rate(1 day)"}
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live_response))):
+        findings = cd._check_rule(rule)
+    assert len(findings) == 1
+    assert "no EventPattern" in findings[0]
+
+
+# ── main() exit codes ───────────────────────────────────────────────────────
+
+
+def test_main_returns_zero_when_clean(cd, monkeypatch):
+    fake_rule = {
+        "rule_name": "fake-rule",
+        "source_file": _REPO_ROOT / "infrastructure" / "lambdas" / "sf-telegram-notifier" / "deploy.sh",
+        "expected_pattern": {"detail": {"stateMachineArn": ["x"]}},
+    }
+    monkeypatch.setattr(cd, "_discover_codified_rules", lambda: [fake_rule])
+    monkeypatch.setattr(cd, "_check_rule", lambda rule: [])
+    monkeypatch.setattr("sys.argv", ["check-drift.py"])
+    assert cd.main() == 0
+
+
+def test_main_returns_one_on_drift(cd, monkeypatch):
+    fake_rule = {
+        "rule_name": "fake-rule",
+        "source_file": _REPO_ROOT / "infrastructure" / "lambdas" / "sf-telegram-notifier" / "deploy.sh",
+        "expected_pattern": {"detail": {"stateMachineArn": ["x"]}},
+    }
+    monkeypatch.setattr(cd, "_discover_codified_rules", lambda: [fake_rule])
+    monkeypatch.setattr(cd, "_check_rule", lambda rule: ["fake-rule: drifted"])
+    monkeypatch.setattr("sys.argv", ["check-drift.py"])
+    assert cd.main() == 1
+
+
+def test_main_returns_zero_when_nothing_to_check(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_discover_codified_rules", lambda: [])
+    monkeypatch.setattr("sys.argv", ["check-drift.py"])
+    assert cd.main() == 0
+
+
+def test_main_rule_filter_no_match_returns_two(cd, monkeypatch, capsys):
+    monkeypatch.setattr(cd, "_discover_codified_rules", lambda: [])
+    monkeypatch.setattr("sys.argv", ["check-drift.py", "--rule", "does-not-exist"])
+    assert cd.main() == 2

--- a/tests/test_sf_logging_config_check_drift.py
+++ b/tests/test_sf_logging_config_check_drift.py
@@ -1,0 +1,259 @@
+"""Tests for infrastructure/step-functions/check-drift.py (alpha-engine-config#1464).
+
+Covers the SF LoggingConfiguration drift guard: discovery of the expected
+LoggingConfiguration per state machine (parsed from
+infrastructure/cloudformation/alpha-engine-orchestration.yaml +
+infrastructure/deploy-infrastructure.sh), and the compare-against-live logic
+(mocked `aws stepfunctions` CLI calls — no real AWS access).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "infrastructure" / "step-functions" / "check-drift.py"
+
+
+@pytest.fixture(scope="module")
+def cd():
+    spec = importlib.util.spec_from_file_location("sf_logging_check_drift", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_run(returncode=0, stdout="", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+# ── Discovery against the real repo state ───────────────────────────────────
+
+
+def test_discovers_all_four_orchestrated_state_machines(cd):
+    entries = cd._discover_expected_logging_configs()
+    names = {e["sf_name"] for e in entries}
+    assert names == {
+        "ne-weekly-freshness-pipeline",
+        "ne-preopen-trading-pipeline",
+        "ne-postclose-trading-pipeline",
+        "alpha-engine-groom-pipeline",
+    }
+
+
+def test_no_discovery_parse_errors(cd):
+    entries = cd._discover_expected_logging_configs()
+    errors = [e for e in entries if "error" in e]
+    assert not errors, f"unexpected parse errors: {errors}"
+
+
+def test_cfn_owned_sfs_expect_error_level_logging(cd):
+    entries = {e["sf_name"]: e for e in cd._discover_expected_logging_configs()}
+    weekly = entries["ne-weekly-freshness-pipeline"]
+    assert weekly["expected_level"] == "ERROR"
+    assert weekly["expected_include_execution_data"] is True
+    assert weekly["expected_log_group_name"] == "/aws/stepfunctions/ne-weekly-freshness-pipeline"
+
+    preopen = entries["ne-preopen-trading-pipeline"]
+    assert preopen["expected_level"] == "ERROR"
+    assert preopen["expected_include_execution_data"] is True
+    assert preopen["expected_log_group_name"] == "/aws/stepfunctions/ne-preopen-trading-pipeline"
+
+
+def test_eod_sf_expects_error_level_logging_from_deploy_script(cd):
+    entries = {e["sf_name"]: e for e in cd._discover_expected_logging_configs()}
+    eod = entries["ne-postclose-trading-pipeline"]
+    assert eod["expected_level"] == "ERROR"
+    assert eod["expected_include_execution_data"] is True
+    assert eod["expected_log_group_name"] == "/aws/stepfunctions/ne-postclose-trading-pipeline"
+
+
+def test_groom_sf_expects_no_logging(cd):
+    """deploy-infrastructure.sh's update_or_create call for groom omits the
+    logging arg on purpose — this guard's codified expectation must match
+    that, not silently assume logging is wanted everywhere."""
+    entries = {e["sf_name"]: e for e in cd._discover_expected_logging_configs()}
+    groom = entries["alpha-engine-groom-pipeline"]
+    assert groom["expected_level"] == "OFF"
+
+
+# ── _live_log_group_name ────────────────────────────────────────────────────
+
+
+def test_live_log_group_name_strips_arn_wrapper(cd):
+    logging_config = {
+        "level": "ERROR",
+        "destinations": [
+            {
+                "cloudWatchLogsLogGroup": {
+                    "logGroupArn": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/stepfunctions/ne-weekly-freshness-pipeline:*"
+                }
+            }
+        ],
+    }
+    assert cd._live_log_group_name(logging_config) == "/aws/stepfunctions/ne-weekly-freshness-pipeline"
+
+
+def test_live_log_group_name_none_when_no_destinations(cd):
+    assert cd._live_log_group_name({"level": "OFF"}) is None
+
+
+# ── _check_sf — mocked AWS CLI ───────────────────────────────────────────────
+
+
+def test_check_sf_no_drift_when_live_matches_codified(cd):
+    entry = {
+        "sf_name": "ne-weekly-freshness-pipeline",
+        "source_file": _REPO_ROOT / "infrastructure" / "cloudformation" / "alpha-engine-orchestration.yaml",
+        "expected_level": "ERROR",
+        "expected_include_execution_data": True,
+        "expected_log_group_name": "/aws/stepfunctions/ne-weekly-freshness-pipeline",
+    }
+    live = {
+        "loggingConfiguration": {
+            "level": "ERROR",
+            "includeExecutionData": True,
+            "destinations": [
+                {
+                    "cloudWatchLogsLogGroup": {
+                        "logGroupArn": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/stepfunctions/ne-weekly-freshness-pipeline:*"
+                    }
+                }
+            ],
+        }
+    }
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live))):
+        findings = cd._check_sf(entry)
+    assert findings == []
+
+
+def test_check_sf_detects_recreate_dropped_logging():
+    """The exact bug class config#1464 documents: CFN recreate drops
+    LoggingConfiguration entirely — live level reverts to OFF."""
+    spec = importlib.util.spec_from_file_location("sf_logging_check_drift2", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    entry = {
+        "sf_name": "ne-weekly-freshness-pipeline",
+        "source_file": _REPO_ROOT / "infrastructure" / "cloudformation" / "alpha-engine-orchestration.yaml",
+        "expected_level": "ERROR",
+        "expected_include_execution_data": True,
+        "expected_log_group_name": "/aws/stepfunctions/ne-weekly-freshness-pipeline",
+    }
+    live = {"loggingConfiguration": {"level": "OFF"}}
+    with patch.object(module.subprocess, "run", return_value=_fake_run(0, json.dumps(live))):
+        findings = module._check_sf(entry)
+    assert len(findings) == 1
+    assert "level drift" in findings[0]
+    assert "ERROR" in findings[0] and "OFF" in findings[0]
+
+
+def test_check_sf_detects_wrong_log_group(cd):
+    entry = {
+        "sf_name": "ne-weekly-freshness-pipeline",
+        "source_file": _REPO_ROOT / "infrastructure" / "cloudformation" / "alpha-engine-orchestration.yaml",
+        "expected_level": "ERROR",
+        "expected_include_execution_data": True,
+        "expected_log_group_name": "/aws/stepfunctions/ne-weekly-freshness-pipeline",
+    }
+    live = {
+        "loggingConfiguration": {
+            "level": "ERROR",
+            "includeExecutionData": True,
+            "destinations": [
+                {
+                    "cloudWatchLogsLogGroup": {
+                        "logGroupArn": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/stepfunctions/some-other-log-group:*"
+                    }
+                }
+            ],
+        }
+    }
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live))):
+        findings = cd._check_sf(entry)
+    assert len(findings) == 1
+    assert "log group drift" in findings[0]
+
+
+def test_check_sf_missing_state_machine_on_aws(cd):
+    entry = {
+        "sf_name": "ne-weekly-freshness-pipeline",
+        "source_file": _REPO_ROOT / "infrastructure" / "cloudformation" / "alpha-engine-orchestration.yaml",
+        "expected_level": "ERROR",
+        "expected_include_execution_data": True,
+        "expected_log_group_name": "/aws/stepfunctions/ne-weekly-freshness-pipeline",
+    }
+    with patch.object(
+        cd.subprocess,
+        "run",
+        return_value=_fake_run(255, "", "StateMachineDoesNotExist"),
+    ):
+        findings = cd._check_sf(entry)
+    assert len(findings) == 1
+    assert "not found on AWS" in findings[0]
+
+
+def test_check_sf_groom_no_drift_when_live_is_off(cd):
+    entry = {
+        "sf_name": "alpha-engine-groom-pipeline",
+        "source_file": _REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh",
+        "expected_level": "OFF",
+        "expected_include_execution_data": None,
+        "expected_log_group_name": None,
+    }
+    live = {}  # describe-state-machine omits loggingConfiguration entirely when disabled
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live))):
+        findings = cd._check_sf(entry)
+    assert findings == []
+
+
+def test_check_sf_reports_precomputed_error(cd):
+    entry = {"sf_name": "broken-sf", "source_file": Path("x"), "error": "boom"}
+    findings = cd._check_sf(entry)
+    assert findings == ["broken-sf: boom"]
+
+
+# ── main() exit codes ───────────────────────────────────────────────────────
+
+
+def test_main_returns_zero_when_clean(cd, monkeypatch):
+    fake_entry = {
+        "sf_name": "fake-sf",
+        "source_file": _REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh",
+        "expected_level": "OFF",
+        "expected_include_execution_data": None,
+        "expected_log_group_name": None,
+    }
+    monkeypatch.setattr(cd, "_discover_expected_logging_configs", lambda: [fake_entry])
+    monkeypatch.setattr(cd, "_check_sf", lambda entry: [])
+    monkeypatch.setattr("sys.argv", ["check-drift.py"])
+    assert cd.main() == 0
+
+
+def test_main_returns_one_on_drift(cd, monkeypatch):
+    fake_entry = {
+        "sf_name": "fake-sf",
+        "source_file": _REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh",
+        "expected_level": "OFF",
+        "expected_include_execution_data": None,
+        "expected_log_group_name": None,
+    }
+    monkeypatch.setattr(cd, "_discover_expected_logging_configs", lambda: [fake_entry])
+    monkeypatch.setattr(cd, "_check_sf", lambda entry: ["fake-sf: drifted"])
+    monkeypatch.setattr("sys.argv", ["check-drift.py"])
+    assert cd.main() == 1
+
+
+def test_main_name_filter_no_match_returns_two(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_discover_expected_logging_configs", lambda: [])
+    monkeypatch.setattr("sys.argv", ["check-drift.py", "--name", "does-not-exist"])
+    assert cd.main() == 2


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

Refs #1464

## What this adds

Two of the four drift-guard axes from the config#1464 EPIC (EventBridge SF-ARN drift, SF LoggingConfiguration drift). The other two (IAM policy drift, consumer-code `RETIRED_STATE_MACHINE_NAMES` denylist) already shipped.

- **`infrastructure/eventbridge/check-drift.py`** — discovers every script-managed EventBridge rule's codified `EVENT_PATTERN` heredoc (glob + regex over `infrastructure/lambdas/*/deploy.sh`, no hardcoded rule table to keep in sync) and diffs the `stateMachineArn` set against `aws events describe-rule`. This is the exact drift class that bit `alpha-engine-sf-status-change` (sf-telegram-notifier), `alpha-engine-friday-shell-run-report`, and `alpha-engine-saturday-succeeded-groom` (saturday-sf-success-groom-dispatcher) after the 2026-06-29 `ne-*` rename (config#1381) — those rules are managed outside CloudFormation and only reconcile when an operator manually re-runs `deploy.sh`. Also picks up `alpha-engine-eod-success-friday-shell-trigger` and `alpha-engine-saturday-sf-watch-failed`, whose deploy scripts wire EventBridge only inside `--bootstrap` (never re-reconciled on a plain deploy) — same risk class, same fix.

- **`infrastructure/step-functions/check-drift.py`** — parses the codified `LoggingConfiguration` for all four orchestrated state machines (two from `infrastructure/cloudformation/alpha-engine-orchestration.yaml`, two — EOD + groom — from `infrastructure/deploy-infrastructure.sh`) and diffs against `aws stepfunctions describe-state-machine`. Catches the "survives a plain deploy, dropped on CFN recreate" failure mode called out in the EPIC — this is what silently broke the L274 MutexConflict CloudWatch metric-filter chain (config#729) after the same rename, until a later PR happened to restore it.

Both scripts mirror `infrastructure/iam/check-drift.py`'s CLI/exit-code contract (`--rule`/`--name` filter, plain-text diff findings, exit 0/1/2) and ship with mocked-AWS-CLI pytest suites (`tests/test_eventbridge_check_drift.py`, `tests/test_sf_logging_config_check_drift.py`) — no real AWS access needed to run them. READMEs in each new directory explain scope + source of truth.

## Investigation notes

- Confirmed via read-only clone that `crucible-executor` does **not** own the SF definitions, EventBridge rules, or LoggingConfiguration for this system — it only holds IAM policies granting SF *read* access to the executor/dashboard roles. All of that is codified in `nousergon-data` (`infrastructure/cloudformation/alpha-engine-orchestration.yaml` + `infrastructure/deploy-infrastructure.sh` + the per-Lambda `deploy.sh` scripts), so both guards live here.
- The two CFN-managed rules (`SaturdayTrigger`/`WeekdayTrigger`) are deliberately **out of scope** for the EventBridge guard — `deploy-infrastructure.yml` already reconciles them on every push to `main`, so they can't silently drift the way the script-managed rules did. The LoggingConfiguration guard *does* cover their two state machines, since a CFN recreate can drop logging without touching the rule or definition at all.
- `saturday-sf-watch-dispatcher`'s codified EventPattern lists two legacy names (`alpha-engine-eod-pipeline`, `alpha-engine-groom-dispatch`) alongside the current `ne-*` names — confirmed via `index.py`'s `PIPELINES` registry this is an intentional transitional dual-registration (config#1408, flagged for re-exam today, 2026-07-03), not drift. The guard diffs live-vs-codified, not live-vs-"canonical name", so it doesn't misfire on this.
- The `ARTIFACT_REGISTRY.yaml` / `validate_artifact_registry.py` consumer-code guard mentioned in the EPIC background actually lives in `alpha-engine-config`, not `nousergon-data` — noted for accuracy, not touched here.

## Deferred / needs manual follow-up

**1. Workflow YAML — needs manual apply (PAT lacks `workflow` scope, tracked: config#1372).** This runner's PAT can't push `.github/workflows/*.yml` changes (403). The intended workflow, mirroring `iam-drift-check.yml`'s structure/triggers/OIDC plumbing exactly, is below — please paste this into `.github/workflows/sf-drift-check.yml` and commit directly:

```yaml
name: SF Drift Check

# Catches two drift classes the config#1464 EPIC identified after the
# 2026-06-29 ne-* Step Function rename (config#1381) silently orphaned live
# infra:
#
#   1. EventBridge SF-ARN drift — a script-managed rule's EventPattern
#      still references a stale SF ARN/name (infrastructure/eventbridge/check-drift.py).
#   2. SF LoggingConfiguration drift — a state machine's live logging
#      config no longer matches what's codified, e.g. because a CFN
#      recreate silently dropped it (infrastructure/step-functions/check-drift.py).
#
# The two CFN-managed SFs + their cron rules are NOT covered by these
# checks' live-vs-codified gap window the way the script-managed ones are
# (deploy-infrastructure.yml reconciles them on every push to main) — but
# the LoggingConfiguration guard still checks them, since a recreate can
# drop logging without changing the definition/rule at all.
#
# Triggers:
#   - Every PR that touches the source-of-truth paths for either guard
#   - Daily at 09:45 UTC (15 min after the IAM drift check) — catches
#     out-of-band manual AWS edits with no matching PR
#   - Manual via workflow_dispatch
#
# AWS auth: OIDC -> github-actions-iam-drift-check role (same role as
# iam-drift-check.yml; codified in crucible-executor). That role's policy
# needs `events:DescribeRule` + `states:DescribeStateMachine` added before
# this workflow can run for real — see the config#1464 PR description for
# the exact IAM diff.

on:
  pull_request:
    paths:
      - 'infrastructure/eventbridge/**'
      - 'infrastructure/step-functions/**'
      - 'infrastructure/lambdas/*/deploy.sh'
      - 'infrastructure/cloudformation/alpha-engine-orchestration.yaml'
      - 'infrastructure/deploy-infrastructure.sh'
      - '.github/workflows/sf-drift-check.yml'
  schedule:
    - cron: '45 9 * * *'
  workflow_dispatch:

permissions:
  id-token: write   # required for OIDC
  contents: read

jobs:
  drift-check:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - name: Configure AWS credentials via OIDC
        uses: aws-actions/configure-aws-credentials@v4
        with:
          role-to-assume: arn:aws:iam::711398986525:role/github-actions-iam-drift-check
          aws-region: us-east-1

      - name: Run EventBridge SF-ARN drift check
        run: python3 infrastructure/eventbridge/check-drift.py

      - name: Run SF LoggingConfiguration drift check
        run: python3 infrastructure/step-functions/check-drift.py
```

**2. OIDC role IAM widening — needs manual apply in `crucible-executor`.** `github-actions-iam-drift-check`'s policy (`crucible-executor/infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json`) currently only grants `iam:*` read actions. The workflow above will fail on every step until this statement is added and `apply.sh` is re-run for that role (I did not push this myself — `crucible-executor` was read-only investigation scope for this task):

```json
{
    "Sid": "ReadEventBridgeAndSFDriftSurfaces",
    "Effect": "Allow",
    "Action": [
        "events:DescribeRule",
        "states:DescribeStateMachine"
    ],
    "Resource": [
        "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-sf-status-change",
        "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-friday-shell-run-report",
        "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-saturday-succeeded-groom",
        "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-eod-success-friday-shell-trigger",
        "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-saturday-sf-watch-failed",
        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-groom-pipeline"
    ]
}
```

## Test plan

- [x] `pytest tests/test_eventbridge_check_drift.py tests/test_sf_logging_config_check_drift.py -q` — 30 passed
- [x] `pytest tests/ -q` (full suite) — 2600 passed, 12 skipped, 0 failed
- [x] Both scripts' discovery functions run against this repo's real source files and correctly find all 5 EventBridge rules / all 4 state machines, with values matching manual inspection of the source
- [x] Both scripts' `--help` and error paths (bad creds, missing rule) exercised manually
- [ ] End-to-end against real AWS — blocked on the two manual-apply items above (OIDC role permissions + workflow file)
