### PR TITLE
fix(groom-dispatch): unblock spot-death auto-relaunch (config#1645)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/sf-execution-iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/sf-execution-iam-policy.json
@@ -22,7 +22,10 @@
     {
       "Sid": "CheckGroomRunCompletionMarker",
       "Effect": "Allow",
-      "Action": "s3:GetObject",
+      "Action": [
+        "s3:GetObject",
+        "s3:HeadObject"
+      ],
       "Resource": "arn:aws:s3:::alpha-engine-research/groom/_control/completed/*"
     },
     {

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -39,7 +39,19 @@
         }
       ],
       "ResultPath": "$.groomLaunch",
-      "Next": "CheckLaunched"
+      "Next": "RelaunchNotifyGate"
+    },
+    "RelaunchNotifyGate": {
+      "Type": "Choice",
+      "Comment": "Relaunch-first, notify-second (2026-07-06): only ping SNS after a successful re-launch (retry_count>0). First launch (retry_count==0) skips straight to polling. NotifyRelaunch failures must not block polling — its Catch routes to CheckLaunched.",
+      "Choices": [
+        {
+          "Variable": "$.retry_count",
+          "NumericGreaterThan": 0,
+          "Next": "NotifyRelaunch"
+        }
+      ],
+      "Default": "CheckLaunched"
     },
     "CheckLaunched": {
       "Type": "Choice",
@@ -135,12 +147,14 @@
     },
     "PrepRelaunch": {
       "Type": "Pass",
-      "Comment": "config#1645: bump the counter for the next attempt (each relaunch calls the Lambda fresh, which mints its own new run_token — the old attempt's absent marker is never confused with the new attempt's).",
+      "Comment": "config#1645: bump the counter for the next attempt (each relaunch calls the Lambda fresh, which mints its own new run_token — the old attempt's absent marker is never confused with the new attempt's). MUST preserve groomPoll/groomLaunch through the relaunch path — NotifyRelaunch (best-effort) and audit trails reference them; dropping them caused States.Runtime on States.Format (2026-07-06 live failure: Opus groom never relaunched after spot death).",
       "Parameters": {
         "schedInput.$": "$.schedInput",
         "retry_count.$": "States.MathAdd($.retry_count, 1)",
         "max_retries.$": "$.max_retries",
-        "fod.$": "$.fod"
+        "fod.$": "$.fod",
+        "groomPoll.$": "$.groomPoll",
+        "groomLaunch.$": "$.groomLaunch"
       },
       "Next": "CheckForceOnDemand"
     },
@@ -154,36 +168,39 @@
           "Next": "SetForceOnDemand"
         }
       ],
-      "Default": "NotifyRelaunch"
+      "Default": "LaunchGroomSpot"
     },
     "SetForceOnDemand": {
       "Type": "Pass",
+      "Comment": "Final relaunch attempt — escalate to on-demand. Preserves groomPoll/groomLaunch for downstream visibility.",
       "Parameters": {
         "schedInput.$": "$.schedInput",
         "retry_count.$": "$.retry_count",
         "max_retries.$": "$.max_retries",
-        "fod": {"force_on_demand": true}
+        "fod": {"force_on_demand": true},
+        "groomPoll.$": "$.groomPoll",
+        "groomLaunch.$": "$.groomLaunch"
       },
-      "Next": "NotifyRelaunch"
+      "Next": "LaunchGroomSpot"
     },
     "NotifyRelaunch": {
       "Type": "Task",
-      "Comment": "config#1645: best-effort WARNING-level ping (distinct from HandleFailure's FAILED alert) so a spot interruption is visible in real time instead of only discoverable after the fact via CloudWatch log archaeology. Never blocks the relaunch on a publish failure.",
+      "Comment": "config#1645: best-effort WARNING-level ping AFTER the relaunch box is already launching (LaunchGroomSpot -> RelaunchNotifyGate -> here). A States.Format intrinsic error in Parameters is NOT catchable (States.Runtime) — groomPoll is preserved through PrepRelaunch/SetForceOnDemand for this message. SNS publish failures ARE catchable and route to CheckLaunched so a notify hiccup never blocks polling the new run.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
         "Subject": "Alpha Engine Backlog Groom — spot interrupted, auto-relaunching",
-        "Message.$": "States.Format('Backlog groom box appears to have been reclaimed mid-run (SSM status={}, no completion marker). Relaunching automatically: attempt {} of {}, force_on_demand={}.', $.groomPoll.Status, $.retry_count, $.max_retries, $.fod.force_on_demand)"
+        "Message.$": "States.Format('Backlog groom box died mid-run (SSM status={}, no completion marker). Relaunched automatically: attempt {} of {} (force_on_demand={}).', $.groomPoll.Status, $.retry_count, $.max_retries, States.JsonToString($.fod.force_on_demand))"
       },
       "ResultPath": "$.relaunch_notify",
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "LaunchGroomSpot",
+          "Next": "CheckLaunched",
           "ResultPath": "$.relaunch_notify_error"
         }
       ],
