### PR TITLE
fix(lambdas): chown Docker-pip output to host UID so deploy cleanup succeeds

### DIFF
--- a/infrastructure/lambdas/lambda_pip_install.sh
+++ b/infrastructure/lambdas/lambda_pip_install.sh
@@ -5,6 +5,18 @@
 # wheels (pydantic_core, etc.) target the host arch and fail at import on Lambda
 # with: No module named 'pydantic_core._pydantic_core'
 #
+# The container runs as root (needed for apt-get to install git), so every file
+# pip writes into the bind-mounted TARGET lands root-owned on the host. On macOS
+# Docker Desktop transparently maps that back to the invoking user, but on a
+# Linux CI runner the bind mount preserves the container UID (0), leaving the
+# non-root `runner` user unable to delete them — so the caller's `trap rm -rf`
+# cleanup fails with "Permission denied" and reds the deploy step AFTER the live
+# Lambda update already succeeded (introduced by the #621 Docker-pip cutover;
+# surfaced by the groom-liveness-probe Deploy red, run 28719203767, 2026-07-04).
+# Fix at this shared chokepoint: chown TARGET back to the host UID/GID inside the
+# container (last step, still as root) so every caller's cleanup works on both
+# host OSes.
+#
 # Usage:
 #   bash infrastructure/lambdas/lambda_pip_install.sh /path/to/pkg /path/to/requirements.txt
 
@@ -20,10 +32,14 @@ fi
 
 mkdir -p "${TARGET}"
 
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+
 echo "Installing Lambda deps via Docker (python3.12 / linux/amd64) into ${TARGET}..."
 docker run --rm --platform linux/amd64 \
   --entrypoint bash \
+  -e HOST_UID="${HOST_UID}" -e HOST_GID="${HOST_GID}" \
   -v "${TARGET}:/out" \
   -v "${REQ_FILE}:/tmp/requirements.txt:ro" \
   python:3.12-slim \
-  -c "apt-get update -qq && apt-get install -qq -y git >/dev/null && pip install --quiet --target /out --upgrade -r /tmp/requirements.txt"
+  -c 'apt-get update -qq && apt-get install -qq -y git >/dev/null && pip install --quiet --target /out --upgrade -r /tmp/requirements.txt && chown -R "${HOST_UID}:${HOST_GID}" /out'


### PR DESCRIPTION
## Root cause
The main-branch Deploy **groom-liveness-probe** run [28719203767](https://github.com/nousergon/nousergon-data/actions/runs/28719203767) went red on its final EXIT-trap cleanup — **after the live Lambda update had already succeeded** (`✓ Code deployed`, then env update completed):

```
rm: cannot remove '/tmp/tmp.q0aJuSd5vk/nousergon_lib-0.82.0.dist-info/...': Permission denied
```

`infrastructure/lambdas/lambda_pip_install.sh` (the shared Docker-pip helper introduced in #621 to fix the pydantic_core arch problem) runs the container **as root** — required so `apt-get` can install `git`. Every file `pip install --target /out` writes into the bind-mounted temp dir therefore lands **root-owned on the host**. On macOS Docker Desktop that UID is transparently mapped back to the operator, but on the **Linux CI runner** the bind mount preserves the container UID (0), so the non-root `runner` (uid 1001) user cannot delete the files. Each caller's `trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT` then fails with "Permission denied", and under `set -e` that non-zero status becomes the step's exit code → red Deploy.

This is deterministic (a plain rerun reds identically) and is **latent in all four helper callers** — `sf-telegram-notifier`, `saturday-integrity-sentinel`, `groom-liveness-probe`, `sf-watch-liveness-probe`. groom-liveness-probe simply red first.

## The fix (SOTA, at the correct layer)
`chown -R "$HOST_UID:$HOST_GID" /out` as the **final in-container step** (still root, so it is permitted), passing the host UID/GID in as env. The container keeps root for `apt-get`/`pip`, but hands the artifacts back to the invoking user so every caller's cleanup trap works on **both** host OSes. Fixed once at the shared chokepoint rather than patching one symptom site — `--user` was rejected because it would break the in-container `apt-get install git`.

## Fail-loud rationale
This is **not** quieting a real failure. The trap failure masked nothing — the Lambda code+config update itself completed successfully; the red was pure cleanup noise appearing *after* the deploy. The change removes a spurious red; it does not skip, weaken, or swallow any genuine failure.

## Guard / coverage
The failure class is now structurally impossible for every helper caller: the helper never leaves host-unremovable files. Validated end-to-end:
- Reproduced the root-owned `rm` failure with the **current** helper (files uid 0, non-root `rm -rf` → Permission denied).
- **Fixed** helper produces uid-1001-owned files; non-root `rm -rf` → exit 0, dir gone.
- `groom-liveness-probe/deploy.sh --dry-run` end-to-end (pytest gate **12 passed**, Docker pip + zip + EXIT trap) → **exit 0**, zero "Permission denied".

Idempotency: the deploy is `update-function-code` + `update-function-configuration` (both idempotent); the original run already applied the live change, so re-deploying on merge is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)