### PR TITLE
[P2/mid] SF: pipeline-contract preflight gate before Saturday spot launch

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -42,7 +42,7 @@
     },
     "CheckSkipLibPinDriftCheck": {
       "Type": "Choice",
-      "Comment": "Skip-gate (L4517). {\"skip_lib_pin_drift_check\": true} bypasses the preventive cross-repo lib-pin drift check — e.g. an operator rerun where pins are known-good.",
+      "Comment": "Skip-gate (L4517). {\"skip_lib_pin_drift_check\": true} bypasses ONLY the preventive cross-repo lib-pin drift check — e.g. an operator rerun where pins are known-good. Routes to CheckPipelineContract (NOT CheckMutexRole): the flag is scoped to the lib-pin check specifically, so skipping it must not also silently bypass the separate pipeline-contract preflight gate (L4595) added afterward.",
       "Choices": [
         {
           "And": [
@@ -55,7 +55,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckMutexRole"
+          "Next": "CheckPipelineContract"
         }
       ],
       "Default": "LibPinDriftCheck"
@@ -87,8 +87,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Fail-open — the probe's own failure must not halt the weekly run; proceed to the pipeline.",
-          "Next": "CheckMutexRole",
+          "Comment": "Fail-open — the probe's own failure must not halt the weekly run; proceed to the next preflight gate (CheckPipelineContract), not straight past it.",
+          "Next": "CheckPipelineContract",
           "ResultPath": "$.libpin_drift_error"
         }
       ],
@@ -105,7 +105,7 @@
           "Next": "ExtractLibPinDriftError"
         }
       ],
