### PR TITLE
fix(lambdas): chown Docker pip output to host user (heal deploy cleanup EPERM)

### DIFF
--- a/infrastructure/lambdas/lambda_pip_install.sh
+++ b/infrastructure/lambdas/lambda_pip_install.sh
@@ -5,6 +5,15 @@
 # wheels (pydantic_core, etc.) target the host arch and fail at import on Lambda
 # with: No module named 'pydantic_core._pydantic_core'
 #
+# The container runs as root (apt-get install git needs it), so pip writes
+# root-owned files into the bind-mounted TARGET. On macOS Docker Desktop that is
+# invisible (the VFS remaps bind mounts to the host user), but on a Linux CI
+# runner the files stay uid 0 and the CALLER's non-root cleanup (`rm -rf` on the
+# scratch dir) then fails with EPERM — a red deploy AFTER the Lambda already
+# updated (2026-07-04, this bug's first CI exposure; it was masked on operator
+# laptops for the same reason the pytest/nousergon_lib gate gaps were). So chown
+# the tree back to the host uid/gid before the container exits.
+#
 # Usage:
 #   bash infrastructure/lambdas/lambda_pip_install.sh /path/to/pkg /path/to/requirements.txt
 
@@ -20,10 +29,14 @@ fi
 
 mkdir -p "${TARGET}"
 
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+
 echo "Installing Lambda deps via Docker (python3.12 / linux/amd64) into ${TARGET}..."
 docker run --rm --platform linux/amd64 \
   --entrypoint bash \
+  -e HOST_UID="${HOST_UID}" -e HOST_GID="${HOST_GID}" \
   -v "${TARGET}:/out" \
   -v "${REQ_FILE}:/tmp/requirements.txt:ro" \
   python:3.12-slim \
-  -c "apt-get update -qq && apt-get install -qq -y git >/dev/null && pip install --quiet --target /out --upgrade -r /tmp/requirements.txt"
+  -c "apt-get update -qq && apt-get install -qq -y git >/dev/null && pip install --quiet --target /out --upgrade -r /tmp/requirements.txt && chown -R \"\${HOST_UID}:\${HOST_GID}\" /out"


### PR DESCRIPTION
## Root cause
Second, distinct failure surfaced on the same **Deploy groom-liveness-probe** run once #623 unblocked the pre-deploy test gate. Ordering in run [28719203767](https://github.com/nousergon/nousergon-data/actions/runs/28719203767):

```
Packaged function.zip (28 MB)
Updating Lambda function code: alpha-engine-groom-liveness-probe
✓ Code deployed.                     ← live Lambda updated successfully (code + config)
##[error]Process completed with exit code 1   ← EXIT-trap cleanup, AFTER deploy
```

`infrastructure/lambdas/lambda_pip_install.sh` runs `docker run` with **no `--user`**, so the container installs deps as root and pip writes **root-owned** files into the bind-mounted scratch `TARGET`. On macOS Docker Desktop this is invisible (bind mounts are remapped to the host user); on the **Linux GitHub runner** the files stay uid 0, so each lambda `deploy.sh`'s non-root EXIT-trap `rm -rf "$PKG" "$TEST_DEPS"` fails with `EPERM` and the step exits 1.

**No partial/inconsistent live state:** `aws lambda update-function-code` (idempotent) already succeeded; only cleanup failed. This is the same *"works on operator laptops, breaks in Linux CI"* class as the pytest / `nousergon_lib` test-gate gaps — masked until CI first reached the packaging step.

## The fix (shared chokepoint, SOTA at the correct layer)
The container still runs as root (its `apt-get install git` for git+ requirements needs it), then **`chown -R` the output tree back to the host uid/gid before exit**. Packaging and the caller's cleanup then both work as the runner user. One change fixes the class for **all four** Docker-pip lambdas: `groom-liveness-probe`, `saturday-integrity-sentinel`, `sf-telegram-notifier`, `sf-watch-liveness-probe`.

## Fail-loud rationale
Nothing is `|| true`'d or swallowed. The deploy still aborts on a genuine pip/apt failure; only the *spurious ownership-induced* cleanup `EPERM` is removed at its source (correct ownership), not hidden.

## Validation (Docker, locally)
- **Current helper** → output owned `root:root`; non-root `rm -rf` fails with `Permission denied` (reproduces the CI red exactly).
- **Fixed helper** → output owned `runner:runner (1001:1001)`; `rm -rf` succeeds cleanly.
- `bash -n` clean.

Success condition is the post-merge Deploy run on `main` going green — will be polled to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)