### PR TITLE
feat(groom-dispatcher): Telegram ping on a pre-boot pace-gate skip

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -118,16 +118,22 @@ but injection protection is cheap).
   `alpha-engine-config/scripts/groom_budget.py` runs on-box); a launch running
   ahead of pace is skipped entirely (`launched: false, reason: "pace_gate_skip"`,
   routed through the existing `CheckLaunched`→`GroomSkipped` Step Function
-  branch, no SF changes needed). Fail-safe on any S3/read error — never blocks
-  a scheduled groom. `GROOM_PACE_GATE_ENABLED=false` disables just this gate
-  (independent of `GROOM_DISPATCH_ENABLED`); `GROOM_WEEKLY_WET_CEILING` /
-  `CCUSAGE_BUCKET` override the calibrated defaults.
-- **Narrow IAM**: the Lambda role needs no secret access (the box reads all
-  secrets itself from SSM via its own instance profile) — its own IAM grants
-  are EC2 launch/terminate, `iam:PassRole` for the executor role, SSM
-  send-command/describe, its own log group, and (2026-07-04) read-only S3
-  access to `claude_code_usage/*` in `alpha-engine-research` for the pace
-  gate. The Scheduler execution role can `lambda:InvokeFunction` this function
+  branch, no SF changes needed) **and sends its own Telegram ping** — the only
+  place a pre-boot skip is ever visible, since a run that never boots has no
+  on-box `groom_run.sh` to notify the way the on-box budget-gate skip does.
+  Fail-safe on any S3/read error — never blocks a scheduled groom (and never
+  pings on a fail-safe pass-through either). `GROOM_PACE_GATE_ENABLED=false`
+  disables just this gate (independent of `GROOM_DISPATCH_ENABLED`);
+  `GROOM_WEEKLY_WET_CEILING` / `CCUSAGE_BUCKET` override the calibrated
+  defaults.
+- **Narrow IAM**: the box reads its own run secrets from SSM via its own
+  instance profile — this Lambda needs none of those. Its own IAM grants are
+  EC2 launch/terminate, `iam:PassRole` for the executor role, SSM
+  send-command/describe, its own log group, read-only S3 access to
+  `claude_code_usage/*` in `alpha-engine-research` for the pace gate, and
+  (2026-07-04) `ssm:GetParameter` on just the two Telegram secret params for
+  the pace-gate-skip ping (mirrors `sf-telegram-notifier`'s exact IAM
+  pattern). The Scheduler execution role can `lambda:InvokeFunction` this function
   only.
 
 ## Deploy

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -63,6 +63,15 @@
       "Effect": "Allow",
       "Action": ["s3:GetObject"],
       "Resource": "arn:aws:s3:::alpha-engine-research/claude_code_usage/*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
     }
   ]
 }

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -20,10 +20,12 @@ fleet chokepoints — no lib change):
      (InstanceInitiatedShutdownBehavior=terminate + a watchdog). The Lambda
      returns immediately — it does NOT babysit the multi-hour run.
 
