### PR TITLE
[P2/mid] feat(freshness-monitor): daily cadence + 30-min intraday mini-rule

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -41,6 +41,7 @@ ROLE_NAME="alpha-engine-freshness-monitor-role"
 POLICY_NAME="alpha-engine-freshness-monitor-policy"
 RULE_NAME="alpha-engine-freshness-monitor-cron"
 HISTORICAL_RULE_NAME="alpha-engine-freshness-monitor-historical-cron"
+INTRADAY_RULE_NAME="alpha-engine-freshness-monitor-intraday-cron"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 
@@ -208,14 +209,19 @@ if $BOOTSTRAP; then
     echo "  Lambda exists, code will be updated in step 3"
   fi
 
-  # EventBridge cron: every 15 minutes. Sub-15min granularity isn't
-  # load-bearing (alerts dedup by cadence window) — this is the floor
-  # for "operator-perceived" probe cadence.
+  # EventBridge cron: daily (config#1297, Brian-directed 2026-06-27 — the
+  # prior 15-min sweep was unnecessary noise once the saturday_sf/run_calendar
+  # staleness models were fixed to be jitter-tolerant). 12:00 UTC gives an
+  # operator-visible check before US market open (13:30 UTC) while landing
+  # comfortably after every prior day's overnight/Saturday-SF producer runs.
+  # The genuinely-intraday artifacts (open_orders_latest,
+  # freshness_monitor_heartbeat) are NOT blinded by this — they're also
+  # covered by the separate 30-min mini-rule below.
   echo "  Creating EventBridge cron: ${RULE_NAME}"
   run aws events put-rule \
     --name "${RULE_NAME}" \
-    --schedule-expression "cron(*/15 * * * ? *)" \
-    --description "Every 15min probe of the artifact freshness registry" \
+    --schedule-expression "cron(0 12 * * ? *)" \
+    --description "Daily 12:00 UTC probe of the artifact freshness registry" \
     --region "${REGION}" \
     --query 'RuleArn' --output text
 
