### PR TITLE
Category-gate flow-doctor GitHub notifier (config#1696)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.77.0" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -11,6 +11,7 @@ notify:
   - type: github
     repo: nousergon/nousergon-data
     token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+    notify_on_category: [CODE, CONFIG]
     # 0.6.0rc2 soak: file an issue on failure (default) AND auto-apply the
     # flow-doctor:fix label so the flow-doctor-fix workflow generates a fix
     # PR with no human step. Both bounded by max_issues_per_day below.

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0
 anyio>=4.0
 tenacity>=8.0
 pyyaml>=6.0
-nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.77.0
+nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.77.0
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via alpha_engine_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -190,6 +190,16 @@ class TestFlowDoctorYamlSchema:
         for key in ("max_alerts_per_day", "max_issues_per_day", "max_diagnosed_per_day"):
             assert key in rl, f"rate_limits.{key} required (Anthropic-cost cap)"
 
+    def test_yaml_github_notifier_category_gated_same_repo(self):
+        """config#1696 — narrow auto_fix_pr eligibility; keep repo local."""
+        import yaml
+        with open(REPO_ROOT / "flow-doctor.yaml") as f:
+            cfg = yaml.safe_load(f)
+        github = next(n for n in cfg["notify"] if n.get("type") == "github")
+        assert github["repo"] == "nousergon/nousergon-data"
+        assert github.get("notify_on_category") == ["CODE", "CONFIG"]
+        assert github.get("auto_fix_pr") is True
+
 
 @flow_doctor_required
 class TestSetupLoggingAttach:

--- a/tests/test_infra_alerts_uses_krepis.py
+++ b/tests/test_infra_alerts_uses_krepis.py
@@ -12,7 +12,7 @@ rebase). Both older names are now shims, and invoking a shim under runpy
     pin < v0.81.1 it fell off its end with exit 0 before the target's
     ``__main__`` guard fired, i.e. a SILENT no-op (the config#1646 incident: a
     weekly Step Function reported SUCCESS while running zero workloads). This
-    repo pins nousergon-lib v0.77.0, so that path no-ops here today.
+    repo pins nousergon-lib v0.82.0, so that path no-ops here today.
 
 The robust, pin-independent entrypoint is ``python -m krepis.alerts`` — ``krepis``
 is a hard transitive dep (``requirements.txt`` floors ``krepis>=0.6.0``), so the


### PR DESCRIPTION
## Summary
- Add `notify_on_category: [CODE, CONFIG]` to `flow-doctor.yaml` github notifier — `repo:` stays `nousergon/nousergon-data` for `auto_fix_pr`
- Bump nousergon-lib to v0.82.0 on EC2 pin surfaces (requirements.txt, Dockerfile, requirements-daily-news.txt) for flow-doctor 0.8.0 category routing
- Wiring test asserts category gate + same-repo + auto_fix_pr preserved

## Test plan
- [x] `pytest tests/test_lib_pin_lockstep.py tests/test_flow_doctor_wiring.py::TestFlowDoctorYamlSchema` locally
- [ ] CI green

Closes config#1696.

Made with [Cursor](https://cursor.com)