### PR TITLE
[P1/high] fix(sf-watch): suppress autonomous dispatch on operator abort

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -123,6 +123,13 @@ PIPELINES: dict[str, dict[str, object]] = {
 }
 SCHEMA_VERSION = 1
 _CAUSE_MAX_CHARS = 600
+# config#1827 — human-abort carve-out. An `ABORTED` execution whose top-level
+# `error` is one of these markers is a DELIBERATE operator/human stop, not a
+# failure needing autonomous recovery: suppress the agent dispatch (still record
+# + Telegram loudly). Keep this set SMALL and EXPLICIT — do NOT suppress on bare
+# `ABORTED`, because a programmatic/self-abort can still be a real defect that
+# must dispatch. `OperatorAbort` is the marker the fleet's manual-stop path sets.
+OPERATOR_ABORT_ERRORS = frozenset({"OperatorAbort"})
 # Bound the history scan: fetch the newest N events (reverseOrder), reconstruct
 # chronological order locally to find the entered-but-not-exited state. The
 # failed state's enclosing StateEntered is always in the tail of the history.
@@ -157,6 +164,21 @@ def _failure_cause(describe_resp: dict | None) -> str:
     if len(snippet) > _CAUSE_MAX_CHARS:
         snippet = snippet[: _CAUSE_MAX_CHARS - 1] + "…"
     return snippet
+
+
+def _is_operator_abort(status: str, describe_resp: dict | None) -> bool:
+    """True iff this is a deliberate human stop — ``status == "ABORTED"`` AND the
+    execution's top-level ``error`` is an explicit operator-abort marker
+    (config#1827). Deliberately narrow: an ``ABORTED`` with any other error (or
+    no error) is NOT treated as operator-initiated, so a programmatic/self-abort
+    still dispatches a recovery agent (guards against over-suppression, the
+    fail-loud violation of the inverse kind)."""
+    if status != "ABORTED":
+        return False
+    if not describe_resp:
+        return False
+    error = (describe_resp.get("error") or "").strip()
+    return error in OPERATOR_ABORT_ERRORS
 
 
 def _is_preflight(describe_resp: dict | None) -> bool:
@@ -257,7 +279,16 @@ def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str,
     # global kill-switch AND this specific pipeline having a wired listener —
     # not the global flag alone (that was the bug: claiming "dispatch" for a
     # pipeline no workflow listens for).
-    will_dispatch = AGENT_DISPATCH_ENABLED and bool(cfg.get("has_listener", True))
+    # config#1827: a deliberate operator abort is recorded loudly but never
+    # auto-dispatches a recovery agent (would waste a cycle and, once weekday/EOD
+    # leave propose-only, risk an automated countermand of a human decision).
+    operator_abort = _is_operator_abort(detail.get("status", ""), describe_resp)
+    dispatch_suppressed = "operator_abort" if operator_abort else None
+    will_dispatch = (
+        AGENT_DISPATCH_ENABLED
+        and bool(cfg.get("has_listener", True))
+        and not operator_abort
+    )
     return {
         "detected_at": now_iso,
         "status": detail.get("status", "UNKNOWN"),
@@ -276,6 +307,10 @@ def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str,
         "action": "dispatch" if will_dispatch else "observe",
         "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
         "has_listener": bool(cfg.get("has_listener", True)),
+        # config#1827: null unless the dispatch was withheld for a recorded
+        # reason; "operator_abort" makes the human-stop decision auditable in the
+        # watch-log and on the dashboard.
+        "dispatch_suppressed": dispatch_suppressed,
     }
 
 
@@ -320,7 +355,10 @@ def _notify(record: dict, key: str, pipeline_name: str) -> bool:
     has_listener = bool(cfg.get("has_listener", True))
     cadence = _pipeline_label(pipeline_name)
     label = f"{cadence} Preflight SF" if record["is_preflight"] else f"{cadence} SF"
