### PR TITLE
feat(sf): decouple pre-open data phase onto a daily data spot (config#1807)

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -1,79 +1,113 @@
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "lambda:InvokeFunction",
-            "Resource": [
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-aggregate-costs*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-scanner*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator*",
-                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ssm:SendCommand",
-                "ssm:GetCommandInvocation"
-            ],
-            "Resource": [
-                "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
-                "arn:aws:ec2:us-east-1:711398986525:instance/i-09b539c844515d549",
-                "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf",
-                "arn:aws:ssm:us-east-1:711398986525:*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": "ssm:DescribeInstanceInformation",
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:StartInstances",
-                "ec2:StopInstances"
-            ],
-            "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "sns:Publish",
-            "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-                "logs:CreateLogDelivery",
-                "logs:GetLogDelivery",
-                "logs:UpdateLogDelivery",
-                "logs:DeleteLogDelivery",
-                "logs:ListLogDeliveries",
-                "logs:PutResourcePolicy",
-                "logs:DescribeResourcePolicies",
-                "logs:DescribeLogGroups"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "dynamodb:PutItem",
-            "Resource": "arn:aws:dynamodb:us-east-1:711398986525:table/alpha-engine-sf-execution-mutex"
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-aggregate-costs*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-scanner*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-health-check*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-substrate*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:GetCommandInvocation"
+      ],
+      "Resource": [
+        "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
+        "arn:aws:ec2:us-east-1:711398986525:instance/i-09b539c844515d549",
+        "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf",
+        "arn:aws:ssm:us-east-1:711398986525:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ssm:DescribeInstanceInformation",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:StartInstances",
+        "ec2:StopInstances"
+      ],
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:CreateLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:UpdateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:PutResourcePolicy",
+        "logs:DescribeResourcePolicies",
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "dynamodb:PutItem",
+      "Resource": "arn:aws:dynamodb:us-east-1:711398986525:table/alpha-engine-sf-execution-mutex"
+    },
+    {
+      "Sid": "SendCommandDailyDataSpot",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand"
+      ],
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringLike": {
+          "ssm:resourceTag/Name": "alpha-engine-data-*"
         }
