### PR TITLE
Restore weekly gated-reverify groom schedule in deploy.sh SoT

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -28,6 +28,7 @@ EventBridge Scheduler rules (UTC, cron)                    THIS Lambda
   alpha-engine-scheduled-groom-0100-daily-opus-high     ─┐      1. nousergon_lib.ec2_spot.launch()
   alpha-engine-scheduled-groom-0700-daily-mid           ─┼───▶     (spot; on-demand fallback)
   alpha-engine-scheduled-groom-1900-daily-low           ─┘      2. wait instance running + SSM Online
+  alpha-engine-scheduled-groom-sun0900-weekly-gated-reverify  (Sun 09:00 UTC, Haiku gated-reverify)
                                                              3. async ssm send-command (detached):
                                                                    │
                                                                    ▼
@@ -52,6 +53,7 @@ flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 | `…-0100-daily-opus-high` | `cron(0 1 * * ? *)` | 6pm | daily (all 7) | full | claude-opus-4-8 | high-only |
 | `…-0700-daily-mid` | `cron(0 7 * * ? *)` | 12am | daily (all 7) | full | claude-sonnet-5 | mid-only |
 | `…-1900-daily-low` | `cron(0 19 * * ? *)` | 12pm | daily (all 7) | full | claude-haiku-4-5 | low-only |
+| `…-sun0900-weekly-gated-reverify` | `cron(0 9 ? * SUN *)` | 2am | Sun only | full | claude-haiku-4-5 | gated-reverify |
 
 > **Tier-split cadence (config#1760, 2026-07-05):** three disjoint queues — Haiku
 > on `complexity:low`, Sonnet on `complexity:mid` (+ unlabeled), Opus on

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -41,6 +41,7 @@
 #   01:00 daily     cron(0 1 * * ? *)         FULL   Opus,   high-only      # 6pm PT, every day
 #   07:00 daily     cron(0 7 * * ? *)         FULL   Sonnet, mid-only       # 12am PT, every day
 #   19:00 daily     cron(0 19 * * ? *)        FULL   Haiku,  low-only       # 12pm PT, every day
+#   Sun 09:00       cron(0 9 ? * SUN *)       FULL   Haiku,  gated-reverify # weekly stale-gate lane (config#1891)
 #
 # SCHED_NAMES is the source of truth: any live scheduler rule under the
 # alpha-engine-scheduled-groom- prefix that is NOT in SCHED_NAMES is PRUNED
@@ -105,16 +106,19 @@ SCHED_NAMES=(
   "alpha-engine-scheduled-groom-0100-daily-opus-high"
   "alpha-engine-scheduled-groom-0700-daily-mid"
   "alpha-engine-scheduled-groom-1900-daily-low"
+  "alpha-engine-scheduled-groom-sun0900-weekly-gated-reverify"
 )
 SCHED_CRONS=(
   "cron(0 1 * * ? *)"
   "cron(0 7 * * ? *)"
   "cron(0 19 * * ? *)"
+  "cron(0 9 ? * SUN *)"
 )
 SCHED_INPUTS=(
   '{"run_mode":"full","model":"claude-opus-4-8","issue_filter":"high-only","pr_budget":100,"schedule":"0 1 * * *"}'
   '{"run_mode":"full","model":"claude-sonnet-5","issue_filter":"mid-only","schedule":"0 7 * * *"}'
   '{"run_mode":"full","model":"claude-haiku-4-5","issue_filter":"low-only","schedule":"0 19 * * *"}'
+  '{"run_mode":"full","model":"claude-haiku-4-5","issue_filter":"gated-reverify","schedule":"0 9 * * 0"}'
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2f).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"


### PR DESCRIPTION
## Summary
- Register `alpha-engine-scheduled-groom-sun0900-weekly-gated-reverify` in `deploy.sh` `SCHED_NAMES` (Sun 09:00 UTC, Haiku `gated-reverify`)
- Prevents the off-peak bootstrap prune from deleting the config#1891 weekly lane again

## Test plan
- [ ] CI green
- [ ] `deploy.sh --bootstrap` recreates the Sun schedule
- [ ] `aws scheduler get-schedule --name alpha-engine-scheduled-groom-sun0900-weekly-gated-reverify` shows ENABLED


Made with [Cursor](https://cursor.com)