-      "Next": "LaunchGroomSpot"
+      "Next": "CheckLaunched"
     },
     "GroomStatusError": {
       "Type": "Pass",

--- a/tests/test_sf_groom_relaunch_wiring.py
+++ b/tests/test_sf_groom_relaunch_wiring.py
@@ -1,0 +1,98 @@
+"""Pins config#1645 groom-dispatch SF relaunch recovery wiring.
+
+Origin: 2026-07-06 — Opus groom died ~7 min in (spot/OOM); the dispatch SF
+detected marker-absent and entered PrepRelaunch, then ExecutionFailed at
+NotifyRelaunch with States.Runtime because PrepRelaunch dropped $.groomPoll
+(and CheckCompletionMarker headObject returned 403 — IAM had GetObject but not
+HeadObject). Recovery never launched a second box.
+
+This test catches regressions like:
+- PrepRelaunch / SetForceOnDemand stripping groomPoll (relaunch notify/runtime)
+- NotifyRelaunch blocking LaunchGroomSpot (notify must follow launch)
+- SF execution role missing s3:HeadObject for the completion-marker check
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_groom.json"
+_IAM_PATH = (
+    _REPO_ROOT
+    / "infrastructure"
+    / "lambdas"
+    / "scheduled-groom-dispatcher"
+    / "sf-execution-iam-policy.json"
+)
+
+_PRESERVE_PATHS = ("groomPoll.$", "groomLaunch.$")
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+@pytest.fixture(scope="module")
+def iam_policy() -> dict:
+    return json.loads(_IAM_PATH.read_text())
+
+
+def test_completion_marker_check_uses_head_object(states):
+    st = states["CheckCompletionMarker"]
+    assert st["Resource"] == "arn:aws:states:::aws-sdk:s3:headObject"
+    assert st["Parameters"]["Bucket"] == "alpha-engine-research"
+    assert "groom/_control/completed/" in st["Parameters"]["Key.$"]
+
+
+def test_sf_role_grants_head_object_on_completion_marker(iam_policy):
+    marker_stmts = [
+        s
+        for s in iam_policy["Statement"]
+        if s.get("Sid") == "CheckGroomRunCompletionMarker"
+    ]
+    assert len(marker_stmts) == 1
+    actions = marker_stmts[0]["Action"]
+    if isinstance(actions, str):
+        actions = [actions]
+    assert "s3:HeadObject" in actions
+    assert "s3:GetObject" in actions
+
+
+def test_prep_relaunch_preserves_poll_context_and_routes_to_force_on_demand_gate(states):
+    st = states["PrepRelaunch"]
+    params = st["Parameters"]
+    for key in _PRESERVE_PATHS:
+        assert key in params, f"PrepRelaunch must preserve {key} through relaunch"
+    assert st["Next"] == "CheckForceOnDemand"
+
+
+def test_set_force_on_demand_preserves_poll_context(states):
+    st = states["SetForceOnDemand"]
+    params = st["Parameters"]
+    for key in _PRESERVE_PATHS:
+        assert key in params
+    assert st["Next"] == "LaunchGroomSpot"
+    assert params["fod"] == {"force_on_demand": True}
+
+
+def test_relaunch_critical_path_launch_before_notify(states):
+    """LaunchGroomSpot must precede NotifyRelaunch; notify must not gate relaunch."""
+    assert states["CheckForceOnDemand"]["Default"] == "LaunchGroomSpot"
+    assert states["SetForceOnDemand"]["Next"] == "LaunchGroomSpot"
+    assert states["LaunchGroomSpot"]["Next"] == "RelaunchNotifyGate"
+    assert states["RelaunchNotifyGate"]["Default"] == "CheckLaunched"
+    relaunch_choices = states["RelaunchNotifyGate"]["Choices"]
+    assert relaunch_choices[0]["Next"] == "NotifyRelaunch"
+    assert states["NotifyRelaunch"]["Next"] == "CheckLaunched"
+    assert states["NotifyRelaunch"]["Catch"][0]["Next"] == "CheckLaunched"
+
+
+def test_notify_relaunch_message_uses_preserved_groom_poll_status(states):
+    msg = states["NotifyRelaunch"]["Parameters"]["Message.$"]
+    assert "$.groomPoll.Status" in msg
+    assert "States.JsonToString($.fod.force_on_demand)" in msg


### PR DESCRIPTION
## Summary
- **IAM:** add `s3:HeadObject` on `groom/_control/completed/*` — `CheckCompletionMarker` uses `headObject` but the SF role only had `GetObject` (live 403 today).
- **SF wiring:** `PrepRelaunch` / `SetForceOnDemand` now preserve `groomPoll` + `groomLaunch` (dropping them caused `States.Runtime` in `NotifyRelaunch` → relaunch never ran).
- **Relaunch-first:** `CheckForceOnDemand` → `LaunchGroomSpot` → `RelaunchNotifyGate` → optional `NotifyRelaunch` → `CheckLaunched` (SNS failure cannot block polling).
- **Tests:** `test_sf_groom_relaunch_wiring.py` pins the above.

## Root cause (2026-07-06 Opus groom)
Spot box died ~7 min in. Dispatch SF polled SSM → marker check → `PrepRelaunch` → **`NotifyRelaunch` crashed** (`$.groomPoll.Status` missing) → `LaunchGroomSpot` never reached. Digest #1812 stuck "RUN IN PROGRESS".

## Deploy
**Requires `deploy.sh --bootstrap`** (IAM + SF definition — CI code-only deploy does not apply these).

## Test plan
- [x] `pytest tests/test_sf_groom_relaunch_wiring.py`
- [ ] `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap`
- [ ] Manual Opus high-only groom relaunch OR wait for 23:00 Sonnet slot; confirm second box launches on simulated spot death


Made with [Cursor](https://cursor.com)