### PR TITLE
Wire C.1 factor-loading zscores into ArcticDB (C.2b risk_model unblock)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -37,6 +37,7 @@ from features.feature_engineer import (
     compute_features,
 )
 from features.factor_momentum import materialize_factor_momentum
+from features.cross_sectional import materialize_factor_loading_zscores
 from features.compute import (
     DEFAULT_BUCKET,
     SOURCE_CATEGORIES,
@@ -797,6 +798,23 @@ def backfill(
             canonical_fn=to_arctic_canonical,
         )
         log.info("Factor-momentum second pass: %s", json.dumps(fm_result, default=str))
+
+    # ── 5c. Factor-loading z-score second pass (C.1 / C.2b) ───────────────────
+    # The 9 *_zscore Barra loadings are cross-sectional (apply_factor_zscores).
+    # S3 feature-store compute.py already emits them; ArcticDB (predictor
+    # training cache + risk_model_persist) needs the same second pass so C.2b
+    # can build F + D from tmp_cache. Full-universe only — a ``--ticker X``
+    # patch can't reconstruct the cross-section.
+    if not dry_run and ticker_filter is None:
+        flz_result = materialize_factor_loading_zscores(
+            universe_lib,
+            universe_tickers,
+            canonical_fn=to_arctic_canonical,
+        )
+        log.info(
+            "Factor-loading z-score second pass: %s",
+            json.dumps(flz_result, default=str),
+        )
 
     # ── 6. Snapshot ──────────────────────────────────────────────────────────
     if not dry_run:

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -2104,6 +2104,28 @@ def _daily_append_impl(
             except Exception as exc:  # belt-and-suspenders — never fail the daily pipeline
                 log.warning("Factor-momentum daily update FAILED (OBSERVE, non-fatal): %s", exc)
 
+        # ── C.1: factor-loading z-score daily go-forward second pass ─────────
+        # The 9 *_zscore Barra loadings (C.3 / predictor risk_model_persist)
+        # are cross-sectional — same structural gap as factor_momentum_ratio.
+        # S3 feature store already runs apply_factor_zscores in compute.py;
+        # this pass keeps ArcticDB (predictor training + C.2b F+D persistence)
+        # in sync. Best-effort + gated; never fails the daily pipeline.
+        if os.environ.get("FACTOR_LOADING_ZSCORE_DAILY_ENABLED", "true").lower() != "false":
+            try:
+                from features.cross_sectional import update_factor_loading_zscores_latest
+                flz_result = update_factor_loading_zscores_latest(
+                    universe_lib, stock_tickers, today_ts,
+                    canonical_fn=to_arctic_canonical,
+                )
+                log.info(
+                    "Factor-loading z-score daily update: %s",
+                    json.dumps(flz_result, default=str),
+                )
+            except Exception as exc:
+                log.warning(
+                    "Factor-loading z-score daily update FAILED (non-fatal): %s", exc,
+                )
+
         # Producer-side post-write validation. Catches the partial-write
         # class (2026-04-21 ASGN/MOH) that the per-ticker error-rate gate
         # above misses — symbols not in today's batch but stale from

--- a/features/cross_sectional.py
+++ b/features/cross_sectional.py
@@ -5,8 +5,8 @@ C.1 of the optimizer-sota-upgrades-260526 arc (factor-risk decomposition).
 The executor's risk decomposition Σ = B·F·Bᵀ + D (workstream C.3) consumes
 a (N × K) factor-loading matrix B where columns are CROSS-SECTIONALLY
 z-scored style factors (mean 0, std 1 across the universe at each date).
-This module adds those columns to the feature-store panel after the
-per-ticker feature computation completes.
+This module adds those columns to the feature-store panel and the ArcticDB
+universe library after the per-ticker feature computation completes.
 
 Convention: Barra USE4 / AQR / BlackRock Aladdin — winsorize at ±3σ then
 re-standardize. The winsorization prevents a single ticker's outlier from
@@ -173,3 +173,246 @@ def apply_factor_zscores(
             col = transform(col)
         out[dst] = _winsorize_and_zscore(col)
     return out
+
+
+def factor_loading_source_columns() -> list[str]:
+    """Raw per-ticker columns that feed the cross-sectional z-score pass."""
+    return list(FACTOR_LOADING_SOURCES.keys())
+
+
+def materialize_factor_loading_zscores(
+    universe_lib,
+    tickers,
+    *,
+    write: bool = True,
+    canonical_fn=None,
+) -> dict:
+    """Second-pass library builder: materialize C.1 ``*_zscore`` loadings in ArcticDB.
+
+    Factor-loading z-scores are cross-sectional — each date's values depend on
+    the WHOLE universe's raw loadings at that date. Per-ticker streaming writes
+    in ``builders/backfill.py`` / ``builders/daily_append.py`` cannot compute
+    them inline, so this runs as a separate pass (mirrors
+    ``factor_momentum.materialize_factor_momentum``):
+
+      * Pass 1 — read back the slim ``(source loadings)`` panel per ticker,
+        group by date, call :func:`apply_factor_zscores` per cross-section.
+      * Pass 2 — read-modify-write the ``*_zscore`` columns per ticker.
+
+    Best-effort per ticker on read/write failures; all-NaN z-score counts are
+    logged LOUD. Never raises into the caller pipeline.
+    """
+    src_cols = factor_loading_source_columns()
+    dst_cols = factor_loading_columns()
+
+    frames: list[pd.DataFrame] = []
+    read_fail = 0
+    for t in tickers:
+        try:
+            df = universe_lib.read(t).data
+        except Exception as exc:
+            log.warning(
+                "factor-loading-zscores: read failed for %s (skipped): %s", t, exc,
+            )
+            read_fail += 1
+            continue
+        if df is None or df.empty:
+            continue
+        sub = pd.DataFrame({"ticker": t, "date": df.index})
+        for c in src_cols:
+            if c in df.columns:
+                # .to_numpy() — sub uses RangeIndex; df[c] is DatetimeIndex-aligned
+                # and would otherwise assign all-NaN via index mismatch.
+                sub[c] = df[c].astype(float).to_numpy()
+        frames.append(sub.reset_index(drop=True))
+
+    if not frames:
+        log.warning(
+            "factor-loading-zscores: no readable tickers (read_fail=%d) — "
+            "nothing materialized",
+            read_fail,
+        )
+        return {"status": "empty", "tickers_written": 0, "read_fail": read_fail}
+
+    panel = pd.concat(frames, ignore_index=True)
+    zscore_parts: list[pd.DataFrame] = []
+    for date, grp in panel.groupby("date", sort=True):
+        cross = grp.drop(columns=["date"]).copy()
+        z = apply_factor_zscores(cross)
+        part = z[["ticker", *dst_cols]].copy()
+        part["date"] = date
+        zscore_parts.append(part)
+
+    zpanel = pd.concat(zscore_parts, ignore_index=True)
+
+    n_written = 0
+    n_all_nan = 0
+    write_fail = 0
+    n_tickers = zpanel["ticker"].nunique()
+    for t, grp in zpanel.groupby("ticker", sort=False):
+        z_by_date = grp.set_index("date")[dst_cols].astype(float)
+        if not np.isfinite(z_by_date.to_numpy()).any():
+            n_all_nan += 1
+        if not write:
+            continue
+        try:
+            df = universe_lib.read(t).data
+            for col in dst_cols:
+                df[col] = z_by_date[col].reindex(df.index).astype("float32")
+            out = canonical_fn(df) if canonical_fn is not None else df
+            universe_lib.write(t, out)
+            n_written += 1
+        except Exception as exc:
+            log.warning(
+                "factor-loading-zscores: write failed for %s (skipped): %s", t, exc,
+            )
+            write_fail += 1
+
+    if n_all_nan:
+        log.warning(
+            "factor-loading-zscores: %d/%d tickers have all-NaN z-score loadings "
+            "(missing source columns / degenerate cross-section → excluded from "
+            "risk-model B matrix downstream, NOT a silent zero).",
+            n_all_nan, n_tickers,
+        )
+    log.info(
+        "factor-loading-zscores materialized: %d written, %d all-NaN, "
+        "%d read-fail, %d write-fail (of %d panel tickers)",
+        n_written, n_all_nan, read_fail, write_fail, n_tickers,
+    )
+    return {
+        "status": "ok",
+        "tickers_written": n_written,
+        "tickers_all_nan": n_all_nan,
+        "read_fail": read_fail,
+        "write_fail": write_fail,
+    }
+
+
+def update_factor_loading_zscores_latest(
+    universe_lib,
+    tickers,
+    as_of_ts,
+    *,
+    write: bool = True,
+    canonical_fn=None,
+) -> dict:
+    """Daily go-forward update of C.1 ``*_zscore`` loadings (ArcticDB second pass).
+
+    Runs AFTER ``builders/daily_append`` has written today's per-ticker raw
+    loading columns so the cross-section is complete. Reads today's rows,
+    applies :func:`apply_factor_zscores`, and updates ONLY ``as_of_ts`` via
+    ``update_batch``. Best-effort — never raises into the daily pipeline.
+    """
+    from arcticdb.version_store.library import ReadRequest, UpdatePayload
+
+    src_cols = factor_loading_source_columns()
+    dst_cols = factor_loading_columns()
+    as_of_ts = pd.Timestamp(as_of_ts)
+    tickers = list(tickers)
+
+    rows: list[dict] = []
+    read_fail = 0
+    try:
+        src_results = universe_lib.read_batch([
+            ReadRequest(symbol=t, date_range=(as_of_ts, as_of_ts), columns=src_cols)
+            for t in tickers
+        ])
+    except Exception as exc:
+        log.warning(
+            "factor-loading-zscores daily: source read_batch failed (skipped): %s", exc,
+        )
+        return {"status": "read_error", "error": str(exc), "tickers_written": 0}
+
+    for t, res in zip(tickers, src_results):
+        data = getattr(res, "data", None)
+        if data is None or data.empty or as_of_ts not in data.index:
+            read_fail += 1
+            continue
+        row = {"ticker": t}
+        for c in src_cols:
+            row[c] = float(data.loc[as_of_ts, c]) if c in data.columns else np.nan
+        rows.append(row)
+
+    if not rows:
+        log.warning(
+            "factor-loading-zscores daily: no readable tickers @ %s (read_fail=%d)",
+            as_of_ts.date(), read_fail,
+        )
+        return {"status": "empty", "tickers_written": 0, "read_fail": read_fail}
+
+    zscored = apply_factor_zscores(pd.DataFrame(rows))
+    z_by_ticker = {
+        r["ticker"]: {c: float(r[c]) for c in dst_cols}
+        for _, r in zscored.iterrows()
+    }
+    n_all_nan = sum(
+        1 for vals in z_by_ticker.values()
+        if not any(np.isfinite(v) for v in vals.values())
+    )
+    if not write:
+        return {
+            "status": "ok",
+            "tickers_written": 0,
+            "tickers_all_nan": n_all_nan,
+            "read_fail": read_fail,
+            "n_computed": len(z_by_ticker),
+        }
+
+    write_tickers = list(z_by_ticker)
+    try:
+        today_results = universe_lib.read_batch(
+            [ReadRequest(symbol=t, date_range=(as_of_ts, as_of_ts)) for t in write_tickers]
+        )
+    except Exception as exc:
+        log.warning(
+            "factor-loading-zscores daily: today read_batch failed (skipped): %s", exc,
+        )
+        return {
+            "status": "read_error",
+            "error": str(exc),
+            "tickers_written": 0,
+            "read_fail": read_fail,
+        }
+
+    payloads = []
+    for t, res in zip(write_tickers, today_results):
+        data = getattr(res, "data", None)
+        if data is None or data.empty or as_of_ts not in data.index:
+            continue
+        row = data.copy()
+        for col in dst_cols:
+            row.loc[as_of_ts, col] = np.float32(z_by_ticker[t][col])
+        out = canonical_fn(row) if canonical_fn is not None else row
+        payloads.append(UpdatePayload(symbol=t, data=out))
+
+    n_written = 0
+    write_fail = 0
+    if payloads:
+        try:
+            universe_lib.update_batch(payloads)
+            n_written = len(payloads)
+        except Exception as exc:
+            log.warning(
+                "factor-loading-zscores daily: update_batch failed (skipped): %s", exc,
+            )
+            write_fail = len(payloads)
+
+    if n_all_nan:
+        log.warning(
+            "factor-loading-zscores daily: %d/%d tickers all-NaN @ %s",
+            n_all_nan, len(z_by_ticker), as_of_ts.date(),
+        )
+    log.info(
+        "factor-loading-zscores daily update @ %s: %d written, %d all-NaN, "
+        "%d read-fail, %d write-fail (of %d computed)",
+        as_of_ts.date(), n_written, n_all_nan, read_fail, write_fail, len(z_by_ticker),
+    )
+    return {
+        "status": "ok",
+        "tickers_written": n_written,
+        "tickers_all_nan": n_all_nan,
+        "read_fail": read_fail,
+        "write_fail": write_fail,
+        "n_computed": len(z_by_ticker),
+    }

--- a/tests/test_arctic_factor_loading_zscores.py
+++ b/tests/test_arctic_factor_loading_zscores.py
@@ -1,0 +1,188 @@
+"""ArcticDB second-pass tests for C.1 factor-loading z-scores.
+
+Mirrors test_factor_momentum.py's mock-lib pattern: materialize rewrites full
+history; update_factor_loading_zscores_latest patches only the latest date.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from features.cross_sectional import (
+    apply_factor_zscores,
+    factor_loading_columns,
+    factor_loading_source_columns,
+    materialize_factor_loading_zscores,
+)
+
+
+def _cross_section_panel(n_tickers: int = 40, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    tickers = [f"T{i:03d}" for i in range(n_tickers)]
+    dates = pd.bdate_range("2024-01-02", periods=80)
+    rows = []
+    for d in dates:
+        for t in tickers:
+            rows.append({
+                "ticker": t,
+                "date": d,
+                "Close": 100.0 + rng.normal(),
+                "momentum_20d": rng.normal(),
+                "return_60d": rng.normal(),
+                "beta_60d": rng.normal(1.0, 0.2),
+                "idio_vol_60d": abs(rng.normal(0.2, 0.05)),
+                "realized_vol_63d": abs(rng.normal(0.25, 0.05)),
+                "dist_from_52w_high": rng.uniform(-0.3, 0.0),
+                "pe_ratio": abs(rng.normal(20, 5)),
+                "roe": rng.normal(0.15, 0.05),
+                "market_cap_raw": abs(rng.normal(5e9, 1e9)),
+            })
+    return pd.DataFrame(rows)
+
+
+class _MockLib:
+    class _Item:
+        def __init__(self, data):
+            self.data = data
+
+    def __init__(self, frames: dict):
+        self._store = {t: df.copy() for t, df in frames.items()}
+
+    def read(self, sym):
+        return self._Item(self._store[sym].copy())
+
+    def write(self, sym, df):
+        self._store[sym] = df.copy()
+
+
+class _BatchResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _BatchLib:
+    def __init__(self, frames: dict):
+        self._store = {t: df.copy() for t, df in frames.items()}
+
+    def read_batch(self, reqs):
+        out = []
+        for req in reqs:
+            sym = req.symbol
+            if sym not in self._store:
+                out.append(_BatchResult(None))
+                continue
+            df = self._store[sym]
+            dr = getattr(req, "date_range", None)
+            if dr is not None:
+                lo, hi = dr
+                if lo is not None:
+                    df = df.loc[df.index >= lo]
+                if hi is not None:
+                    df = df.loc[df.index <= hi]
+            cols = getattr(req, "columns", None)
+            if cols:
+                df = df[[c for c in cols if c in df.columns]]
+            out.append(_BatchResult(df.copy()))
+        return out
+
+    def update_batch(self, payloads):
+        for p in payloads:
+            cur = self._store.get(p.symbol)
+            if cur is None:
+                self._store[p.symbol] = p.data.copy()
+                continue
+            cur = cur.copy()
+            for idx in p.data.index:
+                for c in p.data.columns:
+                    cur.loc[idx, c] = p.data.loc[idx, c]
+            self._store[p.symbol] = cur
+
+
+def _panel_to_universe_frames(panel: pd.DataFrame) -> dict:
+    src = factor_loading_source_columns()
+    frames = {}
+    for t, grp in panel.groupby("ticker", sort=False):
+        g = grp.sort_values("date").set_index("date")
+        frame = {"Close": g["Close"].astype(float)}
+        for c in src:
+            frame[c] = g[c].astype(float)
+        frames[t] = pd.DataFrame(frame)
+    return frames
+
+
+def _expected_latest_zscores(panel: pd.DataFrame, as_of) -> pd.DataFrame:
+    latest = panel[panel["date"] == as_of].drop(columns=["date", "Close"])
+    return apply_factor_zscores(latest)
+
+
+class TestMaterializeFactorLoadingZscores:
+    def test_writes_zscore_columns_consistent_with_pure_fn(self):
+        panel = _cross_section_panel(n_tickers=50, seed=3)
+        tickers = sorted(panel["ticker"].unique())
+        as_of = panel["date"].max()
+        lib = _MockLib(_panel_to_universe_frames(panel))
+
+        result = materialize_factor_loading_zscores(lib, tickers)
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == len(tickers)
+
+        expected = _expected_latest_zscores(panel, as_of).set_index("ticker")
+        dst = factor_loading_columns()
+        for t in tickers[:5]:
+            df = lib.read(t).data
+            for col in dst:
+                assert col in df.columns
+            got = df.loc[as_of, dst].astype(float)
+            exp = expected.loc[t, dst].astype(float)
+            np.testing.assert_allclose(got, exp, rtol=1e-5, atol=1e-6)
+
+    def test_write_false_computes_but_does_not_write(self):
+        panel = _cross_section_panel(n_tickers=30, seed=4)
+        tickers = sorted(panel["ticker"].unique())
+        lib = _MockLib(_panel_to_universe_frames(panel))
+        result = materialize_factor_loading_zscores(lib, tickers, write=False)
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == 0
+        for t in tickers:
+            assert "momentum_20d_zscore" not in lib.read(t).data.columns
+
+
+class TestUpdateFactorLoadingZscoresLatest:
+    def test_writes_latest_value_consistent_with_pure_fn(self):
+        pytest = __import__("pytest")
+        pytest.importorskip("arcticdb")
+        from features.cross_sectional import update_factor_loading_zscores_latest
+
+        panel = _cross_section_panel(n_tickers=50, seed=7)
+        tickers = sorted(panel["ticker"].unique())
+        frames = _panel_to_universe_frames(panel)
+        lib = _BatchLib(frames)
+        as_of = max(df.index.max() for df in frames.values())
+
+        result = update_factor_loading_zscores_latest(lib, tickers, as_of)
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == len(tickers)
+
+        expected = _expected_latest_zscores(panel, as_of).set_index("ticker")
+        dst = factor_loading_columns()
+        t0 = tickers[0]
+        got = lib._store[t0].loc[as_of, dst].astype(float)
+        exp = expected.loc[t0, dst].astype(float)
+        np.testing.assert_allclose(got, exp, rtol=1e-5, atol=1e-6)
+
+    def test_write_false_computes_but_does_not_write(self):
+        pytest = __import__("pytest")
+        pytest.importorskip("arcticdb")
+        from features.cross_sectional import update_factor_loading_zscores_latest
+
+        panel = _cross_section_panel(n_tickers=30, seed=8)
+        tickers = sorted(panel["ticker"].unique())
+        lib = _BatchLib(_panel_to_universe_frames(panel))
+        as_of = max(df.index.max() for df in lib._store.values())
+        result = update_factor_loading_zscores_latest(
+            lib, tickers, as_of, write=False,
+        )
+        assert result["status"] == "ok"
+        assert result["tickers_written"] == 0
+        assert result["n_computed"] == len(tickers)
+        assert "momentum_20d_zscore" not in lib._store[tickers[0]].columns

--- a/tests/test_daily_append_factor_loading_zscores.py
+++ b/tests/test_daily_append_factor_loading_zscores.py
@@ -1,0 +1,22 @@
+"""C.1 / C.2b: daily_append factor-loading z-score integration invariants.
+
+Mirrors test_daily_append_factor_momentum.py — source-inspection guarantees
+that the cross-sectional second pass is wired after the per-ticker write loop
+and is best-effort (never fails the daily pipeline).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_DAILY_APPEND = Path(__file__).parent.parent / "builders" / "daily_append.py"
+
+
+def _source() -> str:
+    return _DAILY_APPEND.read_text()
+
+
+def test_factor_loading_zscore_daily_update_invoked_after_write_loop():
+    src = _source()
+    assert "update_factor_loading_zscores_latest" in src
+    assert "FACTOR_LOADING_ZSCORE_DAILY_ENABLED" in src
+    assert "Factor-loading z-score daily update FAILED" in src

--- a/tests/test_daily_append_skip_if_exists.py
+++ b/tests/test_daily_append_skip_if_exists.py
@@ -57,6 +57,7 @@ def _disable_factor_momentum_daily(monkeypatch):
     # assertions here. The pass has its own tests (test_factor_momentum.py +
     # test_daily_append_factor_momentum.py).
     monkeypatch.setenv("FACTOR_MOMENTUM_DAILY_ENABLED", "false")
+    monkeypatch.setenv("FACTOR_LOADING_ZSCORE_DAILY_ENABLED", "false")
 
 
 def _stub_closes(tickers: list[str]) -> dict:

--- a/tests/test_daily_append_universe_chunking.py
+++ b/tests/test_daily_append_universe_chunking.py
@@ -46,6 +46,7 @@ def _disable_factor_momentum_daily(monkeypatch):
     # second pass (its extra read_batch/update_batch calls would inflate the
     # per-chunk call counts pinned here). The pass has its own tests.
     monkeypatch.setenv("FACTOR_MOMENTUM_DAILY_ENABLED", "false")
+    monkeypatch.setenv("FACTOR_LOADING_ZSCORE_DAILY_ENABLED", "false")
 
 
 def test_universe_pass_chunks_read_batch_calls(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds `materialize_factor_loading_zscores` + `update_factor_loading_zscores_latest` in `features/cross_sectional.py` — mirrors the existing `factor_momentum` second-pass pattern for the 9 Barra `*_zscore` loading columns.
- Wires daily go-forward pass into `builders/daily_append.py` (gated by `FACTOR_LOADING_ZSCORE_DAILY_ENABLED`, default on).
- Wires full-history materialization into `builders/backfill.py` so Saturday DataPhase1 backfill populates historical zscores.

**Why:** S3 feature store already runs `apply_factor_zscores` in `compute.py`, but predictor `risk_model_persist` (C.2b) reads ArcticDB `tmp_cache` and has silently skipped every week — `risk_model/` on S3 is empty. This closes the data-path gap so weekly F+D persistence can start accumulating ahead of C.3.

## Test plan
- [x] `pytest tests/test_arctic_factor_loading_zscores.py tests/test_daily_append_factor_loading_zscores.py`
- [ ] After merge: next Saturday backfill materializes zscores; PredictorTraining `risk_model_persist` writes `s3://alpha-engine-research/risk_model/{date}/`
- [ ] Freshness monitor: `predictor_risk_model_*` rows transition from `missing` → `fresh` (console-only WARNING until first write)

## Post-merge ops
Saturday DataPhase1 backfill is the first full materialization — no manual step unless you want to accelerate before next Sat. Weekday/daily `daily_append` paths keep zscores fresh going forward.


Made with [Cursor](https://cursor.com)