### PR TITLE
fix(groom): route dispatcher lifecycle pings to #groom only

### DIFF
--- a/infrastructure/lambdas/flow_doctor_telegram.py
+++ b/infrastructure/lambdas/flow_doctor_telegram.py
@@ -103,7 +103,7 @@ def notify_via_flow_doctor(
     if fd is None:
         return send_message(text, disable_notification=silent)
 
-    subject = text.split("\n", 1)[0].replace("*", "")
+    subject = text.replace("*", "").strip()
 
     if silent and silent_topic is not None:
         notifier = topic_telegram_notifier(fd, silent_topic)
@@ -112,7 +112,7 @@ def notify_via_flow_doctor(
 
     report_id = fd.notify_event(
         subject,
-        body=text,
+        body=None,
         severity=severity,
         context=context or {},
         dedup_key=dedup_key,

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -83,15 +83,7 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 _FLOW_NAME = "scheduled-groom-dispatcher"
 _DB_BASENAME = "flow_doctor_scheduled_groom_dispatcher"
-_OPS_TOPICS = (
-    FleetTelegramTopic.CRITICAL,
-    FleetTelegramTopic.OPS_HEALTH,
-)
-_GROOM_LIFECYCLE_TOPICS = (
-    FleetTelegramTopic.GROOM,
-    FleetTelegramTopic.CRITICAL,
-    FleetTelegramTopic.OPS_HEALTH,
-)
+_GROOM_LIFECYCLE_TOPICS = (FleetTelegramTopic.GROOM,)
 # Kill-switch: GROOM_DISPATCH_ENABLED=false disables the trigger without deleting
 # the EventBridge Scheduler rules. Default ON.
 DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"


### PR DESCRIPTION
## Summary
- `scheduled-groom-dispatcher` pace-skip lifecycle pings now target `#groom` only (drop `#critical` / `#ops-health` mirror).
- Shared `flow_doctor_telegram.notify_via_flow_doctor` passes full alert text as the Telegram body (same flow-doctor subject-vs-logs bug as config groom-notify).

## Test plan
- [ ] Deploy Lambda after merge
- [ ] Pre-boot pace skip ping lands in `#groom` with full text

## Related
- Companion PR: nousergon/alpha-engine-config (on-box `groom-notify.sh` path)

Made with [Cursor](https://cursor.com)