### PR TITLE
feat(notifications): route pipeline-watchdog Telegram through flow-doctor (config#1742)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/deploy.sh
+++ b/infrastructure/lambdas/pipeline-watchdog/deploy.sh
@@ -11,8 +11,8 @@
 #   - EOD SF:     24h window, watch-day = today is a NYSE trading day
 #   - Saturday SF: 7d window, watch-day = today is Sunday
 # Alerts fire via alpha_engine_lib.alerts.publish to a DISTINCT SNS topic
-# (alpha-engine-watchdog-alerts) + Telegram in parallel — channel
-# independence preserved per plan doc §3.5.
+# (alpha-engine-watchdog-alerts) + flow-doctor forum topics for Telegram
+# (config#1742 T2) — channel independence preserved per plan doc §3.5.
 #
 # Managed outside CloudFormation — same rationale as
 # sf-telegram-notifier / eod-success-friday-shell-trigger /
@@ -70,19 +70,18 @@ if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
 
-echo "Installing deps into ${PKG} (pip install -t)..."
-python3 -m pip install \
-  --quiet \
-  --target "${PKG}" \
-  --upgrade \
-  -r "${SCRIPT_DIR}/requirements.txt"
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
@@ -133,7 +132,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 60 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO}' \
+      --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -184,6 +183,18 @@ if ! $DRY_RUN; then
 fi
 
 echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
 
 # ----- 4. Smoke (synthetic empty event — exercises the full handler) --------
 

