### PR TITLE
feat(sf-watch): drop groom from Fleet-SF Watch auto-fix coverage

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -129,9 +129,9 @@ if $BOOTSTRAP; then
     echo "  Lambda exists, code will be updated in step 3"
   fi
 
-  # EventBridge rule: terminal-failure statuses of ANY of the four registered
-  # SFs (3 trading pipelines + the groom dispatch SF, config#1472). One rule,
-  # one target — keep the ARN list in lockstep with index.PIPELINES.
+  # EventBridge rule: terminal-failure statuses of ANY of the three fleet
+  # trading SFs (+ the transitional EOD alias). One rule, one target — keep
+  # the ARN list in lockstep with index.PIPELINES.
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   EVENT_PATTERN=$(cat <<EOF
 {
@@ -142,8 +142,7 @@ if $BOOTSTRAP; then
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-dispatch"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
     ],
     "status": ["FAILED", "TIMED_OUT", "ABORTED"]
   }
@@ -153,7 +152,7 @@ EOF
   run aws events put-rule \
     --name "${RULE_NAME}" \
     --event-pattern "${EVENT_PATTERN}" \
-    --description "Fleet SF (saturday/weekday/eod/groom) terminal failure → sf-watch-dispatcher" \
+    --description "Fleet SF (weekly/preopen/postclose) terminal failure → sf-watch-dispatcher" \
     --region "${REGION}" \
     --query 'RuleArn' --output text
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -40,8 +40,7 @@
         "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*",
         "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:*",
         "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-groom-dispatch:*"
+        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*"
       ]
     },
     {

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -120,25 +120,6 @@ PIPELINES: dict[str, dict[str, object]] = {
         "dispatch_event_type": "eod-sf-failure",
         "has_listener": True,
     },
-    # Backlog groom dispatch (config#1472) — wraps the EC2-spot-via-SSM groom
-    # dispatch in a Step Function purely for uniform observability (watch-log
-    # artifact + silent Telegram record), replacing the bespoke external
-    # liveness-probe Lambda (data#556). `has_listener=True` (2026-07-01 follow-
-    # up to config#1535): `groom-sf-failure` is now in sf-watch.yml's `types:`
-    # allowlist and the charter (.github/sf-watch-prompt.md) has a dedicated
-    # groom guardrail (STEP 2.5 case 4) — classify-first (most groom failures
-    # are transient infra, not a code defect), plain rerun (no skip-flags, the
-    # groom SF has no multi-stage idempotency concern). Its kill-switch
-    # (/alpha-engine/groom_sf_watch/autonomous_merge_enabled) defaults `true`
-    # from day one — lower stakes than any trading pipeline since it touches no
-    # live capital, unlike weekday/EOD which soak PROPOSE-ONLY (config#1408).
-    "alpha-engine-groom-dispatch": {
-        "cadence_slug": "groom",
-        "label": "Backlog Groom",
-        "watch_prefix": "consolidated/groom_sf_watch",
-        "dispatch_event_type": "groom-sf-failure",
-        "has_listener": True,
-    },
 }
 SCHEMA_VERSION = 1
 _CAUSE_MAX_CHARS = 600

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -19,7 +19,6 @@ import index  # noqa: E402
 SATURDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
 WEEKDAY_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline"
 EOD_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
-GROOM_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-groom-dispatch"
 UNREGISTERED_ARN = "arn:aws:states:us-east-1:711398986525:stateMachine:some-other-pipeline"
 
 
@@ -367,64 +366,11 @@ def test_pat_never_appears_in_result(monkeypatch):
     assert "ghp_SECRET_TOKEN" not in json.dumps(result)
 
 
