### PR TITLE
feat(notifications): route freshness-monitor SLA alerts through flow-doctor (config#1747)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -106,14 +106,22 @@ fi
 
 # ----- 1. Package: pip install runtime deps into $PKG ----------------------
 
-PKG=$(mktemp -d)
-TEST_DEPS=$(mktemp -d)
-trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-echo "Installing runtime deps into ${PKG} (pip install -t)..."
+PKG=$(mktemp -d)
+TEST_PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_PKG' '$TEST_DEPS'" EXIT
+
+echo "Installing runtime deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+# Host-side pytest imports the handler against real lib code — must use
+# macOS wheels. Docker pip targets linux/amd64 for Lambda only (#621).
+echo "Installing host test deps into ${TEST_PKG} (macOS pip for pytest gate)..."
 python3 -m pip install \
   --quiet \
-  --target "${PKG}" \
+  --target "${TEST_PKG}" \
   --upgrade \
   -r "${SCRIPT_DIR}/requirements.txt"
 
@@ -137,13 +145,14 @@ fi
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
   echo "Installing pytest into ${TEST_DEPS}..."
   python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
-  echo "Running handler unit tests (PYTHONPATH=${PKG}:${TEST_DEPS})..."
-  PYTHONPATH="${PKG}:${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+  echo "Running handler unit tests (PYTHONPATH=${TEST_PKG}:${TEST_DEPS})..."
+  PYTHONPATH="${TEST_PKG}:${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
 # ----- 1c. Copy handler + zip Lambda package -------------------------------
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
@@ -294,6 +303,18 @@ if ! $DRY_RUN; then
 fi
 
 echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration; preserve alert flags)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,FRESHNESS_MONITOR_ENABLED=true,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
 
 # ----- 4. Upload registry to S3 ---------------------------------------------
 # Skipped under --code-only: alpha-engine-config's sync-artifact-registry.yml

