### PR TITLE
[P1/mid] Migrate spot_data_weekly.sh mid-run reclaim classify to lib chokepoint

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -289,15 +289,16 @@ cleanup() {
 # fail-fast posture (blind retry would mask a real collector/prune bug).
 #
 # alpha-engine-config#883 — the mid-run reclaim DECISION below is the lib
-# chokepoint `python -m krepis.ec2_spot relaunch-decision` (nousergon-lib
-# v0.65.0+; the module physically lives in krepis, invoked directly per
-# config#1649 — same convention already used for `krepis.ec2_spot launch`
-# and `krepis.ssm_dispatcher run` above). This file was the ORIGINAL
-# reference implementation (PR #349) that #883 is named after; its own
-# inline `describe-spot-instance-requests` + instance-StateReason grep had
-# grown a subtly different counter/threshold convention than the
-# backtester's and predictor's copies. The lib now owns the classify
-# (describe-instances, run while the instance still exists) + the
+# chokepoint (nousergon-lib v0.65.0+; the ec2_spot module physically lives
+# in the MIT krepis package now, invoked directly per config#1649 — the
+# same $LIB_PYTHON venv-path + direct-krepis-module convention this file
+# already uses for its capacity-resilient spot launch and its SSM
+# dispatch further below). This file was the ORIGINAL reference
+# implementation (PR #349) that #883 is named after; its own inline
+# describe-spot-instance-requests + instance-StateReason grep had grown a
+# subtly different counter/threshold convention than the backtester's and
+# predictor's copies. The lib now owns the classify (describe-instances,
+# run while the instance still exists) + the
 # MAX_SPOT_ATTEMPTS/SF_EXECUTION_TIMEOUT-bounded decision (exit 0 =
 # relaunch; NO_RELAUNCH_EXIT_CODE 75 = hold) so all three launchers share
 # one convention instead of three divergent ones.

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -128,6 +128,14 @@ MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-5400}"
 # in lockstep — otherwise the extra attempts are dead budget.
 MAX_SPOT_ATTEMPTS="${MAX_SPOT_ATTEMPTS:-2}"
 SPOT_ATTEMPT="${SPOT_ATTEMPT:-1}"
+# alpha-engine-config#883 — MAX_SPOT_ATTEMPTS ↔ SF executionTimeout coupling
+# guard. Passed to the lib chokepoint's --sf-execution-timeout/
+# --per-attempt-seconds flags (see _spot_failure_reason below); when set, the
+# lib refuses to advise a relaunch the outer SF budget cannot absorb. Empty by
+# default (the SF sets a per-STATE executionTimeout, not one this script reads
+# directly) — the bound is MAX_SPOT_ATTEMPTS only unless an operator threads
+# the actual state's executionTimeout through explicitly.
+SF_EXECUTION_TIMEOUT="${SF_EXECUTION_TIMEOUT:-}"
 # Backoff before a relaunch so a transient regional capacity dip has a
 # moment to clear (the launcher rotates AZ/type anyway, but a brief pause
 # materially raises the odds the next attempt lands).
