### PR TITLE
fix(lambdas): Docker pip for flow-doctor on Lambda (pydantic_core arch)

### DIFF
--- a/infrastructure/lambdas/lambda_pip_install.sh
+++ b/infrastructure/lambdas/lambda_pip_install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Install requirements.txt into TARGET for AWS Lambda python3.12 / linux/amd64.
+#
+# Operator-deployed Lambdas must not use bare `pip install -t` on macOS — binary
+# wheels (pydantic_core, etc.) target the host arch and fail at import on Lambda
+# with: No module named 'pydantic_core._pydantic_core'
+#
+# Usage:
+#   bash infrastructure/lambdas/lambda_pip_install.sh /path/to/pkg /path/to/requirements.txt
+
+set -euo pipefail
+
+TARGET="${1:?target dir required}"
+REQ_FILE="${2:?requirements.txt required}"
+
+if [[ ! -f "${REQ_FILE}" ]]; then
+  echo "ERROR: requirements file not found: ${REQ_FILE}" >&2
+  exit 1
+fi
+
+mkdir -p "${TARGET}"
+
+echo "Installing Lambda deps via Docker (python3.12 / linux/amd64) into ${TARGET}..."
+docker run --rm --platform linux/amd64 \
+  --entrypoint bash \
+  -v "${TARGET}:/out" \
+  -v "${REQ_FILE}:/tmp/requirements.txt:ro" \
+  python:3.12-slim \
+  -c "apt-get update -qq && apt-get install -qq -y git >/dev/null && pip install --quiet --target /out --upgrade -r /tmp/requirements.txt"

--- a/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
@@ -48,11 +48,13 @@ if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 # ----- 1. Package -----------------------------------------------------------
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -62,17 +62,15 @@ if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
 
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install \
-  --quiet \
-  --target "${PKG}" \
-  --upgrade \
-  -r "${SCRIPT_DIR}/requirements.txt"
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"


### PR DESCRIPTION
## Summary
- Root cause of T2 smokes landing in **General** (not forum topics): `pip install -t` on macOS packaged darwin `pydantic_core` → flow-doctor init failed → fallback to unthreaded `send_message`.
- Add `infrastructure/lambdas/lambda_pip_install.sh` (Docker `python:3.12-slim` + git for nousergon-lib).
- Wire `sf-telegram-notifier` + `saturday-integrity-sentinel` deploy.sh to use it.

## Verified live (pre-PR deploy)
CloudWatch after redeploy:
- `sf-telegram-notifier`: `[flow-doctor] initialized` → dispatched to thread **11** (`#pipeline` SSM)
- `saturday-integrity-sentinel`: `[flow-doctor] initialized` → GO silent to `#ops-health`

## Operator follow-up
- **Create `#pipeline` forum topic** (not set up yet; SSM `FLOW_DOCTOR_TELEGRAM_THREAD_PIPELINE=11` is a placeholder). Post once in the new topic → capture `message_thread_id` → update SSM.
- Until then, SF milestone smokes route to thread 11 which may not match a visible topic.

## Test plan
- [x] Both Lambda unit test suites pass locally
- [x] Live redeploy + smoke; flow-doctor init confirmed in CloudWatch


Made with [Cursor](https://cursor.com)