### PR TITLE
feat(freshness-monitor): pin lib v0.85.0 for event_driven cadence (#1726)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -178,6 +178,9 @@ _SPEC_FIELDS = frozenset(
         # S3-contract-safe migration window.
         "active_trading_days_only",
         "active_hours_utc",
+        "produces",
+        "depends_on",
+        "liveness_via",
     }
 )
 

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
-# Substrate bumped to v0.83.0 for flow_doctor_fleet + compat with sibling Lambdas.
+# Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.85.0
 krepis>=0.10.2
 pyyaml>=6.0


### PR DESCRIPTION
## Summary
- Bump freshness-monitor substrate to `nousergon-lib@v0.85.0` (config#1718 merged)
- Parse `liveness_via`, `produces`, `depends_on` registry fields

## Ordering
**Merge + deploy this BEFORE** alpha-engine-config registry PR that adds `event_driven` rows.

## Test plan
- [ ] `pytest infrastructure/lambdas/freshness-monitor/test_handler.py`
- [ ] Deploy via `deploy.sh` after merge

Made with [Cursor](https://cursor.com)