### PR TITLE
feat(notifications): T2 liveness probes → flow-doctor #critical/#ops-health (config#1742)

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -114,10 +114,13 @@ fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
@@ -148,7 +151,7 @@ if $BOOTSTRAP; then
     run aws lambda create-function --function-name "${FUNCTION_NAME}" \
       --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
       --zip-file "fileb://${ZIP}" --timeout 30 --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" \
+      --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
     echo "  Lambda exists, code will be updated in step 3"
@@ -216,6 +219,16 @@ if ! $DRY_RUN; then
 fi
 
 echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
 
 # ----- 4. Smoke (synthetic invoke; read-only — only pings on a REAL miss) ----
 

--- a/infrastructure/lambdas/groom-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/groom-liveness-probe/iam-policy.json
@@ -17,7 +17,9 @@
       "Action": ["ssm:GetParameter"],
       "Resource": [
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
       ]
     },
     {

--- a/infrastructure/lambdas/groom-liveness-probe/index.py
+++ b/infrastructure/lambdas/groom-liveness-probe/index.py
@@ -41,12 +41,19 @@ from datetime import datetime, timedelta, timezone
 
 import boto3
 
-from alpha_engine_lib.telegram import send_message
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
+_FLOW_NAME = "groom-liveness-probe"
+_DB_BASENAME = "flow_doctor_groom_liveness_probe"
+_OPS_TOPICS = (
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
 # De-dup state: ISO timestamps of trigger windows already alerted, so a standing
 # miss isn't re-pinged on every probe run. S3 (not in-Lambda) because the probe is
 # stateless across invocations. Generous lookback + this state = tolerant to
@@ -247,8 +254,19 @@ def _alert(misses: list[dict]) -> bool:
         "never dispatched (schedule/dispatcher broken). Check the "
         "scheduled-groom-dispatcher logs + SSM command history._"
     )
+    text = "\n".join(lines)
+    dedup_key = f"{_FLOW_NAME}:miss:" + "|".join(m["at"].isoformat() for m in misses)
     try:
-        return bool(send_message("\n".join(lines), disable_notification=False))
+        return notify_via_flow_doctor(
+            text,
+            silent=False,
+            severity="error",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={"misses": len(misses)},
+        )
     except Exception as exc:  # noqa: BLE001 — delivery surface; finding still returned
         logger.warning("liveness alert Telegram send failed (non-fatal): %s", exc)
         return False

--- a/infrastructure/lambdas/groom-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/groom-liveness-probe/requirements.txt
@@ -1,6 +1,3 @@
-# Only the stable `telegram.send_message` primitive is used here — no extras.
-# Mirrors the sibling saturday-sf-watch-dispatcher pin (same Fleet-Watch family);
-# the lambda-dir requirements are NOT lockstep-bound to the repo-root pin
-# (tests/test_lib_pin_lockstep.py scans only requirements.txt / Dockerfile /
-# requirements-daily-news.txt), so a recent telegram-stable pin is sufficient.
-alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4
+# config#1742 T2 — flow-doctor forum-topic routing for groom liveness probe.
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -8,20 +8,13 @@ suppression, and the fail-loud contract on the PRIMARY input.
 from __future__ import annotations
 
 import sys
-import types
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
-# Stub alpha_engine_lib.telegram before importing index (the real lib isn't on the
-# test path; the probe only uses send_message).
-_ael = types.ModuleType("alpha_engine_lib")
-_tg = types.ModuleType("alpha_engine_lib.telegram")
-_tg.send_message = lambda *a, **k: True  # type: ignore[attr-defined]
-_ael.telegram = _tg  # type: ignore[attr-defined]
-sys.modules.setdefault("alpha_engine_lib", _ael)
-sys.modules.setdefault("alpha_engine_lib.telegram", _tg)
-
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import index  # noqa: E402
 
 UTC = timezone.utc
@@ -159,7 +152,11 @@ def _wire(monkeypatch, *, triggers, stamps, s3, sent=True, now=_dt(2026, 6, 30, 
     monkeypatch.setattr(index, "_fetch_digest_timestamps", lambda pat: stamps)
     monkeypatch.setattr(index, "_s3_client", lambda: s3)
     sends = []
-    monkeypatch.setattr(index, "send_message", lambda *a, **k: sends.append(a) or sent)
+    monkeypatch.setattr(
+        index,
+        "notify_via_flow_doctor",
+        lambda text, **kwargs: sends.append(text) or sent,
+    )
     return sends
 
 

--- a/infrastructure/lambdas/sf-watch-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/deploy.sh
@@ -87,13 +87,15 @@ fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
 
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
@@ -124,7 +126,7 @@ if $BOOTSTRAP; then
     run aws lambda create-function --function-name "${FUNCTION_NAME}" \
       --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
       --zip-file "fileb://${ZIP}" --timeout 30 --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" \
+      --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,ACCOUNT_ID='"${ACCOUNT_ID}"'}' --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
     echo "  Lambda exists, code will be updated in step 3"
@@ -192,6 +194,16 @@ if ! $DRY_RUN; then
 fi
 
 echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,ACCOUNT_ID='"${ACCOUNT_ID}"'}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
 
 # ----- 4. Smoke (synthetic invoke; read-only — only pings on a REAL problem) -
 

--- a/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
@@ -17,7 +17,9 @@
       "Action": ["ssm:GetParameter"],
       "Resource": [
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
       ]
     },
     {

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -53,13 +53,20 @@ from datetime import datetime, timezone
 
 import boto3
 
-from alpha_engine_lib.telegram import send_message
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
+_FLOW_NAME = "sf-watch-liveness-probe"
+_DB_BASENAME = "flow_doctor_sf_watch_liveness_probe"
+_OPS_TOPICS = (
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
 
 RULE_NAME = os.environ.get("SF_WATCH_RULE_NAME", "alpha-engine-saturday-sf-watch-failed")
 EXPECTED_TARGET_FUNCTION = os.environ.get(
@@ -218,8 +225,18 @@ def _alert(problems: list[str]) -> bool:
         "_Fleet-SF Watch may not catch a real pipeline failure right now. "
         "Check the EventBridge rule + saturday-sf-watch-dispatcher Lambda._"
     )
+    text = "\n".join(lines)
     try:
-        return bool(send_message("\n".join(lines), disable_notification=False))
+        return notify_via_flow_doctor(
+            text,
+            silent=False,
+            severity="error",
+            dedup_key=f"{_FLOW_NAME}:wiring:{_problem_fingerprint(problems)}",
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={"problems": len(problems)},
+        )
     except Exception as exc:  # noqa: BLE001 — delivery surface; finding still returned
         logger.warning("sf-watch liveness alert Telegram send failed (non-fatal): %s", exc)
         return False

--- a/infrastructure/lambdas/sf-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/requirements.txt
@@ -1,6 +1,3 @@
-# Only the stable `telegram.send_message` primitive is used here — no extras.
-# Mirrors the sibling groom-liveness-probe / saturday-sf-watch-dispatcher pins
-# (same Fleet-Watch family); this lambda-dir pin is NOT lockstep-bound to the
-# repo-root pin (tests/test_lib_pin_lockstep.py scans only requirements.txt /
-# Dockerfile / requirements-daily-news.txt at the repo root).
-alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4
+# config#1742 T2 — flow-doctor forum-topic routing for sf-watch liveness probe.
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
@@ -1,30 +1,22 @@
 """Unit tests for sf-watch-liveness-probe index.handler.
 
-Stubs alpha_engine_lib.telegram.send_message (no live Telegram) and mocks
-boto3 events/stepfunctions/lambda/s3 clients. Asserts: a clean environment
-alerts nothing, each individual wiring problem is detected, problems are
-deduplicated by content (not re-alerted every run), and the dedup state
-clears once the environment goes clean again.
+Mocks flow-doctor notify (no live Telegram) and boto3 events/stepfunctions/lambda/s3
+clients. Asserts: a clean environment alerts nothing, each individual wiring problem is
+detected, problems are deduplicated by content (not re-alerted every run), and the dedup
+state clears once the environment goes clean again.
 """
 
 from __future__ import annotations
 
 import json
 import sys
-import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-_lib_pkg = types.ModuleType("alpha_engine_lib")
-_telegram_mod = types.ModuleType("alpha_engine_lib.telegram")
-_telegram_mod.send_message = MagicMock(return_value=True)
-_lib_pkg.telegram = _telegram_mod
-sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
-sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
-
 sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 import index  # noqa: E402
 
 REGION = "us-east-1"
@@ -108,10 +100,10 @@ def _clients_factory(events, sfn, lam, s3):
 
 
 @pytest.fixture(autouse=True)
-def reset_telegram():
-    _telegram_mod.send_message.reset_mock()
-    _telegram_mod.send_message.return_value = True
-    yield
+def reset_notify(monkeypatch):
+    mock = MagicMock(return_value=True)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock)
+    yield mock
 
 
 def test_all_clean_alerts_nothing():
@@ -122,7 +114,7 @@ def test_all_clean_alerts_nothing():
     with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
         result = index.handler({}, None)
     assert result == {"problems": [], "alerted": False, "clean": True}
-    _telegram_mod.send_message.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
 
 
 def test_dead_rule_alerts():
@@ -134,7 +126,7 @@ def test_dead_rule_alerts():
         result = index.handler({}, None)
     assert any("does NOT EXIST" in p for p in result["problems"])
     assert result["alerted"] is True
-    _telegram_mod.send_message.assert_called_once()
+    index.notify_via_flow_doctor.assert_called_once()
 
 
 def test_disabled_rule_alerts():
@@ -209,7 +201,7 @@ def test_repeat_problem_is_suppressed_not_realerted():
     with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
         result = index.handler({}, None)
     assert result["alerted"] is False  # same problem as last time — suppressed
-    _telegram_mod.send_message.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
 
 
 def test_dedup_state_cleared_once_healthy_again():


### PR DESCRIPTION
## Summary
- Migrate **groom-liveness-probe** + **sf-watch-liveness-probe** off raw `send_message` → `flow_doctor_telegram.notify_via_flow_doctor` (loud `error` severity → `#critical` + `#ops-health`).
- Update requirements (lib v0.82.0 + krepis), IAM (thread SSM params), deploy.sh (Docker pip + `FLOW_DOCTOR_ENABLED=1` env reconcile).

## Test plan
- [x] `pytest infrastructure/lambdas/groom-liveness-probe/test_handler.py` — 12 passed
- [x] `pytest infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py` — 11 passed
- [ ] After merge + auth: `put-role-policy` both roles + `deploy.sh --smoke` each (clean env → no Telegram ping)

## Deploy notes
Both probes are silent-unless-broken — smoke on a healthy fleet should return `alerted: false` with flow-doctor initialized in CloudWatch.


Made with [Cursor](https://cursor.com)