### PR TITLE
feat(sf-watch): deterministic zero-token fast path for signature-matched transients (config#1900)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -122,7 +122,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 60 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,FAST_PATH_ENABLED=false,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -203,10 +203,18 @@ CURRENT_DISPATCH=$(aws lambda get-function-configuration \
   --region "${REGION}" \
   --query 'Environment.Variables.AGENT_DISPATCH_ENABLED' --output text 2>/dev/null)
 case "${CURRENT_DISPATCH}" in true|false) ;; *) CURRENT_DISPATCH=false ;; esac
+# FAST_PATH_ENABLED (config#1900) is operator-owned exactly like
+# AGENT_DISPATCH_ENABLED — preserve the live value across redeploys.
+CURRENT_FAST_PATH=$(aws lambda get-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --region "${REGION}" \
+  --query 'Environment.Variables.FAST_PATH_ENABLED' --output text 2>/dev/null)
+case "${CURRENT_FAST_PATH}" in true|false) ;; *) CURRENT_FAST_PATH=false ;; esac
 echo "  preserving AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH} (operator-owned)"
+echo "  preserving FAST_PATH_ENABLED=${CURRENT_FAST_PATH} (operator-owned)"
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment "Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH},FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}" \
+  --environment "Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH},FAST_PATH_ENABLED=${CURRENT_FAST_PATH},FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}" \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -48,6 +48,20 @@
       "Effect": "Allow",
       "Action": ["s3:GetObject", "s3:PutObject"],
       "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/*_sf_watch/*"
+    },
+    {
+      "Sid": "FastPathRerun",
+      "Effect": "Allow",
+      "Action": [
+        "states:StartExecution",
+        "states:ListExecutions"
+      ],
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+      ]
     }
   ]
 }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -62,6 +62,18 @@ _DB_BASENAME = "flow_doctor_saturday_sf_watch_dispatcher"
 AGENT_DISPATCH_ENABLED = (
     os.environ.get("AGENT_DISPATCH_ENABLED", "false").lower() == "true"
 )
+# config#1900 — deterministic zero-token fast path. When true, a failure whose
+# execution history exactly matches a known-transient signature (see
+# _match_transient_signature) is recovered by a plain fresh rerun started BY
+# THIS LAMBDA — no agent dispatch, no tokens. Strictly narrower than the agent:
+# first-failure-of-the-day only, never when an order-emitting state ran, never
+# on preflight/operator-abort, and any fall-through (signature miss, prior
+# attempt, StartExecution error) lands on the normal agent dispatch path.
+# OPERATOR-OWNED runtime flag like AGENT_DISPATCH_ENABLED (deploy.sh preserves
+# the live value across redeploys — the config#1818 lesson).
+FAST_PATH_ENABLED = (
+    os.environ.get("FAST_PATH_ENABLED", "false").lower() == "true"
+)
 # repository_dispatch target — the private alpha-engine-config repo hosts the
 # agent GHA workflow (on: repository_dispatch, types: [*-sf-failure]).
 DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
