### PR TITLE
Groom dispatcher: honor SSM pace-gate override

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -75,6 +75,12 @@
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH",
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_GROOM"
       ]
+    },
+    {
+      "Sid": "ReadGroomBudgetOverrideParam",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/groom/dynamic_budget_override_until"
     }
   ]
 }

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -102,6 +102,8 @@ WEEKLY_RESET_ANCHOR = datetime(2026, 6, 28, 20, 59)   # PT, naive — one observ
 WEEKLY_PERIOD = timedelta(days=7)
 CCUSAGE_BUCKET = os.environ.get("CCUSAGE_BUCKET", "alpha-engine-research")
 CCUSAGE_PREFIX = "claude_code_usage/"
+# Self-expiring operator override — MUST track groom_budget.py::OVERRIDE_UNTIL_PARAM.
+OVERRIDE_UNTIL_PARAM = "/alpha-engine/groom/dynamic_budget_override_until"
 
 # ── Spot launch config (env-overridable; defaults mirror spot_data_weekly.sh) ──
 # t3/t3a/t2 .medium (4 GB) across all 6 default-VPC subnets; the lib CLI rotates
@@ -185,6 +187,30 @@ def _read_weekly_wet(window_start: datetime) -> float:
     return total
 
 
+def _parse_override_until(raw: str) -> "datetime | None":
+    """PT-naive datetime from the SSM value; None if blank/unparseable."""
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(_PT).replace(tzinfo=None)
+    return dt
+
+
+def _read_override_until() -> "datetime | None":
+    """Active override expiry from SSM; None when absent/unreadable."""
+    try:
+        ssm = boto3.client("ssm", region_name=REGION)
+        raw = ssm.get_parameter(Name=OVERRIDE_UNTIL_PARAM)["Parameter"]["Value"]
+    except Exception:  # noqa: BLE001 — absent override => normal policy
+        return None
+    return _parse_override_until(raw)
+
+
 def _pace_gate_status() -> dict:
     """Compute the pre-boot pace-gate decision. Fail-safe: ANY error (S3 read,
     parse, credentials) returns ``exceeded: False`` with the error recorded —
@@ -192,6 +218,13 @@ def _pace_gate_status() -> dict:
     groom_budget.py's own fail-safe posture."""
     try:
         now_pt = datetime.now(_PT).replace(tzinfo=None)
+        override_until = _read_override_until()
+        if override_until is not None and now_pt < override_until:
+            return {
+                "exceeded": False,
+                "override_until": override_until.isoformat(),
+                "reason": "operator override active — pace gate suspended",
+            }
         window_start, _next_reset = reset_window(now_pt, WEEKLY_RESET_ANCHOR, WEEKLY_PERIOD)
         wet = _read_weekly_wet(window_start)
         used_frac = wet / WEEKLY_WET_CEILING if WEEKLY_WET_CEILING else 0.0

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -69,8 +69,9 @@ class _FakeEc2:
 
 
 class _FakeSsm:
-    def __init__(self):
+    def __init__(self, parameters=None):
         self.sent = []
+        self.parameters = dict(parameters or {})
 
     def describe_instance_information(self, **kw):
         return {"InstanceInformationList": [{"PingStatus": "Online"}]}
@@ -78,6 +79,11 @@ class _FakeSsm:
     def send_command(self, **kw):
         self.sent.append(kw)
         return {"Command": {"CommandId": "cmd-123"}}
+
+    def get_parameter(self, Name):  # noqa: N803 — boto3 API
+        if Name not in self.parameters:
+            raise RuntimeError(f"Parameter {Name} not found")
+        return {"Parameter": {"Value": self.parameters[Name]}}
 
 
 class _FakeS3Body:
@@ -115,10 +121,10 @@ class _FakeS3:
         return {"Body": _FakeS3Body(self._objects[Key])}
 
 
-def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None):
+def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None, ssm_parameters=None):
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
-    ssm = _FakeSsm()
+    ssm = _FakeSsm(ssm_parameters)
     ec2 = _FakeEc2()
     s3 = _FakeS3(s3_objects)
     clients = {"ec2": ec2, "ssm": ssm, "s3": s3}
@@ -313,6 +319,22 @@ def test_pace_gate_allows_launch_when_on_pace(monkeypatch):
     assert out["groom"]["launched"] is True
     assert len(idx._test_ssm.sent) == 1
     assert notified == []  # no ping when nothing was skipped
+
+
+def test_pace_gate_suspended_when_operator_override_active(monkeypatch):
+    # Way over pace, but SSM override is active -> still launch.
+    idx = _load(
+        monkeypatch,
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+        s3_objects={"claude_code_usage/groom/2026-06-29.json":
+                    _wet_doc(0.9 * 1_140_000_000)},
+        ssm_parameters={"/alpha-engine/groom/dynamic_budget_override_until": "2099-01-01T00:00"},
+    )
+    fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
+    monkeypatch.setattr(idx, "datetime", type("D", (), {
+        "now": staticmethod(lambda tz=None: fixed_now)}))
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    assert out["groom"]["launched"] is True
 
 
 def test_pace_gate_disabled_still_launches_even_if_ahead_of_pace(monkeypatch):


### PR DESCRIPTION
## Summary
- Pre-boot pace gate reads `/alpha-engine/groom/dynamic_budget_override_until` and suspends skips while active
- IAM: `ssm:GetParameter` on the override param
- Unit test + `_FakeSsm.get_parameter` stub

## Ops
IAM applied live + `deploy.sh` run in-session for immediate effect.

## Test plan
- [ ] CI green on data repo

Made with [Cursor](https://cursor.com)