### PR TITLE
feat(sf): weekly run-day gate — THU-SAT cron + self-selecting calendar gate (config#1824)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -179,11 +179,18 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: alpha-engine-saturday
-      # Schedule chosen so polygon's Friday daily aggregate has settled
-      # (T+1 lag) before MorningEnrich + DataPhase1 fetch it.
-      # 09:00 UTC = 02:00 AM PT Sat (PDT) / 01:00 AM PT Sat (PST).
-      Description: Saturday 09:00 UTC (02:00 AM PT) — triggers full Alpha Engine pipeline after polygon T+1 settle
-      ScheduleExpression: 'cron(0 9 ? * SAT *)'
+      # 09:00 UTC chosen so polygon's prior-session daily aggregate has
+      # settled (T+1 lag) before MorningEnrich + DataPhase1 fetch it.
+      # THU-SAT (config#1824, Brian-ratified 2026-07-06): the weekly runs
+      # ONE DAY AFTER the week's LAST trading session — Saturday normally,
+      # Friday when Friday is an NYSE holiday, Thursday on a Thu+Fri double
+      # holiday. The cron fires all three days; the SF's WeeklyRunDayGate
+      # (predictor Lambda action=check_weekly_run_day, pure calendar math)
+      # self-selects the single correct firing and Succeed-skips the rest.
+      # Replaces the hand-built one-shot shift used for the 2026-07-03
+      # holiday week.
+      Description: Thu-Sat 09:00 UTC — weekly pipeline fires day after last trading session (WeeklyRunDayGate self-selects; config#1824)
+      ScheduleExpression: 'cron(0 9 ? * THU-SAT *)'
       State: ENABLED
       Targets:
         # SINGLE TARGET PER RULE. EventBridge dispatches the cron event

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -6,9 +6,97 @@
       "Type": "Pass",
       "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + ec2_instance_id explicitly; manual runs for partial-execution testing often omit sns_topic_arn, which previously caused HandleFailure/NotifyComplete to error on missing JSONPath. States.JsonMerge with user-input as the second arg lets explicit values win. | 2026-05-17: also stamps run_date = date($$.Execution.StartTime) so every spot stage of one execution keys backtest/{date}/ off ONE date (fixes the Backtester=05-17 vs Evaluator=05-18 UTC-midnight split). User-passed run_date still wins. | 2026-05-18 (shell-run keystone): also seeds the dry-path control vars at their NON-DRY identity values — preflight_args=\"\" (empty spot-command suffix), research_dry=false, data_phase2_dry=false, regime_action=\"produce\". These exist on EVERY run so the spot States.Format / Lambda Payload .$ references always resolve; on the real Saturday run (no shell_run) they hold these identity values, making every spot command string byte-identical to pre-keystone and every Lambda Payload behaviourally identical (handlers default dry_run_llm/dry_run to false; regime action 'produce' is the pre-keystone hardcoded value). ApplyShellRunDefaults (shell_run=true only) overrides them with the dry values. innermost defaults blob is merged UNDER run_date which is merged UNDER sns_topic_arn which is merged UNDER the user input, so user/ApplyShellRunDefaults values always win.",
       "Parameters": {
-        "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"preflight_args\":\"\",\"research_dry\":false,\"data_phase2_dry\":false,\"regime_action\":\"produce\",\"pipeline_label\":\"\",\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
+        "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"preflight_args\":\"\",\"skip_weekly_run_day_gate\":false,\"research_dry\":false,\"data_phase2_dry\":false,\"regime_action\":\"produce\",\"pipeline_label\":\"\",\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
       "OutputPath": "$.merged",
+      "Next": "CheckWeeklyRunDayGate"
+    },
+    "CheckWeeklyRunDayGate": {
+      "Type": "Choice",
+      "Comment": "config#1824 (Brian-ratified 2026-07-06): the weekly runs ONE DAY AFTER the week's last trading session, so the cron fires THU-SAT and this gate self-selects the single correct day. Applies ONLY to the scheduled weekly cadence (pipeline_role='weekly', set by the EventBridge CFN Input) — manual / recovery / watch-rerun / shell executions carry other roles (or none) and bypass automatically; skip_weekly_run_day_gate=true (defaulted false by InitializeInput) is the explicit operator bypass per the config#1617 skip-flag charter.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "weekly"
+            },
+            {
+              "Variable": "$.skip_weekly_run_day_gate",
+              "BooleanEquals": false
+            }
+          ],
+          "Next": "WeeklyRunDayGate"
+        }
+      ],
+      "Default": "CheckRunMode"
+    },
+    "WeeklyRunDayGate": {
+      "Type": "Task",
+      "Comment": "Run-day gate (config#1824) — mirrors the weekday TradingDayGate (config#1430): predictor Lambda action=check_weekly_run_day is pure NYSE-calendar math with zero infra dependency, returning before preflight. True iff yesterday was the week's LAST trading session (Sat on normal weeks; Fri/Thu on holiday-shortened weeks — real precedent Fri 2026-07-03).",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_weekly_run_day"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.TaskFailed"
+          ],
+          "IntervalSeconds": 3,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "WeeklyRunDayGateFailed",
+          "ResultPath": "$.weekly_run_day_gate_error"
+        }
+      ],
+      "ResultPath": "$.weekly_run_day_gate",
+      "Next": "WeeklyRunDayGateChoice"
+    },
+    "WeeklyRunDayGateChoice": {
+      "Type": "Choice",
+      "Comment": "Not the run day -> clean Succeed skip BEFORE any spend (no mutex, no lib-pin check, no spot, no alert): on a normal week 2 of the 3 THU-SAT firings land here by design. Run day or any non-false result -> proceed. Fail-open mirrors the weekday gate posture: missing the weekly run is worse than a duplicate.",
+      "Choices": [
+        {
+          "Variable": "$.weekly_run_day_gate.Payload.is_weekly_run_day",
+          "BooleanEquals": false,
+          "Next": "WeeklyRunDaySkip"
+        }
+      ],
+      "Default": "CheckRunMode"
+    },
+    "WeeklyRunDaySkip": {
+      "Type": "Succeed",
+      "Comment": "Designed no-op: scheduled THU-SAT firing on a non-run day. Succeed (never Fail) so SF-success metrics, the SF-watch agent, and page-25 treat this exactly like the weekday NotifyHolidaySkip — a green skip, not a failure. Cycle health remains artifact-freshness-as-authority (config#1724); this state produces no artifacts on purpose."
+    },
+    "WeeklyRunDayGateFailed": {
+      "Type": "Task",
+      "Comment": "Gate Lambda failed for infrastructure reasons — alert and PROCEED as run day (fail-open, mirroring the weekday TradingDayGateFailed). Worst case a broken predictor Lambda all week yields up to 3 alerted duplicate runs (distinct run_dates, idempotent artifact keys) — accepted: the same Lambda gates every weekday morning, so a multi-day outage is already loudly visible. Message fields are all structurally guaranteed (sns_topic_arn defaulted by InitializeInput; error set by the Catch ResultPath) per the config#1819 notifier-totality lesson.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekly Pipeline — Run-Day Gate Failed (Proceeding)",
+        "Message.$": "States.Format('Weekly run-day gate Lambda failed (infra error, not a calendar decision). Pipeline proceeding as run day. Error: {}', States.JsonToString($.weekly_run_day_gate_error))"
+      },
+      "ResultPath": "$.weekly_run_day_gate_error_notify",
       "Next": "CheckRunMode"
     },
     "CheckRunMode": {

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -80,6 +80,8 @@ _CFN_PATH = (
 # targeted operator skips) — this constant + test_skip_gates_still_intact
 # enforce that none were deleted.
 _EXPECTED_SKIPS = {
+    # config#1824: scheduled-weekly run-day gate operator bypass.
+    "skip_weekly_run_day_gate",
     # Added 2026-06-08 (L4517 — preventive cross-repo lib-pin drift gate,
     # the first state after InitializeInput).
     "skip_lib_pin_drift_check",
@@ -414,7 +416,9 @@ class TestStrictSuperset:
         # so the mutex→CheckShellRun superset property below is unchanged.
         # config#830: CheckRunMode (cadence preset) precedes the lib-pin gate;
         # its Default → CheckSkipLibPinDriftCheck, so the superset chain holds.
-        assert states["InitializeInput"]["Next"] == "CheckRunMode"
+        assert states["InitializeInput"]["Next"] == "CheckWeeklyRunDayGate"
+        # config#1824: run-day gate precedes CheckRunMode; bypass Default keeps chain.
+        assert states["CheckWeeklyRunDayGate"]["Default"] == "CheckRunMode"
         assert states["CheckRunMode"]["Default"] == "CheckSkipLibPinDriftCheck"
         assert states["CheckMutexRole"]["Default"] == "CheckShellRun", (
             "Mutex bypass path must route to CheckShellRun so the shell-run "
@@ -988,8 +992,11 @@ class TestHappyPathTraversal:
         # config#830: CheckRunMode (cadence preset) sits between InitializeInput
         # and the lib-pin gate; with no `mode` on the input it takes its Default
         # to CheckSkipLibPinDriftCheck — one extra Choice in the visited order.
+        # config#1824: the run-day gate is the first hop; a role-less input
+        # takes its Default straight to CheckRunMode — one extra Choice.
         assert order[: order.index("CheckSkipMorningEnrich") + 2] == [
             "InitializeInput",
+            "CheckWeeklyRunDayGate",
             "CheckRunMode",
             "CheckSkipLibPinDriftCheck",
             "LibPinDriftCheck",

--- a/tests/test_sf_lib_pin_drift_wiring.py
+++ b/tests/test_sf_lib_pin_drift_wiring.py
@@ -45,7 +45,9 @@ def test_runs_first_off_initialize_input(sf, states):
     # this gate; CheckRunMode.Default → CheckSkipLibPinDriftCheck, so the lib-pin
     # gate still runs first for any non-preset input.
     assert sf["StartAt"] == "InitializeInput"
-    assert states["InitializeInput"]["Next"] == "CheckRunMode"
+    assert states["InitializeInput"]["Next"] == "CheckWeeklyRunDayGate"
+    # config#1824: run-day gate precedes CheckRunMode; bypass Default keeps chain.
+    assert states["CheckWeeklyRunDayGate"]["Default"] == "CheckRunMode"
     assert states["CheckRunMode"]["Default"] == "CheckSkipLibPinDriftCheck"
 
 

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -83,8 +83,9 @@ class TestChainOrdering:
         # downstream mutex→CheckShellRun→CheckSkipMorningEnrich chain is unchanged.
         # config#830: a cadence-preset gate (CheckRunMode) now precedes the lib-pin
         # gate; CheckRunMode.Default → CheckSkipLibPinDriftCheck, so the chain holds.
-        assert states["InitializeInput"]["Next"] == "CheckRunMode", (
-            "InitializeInput now hands off to the config#830 cadence-preset gate; "
+        assert states["InitializeInput"]["Next"] == "CheckWeeklyRunDayGate", (
+            "InitializeInput hands off to the config#1824 run-day gate, whose "
+            "bypass Default -> CheckRunMode (config#830 cadence preset); "
             "CheckRunMode.Default → CheckSkipLibPinDriftCheck (the L4517 lib-pin "
             "gate); see tests/test_sf_lib_pin_drift_wiring.py for the gate→mutex chain"
         )

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -176,7 +176,9 @@ class TestMutexWiring:
         # workload gate; its skip-default + gate-default converge on
         # CheckMutexRole — the mutex still sits between entry and the
         # former-first-state, one gate further down.
-        assert saturday_sf["States"]["InitializeInput"]["Next"] == "CheckRunMode"
+        assert saturday_sf["States"]["InitializeInput"]["Next"] == "CheckWeeklyRunDayGate"
+        # config#1824: run-day gate precedes CheckRunMode; bypass Default keeps chain.
+        assert saturday_sf["States"]["CheckWeeklyRunDayGate"]["Default"] == "CheckRunMode"
         assert saturday_sf["States"]["CheckRunMode"]["Default"] == "CheckSkipLibPinDriftCheck"
         assert saturday_sf["States"]["LibPinDriftGate"]["Default"] == "CheckMutexRole"
 

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -73,6 +73,8 @@ def _flatten_states(sf_doc: dict) -> dict:
 _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # L4517: preventive cross-repo lib-pin drift gate (predictor-inference Lambda).
     "LibPinDriftCheck": frozenset({"action"}),
+    # config#1824 weekly run-day gate (pure calendar; mirrors LibPinDriftCheck shape).
+    "WeeklyRunDayGate": frozenset({"action"}),
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),
     "RegimeSubstrate": frozenset({"action.$"}),
     "RegimeRetrospectiveEval": frozenset({"action.$"}),

--- a/tests/test_sf_weekly_run_day_gate_wiring.py
+++ b/tests/test_sf_weekly_run_day_gate_wiring.py
@@ -1,0 +1,109 @@
+"""Pin the weekly run-day gate wiring (config#1824, Brian-ratified 2026-07-06).
+
+Policy: the weekly pipeline runs ONE calendar day after the LAST trading
+session of its Mon-Fri week — Saturday normally, Friday when Friday is an
+NYSE holiday (real precedent 2026-07-03), Thursday on a Thu+Fri double
+holiday. Mechanism: the EventBridge cron fires THU-SAT and the SF's
+WeeklyRunDayGate (predictor Lambda ``action=check_weekly_run_day``, pure
+calendar math per the config#1430 posture) self-selects the single correct
+firing, Succeed-skipping the rest BEFORE any spend.
+
+Pins:
+  1. CFN cron is THU-SAT (not the old fixed SAT).
+  2. InitializeInput defaults ``skip_weekly_run_day_gate`` false and routes
+     into the gate choice first.
+  3. The gate applies ONLY to ``pipeline_role == "weekly"`` (scheduled
+     cadence) — manual/recovery/watch-rerun/shell runs bypass automatically,
+     and the skip flag is the explicit operator bypass.
+  4. Non-run-day exits via a Succeed state (green skip — SF-watch and
+     success metrics must not read it as a failure).
+  5. Gate infra-failure is fail-open: alert then proceed (mirror of the
+     weekday TradingDayGateFailed), with all message fields structurally
+     guaranteed (config#1819 notifier-totality lesson).
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+_INFRA = pathlib.Path(__file__).parent.parent / "infrastructure"
+_SF_JSON = _INFRA / "step_function.json"
+_CFN = _INFRA / "cloudformation" / "alpha-engine-orchestration.yaml"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_JSON.read_text())["States"]
+
+
+class TestCronSchedule:
+    def test_saturday_trigger_fires_thu_through_sat(self):
+        cfn = _CFN.read_text()
+        block = cfn.split("SaturdayTrigger:", 1)[1].split("WeekdayTrigger:", 1)[0]
+        assert "cron(0 9 ? * THU-SAT *)" in block, (
+            "weekly cron must fire THU-SAT so the run-day gate can "
+            "self-select holiday-shortened weeks (config#1824)"
+        )
+        assert "cron(0 9 ? * SAT *)" not in block
+
+
+class TestGateRouting:
+    def test_initialize_input_routes_to_gate_choice(self, states):
+        assert states["InitializeInput"]["Next"] == "CheckWeeklyRunDayGate"
+
+    def test_skip_flag_defaulted_false(self, states):
+        merged = states["InitializeInput"]["Parameters"]["merged.$"]
+        assert '\\"skip_weekly_run_day_gate\\":false' in json.dumps(merged) or (
+            '"skip_weekly_run_day_gate":false' in merged
+        ), "InitializeInput must default skip_weekly_run_day_gate=false"
+
+    def test_gate_scoped_to_scheduled_weekly_role_only(self, states):
+        choice = states["CheckWeeklyRunDayGate"]
+        assert choice["Type"] == "Choice"
+        assert choice["Default"] == "CheckRunMode", (
+            "non-weekly roles (manual/recovery/watch/shell) must bypass the gate"
+        )
+        (rule,) = choice["Choices"]
+        conds = {
+            (c["Variable"], next(k for k in c if k not in ("Variable",))): c
+            for c in rule["And"]
+        }
+        assert ("$.pipeline_role", "IsPresent") in conds
+        assert conds[("$.pipeline_role", "StringEquals")]["StringEquals"] == "weekly"
+        assert conds[("$.skip_weekly_run_day_gate", "BooleanEquals")]["BooleanEquals"] is False
+        assert rule["Next"] == "WeeklyRunDayGate"
+
+    def test_gate_invokes_predictor_calendar_action(self, states):
+        gate = states["WeeklyRunDayGate"]
+        assert gate["Parameters"]["FunctionName"] == "alpha-engine-predictor-inference:live"
+        assert gate["Parameters"]["Payload"] == {"action": "check_weekly_run_day"}
+        assert gate["Next"] == "WeeklyRunDayGateChoice"
+        (catch,) = gate["Catch"]
+        assert catch["Next"] == "WeeklyRunDayGateFailed"
+        assert catch["ResultPath"] == "$.weekly_run_day_gate_error"
+
+
+class TestGateOutcomes:
+    def test_non_run_day_is_green_succeed_skip(self, states):
+        choice = states["WeeklyRunDayGateChoice"]
+        (rule,) = choice["Choices"]
+        assert rule["Variable"] == "$.weekly_run_day_gate.Payload.is_weekly_run_day"
+        assert rule["BooleanEquals"] is False
+        assert rule["Next"] == "WeeklyRunDaySkip"
+        assert states["WeeklyRunDaySkip"]["Type"] == "Succeed"
+
+    def test_run_day_proceeds_to_normal_head(self, states):
+        assert states["WeeklyRunDayGateChoice"]["Default"] == "CheckRunMode"
+
+    def test_gate_failure_is_fail_open_with_alert(self, states):
+        failed = states["WeeklyRunDayGateFailed"]
+        assert failed["Resource"] == "arn:aws:states:::sns:publish"
+        assert failed["Next"] == "CheckRunMode", "fail-open: proceed as run day"
+        # Notifier totality (config#1819): Subject constant + short; every
+        # JSONPath in the message structurally guaranteed on this path.
+        subject = failed["Parameters"]["Subject"]
+        assert isinstance(subject, str) and len(subject) <= 100 and "\n" not in subject
+        assert "$.weekly_run_day_gate_error" in failed["Parameters"]["Message.$"]
+        assert failed["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"


### PR DESCRIPTION
## Summary

Mechanizes the config#1824 policy (Brian, 2026-07-06): the weekly SF runs **one calendar day after the last trading session of the week** — Saturday normally, Friday on a Friday NYSE holiday (the hand-shifted 2026-07-03 case), Thursday on a Thu+Fri double holiday. No more one-shot manual shifts on holiday weeks, and no double-fire risk from the fixed SAT cron.

## Design

- **CFN**: `SaturdayTrigger` cron widens to `THU-SAT 09:00 UTC`; the SF's new head gate self-selects the single correct firing.
- **Scoping**: the gate applies ONLY to `pipeline_role == "weekly"` (set by the EventBridge CFN Input) — manual/recovery/watch-rerun/shell executions bypass automatically via the Choice Default; `skip_weekly_run_day_gate=true` (defaulted false by InitializeInput) is the explicit operator bypass per the config#1617 charter.
- **Non-run day** → `Succeed` skip **before any spend** (no mutex, no lib-pin check, no spot): 2 of 3 firings on a normal week land here by design, green to SF-watch and success metrics (mirrors weekday `NotifyHolidaySkip` semantics). Cycle health stays artifact-freshness-as-authority.
- **Gate infra-failure** → alert + proceed as run day (fail-open, mirroring weekday `TradingDayGateFailed`); worst case is up to 3 alerted duplicate runs in a week where the predictor Lambda — which also gates every weekday morning — is already loudly broken. Notifier fields are all structurally guaranteed (config#1819 lesson).
- Head-chain wiring pins updated across 4 test files; #258 skip-flag registry + Saturday Lambda-payload registry extended; new `test_sf_weekly_run_day_gate_wiring.py` (8 pins).

## Deploy order

**Merge nousergon/crucible-predictor#344 FIRST** — it adds the `check_weekly_run_day` Lambda action this SF invokes (its image auto-deploys on merge). Then this PR (SF + CFN auto-deploy via `deploy-infrastructure.yml`). Wrong order = the gate Catch fires fail-open with an alert on the next THU/FRI firing — recoverable but noisy.

## Verification

- Suite: **2661 passed, 8 skipped.**
- First live exercise: Thu 7/9 + Fri 7/10 firings must Succeed-skip; Sat 7/11 must run (config#1824 Re-exam 7/11). The gate function itself is unit-pinned on the real July-4th week in the predictor PR.

Closes the mechanism half of config#1824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)