### PR TITLE
[P1/high] feat(sf): terminal fail/complete notifications deep-link to console pipeline-status page (config#856)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -3100,7 +3100,7 @@
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Saturday Preflight Pipeline — SUCCESS",
-        "Message": "Friday-PM Preflight Pipeline of the Saturday SF completed: all workload states ran in --preflight-only / dry mode, health/substrate checks ran. No Saturday-fatal bootstrap break detected for tomorrow's 02:00 PT real run. Check dashboard / execution history for per-state detail."
+        "Message": "Friday-PM Preflight Pipeline of the Saturday SF completed: all workload states ran in --preflight-only / dry mode, health/substrate checks ran. No Saturday-fatal bootstrap break detected for tomorrow's 02:00 PT real run. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "End": true
@@ -3112,7 +3112,7 @@
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Saturday Pipeline — SUCCESS",
-        "Message": "All steps completed successfully. Check dashboard for results."
+        "Message": "All steps completed successfully. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "End": true
@@ -3201,7 +3201,7 @@
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — FAILED', $.pipeline_label)",
-        "Message.$": "States.Format('Saturday{} Pipeline failed. Error: {}. Use Step Functions console to redrive from failed step.', $.pipeline_label, States.JsonToString($.error))"
+        "Message.$": "States.Format('Saturday{} Pipeline failed. Error: {}. View the failing state + per-state detail at https://console.nousergon.ai/pipeline-status  (Use the Step Functions console to redrive from the failed step.)', $.pipeline_label, States.JsonToString($.error))"
       },
       "ResultPath": "$.failure_notify",
       "Next": "FailExecution"

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1048,7 +1048,7 @@
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekday Pipeline — FAILED",
-        "Message.$": "States.Format('Weekday pipeline failed. State: {}', States.JsonToString($))"
+        "Message.$": "States.Format('Weekday pipeline failed. State: {}. View the failing state + per-state detail at https://console.nousergon.ai/pipeline-status', States.JsonToString($))"
       },
       "ResultPath": "$.failure_notify",
       "Next": "FailExecution"

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1107,7 +1107,7 @@
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
         "Subject": "Alpha Engine EOD Pipeline \u2014 FAILED",