-The box reads ALL secrets itself from SSM via its instance profile
+The box reads its OWN run secrets (PAT, etc.) from SSM via its instance profile
 (alpha-engine-executor-profile → alpha-engine-executor-role, which already has
-ssm:GetParameter on /alpha-engine/*), so this Lambda needs NO secret access — it
-only needs ec2:RunInstances, iam:PassRole (the executor role), and ssm:SendCommand.
+ssm:GetParameter on /alpha-engine/*) — this Lambda needs none of those. It DOES
+(2026-07-04) read the two Telegram secrets itself, scoped narrowly (see the
+pre-boot pace gate note below), for the one notification only IT can send (a
+pre-boot skip never boots a box, so there's no on-box groom_run.sh to ping).
 
 Fail-loud (a scheduled groom IS the deliverable): a launch/SSM failure RAISES so
 EventBridge retries + the Lambda error metric + a CloudWatch alarm surface the
@@ -44,7 +46,13 @@ ANY error reading S3/computing the gate → launch proceeds, never blocked by a
 pace-gate infra hiccup (mirrors `groom_budget.py`'s own fail-safe posture).
 A pace-gate skip returns ``launched: False`` — the dispatch Step Function's
 existing `CheckLaunched` → `GroomSkipped` branch (already used for the
-`GROOM_DISPATCH_ENABLED=false` kill-switch) handles it with no SF changes.
+`GROOM_DISPATCH_ENABLED=false` kill-switch) handles it with no SF changes. A
+skip also sends its own Telegram ping — best-effort via `krepis.telegram
+.send_message` (never raises), scoped IAM to read just the two Telegram SSM
+params (see iam-policy.json). Distinct from the on-box budget gate's own
+Telegram ping (`groom_budget.py` skip, or `groom_driver.py`'s mid-run
+recheck via `groom_run.sh`'s "WOUND DOWN" message) — a pre-boot skip never
+reaches the box, so this Lambda is the ONLY place that can notify for it.
 
 Managed OUTSIDE CloudFormation (same as before): operator-deployed via
 `deploy.sh --bootstrap`. Merging the PR has ZERO live effect until the new code +
@@ -63,6 +71,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import boto3
+from krepis.telegram import send_message
 from krepis.usage_pacing import pace_check, reset_window
 from nousergon_lib import ec2_spot
 from nousergon_lib.ec2_spot import SpotCapacityExhausted
@@ -451,7 +460,11 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     Pre-boot pace gate (2026-07-04): if weekly Claude usage is running ahead
     of a linear pace through the current reset window, the launch is skipped
     entirely — before any spot cost is incurred — rather than deferring the
-    decision to the on-box `groom_budget.py` gate. See module docstring.
+    decision to the on-box `groom_budget.py` gate. See module docstring. A
+    skip here sends its own Telegram ping (best-effort — `krepis.telegram
+    .send_message` never raises) since this is the ONLY place a pre-boot skip
+    is ever visible; a run that never boots has no on-box `groom_run.sh` to
+    fire its own notification the way the on-box budget-gate skip does.
     """
     event = event or {}
     run_mode = _resolve_run_mode(event)
@@ -473,6 +486,14 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 "pace gate SKIP — used_frac=%.4f > elapsed_frac=%.4f (overrun=%+.4f, "
                 "wet=%.0f) — groom spot NOT launched, resumes next schedule/reset",
                 pace["used_frac"], pace["elapsed_frac"], pace["overrun"], pace["wet"],
+            )
+            send_message(
+                "🟡 Backlog groom SKIPPED — soft budget threshold passed before boot "
+                f"(schedule={schedule_label}, run_mode={run_mode}). Weekly usage "
+                f"{pace['used_frac']:.0%} > {pace['elapsed_frac']:.0%} elapsed "
+                f"(overrun {pace['overrun']:+.0%}). Spot box was never launched — no "
+                "cost incurred. Resumes automatically on the next scheduled run "
+                "(or after the weekly reset)."
             )
             return {"groom": {"launched": False, "reason": "pace_gate_skip", **pace}}
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -215,6 +215,17 @@ def _wet_doc(wet: float) -> bytes:
     return json.dumps({"by_hour": {"10": {"opus": {"wet": wet}}}}).encode()
 
 
+def _spy_send_message(monkeypatch, idx):
+    """Replace krepis.telegram.send_message (imported into index as
+    `send_message`) with a recorder — avoids exercising the real secret
+    resolution / HTTP path (this test harness's fake SSM client doesn't
+    implement get_parameter, so the real krepis.secrets code path would blow
+    up on an AttributeError it isn't built to catch)."""
+    calls = []
+    monkeypatch.setattr(idx, "send_message", lambda text, **kw: calls.append(text) or True)
+    return calls
+
+
 def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
     # 1 day into the window (elapsed_frac ~= 1/7 ~= 0.143): 50% of the weekly
     # ceiling already consumed is way ahead of pace -> skip BEFORE any launch.
@@ -224,6 +235,7 @@ def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
     fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
     monkeypatch.setattr(idx, "datetime", type("D", (), {
         "now": staticmethod(lambda tz=None: fixed_now)}))
+    notified = _spy_send_message(monkeypatch, idx)
 
     def _launch(types_, subnets, **kw):
         raise AssertionError("spot launch must NOT be attempted when the pace gate skips")
@@ -235,6 +247,12 @@ def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
     assert g["reason"] == "pace_gate_skip"
     assert g["exceeded"] is True
     assert idx._test_ssm.sent == []  # no bootstrap command ever sent
+    # The pre-boot skip must notify — it's the ONLY place this outcome is ever
+    # visible (a run that never boots has no on-box groom_run.sh to ping).
+    assert len(notified) == 1
+    assert "SKIPPED" in notified[0]
+    assert "soft budget threshold passed before boot" in notified[0]
+    assert "never launched" in notified[0]
 
 
 def test_pace_gate_allows_launch_when_on_pace(monkeypatch):
@@ -245,9 +263,11 @@ def test_pace_gate_allows_launch_when_on_pace(monkeypatch):
     fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=3, hours=12)
     monkeypatch.setattr(idx, "datetime", type("D", (), {
         "now": staticmethod(lambda tz=None: fixed_now)}))
+    notified = _spy_send_message(monkeypatch, idx)
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     assert out["groom"]["launched"] is True
     assert len(idx._test_ssm.sent) == 1
+    assert notified == []  # no ping when nothing was skipped
 
 
 def test_pace_gate_disabled_still_launches_even_if_ahead_of_pace(monkeypatch):
@@ -258,18 +278,22 @@ def test_pace_gate_disabled_still_launches_even_if_ahead_of_pace(monkeypatch):
     fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
     monkeypatch.setattr(idx, "datetime", type("D", (), {
         "now": staticmethod(lambda tz=None: fixed_now)}))
+    notified = _spy_send_message(monkeypatch, idx)
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     assert out["groom"]["launched"] is True
+    assert notified == []  # kill-switch disables the ping too — the gate never ran
 
 
 def test_pace_gate_fails_safe_and_still_launches_on_s3_error(monkeypatch):
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    notified = _spy_send_message(monkeypatch, idx)
 
     def _boom(**kw):
         raise RuntimeError("S3 unreachable")
     monkeypatch.setattr(idx._test_s3, "get_paginator", _boom)
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     assert out["groom"]["launched"] is True
+    assert notified == []  # fail-safe path never trips (exceeded=False), no ping
 
 
 def test_missing_model_and_issue_filter_default_to_sonnet_queue(monkeypatch):


### PR DESCRIPTION
## Summary
Follow-up to #617 (merged). Brian asked for a Telegram notification distinguishing "short-circuited at the beginning" from "short-circuited to soft budget during the run." This PR is the **pre-boot** half — the mid-run half is the companion alpha-engine-config PR (link below).

- A pre-boot pace-gate skip never reaches the box, so there's no on-box `groom_run.sh` to send the notification the way the existing budget-gate skip does — this Lambda is the **only** place that can.
- Uses `krepis.telegram.send_message` (best-effort, never raises per its own contract).
- New IAM (`ssm:GetParameter` scoped to just `/alpha-engine/TELEGRAM_BOT_TOKEN` and `/alpha-engine/TELEGRAM_CHAT_ID`) mirrors `sf-telegram-notifier`'s **exact, already-live-working** pattern — no KMS grant needed, confirmed by that Lambda's live precedent. Per this repo's operational split, zero live effect until `deploy.sh --bootstrap` runs.
- No ping on the non-skip paths (on-pace launch, kill-switch disabled, fail-safe S3-error pass-through) — only the actual skip notifies, verified by explicit tests asserting the spy was never called.

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py -v` — 22 passed (krepis 0.10.0 installed for real from PyPI; `send_message` monkeypatched to a spy — the test harness's fake SSM client doesn't implement `get_parameter`, so exercising the real secret-resolution path isn't meaningful here and would blow up on an AttributeError krepis.secrets isn't built to catch)
- [x] `ast.parse(index.py)` — OK; `iam-policy.json` valid JSON
- [x] `ruff check` on changed files — clean
- [x] This PR's actual PR-gate CI (repo-level `pytest tests/ -v`, unrelated to this Lambda's own suite) should be green — same situation as #617

## Post-merge operator step
Once merged: `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap` to apply the new Telegram-secrets IAM (code itself auto-deploys via the existing GHA workflow).

Companion: nousergon/alpha-engine-config (mid-run "WOUND DOWN" ping + a floor-breach false-positive fix) — no merge-order dependency between these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)