### PR TITLE
feat(sf): liveness-aware SSM watchdog + front-loaded code-freshness gate (config#1811)

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -18,7 +18,8 @@
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate*",
                 "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator*"
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller*"
             ]
         },
         {

--- a/infrastructure/lambdas/ssm-liveness-poller/README.md
+++ b/infrastructure/lambdas/ssm-liveness-poller/README.md
@@ -1,0 +1,47 @@
+# ssm-liveness-poller
+
+Liveness-aware poll iteration for `ne-preopen-trading-pipeline`'s SSM
+command loops. One invocation = one poll: command status
+(`ssm:GetCommandInvocation`) + independent SSM-agent liveness
+(`ssm:DescribeInstanceInformation` `PingStatus`) + bounded attempt /
+consecutive-ping-miss accounting, returning a single `verdict` the SF
+Choice states branch on:
+
+| verdict | meaning | SF routing |
+|---|---|---|
+| `SUCCESS` | command Status=Success | next pipeline state |
+| `IN_PROGRESS` | still running, box responsive, budgets OK | Wait → re-poll |
+| `COMMAND_FAILED` | terminal non-success (Failed/TimedOut/Cancelled) | HandleFailure (or fail-soft continue for chronic-gap) |
+| `INSTANCE_UNRESPONSIVE` | ≥N consecutive polls with PingStatus≠Online while nominally running | stamp error → ForceStopUnresponsiveInstance → HandleFailure |
+| `POLL_BUDGET_EXHAUSTED` | attempt cap hit without terminal status | stamp error → HandleFailure |
+
+## Why (config#1811)
+
+The SSM agent enforces `executionTimeout` from **inside** the box being
+watched. 2026-07-06 (config#1807): the trading box wedged under memory
+pressure mid-`MorningArcticAppend`; the agent went `ConnectionLost`, the
+timeout could not fire, and the SF poll loop read a frozen `InProgress`
+for 62 minutes (22 past the timeout) until the agent self-recovered.
+This poller detects that shape in ~1 minute (3 misses × 20s), from
+outside the box. Also consolidates the previously copy-pasted poll
+blocks whose semantics had drifted (only MorningEnrich ever received
+the #970 bounded-attempt cap).
+
+Counters are carried through SF state (`$.<step>_poll.attempts` /
+`.ping_misses` round-trip through the invoke Parameters) — the Lambda
+is stateless.
+
+Read-only by design: force-stop remediation belongs to the state
+machine's role, not this function.
+
+## Deploy
+
+```bash
+bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh --bootstrap  # first time
+bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh              # code update
+bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh --smoke      # read-only smoke
+```
+
+Caller grant: `lambda:InvokeFunction` for
+`alpha-engine-step-functions-role` lives in the codified IAM
+(`alpha-engine/infrastructure/iam/`), applied via `apply.sh` — not here.

--- a/infrastructure/lambdas/ssm-liveness-poller/deploy.sh
+++ b/infrastructure/lambdas/ssm-liveness-poller/deploy.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-ssm-liveness-poller Lambda.
+#
+# config#1811: liveness-aware SSM poll iteration for the weekday pipeline's
+# SSM command loops (MorningEnrich / MorningArcticAppend / ChronicGapSelfHeal /
+# RunMorningPlanner / CodeFreshnessGate). One invocation = one poll: command
+# status + independent SSM-agent PingStatus + bounded attempt/ping-miss
+# accounting. See index.py for the full rationale (2026-07-06 incident: the
+# in-box executionTimeout cannot fire when the box itself is wedged).
+#
+# No EventBridge trigger — invoked ONLY by ne-preopen-trading-pipeline
+# (lambda:InvokeFunction is granted to alpha-engine-step-functions-role in
+# the codified IAM: alpha-engine/infrastructure/iam/).
+#
+# Managed outside CloudFormation — same rationale as pipeline-watchdog /
+# eod-backstop (operator-deployed only, narrow OIDC blast radius).
+#
+# Usage:
+#   bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh             # update code only
+#   bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh --bootstrap # first-time create
+#   bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh --smoke     # one read-only invoke against a dummy command id
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-ssm-liveness-poller"
+ROLE_NAME="alpha-engine-ssm-liveness-poller-role"
+POLICY_NAME="alpha-engine-ssm-liveness-poller-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Running handler unit tests..."
+  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 30 \
+      --memory-size 128 \
+      --environment 'Variables={LOG_LEVEL=INFO}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  echo "  NOTE: grant lambda:InvokeFunction on this function to"
+  echo "        alpha-engine-step-functions-role via the codified IAM"
+  echo "        (alpha-engine/infrastructure/iam/ + apply.sh) before"
+  echo "        deploying the SF definition that calls it."
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (read-only — a nonexistent command id exercises the
+#          registration-window path and both SSM read calls) ----------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke: read-only invoke (nonexistent command id → IN_PROGRESS/Registering)"
+  RESP=$(mktemp)
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{"instance_id":"i-018eb3307a21329bf","command_id":"00000000-0000-0000-0000-000000000000","attempts":0,"ping_misses":0,"max_attempts":3,"max_ping_misses":3,"step":"smoke"}' \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/ssm-liveness-poller/iam-policy.json
+++ b/infrastructure/lambdas/ssm-liveness-poller/iam-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SsmReadOnlyPolling",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetCommandInvocation",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-ssm-liveness-poller*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/ssm-liveness-poller/index.py
+++ b/infrastructure/lambdas/ssm-liveness-poller/index.py
@@ -1,0 +1,186 @@
+"""alpha-engine-ssm-liveness-poller — liveness-aware SSM command poller.
+
+One Lambda invocation = one poll iteration for a Step Functions SSM
+polling loop. Replaces the bare ``ssm:getCommandInvocation`` poll states
+in ``ne-preopen-trading-pipeline`` (previously copy-pasted 4x with
+drifted semantics: only MorningEnrich ever got the bounded-attempt cap
+from #970, and none of them checked instance liveness).
+
+Why this exists (config#1811, 2026-07-06 incident): the SSM agent
+enforces a command's ``executionTimeout`` FROM INSIDE the box being
+watched. When the trading box became unresponsive under memory pressure
+(config#1807), the stuck ``MorningArcticAppend`` command was not killed
+until the agent happened to reconnect — 22 minutes PAST its 40-minute
+timeout — while the SF poll loop read a frozen ``InProgress`` forever.
+A watchdog that dies with its watchee is not a watchdog. This poller
+combines, per iteration, in one place OUTSIDE the box:
+
+  1. ``ssm:GetCommandInvocation``    — command status (as before);
+  2. ``ssm:DescribeInstanceInformation`` — the agent's ``PingStatus``,
+     the independent liveness signal (per the config#1724 principle:
+     independent observation beats self-report);
+  3. bounded-attempt + consecutive-ping-miss accounting (counters are
+     carried through SF state — this Lambda is stateless).
+
+Verdicts (the Choice states branch on exactly these):
+  SUCCESS               — command reached Status=Success.
+  IN_PROGRESS           — command still running (Pending/InProgress/
+                          Delayed, or invocation not yet registered),
+                          instance responsive, budgets not exhausted.
+  COMMAND_FAILED        — command reached a terminal non-success status
+                          (Failed / TimedOut / Cancelled / Cancelling).
+  INSTANCE_UNRESPONSIVE — >= max_ping_misses consecutive polls saw
+                          PingStatus != Online while the command was
+                          nominally running. The 2026-07-06 shape:
+                          detection in ~1 minute instead of 62.
+  POLL_BUDGET_EXHAUSTED — attempts >= max_attempts without a terminal
+                          status (the #970 stuck-InProgress shape).
+
+Fail-loud: unexpected AWS errors RAISE (the SF Catch routes to
+HandleFailure). The only swallowed error is InvocationDoesNotExist
+during the registration window, which is expected SSM eventual
+consistency and is still bounded by the attempt budget.
+
+This Lambda is deliberately READ-ONLY (least privilege): remediation of
+INSTANCE_UNRESPONSIVE (force-stopping the box) is a separate SF state
+owned by the state machine's role, not this function.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+_ssm = boto3.client("ssm")
+
+# Command statuses that mean "still running / not yet terminal".
+_RUNNING_STATUSES = {"Pending", "InProgress", "Delayed"}
+# Terminal, non-success.
+_FAILED_STATUSES = {"Failed", "TimedOut", "Cancelled", "Cancelling"}
+
+_STDERR_TAIL_CHARS = 1500
+
+
+def _get_command_status(command_id: str, instance_id: str) -> dict[str, Any]:
+    """Return the invocation's status fields, or a registering sentinel.
+
+    InvocationDoesNotExist right after sendCommand is expected eventual
+    consistency (the old ASL states carried a 10-attempt Retry for it);
+    it is reported as still-registering rather than raised, and remains
+    bounded by the caller's attempt budget.
+    """
+    try:
+        inv = _ssm.get_command_invocation(
+            CommandId=command_id, InstanceId=instance_id
+        )
+        return {
+            "status": inv["Status"],
+            "response_code": inv.get("ResponseCode", -1),
+            "status_details": inv.get("StatusDetails", ""),
+            "stderr_tail": (inv.get("StandardErrorContent") or "")[
+                -_STDERR_TAIL_CHARS:
+            ],
+            "registered": True,
+        }
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "InvocationDoesNotExist":
+            return {
+                "status": "Registering",
+                "response_code": -1,
+                "status_details": "InvocationDoesNotExist (registration window)",
+                "stderr_tail": "",
+                "registered": False,
+            }
+        raise
+
+
+def _get_ping_status(instance_id: str) -> str:
+    """The SSM agent's PingStatus — Online / ConnectionLost / Inactive.
+
+    An empty InstanceInformationList (instance unknown to SSM) is
+    reported as NotRegistered and counts as a ping miss: for a box that
+    was reachable at sendCommand time, vanishing from SSM inventory is
+    at least as alarming as ConnectionLost.
+    """
+    resp = _ssm.describe_instance_information(
+        Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
+    )
+    info = resp.get("InstanceInformationList") or []
+    if not info:
+        return "NotRegistered"
+    return info[0].get("PingStatus", "Unknown")
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    instance_id = event["instance_id"]
+    command_id = event["command_id"]
+    attempts = int(event.get("attempts", 0)) + 1
+    ping_misses = int(event.get("ping_misses", 0))
+    max_attempts = int(event["max_attempts"])
+    max_ping_misses = int(event.get("max_ping_misses", 3))
+    step = event.get("step", "unknown")
+
+    cmd = _get_command_status(command_id, instance_id)
+    ping = _get_ping_status(instance_id)
+
+    result: dict[str, Any] = {
+        "attempts": attempts,
+        "ping_misses": ping_misses,
+        "status": cmd["status"],
+        "response_code": cmd["response_code"],
+        "status_details": cmd["status_details"],
+        "stderr_tail": cmd["stderr_tail"],
+        "ping_status": ping,
+        "step": step,
+        # Always present so the ASL ResultSelector's detail.$ path never
+        # errors on a missing field (States.Runtime on absent paths).
+        "detail": "",
+    }
+
+    if cmd["status"] == "Success":
+        result["verdict"] = "SUCCESS"
+    elif cmd["status"] in _FAILED_STATUSES:
+        result["verdict"] = "COMMAND_FAILED"
+        result["detail"] = (
+            f"[{step}] SSM command {command_id} terminal status "
+            f"{cmd['status']} (rc={cmd['response_code']}): "
+            f"{cmd['status_details']}"
+        )
+    else:
+        # Still running (or registering). Liveness + budget accounting.
+        if ping != "Online":
+            ping_misses += 1
+        else:
+            ping_misses = 0
+        result["ping_misses"] = ping_misses
+
+        if ping_misses >= max_ping_misses:
+            result["verdict"] = "INSTANCE_UNRESPONSIVE"
+            result["detail"] = (
+                f"[{step}] instance {instance_id} PingStatus={ping} for "
+                f"{ping_misses} consecutive polls while command "
+                f"{command_id} is nominally {cmd['status']}. The box is "
+                f"wedged (config#1807 shape) — the in-box executionTimeout "
+                f"cannot fire. Recommended action: force-stop the instance."
+            )
+        elif attempts >= max_attempts:
+            result["verdict"] = "POLL_BUDGET_EXHAUSTED"
+            result["detail"] = (
+                f"[{step}] command {command_id} did not reach a terminal "
+                f"status within {max_attempts} poll iterations (last "
+                f"status {cmd['status']}, PingStatus={ping}). Stuck "
+                f"InProgress past the command's own executionTimeout "
+                f"(#970 shape)."
+            )
+        else:
+            result["verdict"] = "IN_PROGRESS"
+
+    logger.info(json.dumps({k: v for k, v in result.items() if k != "stderr_tail"}))
+    return result

--- a/infrastructure/lambdas/ssm-liveness-poller/requirements.txt
+++ b/infrastructure/lambdas/ssm-liveness-poller/requirements.txt
@@ -1,0 +1,2 @@
+# boto3 is provided by the Lambda python3.12 runtime; no external deps.
+# (File kept so deploy.sh's uniform pip-install packaging step works.)

--- a/infrastructure/lambdas/ssm-liveness-poller/test_handler.py
+++ b/infrastructure/lambdas/ssm-liveness-poller/test_handler.py
@@ -1,0 +1,164 @@
+"""Unit tests for the ssm-liveness-poller handler.
+
+Covers every verdict the ne-preopen-trading-pipeline Choice states
+branch on, plus the two incident shapes that motivated the Lambda:
+- config#1807 / 2026-07-06: command frozen InProgress while the SSM
+  agent is ConnectionLost → INSTANCE_UNRESPONSIVE after N consecutive
+  ping misses (was: 62 minutes of blind polling).
+- #970 / 2026-06-11: command stuck InProgress with a healthy agent →
+  POLL_BUDGET_EXHAUSTED at the attempt cap.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+
+def _event(**over):
+    base = {
+        "instance_id": "i-018eb3307a21329bf",
+        "command_id": "cmd-123",
+        "attempts": 0,
+        "ping_misses": 0,
+        "max_attempts": 210,
+        "max_ping_misses": 3,
+        "step": "morning-enrich",
+    }
+    base.update(over)
+    return base
+
+
+def _mock_ssm(status="InProgress", ping="Online", rc=-1, stderr="",
+              invocation_exists=True, instance_registered=True):
+    ssm = mock.Mock()
+    if invocation_exists:
+        ssm.get_command_invocation.return_value = {
+            "Status": status,
+            "ResponseCode": rc,
+            "StatusDetails": status,
+            "StandardErrorContent": stderr,
+        }
+    else:
+        ssm.get_command_invocation.side_effect = ClientError(
+            {"Error": {"Code": "InvocationDoesNotExist", "Message": "x"}},
+            "GetCommandInvocation",
+        )
+    ssm.describe_instance_information.return_value = {
+        "InstanceInformationList": (
+            [{"PingStatus": ping}] if instance_registered else []
+        )
+    }
+    return ssm
+
+
+def test_success():
+    with mock.patch.object(index, "_ssm", _mock_ssm(status="Success", rc=0)):
+        out = index.handler(_event(), None)
+    assert out["verdict"] == "SUCCESS"
+    assert out["attempts"] == 1
+
+
+@pytest.mark.parametrize("status", ["Failed", "TimedOut", "Cancelled", "Cancelling"])
+def test_terminal_failure(status):
+    with mock.patch.object(
+        index, "_ssm", _mock_ssm(status=status, rc=137, stderr="boom")
+    ):
+        out = index.handler(_event(), None)
+    assert out["verdict"] == "COMMAND_FAILED"
+    assert "137" in out["detail"]
+    assert out["stderr_tail"] == "boom"
+
+
+def test_in_progress_healthy_resets_ping_misses():
+    with mock.patch.object(index, "_ssm", _mock_ssm(status="InProgress", ping="Online")):
+        out = index.handler(_event(ping_misses=2), None)
+    assert out["verdict"] == "IN_PROGRESS"
+    assert out["ping_misses"] == 0  # Online resets the consecutive counter
+
+
+def test_ping_miss_accumulates_below_threshold():
+    with mock.patch.object(
+        index, "_ssm", _mock_ssm(status="InProgress", ping="ConnectionLost")
+    ):
+        out = index.handler(_event(ping_misses=1), None)
+    assert out["verdict"] == "IN_PROGRESS"
+    assert out["ping_misses"] == 2
+
+
+def test_instance_unresponsive_at_threshold_config1807_shape():
+    """The 2026-07-06 incident: InProgress + ConnectionLost, 3rd miss."""
+    with mock.patch.object(
+        index, "_ssm", _mock_ssm(status="InProgress", ping="ConnectionLost")
+    ):
+        out = index.handler(_event(ping_misses=2), None)
+    assert out["verdict"] == "INSTANCE_UNRESPONSIVE"
+    assert "force-stop" in out["detail"].lower()
+
+
+def test_unregistered_instance_counts_as_ping_miss():
+    with mock.patch.object(
+        index, "_ssm",
+        _mock_ssm(status="InProgress", instance_registered=False),
+    ):
+        out = index.handler(_event(ping_misses=2), None)
+    assert out["verdict"] == "INSTANCE_UNRESPONSIVE"
+    assert out["ping_status"] == "NotRegistered"
+
+
+def test_poll_budget_exhausted_970_shape():
+    """#970: healthy agent, command frozen InProgress → budget cap."""
+    with mock.patch.object(index, "_ssm", _mock_ssm(status="InProgress", ping="Online")):
+        out = index.handler(_event(attempts=209), None)
+    assert out["verdict"] == "POLL_BUDGET_EXHAUSTED"
+    assert out["attempts"] == 210
+
+
+def test_unresponsive_wins_over_budget_when_both_trip():
+    with mock.patch.object(
+        index, "_ssm", _mock_ssm(status="InProgress", ping="ConnectionLost")
+    ):
+        out = index.handler(_event(attempts=209, ping_misses=2), None)
+    assert out["verdict"] == "INSTANCE_UNRESPONSIVE"
+
+
+def test_registration_window_is_in_progress_not_error():
+    with mock.patch.object(index, "_ssm", _mock_ssm(invocation_exists=False)):
+        out = index.handler(_event(), None)
+    assert out["verdict"] == "IN_PROGRESS"
+    assert out["status"] == "Registering"
+
+
+def test_registration_window_still_bounded_by_attempts():
+    with mock.patch.object(index, "_ssm", _mock_ssm(invocation_exists=False)):
+        out = index.handler(_event(attempts=209), None)
+    assert out["verdict"] == "POLL_BUDGET_EXHAUSTED"
+
+
+def test_unexpected_client_error_raises_fail_loud():
+    ssm = mock.Mock()
+    ssm.get_command_invocation.side_effect = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "x"}},
+        "GetCommandInvocation",
+    )
+    with mock.patch.object(index, "_ssm", ssm):
+        with pytest.raises(ClientError):
+            index.handler(_event(), None)
+
+
+def test_success_ignores_stale_ping_state():
+    """A completed command is SUCCESS even if the agent is currently dark
+    (e.g. it finished right before a blip) — command outcome outranks
+    liveness once terminal."""
+    with mock.patch.object(
+        index, "_ssm", _mock_ssm(status="Success", rc=0, ping="ConnectionLost")
+    ):
+        out = index.handler(_event(ping_misses=2), None)
+    assert out["verdict"] == "SUCCESS"

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -203,28 +203,41 @@
 
     "InitMorningEnrichPoll": {
       "Type": "Pass",
-      "Comment": "Initialize the bounded poll-iteration counter for the MorningEnrich SSM status loop (L4552b, 2026-06-14). Mirrors InitSSMPollCounter. The loop polls every ~15s; a stuck-InProgress (SSM agent stops reporting a terminal status past the command's executionTimeout — the 2026-06-11 weekday symptom in #970) would otherwise spin until the SF state TimeoutSeconds with no clear cause. The attempt cap fails fast into MorningEnrichPollTimeout with an explicit Cause instead.",
-      "Result": {"attempts": 0},
-      "ResultPath": "$.morning_enrich_poll_counter",
+      "Comment": "Seed the liveness-aware poll slot for the MorningEnrich loop (config#1811; supersedes the #970/L4552b counter-only pattern). attempts/ping_misses round-trip through the ssm-liveness-poller Lambda, which increments/reset them — no separate Increment state.",
+      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "ResultPath": "$.morning_enrich_poll",
       "Next": "WaitForMorningEnrich"
     },
 
     "WaitForMorningEnrich": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Comment": "Liveness-aware poll iteration (config#1811): command status + independent SSM-agent PingStatus in one Lambda call, OUTSIDE the box being watched. Replaces the bare getCommandInvocation poll — on 2026-07-06 (config#1807) the in-box executionTimeout could not fire while the box was wedged and the old loop read a frozen InProgress for 62 min; this detects that shape in ~3 polls.",
+      "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
-        "CommandId.$": "$.morning_enrich_result.Command.CommandId",
-        "InstanceId.$": "$.trading_instance_id[0]"
+        "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
+        "Payload": {
+          "instance_id.$": "$.trading_instance_id[0]",
+          "command_id.$": "$.morning_enrich_result.Command.CommandId",
+          "attempts.$": "$.morning_enrich_poll.attempts",
+          "ping_misses.$": "$.morning_enrich_poll.ping_misses",
+          "max_attempts": 210,
+          "max_ping_misses": 3,
+          "step": "morning-enrich"
+        }
       },
+      "TimeoutSeconds": 65,
       "Retry": [
         {
           "ErrorEquals": [
-            "Ssm.InvocationDoesNotExistException",
-            "Ssm.InvocationDoesNotExist"
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.Timeout"
           ],
-          "MaxAttempts": 10,
-          "IntervalSeconds": 10,
-          "BackoffRate": 1.5
+          "MaxAttempts": 3,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
         }
       ],
       "Catch": [
@@ -235,10 +248,15 @@
         }
       ],
       "ResultSelector": {
-        "Status.$": "$.Status",
-        "ResponseCode.$": "$.ResponseCode",
-        "StatusDetails.$": "$.StatusDetails",
-        "StandardErrorContent.$": "$.StandardErrorContent"
+        "verdict.$": "$.Payload.verdict",
+        "attempts.$": "$.Payload.attempts",
+        "ping_misses.$": "$.Payload.ping_misses",
+        "Status.$": "$.Payload.status",
+        "ResponseCode.$": "$.Payload.response_code",
+        "StatusDetails.$": "$.Payload.status_details",
+        "StandardErrorContent.$": "$.Payload.stderr_tail",
+        "ping_status.$": "$.Payload.ping_status",
+        "detail.$": "$.Payload.detail"
       },
       "ResultPath": "$.morning_enrich_poll",
       "Next": "CheckMorningEnrichStatus"
