### PR TITLE
[P2/low] docs(readme): Crucible product / Nous Ergon umbrella tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # alpha-engine-data
 
-> Part of [**Nous Ergon**](https://nousergon.ai) — a harness for rigorous AI/ML experiments in finance: an equity research-and-trading system instrumented end-to-end. Repo and S3 names use the underlying project name `alpha-engine`.
+> Part of [**Crucible**](https://nousergon.ai) — a [Nous Ergon](https://nousergon.ai) product: a harness for rigorous AI/ML experiments in finance, an equity research-and-trading system instrumented end-to-end. Repo and S3 names use the underlying project codename `alpha-engine`.
 
-[![Part of Nous Ergon](https://img.shields.io/badge/Part_of-Nous_Ergon-1a73e8?style=flat-square)](https://nousergon.ai)
+[![Part of Crucible](https://img.shields.io/badge/Part_of-Crucible-1a73e8?style=flat-square)](https://nousergon.ai)
 [![Python](https://img.shields.io/badge/python-3.13+-blue?style=flat-square)](https://www.python.org/)
 [![ArcticDB](https://img.shields.io/badge/ArcticDB-0e1117?style=flat-square)](https://docs.arcticdb.io/)
 [![Polygon.io](https://img.shields.io/badge/Polygon.io-1a73e8?style=flat-square)](https://polygon.io/)


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** low

Part of nousergon/alpha-engine-config#904 (Crucible-rename cascade). Applies the exact wording established in crucible-executor#294 (the first of the 9-repo fan-out): tagline blockquote + badge swap from "Part of Nous Ergon" to "Part of Crucible — a Nous Ergon product", per the 2026-06-10 brand architecture (Nous Ergon = studio/brand; Crucible = the experiment-harness product).

Docs-only, no code/behavior change.