### PR TITLE
[P1/high] fix(lambdas): derive hermetic deploy-gate stub requirement from index.py imports

### DIFF
--- a/infrastructure/lambdas/_shared/hermetic_import_guard.py
+++ b/infrastructure/lambdas/_shared/hermetic_import_guard.py
@@ -1,0 +1,174 @@
+"""Source-derived guard for the hermetic Lambda test/deploy gates (config#1746).
+
+## Why this exists
+
+Several Lambda handler unit tests run in a *hermetic* interpreter — the
+pre-deploy gate in each ``deploy.sh`` runs ``pytest`` on **bare python + boto3**
+and deliberately does NOT install the git-only ``nousergon_lib`` /
+``alpha_engine_lib`` packages the handler imports at module scope. Those imports
+are satisfied by a hand-written ``sys.modules`` stub block at the top of the
+test file, which MUST be kept in lockstep with ``index.py``'s (transitive)
+module-level import graph.
+
+That hand-maintained lockstep has drifted **twice**, same class each time:
+
+* 2026-07-02 — ``No module named pytest`` (gate assumed pytest/boto3 ambient).
+* 2026-07-04 — ``No module named nousergon_lib`` (the config#1742 flow-doctor
+  cutover moved ``index.py`` onto ``nousergon_lib.*`` but the stub was dropped
+  instead of migrated).
+
+Each drift surfaced only as a cryptic ``ModuleNotFoundError`` raised by
+``import index`` **at deploy time** (post-merge), redding ``main``.
+
+## What this guards
+
+Rather than continue to hand-maintain (and silently drift) the stub, this
+helper **derives the invariant from the live source**: it statically walks
+``index.py``'s module-level imports — transitively through any sibling handler
+modules that live inside the Lambda package (e.g. ``flow_doctor_telegram``) —
+and asserts that every non-stdlib, non-installed module the handler imports is
+already resolvable (installed) or present in ``sys.modules`` (stubbed) BEFORE
+``import index`` runs.
+
+If ``index.py`` (or one of its local siblings) grows a new git-only import that
+the stub does not cover, this fails LOUD with a precise, actionable message
+naming the exact missing module — turning a silent deploy-time
+``ModuleNotFoundError`` into a source-derived pre-merge test failure.
+
+Call it from a hermetic test's stub block, right after the stubs are installed
+and before ``import index``::
+
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+    assert_hermetic_imports_satisfied(__file__)
+
+``__file__`` is the *test* file; the handler (``index.py``) is resolved as its
+sibling. Pass ``handler="foo.py"`` to point at a differently-named handler.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+# Modules the hermetic gate installs explicitly (deploy.sh: `pip install boto3`,
+# plus pytest as the runner). Treated as always-available so the guard does not
+# demand a stub for them.
+_GATE_INSTALLED = frozenset({"boto3", "botocore", "pytest"})
+
+
+def _top_level_module_names(source: str) -> set[str]:
+    """Return the fully-dotted module targets of every module-level import.
+
+    Only module-scope imports matter — imports inside functions are deferred and
+    do not run at ``import index`` time. ``from a.b import c`` yields ``a.b``
+    (Python must import the submodule ``a.b``); ``import a.b`` yields ``a.b``.
+    """
+    targets: set[str] = set()
+    tree = ast.parse(source)
+    for node in tree.body:  # module scope only — do not recurse into functions
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                targets.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            # Skip relative imports (level > 0) and __future__.
+            if node.level == 0 and node.module and node.module != "__future__":
+                targets.add(node.module)
+    return targets
+
+
+def _is_local_sibling(module: str, search_dirs: list[Path]) -> Path | None:
+    """Resolve ``module`` to a ``.py`` file inside the Lambda package, if any."""
+    rel = Path(*module.split("."))
+    for base in search_dirs:
+        candidate = base / rel.with_suffix(".py")
+        if candidate.is_file():
+            return candidate
+        pkg = base / rel / "__init__.py"
+        if pkg.is_file():
+            return pkg
+    return None
+
+
+def _is_satisfied(module: str) -> bool:
+    """True if ``module`` is stubbed (in sys.modules), installed, or stdlib."""
+    if module in sys.modules:
+        return True
+    top = module.split(".")[0]
+    if top in sys.modules or top in _GATE_INSTALLED:
+        return True
+    if top in sys.stdlib_module_names:
+        return True
+    try:
+        # find_spec raises ModuleNotFoundError when a parent package is a bare
+        # stub with no __path__; that means "not installed" → not satisfied.
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def assert_hermetic_imports_satisfied(
+    test_file: str, *, handler: str = "index.py"
+) -> None:
+    """Fail loud if the handler's module-level imports are not all satisfiable.
+
+    Walks ``handler``'s module-level imports transitively through sibling
+    modules that live inside the Lambda package (so a git-only import pulled in
+    *via* ``flow_doctor_telegram`` is caught too), and asserts each non-local,
+    non-stdlib, non-installed module is already in ``sys.modules`` (stubbed).
+
+    Args:
+        test_file: the calling test's ``__file__``.
+        handler: the handler module filename (default ``index.py``), resolved as
+            a sibling of ``test_file``.
+
+    Raises:
+        AssertionError: naming the exact unsatisfied module(s) and how to fix.
+    """
+    test_dir = Path(test_file).resolve().parent
+    # sys.path in the hermetic tests inserts both the Lambda dir and the shared
+    # lambdas/ root; mirror that so sibling handler modules resolve either place.
+    search_dirs = [test_dir, test_dir.parent]
+
+    handler_path = test_dir / handler
+    if not handler_path.is_file():
+        raise AssertionError(
+            f"hermetic_import_guard: handler {handler!r} not found next to "
+            f"{test_file!r}"
+        )
+
+    # BFS over local modules, collecting external imports along the way.
+    seen: set[Path] = set()
+    queue: list[Path] = [handler_path]
+    external: set[str] = set()
+    while queue:
+        path = queue.pop()
+        if path in seen:
+            continue
+        seen.add(path)
+        for module in _top_level_module_names(path.read_text()):
+            if module in sys.modules:
+                # Already stubbed/imported: the real source will not execute, so
+                # its own imports are irrelevant. This covers a test that stubs a
+                # whole sibling module (e.g. flow_doctor_telegram) wholesale
+                # rather than letting the real file import its git-only deps.
+                continue
+            sibling = _is_local_sibling(module, search_dirs)
+            if sibling is not None:
+                queue.append(sibling)  # walk transitively into the package
+            else:
+                external.add(module)
+
+    unsatisfied = sorted(m for m in external if not _is_satisfied(m))
+    if unsatisfied:
+        raise AssertionError(
+            "hermetic_import_guard (config#1746): "
+            f"{handler} imports {unsatisfied} at module scope, but "
+            "the deploy test-gate neither installs nor stubs "
+            f"{'them' if len(unsatisfied) > 1 else 'it'}. Either add the "
+            "module to the sys.modules stub block above (git-only deps like "
+            "nousergon_lib.*) or install it in deploy.sh's gate. This derives "
+            "the stub requirement from index.py's live import graph so it "
+            "cannot silently drift again."
+        )

--- a/infrastructure/lambdas/_shared/test_hermetic_import_guard.py
+++ b/infrastructure/lambdas/_shared/test_hermetic_import_guard.py
@@ -1,0 +1,102 @@
+"""Tests for the source-derived hermetic import guard (config#1746).
+
+Runs on bare python (unittest, no pytest/boto3 needed) so it can join the
+_shared suite the CI/deploy gates execute as ``python3 <path>``.
+"""
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _shared.hermetic_import_guard import (  # noqa: E402
+    assert_hermetic_imports_satisfied,
+)
+
+
+class HermeticImportGuardTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.pkg = Path(self._tmp.name)
+        # Mirror the hermetic tests' sys.path (lambda dir + lambdas/ root).
+        sys.path.insert(0, str(self.pkg))
+        self._stubbed: list[str] = []
+
+    def tearDown(self):
+        for name in self._stubbed:
+            sys.modules.pop(name, None)
+        if str(self.pkg) in sys.path:
+            sys.path.remove(str(self.pkg))
+        self._tmp.cleanup()
+
+    def _stub(self, name: str) -> None:
+        sys.modules[name] = types.ModuleType(name)
+        self._stubbed.append(name)
+
+    def _write(self, name: str, body: str) -> None:
+        (self.pkg / name).write_text(body)
+
+    # A test file the guard resolves index.py relative to. Its own imports are
+    # irrelevant — the guard walks the *handler*, not the caller.
+    def _test_file(self) -> str:
+        f = self.pkg / "test_handler.py"
+        f.write_text("# hermetic test stub\n")
+        return str(f)
+
+    def test_passes_when_all_imports_stdlib_or_stubbed(self):
+        self._write(
+            "index.py",
+            "import json\nimport os\nfrom acme_lib.thing import Widget\n",
+        )
+        self._stub("acme_lib")
+        self._stub("acme_lib.thing")
+        # Does not raise.
+        assert_hermetic_imports_satisfied(self._test_file())
+
+    def test_raises_on_unstubbed_git_only_import(self):
+        self._write("index.py", "import json\nfrom acme_lib.thing import Widget\n")
+        # acme_lib deliberately NOT stubbed — this is the drift.
+        with self.assertRaises(AssertionError) as ctx:
+            assert_hermetic_imports_satisfied(self._test_file())
+        self.assertIn("acme_lib.thing", str(ctx.exception))
+        self.assertIn("config#1746", str(ctx.exception))
+
+    def test_walks_transitive_sibling_imports(self):
+        # index imports a LOCAL sibling that itself pulls an unstubbed dep — the
+        # 2026-07-04 class (source moved onto nousergon_lib via a sibling).
+        self._write("index.py", "from sibling import thing\n")
+        self._write("sibling.py", "from deep_lib.core import q\n")
+        with self.assertRaises(AssertionError) as ctx:
+            assert_hermetic_imports_satisfied(self._test_file())
+        self.assertIn("deep_lib.core", str(ctx.exception))
+
+    def test_transitive_sibling_import_satisfied_when_stubbed(self):
+        self._write("index.py", "from sibling import thing\n")
+        self._write("sibling.py", "from deep_lib.core import q\n")
+        self._stub("deep_lib")
+        self._stub("deep_lib.core")
+        assert_hermetic_imports_satisfied(self._test_file())  # no raise
+
+    def test_stubbed_sibling_is_not_walked(self):
+        # When the test stubs a whole sibling module wholesale, the real file's
+        # own imports never execute — the guard must NOT flag them (the
+        # scheduled-groom-dispatcher flow_doctor_telegram pattern).
+        self._write("index.py", "from sibling import thing\n")
+        self._write("sibling.py", "from unstubbed_dep.x import y\n")
+        self._stub("sibling")  # sibling stubbed → its imports irrelevant
+        assert_hermetic_imports_satisfied(self._test_file())  # no raise
+
+    def test_function_scope_imports_are_ignored(self):
+        # Deferred (in-function) imports do not run at `import index` time.
+        self._write(
+            "index.py",
+            "import json\n\n\ndef handler(e, c):\n    from lazy_lib import z\n    return z\n",
+        )
+        assert_hermetic_imports_satisfied(self._test_file())  # no raise
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -48,6 +48,15 @@ sys.modules.setdefault("nousergon_lib", _ng)
 sys.modules.setdefault("nousergon_lib.telegram", _ng_telegram)
 sys.modules.setdefault("nousergon_lib.flow_doctor_fleet", _ng_fleet)
 
+# Derive the stub requirement from index.py's live (transitive) import graph and
+# fail loud here if it has drifted, rather than as a cryptic ModuleNotFoundError
+# at deploy time. See _shared/hermetic_import_guard.py (config#1746).
+from _shared.hermetic_import_guard import (  # noqa: E402
+    assert_hermetic_imports_satisfied,
+)
+
+assert_hermetic_imports_satisfied(__file__)
+
 import index  # noqa: E402
 
 UTC = timezone.utc

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -141,6 +141,12 @@ def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None):
     if launch_impl is None:
         launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
     _install_stubs(launch_impl, clients)
+    # Derive the stub requirement from index.py's live import graph and fail
+    # loud on drift here, rather than as a ModuleNotFoundError at deploy time
+    # (config#1746 — this stub has drifted three times: config#1742/#1748).
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+
+    assert_hermetic_imports_satisfied(__file__)
     import index
 
     importlib.reload(index)


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** high

Refs nousergon/alpha-engine-config#1746

## Root cause
The hermetic Lambda deploy test-gate (`deploy.sh` step 0b) resolves `import index`'s git-only deps by a **hand-maintained `sys.modules` stub** that must be kept in lockstep with `index.py`'s (transitive) module-level import graph. That lockstep is not derived from any source of truth, so it has silently drifted — surfacing only as a cryptic `ModuleNotFoundError` at **deploy time (post-merge), redding `main`**:
- 2026-07-02 — `No module named pytest` (gate assumed pytest/boto3 ambient).
- 2026-07-04 — `No module named nousergon_lib` (config#1742 flow-doctor cutover moved the source onto `nousergon_lib.*`; stub dropped, not migrated).
- 2026-07-05 — `FleetTelegramTopic.GROOM` missing from the stub (config#1748).

## Fix — derive the invariant from source
New shared guard `infrastructure/lambdas/_shared/hermetic_import_guard.py`. It statically walks `index.py`'s module-level imports — **transitively through sibling handler modules inside the Lambda package** (e.g. `flow_doctor_telegram`) — and asserts every non-stdlib, non-installed module is already resolvable (installed by the gate) **or** present in `sys.modules` (stubbed) *before* `import index`. If `index.py` (or a local sibling) grows a git-only import the gate neither installs nor stubs, it fails **loud, pre-`import`, naming the exact module** and how to fix it — instead of a silent deploy-time `ModuleNotFoundError`.

It is environment-accurate: "satisfied" means "importable in the interpreter the gate actually runs," which is exactly the invariant *the gate can import `index` exactly as the deployed Lambda does*. A test that stubs a whole sibling wholesale is handled (the guard does not walk a sibling already shadowed in `sys.modules`); deferred in-function imports are correctly ignored.

Wired into the two explicit-`sys.modules`-stub handlers that have carried this drift:
- `groom-liveness-probe/test_handler.py`
- `scheduled-groom-dispatcher/test_handler.py`

**This guard caught a live, still-unfixed instance while validating:** run bare (as the gate does), `scheduled-groom-dispatcher` already fails `No module named 'krepis'` — `index.py` gained `from krepis.usage_pacing import …` (the 2026-07-04 pace gate) and the gate installs `krepis==0.10.0`; with that install present the guard passes, without it the guard names `krepis.usage_pacing` precisely.

## Validation (bare python + gate deps, mirroring `deploy.sh` per lambda)
- `groom-liveness-probe/test_handler.py` (pytest + boto3) → **12 passed**
- `scheduled-groom-dispatcher/test_handler.py` (pytest + krepis==0.10.0) → **23 passed**
- `_shared/test_hermetic_import_guard.py` (bare `python3`, unittest) → **6 passed** — positive, drift-raises, transitive-walk, stubbed-sibling-not-walked, and function-scope-ignored cases.

## Follow-up (needs a `workflow`-scoped actor — config#1372)
`_shared/test_hermetic_import_guard.py` should join the `_shared` suite that `ci.yml` runs as `python3 <path>`; adding it (and the broader "run ALL lambda handler tests pre-merge" of config#1759) touches `.github/workflows/ci.yml`, which this groomer's PAT cannot push. Diff posted on config#1759.
