### PR TITLE
fix(groom-dispatcher): add GROOM to hermetic test stub (config#1748)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -40,9 +40,17 @@ def _install_stubs(launch_impl, boto_clients):
     pkg.ec2_spot = ec2_spot_mod
     fleet_mod = types.ModuleType("nousergon_lib.flow_doctor_fleet")
 
+    # Mirror the members of the real nousergon_lib.flow_doctor_fleet
+    # .FleetTelegramTopic that index.py references at IMPORT time (module-level
+    # _OPS_TOPICS / _GROOM_LIFECYCLE_TOPICS tuples). A member missing here fails
+    # `import index` at load and takes the WHOLE suite down — not just the test
+    # that exercises it (2026-07-05: GROOM was added to index.py + the real enum
+    # in nousergon-lib v0.82.0, but this hermetic stub was not kept in lockstep;
+    # config#1748).
     class _FleetTelegramTopic:
         CRITICAL = "critical"
         OPS_HEALTH = "ops_health"
+        GROOM = "groom"
 
     fleet_mod.FleetTelegramTopic = _FleetTelegramTopic
     pkg.flow_doctor_fleet = fleet_mod


### PR DESCRIPTION
## Root cause
The **Deploy scheduled-groom-dispatcher** workflow went RED on `main` (run [28744549870](https://github.com/nousergon/nousergon-data/actions/runs/28744549870), commit `f2d9f5a`). The failure was in `deploy.sh` **step 0b — the preflight pytest gate**, which runs *before* any AWS mutation (packaging is step 1, `update-function-code` is step 3). So **no Lambda code was redeployed and no live state was applied** — the gate caught this pre-deploy.

`import index` failed at module load:
```
AttributeError: type object '_FleetTelegramTopic' has no attribute 'GROOM'
infrastructure/lambdas/scheduled-groom-dispatcher/index.py:91
```
`index.py` builds `_GROOM_LIFECYCLE_TOPICS = (FleetTelegramTopic.GROOM, ...)` at module level. Because `import index` failed, **every test in the file** failed, not just the pace-gate test.

The trigger was PR #634 (config#1748): it correctly added `FleetTelegramTopic.GROOM` to `index.py` — that member **exists in the pinned `nousergon-lib` v0.82.0 real enum** (`_FleetTelegramTopic`: CRITICAL, TRADES, PIPELINE, OPS_HEALTH, **GROOM**, RESEARCH) — and updated the pace-gate assertions, but did **not** mirror `GROOM` into the test's *hand-rolled hermetic stub* of `_FleetTelegramTopic`. The stub (which lets the preflight tests run without `nousergon_lib` installed) drifted from its live source of truth.

## The fix (SOTA at this layer)
Test-only: add `GROOM = "groom"` to the stub `_FleetTelegramTopic` so it faithfully mirrors the real enum, plus a comment tying the stub's fidelity requirement to the real enum + config#1748. **Production code (`index.py`) is correct and untouched.** This is not a fail-loud swallow — it *restores* the suite's ability to import `index` and exercise the real GROOM-routing behavior; coverage increases, nothing is skipped or weakened.

## Guard / coverage that now covers this class
`test_pace_gate_skips_launch_when_usage_ahead_of_pace` now runs (it was import-dead) and asserts the skip routes to the silent GROOM topic (`silent_topic is not None`, `severity == 'info'`, `silent == True`). All 23 tests pass locally under the exact `deploy.sh` preflight (`pytest` + `krepis==0.10.0` in a scratch `--target`).

## Residual gap (tracked)
The stub is hand-maintained and *will* drift again. A follow-up issue on alpha-engine-config proposes the structural chokepoint fix: have the preflight use the **real** `flow_doctor_fleet` enum (it is pure stdlib — no boto3/creds, like `krepis` which the preflight already installs for real) instead of a hand-rolled fake, so this class of drift becomes impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)