--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -12,12 +12,14 @@
       "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-freshness-monitor:*"
     },
     {
-      "Sid": "TelegramSecretsSSM",
+      "Sid": "TelegramAndFlowDoctorThreadSSM",
       "Effect": "Allow",
       "Action": ["ssm:GetParameter"],
       "Resource": [
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
       ]
     },
     {

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -24,9 +24,10 @@ invocation:
      — the monitor monitors itself; substrate-health-check daily
      watches the heartbeat.
   5. For misses past SLA (``state ∈ {missing, stale, probe_failed}``),
-     route to :func:`krepis.alerts.publish` with
-     ``dedup_key=resolve_dedup_key(spec, now)`` — dedup collapses
-     4×/hour retries to one alert per cycle per artifact.
+     route SNS via :func:`krepis.alerts.publish` (``telegram=False``) and
+     Telegram via flow-doctor forum topics (config#1742 T2 /
+     config#1747) with ``dedup_key=resolve_dedup_key(spec, now)`` — dedup
+     collapses 4×/hour retries to one alert per cycle per artifact.
   6. **OBSERVE-mode gate**: when env
      ``FRESHNESS_MONITOR_ENABLED`` is anything other than
      ``"true"`` (case-insensitive), alerts are suppressed but the
@@ -64,10 +65,18 @@ from alpha_engine_lib.artifact_freshness import (
     resolve_dedup_key,
 )
 from alpha_engine_lib.trading_calendar import previous_trading_day
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
+_FLOW_NAME = "freshness-monitor"
+_DB_BASENAME = "flow_doctor_freshness_monitor"
+_FRESHNESS_TELEGRAM_TOPICS = (
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
 
 # ── Configuration (env-driven so Phase 6 cutover is a single CLI flip) ──────
 
@@ -696,6 +705,21 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime) -> bool
         source="freshness-monitor",
         dedup_key=dedup_key,
         dedup_window_min=None,  # one alert per cadence window — substrate handles cycle bucketing
+        telegram=False,
+    )
+    notify_via_flow_doctor(
+        body,
+        silent=False,
+        severity=severity,
+        dedup_key=dedup_key,
+        flow_name=_FLOW_NAME,
+        topics=_FRESHNESS_TELEGRAM_TOPICS,
+        db_basename=_DB_BASENAME,
+        context={
+            "artifact_id": spec.artifact_id,
+            "state": result.state,
+            "owner_repo": spec.owner_repo,
+        },
     )
     return True
 

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,16 +1,6 @@
-# Pinned to nousergon-lib v0.73.0 — adds the continuous `run_calendar` enum
-# (trading_days / all_days / market_hours): the single source of truth for a
-# continuous artifact's calendar-awareness, driving BOTH the idle
-# short-circuit AND a trading-day-aware freshness floor. Fixes the
-# Monday-morning false positive that the v0.63.0 active-window gate left
-# unfixed (the wall-clock `now - interval - sla` floor reaches back across
-# the weekend and flags a daily trading-day producer stale before its run;
-# the trading-day floor counts only session days). v0.63.0 added the
-# active-window gate (open_orders overnight storm); v0.62.0 the RECENCY
-# redesign (PR #128). active_trading_days_only is now DEPRECATED (subsumed
-# by run_calendar="trading_days"); honored as a fallback during migration.
-# Name changed alpha-engine-lib -> nousergon-lib at the 0.60 rename; index.py's
-# alpha_engine_lib imports keep working via the compat shim (lib >=0.60.2).
+# config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
+# Substrate bumped to v0.82.0 for flow_doctor_fleet + compat with sibling Lambdas.
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.73.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+krepis>=0.10.2
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -6,8 +6,8 @@ contract: registry loading, per-spec exception isolation, heartbeat
 + check_results emission, OBSERVE-mode alert suppression, dedup-key
 threading, severity routing for probe_failed.
 
-Tests mock both ``boto3.client`` AND ``alpha_engine_lib.alerts.publish``
-so no live AWS or Telegram calls fire. The lib substrate
+Tests mock ``boto3.client``, ``krepis.alerts.publish``, and
+``notify_via_flow_doctor`` so no live AWS or Telegram calls fire. The lib substrate
 (``check_freshness`` itself) is exercised through real code — only
 the S3 client is mocked, mirroring the substrate's own test pattern.
 
@@ -30,6 +30,7 @@ import pytest
 
 # Make the Lambda handler importable.
 sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
@@ -314,12 +315,15 @@ def test_handler_alerts_enabled_fires_with_dedup_key(
     monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
 
     publish_mock = mock.Mock()
+    notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
 
     result = index.handler({}, None)
 
     assert result["alerts_enabled"] is True
     assert publish_mock.called
+    assert notify_mock.called
 
     # Inspect the publish calls — dedup keys should be unique per-artifact
     # and reflect the cycle window.
@@ -367,7 +371,9 @@ def test_handler_probe_failed_routes_to_critical(
     monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
 
     publish_mock = mock.Mock()
+    notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
 
     index.handler({}, None)
 
@@ -523,13 +529,18 @@ def test_maybe_alert_fires_missing_past_sla(monkeypatch, fixed_now):
         canonical_key="k/2026-05-30", reason="absent",
     )
     publish_mock = mock.Mock()
+    notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
     assert index._maybe_alert(spec, result, fixed_now) is True
     publish_mock.assert_called_once()
     call = publish_mock.call_args
     assert "artifact_id=x" in call.args[0]
     assert call.kwargs["severity"] == "warning"  # spec severity, not bumped
+    assert call.kwargs["telegram"] is False
     assert call.kwargs["dedup_key"] == "freshness_x_2026-W22"
+    notify_mock.assert_called_once()
+    assert notify_mock.call_args.kwargs["dedup_key"] == "freshness_x_2026-W22"
 
 
 def test_maybe_alert_probe_failed_uses_critical_severity(monkeypatch, fixed_now):
@@ -548,10 +559,15 @@ def test_maybe_alert_probe_failed_uses_critical_severity(monkeypatch, fixed_now)
     )
     result = CheckResult(state="probe_failed", reason="403")
     publish_mock = mock.Mock()
+    notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
     assert index._maybe_alert(spec, result, fixed_now) is True
     publish_mock.assert_called_once()
     assert publish_mock.call_args.kwargs["severity"] == "critical"
+    assert publish_mock.call_args.kwargs["telegram"] is False
+    notify_mock.assert_called_once()
+    assert notify_mock.call_args.kwargs["severity"] == "critical"
 
 
 # ── Historical-mode tests ────────────────────────────────────────────────────
@@ -1193,7 +1209,9 @@ def test_recovery_mode_dispatch_suppresses_page(monkeypatch, fake_s3, fixed_now)
     factory, sf, lam = _make_clients(fake_s3)
     monkeypatch.setattr(index, "boto3", mock.Mock(client=factory))
     publish_mock = mock.Mock()
+    notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
 
     result = index.handler({}, None)
 


### PR DESCRIPTION
## Summary
- Last T2 external-observer bypass: `freshness-monitor` SLA misses now split **SNS** (`krepis.publish(..., telegram=False)` → email) from **Telegram** (`notify_via_flow_doctor` → `#critical` + `#ops-health` by severity gate).
- Lib bump v0.73.0 → v0.82.0 `[flow-doctor]`; Docker pip for Lambda zip; dual macOS pip for host pytest gate (real substrate tests).
- Deploy adds `FLOW_DOCTOR_ENABLED=1` while preserving `FRESHNESS_MONITOR_ENABLED=true`.

## Test plan
- [x] `bash infrastructure/lambdas/freshness-monitor/deploy.sh --code-only` — 44 passed
- [ ] Brian merge
- [ ] IAM apply: `aws iam put-role-policy --role-name alpha-engine-freshness-monitor-role --policy-name alpha-engine-freshness-monitor-policy --policy-document file://infrastructure/lambdas/freshness-monitor/iam-policy.json`
- [ ] Post-merge: GHA auto-deploy aligns main; verify CloudWatch `[flow-doctor] initialized` on next SLA alert (do NOT `--smoke` — fires real alerts)

## Note
Accidental pre-merge live deploy during local validation (`deploy.sh --code-only` without `--dry-run`) — Lambda code + env already updated from this branch. IAM thread SSM params **not yet applied**; flow-doctor may fall back to unthreaded `send_message` until IAM lands.

Closes config#1747; completes config#1742 T2 scope.


Made with [Cursor](https://cursor.com)