### PR TITLE
[P3/low] docs(infra): fix stale cipher813 -> nousergon links (ops repo + OIDC example)

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,7 +1,7 @@
 ## Relocated to nous-ergon-ops (private)
 
 The following operational files were relocated to the private
-`cipher813/nous-ergon-ops` repo (mirrored layout) in the Phase-2 scoped
+`nousergon/nous-ergon-ops` repo (mirrored layout) in the Phase-2 scoped
 ops migration (alpha-engine-config#636, 2026-06-11). Each was verified
 consumer-free (no workflow/test/SF-literal/box-runtime path) before
 removal. Operators: find them at `nous-ergon-ops/<this-repo>/<same-path>`.

--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -91,7 +91,7 @@ aws iam update-assume-role-policy --role-name github-actions-lambda-deploy --pol
 ```
 
 When a new repo needs to auto-deploy, add its
-`repo:cipher813/<repo>:ref:refs/heads/main` (+ `:pull_request`) entry to
+`repo:nousergon/<repo>:ref:refs/heads/main` (+ `:pull_request`) entry to
 the trust JSON AND add its resource ARNs to the permission JSON, then
 apply both.
 


### PR DESCRIPTION
**Priority:** P3 · **Complexity:** low

Two stale org-slug refs, both docs-only / non-runtime:
- `infrastructure/README.md`: `cipher813/nous-ergon-ops` -> `nousergon/nous-ergon-ops` (confirmed current repo home via `gh repo view`).
- `infrastructure/iam/README.md`: operator instructions for adding a new repo's OIDC trust-policy entry showed `repo:cipher813/<repo>:ref:refs/heads/main` -> `repo:nousergon/<repo>:ref:refs/heads/main`. No `.trust.json` file exists in-repo to cross-check against live state; this only corrects the documented example.

Part of nousergon/alpha-engine-config#1137.