-def test_groom_failure_dispatches_when_enabled(monkeypatch):
-    """2026-07-01 (config#1535 follow-up): groom flipped to has_listener=True
-    once `groom-sf-failure` was added to sf-watch.yml's `types:` allowlist and
-    the charter gained a dedicated groom guardrail — it now dispatches exactly
-    like the trading pipelines when the global flag is on."""
-    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
-    sent = {}
-
-    def fake_urlopen(req, timeout=None):
-        sent["data"] = json.loads(req.data)
-        return _FakeResp()
-
-    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
-    factory, _, _ = _make_clients()
-    with patch("index.boto3.client", side_effect=factory):
-        result = index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
-    assert result["agent_dispatch"] == {
-        "dispatched": True, "status_code": 204, "event_type": "groom-sf-failure",
-    }
-    assert result["action"] == "dispatched"
-    assert sent["data"]["event_type"] == "groom-sf-failure"
-    assert sent["data"]["client_payload"]["cadence_slug"] == "groom"
-
-
-def test_groom_telegram_claims_autonomous_fix_when_dispatched(monkeypatch):
-    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
-    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
-    factory, _, _ = _make_clients()
-    with patch("index.boto3.client", side_effect=factory):
-        index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
-    text = index.notify_via_flow_doctor.call_args.args[0]
-    assert "Fleet-SF Watch — AUTO-FIX" in text
-    assert "Backlog Groom SF: FAILED" in text
-    assert "autonomous fix ACTIVE" in text
-
-
-def test_groom_watch_log_records_has_listener_true(monkeypatch):
-    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
-    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
-    factory, _, s3 = _make_clients()
-    with patch("index.boto3.client", side_effect=factory):
-        index.handler(_event("FAILED", sm_arn=GROOM_ARN), None)
-    written = json.loads(s3.put_object.call_args.kwargs["Body"])
-    event = written["events"][-1]
-    assert event["has_listener"] is True
-    assert event["action"] == "dispatch"
-    assert event["agent_dispatch_enabled"] is True
-
-
 def test_no_listener_pipeline_never_dispatches_even_when_globally_enabled(monkeypatch):
     """Regression guard for the has_listener MECHANISM itself (config#1535):
     a pipeline registered with has_listener=False must never fire a
     repository_dispatch nor claim "autonomous fix ACTIVE", regardless of the
-    global kill-switch — exercised here via a synthetic entry now that groom
-    (the original motivating case) has flipped to True."""
+    global kill-switch."""
     fake_pipelines = dict(index.PIPELINES)
     fake_pipelines["some-other-pipeline"] = {
         "cadence_slug": "other",
@@ -455,7 +401,7 @@ def test_no_listener_pipeline_never_dispatches_even_when_globally_enabled(monkey
     assert "observe-only for this pipeline" in text
 
 
-def test_saturday_still_dispatches_normally_alongside_groom_fix(monkeypatch):
+def test_saturday_still_dispatches_when_enabled(monkeypatch):
     """Non-regression: the has_listener plumbing must not change behavior for
     the 3 trading pipelines, which all default has_listener=True."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)

--- a/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
@@ -36,8 +36,7 @@
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-groom-dispatch"
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
       ]
     },
     {

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -81,7 +81,6 @@ EXPECTED_PIPELINE_NAMES = [
     "ne-preopen-trading-pipeline",
     "ne-postclose-trading-pipeline",
     "alpha-engine-eod-pipeline",  # transitional alias, config#1408 / re-exam 2026-07-03
-    "alpha-engine-groom-dispatch",  # config#1472
 ]
 
 WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")

--- a/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
@@ -157,7 +157,7 @@ def test_missing_pipeline_arn_in_rule_alerts():
             "stateMachineArn": [
                 f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{name}"
                 for name in index.EXPECTED_PIPELINE_NAMES
-                if name != "alpha-engine-groom-dispatch"
+                if name != "ne-weekly-freshness-pipeline"
             ]
         }
     })
@@ -167,7 +167,7 @@ def test_missing_pipeline_arn_in_rule_alerts():
     s3 = _make_s3_client()
     with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
         result = index.handler({}, None)
-    assert any("MISSING expected pipeline" in p and "alpha-engine-groom-dispatch" in p for p in result["problems"])
+    assert any("MISSING expected pipeline" in p and "ne-weekly-freshness-pipeline" in p for p in result["problems"])
 
 
 def test_dead_state_machine_arn_alerts():


### PR DESCRIPTION
## Summary
- Remove `alpha-engine-groom-dispatch` from the sf-watch-dispatcher `PIPELINES` registry and EventBridge failure rule
- Trim groom execution permissions from dispatcher + liveness-probe IAM policies
- Update liveness-probe expected pipeline list and remove groom-specific dispatch tests

Fleet-SF Watch auto-fix now covers only the three trading Step Functions (weekly freshness, pre-open trading, post-close trading). Groom still runs on schedule and still alerts via `sf-telegram-notifier`; it just no longer dispatches the resilience agent.

## Test plan
- [x] `pytest infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py -q` (CI)
- [ ] After merge: `bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh` (updates EventBridge rule + Lambda IAM)
- [ ] After merge: `bash infrastructure/lambdas/sf-watch-liveness-probe/deploy.sh` (updates liveness probe IAM)

Companion PR: nousergon/alpha-engine-config (charter + GHA workflow + sf-watch-role IAM)

Made with [Cursor](https://cursor.com)