### PR TITLE
[P1/mid] docs: remove stale ssm_secrets.py reference from OVERVIEW.md

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -41,7 +41,6 @@ Centralized data collection — price universe, macro, alternative data, feature
 | RAG ingestion pipelines | [`rag/pipelines/`](rag/pipelines/) |
 | Per-step completion emails | [`emailer.py`](emailer.py) |
 | Step Function preflight | [`sf_preflight.py`](sf_preflight.py) |
-| SSM secret loader | [`ssm_secrets.py`](ssm_secrets.py) |
 
 ## Inputs / outputs
 


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

Addresses nousergon/alpha-engine-config#890 (residual code-cleanup housekeeping — the `.env` deletion itself remains operator-blocked, not addressed here).

## What
The legacy `ssm_secrets.py` bulk-load shim was deleted from this repo in PR 9f of the `.env`->SSM migration arc, but `OVERVIEW.md` still listed it as the "SSM secret loader" with a dead link. Secrets now load per-call-site via `alpha_engine_lib.secrets.get_secret()` (see `lambda/handler.py` comment: "the bulk-load shim (ssm_secrets.load_secrets) was retired in PR 9f").

## NOT included here (workflow-scope limitation)
`.github/workflows/deploy.yml` also has a stale `'ssm_secrets.py'` entry in its `paths:` trigger filter (the file no longer exists, so this filter entry never matches anything — harmless but stale). This PR's actor has no `workflow` scope and cannot push changes under `.github/workflows/`. The one-line diff has been posted as a comment on config#890 for a workflow-scoped actor to apply (tracked config#1372).

## Validation
No code paths changed (docs-only); repo-wide grep confirms `ssm_secrets.py` does not exist anywhere else in this repo.

Not merging — per config#890 dispositioning, only Brian closes P1s.