### PR TITLE
chore(infra): tier-split groom dispatcher schedules (#1762)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -25,9 +25,9 @@ then self-terminates (~$2/mo).
 
 ```
 EventBridge Scheduler rules (UTC, cron)                    THIS Lambda
-  alpha-engine-scheduled-groom-0700-daily           ─┐      1. nousergon_lib.ec2_spot.launch()
-  alpha-engine-scheduled-groom-2300-daily           ─┼───▶     (spot; on-demand fallback)
-  alpha-engine-scheduled-groom-1500-daily-opus-high ─┘      2. wait instance running + SSM Online
+  alpha-engine-scheduled-groom-0700-daily-low           ─┐      1. nousergon_lib.ec2_spot.launch()
+  alpha-engine-scheduled-groom-1500-daily-opus-high     ─┼───▶     (spot; on-demand fallback)
+  alpha-engine-scheduled-groom-2300-daily-mid           ─┘      2. wait instance running + SSM Online
                                                              3. async ssm send-command (detached):
                                                                    │
                                                                    ▼
@@ -49,24 +49,14 @@ flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 
 | Scheduler rule | Expression (UTC) | PT | Day mask | run_mode | model | issue_filter |
 |---|---|---|---|---|---|---|
-| `…-0700-daily` | `cron(0 7 * * ? *)` | 12am | daily (all 7) | full | claude-sonnet-5 | default |
-| `…-2300-daily` | `cron(0 23 * * ? *)` | 4pm | daily (all 7) | full | claude-sonnet-5 | default |
+| `…-0700-daily-low` | `cron(0 7 * * ? *)` | 12am | daily (all 7) | full | claude-haiku-4-5 | low-only |
 | `…-1500-daily-opus-high` | `cron(0 15 * * ? *)` | 8am | daily (all 7) | full | claude-opus-4-8 | high-only |
+| `…-2300-daily-mid` | `cron(0 23 * * ? *)` | 4pm | daily (all 7) | full | claude-sonnet-5 | mid-only |
 
-> **Reduced 3→2/day on 2026-06-29** (usage pacing): the former
-> `…-1500-sunfri` rule (`cron(0 15 ? * SUN-FRI *)`, 8am PT, Sonnet/default) was
-> dropped. **Re-added 2026-07-01** at the same 15:00 UTC slot (config#1495
-> follow-up) as a DIFFERENT tier, not a reinstatement: `…-1500-daily-opus-high`
-> runs **Opus** against **`complexity:high` issues only** — the queue the two
-> Sonnet schedules above explicitly exclude. It shares the SAME weekly Max-quota
-> reserve-for-interactive budget gate (`scripts/groom_budget.py`) as the Sonnet
-> schedules — it competes for the same pool, not a separate one — and shuts
-> down immediately/cleanly if the `complexity:high` queue is empty (a
-> `total == 0` clean stop, never a floor-breach false-positive; see
-> `scripts/groom_driver.py`). An issue an Opus chunk judges to need Brian's own
-> judgment (a genuine, irreducible product/architecture fork — not mere
-> difficulty) gets relabeled `complexity:ultra`, which permanently exits ALL
-> automated grooming (both this schedule and the two Sonnet ones).
+> **Tier-split cadence (config#1760, 2026-07-05):** three disjoint queues — Haiku
+> on `complexity:low`, Sonnet on `complexity:mid` (+ unlabeled), Opus on
+> `complexity:high`. Requires `alpha-engine-config` driver filters (#1761) on
+> the box's cloned `main` before `--bootstrap` deploys these schedules live.
 
 > **Sat-skip removed 2026-07-02, uniform 3x/day/7-days, no exceptions.** The
 > former `…-0700-sunfri` rule (`cron(0 7 ? * SUN-FRI *)`) skipped Saturday to

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -97,24 +97,22 @@ SF_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SF_ROLE_NAME}"
 SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
 
 # Schedule definitions: name | cron expression (UTC) | JSON input (run_mode +
-# label, plus model/issue_filter for the Opus high-tier schedule). The two
-# Sonnet schedules omit model/issue_filter — the Lambda defaults them to
-# claude-sonnet-5 / "default" (the pre-existing mid-tier queue), so this is not
-# a behavior change for them.
+# schedule label, plus model/issue_filter per tier — config#1760 tier-split).
+# deploy.sh prune drops orphaned rule names when cadence changes.
 SCHED_NAMES=(
-  "alpha-engine-scheduled-groom-0700-daily"
-  "alpha-engine-scheduled-groom-2300-daily"
+  "alpha-engine-scheduled-groom-0700-daily-low"
   "alpha-engine-scheduled-groom-1500-daily-opus-high"
+  "alpha-engine-scheduled-groom-2300-daily-mid"
 )
 SCHED_CRONS=(
   "cron(0 7 * * ? *)"
-  "cron(0 23 * * ? *)"
   "cron(0 15 * * ? *)"
+  "cron(0 23 * * ? *)"
 )
 SCHED_INPUTS=(
-  '{"run_mode":"full","schedule":"0 7 * * *"}'
-  '{"run_mode":"full","schedule":"0 23 * * *"}'
+  '{"run_mode":"full","model":"claude-haiku-4-5","issue_filter":"low-only","schedule":"0 7 * * *"}'
   '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","schedule":"0 15 * * *"}'
+  '{"run_mode":"full","model":"claude-sonnet-5","issue_filter":"mid-only","schedule":"0 23 * * *"}'
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2f).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -141,8 +141,8 @@ CW_LOG_GROUP = os.environ.get("GROOM_CW_LOG_GROUP", "/alpha-engine/groom-spot")
 
 _VALID_RUN_MODES = {"full", "sweep"}
 _DEFAULT_RUN_MODE = "full"
-_VALID_ISSUE_FILTERS = {"default", "high-only"}
-_DEFAULT_ISSUE_FILTER = "default"
+_VALID_ISSUE_FILTERS = {"default", "mid-only", "low-only", "high-only"}
+_DEFAULT_ISSUE_FILTER = "mid-only"
 _DEFAULT_MODEL = "claude-sonnet-5"
 # Defense-in-depth allowlist for the model id (embedded verbatim into the SSM
 # shell command below) — model ids are Lambda-config-controlled, not raw user
@@ -222,8 +222,10 @@ def _resolve_run_mode(event: dict) -> str:
 
 
 def _resolve_issue_filter(event: dict) -> str:
-    """Pull issue_filter from the schedule input; unknown/missing → default (Sonnet queue)."""
+    """Pull issue_filter from the schedule input; unknown/missing → mid-only (Sonnet queue)."""
     f = str(event.get("issue_filter") or _DEFAULT_ISSUE_FILTER).strip().lower()
+    if f == "default":
+        f = "mid-only"
     if f not in _VALID_ISSUE_FILTERS:
         logger.warning("unknown issue_filter %r — defaulting to %s", f, _DEFAULT_ISSUE_FILTER)
         f = _DEFAULT_ISSUE_FILTER

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -311,23 +311,37 @@ def test_pace_gate_fails_safe_and_still_launches_on_s3_error(monkeypatch):
     assert notified == []  # fail-safe path never trips (exceeded=False), no ping
 
 
-def test_missing_model_and_issue_filter_default_to_sonnet_queue(monkeypatch):
-    # The 2 pre-existing Sonnet schedules don't set model/issue_filter — must
-    # default exactly like before this feature (no behavior change for them).
+def test_missing_model_and_issue_filter_default_to_mid_queue(monkeypatch):
+    # Schedules with no model/issue_filter must default to Sonnet / mid-only.
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     g = out["groom"]
     assert g["model"] == "claude-sonnet-5"
-    assert g["issue_filter"] == "default"
+    assert g["issue_filter"] == "mid-only"
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
     assert "export GROOM_MODEL=claude-sonnet-5" in cmd
-    assert "export GROOM_ISSUE_FILTER=default" in cmd
+    assert "export GROOM_ISSUE_FILTER=mid-only" in cmd
 
 
-def test_unknown_issue_filter_falls_back_to_default(monkeypatch):
+def test_low_only_schedule_forwards_haiku_model_and_filter(monkeypatch):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler(
+        {"run_mode": "full", "model": "claude-haiku-4-5", "issue_filter": "low-only",
+         "schedule": "0 7 * * *"},
+        None,
+    )
+    g = out["groom"]
+    assert g["model"] == "claude-haiku-4-5"
+    assert g["issue_filter"] == "low-only"
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "export GROOM_MODEL=claude-haiku-4-5" in cmd
+    assert "export GROOM_ISSUE_FILTER=low-only" in cmd
+
+
+def test_unknown_issue_filter_falls_back_to_mid_only(monkeypatch):
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler({"run_mode": "full", "issue_filter": "bogus"}, None)
-    assert out["groom"]["issue_filter"] == "default"
+    assert out["groom"]["issue_filter"] == "mid-only"
 
 
 def test_malformed_model_falls_back_to_default(monkeypatch):


### PR DESCRIPTION
## Summary
Retier EventBridge schedules to disjoint model/filter pairs (config#1760):
- 07:00 UTC — Haiku / `low-only`
- 15:00 UTC — Opus / `high-only` (unchanged tier, same slot)
- 23:00 UTC — Sonnet / `mid-only`

Prunes old `…-0700-daily` and `…-2300-daily` implicit-default rules on `--bootstrap`.

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` (CI)
- [ ] **Blocked until** alpha-engine-config #1761 merges (driver must understand new filters)
- [ ] Operator: `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap`
- [ ] Verify next Telegram START pings show `filter=low-only` / `filter=mid-only`

Part of config#1760. Do not bootstrap until config PR merges.

Made with [Cursor](https://cursor.com)