### PR TITLE
feat(notifications): T2 dispatchers → flow-doctor (config#1742)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -71,17 +71,15 @@ fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
 
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install \
-  --quiet \
-  --target "${PKG}" \
-  --upgrade \
-  -r "${SCRIPT_DIR}/requirements.txt"
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
@@ -124,7 +122,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 60 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false}' \
+      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -191,6 +189,18 @@ if ! $DRY_RUN; then
 fi
 
 echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
 
 # ----- 4. Smoke (synthetic FAILED event) ------------------------------------
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -17,7 +17,10 @@
       "Action": ["ssm:GetParameter"],
       "Resource": [
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_PIPELINE",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
       ]
     },
     {

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -40,13 +40,19 @@ from datetime import date, datetime, timezone
 
 import boto3
 
-from alpha_engine_lib.telegram import send_message
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import (
+    FleetTelegramTopic,
+    PIPELINE_OBSERVER_TELEGRAM_TOPICS,
+)
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
+_FLOW_NAME = "saturday-sf-watch-dispatcher"
+_DB_BASENAME = "flow_doctor_saturday_sf_watch_dispatcher"
 # M2 gate — default OFF. When true, a failure also fires a repository_dispatch
 # that triggers the autonomous resilience agent (which diagnoses → fixes →
 # merges → reruns from the failed step). The watch-log is written FIRST (so the
@@ -351,8 +357,24 @@ def _notify(record: dict, key: str, pipeline_name: str) -> bool:
     else:
         footer = "_autonomous fix DISABLED (observe-only)_"
     lines.append(footer)
+    text = "\n".join(lines)
+    dedup_key = f"{_FLOW_NAME}:{pipeline_name}:{record.get('execution_arn', key)}"
     try:
-        return bool(send_message("\n".join(lines), disable_notification=True))
+        return notify_via_flow_doctor(
+            text,
+            silent=True,
+            severity="info",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=PIPELINE_OBSERVER_TELEGRAM_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={
+                "pipeline": pipeline_name,
+                "status": record.get("status"),
+                "failed_state": record.get("failed_state"),
+            },
+            silent_topic=FleetTelegramTopic.OPS_HEALTH,
+        )
     except Exception as exc:  # noqa: BLE001 — secondary observability
         logger.warning("watch Telegram record failed (non-fatal): %s", exc)
         return False

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,5 +1,3 @@
-# Pinned to match alpha-engine-data/requirements.txt (the main data Lambda) so
-# the lib substrate stays coherent across alpha-engine-data Lambdas and stays
-# above the Saturday-SF LibPinDriftCheck v0.39.0 floor. Only the stable
-# `telegram.send_message` primitive is used here — no extras required.
-alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.59.4
+# config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -1,31 +1,19 @@
 """Unit tests for sf-watch-dispatcher index.handler (Fleet-SF Watch).
 
-Stubs ``alpha_engine_lib.telegram.send_message`` (no live Telegram) and mocks
-boto3 stepfunctions + s3 clients. Asserts: watch-log artifact written (append +
-fresh-skeleton), failed-state extraction from history, fail-loud on the S3 write,
-best-effort enrichment + Telegram, per-pipeline routing (saturday/weekday prefix
-+ dispatch event type), the unregistered-SF guard, and the dispatch seam.
+Mocks flow-doctor notify (no live Telegram) and boto3 stepfunctions + s3 clients.
 """
 
 from __future__ import annotations
 
 import json
 import sys
-import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Stub the lib before importing the handler (CI runners pre-pip-install).
-_lib_pkg = types.ModuleType("alpha_engine_lib")
-_telegram_mod = types.ModuleType("alpha_engine_lib.telegram")
-_telegram_mod.send_message = MagicMock(return_value=True)
-_lib_pkg.telegram = _telegram_mod
-sys.modules.setdefault("alpha_engine_lib", _lib_pkg)
-sys.modules.setdefault("alpha_engine_lib.telegram", _telegram_mod)
-
 sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 import index  # noqa: E402
 
 SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
@@ -96,10 +84,10 @@ def _make_clients(*, describe=None, history=None, existing=None, put=None):
 
 
 @pytest.fixture(autouse=True)
-def reset_telegram():
-    _telegram_mod.send_message.reset_mock()
-    _telegram_mod.send_message.return_value = True
-    yield
+def reset_notify(monkeypatch):
+    mock = MagicMock(return_value=True)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock)
+    yield mock
 
 
 def test_failed_writes_watch_log_and_returns_state():
