### PR TITLE
Bump nousergon-lib to v0.83.0 (config#1775)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
-# Substrate bumped to v0.82.0 for flow_doctor_fleet + compat with sibling Lambdas.
+# Substrate bumped to v0.83.0 for flow_doctor_fleet + compat with sibling Lambdas.
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2
 pyyaml>=6.0

--- a/infrastructure/lambdas/groom-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/groom-liveness-probe/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for groom liveness probe.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -1,5 +1,5 @@
 # boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
 boto3>=1.34.0
 # config#1742 T2 — flow-doctor forum routing + ec2_spot launch chokepoint.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -45,7 +45,7 @@ def _install_stubs(launch_impl, boto_clients):
     # _OPS_TOPICS / _GROOM_LIFECYCLE_TOPICS tuples). A member missing here fails
     # `import index` at load and takes the WHOLE suite down — not just the test
     # that exercises it (2026-07-05: GROOM was added to index.py + the real enum
-    # in nousergon-lib v0.82.0, but this hermetic stub was not kept in lockstep;
+    # in nousergon-lib v0.83.0, but this hermetic stub was not kept in lockstep;
     # config#1748).
     class _FleetTelegramTopic:
         CRITICAL = "critical"

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch liveness probe.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 krepis>=0.10.2

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0
 anyio>=4.0
 tenacity>=8.0
 pyyaml>=6.0
-nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.82.0
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via alpha_engine_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_infra_alerts_uses_krepis.py
+++ b/tests/test_infra_alerts_uses_krepis.py
@@ -12,7 +12,7 @@ rebase). Both older names are now shims, and invoking a shim under runpy
     pin < v0.81.1 it fell off its end with exit 0 before the target's
     ``__main__`` guard fired, i.e. a SILENT no-op (the config#1646 incident: a
     weekly Step Function reported SUCCESS while running zero workloads). This
-    repo pins nousergon-lib v0.82.0, so that path no-ops here today.
+    repo pins nousergon-lib v0.83.0, so that path no-ops here today.
 
 The robust, pin-independent entrypoint is ``python -m krepis.alerts`` — ``krepis``
 is a hard transitive dep (``requirements.txt`` floors ``krepis>=0.6.0``), so the


### PR DESCRIPTION
Fleet pin sweep — EC2 + 9 lambda requirements + Dockerfile lockstep.

Made with [Cursor](https://cursor.com)