@@ -99,6 +111,24 @@ PIPELINES: dict[str, dict[str, object]] = {
         "watch_prefix": "consolidated/weekday_sf_watch",
         "dispatch_event_type": "weekday-sf-failure",
         "has_listener": True,
+        # config#1900 — fast-path signature scope for THIS pipeline only.
+        # `poll_states` are the SSM-poll Task states whose Lambda output carries
+        # the raw host-death evidence (status/status_details/ping_status);
+        # `data_task_states` are the ephemeral-data-spot SSM states where an
+        # Ssm.InvalidInstanceIdException means the target box died (transient);
+        # `veto_states` — if ANY of these ever entered, the fast path is
+        # forbidden regardless of signature (order-emitting surface: a rerun
+        # decision there belongs to the agent's Lane-D discipline, never a
+        # deterministic rule).
+        "fast_path": {
+            "poll_states": frozenset(
+                {"WaitForMorningEnrich", "WaitForMorningArcticAppend", "WaitForChronicGap"}
+            ),
+            "data_task_states": frozenset(
+                {"MorningEnrich", "MorningArcticAppend", "ChronicGapSelfHeal"}
+            ),
+            "veto_states": frozenset({"RunMorningPlanner", "RunDaemon"}),
+        },
     },
     "ne-postclose-trading-pipeline": {
         "cadence_slug": "eod",
@@ -229,6 +259,195 @@ def _failed_state_from_history(execution_arn: str) -> str | None:
     return current
 
 
+# --- config#1900: deterministic zero-token fast path -------------------------
+# Signature ids (stable, recorded in the watch-log + Telegram receipt):
+#   data_spot_host_death      — SSM poll evidence says the command never ran on a
+#                               live box (Undeliverable / DeliveryTimedOut, or
+#                               rc=-1 with the agent unregistered): a spot
+#                               reclaim / host death mid-data-state. Matched on
+#                               the RAW poll fields, not the poller's `verdict`
+#                               label, so the match is stable across poller
+#                               classification changes (nousergon-data#675).
+#   data_spot_invalid_instance — SendCommand itself rejected with
+#                               Ssm.InvalidInstanceIdException on a data state:
+#                               the target spot died before delivery.
+# Both mean: no code defect, the ephemeral data spot vanished; recovery is a
+# PLAIN fresh rerun (the SF relaunches its own spot; id artifact is
+# execution-scoped since nousergon-data#676).
+_HOST_DEATH_STATUS_DETAILS = frozenset({"Undeliverable", "DeliveryTimedOut"})
+_HOST_DEATH_PING_STATUSES = frozenset({"NotRegistered", "ConnectionLost", "Inactive"})
+
+
+def _fetch_history_with_data(execution_arn: str) -> list[dict] | None:
+    """Newest ``_HISTORY_MAX_EVENTS`` events WITH payloads (the poll-state
+    outputs carry the host-death evidence), reversed to chronological order.
+    Best-effort: ``None`` on any API error → the caller falls through to the
+    normal agent dispatch (never guess a signature without evidence)."""
+    if not execution_arn:
+        return None
+    try:
+        resp = _sf_client().get_execution_history(
+            executionArn=execution_arn,
+            maxResults=_HISTORY_MAX_EVENTS,
+            reverseOrder=True,
+            includeExecutionData=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — fast path is optional, dispatch remains
+        logger.warning("fast-path history fetch failed for %s: %s", execution_arn, exc)
+        return None
+    return list(reversed(resp.get("events", [])))
+
+
+def _scan_history_for_fast_path(events: list[dict], fp_cfg: dict) -> dict:
+    """One chronological walk collecting everything the signature match needs:
+    whether any order-emitting veto state ever entered, the LAST poll-state
+    Lambda output payload, and any TaskFailed errors on the data-spot states."""
+    veto_entered = False
+    last_poll_payload: dict | None = None
+    data_task_errors: list[str] = []
+    current: str | None = None
+    for ev in events:
+        etype = ev.get("type", "")
+        if etype.endswith("StateEntered"):
+            name = (ev.get("stateEnteredEventDetails") or {}).get("name")
+            current = name or current
+            if name in fp_cfg["veto_states"]:
+                veto_entered = True
+        elif etype.endswith("StateExited"):
+            det = ev.get("stateExitedEventDetails") or {}
+            if det.get("name") == current:
+                current = None
+        elif etype == "TaskSucceeded" and current in fp_cfg["poll_states"]:
+            try:
+                out = json.loads(
+                    (ev.get("taskSucceededEventDetails") or {}).get("output") or "{}"
+                )
+            except (ValueError, TypeError):
+                continue
+            payload = out.get("Payload")
+            if isinstance(payload, dict):
+                last_poll_payload = payload
+        elif etype == "TaskFailed" and current in fp_cfg["data_task_states"]:
+            err = (ev.get("taskFailedEventDetails") or {}).get("error") or ""
+            data_task_errors.append(err)
+    return {
+        "veto_entered": veto_entered,
+        "last_poll_payload": last_poll_payload,
+        "data_task_errors": data_task_errors,
+    }
+
+
+def _match_transient_signature(scan: dict) -> str | None:
+    """EXACT-match against the known-transient signature table. No fuzzy
+    matching: anything that doesn't match falls through to the agent."""
+    payload = scan.get("last_poll_payload")
+    if isinstance(payload, dict) and payload.get("status") == "Failed":
+        if payload.get("status_details") in _HOST_DEATH_STATUS_DETAILS:
+            return "data_spot_host_death"
+        if (
+            payload.get("response_code") == -1
+            and payload.get("ping_status") in _HOST_DEATH_PING_STATUSES
+        ):
+            return "data_spot_host_death"
+    if any(err == "Ssm.InvalidInstanceIdException" for err in scan.get("data_task_errors", [])):
+        return "data_spot_invalid_instance"
+    return None
+
+
+def _prior_attempt_state(existing_events: list[dict]) -> tuple[int, int]:
+    """(prior_attempts, prior_events) for today from the already-loaded
+    watch-log. `agent_attempt`-marked events are agent OR fast-path attempts —
+    both consume the SAME budget the charter's STEP 2 counts, so the two
+    recovery layers can never exceed the shared 2-attempt ceiling."""
+    attempts = sum(
+        1
+        for ev in existing_events
+        if ev.get("agent_attempt") is not None or ev.get("action") == "fast_path_rerun"
+    )
+    return attempts, len(existing_events)
+
+
+def _maybe_fast_path(
+    record: dict,
+    existing_events: list[dict],
+    cfg: dict,
+    sm_arn: str,
+    describe_resp: dict | None,
+    run_date: str,
+) -> dict:
+    """Deterministic recovery, strictly narrower than the agent (config#1900).
+
+    Fires ONLY when ALL hold: flag on; this pipeline declares a `fast_path`
+    scope; a genuine FAILED (not preflight, not operator-abort); the FIRST
+    recovery attempt of the day (no prior agent/fast-path attempt, fewer than 2
+    prior events — a repeat failure earns the agent's judgment); no
+    order-emitting state ever entered; the history evidence EXACTLY matches a
+    known-transient signature; and no concurrent execution is RUNNING (mutex).
+    On success it mutates ``record`` in place (action/lane/attempt/rerun arn)
+    BEFORE the watch-log write so the artifact carries the full audit trail.
+    Every non-fire returns a reason; StartExecution errors are recorded on the
+    record (`fast_path_error`) and fall through to the agent — never silent.
+    """
+    if not FAST_PATH_ENABLED:
+        return {"fast_path": False, "reason": "disabled"}
+    fp_cfg = cfg.get("fast_path")
+    if not fp_cfg:
+        return {"fast_path": False, "reason": "no_fast_path_config"}
+    if record.get("status") != "FAILED":
+        return {"fast_path": False, "reason": "not_failed_status"}
+    if record.get("is_preflight"):
+        return {"fast_path": False, "reason": "preflight"}
+    if record.get("dispatch_suppressed"):
+        return {"fast_path": False, "reason": record["dispatch_suppressed"]}
+    if not describe_resp or not describe_resp.get("input"):
+        return {"fast_path": False, "reason": "no_original_input"}
+    prior_attempts, prior_events = _prior_attempt_state(existing_events)
+    if prior_attempts > 0:
+        return {"fast_path": False, "reason": "prior_attempt_exists"}
+    if prior_events >= 2:
+        return {"fast_path": False, "reason": "repeat_failure_day"}
+    events = _fetch_history_with_data(record.get("execution_arn", ""))
+    if events is None:
+        return {"fast_path": False, "reason": "history_unavailable"}
+    scan = _scan_history_for_fast_path(events, fp_cfg)
+    if scan["veto_entered"]:
+        return {"fast_path": False, "reason": "order_emitting_state_ran"}
+    signature = _match_transient_signature(scan)
+    if signature is None:
+        return {"fast_path": False, "reason": "no_signature_match"}
+    sf = _sf_client()
+    try:
+        running = sf.list_executions(
+            stateMachineArn=sm_arn, statusFilter="RUNNING", maxResults=1
+        ).get("executions", [])
+    except Exception as exc:  # noqa: BLE001 — can't prove mutex free → agent decides
+        logger.warning("fast-path list_executions failed: %s", exc)
+        return {"fast_path": False, "reason": "mutex_check_unavailable"}
+    if running:
+        return {"fast_path": False, "reason": "execution_already_running"}
+    detected_hms = record["detected_at"][11:19].replace(":", "")
+    rerun_name = f"fast-path-rerun-{run_date}-{detected_hms}"
+    try:
+        resp = sf.start_execution(
+            stateMachineArn=sm_arn,
+            name=rerun_name,
+            input=describe_resp["input"],
+        )
+    except Exception as exc:  # noqa: BLE001 — recorded on the artifact + agent takes over
+        logger.warning("fast-path StartExecution failed (falling back to agent): %s", exc)
+        record["fast_path_error"] = f"{type(exc).__name__}: {exc}"
+        return {"fast_path": False, "reason": "start_execution_error"}
+    record["action"] = "fast_path_rerun"
+    record["lane"] = "A"
+    record["agent_attempt"] = prior_attempts + 1
+    record["fast_path_signature"] = signature
+    record["rerun_execution_arn"] = resp.get("executionArn", "")
+    logger.info(
+        "fast-path rerun started: signature=%s rerun=%s", signature, rerun_name
+    )
+    return {"fast_path": True, "signature": signature, "rerun_execution_arn": record["rerun_execution_arn"]}
+
+
 def _run_date(describe_resp: dict | None, detail: dict) -> str:
     """Resolve the Saturday firing date (YYYY-MM-DD) for the artifact key.
 
@@ -314,12 +533,17 @@ def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str,
     }
 
 
-def _write_watch_log(s3, watch_prefix: str, run_date: str, record: dict) -> str:
+def _write_watch_log(
+    s3, watch_prefix: str, run_date: str, record: dict, doc: dict | None = None
+) -> str:
     """Append the event to the date's watch-log and write it back. PRIMARY
     deliverable — RAISES on failure (fail-loud: a broken producer must surface
-    via the Lambda error metric + CW alarm, never silently)."""
+    via the Lambda error metric + CW alarm, never silently). ``doc`` lets the
+    handler pass the already-loaded document (the fast path reads prior events
+    from it first) so load-append-write stays a single read."""
     key = _artifact_key(watch_prefix, run_date)
-    doc = _load_existing(s3, key)
+    if doc is None:
+        doc = _load_existing(s3, key)
     doc["schema_version"] = SCHEMA_VERSION
     doc["run_date"] = run_date
     doc["updated_at"] = record["detected_at"]
@@ -358,8 +582,11 @@ def _notify(record: dict, key: str, pipeline_name: str) -> bool:
     # config#1827: an operator-abort suppresses the dispatch even when the flag +
     # listener are on — the receipt must read OBSERVE, not AUTO-FIX.
     suppressed = record.get("dispatch_suppressed")
-    will_dispatch = AGENT_DISPATCH_ENABLED and has_listener and not suppressed
-    mode = "AUTO-FIX" if will_dispatch else "OBSERVE"
+    fast_path = record.get("action") == "fast_path_rerun"
+    will_dispatch = (
+        AGENT_DISPATCH_ENABLED and has_listener and not suppressed and not fast_path
+    )
+    mode = "AUTO-RERUN" if fast_path else ("AUTO-FIX" if will_dispatch else "OBSERVE")
     lines = [
         f"\U0001f6f0️ *Fleet-SF Watch — {mode}*",
         f"{label}: {record['status']}",
@@ -369,7 +596,13 @@ def _notify(record: dict, key: str, pipeline_name: str) -> bool:
     if record.get("cause"):
         lines.append(f"Cause: `{record['cause']}`")
     lines.append(f"Watch log: `s3://{WATCH_BUCKET}/{key}`")
-    if will_dispatch:
+    if fast_path:
+        lines.append(f"Rerun: `{record.get('rerun_execution_arn', '')}`")
+        footer = (
+            f"_fast path: known-transient signature `{record.get('fast_path_signature')}` — "
+            "plain rerun started, no agent (zero-token recovery, config#1900)_"
+        )
+    elif will_dispatch:
         footer = "_autonomous fix ACTIVE — resilience agent dispatched (diagnose→fix→merge→rerun)_"
     elif suppressed == "operator_abort":
         footer = "_operator abort — recorded loudly, no autonomous recovery (deliberate human stop)_"
@@ -498,14 +731,27 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     record = _build_event_record(detail, describe_resp, run_date, cfg)
 
     s3 = _s3_client()
-    key = _write_watch_log(s3, cfg["watch_prefix"], run_date, record)  # PRIMARY — fail-loud
-    telegram_sent = _notify(record, key, sm_name)                      # secondary — best-effort
+    key = _artifact_key(cfg["watch_prefix"], run_date)
+    doc = _load_existing(s3, key)
+    # config#1900: the deterministic fast path runs BEFORE the write so the
+    # watch-log event carries the full outcome (action/signature/rerun arn) in
+    # one record. It mutates `record` in place on success; every non-fire is a
+    # recorded reason and the normal agent dispatch below takes over.
+    fast_path = _maybe_fast_path(record, doc.get("events", []), cfg, sm_arn, describe_resp, run_date)
+
+    _write_watch_log(s3, cfg["watch_prefix"], run_date, record, doc=doc)  # PRIMARY — fail-loud
+    telegram_sent = _notify(record, key, sm_name)                         # secondary — best-effort
     # M2: fire the agent AFTER the watch-log lands (agent reads fresh context).
-    dispatch = _maybe_dispatch_agent(record, run_date, key, cfg, sm_name, sm_arn)  # secondary
+    # A successful fast-path rerun REPLACES the agent dispatch for this event.
+    if fast_path.get("fast_path"):
+        dispatch = {"dispatched": False, "reason": "fast_path_rerun"}
+    else:
+        dispatch = _maybe_dispatch_agent(record, run_date, key, cfg, sm_name, sm_arn)  # secondary
 
     logger.info(
-        "Fleet-SF Watch recorded: sf=%s run_date=%s failed_state=%s key=%s telegram=%s dispatched=%s",
-        sm_name, run_date, record.get("failed_state"), key, telegram_sent, dispatch.get("dispatched"),
+        "Fleet-SF Watch recorded: sf=%s run_date=%s failed_state=%s key=%s telegram=%s fast_path=%s dispatched=%s",
+        sm_name, run_date, record.get("failed_state"), key, telegram_sent,
+        fast_path.get("fast_path"), dispatch.get("dispatched"),
     )
     return {
         "status": status,
@@ -515,8 +761,11 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "watch_log_key": key,
         "telegram_sent": telegram_sent,
         "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
+        "fast_path_enabled": FAST_PATH_ENABLED,
+        "fast_path": fast_path,
         "agent_dispatch": dispatch,
         # "observe" until the agent enriches the event with its lane/action;
         # when dispatch fires the agent owns the downstream action record.
-        "action": "dispatched" if dispatch.get("dispatched") else "observe",
+        "action": record["action"] if fast_path.get("fast_path")
+        else ("dispatched" if dispatch.get("dispatched") else "observe"),
     }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -533,3 +533,220 @@ def test_programmatic_abort_still_dispatches(monkeypatch):
     assert result["action"] == "dispatched"
     written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
     assert written["events"][-1]["dispatch_suppressed"] is None
+
+
+# ── config#1900: deterministic zero-token fast path ──────────────────────────
+# A weekday failure whose history EXACTLY matches a known-transient signature
+# (data-spot host death / SendCommand invalid-instance) is recovered by a plain
+# StartExecution from the dispatcher itself — no agent dispatch. Everything
+# else falls through to the normal dispatch path with a recorded reason.
+
+WEEKDAY_INPUT = json.dumps({"pipeline_role": "daily", "trading_instance_id": ["i-018eb3307a21329bf"]})
+
+
+def _poll_output(payload: dict) -> str:
+    return json.dumps({"ExecutedVersion": "$LATEST", "Payload": payload})
+
+
+_HOST_DEATH_PAYLOAD = {
+    "attempts": 67,
+    "ping_misses": 0,
+    "status": "Failed",
+    "response_code": -1,
+    "status_details": "Undeliverable",
+    "ping_status": "NotRegistered",
+    "step": "morning-arctic-append",
+    "verdict": "COMMAND_FAILED",
+}
+
+
+def _weekday_history(payload=None, *, veto=False, task_failed_error=None, poll=True):
+    """Chronological weekday history ending in HandleFailure→FailExecution."""
+    h = [
+        {"type": "ExecutionStarted"},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "MorningEnrich"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "MorningEnrich"}},
+    ]
+    if veto:
+        h += [
+            {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "RunDaemon"}},
+            {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "RunDaemon"}},
+        ]
+    if task_failed_error is not None:
+        h += [
+            {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "MorningEnrich"}},
+            {"type": "TaskFailed", "taskFailedEventDetails": {"error": task_failed_error}},
+        ]
+    if poll:
+        h += [
+            {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "WaitForMorningArcticAppend"}},
+            {"type": "TaskSucceeded", "taskSucceededEventDetails": {
+                "output": _poll_output(payload if payload is not None else _HOST_DEATH_PAYLOAD)}},
+            {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "WaitForMorningArcticAppend"}},
+        ]
+    h += [
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "HandleFailure"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "HandleFailure"}},
+        {"type": "FailStateEntered", "stateEnteredEventDetails": {"name": "FailExecution"}},
+        {"type": "ExecutionFailed"},
+    ]
+    return h
+
+
+def _fast_path_clients(*, history=None, existing=None, describe_input=WEEKDAY_INPUT,
+                       running=None, start_error=None):
+    factory, sf, s3 = _make_clients(
+        describe={"input": describe_input, "error": "DailyPipelineFailure",
+                  "cause": "One or more weekday pipeline steps failed."},
+        history=history if history is not None else _weekday_history(),
+        existing=existing,
+    )
+    sf.list_executions.return_value = {"executions": running or []}
+    if start_error is not None:
+        sf.start_execution.side_effect = start_error
+    else:
+        sf.start_execution.return_value = {
+            "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:fast-path-rerun-x"
+        }
+    return factory, sf, s3
+
+
+@pytest.fixture()
+def fast_path_on(monkeypatch):
+    monkeypatch.setattr(index, "FAST_PATH_ENABLED", True)
+
+
+def _put_body(s3) -> dict:
+    return json.loads(s3.put_object.call_args.kwargs["Body"])
+
+
+def test_fast_path_reruns_on_host_death_signature(fast_path_on):
+    factory, sf, s3 = _fast_path_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_called_once()
+    kwargs = sf.start_execution.call_args.kwargs
+    assert kwargs["stateMachineArn"] == WEEKDAY_ARN
+    assert kwargs["input"] == WEEKDAY_INPUT  # plain rerun: ORIGINAL input, no skips
+    assert kwargs["name"].startswith("fast-path-rerun-")
+    assert result["fast_path"]["fast_path"] is True
+    assert result["fast_path"]["signature"] == "data_spot_host_death"
+    assert result["agent_dispatch"] == {"dispatched": False, "reason": "fast_path_rerun"}
+    ev = _put_body(s3)["events"][-1]
+    assert ev["action"] == "fast_path_rerun"
+    assert ev["lane"] == "A"
+    assert ev["agent_attempt"] == 1  # consumes the SAME budget the charter counts
+    assert ev["fast_path_signature"] == "data_spot_host_death"
+    assert ev["rerun_execution_arn"].endswith("fast-path-rerun-x")
+
+
+def test_fast_path_invalid_instance_signature(fast_path_on):
+    history = _weekday_history(poll=False, task_failed_error="Ssm.InvalidInstanceIdException")
+    factory, sf, s3 = _fast_path_clients(history=history)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    assert result["fast_path"]["fast_path"] is True
+    assert result["fast_path"]["signature"] == "data_spot_invalid_instance"
+    sf.start_execution.assert_called_once()
+
+
+def test_fast_path_vetoed_when_order_state_ran(fast_path_on):
+    factory, sf, s3 = _fast_path_clients(history=_weekday_history(veto=True))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"] == {"fast_path": False, "reason": "order_emitting_state_ran"}
+
+
+def test_fast_path_skipped_on_prior_attempt(fast_path_on):
+    existing = {"schema_version": 1, "events": [{"agent_attempt": 1, "action": "escalated"}]}
+    factory, sf, s3 = _fast_path_clients(existing=existing)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"]["reason"] == "prior_attempt_exists"
+
+
+def test_fast_path_skipped_on_repeat_failure_day(fast_path_on):
+    existing = {"schema_version": 1, "events": [{"action": "observe"}, {"action": "observe"}]}
+    factory, sf, s3 = _fast_path_clients(existing=existing)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"]["reason"] == "repeat_failure_day"
+
+
+def test_fast_path_signature_miss_falls_through(fast_path_on):
+    benign = dict(_HOST_DEATH_PAYLOAD, status_details="CommandFailed",
+                  response_code=1, ping_status="Online")
+    factory, sf, s3 = _fast_path_clients(history=_weekday_history(payload=benign))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"]["reason"] == "no_signature_match"
+
+
+def test_fast_path_start_execution_error_falls_back_to_dispatch(fast_path_on, monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "fake-pat")
+    factory, sf, s3 = _fast_path_clients(start_error=RuntimeError("boom"))
+
+    class _FakeResp:
+        status = 204
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    with patch("index.boto3.client", side_effect=factory), \
+         patch("index.urllib.request.urlopen", return_value=_FakeResp()) as urlopen:
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    assert result["fast_path"]["reason"] == "start_execution_error"
+    ev = _put_body(s3)["events"][-1]
+    assert "RuntimeError" in ev["fast_path_error"]
+    assert result["agent_dispatch"]["dispatched"] is True  # agent takes over
+    urlopen.assert_called_once()
+
+
+def test_fast_path_disabled_by_default():
+    factory, sf, s3 = _fast_path_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"]["reason"] == "disabled"
+    assert result["fast_path_enabled"] is False
+
+
+def test_fast_path_blocked_by_running_execution(fast_path_on):
+    factory, sf, s3 = _fast_path_clients(running=[{"name": "concurrent"}])
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"]["reason"] == "execution_already_running"
+
+
+def test_fast_path_not_configured_for_saturday(fast_path_on):
+    factory, sf, s3 = _fast_path_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", SATURDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"]["reason"] == "no_fast_path_config"
+
+
+def test_fast_path_preflight_excluded(fast_path_on):
+    factory, sf, s3 = _fast_path_clients(
+        describe_input=json.dumps({"shell_run": True, "pipeline_role": "daily"})
+    )
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", WEEKDAY_ARN), None)
+
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"]["reason"] == "preflight"


