### PR TITLE
[P2/mid] feat(sf): wire pre-spend pipeline-contract preflight gate (#693)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -35,7 +35,7 @@
       "Type": "Pass",
       "Comment": "mode=backtest-eval ONLY (config#830). Seeds skip_* defaults that bypass every stage EXCEPT Backtester + Evaluator: the front half (lib-pin/morning-enrich/data-phase1/rag/regime/research/data-phase2/eval-judge chain/aggregate-costs/predictor-training/drift-detection), the post-backtest model block (predictor-backtest + portfolio-optimizer), parity, and the post-eval tail (health checks/report-card/director via skip_post_eval). skip_backtester / skip_evaluator are deliberately NOT set, so those two run. Merge order States.JsonMerge(preset, $, false) makes the preset the BASE and the live input ($) WIN — so an operator can still override any single flag (e.g. {\"mode\": \"backtest-eval\", \"skip_parity\": false}) and it takes effect. Mirrors InitializeInput's JsonMerge-defaults idiom.",
       "Parameters": {
-        "merged.$": "States.JsonMerge(States.StringToJson('{\"skip_lib_pin_drift_check\":true,\"skip_morning_enrich\":true,\"skip_data_phase1\":true,\"skip_rag_ingestion\":true,\"skip_regime_substrate\":true,\"skip_regime_retrospective_eval\":true,\"skip_research\":true,\"skip_data_phase2\":true,\"skip_eval_judge\":true,\"skip_rationale_clustering\":true,\"skip_replay_concordance\":true,\"skip_counterfactual\":true,\"skip_aggregate_costs\":true,\"skip_predictor_training\":true,\"skip_predictor_backtest\":true,\"skip_portfolio_optimizer_backtest\":true,\"skip_parity\":true,\"skip_post_eval\":true}'),$,false)"
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"skip_lib_pin_drift_check\":true,\"skip_pipeline_contract_check\":true,\"skip_morning_enrich\":true,\"skip_data_phase1\":true,\"skip_rag_ingestion\":true,\"skip_regime_substrate\":true,\"skip_regime_retrospective_eval\":true,\"skip_research\":true,\"skip_data_phase2\":true,\"skip_eval_judge\":true,\"skip_rationale_clustering\":true,\"skip_replay_concordance\":true,\"skip_counterfactual\":true,\"skip_aggregate_costs\":true,\"skip_predictor_training\":true,\"skip_predictor_backtest\":true,\"skip_portfolio_optimizer_backtest\":true,\"skip_parity\":true,\"skip_post_eval\":true}'),$,false)"
       },
       "OutputPath": "$.merged",
       "Next": "CheckSkipLibPinDriftCheck"
@@ -105,7 +105,7 @@
           "Next": "ExtractLibPinDriftError"
         }
       ],
