### PR TITLE
feat(notifications): shared flow-doctor helper + sentinel forum routing (config#1742)

### DIFF
--- a/infrastructure/lambdas/flow_doctor_telegram.py
+++ b/infrastructure/lambdas/flow_doctor_telegram.py
@@ -1,0 +1,120 @@
+"""Shared flow-doctor Telegram routing for alpha-engine-data Lambdas (config#1742)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from nousergon_lib.telegram import send_message
+
+logger = logging.getLogger(__name__)
+
+_FLOW_DOCTOR_BY_NAME: dict[str, Any | None] = {}
+_INIT_ATTEMPTED: set[str] = set()
+
+
+def reset_flow_doctor_cache() -> None:
+    """Test hook — clear lazy-init state between handler invocations."""
+    _FLOW_DOCTOR_BY_NAME.clear()
+    _INIT_ATTEMPTED.clear()
+
+
+def build_flow_doctor_config(
+    flow_name: str,
+    topics: Sequence[Any],
+    *,
+    db_basename: str,
+    repo: str = "nousergon/nousergon-data",
+) -> dict:
+    from nousergon_lib.flow_doctor_fleet import fleet_telegram_notifier_dicts
+
+    return {
+        "flow_name": flow_name,
+        "repo": repo,
+        "owner": "@brianmcmahon",
+        "notify": fleet_telegram_notifier_dicts(topics),
+        "store": {"type": "sqlite", "path": f"/tmp/{db_basename}.db"},
+        "dedup_cooldown_minutes": 1,
+        "rate_limits": {"max_alerts_per_day": 100},
+    }
+
+
+def get_flow_doctor(
+    flow_name: str,
+    topics: Sequence[Any],
+    *,
+    db_basename: str,
+) -> Any | None:
+    if flow_name in _FLOW_DOCTOR_BY_NAME:
+        return _FLOW_DOCTOR_BY_NAME[flow_name]
+    if flow_name in _INIT_ATTEMPTED:
+        return None
+    _INIT_ATTEMPTED.add(flow_name)
+    if os.environ.get("FLOW_DOCTOR_ENABLED", "1") != "1":
+        _FLOW_DOCTOR_BY_NAME[flow_name] = None
+        return None
+    try:
+        import yaml
+        from nousergon_lib.logging import get_flow_doctor, setup_logging
+
+        cfg = build_flow_doctor_config(flow_name, topics, db_basename=db_basename)
+        path = Path(f"/tmp/flow_doctor_{db_basename}.yaml")
+        path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+        setup_logging(flow_name, flow_doctor_yaml=str(path))
+        fd = get_flow_doctor()
+        _FLOW_DOCTOR_BY_NAME[flow_name] = fd
+        return fd
+    except Exception as exc:  # noqa: BLE001 — fall back to send_message
+        logger.warning("flow-doctor init failed for %s: %s", flow_name, exc)
+        _FLOW_DOCTOR_BY_NAME[flow_name] = None
+        return None
+
+
+def topic_telegram_notifier(fd: Any, topic: Any) -> Any | None:
+    from flow_doctor.notify.telegram import TelegramNotifier
+    from nousergon_lib.flow_doctor_fleet import fleet_telegram_thread_id_env
+
+    want = os.environ.get(fleet_telegram_thread_id_env(topic))
+    for notifier in fd._notifiers:
+        if not isinstance(notifier, TelegramNotifier):
+            continue
+        thread_id = getattr(notifier, "message_thread_id", None)
+        if thread_id is not None and str(thread_id) == str(want):
+            return notifier
+    return None
+
+
+def notify_via_flow_doctor(
+    text: str,
+    *,
+    silent: bool,
+    severity: str,
+    dedup_key: str,
+    flow_name: str,
+    topics: Sequence[Any],
+    db_basename: str,
+    context: Optional[Dict[str, Any]] = None,
+    silent_topic: Any | None = None,
+) -> bool:
+    """Route ``text`` through flow-doctor forum topics; fallback to ``send_message``."""
+    fd = get_flow_doctor(flow_name, topics, db_basename=db_basename)
+    if fd is None:
+        return send_message(text, disable_notification=silent)
+
+    subject = text.split("\n", 1)[0].replace("*", "")
+
+    if silent and silent_topic is not None:
+        notifier = topic_telegram_notifier(fd, silent_topic)
+        if notifier is not None:
+            return notifier.send_raw(text, disable_notification=True) is not None
+
+    report_id = fd.notify_event(
+        subject,
+        body=text,
+        severity=severity,
+        context=context or {},
+        dedup_key=dedup_key,
+    )
+    return report_id is not None

--- a/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
@@ -54,6 +54,7 @@ trap "rm -rf '$PKG'" EXIT
 echo "Installing deps into ${PKG} (pip install -t)..."
 python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
@@ -79,7 +80,7 @@ if $BOOTSTRAP; then
     echo "  Creating Lambda: ${FUNCTION_NAME}"
     run aws lambda create-function --function-name "${FUNCTION_NAME}" --runtime python3.12 --role "${ROLE_ARN}" \
       --handler index.handler --zip-file "fileb://${ZIP}" --timeout 60 --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" --query 'FunctionArn' --output text
+      --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' --region "${REGION}" --query 'FunctionArn' --output text
   else
     echo "  Lambda exists, code will be updated in step 3"
   fi
@@ -101,6 +102,14 @@ echo "Updating Lambda function code: ${FUNCTION_NAME}"
 run aws lambda update-function-code --function-name "${FUNCTION_NAME}" --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"; fi
 echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"; fi
 
 # ----- 4. Smoke -------------------------------------------------------------
 if $SMOKE; then

--- a/infrastructure/lambdas/saturday-integrity-sentinel/iam-policy.json
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/iam-policy.json
@@ -17,7 +17,9 @@
       "Action": ["ssm:GetParameter"],
       "Resource": [
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
       ]
     },
     {

--- a/infrastructure/lambdas/saturday-integrity-sentinel/index.py
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/index.py
@@ -37,7 +37,8 @@ from datetime import datetime, timezone
 
 import boto3
 
-from alpha_engine_lib.telegram import send_message
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -58,6 +59,12 @@ MARKER_PREFIX = os.environ.get(
 )
 TARGET_CADENCE = "saturday_sf"
 TARGET_SEVERITY = "critical"
+_FLOW_NAME = "saturday-integrity-sentinel"
+_DB_BASENAME = "flow_doctor_saturday_integrity_sentinel"
+_OPS_HEALTH_TOPICS = (
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
 # Per-spec states that count as "present + safe to trade on" (mirrors the
 # freshness substrate's cycle_completion, which filters to severity=critical).
 _OK_STATES = frozenset({"fresh", "grace_period"})
@@ -152,9 +159,10 @@ def _write_marker(s3, run_date: str, verdict: dict) -> str:
     return key
 
 
-def _notify(verdict: dict, key: str) -> bool:
+def _notify(verdict: dict, key: str, run_date: str) -> bool:
     """LOUD on NO-GO; silent heartbeat on GO. Best-effort — never raises."""
     go = verdict["go"]
+    uncertain = verdict.get("uncertain", False)
     if go:
         text = (
             "🟢 *Saturday Integrity — GO*\n"
@@ -162,8 +170,9 @@ def _notify(verdict: dict, key: str) -> bool:
             "_safe to trade on Saturday's outputs_"
         )
         silent = True
+        severity = "info"
     else:
-        flag = "⚠️ UNCERTAIN" if verdict.get("uncertain") else "🔴 NO-GO"
+        flag = "⚠️ UNCERTAIN" if uncertain else "🔴 NO-GO"
         lines = [f"{flag} *Saturday Integrity — NO-GO*", verdict["reason"]]
         if verdict.get("missing"):
             lines.append(f"Missing: {', '.join(verdict['missing'])}")
@@ -173,8 +182,19 @@ def _notify(verdict: dict, key: str) -> bool:
         lines.append("_independent of the watch agent — a swallow can't hide here_")
         text = "\n".join(lines)
         silent = False
+        severity = "warning" if uncertain else "error"
     try:
-        return bool(send_message(text, disable_notification=silent))
+        return notify_via_flow_doctor(
+            text,
+            silent=silent,
+            severity=severity,
+            dedup_key=f"{_FLOW_NAME}:{run_date}:go={go}:uncertain={uncertain}",
+            flow_name=_FLOW_NAME,
+            topics=_OPS_HEALTH_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={"run_date": run_date, "go": go, "uncertain": uncertain},
+            silent_topic=FleetTelegramTopic.OPS_HEALTH,
+        )
     except Exception as exc:  # noqa: BLE001 — secondary observability
         logger.warning("integrity Telegram failed (non-fatal): %s", exc)
         return False
@@ -192,7 +212,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     verdict["checked_at"] = now.isoformat()
 
     key = _write_marker(s3, run_date, verdict)  # PRIMARY — fail-loud
-    telegram_sent = _notify(verdict, key)       # secondary — best-effort
+    telegram_sent = _notify(verdict, key, run_date)       # secondary — best-effort
 
     logger.info(
         "Saturday integrity %s: %s (marker=%s telegram=%s)",

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,4 +1,3 @@
-# Pinned to match alpha-engine-data/requirements.txt (coherent lib substrate
-# across alpha-engine-data Lambdas; above the LibPinDriftCheck v0.39.0 floor).
-# Only the stable telegram.send_message primitive is used.
-alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4
+# config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-integrity-sentinel/test_handler.py
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/test_handler.py
@@ -24,7 +24,10 @@ sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
 sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
 
 sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 import index  # noqa: E402
+import flow_doctor_telegram  # noqa: E402
+from flow_doctor_telegram import reset_flow_doctor_cache  # noqa: E402
 
 
 class FakeClientError(Exception):
@@ -59,9 +62,12 @@ def _s3(doc=None, missing=False, put=None):
 
 
 @pytest.fixture(autouse=True)
-def reset_telegram():
+def reset_telegram(monkeypatch):
+    monkeypatch.setenv("FLOW_DOCTOR_ENABLED", "0")
     _telegram_mod.send_message.reset_mock()
     _telegram_mod.send_message.return_value = True
+    monkeypatch.setattr(flow_doctor_telegram, "send_message", _telegram_mod.send_message)
+    reset_flow_doctor_cache()
     yield
 
 

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -75,6 +75,7 @@ python3 -m pip install \
   -r "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"

--- a/infrastructure/lambdas/sf-telegram-notifier/index.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/index.py
@@ -17,19 +17,21 @@ from __future__ import annotations
 import json
 import logging
 import os
-from pathlib import Path
 
 import boto3
 
-from alpha_engine_lib.telegram import send_message
+from flow_doctor_telegram import build_flow_doctor_config, notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import (
+    FleetTelegramTopic,
+    PIPELINE_OBSERVER_TELEGRAM_TOPICS,
+)
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
-
-_flow_doctor = None
-_flow_doctor_init_attempted = False
+_FLOW_NAME = "sf-telegram-notifier"
+_DB_BASENAME = "flow_doctor_sf_telegram_notifier"
 
 _SF_LABELS: dict[str, str] = {
     "ne-weekly-freshness-pipeline": "Weekly Freshness SF",
@@ -42,7 +44,7 @@ _PREFLIGHT_LABEL_OVERRIDE: dict[str, str] = {
 }
 
 _STATUS_EMOJI: dict[str, str] = {
-    "RUNNING": "\U0001f680",    # 🚀
+    "RUNNING": "\U0001f680",
     "SUCCEEDED": "✅",
     "FAILED": "\U0001f534",
     "TIMED_OUT": "⏰",
@@ -52,83 +54,13 @@ _STATUS_EMOJI: dict[str, str] = {
 _CAUSE_MAX_CHARS = 280
 
 
-def build_flow_doctor_config() -> dict:
-    """Build lambda flow-doctor config from fleet canonical topic layout."""
-    from nousergon_lib.flow_doctor_fleet import (
+def build_flow_doctor_config_for_tests() -> dict:
+    """Expose config builder for fleet wiring contract tests."""
+    return build_flow_doctor_config(
+        _FLOW_NAME,
         PIPELINE_OBSERVER_TELEGRAM_TOPICS,
-        fleet_telegram_notifier_dicts,
+        db_basename=_DB_BASENAME,
     )
-
-    return {
-        "flow_name": "sf-telegram-notifier",
-        "repo": "nousergon/nousergon-data",
-        "owner": "@brianmcmahon",
-        "notify": fleet_telegram_notifier_dicts(
-            PIPELINE_OBSERVER_TELEGRAM_TOPICS
-        ),
-        "store": {
-            "type": "sqlite",
-            "path": "/tmp/flow_doctor_sf_telegram_notifier.db",
-        },
-        "dedup_cooldown_minutes": 1,
-        "rate_limits": {"max_alerts_per_day": 100},
-    }
-
-
-def _materialize_flow_doctor_yaml() -> str:
-    import yaml
-
-    path = Path("/tmp/flow_doctor_sf_telegram_notifier.yaml")
-    path.write_text(
-        yaml.safe_dump(build_flow_doctor_config(), sort_keys=False),
-        encoding="utf-8",
-    )
-    return str(path)
-
-
-def _get_flow_doctor():
-    """Lazy-init shared FlowDoctor (forum routing). Returns None on fallback path."""
-    global _flow_doctor, _flow_doctor_init_attempted
-    if _flow_doctor is not None:
-        return _flow_doctor
-    if _flow_doctor_init_attempted:
-        return None
-    _flow_doctor_init_attempted = True
-    if os.environ.get("FLOW_DOCTOR_ENABLED", "1") != "1":
-        return None
-    try:
-        from nousergon_lib.logging import get_flow_doctor, setup_logging
-
-        setup_logging(
-            "sf-telegram-notifier",
-            flow_doctor_yaml=_materialize_flow_doctor_yaml(),
-        )
-        _flow_doctor = get_flow_doctor()
-    except Exception as exc:  # noqa: BLE001 — fall back to send_message
-        logger.warning(
-            "flow-doctor init failed — falling back to send_message: %s", exc
-        )
-    return _flow_doctor
-
-
-def _pipeline_telegram_notifier(fd):
-    """Return the ``#pipeline`` TelegramNotifier, if configured."""
-    from flow_doctor.notify.telegram import TelegramNotifier
-    from nousergon_lib.flow_doctor_fleet import (
-        FleetTelegramTopic,
-        fleet_telegram_thread_id_env,
-    )
-
-    want = os.environ.get(
-        fleet_telegram_thread_id_env(FleetTelegramTopic.PIPELINE)
-    )
-    for notifier in fd._notifiers:
-        if not isinstance(notifier, TelegramNotifier):
-            continue
-        thread_id = getattr(notifier, "message_thread_id", None)
-        if thread_id is not None and str(thread_id) == str(want):
-            return notifier
-    return None
 
 
 def _severity_for_status(status: str) -> str:
@@ -140,46 +72,11 @@ def _severity_for_status(status: str) -> str:
 def _dedup_key(detail: dict) -> str:
     return ":".join(
         [
-            "sf-telegram-notifier",
+            _FLOW_NAME,
             detail.get("executionArn") or detail.get("name") or "unknown",
             detail.get("status") or "UNKNOWN",
         ]
     )
-
-
-def _notify_via_flow_doctor(
-    text: str,
-    *,
-    detail: dict,
-    silent: bool,
-) -> bool:
-    fd = _get_flow_doctor()
-    if fd is None:
-        return send_message(text, disable_notification=silent)
-
-    status = detail.get("status", "UNKNOWN")
-    subject = text.split("\n", 1)[0].replace("*", "")
-
-    if silent:
-        pipeline = _pipeline_telegram_notifier(fd)
-        if pipeline is not None:
-            return pipeline.send_raw(text, disable_notification=True) is not None
-        logger.warning(
-            "pipeline Telegram notifier missing — RUNNING ping via notify_event"
-        )
-
-    report_id = fd.notify_event(
-        subject,
-        body=text,
-        severity=_severity_for_status(status),
-        context={
-            "state_machine": (detail.get("stateMachineArn") or "").rsplit(":", 1)[-1],
-            "execution": detail.get("name"),
-            "status": status,
-        },
-        dedup_key=_dedup_key(detail),
-    )
-    return report_id is not None
 
 
 def _label_for_arn(sm_arn: str, *, is_preflight: bool = False) -> str:
@@ -206,7 +103,7 @@ def _describe_execution(execution_arn: str) -> dict | None:
     try:
         sf = boto3.client("stepfunctions", region_name=REGION)
         return sf.describe_execution(executionArn=execution_arn)
-    except Exception as exc:  # noqa: BLE001 — fire-and-forget enrichment
+    except Exception as exc:  # noqa: BLE001
         logger.warning("describe_execution failed for %s: %s", execution_arn, exc)
         return None
 
@@ -237,7 +134,6 @@ def _failure_cause_from(describe_resp: dict | None) -> str:
 
 
 def _build_message(detail: dict) -> tuple[str, bool]:
-    """Return (text, silent) for the given event detail."""
     status = detail.get("status", "UNKNOWN")
     describe_resp = _describe_execution(detail.get("executionArn", ""))
     is_preflight = _is_preflight_execution(describe_resp)
@@ -266,14 +162,28 @@ def _build_message(detail: dict) -> tuple[str, bool]:
     return "\n".join(lines), False
 
 
-def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+def handler(event: dict, context) -> dict:  # noqa: ARG001
     detail = event.get("detail") or {}
     status = detail.get("status", "UNKNOWN")
     sm_name = (detail.get("stateMachineArn") or "").rsplit(":", 1)[-1]
     logger.info("SF status change: sf=%s status=%s", sm_name, status)
 
     text, silent = _build_message(detail)
-    ok = _notify_via_flow_doctor(text, detail=detail, silent=silent)
+    ok = notify_via_flow_doctor(
+        text,
+        silent=silent,
+        severity=_severity_for_status(status),
+        dedup_key=_dedup_key(detail),
+        flow_name=_FLOW_NAME,
+        topics=PIPELINE_OBSERVER_TELEGRAM_TOPICS,
+        db_basename=_DB_BASENAME,
+        context={
+            "state_machine": sm_name,
+            "execution": detail.get("name"),
+            "status": status,
+        },
+        silent_topic=FleetTelegramTopic.PIPELINE,
+    )
 
     return {
         "status": status,

--- a/infrastructure/lambdas/sf-telegram-notifier/test_flow_doctor_fleet_wiring.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_flow_doctor_fleet_wiring.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from nousergon_lib.flow_doctor_fleet import (
     PIPELINE_OBSERVER_TELEGRAM_TOPICS,
     fleet_telegram_notifier_dicts,
 )
 
-from index import build_flow_doctor_config
+from index import build_flow_doctor_config_for_tests
 
 
 def test_build_flow_doctor_config_matches_pipeline_observer_topics():
-    cfg = build_flow_doctor_config()
+    cfg = build_flow_doctor_config_for_tests()
     telegram_blocks = [n for n in cfg["notify"] if n.get("type") == "telegram"]
     expected = fleet_telegram_notifier_dicts(PIPELINE_OBSERVER_TELEGRAM_TOPICS)
     assert telegram_blocks == expected

--- a/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
@@ -25,7 +25,10 @@ sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
 sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
 
 sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 import index  # noqa: E402
+import flow_doctor_telegram  # noqa: E402
+from flow_doctor_telegram import reset_flow_doctor_cache  # noqa: E402
 
 
 SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
@@ -47,11 +50,12 @@ def _event(status: str, sm_arn: str = SATURDAY_ARN, **detail_overrides) -> dict:
 
 
 @pytest.fixture(autouse=True)
-def reset_send_message():
+def reset_send_message(monkeypatch):
+    monkeypatch.setenv("FLOW_DOCTOR_ENABLED", "0")
     _telegram_mod.send_message.reset_mock()
     _telegram_mod.send_message.return_value = True
-    index._flow_doctor = None
-    index._flow_doctor_init_attempted = False
+    monkeypatch.setattr(flow_doctor_telegram, "send_message", _telegram_mod.send_message)
+    reset_flow_doctor_cache()
     yield
 
 


### PR DESCRIPTION
## Summary
- Extract `infrastructure/lambdas/flow_doctor_telegram.py` — shared lazy-init + forum-topic routing helper for T2 Lambda migrations (config#1742).
- Refactor `sf-telegram-notifier` to import the shared module; `deploy.sh` now packages `flow_doctor_telegram.py` (fixes live break if #619 inline code were replaced without packaging).
- Migrate `saturday-integrity-sentinel` to flow-doctor: GO → silent `#ops-health`; NO-GO/UNCERTAIN → loud `#critical` + `#ops-health`. Updates requirements (lib v0.82.0), IAM (thread SSM params), deploy env (`FLOW_DOCTOR_ENABLED=1`).

## Test plan
- [x] `pytest infrastructure/lambdas/sf-telegram-notifier/` — 21 passed
- [x] `pytest infrastructure/lambdas/saturday-integrity-sentinel/` — 7 passed
- [ ] After merge + auth: `put-role-policy` on sentinel role + `deploy.sh` for both Lambdas
- [ ] Smoke: `sf-telegram-notifier/deploy.sh --smoke` (synthetic SUCCEEDED)
- [ ] Smoke: `saturday-integrity-sentinel/deploy.sh --smoke` (reads live verdict)

## Deploy notes
Both Lambdas need IAM reconcile + deploy after merge. sf-telegram-notifier is already live on #619 code — this PR redeploys with shared-module packaging (behavior unchanged). Sentinel is net-new flow-doctor routing.


Made with [Cursor](https://cursor.com)