### PR TITLE
fix(freshness-monitor): warning-severity SLA misses console-only (config#1724)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -28,6 +28,9 @@ invocation:
      Telegram via flow-doctor forum topics (config#1742 T2 /
      config#1747) with ``dedup_key=resolve_dedup_key(spec, now)`` — dedup
      collapses 4×/hour retries to one alert per cycle per artifact.
+     **``severity=warning`` registry rows are console-only** (written to
+     ``check_results.json``; no SNS/Telegram — see ARTIFACT_REGISTRY
+     "dashboard-only" convention).
   6. **OBSERVE-mode gate**: when env
      ``FRESHNESS_MONITOR_ENABLED`` is anything other than
      ``"true"`` (case-insensitive), alerts are suppressed but the
@@ -662,6 +665,8 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime) -> bool
         the SLA grace window), OR ``probe_failed`` (no grace for
         broken probes — operator needs to know immediately)
       - :data:`ALERTS_ENABLED` is True
+      - resolved severity is ``critical`` (``severity=warning`` rows are
+        console-only via ``check_results.json`` — no SNS/Telegram)
 
     Dedup-key resolution via
     :func:`alpha_engine_lib.artifact_freshness.resolve_dedup_key` ⇒
@@ -684,6 +689,23 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime) -> bool
         )
         return False
 
+    # Probe failures route to critical (the monitor itself is broken);
+    # missing/stale respect the spec's severity. Plan §3 invariant 6.
+    severity = "critical" if result.state == "probe_failed" else spec.severity
+
+    # Registry convention: severity=warning means dashboard/console-only —
+    # the operator surface is check_results.json + this page, not ops-health
+    # Telegram. Critical (and probe_failed, coerced above) pages via SNS +
+    # flow-doctor. Aligns with ARTIFACT_REGISTRY comments ("dashboard-only")
+    # and the fleet notification consolidation arc (config#1740 / #1724).
+    if severity == "warning":
+        logger.info(
+            "console-only (severity=warning): %s state=%s — surfaced in "
+            "check_results.json, no SNS/Telegram",
+            spec.artifact_id, result.state,
+        )
+        return False
+
     # Compose the alert body.
     body = (
         f"artifact_id={spec.artifact_id} "
@@ -694,10 +716,6 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime) -> bool
         f"reason={result.reason}"
     )
     dedup_key = resolve_dedup_key(spec, now)
-
-    # Probe failures route to critical (the monitor itself is broken);
-    # missing/stale respect the spec's severity. Plan §3 invariant 6.
-    severity = "critical" if result.state == "probe_failed" else spec.severity
 
     publish(
         body,

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -332,6 +332,60 @@ def test_handler_alerts_enabled_fires_with_dedup_key(
     assert "freshness_probe_missing_2026-W22" in dedup_keys
 
 
+def test_handler_warning_severity_console_only_no_alert(
+    monkeypatch, fake_s3, fixed_now
+):
+    """severity=warning misses surface in check_results but do NOT page
+    (no SNS / flow-doctor) — console-only per ARTIFACT_REGISTRY convention."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+  grace_period_cycles: 0
+  calendar_aware: true
+artifacts:
+  - artifact_id: probe_stale_warning
+    s3_key_template: "path/{date}/stale.json"
+    cadence: saturday_sf
+    sla_minutes_after_cron: 60
+    severity: warning
+    owner_repo: alpha-engine-test
+    created_at: 2025-01-01
+"""
+    # Object exists but is older than SLA floor → stale + sla_violated > 0
+    cycle_tick = datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)
+    fake_s3._head_returns["path/2026-05-30/stale.json"] = {
+        "LastModified": cycle_tick.replace(hour=9, minute=30),
+    }
+
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+
+    publish_mock = mock.Mock()
+    notify_mock = mock.Mock(return_value=True)
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
+
+    result = index.handler({}, None)
+
+    assert result["alerts_enabled"] is True
+    assert result["counts"].get("stale", 0) >= 1
+    publish_mock.assert_not_called()
+    notify_mock.assert_not_called()
+
+    check_body = next(
+        body for (_, k, body) in fake_s3._put_calls
+        if k == "_freshness_monitor/check_results.json"
+    )
+    check = json.loads(check_body)
+    row = next(r for r in check["results"] if r["artifact_id"] == "probe_stale_warning")
+    assert row["state"] == "stale"
+
+
 def test_handler_probe_failed_routes_to_critical(
     monkeypatch, yaml_registry_body, fake_s3, fixed_now
 ):


### PR DESCRIPTION
## Summary
- Stop routing `severity=warning` freshness SLA misses to SNS + flow-doctor `#ops-health` — registry convention is dashboard/console-only via `check_results.json`
- **Critical** + **probe_failed** still page as before
- Adds unit test pinning the console-only path

## Why
Ops-health was drowning in warning-level freshness alerts (e.g. `config_research_params`, macro_history, universe_board) that are intentionally WATCH/dashboard surfaces per `ARTIFACT_REGISTRY.yaml`.

## Test plan
- [ ] CI green on `test_handler.py`
- [ ] Post-merge: redeploy `alpha-engine-freshness-monitor` Lambda
- [ ] Confirm a known warning-severity stale row still appears on console `/Artifact_Freshness` but does NOT buzz #ops-health


Made with [Cursor](https://cursor.com)