-    will_dispatch = AGENT_DISPATCH_ENABLED and has_listener
+    # config#1827: an operator-abort suppresses the dispatch even when the flag +
+    # listener are on — the receipt must read OBSERVE, not AUTO-FIX.
+    suppressed = record.get("dispatch_suppressed")
+    will_dispatch = AGENT_DISPATCH_ENABLED and has_listener and not suppressed
     mode = "AUTO-FIX" if will_dispatch else "OBSERVE"
     lines = [
         f"\U0001f6f0️ *Fleet-SF Watch — {mode}*",
@@ -333,6 +371,8 @@ def _notify(record: dict, key: str, pipeline_name: str) -> bool:
     lines.append(f"Watch log: `s3://{WATCH_BUCKET}/{key}`")
     if will_dispatch:
         footer = "_autonomous fix ACTIVE — resilience agent dispatched (diagnose→fix→merge→rerun)_"
+    elif suppressed == "operator_abort":
+        footer = "_operator abort — recorded loudly, no autonomous recovery (deliberate human stop)_"
     elif AGENT_DISPATCH_ENABLED and not has_listener:
         footer = "_observe-only for this pipeline — no autonomous remediation wired yet (needs Brian)_"
     else:
@@ -381,6 +421,12 @@ def _maybe_dispatch_agent(
     does NOT raise — the primary observe deliverable (watch-log) already landed.
     The watch-log is written BEFORE this call so the agent reads fresh context.
     """
+    if record.get("dispatch_suppressed"):
+        # config#1827: a deliberate operator abort (or any other recorded
+        # suppression reason) never auto-summons a recovery agent. The watch-log
+        # + Telegram receipt already fired, so nothing is silenced — only the
+        # autonomous ACTION on a human decision is withheld.
+        return {"dispatched": False, "reason": record["dispatch_suppressed"]}
     if not AGENT_DISPATCH_ENABLED:
         return {"dispatched": False, "reason": "disabled"}
     if not cfg.get("has_listener", True):

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -451,3 +451,85 @@ def test_live_old_named_eod_is_registered_during_rename_transition():
     ARN is removed from the registry + rule at cutover."""
     assert "alpha-engine-eod-pipeline" in index.PIPELINES
     assert index.PIPELINES["alpha-engine-eod-pipeline"]["cadence_slug"] == "eod"
+
+
+# ── config#1827: operator-abort dispatch carve-out ──────────────────────────
+
+
+def test_operator_abort_suppresses_dispatch_but_still_records(monkeypatch):
+    """A deliberate operator abort (status ABORTED + error == "OperatorAbort")
+    must NOT auto-dispatch a recovery agent even when the flag + listener are on,
+    yet MUST still write the watch-log and fire the Telegram receipt (fail-loud
+    preserved — only the autonomous ACTION on a human decision is withheld)."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    fired = {"called": False}
+
+    def fake_urlopen(req, timeout=None):
+        fired["called"] = True
+        return _FakeResp()
+
+    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
+    describe = {
+        "input": json.dumps({"pipeline_role": "verify-1807"}),
+        "error": "OperatorAbort",
+        "cause": "Verification mistakenly started during market hours; rescheduling post-close",
+    }
+    factory, _, s3 = _make_clients(describe=describe)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("ABORTED", sm_arn=WEEKDAY_ARN), None)
+
+    # Dispatch suppressed — no repository_dispatch HTTP call fired.
+    assert result["agent_dispatch"] == {"dispatched": False, "reason": "operator_abort"}
+    assert result["action"] == "observe"
+    assert fired["called"] is False
+    # Watch-log STILL written (fail-loud) and carries the auditable reason.
+    s3.put_object.assert_called_once()
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    ev = written["events"][-1]
+    assert ev["status"] == "ABORTED"
+    assert ev["dispatch_suppressed"] == "operator_abort"
+    assert ev["action"] == "observe"
+    # Telegram receipt STILL fired, labelled OBSERVE with the operator-abort note.
+    assert result["telegram_sent"] is True
+    text = index.notify_via_flow_doctor.call_args.args[0]
+    assert "Fleet-SF Watch — OBSERVE" in text
+    assert "autonomous fix ACTIVE" not in text
+    assert "operator abort" in text.lower()
+
+
+def test_genuine_failed_still_dispatches(monkeypatch):
+    """Over-suppression guard: a real FAILED (not an operator abort) must still
+    dispatch when the flag + listener are on."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, _, s3 = _make_clients()  # default describe error = States.TaskFailed
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["action"] == "dispatched"
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    assert written["events"][-1]["dispatch_suppressed"] is None
+
+
+def test_programmatic_abort_still_dispatches(monkeypatch):
+    """Over-suppression guard (the inverse fail-loud violation): an ABORTED whose
+    error is NOT the operator marker (e.g. a programmatic/self-abort) is a real
+    defect and must still dispatch — suppression is on the marker, not on bare
+    ABORTED."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    describe = {
+        "input": "{}",
+        "error": "States.Runtime",
+        "cause": "self-abort on invariant breach",
+    }
+    factory, _, s3 = _make_clients(describe=describe)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("ABORTED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["action"] == "dispatched"
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    assert written["events"][-1]["dispatch_suppressed"] is None


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** high

Closes nousergon/alpha-engine-config#1827

## Problem
`saturday-sf-watch-dispatcher/index.py` classified **any** terminal status (`FAILED`/`TIMED_OUT`/`ABORTED`) as dispatch-worthy, with no carve-out for the execution `error`/cause. An **operator abort** (a deliberate human stop — `status=ABORTED`, `error="OperatorAbort"`) would therefore auto-summon the resilience agent. It was benign on 2026-07-06 only because the weekday kill-switch was still `propose-only`; once weekday/EOD leave soak, STEP 5's rerun path could re-drive a market-hours execution the operator had just intentionally stopped.

## Fix (structural, dispatch-gating only — Lane-D untouched)
- `OPERATOR_ABORT_ERRORS` marker set + `_is_operator_abort(status, describe_resp)` — **narrow**: `status == "ABORTED"` **and** top-level `error` in the marker set. Bare `ABORTED` is *not* suppressed, so a programmatic/self-abort still dispatches (guards the inverse fail-loud violation).
- `_build_event_record` folds it into `will_dispatch` and stamps `dispatch_suppressed="operator_abort"` for audit (surfaced in the watch-log record + handler result).
- `_maybe_dispatch_agent` short-circuits on `record["dispatch_suppressed"]` -> `{"dispatched": False, "reason": "operator_abort"}`.
- `_notify` renders `OBSERVE` (not `AUTO-FIX`) with an operator-abort footer.

**Fail-loud preserved:** the watch-log S3 put and the Telegram receipt still fire on the suppressed path — nothing is silenced, only the autonomous *action* on a human decision is withheld.

## Tests (in sibling `test_handler.py`)
- `test_operator_abort_suppresses_dispatch_but_still_records` — ABORTED+OperatorAbort -> `dispatched: False` / `action: observe`, **no** repository_dispatch HTTP call, **but** S3 put happened + record present + Telegram fired labelled OBSERVE.
- `test_genuine_failed_still_dispatches` + `test_programmatic_abort_still_dispatches` — over-suppression guards.

Local: `python -m pytest test_handler.py -q` -> **28 passed**.