### PR DESCRIPTION
Implements config#1900. The dispatcher evaluates an exact-match transient-signature table before dispatching the Opus agent: `data_spot_host_death` (SSM poll evidence: Undeliverable/DeliveryTimedOut, or rc=-1 + agent unregistered — matched on RAW poll fields so it stays stable across #675 verdict changes) and `data_spot_invalid_instance` (SendCommand `Ssm.InvalidInstanceIdException` on a data state). On match: plain fresh rerun via `states:StartExecution` (original input, NO skip flags), no agent run, zero tokens.

**Guardrails (strictly narrower than the agent):** weekday pipeline only (registry-scoped `fast_path` config); first-recovery-of-the-day only — the fast-path event sets `agent_attempt` so it consumes the SAME 2-attempt budget the charter STEP 2 counts, and any repeat failure goes to the agent (the 2026-07-07 stale-pointer incident is the canonical fall-through case); hard veto if `RunMorningPlanner`/`RunDaemon` ever entered; excluded on preflight/operator-abort; mutex-checked via `ListExecutions` RUNNING; every non-fire is a recorded reason; `StartExecution` errors land on the watch-log event (`fast_path_error`) and fall back to agent dispatch.

**Rollout:** `FAST_PATH_ENABLED` is operator-owned (deploy.sh preserves the live value across redeploys — the config#1818 pattern; bootstrap default `false`). IAM `iam-policy.json` adds `states:StartExecution` + `states:ListExecutions` on the four registered SF ARNs — applied at deploy via `put-role-policy` (will be applied live post-merge in the same session).

**Tests:** 11 new unit tests (signature match + input equality, budget consumption, order-emitting veto, signature-miss/StartExecution-error fall-through, disabled default, running-execution mutex, per-pipeline scoping, preflight exclusion). Dispatcher suite 39 passed; `tests/` 2700 passed.

Token-efficiency context: ~23 Opus watch runs the week of 2026-07-01..07 (median 14 min). Companion telemetry PR (config#1899) lands in alpha-engine-config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)