### PR TITLE
Reschedule groom to off-peak UTC slots (01:00/07:00/19:00)

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/README.md
+++ b/infrastructure/lambdas/groom-liveness-probe/README.md
@@ -18,7 +18,8 @@ Schedule-aware, per-trigger accounting:
 1. Enumerate every scheduled groom trigger in the last `GROOM_LOOKBACK_HOURS`
    that has had `GROOM_CEILING_MIN + GROOM_MARGIN_MIN` to finish (so a still-running
    groom never false-alarms). The schedule mirrors the dispatcher's crons
-   (07:00 daily, 15:00 daily Opus high-only, 23:00 daily) and is overridable via
+   (01:00 daily Opus high-only, 07:00 daily Sonnet mid-only, 19:00 daily Haiku
+   low-only) and is overridable via
    `GROOM_SCHEDULE` (JSON).
 2. Fetch recent `groom-digest`-labeled issues from `nousergon/alpha-engine-config`
    (success digests **and** loud-failure issues both carry the label).

--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -20,10 +20,10 @@
 # Cadence (UTC): two runs/day, each after a groom's worst-case completion
 # (groom hard-ceiling 360 min + slack). Per-trigger windows + S3 dedup make the
 # exact times non-load-bearing (generous LOOKBACK tolerates schedule drift):
-#   06:30 daily   cron(30 6 * * ? *)   # after the 23:00 groom matures (~05:45)
-#   14:30 daily   cron(30 14 * * ? *)  # after the 07:00 groom matures (~13:45; the
-#                                      #   07:00 groom runs daily since 2026-07-02 —
-#                                      #   the old "Sun-Fri" framing is gone)
+#   06:30 daily   cron(30 6 * * ? *)   # after the 19:00 groom matures (~01:45)
+#   14:30 daily   cron(30 14 * * ? *)  # after the 07:00 groom matures (~13:45)
+#                                      #   (the 01:00 Opus run matures ~07:45 —
+#                                      #   also covered by the 14:30 pass)
 #
 # Managed OUTSIDE CloudFormation — mirrors the sibling dispatchers (narrow OIDC
 # blast radius: the CI role deliberately lacks iam:CreateRole/iam:PutRolePolicy,

--- a/infrastructure/lambdas/groom-liveness-probe/index.py
+++ b/infrastructure/lambdas/groom-liveness-probe/index.py
@@ -93,17 +93,16 @@ _PAT_TIMEOUT_SEC = 15
 # clean-stop case: groom_driver.py files a groom-digest issue even on a
 # total==0 clean shutdown, so _missed()'s presence-in-window check (it never
 # inspects digest CONTENT) already treats that correctly as "not missed."
-#   cron(0 7 * * ? *)  → 07:00 daily
-#   cron(0 15 * * ? *) → 15:00 daily (Opus, complexity:high only)
-#   cron(0 23 * * ? *) → 23:00 daily
-# The three windows [T, T+CEILING+MARGIN] never overlap at the default
-# CEILING_MIN=360/MARGIN_MIN=45 (6h45m): 07:00+6:45=13:45 (< 15:00),
-# 15:00+6:45=21:45 (< 23:00), 23:00+6:45=05:45 next day (< 07:00) — so
-# per-trigger attribution stays 1:1 (see _missed's docstring).
+#   cron(0 1 * * ? *)  → 01:00 daily (Opus, complexity:high only)
+#   cron(0 7 * * ? *)  → 07:00 daily (Sonnet, complexity:mid only)
+#   cron(0 19 * * ? *) → 19:00 daily (Haiku, complexity:low only)
+# At CEILING_MIN=360/MARGIN_MIN=45 (6h45m) the windows can overlap slightly
+# (01:00→07:45 vs 07:00 Sonnet; 19:00→01:45 vs next-day 01:00 Opus) — _missed
+# attributes by trigger timestamp, not by exclusive window.
 _DEFAULT_SCHEDULE = [
-    {"hour": 7, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "07:00 daily"},
-    {"hour": 15, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "15:00 daily (Opus high-only)"},
-    {"hour": 23, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "23:00 daily"},
+    {"hour": 1, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "01:00 daily (Opus high-only)"},
+    {"hour": 7, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "07:00 daily (Sonnet mid-only)"},
+    {"hour": 19, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "19:00 daily (Haiku low-only)"},
 ]
 
 

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -74,13 +74,14 @@ def test_only_mature_triggers_returned(monkeypatch):
     monkeypatch.setattr(index, "CEILING_MIN", 360)
     monkeypatch.setattr(index, "MARGIN_MIN", 45)
     monkeypatch.setattr(index, "LOOKBACK_HOURS", 30)
