### PR TITLE
fix(sf): Research state checkpoint-resume retry on States.Timeout (config#1650)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -901,7 +901,7 @@
             },
             "Research": {
               "Type": "Task",
-              "Comment": "Research Lambda — generates signals.json. skip_dry_run_gate=true (L4464 perf): the scheduled production path skips the in-handler stub-LLM dry-run gate, which ran a FULL second graph pass (incl. a real ~4-min fetch_data) before the real pass — ~8 min of the 900s budget. Wiring is validated by CI + the Friday shell-run preflight; the gate stays available for manual/dev invokes (default off-skip). Composes with the L1995 Phase 5 universe reduction (research #256) which is the load-bearing timeout fix.",
+              "Comment": "Research Lambda — generates signals.json. skip_dry_run_gate=true (L4464 perf): the scheduled production path skips the in-handler stub-LLM dry-run gate, which ran a FULL second graph pass (incl. a real ~4-min fetch_data) before the real pass — ~8 min of the 900s budget. Wiring is validated by CI + the Friday shell-run preflight; the gate stays available for manual/dev invokes (default off-skip). Composes with the L1995 Phase 5 universe reduction (research #256) which is the load-bearing timeout fix. TIMEOUT RETRY = CHECKPOINT-RESUME (config#1650, 2026-07-06): the runner persists per-node state (archive/agent_runs + sector_team_runs) and RESUMEs completed nodes at near-zero LLM cost, so one retry on States.Timeout/Lambda.Unknown converts the manual watch-rerun into the automatic contract (the 7/3 timeout's rerun finished in ~5.9 min). IntervalSeconds=60 is LOAD-BEARING: it guarantees the first invocation is dead past its own 900s Lambda ceiling before the retry fires (runner has reserved-concurrency=1 — an overlapping invoke would throttle). Bridge until the config#1687 spot-EC2 migration removes the 900s ceiling entirely.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-runner:live",
@@ -918,6 +918,15 @@
                   "ErrorEquals": [
                     "Lambda.ServiceException",
                     "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                },
+                {
+                  "ErrorEquals": [
+                    "States.Timeout",
+                    "Lambda.Unknown"
                   ],
                   "MaxAttempts": 1,
                   "IntervalSeconds": 60,

--- a/tests/test_sf_research_timeout_retry.py
+++ b/tests/test_sf_research_timeout_retry.py
@@ -1,0 +1,84 @@
+"""Pin the weekly SF Research state's checkpoint-resume timeout retry
+(config#1650 item 1, 2026-07-06).
+
+The 2026-07-03 scheduled weekly failed the primary execution because the
+Research state — a synchronous `lambda:invoke` with `TimeoutSeconds: 900`
+(the Lambda hard maximum, walls identical on both sides) — hit
+`States.Timeout`. The runner persists per-node state
+(`archive/agent_runs/{date}/` + `archive/sector_team_runs/{date}/`) and
+RESUMEs completed nodes at near-zero LLM cost: the 7/3 manual watch-rerun
+re-entered Research and completed in ~5.9 min, re-running only
+fetch_data + archive_writer + email. A single SF-level retry on the
+timeout therefore IS "checkpoint+resume across invocations" — it turns
+the manual watch-rerun into the automatic contract.
+
+Pins:
+  1. The Research state retries on BOTH `States.Timeout` (SF task-level
+     timer) and `Lambda.Unknown` (Lambda-side function timeout surfaced
+     in the invoke response) — with equal 900s walls either can fire
+     first depending on which timer wins.
+  2. `IntervalSeconds >= 60` — LOAD-BEARING: the retry must not fire
+     until the first invocation is dead past its own 900s Lambda
+     ceiling; the runner has reserved-concurrency=1 (verified live
+     2026-07-06), so an overlapping invoke would throttle.
+  3. `MaxAttempts == 1` — one resume pass; a second consecutive timeout
+     means the corpus/runtime has genuinely outgrown the Lambda and the
+     config#1687 spot-EC2 migration is due, not more retries.
+
+Bridge until config#1687 (Brian-ratified 2026-07-03) moves Research off
+the 900s Lambda ceiling entirely; remove this pin with that migration.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+SF_JSON = pathlib.Path(__file__).parent.parent / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def research_state() -> dict:
+    definition = json.loads(SF_JSON.read_text())
+    parallel = definition["States"]["ResearchPredictorParallel"]
+    for branch in parallel["Branches"]:
+        if "Research" in branch["States"]:
+            return branch["States"]["Research"]
+    raise AssertionError("Research state not found in ResearchPredictorParallel branches")
+
+
+@pytest.fixture(scope="module")
+def timeout_retry(research_state: dict) -> dict:
+    matches = [
+        r for r in research_state.get("Retry", [])
+        if "States.Timeout" in r.get("ErrorEquals", [])
+    ]
+    assert len(matches) == 1, (
+        "Research state must carry exactly one States.Timeout retry policy "
+        "(checkpoint-resume contract, config#1650)"
+    )
+    return matches[0]
+
+
+def test_research_retries_both_timeout_error_forms(timeout_retry: dict):
+    assert set(timeout_retry["ErrorEquals"]) == {"States.Timeout", "Lambda.Unknown"}
+
+
+def test_research_timeout_retry_is_single_attempt(timeout_retry: dict):
+    assert timeout_retry["MaxAttempts"] == 1
+
+
+def test_research_timeout_retry_waits_out_first_invocation(timeout_retry: dict):
+    # 60s past the SF timeout guarantees the first invocation has died at
+    # its own 900s Lambda ceiling (reserved-concurrency=1 would throttle
+    # an overlapping invoke).
+    assert timeout_retry["IntervalSeconds"] >= 60
+
+
+def test_research_walls_still_equal_lambda_maximum(research_state: dict):
+    # The retry design assumes SF and Lambda walls are both 900s (the
+    # Lambda hard max). If someone raises TimeoutSeconds past 900, the
+    # States.Timeout arm goes dead and Lambda.Unknown carries alone —
+    # revisit the retry (and config#1687's priority) instead.
+    assert research_state["TimeoutSeconds"] == 900


### PR DESCRIPTION
## Summary

Fixes config#1650 item 1 (immediate layer). The 7/3 weekly's primary execution failed on the Research state's `States.Timeout` at the 900s wall while the runner's work survived in per-node checkpoints — the manual watch-rerun resumed and finished in ~5.9 min with near-zero marginal LLM cost (`RESUME: loaded persisted macro ... zero LLM calls`, ×6 sector teams, + CIO).

This PR makes that recovery automatic: one SF-level retry on `States.Timeout` / `Lambda.Unknown`. Because node-level resume already exists in the runner, the retry IS checkpoint+resume across invocations.

Design constraints baked into the state comment + pinned by `tests/test_sf_research_timeout_retry.py`:
- **Both error forms**: with SF and Lambda walls both at 900s, either timer can fire first.
- **`IntervalSeconds: 60` is load-bearing**: it guarantees the first invocation is dead past its own Lambda ceiling before the retry fires — the runner has reserved-concurrency=1 (verified live today), so an overlapping invoke would throttle.
- **`MaxAttempts: 1`**: a second consecutive timeout means the runtime has genuinely outgrown Lambda — that's config#1687's job (Brian-ratified 7/3: migrate Research onto spot-EC2 submit+poll), not more retries. This PR is the bridge until that migration lands; the pin test documents its removal with #1687.

## Testing
- New pin test (4 cases) + full suite: **2651 passed, 8 skipped**.
- SF auto-deploys on merge via `deploy-infrastructure.yml` (no manual apply).

Verification gate (config#1650 closes-when c): next weekly's Research state completes without failing the primary execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)