### PR TITLE
[P2/high] refactor(store): route universe/macro opens through nousergon_lib.arcticdb (config#804)

### DIFF
--- a/store/arctic_store.py
+++ b/store/arctic_store.py
@@ -23,6 +23,7 @@ from typing import Sequence
 
 import arcticdb as adb
 import pandas as pd
+from nousergon_lib.arcticdb import arctic_uri, open_macro_lib, open_universe_lib
 
 log = logging.getLogger(__name__)
 
@@ -72,7 +73,11 @@ def _get_arctic(bucket: str | None = None) -> adb.Arctic:
 
     bucket = bucket or os.environ.get("ARCTIC_BUCKET", DEFAULT_BUCKET)
     region = os.environ.get("AWS_REGION", "us-east-1")
-    uri = f"s3s://s3.{region}.amazonaws.com:{bucket}?path_prefix={ARCTIC_PREFIX}&aws_auth=true"
+    # Single source of truth for the S3 URI — nousergon_lib.arcticdb.arctic_uri
+    # (path_prefix=arcticdb, aws_auth=true). Hand-rolling this f-string here was
+    # the SNDK-incident bug class (path_prefix collapsing under shell quoting,
+    # 2026-04-21); route it through the lib so it stays consistent everywhere.
+    uri = arctic_uri(bucket, region=region)
 
     log.info("Connecting to ArcticDB: s3://%s/%s (region=%s)", bucket, ARCTIC_PREFIX, region)
     _arctic_instance = adb.Arctic(uri)
@@ -80,15 +85,26 @@ def _get_arctic(bucket: str | None = None) -> adb.Arctic:
 
 
 def get_universe_lib(bucket: str | None = None) -> adb.library.Library:
-    """Get the universe library (per-ticker OHLCV + features)."""
-    arctic = _get_arctic(bucket)
-    return arctic.get_library("universe", create_if_missing=True)
+    """Get the universe library (per-ticker OHLCV + features).
+
+    Delegates to ``nousergon_lib.arcticdb.open_universe_lib`` — the shared
+    library-open chokepoint (uniform URI + uniform RuntimeError-with-bucket
+    error shape, config#804). This is a PRODUCER site, so ``create_if_missing``
+    stays ``True`` to preserve cold-start bootstrap on a fresh bucket.
+    """
+    bucket = bucket or os.environ.get("ARCTIC_BUCKET", DEFAULT_BUCKET)
+    return open_universe_lib(bucket, create_if_missing=True)
 
 
 def get_macro_lib(bucket: str | None = None) -> adb.library.Library:
-    """Get the macro library (market-wide time series)."""
-    arctic = _get_arctic(bucket)
-    return arctic.get_library("macro", create_if_missing=True)
+    """Get the macro library (market-wide time series).
+
+    Delegates to ``nousergon_lib.arcticdb.open_macro_lib`` (shared open
+    chokepoint, config#804); ``create_if_missing=True`` preserves the
+    producer cold-start bootstrap.
+    """
+    bucket = bucket or os.environ.get("ARCTIC_BUCKET", DEFAULT_BUCKET)
+    return open_macro_lib(bucket, create_if_missing=True)
 
 
 def get_scratch_universe_lib(name: str, bucket: str | None = None) -> adb.library.Library:


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** high

Part of **config#804** (migrate the remaining raw ArcticDB `get_library("universe"/"macro")` sites to the shared `nousergon_lib.arcticdb` helpers). This is the **nousergon-data leg**; the companion **crucible-backtester leg** (two residual `get_library("macro")` opens in `store/arctic_reader.py`) is a separate PR. Together they close config#804 — the rest of the sites named in the issue were already migrated (predictor, research, executor, backtester `feature_drift`, data `postflight`).

## What
`store/arctic_store.py` was the last producer holding hand-rolled ArcticDB access:
- `get_universe_lib` / `get_macro_lib` now delegate to `nousergon_lib.arcticdb.open_universe_lib` / `open_macro_lib` — the shared open chokepoint (single-source S3 URI + uniform `RuntimeError`-with-bucket error shape). `create_if_missing=True` is preserved (these are producer cold-start openers, unlike read-only consumers).
- `_get_arctic` (still used by the scratch-library path + `reset_connection`) now builds its URI via `nousergon_lib.arcticdb.arctic_uri` instead of the local f-string. That hand-rolled `path_prefix=…` string was the **SNDK-incident bug class** (path_prefix collapsing under shell quoting, 2026-04-21) — routing it through the lib removes the last copy.
- `get_scratch_universe_lib` intentionally stays on `_get_arctic` + `get_library(name)` (the lib has no arbitrary-named-library helper; the live-name guard is the point).

Transitively completes `builders/backfill.py` and `builders/daily_append.py` (both import these two openers; neither has its own raw opens).

## Validation
- URI equivalence confirmed: `nousergon_lib.arcticdb.arctic_uri` emits byte-identical `s3s://s3.{region}.amazonaws.com:{bucket}?path_prefix=arcticdb&aws_auth=true` (same region resolution) — and `validators/postflight.py` already reads live data through the same helper.
- No lib pin bump needed (repo already pins `nousergon-lib[arcticdb,…]@v0.86.0`, which ships the helpers).
- Tests: the full arctic_store-touching set is green locally — `test_backfill_no_regression`, `test_backfill_unified_and_macro_scoping`, `test_corporate_actions_sync`, `test_chronic_polygon_gap_self_heal`, `test_daily_append_skip_if_exists`, `test_spy_universe_member`, `test_arctic_write_contract` → **69 passed**. These patch `get_universe_lib`/`get_macro_lib` at the boundary, so the delegation is transparent to them. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)