### PR TITLE
[P2/high] fix(collector): wire point-in-time historical_constituents into weekly Phase-1 sweep (config#657)

### DIFF
--- a/tests/test_weekly_collector_historical_constituents_wiring.py
+++ b/tests/test_weekly_collector_historical_constituents_wiring.py
@@ -1,0 +1,90 @@
+"""Wiring pin for the point-in-time (historical) constituents collector.
+
+config#657 (G12, survivorship-free universe). The collector
+``collectors/historical_constituents.py`` shipped in nousergon-data#490 but was
+never invoked from ``weekly_collector`` — so ``market_data/historical_constituents.json``
+was never written and any downstream consumer would read a nonexistent key.
+This pins that it now runs in the Phase-1 sweep and is reachable via
+``--only historical_constituents``, reusing the roster the constituents phase
+already produced.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import weekly_collector
+
+
+def _args(**kw) -> SimpleNamespace:
+    base = dict(
+        date="2026-06-13", dry_run=True, only=None,
+        skip_phases="", force_phases="", force=False,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _fake_constituents(roster) -> MagicMock:
+    fake = MagicMock()
+    fake.load_from_s3.return_value = {"tickers": list(roster)}
+    return fake
+
+
+def test_historical_constituents_runs_with_roster_and_correct_key():
+    """--only historical_constituents replays PIT membership off today's roster
+    and writes to market_data/historical_constituents.json."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    captured: dict = {}
+
+    def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok", "n_changes": 3, "n_snapshots": 2}
+
+    fake_hist = MagicMock()
+    fake_hist.collect.side_effect = fake_collect
+
+    with patch("weekly_collector.constituents", _fake_constituents(["AAPL", "MSFT"])), \
+         patch("weekly_collector.historical_constituents", fake_hist):
+        results = weekly_collector._run_phase1(config, _args(only="historical_constituents"))
+
+    # The collector was invoked with the roster (no second live fetch) + the
+    # market-data prefix that resolves to market_data/historical_constituents.json.
+    assert captured["current_tickers"] == ["AAPL", "MSFT"]
+    assert captured["s3_prefix"] == "market_data/"
+    assert captured["bucket"] == "test-bucket"
+    assert results["collectors"]["historical_constituents"]["status"] == "ok"
+
+
+def test_historical_constituents_skips_gracefully_without_roster():
+    """No roster available (S3 empty) → skip with a reason, never crash."""
+    config = {"bucket": "test-bucket", "market_data": {"s3_prefix": "market_data/"}}
+    empty = MagicMock()
+    empty.load_from_s3.return_value = {"tickers": []}
+    fake_hist = MagicMock()
+
+    with patch("weekly_collector.constituents", empty), \
+         patch("weekly_collector.historical_constituents", fake_hist):
+        results = weekly_collector._run_phase1(config, _args(only="historical_constituents"))
+
+    fake_hist.collect.assert_not_called()
+    assert results["collectors"]["historical_constituents"] == {
+        "status": "skipped", "reason": "no tickers",
+    }
+
+
+def test_historical_constituents_is_an_only_choice():
+    """The operator can target just this collector — guards against the wiring
+    silently regressing to dead code again."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--only",
+        choices=["constituents", "historical_constituents", "prices", "macro",
+                 "short_interest", "universe_classification", "universe_returns",
+                 "alternative", "daily_closes", "features", "arcticdb"],
+    )
+    ns = parser.parse_args(["--only", "historical_constituents"])
+    assert ns.only == "historical_constituents"

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -80,7 +80,7 @@ setup_logging(
     exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
 )
 
-from collectors import constituents, prices, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest, metron_market_data, universe_classification
+from collectors import constituents, historical_constituents, prices, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest, metron_market_data, universe_classification
 from builders._price_cache_writeboth import (
     price_cache_read_prefixes as _price_cache_read_prefixes,
     price_cache_write_prefixes as _price_cache_write_prefixes,
@@ -259,7 +259,7 @@ def run_weekly(config: dict, args: argparse.Namespace) -> dict:
 
 
 def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
-    """Phase 1: constituents, prices, macro, universe returns."""
+    """Phase 1: constituents, historical (PIT) constituents, prices, macro, universe returns."""
     bucket = config["bucket"]
     price_cfg = config.get("price_cache", {})
     market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
@@ -309,6 +309,37 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
                 logger.info("Loaded %d tickers from existing constituents.json", len(tickers))
         except Exception as exc:
             logger.warning("S3 constituents load failed — will fall back to Wikipedia: %s", exc)
+
+    # ── 1b. Historical (point-in-time) constituents ──────────────────────────
+    # Replays the S&P 500 "Selected changes" table backward from today's roster
+    # to a {date: [tickers]} PIT membership map at
+    # market_data/historical_constituents.json — the survivorship-free universe
+    # substrate the backtester consumes (config#657, G12). Reuses `tickers` (the
+    # roster already collected/loaded above) so the two collectors' rosters stay
+    # consistent and it avoids a second live fetch. Runs in the default Phase-1
+    # sweep; without this wiring the collector was dead code and the S3 key was
+    # never written.
+    if only in (None, "historical_constituents"):
+        logger.info("=" * 60)
+        logger.info("COLLECTING: historical constituents (point-in-time membership)")
+        logger.info("=" * 60)
+        if not tickers:
+            logger.warning(
+                "No tickers available — skipping historical constituents (PIT map "
+                "needs today's roster to replay changes from)"
+            )
+            results["collectors"]["historical_constituents"] = {
+                "status": "skipped", "reason": "no tickers",
+            }
+        else:
+            results["collectors"]["historical_constituents"] = _phase_collect(
+                reg, "historical_constituents",
+                lambda: historical_constituents.collect(
+                    bucket=bucket, current_tickers=tickers,
+                    s3_prefix=market_prefix, dry_run=dry_run,
+                ),
+                artifact_key=f"{market_prefix}historical_constituents.json",
+            )
 
     # ── 2. Price cache refresh ───────────────────────────────────────────────
     if only in (None, "prices"):
@@ -2629,7 +2660,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--only",
-        choices=["constituents", "prices", "macro", "short_interest", "universe_classification", "universe_returns", "alternative", "daily_closes", "features", "arcticdb"],
+        choices=["constituents", "historical_constituents", "prices", "macro", "short_interest", "universe_classification", "universe_returns", "alternative", "daily_closes", "features", "arcticdb"],
         help="Run a single collector instead of all",
     )
     # Phase-registry recovery controls (L4528 — markers under data/{date}/.phases/).


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** high

Refs nousergon/alpha-engine-config#657 (survivorship-free universe, G12). Does **not** close it — this is one leg of a cross-repo EPIC (see Scope below).

## Problem
`collectors/historical_constituents.py` shipped in #490 (replays the S&P 500 'Selected changes' table backward into a `{date: [tickers]}` PIT membership map) but was **never invoked** from `weekly_collector` — no call site, not in the `--only` choices, no cron reference. So `market_data/historical_constituents.json` has **never been written to S3**, and any consumer built today would read a nonexistent key. Same scheduling-gap shape flagged in the #657 thread.

## Change (producer-scheduling leg)
- New **Phase-1b** block in `_run_phase1`: runs `historical_constituents.collect` right after the roster is resolved, passing the already-collected/loaded `tickers` as `current_tickers` (no second live fetch; keeps the two collectors' rosters consistent). Writes `{market_prefix}historical_constituents.json`.
- Skips gracefully with `{status: skipped, reason: no tickers}` when no roster is available — never crashes the sweep.
- Reachable via `--only historical_constituents` (added to the CLI choices).
- `tests/test_weekly_collector_historical_constituents_wiring.py`: pins the wiring (roster + `s3_prefix` → `market_data/historical_constituents.json`), the no-roster skip, and the `--only` choice, so it can't silently regress to dead code.

## Explicitly still open (tracked follow-on, NOT in this PR)
Per the #657 thread, full closure needs two more design-bearing pieces this producer leg is a prerequisite for:
1. **Consumer wiring** — a survivorship-aware as-of-date parameter on the shared `nousergon_lib.arcticdb.get_universe_symbols` that the backtester's 5 `backtest.py` call sites route through (a shared-lib API change + repin lockstep across the repos that pin it).
2. **Delisted-ticker price retention** — `builders/prune_delisted_tickers.py` prunes failed names' price history, so PIT membership alone fixes only look-ahead inclusion, not the dominant omission-of-failed-names bias. That is a separate S3-schema decision (#490's memo Phase 2).

## Validation (local, py3.12, full requirements)
New wiring suite: 3 passed. Related existing suites (`test_historical_constituents`, `test_weekly_collector_phase_registry`, `test_artifact_registry_coverage`): 23 passed. NOT merging — Brian reviews.