@@ -131,10 +119,10 @@ def test_telegram_is_silent_and_records_artifact_location():
     factory, _, _ = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
         index.handler(_event("FAILED"), None)
-    _telegram_mod.send_message.assert_called_once()
-    text = _telegram_mod.send_message.call_args.args[0]
-    kwargs = _telegram_mod.send_message.call_args.kwargs
-    assert kwargs["disable_notification"] is True  # notifier already buzzed loud
+    index.notify_via_flow_doctor.assert_called_once()
+    text = index.notify_via_flow_doctor.call_args.args[0]
+    kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert kwargs["silent"] is True  # notifier already buzzed loud
     assert "Fleet-SF Watch — OBSERVE" in text
     assert "Weekly Freshness SF: FAILED" in text  # pipeline-aware label
     assert "Failed state: `RAGIngestion`" in text
@@ -148,7 +136,7 @@ def test_watch_log_path_is_code_fenced():
     factory, _, _ = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
         index.handler(_event("FAILED"), None)
-    text = _telegram_mod.send_message.call_args.args[0]
+    text = index.notify_via_flow_doctor.call_args.args[0]
     assert "`s3://alpha-engine-research/consolidated/saturday_sf_watch/2023-11-14.json`" in text
     assert "Failed state: `RAGIngestion`" in text
     assert "Cause: `States.TaskFailed: RAGIngestion failed`" in text
@@ -206,7 +194,7 @@ def test_describe_error_still_writes_artifact():
 
 
 def test_telegram_failure_is_non_fatal():
-    _telegram_mod.send_message.side_effect = RuntimeError("bot down")
+    index.notify_via_flow_doctor.side_effect = RuntimeError("bot down")
     factory, _, s3 = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED"), None)
@@ -222,7 +210,7 @@ def test_preflight_shell_run_marks_record():
         index.handler(_event("FAILED"), None)
     written = json.loads(s3.put_object.call_args.kwargs["Body"])
     assert written["events"][0]["is_preflight"] is True
-    text = _telegram_mod.send_message.call_args.args[0]
+    text = index.notify_via_flow_doctor.call_args.args[0]
     assert "Weekly Freshness Preflight SF" in text
 
 
@@ -241,7 +229,7 @@ def test_weekday_sf_routes_to_weekday_prefix_and_label():
     assert result["state_machine"] == "ne-preopen-trading-pipeline"
     assert result["watch_log_key"] == "consolidated/weekday_sf_watch/2023-11-14.json"
     assert s3.put_object.call_args.kwargs["Key"].startswith("consolidated/weekday_sf_watch/")
-    text = _telegram_mod.send_message.call_args.args[0]
+    text = index.notify_via_flow_doctor.call_args.args[0]
     assert "Pre-open Trading SF: FAILED" in text
 
 
@@ -250,7 +238,7 @@ def test_eod_sf_routes_to_eod_prefix():
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED", sm_arn=EOD_ARN), None)
     assert result["watch_log_key"] == "consolidated/eod_sf_watch/2023-11-14.json"
-    text = _telegram_mod.send_message.call_args.args[0]
+    text = index.notify_via_flow_doctor.call_args.args[0]
     assert "Post-close Trading SF: FAILED" in text
 
 
@@ -411,7 +399,7 @@ def test_groom_telegram_claims_autonomous_fix_when_dispatched(monkeypatch):
     factory, _, _ = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
         index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