@@ -246,27 +264,27 @@
 
     "CheckMorningEnrichStatus": {
       "Type": "Choice",
-      "Comment": "Block predictor inference until polygon enrichment confirms the prior trading day's row is overwritten with authoritative VWAP. SSM Failed → HandleFailure (must not proceed to inference on uncorrected data per feedback_no_silent_fails). Success → ChronicGapSelfHeal (best-effort, fail-soft) → PredictorInference; the chronic-gap heal was split out of MorningEnrich 2026-06-11 so a yfinance hang in it can never SIGKILL the load-bearing enrich. The poll-iteration cap (≥210 attempts ≈ >57 min at ~15s/iter, just past the 3000s SSM executionTimeout) fails fast into MorningEnrichPollTimeout with a clear cause if the SSM command never reports a terminal status (L4552b / #970 — the 2026-06-11 stuck-InProgress shape).",
+      "Comment": "Block predictor inference until polygon enrichment confirms the prior trading day's row is overwritten with authoritative VWAP. Branches on the ssm-liveness-poller verdict (config#1811): COMMAND_FAILED (Default) → HandleFailure per feedback_no_silent_fails; INSTANCE_UNRESPONSIVE (≥3 consecutive PingStatus≠Online, the config#1807 wedged-box shape) → stamp error → force-stop the box → HandleFailure; POLL_BUDGET_EXHAUSTED (210 × ~15s ≈ >57 min, just past the 3000s executionTimeout — the #970 stuck-InProgress shape) → MorningEnrichPollTimeout.",
       "Choices": [
         {
-          "Variable": "$.morning_enrich_poll.Status",
-          "StringEquals": "Success",
+          "Variable": "$.morning_enrich_poll.verdict",
+          "StringEquals": "SUCCESS",
           "Next": "CheckSkipMorningArcticAppend"
         },
         {
-          "Variable": "$.morning_enrich_poll_counter.attempts",
-          "NumericGreaterThanEquals": 210,
+          "Variable": "$.morning_enrich_poll.verdict",
+          "StringEquals": "IN_PROGRESS",
+          "Next": "MorningEnrichWait"
+        },
+        {
+          "Variable": "$.morning_enrich_poll.verdict",
+          "StringEquals": "INSTANCE_UNRESPONSIVE",
+          "Next": "StampMorningEnrichUnresponsive"
+        },
+        {
+          "Variable": "$.morning_enrich_poll.verdict",
+          "StringEquals": "POLL_BUDGET_EXHAUSTED",
           "Next": "MorningEnrichPollTimeout"
-        },
-        {
-          "Variable": "$.morning_enrich_poll.Status",
-          "StringEquals": "InProgress",
-          "Next": "MorningEnrichWait"
-        },
-        {
-          "Variable": "$.morning_enrich_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "MorningEnrichWait"
         }
       ],
       "Default": "HandleFailure"
@@ -275,17 +293,18 @@
     "MorningEnrichWait": {
       "Type": "Wait",
       "Seconds": 15,
-      "Next": "IncrementMorningEnrichPoll"
+      "Next": "WaitForMorningEnrich"
     },
 
-    "IncrementMorningEnrichPoll": {
+    "StampMorningEnrichUnresponsive": {
       "Type": "Pass",
-      "Comment": "Increment the MorningEnrich poll-iteration counter (L4552b). Mirrors IncrementSSMPoll.",
+      "Comment": "The trading box went unresponsive (SSM PingStatus≠Online for ≥3 consecutive polls) mid-MorningEnrich — the config#1807 wedged-box shape. Stamp the poller's detail into $.error, then force-stop the instance (the in-box executionTimeout cannot fire on a wedged box) and alert via HandleFailure.",
       "Parameters": {
-        "attempts.$": "States.MathAdd($.morning_enrich_poll_counter.attempts, 1)"
+        "Error": "MorningEnrichInstanceUnresponsive",
+        "Cause.$": "$.morning_enrich_poll.detail"
       },
-      "ResultPath": "$.morning_enrich_poll_counter",
-      "Next": "WaitForMorningEnrich"
+      "ResultPath": "$.error",
+      "Next": "ForceStopUnresponsiveInstance"
     },
 
     "MorningEnrichPollTimeout": {
@@ -338,25 +357,46 @@
         }
       ],
       "ResultPath": "$.chronic_gap_result",
+      "Next": "InitChronicGapPoll"
+    },
+
+    "InitChronicGapPoll": {
+      "Type": "Pass",
+      "Comment": "Seed the liveness-aware poll slot for the fail-soft ChronicGapSelfHeal loop (config#1811).",
+      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "ResultPath": "$.chronic_gap_poll",
       "Next": "WaitForChronicGap"
     },
 
     "WaitForChronicGap": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 30 × ~15s ≈ 7.5 min, past the 300s executionTimeout.",
