### PR TITLE
fix(groom-dispatcher): real lib enum in deploy gate + Opus PR budget 100

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -81,7 +81,9 @@ day-of-week year)` with `?` for an unspecified day field.
 ## Schedule-input routing
 
 Each schedule passes a JSON input, e.g. `{"run_mode": "full", "model":
-"claude-opus-4-8", "issue_filter": "high-only", "schedule": "0 15 * * *"}`.
+"claude-opus-4-8", "issue_filter": "high-only", "pr_budget": 100, "schedule": "0 15 * * *"}`.
+The Opus schedule alone carries `pr_budget: 100` (config#1769) — forwarded as
+`GROOM_PR_BUDGET` on the spot box; Haiku/Sonnet stay at the bootstrap default (50).
 The Lambda resolves each field (unknown/missing values degrade to a safe
 default — `full` / `claude-sonnet-5` / `default`) and exports `GROOM_MODEL` +
 `GROOM_ISSUE_FILTER` in the SSM bootstrap prelude ahead of invoking

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -111,7 +111,7 @@ SCHED_CRONS=(
 )
 SCHED_INPUTS=(
   '{"run_mode":"full","model":"claude-haiku-4-5","issue_filter":"low-only","schedule":"0 7 * * *"}'
-  '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","schedule":"0 15 * * *"}'
+  '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","pr_budget":100,"schedule":"0 15 * * *"}'
   '{"run_mode":"full","model":"claude-sonnet-5","issue_filter":"mid-only","schedule":"0 23 * * *"}'
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2f).
@@ -154,21 +154,18 @@ print('index.py syntax OK')
 "
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
-# Hermetic for AWS (boto3/nousergon_lib are stubbed in sys.modules before
-# `import index` — see test_handler.py's header): those need real AWS creds/
-# services to exercise for real, so tests fake them instead. krepis (2026-07-04,
-# the pre-boot pace gate's linear-pace math) is pure stdlib with no AWS/creds
-# dependency, so it's installed for real here rather than stubbed — the tests
-# exercise the ACTUAL pace_check arithmetic, not a faked stand-in. Both land in
-# a scratch TEST_DEPS dir — NOT the caller's global site-packages, not bundled
-# into the Lambda zip — so this works on a bare CI runner (2026-07-02: the CI
-# auto-deploy workflow's FIRST real run failed here with "No module named
-# pytest" — this script had only ever been run from an operator's laptop
-# before, where pytest happened to already be installed as a dev dependency;
-# the gap was invisible until CI actually exercised this path).
+# Hermetic for AWS: boto3 + nousergon_lib.ec2_spot are stubbed in sys.modules
+# before `import index` (see test_handler.py). nousergon_lib.flow_doctor_fleet
+# is pure stdlib — install the REAL pinned enum from requirements.txt so the
+# hand-maintained FleetTelegramTopic fake cannot drift (config#1772). krepis
+# (pre-boot pace gate math) is also installed for real. Both land in a scratch
+# TEST_DEPS dir — NOT the caller's global site-packages, not bundled into the
+# Lambda zip.
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Installing pytest + krepis into ${TEST_DEPS}..."
-  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "krepis==0.10.0"
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
   echo "Running handler unit tests..."
   PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -275,8 +275,31 @@ def _resolve_soft_limit_min(event: dict) -> int | None:
     return n
 
 
+def _resolve_pr_budget(event: dict) -> int | None:
+    """Optional per-schedule PR budget override (config#1769).
+
+    Only the Opus high-only schedule sets this today; missing/invalid → None
+    (groom_spot_bootstrap.sh's GROOM_PR_BUDGET default of 50 applies).
+    """
+    raw = event.get("pr_budget")
+    if raw is None:
+        raw = event.get("GROOM_PR_BUDGET")
+    if raw is None:
+        return None
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("malformed pr_budget %r — ignoring (default 50 applies)", raw)
+        return None
+    if n <= 0:
+        logger.warning("non-positive pr_budget %r — ignoring (default 50 applies)", raw)
+        return None
+    return n
+
+
 def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: str,
-                       run_token: str, soft_limit_min: int | None = None) -> str:
+                       run_token: str, soft_limit_min: int | None = None,
+                       pr_budget: int | None = None) -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec bootstrap.
 
     Runs as root on the box. The heavy, version-controlled logic lives in the
@@ -285,6 +308,7 @@ def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: st
     Any prelude failure shuts the box down so a botched launch never idles.
     """
     soft_limit_flag = f" --soft-limit-min {soft_limit_min}" if soft_limit_min else ""
+    pr_budget_export = f"export GROOM_PR_BUDGET={pr_budget}\n" if pr_budget else ""
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
 # SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
@@ -307,7 +331,7 @@ cd /home/ec2-user/alpha-engine-config
 export GROOM_MODEL={model}
 export GROOM_ISSUE_FILTER={issue_filter}
 export GROOM_RUN_TOKEN={run_token}
-exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"{soft_limit_flag}
+{pr_budget_export}exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"{soft_limit_flag}
 """
 
 
