### PR TITLE
fix(groom-liveness-probe): migrate test stub onto nousergon_lib (heal Deploy gate)

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -94,17 +94,20 @@ trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
-# Only alpha_engine_lib.telegram is stubbed in sys.modules (see
-# test_handler.py's header) — `index.py`'s `import boto3` is REAL, and
-# requirements.txt deliberately omits boto3 (provided by the Lambda runtime
-# at deploy time, per its own comment), so pytest's `import index` needs it
-# installed explicitly here. Installed into a scratch TEST_DEPS dir — NOT the
-# caller's global site-packages, not bundled into the Lambda zip (mirrors
-# freshness-monitor/deploy.sh). 2026-07-02: the CI auto-deploy workflow's
-# FIRST real run failed here with "No module named pytest" — this script had
-# only ever been run from an operator's laptop before, where pytest/boto3
-# happened to already be installed as dev/tooling dependencies; the gap was
-# invisible until CI actually exercised this path.
+# The git-only nousergon_lib submodules index.py imports at module scope
+# (flow_doctor_fleet.FleetTelegramTopic; telegram.send_message via
+# flow_doctor_telegram) are stubbed in sys.modules by test_handler.py BEFORE
+# `import index` (see its header) — so this gate stays hermetic on bare python.
+# `index.py`'s `import boto3` is REAL, and requirements.txt deliberately omits
+# boto3 (provided by the Lambda runtime at deploy time, per its own comment),
+# so pytest's `import index` needs it installed explicitly here. Installed into
+# a scratch TEST_DEPS dir — NOT the caller's global site-packages, not bundled
+# into the Lambda zip (mirrors freshness-monitor/deploy.sh). Two prior gaps
+# here, same class (the gate's dep/stub set drifting from index.py's real
+# module-level imports): 2026-07-02 "No module named pytest" (script had only
+# run on operator laptops where pytest/boto3 were ambient); 2026-07-04 "No
+# module named nousergon_lib" (config#1742 flow-doctor cutover moved the source
+# onto nousergon_lib but the sys.modules stub was not migrated in lockstep).
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   echo "Installing pytest + boto3 into ${TEST_DEPS}..."
   python3 -m pip install --quiet --target "${TEST_DEPS}" pytest boto3

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -3,11 +3,24 @@
 Cover the load-bearing logic with no AWS/GitHub I/O: trigger enumeration
 (maturity + day-of-week filtering), per-trigger miss attribution, S3 dedup
 suppression, and the fail-loud contract on the PRIMARY input.
+
+Hermetic: `nousergon_lib` is a git-only dependency the deploy test gate does NOT
+install (deploy.sh runs pytest on bare python + boto3), so its two submodules
+that `index` imports at module scope are stubbed in sys.modules BEFORE
+`import index` — matching the sibling scheduled-groom-dispatcher test. `index`
+only touches nousergon_lib at import time via the `_OPS_TOPICS` tuple
+(`flow_doctor_fleet.FleetTelegramTopic`) and, transitively through
+`flow_doctor_telegram`, `telegram.send_message`; the notify path itself is
+monkeypatched per-test (`index.notify_via_flow_doctor`). Migrated onto
+`nousergon_lib.*` from the old `alpha_engine_lib.telegram` stub by the
+flow-doctor cutover (config#1742, #622) — keep this stub tracking `index.py`'s
+real module-level imports.
 """
 
 from __future__ import annotations
 
 import sys
+import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -15,6 +28,26 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# ── Stub nousergon_lib submodules before importing index ──────────────────────
+_ng = types.ModuleType("nousergon_lib")
+_ng_telegram = types.ModuleType("nousergon_lib.telegram")
+_ng_telegram.send_message = lambda *a, **k: None
+_ng_fleet = types.ModuleType("nousergon_lib.flow_doctor_fleet")
+
+
+class _FleetTelegramTopic:
+    CRITICAL = "CRITICAL"
+    OPS_HEALTH = "OPS_HEALTH"
+
+
+_ng_fleet.FleetTelegramTopic = _FleetTelegramTopic
+_ng.telegram = _ng_telegram
+_ng.flow_doctor_fleet = _ng_fleet
+sys.modules.setdefault("nousergon_lib", _ng)
+sys.modules.setdefault("nousergon_lib.telegram", _ng_telegram)
+sys.modules.setdefault("nousergon_lib.flow_doctor_fleet", _ng_fleet)
+
 import index  # noqa: E402
 
 UTC = timezone.utc


### PR DESCRIPTION
## Root cause
The **Deploy groom-liveness-probe** workflow went red on `main` (run [28718985980](https://github.com/nousergon/nousergon-data/actions/runs/28718985980), sha `f946126`). The failure was in `deploy.sh`'s **pre-deploy handler unit-test gate** (step 0b), at pytest *collection*:

```
index.py:44  from flow_doctor_telegram import notify_via_flow_doctor
flow_doctor_telegram.py:10  from nousergon_lib.telegram import send_message
E  ModuleNotFoundError: No module named 'nousergon_lib'
```

PR #622 (config#1742 flow-doctor cutover) moved `index.py` + `flow_doctor_telegram.py` onto `nousergon_lib.telegram.send_message` and `nousergon_lib.flow_doctor_fleet.FleetTelegramTopic`, **but `test_handler.py`'s hermetic `sys.modules` stub was dropped instead of migrated.** The gate deliberately runs pytest on **bare python + boto3** (`nousergon_lib` is a git-only dep, never installed into the fast gate — same hermetic convention as the sibling `scheduled-groom-dispatcher` test), so a bare `import index` now hit the real, uninstalled `nousergon_lib`.

**No partial live state:** `set -euo pipefail` + the gate runs *before* `aws lambda update-function-code` (step 3). The deploy aborted at the gate; the live Lambda was never touched. Deploy is idempotent regardless (create-or-update + `wait function-updated`).

## The fix (SOTA at the correct layer)
Restore the hermetic stub in `test_handler.py`, **migrated onto the real `nousergon_lib.*` module names** `index.py` imports at module scope, registered before `import index` — exactly matching the institutional sibling pattern (`scheduled-groom-dispatcher/test_handler.py`). This *completes* the flow-doctor migration in the test rather than reviving anything on the deprecated `alpha_engine_lib` path. `sys.modules.setdefault` is used so a real installed `nousergon_lib` (operator laptop) still wins and exercises real code. Also refreshes the stale step-0b comment in `deploy.sh` (it still named `alpha_engine_lib` and only the 2026-07-02 gap).

## Guard / coverage
The 12 existing behavior tests are the guard for this failure class — with the stub restored they run green and continue to fully cover trigger enumeration, per-trigger miss attribution, S3 dedup, and the fail-loud-on-primary-input contract. Validated locally by reproducing the exact CI failure, then running the gate the way `deploy.sh` does (bare python + `pytest boto3`): **12 passed**.

## Fail-loud rationale
No test was skipped, xfailed, or weakened; no error was swallowed. The stub only satisfies the module-level import — the notify path is monkeypatched per-test as before, so nothing about what the probe *detects or reports* changed.

## Residual gap (tracked)
This re-arms a hand-maintained stub that must track `index.py`'s module-level imports — it drifted here, and this is the **second** occurrence of the same class (2026-07-02 was "No module named pytest" in this same gate). Structural chokepoint fix filed as a follow-up on alpha-engine-config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)