### PR TITLE
[P1/mid] Pipeline deadman-switch alarm — ExecutionsStarted=0 on independent backstop topic

### DIFF
--- a/infrastructure/setup_pipeline_deadman_alarms.sh
+++ b/infrastructure/setup_pipeline_deadman_alarms.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# setup_pipeline_deadman_alarms.sh — CloudWatch "dead man's switch" alarms for
+# the three Alpha Engine orchestration Step Functions (config#856 Pipeline
+# Reporting Revamp, infra scope item (b)).
+#
+# Why this exists: the existing per-state HandleFailure alerts (NotifyComplete
+# / HandleFailure in step_function.json / step_function_daily.json /
+# step_function_eod.json) only fire when a state machine's EXECUTION runs and
+# fails. They cannot detect the strictly worse case — the state machine never
+# starts at all (EventBridge rule silently disabled/deleted, a CFN stack
+# rollback that drops the rule, an IAM permission regression on the
+# EventBridge→SFN invoke role, etc.). AWS/States ExecutionsStarted is the
+# metric that names that gap: alarm when it drops to zero over a window sized
+# to the pipeline's cadence.
+#
+# INDEPENDENT alerting channel (the point of this script): every existing
+# alarm in this repo (see setup_substrate_alarms.sh,
+# setup_changelog_observability_alarms.sh, setup_research_runner_timeout_alarm.sh,
+# and the CloudFormation-managed alarms in cloudformation/alpha-engine-orchestration.yaml)
+# routes to the SAME alpha-engine-alerts SNS topic. That is correct for
+# failure-of-a-running-pipeline alerts, but it creates a single point of
+# failure for a "did the pipeline even start" watchdog: if alpha-engine-alerts
+# itself goes dark (email subscription silently unconfirmed/removed, topic
+# policy drift, accidental deletion, ...) then EVERY alarm routed through it
+# goes dark at once, INCLUDING the one alarm whose entire job is to catch
+# silent breakage. This script provisions + subscribes a SEPARATE SNS topic
+# (alpha-engine-alarm-backstop) purely for these three deadman alarms, so a
+# blackout of the primary channel cannot also silence the backstop.
+#
+# Metric semantics: AWS/States does not emit an explicit ExecutionsStarted=0
+# datapoint during a quiet period — it emits NO datapoint at all when a state
+# machine has zero executions. So "zero executions" surfaces as MISSING DATA,
+# not as a real zero-valued point. --treat-missing-data breaching is required
+# (not notBreaching) for this class of alarm to ever fire — mirrors the
+# existing alpha-engine-research-runner-no-invocations /
+# alpha-engine-backtester-no-heartbeat / alpha-engine-evaluator-no-heartbeat /
+# alpha-engine-rag-ingestion-no-heartbeat alarms in
+# cloudformation/alpha-engine-orchestration.yaml, all of which use
+# TreatMissingData: breaching for the same "must run on this cadence" shape.
+#
+# Window: Period=604800 (7 days), EvaluationPeriods=1, Threshold=1,
+# LessThanThreshold. A 7-day trailing window is used for ALL THREE state
+# machines — including the two weekday-cadence pipelines (preopen-trading,
+# postclose-trading) — rather than a 1-day window, because AWS/States (like
+# AWS/Lambda) reports no datapoint on a quiet day, so a 1-day window cannot
+# distinguish "expected weekend/holiday silence" from "pipeline silently
+# stopped starting on a weekday" — both look identical (no data) to
+# CloudWatch. A 7-day window sidesteps that ambiguity: any calendar week with
+# zero executions across a state machine that is supposed to run 1x (weekly)
+# or ~5x (weekday cadence) times is unambiguously broken.
+#
+# Idempotent: put-metric-alarm upserts by name; sns create-topic / subscribe
+# dedupe by name/endpoint. Safe to re-run after threshold tweaks.
+#
+# Usage:
+#   ./infrastructure/setup_pipeline_deadman_alarms.sh [--dry-run]
+#   BACKSTOP_ALERT_EMAIL=you@example.com ./infrastructure/setup_pipeline_deadman_alarms.sh
+
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
+
+# Deliberately NOT alpha-engine-alerts — see header comment.
+BACKSTOP_TOPIC_NAME="alpha-engine-alarm-backstop"
+BACKSTOP_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${BACKSTOP_TOPIC_NAME}"
+# Same default recipient as the CFN AlertEmail parameter is fine — the
+# independence property this script provides is at the SNS-topic/subscription
+# infrastructure layer (a break in one topic's plumbing cannot silence the
+# other), not necessarily a different human inbox. Override via env var if a
+# distinct on-call address is preferred.
+BACKSTOP_ALERT_EMAIL="${BACKSTOP_ALERT_EMAIL:-cipher813@gmail.com}"
+
+# The three canonical Alpha Engine orchestration state machines (per the
+# pipeline-reporting-revamp scope / crucible-dashboard views/25_Pipeline_Status.py
+# _SF_ORDER). alpha-engine-groom-pipeline is intentionally excluded — it is
+# not part of the reporting-revamp's operator-facing pipeline set.
+declare -A STATE_MACHINES=(
+  ["weekly-freshness"]="ne-weekly-freshness-pipeline"
+  ["preopen-trading"]="ne-preopen-trading-pipeline"
+  ["postclose-trading"]="ne-postclose-trading-pipeline"
+)
+
+echo "Configuring pipeline deadman alarms"
+echo "  Region:         $REGION"
+echo "  Backstop topic: $BACKSTOP_TOPIC_ARN"
+echo "  Backstop email: $BACKSTOP_ALERT_EMAIL"
+
+run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+
+# --- 1. Provision the independent backstop SNS topic + subscription --------
+# Deliberately create/subscribe here rather than assume-and-fail-fast like
+# the other setup_*_alarms.sh scripts: this topic is NEW and has no other
+# owning deploy script, so this script is its sole provisioner (mirrors how
+# update_eod_pipeline_sf.sh is the EOD state machine's sole manager).
+
+echo ""
+echo "==> Ensuring backstop SNS topic exists..."
+if $DRY_RUN; then
+  echo "DRY: aws sns create-topic --name $BACKSTOP_TOPIC_NAME"
+else
+  aws sns create-topic --name "$BACKSTOP_TOPIC_NAME" --region "$REGION" --query "TopicArn" --output text >/dev/null
+fi
+
+EXISTING_SUBS=""
+if ! $DRY_RUN; then
+  EXISTING_SUBS=$(aws sns list-subscriptions-by-topic \
+    --topic-arn "$BACKSTOP_TOPIC_ARN" \
+    --query "Subscriptions[?Protocol=='email' && Endpoint=='${BACKSTOP_ALERT_EMAIL}'].Endpoint" \
+    --output text --region "$REGION" 2>/dev/null || echo "")
+fi
+if [[ -z "$EXISTING_SUBS" ]]; then
+  echo "  Subscribing $BACKSTOP_ALERT_EMAIL (requires manual email confirmation)..."
+  run aws sns subscribe \
+    --region "$REGION" \
+    --topic-arn "$BACKSTOP_TOPIC_ARN" \
+    --protocol email \
+    --notification-endpoint "$BACKSTOP_ALERT_EMAIL" >/dev/null
+else
+  echo "  Subscription for $BACKSTOP_ALERT_EMAIL already present."
+fi
+
+# Fail fast if the topic isn't actually there before wiring alarms to it
+# (mirrors the fail-fast-on-missing-topic convention in
+# setup_substrate_alarms.sh / setup_changelog_observability_alarms.sh).
+if ! $DRY_RUN && ! aws sns get-topic-attributes --topic-arn "$BACKSTOP_TOPIC_ARN" --region "$REGION" >/dev/null 2>&1; then
+  echo "ERROR: backstop SNS topic $BACKSTOP_TOPIC_ARN not found after create-topic. Aborting before creating dangling alarms." >&2
+  exit 1
+fi
+
+# --- 2. Per-state-machine ExecutionsStarted=0 deadman alarms ----------------
+
+echo ""
+echo "==> Creating per-state-machine deadman alarms..."
+for label in "${!STATE_MACHINES[@]}"; do
+  sf_name="${STATE_MACHINES[$label]}"
+  sf_arn="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:${sf_name}"
+  alarm_name="alpha-engine-pipeline-deadman-${label}"
+
+  echo "  -> $alarm_name (StateMachineArn=$sf_arn)"
+  run aws cloudwatch put-metric-alarm \
+    --region "$REGION" \
+    --alarm-name "$alarm_name" \
+    --alarm-description "Dead man's switch: fires when ${sf_name} has zero ExecutionsStarted in the trailing 7 days — the state machine did not even start (EventBridge rule disabled/deleted, IAM regression on the invoke role, CFN drift, ...), a failure class the per-execution HandleFailure SNS alert cannot see because it only runs when an execution exists. Routes to the INDEPENDENT ${BACKSTOP_TOPIC_NAME} topic (not alpha-engine-alerts) so a blackout of the primary alert channel cannot also silence this backstop (config#856 infra item b). TreatMissingData=breaching is required: AWS/States emits no datapoint at all for a quiet state machine, so 'zero executions' IS missing data, not a real zero — notBreaching would make this alarm impossible to fire." \
+    --namespace "AWS/States" \
+    --metric-name "ExecutionsStarted" \
+    --dimensions "Name=StateMachineArn,Value=${sf_arn}" \
+    --statistic "Sum" \
+    --period 604800 \
+    --evaluation-periods 1 \
+    --datapoints-to-alarm 1 \
+    --threshold 1 \
+    --comparison-operator "LessThanThreshold" \
+    --treat-missing-data "breaching" \
+    --alarm-actions "$BACKSTOP_TOPIC_ARN" \
+    --ok-actions "$BACKSTOP_TOPIC_ARN" >/dev/null
+done
+
+echo ""
+echo "Done — ${#STATE_MACHINES[@]} deadman alarms upserted, routed to $BACKSTOP_TOPIC_ARN."
+echo ""
+echo "Validation:"
+echo "  aws cloudwatch describe-alarms --region $REGION \\"
+echo "    --alarm-name-prefix alpha-engine-pipeline-deadman- \\"
+echo "    --query 'MetricAlarms[].[AlarmName,StateValue]' --output table"
+echo ""
+echo "NOTE: the email subscription above is pending until confirmed via the"
+echo "confirmation link SNS sends to $BACKSTOP_ALERT_EMAIL — the backstop"
+echo "channel is not actually live until that confirmation completes."