@@ -363,7 +387,8 @@ def _wait_ssm_online(instance_id: str) -> None:
 
 
 def _send_bootstrap(instance_id: str, run_mode: str, run_url: str, model: str, issue_filter: str,
-                    run_token: str, soft_limit_min: int | None = None) -> str:
+                    run_token: str, soft_limit_min: int | None = None,
+                    pr_budget: int | None = None) -> str:
     """Fire the async, detached SSM command that runs the groom + self-terminates."""
     ssm = boto3.client("ssm", region_name=REGION)
     resp = ssm.send_command(
@@ -371,7 +396,9 @@ def _send_bootstrap(instance_id: str, run_mode: str, run_url: str, model: str, i
         DocumentName="AWS-RunShellScript",
         Comment=f"backlog groom ({run_mode}, {model}, {issue_filter}) — config#1432/#1495/#1645",
         Parameters={
-            "commands": [_bootstrap_command(run_mode, run_url, model, issue_filter, run_token, soft_limit_min)],
+            "commands": [_bootstrap_command(
+                run_mode, run_url, model, issue_filter, run_token, soft_limit_min, pr_budget,
+            )],
             # Execution timeout (NOT the start timeout) — without this SSM kills the
             # command at the 3600s default, guillotining a multi-hour groom.
             "executionTimeout": [str(MAX_RUNTIME_SECONDS)],
@@ -402,7 +429,8 @@ def _terminate_instance(instance_id: str) -> None:
 
 
 def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_filter: str,
-                       soft_limit_min: int | None = None, force_on_demand: bool = False) -> dict:
+                       soft_limit_min: int | None = None, pr_budget: int | None = None,
+                       force_on_demand: bool = False) -> dict:
     """Launch + bootstrap the groom box. Fail-loud — any error RAISES."""
     if not DISPATCH_ENABLED:
         logger.warning("GROOM_DISPATCH_ENABLED=false — groom spot NOT launched")
@@ -431,7 +459,7 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
             f"#logsV2:log-groups (log group {CW_LOG_GROUP}, instance {instance_id})"
         )
         command_id = _send_bootstrap(
-            instance_id, run_mode, run_url, model, issue_filter, run_token, soft_limit_min
+            instance_id, run_mode, run_url, model, issue_filter, run_token, soft_limit_min, pr_budget,
         )
     except Exception:
         _terminate_instance(instance_id)
@@ -457,6 +485,7 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         "model": model,
         "issue_filter": issue_filter,
         "run_token": run_token,
+        **({"pr_budget": pr_budget} if pr_budget is not None else {}),
     }
 
 