@@ -275,38 +283,47 @@ cleanup() {
 # Echoes a non-empty reason string + returns 0 when the just-failed run
 # was a CONFIRMED spot interruption — either the launcher exhausted every
 # instance_type × subnet (ec2_spot rc 64) or AWS reclaimed the running
-# spot (no-capacity / by-price / capacity-oversubscribed). A GENUINE
-# inner-workload failure leaves the instance fulfilled/running and
-# returns 1 → NOT retryable, fails loud per the fail-fast posture (blind
-# retry would mask a real collector/prune bug).
+# spot (no-capacity / by-price / capacity-oversubscribed / budget still
+# available). A GENUINE inner-workload failure leaves the instance
+# fulfilled/running and returns 1 → NOT retryable, fails loud per the
+# fail-fast posture (blind retry would mask a real collector/prune bug).
+#
+# alpha-engine-config#883 — the mid-run reclaim DECISION below is the lib
+# chokepoint `python -m krepis.ec2_spot relaunch-decision` (nousergon-lib
+# v0.65.0+; the module physically lives in krepis, invoked directly per
+# config#1649 — same convention already used for `krepis.ec2_spot launch`
+# and `krepis.ssm_dispatcher run` above). This file was the ORIGINAL
+# reference implementation (PR #349) that #883 is named after; its own
+# inline `describe-spot-instance-requests` + instance-StateReason grep had
+# grown a subtly different counter/threshold convention than the
+# backtester's and predictor's copies. The lib now owns the classify
+# (describe-instances, run while the instance still exists) + the
+# MAX_SPOT_ATTEMPTS/SF_EXECUTION_TIMEOUT-bounded decision (exit 0 =
+# relaunch; NO_RELAUNCH_EXIT_CODE 75 = hold) so all three launchers share
+# one convention instead of three divergent ones.
 _spot_failure_reason() {
     local rc="$1"
-    # Launch-time exhaustion across all combinations (ec2_spot exit 64).
+    # Launch-time exhaustion across all combinations (ec2_spot exit 64) —
+    # no instance was ever created, so there is nothing for the lib to
+    # describe-instances; the launcher's own exit code IS the
+    # classification. Retained as-is: this is a launch-time-capacity
+    # feature the backtester/predictor siblings don't have, not part of
+    # the mid-run reclaim classifier #883 lifts to the lib.
     if [ "$rc" -eq 64 ]; then echo "launch-capacity-exhausted"; return 0; fi
     # Nothing launched and not a clean exit → unclassifiable, treat hard.
     [ -z "$INSTANCE_ID" ] && return 1
-    # Authoritative signal: the spot REQUEST status code.
-    local sir_code
-    sir_code=$(aws ec2 describe-spot-instance-requests \
-        --filters "Name=instance-id,Values=$INSTANCE_ID" \
-        --query 'SpotInstanceRequests[0].Status.Code' \
-        --output text --region "$AWS_REGION" 2>/dev/null || echo "")
-    case "$sir_code" in
-        instance-terminated-no-capacity|instance-terminated-by-price|instance-terminated-capacity-oversubscribed|instance-stopped-no-capacity|instance-stopped-by-price|instance-stopped-capacity-oversubscribed|marked-for-termination)
-            echo "$sir_code"; return 0 ;;
-    esac
-    # Fallback: the instance's own StateReason (spot reclamation surfaces
-    # as Server.SpotInstanceTermination; capacity events as
-    # Server.InsufficientInstanceCapacity).
-    local state_reason
-    state_reason=$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" \
-        --query 'Reservations[].Instances[].StateReason.Code' \
-        --output text --region "$AWS_REGION" 2>/dev/null || echo "")
-    case "$state_reason" in
-        Server.SpotInstanceTermination|Server.InsufficientInstanceCapacity)
-            echo "$state_reason"; return 0 ;;
-    esac
-    return 1
+    local _decide_out _decide_rc
+    _decide_out="$("$LIB_PYTHON" -m krepis.ec2_spot relaunch-decision \
+        --instance-id "$INSTANCE_ID" \
+        --region "$AWS_REGION" \
+        --attempt "$SPOT_ATTEMPT" \
+        --max-attempts "$MAX_SPOT_ATTEMPTS" \
+        ${SF_EXECUTION_TIMEOUT:+--sf-execution-timeout "$SF_EXECUTION_TIMEOUT" --per-attempt-seconds "$MAX_RUNTIME_SECONDS"} \
+        2>/dev/null)"
+    _decide_rc=$?
+    echo "  spot relaunch-decision (attempt $SPOT_ATTEMPT/$MAX_SPOT_ATTEMPTS): rc=$_decide_rc ${_decide_out:+[$_decide_out]}" >&2
+    [ "$_decide_rc" -eq 0 ] || return 1
+    echo "confirmed-reclaim${_decide_out:+ ($_decide_out)}"
 }
 
 on_exit() {

--- a/tests/test_spot_data_weekly_interruption_retry.py
+++ b/tests/test_spot_data_weekly_interruption_retry.py
@@ -187,8 +187,13 @@ class TestLibChokepointAdoption:
 
     def test_classifier_calls_lib_before_terminate(self, text):
         """Classification must happen while the instance still exists —
-        BEFORE cleanup() terminates it. on_exit computes `reason` (which
-        calls the lib chokepoint) before calling cleanup."""
+        BEFORE cleanup() terminates it. on_exit CALLS `_spot_failure_reason`
+        (which invokes the lib chokepoint) before calling `cleanup`
+        (which terminates the instance). Note: this must be checked on
+        on_exit()'s CALL order, not the functions' textual definition
+        order — cleanup() and _spot_failure_reason() are declared as
+        separate top-level functions, so a raw whole-file string search
+        would just reflect definition order, not execution order."""
         on_exit = text[text.index("on_exit() {"):]
         reason_at = on_exit.index("_spot_failure_reason")
         cleanup_at = on_exit.index("\n    cleanup")
@@ -196,12 +201,6 @@ class TestLibChokepointAdoption:
             "Failure must be classified (via the lib chokepoint) BEFORE "
             "cleanup() terminates the instance — the lib's describe-"
             "instances call requires a live instance."
-        )
-        decide_idx = text.index("krepis.ec2_spot relaunch-decision")
-        term_idx = text.index("aws ec2 terminate-instances")
-        assert decide_idx < term_idx, (
-            "the lib relaunch-decision call must appear before "
-            "terminate-instances in the script."
         )
 
 

--- a/tests/test_spot_data_weekly_interruption_retry.py
+++ b/tests/test_spot_data_weekly_interruption_retry.py
@@ -4,26 +4,37 @@ infrastructure/spot_data_weekly.sh.
 Origin: 2026-05-30 Saturday SF DataPhase1 failure. The nested data spot
 (i-02e498e018441751f, c5.large/us-east-1a) was reclaimed by AWS *mid-
 workload* with spot-request status `instance-terminated-no-capacity`.
-The lib launcher (nousergon_lib.ec2_spot) rotates instance_type ×
-subnet on *acquisition* capacity errors, but nothing relaunched after a
-*mid-run* reclamation — the workload SSM command returned ResponseCode
--1, the orchestrator exited 1, and the entire weekly pipeline failed.
+The lib launcher (krepis.ec2_spot) rotates instance_type × subnet on
+*acquisition* capacity errors, but nothing relaunched after a *mid-run*
+reclamation — the workload SSM command returned ResponseCode -1, the
+orchestrator exited 1, and the entire weekly pipeline failed.
 
-The fix adds an EXIT trap (`on_exit`) that classifies the failure: a
-CONFIRMED spot interruption (no-capacity / price / capacity-
-oversubscribed reclamation, or all-combinations-exhausted launch)
-relaunches a fresh spot up to MAX_SPOT_ATTEMPTS; a GENUINE workload
-error is NOT retried and fails loud (blind retry would mask a real bug).
+The original fix (PR #349) added an EXIT trap (`on_exit`) with an INLINE
+classifier (`_spot_failure_reason`) reading `describe-spot-instance-
+requests` + the instance StateReason directly. alpha-engine-config#883
+observed that this file was the reference implementation the backtester's
+and predictor's launchers copied — and each grew a subtly divergent
+counter/threshold convention. nousergon-lib PR #133 (v0.65.0+, module now
+lives in ``krepis.ec2_spot``) lifted the classify+decide DECISION into a
+shared chokepoint (`python -m krepis.ec2_spot relaunch-decision`); this
+repo's alpha-engine-predictor sibling adopted it in PR #308. This is
+launcher 3/3 (data): `_spot_failure_reason`'s mid-run branch now calls the
+lib chokepoint instead of re-inlining the AWS describe-calls, while the
+launch-time-capacity-exhaustion bypass (ec2_spot rc 64 — a feature this
+launcher has that the siblings don't) is unchanged.
 
 These are static greps (the script only runs end-to-end on a real spot)
 mirroring tests/test_spot_data_weekly_run_modes.py — they catch the
 regression class where the retry is removed, un-gated from the
-interruption-classification, or made to retry genuine workload errors.
+interruption-classification, made to retry genuine workload errors, or
+where the lib chokepoint is silently swapped back out for a re-inlined
+AWS describe-calls classifier.
 """
 
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -37,6 +48,14 @@ def text() -> str:
     return _SCRIPT.read_text()
 
 
+def test_script_syntactically_valid():
+    """``bash -n`` must accept the script — the lib-chokepoint call is a
+    command substitution + parameter-expansion flag list that must parse
+    cleanly under bash."""
+    r = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True)
+    assert r.returncode == 0, f"bash -n rejected spot_data_weekly.sh:\n{r.stderr}"
+
+
 class TestRetryConfig:
     def test_max_attempts_env_overridable(self, text):
         assert 'MAX_SPOT_ATTEMPTS="${MAX_SPOT_ATTEMPTS:-2}"' in text, (
@@ -47,6 +66,17 @@ class TestRetryConfig:
     def test_attempt_counter_threaded_via_env(self, text):
         assert 'SPOT_ATTEMPT="${SPOT_ATTEMPT:-1}"' in text, (
             "SPOT_ATTEMPT must be env-threaded so a re-exec knows its attempt #."
+        )
+
+    def test_sf_execution_timeout_threaded_via_env(self, text):
+        """#883 — the MAX_SPOT_ATTEMPTS <-> SF-executionTimeout coupling
+        guard needs SF_EXECUTION_TIMEOUT threaded (empty by default; the
+        lib guard is inert until an operator sets it to the actual outer
+        SF state's executionTimeout)."""
+        assert 'SF_EXECUTION_TIMEOUT="${SF_EXECUTION_TIMEOUT:-}"' in text, (
+            "SF_EXECUTION_TIMEOUT must be env-overridable (default empty) "
+            "so the lib's --sf-execution-timeout/--per-attempt-seconds "
+            "coupling guard can be armed without editing this script."
         )
 
     def test_orig_args_captured_before_parse(self, text):
@@ -73,52 +103,113 @@ class TestTrapInstalledBeforeLaunch:
         )
 
 
