### PR TITLE
fix(sf-daily): balance parens in LaunchDailyDataSpot id-artifact intrinsic (config#1897 follow-up)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1545,7 +1545,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','export FLOW_DOCTOR_ENABLED=1','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-daily-launch --log /var/log/data-daily-launch.log -- bash infrastructure/spot_data_weekly.sh --launch-only --id-artifact-key ops/daily_data_spot/{}/{}.json --max-runtime-seconds 10800', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0), $$.Execution.Name)))",
+          "commands.$": "States.Array('set -eo pipefail','export FLOW_DOCTOR_ENABLED=1','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-daily-launch --log /var/log/data-daily-launch.log -- bash infrastructure/spot_data_weekly.sh --launch-only --id-artifact-key ops/daily_data_spot/{}/{}.json --max-runtime-seconds 10800', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0), $$.Execution.Name))",
           "executionTimeout": [
             "1800"
           ]

--- a/tests/test_sf_daily_data_spot_wiring.py
+++ b/tests/test_sf_daily_data_spot_wiring.py
@@ -125,6 +125,23 @@ class TestReadArtifact:
             "$$.Execution.Name" in writer_cmds
         )
 
+        # An intrinsic-function value with unbalanced parentheses is a valid
+        # JSON string (so the wiring asserts above pass) but SFN rejects it at
+        # UpdateStateMachine time with SCHEMA_VALIDATION_FAILED — the deploy,
+        # not CI, is where it surfaces. This exact defect (one extra ')' on the
+        # writer's States.Format) broke the 2026-07-07 deploy. Balance the
+        # parens here so CI catches it. (No literal '(' or ')' appear inside
+        # the quoted command strings, so a net depth of 0 == balanced.)
+        for label, expr in (("writer", writer_cmds), ("reader", reader_key)):
+            depth = 0
+            for ch in expr:
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                assert depth >= 0, f"{label} intrinsic closes a paren it never opened"
+            assert depth == 0, f"{label} intrinsic has unbalanced parentheses ({depth:+d})"
+
     def test_read_only_when_launch_dispatched(self, states):
         gate = states["CheckDataSpotLaunched"]
         (rule,) = gate["Choices"]


### PR DESCRIPTION
## Root cause

The execution-scoped id-artifact fix (config#1897, #676) left **one extra `)`** on `LaunchDailyDataSpot`'s `States.Format(...)` intrinsic. It is a valid JSON *string*, so the wiring guards and the PR's `test` CI passed — but Step Functions rejected it at deploy (`UpdateStateMachine`) time:

```
InvalidDefinition: SCHEMA_VALIDATION_FAILED: The value for the field 'commands.$'
must be a valid JSONPath or a valid intrinsic function call
at /States/LaunchDailyDataSpot/Parameters
```

`deploy-infrastructure` (run 28871616034) failed, leaving the **weekday SF undeployed**. The reader (`ReadDataSpotId.Key.$`) was already balanced; only the writer was malformed.

## Fix

Remove the stray paren — the writer intrinsic now nets to paren-depth 0, matching the reader. `States.ArrayGetItem(...)` is closed *before* the new `$$.Execution.Name` Format arg, so the tail needs exactly two closing parens (Format, Array), not three.

Resulting key emulates to `ops/daily_data_spot/2026-07-07/<execution-name>.json` as intended.

## Guard hardening

Added a **parenthesis-balance assertion** to the config#1897 regression guard (`test_id_artifact_key_is_execution_scoped_and_reader_matches_writer`): it walks both the writer and reader intrinsics and asserts net paren-depth 0 with no premature close. CI — not the deploy — now catches an intrinsic that is a well-formed string but a malformed function call. (No literal parens appear inside the quoted command strings, so net-depth 0 == balanced.)

Local validation: `test_sf_daily_data_spot_wiring.py` 17 passed; `ruff` clean. The scoped watch role lacks `states:ValidateStateMachineDefinition`, so the paren-balance guard is the CI-side stand-in for SFN's validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)