### PR TITLE
[P2/mid] feat(sf): wire pipeline-contract preflight into Saturday SF (closes alpha-engine-config#693)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -185,7 +185,7 @@
     },
     "LibPinDriftGate": {
       "Type": "Choice",
-      "Comment": "Hard-fail when the lib-pin probe reports has_drift=true (a confirmed co-install parity break or below-floor regression). Surfaces cross-repo pin drift loudly before the SF spends on any spot launch. Routes via ExtractLibPinDriftError (NOT straight to HandleFailure): a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — jumping here directly made HandleFailure itself die with States.Runtime ('$.error could not be found', 2026-07-03 offcycle-shell), swallowing the drift reason behind an opaque meta-error. Mirrors the existing Extract*Error normalizer convention.",
+      "Comment": "Hard-fail when the lib-pin probe reports has_drift=true (a confirmed co-install parity break or below-floor regression). Surfaces cross-repo pin drift loudly before the SF spends on any spot launch. Routes via ExtractLibPinDriftError (NOT straight to HandleFailure): a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — jumping here directly made HandleFailure itself die with States.Runtime ('$.error could not be found', 2026-07-03 offcycle-shell), swallowing the drift reason behind an opaque meta-error. Mirrors the existing Extract*Error normalizer convention. On pass, proceeds to PipelineContractCheck (L4595 / config#693) — the sibling pre-spend preflight gate — rather than straight to CheckMutexRole, composing both invariant probes into one preflight chain before any spot spend.",
       "Choices": [
         {
           "Variable": "$.libpin_drift_result.Payload.has_drift",
@@ -193,7 +193,7 @@
           "Next": "ExtractLibPinDriftError"
         }
       ],
-      "Default": "CheckMutexRole"
+      "Default": "PipelineContractCheck"
     },
     "ExtractLibPinDriftError": {
       "Type": "Pass",
@@ -202,6 +202,64 @@
         "phase": "LibPinDriftGate",
         "source": "LibPinDriftGate.has_drift",
         "drift.$": "$.libpin_drift_result.Payload"
+      },
+      "ResultPath": "$.error",
+      "Next": "HandleFailure"
+    },
+    "PipelineContractCheck": {
+      "Type": "Task",
+      "Comment": "Preventive pre-spend PIPELINE_CONTRACT.yaml preflight gate (L4595 / config#693). Sibling to LibPinDriftCheck: runs immediately after it, BEFORE any spot launch, and asserts PIPELINE_CONTRACT.yaml is internally self-consistent AND every artifact_id it references exists in ARTIFACT_REGISTRY.yaml. A CI validator (validate_pipeline_contract.py) already catches this at PR time, but a config/SF-definition change made outside that CI could still spend a Saturday spot before failing; this probe re-runs the same invariants at SF start so a contract break halts in seconds. FAIL-OPEN: a GitHub-fetch/parse miss sets has_violation=false (the probe's own degraded mode, reason=fetch_failed), and the Catch routes any Lambda failure straight to the pipeline — so the checker NEVER false-halts the weekly run, mirroring LibPinDriftCheck's fail-open semantics exactly.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_pipeline_contract"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-open — the probe's own failure must not halt the weekly run; proceed to the pipeline.",
+          "Next": "CheckMutexRole",
+          "ResultPath": "$.pipeline_contract_error"
+        }
+      ],
+      "ResultPath": "$.pipeline_contract_result",
+      "Next": "PipelineContractGate"
+    },
+    "PipelineContractGate": {
+      "Type": "Choice",
+      "Comment": "Hard-fail when the pipeline-contract probe reports has_violation=true (a confirmed PIPELINE_CONTRACT.yaml self-consistency breach or dangling artifact_id). Surfaces the contract break loudly before the SF spends on any spot launch. Routes via ExtractPipelineContractError (NOT straight to HandleFailure), mirroring LibPinDriftGate: a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — a direct Choice→HandleFailure jump would die with States.Runtime ('$.error could not be found'), swallowing the violation list behind an opaque meta-error.",
+      "Choices": [
+        {
+          "Variable": "$.pipeline_contract_result.Payload.has_violation",
+          "BooleanEquals": true,
+          "Next": "ExtractPipelineContractError"
+        }
+      ],
+      "Default": "CheckMutexRole"
+    },
+    "ExtractPipelineContractError": {
+      "Type": "Pass",
+      "Comment": "Normalize a confirmed pipeline-contract violation (PipelineContractGate has_violation==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) — it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the violation list. Carries the whole probe Payload (has_violation/violations/boundary_count/reason) so the FAILED SNS alert names the exact contract breach a human must resolve. References only $.pipeline_contract_result.Payload — guaranteed present because the gate already dereferenced Payload.has_violation to route here — so this normalizer cannot itself raise a missing-field States.Runtime. Mirrors ExtractLibPinDriftError → HandleFailure convention; no new error channel. FAIL-LOUD PRESERVED: still → HandleFailure → FailExecution (the pipeline still hard-fails on a real contract violation by design).",
+      "Parameters": {
+        "phase": "PipelineContractGate",
+        "source": "PipelineContractGate.has_violation",
+        "violation.$": "$.pipeline_contract_result.Payload"
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -994,6 +994,10 @@ class TestHappyPathTraversal:
         # to CheckSkipLibPinDriftCheck — one extra Choice in the visited order.
         # config#1824: the run-day gate is the first hop; a role-less input
         # takes its Default straight to CheckRunMode — one extra Choice.
+        # config#693 (L4595): the pipeline-contract preflight gate is now
+        # composed directly after LibPinDriftGate's pass-through (no drift ->
+        # PipelineContractCheck -> PipelineContractGate -> CheckMutexRole on no
+        # violation) — two extra states in the visited order.
         assert order[: order.index("CheckSkipMorningEnrich") + 2] == [
             "InitializeInput",
             "CheckWeeklyRunDayGate",
@@ -1001,6 +1005,8 @@ class TestHappyPathTraversal:
             "CheckSkipLibPinDriftCheck",
             "LibPinDriftCheck",
             "LibPinDriftGate",
+            "PipelineContractCheck",
+            "PipelineContractGate",
             "CheckMutexRole",
             "CheckShellRun",
             "CheckSkipMorningEnrich",

--- a/tests/test_sf_lib_pin_drift_wiring.py
+++ b/tests/test_sf_lib_pin_drift_wiring.py
@@ -88,8 +88,9 @@ def test_gate_halts_only_on_confirmed_drift(states):
     # Confirmed drift halts, but routes through the $.error normalizer FIRST
     # (not straight to HandleFailure) — see test_drift_halt_normalizes_error.
     assert c["Next"] == "ExtractLibPinDriftError"
-    # No drift → proceed into the pipeline.
-    assert gate["Default"] == "CheckMutexRole"
+    # No drift → proceed into the pipeline-contract preflight gate (config#693),
+    # composed directly after this gate's pass-through.
+    assert gate["Default"] == "PipelineContractCheck"
 
 
 def test_drift_halt_normalizes_error_before_handle_failure(states):

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -180,7 +180,12 @@ class TestMutexWiring:
         # config#1824: run-day gate precedes CheckRunMode; bypass Default keeps chain.
         assert saturday_sf["States"]["CheckWeeklyRunDayGate"]["Default"] == "CheckRunMode"
         assert saturday_sf["States"]["CheckRunMode"]["Default"] == "CheckSkipLibPinDriftCheck"
-        assert saturday_sf["States"]["LibPinDriftGate"]["Default"] == "CheckMutexRole"
+        # config#693: the pipeline-contract preflight gate now sits between
+        # LibPinDriftGate and CheckMutexRole (see
+        # test_sf_pipeline_contract_wiring.py); its own pass-through Default
+        # still lands on CheckMutexRole, one gate further down.
+        assert saturday_sf["States"]["LibPinDriftGate"]["Default"] == "PipelineContractCheck"
+        assert saturday_sf["States"]["PipelineContractGate"]["Default"] == "CheckMutexRole"
 
     def test_weekday_initialize_input_routes_to_check_mutex_role(self, weekday_sf):
         assert weekday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -73,6 +73,9 @@ def _flatten_states(sf_doc: dict) -> dict:
 _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # L4517: preventive cross-repo lib-pin drift gate (predictor-inference Lambda).
     "LibPinDriftCheck": frozenset({"action"}),
+    # config#693 (L4595): pre-spend pipeline-contract preflight gate, wired
+    # directly after LibPinDriftGate's pass-through (predictor-inference Lambda).
+    "PipelineContractCheck": frozenset({"action"}),
     # config#1824 weekly run-day gate (pure calendar; mirrors LibPinDriftCheck shape).
     "WeeklyRunDayGate": frozenset({"action"}),
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),

--- a/tests/test_sf_pipeline_contract_wiring.py
+++ b/tests/test_sf_pipeline_contract_wiring.py
@@ -1,0 +1,187 @@
+"""Pins the pre-spend pipeline-contract preflight gate in the Saturday SF
+(L4595 / config#693).
+
+The gate (`PipelineContractCheck` -> `PipelineContractGate`) MUST run right
+after the lib-pin-drift gate passes, and BEFORE any spot launch, hard-failing
+the SF on a CONFIRMED `PIPELINE_CONTRACT.yaml` self-consistency / dangling
+`artifact_id` violation, while failing OPEN on the probe's own error. These
+tests catch regressions like: someone reorders it after a spot launch
+(defeating "fail before spend"), drops the fail-open Catch (probe fragility
+false-halts the weekly run), or inverts the gate's halt condition.
+
+Mirrors `tests/test_sf_lib_pin_drift_wiring.py` exactly — this is the sibling
+gate composed directly after `LibPinDriftGate`'s pass-through.
+
+Pairs with alpha-engine-predictor `inference/pipeline_contract_check.py` (the
+`action=check_pipeline_contract` Lambda handler).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def sf():
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf):
+    return sf["States"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["PipelineContractCheck", "PipelineContractGate", "ExtractPipelineContractError"],
+)
+def test_gate_states_exist(states, name):
+    assert name in states, f"{name} missing from Saturday SF States"
+
+
+def test_lib_pin_drift_gate_pass_through_routes_here(states):
+    # LibPinDriftGate's no-drift Default used to go straight to CheckMutexRole;
+    # config#693 inserts this gate immediately after it in the preflight chain.
+    assert states["LibPinDriftGate"]["Default"] == "PipelineContractCheck"
+
+
+def test_check_invokes_predictor_lambda_with_action(states):
+    chk = states["PipelineContractCheck"]
+    assert chk["Type"] == "Task"
+    assert chk["Resource"] == "arn:aws:states:::lambda:invoke"
+    assert chk["Parameters"]["FunctionName"] == "alpha-engine-predictor-inference:live"
+    assert chk["Parameters"]["Payload"]["action"] == "check_pipeline_contract"
+    assert chk["ResultPath"] == "$.pipeline_contract_result"
+    assert chk["Next"] == "PipelineContractGate"
+
+
+def test_check_fails_open_via_catch(states):
+    # The probe's own failure must proceed into the pipeline, NOT halt the
+    # weekly run.
+    catch = states["PipelineContractCheck"]["Catch"][0]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "CheckMutexRole"  # the pipeline, not HandleFailure
+
+
+def test_gate_halts_only_on_confirmed_violation(states):
+    gate = states["PipelineContractGate"]
+    assert gate["Type"] == "Choice"
+    c = gate["Choices"][0]
+    assert c["Variable"] == "$.pipeline_contract_result.Payload.has_violation"
+    assert c["BooleanEquals"] is True
+    # Confirmed violation halts, but routes through the $.error normalizer
+    # FIRST (not straight to HandleFailure) — see
+    # test_violation_halt_normalizes_error.
+    assert c["Next"] == "ExtractPipelineContractError"
+    # No violation -> proceed into the pipeline, same target LibPinDriftGate
+    # used before this gate was inserted.
+    assert gate["Default"] == "CheckMutexRole"
+
+
+def test_violation_halt_normalizes_error_before_handle_failure(states):
+    """The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) —
+    its transition does NOT populate $.error. HandleFailure's Message calls
+    States.JsonToString($.error), so a direct Choice->HandleFailure jump would
+    kill the SF with an opaque States.Runtime ('$.error could not be found')
+    that swallows the violation list. The violation path must first hit an
+    Extract*Error normalizer that writes $.error, matching every other
+    HandleFailure entry (see ExtractLibPinDriftError)."""
+    norm = states["ExtractPipelineContractError"]
+    assert norm["Type"] == "Pass"
+    assert norm["ResultPath"] == "$.error"
+    assert norm["Next"] == "HandleFailure"
+    # References only the whole probe Payload — guaranteed present because the
+    # gate already dereferenced Payload.has_violation to route here — so the
+    # normalizer cannot itself raise a missing-field States.Runtime.
+    assert norm["Parameters"]["violation.$"] == "$.pipeline_contract_result.Payload"
+
+
+def test_every_handle_failure_entry_populates_error(states):
+    """CHOKEPOINT for the whole failure class (2026-07-03): HandleFailure's
+    Message template hard-requires $.error via States.JsonToString($.error), so
+    EVERY transition that lands on HandleFailure must guarantee $.error is set —
+    either a Task Catch with ResultPath '$.error', or a Pass normalizer with
+    ResultPath '$.error'. A future soft-path/Choice that jumps straight to
+    HandleFailure would re-introduce the opaque States.Runtime meta-crash; this
+    test fails loudly if any such path appears. Duplicated from
+    test_sf_lib_pin_drift_wiring.py so this file is a self-contained sibling
+    check for the pipeline-contract gate's own contribution to that
+    invariant."""
+    offenders = []
+    for name, st in states.items():
+        # Catch-based entries.
+        for cat in st.get("Catch", []):
+            if cat.get("Next") == "HandleFailure" and cat.get("ResultPath") != "$.error":
+                offenders.append(f"{name} Catch ResultPath={cat.get('ResultPath')!r}")
+        # State-transition entries (Next / Default / Choice).
+        transitions = [st.get("Next"), st.get("Default")]
+        transitions += [c.get("Next") for c in st.get("Choices", [])]
+        if "HandleFailure" in transitions:
+            # The source state must itself write $.error before handing off —
+            # i.e. be a Pass normalizer with ResultPath '$.error'.
+            if not (st.get("Type") == "Pass" and st.get("ResultPath") == "$.error"):
+                offenders.append(
+                    f"{name} (Type={st.get('Type')}) transitions to HandleFailure "
+                    f"without setting $.error (ResultPath={st.get('ResultPath')!r})"
+                )
+    assert not offenders, (
+        "State(s) reach HandleFailure without populating $.error — "
+        "HandleFailure will die with States.Runtime: " + "; ".join(offenders)
+    )
+
+
+def test_gate_runs_before_any_spot_launch(sf, states):
+    """Walk the happy path (Next / Choice-Default) from StartAt and assert
+    PipelineContractGate is reached BEFORE the first ssm:sendCommand spot
+    launch — the whole point of L4595 is to fail before any spot spend, same
+    as L4517's lib-pin-drift gate."""
+    seen_gate = False
+    cur = sf["StartAt"]
+    for _ in range(40):  # bounded walk
+        st = states[cur]
+        res = st.get("Resource", "")
+        if "ssm:sendCommand" in res:
+            assert seen_gate, (
+                f"spot launch {cur} reached before PipelineContractGate — the "
+                f"gate must precede all spot spend"
+            )
+            return
+        if cur == "PipelineContractGate":
+            seen_gate = True
+        nxt = st.get("Next") or st.get("Default")
+        if nxt is None:
+            break
+        cur = nxt
+    assert seen_gate, "walk never reached PipelineContractGate"
+
+
+def test_gate_runs_immediately_after_lib_pin_drift_gate(sf, states):
+    """Walk the happy path and assert PipelineContractGate is reached right
+    after LibPinDriftGate (with only the PipelineContractCheck Task state in
+    between) — the composed 'preflight the pipeline's invariants' chain from
+    config#693."""
+    cur = sf["StartAt"]
+    seen_lib_pin_gate = False
+    for _ in range(40):
+        st = states[cur]
+        if seen_lib_pin_gate:
+            # The very next states after LibPinDriftGate's pass-through must
+            # be PipelineContractCheck then PipelineContractGate.
+            assert cur == "PipelineContractCheck", (
+                f"expected PipelineContractCheck immediately after "
+                f"LibPinDriftGate's pass-through, got {cur}"
+            )
+            assert st["Next"] == "PipelineContractGate"
+            return
+        if cur == "LibPinDriftGate":
+            seen_lib_pin_gate = True
+        nxt = st.get("Next") or st.get("Default")
+        if nxt is None:
+            break
+        cur = nxt
+    assert seen_lib_pin_gate, "walk never reached LibPinDriftGate"


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** mid

Closes nousergon/alpha-engine-config#693

## Summary

Wires the already-implemented `check_pipeline_contract` Lambda action (crucible-predictor `inference/pipeline_contract_check.py`) into the Saturday Step Function as a pre-spend preflight gate, composed directly after the existing `LibPinDriftCheck` / `LibPinDriftGate` pair.

New states in `infrastructure/step_function.json`:

- **`PipelineContractCheck`** (Task) — invokes the same `alpha-engine-predictor-inference:live` Lambda with `action=check_pipeline_contract`. Same `Retry`/`Catch` shape as `LibPinDriftCheck`: fails open (routes to `CheckMutexRole`) on any Lambda-invocation error (`States.ALL`), since the probe itself already fails open on GitHub fetch/parse errors.
- **`PipelineContractGate`** (Choice) — routes on `$.pipeline_contract_result.Payload.has_violation`. `true` → `ExtractPipelineContractError`; otherwise (`Default`) → `CheckMutexRole`, matching where `LibPinDriftGate` used to go on pass.
- **`ExtractPipelineContractError`** (Pass) — normalizes the violation payload into `$.error` before handing off to `HandleFailure`, mirroring `ExtractLibPinDriftError` (a bare Choice→HandleFailure jump would leave `$.error` unset and crash `HandleFailure`'s `States.JsonToString($.error)` template).

Rewiring: `LibPinDriftGate`'s pass-through `Default` now points at `PipelineContractCheck` instead of `CheckMutexRole`. Resulting happy path:

```
LibPinDriftCheck -> LibPinDriftGate -> (pass) -> PipelineContractCheck -> PipelineContractGate -> (pass) -> CheckMutexRole
                                    \-> (violation) -> ExtractLibPinDriftError -> HandleFailure
                                                                      PipelineContractGate -> (violation) -> ExtractPipelineContractError -> HandleFailure
```

## Tests

- Added `tests/test_sf_pipeline_contract_wiring.py`, mirroring `tests/test_sf_lib_pin_drift_wiring.py`'s structure (state existence, Task resource/payload/ResultPath, fail-open Catch, Choice routing on `has_violation`, `$.error` normalization, chokepoint scan for ungated `HandleFailure` transitions, spot-launch-precedence walk).
- Updated existing wiring tests whose assertions encoded the old topology: `test_sf_lib_pin_drift_wiring.py`, `test_sf_mutex_wiring.py`, `test_sf_friday_shell_run_wiring.py` (traversal-order list), `test_sf_payload_uniqueness.py` (Lambda payload registry).
- `python3 -m json.tool infrastructure/step_function.json` passes.
- Full `test_sf_*.py` + `test_deploy_infrastructure_sf_coverage.py` + `test_deploy_step_function_eventbridge_input.py` suite: 810 passed, 6 skipped (pre-existing, unrelated to this change), 8 deselected in `test_sf_preflight.py` (pre-existing `ModuleNotFoundError: nousergon_lib` in this sandbox, reproduced identically on unmodified `main`).

## Test plan

- [x] `python3 -m json.tool infrastructure/step_function.json`
- [x] `pytest tests/test_sf_pipeline_contract_wiring.py`
- [x] `pytest tests/test_sf_*.py tests/test_deploy_infrastructure_sf_coverage.py tests/test_deploy_step_function_eventbridge_input.py`

---
Groom-Run: 85610c88b4c34c649e67170af7bb7fe1