-    # Tue 14:00 UTC. The 07:00 Tue trigger matured (7h ago); a hypothetical recent
-    # one would not. 23:00 Mon (prev day) also mature.
+    # Tue 14:00 UTC. The 07:00 Tue trigger matured (7h ago); 01:00 Tue matured
+    # (13h ago). 19:00 Mon (prev day) also mature.
     now = _dt(2026, 6, 30, 14, 0)  # 2026-06-30 is a Tuesday
     trigs = index._expected_triggers(now)
     ats = {t["at"] for t in trigs}
-    assert _dt(2026, 6, 30, 7, 0) in ats   # 07:00 Tue, matured
-    assert _dt(2026, 6, 29, 23, 0) in ats  # 23:00 Mon, matured
+    assert _dt(2026, 6, 30, 7, 0) in ats   # 07:00 Tue Sonnet, matured
+    assert _dt(2026, 6, 30, 1, 0) in ats   # 01:00 Tue Opus, matured
+    assert _dt(2026, 6, 29, 19, 0) in ats  # 19:00 Mon Haiku, matured
     # Nothing in the immature zone (now - 6.75h .. now).
     assert all(t["at"] <= now - timedelta(minutes=405) for t in trigs)
 
@@ -98,34 +99,28 @@ def test_saturday_0700_included(monkeypatch):
     assert _dt(2026, 6, 27, 7, 0) in {t["at"] for t in trigs}
 
 
-def test_1500_opus_schedule_included(monkeypatch):
-    """config#1571: the 15:00 UTC Opus/complexity:high schedule must be tracked
-    too, not just the two Sonnet schedules — its silent death was previously
-    invisible to this probe (the schedule existed since 2026-07-01, config#1495
-    follow-up, but was never added here)."""
+def test_0100_opus_schedule_included(monkeypatch):
+    """The 01:00 UTC Opus/complexity:high schedule must be tracked."""
     monkeypatch.setattr(index, "CEILING_MIN", 360)
     monkeypatch.setattr(index, "MARGIN_MIN", 45)
     monkeypatch.setattr(index, "LOOKBACK_HOURS", 30)
-    # Wed 2026-07-01 22:00 UTC -> 15:00 Wed matured (7h ago).
-    now = _dt(2026, 7, 1, 22, 0)
+    # Wed 2026-07-01 10:00 UTC -> 01:00 Wed matured (9h ago).
+    now = _dt(2026, 7, 1, 10, 0)
     trigs = index._expected_triggers(now)
-    assert _dt(2026, 7, 1, 15, 0) in {t["at"] for t in trigs}
+    assert _dt(2026, 7, 1, 1, 0) in {t["at"] for t in trigs}
 
 
-def test_three_daily_triggers_dont_overlap_in_one_day(monkeypatch):
-    """The three windows [T, T+CEILING+MARGIN] must stay disjoint so per-trigger
-    attribution remains 1:1 (see _missed's docstring) now that a 3rd schedule
-    shares the day with the original two."""
+def test_three_daily_triggers_returned(monkeypatch):
+    """All three tier-split schedules appear in a single day's lookback."""
     monkeypatch.setattr(index, "CEILING_MIN", 360)
     monkeypatch.setattr(index, "MARGIN_MIN", 45)
     monkeypatch.setattr(index, "LOOKBACK_HOURS", 24)
-    now = _dt(2026, 7, 2, 6, 0)
+    now = _dt(2026, 7, 2, 14, 0)
     trigs = index._expected_triggers(now)