-    text = _telegram_mod.send_message.call_args.args[0]
+    text = index.notify_via_flow_doctor.call_args.args[0]
     assert "Fleet-SF Watch — AUTO-FIX" in text
     assert "Backlog Groom SF: FAILED" in text
     assert "autonomous fix ACTIVE" in text
@@ -461,7 +449,7 @@ def test_no_listener_pipeline_never_dispatches_even_when_globally_enabled(monkey
     assert result["agent_dispatch"] == {"dispatched": False, "reason": "no_listener"}
     assert result["action"] == "observe"
     assert fired["called"] is False
-    text = _telegram_mod.send_message.call_args.args[0]
+    text = index.notify_via_flow_doctor.call_args.args[0]
     assert "Fleet-SF Watch — OBSERVE" in text
     assert "autonomous fix ACTIVE" not in text
     assert "observe-only for this pipeline" in text

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -177,14 +177,13 @@ fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install \
-  --quiet \
-  --target "${PKG}" \
-  --upgrade \
-  -r "${SCRIPT_DIR}/requirements.txt"
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
@@ -229,7 +228,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 300 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true}' \
+      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -386,6 +385,18 @@ if ! $DRY_RUN; then
 fi
 
 echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
 
 # ----- 4. Smoke (synthetic schedule event, via the SF — the real live path) --
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -70,7 +70,9 @@
       "Action": ["ssm:GetParameter"],
       "Resource": [
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
       ]
     }
   ]

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -71,15 +71,22 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import boto3
-from krepis.telegram import send_message
+from flow_doctor_telegram import notify_via_flow_doctor
 from krepis.usage_pacing import pace_check, reset_window
 from nousergon_lib import ec2_spot
 from nousergon_lib.ec2_spot import SpotCapacityExhausted
+from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
+_FLOW_NAME = "scheduled-groom-dispatcher"
+_DB_BASENAME = "flow_doctor_scheduled_groom_dispatcher"
+_OPS_TOPICS = (
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
 # Kill-switch: GROOM_DISPATCH_ENABLED=false disables the trigger without deleting
 # the EventBridge Scheduler rules. Default ON.
 DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
@@ -446,6 +453,31 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
     }
 
 
+def _notify_pace_skip(pace: dict, schedule_label: str, run_mode: str) -> None:
+    """Best-effort loud ping for a pre-boot pace skip — never raises."""
+    text = (
+        "🟡 Backlog groom SKIPPED — soft budget threshold passed before boot "
+        f"(schedule={schedule_label}, run_mode={run_mode}). Weekly usage "
+        f"{pace['used_frac']:.0%} > {pace['elapsed_frac']:.0%} elapsed "
+        f"(overrun {pace['overrun']:+.0%}). Spot box was never launched — no "
+        "cost incurred. Resumes automatically on the next scheduled run "
+        "(or after the weekly reset)."
+    )
+    try:
+        notify_via_flow_doctor(
+            text,
+            silent=False,
+            severity="warning",
+            dedup_key=f"{_FLOW_NAME}:pace_skip:{schedule_label}",
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={"schedule": schedule_label, "run_mode": run_mode, **pace},
+        )
+    except Exception as exc:  # noqa: BLE001 — secondary observability
+        logger.warning("pace-gate skip Telegram failed (non-fatal): %s", exc)
+
+
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge Scheduler handler — launches the groom spot box on cadence.
 
@@ -487,14 +519,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 "wet=%.0f) — groom spot NOT launched, resumes next schedule/reset",
                 pace["used_frac"], pace["elapsed_frac"], pace["overrun"], pace["wet"],
             )
