### PR TITLE
fix(sf-daily): balance LaunchDailyDataSpot commands.$ intrinsic (deploy-red run 28871616034)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1545,7 +1545,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','export FLOW_DOCTOR_ENABLED=1','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-daily-launch --log /var/log/data-daily-launch.log -- bash infrastructure/spot_data_weekly.sh --launch-only --id-artifact-key ops/daily_data_spot/{}/{}.json --max-runtime-seconds 10800', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0), $$.Execution.Name)))",
+          "commands.$": "States.Array('set -eo pipefail','export FLOW_DOCTOR_ENABLED=1','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-daily-launch --log /var/log/data-daily-launch.log -- bash infrastructure/spot_data_weekly.sh --launch-only --id-artifact-key ops/daily_data_spot/{}/{}.json --max-runtime-seconds 10800', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0), $$.Execution.Name))",
           "executionTimeout": [
             "1800"
           ]

--- a/tests/test_sf_daily_data_spot_wiring.py
+++ b/tests/test_sf_daily_data_spot_wiring.py
@@ -215,3 +215,60 @@ class TestIamAndLauncher:
         assert 'KEEP_INSTANCE=1' in sh
         # The Name tag routes the IAM condition (alpha-engine-data-*).
         assert "alpha-engine-data-" in sh
+
+
+class TestIntrinsicsWellFormed:
+    """config#1897 (2026-07-07 deploy-red): every States.* intrinsic in the
+    definition must be a *well-formed* intrinsic, not merely contain the right
+    substrings.
+
+    The regression: PR #676 added a second arg ($$.Execution.Name) to
+    LaunchDailyDataSpot's inner States.Format but left the original single-arg
+    version's trailing ')))' — one paren too many. The wiring tests above
+    substring-match the key template + args, so they stayed green, but AWS
+    rejected the definition at UpdateStateMachine time
+    (SCHEMA_VALIDATION_FAILED: 'commands.$' must be a valid ... intrinsic
+    function call) and the "Deploy Infrastructure" workflow went red on main.
+
+    Parenthesis balance is the exact invariant that broke and the cheapest
+    offline proxy for "is this a parseable intrinsic call". This walks the
+    WHOLE definition so a malformed intrinsic anywhere — not just the two
+    fields the wiring tests happen to name — fails loud in CI, pre-merge,
+    instead of at deploy time (post-merge, partial-apply).
+    """
+
+    @staticmethod
+    def _intrinsic_fields(node, path=""):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k.endswith(".$") and isinstance(v, str) and v.lstrip().startswith("States."):
+                    yield f"{path}/{k}", v
+                yield from TestIntrinsicsWellFormed._intrinsic_fields(v, f"{path}/{k}")
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                yield from TestIntrinsicsWellFormed._intrinsic_fields(v, f"{path}[{i}]")
+
+    def test_all_states_intrinsics_have_balanced_parens(self):
+        defn = json.loads((_INFRA / "step_function_daily.json").read_text())
+        fields = list(self._intrinsic_fields(defn))
+        assert fields, "expected at least one States.* intrinsic to guard"
+        offenders = []
+        for path, expr in fields:
+            # Only count parens outside single-quoted literals — a bash command
+            # string embedded in States.Array may legitimately contain
+            # unbalanced parens inside its quotes; only the intrinsic-call
+            # structure between literals must balance.
+            depth, in_str, prev = 0, False, ""
+            for ch in expr:
+                if ch == "'" and prev != "\\":
+                    in_str = not in_str
+                elif not in_str and ch == "(":
+                    depth += 1
+                elif not in_str and ch == ")":
+                    depth -= 1
+                prev = ch
+                if depth < 0:
+                    break
+            if depth != 0:
+                offenders.append(f"{path}: paren balance {depth:+d} in {expr!r}")
+        assert not offenders, "malformed intrinsic(s):\n" + "\n".join(offenders)


### PR DESCRIPTION
## Root cause
`Deploy Infrastructure` went **red on main** (run [28871616034](https://github.com/nousergon/nousergon-data/actions/runs/28871616034)) with:

```
aws: [ERROR]: An error occurred (InvalidDefinition) when calling the UpdateStateMachine operation:
Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: The value for the field 'commands.$'
must be a valid JSONPath or a valid intrinsic function call at /States/LaunchDailyDataSpot/Parameters'
```

PR #676 execution-scoped the daily data-spot id artifact key by adding a **second argument** (`$$.Execution.Name`) to `LaunchDailyDataSpot`'s inner `States.Format(...)`, but left the single-arg version's trailing `)))` — **one closing paren too many**. The writer's `States.Array(...)` intrinsic no longer balanced (4 opens, 5 closes). The reader (`ReadDataSpotId` `Key.$`), written fresh in the same PR, was correctly balanced — which is why only the writer failed.

The existing wiring guard `test_id_artifact_key_is_execution_scoped_and_reader_matches_writer` **substring-matches** the key template + args, so all its assertions passed. AWS validates the intrinsic-call *structure* only at `UpdateStateMachine` time (deploy, post-merge), so CI stayed green and `main` deployed red.

## Post-merge state (safe)
The daily SF was **rejected, not applied** — it kept running its prior valid definition. No partial-apply corruption. `infrastructure/deploy-infrastructure.sh` is a full idempotent re-apply (`update-state-machine` per SF), so re-deploy on merge restamps everything cleanly.

## The SOTA fix at the correct layer
Drop the stray `)` so `States.Array(...)` balances — matching the reader's construction exactly (the lockstep the wiring test already asserts). One-character defect, one-character fix.

## Guard that now covers this class (fail-loud)
`TestIntrinsicsWellFormed.test_all_states_intrinsics_have_balanced_parens` walks the **whole** definition and asserts every `States.*` intrinsic field has balanced parentheses (counting only parens *outside* single-quoted literals, so embedded bash is not miscounted). Substring wiring tests cannot catch a malformed intrinsic that still contains the right substrings; this pins the exact invariant that broke and fails in CI **pre-merge** instead of at deploy time.

Verified locally: the guard **fails** on the pre-fix definition (`paren balance -1`) and **passes** on the fix. Full `tests/test_sf_daily_data_spot_wiring.py`: 18 passed.

No error-handling touched (no fail-loud rationale needed); no IAM change; no `executor/` change.

---
Autonomous Fleet CI Watch — deploy-red on `main`, Lane B/C. Follow-up for the deeper chokepoint (real `validate-state-machine-definition` preflight) filed on alpha-engine-config.