+      "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
-        "CommandId.$": "$.chronic_gap_result.Command.CommandId",
-        "InstanceId.$": "$.trading_instance_id[0]"
+        "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
+        "Payload": {
+          "instance_id.$": "$.trading_instance_id[0]",
+          "command_id.$": "$.chronic_gap_result.Command.CommandId",
+          "attempts.$": "$.chronic_gap_poll.attempts",
+          "ping_misses.$": "$.chronic_gap_poll.ping_misses",
+          "max_attempts": 30,
+          "max_ping_misses": 3,
+          "step": "chronic-gap-heal"
+        }
       },
+      "TimeoutSeconds": 65,
       "Retry": [
         {
           "ErrorEquals": [
-            "Ssm.InvocationDoesNotExistException",
-            "Ssm.InvocationDoesNotExist"
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.Timeout"
           ],
-          "MaxAttempts": 10,
-          "IntervalSeconds": 10,
-          "BackoffRate": 1.5
+          "MaxAttempts": 3,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
         }
       ],
       "Catch": [
@@ -370,10 +410,15 @@
         }
       ],
       "ResultSelector": {
-        "Status.$": "$.Status",
-        "ResponseCode.$": "$.ResponseCode",
-        "StatusDetails.$": "$.StatusDetails",
-        "StandardErrorContent.$": "$.StandardErrorContent"
+        "verdict.$": "$.Payload.verdict",
+        "attempts.$": "$.Payload.attempts",
+        "ping_misses.$": "$.Payload.ping_misses",
+        "Status.$": "$.Payload.status",
+        "ResponseCode.$": "$.Payload.response_code",
+        "StatusDetails.$": "$.Payload.status_details",
+        "StandardErrorContent.$": "$.Payload.stderr_tail",
+        "ping_status.$": "$.Payload.ping_status",
+        "detail.$": "$.Payload.detail"
       },
       "ResultPath": "$.chronic_gap_poll",
       "Next": "CheckChronicGapStatus"
