### PR TITLE
[P1/mid] fix: complete PR4 cutover for sector_map.json (config#780)

### DIFF
--- a/collectors/constituents.py
+++ b/collectors/constituents.py
@@ -109,18 +109,15 @@ def collect(
     )
     logger.info("Wrote constituents.json to s3://%s/%s (%d tickers)", bucket, key, len(tickers))
 
-    # Write sector_map.json to canonical data path + legacy predictor
-    # path + Wave-3 new reference/ path. The new ``reference/`` write
-    # was missing from PR1 #270 because that PR scoped only the
-    # ticker-parquet write paths (yfinance / FRED / chronic-gap);
-    # sector_map.json travels through this separate constituents
-    # collector and needs its own write-both update so the Wave-3
-    # readers don't see a stale ``reference/`` copy after PR4 retires
-    # legacy.
+    # Write sector_map.json to canonical data path + Wave-3 reference/
+    # path. PR4 (config#780) retired the legacy predictor/price_cache/
+    # write: the ticker-parquet side already writes reference/ only via
+    # _price_cache_write_prefixes(), and this collector's own legacy
+    # write was the one straggler still recreating the deleted prefix
+    # on every weekly run.
     sector_map_body = json.dumps(sector_etf_map, indent=2, sort_keys=True)
     for sector_map_key in (
         "data/sector_map.json",
-        "predictor/price_cache/sector_map.json",
         "reference/price_cache/sector_map.json",
     ):
         s3.put_object(
@@ -128,7 +125,7 @@ def collect(
             Body=sector_map_body, ContentType="application/json",
         )
     logger.info(
-        "Wrote sector_map.json to data/, predictor/, and reference/ paths",
+        "Wrote sector_map.json to data/ and reference/ paths",
     )
 
     # tickers is included in the return so callers don't need an S3 round-trip

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -34,7 +34,7 @@ market_data:
 # Universe returns (Phase 1) — polygon.io forward return computation
 universe_returns:
   signals_prefix: signals           # S3 prefix for signal dates
-  sector_map_key: predictor/price_cache/sector_map.json
+  sector_map_key: reference/price_cache/sector_map.json
   # db_path: /tmp/research.db       # optional: override local DB path (auto-downloaded from S3)
 
 # Signal returns (Phase 1) — score_performance + predictor_outcomes backfill

--- a/tests/test_constituents_sector_map.py
+++ b/tests/test_constituents_sector_map.py
@@ -450,17 +450,18 @@ def test_collect_returns_tickers_in_dict() -> None:
     assert set(result["tickers"]) == {"AAPL", "MSFT", "JHG", "WSO"}
 
 
-def test_sector_map_writes_to_all_three_paths() -> None:
-    """Wave-3 PR3 (ROADMAP L1401): sector_map.json must be written to:
+def test_sector_map_writes_to_canonical_paths_only() -> None:
+    """PR4 cutover (config#780): sector_map.json must be written to:
 
       1. ``data/sector_map.json`` — canonical \"new\" data path.
-      2. ``predictor/price_cache/sector_map.json`` — legacy path (retired
-         in PR4).
-      3. ``reference/price_cache/sector_map.json`` — Wave-3 new home for
-         the predictor/price_cache/ migration. PR1 #270 missed this
-         write (it scoped only the ticker-parquet writes); without it,
-         readers that hit ``reference/`` first see a stale snapshot
-         after PR4 deletes legacy.
+      2. ``reference/price_cache/sector_map.json`` — Wave-3 home for
+         the predictor/price_cache/ migration.
+
+    The legacy ``predictor/price_cache/sector_map.json`` write is gone —
+    it was the one straggler still recreating the deleted legacy prefix
+    on every weekly run after the ticker-parquet side (via
+    ``_price_cache_write_prefixes()``) had already cut over to
+    ``reference/`` only.
     """
     from unittest.mock import MagicMock
 
@@ -489,7 +490,6 @@ def test_sector_map_writes_to_all_three_paths() -> None:
     written_keys = {c["Key"] for c in sector_map_writes}
     assert written_keys == {
         "data/sector_map.json",
-        "predictor/price_cache/sector_map.json",
         "reference/price_cache/sector_map.json",
     }, written_keys
     # Bodies must be byte-equal — readers can pick any path safely.

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -463,7 +463,7 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
                     db_path=db_path,
                     signals_prefix=ur_cfg.get("signals_prefix", "signals"),
                     sector_map_key=ur_cfg.get(
-                        "sector_map_key", "predictor/price_cache/sector_map.json"
+                        "sector_map_key", "reference/price_cache/sector_map.json"
                     ),
                     dry_run=dry_run,
                 ),


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

## Summary
While grooming `nousergon/alpha-engine-config#780` (predictor S3 namespace rationalization), live S3 evidence showed `predictor/price_cache/sector_map.json` (the legacy prefix, believed fully migrated and safe to delete) still received a fresh write on 2026-07-03 — one day after the per-ticker parquet writes there had stopped (2026-06-27, when the Wave-3 PR4 cutover moved those to `reference/price_cache/` only via `_price_cache_write_prefixes()`).

Root cause: `collectors/constituents.py`'s `collect()` writes `sector_map.json` through a separate write-both loop that was never updated in step with the parquet writer's PR4 cutover — it unconditionally wrote `data/`, `predictor/price_cache/`, and `reference/price_cache/` every weekly run. So the "all migration waves are code-complete, only the destructive `aws s3 rm` remains" conclusion on config#780 was incomplete: deleting the legacy prefix today would have had the very next weekly run silently recreate `predictor/price_cache/sector_map.json`.

## Changes
- `collectors/constituents.py`: drop the legacy write; write only `data/sector_map.json` + `reference/price_cache/sector_map.json`.
- `weekly_collector.py`: update the `sector_map_key` config-default fallback from the legacy path to `reference/price_cache/sector_map.json`.
- `config.yaml.example`: same default update.
- `tests/test_constituents_sector_map.py`: updated to assert the two-path (not three-path) write contract.

## Test plan
- [x] `pytest tests/test_constituents_sector_map.py tests/test_sf_preflight.py` — 41 passed
- [x] Full suite: `pytest -q` — 2626 passed, 15 skipped (pre-existing skips, unrelated)

Companion PR: `nousergon/alpha-engine-config` updates its own `sector_map_key` config default in the same direction (that config value is read verbatim with no legacy fallback, unlike `price_cache.s3_prefix` which is sentinel-translated).

Closes #780 (sector_map.json portion of the PR4 cutover — the destructive `aws s3 rm --recursive` on the two legacy prefixes remains a separate operator step per that issue).