-        "Message.$": "States.Format('EOD pipeline failed. Error: {}', States.JsonToString($.error))"
+        "Message.$": "States.Format('EOD pipeline failed. Error: {}. View the failing state + per-state detail at https://console.nousergon.ai/pipeline-status', States.JsonToString($.error))"
       },
       "ResultPath": "$.failure_notify",
       "Catch": [

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -452,14 +452,16 @@ class TestStrictSuperset:
         assert choices[0]["Next"] == "ApplyShellRunDefaults"
 
     def test_notify_complete_is_byte_identical(self, states):
-        """The real Saturday SUCCESS email must not change."""
+        """The real Saturday SUCCESS email — now deep-links to the console
+        pipeline-status page (config#856 push-on-transition revamp)."""
         nc = states["NotifyComplete"]
         assert nc["Resource"] == "arn:aws:states:::sns:publish"
         assert nc["Parameters"]["Subject"] == (
             "Alpha Engine Saturday Pipeline — SUCCESS"
         )
         assert nc["Parameters"]["Message"] == (
-            "All steps completed successfully. Check dashboard for results."
+            "All steps completed successfully. "
+            "View pipeline status: https://console.nousergon.ai/pipeline-status"
         )
         assert nc["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"
         assert nc["ResultPath"] == "$.notify_result"

--- a/tests/test_sf_pipeline_status_console_link_wiring.py
+++ b/tests/test_sf_pipeline_status_console_link_wiring.py
@@ -1,0 +1,113 @@
+"""Pins the console deep-link in the terminal (fail/complete) SNS notifications
+of the three producer Step Functions (config#856).
+
+Pipeline reporting revamp shape: *pull-for-state console page + push-on-
+transition emails*. The push-on-transition notifications (DAG complete / DAG
+fail) must deep-link to the pull-for-state console page
+(``https://console.nousergon.ai/pipeline-status`` — the ``pipeline-status``
+slug pinned on the dashboard's ``25_Pipeline_Status.py``) so the operator can
+jump from the terminal email to the full per-state render, instead of the old
+generic "Check dashboard" / bare ``JsonToString($.error)`` text.
+
+This is a wiring pin, not a soak-gated content-email change: these terminal
+notifications are the emails the revamp KEEPS (it only drops the per-step
+*content* emails), so pinning their console link is safe to land ahead of the
+content-email holdback soak.
+
+Guards, per SF:
+- every terminal SNS ``publish`` state (``End: true`` success notifies +
+  ``HandleFailure``) carries the console URL in its Message;
+- the URL host + slug are exactly the canonical console page
+  (a slug drift on either side silently breaks the deep-link).
+"""
+
+import json
+import pathlib
+import unittest
+
+_INFRA = pathlib.Path(__file__).resolve().parent.parent / "infrastructure"
+
+# Must match krepis.console (host) + the dashboard 25_Pipeline_Status.py url_path
+# (slug). If either moves, this pin and the dashboard slug-drift test both fail.
+CONSOLE_PIPELINE_URL = "https://console.nousergon.ai/pipeline-status"
+
+# The three producer pipelines the console page renders (weekly / weekday / EOD).
+_TEMPLATES = [
+    "step_function.json",
+    "step_function_daily.json",
+    "step_function_eod.json",
+]
+
+
+def _message_of(state: dict) -> str:
+    p = state.get("Parameters", {})
+    return p.get("Message.$") or p.get("Message") or ""
+
+
+def _terminal_notify_states(sf: dict) -> dict[str, dict]:
+    """SNS-publish states that are a genuine DAG fail/complete transition — the
+    two the revamp keeps and deep-links.
+
+    Includes ``HandleFailure`` and any success-complete notify (Subject carries
+    ``SUCCESS``). Deliberately EXCLUDES informational mid-DAG transitions that
+    have nothing to render on the console — a market-holiday skip ("nothing
+    ran") or a gate-failed-but-proceeding warning.
+    """
+    out = {}
+    for name, st in sf["States"].items():
+        if st.get("Resource") != "arn:aws:states:::sns:publish":
+            continue
+        subject = st.get("Parameters", {}).get("Subject", "") or st.get(
+            "Parameters", {}
+        ).get("Subject.$", "")
+        if name == "HandleFailure" or "SUCCESS" in subject:
+            out[name] = st
+    return out
+
+
+class PipelineStatusConsoleLinkWiringTest(unittest.TestCase):
+    def _load(self, fname: str) -> dict:
+        return json.loads((_INFRA / fname).read_text())
+
+    def test_each_template_has_terminal_notify_states(self):
+        for fname in _TEMPLATES:
+            sf = self._load(fname)
+            self.assertTrue(
+                _terminal_notify_states(sf),
+                f"{fname}: expected at least one terminal SNS-publish state",
+            )
+
+    def test_terminal_notifications_deeplink_to_console(self):
+        for fname in _TEMPLATES:
+            sf = self._load(fname)
+            for name, st in _terminal_notify_states(sf).items():
+                msg = _message_of(st)
+                self.assertIn(
+                    CONSOLE_PIPELINE_URL,
+                    msg,
+                    f"{fname}:{name} terminal notification must deep-link to "
+                    f"the console pipeline-status page (config#856). Got: {msg!r}",
+                )
+
+    def test_no_terminal_notify_uses_bare_check_dashboard(self):
+        # The old generic "Check dashboard" text is what the revamp replaces —
+        # a regression to it means the console deep-link was dropped.
+        for fname in _TEMPLATES:
+            sf = self._load(fname)
+            for name, st in _terminal_notify_states(sf).items():
+                msg = _message_of(st)
+                self.assertNotIn(
+                    "Check dashboard for results",
+                    msg,
+                    f"{fname}:{name} reverted to the pre-revamp generic text",
+                )
+
+    def test_templates_are_valid_json(self):
+        # The URL was spliced into raw template strings — guard that every
+        # template still parses (a stray quote would break the deploy).
+        for fname in _TEMPLATES:
+            self.assertIsInstance(self._load(fname)["States"], dict)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** high

Refs nousergon/alpha-engine-config#856 (Phase 3 — push-on-transition emails deep-link to the pull-for-state console page)

## What
The pipeline-reporting revamp's shape is *pull-for-state console page + push-on-transition emails*. The push-on-transition notifications (DAG **complete** / DAG **fail**) are the emails the revamp KEEPS — but they still carried the pre-revamp generic text (`"Check dashboard for results"` / a bare `JsonToString($.error)`). This rewrites the **terminal** SNS notifications of the three producer Step Functions to deep-link to the canonical console page, so the operator jumps from the 2-line email straight to the full per-state render.

Deep-link target: **`https://console.nousergon.ai/pipeline-status`** — the `pipeline-status` slug the dashboard's `25_Pipeline_Status.py` pins in crucible-dashboard#324 (Phase 2.5). Host = `krepis.console` base; slug = the page `url_path`. The new wiring test and the dashboard's slug-drift test guard both ends of that contract.

## States rewritten (fail + success-complete only)
- `step_function.json` (weekly/Saturday): `NotifyShellRunComplete`, `NotifyComplete`, `HandleFailure`
- `step_function_daily.json` (weekday): `HandleFailure`
- `step_function_eod.json` (EOD): `HandleFailure`

Deliberately NOT touched: the market-holiday skip and gate-failed-but-proceeding *informational* notifies (nothing to render on the console for a "nothing ran" transition), and the ops `step_function_groom.json` (not a producer surface the console page renders). No `States.Format` arg binding changed — the URL is literal text with no `{}`.

## Scope boundary
This is safe to land ahead of the content-email holdback soak: it only improves the terminal emails the revamp keeps; it does NOT drop any per-step content email (that remains gated on Brian's ≥1-week console-only soak sign-off). Independent of the still-open Phase 2.5 `?run=` work — the plain `/pipeline-status` link already lands on the page, which auto-selects the most-recent (= the just-failed) run per role; crucible-dashboard#324 makes `?run=`-specific deep-links possible as a follow-up.

## Tests
`tests/test_sf_pipeline_status_console_link_wiring.py` (new): every terminal fail/complete SNS notification across the 3 producer templates deep-links to the console page; no regression to the pre-revamp generic text; templates still parse. → **4 passed**. Full SF-structural wiring suite (mutex / coverage / eventbridge-input / poll-resultselector / ssm-pipefail / deadman) re-run green → **141 passed** (JSON edits touched only Message strings).