@@ -381,20 +426,31 @@
 
     "CheckChronicGapStatus": {
       "Type": "Choice",
-      "Comment": "Chronic-gap heal is fail-soft: any TERMINAL status (Success OR failure OR timeout) proceeds to PredictorInference; only keep polling while InProgress/Pending. This is the inverse of CheckMorningEnrichStatus (which HandleFailures on non-success) — MorningEnrich is load-bearing, this best-effort heal is not.",
+      "Comment": "Chronic-gap heal is fail-soft for HEAL failures: COMMAND_FAILED and POLL_BUDGET_EXHAUSTED (Default) proceed to PredictorInference — a broken/stuck best-effort heal must never block predictions. EXCEPTION (config#1811): INSTANCE_UNRESPONSIVE is NOT a heal failure, it is a host failure — the same wedged box the daemon must run on later. Proceeding fail-soft would just fail at RunMorningPlanner after burning PredictorInference; stamp + force-stop + HandleFailure instead.",
       "Choices": [
         {
-          "Variable": "$.chronic_gap_poll.Status",
-          "StringEquals": "InProgress",
+          "Variable": "$.chronic_gap_poll.verdict",
+          "StringEquals": "IN_PROGRESS",
           "Next": "ChronicGapWait"
         },
         {
-          "Variable": "$.chronic_gap_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "ChronicGapWait"
+          "Variable": "$.chronic_gap_poll.verdict",
+          "StringEquals": "INSTANCE_UNRESPONSIVE",
+          "Next": "StampChronicGapUnresponsive"
         }
       ],
       "Default": "CheckSkipPredictorInference"
+    },
+
+    "StampChronicGapUnresponsive": {
+      "Type": "Pass",
+      "Comment": "The trading box went unresponsive during the (otherwise fail-soft) chronic-gap heal — a host failure, not a heal failure. Stamp the poller's detail into $.error, force-stop, alert.",
+      "Parameters": {
+        "Error": "ChronicGapInstanceUnresponsive",
+        "Cause.$": "$.chronic_gap_poll.detail"
+      },
+      "ResultPath": "$.error",
+      "Next": "ForceStopUnresponsiveInstance"
     },
 
     "ChronicGapWait": {
@@ -491,7 +547,7 @@
 
     "SSMReadyChoice": {
       "Type": "Choice",
-      "Comment": "PingStatus=Online → CheckSkipMorningEnrich (the NYSE holiday gate already ran pre-boot via TradingDayGate, config#1430). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail when budget exhausted (per feedback_no_silent_fails — agent not registering after 3 min indicates a real boot problem, not just timing).",
+      "Comment": "PingStatus=Online → CodeFreshnessGate (config#1811; the NYSE holiday gate already ran pre-boot via TradingDayGate, config#1430). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail when budget exhausted (per feedback_no_silent_fails — agent not registering after 3 min indicates a real boot problem, not just timing).",
       "Choices": [
         {
           "And": [
@@ -504,7 +560,7 @@
               "StringEquals": "Online"
             }
           ],
-          "Next": "CheckSkipMorningEnrich"
+          "Next": "CodeFreshnessGate"
         },
         {
           "Variable": "$.ssm_poll.attempts",
@@ -528,6 +584,180 @@
       },
       "ResultPath": "$.ssm_poll",
       "Next": "DescribeInstanceInfo"
+    },
+
+    "CodeFreshnessGate": {
+      "Type": "Task",
+      "Comment": "config#1811 Part A — verify the three repo checkouts on ae-trading (alpha-engine, alpha-engine-data, alpha-engine-config) are on branch main at origin/main's SHA BEFORE any pipeline work runs, with one in-place self-heal (ownership reclaim + checkout -f main + reset --hard). Front-loads the check the executor's deploy-drift preflight only makes at RunMorningPlanner time — on 2026-07-06 a boot-pull failure (root-owned files in the checkout) left the box on a stray branch 4 commits stale, and the pipeline burned ~40 min of MorningEnrich/ArcticAppend/PredictorInference before that preflight refused. The executor-repo AST syntax gate mirrors boot-pull's deploy gate but FAILS the pipeline instead of rolling back: at pipeline time, neither stale nor broken code may proceed (fail-loud). Runs as root via SSM (bare chown), git as ec2-user. The executor's in-process check_deploy_drift stays as defense-in-depth.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.trading_instance_id",
+        "Parameters": {
+          "commands": [
+            "set -eo pipefail",
+            "export FLOW_DOCTOR_ENABLED=1",
+            "export ALPHA_ENGINE_DEPLOYED=1",
+            "REPOS='alpha-engine alpha-engine-data alpha-engine-config'",
+            "for r in $REPOS; do sudo -u ec2-user git -C /home/ec2-user/$r fetch --quiet origin main; done",
+            "drift=0",
+            "for r in $REPOS; do d=/home/ec2-user/$r; br=$(sudo -u ec2-user git -C $d rev-parse --abbrev-ref HEAD); h=$(sudo -u ec2-user git -C $d rev-parse HEAD); u=$(sudo -u ec2-user git -C $d rev-parse origin/main); if [ \"$br\" != \"main\" ] || [ \"$h\" != \"$u\" ]; then echo \"DRIFT $r branch=$br head=$h upstream=$u\"; drift=1; fi; done",
+            "if [ $drift -eq 1 ]; then echo 'SELF-HEAL: ownership reclaim + reset to origin/main'; for r in $REPOS; do d=/home/ec2-user/$r; chown -R ec2-user:ec2-user $d; sudo -u ec2-user git -C $d checkout -f main; sudo -u ec2-user git -C $d reset --hard origin/main; done; fi",
+            "for r in $REPOS; do d=/home/ec2-user/$r; br=$(sudo -u ec2-user git -C $d rev-parse --abbrev-ref HEAD); h=$(sudo -u ec2-user git -C $d rev-parse HEAD); u=$(sudo -u ec2-user git -C $d rev-parse origin/main); if [ \"$br\" != \"main\" ] || [ \"$h\" != \"$u\" ]; then echo \"CODE-STALE-AFTER-HEAL $r branch=$br head=$h upstream=$u\"; exit 1; fi; done",
+            "cd /home/ec2-user/alpha-engine && sudo -u ec2-user .venv/bin/python -c \"import ast; [ast.parse(open(f).read()) for f in ('executor/main.py','executor/daemon.py','executor/eod_reconcile.py')]\"",
+            "echo CODE_FRESH"
+          ],
+          "executionTimeout": ["300"]
+        },
+        "TimeoutSeconds": 300
+      },
+      "TimeoutSeconds": 360,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.code_freshness_result",
+      "Next": "InitCodeFreshnessPoll"
+    },
+
+    "InitCodeFreshnessPoll": {
+      "Type": "Pass",
+      "Comment": "Seed the liveness-aware poll slot for the CodeFreshnessGate loop (config#1811).",
+      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "ResultPath": "$.code_freshness_poll",
+      "Next": "WaitForCodeFreshness"
+    },
+
+    "WaitForCodeFreshness": {
+      "Type": "Task",
+      "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 36 × ~10s ≈ 6 min, past the 300s executionTimeout.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
+        "Payload": {
+          "instance_id.$": "$.trading_instance_id[0]",
+          "command_id.$": "$.code_freshness_result.Command.CommandId",
+          "attempts.$": "$.code_freshness_poll.attempts",
+          "ping_misses.$": "$.code_freshness_poll.ping_misses",
+          "max_attempts": 36,
+          "max_ping_misses": 3,
+          "step": "code-freshness-gate"
+        }
+      },
+      "TimeoutSeconds": 65,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 3,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultSelector": {
+        "verdict.$": "$.Payload.verdict",
+        "attempts.$": "$.Payload.attempts",
+        "ping_misses.$": "$.Payload.ping_misses",
+        "Status.$": "$.Payload.status",
+        "ResponseCode.$": "$.Payload.response_code",
+        "StatusDetails.$": "$.Payload.status_details",
+        "StandardErrorContent.$": "$.Payload.stderr_tail",
+        "ping_status.$": "$.Payload.ping_status",
+        "detail.$": "$.Payload.detail"
+      },
+      "ResultPath": "$.code_freshness_poll",
+      "Next": "CheckCodeFreshnessStatus"
+    },
+
+    "CheckCodeFreshnessStatus": {
+      "Type": "Choice",
+      "Comment": "SUCCESS → the box is verified on current main across all 3 repos → CheckSkipMorningEnrich (the pipeline proper). COMMAND_FAILED (Default) → HandleFailure — code stale after self-heal, or broken syntax on main; either way NOTHING may run (~2 min into the pipeline, not 40). INSTANCE_UNRESPONSIVE → stamp → force-stop → HandleFailure. POLL_BUDGET_EXHAUSTED → CodeFreshnessPollTimeout.",
+      "Choices": [
+        {
+          "Variable": "$.code_freshness_poll.verdict",
+          "StringEquals": "SUCCESS",
+          "Next": "CheckSkipMorningEnrich"
+        },
+        {
+          "Variable": "$.code_freshness_poll.verdict",
+          "StringEquals": "IN_PROGRESS",
+          "Next": "CodeFreshnessWait"
+        },
+        {
+          "Variable": "$.code_freshness_poll.verdict",
+          "StringEquals": "INSTANCE_UNRESPONSIVE",
+          "Next": "StampCodeFreshnessUnresponsive"
+        },
+        {
+          "Variable": "$.code_freshness_poll.verdict",
+          "StringEquals": "POLL_BUDGET_EXHAUSTED",
+          "Next": "CodeFreshnessPollTimeout"
+        }
+      ],
+      "Default": "HandleFailure"
+    },
+
+    "CodeFreshnessWait": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "Next": "WaitForCodeFreshness"
+    },
+
+    "StampCodeFreshnessUnresponsive": {
+      "Type": "Pass",
+      "Comment": "The trading box went unresponsive during the code-freshness gate (right after reporting PingStatus=Online — a fast wedge). Stamp, force-stop, alert.",
+      "Parameters": {
+        "Error": "CodeFreshnessInstanceUnresponsive",
+        "Cause.$": "$.code_freshness_poll.detail"
+      },
+      "ResultPath": "$.error",
+      "Next": "ForceStopUnresponsiveInstance"
+    },
+
+    "CodeFreshnessPollTimeout": {
+      "Type": "Pass",
+      "Comment": "Bounded poll budget exhausted on the CodeFreshnessGate loop with the box still responsive (#970 shape). Stamp + alert via HandleFailure.",
+      "Result": {
+        "Error": "CodeFreshnessPollTimeout",
+        "Cause": "CodeFreshnessGate SSM command did not reach a terminal status within the bounded poll budget (~36 iterations / ~6 min, past the 300s executionTimeout) while the SSM agent stayed Online."
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+
+    "ForceStopUnresponsiveInstance": {
+      "Type": "Task",
+      "Comment": "config#1811 — deterministic remediation for INSTANCE_UNRESPONSIVE: the box is wedged (the 2026-07-06 config#1807 shape: memory-pressure stall, SSM agent dark, in-box executionTimeout unable to fire) and every remaining pipeline step needs this same host, so force-stop it NOW rather than leave it thrashing with IB Gateway credentials on it. Validated as the actual recovery action in the 2026-07-06 incident. $.error was stamped by the per-loop Stamp state before arriving here; this state's own result/error use separate ResultPaths so the stamped cause survives into HandleFailure's SNS alert. A stop failure still routes to HandleFailure — alerting is the priority, the stop is best-effort remediation.",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:stopInstances",
+      "Parameters": {
+        "InstanceIds.$": "$.trading_instance_id",
+        "Force": true
+      },
+      "TimeoutSeconds": 30,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "HandleFailure",
+          "ResultPath": "$.force_stop_error"
+        }
+      ],
+      "ResultPath": "$.force_stop_result",
+      "Next": "HandleFailure"
     },
 
     "PredictorInference": {
@@ -748,25 +978,46 @@
         }
       ],
       "ResultPath": "$.planner_result",