-            send_message(
-                "🟡 Backlog groom SKIPPED — soft budget threshold passed before boot "
-                f"(schedule={schedule_label}, run_mode={run_mode}). Weekly usage "
-                f"{pace['used_frac']:.0%} > {pace['elapsed_frac']:.0%} elapsed "
-                f"(overrun {pace['overrun']:+.0%}). Spot box was never launched — no "
-                "cost incurred. Resumes automatically on the next scheduled run "
-                "(or after the weekly reset)."
-            )
+            _notify_pace_skip(pace, schedule_label, run_mode)
             return {"groom": {"launched": False, "reason": "pace_gate_skip", **pace}}
 
     result = _launch_groom_spot(run_mode, schedule_label, model, issue_filter, soft_limit_min, force_on_demand)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -1,14 +1,5 @@
-# boto3 is provided by the Lambda python3.12 runtime; pinned here for an
-# explicit, reproducible package build (mirrors the sibling dispatchers).
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
 boto3>=1.34.0
-# ec2_spot launch chokepoint (capacity-resilient spot/on-demand rotation) — the
-# dispatcher launches the groom box via nousergon_lib.ec2_spot instead of
-# re-implementing run_instances (config#1432). Pin matches the repo's lib pin
-# (root requirements.txt @v0.70.0). Base package only (no extras) — ec2_spot needs
-# just boto3, which the runtime provides; base deps (pydantic/pyyaml/requests) are
-# light and well under the Lambda size limit.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.70.0
-# usage_pacing (linear-pace short-circuit math) for the pre-boot pace gate
-# (2026-07-04) — mirrors alpha-engine-config/scripts/groom_budget.py's on-box
-# gate. Pure-stdlib module, published to PyPI (nousergon/krepis).
-krepis==0.10.0
+# config#1742 T2 — flow-doctor forum routing + ec2_spot launch chokepoint.
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -19,6 +19,7 @@ import types
 import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 # ── Stub nousergon_lib.ec2_spot + boto3 before importing index ─────────────────
@@ -37,8 +38,21 @@ def _install_stubs(launch_impl, boto_clients):
     ec2_spot_mod.launch = launch_impl
     pkg = types.ModuleType("nousergon_lib")
     pkg.ec2_spot = ec2_spot_mod
+    fleet_mod = types.ModuleType("nousergon_lib.flow_doctor_fleet")
+
+    class _FleetTelegramTopic:
+        CRITICAL = "critical"
+        OPS_HEALTH = "ops_health"
+
+    fleet_mod.FleetTelegramTopic = _FleetTelegramTopic
+    pkg.flow_doctor_fleet = fleet_mod
     sys.modules["nousergon_lib"] = pkg
     sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
+    sys.modules["nousergon_lib.flow_doctor_fleet"] = fleet_mod
+
+    fdt_mod = types.ModuleType("flow_doctor_telegram")
+    fdt_mod.notify_via_flow_doctor = lambda *a, **k: True  # type: ignore[attr-defined]
+    sys.modules["flow_doctor_telegram"] = fdt_mod
 
     boto3_mod = types.ModuleType("boto3")
     boto3_mod.client = lambda name, **kw: boto_clients[name]
@@ -215,14 +229,14 @@ def _wet_doc(wet: float) -> bytes:
     return json.dumps({"by_hour": {"10": {"opus": {"wet": wet}}}}).encode()
 
 
-def _spy_send_message(monkeypatch, idx):
-    """Replace krepis.telegram.send_message (imported into index as
-    `send_message`) with a recorder — avoids exercising the real secret
-    resolution / HTTP path (this test harness's fake SSM client doesn't
-    implement get_parameter, so the real krepis.secrets code path would blow
-    up on an AttributeError it isn't built to catch)."""
+def _spy_notify(monkeypatch, idx):
+    """Replace notify_via_flow_doctor with a recorder."""
     calls = []
-    monkeypatch.setattr(idx, "send_message", lambda text, **kw: calls.append(text) or True)
+    monkeypatch.setattr(
+        idx,
+        "notify_via_flow_doctor",
+        lambda text, **kw: calls.append((text, kw)) or True,
+    )
     return calls
 
 