@@ -494,6 +523,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     `model`/`issue_filter` default to the Sonnet mid-tier queue when absent
     (the two pre-existing Sonnet schedules don't set them). `soft_limit_min` is
     a manual-invoke-ONLY bounded-test override — no live schedule sets it.
+    `pr_budget` is set only on the Opus high-only schedule (config#1769).
     `force_on_demand` (config#1645) is set only by the dispatch Step Function's
     own relaunch loop on its final bounded retry — no live schedule sets it.
 
@@ -511,12 +541,13 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     model = _resolve_model(event)
     issue_filter = _resolve_issue_filter(event)
     soft_limit_min = _resolve_soft_limit_min(event)
+    pr_budget = _resolve_pr_budget(event)
     force_on_demand = _resolve_force_on_demand(event)
     schedule_label = str(event.get("schedule") or "unknown")
     logger.info(
         "scheduled groom trigger: run_mode=%s model=%s issue_filter=%s soft_limit_min=%s "
-        "force_on_demand=%s schedule=%s",
-        run_mode, model, issue_filter, soft_limit_min, force_on_demand, schedule_label,
+        "pr_budget=%s force_on_demand=%s schedule=%s",
+        run_mode, model, issue_filter, soft_limit_min, pr_budget, force_on_demand, schedule_label,
     )
 
     if PACE_GATE_ENABLED:
@@ -530,5 +561,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
             _notify_pace_skip(pace, schedule_label, run_mode)
             return {"groom": {"launched": False, "reason": "pace_gate_skip", **pace}}
 
-    result = _launch_groom_spot(run_mode, schedule_label, model, issue_filter, soft_limit_min, force_on_demand)
+    result = _launch_groom_spot(
+        run_mode, schedule_label, model, issue_filter, soft_limit_min, pr_budget, force_on_demand,
+    )
     return {"groom": result}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -1,12 +1,13 @@
 """Unit tests for the EventBridge-Scheduler → groom-spot dispatcher (config#1432).
 
-Hermetic: `nousergon_lib.ec2_spot` and `boto3` are stubbed in sys.modules BEFORE
-importing index, so the tests run without either installed (matching how
-deploy.sh runs them with bare python3). Validates: a schedule event launches a
-spot box and fires an async SSM command carrying the run_mode; the on-demand
-fallback on spot capacity exhaustion; run_mode normalisation; the kill-switch
-short-circuit; and fail-loud (a launch failure RAISES so EventBridge retries +
-the error metric surface the miss).
+Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
+BEFORE importing index; ``nousergon_lib.flow_doctor_fleet`` is the REAL pinned
+enum installed by deploy.sh's preflight gate (config#1772 — no hand-maintained
+FleetTelegramTopic fake). Validates: a schedule event launches a spot box and
+fires an async SSM command carrying the run_mode; the on-demand fallback on spot
+capacity exhaustion; run_mode normalisation; the kill-switch short-circuit; and
+fail-loud (a launch failure RAISES so EventBridge retries + the error metric
+surface the miss).
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ import importlib
 import os
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
@@ -32,31 +34,13 @@ class _SpotCapacityExhausted(_SpotLaunchError):
 
 
 def _install_stubs(launch_impl, boto_clients):
+    # Real nousergon_lib.flow_doctor_fleet (FleetTelegramTopic enum) is installed
+    # into TEST_DEPS by deploy.sh — do NOT hand-roll it here (config#1772).
     ec2_spot_mod = types.ModuleType("nousergon_lib.ec2_spot")
     ec2_spot_mod.SpotLaunchError = _SpotLaunchError
     ec2_spot_mod.SpotCapacityExhausted = _SpotCapacityExhausted
     ec2_spot_mod.launch = launch_impl
-    pkg = types.ModuleType("nousergon_lib")
-    pkg.ec2_spot = ec2_spot_mod
-    fleet_mod = types.ModuleType("nousergon_lib.flow_doctor_fleet")
-
-    # Mirror the members of the real nousergon_lib.flow_doctor_fleet
-    # .FleetTelegramTopic that index.py references at IMPORT time (module-level
-    # _OPS_TOPICS / _GROOM_LIFECYCLE_TOPICS tuples). A member missing here fails
-    # `import index` at load and takes the WHOLE suite down — not just the test
-    # that exercises it (2026-07-05: GROOM was added to index.py + the real enum
-    # in nousergon-lib v0.83.0, but this hermetic stub was not kept in lockstep;
-    # config#1748).
-    class _FleetTelegramTopic:
-        CRITICAL = "critical"
-        OPS_HEALTH = "ops_health"
-        GROOM = "groom"
-
-    fleet_mod.FleetTelegramTopic = _FleetTelegramTopic
-    pkg.flow_doctor_fleet = fleet_mod
-    sys.modules["nousergon_lib"] = pkg
     sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
-    sys.modules["nousergon_lib.flow_doctor_fleet"] = fleet_mod
 
     fdt_mod = types.ModuleType("flow_doctor_telegram")
     fdt_mod.notify_via_flow_doctor = lambda *a, **k: True  # type: ignore[attr-defined]
@@ -235,6 +219,36 @@ def test_high_only_schedule_forwards_model_and_issue_filter(monkeypatch):
     assert "export GROOM_MODEL=claude-opus-4-8" in cmd
     assert "export GROOM_ISSUE_FILTER=high-only" in cmd
     assert cmd.index("export GROOM_MODEL") < cmd.index("groom_spot_bootstrap.sh")
+
+
+def test_high_only_schedule_forwards_pr_budget(monkeypatch):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler(
+        {
+            "run_mode": "full",
+            "model": "claude-opus-4-8",
+            "issue_filter": "high-only",
+            "schedule": "0 15 * * *",
+            "pr_budget": 100,
+        },
+        None,
+    )
+    assert out["groom"]["pr_budget"] == 100
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "export GROOM_PR_BUDGET=100" in cmd
+
+
+def test_deploy_schedule_high_only_carries_pr_budget():
+    deploy_sh = (
+        Path(__file__).resolve().parent / "deploy.sh"
+    ).read_text()
+    assert '"pr_budget":100' in deploy_sh or '"pr_budget": 100' in deploy_sh
+    # Haiku/Sonnet schedules must NOT inherit the Opus override.
+    low_line = next(
+        line for line in deploy_sh.splitlines()
+        if "low-only" in line and "SCHED_INPUTS" not in line
+    )
+    assert "pr_budget" not in low_line
 
 
 # ── Pre-boot pace gate (2026-07-04) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **config#1772:** deploy.sh preflight installs the pinned `nousergon-lib` enum for real — drops the hand-maintained `FleetTelegramTopic` stub that drifted on GROOM (PR #636 band-aid). `hermetic_import_guard` still catches any future import-graph drift.
- **config#1769:** Opus `high-only` schedule input adds `"pr_budget":100` → exported as `GROOM_PR_BUDGET` on the spot box. Haiku/Sonnet schedules unchanged (default 50).

## Post-merge (operator)
Schedule JSON changed — run once after merge:
```bash
bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap
```

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` (25 passed, real lib in TEST_DEPS)
- [ ] Deploy workflow green
- [ ] `--bootstrap` applied; next Opus digest stop reason ≠ `PR budget reached` while time remains

Closes config#1772, config#1769

Made with [Cursor](https://cursor.com)