+      "Next": "InitMorningPlannerPoll"
+    },
+
+    "InitMorningPlannerPoll": {
+      "Type": "Pass",
+      "Comment": "Seed the liveness-aware poll slot for the RunMorningPlanner loop (config#1811).",
+      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "ResultPath": "$.planner_poll",
       "Next": "WaitForMorningPlanner"
     },
 
     "WaitForMorningPlanner": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 30 × ~15s ≈ 7.5 min, past the 300s executionTimeout.",
+      "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
-        "CommandId.$": "$.planner_result.Command.CommandId",
-        "InstanceId.$": "$.trading_instance_id[0]"
+        "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
+        "Payload": {
+          "instance_id.$": "$.trading_instance_id[0]",
+          "command_id.$": "$.planner_result.Command.CommandId",
+          "attempts.$": "$.planner_poll.attempts",
+          "ping_misses.$": "$.planner_poll.ping_misses",
+          "max_attempts": 30,
+          "max_ping_misses": 3,
+          "step": "morning-planner"
+        }
       },
+      "TimeoutSeconds": 65,
       "Retry": [
         {
           "ErrorEquals": [
-            "Ssm.InvocationDoesNotExistException",
-            "Ssm.InvocationDoesNotExist"
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.Timeout"
           ],
-          "MaxAttempts": 10,
-          "IntervalSeconds": 10,
-          "BackoffRate": 1.5
+          "MaxAttempts": 3,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
         }
       ],
       "Catch": [
@@ -777,10 +1028,15 @@
         }
       ],
       "ResultSelector": {
-        "Status.$": "$.Status",
-        "ResponseCode.$": "$.ResponseCode",
-        "StatusDetails.$": "$.StatusDetails",
-        "StandardErrorContent.$": "$.StandardErrorContent"
+        "verdict.$": "$.Payload.verdict",
+        "attempts.$": "$.Payload.attempts",
+        "ping_misses.$": "$.Payload.ping_misses",
+        "Status.$": "$.Payload.status",
+        "ResponseCode.$": "$.Payload.response_code",
+        "StatusDetails.$": "$.Payload.status_details",
+        "StandardErrorContent.$": "$.Payload.stderr_tail",
+        "ping_status.$": "$.Payload.ping_status",
+        "detail.$": "$.Payload.detail"
       },
       "ResultPath": "$.planner_poll",
       "Next": "CheckMorningPlannerStatus"
@@ -788,24 +1044,52 @@
 
     "CheckMorningPlannerStatus": {
       "Type": "Choice",
+      "Comment": "Branches on the ssm-liveness-poller verdict (config#1811). COMMAND_FAILED (Default) → HandleFailure — the 2026-07-06 deploy-drift refusal surfaced here with rc=1. INSTANCE_UNRESPONSIVE → stamp → force-stop → HandleFailure. POLL_BUDGET_EXHAUSTED → MorningPlannerPollTimeout.",
       "Choices": [
         {
-          "Variable": "$.planner_poll.Status",
-          "StringEquals": "Success",
+          "Variable": "$.planner_poll.verdict",
+          "StringEquals": "SUCCESS",
           "Next": "CheckSkipRunDaemon"
         },
         {
-          "Variable": "$.planner_poll.Status",
-          "StringEquals": "InProgress",
+          "Variable": "$.planner_poll.verdict",
+          "StringEquals": "IN_PROGRESS",
           "Next": "MorningPlannerWait"
         },
         {
-          "Variable": "$.planner_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "MorningPlannerWait"
+          "Variable": "$.planner_poll.verdict",
+          "StringEquals": "INSTANCE_UNRESPONSIVE",
+          "Next": "StampMorningPlannerUnresponsive"
+        },
+        {
+          "Variable": "$.planner_poll.verdict",
+          "StringEquals": "POLL_BUDGET_EXHAUSTED",
+          "Next": "MorningPlannerPollTimeout"
         }
       ],
       "Default": "HandleFailure"
+    },
+
+    "StampMorningPlannerUnresponsive": {
+      "Type": "Pass",
+      "Comment": "The trading box went unresponsive mid-planner. Stamp the poller's detail into $.error, force-stop, alert.",
+      "Parameters": {
+        "Error": "MorningPlannerInstanceUnresponsive",
+        "Cause.$": "$.planner_poll.detail"
+      },
+      "ResultPath": "$.error",
+      "Next": "ForceStopUnresponsiveInstance"
+    },
+
+    "MorningPlannerPollTimeout": {
+      "Type": "Pass",
+      "Comment": "Bounded poll budget exhausted on the RunMorningPlanner loop with the box still responsive (#970 shape). Stamp + alert via HandleFailure.",
+      "Result": {
+        "Error": "MorningPlannerPollTimeout",
+        "Cause": "RunMorningPlanner SSM command did not reach a terminal status within the bounded poll budget (~30 iterations / ~7.5 min, past the 300s executionTimeout) while the SSM agent stayed Online. See /var/log/executor.log on ae-trading."
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
     },
 
     "MorningPlannerWait": {
@@ -910,25 +1194,46 @@
         }
       ],
       "ResultPath": "$.arctic_append_result",
+      "Next": "InitMorningArcticAppendPoll"
+    },
+
+    "InitMorningArcticAppendPoll": {
+      "Type": "Pass",
+      "Comment": "Seed the liveness-aware poll slot for the MorningArcticAppend loop (config#1811). This loop previously had NO bounded-attempt cap (the #970 fix only ever landed on MorningEnrich — copy-drift) and no liveness check: on 2026-07-06 (config#1807) it polled a frozen InProgress for 62 minutes while the box was wedged.",
+      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "ResultPath": "$.arctic_append_poll",
       "Next": "WaitForMorningArcticAppend"
     },
 
     "WaitForMorningArcticAppend": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 150 × ~20s ≈ 50 min, just past the 2400s executionTimeout.",
+      "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
-        "CommandId.$": "$.arctic_append_result.Command.CommandId",
-        "InstanceId.$": "$.trading_instance_id[0]"
+        "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
+        "Payload": {
+          "instance_id.$": "$.trading_instance_id[0]",
+          "command_id.$": "$.arctic_append_result.Command.CommandId",
+          "attempts.$": "$.arctic_append_poll.attempts",
+          "ping_misses.$": "$.arctic_append_poll.ping_misses",
+          "max_attempts": 150,
+          "max_ping_misses": 3,
+          "step": "morning-arctic-append"
+        }
       },