-class TestInterruptionClassification:
-    @pytest.mark.parametrize(
-        "code",
-        [
+class TestLibChokepointAdoption:
+    """#883 — the mid-run reclaim DECISION must come from the shared lib
+    chokepoint, not a re-inlined per-launcher classifier."""
+
+    def _classifier_body(self, text: str) -> str:
+        m = re.search(
+            r"^_spot_failure_reason\(\)\s*\{.*?^\}", text, re.MULTILINE | re.DOTALL
+        )
+        assert m, "no _spot_failure_reason() function found in spot_data_weekly.sh"
+        return m.group(0)
+
+    def test_uses_lib_relaunch_decision_chokepoint(self, text):
+        body = self._classifier_body(text)
+        assert "krepis.ec2_spot relaunch-decision" in body, (
+            "_spot_failure_reason() does not call the lib chokepoint "
+            "`python -m krepis.ec2_spot relaunch-decision` — #883 lifts the "
+            "mid-run reclaim classify+decide logic into the lib; the "
+            "launcher must consume it, not re-inline the AWS describe-calls."
+        )
+        for flag in ("--instance-id", "--attempt", "--max-attempts"):
+            assert flag in body, (
+                f"_spot_failure_reason()'s relaunch-decision call is missing "
+                f"{flag} — the lib needs the 1-based attempt + total-"
+                "attempts budget to decide."
+            )
+
+    def test_uses_same_lib_python_convention_as_existing_launch_call(self, text):
+        """The new relaunch-decision call must reuse the exact
+        $LIB_PYTHON venv-path convention this script already uses for
+        `krepis.ec2_spot launch` and `krepis.ssm_dispatcher run` — not a
+        bare `python`/`python3` that resolves to system python (which
+        does not carry the lib)."""
+        assert (
+            '"$LIB_PYTHON" -m krepis.ec2_spot relaunch-decision' in text
+        ), (
+            "relaunch-decision must be invoked as "
+            '`"$LIB_PYTHON" -m krepis.ec2_spot relaunch-decision`, matching '
+            "the launch call's convention."
+        )
+
+    def test_no_inline_reclaim_classifier(self, text):
+        """The launcher must NOT re-inline the spot-reclaim classification
+        (that's exactly what #883 lifted to the lib). A non-comment line
+        that queries the spot-request status or instance StateReason
+        directly is the divergent-copy regression the chokepoint exists
+        to prevent."""
+        forbidden = (
+            "describe-spot-instance-requests",
+            "Server.SpotInstanceTermination",
+            "Server.InsufficientInstanceCapacity",
             "instance-terminated-no-capacity",
             "instance-terminated-by-price",
             "instance-terminated-capacity-oversubscribed",
-            "instance-stopped-no-capacity",
-            "marked-for-termination",
-        ],
-    )
-    def test_spot_request_status_codes_classified(self, text, code):
-        assert code in text, (
-            f"spot-request status {code!r} must be classified as a retryable "
-            "interruption in _spot_failure_reason."
+        )
+        offenders = []
+        for i, raw in enumerate(_SCRIPT.read_text().splitlines(), start=1):
+            if raw.strip().startswith("#"):
+                continue
+            for tok in forbidden:
+                if tok in raw:
+                    offenders.append((i, tok, raw.strip()))
+        assert not offenders, (
+            "spot_data_weekly.sh re-inlines reclaim classification instead "
+            "of using the lib chokepoint:\n"
+            + "\n".join(f"  line {n}: {tok} :: {ln}" for n, tok, ln in offenders)
+            + "\n\nRoute through `python -m krepis.ec2_spot relaunch-decision`."
         )
 
-    def test_launch_exhaustion_rc64_retryable(self, text):
-        assert re.search(r'\[ "\$rc" -eq 64 \]', text), (
-            "ec2_spot rc 64 (all instance_type × subnet exhausted) must be "
-            "treated as a retryable capacity interruption."
+    def test_launch_capacity_exhaustion_bypass_retained(self, text):
+        """rc 64 (ec2_spot launch-time capacity exhaustion — no instance
+        ever existed) must still bypass the lib call directly; there is
+        nothing for the lib's describe-instances to classify. This is a
+        launcher-specific feature (not present in the backtester/predictor
+        siblings), unrelated to the mid-run reclaim classifier #883 lifts,
+        and must survive the migration unchanged."""
+        body = self._classifier_body(text)
+        assert re.search(r'\[ "\$rc" -eq 64 \]', body), (
+            "ec2_spot rc 64 (all instance_type × subnet exhausted) must "
+            "still be treated as a retryable capacity interruption "
+            "WITHOUT calling the lib (no instance exists to describe)."
         )
 
-    def test_instance_statereason_fallback(self, text):
-        assert "Server.SpotInstanceTermination" in text, (
-            "Instance StateReason fallback must recognize spot reclamation."
-        )
-
-    def test_classifier_queries_spot_request_before_terminate(self, text):
-        """Classification must read the spot-request status; the comment +
-        call order ensure it happens before cleanup() terminates."""
-        assert "describe-spot-instance-requests" in text
-        # on_exit computes `reason` before calling cleanup.
+    def test_classifier_calls_lib_before_terminate(self, text):
+        """Classification must happen while the instance still exists —
+        BEFORE cleanup() terminates it. on_exit computes `reason` (which
+        calls the lib chokepoint) before calling cleanup."""
         on_exit = text[text.index("on_exit() {"):]
         reason_at = on_exit.index("_spot_failure_reason")
         cleanup_at = on_exit.index("\n    cleanup")
         assert reason_at < cleanup_at, (
-            "Failure must be classified BEFORE cleanup() terminates the "
-            "instance (the spot-request status is only queryable while it lives)."
+            "Failure must be classified (via the lib chokepoint) BEFORE "
+            "cleanup() terminates the instance — the lib's describe-"
+            "instances call requires a live instance."
+        )
+        decide_idx = text.index("krepis.ec2_spot relaunch-decision")
+        term_idx = text.index("aws ec2 terminate-instances")
+        assert decide_idx < term_idx, (
+            "the lib relaunch-decision call must appear before "
+            "terminate-instances in the script."
         )
 
 
 class TestFailLoudOnGenuineError:
     def test_retry_gated_on_nonempty_reason(self, text):
         """The relaunch must be gated on a non-empty interruption reason —
-        a genuine workload failure (empty reason) must NOT retry."""
+        a genuine workload failure (empty reason, i.e. the lib classified
+        it as not a confirmed reclaim) must NOT retry."""
         assert re.search(
             r'\[ "\$rc" -ne 0 \] && \[ -n "\$reason" \] && '
             r'\[ "\$SPOT_ATTEMPT" -lt "\$MAX_SPOT_ATTEMPTS" \]',
@@ -164,4 +255,12 @@ class TestReexecAndObservability:
         assert 'metric-name "SpotInterruptionRetry"' in text, (
             "Each absorbed interruption must emit the SpotInterruptionRetry "
             "CloudWatch metric — the retry is observable, never silent."
+        )
+
+    def test_retry_metric_carries_process_dimension(self, text):
+        """The metric must carry Process=data-weekly to discriminate this
+        launcher from the backtester/predictor siblings on the shared
+        AlphaEngine namespace (unchanged by the #883 migration)."""
+        assert 'dimensions "Process=data-weekly"' in text, (
+            "SpotInterruptionRetry must carry Process=data-weekly."
         )


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

## What

Migrates `infrastructure/spot_data_weekly.sh`'s mid-run spot-interruption reclaim classification off its own inline `describe-spot-instance-requests` / instance-`StateReason` grep and onto the shared `nousergon-lib` chokepoint (`python -m krepis.ec2_spot relaunch-decision`, lib v0.65.0+ — the module now physically lives in the MIT `krepis` package, invoked directly per config#1649, the same convention this script already uses for `krepis.ec2_spot launch` and `krepis.ssm_dispatcher run`).

This file (`spot_data_weekly.sh`) was the **ORIGINAL reference implementation** (PR #349) that nousergon/alpha-engine-config#883 is named after. The issue is explicit that even this original copy needed migrating onto the new chokepoint once it existed, since its own counter/threshold convention had drifted subtly from the backtester's and predictor's copies — exactly the divergent-duplication #883 exists to eliminate. This is **launcher 3/3** per the issue's plan (backtester and alpha-engine-predictor#308 landed first).

## How

- `_spot_failure_reason()`'s mid-run branch now calls `"$LIB_PYTHON" -m krepis.ec2_spot relaunch-decision --instance-id ... --region ... --attempt "$SPOT_ATTEMPT" --max-attempts "$MAX_SPOT_ATTEMPTS"` (plus `--sf-execution-timeout`/`--per-attempt-seconds` when `SF_EXECUTION_TIMEOUT` is set), replacing the inline `describe-spot-instance-requests` status-code case + instance `StateReason` fallback. Exit 0 = confirmed reclaim; `NO_RELAUNCH_EXIT_CODE` (75) = hold (fail loud).
- The launch-time capacity-exhaustion bypass (`ec2_spot` exit 64 — a feature this launcher has that the backtester/predictor siblings don't, since no instance ever exists to `describe-instances`) is **unchanged**.
- Added `SF_EXECUTION_TIMEOUT="${SF_EXECUTION_TIMEOUT:-}"` (default empty — this script's Saturday SF sets a per-*state* `executionTimeout`, not one read directly here, so the coupling guard stays inert unless armed) to thread the `MAX_SPOT_ATTEMPTS` ↔ SF-timeout coupling guard through to the lib, matching #883's explicit requirement.
- `on_exit()`'s existing structure is otherwise untouched: it already captured `rc=$?` first, classified BEFORE calling `cleanup()` (which terminates the instance), and ended on `exit "$rc"` — so the status-capture/re-exit discipline and the classify-before-terminate/exec-after-teardown ordering were already correct and are preserved.
- `ORIG_ARGS=("$@")` was already captured before the flag-parse loop; unchanged.
- The `AlphaEngine/SpotInterruptionRetry` metric (`Process=data-weekly`) is preserved verbatim.
- No `requirements.txt` change needed — `krepis>=0.6.0` is already an unbounded floor (same as predictor's PR #308), so a fresh `pip install` picks up a `krepis` release that ships `relaunch-decision` regardless.

## Tests

Rewrote `tests/test_spot_data_weekly_interruption_retry.py` (the file that previously pinned the inline classifier) to pin the migration instead:
- the lib chokepoint (`krepis.ec2_spot relaunch-decision`, with `--instance-id`/`--attempt`/`--max-attempts`) is the decision surface, invoked via the same `$LIB_PYTHON` convention as the existing launch/SSM calls
- **no re-inlined classifier** — non-comment lines may not reference `describe-spot-instance-requests` / `Server.SpotInstanceTermination` / the spot-request status codes
- the launch-time-capacity-exhaustion (`rc 64`) bypass is retained
- classify happens before `cleanup()`'s terminate (via `on_exit()`'s call order — the file splits classify/cleanup/trap into separate functions, so this is checked on `on_exit()`'s call order, not textual function-definition order)
- status capture + re-exit (`exit "$rc"`), bounded relaunch, `_ORIG_ARGS`-before-parse, reexec-with-incremented-attempt, `trap - EXIT` before reexec, and the named CloudWatch metric (including its `Process=data-weekly` dimension) are all still pinned
- `bash -n` validity

Local: `bash -n infrastructure/spot_data_weekly.sh` clean. Full spot/infra suite green: `test_spot_data_weekly_interruption_retry.py` (19), plus `test_spot_data_weekly_run_modes.py`, `test_spot_data_weekly_ssm_transport.py`, `test_spot_env_source_aws_region.py`, `test_spot_launchers_krepis_cli_executes.py`, `test_spot_drift_detection_preflight_only.py`, `test_spot_drift_detection_ssm_transport.py` (64 total), plus the other files referencing this launcher (`test_sf_friday_shell_run_wiring.py`, `test_sf_morning_enrich_split_wiring.py`, `test_preflight_only_dry_path.py`, `test_infra_alerts_uses_krepis.py`, 92 total) — all pass, nothing regressed.

Refs nousergon/alpha-engine-config#883

🤖 Generated with [Claude Code](https://claude.com/claude-code)