### PR TITLE
feat(groom-dispatcher): pre-boot pace gate — skip spot launch before any cost

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -112,8 +112,22 @@ but injection protection is cheap).
   `Errors` metric during bootstrap-ops to page on it.)
 - **Kill-switch**: set the Lambda env `GROOM_DISPATCH_ENABLED=false` to disable
   without deleting the Scheduler rules.
-- **Narrow IAM**: the Lambda role reads only the one SSM PAT + its own log
-  group; the Scheduler execution role can `lambda:InvokeFunction` this function
+- **Pre-boot pace gate (2026-07-04)**: before launching the spot box, compares
+  reset-aligned weekly Claude usage (WET) against how much of the current
+  weekly window has elapsed (`krepis.usage_pacing.pace_check` — same gate
+  `alpha-engine-config/scripts/groom_budget.py` runs on-box); a launch running
+  ahead of pace is skipped entirely (`launched: false, reason: "pace_gate_skip"`,
+  routed through the existing `CheckLaunched`→`GroomSkipped` Step Function
+  branch, no SF changes needed). Fail-safe on any S3/read error — never blocks
+  a scheduled groom. `GROOM_PACE_GATE_ENABLED=false` disables just this gate
+  (independent of `GROOM_DISPATCH_ENABLED`); `GROOM_WEEKLY_WET_CEILING` /
+  `CCUSAGE_BUCKET` override the calibrated defaults.
+- **Narrow IAM**: the Lambda role needs no secret access (the box reads all
+  secrets itself from SSM via its own instance profile) — its own IAM grants
+  are EC2 launch/terminate, `iam:PassRole` for the executor role, SSM
+  send-command/describe, its own log group, and (2026-07-04) read-only S3
+  access to `claude_code_usage/*` in `alpha-engine-research` for the pace
+  gate. The Scheduler execution role can `lambda:InvokeFunction` this function
   only.
 
 ## Deploy

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -156,18 +156,21 @@ print('index.py syntax OK')
 "
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
-# Hermetic (boto3/nousergon_lib are stubbed in sys.modules before `import
-# index` — see test_handler.py's header), so only pytest itself needs to be
-# resolvable here, not the runtime deps. Installed into a scratch TEST_DEPS
-# dir — NOT the caller's global site-packages, not bundled into the Lambda
-# zip — so this works on a bare CI runner (2026-07-02: the CI auto-deploy
-# workflow's FIRST real run failed here with "No module named pytest" — this
-# script had only ever been run from an operator's laptop before, where
-# pytest happened to already be installed as a dev dependency; the gap was
-# invisible until CI actually exercised this path).
+# Hermetic for AWS (boto3/nousergon_lib are stubbed in sys.modules before
+# `import index` — see test_handler.py's header): those need real AWS creds/
+# services to exercise for real, so tests fake them instead. krepis (2026-07-04,
+# the pre-boot pace gate's linear-pace math) is pure stdlib with no AWS/creds
+# dependency, so it's installed for real here rather than stubbed — the tests
+# exercise the ACTUAL pace_check arithmetic, not a faked stand-in. Both land in
+# a scratch TEST_DEPS dir — NOT the caller's global site-packages, not bundled
+# into the Lambda zip — so this works on a bare CI runner (2026-07-02: the CI
+# auto-deploy workflow's FIRST real run failed here with "No module named
+# pytest" — this script had only ever been run from an operator's laptop
+# before, where pytest happened to already be installed as a dev dependency;
+# the gap was invisible until CI actually exercised this path).
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Installing pytest into ${TEST_DEPS}..."
-  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
+  echo "Installing pytest + krepis into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "krepis==0.10.0"
   echo "Running handler unit tests..."
   PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -48,6 +48,21 @@
       "Condition": {
         "StringEquals": { "ec2:ResourceTag/Name": "alpha-engine-groom-spot" }
       }