-      "Default": "CheckMutexRole"
+      "Default": "CheckPipelineContract"
     },
     "ExtractLibPinDriftError": {
       "Type": "Pass",
@@ -114,6 +114,64 @@
         "phase": "LibPinDriftGate",
         "source": "LibPinDriftGate.has_drift",
         "drift.$": "$.libpin_drift_result.Payload"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "CheckPipelineContract": {
+      "Type": "Task",
+      "Comment": "Preventive pipeline-contract preflight gate (L4595, L4520(b)). Runs BEFORE any spot launch, immediately after the lib-pin-drift gate: asserts the Saturday-SF stage graph matches PIPELINE_CONTRACT.yaml's declared producer/consumer boundaries against ARTIFACT_REGISTRY.yaml (fetched from nousergon/alpha-engine-config raw GitHub). has_violation=true halts in seconds with the named boundary break instead of the pipeline discovering a contract mismatch mid-run after already spending on a spot launch. FAIL-OPEN: a GitHub-fetch/parse miss sets has_violation=false (the probe's own degraded mode, same convention as check_lib_pin_drift), and the Catch routes any Lambda failure straight to the pipeline — so the checker NEVER false-halts the weekly run.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_pipeline_contract"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-open — the probe's own failure must not halt the weekly run; proceed to the pipeline.",
+          "Next": "CheckMutexRole",
+          "ResultPath": "$.pipeline_contract_error"
+        }
+      ],
+      "ResultPath": "$.pipeline_contract_result",
+      "Next": "PipelineContractGate"
+    },
+    "PipelineContractGate": {
+      "Type": "Choice",
+      "Comment": "Hard-fail when the pipeline-contract probe reports has_violation=true (a confirmed producer/consumer boundary break against PIPELINE_CONTRACT.yaml). Surfaces the contract violation loudly before the SF spends on any spot launch. Routes via ExtractPipelineContractError (NOT straight to HandleFailure): a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — jumping here directly would make HandleFailure itself die with States.Runtime ('$.error could not be found', same failure mode observed 2026-07-03 offcycle-shell for LibPinDriftGate), swallowing the violation reason behind an opaque meta-error. Mirrors the existing Extract*Error normalizer convention.",
+      "Choices": [
+        {
+          "Variable": "$.pipeline_contract_result.Payload.has_violation",
+          "BooleanEquals": true,
+          "Next": "ExtractPipelineContractError"
+        }
+      ],
+      "Default": "CheckMutexRole"
+    },
+    "ExtractPipelineContractError": {
+      "Type": "Pass",
+      "Comment": "Normalize a confirmed pipeline-contract violation (PipelineContractGate has_violation==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) — it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the violation offenders. Carries the whole probe Payload (reason/boundary_count/violations) so the FAILED SNS alert names the exact contract boundary break a human must resolve. References only $.pipeline_contract_result.Payload — guaranteed present because the gate already dereferenced Payload.has_violation to route here — so this normalizer cannot itself raise a missing-field States.Runtime. Mirrors the existing Extract*Error → HandleFailure convention (ExtractLibPinDriftError); no new error channel. FAIL-LOUD PRESERVED: still → HandleFailure → FailExecution (the pipeline still hard-fails on a real contract violation by design).",
+      "Parameters": {
+        "phase": "PipelineContractGate",
+        "source": "PipelineContractGate.has_violation",
+        "violation.$": "$.pipeline_contract_result.Payload"
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -981,17 +981,22 @@ class TestHappyPathTraversal:
         assert not skipped, "nothing skipped when shell_run absent"
         # 2026-06-08 (L4517): the lib-pin drift gate is now the first hop after
         # InitializeInput; with no skip flag + no drift, its skip/check/gate
-        # Defaults converge on CheckMutexRole — same downstream chain, three
-        # extra states in the visited order.
+        # Defaults converge on CheckPipelineContract (L4595, added afterward)
+        # — same downstream chain, extra states in the visited order.
         # config#830: CheckRunMode (cadence preset) sits between InitializeInput
         # and the lib-pin gate; with no `mode` on the input it takes its Default
         # to CheckSkipLibPinDriftCheck — one extra Choice in the visited order.
+        # 2026-07-04 (L4595/L4520(b)): CheckPipelineContract + PipelineContractGate
+        # inserted between LibPinDriftGate and CheckMutexRole — the pipeline-
+        # contract preflight gate, converging on CheckMutexRole in turn.
         assert order[: order.index("CheckSkipMorningEnrich") + 2] == [
             "InitializeInput",
             "CheckRunMode",
             "CheckSkipLibPinDriftCheck",
             "LibPinDriftCheck",
             "LibPinDriftGate",
+            "CheckPipelineContract",
+            "PipelineContractGate",
             "CheckMutexRole",
             "CheckShellRun",
             "CheckSkipMorningEnrich",

--- a/tests/test_sf_lib_pin_drift_wiring.py
+++ b/tests/test_sf_lib_pin_drift_wiring.py
@@ -53,8 +53,10 @@ def test_skip_gate_default_runs_check_and_skip_bypasses(states):
     skip = states["CheckSkipLibPinDriftCheck"]
     assert skip["Default"] == "LibPinDriftCheck"
     c = skip["Choices"][0]
-    # skip_lib_pin_drift_check == true bypasses straight into the pipeline
-    assert c["Next"] == "CheckMutexRole"
+    # skip_lib_pin_drift_check == true bypasses ONLY the lib-pin check; it
+    # still routes into CheckPipelineContract (L4595), the next preflight
+    # gate, rather than skipping straight past it into the pipeline.
+    assert c["Next"] == "CheckPipelineContract"
     variables = {x["Variable"] for x in c["And"]}
     assert variables == {"$.skip_lib_pin_drift_check"}
 
@@ -71,10 +73,11 @@ def test_check_invokes_predictor_lambda_with_action(states):
 
 def test_check_fails_open_via_catch(states):
     # The probe's own failure (incl. an unknown action pre-PR-A-deploy) must
-    # proceed into the pipeline, NOT halt the weekly run.
+    # proceed into the NEXT preflight gate (CheckPipelineContract, L4595), not
+    # skip it, and must NOT halt the weekly run.
     catch = states["LibPinDriftCheck"]["Catch"][0]
     assert catch["ErrorEquals"] == ["States.ALL"]
-    assert catch["Next"] == "CheckMutexRole"  # the pipeline, not HandleFailure
+    assert catch["Next"] == "CheckPipelineContract"
 
 
 def test_gate_halts_only_on_confirmed_drift(states):
@@ -86,8 +89,9 @@ def test_gate_halts_only_on_confirmed_drift(states):
     # Confirmed drift halts, but routes through the $.error normalizer FIRST
     # (not straight to HandleFailure) — see test_drift_halt_normalizes_error.
     assert c["Next"] == "ExtractLibPinDriftError"
-    # No drift → proceed into the pipeline.
-    assert gate["Default"] == "CheckMutexRole"
+    # No drift → proceed into the next preflight gate (CheckPipelineContract,
+    # L4595), which sits before CheckMutexRole in the pipeline.
+    assert gate["Default"] == "CheckPipelineContract"
 
 
 def test_drift_halt_normalizes_error_before_handle_failure(states):

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -174,11 +174,13 @@ class TestMutexWiring:
         # CheckSkipLibPinDriftCheck so the chain is unchanged for non-preset input.
         # 2026-06-08 (L4517): the preventive lib-pin drift gate is the first
         # workload gate; its skip-default + gate-default converge on
-        # CheckMutexRole — the mutex still sits between entry and the
-        # former-first-state, one gate further down.
+        # CheckPipelineContract (L4595, added 2026-07-04) — the mutex still
+        # sits between entry and the former-first-state, two gates further
+        # down now.
         assert saturday_sf["States"]["InitializeInput"]["Next"] == "CheckRunMode"
         assert saturday_sf["States"]["CheckRunMode"]["Default"] == "CheckSkipLibPinDriftCheck"
-        assert saturday_sf["States"]["LibPinDriftGate"]["Default"] == "CheckMutexRole"
+        assert saturday_sf["States"]["LibPinDriftGate"]["Default"] == "CheckPipelineContract"
+        assert saturday_sf["States"]["PipelineContractGate"]["Default"] == "CheckMutexRole"
 
     def test_weekday_initialize_input_routes_to_check_mutex_role(self, weekday_sf):
         assert weekday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -73,6 +73,8 @@ def _flatten_states(sf_doc: dict) -> dict:
 _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # L4517: preventive cross-repo lib-pin drift gate (predictor-inference Lambda).
     "LibPinDriftCheck": frozenset({"action"}),
+    # L4595/L4520(b): preventive pipeline-contract preflight gate (predictor-inference Lambda).
+    "CheckPipelineContract": frozenset({"action"}),
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),
     "RegimeSubstrate": frozenset({"action.$"}),
     "RegimeRetrospectiveEval": frozenset({"action.$"}),

--- a/tests/test_sf_pipeline_contract_wiring.py
+++ b/tests/test_sf_pipeline_contract_wiring.py
@@ -1,0 +1,132 @@
+"""Pins the preventive pipeline-contract preflight gate in the Saturday SF
+(L4595, L4520(b)).
+
+The gate (`CheckPipelineContract` → `PipelineContractGate`) MUST run before
+any spot launch — immediately after the lib-pin-drift gate (L4517) and
+before `CheckMutexRole` — and hard-fail the SF on a CONFIRMED pipeline
+producer/consumer boundary violation (`has_violation=true`), while failing
+OPEN on the probe's own error. These tests catch regressions like: someone
+reorders it after a spot launch (defeating "fail before spend"), drops the
+fail-open Catch (probe fragility false-halts the weekly run), inverts the
+gate's halt condition, or reintroduces a bypass around it (e.g. via the
+lib-pin skip-flag path).
+
+Pairs with alpha-engine-predictor `inference/pipeline_contract_check.py` (the
+`action=check_pipeline_contract` Lambda handler, crucible-predictor PR #297).
+Mirrors the existing `test_sf_lib_pin_drift_wiring.py` convention.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def sf():
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf):
+    return sf["States"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["CheckPipelineContract", "PipelineContractGate", "ExtractPipelineContractError"],
+)
+def test_gate_states_exist(states, name):
+    assert name in states, f"{name} missing from Saturday SF States"
+
+
+def test_runs_immediately_after_lib_pin_drift_gate(states):
+    # LibPinDriftGate's no-drift Default, LibPinDriftCheck's own fail-open
+    # Catch, AND the lib-pin skip-flag path must all converge on
+    # CheckPipelineContract — it sits directly after the lib-pin gate and
+    # before the rest of the pipeline (CheckMutexRole), with no bypass.
+    assert states["LibPinDriftGate"]["Default"] == "CheckPipelineContract"
+    assert states["LibPinDriftCheck"]["Catch"][0]["Next"] == "CheckPipelineContract"
+    skip_choice = states["CheckSkipLibPinDriftCheck"]["Choices"][0]
+    assert skip_choice["Next"] == "CheckPipelineContract"
+
+
+def test_check_invokes_predictor_lambda_with_action(states):
+    chk = states["CheckPipelineContract"]
+    assert chk["Type"] == "Task"
+    assert chk["Resource"] == "arn:aws:states:::lambda:invoke"
+    assert chk["Parameters"]["FunctionName"] == "alpha-engine-predictor-inference:live"
+    assert chk["Parameters"]["Payload"]["action"] == "check_pipeline_contract"
+    assert chk["ResultPath"] == "$.pipeline_contract_result"
+    assert chk["Next"] == "PipelineContractGate"
+
+
+def test_check_fails_open_via_catch(states):
+    # The probe's own failure must proceed into the pipeline (CheckMutexRole
+    # is the real first pipeline state after both preflight gates), NOT halt
+    # the weekly run.
+    catch = states["CheckPipelineContract"]["Catch"][0]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "CheckMutexRole"
+
+
+def test_gate_halts_only_on_confirmed_violation(states):
+    gate = states["PipelineContractGate"]
+    assert gate["Type"] == "Choice"
+    c = gate["Choices"][0]
+    assert c["Variable"] == "$.pipeline_contract_result.Payload.has_violation"
+    assert c["BooleanEquals"] is True
+    # Confirmed violation halts, but routes through the $.error normalizer
+    # FIRST (not straight to HandleFailure) — see
+    # test_violation_halt_normalizes_error_before_handle_failure.
+    assert c["Next"] == "ExtractPipelineContractError"
+    # No violation → proceed into the pipeline.
+    assert gate["Default"] == "CheckMutexRole"
+
+
+def test_violation_halt_normalizes_error_before_handle_failure(states):
+    """The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) —
+    its transition does NOT populate $.error. HandleFailure's Message calls
+    States.JsonToString($.error), so a direct Choice→HandleFailure jump would
+    kill the SF with an opaque States.Runtime ('$.error could not be found'),
+    the same failure mode observed for LibPinDriftGate (2026-07-03
+    offcycle-shell). The violation path must first hit an Extract*Error
+    normalizer that writes $.error, matching every other HandleFailure
+    entry."""
+    norm = states["ExtractPipelineContractError"]
+    assert norm["Type"] == "Pass"
+    assert norm["ResultPath"] == "$.error"
+    assert norm["Next"] == "HandleFailure"
+    # References only the whole probe Payload — guaranteed present because
+    # the gate already dereferenced Payload.has_violation to route here — so
+    # the normalizer cannot itself raise a missing-field States.Runtime.
+    assert norm["Parameters"]["violation.$"] == "$.pipeline_contract_result.Payload"
+
+
+def test_gate_runs_before_any_spot_launch(sf, states):
+    """Walk the happy path (Next / Choice-Default) from StartAt and assert
+    PipelineContractGate is reached BEFORE the first ssm:sendCommand spot
+    launch — the whole point of L4595/L4520(b) is to fail before any spot
+    spend."""
+    seen_gate = False
+    cur = sf["StartAt"]
+    for _ in range(40):  # bounded walk
+        st = states[cur]
+        res = st.get("Resource", "")
+        if "ssm:sendCommand" in res:
+            assert seen_gate, (
+                f"spot launch {cur} reached before PipelineContractGate — the "
+                f"gate must precede all spot spend"
+            )
+            return
+        if cur == "PipelineContractGate":
+            seen_gate = True
+        nxt = st.get("Next") or st.get("Default")
+        if nxt is None:
+            break
+        cur = nxt
+    assert seen_gate, "walk never reached PipelineContractGate"


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** mid

Adds the pipeline-contract preflight gate to the Saturday Step Function, wired immediately after the existing lib-pin-drift gate (L4517) and before `CheckMutexRole` / the rest of the pipeline. Mirrors that gate's exact shape:

- `CheckPipelineContract` (Task) — invokes `alpha-engine-predictor-inference:live` with `action=check_pipeline_contract` (already merged and unit-tested in crucible-predictor PR #297). Same Retry/Timeout shape as the lib-pin gate. `Catch` fails open (routes to `CheckMutexRole` on the probe's own failure — a probe error must never false-halt the weekly run).
- `PipelineContractGate` (Choice) — `has_violation == true` routes to the normalizer; otherwise proceeds to `CheckMutexRole`.
- `ExtractPipelineContractError` (Pass) — normalizes the violation payload into `$.error` for `HandleFailure`'s `States.JsonToString($.error)` template, mirroring `ExtractLibPinDriftError` (a Choice transition doesn't populate `$.error` the way a Task Catch does).

Also rewired three existing convergence points that previously jumped straight to `CheckMutexRole`, since after this change that would silently bypass the new gate:
- `LibPinDriftGate.Default` (no drift) → now `CheckPipelineContract`
- `LibPinDriftCheck.Catch.Next` (probe's own failure, fail-open) → now `CheckPipelineContract`
- `CheckSkipLibPinDriftCheck`'s skip-flag path (`skip_lib_pin_drift_check=true`) → now `CheckPipelineContract` (the flag is scoped to skipping only the lib-pin check, not the pipeline-contract check)

Updated the pinned structural tests that hardcoded the old wiring (`test_sf_lib_pin_drift_wiring.py`, `test_sf_mutex_wiring.py`, `test_sf_friday_shell_run_wiring.py`, `test_sf_payload_uniqueness.py`'s Lambda-payload registry) and added `test_sf_pipeline_contract_wiring.py` mirroring the existing per-gate test convention. All ran locally and pass (`python3 -m pytest` on the full `test_sf_*` + `test_deploy_*` suite: 721 passed, 5 skipped — unrelated pre-existing collection errors in unrelated data-pipeline test modules are due to missing `pydantic`/etc in this sandbox, confirmed present on `main` too, not caused by this change). `python3 -m json.tool infrastructure/step_function.json` parses clean.

Ref: nousergon/alpha-engine-config#693

**Unvalidated / not exercised:** no AWS credentials available to actually execute a Saturday SF run or the Friday shell-run smoke test this issue's closes-when bar requires; validate by triggering a manual Friday shell-run of the Saturday SF (or a targeted state-machine test-execution starting at `CheckPipelineContract`) and confirming an injected `PIPELINE_CONTRACT.yaml` violation halts before `CheckMutexRole`.