@@ -275,6 +281,47 @@ EOF
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${HIST_RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+
+  # Intraday mini-rule (config#1297): 30-min, weekdays 14-21 UTC (covers US
+  # market hours 13:30-20:00 UTC with a buffer either side). Fires the same
+  # Lambda with event={"mode": "intraday"} so it probes ONLY the two
+  # genuinely-intraday artifacts (open_orders_latest,
+  # freshness_monitor_heartbeat) without touching the shared
+  # check_results/heartbeat/cycle_verdict surfaces the daily sweep owns.
+  echo "  Creating EventBridge intraday cron: ${INTRADAY_RULE_NAME}"
+  run aws events put-rule \
+    --name "${INTRADAY_RULE_NAME}" \
+    --schedule-expression "cron(0/30 14-21 ? * MON-FRI *)" \
+    --description "30-min weekday 14-21 UTC intraday probe (mode=intraday)" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  # Same file:// dodge as the historical target above (embedded-quote JSON
+  # doesn't survive the put-targets shorthand form).
+  INTRADAY_TARGET_JSON=$(mktemp)
+  cat > "${INTRADAY_TARGET_JSON}" <<EOF
+[
+  {
+    "Id": "1",
+    "Arn": "${FN_ARN}",
+    "Input": "{\"mode\":\"intraday\"}"
+  }
+]
+EOF
+  run aws events put-targets \
+    --rule "${INTRADAY_RULE_NAME}" \
+    --targets "file://${INTRADAY_TARGET_JSON}" \
+    --region "${REGION}"
+  rm -f "${INTRADAY_TARGET_JSON}"
+
+  INTRADAY_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${INTRADAY_RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${INTRADAY_RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${INTRADAY_RULE_ARN}" \
     --region "${REGION}" 2>/dev/null || true
 fi
 

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -80,6 +80,17 @@ CHECK_RESULTS_KEY = "_freshness_monitor/check_results.json"
 HISTORY_KEY = "_freshness_monitor/history.json"
 CYCLE_VERDICT_KEY = "_freshness_monitor/cycle_verdict.json"
 
+# config#1297 — the general sweep moved from a 15-min cron to daily (Brian's
+# 2026-06-27 directive: the 15-min sweep was unnecessary noise once the
+# saturday_sf/run_calendar staleness models were fixed). These two artifacts
+# stay on a 30-min weekday-market-hours mini-rule (separate EB cron, event={
+# "mode": "intraday"}) so genuinely intraday monitoring isn't blinded by the
+# daily cadence: `open_orders_latest` (market-hours order-book freshness) and
+# `freshness_monitor_heartbeat` (the monitor's OWN dead-man's-switch artifact
+# — its whole purpose is fast detection of a monitor outage, which a daily
+# cadence would defeat).
+INTRADAY_ARTIFACT_IDS = frozenset({"open_orders_latest", "freshness_monitor_heartbeat"})
+
 # config#1240 — auto-remediation dispatch. The confirmed-miss path reads the
 # per-artifact `recovery:` spec from the registry and DISPATCHES the named
 # backfill primitive (SF start_execution / Lambda invoke) instead of (or, per
@@ -983,41 +994,76 @@ def _handle_historical(
     }
 
 
-# ── Main handler ────────────────────────────────────────────────────────────
+# ── Intraday-mode probe (config#1297) ───────────────────────────────────────
 
 
-def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
-    """EventBridge cron handler — every 15min walk the registry,
-    emit heartbeat + check_results, alert on misses past SLA.
+def _handle_intraday(s3_client: Any, now: datetime, started_at: float) -> dict:
+    """30-min weekday-market-hours mini-rule, scoped to
+    :data:`INTRADAY_ARTIFACT_IDS` only.
 
-    ``event["mode"] == "historical"`` dispatches to the daily
-    historical-probe path instead (separate EB cron at ~04:00 UTC).
+    Alerts/dispatches exactly like the daily full sweep (same
+    :func:`_run_probe_pass`) but writes NO check_results/heartbeat/
+    cycle_verdict — those full-registry dashboard surfaces are owned solely
+    by the daily sweep (which itself checks these same two artifacts, just
+    once a day), so a partial pass can never overwrite them with a
+    2-artifact-only view.
     """
-    started_at = time.time()
-    now = datetime.now(timezone.utc)
-    s3 = boto3.client("s3")
-
-    if event and event.get("mode") == "historical":
-        return _handle_historical(
-            s3, now, started_at, event.get("lookback"),
-        )
-
     logger.info(
-        "freshness-monitor invoked at %s (alerts_enabled=%s)",
+        "freshness-monitor invoked in INTRADAY mode at %s (alerts_enabled=%s)",
         now.isoformat(), ALERTS_ENABLED,
     )
 
-    # Load registry. If THIS fails, we want the Lambda to error out
-    # so the CW alarm fires — a broken registry must not be silent.
     specs, recovery_by_id = load_registry_with_recovery(
-        s3, REGISTRY_BUCKET, REGISTRY_KEY
+        s3_client, REGISTRY_BUCKET, REGISTRY_KEY
     )
-    logger.info(
-        "loaded %d specs from registry (%d with recovery specs)",
-        len(specs), len(recovery_by_id),
+    intraday_specs = [s for s in specs if s.artifact_id in INTRADAY_ARTIFACT_IDS]
+    missing_ids = INTRADAY_ARTIFACT_IDS - {s.artifact_id for s in intraday_specs}
+    if missing_ids:
+        logger.warning(
+            "intraday mode: registry is missing expected artifact_id(s) %s",
+            sorted(missing_ids),
+        )
+
+    pairs, alerted, dispatched, per_spec_exceptions = _run_probe_pass(
+        s3_client, intraday_specs, recovery_by_id, now,
     )
 
-    # Walk and probe.
+    duration_seconds = round(time.time() - started_at, 2)
+    logger.info(
+        "freshness-monitor INTRADAY complete: %s checked, %s alerted, %s dispatched, "
+        "%s per-spec exceptions, duration=%.2fs",
+        len(pairs), alerted, dispatched, per_spec_exceptions, duration_seconds,
+    )
+
+    return {
+        "mode": "intraday",
+        "n_entries_checked": len(pairs),
+        "alerts_enabled": ALERTS_ENABLED,
+        "alerted": alerted,
+        "dispatched": dispatched,
+        "per_spec_exceptions": per_spec_exceptions,
+        "duration_seconds": duration_seconds,
+    }
+
+
+# ── Probe pass (shared by the daily full sweep + the intraday mini-rule) ────
+
+
+def _run_probe_pass(
+    s3_client: Any,
+    specs: list[ArtifactSpec],
+    recovery_by_id: dict[str, dict],
+    now: datetime,
+) -> tuple[list[tuple[ArtifactSpec, CheckResult]], int, int, int]:
+    """Walk ``specs``, probe each, dispatch confirmed-miss recoveries, and
+    alert. Returns ``(pairs, alerted, dispatched, per_spec_exceptions)``.
+
+    Shared verbatim by the daily full-registry sweep and the intraday
+    mini-rule (config#1297) — the only difference between the two callers
+    is which `specs` they pass in and what they do with the returned
+    `pairs` (the full sweep serializes them to the shared dashboard
+    surfaces; the intraday mini-rule only alerts, per `handler`'s docstring).
+    """
     pairs: list[tuple[ArtifactSpec, CheckResult]] = []
     alerted = 0
     dispatched = 0
@@ -1026,7 +1072,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     # walk so a pass dispatching several recoveries reuses one client each).
     aws_clients: dict[str, Any] = {}
     for spec in specs:
-        result, exc = _check_one(s3, spec, now)
+        result, exc = _check_one(s3_client, spec, now)
         if exc is not None:
             per_spec_exceptions += 1
             logger.warning(
@@ -1043,7 +1089,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         did_dispatch = False
         try:
             did_dispatch = _maybe_dispatch_recovery(
-                s3, aws_clients, spec, recovery, result, now,
+                s3_client, aws_clients, spec, recovery, result, now,
             )
         except Exception as disp_exc:  # noqa: BLE001 — dispatch must not sink the pass
             logger.warning(
@@ -1060,6 +1106,58 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         )
         if not suppress_page and _maybe_alert(spec, result, now):
             alerted += 1
+
+    return pairs, alerted, dispatched, per_spec_exceptions
+
+
+# ── Main handler ────────────────────────────────────────────────────────────
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """EventBridge cron handler — daily walk of the full registry, emit
+    heartbeat + check_results, alert on misses past SLA.
+
+    ``event["mode"] == "historical"`` dispatches to the daily
+    historical-probe path instead (separate EB cron at ~04:00 UTC).
+
+    ``event["mode"] == "intraday"`` (config#1297) dispatches to a lighter
+    pass scoped to :data:`INTRADAY_ARTIFACT_IDS` only, on a separate 30-min
+    weekday-market-hours EB cron. It alerts/dispatches exactly like the full
+    sweep but does NOT write check_results/heartbeat/cycle_verdict — those
+    are the full-registry dashboard surfaces and only the daily sweep (which
+    covers every artifact, including these two) owns them, so a partial
+    intraday pass can never clobber them with a 2-artifact-only view.
+    """
+    started_at = time.time()
+    now = datetime.now(timezone.utc)
+    s3 = boto3.client("s3")
+
+    if event and event.get("mode") == "historical":
+        return _handle_historical(
+            s3, now, started_at, event.get("lookback"),
+        )
+
+    if event and event.get("mode") == "intraday":
+        return _handle_intraday(s3, now, started_at)
+
+    logger.info(
+        "freshness-monitor invoked at %s (alerts_enabled=%s)",
+        now.isoformat(), ALERTS_ENABLED,
+    )
+
+    # Load registry. If THIS fails, we want the Lambda to error out
+    # so the CW alarm fires — a broken registry must not be silent.
+    specs, recovery_by_id = load_registry_with_recovery(
+        s3, REGISTRY_BUCKET, REGISTRY_KEY
+    )
+    logger.info(
+        "loaded %d specs from registry (%d with recovery specs)",
+        len(specs), len(recovery_by_id),
+    )
+
+    pairs, alerted, dispatched, per_spec_exceptions = _run_probe_pass(
+        s3, specs, recovery_by_id, now,
+    )
 
     # Emit dashboard surface + self-heartbeat.
     check_results = _serialize_check_results(pairs, now)

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -648,6 +648,152 @@ def test_handler_dispatches_to_historical_on_mode_flag(monkeypatch, fixed_now):
     index.load_registry.assert_not_called()  # current-state path NOT taken
 
 
+# ── Intraday-mode probe (config#1297) ───────────────────────────────────────
+
+
+def test_handler_dispatches_to_intraday_on_mode_flag(monkeypatch, fixed_now):
+    """event={'mode': 'intraday'} routes to _handle_intraday without
+    touching the current-state (daily full-sweep) path."""
+    import importlib
+    import index
+    importlib.reload(index)
+    monkeypatch.setattr(
+        index, "_handle_intraday",
+        mock.Mock(return_value={"mode": "intraday", "n_entries_checked": 0,
+                                 "alerts_enabled": False, "alerted": 0,
+                                 "dispatched": 0, "per_spec_exceptions": 0,
+                                 "duration_seconds": 0.0}),
+    )
+    monkeypatch.setattr(index, "load_registry_with_recovery", mock.Mock())  # would fail otherwise
+    monkeypatch.setattr(
+        index, "datetime", mock.Mock(
+            now=mock.Mock(return_value=fixed_now),
+        ),
+    )
+    result = index.handler({"mode": "intraday"}, None)
+    assert result["mode"] == "intraday"
+    index._handle_intraday.assert_called_once()
+    index.load_registry_with_recovery.assert_not_called()  # daily full-sweep path NOT taken
+
+
+@pytest.fixture
+def intraday_registry_body() -> bytes:
+    """A registry with the two intraday artifacts plus one unrelated
+    daily artifact — the intraday pass must check only the former two."""
+    return b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+  grace_period_cycles: 2
+  severity: warning
+artifacts:
+  - artifact_id: open_orders_latest
+    s3_key_template: "trades/open_orders/latest.json"
+    cadence: continuous
+    interval_minutes: 30
+    sla_minutes_after_cron: 15
+    severity: warning
+    owner_repo: alpha-engine
+    created_at: "2025-01-01"
+    run_calendar: market_hours
+    active_hours_utc: [14, 21]
+  - artifact_id: freshness_monitor_heartbeat
+    s3_key_template: "_freshness_monitor/heartbeat.json"
+    cadence: continuous
+    interval_minutes: 1440
+    sla_minutes_after_cron: 15
+    severity: critical
+    owner_repo: alpha-engine-data
+    created_at: "2025-01-01"
+    run_calendar: all_days
+  - artifact_id: probe_missing
+    s3_key_template: "path/{date}/missing.json"
+    cadence: saturday_sf
+    sla_minutes_after_cron: 60
+    severity: critical
+    owner_repo: alpha-engine-test
+    created_at: "2025-01-01"
+"""
+
+
+def test_handle_intraday_scopes_to_intraday_artifact_ids_only(
+    monkeypatch, intraday_registry_body, fake_s3, fixed_now
+):
+    """The intraday pass must check exactly INTRADAY_ARTIFACT_IDS, never the
+    rest of the registry (probe_missing here) — that's the daily sweep's job."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = intraday_registry_body
+
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+
+    result = index.handler({"mode": "intraday"}, None)
+
+    assert result["mode"] == "intraday"
+    assert result["n_entries_checked"] == 2  # open_orders_latest + heartbeat only
+
+
+def test_handle_intraday_does_not_write_shared_dashboard_surfaces(
+    monkeypatch, intraday_registry_body, fake_s3, fixed_now
+):
+    """The intraday pass alerts but must NOT write check_results/heartbeat/
+    cycle_verdict — those full-registry surfaces are owned solely by the
+    daily sweep; a partial write would clobber them with a 2-artifact view."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = intraday_registry_body
+
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+
+    index.handler({"mode": "intraday"}, None)
+
+    put_keys = [k for (_, k, _) in fake_s3._put_calls]
+    assert index.CHECK_RESULTS_KEY not in put_keys
+    assert index.HEARTBEAT_KEY not in put_keys
+    assert index.CYCLE_VERDICT_KEY not in put_keys
+
+
+def test_handle_intraday_warns_on_missing_expected_artifact_id(
+    monkeypatch, fake_s3, fixed_now
+):
+    """A registry missing one of the two hardcoded intraday ids logs a
+    warning rather than silently checking zero/one artifact."""
+    fake_s3._registry_body = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+artifacts:
+  - artifact_id: open_orders_latest
+    s3_key_template: "trades/open_orders/latest.json"
+    cadence: continuous
+    interval_minutes: 30
+    sla_minutes_after_cron: 15
+    severity: warning
+    owner_repo: alpha-engine
+    created_at: "2025-01-01"
+    run_calendar: market_hours
+    active_hours_utc: [14, 21]
+"""
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+
+    result = index.handler({"mode": "intraday"}, None)
+
+    assert result["n_entries_checked"] == 1  # only open_orders_latest present
+
+
 # ── Trading-day-axis historical-probe tests ─────────────────────────────────
 
 


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** mid

Closes-partially: nousergon/alpha-engine-config#1297 (reopens the code-shipped portion of the issue that was previously auto-cleared from `in-progress`; the 10-day max-age `saturday_sf` staleness model (nousergon-lib#139) and the `run_calendar` continuous-cadence fix (nousergon-lib#141 / nousergon-data#513) already shipped separately — this PR is the last remaining piece, the EventBridge cadence change itself).

## What changed

- `RULE_NAME` (`alpha-engine-freshness-monitor-cron`) schedule: `cron(*/15 * * * ? *)` -> `cron(0 12 * * ? *)` (daily, 12:00 UTC -- before US market open, after the prior day's overnight/Saturday-SF producer runs). Per Brian's 2026-06-27 directive: the 15-min sweep was unnecessary noise once the staleness models were fixed to be jitter-tolerant.
- New `INTRADAY_RULE_NAME` (`alpha-engine-freshness-monitor-intraday-cron`): `cron(0/30 14-21 ? * MON-FRI *)`, invoking the same Lambda with `event={"mode": "intraday"}`.
- `index.py`: new `_handle_intraday` dispatch, scoped to `INTRADAY_ARTIFACT_IDS = {"open_orders_latest", "freshness_monitor_heartbeat"}` -- the two genuinely-intraday artifacts (market-hours order-book freshness, and the monitor's own dead-man's-switch heartbeat, whose whole purpose is fast outage detection that a daily cadence would defeat). Reuses the exact probe/alert/dispatch loop (extracted into `_run_probe_pass`, shared with the daily full sweep) but **deliberately does not write** `check_results.json`/`heartbeat.json`/`cycle_verdict.json` -- those full-registry dashboard surfaces stay owned solely by the daily sweep, so a 2-artifact partial pass can never clobber them with a partial view.
- `test_handler.py`: 5 new tests -- mode-flag dispatch routing, scoping to exactly the 2 intraday ids (never the rest of the registry), non-clobber of the shared S3 surfaces, and a missing-expected-id warning path. Full suite green: `pytest infrastructure/lambdas/freshness-monitor` -> 48 passed.

## What is NOT validated here (no AWS access from this environment)

This repo's `deploy.sh` only wires EventBridge rules inside its `--bootstrap` path; the auto-deploy CI (`.github/workflows/deploy-freshness-monitor.yml`) runs `--code-only` on merge, which updates the Lambda **code** but does **not** touch EventBridge rule schedules. The rules were already bootstrapped once (pre-existing 15-min cron); changing the schedule expressions in `deploy.sh` alone does not retroactively update the live AWS rule.

**The one command to apply this live** (idempotent -- IAM role/Lambda function already exist so those steps no-op; `aws events put-rule`/`put-targets` update the existing rules in place):

```
bash infrastructure/lambdas/freshness-monitor/deploy.sh --bootstrap
```

Draft until that's run and the two rules are confirmed live (`aws events describe-rule --name alpha-engine-freshness-monitor-cron` / `-intraday-cron`).

Re-exam: 2026-07-19