+    },
+    {
+      "Sid": "ReadClaudeCodeUsageForPaceGate",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": { "s3:prefix": "claude_code_usage/*" }
+      }
+    },
+    {
+      "Sid": "ReadClaudeCodeUsageObjectsForPaceGate",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/claude_code_usage/*"
     }
   ]
 }

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -29,6 +29,23 @@ Fail-loud (a scheduled groom IS the deliverable): a launch/SSM failure RAISES so
 EventBridge retries + the Lambda error metric + a CloudWatch alarm surface the
 miss, rather than silently dropping a pass.
 
+**Pre-boot pace gate (Brian-ratified 2026-07-04).** Before launching the spot
+box at all, this handler compares the reset-aligned weekly WET (interactive +
+groom, same S3 source `alpha-engine-config/scripts/groom_budget.py` reads) to
+how much of the current weekly reset window has already elapsed. If usage is
+running ahead of a straight-line pace through the window (the same
+``krepis.usage_pacing.pace_check`` gate `groom_budget.py` runs on-box), the
+launch is skipped entirely — no spot cost at all, not even the ~2-5 min boot.
+This REPLACES the box-side static 85%/95% floor/taper (config#1348) as the
+short-circuit's first line; `groom_budget.py`'s on-box gate (same pace check,
+different vantage point — sees this run's own live consumption too) remains
+as the second line for the GHA path and as a belt for this one. Fail-safe:
+ANY error reading S3/computing the gate → launch proceeds, never blocked by a
+pace-gate infra hiccup (mirrors `groom_budget.py`'s own fail-safe posture).
+A pace-gate skip returns ``launched: False`` — the dispatch Step Function's
+existing `CheckLaunched` → `GroomSkipped` branch (already used for the
+`GROOM_DISPATCH_ENABLED=false` kill-switch) handles it with no SF changes.
+
 Managed OUTSIDE CloudFormation (same as before): operator-deployed via
 `deploy.sh --bootstrap`. Merging the PR has ZERO live effect until the new code +
 IAM are deployed AND the GHA `schedule:` crons are disabled (the gated cutover).
@@ -36,13 +53,17 @@ IAM are deployed AND the GHA `schedule:` crons are disabled (the gated cutover).
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
 import time
 import uuid
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import boto3
+from krepis.usage_pacing import pace_check, reset_window
 from nousergon_lib import ec2_spot
 from nousergon_lib.ec2_spot import SpotCapacityExhausted
 
@@ -53,6 +74,21 @@ REGION = os.environ.get("AWS_REGION", "us-east-1")
 # Kill-switch: GROOM_DISPATCH_ENABLED=false disables the trigger without deleting
 # the EventBridge Scheduler rules. Default ON.
 DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
+
+# ── Pre-boot pace gate (mirrors alpha-engine-config/scripts/groom_budget.py) ───
+# Kill-switch independent of GROOM_DISPATCH_ENABLED — lets ops disable JUST the
+# pace gate (e.g. during a known burst) without touching the dispatch trigger.
+PACE_GATE_ENABLED = os.environ.get("GROOM_PACE_GATE_ENABLED", "true").lower() == "true"
+# Calibrated 2026-06-28 — MUST track alpha-engine-config/scripts/groom_budget.py's
+# WEEKLY_WET_CEILING; refine both together against /usage (config#1347).
+WEEKLY_WET_CEILING = int(os.environ.get("GROOM_WEEKLY_WET_CEILING", "1140000000"))
+_PT = ZoneInfo("America/Los_Angeles")
+# MUST match groom_budget.py's WEEKLY_RESET_ANCHOR/WEEKLY_PERIOD exactly — both
+# derive the SAME reset-aligned window from one observed reset instant.
+WEEKLY_RESET_ANCHOR = datetime(2026, 6, 28, 20, 59)   # PT, naive — one observed reset
+WEEKLY_PERIOD = timedelta(days=7)
+CCUSAGE_BUCKET = os.environ.get("CCUSAGE_BUCKET", "alpha-engine-research")
+CCUSAGE_PREFIX = "claude_code_usage/"
 
 # ── Spot launch config (env-overridable; defaults mirror spot_data_weekly.sh) ──
 # t3/t3a/t2 .medium (4 GB) across all 6 default-VPC subnets; the lib CLI rotates
@@ -96,6 +132,68 @@ _DEFAULT_MODEL = "claude-sonnet-5"
 # shell command below) — model ids are Lambda-config-controlled, not raw user
 # input, but this is cheap and rules out shell-metacharacter injection outright.
 _MODEL_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+def _parse_ccusage_key(key: str) -> "str | None":
+    """Date string from either layout: {source}/{date}.json or {source}/{date}/{run}.json.
+
+    Boto3 mirror of alpha-engine-config/scripts/groom_budget.py::_parse_key —
+    duplicated (not imported) because that script is a different repo and this
+    Lambda needs a boto3, not subprocess-`aws`-CLI, S3 client."""
+    p = key[len(CCUSAGE_PREFIX):].split("/")
+    if len(p) == 2 and p[1].endswith(".json"):
+        return p[1][:-5]
+    if len(p) == 3 and p[2].endswith(".json"):
+        return p[1]
+    return None
+
+
+def _read_weekly_wet(window_start: datetime) -> float:
+    """Sum WET (all sources) at/after the PT datetime ``window_start``, hour-precise.
+
+    Boto3 mirror of groom_budget.py::read_weekly_wet (same S3 layout, same
+    hour-boundary trim on the window's start day)."""
+    s3 = boto3.client("s3", region_name=REGION)
+    total = 0.0
+    start_date = window_start.date().isoformat()
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=CCUSAGE_BUCKET, Prefix=CCUSAGE_PREFIX):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            d = _parse_ccusage_key(key)
+            if not d or d < start_date:
+                continue
+            body = s3.get_object(Bucket=CCUSAGE_BUCKET, Key=key)["Body"].read()
+            doc = json.loads(body or b"{}")
+            for hr, models in (doc.get("by_hour") or {}).items():
+                if d == start_date and int(hr) < window_start.hour:
+                    continue
+                total += sum(r.get("wet", 0) for r in models.values())
+    return total
+
+
+def _pace_gate_status() -> dict:
+    """Compute the pre-boot pace-gate decision. Fail-safe: ANY error (S3 read,
+    parse, credentials) returns ``exceeded: False`` with the error recorded —
+    a pace-gate infra hiccup must never block a scheduled groom, mirroring
+    groom_budget.py's own fail-safe posture."""
+    try:
+        now_pt = datetime.now(_PT).replace(tzinfo=None)
+        window_start, _next_reset = reset_window(now_pt, WEEKLY_RESET_ANCHOR, WEEKLY_PERIOD)
+        wet = _read_weekly_wet(window_start)
+        used_frac = wet / WEEKLY_WET_CEILING if WEEKLY_WET_CEILING else 0.0
+        status = pace_check(used_frac, now_pt, WEEKLY_RESET_ANCHOR, WEEKLY_PERIOD)
+        return {
+            "exceeded": status.exceeded,
+            "used_frac": round(status.used_frac, 4),
+            "elapsed_frac": round(status.elapsed_frac, 4),
+            "overrun": round(status.overrun, 4),
+            "wet": round(wet, 1),
+        }
+    except Exception as e:  # noqa: BLE001 — fail-safe: never block a scheduled groom
+        logger.warning("pace gate check failed (non-fatal, launching anyway): %s: %s",
+                       type(e).__name__, e)
+        return {"exceeded": False, "error": f"{type(e).__name__}: {e}"}
 
 
 def _resolve_run_mode(event: dict) -> str:
@@ -349,6 +447,11 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     a manual-invoke-ONLY bounded-test override — no live schedule sets it.
     `force_on_demand` (config#1645) is set only by the dispatch Step Function's
     own relaunch loop on its final bounded retry — no live schedule sets it.
+
+    Pre-boot pace gate (2026-07-04): if weekly Claude usage is running ahead
+    of a linear pace through the current reset window, the launch is skipped
+    entirely — before any spot cost is incurred — rather than deferring the
+    decision to the on-box `groom_budget.py` gate. See module docstring.
     """
     event = event or {}
     run_mode = _resolve_run_mode(event)
@@ -362,5 +465,16 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "force_on_demand=%s schedule=%s",
         run_mode, model, issue_filter, soft_limit_min, force_on_demand, schedule_label,
     )
+
+    if PACE_GATE_ENABLED:
+        pace = _pace_gate_status()
+        if pace.get("exceeded"):
+            logger.warning(
+                "pace gate SKIP — used_frac=%.4f > elapsed_frac=%.4f (overrun=%+.4f, "
+                "wet=%.0f) — groom spot NOT launched, resumes next schedule/reset",
+                pace["used_frac"], pace["elapsed_frac"], pace["overrun"], pace["wet"],
+            )
+            return {"groom": {"launched": False, "reason": "pace_gate_skip", **pace}}
+
     result = _launch_groom_spot(run_mode, schedule_label, model, issue_filter, soft_limit_min, force_on_demand)
     return {"groom": result}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -8,3 +8,7 @@ boto3>=1.34.0
 # just boto3, which the runtime provides; base deps (pydantic/pyyaml/requests) are
 # light and well under the Lambda size limit.
 nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.70.0
+# usage_pacing (linear-pace short-circuit math) for the pre-boot pace gate
+# (2026-07-04) — mirrors alpha-engine-config/scripts/groom_budget.py's on-box
+# gate. Pure-stdlib module, published to PyPI (nousergon/krepis).
+krepis==0.10.0

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -74,12 +74,48 @@ class _FakeSsm:
         return {"Command": {"CommandId": "cmd-123"}}
 
 
-def _load(monkeypatch, *, launch_impl=None, env=None):
+class _FakeS3Body:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FakeS3Paginator:
+    def __init__(self, objects: dict):
+        self._objects = objects
+
+    def paginate(self, Bucket, Prefix):  # noqa: N803 — boto3 kwarg names
+        keys = [k for k in self._objects if k.startswith(Prefix)]
+        yield {"Contents": [{"Key": k} for k in keys]}
+
+
+class _FakeS3:
+    """Fake S3 client for the pace gate's boto3-native WET reader.
+
+    ``objects`` maps a full S3 key to its raw JSON bytes content — mirrors the
+    real ``claude_code_usage/{source}/{date}[/{run}].json`` layout.
+    """
+
+    def __init__(self, objects: dict | None = None):
+        self._objects = objects or {}
+
+    def get_paginator(self, name):
+        assert name == "list_objects_v2"
+        return _FakeS3Paginator(self._objects)
+
+    def get_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg names
+        return {"Body": _FakeS3Body(self._objects[Key])}
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None):
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
     ssm = _FakeSsm()
     ec2 = _FakeEc2()
-    clients = {"ec2": ec2, "ssm": ssm}
+    s3 = _FakeS3(s3_objects)
+    clients = {"ec2": ec2, "ssm": ssm, "s3": s3}
     if launch_impl is None:
         launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
     _install_stubs(launch_impl, clients)
@@ -88,6 +124,7 @@ def _load(monkeypatch, *, launch_impl=None, env=None):
     importlib.reload(index)
     index._test_ssm = ssm  # expose for assertions
     index._test_ec2 = ec2
+    index._test_s3 = s3
     return index
 
 
@@ -170,6 +207,69 @@ def test_high_only_schedule_forwards_model_and_issue_filter(monkeypatch):
     assert "export GROOM_MODEL=claude-opus-4-8" in cmd
     assert "export GROOM_ISSUE_FILTER=high-only" in cmd
     assert cmd.index("export GROOM_MODEL") < cmd.index("groom_spot_bootstrap.sh")
+
+
+# ── Pre-boot pace gate (2026-07-04) ─────────────────────────────────────────
+def _wet_doc(wet: float) -> bytes:
+    import json
+    return json.dumps({"by_hour": {"10": {"opus": {"wet": wet}}}}).encode()
+
+
+def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
+    # 1 day into the window (elapsed_frac ~= 1/7 ~= 0.143): 50% of the weekly
+    # ceiling already consumed is way ahead of pace -> skip BEFORE any launch.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"},
+                s3_objects={"claude_code_usage/groom/2026-06-29.json":
+                            _wet_doc(0.5 * 1_140_000_000)})
+    fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
+    monkeypatch.setattr(idx, "datetime", type("D", (), {
+        "now": staticmethod(lambda tz=None: fixed_now)}))
+
+    def _launch(types_, subnets, **kw):
+        raise AssertionError("spot launch must NOT be attempted when the pace gate skips")
+
+    monkeypatch.setattr(idx.ec2_spot, "launch", _launch)
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    g = out["groom"]
+    assert g["launched"] is False
+    assert g["reason"] == "pace_gate_skip"
+    assert g["exceeded"] is True
+    assert idx._test_ssm.sent == []  # no bootstrap command ever sent
+
+
+def test_pace_gate_allows_launch_when_on_pace(monkeypatch):
+    # 50% elapsed, only 10% of the ceiling used -> well under pace -> launches.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"},
+                s3_objects={"claude_code_usage/groom/2026-06-29.json":
+                            _wet_doc(0.1 * 1_140_000_000)})
+    fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=3, hours=12)
+    monkeypatch.setattr(idx, "datetime", type("D", (), {
+        "now": staticmethod(lambda tz=None: fixed_now)}))
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    assert out["groom"]["launched"] is True
+    assert len(idx._test_ssm.sent) == 1
+
+
+def test_pace_gate_disabled_still_launches_even_if_ahead_of_pace(monkeypatch):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true",
+                                   "GROOM_PACE_GATE_ENABLED": "false"},
+                s3_objects={"claude_code_usage/groom/2026-06-29.json":
+                            _wet_doc(0.99 * 1_140_000_000)})
+    fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
+    monkeypatch.setattr(idx, "datetime", type("D", (), {
+        "now": staticmethod(lambda tz=None: fixed_now)}))
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    assert out["groom"]["launched"] is True
+
+
+def test_pace_gate_fails_safe_and_still_launches_on_s3_error(monkeypatch):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+
+    def _boom(**kw):
+        raise RuntimeError("S3 unreachable")
+    monkeypatch.setattr(idx._test_s3, "get_paginator", _boom)
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    assert out["groom"]["launched"] is True
 
 
 def test_missing_model_and_issue_filter_default_to_sonnet_queue(monkeypatch):


### PR DESCRIPTION
## Summary
- Before launching the backlog groom's EC2 spot box, `scheduled-groom-dispatcher`'s `handler()` now checks whether weekly Claude usage (WET) is running ahead of a linear pace through the current reset window (`krepis.usage_pacing.pace_check`) — the same gate `alpha-engine-config/scripts/groom_budget.py` runs on-box (see companion PR nousergon/alpha-engine-config#1721, replacing that repo's static 85%/95% floor/taper, config#1348).
- A launch running ahead of pace is skipped **entirely** — before any spot cost is incurred at all (cheaper than the on-box gate, which still pays for the ~2-5 min boot). Returns `{"groom": {"launched": false, "reason": "pace_gate_skip", ...}}`, which routes through the **existing** `CheckLaunched` → `GroomSkipped` Step Function branch (already used for the `GROOM_DISPATCH_ENABLED` kill-switch) — **zero Step Function changes needed**.
- New boto3-native S3 WET reader (mirrors `groom_budget.py`'s subprocess-`aws`-CLI version — a Lambda needs boto3, not a shell-out) needs new read-only IAM (`s3:ListBucket`/`s3:GetObject` scoped to `claude_code_usage/*` in `alpha-engine-research`) — see `iam-policy.json`. Per this repo's operational split, this IAM change has **zero live effect until an operator runs `deploy.sh --bootstrap`** (the CI OIDC role can't modify IAM); the code itself auto-deploys on merge.
- Independent kill-switch (`GROOM_PACE_GATE_ENABLED=false`) separate from `GROOM_DISPATCH_ENABLED`; fail-safe on any S3/read error (launch proceeds, mirrors `groom_budget.py`'s posture).

## Merge-order dependency — post-merge deploy risk, not a PR-gate check
`requirements.txt` and `deploy.sh`'s preflight-test step pin `krepis==0.10.0`, not yet on PyPI — it ships when **nousergon/krepis#12** merges (CI green across py3.9-3.13). This repo's PR-gate CI (below) doesn't exercise that pin — `deploy-scheduled-groom-dispatcher.yml` only triggers on `push` to `main`, not on PRs — so this PR's own checks are genuinely green. But if THIS PR merges before krepis#12, the merge-triggered auto-deploy run will fail at `deploy.sh`'s "install pytest + krepis" step (package not found), leaving the Lambda's code deploy stuck red until krepis#12 merges. **Merge krepis#12 first**, then this PR, to avoid that. Same note applies to the companion `alpha-engine-config` PR (whose `scripts-tests.yml` DOES run on PRs and is currently red on this same pin, confirmed by log — see that PR).

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py -v` — 22 passed (18 pre-existing + 4 new pace-gate tests: skip-when-ahead, launch-when-on-pace, kill-switch, fail-safe-on-S3-error), krepis installed for real from the companion krepis PR's branch, boto3/nousergon_lib still hermetically stubbed
- [x] `ast.parse(index.py)` — syntax OK; `iam-policy.json` valid JSON; `bash -n deploy.sh` — OK
- [x] `ruff check` on changed files — clean
- [x] This PR's actual CI (`test` — repo-level `pytest tests/ -v`, unrelated to the Lambda-specific suite) — **PASS**, confirmed via `gh pr checks`

## Post-merge operator step
Once merged + krepis#12 is live: `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap` to apply the new IAM (code itself auto-deploys via the existing GHA workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)