-    ats = sorted(t["at"] for t in trigs)
-    assert len(ats) == 3
-    window = timedelta(minutes=360 + 45)
-    for a, b in zip(ats, ats[1:]):
-        assert a + window <= b, f"{a} window overlaps {b}"
+    ats = {t["at"] for t in trigs}
+    assert _dt(2026, 7, 2, 1, 0) in ats
+    assert _dt(2026, 7, 2, 7, 0) in ats
+    assert _dt(2026, 7, 1, 19, 0) in ats
 
 
 # ---- _missed ---------------------------------------------------------------

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -25,9 +25,9 @@ then self-terminates (~$2/mo).
 
 ```
 EventBridge Scheduler rules (UTC, cron)                    THIS Lambda
-  alpha-engine-scheduled-groom-0700-daily-low           ─┐      1. nousergon_lib.ec2_spot.launch()
-  alpha-engine-scheduled-groom-1500-daily-opus-high     ─┼───▶     (spot; on-demand fallback)
-  alpha-engine-scheduled-groom-2300-daily-mid           ─┘      2. wait instance running + SSM Online
+  alpha-engine-scheduled-groom-0100-daily-opus-high     ─┐      1. nousergon_lib.ec2_spot.launch()
+  alpha-engine-scheduled-groom-0700-daily-mid           ─┼───▶     (spot; on-demand fallback)
+  alpha-engine-scheduled-groom-1900-daily-low           ─┘      2. wait instance running + SSM Online
                                                              3. async ssm send-command (detached):
                                                                    │
                                                                    ▼
@@ -49,9 +49,9 @@ flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 
 | Scheduler rule | Expression (UTC) | PT | Day mask | run_mode | model | issue_filter |
 |---|---|---|---|---|---|---|
-| `…-0700-daily-low` | `cron(0 7 * * ? *)` | 12am | daily (all 7) | full | claude-haiku-4-5 | low-only |
-| `…-1500-daily-opus-high` | `cron(0 15 * * ? *)` | 8am | daily (all 7) | full | claude-opus-4-8 | high-only |
-| `…-2300-daily-mid` | `cron(0 23 * * ? *)` | 4pm | daily (all 7) | full | claude-sonnet-5 | mid-only |
+| `…-0100-daily-opus-high` | `cron(0 1 * * ? *)` | 6pm | daily (all 7) | full | claude-opus-4-8 | high-only |
+| `…-0700-daily-mid` | `cron(0 7 * * ? *)` | 12am | daily (all 7) | full | claude-sonnet-5 | mid-only |
+| `…-1900-daily-low` | `cron(0 19 * * ? *)` | 12pm | daily (all 7) | full | claude-haiku-4-5 | low-only |
 
 > **Tier-split cadence (config#1760, 2026-07-05):** three disjoint queues — Haiku
 > on `complexity:low`, Sonnet on `complexity:mid` (+ unlabeled), Opus on
@@ -81,7 +81,7 @@ day-of-week year)` with `?` for an unspecified day field.
 ## Schedule-input routing
 
 Each schedule passes a JSON input, e.g. `{"run_mode": "full", "model":
-"claude-opus-4-8", "issue_filter": "high-only", "pr_budget": 100, "schedule": "0 15 * * *"}`.
+"claude-opus-4-8", "issue_filter": "high-only", "pr_budget": 100, "schedule": "0 1 * * *"}`.
 The Opus schedule alone carries `pr_budget: 100` (config#1769) — forwarded as
 `GROOM_PR_BUDGET` on the spot box; Haiku/Sonnet stay at the bootstrap default (50).
 The Lambda resolves each field (unknown/missing values degrade to a safe

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -36,9 +36,11 @@
 # r5/r5a/r6i.large). No exceptions kept — the weekly SF can also now land on any
 # day (e.g. Friday, per the holiday-aware weekly-schedule-adjuster, #578) without
 # the groom cadence needing to track it.
-#   07:00 daily     cron(0 7 * * ? *)         FULL   Sonnet, default queue  # 12am PT, every day
-#   23:00 daily     cron(0 23 * * ? *)        FULL   Sonnet, default queue  # 4pm PT, every day
-#   15:00 daily     cron(0 15 * * ? *)        FULL   Opus,   high-only      # 8am PT, every day
+# Off-peak tier-split cadence (2026-07-07): avoid Anthropic Max weekday peak
+# (5–11am PT / 12:00–18:00 UTC PDT) and Brian's interactive hours where possible.
+#   01:00 daily     cron(0 1 * * ? *)         FULL   Opus,   high-only      # 6pm PT, every day
+#   07:00 daily     cron(0 7 * * ? *)         FULL   Sonnet, mid-only       # 12am PT, every day
+#   19:00 daily     cron(0 19 * * ? *)        FULL   Haiku,  low-only       # 12pm PT, every day
 #
 # SCHED_NAMES is the source of truth: any live scheduler rule under the
 # alpha-engine-scheduled-groom- prefix that is NOT in SCHED_NAMES is PRUNED
@@ -100,19 +102,19 @@ SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
 # schedule label, plus model/issue_filter per tier — config#1760 tier-split).
 # deploy.sh prune drops orphaned rule names when cadence changes.
 SCHED_NAMES=(
-  "alpha-engine-scheduled-groom-0700-daily-low"
-  "alpha-engine-scheduled-groom-1500-daily-opus-high"
-  "alpha-engine-scheduled-groom-2300-daily-mid"
+  "alpha-engine-scheduled-groom-0100-daily-opus-high"
+  "alpha-engine-scheduled-groom-0700-daily-mid"
+  "alpha-engine-scheduled-groom-1900-daily-low"
 )
 SCHED_CRONS=(
+  "cron(0 1 * * ? *)"
   "cron(0 7 * * ? *)"
-  "cron(0 15 * * ? *)"
-  "cron(0 23 * * ? *)"
+  "cron(0 19 * * ? *)"
 )
 SCHED_INPUTS=(
-  '{"run_mode":"full","model":"claude-haiku-4-5","issue_filter":"low-only","schedule":"0 7 * * *"}'
-  '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","pr_budget":100,"schedule":"0 15 * * *"}'
-  '{"run_mode":"full","model":"claude-sonnet-5","issue_filter":"mid-only","schedule":"0 23 * * *"}'
+  '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","pr_budget":100,"schedule":"0 1 * * *"}'
+  '{"run_mode":"full","model":"claude-sonnet-5","issue_filter":"mid-only","schedule":"0 7 * * *"}'
+  '{"run_mode":"full","model":"claude-haiku-4-5","issue_filter":"low-only","schedule":"0 19 * * *"}'
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2f).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -544,7 +544,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge Scheduler handler — launches the groom spot box on cadence.
 
     `event` is the schedule's JSON input, e.g. {"run_mode": "full", "model":
-    "claude-opus-4-8", "issue_filter": "high-only", "schedule": "0 15 * * *"}.
+    "claude-opus-4-8", "issue_filter": "high-only", "schedule": "0 1 * * *"}.
     `model`/`issue_filter` default to the Sonnet mid-tier queue when absent
     (the two pre-existing Sonnet schedules don't set them). `soft_limit_min` is
     a manual-invoke-ONLY bounded-test override — no live schedule sets it.

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -210,12 +210,12 @@ def test_sweep_run_mode_is_forwarded(monkeypatch):
 
 
 def test_high_only_schedule_forwards_model_and_issue_filter(monkeypatch):
-    # The 3rd (Opus, 8am PT) schedule's event carries model + issue_filter —
+    # The Opus (6pm PT) schedule's event carries model + issue_filter —
     # these must reach the box as exported env vars ahead of the bootstrap exec.
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler(
         {"run_mode": "full", "model": "claude-opus-4-8", "issue_filter": "high-only",
-         "schedule": "0 15 * * *"},
+         "schedule": "0 1 * * *"},
         None,
     )
     g = out["groom"]
@@ -234,7 +234,7 @@ def test_high_only_schedule_forwards_pr_budget(monkeypatch):
             "run_mode": "full",
             "model": "claude-opus-4-8",
             "issue_filter": "high-only",
-            "schedule": "0 15 * * *",
+            "schedule": "0 1 * * *",
             "pr_budget": 100,
         },
         None,
@@ -379,7 +379,7 @@ def test_low_only_schedule_forwards_haiku_model_and_filter(monkeypatch):
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler(
         {"run_mode": "full", "model": "claude-haiku-4-5", "issue_filter": "low-only",
-         "schedule": "0 7 * * *"},
+         "schedule": "0 19 * * *"},
         None,
     )
     g = out["groom"]


### PR DESCRIPTION
## Summary
- Reschedule tier-split groom EventBridge rules to avoid Anthropic Max weekday peak (5–11am PT):
  - **Opus high-only:** 15:00 → **01:00 UTC** (6pm PT)
  - **Sonnet mid-only:** 23:00 → **07:00 UTC** (12am PT)
  - **Haiku low-only:** 07:00 → **19:00 UTC** (12pm PT)
- Rename scheduler rules (`0100-daily-opus-high`, `0700-daily-mid`, `1900-daily-low`); old rules pruned on `--bootstrap`
- Sync groom-liveness-probe default schedule + tests

## Test plan
- [x] `pytest infrastructure/lambdas/groom-liveness-probe/test_handler.py` (12/12)
- [ ] CI green on merge
- [ ] **Operator step after merge:** `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --bootstrap`
- [ ] Verify: `aws scheduler list-schedules --name-prefix alpha-engine-scheduled-groom --region us-east-1` shows 3 new rules, zero orphans


Made with [Cursor](https://cursor.com)