### PR TITLE
[P1/high] fix(features): point-in-time discipline for avg_volume_20d (config#833)

### DIFF
--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -420,11 +420,19 @@ def compute_features(
     _vol_slow = _FC["volume_slow"]
     avg_vol_20d_raw = volume.rolling(window=_vol_slow, min_periods=_vol_slow).mean()
     df["avg_volume_20d_raw"] = avg_vol_20d_raw
-    volume_global_mean = volume.mean()
-    if volume_global_mean > 0:
-        df["avg_volume_20d"] = avg_vol_20d_raw / volume_global_mean
-    else:
-        df["avg_volume_20d"] = 1.0
+    # Point-in-time discipline (config#833 / L3293): normalize by a BACKWARD-ONLY
+    # per-ticker mean (expanding through T), NOT a full-sample volume.mean(). The
+    # backtest replay path computes features once over each ticker's ENTIRE history
+    # and then slices by decision date, so a whole-series mean here injected volume
+    # from T+1..T+N into every historical row's avg_volume_20d — a genuine (if mild)
+    # look-ahead. An expanding mean at row T sees only volume observed through T, so
+    # the value is identical whether features are computed on df[:T] or the full df.
+    # Warmup rows stay NaN (raw itself is NaN there); a degenerate all-zero-volume
+    # window maps to the neutral 1.0 the old scalar else-branch produced.
+    volume_expanding_mean = volume.expanding(min_periods=_vol_slow).mean()
+    df["avg_volume_20d"] = (
+        (avg_vol_20d_raw / volume_expanding_mean).replace([np.inf, -np.inf], 1.0)
+    )
 
     # ── Distance from 52-week high ─────────────────────────────────────────────
     _52w = _FC["weeks_52_days"]
@@ -801,6 +809,13 @@ def compute_features(
         df["put_call_ratio"] = _safe_float(options_data.get("put_call_ratio"), 0.0)
         df["iv_rank"] = _safe_float(options_data.get("iv_rank"), 0.5)
         atm_iv = _safe_float(options_data.get("atm_iv"), 0.0)
+        # NOT a look-ahead: this whole O12 options block is an as-of-SNAPSHOT
+        # broadcast — `options_data` (atm_iv etc.) is the current, time-axis-less
+        # options state, written as one scalar to every row. Pairing the scalar
+        # atm_iv with the TERMINAL realized_vol (`.iloc[-1]`, i.e. "now") is the
+        # correct current-state reference; it is never sliced per-decision-date in
+        # the PIT replay (config#833). Do NOT "PIT-fix" this to a per-row
+        # realized_vol — that would pair a single snapshot IV with historical RV.
         realized_vol = df["realized_vol_20d"].iloc[-1] if "realized_vol_20d" in df.columns else 0.0
         if realized_vol > 0 and atm_iv > 0:
             df["iv_vs_rv"] = atm_iv / realized_vol

--- a/tests/test_feature_engineer_point_in_time.py
+++ b/tests/test_feature_engineer_point_in_time.py
@@ -1,0 +1,105 @@
+"""Point-in-time (as-of) invariant for feature engineering (config#833 / L3293).
+
+The backtest replay path (crucible-backtester `synthetic/predictor_backtest.py`)
+computes features ONCE over each ticker's ENTIRE history and then slices the result
+by decision date. That is only sound if every feature at row T depends solely on
+rows <= T — i.e. `compute_features(df[:k]).loc[t] == compute_features(df).loc[t]`
+for every t < k. A single full-sample statistic (a `.mean()`/`.std()`/`.iloc[-1]`
+over the whole series) silently injects future rows into every historical value.
+
+This test is the regression tripwire. It caught `avg_volume_20d`, which normalized
+the rolling-20d volume by a WHOLE-SERIES `volume.mean()` — now an expanding
+(backward-only) mean. Any future feature that reaches forward in time trips it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from features.feature_engineer import compute_features
+
+# Features fully computable from Close+Volume alone (no macro/cross-sectional/
+# snapshot inputs), hence expected to be strictly as-of stable. The options/
+# earnings/revision dict inputs are intentional current-snapshot broadcasts and
+# are excluded by construction (their dicts are not passed).
+_ASOF_COLUMNS = [
+    "avg_volume_20d",        # the fixed one (was full-sample volume.mean())
+    "avg_volume_20d_raw",
+    "momentum_5d",
+    "momentum_20d",
+    "price_vs_ma50",
+    "rsi_14",
+    "realized_vol_20d",
+    "vol_ratio_10_60",
+    "return_60d",
+]
+
+
+def _synthetic_ohlcv(n: int, seed: int = 7, start: str = "2019-01-01") -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    daily = rng.normal(0, 0.012, n)
+    close = 100.0 * np.exp(np.cumsum(daily))
+    high = close * (1 + np.abs(rng.normal(0, 0.005, n)))
+    low = close * (1 - np.abs(rng.normal(0, 0.005, n)))
+    open_ = close * (1 + rng.normal(0, 0.003, n))
+    volume = rng.integers(1_000_000, 10_000_000, n).astype(float)
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.DataFrame(
+        {"Open": open_, "High": high, "Low": low, "Close": close, "Volume": volume},
+        index=idx,
+    )
+
+
+def test_features_are_as_of_stable_under_truncation():
+    """Truncating the input to df[:k] must not change any as-of feature at t < k."""
+    full = _synthetic_ohlcv(n=300)
+    k = 240
+    prefix = full.iloc[:k].copy()
+
+    f_full = compute_features(full)
+    f_pref = compute_features(prefix)
+
+    # Compare a band of fully-warmed-up rows strictly inside the prefix.
+    compare_idx = full.index[200:k]
+    common = [c for c in _ASOF_COLUMNS if c in f_full.columns and c in f_pref.columns]
+    assert "avg_volume_20d" in common, "avg_volume_20d must be present to guard the fix"
+
+    for col in common:
+        a = f_full.loc[compare_idx, col]
+        b = f_pref.loc[compare_idx, col]
+        # equal_nan so warmup NaNs (identical in both) don't spuriously fail.
+        assert np.allclose(a.to_numpy(dtype=float), b.to_numpy(dtype=float),
+                           rtol=1e-9, atol=1e-9, equal_nan=True), (
+            f"{col} is NOT point-in-time stable: value at rows <k differs between "
+            f"compute_features(df[:k]) and compute_features(df) — a look-ahead leak."
+        )
+
+
+def test_avg_volume_20d_uses_backward_only_normalizer():
+    """Direct guard: the avg_volume_20d normalizer must be expanding, not full-sample.
+
+    Appending FUTURE rows must not change avg_volume_20d at earlier dates.
+    """
+    full = _synthetic_ohlcv(n=260)
+    base = full.iloc[:200].copy()
+    # Same first 200 rows as `base`, but a 5x high-volume FUTURE tail. That tail
+    # would drag a full-sample volume.mean() up and shrink every earlier
+    # avg_volume_20d ratio; an expanding (as-of) mean sees only volume<=t and is
+    # therefore identical to `base` on the shared rows.
+    spiked = full.copy()
+    spiked.iloc[200:, spiked.columns.get_loc("Volume")] *= 5.0
+
+    v_base = compute_features(base)["avg_volume_20d"]
+    v_spiked = compute_features(spiked)["avg_volume_20d"]
+
+    shared = base.index[100:200]
+    assert np.allclose(
+        v_base.loc[shared].to_numpy(dtype=float),
+        v_spiked.loc[shared].to_numpy(dtype=float),
+        rtol=1e-9, atol=1e-9, equal_nan=True,
+    ), "avg_volume_20d at earlier dates changed when future volume was appended — leak."


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** high

Refs #833 (the feature-engineering side audit — the issue's stated "actual new work"; the P1 does not fully close until Brian's Brian-gated `--walk-forward` flip, so this is `Refs`, not `Closes`).

## Root cause
The PIT arc requires every feature at row T to depend only on rows ≤ T, because the backtest replay path (`crucible-backtester synthetic/predictor_backtest.py`) computes features **once** over each ticker's entire history, then slices by decision date.

`features/feature_engineer.py` normalized `avg_volume_20d` by a **whole-series** `volume.mean()` — a full-sample statistic that injected volume from T+1..T+N into every historical row during replay. It's a genuine (if mild) look-ahead: `avg_volume_20d` is a trained predictor input, and its normalizer at date T saw future volume.

## Fix
Normalize by a **backward-only expanding mean** (`volume.expanding(min_periods=_vol_slow).mean()`), so the value at T uses only volume observed through T. Warmup rows stay NaN (raw is NaN there); a degenerate all-zero-volume window maps to the neutral `1.0` the old scalar else-branch produced.

## Audit of the rest of the module (per the issue)
Every other rolling/shift computation is already backward-only (right-anchored `rolling`, `.shift(N)`, EWM); the cross-sectional (`cross_sectional.py`) and factor-momentum (`factor_momentum.py`) families carry their own as-of guards + tests. The one remaining full-sample-*looking* reference — `iv_vs_rv`'s `realized_vol_20d.iloc[-1]` — is **not** a leak: the whole O12 options block is an as-of-snapshot broadcast (the `atm_iv` scalar has no time axis), so pairing it with the terminal "now" row is correct and it never enters the PIT replay's scored set. Added a guard comment there to prevent a future mis-"fix".

## Tests
New `tests/test_feature_engineer_point_in_time.py` — the as-of invariant tripwire:
- `compute_features(df[:k]).loc[t] == compute_features(df).loc[t]` for a band of warmed-up rows across the backward-only feature set.
- A direct guard that a 5× future-volume tail does not change `avg_volume_20d` at earlier dates.

Both **FAIL on the pre-fix full-sample mean and PASS after**.

## Validation (local, py3.9 venv)
`pytest tests/test_feature_engineer_point_in_time.py tests/test_feature_engineer_risk_features.py tests/test_feature_engineer_residual_momentum.py tests/test_schema_roundtrip.py tests/test_schema_contract.py tests/test_feature_cfg_package.py` → **all pass** (48). `ruff check` on the changed files → clean. (Other repo tests need arcticdb/heavy deps not stood up here; the changed surface is fully covered.)