+      "TimeoutSeconds": 65,
       "Retry": [
         {
           "ErrorEquals": [
-            "Ssm.InvocationDoesNotExistException",
-            "Ssm.InvocationDoesNotExist"
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.Timeout"
           ],
-          "MaxAttempts": 10,
-          "IntervalSeconds": 10,
-          "BackoffRate": 1.5
+          "MaxAttempts": 3,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
         }
       ],
       "Catch": [
@@ -939,10 +1244,15 @@
         }
       ],
       "ResultSelector": {
-        "Status.$": "$.Status",
-        "ResponseCode.$": "$.ResponseCode",
-        "StatusDetails.$": "$.StatusDetails",
-        "StandardErrorContent.$": "$.StandardErrorContent"
+        "verdict.$": "$.Payload.verdict",
+        "attempts.$": "$.Payload.attempts",
+        "ping_misses.$": "$.Payload.ping_misses",
+        "Status.$": "$.Payload.status",
+        "ResponseCode.$": "$.Payload.response_code",
+        "StatusDetails.$": "$.Payload.status_details",
+        "StandardErrorContent.$": "$.Payload.stderr_tail",
+        "ping_status.$": "$.Payload.ping_status",
+        "detail.$": "$.Payload.detail"
       },
       "ResultPath": "$.arctic_append_poll",
       "Next": "CheckMorningArcticAppendStatus"