--- a/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
+++ b/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
@@ -28,12 +28,15 @@
       "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-watchdog-alerts"
     },
     {
-      "Sid": "ReadTelegramSecretsForLibAlerts",
+      "Sid": "TelegramAndFlowDoctorThreadSSM",
       "Effect": "Allow",
       "Action": ["ssm:GetParameter"],
       "Resource": [
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_PIPELINE"
       ]
     },
     {

--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -10,8 +10,9 @@ of the 3 Step Functions, checks whether at least one execution started in
 the expected window. If a check fails, publishes an alert via
 ``alpha_engine_lib.alerts.publish`` to a DISTINCT SNS topic
 (``alpha-engine-watchdog-alerts``, NOT the existing ``alpha-engine-alerts``
-topic) and to Telegram in parallel — channel independence preserved per
-plan doc §3.5.
+topic) and routes Telegram through flow-doctor forum topics
+(``PIPELINE_OBSERVER_TELEGRAM_TOPICS`` — config#1742 T2) — channel
+independence preserved per plan doc §3.5.
 
 **Per-SF watchdog semantics:**
 
@@ -88,11 +89,15 @@ from alpha_engine_lib.trading_calendar import (
     last_closed_trading_day,
     previous_trading_day,
 )
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import PIPELINE_OBSERVER_TELEGRAM_TOPICS
 
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
+_FLOW_NAME = "pipeline-watchdog"
+_DB_BASENAME = "flow_doctor_pipeline_watchdog"
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
@@ -369,16 +374,26 @@ def _check_sf(
         severity="error",
         source="alpha-engine-pipeline-watchdog",
         sns=True,
-        telegram=True,
+        telegram=False,
         sns_topic_arn=WATCHDOG_SNS_TOPIC_ARN,
         dedup_key=dedup_key,
         dedup_window_min=12 * 60,
+    )
+    telegram_ok = notify_via_flow_doctor(
+        message,
+        silent=False,
+        severity="error",
+        dedup_key=dedup_key,
+        flow_name=_FLOW_NAME,
+        topics=PIPELINE_OBSERVER_TELEGRAM_TOPICS,
+        db_basename=_DB_BASENAME,
+        context={"sf_label": sf_label, "sf_arn": sf_arn},
     )
     logger.warning(
         "watchdog ALERT: sf=%s sns_ok=%s telegram_ok=%s dedup_skipped=%s",
         sf_label,
         result.sns.ok,
-        result.telegram.ok,
+        telegram_ok,
         getattr(result, "dedup_skipped", False),
     )
     return CheckResult(
@@ -388,7 +403,7 @@ def _check_sf(
         executions_seen=0,
         alert_emitted=True,
         alert_detail=(
-            f"sns_ok={result.sns.ok} telegram_ok={result.telegram.ok} "
+            f"sns_ok={result.sns.ok} telegram_ok={telegram_ok} "
             f"dedup_skipped={getattr(result, 'dedup_skipped', False)}"
         ),
     )

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,9 +1,4 @@
-# alpha-engine-lib provides:
-#   - alpha_engine_lib.trading_calendar.last_closed_trading_day (v0.27.0+)
-#     for NYSE-holiday-aware trading-day gating
-#   - alpha_engine_lib.alerts.publish (v0.24.0+) for dual-channel SNS +
-#     Telegram fan-out with dedup_key idempotency
-# Pinned to match sf-telegram-notifier + eod-success-friday-shell-trigger
-# sibling Lambdas; keeping the pin coherent across sibling Lambdas avoids
-# divergence on lib-side helpers.
-alpha-engine-lib @ git+https://github.com/nousergon/nousergon-lib@v0.28.1
+# config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
+# trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/pipeline-watchdog/test_handler.py
+++ b/infrastructure/lambdas/pipeline-watchdog/test_handler.py
@@ -1,10 +1,10 @@
 """Unit tests for alpha-engine-pipeline-watchdog index.handler.
 
 Stubs ``alpha_engine_lib.trading_calendar.last_closed_trading_day``,
-``alpha_engine_lib.alerts.publish``, and ``boto3.client('stepfunctions')``
-so tests do not hit AWS or the lib. Each test pins one decision branch
-(watch-day eligibility, alert-or-skip, dedup wiring, fail-loud) per the
-``feedback_no_silent_fails`` discipline.
+``alpha_engine_lib.alerts.publish``, ``flow_doctor_telegram.notify_via_flow_doctor``,
+and ``boto3.client('stepfunctions')`` so tests do not hit AWS or the lib.
+Each test pins one decision branch (watch-day eligibility, alert-or-skip,
+dedup wiring, fail-loud) per the ``feedback_no_silent_fails`` discipline.
 """
 
 from __future__ import annotations
@@ -32,6 +32,17 @@ sys.modules["alpha_engine_lib"] = _lib_pkg
 sys.modules["alpha_engine_lib.trading_calendar"] = _tc_mod
 sys.modules["alpha_engine_lib.alerts"] = _alerts_mod
 
+_ng_pkg = types.ModuleType("nousergon_lib")
+_ng_fleet_mod = types.ModuleType("nousergon_lib.flow_doctor_fleet")
+_ng_fleet_mod.PIPELINE_OBSERVER_TELEGRAM_TOPICS = ("CRITICAL", "PIPELINE", "OPS_HEALTH")
+_ng_pkg.flow_doctor_fleet = _ng_fleet_mod
+sys.modules["nousergon_lib"] = _ng_pkg
+sys.modules["nousergon_lib.flow_doctor_fleet"] = _ng_fleet_mod
+
+_fd_mod = types.ModuleType("flow_doctor_telegram")
+_fd_mod.notify_via_flow_doctor = MagicMock(return_value=True)
+sys.modules["flow_doctor_telegram"] = _fd_mod
+
 sys.path.insert(0, str(Path(__file__).parent))
 import index  # noqa: E402
 
@@ -55,6 +66,8 @@ def _reset_lib_mocks():
     _alerts_mod.publish.reset_mock()
     _alerts_mod.publish.side_effect = None
     _alerts_mod.publish.return_value = _make_publish_result(sns_ok=True, telegram_ok=True)
+    _fd_mod.notify_via_flow_doctor.reset_mock()
+    _fd_mod.notify_via_flow_doctor.return_value = True
 
 
 def _make_publish_result(*, sns_ok: bool, telegram_ok: bool, dedup_skipped: bool = False):
@@ -208,9 +221,16 @@ def test_check_sf_emits_alert_when_zero_executions_in_window():
     assert call_kwargs["severity"] == "error"
     assert call_kwargs["source"] == "alpha-engine-pipeline-watchdog"
     assert call_kwargs["sns_topic_arn"] == index.WATCHDOG_SNS_TOPIC_ARN
-    assert call_kwargs["telegram"] is True
+    assert call_kwargs["telegram"] is False
     assert "Weekday SF" in call_kwargs["message"]
     assert "24h" in call_kwargs["message"]
+    _fd_mod.notify_via_flow_doctor.assert_called_once()
+    fd_kwargs = _fd_mod.notify_via_flow_doctor.call_args.kwargs
+    assert fd_kwargs["silent"] is False
+    assert fd_kwargs["severity"] == "error"
+    assert fd_kwargs["flow_name"] == index._FLOW_NAME
+    assert fd_kwargs["topics"] == _ng_fleet_mod.PIPELINE_OBSERVER_TELEGRAM_TOPICS
+    assert "Weekday SF" in _fd_mod.notify_via_flow_doctor.call_args.args[0]
 
 
 def test_check_sf_alert_uses_distinct_watchdog_sns_topic_not_alpha_engine_alerts():


### PR DESCRIPTION
## Summary
- Migrates `alpha-engine-pipeline-watchdog` off `alerts.publish(..., telegram=True)` (raw General-channel `send_message`) onto shared `flow_doctor_telegram.notify_via_flow_doctor` with `PIPELINE_OBSERVER_TELEGRAM_TOPICS` (#critical + #pipeline + #ops-health).
- SNS path unchanged: still publishes to distinct `alpha-engine-watchdog-alerts` topic with 12h dedup.
- Deploy: Docker pip (`lambda_pip_install.sh`), lib v0.82.0 `[flow-doctor]`, flow-doctor env vars, IAM for forum thread SSM params.

## Test plan
- [x] `pytest infrastructure/lambdas/pipeline-watchdog/test_handler.py -q` (21 passed)
- [ ] Brian merge
- [ ] IAM apply: `aws iam put-role-policy --role-name alpha-engine-pipeline-watchdog-role --policy-name alpha-engine-pipeline-watchdog-policy --policy-document file://infrastructure/lambdas/pipeline-watchdog/iam-policy.json`
- [ ] Deploy: `bash infrastructure/lambdas/pipeline-watchdog/deploy.sh` (no `--smoke` — would page on real outage)
- [ ] CloudWatch: confirm `[flow-doctor] initialized` on next alert or manual invoke on a non-watch-day

## Notes
- Closes the last T2 Lambda bypass in alpha-engine-data (`freshness-monitor` is T3 — separate issue).
- `#pipeline` forum topic still placeholder in SSM (thread 11 unverified); messages mirror to #critical + #ops-health regardless.


Made with [Cursor](https://cursor.com)