--- a/tests/test_pipeline_deadman_alarms_script.py
+++ b/tests/test_pipeline_deadman_alarms_script.py
@@ -1,0 +1,174 @@
+"""Pins the pipeline deadman-alarm setup script (config#856 infra item b).
+
+setup_pipeline_deadman_alarms.sh puts a CloudWatch "zero executions" alarm on
+each of the three Alpha Engine orchestration state machines, routed through a
+SEPARATE SNS topic from the existing alpha-engine-alerts one. The independence
+is the entire point (a blackout of the primary alert channel must not also
+silence the one alarm that watches for "pipeline didn't even start"), so these
+tests pin the load-bearing shape:
+
+- The backstop topic must be DIFFERENT from alpha-engine-alerts.
+- All three canonical state machines must be alarmed — dropping one silently
+  loses deadman coverage for that pipeline.
+- TreatMissingData must be "breaching" (not "notBreaching") — AWS/States does
+  not emit an explicit zero datapoint for a quiet state machine, so "breaching"
+  is required for the alarm to ever fire at all; "notBreaching" would silently
+  make this alarm a no-op.
+- The backstop topic must be created/verified before any put-metric-alarm call,
+  mirroring the fail-fast-before-dangling-alarms convention used by
+  setup_substrate_alarms.sh / setup_changelog_observability_alarms.sh.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "infrastructure" / "setup_pipeline_deadman_alarms.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _SCRIPT.read_text()
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT.is_file()
+    assert _SCRIPT.stat().st_mode & 0o111, "script must be chmod +x"
+
+
+def test_bash_syntax_is_valid():
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash not available")
+    result = subprocess.run([bash, "-n", str(_SCRIPT)], capture_output=True)
+    assert result.returncode == 0, result.stderr.decode()
+
+
+class TestIndependentBackstopTopic:
+    """The whole point of this script: a topic separate from alpha-engine-alerts."""
+
+    def test_uses_a_dedicated_backstop_topic_name(self, script_text):
+        assert 'BACKSTOP_TOPIC_NAME="alpha-engine-alarm-backstop"' in script_text
+
+    def test_backstop_topic_is_not_the_primary_alerts_topic(self, script_text):
+        # The primary alerts topic name is fine in prose comments (contrasting
+        # it), but it must never be constructed as an ARN and used as an
+        # actual alarm-routing variable — that would silently reintroduce the
+        # single-point-of-failure this script exists to remove.
+        assert ":alpha-engine-alerts" not in script_text
+        assert 'SNS_TOPIC_ARN="arn:aws:sns' not in script_text
+
+    def test_topic_created_before_any_alarm(self, script_text):
+        create_pos = script_text.find("aws sns create-topic")
+        first_alarm_pos = script_text.find("aws cloudwatch put-metric-alarm")
+        assert create_pos != -1
+        assert first_alarm_pos != -1
+        assert create_pos < first_alarm_pos
+
+    def test_topic_existence_verified_before_alarm_wiring(self, script_text):
+        # Fail-fast-on-missing-topic convention shared with
+        # setup_substrate_alarms.sh / setup_changelog_observability_alarms.sh.
+        verify_pos = script_text.find("aws sns get-topic-attributes")
+        first_alarm_pos = script_text.find("aws cloudwatch put-metric-alarm")
+        assert verify_pos != -1
+        assert verify_pos < first_alarm_pos
+
+    def test_email_subscription_is_wired(self, script_text):
+        assert "aws sns subscribe" in script_text
+        assert "--protocol email" in script_text
+
+    def test_all_alarms_route_to_backstop_topic(self, script_text):
+        assert '--alarm-actions "$BACKSTOP_TOPIC_ARN"' in script_text
+        assert '--ok-actions "$BACKSTOP_TOPIC_ARN"' in script_text
+
+
+class TestStateMachineCoverage:
+    """All three canonical orchestration state machines must be alarmed."""
+
+    @pytest.mark.parametrize(
+        "sf_name",
+        [
+            "ne-weekly-freshness-pipeline",
+            "ne-preopen-trading-pipeline",
+            "ne-postclose-trading-pipeline",
+        ],
+    )
+    def test_state_machine_is_present(self, script_text, sf_name):
+        assert sf_name in script_text, (
+            f"{sf_name} must be in the deadman alarm target set — dropping it "
+            "silently loses 'did this pipeline even start' coverage for that SF."
+        )
+
+    def test_groom_pipeline_intentionally_excluded(self, script_text):
+        # Not part of the pipeline-reporting-revamp operator-facing set
+        # (crucible-dashboard views/25_Pipeline_Status.py _SF_ORDER). The name
+        # may appear in a prose comment explaining the exclusion, but it must
+        # never be a value inside the actual STATE_MACHINES array.
+        block = script_text[
+            script_text.find("declare -A STATE_MACHINES=(") : script_text.find(")", script_text.find("declare -A STATE_MACHINES=("))
+        ]
+        assert "alpha-engine-groom-pipeline" not in block
+
+    def test_three_state_machines_declared(self, script_text):
+        assert re.search(r"declare -A STATE_MACHINES=\(", script_text)
+        # Exactly 3 quoted values assigned in the associative array block.
+        block = script_text[
+            script_text.find("declare -A STATE_MACHINES=(") : script_text.find(")", script_text.find("declare -A STATE_MACHINES=("))
+        ]
+        assert block.count('"ne-') == 3
+
+
+class TestAlarmSemantics:
+    def test_watches_executions_started_metric(self, script_text):
+        assert '--namespace "AWS/States"' in script_text
+        assert '--metric-name "ExecutionsStarted"' in script_text
+
+    def test_dimension_is_state_machine_arn(self, script_text):
+        assert "Name=StateMachineArn,Value=" in script_text
+
+    def test_fires_below_one_execution(self, script_text):
+        assert '--comparison-operator "LessThanThreshold"' in script_text
+        assert "--threshold 1" in script_text
+        assert '--statistic "Sum"' in script_text
+
+    def test_treat_missing_data_is_breaching(self, script_text):
+        # Regression guard: AWS/States emits NO datapoint at all during a
+        # quiet period, so "zero executions" IS missing data. notBreaching
+        # would silently make this alarm never fire — the opposite of a
+        # deadman switch.
+        assert '--treat-missing-data "breaching"' in script_text
+        assert '--treat-missing-data "notBreaching"' not in script_text
+
+    def test_period_is_seven_days(self, script_text):
+        # A 7-day trailing window avoids the weekday/weekend missing-data
+        # ambiguity a 1-day window would have for the two weekday-cadence
+        # pipelines (AWS/States reports no datapoint on ANY quiet day,
+        # expected-weekend or genuinely-broken-weekday alike).
+        assert "--period 604800" in script_text
+
+    def test_evaluation_window_is_single_period(self, script_text):
+        assert "--evaluation-periods 1" in script_text
+        assert "--datapoints-to-alarm 1" in script_text
+
+
+class TestRegionDefault:
+    def test_region_defaults_to_us_east_1(self, script_text):
+        assert 'REGION="${AWS_REGION:-us-east-1}"' in script_text
+
+
+class TestDryRun:
+    def test_supports_dry_run_flag(self, script_text):
+        assert '"${1:-}" == "--dry-run"' in script_text
+
+    def test_dry_run_gates_mutating_calls_via_run_helper(self, script_text):
+        assert "run() {" in script_text
+        # The alarm-creation call must be dispatched through the run() gate
+        # (or an explicit DRY_RUN check) so --dry-run never mutates AWS.
+        alarm_block = script_text[script_text.find("Creating per-state-machine") :]
+        assert "run aws cloudwatch put-metric-alarm" in alarm_block


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

## Scope

This PR ships **only** infra scope item (b) of #856's remaining Pipeline Reporting Revamp work: a CloudWatch "dead man's switch" alarm per orchestration Step Function, firing on `AWS/States ExecutionsStarted` dropping to zero, routed through a **new, independent** SNS topic (`alpha-engine-alarm-backstop`) rather than the existing `alpha-engine-alerts` topic — so a silent blackout of the primary channel can't also kill the one alarm whose job is to catch silent breakage.

- `infrastructure/setup_pipeline_deadman_alarms.sh` — idempotent aws-cli script, mirrors the shape of `setup_substrate_alarms.sh` / `setup_research_runner_timeout_alarm.sh`:
  - Creates + subscribes the new `alpha-engine-alarm-backstop` SNS topic (idempotent; email confirmation still required by AWS before the channel is live).
  - Puts one alarm per canonical state machine (`ne-weekly-freshness-pipeline`, `ne-preopen-trading-pipeline`, `ne-postclose-trading-pipeline` — matches `crucible-dashboard/views/25_Pipeline_Status.py`'s `_SF_ORDER`; `alpha-engine-groom-pipeline` intentionally excluded, it's not part of the reporting-revamp operator-facing set).
  - `ExecutionsStarted` Sum < 1 over a trailing **7-day** window, `TreatMissingData=breaching`. Both choices are deliberate, not copy-paste defaults — see script header comment: `AWS/States` (like `AWS/Lambda`) emits **no datapoint at all** during a quiet period, so "zero executions" *is* missing data, not a real zero — `notBreaching` would make the alarm a permanent no-op. A 7-day window (rather than 1-day) avoids an ambiguity a daily window would have for the two weekday-cadence pipelines: a quiet weekend and a silently-broken weekday both look identical (no data) to CloudWatch at day granularity.
- `tests/test_pipeline_deadman_alarms_script.py` — pins bash syntax, the independent-topic property (topic name, ordering of create/verify-before-alarm, that alarms route to the backstop topic and never to `alpha-engine-alerts`), full 3-state-machine coverage, and the `breaching`/7-day alarm semantics. 22 tests, all passing. Full repo suite (`pytest tests/`) run clean apart from one pre-existing, unrelated failure (`test_load_config_experiment_package.py::test_falls_back_to_legacy_when_no_package`, reproduces identically on `main` before this change).

Not runnable against real AWS from this environment (no live credentials) — same constraint as the precedent scripts it mirrors, whose tests also only pin script *text*, not live `aws` calls. Opening as a normal (non-draft) PR since the script is a straightforward, well-precedented mirror of already-merged idempotent alarm scripts and the test suite is fully green; happy to convert to draft if you'd rather have it live-validated against real AWS first.

## Explicitly deferred (not in this PR)

**(a) `NotifyComplete`/`HandleFailure` `States.Format` message rewrite** — deferred, for two independent reasons:

1. **Cross-repo blocker confirmed missing.** I checked the current state of `crucible-dashboard/views/25_Pipeline_Status.py` (453 lines) — it has **no `?run=` / `?run_id=`-style query-param handling at all** (no `st.query_params`, no `st.experimental_get_query_params`, nothing). The page currently only ever shows the *most recent* execution per state machine. Per #856's own "Phase 2.5" prereq, wiring a per-run deep link into the new alert messages before that lands would point at a page that silently can't filter to the specific run — not a 404, just a misleading "here's *a* run" link. That dashboard-side prereq should be tracked as its own follow-up in `crucible-dashboard` before the console-link wiring ships.
2. **Independent of the dashboard blocker**, a correct message rewrite also needs a uniform "failing state name" field threaded through every `Catch`/`Extract*Error` path in all three SF templates (`step_function.json`, `step_function_daily.json`, `step_function_eod.json`) — today `$.error`'s shape varies per path (raw SF `Catch` output `{Error, Cause}` in some places, custom `{phase, source, poll}` Pass-normalizer output in others), and there are 30+ `Next: HandleFailure` edges across the three files. That's a much larger, its-own-PR-sized change with real blast-radius risk against the several existing wiring-pin tests (`test_sf_research_perf_and_timeout_alarm.py`, `test_sf_substrate_check_wiring.py`, `test_sf_eod_substrate_check_wiring.py`, `test_sf_regime_substrate_wiring.py`, etc.) — better scoped and reviewed on its own once (1) is resolved.

**EOD `HandleFailure`'s hardcoded `TopicArn`** — left as-is, **not** parametrized to `${AlertsTopic}`. I verified how these SF definitions actually deploy (`infrastructure/deploy-infrastructure.sh`): the post-close (EOD) state machine is explicitly **not** a CloudFormation-managed resource — the script's own comment says "The post-close (EOD) SF is NOT in CloudFormation — this script is its sole manager," and it's pushed via a bare `aws stepfunctions update-state-machine --definition file://...` call with zero templating layer. `${AlertsTopic}` *is* a real, working `Fn::Sub` substitution elsewhere in this stack (`cloudformation/alpha-engine-orchestration.yaml`'s EventBridge rule `Input` blocks), but that substitution only happens inside the CFN template itself — it is never applied to the raw JSON files fed to `aws stepfunctions`. Writing `${AlertsTopic}` literally into `step_function_eod.json` would ship as that literal string to `sns:publish`, i.e. a **guaranteed-broken ARN on every EOD failure**, which is strictly worse than the "malformed `sns_topic_arn` input" scenario the hardcode already defends against. The defense-in-depth property (a bad config value must never swallow the cost-guard alert) is preserved by leaving this exactly as it is.

## Findings for #856 tracking

Posting a summary comment on alpha-engine-config#856 with the same findings, flagging the dashboard `?run=` prereq as a distinct blocking follow-up to track separately.

Refs nousergon/alpha-engine-config#856