### PR TITLE
Groom pace-gate skip → silent #groom topic (config#1748)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -87,6 +87,11 @@ _OPS_TOPICS = (
     FleetTelegramTopic.CRITICAL,
     FleetTelegramTopic.OPS_HEALTH,
 )
+_GROOM_LIFECYCLE_TOPICS = (
+    FleetTelegramTopic.GROOM,
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
 # Kill-switch: GROOM_DISPATCH_ENABLED=false disables the trigger without deleting
 # the EventBridge Scheduler rules. Default ON.
 DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
@@ -468,13 +473,14 @@ def _notify_pace_skip(pace: dict, schedule_label: str, run_mode: str) -> None:
     try:
         notify_via_flow_doctor(
             text,
-            silent=False,
-            severity="warning",
+            silent=True,
+            severity="info",
             dedup_key=f"{_FLOW_NAME}:pace_skip:{schedule_label}",
             flow_name=_FLOW_NAME,
-            topics=_OPS_TOPICS,
+            topics=_GROOM_LIFECYCLE_TOPICS,
             db_basename=_DB_BASENAME,
             context={"schedule": schedule_label, "run_mode": run_mode, **pace},
+            silent_topic=FleetTelegramTopic.GROOM,
         )
     except Exception as exc:  # noqa: BLE001 — secondary observability
         logger.warning("pace-gate skip Telegram failed (non-fatal): %s", exc)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -264,7 +264,9 @@ def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
     # The pre-boot skip must notify — it's the ONLY place this outcome is ever
     # visible (a run that never boots has no on-box groom_run.sh to ping).
     assert len(notified) == 1
-    assert notified[0][1]["silent"] is False
+    assert notified[0][1]["silent"] is True
+    assert notified[0][1]["severity"] == "info"
+    assert notified[0][1]["silent_topic"] is not None
     assert "SKIPPED" in notified[0][0]
     assert "soft budget threshold passed before boot" in notified[0][0]
     assert "never launched" in notified[0][0]


### PR DESCRIPTION
## Summary
Pre-boot pace-gate skips are groom lifecycle signals — route to silent `#groom` (info) instead of `#ops-health` (warning buzz).

Requires SSM `FLOW_DOCTOR_TELEGRAM_THREAD_GROOM` (seeded 2026-07-05 as thread 230).

## Test plan
- [x] Updated `test_pace_gate_skips_launch_when_usage_ahead_of_pace` asserts silent/info + silent_topic
- [ ] Deploy Lambda after merge; trigger pace skip → message in `#groom`


Made with [Cursor](https://cursor.com)