### PR TITLE
feat(data): migrate to nousergon_lib.health (#1727)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.86.0" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0
 anyio>=4.0
 tenacity>=8.0
 pyyaml>=6.0
-nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
+nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.86.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ arcticdb>=6.11
 # invariant (ROADMAP L286). Gated default-OFF via
 # ``ALPHA_ENGINE_UNIVERSE_WRITER_LOCK_ENABLED``.
 # All additive surface — existing imports unchanged.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.86.0
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -121,7 +121,9 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "rag/pipelines/emit_manifest.py": 2,
     "rag/pipelines/filing_change_detection.py": 2,
     "rag/pipelines/ingest_form4.py": 2,
-    "weekly_collector.py": 6,
+    # config#1727: _write_module_health delegates to nousergon_lib.health (1 fewer
+    # local put_object); health/{module}.json still written via lib.
+    "weekly_collector.py": 5,
 }
 
 

--- a/tests/test_module_health.py
+++ b/tests/test_module_health.py
@@ -1,11 +1,11 @@
 """Unit tests for weekly_collector._write_module_health.
 
 Validates that the module-scoped health stamp consumed by the executor's
-upstream gate (alpha-engine/executor/health_status.py::check_upstream_health)
-is written with the correct schema and key pattern.
+upstream gate delegates to nousergon_lib.health.write_health with the correct
+schema, deliverables mapping, and key pattern.
 """
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import patch, MagicMock
 
 from weekly_collector import _write_module_health
@@ -43,7 +43,14 @@ class TestWriteModuleHealth:
         assert payload["warnings"] == []
         assert payload["error"] is None
         assert payload["last_success"] is not None
-        # Parseable as ISO timestamp
+        assert payload["deliverables"] == [
+            {
+                "name": "daily_data",
+                "required": True,
+                "produced": True,
+                "detail": "",
+            }
+        ]
         datetime.fromisoformat(payload["last_success"])
 
     @patch("weekly_collector.boto3")
@@ -60,6 +67,7 @@ class TestWriteModuleHealth:
         assert payload["status"] == "failed"
         assert payload["last_success"] is None
         assert payload["error"] == "polygon 429 rate-limited"
+        assert payload["deliverables"][0]["produced"] is False
 
     @patch("weekly_collector.boto3")
     def test_degraded_status_populates_last_success(self, mock_boto3):

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -2535,32 +2535,57 @@ def _write_module_health(
     """Write module-scoped health stamp consumed by the executor's
     check_upstream_health() (alpha-engine/executor/health_status.py:91).
 
-    Schema matches executor's write_health() — key pattern
-    `health/{module_name}.json` with `last_success` nulled on failure so
-    downstream staleness checks can distinguish "ran and failed today" from
-    "hasn't run in N hours". Called on both success AND failure paths so the
-    stamp reflects the actual last run outcome.
+    Delegates to ``nousergon_lib.health.write_health`` (config#1727 Phase C).
+    The legacy ``status`` string is mapped to :class:`Deliverable` objects;
+    status is derived by the lib (required-missing / error / warnings) so a
+    caller cannot stamp ``"ok"`` over a failed run. Key pattern remains
+    ``health/{module_name}.json`` with ``last_success`` nulled on failure.
     """
+    from nousergon_lib.health import Deliverable, write_health
+
+    warnings = warnings or []
+    if error:
+        deliverables = [
+            Deliverable(
+                name=module_name,
+                required=True,
+                produced=False,
+                detail=error,
+            ),
+        ]
+    elif status == "failed":
+        deliverables = [
+            Deliverable(name=module_name, required=True, produced=False),
+        ]
+    elif status == "degraded":
+        deliverables = [
+            Deliverable(name=module_name, required=True, produced=True),
+        ]
+        if not warnings:
+            deliverables.append(
+                Deliverable(
+                    name=f"{module_name}_optional",
+                    required=False,
+                    produced=False,
+                )
+            )
+    else:
+        deliverables = [
+            Deliverable(name=module_name, required=True, produced=True),
+        ]
+
     s3 = boto3.client("s3")
-    key = f"health/{module_name}.json"
-    now_iso = datetime.now(timezone.utc).isoformat()
-    payload = {
-        "module": module_name,
-        "status": status,
-        "last_success": now_iso if status != "failed" else None,
-        "run_date": run_date,
-        "duration_seconds": round(duration_seconds, 1),
-        "summary": summary or {},
-        "warnings": warnings or [],
-        "error": error,
-    }
-    s3.put_object(
-        Bucket=bucket,
-        Key=key,
-        Body=json.dumps(payload, indent=2).encode("utf-8"),
-        ContentType="application/json",
+    write_health(
+        module_name=module_name,
+        deliverables=deliverables,
+        run_date=run_date,
+        duration_seconds=duration_seconds,
+        summary=summary,
+        warnings=warnings or None,
+        error=error,
+        bucket=bucket,
+        s3_client=s3,
     )
-    logger.info("Wrote module health: s3://%s/%s (%s)", bucket, key, status)
 
 
 def _parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- Replace inline `_write_module_health()` in `weekly_collector.py` with delegation to `nousergon_lib.health.write_health`, mapping legacy status strings to `Deliverable` objects (error / required-missing / warnings → derived status).
- Leave `_write_health_marker` (phase markers) unchanged.
- Bump `nousergon-lib` to v0.86.0 on all lockstep pin surfaces (`requirements.txt`, `Dockerfile`, `requirements-daily-news.txt`).

## Test plan
- [x] `pytest tests/test_module_health.py tests/test_lib_pin_lockstep.py tests/test_weekly_collector_morning_enrich.py`


Made with [Cursor](https://cursor.com)