@@ -235,7 +249,7 @@ def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
     fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
     monkeypatch.setattr(idx, "datetime", type("D", (), {
         "now": staticmethod(lambda tz=None: fixed_now)}))
-    notified = _spy_send_message(monkeypatch, idx)
+    notified = _spy_notify(monkeypatch, idx)
 
     def _launch(types_, subnets, **kw):
         raise AssertionError("spot launch must NOT be attempted when the pace gate skips")
@@ -250,9 +264,10 @@ def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
     # The pre-boot skip must notify — it's the ONLY place this outcome is ever
     # visible (a run that never boots has no on-box groom_run.sh to ping).
     assert len(notified) == 1
-    assert "SKIPPED" in notified[0]
-    assert "soft budget threshold passed before boot" in notified[0]
-    assert "never launched" in notified[0]
+    assert notified[0][1]["silent"] is False
+    assert "SKIPPED" in notified[0][0]
+    assert "soft budget threshold passed before boot" in notified[0][0]
+    assert "never launched" in notified[0][0]
 
 
 def test_pace_gate_allows_launch_when_on_pace(monkeypatch):
@@ -263,7 +278,7 @@ def test_pace_gate_allows_launch_when_on_pace(monkeypatch):
     fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=3, hours=12)
     monkeypatch.setattr(idx, "datetime", type("D", (), {
         "now": staticmethod(lambda tz=None: fixed_now)}))
-    notified = _spy_send_message(monkeypatch, idx)
+    notified = _spy_notify(monkeypatch, idx)
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     assert out["groom"]["launched"] is True
     assert len(idx._test_ssm.sent) == 1
@@ -278,7 +293,7 @@ def test_pace_gate_disabled_still_launches_even_if_ahead_of_pace(monkeypatch):
     fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
     monkeypatch.setattr(idx, "datetime", type("D", (), {
         "now": staticmethod(lambda tz=None: fixed_now)}))
-    notified = _spy_send_message(monkeypatch, idx)
+    notified = _spy_notify(monkeypatch, idx)
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     assert out["groom"]["launched"] is True
     assert notified == []  # kill-switch disables the ping too — the gate never ran
@@ -286,7 +301,7 @@ def test_pace_gate_disabled_still_launches_even_if_ahead_of_pace(monkeypatch):
 
 def test_pace_gate_fails_safe_and_still_launches_on_s3_error(monkeypatch):
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
-    notified = _spy_send_message(monkeypatch, idx)
+    notified = _spy_notify(monkeypatch, idx)
 
     def _boom(**kw):
         raise RuntimeError("S3 unreachable")


### PR DESCRIPTION
## Summary
- **scheduled-groom-dispatcher**: pre-boot pace-gate skip → `notify_via_flow_doctor` (loud `warning` → `#critical` + `#ops-health`)
- **saturday-sf-watch-dispatcher**: silent Fleet-SF Watch receipt → `#ops-health` via `send_raw` (sf-telegram-notifier already buzzed loud)
- Docker pip + `flow_doctor_telegram.py` packaging; IAM thread SSM; `FLOW_DOCTOR_ENABLED=1` env reconcile on both

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` — 22 passed
- [x] `pytest infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py` — 28 passed
- [ ] After merge + auth: `put-role-policy` both roles + `deploy.sh` each
- [ ] Smoke sf-watch: `deploy.sh --smoke` (synthetic FAILED → silent #ops-health receipt)
- [ ] Groom dispatcher: code deploy only on merge (GHA auto-deploy path); IAM + env reconcile via deploy.sh

## Notes
- `#groom` SSM not seeded yet — groom pace skip routes to `#ops-health` (same as liveness probes). Add `#groom` topic + SSM when created.
- `#pipeline` still placeholder (thread 11) — SF-watch uses PIPELINE_OBSERVER topics but silent path targets `#ops-health` only.


Made with [Cursor](https://cursor.com)