### PR TITLE
Sync groom dispatcher WET ceiling default to 674M

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -92,9 +92,9 @@ DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "
 # Kill-switch independent of GROOM_DISPATCH_ENABLED — lets ops disable JUST the
 # pace gate (e.g. during a known burst) without touching the dispatch trigger.
 PACE_GATE_ENABLED = os.environ.get("GROOM_PACE_GATE_ENABLED", "true").lower() == "true"
-# Calibrated 2026-06-28 — MUST track alpha-engine-config/scripts/groom_budget.py's
-# WEEKLY_WET_CEILING; refine both together against /usage (config#1347).
-WEEKLY_WET_CEILING = int(os.environ.get("GROOM_WEEKLY_WET_CEILING", "1140000000"))
+# Calibrated 2026-07-06 — MUST track alpha-engine-config/scripts/groom_budget.py's
+# WEEKLY_WET_CEILING; re-calibrate both together against /usage every few days.
+WEEKLY_WET_CEILING = int(os.environ.get("GROOM_WEEKLY_WET_CEILING", "674000000"))
 _PT = ZoneInfo("America/Los_Angeles")
 # MUST match groom_budget.py's WEEKLY_RESET_ANCHOR/WEEKLY_PERIOD exactly — both
 # derive the SAME reset-aligned window from one observed reset instant.


### PR DESCRIPTION
## Summary
- Update `scheduled-groom-dispatcher` default `GROOM_WEEKLY_WET_CEILING` fallback **1.14B → 674M** to match `alpha-engine-config/scripts/groom_budget.py` (calibrated 2026-07-06 @ `/usage` 26%)

## Test plan
- [ ] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py`
- [ ] After merge: `deploy.sh` for dispatcher Lambda (or confirm env override not pinning old value)

## Notes
Depends on alpha-engine-config PR for the canonical constant. Re-calibrate both together every few days.

Made with [Cursor](https://cursor.com)