-    ]
+      }
+    },
+    {
+      "Sid": "TerminateDailyDataSpot",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringLike": {
+          "aws:ResourceTag/Name": "alpha-engine-data-*"
+        }
+      }
+    },
+    {
+      "Sid": "ReadDailyDataSpotArtifact",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/ops/daily_data_spot/*"
+    }
+  ]
 }

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -175,6 +175,14 @@ LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python
 #                          terminate (Saturday SF MorningEnrich state)
 #   phase1-only         — ONLY weekly_collector.py --phase 1 + prune, then
 #                          terminate (Saturday SF DataPhase1 state)
+#   launch-only         — launch + bootstrap + deps, write the instance-id
+#                          artifact to --id-artifact-key, then EXIT LEAVING
+#                          THE SPOT RUNNING (weekday LaunchDailyDataSpot
+#                          state, config#1807: the pre-open data phase runs
+#                          on this spot instead of the trading box; the SF
+#                          SSM-dispatches each data state to the spot
+#                          directly and terminates it afterwards; the
+#                          on-box systemd watchdog is the orphan backstop)
 #
 # The preflight-task-split (2026-05-16, plan
 # alpha-engine-docs/private/preflight-task-split-260516.md) introduced
@@ -204,12 +212,27 @@ while [[ $# -gt 0 ]]; do
         --data-only) RUN_MODE="data-only"; shift ;;
         --morning-enrich-only) RUN_MODE="morning-enrich-only"; shift ;;
         --phase1-only) RUN_MODE="phase1-only"; shift ;;
+        --launch-only) RUN_MODE="launch-only"; shift ;;
+        --id-artifact-key) ID_ARTIFACT_KEY="$2"; shift 2 ;;
+        --max-runtime-seconds) MAX_RUNTIME_SECONDS="$2"; shift 2 ;;
         --preflight-only) PREFLIGHT_ONLY=1; shift ;;
         --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;  # legacy: collapses INSTANCE_TYPES to single value
         --branch) BRANCH="$2"; shift 2 ;;
         *) echo "Unknown flag: $1"; exit 1 ;;
     esac
 done
+
+# launch-only contract: the id artifact is how the weekday SF finds the
+# spot — launching without it would orphan the instance until the
+# watchdog fires. KEEP_INSTANCE stays 0 until the artifact is durably
+# written, so every failure before that point still terminates+retries
+# via the normal cleanup/on_exit path.
+ID_ARTIFACT_KEY="${ID_ARTIFACT_KEY:-}"
+KEEP_INSTANCE=0
+if [ "$RUN_MODE" = "launch-only" ] && [ -z "$ID_ARTIFACT_KEY" ]; then
+    echo "ERROR: --launch-only requires --id-artifact-key <s3-key>" >&2
+    exit 2
+fi
 
 echo "═══════════════════════════════════════════════════════════════"
 echo "  Weekly Data Spot Run (Phase1 + RAG) — $(date +%Y-%m-%d)"
@@ -270,6 +293,14 @@ INSTANCE_ID=""
 S3_STAGING=""
 
 cleanup() {
+    if [ "$KEEP_INSTANCE" = "1" ]; then
+        # launch-only success: the spot is handed to the weekday SF (id
+        # artifact written); the SF's TerminateDailyDataSpot state + the
+        # on-box systemd watchdog own its lifecycle from here.
+        [ -n "$S3_STAGING" ] && aws s3 rm "$S3_STAGING" --recursive --quiet 2>/dev/null || true
+        echo "  launch-only: instance $INSTANCE_ID left running (SF-owned); staging cleaned."
+        return 0
+    fi
     if [ -n "$INSTANCE_ID" ]; then
         echo ""
         echo "==> Terminating spot instance $INSTANCE_ID..."
@@ -367,7 +398,7 @@ INSTANCE_ID=$("$LIB_PYTHON" -m krepis.ec2_spot launch \
     --key-name "$KEY_NAME" \
     --security-group "$SECURITY_GROUP" \
     --iam-profile "$IAM_PROFILE" \
-    --name "alpha-engine-data-weekly-$(date +%Y%m%d)" \
+    --name "alpha-engine-data-$( [ "$RUN_MODE" = "launch-only" ] && echo daily || echo weekly )-$(date +%Y%m%d)" \
     --region "$AWS_REGION")
 ec2_spot_rc=$?
 if [ "$ec2_spot_rc" -ne 0 ] || [ -z "$INSTANCE_ID" ]; then
@@ -553,6 +584,29 @@ PIP="\$PYTHON_BIN -m pip"
 
 echo "Dependencies installed."
 DEPS
+
+# ── Launch-only: hand the bootstrapped spot to the weekday SF ────────────────
+# config#1807: the weekday pre-open data phase (MorningEnrich +
+# MorningArcticAppend + ChronicGapSelfHeal) runs on this spot instead of
+# the trading box, whose 2026-07-06 swap-thrash starved its own SSM agent
+# and blocked RunDaemon at market open. This mode ends at the exact point
+# the per-state workload dispatch would begin: the SF owns the workloads
+# (per-state granularity + liveness polling + skip flags preserved) and
+# the termination; the bootstrap watchdog above (MAX_RUNTIME_SECONDS,
+# pass --max-runtime-seconds 10800 from the SF) is the orphan backstop if
+# the SF dies without reaching TerminateDailyDataSpot.
+if [ "$RUN_MODE" = "launch-only" ]; then
+    echo "==> launch-only: writing instance-id artifact s3://${S3_BUCKET}/${ID_ARTIFACT_KEY}"
+    printf '{"instance_id": "%s", "launched_at": "%s", "mode": "launch-only", "max_runtime_seconds": %s}\n' \
+        "$INSTANCE_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MAX_RUNTIME_SECONDS" \
+        | aws s3 cp - "s3://${S3_BUCKET}/${ID_ARTIFACT_KEY}" --region "$AWS_REGION" --only-show-errors
+    # Verify the write landed before disarming termination — an unreadable
+    # artifact means the SF can never find the spot (fail loud + terminate).
+    aws s3api head-object --bucket "$S3_BUCKET" --key "$ID_ARTIFACT_KEY" --region "$AWS_REGION" > /dev/null
+    KEEP_INSTANCE=1
+    echo "==> launch-only complete: $INSTANCE_ID running, artifact written."
+    exit 0
+fi
 
 # ── Smoke-only: imports + --phase 1 --dry-run ────────────────────────────────
 if [ "$RUN_MODE" = "smoke-only" ]; then

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -2,7 +2,6 @@
   "Comment": "Alpha Engine Weekday Pipeline — morning polygon enrichment, predictor inference, executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). MorningEnrich (added 2026-04-24) overwrites the prior trading day's ArcticDB row with polygon's authoritative OHLCV+VWAP before predictor inference reads it — fixes the 2026-04-17→2026-04-23 silent VWAP outage where the EOD yfinance pass was the only source. EOD yfinance collection runs via the post-close EOD SF on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only.",
   "StartAt": "InitializeInput",
   "States": {
-
     "InitializeInput": {
       "Type": "Pass",
       "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + trading_instance_id explicitly; manual reruns (which happened multiple times 2026-04-23) often omit sns_topic_arn, which caused HandleFailure to error on missing $.sns_topic_arn JSONPath. Mirrors the Saturday SF InitializeInput pattern — States.JsonMerge with user-input as the second arg lets explicit values win.",
@@ -12,20 +11,34 @@
       "OutputPath": "$.merged",
       "Next": "CheckMutexRole"
     },
-
     "CheckMutexRole": {
       "Type": "Choice",
       "Comment": "L274 SF MutualExclusionGuard — gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations — that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell. Trigger of record: 2026-05-26 duplicate-EventBridge-target incident (PR #322 closed the SPECIFIC dup-target shape via CI; this mutex closes the broader class — operator double-paste / EB internal retry-on-throttle / cross-region replay / future shapes the CI chokepoint misses).",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.pipeline_role", "IsPresent": true},
+            {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
             {
               "Or": [
-                {"Variable": "$.pipeline_role", "StringEquals": "daily"},
-                {"Variable": "$.pipeline_role", "StringEquals": "weekly"},
-                {"Variable": "$.pipeline_role", "StringEquals": "eod"},
-                {"Variable": "$.pipeline_role", "StringEquals": "shell-run"}
+                {
+                  "Variable": "$.pipeline_role",
+                  "StringEquals": "daily"
+                },
+                {
+                  "Variable": "$.pipeline_role",
+                  "StringEquals": "weekly"
+                },
+                {
+                  "Variable": "$.pipeline_role",
+                  "StringEquals": "eod"
+                },
+                {
+                  "Variable": "$.pipeline_role",
+                  "StringEquals": "shell-run"
+                }
               ]
             }
           ],
@@ -34,7 +47,6 @@
       ],
       "Default": "DeployDriftCheck"
     },
-
     "AcquireMutex": {
       "Type": "Task",
       "Comment": "L274 — DynamoDB conditional PUT. mutex_key = '{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}' (UTC minute bucket parsed from $$.Execution.StartTime). Two duplicate cron-fired executions started in the same minute produce identical keys; the second loses with ConditionalCheckFailedException → MutexConflict Fail. No TTL / no release: the date+minute in the key is itself the staleness window — a successfully-acquired key is naturally single-use because no future execution can land in the same past minute-bucket. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
@@ -45,22 +57,34 @@
           "mutex_key": {
             "S.$": "States.Format('{}#{}#{}:{}', $$.StateMachine.Name, $.pipeline_role, States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 0), States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, ':'), 1))"
           },
-          "execution_arn": {"S.$": "$$.Execution.Id"},
-          "started_at": {"S.$": "$$.Execution.StartTime"},
-          "state_machine": {"S.$": "$$.StateMachine.Name"},
-          "pipeline_role": {"S.$": "$.pipeline_role"}
+          "execution_arn": {
+            "S.$": "$$.Execution.Id"
+          },
+          "started_at": {
+            "S.$": "$$.Execution.StartTime"
+          },
+          "state_machine": {
+            "S.$": "$$.StateMachine.Name"
+          },
+          "pipeline_role": {
+            "S.$": "$.pipeline_role"
+          }
         },
         "ConditionExpression": "attribute_not_exists(mutex_key)"
       },
       "Catch": [
         {
-          "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"],
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
           "Comment": "Mutex held by another concurrent execution in the same minute bucket — the duplicate-trigger case we are explicitly protecting against. Fail loud so the dup is visible in SF execution history + SNS alert (HandleFailure picks it up via MutexConflict's terminal Fail).",
           "Next": "MutexConflict",
           "ResultPath": "$.mutex_conflict"
         },
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block a real trading cadence run. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability hung off a primary path' carve-out, the primary deliverable survives a mutex-side failure. The error is captured in $.mutex_error for forensic review via SF execution history; CW alarm wiring deferred (operator-decision when first non-Conditional-Check mutex error appears).",
           "Next": "DeployDriftCheck",
           "ResultPath": "$.mutex_error"
@@ -69,13 +93,11 @@
       "ResultPath": "$.mutex_result",
       "Next": "DeployDriftCheck"
     },
-
     "MutexConflict": {
       "Type": "Fail",
       "Error": "MutexConflict",
       "Cause": "L274: another SF execution with the same state-machine + pipeline_role + start-minute already holds the mutex. Most likely cause: duplicate EventBridge target fan-out (PR #322 closes the specific CFN-vs-deploy-script shape; this Fail catches the broader class). Forensic: check execution history for the prior holder's executionArn via DynamoDB GetItem on the mutex_key in $.mutex_conflict."
     },
-
     "DeployDriftCheck": {
       "Type": "Task",
       "Comment": "Verify the deployed SF definition + CloudFormation stack SHAs match alpha-engine-data@main HEAD. Halts the pipeline when infrastructure code has merged but deploy-infrastructure.sh never ran. Degraded modes (missing stamps, GitHub outage) set has_drift=false so legacy artifacts and API outages do not block trading-hours runs.",
@@ -89,7 +111,10 @@
       "TimeoutSeconds": 60,
       "Retry": [
         {
-          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
           "MaxAttempts": 1,
           "IntervalSeconds": 15,
           "BackoffRate": 1.0
@@ -97,7 +122,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -105,7 +132,6 @@
       "ResultPath": "$.drift_result",
       "Next": "DeployDriftGate"
     },
-
     "DeployDriftGate": {
       "Type": "Choice",
       "Comment": "Hard-fail when the drift probe reports has_drift=true. Surfaces deploy lag loudly instead of silently running new SF definitions against stale Lambda images (or vice versa).",
@@ -118,39 +144,54 @@
       ],
       "Default": "TradingDayGate"
     },
-
     "TradingDayGate": {
       "Type": "Task",
       "Comment": "NYSE trading-day gate, run BEFORE StartExecutorEC2. Invokes the predictor Lambda (action=check_trading_day) — pure calendar math, no box dependency. Replaces the prior on-box SSM trading_calendar check whose stdout was unreliably captured on a just-cold-booted instance (2026-06-30 false trading-day-check failure alert; config#1430). On holiday the box is never booted.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
-        "Payload": { "action": "check_trading_day" }
+        "Payload": {
+          "action": "check_trading_day"
+        }
       },
       "Retry": [
         {
-          "ErrorEquals": ["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException","Lambda.TooManyRequestsException","States.TaskFailed"],
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.TaskFailed"
+          ],
           "IntervalSeconds": 3,
           "MaxAttempts": 3,
           "BackoffRate": 2.0
         }
       ],
       "Catch": [
-        { "ErrorEquals": ["States.ALL"], "Next": "TradingDayGateFailed", "ResultPath": "$.trading_day_gate_error" }
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "TradingDayGateFailed",
+          "ResultPath": "$.trading_day_gate_error"
+        }
       ],
       "ResultPath": "$.trading_day_gate",
       "Next": "TradingDayGateChoice"
     },
-
     "TradingDayGateChoice": {
       "Type": "Choice",
       "Comment": "Holiday/weekend (is_trading_day=false) -> skip without ever booting the box. Trading day or any non-false result -> proceed. Fail-open to trading matches the prior fail-soft posture: missing a real trading day is worse than a wasted holiday boot.",
       "Choices": [
-        { "Variable": "$.trading_day_gate.Payload.is_trading_day", "BooleanEquals": false, "Next": "NotifyHolidaySkip" }
+        {
+          "Variable": "$.trading_day_gate.Payload.is_trading_day",
+          "BooleanEquals": false,
+          "Next": "NotifyHolidaySkip"
+        }
       ],
-      "Default": "StartExecutorEC2"
+      "Default": "CheckSkipDataSpot"
     },
-
     "TradingDayGateFailed": {
       "Type": "Task",
       "Comment": "Trading-day gate Lambda failed for infrastructure reasons — alert and proceed (assume trading day). Predictor inference + downstream remain gated on enrichment success.",
@@ -161,38 +202,41 @@
         "Message.$": "States.Format('Trading-day gate Lambda failed (infra error, not a holiday detection). Pipeline proceeding as trading day. Error: {}', States.JsonToString($.trading_day_gate_error))"
       },
       "ResultPath": "$.trading_day_gate_error_notify",
-      "Next": "StartExecutorEC2"
+      "Next": "CheckSkipDataSpot"
     },
-
     "MorningEnrich": {
       "Type": "Task",
-      "Comment": "Polygon morning enrichment — overwrites the prior trading day's daily_closes parquet + ArcticDB row with polygon's authoritative OHLCV+VWAP. Hard-fails on PolygonForbiddenError (no yfinance fallback masks polygon outages). Predictor inference reads ArcticDB right after this step and must see polygon-corrected data, so failure → HandleFailure (do NOT proceed to PredictorInference with stale yfinance values). See alpha-engine-data/collectors/daily_closes.py for source-mode contract. Timeout raised 1800→3000s (L4552b, 2026-06-14): the 2026-06-11 weekday run timed out against the EXACT 1800s ceiling — daily_closes+intraday collection is legitimately >30 min on the t3.small, not hung (the slow ArcticDB append was already split to MorningArcticAppend / #983, so this is the remaining fetch tail). 50 min absorbs that without masking a real hang; the CheckMorningEnrichStatus poll loop now also fails fast at a bounded attempt cap. Predictor still gated on Success status.",
+      "Comment": "Polygon morning enrichment — overwrites the prior trading day's daily_closes parquet + ArcticDB row with polygon's authoritative OHLCV+VWAP. Hard-fails on PolygonForbiddenError (no yfinance fallback masks polygon outages). Predictor inference reads ArcticDB right after this step and must see polygon-corrected data, so failure → HandleFailure (do NOT proceed to PredictorInference with stale yfinance values). See alpha-engine-data/collectors/daily_closes.py for source-mode contract. Timeout raised 1800→3000s (L4552b, 2026-06-14): the 2026-06-11 weekday run timed out against the EXACT 1800s ceiling — daily_closes+intraday collection is legitimately >30 min on the t3.small, not hung (the slow ArcticDB append was already split to MorningArcticAppend / #983, so this is the remaining fetch tail). 50 min absorbs that without masking a real hang; the CheckMorningEnrichStatus poll loop now also fails fast at a bounded attempt cap. Predictor still gated on Success status. | config#1807 (2026-07-06): RUNS ON THE DAILY DATA SPOT ($.data_spot.info.instance_id, launched by LaunchDailyDataSpot), not the trading box — the data phase can no longer starve the trading box's SSM agent/daemon path. Spot flavor: fresh clone at bootstrap (no git pull / no CodeFreshnessGate dependency), deps installed from requirements.txt at bootstrap (the lib pin — ensure_lib_pin.sh is venv-only and unneeded on a fresh install), secrets from SSM at python startup (no .alpha-engine.env), system python3.12 (no .venv), runs as root with HOME set (weekly-spot convention).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.trading_instance_id",
+        "InstanceIds.$": "States.Array($.data_spot.info.instance_id)",
         "Parameters": {
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
             "export ALPHA_ENGINE_DEPLOYED=1",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+            "export HOME=/home/ec2-user",
+            "export XDG_CACHE_HOME=/tmp",
+            "export AWS_REGION=us-east-1",
+            "export AWS_DEFAULT_REGION=us-east-1",
+            "command -v python3.12 >/dev/null && PYTHON_BIN=python3.12 || PYTHON_BIN=python3",
             "cd /home/ec2-user/alpha-engine-data",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/morning-enrich.log \"s3://alpha-engine-research/_ssm_logs/morning-enrich/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/morning-enrich.log",
-            "python weekly_collector.py --morning-enrich --skip-chronic-heal --skip-arctic-append 2>&1 | tee -a /var/log/morning-enrich.log"
+            "$PYTHON_BIN weekly_collector.py --morning-enrich --skip-chronic-heal --skip-arctic-append 2>&1 | tee -a /var/log/morning-enrich.log"
           ],
-          "executionTimeout": ["3000"]
+          "executionTimeout": [
+            "3000"
+          ]
         },
         "TimeoutSeconds": 3000
       },
       "TimeoutSeconds": 3060,
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -200,15 +244,17 @@
       "ResultPath": "$.morning_enrich_result",
       "Next": "InitMorningEnrichPoll"
     },
-
     "InitMorningEnrichPoll": {
       "Type": "Pass",
       "Comment": "Seed the liveness-aware poll slot for the MorningEnrich loop (config#1811; supersedes the #970/L4552b counter-only pattern). attempts/ping_misses round-trip through the ssm-liveness-poller Lambda, which increments/reset them — no separate Increment state.",
-      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "Result": {
+        "verdict": "INIT",
+        "attempts": 0,
+        "ping_misses": 0
+      },
       "ResultPath": "$.morning_enrich_poll",
       "Next": "WaitForMorningEnrich"
     },
-
     "WaitForMorningEnrich": {
       "Type": "Task",
       "Comment": "Liveness-aware poll iteration (config#1811): command status + independent SSM-agent PingStatus in one Lambda call, OUTSIDE the box being watched. Replaces the bare getCommandInvocation poll — on 2026-07-06 (config#1807) the in-box executionTimeout could not fire while the box was wedged and the old loop read a frozen InProgress for 62 min; this detects that shape in ~3 polls.",
@@ -216,7 +262,7 @@
       "Parameters": {
         "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
         "Payload": {
-          "instance_id.$": "$.trading_instance_id[0]",
+          "instance_id.$": "$.data_spot.info.instance_id",
           "command_id.$": "$.morning_enrich_result.Command.CommandId",
           "attempts.$": "$.morning_enrich_poll.attempts",
           "ping_misses.$": "$.morning_enrich_poll.ping_misses",
@@ -242,7 +288,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -261,7 +309,6 @@
       "ResultPath": "$.morning_enrich_poll",
       "Next": "CheckMorningEnrichStatus"
     },
-
     "CheckMorningEnrichStatus": {
       "Type": "Choice",
       "Comment": "Block predictor inference until polygon enrichment confirms the prior trading day's row is overwritten with authoritative VWAP. Branches on the ssm-liveness-poller verdict (config#1811): COMMAND_FAILED (Default) → HandleFailure per feedback_no_silent_fails; INSTANCE_UNRESPONSIVE (≥3 consecutive PingStatus≠Online, the config#1807 wedged-box shape) → stamp error → force-stop the box → HandleFailure; POLL_BUDGET_EXHAUSTED (210 × ~15s ≈ >57 min, just past the 3000s executionTimeout — the #970 stuck-InProgress shape) → MorningEnrichPollTimeout.",
@@ -289,24 +336,21 @@
       ],
       "Default": "HandleFailure"
     },
-
     "MorningEnrichWait": {
       "Type": "Wait",
       "Seconds": 15,
       "Next": "WaitForMorningEnrich"
     },
-
     "StampMorningEnrichUnresponsive": {
       "Type": "Pass",
-      "Comment": "The trading box went unresponsive (SSM PingStatus≠Online for ≥3 consecutive polls) mid-MorningEnrich — the config#1807 wedged-box shape. Stamp the poller's detail into $.error, then force-stop the instance (the in-box executionTimeout cannot fire on a wedged box) and alert via HandleFailure.",
+      "Comment": "The trading box went unresponsive (SSM PingStatus≠Online for ≥3 consecutive polls) mid-MorningEnrich — the config#1807 wedged-box shape. Stamp the poller's detail into $.error, then terminate the DATA SPOT (config#1807 — the trading box is not involved in this state anymore) (the in-box executionTimeout cannot fire on a wedged box) and alert via HandleFailure.",
       "Parameters": {
         "Error": "MorningEnrichInstanceUnresponsive",
         "Cause.$": "$.morning_enrich_poll.detail"
       },
       "ResultPath": "$.error",
-      "Next": "ForceStopUnresponsiveInstance"
+      "Next": "ForceTerminateUnresponsiveDataSpot"
     },
-
     "MorningEnrichPollTimeout": {
       "Type": "Pass",
       "Comment": "Bounded poll-iteration cap exhausted on the MorningEnrich SSM status loop (L4552b / #970). The SSM command never reported a terminal status (Success/Failed) within the poll budget (~210 × 15s ≈ >57 min, past the 3000s executionTimeout) — i.e. it is genuinely stuck-InProgress, not slow. Stamp a clear cause into $.error then route through HandleFailure so the SNS failure alert carries it (a bare Fail would skip the alert). Distinct from a legitimately-long collection (which now has the raised 3000s ceiling). Operator action: inspect /var/log/morning-enrich.log on ae-trading + the SSM command invocation.",
@@ -317,27 +361,26 @@
       "ResultPath": "$.error",
       "Next": "HandleFailure"
     },
-
     "ChronicGapSelfHeal": {
       "Type": "Task",
-      "Comment": "Best-effort chronic-polygon-gap yfinance self-heal (BF-B/BRK-B/MOG-A/PSTG — polygon doesn't reliably serve them) + polygon-recovery / constituents-drift alarms. SPLIT OUT of MorningEnrich 2026-06-11: inline, an unbounded yf.download hang ran out MorningEnrich's SSM executionTimeout and SIGKILLed the whole command, discarding ~20 min of completed daily_append and failing the weekday pipeline (no predictions that day). Per the standing rule (a best-effort downstream step must never force re-running a completed upstream task — same rule that split MorningEnrich out of DataPhase1), this runs as its OWN FAIL-SOFT state: short executionTimeout, and the Catch + CheckChronicGapStatus Default both route to PredictorInference so a heal failure/hang can never block the trading path. Runs before PredictorInference so the healed chronic rows are fresh for inference; postflight remains the load-bearing freshness gate.",
+      "Comment": "Best-effort chronic-polygon-gap yfinance self-heal (BF-B/BRK-B/MOG-A/PSTG — polygon doesn't reliably serve them) + polygon-recovery / constituents-drift alarms. SPLIT OUT of MorningEnrich 2026-06-11: inline, an unbounded yf.download hang ran out MorningEnrich's SSM executionTimeout and SIGKILLed the whole command, discarding ~20 min of completed daily_append and failing the weekday pipeline (no predictions that day). Per the standing rule (a best-effort downstream step must never force re-running a completed upstream task — same rule that split MorningEnrich out of DataPhase1), this runs as its OWN FAIL-SOFT state: short executionTimeout, and the Catch + CheckChronicGapStatus Default both route to PredictorInference so a heal failure/hang can never block the trading path. Runs before PredictorInference so the healed chronic rows are fresh for inference; postflight remains the load-bearing freshness gate. | config#1807 (2026-07-06): RUNS ON THE DAILY DATA SPOT — see MorningEnrich.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.trading_instance_id",
+        "InstanceIds.$": "States.Array($.data_spot.info.instance_id)",
         "Parameters": {
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
             "export ALPHA_ENGINE_DEPLOYED=1",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+            "export HOME=/home/ec2-user",
+            "export XDG_CACHE_HOME=/tmp",
+            "export AWS_REGION=us-east-1",
+            "export AWS_DEFAULT_REGION=us-east-1",
+            "command -v python3.12 >/dev/null && PYTHON_BIN=python3.12 || PYTHON_BIN=python3",
             "cd /home/ec2-user/alpha-engine-data",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/chronic-gap-heal.log \"s3://alpha-engine-research/_ssm_logs/chronic-gap-heal/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/chronic-gap-heal.log",
-            "python weekly_collector.py --chronic-gap-heal 2>&1 | tee -a /var/log/chronic-gap-heal.log"
+            "$PYTHON_BIN weekly_collector.py --chronic-gap-heal 2>&1 | tee -a /var/log/chronic-gap-heal.log"
           ],
           "executionTimeout": [
             "300"
@@ -352,22 +395,24 @@
             "States.ALL"
           ],
           "Comment": "Fail-soft — a chronic-gap heal failure (incl. the SSM-timeout SIGKILL it used to cause) must never block predictions. Proceed to PredictorInference.",
-          "Next": "CheckSkipPredictorInference",
+          "Next": "CheckDataSpotToTerminate",
           "ResultPath": "$.chronic_gap_error"
         }
       ],
       "ResultPath": "$.chronic_gap_result",
       "Next": "InitChronicGapPoll"
     },
-
     "InitChronicGapPoll": {
       "Type": "Pass",
       "Comment": "Seed the liveness-aware poll slot for the fail-soft ChronicGapSelfHeal loop (config#1811).",
-      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "Result": {
+        "verdict": "INIT",
+        "attempts": 0,
+        "ping_misses": 0
+      },
       "ResultPath": "$.chronic_gap_poll",
       "Next": "WaitForChronicGap"
     },
-
     "WaitForChronicGap": {
       "Type": "Task",
       "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 30 × ~15s ≈ 7.5 min, past the 300s executionTimeout.",
@@ -375,7 +420,7 @@
       "Parameters": {
         "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
         "Payload": {
-          "instance_id.$": "$.trading_instance_id[0]",
+          "instance_id.$": "$.data_spot.info.instance_id",
           "command_id.$": "$.chronic_gap_result.Command.CommandId",
           "attempts.$": "$.chronic_gap_poll.attempts",
           "ping_misses.$": "$.chronic_gap_poll.ping_misses",
@@ -405,7 +450,7 @@
             "States.ALL"
           ],
           "Comment": "Fail-soft — a poll failure proceeds to PredictorInference, no heal that day.",
-          "Next": "CheckSkipPredictorInference",
+          "Next": "CheckDataSpotToTerminate",
           "ResultPath": "$.chronic_gap_error"
         }
       ],
@@ -423,7 +468,6 @@
       "ResultPath": "$.chronic_gap_poll",
       "Next": "CheckChronicGapStatus"
     },
-
     "CheckChronicGapStatus": {
       "Type": "Choice",
       "Comment": "Chronic-gap heal is fail-soft for HEAL failures: COMMAND_FAILED and POLL_BUDGET_EXHAUSTED (Default) proceed to PredictorInference — a broken/stuck best-effort heal must never block predictions. EXCEPTION (config#1811): INSTANCE_UNRESPONSIVE is NOT a heal failure, it is a host failure — the same wedged box the daemon must run on later. Proceeding fail-soft would just fail at RunMorningPlanner after burning PredictorInference; stamp + force-stop + HandleFailure instead.",
@@ -439,9 +483,8 @@
           "Next": "StampChronicGapUnresponsive"
         }
       ],
-      "Default": "CheckSkipPredictorInference"
+      "Default": "CheckDataSpotToTerminate"
     },
-
     "StampChronicGapUnresponsive": {
       "Type": "Pass",
       "Comment": "The trading box went unresponsive during the (otherwise fail-soft) chronic-gap heal — a host failure, not a heal failure. Stamp the poller's detail into $.error, force-stop, alert.",
@@ -450,15 +493,13 @@
         "Cause.$": "$.chronic_gap_poll.detail"
       },
       "ResultPath": "$.error",
-      "Next": "ForceStopUnresponsiveInstance"
+      "Next": "ForceTerminateUnresponsiveDataSpot"
     },
-
     "ChronicGapWait": {
       "Type": "Wait",
       "Seconds": 15,
       "Next": "WaitForChronicGap"
     },
-
     "NotifyHolidaySkip": {
       "Type": "Task",
       "Comment": "Notify that the pipeline was skipped — TradingDayGate reported is_trading_day=false (NYSE holiday/weekend). The executor box was never started (gate runs before StartExecutorEC2).",
@@ -471,7 +512,6 @@
       "ResultPath": "$.holiday_notify",
       "End": true
     },
-
     "StartExecutorEC2": {
       "Type": "Task",
       "Comment": "Start ae-trading (t3.small) early — needed for both DailyData (data collection) and RunMorningPlanner (executor). No-op if already running.",
@@ -481,7 +521,9 @@
       },
       "Retry": [
         {
-          "ErrorEquals": ["States.TaskFailed"],
+          "ErrorEquals": [
+            "States.TaskFailed"
+          ],
           "MaxAttempts": 2,
           "IntervalSeconds": 30,
           "BackoffRate": 1.0
@@ -489,7 +531,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -497,22 +541,21 @@
       "ResultPath": "$.ec2_start_result",
       "Next": "WaitForInstanceReady"
     },
-
     "WaitForInstanceReady": {
       "Type": "Wait",
       "Comment": "Initial settle before polling for SSM-agent registration. EC2 stopped→running takes ~15-25s; polling describeInstanceInformation any earlier just burns API calls.",
       "Seconds": 15,
       "Next": "InitSSMPollCounter"
     },
-
     "InitSSMPollCounter": {
       "Type": "Pass",
       "Comment": "Initialize attempts counter for the SSM-readiness poll loop.",
-      "Result": {"attempts": 0},
+      "Result": {
+        "attempts": 0
+      },
       "ResultPath": "$.ssm_poll",
       "Next": "DescribeInstanceInfo"
     },
-
     "DescribeInstanceInfo": {
       "Type": "Task",
       "Comment": "Poll SSM-agent registration on the trading instance. Replaces the prior fixed Wait 60s, which was insufficient on cold-boot t3.small (race observed 2026-05-05 morning — Ssm.InvalidInstanceIdException at the first SSM step because PingStatus had not yet flipped to Online when the SSM SendCommand fired). SSMReadyChoice routes to CheckSkipMorningEnrich (the first morning work gate; the NYSE holiday check now runs BEFORE the box boots via TradingDayGate, config#1430) when PingStatus=Online or HandleFailure when the bounded retry budget (~3 min) is exhausted.",
@@ -528,7 +571,10 @@
       "TimeoutSeconds": 15,
       "Retry": [
         {
-          "ErrorEquals": ["Ssm.SdkClientException", "States.Timeout"],
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
           "MaxAttempts": 2,
           "IntervalSeconds": 5,
           "BackoffRate": 1.5
@@ -536,7 +582,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -544,7 +592,6 @@
       "ResultPath": "$.ssm_describe_result",
       "Next": "SSMReadyChoice"
     },
-
     "SSMReadyChoice": {
       "Type": "Choice",
       "Comment": "PingStatus=Online → CodeFreshnessGate (config#1811; the NYSE holiday gate already ran pre-boot via TradingDayGate, config#1430). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail when budget exhausted (per feedback_no_silent_fails — agent not registering after 3 min indicates a real boot problem, not just timing).",
@@ -570,13 +617,11 @@
       ],
       "Default": "WaitSSMPoll"
     },
-
     "WaitSSMPoll": {
       "Type": "Wait",
       "Seconds": 15,
       "Next": "IncrementSSMPoll"
     },
-
     "IncrementSSMPoll": {
       "Type": "Pass",
       "Parameters": {
@@ -585,7 +630,6 @@
       "ResultPath": "$.ssm_poll",
       "Next": "DescribeInstanceInfo"
     },
-
     "CodeFreshnessGate": {
       "Type": "Task",
       "Comment": "config#1811 Part A — verify the three repo checkouts on ae-trading (alpha-engine, alpha-engine-data, alpha-engine-config) are on branch main at origin/main's SHA BEFORE any pipeline work runs, with one in-place self-heal (ownership reclaim + checkout -f main + reset --hard). Front-loads the check the executor's deploy-drift preflight only makes at RunMorningPlanner time — on 2026-07-06 a boot-pull failure (root-owned files in the checkout) left the box on a stray branch 4 commits stale, and the pipeline burned ~40 min of MorningEnrich/ArcticAppend/PredictorInference before that preflight refused. The executor-repo AST syntax gate mirrors boot-pull's deploy gate but FAILS the pipeline instead of rolling back: at pipeline time, neither stale nor broken code may proceed (fail-loud). Runs as root via SSM (bare chown), git as ec2-user. The executor's in-process check_deploy_drift stays as defense-in-depth.",
@@ -607,14 +651,18 @@
             "cd /home/ec2-user/alpha-engine && sudo -u ec2-user .venv/bin/python -c \"import ast; [ast.parse(open(f).read()) for f in ('executor/main.py','executor/daemon.py','executor/eod_reconcile.py')]\"",
             "echo CODE_FRESH"
           ],
-          "executionTimeout": ["300"]
+          "executionTimeout": [
+            "300"
+          ]
         },
         "TimeoutSeconds": 300
       },
       "TimeoutSeconds": 360,
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -622,15 +670,17 @@
       "ResultPath": "$.code_freshness_result",
       "Next": "InitCodeFreshnessPoll"
     },
-
     "InitCodeFreshnessPoll": {
       "Type": "Pass",
       "Comment": "Seed the liveness-aware poll slot for the CodeFreshnessGate loop (config#1811).",
-      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "Result": {
+        "verdict": "INIT",
+        "attempts": 0,
+        "ping_misses": 0
+      },
       "ResultPath": "$.code_freshness_poll",
       "Next": "WaitForCodeFreshness"
     },
-
     "WaitForCodeFreshness": {
       "Type": "Task",
       "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 36 × ~10s ≈ 6 min, past the 300s executionTimeout.",
@@ -664,7 +714,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -683,7 +735,6 @@
       "ResultPath": "$.code_freshness_poll",
       "Next": "CheckCodeFreshnessStatus"
     },
-
     "CheckCodeFreshnessStatus": {
       "Type": "Choice",
       "Comment": "SUCCESS → the box is verified on current main across all 3 repos → CheckSkipMorningEnrich (the pipeline proper). COMMAND_FAILED (Default) → HandleFailure — code stale after self-heal, or broken syntax on main; either way NOTHING may run (~2 min into the pipeline, not 40). INSTANCE_UNRESPONSIVE → stamp → force-stop → HandleFailure. POLL_BUDGET_EXHAUSTED → CodeFreshnessPollTimeout.",
@@ -691,7 +742,7 @@
         {
           "Variable": "$.code_freshness_poll.verdict",
           "StringEquals": "SUCCESS",
-          "Next": "CheckSkipMorningEnrich"
+          "Next": "CheckDataSpotLaunched"
         },
         {
           "Variable": "$.code_freshness_poll.verdict",
@@ -711,13 +762,11 @@
       ],
       "Default": "HandleFailure"
     },
-
     "CodeFreshnessWait": {
       "Type": "Wait",
       "Seconds": 10,
       "Next": "WaitForCodeFreshness"
     },
-
     "StampCodeFreshnessUnresponsive": {
       "Type": "Pass",
       "Comment": "The trading box went unresponsive during the code-freshness gate (right after reporting PingStatus=Online — a fast wedge). Stamp, force-stop, alert.",
@@ -728,7 +777,6 @@
       "ResultPath": "$.error",
       "Next": "ForceStopUnresponsiveInstance"
     },
-
     "CodeFreshnessPollTimeout": {
       "Type": "Pass",
       "Comment": "Bounded poll budget exhausted on the CodeFreshnessGate loop with the box still responsive (#970 shape). Stamp + alert via HandleFailure.",
@@ -739,7 +787,6 @@
       "ResultPath": "$.error",
       "Next": "HandleFailure"
     },
-
     "ForceStopUnresponsiveInstance": {
       "Type": "Task",
       "Comment": "config#1811 — deterministic remediation for INSTANCE_UNRESPONSIVE: the box is wedged (the 2026-07-06 config#1807 shape: memory-pressure stall, SSM agent dark, in-box executionTimeout unable to fire) and every remaining pipeline step needs this same host, so force-stop it NOW rather than leave it thrashing with IB Gateway credentials on it. Validated as the actual recovery action in the 2026-07-06 incident. $.error was stamped by the per-loop Stamp state before arriving here; this state's own result/error use separate ResultPaths so the stamped cause survives into HandleFailure's SNS alert. A stop failure still routes to HandleFailure — alerting is the priority, the stop is best-effort remediation.",
@@ -751,7 +798,9 @@
       "TimeoutSeconds": 30,
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.force_stop_error"
         }
@@ -759,7 +808,6 @@
       "ResultPath": "$.force_stop_result",
       "Next": "HandleFailure"
     },
-
     "PredictorInference": {
       "Type": "Task",
       "Comment": "Run daily GBM predictions + morning briefing email",
@@ -773,7 +821,10 @@
       "TimeoutSeconds": 900,
       "Retry": [
         {
-          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
           "MaxAttempts": 1,
           "IntervalSeconds": 60,
           "BackoffRate": 1.0
@@ -781,7 +832,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -789,7 +842,6 @@
       "ResultPath": "$.predictor_result",
       "Next": "CheckPredictorCoverage"
     },
-
     "CheckPredictorCoverage": {
       "Type": "Task",
       "Comment": "Self-healing coverage gate: detect buy_candidates in signals.json that lack a prediction row. Primary guard against the 2026-04-20 silent-veto-bypass bug. If any are missing, ReinvokePredictor scores them and RecheckCoverage verifies before we proceed to executor.",
@@ -803,7 +855,10 @@
       "TimeoutSeconds": 60,
       "Retry": [
         {
-          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
           "MaxAttempts": 1,
           "IntervalSeconds": 15,
           "BackoffRate": 1.0
@@ -811,7 +866,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -819,7 +876,6 @@
       "ResultPath": "$.coverage_result",
       "Next": "CoverageGapChoice"
     },
-
     "CoverageGapChoice": {
       "Type": "Choice",
       "Comment": "If buy_candidates have unscored tickers, re-invoke the predictor with --tickers. Otherwise advance to PredictorHealthCheck.",
@@ -832,7 +888,6 @@
       ],
       "Default": "PredictorHealthCheck"
     },
-
     "ReinvokePredictor": {
       "Type": "Task",
       "Comment": "Supplemental-scoring re-invoke for the tickers CheckPredictorCoverage flagged as missing. Predictor merges the new predictions into predictions/{date}.json (re-ranks the union).",
@@ -847,7 +902,10 @@
       "TimeoutSeconds": 900,
       "Retry": [
         {
-          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
           "MaxAttempts": 1,
           "IntervalSeconds": 60,
           "BackoffRate": 1.0
@@ -855,7 +913,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -863,7 +923,6 @@
       "ResultPath": "$.reinvoke_result",
       "Next": "RecheckCoverage"
     },
-
     "RecheckCoverage": {
       "Type": "Task",
       "Comment": "Second coverage check after ReinvokePredictor. If the gap persists (e.g. some ticker genuinely cannot be scored), bail out instead of looping — HandleFailure fires the SNS alert.",
@@ -877,7 +936,10 @@
       "TimeoutSeconds": 60,
       "Retry": [
         {
-          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
           "MaxAttempts": 1,
           "IntervalSeconds": 15,
           "BackoffRate": 1.0
@@ -885,7 +947,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -893,7 +957,6 @@
       "ResultPath": "$.coverage_recheck_result",
       "Next": "FinalCoverageGate"
     },
-
     "FinalCoverageGate": {
       "Type": "Choice",
       "Comment": "After one re-invocation attempt, either coverage is complete (proceed) or we have a deeper problem (fail). No further retry loop — prevents runaway invocations if a ticker is un-scorable by the model.",
@@ -906,7 +969,6 @@
       ],
       "Default": "PredictorHealthCheck"
     },
-
     "PredictorHealthCheck": {
       "Type": "Task",
       "Comment": "Daily predictor model health — IC, hit rate, calibration, retrain triggers",
@@ -920,7 +982,10 @@
       "TimeoutSeconds": 180,
       "Retry": [
         {
-          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
           "MaxAttempts": 1,
           "IntervalSeconds": 30,
           "BackoffRate": 1.0
@@ -928,7 +993,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Comment": "Predictor health check is non-blocking — continue to morning planner. Executor's own upstream-health gate catches real data-freshness problems before placing orders.",
           "Next": "CheckSkipMorningPlanner",
           "ResultPath": "$.predictor_health_error"
@@ -937,7 +1004,6 @@
       "ResultPath": "$.predictor_health_result",
       "Next": "CheckSkipMorningPlanner"
     },
-
     "RunMorningPlanner": {
       "Type": "Task",
       "Comment": "Run morning order-book planner via SSM",
@@ -957,14 +1023,18 @@
             "trap 'aws s3 cp /var/log/executor.log \"s3://alpha-engine-research/_ssm_logs/executor/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python executor/main.py 2>&1 | tee -a /var/log/executor.log"
           ],
-          "executionTimeout": ["300"]
+          "executionTimeout": [
+            "300"
+          ]
         },
         "TimeoutSeconds": 300
       },
       "TimeoutSeconds": 360,
       "Retry": [
         {
-          "ErrorEquals": ["States.TaskFailed"],
+          "ErrorEquals": [
+            "States.TaskFailed"
+          ],
           "MaxAttempts": 1,
           "IntervalSeconds": 60,
           "BackoffRate": 1.0
@@ -972,7 +1042,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -980,15 +1052,17 @@
       "ResultPath": "$.planner_result",
       "Next": "InitMorningPlannerPoll"
     },
-
     "InitMorningPlannerPoll": {
       "Type": "Pass",
       "Comment": "Seed the liveness-aware poll slot for the RunMorningPlanner loop (config#1811).",
-      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "Result": {
+        "verdict": "INIT",
+        "attempts": 0,
+        "ping_misses": 0
+      },
       "ResultPath": "$.planner_poll",
       "Next": "WaitForMorningPlanner"
     },
-
     "WaitForMorningPlanner": {
       "Type": "Task",
       "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 30 × ~15s ≈ 7.5 min, past the 300s executionTimeout.",
@@ -1022,7 +1096,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -1041,7 +1117,6 @@
       "ResultPath": "$.planner_poll",
       "Next": "CheckMorningPlannerStatus"
     },
-
     "CheckMorningPlannerStatus": {
       "Type": "Choice",
       "Comment": "Branches on the ssm-liveness-poller verdict (config#1811). COMMAND_FAILED (Default) → HandleFailure — the 2026-07-06 deploy-drift refusal surfaced here with rc=1. INSTANCE_UNRESPONSIVE → stamp → force-stop → HandleFailure. POLL_BUDGET_EXHAUSTED → MorningPlannerPollTimeout.",
@@ -1069,7 +1144,6 @@
       ],
       "Default": "HandleFailure"
     },
-
     "StampMorningPlannerUnresponsive": {
       "Type": "Pass",
       "Comment": "The trading box went unresponsive mid-planner. Stamp the poller's detail into $.error, force-stop, alert.",
@@ -1080,7 +1154,6 @@
       "ResultPath": "$.error",
       "Next": "ForceStopUnresponsiveInstance"
     },
-
     "MorningPlannerPollTimeout": {
       "Type": "Pass",
       "Comment": "Bounded poll budget exhausted on the RunMorningPlanner loop with the box still responsive (#970 shape). Stamp + alert via HandleFailure.",
@@ -1091,13 +1164,11 @@
       "ResultPath": "$.error",
       "Next": "HandleFailure"
     },
-
     "MorningPlannerWait": {
       "Type": "Wait",
       "Seconds": 15,
       "Next": "WaitForMorningPlanner"
     },
-
     "RunDaemon": {
       "Type": "Task",
       "Comment": "Restart the intraday daemon via SSM",
@@ -1113,14 +1184,18 @@
             "sudo systemctl restart alpha-engine-daemon.service",
             "echo 'Daemon restarted'"
           ],
-          "executionTimeout": ["30"]
+          "executionTimeout": [
+            "30"
+          ]
         },
         "TimeoutSeconds": 30
       },
       "TimeoutSeconds": 60,
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Comment": "Daemon restart failure is non-fatal — systemd boot trigger is backup",
           "Next": "PipelineComplete",
           "ResultPath": "$.daemon_error"
@@ -1129,66 +1204,79 @@
       "ResultPath": "$.daemon_result",
       "Next": "PipelineComplete"
     },
-
     "CheckSkipMorningEnrich": {
       "Type": "Choice",
       "Comment": "Per-task rerun gate (L4606). Input {\"skip_morning_enrich\": true} routes past MorningEnrich (fetch: constituents + prune + polygon daily_closes) to the next gate (CheckSkipMorningArcticAppend); missing flag = run as normal. Mirrors the Saturday SF CheckSkip<State> structure so the weekday pipeline is rerunnable task-by-task — an operator recovery rerun resumes at the first incomplete task instead of re-running completed upstream work. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.skip_morning_enrich", "IsPresent": true},
-            {"Variable": "$.skip_morning_enrich", "BooleanEquals": true}
+            {
+              "Variable": "$.skip_morning_enrich",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_morning_enrich",
+              "BooleanEquals": true
+            }
           ],
           "Next": "CheckSkipMorningArcticAppend"
         }
       ],
       "Default": "MorningEnrich"
     },
-
     "CheckSkipMorningArcticAppend": {
       "Type": "Choice",
       "Comment": "Per-task rerun gate (L4608). Input {\"skip_morning_arctic_append\": true} routes past MorningArcticAppend to the next gate (CheckSkipChronicGapHeal); missing flag = run as normal. The slow ArcticDB daily_append was split out of MorningEnrich 2026-06-11 — it ran ~20-38 min and a same-morning rerun exceeded MorningEnrich's 1800s SSM timeout and SIGKILLed it. As its own state it gets a longer timeout decoupled from the fast fetch, and a recovery rerun can skip whichever half already completed. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.skip_morning_arctic_append", "IsPresent": true},
-            {"Variable": "$.skip_morning_arctic_append", "BooleanEquals": true}
+            {
+              "Variable": "$.skip_morning_arctic_append",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_morning_arctic_append",
+              "BooleanEquals": true
+            }
           ],
           "Next": "CheckSkipChronicGapHeal"
         }
       ],
       "Default": "MorningArcticAppend"
     },
-
     "MorningArcticAppend": {
       "Type": "Task",
-      "Comment": "LOAD-BEARING: ArcticDB universe daily_append for the prior trading day — writes the polygon-corrected OHLCV row + recomputed features that predictor inference reads next. Split out of MorningEnrich (L4608, 2026-06-11): the append is the slow part (~20-38 min on the t3.small) and on 2026-06-11 a same-morning rerun's append exceeded MorningEnrich's 1800s executionTimeout and SIGKILLed the whole command. Own longer timeout (2400s) decoupled from the fast fetch; reads the constituents MorningEnrich just refreshed to S3. Failure → HandleFailure (predictor must not run on a stale ArcticDB).",
+      "Comment": "LOAD-BEARING: ArcticDB universe daily_append for the prior trading day — writes the polygon-corrected OHLCV row + recomputed features that predictor inference reads next. Split out of MorningEnrich (L4608, 2026-06-11): the append is the slow part (~20-38 min on the t3.small) and on 2026-06-11 a same-morning rerun's append exceeded MorningEnrich's 1800s executionTimeout and SIGKILLed the whole command. Own longer timeout (2400s) decoupled from the fast fetch; reads the constituents MorningEnrich just refreshed to S3. Failure → HandleFailure (predictor must not run on a stale ArcticDB). | config#1807 (2026-07-06): RUNS ON THE DAILY DATA SPOT — see MorningEnrich. The 2026-07-06 incident (this state swap-thrashing the t3.small into SSM darkness at market open) is the reason the whole data phase moved; the t3.large resize becomes revertible once this soaks.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
-        "InstanceIds.$": "$.trading_instance_id",
+        "InstanceIds.$": "States.Array($.data_spot.info.instance_id)",
         "Parameters": {
           "commands": [
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
             "export ALPHA_ENGINE_DEPLOYED=1",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+            "export HOME=/home/ec2-user",
+            "export XDG_CACHE_HOME=/tmp",
+            "export AWS_REGION=us-east-1",
+            "export AWS_DEFAULT_REGION=us-east-1",
+            "command -v python3.12 >/dev/null && PYTHON_BIN=python3.12 || PYTHON_BIN=python3",
             "cd /home/ec2-user/alpha-engine-data",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
-            "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/morning-arctic-append.log \"s3://alpha-engine-research/_ssm_logs/morning-arctic-append/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/morning-arctic-append.log",
-            "python weekly_collector.py --morning-arctic-append 2>&1 | tee -a /var/log/morning-arctic-append.log"
+            "$PYTHON_BIN weekly_collector.py --morning-arctic-append 2>&1 | tee -a /var/log/morning-arctic-append.log"
           ],
-          "executionTimeout": ["2400"]
+          "executionTimeout": [
+            "2400"
+          ]
         },
         "TimeoutSeconds": 2400
       },
       "TimeoutSeconds": 2460,
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -1196,15 +1284,17 @@
       "ResultPath": "$.arctic_append_result",
       "Next": "InitMorningArcticAppendPoll"
     },
-
     "InitMorningArcticAppendPoll": {
       "Type": "Pass",
       "Comment": "Seed the liveness-aware poll slot for the MorningArcticAppend loop (config#1811). This loop previously had NO bounded-attempt cap (the #970 fix only ever landed on MorningEnrich — copy-drift) and no liveness check: on 2026-07-06 (config#1807) it polled a frozen InProgress for 62 minutes while the box was wedged.",
-      "Result": {"verdict": "INIT", "attempts": 0, "ping_misses": 0},
+      "Result": {
+        "verdict": "INIT",
+        "attempts": 0,
+        "ping_misses": 0
+      },
       "ResultPath": "$.arctic_append_poll",
       "Next": "WaitForMorningArcticAppend"
     },
-
     "WaitForMorningArcticAppend": {
       "Type": "Task",
       "Comment": "Liveness-aware poll iteration (config#1811) — see WaitForMorningEnrich. max_attempts 150 × ~20s ≈ 50 min, just past the 2400s executionTimeout.",
@@ -1212,7 +1302,7 @@
       "Parameters": {
         "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
         "Payload": {
-          "instance_id.$": "$.trading_instance_id[0]",
+          "instance_id.$": "$.data_spot.info.instance_id",
           "command_id.$": "$.arctic_append_result.Command.CommandId",
           "attempts.$": "$.arctic_append_poll.attempts",
           "ping_misses.$": "$.arctic_append_poll.ping_misses",
@@ -1238,7 +1328,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -1257,7 +1349,6 @@
       "ResultPath": "$.arctic_append_poll",
       "Next": "CheckMorningArcticAppendStatus"
     },
-
     "CheckMorningArcticAppendStatus": {
       "Type": "Choice",
       "Comment": "LOAD-BEARING like CheckMorningEnrichStatus: only SUCCESS proceeds (to the chronic-gap heal gate, then PredictorInference); COMMAND_FAILED (Default) → HandleFailure (predictor must not run on a stale ArcticDB universe). INSTANCE_UNRESPONSIVE (the config#1807 wedged-box shape — THIS loop's 2026-07-06 incident) → stamp error → force-stop → HandleFailure. POLL_BUDGET_EXHAUSTED → MorningArcticAppendPollTimeout.",
@@ -1285,24 +1376,21 @@
       ],
       "Default": "HandleFailure"
     },
-
     "MorningArcticAppendWait": {
       "Type": "Wait",
       "Seconds": 20,
       "Next": "WaitForMorningArcticAppend"
     },
-
     "StampMorningArcticAppendUnresponsive": {
       "Type": "Pass",
-      "Comment": "The trading box went unresponsive mid-ArcticDB-append — the exact 2026-07-06 config#1807 incident shape (memory-pressure wedge; SSM agent ConnectionLost; in-box executionTimeout unable to fire). Stamp the poller's detail into $.error, then force-stop the instance and alert via HandleFailure. Detection budget: ~3 polls ≈ 1 min (was: 62 min of blind polling).",
+      "Comment": "The trading box went unresponsive mid-ArcticDB-append — the exact 2026-07-06 config#1807 incident shape (memory-pressure wedge; SSM agent ConnectionLost; in-box executionTimeout unable to fire). Stamp the poller's detail into $.error, then terminate the DATA SPOT (config#1807 — the trading box is not involved in this state anymore) and alert via HandleFailure. Detection budget: ~3 polls ≈ 1 min (was: 62 min of blind polling).",
       "Parameters": {
         "Error": "MorningArcticAppendInstanceUnresponsive",
         "Cause.$": "$.arctic_append_poll.detail"
       },
       "ResultPath": "$.error",
-      "Next": "ForceStopUnresponsiveInstance"
+      "Next": "ForceTerminateUnresponsiveDataSpot"
     },
-
     "MorningArcticAppendPollTimeout": {
       "Type": "Pass",
       "Comment": "Bounded poll budget exhausted on the MorningArcticAppend loop with the box still responsive (the #970 stuck-InProgress shape — distinct from INSTANCE_UNRESPONSIVE). Stamp a clear cause into $.error then route through HandleFailure so the SNS alert carries it. Operator action: inspect /var/log/morning-arctic-append.log on ae-trading + the SSM command invocation.",
@@ -1313,71 +1401,89 @@
       "ResultPath": "$.error",
       "Next": "HandleFailure"
     },
-
     "CheckSkipChronicGapHeal": {
       "Type": "Choice",
       "Comment": "Per-task rerun gate (L4606). Input {\"skip_chronic_gap_heal\": true} routes past ChronicGapSelfHeal to the next gate (CheckSkipPredictorInference); missing flag = run as normal. The heal is already best-effort/fail-soft, so skipping it on a rerun is always safe. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.skip_chronic_gap_heal", "IsPresent": true},
-            {"Variable": "$.skip_chronic_gap_heal", "BooleanEquals": true}
+            {
+              "Variable": "$.skip_chronic_gap_heal",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_chronic_gap_heal",
+              "BooleanEquals": true
+            }
           ],
-          "Next": "CheckSkipPredictorInference"
+          "Next": "CheckDataSpotToTerminate"
         }
       ],
       "Default": "ChronicGapSelfHeal"
     },
-
     "CheckSkipPredictorInference": {
       "Type": "Choice",
       "Comment": "Per-task rerun gate (L4606). Input {\"skip_predictor_inference\": true} routes past PredictorInference (and its coverage/health sub-chain) to the next gate (CheckSkipMorningPlanner); missing flag = run as normal. Skip only when predictions/{date}.json already exists from a prior run. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.skip_predictor_inference", "IsPresent": true},
-            {"Variable": "$.skip_predictor_inference", "BooleanEquals": true}
+            {
+              "Variable": "$.skip_predictor_inference",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_predictor_inference",
+              "BooleanEquals": true
+            }
           ],
           "Next": "CheckSkipMorningPlanner"
         }
       ],
       "Default": "PredictorInference"
     },
-
     "CheckSkipMorningPlanner": {
       "Type": "Choice",
       "Comment": "Per-task rerun gate (L4606). Input {\"skip_morning_planner\": true} routes past RunMorningPlanner to the next gate (CheckSkipRunDaemon); missing flag = run as normal. The planner writes the order book but places no orders, so re-running it is normally safe; skip is for reruns where the book is already current. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.skip_morning_planner", "IsPresent": true},
-            {"Variable": "$.skip_morning_planner", "BooleanEquals": true}
+            {
+              "Variable": "$.skip_morning_planner",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_morning_planner",
+              "BooleanEquals": true
+            }
           ],
           "Next": "CheckSkipRunDaemon"
         }
       ],
       "Default": "RunMorningPlanner"
     },
-
     "CheckSkipRunDaemon": {
       "Type": "Choice",
       "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daemon\": true} routes past RunDaemon (the daemon restart) directly to PipelineComplete; missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
-            {"Variable": "$.skip_run_daemon", "IsPresent": true},
-            {"Variable": "$.skip_run_daemon", "BooleanEquals": true}
+            {
+              "Variable": "$.skip_run_daemon",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_run_daemon",
+              "BooleanEquals": true
+            }
           ],
           "Next": "PipelineComplete"
         }
       ],
       "Default": "RunDaemon"
     },
-
     "PipelineComplete": {
       "Type": "Succeed"
     },
-
     "HandleFailure": {
       "Type": "Task",
       "Comment": "Failure alert via SNS",
@@ -1390,11 +1496,218 @@
       "ResultPath": "$.failure_notify",
       "Next": "FailExecution"
     },
-
     "FailExecution": {
       "Type": "Fail",
       "Error": "DailyPipelineFailure",
       "Cause": "One or more weekday pipeline steps failed."
+    },
+    "CheckSkipDataSpot": {
+      "Type": "Choice",
+      "Comment": "config#1807: the pre-open data phase (MorningEnrich + MorningArcticAppend + ChronicGapSelfHeal) runs on a short-lived spot instead of the trading box, whose 2026-07-06 swap-thrash starved its own SSM agent and blocked RunDaemon at market open. Launch the spot ONLY if at least one data state will run — a recovery rerun that skips all three (the 2026-07-06 recovery2 shape) boots no spot at all.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_morning_enrich",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_morning_enrich",
+              "BooleanEquals": true
+            },
+            {
+              "Variable": "$.skip_morning_arctic_append",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_morning_arctic_append",
+              "BooleanEquals": true
+            },
+            {
+              "Variable": "$.skip_chronic_gap_heal",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_chronic_gap_heal",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "StartExecutorEC2"
+        }
+      ],
+      "Default": "LaunchDailyDataSpot"
+    },
+    "LaunchDailyDataSpot": {
+      "Type": "Task",
+      "Comment": "config#1807 — fire-and-forget: SSM ae-dashboard (the fleet spot dispatcher, $.ec2_instance_id — ALREADY carried by the WeekdayTrigger CFN Input as [MicroInstanceId]) to run spot_data_weekly.sh --launch-only, which launches + bootstraps the daily data spot (capacity rotation + interruption retry via krepis.ec2_spot, systemd dead-man watchdog armed at 10800s) and writes {instance_id} to ops/daily_data_spot/{date}.json. The SF does NOT poll this command — the ~7-min spot bootstrap overlaps the trading-box boot + SSM-ready + CodeFreshnessGate chain, and ReadDataSpotId's retry-until-present loop is the synchronization point (a launch failure surfaces there as a loud timeout). Manual executions that run any data state must pass ec2_instance_id (ae-dashboard's instance id, as a 1-element list — same field the scheduled input carries) or set all three data skip_* flags.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+      "Parameters": {
+        "DocumentName": "AWS-RunShellScript",
+        "InstanceIds.$": "$.ec2_instance_id",
+        "Parameters": {
+          "commands.$": "States.Array('set -eo pipefail','export FLOW_DOCTOR_ENABLED=1','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-daily-launch --log /var/log/data-daily-launch.log -- bash infrastructure/spot_data_weekly.sh --launch-only --id-artifact-key ops/daily_data_spot/{}.json --max-runtime-seconds 10800', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0)))",
+          "executionTimeout": [
+            "1800"
+          ]
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist",
+            "States.TaskFailed",
+            "States.Timeout"
+          ],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "ResultPath": "$.data_spot_launch",
+      "Next": "StartExecutorEC2"
+    },
+    "CheckDataSpotLaunched": {
+      "Type": "Choice",
+      "Comment": "config#1807 — only executions that dispatched a spot launch read the id artifact; the all-three-skips path (no launch) proceeds straight to the (all-skipping) data gates.",
+      "Choices": [
+        {
+          "Variable": "$.data_spot_launch",
+          "IsPresent": true,
+          "Next": "ReadDataSpotId"
+        }
+      ],
+      "Default": "CheckSkipMorningEnrich"
+    },
+    "ReadDataSpotId": {
+      "Type": "Task",
+      "Comment": "config#1807 — synchronization point with the fire-and-forget launch: the id artifact appears once the spot is bootstrapped (~7 min, overlapped with the trading-box boot chain that just completed). Date-keyed so a stale artifact from a prior day can never be read (S3.NoSuchKey until today's launch writes it). Retry budget 24x20s = 8 min past the boot chain; exhaustion -> HandleFailure (loud), covering both a failed launch and a capacity-exhausted spot request.",
+      "Resource": "arn:aws:states:::aws-sdk:s3:getObject",
+      "Parameters": {
+        "Bucket": "alpha-engine-research",
+        "Key.$": "States.Format('ops/daily_data_spot/{}.json', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))"
+      },
+      "ResultSelector": {
+        "Body.$": "$.Body"
+      },
+      "ResultPath": "$.data_spot_raw",
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "S3.NoSuchKeyException",
+            "S3.NoSuchKey",
+            "States.TaskFailed",
+            "States.Timeout"
+          ],
+          "IntervalSeconds": 20,
+          "MaxAttempts": 24,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.error"
+        }
+      ],
+      "Next": "ParseDataSpotId"
+    },
+    "ParseDataSpotId": {
+      "Type": "Pass",
+      "Comment": "Lift the artifact JSON into $.data_spot.info — data states target $.data_spot.info.instance_id.",
+      "Parameters": {
+        "info.$": "States.StringToJson($.data_spot_raw.Body)"
+      },
+      "ResultPath": "$.data_spot",
+      "Next": "CheckSkipMorningEnrich"
+    },
+    "CheckDataSpotToTerminate": {
+      "Type": "Choice",
+      "Comment": "config#1807 — every data-phase exit (chronic-gap success, its fail-soft Catch, and the all-skip route) converges here so the spot is terminated exactly once, before PredictorInference. No spot launched (all-skips) -> pass through.",
+      "Choices": [
+        {
+          "Variable": "$.data_spot",
+          "IsPresent": true,
+          "Next": "TerminateDailyDataSpot"
+        }
+      ],
+      "Default": "CheckSkipPredictorInference"
+    },
+    "TerminateDailyDataSpot": {
+      "Type": "Task",
+      "Comment": "config#1807 — best-effort cleanup: a terminate failure must not fail a pipeline whose data work already succeeded (Catch -> proceed; the failure is recorded in $.data_spot_terminate_error and the spot's own systemd watchdog (10800s, armed at bootstrap) is the named backstop that bounds an orphan to ~3h of spot cost). Success path removes the box ~2h before the watchdog would.",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:terminateInstances",
+      "Parameters": {
+        "InstanceIds.$": "States.Array($.data_spot.info.instance_id)"
+      },
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.TaskFailed",
+            "States.Timeout"
+          ],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 2,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "CheckSkipPredictorInference",
+          "ResultPath": "$.data_spot_terminate_error"
+        }
+      ],
+      "ResultPath": "$.data_spot_terminate",
+      "Next": "CheckSkipPredictorInference"
+    },
+    "ForceTerminateUnresponsiveDataSpot": {
+      "Type": "Task",
+      "Comment": "config#1807/#1811 — the DATA SPOT went unresponsive mid data-state (PingStatus dark >=3 polls). Terminate the SPOT (not the trading box — it is healthy and holds no failed work) and fail loud. Mirrors ForceStopUnresponsiveInstance's posture; a terminate failure still routes to HandleFailure with the stamped cause intact, and the spot watchdog bounds any orphan.",
+      "Resource": "arn:aws:states:::aws-sdk:ec2:terminateInstances",
+      "Parameters": {
+        "InstanceIds.$": "States.Array($.data_spot.info.instance_id)"
+      },
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.TaskFailed",
+            "States.Timeout"
+          ],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 2,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "HandleFailure",
+          "ResultPath": "$.data_spot_force_terminate_error"
+        }
+      ],
+      "ResultPath": "$.data_spot_force_terminate",
+      "Next": "HandleFailure"
     }
   }
 }

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -114,8 +114,10 @@ class TestChainOrdering:
         }
         assert nexts["INSTANCE_UNRESPONSIVE"] == "StampChronicGapUnresponsive"
         assert (
+            # config#1807: the heal runs on the daily data spot — an
+            # unresponsive host terminates the SPOT, not the trading box.
             states["StampChronicGapUnresponsive"]["Next"]
-            == "ForceStopUnresponsiveInstance"
+            == "ForceTerminateUnresponsiveDataSpot"
         )
 
     def test_heal_precedes_predictor_inference(self, sf, states):
@@ -151,13 +153,18 @@ class TestFailSoft:
     # directly — still fail-soft: it proceeds toward predictions, never to
     # HandleFailure.
     _FWD = "CheckSkipPredictorInference"
+    # config#1807: data-phase exits route through the spot-terminate hook
+    # first; its Default (and TerminateDailyDataSpot both ways) proceed to
+    # _FWD, so the fail-soft guarantee is unchanged.
+    _HOOK = "CheckDataSpotToTerminate"
 
     def test_check_default_proceeds_toward_predictions_not_handlefailure(self, states):
         # Inverse of CheckMorningEnrichStatus, whose Default is HandleFailure.
-        assert states[_CHECK]["Default"] == self._FWD, (
+        assert states[_CHECK]["Default"] == self._HOOK, (
             "Chronic-gap heal is best-effort: any terminal status (incl. "
             "failure) must proceed toward PredictorInference, not HandleFailure."
         )
+        assert states[self._HOOK]["Default"] == self._FWD
         # And the gate it hands to must actually run PredictorInference.
         assert states[self._FWD]["Default"] == "PredictorInference"
 
@@ -165,16 +172,16 @@ class TestFailSoft:
         catches = states[_HEAL].get("Catch", [])
         assert catches, f"{_HEAL} must have a fail-soft Catch"
         for c in catches:
-            assert c["Next"] == self._FWD, (
+            assert c["Next"] == self._HOOK, (
                 f"{_HEAL} Catch must proceed toward PredictorInference via "
-                f"{self._FWD} (fail-soft), got {c['Next']}"
+                f"{self._HOOK} (fail-soft through the spot-terminate hook), got {c['Next']}"
             )
 
     def test_poll_catch_proceeds_toward_predictions(self, states):
         catches = states[_POLL].get("Catch", [])
         assert catches, f"{_POLL} must have a fail-soft Catch"
         for c in catches:
-            assert c["Next"] == self._FWD
+            assert c["Next"] == self._HOOK
 
     def test_no_heal_state_routes_to_handlefailure(self, states):
         """No Next/Default/Catch target across the heal quartet may be

--- a/tests/test_sf_daily_data_spot_wiring.py
+++ b/tests/test_sf_daily_data_spot_wiring.py
@@ -1,0 +1,155 @@
+"""Pin the daily data-spot decouple topology (config#1807, 2026-07-06).
+
+The pre-open data phase (MorningEnrich + MorningArcticAppend +
+ChronicGapSelfHeal) runs on a short-lived spot instance instead of the
+trading box: on 2026-07-06 the arctic append swap-thrashed the t3.small
+trading box into SSM darkness and blocked RunDaemon at market open.
+Topology: launch-once (fire-and-forget on ae-dashboard) -> per-state SSM
+dispatch to the spot (task-split + liveness polling preserved) ->
+explicit terminate, with the spot's own systemd watchdog as the orphan
+backstop.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+_INFRA = pathlib.Path(__file__).parent.parent / "infrastructure"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads((_INFRA / "step_function_daily.json").read_text())["States"]
+
+
+class TestLaunch:
+    def test_launch_is_fire_and_forget_on_dashboard(self, states):
+        st = states["LaunchDailyDataSpot"]
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:ssm:sendCommand"
+        # ae-dashboard, already carried by the WeekdayTrigger CFN Input.
+        assert st["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
+        cmds = st["Parameters"]["Parameters"]["commands.$"]
+        assert "--launch-only" in cmds
+        assert "spot_data_weekly.sh" in cmds
+        assert "--max-runtime-seconds 10800" in cmds, "dead-man watchdog budget"
+        assert "export FLOW_DOCTOR_ENABLED=1" in cmds
+        # Date-keyed artifact — a stale prior-day artifact can never be read.
+        assert "ops/daily_data_spot/{}.json" in cmds
+        assert "$$.Execution.StartTime" in cmds
+        # Fire-and-forget: proceeds to the box boot, no poll loop.
+        assert st["Next"] == "StartExecutorEC2"
+
+    def test_launch_skipped_when_all_three_data_states_skip(self, states):
+        gate = states["CheckSkipDataSpot"]
+        (rule,) = gate["Choices"]
+        flags = {c["Variable"] for c in rule["And"]}
+        assert flags == {
+            "$.skip_morning_enrich",
+            "$.skip_morning_arctic_append",
+            "$.skip_chronic_gap_heal",
+        }
+        assert rule["Next"] == "StartExecutorEC2"
+        assert gate["Default"] == "LaunchDailyDataSpot"
+
+
+class TestReadArtifact:
+    def test_read_is_the_synchronization_point(self, states):
+        st = states["ReadDataSpotId"]
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:s3:getObject"
+        assert st["Parameters"]["Bucket"] == "alpha-engine-research"
+        assert "ops/daily_data_spot/{}.json" in st["Parameters"]["Key.$"]
+        (retry,) = st["Retry"]
+        # Retry-until-present covers the overlapped spot bootstrap; exhaustion
+        # fails loud (a failed/capacity-starved launch surfaces HERE).
+        assert retry["MaxAttempts"] * retry["IntervalSeconds"] >= 300
+        assert st["Catch"][0]["Next"] == "HandleFailure"
+        assert st["Next"] == "ParseDataSpotId"
+
+    def test_read_only_when_launch_dispatched(self, states):
+        gate = states["CheckDataSpotLaunched"]
+        (rule,) = gate["Choices"]
+        assert rule["Variable"] == "$.data_spot_launch"
+        assert rule["IsPresent"] is True
+        assert rule["Next"] == "ReadDataSpotId"
+        assert gate["Default"] == "CheckSkipMorningEnrich"
+
+
+class TestDataStatesTargetSpot:
+    @pytest.mark.parametrize(
+        "state", ["MorningEnrich", "MorningArcticAppend", "ChronicGapSelfHeal"]
+    )
+    def test_state_targets_spot_not_trading_box(self, states, state):
+        st = states[state]
+        assert st["Parameters"]["InstanceIds.$"] == (
+            "States.Array($.data_spot.info.instance_id)"
+        ), f"{state} must run on the daily data spot (config#1807)"
+        cmds = "\n".join(st["Parameters"]["Parameters"]["commands"])
+        assert "trading_instance_id" not in cmds
+        # Spot flavor: fresh bootstrap owns venv/pin/config — no pull, no
+        # .alpha-engine.env, no .venv (weekly-spot convention).
+        assert "git pull" not in cmds and "git -C" not in cmds
+        assert ".alpha-engine.env" not in cmds
+        assert "source .venv" not in cmds
+        assert "export FLOW_DOCTOR_ENABLED=1" in cmds
+
+    @pytest.mark.parametrize(
+        "wait", ["WaitForMorningEnrich", "WaitForMorningArcticAppend", "WaitForChronicGap"]
+    )
+    def test_liveness_poller_watches_the_spot(self, states, wait):
+        payload = states[wait]["Parameters"]["Payload"]
+        assert payload["instance_id.$"] == "$.data_spot.info.instance_id"
+
+    def test_morning_enrich_keeps_task_split_flags(self, states):
+        cmds = "\n".join(states["MorningEnrich"]["Parameters"]["Parameters"]["commands"])
+        assert "--skip-chronic-heal --skip-arctic-append" in cmds, (
+            "the L4608/2026-06-11 task-split flags must survive the spot move"
+        )
+
+
+class TestTerminate:
+    def test_every_data_phase_exit_converges_on_the_hook(self, states):
+        assert states["CheckChronicGapStatus"]["Default"] == "CheckDataSpotToTerminate"
+        assert states["ChronicGapSelfHeal"]["Catch"][0]["Next"] == "CheckDataSpotToTerminate"
+        assert states["WaitForChronicGap"]["Catch"][0]["Next"] == "CheckDataSpotToTerminate"
+        skip_edge = [
+            c for c in states["CheckSkipChronicGapHeal"]["Choices"]
+            if c["Next"] == "CheckDataSpotToTerminate"
+        ]
+        assert len(skip_edge) == 1
+
+    def test_terminate_is_best_effort_and_proceeds(self, states):
+        st = states["TerminateDailyDataSpot"]
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:ec2:terminateInstances"
+        assert st["Next"] == "CheckSkipPredictorInference"
+        # Cleanup failure must not fail a pipeline whose data work succeeded;
+        # the spot watchdog is the named backstop.
+        assert st["Catch"][0]["Next"] == "CheckSkipPredictorInference"
+
+    def test_unresponsive_data_spot_terminates_spot_not_trading_box(self, states):
+        st = states["ForceTerminateUnresponsiveDataSpot"]
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:ec2:terminateInstances"
+        assert st["Parameters"]["InstanceIds.$"] == (
+            "States.Array($.data_spot.info.instance_id)"
+        )
+        assert st["Next"] == "HandleFailure"
+        assert st["Catch"][0]["Next"] == "HandleFailure"
+
+
+class TestIamAndLauncher:
+    def test_sf_role_carries_the_three_new_grants(self):
+        policy = json.loads(
+            (_INFRA / "iam" / "alpha-engine-step-functions-role.json").read_text()
+        )
+        sids = {st.get("Sid") for st in policy["Statement"]}
+        assert {"SendCommandDailyDataSpot", "TerminateDailyDataSpot",
+                "ReadDailyDataSpotArtifact"} <= sids
+
+    def test_launcher_has_launch_only_mode(self):
+        sh = (_INFRA / "spot_data_weekly.sh").read_text()
+        assert "--launch-only" in sh
+        assert "--id-artifact-key" in sh
+        assert 'KEEP_INSTANCE=1' in sh
+        # The Name tag routes the IAM condition (alpha-engine-data-*).
+        assert "alpha-engine-data-" in sh

--- a/tests/test_sf_lib_pin_self_heal_wiring.py
+++ b/tests/test_sf_lib_pin_self_heal_wiring.py
@@ -42,8 +42,15 @@ def _data_repo_entrypoints() -> dict[str, list[str]]:
             continue
         cmds = extract_commands(state)
         joined = "\n".join(cmds)
-        # In scope: pulls the data repo AND runs from the data-repo venv.
-        if _DATA_PULL in joined and _DATA_CD in joined:
+        # In scope: pulls the data repo AND runs from the data-repo VENV.
+        # config#1807 refinement: the venv-activate marker is load-bearing —
+        # the data states moved to the daily data spot, where deps are
+        # installed FRESH from requirements.txt at every bootstrap (the pin
+        # is satisfied by construction; there is no pull->stale-venv window),
+        # and LaunchDailyDataSpot pulls the data repo on ae-dashboard but
+        # only runs bash + the DASHBOARD venv (maintained by the dashboard
+        # deploy), never data-repo python.
+        if _DATA_PULL in joined and _DATA_CD in joined and _VENV_ACTIVATE in joined:
             out[name] = cmds
     return out
 
@@ -54,7 +61,12 @@ def test_known_data_entrypoints_in_scope():
     # data-repo entrypoint. MorningEnrich + MorningArcticAppend + ChronicGapSelfHeal
     # remain (they pull alpha-engine-data and run from its venv).
     eps = set(_data_repo_entrypoints())
-    assert {"MorningEnrich", "MorningArcticAppend", "ChronicGapSelfHeal"} <= eps, sorted(eps)
+    # config#1807: MorningEnrich / MorningArcticAppend / ChronicGapSelfHeal
+    # moved to the daily data spot (fresh clone + fresh deps per bootstrap
+    # — no pull->stale-venv window remains), so NO daily-SF state is a
+    # data-venv entrypoint today. The detector + parametrized heal test
+    # stay armed for any future re-addition.
+    assert eps == set(), sorted(eps)
 
 
 @pytest.mark.parametrize("name", sorted(_data_repo_entrypoints()))

--- a/tests/test_sf_liveness_watchdog_wiring.py
+++ b/tests/test_sf_liveness_watchdog_wiring.py
@@ -123,11 +123,19 @@ def test_loop_wiring(states, step):
     assert states[wait]["Next"] == poll
     assert nexts["INSTANCE_UNRESPONSIVE"] == stamp
 
-    # Stamp carries the poller's detail into $.error, then force-stops.
+    # Stamp carries the poller's detail into $.error, then force-stops the
+    # wedged host. config#1807: the three DATA loops run on the daily data
+    # spot, so their remediation terminates the SPOT; the trading-box loops
+    # keep the force-stop.
     st_stamp = states[stamp]
     assert st_stamp["ResultPath"] == "$.error"
     assert st_stamp["Parameters"]["Cause.$"] == f"{slot}.detail"
-    assert st_stamp["Next"] == "ForceStopUnresponsiveInstance"
+    _data_spot_steps = ("morning-enrich", "morning-arctic-append", "chronic-gap-heal")
+    expected_force = (
+        "ForceTerminateUnresponsiveDataSpot" if step in _data_spot_steps
+        else "ForceStopUnresponsiveInstance"
+    )
+    assert st_stamp["Next"] == expected_force
 
 
 def test_force_stop_is_forceful_and_alerts(states):
@@ -170,5 +178,7 @@ def test_code_freshness_gate_front_loads_the_drift_check(states):
         c["Next"] for c in states["CheckCodeFreshnessStatus"]["Choices"]
         if c.get("StringEquals") == "SUCCESS"
     ]
-    assert fresh == ["CheckSkipMorningEnrich"]
+    # config#1807: freshness success synchronizes with the data-spot launch
+    # (CheckDataSpotLaunched -> ReadDataSpotId) before the morning gates.
+    assert fresh == ["CheckDataSpotLaunched"]
     assert states["CheckCodeFreshnessStatus"]["Default"] == "HandleFailure"

--- a/tests/test_sf_trading_day_gate_wiring.py
+++ b/tests/test_sf_trading_day_gate_wiring.py
@@ -75,7 +75,11 @@ class TestTradingDayGateChoice:
         assert false_branch == ["NotifyHolidaySkip"]
 
     def test_default_proceeds_to_start_box(self, states):
-        assert states["TradingDayGateChoice"]["Default"] == "StartExecutorEC2"
+        # config#1807: trading day confirmed -> dispatch the data-spot launch
+        # first (fire-and-forget), then boot the box.
+        assert states["TradingDayGateChoice"]["Default"] == "CheckSkipDataSpot"
+        assert states["CheckSkipDataSpot"]["Default"] == "LaunchDailyDataSpot"
+        assert states["LaunchDailyDataSpot"]["Next"] == "StartExecutorEC2"
 
     def test_choice_reads_is_trading_day_off_gate_payload(self, states):
         var = states["TradingDayGateChoice"]["Choices"][0]["Variable"]
@@ -86,7 +90,8 @@ class TestTradingDayGateFailed:
     def test_failed_proceeds_to_start_box(self, states):
         failed = states["TradingDayGateFailed"]
         assert failed["Resource"] == "arn:aws:states:::sns:publish"
-        assert failed["Next"] == "StartExecutorEC2"
+        # config#1807: fail-open path also routes through the spot-launch gate.
+        assert failed["Next"] == "CheckSkipDataSpot"
 
 
 class TestDeadStatesRemoved:

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -33,7 +33,8 @@ _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
 _CHAIN = [
     ("CheckSkipMorningEnrich", "MorningEnrich", "skip_morning_enrich", "CheckSkipMorningArcticAppend"),
     ("CheckSkipMorningArcticAppend", "MorningArcticAppend", "skip_morning_arctic_append", "CheckSkipChronicGapHeal"),
-    ("CheckSkipChronicGapHeal", "ChronicGapSelfHeal", "skip_chronic_gap_heal", "CheckSkipPredictorInference"),
+    # config#1807: the data phase exits through the spot-terminate hook.
+    ("CheckSkipChronicGapHeal", "ChronicGapSelfHeal", "skip_chronic_gap_heal", "CheckDataSpotToTerminate"),
     ("CheckSkipPredictorInference", "PredictorInference", "skip_predictor_inference", "CheckSkipMorningPlanner"),
     ("CheckSkipMorningPlanner", "RunMorningPlanner", "skip_morning_planner", "CheckSkipRunDaemon"),
     ("CheckSkipRunDaemon", "RunDaemon", "skip_run_daemon", "PipelineComplete"),
@@ -81,7 +82,12 @@ class TestEntryEdgesRouteThroughGates:
         # config#1430: the NYSE holiday check moved OFF the box into the predictor
         # Lambda and now gates BEFORE StartExecutorEC2.
         assert states["DeployDriftGate"]["Default"] == "TradingDayGate"
-        assert states["TradingDayGateChoice"]["Default"] == "StartExecutorEC2"
+        # config#1807: a confirmed trading day first dispatches the daily data
+        # spot launch (fire-and-forget on ae-dashboard), THEN boots the box.
+        assert states["TradingDayGateChoice"]["Default"] == "CheckSkipDataSpot"
+        assert states["CheckSkipDataSpot"]["Default"] == "LaunchDailyDataSpot"
+        assert states["LaunchDailyDataSpot"]["Next"] == "StartExecutorEC2"
+        assert states["CheckSkipDataSpot"]["Choices"][0]["Next"] == "StartExecutorEC2"
         false_branch = [
             c["Next"]
             for c in states["TradingDayGateChoice"]["Choices"]
@@ -102,10 +108,15 @@ class TestEntryEdgesRouteThroughGates:
         assert online == ["CodeFreshnessGate"]
         fresh = [c["Next"] for c in states["CheckCodeFreshnessStatus"]["Choices"]
                  if c.get("StringEquals") == "SUCCESS"]
-        assert fresh == ["CheckSkipMorningEnrich"]
+        # config#1807: boot-chain success synchronizes with the spot launch
+        # (ReadDataSpotId) before entering the morning gates.
+        assert fresh == ["CheckDataSpotLaunched"]
+        assert states["CheckDataSpotLaunched"]["Default"] == "CheckSkipMorningEnrich"
+        assert states["CheckDataSpotLaunched"]["Choices"][0]["Next"] == "ReadDataSpotId"
 
     def test_trading_day_gate_failed_proceeds_as_trading_day(self, states):
-        assert states["TradingDayGateFailed"]["Next"] == "StartExecutorEC2"
+        # config#1807: fail-open path also routes through the spot-launch gate.
+        assert states["TradingDayGateFailed"]["Next"] == "CheckSkipDataSpot"
 
     def test_morning_enrich_success_enters_append_gate(self, states):
         # L4608: the slow daily_append is now its own load-bearing state behind
@@ -134,10 +145,15 @@ class TestEntryEdgesRouteThroughGates:
         assert int(et[0] if isinstance(et, list) else et) > 1800
 
     def test_chronic_gap_terminal_enters_predictor_gate(self, states):
-        # CheckChronicGapStatus Default + both heal Catches.
-        assert states["CheckChronicGapStatus"]["Default"] == "CheckSkipPredictorInference"
-        assert states["ChronicGapSelfHeal"]["Catch"][0]["Next"] == "CheckSkipPredictorInference"
-        assert states["WaitForChronicGap"]["Catch"][0]["Next"] == "CheckSkipPredictorInference"
+        # CheckChronicGapStatus Default + both heal Catches. config#1807: all
+        # three converge on the spot-terminate hook, whose Default proceeds to
+        # the predictor gate — fail-soft posture preserved, spot never leaked.
+        assert states["CheckChronicGapStatus"]["Default"] == "CheckDataSpotToTerminate"
+        assert states["ChronicGapSelfHeal"]["Catch"][0]["Next"] == "CheckDataSpotToTerminate"
+        assert states["WaitForChronicGap"]["Catch"][0]["Next"] == "CheckDataSpotToTerminate"
+        assert states["CheckDataSpotToTerminate"]["Default"] == "CheckSkipPredictorInference"
+        assert states["TerminateDailyDataSpot"]["Next"] == "CheckSkipPredictorInference"
+        assert states["TerminateDailyDataSpot"]["Catch"][0]["Next"] == "CheckSkipPredictorInference"
 
     def test_predictor_health_enters_planner_gate(self, states):
         assert states["PredictorHealthCheck"]["Next"] == "CheckSkipMorningPlanner"
@@ -191,7 +207,9 @@ class TestPaths:
         order = self._walk(states, "CheckSkipMorningEnrich", skip_flags=all_flags)
         for task in (c[1] for c in _CHAIN):
             assert task not in order, f"{task} ran despite its skip flag"
-        assert order == ["PipelineComplete"]
+        # config#1807: the all-skip walk passes through the (no-op) terminate
+        # hook — no spot was launched, so its Default falls straight through.
+        assert order == ["CheckDataSpotToTerminate", "PipelineComplete"]
 
     def test_skip_fetch_only_resumes_at_append(self, states):
         """MorningEnrich fetch already done → skip it, run the append onward."""


### PR DESCRIPTION
## Summary

Structural fix for config#1807: the pre-open data phase (MorningEnrich + MorningArcticAppend + ChronicGapSelfHeal) moves off the trading box onto a short-lived daily data spot. After the 2026-07-06 incident (append swap-thrashed the t3.small into SSM darkness, daemon blocked past the open), the resize mitigates — this removes the class: data-plane compute can never again starve the trading control-plane box.

**Topology** (ratified on config#1807): launch-once → per-state dispatch → explicit terminate.
- `LaunchDailyDataSpot` fire-and-forgets `spot_data_weekly.sh --launch-only` (new launcher mode) on ae-dashboard; spot bootstrap (~7 min, capacity-rotation + interruption-retry preserved) **overlaps the trading-box boot chain**; `ReadDataSpotId` (date-keyed S3 artifact, retry-until-present, loud on exhaustion) is the sync point.
- The three data states keep task-split granularity, skip gates, and #1811 liveness polling — only the host changes. The 6/11 task-split flags (`--skip-chronic-heal --skip-arctic-append`) are pinned by test.
- Every data-phase exit converges on a terminate hook (best-effort; the spot's own 10800s systemd dead-man watchdog is the named orphan backstop). Unresponsive-host remediation for data loops terminates the **spot**, never the trading box.
- All-three-skips recovery runs (the 7/6 recovery2 shape) launch no spot at all.

**Cost note:** ~$1–2/mo of spot vs. the +$8/mo t3.large resize delta — after this soaks, the trading box reverts to t3.small (follow-up tracked on config#1807).

## Why DRAFT (gate:live-run)

This must not own a market morning untested. Unblocking steps, in order:
1. **IAM apply** (`infrastructure/iam/apply.sh`) — the drift check will read red-by-design on this PR until applied: three additive grants (tag-scoped `ssm:SendCommand` + `ec2:TerminateInstances` on `alpha-engine-data-*`, `s3:GetObject` on `ops/daily_data_spot/*`).
2. **Live verification run** on a non-market morning or with skip flags: manual execution exercising Launch → Read → one data state on the spot → Terminate (mirror of the 7/6 `verify-1811-freshness-gate` pattern).
3. Merge (SF auto-deploys) the evening before the target first scheduled morning.

## Testing
Full suite: **2674 passed, 9 skipped**, including the new 16-pin `test_sf_daily_data_spot_wiring.py` and the refined lib-pin self-heal detector (scope = pull + cd + data-venv activate; spot states satisfy the pin invariant by fresh-install construction).

Closes-when for config#1807's remaining scope; sequential-gate re-exam already resolved on the issue (inference hard-depends on the append via `_verify_arctic_fresh` — order preserved, compute decoupled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)