@@ -950,22 +1260,27 @@
 
     "CheckMorningArcticAppendStatus": {
       "Type": "Choice",
-      "Comment": "LOAD-BEARING like CheckMorningEnrichStatus: only Success proceeds (to the chronic-gap heal gate, then PredictorInference); any other terminal SSM status → HandleFailure (predictor must not run on a stale ArcticDB universe). Only InProgress/Pending keep polling.",
+      "Comment": "LOAD-BEARING like CheckMorningEnrichStatus: only SUCCESS proceeds (to the chronic-gap heal gate, then PredictorInference); COMMAND_FAILED (Default) → HandleFailure (predictor must not run on a stale ArcticDB universe). INSTANCE_UNRESPONSIVE (the config#1807 wedged-box shape — THIS loop's 2026-07-06 incident) → stamp error → force-stop → HandleFailure. POLL_BUDGET_EXHAUSTED → MorningArcticAppendPollTimeout.",
       "Choices": [
         {
-          "Variable": "$.arctic_append_poll.Status",
-          "StringEquals": "Success",
+          "Variable": "$.arctic_append_poll.verdict",
+          "StringEquals": "SUCCESS",
           "Next": "CheckSkipChronicGapHeal"
         },
         {
-          "Variable": "$.arctic_append_poll.Status",
-          "StringEquals": "InProgress",
+          "Variable": "$.arctic_append_poll.verdict",
+          "StringEquals": "IN_PROGRESS",
           "Next": "MorningArcticAppendWait"
         },
         {
-          "Variable": "$.arctic_append_poll.Status",
-          "StringEquals": "Pending",
-          "Next": "MorningArcticAppendWait"
+          "Variable": "$.arctic_append_poll.verdict",
+          "StringEquals": "INSTANCE_UNRESPONSIVE",
+          "Next": "StampMorningArcticAppendUnresponsive"
+        },
+        {
+          "Variable": "$.arctic_append_poll.verdict",
+          "StringEquals": "POLL_BUDGET_EXHAUSTED",
+          "Next": "MorningArcticAppendPollTimeout"
         }
       ],
       "Default": "HandleFailure"
@@ -975,6 +1290,28 @@
       "Type": "Wait",
       "Seconds": 20,
       "Next": "WaitForMorningArcticAppend"
+    },
+
+    "StampMorningArcticAppendUnresponsive": {
+      "Type": "Pass",
+      "Comment": "The trading box went unresponsive mid-ArcticDB-append — the exact 2026-07-06 config#1807 incident shape (memory-pressure wedge; SSM agent ConnectionLost; in-box executionTimeout unable to fire). Stamp the poller's detail into $.error, then force-stop the instance and alert via HandleFailure. Detection budget: ~3 polls ≈ 1 min (was: 62 min of blind polling).",
+      "Parameters": {
+        "Error": "MorningArcticAppendInstanceUnresponsive",
+        "Cause.$": "$.arctic_append_poll.detail"
+      },
+      "ResultPath": "$.error",
+      "Next": "ForceStopUnresponsiveInstance"
+    },
+
+    "MorningArcticAppendPollTimeout": {
+      "Type": "Pass",
+      "Comment": "Bounded poll budget exhausted on the MorningArcticAppend loop with the box still responsive (the #970 stuck-InProgress shape — distinct from INSTANCE_UNRESPONSIVE). Stamp a clear cause into $.error then route through HandleFailure so the SNS alert carries it. Operator action: inspect /var/log/morning-arctic-append.log on ae-trading + the SSM command invocation.",
+      "Result": {
+        "Error": "MorningArcticAppendPollTimeout",
+        "Cause": "MorningArcticAppend SSM command did not reach a terminal status within the bounded poll budget (~150 iterations / ~50 min, past the 2400s executionTimeout) while the SSM agent stayed Online. Stuck-InProgress, not slow. See /var/log/morning-arctic-append.log on ae-trading."
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
     },
 
     "CheckSkipChronicGapHeal": {

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -70,7 +70,7 @@ class TestChainOrdering:
         success = [
             c["Next"]
             for c in states["CheckMorningEnrichStatus"]["Choices"]
-            if c.get("StringEquals") == "Success"
+            if c.get("StringEquals") == "SUCCESS"
         ]
         assert success == ["CheckSkipMorningArcticAppend"], (
             "MorningEnrich success must hand off to the arctic-append gate"
@@ -79,25 +79,44 @@ class TestChainOrdering:
         append_success = [
             c["Next"]
             for c in states["CheckMorningArcticAppendStatus"]["Choices"]
-            if c.get("StringEquals") == "Success"
+            if c.get("StringEquals") == "SUCCESS"
         ]
         assert append_success == ["CheckSkipChronicGapHeal"]
         assert states["CheckSkipChronicGapHeal"]["Default"] == _HEAL
 
     def test_heal_routes_to_poll(self, states):
-        assert states[_HEAL]["Next"] == _POLL
+        # config#1811: an Init pass seeds the liveness-poll counters first.
+        assert states[_HEAL]["Next"] == "InitChronicGapPoll"
+        assert states["InitChronicGapPoll"]["Next"] == _POLL
 
     def test_poll_routes_to_status_check(self, states):
         assert states[_POLL]["Next"] == _CHECK
 
     def test_status_inprogress_and_pending_loop_via_wait(self, states):
+        # config#1811: the poller folds Pending/Delayed/registering into a
+        # single IN_PROGRESS verdict; only that verdict keeps polling.
         nexts = {
             c["StringEquals"]: c["Next"]
             for c in states[_CHECK]["Choices"]
         }
-        assert nexts["InProgress"] == _WAIT
-        assert nexts["Pending"] == _WAIT
+        assert nexts["IN_PROGRESS"] == _WAIT
         assert states[_WAIT]["Next"] == _POLL
+
+    def test_unresponsive_host_is_not_fail_soft(self, states):
+        """config#1811 carve-out: INSTANCE_UNRESPONSIVE is a HOST failure,
+        not a heal failure — the same wedged box every later step (planner,
+        daemon) needs. Proceeding fail-soft would just fail at
+        RunMorningPlanner after burning PredictorInference. It must route
+        to the stamp → force-stop → HandleFailure chain instead."""
+        nexts = {
+            c["StringEquals"]: c["Next"]
+            for c in states[_CHECK]["Choices"]
+        }
+        assert nexts["INSTANCE_UNRESPONSIVE"] == "StampChronicGapUnresponsive"
+        assert (
+            states["StampChronicGapUnresponsive"]["Next"]
+            == "ForceStopUnresponsiveInstance"
+        )
 
     def test_heal_precedes_predictor_inference(self, sf, states):
         """Walk the happy path from MorningEnrich success and assert

--- a/tests/test_sf_invocationdoesnotexist_retry.py
+++ b/tests/test_sf_invocationdoesnotexist_retry.py
@@ -71,7 +71,23 @@ def test_every_get_command_invocation_retries_both_error_forms(sf_path):
     with open(repo_root / sf_path) as fh:
         definition = json.load(fh)
     targets = _find_get_command_invocation_states(definition)
-    assert targets, f"No getCommandInvocation Tasks found in {sf_path}"
+    if not targets:
+        # config#1811: the weekday SF's poll loops migrated to the
+        # liveness-aware ssm-liveness-poller Lambda, which handles the
+        # InvocationDoesNotExist registration race INTERNALLY (reported
+        # as a Registering/IN_PROGRESS verdict, bounded by the attempt
+        # budget) — legitimately zero bare getCommandInvocation Tasks
+        # remain in that file. The invariant pinned here only applies
+        # where the bare aws-sdk poll form is still in use (Saturday +
+        # EOD). Require the poller to actually be present so a future
+        # removal of BOTH forms still fails loud.
+        content = json.dumps(definition)
+        assert "alpha-engine-ssm-liveness-poller" in content, (
+            f"{sf_path}: no getCommandInvocation Tasks AND no "
+            f"ssm-liveness-poller invocations — SSM polling vanished "
+            f"entirely?"
+        )
+        return
 
     missing_both: list[str] = []
     missing_bare: list[str] = []

--- a/tests/test_sf_liveness_watchdog_wiring.py
+++ b/tests/test_sf_liveness_watchdog_wiring.py
@@ -1,0 +1,174 @@
+"""Pins the config#1811 liveness-watchdog wiring in the WEEKDAY SF.
+
+Origin: 2026-07-06 (config#1807) — the trading box wedged under memory
+pressure mid-MorningArcticAppend. The SSM agent went ConnectionLost, so
+the command's own executionTimeout (enforced by that agent, INSIDE the
+box) could not fire; the SF poll loop read a frozen InProgress for 62
+minutes (22 past the timeout) until the agent self-recovered. Meanwhile
+RunDaemon — the sole intraday order executor — sat blocked with the
+market open. A watchdog that dies with its watchee is not a watchdog.
+
+The fix: every SSM poll loop in the weekday SF goes through the
+ssm-liveness-poller Lambda (command status + independent PingStatus +
+bounded budgets, evaluated OUTSIDE the box), and INSTANCE_UNRESPONSIVE
+routes deterministically to stamp → ForceStopUnresponsiveInstance →
+HandleFailure. Detection budget: ~3 polls (~1 min), not 62.
+
+This test catches regressions like:
+- A new SSM step added with a bare getCommandInvocation poll instead of
+  the liveness poller (re-introducing the copy-drift that left
+  MorningArcticAppend uncapped after #970 only patched MorningEnrich).
+- An INSTANCE_UNRESPONSIVE branch dropped or rerouted around the
+  force-stop.
+- A poll loop whose Init state stops seeding both counters, or whose
+  invoke stops round-tripping them (the Lambda is stateless — the SF
+  state IS the counter storage).
+- The CodeFreshnessGate unhooked from the SSM-ready path (re-opening
+  the 40-minutes-to-discover-stale-code gap).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
+
+_POLLER_ARN_FRAGMENT = "alpha-engine-ssm-liveness-poller"
+
+# loop name -> (init, poll, check, wait, poll slot, stamp)
+_LOOPS = {
+    "code-freshness-gate": (
+        "InitCodeFreshnessPoll", "WaitForCodeFreshness",
+        "CheckCodeFreshnessStatus", "CodeFreshnessWait",
+        "$.code_freshness_poll", "StampCodeFreshnessUnresponsive",
+    ),
+    "morning-enrich": (
+        "InitMorningEnrichPoll", "WaitForMorningEnrich",
+        "CheckMorningEnrichStatus", "MorningEnrichWait",
+        "$.morning_enrich_poll", "StampMorningEnrichUnresponsive",
+    ),
+    "morning-arctic-append": (
+        "InitMorningArcticAppendPoll", "WaitForMorningArcticAppend",
+        "CheckMorningArcticAppendStatus", "MorningArcticAppendWait",
+        "$.arctic_append_poll", "StampMorningArcticAppendUnresponsive",
+    ),
+    "chronic-gap-heal": (
+        "InitChronicGapPoll", "WaitForChronicGap",
+        "CheckChronicGapStatus", "ChronicGapWait",
+        "$.chronic_gap_poll", "StampChronicGapUnresponsive",
+    ),
+    "morning-planner": (
+        "InitMorningPlannerPoll", "WaitForMorningPlanner",
+        "CheckMorningPlannerStatus", "MorningPlannerWait",
+        "$.planner_poll", "StampMorningPlannerUnresponsive",
+    ),
+}
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+def test_no_bare_get_command_invocation_polls_remain(states):
+    """Every weekday SSM poll must go through the liveness poller — a bare
+    getCommandInvocation poll has no independent liveness signal and no
+    shared budget contract (the exact copy-drift class that left
+    MorningArcticAppend uncapped)."""
+    bare = [
+        n for n, st in states.items()
+        if "getCommandInvocation" in str(st.get("Resource", ""))
+    ]
+    assert not bare, (
+        f"bare getCommandInvocation polls in weekday SF: {bare} — use the "
+        f"ssm-liveness-poller (config#1811)"
+    )
+
+
+@pytest.mark.parametrize("step", sorted(_LOOPS))
+def test_loop_wiring(states, step):
+    init, poll, check, wait, slot, stamp = _LOOPS[step]
+
+    # Init seeds BOTH counters into the poll slot the invoke reads.
+    st_init = states[init]
+    assert st_init["ResultPath"] == slot
+    assert st_init["Result"]["attempts"] == 0
+    assert st_init["Result"]["ping_misses"] == 0
+    assert st_init["Next"] == poll
+
+    # The poll invokes the liveness poller and round-trips the counters.
+    st_poll = states[poll]
+    assert st_poll["Resource"] == "arn:aws:states:::lambda:invoke"
+    fn = st_poll["Parameters"]["FunctionName"]
+    assert _POLLER_ARN_FRAGMENT in fn
+    payload = st_poll["Parameters"]["Payload"]
+    assert payload["attempts.$"] == f"{slot}.attempts"
+    assert payload["ping_misses.$"] == f"{slot}.ping_misses"
+    assert payload["step"] == step
+    assert payload["max_ping_misses"] == 3
+    assert st_poll["ResultPath"] == slot
+    assert st_poll["Next"] == check
+
+    # Choice: IN_PROGRESS loops via Wait; INSTANCE_UNRESPONSIVE stamps.
+    nexts = {
+        c["StringEquals"]: c["Next"]
+        for c in states[check]["Choices"]
+        if "StringEquals" in c
+    }
+    assert nexts["IN_PROGRESS"] == wait
+    assert states[wait]["Next"] == poll
+    assert nexts["INSTANCE_UNRESPONSIVE"] == stamp
+
+    # Stamp carries the poller's detail into $.error, then force-stops.
+    st_stamp = states[stamp]
+    assert st_stamp["ResultPath"] == "$.error"
+    assert st_stamp["Parameters"]["Cause.$"] == f"{slot}.detail"
+    assert st_stamp["Next"] == "ForceStopUnresponsiveInstance"
+
+
+def test_force_stop_is_forceful_and_alerts(states):
+    st = states["ForceStopUnresponsiveInstance"]
+    assert st["Resource"] == "arn:aws:states:::aws-sdk:ec2:stopInstances"
+    assert st["Parameters"]["Force"] is True
+    assert st["Parameters"]["InstanceIds.$"] == "$.trading_instance_id"
+    # Alert either way: success AND stop-failure both end at HandleFailure,
+    # and neither may clobber the $.error stamped by the Stamp state.
+    assert st["Next"] == "HandleFailure"
+    assert st["Catch"][0]["Next"] == "HandleFailure"
+    assert st["ResultPath"] != "$.error"
+    assert st["Catch"][0]["ResultPath"] != "$.error"
+
+
+def test_code_freshness_gate_front_loads_the_drift_check(states):
+    """The gate must sit between SSM-ready and the first morning work gate,
+    verify all three repos, self-heal once, and fail loud — closing the
+    2026-07-06 gap where stale code was only discovered ~40 min in at
+    RunMorningPlanner."""
+    online = [
+        c["Next"] for c in states["SSMReadyChoice"]["Choices"] if "And" in c
+    ]
+    assert online == ["CodeFreshnessGate"]
+
+    cmds = "\n".join(
+        states["CodeFreshnessGate"]["Parameters"]["Parameters"]["commands"]
+    )
+    for repo in ("alpha-engine", "alpha-engine-data", "alpha-engine-config"):
+        assert repo in cmds
+    assert "rev-parse origin/main" in cmds, "must compare against origin/main"
+    assert "chown -R ec2-user:ec2-user" in cmds, "self-heal must reclaim ownership"
+    assert "reset --hard origin/main" in cmds, "self-heal must reset to main"
+    assert "CODE-STALE-AFTER-HEAL" in cmds and "exit 1" in cmds, (
+        "persistent drift after the one self-heal must exit non-zero (fail loud)"
+    )
+    assert "ast.parse" in cmds, "executor syntax gate must run (broken main may not proceed)"
+
+    fresh = [
+        c["Next"] for c in states["CheckCodeFreshnessStatus"]["Choices"]
+        if c.get("StringEquals") == "SUCCESS"
+    ]
+    assert fresh == ["CheckSkipMorningEnrich"]
+    assert states["CheckCodeFreshnessStatus"]["Default"] == "HandleFailure"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -116,7 +116,21 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     "Director": frozenset({"date.$", "dry_run.$"}),
 }
 
-# Weekday SF — alpha-engine-predictor Lambdas
+# config#1811: the liveness-aware SSM poll iteration — one shared payload
+# contract across all five weekday poll loops (the point of the
+# consolidation; a divergent key-set here means a loop drifted from the
+# shared ssm-liveness-poller contract).
+_LIVENESS_POLLER_KEYS = frozenset({
+    "instance_id.$",
+    "command_id.$",
+    "attempts.$",
+    "ping_misses.$",
+    "max_attempts",
+    "max_ping_misses",
+    "step",
+})
+
+# Weekday SF — alpha-engine-predictor Lambdas + the ssm-liveness-poller
 _WEEKDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     "DeployDriftCheck": frozenset({"action"}),
     # config#1430: NYSE trading-day gate, moved OFF the box into the
@@ -128,6 +142,11 @@ _WEEKDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     "ReinvokePredictor": frozenset({"action", "tickers.$"}),
     "RecheckCoverage": frozenset({"action"}),
     "PredictorHealthCheck": frozenset({"action"}),
+    "WaitForCodeFreshness": _LIVENESS_POLLER_KEYS,
+    "WaitForMorningEnrich": _LIVENESS_POLLER_KEYS,
+    "WaitForMorningArcticAppend": _LIVENESS_POLLER_KEYS,
+    "WaitForChronicGap": _LIVENESS_POLLER_KEYS,
+    "WaitForMorningPlanner": _LIVENESS_POLLER_KEYS,
 }
 
 

--- a/tests/test_sf_poll_resultselector.py
+++ b/tests/test_sf_poll_resultselector.py
@@ -58,15 +58,34 @@ def _walk_states(states: dict):
                 yield from _walk_states(b["States"])
 
 
+def _is_liveness_poller(st: dict) -> bool:
+    """config#1811: the weekday SF's poll loops migrated from bare
+    aws-sdk getCommandInvocation to the ssm-liveness-poller Lambda. The
+    256 KB invariant applies identically — the poller's result rides in
+    SF state through the same Wait/Choice loops and HandleFailure still
+    serializes all of $ — so those states are held to the same
+    ResultSelector rules. (The Lambda caps stderr_tail at 1500 chars and
+    never returns stdout, but the ResultSelector remains the SF-side
+    guard.)"""
+    if "lambda:invoke" not in str(st.get("Resource", "")).lower():
+        return False
+    return "alpha-engine-ssm-liveness-poller" in json.dumps(
+        st.get("Parameters", {})
+    )
+
+
 def _poll_states():
-    """Yield (sf, name, state, sf_text) for every SSM getCommandInvocation poll
+    """Yield (sf, name, state, sf_text) for every SSM command poll —
+    bare getCommandInvocation Tasks AND ssm-liveness-poller invocations —
     across all three SFs."""
     out = []
     for sf, path in _SF_FILES.items():
         text = path.read_text()
         sf_def = json.loads(text)
         for name, st in _walk_states(sf_def.get("States", {})):
-            if "aws-sdk:ssm:getCommandInvocation" in str(st.get("Resource", "")):
+            if "aws-sdk:ssm:getCommandInvocation" in str(
+                st.get("Resource", "")
+            ) or _is_liveness_poller(st):
                 out.append((sf, name, st, text))
     return out
 
@@ -80,7 +99,10 @@ def _fields_read_downstream(result_path: str, sf_text: str) -> set:
     if not result_path:
         return set()
     esc = re.escape(result_path)
-    return set(re.findall(rf"{esc}\.([A-Za-z][A-Za-z0-9]*)", sf_text))
+    # Field charset includes underscore: the config#1811 liveness-poller
+    # fields are snake_case (ping_misses, attempts, verdict, detail) — the
+    # pre-1811 charset silently truncated ping_misses to "ping".
+    return set(re.findall(rf"{esc}\.([A-Za-z][A-Za-z0-9_]*)", sf_text))
 
 
 def _rs_keeps(rs: dict) -> set:

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -88,14 +88,21 @@ class TestEntryEdgesRouteThroughGates:
             if c.get("BooleanEquals") is False
         ]
         assert false_branch == ["NotifyHolidaySkip"]
-        # Once the box is up, the SSM-ready success branch enters the first morning
-        # work gate (CheckSkipMorningEnrich) — it no longer runs an on-box check.
+        # Once the box is up, the SSM-ready success branch enters the
+        # CodeFreshnessGate (config#1811: verify all 3 repo checkouts are on
+        # current main BEFORE any pipeline work — the 2026-07-06 incident
+        # burned ~40 min before the planner-time deploy-drift preflight
+        # refused), whose SUCCESS verdict then enters the first morning work
+        # gate (CheckSkipMorningEnrich).
         online = [
             c["Next"]
             for c in states["SSMReadyChoice"]["Choices"]
             if "And" in c
         ]
-        assert online == ["CheckSkipMorningEnrich"]
+        assert online == ["CodeFreshnessGate"]
+        fresh = [c["Next"] for c in states["CheckCodeFreshnessStatus"]["Choices"]
+                 if c.get("StringEquals") == "SUCCESS"]
+        assert fresh == ["CheckSkipMorningEnrich"]
 
     def test_trading_day_gate_failed_proceeds_as_trading_day(self, states):
         assert states["TradingDayGateFailed"]["Next"] == "StartExecutorEC2"
@@ -104,12 +111,12 @@ class TestEntryEdgesRouteThroughGates:
         # L4608: the slow daily_append is now its own load-bearing state behind
         # CheckSkipMorningArcticAppend, after the fast MorningEnrich fetch.
         success = [c["Next"] for c in states["CheckMorningEnrichStatus"]["Choices"]
-                   if c.get("StringEquals") == "Success"]
+                   if c.get("StringEquals") == "SUCCESS"]
         assert success == ["CheckSkipMorningArcticAppend"]
 
     def test_arctic_append_success_enters_heal_gate(self, states):
         success = [c["Next"] for c in states["CheckMorningArcticAppendStatus"]["Choices"]
-                   if c.get("StringEquals") == "Success"]
+                   if c.get("StringEquals") == "SUCCESS"]
         assert success == ["CheckSkipChronicGapHeal"]
 
     def test_arctic_append_is_load_bearing(self, states):
@@ -138,7 +145,7 @@ class TestEntryEdgesRouteThroughGates:
 
     def test_planner_success_enters_daemon_gate(self, states):
         success = [c["Next"] for c in states["CheckMorningPlannerStatus"]["Choices"]
-                   if c.get("StringEquals") == "Success"]
+                   if c.get("StringEquals") == "SUCCESS"]
         assert success == ["CheckSkipRunDaemon"]
 
     def test_daemon_is_last_step(self, states):
@@ -164,7 +171,8 @@ class TestPaths:
             if st["Type"] == "Succeed":
                 break
             if st["Type"] == "Choice":
-                succ = [c["Next"] for c in st.get("Choices", []) if c.get("StringEquals") == "Success"]
+                succ = [c["Next"] for c in st.get("Choices", [])
+                        if c.get("StringEquals") in ("Success", "SUCCESS")]
                 cur = succ[0] if succ else st.get("Default")
             else:
                 cur = st.get("Next")


### PR DESCRIPTION
## What

The two structural fixes from today's incident (nousergon/alpha-engine-config#1811, incident context in nousergon/alpha-engine-config#1807):

**Part A — `CodeFreshnessGate`** (new SF state, SSM-ready → gate → `CheckSkipMorningEnrich`): verifies all three repo checkouts on ae-trading (`alpha-engine`, `alpha-engine-data`, `alpha-engine-config`) are on branch `main` at `origin/main`'s SHA before ANY pipeline work runs. One in-place self-heal (ownership reclaim + `checkout -f main` + `reset --hard origin/main`, mirroring boot-pull), then the executor AST syntax gate; persistent drift or broken syntax fails the pipeline in ~2 minutes with a clear SNS cause. Today, stale code wasn't discovered until `RunMorningPlanner`'s in-process preflight refused — ~40 minutes and three completed pipeline stages too late. That preflight stays as defense-in-depth.

**Part B — `ssm-liveness-poller` Lambda + loop consolidation**: every SSM poll iteration now checks command status AND the SSM agent's independent `PingStatus` from OUTSIDE the box, with bounded attempt + consecutive-ping-miss budgets carried through SF state. All five weekday poll loops migrate to it (freshness gate, enrich, arctic-append, chronic-gap, planner). New verdicts and routing:

| verdict | routing |
|---|---|
| `SUCCESS` | next pipeline state |
| `IN_PROGRESS` | Wait → re-poll |
| `COMMAND_FAILED` (Default) | `HandleFailure` (chronic-gap: fail-soft continue) |
| `INSTANCE_UNRESPONSIVE` (3 consecutive non-Online pings ≈ 1 min) | stamp `$.error` → `ForceStopUnresponsiveInstance` (`ec2:stopInstances Force=true`) → `HandleFailure` |
| `POLL_BUDGET_EXHAUSTED` | per-loop PollTimeout stamp → `HandleFailure` |

## Why

2026-07-06: the trading box wedged under memory pressure mid-`MorningArcticAppend` (config#1807). The SSM agent enforces `executionTimeout` from inside the box — it went `ConnectionLost`, the timeout couldn't fire, and the SF polled a frozen `InProgress` for **62 minutes** (22 past the timeout) with `RunDaemon` blocked and the market open. Separately, the poll loops had copy-drifted: the #970 bounded-attempt cap only ever landed on MorningEnrich; ArcticAppend/ChronicGap/Planner had no cap at all. One shared poller ends that class — the payload-registry test now pins all five loops to one contract.

Force-stop on `INSTANCE_UNRESPONSIVE` is the validated remediation (it was today's actual recovery action); the Lambda itself stays read-only (least privilege) — the stop belongs to the SF role, which already held `ec2:StopInstances` on the trading instance. IAM delta is exactly one line: `lambda:InvokeFunction` on the new poller.

## Tests

- New `tests/test_sf_liveness_watchdog_wiring.py`: pins no-bare-`getCommandInvocation`-polls-may-reappear, counter round-tripping per loop, unresponsive → force-stop → alert routing (with `$.error` survival), and the freshness gate's verify/heal/fail-loud command contract.
- 15 unit tests on the poller handler, including both incident shapes (config#1807 wedge → `INSTANCE_UNRESPONSIVE` at 3 misses; #970 stuck-InProgress → `POLL_BUDGET_EXHAUSTED`) and fail-loud on unexpected AWS errors.
- Contract tests updated to the new topology (payload registry, poll ResultSelector 256KB guard — incl. a latent snake_case regex fix — invocation-retry, chronic-gap fail-soft with the host-failure carve-out, skip-gate walker).
- **Full suite: 2647 passed, 8 skipped.**

## Deploy (post-merge, order matters)

1. `bash infrastructure/lambdas/ssm-liveness-poller/deploy.sh --bootstrap` (+ `--smoke` — read-only)
2. `bash infrastructure/iam/apply.sh` (adds the InvokeFunction grant)
3. `bash infrastructure/deploy_step_function_daily.sh`

The SF definition references the Lambda ARN, so 1+2 must precede 3. I'll run these + a skip-flag verification execution on approval.

Companion PR: nousergon/crucible-executor#336 (boot-pull ownership-reclaim hardening — the root cause of today's stale checkout).

Refs: nousergon/alpha-engine-config#1811, nousergon/alpha-engine-config#1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)