### PR TITLE
[P1/mid] fix(infra): migrate spot launcher to krepis CLI (config#1649)

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -23,7 +23,9 @@
 # **2026-05-27 — SSH/SCP → SSM transport migration (ROADMAP L342 PR 2).**
 # Communication with the spot is now via `aws ssm send-command`
 # (IAM-authenticated, CloudTrail-audited) wrapped at the lib chokepoint
-# `python -m nousergon_lib.ssm_dispatcher run`. No port-22 inbound on
+# `python -m krepis.ssm_dispatcher run` (invoked directly via krepis per
+# config#1649 — the nousergon_lib re-export shim is guard-less under
+# `python -m` on lib >=0.81.0 and silently no-ops). No port-22 inbound on
 # the spot SG; no ssh / scp / ssh-keyscan. The private config.yaml is
 # staged to a temporary S3 prefix the dispatcher controls and pulled
 # down by the spot via its existing `alpha-engine-executor-profile` IAM
@@ -219,7 +221,7 @@ echo "  Run mode      : $RUN_MODE"
 echo "  Spot attempt  : $SPOT_ATTEMPT/$MAX_SPOT_ATTEMPTS  (relaunch on confirmed spot interruption)"
 echo "  Preflight-only: $PREFLIGHT_ONLY  (1 = boot + preflight + exit 0, NO fetch/write)"
 echo "  S3 bucket     : $S3_BUCKET"
-echo "  Transport     : SSM via lib chokepoint (python -m nousergon_lib.ssm_dispatcher)"
+echo "  Transport     : SSM via lib chokepoint (python -m krepis.ssm_dispatcher)"
 echo ""
 
 # ── Preflight ───────────────────────────────────────────────────────────────
@@ -340,7 +342,7 @@ trap on_exit EXIT
 
 echo "==> Requesting spot instance (lib CLI rotation: types=[$INSTANCE_TYPES], subnets=[$SUBNETS])..."
 
-INSTANCE_ID=$("$LIB_PYTHON" -m nousergon_lib.ec2_spot launch \
+INSTANCE_ID=$("$LIB_PYTHON" -m krepis.ec2_spot launch \
     --types "$INSTANCE_TYPES" \
     --subnets "$SUBNETS" \
     --image-id "$AMI_ID" \
@@ -357,7 +359,8 @@ if [ "$ec2_spot_rc" -ne 0 ] || [ -z "$INSTANCE_ID" ]; then
     if [ "$ec2_spot_rc" -eq 0 ]; then
       # rc=0 with an EMPTY instance id = the launch layer produced nothing
       # (e.g. the guard-less `-m nousergon_lib.ec2_spot` shim no-op,
-      # config#1646). `${ec2_spot_rc:-1}` defaults only when UNSET — a
+      # config#1646 — closed at this launcher's transport by the krepis
+      # migration, config#1649). `${ec2_spot_rc:-1}` defaults only when UNSET — a
       # captured 0 passed through and the SF recorded a silent success
       # on 2026-07-03. An empty id must always fail loud.
       echo "ERROR: ec2_spot launch exited 0 without an instance id — failing loud (config#1646)" >&2
@@ -409,9 +412,12 @@ done
 # ── SSM dispatch primitive (lib chokepoint) ──────────────────────────────────
 # run_ssm "<description>" [timeout_seconds] <<HEREDOC ... HEREDOC
 #
-# Thin wrapper around `python -m nousergon_lib.ssm_dispatcher run` (lib
-# v0.35.0+). The lib base64-wraps the script body (read from stdin via the
-# `--script-stdin` flag) for AWS-RunShellScript transport, polls
+# Thin wrapper around `python -m krepis.ssm_dispatcher run` (lib
+# v0.35.0+ as nousergon_lib.ssm_dispatcher; invoked directly via krepis
+# per config#1649 — the nousergon_lib re-export shim is guard-less under
+# `python -m` on lib >=0.81.0 and silently no-ops). The lib base64-wraps
+# the script body (read from stdin via the `--script-stdin` flag) for
+# AWS-RunShellScript transport, polls
 # get-command-invocation, streams StandardOutputContent delta to this
 # process's stdout, and propagates the inner script's exit status (0 on
 # Success; 1 on Failed/TimedOut/Cancelled). Full stdout/stderr beyond
@@ -446,7 +452,7 @@ done
 # (substrate is failure-only).
 run_ssm() {
     local description="$1" timeout_s="${2:-3600}"
-    "$LIB_PYTHON" -m nousergon_lib.ssm_dispatcher run \
+    "$LIB_PYTHON" -m krepis.ssm_dispatcher run \
         --instance-id "$INSTANCE_ID" \
         --description "data-weekly: $description" \
         --timeout "$timeout_s" \

--- a/infrastructure/spot_drift_detection.sh
+++ b/infrastructure/spot_drift_detection.sh
@@ -14,8 +14,11 @@
 # spot since drift depends on predictor weights produced by that step.
 #
 # Transport: dispatcher→spot communication is via `aws ssm send-command`
-# (routed through the lib chokepoint `python -m nousergon_lib.ssm_dispatcher`,
-# lib v0.35.0+) — NO ssh / scp / ssh-keyscan and NO port-22 inbound
+# (routed through the lib chokepoint `python -m krepis.ssm_dispatcher`,
+# lib v0.35.0+ as nousergon_lib.ssm_dispatcher; invoked directly via
+# krepis per config#1649 — the nousergon_lib re-export shim is guard-less
+# under `python -m` on lib >=0.81.0 and silently no-ops) — NO ssh / scp /
+# ssh-keyscan and NO port-22 inbound
 # dependency. This is the SSH/SCP→SSM migration of config#893's drift
 # sibling, mirroring spot_data_weekly.sh #330 / spot_backtest.sh #405 /
 # spot_train.sh #168 1:1. The spot pulls everything over HTTPS git-clone
@@ -156,7 +159,7 @@ trap cleanup EXIT
 # directly from git+https with no auth required.
 
 echo "==> Requesting spot instance (lib CLI rotation: types=[$INSTANCE_TYPES], subnets=[$SUBNETS])..."
-INSTANCE_ID=$("$LIB_PYTHON" -m nousergon_lib.ec2_spot launch \
+INSTANCE_ID=$("$LIB_PYTHON" -m krepis.ec2_spot launch \
     --types "$INSTANCE_TYPES" \
     --subnets "$SUBNETS" \
     --image-id "$AMI_ID" \
@@ -173,7 +176,8 @@ if [ "$ec2_spot_rc" -ne 0 ] || [ -z "$INSTANCE_ID" ]; then
     if [ "$ec2_spot_rc" -eq 0 ]; then
       # rc=0 with an EMPTY instance id = the launch layer produced nothing
       # (e.g. the guard-less `-m nousergon_lib.ec2_spot` shim no-op,
-      # config#1646). `${ec2_spot_rc:-1}` defaults only when UNSET — a
+      # config#1646 — closed at this launcher's transport by the krepis
+      # migration, config#1649). `${ec2_spot_rc:-1}` defaults only when UNSET — a
       # captured 0 passed through and the SF recorded a silent success
       # on 2026-07-03. An empty id must always fail loud.
       echo "ERROR: ec2_spot launch exited 0 without an instance id — failing loud (config#1646)" >&2
@@ -219,9 +223,12 @@ done
 # ── SSM dispatch primitive (lib chokepoint) ──────────────────────────────────
 # run_ssm "<description>" [timeout_seconds] <<HEREDOC ... HEREDOC
 #
-# Thin wrapper around `python -m nousergon_lib.ssm_dispatcher run` (lib
-# v0.35.0+). The lib base64-wraps the script body (read from stdin via the
-# `--script-stdin` flag) for AWS-RunShellScript transport, polls
+# Thin wrapper around `python -m krepis.ssm_dispatcher run` (lib
+# v0.35.0+ as nousergon_lib.ssm_dispatcher; invoked directly via krepis
+# per config#1649 — the nousergon_lib re-export shim is guard-less under
+# `python -m` on lib >=0.81.0 and silently no-ops). The lib base64-wraps
+# the script body (read from stdin via the `--script-stdin` flag) for
+# AWS-RunShellScript transport, polls
 # get-command-invocation, streams StandardOutputContent delta to this
 # process's stdout, and propagates the inner script's exit status (0 on
 # Success; 1 on Failed/TimedOut/Cancelled). Full stdout/stderr beyond
@@ -241,7 +248,7 @@ done
 # exit code is preserved. No-op on Success (substrate is failure-only).
 run_ssm() {
     local description="$1" timeout_s="${2:-3600}"
-    "$LIB_PYTHON" -m nousergon_lib.ssm_dispatcher run \
+    "$LIB_PYTHON" -m krepis.ssm_dispatcher run \
         --instance-id "$INSTANCE_ID" \
         --description "drift-detection: $description" \
         --timeout "$timeout_s" \

--- a/tests/test_spot_data_weekly_interruption_retry.py
+++ b/tests/test_spot_data_weekly_interruption_retry.py
@@ -67,7 +67,7 @@ class TestTrapInstalledBeforeLaunch:
         covers an all-combinations-exhausted launch (rc 64), not only a
         mid-run reclamation."""
         trap_at = text.index("trap on_exit EXIT")
-        launch_at = text.index("nousergon_lib.ec2_spot launch")
+        launch_at = text.index("krepis.ec2_spot launch")
         assert trap_at < launch_at, (
             "trap on_exit EXIT must be installed before the spot launch."
         )

--- a/tests/test_spot_data_weekly_ssm_transport.py
+++ b/tests/test_spot_data_weekly_ssm_transport.py
@@ -87,7 +87,7 @@ def test_no_top_level_ssh_invocation():
         f"spot_data_weekly.sh:\n"
         + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
         + "\n\nThe 2026-05-27 SSH→SSM migration moved all dispatch to "
-        "``python -m nousergon_lib.ssm_dispatcher``. Re-introducing "
+        "``python -m krepis.ssm_dispatcher``. Re-introducing "
         "ssh re-opens the port-22 dependency the migration retired. "
         "If the change is deliberate, update this test + ROADMAP L342 "
         "PR 5 (the planned port-22 SG revoke)."
@@ -139,18 +139,33 @@ def test_no_ssh_keyscan_invocation():
 
 def test_uses_lib_ssm_dispatcher_chokepoint():
     """The migration's load-bearing surface: ``python -m
-    nousergon_lib.ssm_dispatcher`` MUST appear in the script. Pinning
+    krepis.ssm_dispatcher`` MUST appear in the script. Pinning
     this catches a regression where a future PR replaces the lib CLI
     with an inline ``aws ssm send-command`` bash helper (the
     alpha-engine-predictor #168 pre-lift pattern that L342 explicitly
     lifts to the lib chokepoint)."""
     body = _SCRIPT.read_text()
-    assert "nousergon_lib.ssm_dispatcher" in body, (
+    assert "krepis.ssm_dispatcher" in body, (
         "spot_data_weekly.sh does not reference "
-        "nousergon_lib.ssm_dispatcher. The 2026-05-27 migration uses "
+        "krepis.ssm_dispatcher. The 2026-05-27 migration uses "
         "the lib chokepoint as the SSM dispatch path; re-introducing a "
         "raw `aws ssm send-command` bash helper would undo the lift to "
         "``alpha-engine-lib`` v0.35.0."
+    )
+    offenders = [
+        (n, line)
+        for n, line in _script_lines()
+        if "-m nousergon_lib." in line
+    ]
+    assert not offenders, (
+        f"Found {len(offenders)} non-comment 'python -m nousergon_lib.<mod>' "
+        f"invocation(s) in spot_data_weekly.sh:\n"
+        + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+        + "\n\nOn lib >=0.81.0 that path is a guard-less re-export shim: "
+        "under `python -m` (runpy) it exits 0 silently WITHOUT executing "
+        "the inner dispatch (config#1646 bug class). Invoke `-m "
+        "krepis.ssm_dispatcher` / `-m krepis.ec2_spot` directly "
+        "(config#1649)."
     )
 
 
@@ -206,7 +221,7 @@ def test_no_inline_aws_ssm_send_command():
         f"Found {len(offenders)} non-comment ``aws ssm send-command`` "
         f"invocations in spot_data_weekly.sh:\n"
         + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
-        + "\n\nRoute through ``python -m nousergon_lib.ssm_dispatcher "
+        + "\n\nRoute through ``python -m krepis.ssm_dispatcher "
         "run`` instead — that's the chokepoint v0.35.0 lifted."
     )
 

--- a/tests/test_spot_drift_detection_ssm_transport.py
+++ b/tests/test_spot_drift_detection_ssm_transport.py
@@ -119,27 +119,42 @@ def test_no_ssh_keyscan_invocation():
 
 def test_uses_lib_ssm_dispatcher_chokepoint():
     """The migration's load-bearing surface: ``python -m
-    nousergon_lib.ssm_dispatcher`` MUST appear in the script. Pinning
+    krepis.ssm_dispatcher`` MUST appear in the script. Pinning
     this catches a regression where a future PR replaces the lib CLI
     with an inline ``aws ssm send-command`` bash helper (the predictor
     #168 pre-lift pattern that L342 explicitly lifts to the lib
     chokepoint)."""
     body = _SCRIPT.read_text()
-    assert "nousergon_lib.ssm_dispatcher" in body, (
+    assert "krepis.ssm_dispatcher" in body, (
         "spot_drift_detection.sh does not reference "
-        "nousergon_lib.ssm_dispatcher. The config#893 migration uses the "
+        "krepis.ssm_dispatcher. The config#893 migration uses the "
         "lib chokepoint as the SSM dispatch path."
     )
 
 
 def test_uses_lib_ec2_spot_launcher():
-    """Launch goes through ``python -m nousergon_lib.ec2_spot`` (the same
+    """Launch goes through ``python -m krepis.ec2_spot`` (the same
     capacity-rotating launcher the data/backtest siblings use), not a raw
     ``aws ec2 run-instances`` with a hard ``--key-name`` SSH dependency."""
     body = _SCRIPT.read_text()
-    assert "nousergon_lib.ec2_spot" in body, (
-        "spot_drift_detection.sh does not launch via nousergon_lib.ec2_spot; "
+    assert "krepis.ec2_spot" in body, (
+        "spot_drift_detection.sh does not launch via krepis.ec2_spot; "
         "the migration routes launch through the lib's capacity-rotating CLI."
+    )
+    offenders = [
+        (n, line)
+        for n, line in _script_lines()
+        if "-m nousergon_lib." in line
+    ]
+    assert not offenders, (
+        f"Found {len(offenders)} non-comment 'python -m nousergon_lib.<mod>' "
+        f"invocation(s) in spot_drift_detection.sh:\n"
+        + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+        + "\n\nOn lib >=0.81.0 that path is a guard-less re-export shim: "
+        "under `python -m` (runpy) it exits 0 silently WITHOUT executing "
+        "the inner dispatch/launch (config#1646 bug class). Invoke `-m "
+        "krepis.ssm_dispatcher` / `-m krepis.ec2_spot` directly "
+        "(config#1649)."
     )
 
 
@@ -182,7 +197,7 @@ def test_no_inline_aws_ssm_send_command():
         f"Found {len(offenders)} non-comment ``aws ssm send-command`` "
         f"invocations in spot_drift_detection.sh:\n"
         + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
-        + "\n\nRoute through ``python -m nousergon_lib.ssm_dispatcher run`` "
+        + "\n\nRoute through ``python -m krepis.ssm_dispatcher run`` "
         "instead — that's the chokepoint v0.35.0 lifted."
     )
 

--- a/tests/test_spot_launchers_krepis_cli_executes.py
+++ b/tests/test_spot_launchers_krepis_cli_executes.py
@@ -1,0 +1,186 @@
+"""The data-repo spot launchers' ``-m krepis.{ec2_spot,ssm_dispatcher}``
+CLI callsites must EXECUTE, not merely import (config#1649).
+
+Bug class this guards (config#1646, 2026-07-03): nousergon-lib 0.81.0
+turned ``nousergon_lib.ec2_spot`` / ``nousergon_lib.ssm_dispatcher`` /
+``nousergon_lib.ssm_log_capture`` into guard-less re-export shims
+(``import krepis.<mod> as _mod; sys.modules[__name__] = _mod`` with no
+``if __name__ == "__main__":`` block). Under ``python -m`` (runpy) such a
+shim imports, rebinds, falls off the end — **exit 0, nothing runs, no
+output**. The 2026-05-27 wrapper-layer fix (this repo's #602) moved the SF's
+``ssm_log_capture`` caller to the canonical ``krepis`` path (see
+``test_ssm_log_capture_wrapper_executes.py``); this file is the
+LAUNCHER-layer instance of the exact same class for
+``infrastructure/spot_data_weekly.sh`` and
+``infrastructure/spot_drift_detection.sh`` (config#1649).
+
+String-pinning wiring tests (``test_spot_data_weekly_ssm_transport.py``,
+``test_spot_drift_detection_ssm_transport.py``) prove the launcher's
+source text NAMES the krepis module — they provably cannot prove the
+module is *executable* under ``python -m`` (importable-but-not-executable
+is exactly how the 2026-07-03 incident hid). This file mirrors
+``test_ssm_log_capture_wrapper_executes.py``'s chokepoint-extraction
+pattern: it collects the exact ``ec2_spot``/``ssm_dispatcher`` module
+paths BOTH launchers invoke and proves each one's CLI actually parses
+argv and dispatches — entirely offline (no AWS calls): a guard-less shim
+prints NOTHING and exits 0 for ``--help`` or a bare invocation; a real,
+executing CLI prints usage/errors and exits non-zero where argparse
+requires it. That divergence is the structural guard.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = [
+    _REPO_ROOT / "infrastructure" / "spot_data_weekly.sh",
+    _REPO_ROOT / "infrastructure" / "spot_drift_detection.sh",
+]
+
+# `python -m <module>.{ec2_spot,ssm_dispatcher}` as invoked by a launcher
+# (LIB_PYTHON is a runtime path, not part of the module name).
+_MODULE_RE = re.compile(r"-m\s+([\w.]+\.(?:ec2_spot|ssm_dispatcher))\b")
+
+
+def _invoked_modules() -> set[str]:
+    """Every ec2_spot / ssm_dispatcher module path either launcher
+    ACTUALLY invokes on a non-comment line (comment-only mentions — e.g.
+    historical prose citing the old `-m nousergon_lib.ec2_spot` shim
+    no-op, config#1646 — must not be mistaken for a real callsite)."""
+    modules: set[str] = set()
+    for script in _SCRIPTS:
+        if not script.exists():
+            continue
+        for raw in script.read_text().splitlines():
+            if raw.strip().startswith("#"):
+                continue
+            modules.update(_MODULE_RE.findall(raw))
+    return modules
+
+
+def test_launcher_scripts_exist():
+    """Guards against accidental script deletion. Without the scripts,
+    the extraction + executability assertions below silently no-op."""
+    for script in _SCRIPTS:
+        assert script.exists(), (
+            f"{script.relative_to(_REPO_ROOT)} missing — CI cannot "
+            "validate its krepis CLI executability invariant without it."
+        )
+
+
+def test_launchers_reference_at_least_one_krepis_module():
+    """Sanity: extraction must find both chokepoints across the two
+    launchers — an empty/partial set would make the executability tests
+    below vacuously pass (the silent-no-op of tests)."""
+    modules = _invoked_modules()
+    assert modules, (
+        "No `-m <module>.{ec2_spot,ssm_dispatcher}` invocations found in "
+        "spot_data_weekly.sh or spot_drift_detection.sh — either the "
+        "launchers no longer use the lib CLI (update this test's "
+        "extraction) or the regex went stale."
+    )
+    assert "krepis.ec2_spot" in modules, (
+        "Neither launcher invokes `-m krepis.ec2_spot` — the config#1649 "
+        "migration off the guard-less nousergon_lib re-export shim "
+        "appears to have regressed."
+    )
+    assert "krepis.ssm_dispatcher" in modules, (
+        "Neither launcher invokes `-m krepis.ssm_dispatcher` — the "
+        "config#1649 migration off the guard-less nousergon_lib "
+        "re-export shim appears to have regressed."
+    )
+
+
+def test_launchers_do_not_invoke_nousergon_lib_cli():
+    """Regression guard: neither launcher may fall back to `-m
+    nousergon_lib.{ec2_spot,ssm_dispatcher}`. On lib >=0.81.0 those paths
+    are guard-less re-export shims — silent exit-0 no-ops under `python
+    -m` (the exact 2026-07-03 failure mode, one layer up)."""
+    pattern = re.compile(r"-m\s+nousergon_lib\.(?:ec2_spot|ssm_dispatcher)\b")
+    for script in _SCRIPTS:
+        if not script.exists():
+            continue
+        offenders = [
+            (n, line)
+            for n, line in enumerate(script.read_text().splitlines(), start=1)
+            if not line.strip().startswith("#") and pattern.search(line)
+        ]
+        assert not offenders, (
+            f"Found {len(offenders)} non-comment `-m nousergon_lib."
+            f"{{ec2_spot,ssm_dispatcher}}` invocation(s) in "
+            f"{script.relative_to(_REPO_ROOT)}:\n"
+            + "\n".join(f"  line {n}: {line.strip()}" for n, line in offenders)
+            + "\n\nRoute through the krepis CLI directly (config#1649) — "
+            "the nousergon_lib re-export shim is guard-less on lib "
+            ">=0.81.0."
+        )
+
+
+@pytest.mark.parametrize("module", sorted(_invoked_modules()))
+def test_krepis_module_help_executes(module):
+    """`python -m <module> --help` must print real usage text and exit 0.
+
+    A guard-less re-export shim (`sys.modules[__name__] = _mod`, no
+    `__main__` guard) never reaches argparse under runpy: it exits 0 with
+    EMPTY stdout regardless of the argv given, including `--help`. A real
+    CLI's `--help` prints a non-empty `usage:` block. This assertion is
+    the offline-safe analog of the sentinel-execution proof in
+    `test_ssm_log_capture_wrapper_executes.py` — no AWS credentials or
+    network access required.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"`python -m {module} --help` exited {proc.returncode} "
+        f"(stderr tail={proc.stderr[-300:]!r})"
+    )
+    assert "usage:" in proc.stdout.lower(), (
+        f"`python -m {module} --help` produced no usage text "
+        f"(stdout={proc.stdout!r}). A guard-less re-export shim (the "
+        "config#1646 bug class) imports, rebinds sys.modules, and falls "
+        "off the end WITHOUT ever reaching argparse — silent exit 0 with "
+        "empty stdout for any argv, including --help."
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_invoked_modules()))
+def test_krepis_module_bare_invocation_fails_loud(module):
+    """`python -m <module>` with NO subcommand must exit non-zero with a
+    stderr error naming the missing required subcommand.
+
+    Both `krepis.ec2_spot` and `krepis.ssm_dispatcher` declare their
+    subparsers with `required=True`; a bare invocation hits that argparse
+    guard and exits 2. A guard-less shim exits 0 with empty stderr for
+    ANY argv — this is the same silent-no-op signature `--help` catches,
+    proved from the opposite (missing-required-arg) direction.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", module],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode != 0, (
+        f"`python -m {module}` (no subcommand) exited 0 — a real CLI with "
+        "a required subparser must fail loud on a missing subcommand. "
+        "Exit 0 here is the guard-less re-export shim's silent no-op "
+        "signature (config#1646 bug class)."
+    )
+    assert proc.stderr.strip(), (
+        f"`python -m {module}` (no subcommand) exited "
+        f"{proc.returncode} but printed nothing to stderr — expected an "
+        "argparse 'the following arguments are required' error. Empty "
+        "output on a non-zero exit is still consistent with a shim that "
+        "crashed for an unrelated reason; this asserts the CLI actually "
+        "ran its argument parser."
+    )


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

Refs #1649

## Deliverable A of alpha-engine-config#1649

nousergon-lib 0.81.0's `-m nousergon_lib.*` CLI submodules are guard-less
re-export shims (`import krepis.<mod> as _mod; sys.modules[__name__] = _mod`
with no `if __name__ == "__main__":` block). Under `python -m` (runpy) such
a shim imports, rebinds, and falls off the end — exit 0, nothing runs, no
output. This repo's SF wrapper layer already fixed the exact same class
(`ssm_log_capture` → krepis, #602); this PR closes the LAUNCHER-layer
instance for the two data-repo spot scripts.

## Change

- `infrastructure/spot_data_weekly.sh`, `infrastructure/spot_drift_detection.sh`:
  migrate all 4 launcher-layer callsites (`-m nousergon_lib.ec2_spot launch`
  x2, `-m nousergon_lib.ssm_dispatcher run` x2) to the `krepis` equivalents.
  krepis 0.5.0+ delegates correctly on-box (verified live) and is already a
  direct `requirements.txt` dependency (`krepis>=0.6.0`).
- `tests/test_spot_data_weekly_interruption_retry.py`,
  `tests/test_spot_data_weekly_ssm_transport.py`,
  `tests/test_spot_drift_detection_ssm_transport.py`: update the
  string-pinned wiring assertions to the krepis path and add explicit
  `-m nousergon_lib.` regression guards.
- `tests/test_spot_launchers_krepis_cli_executes.py` (new): an
  execute-the-CLI guard mirroring `tests/test_ssm_log_capture_wrapper_executes.py`
  (#602). It extracts the exact `ec2_spot`/`ssm_dispatcher` module paths
  both launchers invoke and proves each one's CLI actually reaches
  argparse — `--help` prints real usage text and a bare invocation fails
  loud on the missing required subcommand — entirely offline (no AWS
  credentials/network needed). A guard-less shim prints nothing and
  exits 0 for either case.

## Scope note

Per config#1649, only the two launcher scripts + their tests are touched
— the Saturday SF itself is untouched (already krepis per #602). The
launchers' empty-instance-id fail-loud fix (#604) is already merged on
`main`; this branch is based on current `main`.

**Fleet-wide grep of this repo** for other `-m nousergon_lib.` subprocess
callsites found one additional hit OUT OF SCOPE for this PR:
`infrastructure/step_function.json` and `infrastructure/step_function_eod.json`
each embed `python -m nousergon_lib.transparency --cadence {weekly,daily}
--alert` directly in the SF definition (pinned by
`test_sf_substrate_check_wiring.py` / `test_sf_eod_substrate_check_wiring.py`).
Per config#1649's explicit "DO NOT touch the SF" scope, I have NOT touched
this — flagging it here for Brian/a follow-up so it isn't missed before
the issue's fleet-wide-grep-clean closes-when criterion is declared met.
`infrastructure/deploy.sh` and the changelog-mirror Lambda's `deploy.sh`
already use `krepis.alerts` (config#1339/#1545).

## Tests

Full suite: **2576 passed, 12 skipped**, 1 pre-existing unrelated failure
(`test_load_config_experiment_package.py::test_falls_back_to_legacy_when_no_package`,
`KeyError: 'source'` — reproduces identically on `origin/main` before this
change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)