-      "Default": "CheckMutexRole"
+      "Default": "CheckSkipPipelineContractCheck"
     },
     "ExtractLibPinDriftError": {
       "Type": "Pass",
@@ -114,6 +114,84 @@
         "phase": "LibPinDriftGate",
         "source": "LibPinDriftGate.has_drift",
         "drift.$": "$.libpin_drift_result.Payload"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "CheckSkipPipelineContractCheck": {
+      "Type": "Choice",
+      "Comment": "Skip-gate (L4595 / config#693). {\"skip_pipeline_contract_check\": true} bypasses the pre-spend PIPELINE_CONTRACT.yaml preflight — e.g. an operator rerun where the contract is known-good. Mirrors CheckSkipLibPinDriftCheck.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_pipeline_contract_check",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_pipeline_contract_check",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "CheckMutexRole"
+        }
+      ],
+      "Default": "CheckPipelineContract"
+    },
+    "CheckPipelineContract": {
+      "Type": "Task",
+      "Comment": "Preventive pre-spend PIPELINE_CONTRACT.yaml preflight gate (L4595 / config#693). Runs right after LibPinDriftCheck, before any spot launch: fetches PIPELINE_CONTRACT.yaml + ARTIFACT_REGISTRY.yaml from GitHub raw and asserts self-consistency (every boundary's required keys present, every artifact_id present in ARTIFACT_REGISTRY.yaml). The CI validator + per-repo contract tests (L4520(a)) catch a producer/consumer field drift at PR time, but a config/SF-definition change made outside those repos' CI can still spend a Saturday spot before failing — this closes that gap. has_violation=true halts in seconds with the named violation(s) instead of failing mid-pipeline. FAIL-OPEN: a GitHub-fetch/parse miss sets has_violation=false (the probe's own degraded mode, reason=fetch_failed), and the Catch routes any Lambda failure straight to the pipeline — so the checker NEVER false-halts the weekly run.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_pipeline_contract"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-open — the probe's own failure must not halt the weekly run; proceed to the pipeline.",
+          "Next": "CheckMutexRole",
+          "ResultPath": "$.pipeline_contract_error"
+        }
+      ],
+      "ResultPath": "$.pipeline_contract_result",
+      "Next": "PipelineContractGate"
+    },
+    "PipelineContractGate": {
+      "Type": "Choice",
+      "Comment": "Hard-fail when the pipeline-contract probe reports has_violation=true (a confirmed PIPELINE_CONTRACT.yaml self-consistency break or a dangling artifact_id not in ARTIFACT_REGISTRY.yaml). Surfaces the contract break loudly before the SF spends on any spot launch. Routes via ExtractPipelineContractError (NOT straight to HandleFailure) — mirrors LibPinDriftGate's normalizer convention (a bare Choice→HandleFailure jump does not populate $.error, and HandleFailure's Message template hard-requires it via States.JsonToString($.error)).",
+      "Choices": [
+        {
+          "Variable": "$.pipeline_contract_result.Payload.has_violation",
+          "BooleanEquals": true,
+          "Next": "ExtractPipelineContractError"
+        }
+      ],
+      "Default": "CheckMutexRole"
+    },
+    "ExtractPipelineContractError": {
+      "Type": "Pass",
+      "Comment": "Normalize a confirmed pipeline-contract violation (PipelineContractGate has_violation==true) into $.error for HandleFailure's States.Format/JsonToString template. Mirrors ExtractLibPinDriftError — the gate is a Choice so it does not itself populate $.error; without this normalizer HandleFailure would die with States.Runtime instead of surfacing the violation(s). Carries the whole probe Payload (reason/violations/boundary_count) so the FAILED SNS alert names the exact contract break a human must resolve. References only $.pipeline_contract_result.Payload — guaranteed present because the gate already dereferenced Payload.has_violation to route here — so this normalizer cannot itself raise a missing-field States.Runtime.",
+      "Parameters": {
+        "phase": "PipelineContractGate",
+        "source": "PipelineContractGate.has_violation",
+        "violation.$": "$.pipeline_contract_result.Payload"
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -83,6 +83,9 @@ _EXPECTED_SKIPS = {
     # Added 2026-06-08 (L4517 — preventive cross-repo lib-pin drift gate,
     # the first state after InitializeInput).
     "skip_lib_pin_drift_check",
+    # Added 2026-07-04 (L4595 / config#693 — pre-spend PIPELINE_CONTRACT.yaml
+    # preflight gate, right after the lib-pin drift gate).
+    "skip_pipeline_contract_check",
     "skip_morning_enrich",
     "skip_data_phase1",
     "skip_rag_ingestion",
@@ -986,12 +989,19 @@ class TestHappyPathTraversal:
         # config#830: CheckRunMode (cadence preset) sits between InitializeInput
         # and the lib-pin gate; with no `mode` on the input it takes its Default
         # to CheckSkipLibPinDriftCheck — one extra Choice in the visited order.
+        # config#693 (L4595): the pipeline-contract preflight gate sits between
+        # LibPinDriftGate and CheckMutexRole — three extra states (skip-gate,
+        # check, gate) in the visited order, converging on CheckMutexRole with
+        # no drift/violation on the input.
         assert order[: order.index("CheckSkipMorningEnrich") + 2] == [
             "InitializeInput",
             "CheckRunMode",
             "CheckSkipLibPinDriftCheck",
             "LibPinDriftCheck",
             "LibPinDriftGate",
+            "CheckSkipPipelineContractCheck",
+            "CheckPipelineContract",
+            "PipelineContractGate",
             "CheckMutexRole",
             "CheckShellRun",
             "CheckSkipMorningEnrich",

--- a/tests/test_sf_lib_pin_drift_wiring.py
+++ b/tests/test_sf_lib_pin_drift_wiring.py
@@ -86,8 +86,9 @@ def test_gate_halts_only_on_confirmed_drift(states):
     # Confirmed drift halts, but routes through the $.error normalizer FIRST
     # (not straight to HandleFailure) — see test_drift_halt_normalizes_error.
     assert c["Next"] == "ExtractLibPinDriftError"
-    # No drift → proceed into the pipeline.
-    assert gate["Default"] == "CheckMutexRole"
+    # No drift → proceed into the pipeline-contract preflight gate (L4595 /
+    # config#693), the next pre-spend probe in the chain, then the pipeline.
+    assert gate["Default"] == "CheckSkipPipelineContractCheck"
 
 
 def test_drift_halt_normalizes_error_before_handle_failure(states):

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -176,9 +176,16 @@ class TestMutexWiring:
         # workload gate; its skip-default + gate-default converge on
         # CheckMutexRole — the mutex still sits between entry and the
         # former-first-state, one gate further down.
+        # 2026-07-04 (L4595 / config#693): the pipeline-contract preflight
+        # gate now sits between LibPinDriftGate and CheckMutexRole; its own
+        # skip-default + gate-default converge on CheckMutexRole in turn.
         assert saturday_sf["States"]["InitializeInput"]["Next"] == "CheckRunMode"
         assert saturday_sf["States"]["CheckRunMode"]["Default"] == "CheckSkipLibPinDriftCheck"
-        assert saturday_sf["States"]["LibPinDriftGate"]["Default"] == "CheckMutexRole"
+        assert (
+            saturday_sf["States"]["LibPinDriftGate"]["Default"]
+            == "CheckSkipPipelineContractCheck"
+        )
+        assert saturday_sf["States"]["PipelineContractGate"]["Default"] == "CheckMutexRole"
 
     def test_weekday_initialize_input_routes_to_check_mutex_role(self, weekday_sf):
         assert weekday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -73,6 +73,8 @@ def _flatten_states(sf_doc: dict) -> dict:
 _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # L4517: preventive cross-repo lib-pin drift gate (predictor-inference Lambda).
     "LibPinDriftCheck": frozenset({"action"}),
+    # L4595 / config#693: pre-spend pipeline-contract preflight gate (predictor-inference Lambda).
+    "CheckPipelineContract": frozenset({"action"}),
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),
     "RegimeSubstrate": frozenset({"action.$"}),
     "RegimeRetrospectiveEval": frozenset({"action.$"}),

--- a/tests/test_sf_pipeline_contract_wiring.py
+++ b/tests/test_sf_pipeline_contract_wiring.py
@@ -1,0 +1,144 @@
+"""Pins the pre-spend PIPELINE_CONTRACT.yaml preflight gate in the Saturday
+SF (L4595 / config#693).
+
+The gate (`CheckPipelineContract` → `PipelineContractGate`) MUST run before
+any spot launch and hard-fail the SF on a CONFIRMED PIPELINE_CONTRACT.yaml
+self-consistency break (a dangling `artifact_id` or a boundary missing a
+required key), while failing OPEN on the probe's own error. These tests
+catch regressions like: someone reorders it after a spot launch (defeating
+"fail before spend"), drops the fail-open Catch (probe fragility false-halts
+the weekly run), or inverts the gate's halt condition.
+
+Pairs with alpha-engine-predictor `inference/pipeline_contract_check.py`
+(the `action=check_pipeline_contract` Lambda handler, PR crucible-predictor
+#297). Modeled directly on `test_sf_lib_pin_drift_wiring.py` — the sibling
+gate this one runs immediately after.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def sf():
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf):
+    return sf["States"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "CheckSkipPipelineContractCheck",
+        "CheckPipelineContract",
+        "PipelineContractGate",
+    ],
+)
+def test_gate_states_exist(states, name):
+    assert name in states, f"{name} missing from Saturday SF States"
+
+
+def test_runs_immediately_after_lib_pin_drift_gate(states):
+    # The gate must be the next WORKLOAD gate after LibPinDriftGate — no spot
+    # launch or other work state may sit between the two pre-spend probes.
+    assert states["LibPinDriftGate"]["Default"] == "CheckSkipPipelineContractCheck"
+
+
+def test_skip_gate_default_runs_check_and_skip_bypasses(states):
+    skip = states["CheckSkipPipelineContractCheck"]
+    assert skip["Default"] == "CheckPipelineContract"
+    c = skip["Choices"][0]
+    # skip_pipeline_contract_check == true bypasses straight into the pipeline
+    assert c["Next"] == "CheckMutexRole"
+    variables = {x["Variable"] for x in c["And"]}
+    assert variables == {"$.skip_pipeline_contract_check"}
+
+
+def test_check_invokes_predictor_lambda_with_action(states):
+    chk = states["CheckPipelineContract"]
+    assert chk["Type"] == "Task"
+    assert chk["Resource"] == "arn:aws:states:::lambda:invoke"
+    assert chk["Parameters"]["FunctionName"] == "alpha-engine-predictor-inference:live"
+    assert chk["Parameters"]["Payload"]["action"] == "check_pipeline_contract"
+    assert chk["ResultPath"] == "$.pipeline_contract_result"
+    assert chk["Next"] == "PipelineContractGate"
+
+
+def test_check_fails_open_via_catch(states):
+    # The probe's own failure must proceed into the pipeline, NOT halt the
+    # weekly run.
+    catch = states["CheckPipelineContract"]["Catch"][0]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "CheckMutexRole"  # the pipeline, not HandleFailure
+
+
+def test_gate_halts_only_on_confirmed_violation(states):
+    gate = states["PipelineContractGate"]
+    assert gate["Type"] == "Choice"
+    c = gate["Choices"][0]
+    assert c["Variable"] == "$.pipeline_contract_result.Payload.has_violation"
+    assert c["BooleanEquals"] is True
+    # Confirmed violation halts, but routes through the $.error normalizer
+    # FIRST (not straight to HandleFailure) — see
+    # test_violation_halt_normalizes_error.
+    assert c["Next"] == "ExtractPipelineContractError"
+    # No violation → proceed into the pipeline.
+    assert gate["Default"] == "CheckMutexRole"
+
+
+def test_violation_halt_normalizes_error_before_handle_failure(states):
+    """The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) —
+    its transition does NOT populate $.error. HandleFailure's Message calls
+    States.JsonToString($.error), so a direct Choice→HandleFailure jump would
+    kill the SF with an opaque States.Runtime that swallows the violation
+    reason (the exact 2026-07-03 lib-pin-drift incident this mirrors). The
+    violation path must first hit a normalizer that writes $.error, matching
+    every other HandleFailure entry."""
+    norm = states["ExtractPipelineContractError"]
+    assert norm["Type"] == "Pass"
+    assert norm["ResultPath"] == "$.error"
+    assert norm["Next"] == "HandleFailure"
+    # References only the whole probe Payload — guaranteed present because
+    # the gate already dereferenced Payload.has_violation to route here — so
+    # the normalizer cannot itself raise a missing-field States.Runtime.
+    assert norm["Parameters"]["violation.$"] == "$.pipeline_contract_result.Payload"
+
+
+def test_gate_runs_before_any_spot_launch(sf, states):
+    """Walk the happy path (Next / Choice-Default) from StartAt and assert
+    PipelineContractGate is reached BEFORE the first ssm:sendCommand spot
+    launch — the whole point of this gate is to fail before any spot spend."""
+    seen_gate = False
+    cur = sf["StartAt"]
+    for _ in range(40):  # bounded walk
+        st = states[cur]
+        res = st.get("Resource", "")
+        if "ssm:sendCommand" in res:
+            assert seen_gate, (
+                f"spot launch {cur} reached before PipelineContractGate — "
+                f"the gate must precede all spot spend"
+            )
+            return
+        if cur == "PipelineContractGate":
+            seen_gate = True
+        nxt = st.get("Next") or st.get("Default")
+        if nxt is None:
+            break
+        cur = nxt
+    assert seen_gate, "walk never reached PipelineContractGate"
+
+
+def test_backtest_eval_preset_skips_pipeline_contract_check(states):
+    # config#830's mid-week Backtester→Evaluator-only preset must also skip
+    # this gate — a partial rerun has no reason to re-validate the contract.
+    preset = states["ApplyBacktestEvalPreset"]
+    assert '"skip_pipeline_contract_check":true' in preset["Parameters"]["merged.$"]


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** mid

Closes #693 (nousergon/alpha-engine-config#693).

Wires the predictor's `action=check_pipeline_contract` probe (crucible-predictor#297, already MERGED) into the Saturday Step Function as a new `CheckPipelineContract` → `PipelineContractGate` pair, inserted immediately after the existing `LibPinDriftCheck`/`LibPinDriftGate` — same Lambda ARN, same fail-open Catch, same `Extract*Error` → `HandleFailure` normalizer convention (the 2026-07-03 incident where a bare Choice→HandleFailure jump crashes with `States.Runtime` because `$.error` was never populated). Adds a `skip_pipeline_contract_check` Choice gate mirroring `skip_lib_pin_drift_check`, and folds it into the config#830 `backtest-eval` mid-week preset's skip bundle.

**Validated locally (green):**
- `python3 -m pytest tests/test_sf_pipeline_contract_wiring.py tests/test_sf_lib_pin_drift_wiring.py tests/test_sf_friday_shell_run_wiring.py tests/test_sf_mutex_wiring.py tests/test_sf_payload_uniqueness.py -q` → all pass (new wiring test added; 4 existing exact-order/registry chokepoint tests updated for the state insertion).
- Full `pytest tests/ --ignore=tests/test_crypto_balances.py` → 2616 passed, only 1 unrelated pre-existing failure (`test_edgar_redirect_is_effective_for_installed_edgartools`, an environment cache-path artifact — reproduces identically on `origin/main` with this branch's changes stashed).

**Why DRAFT, not ready:** the issue's own closing criterion is a *live* verification — "the Saturday SF halts early with a clear cause on a contract violation before any spot launch, verified (a Friday shell-run preflight exercises it)". That requires an actual AWS Step Functions execution, which this runner cannot perform. The one command Brian runs to close the loop:

```
aws stepfunctions start-execution --state-machine-arn <saturday-sf-arn> \
  --input '{"shell_run": true}'
```

then confirm `CheckPipelineContract`/`PipelineContractGate` appear in the execution history on the green path (no halt, since `origin/main`'s `PIPELINE_CONTRACT.yaml` is self-consistent). To exercise the halt path itself, temporarily break `PIPELINE_CONTRACT.yaml` on a scratch branch (e.g. reference a nonexistent `artifact_id`) and re-run — the execution should halt at `PipelineContractGate` with a populated `$.error` before any spot-launch state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)