### PR TITLE
fix(dispatcher): accept issue_filter=gated-reverify (Sunday lane silently degraded to mid-only)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -140,7 +140,10 @@ CW_LOG_GROUP = os.environ.get("GROOM_CW_LOG_GROUP", "/alpha-engine/groom-spot")
 
 _VALID_RUN_MODES = {"full", "sweep"}
 _DEFAULT_RUN_MODE = "full"
-_VALID_ISSUE_FILTERS = {"default", "mid-only", "low-only", "high-only"}
+# config#1891: "gated-reverify" is the weekly Sunday stale-gate lane — missing
+# from this set until 2026-07-07, so the Sunday schedule would have silently
+# degraded to mid-only (caught by a manual dispatch before the first fire).
+_VALID_ISSUE_FILTERS = {"default", "mid-only", "low-only", "high-only", "gated-reverify"}
 _DEFAULT_ISSUE_FILTER = "mid-only"
 _DEFAULT_MODEL = "claude-sonnet-5"
 # Defense-in-depth allowlist for the model id (embedded verbatim into the SSM

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -363,6 +363,23 @@ def test_pace_gate_fails_safe_and_still_launches_on_s3_error(monkeypatch):
     assert notified == []  # fail-safe path never trips (exceeded=False), no ping
 
 
+def test_gated_reverify_schedule_forwards_filter(monkeypatch):
+    # config#1891 Sunday lane: "gated-reverify" must pass validation — it was
+    # missing from _VALID_ISSUE_FILTERS (PR #681 added only the schedule), so
+    # the weekly lane would have silently run as mid-only.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler(
+        {"run_mode": "full", "model": "claude-haiku-4-5",
+         "issue_filter": "gated-reverify", "schedule": "0 9 * * 0"},
+        None,
+    )
+    g = out["groom"]
+    assert g["issue_filter"] == "gated-reverify"
+    assert g["model"] == "claude-haiku-4-5"
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "export GROOM_ISSUE_FILTER=gated-reverify" in cmd
+
+
 def test_missing_model_and_issue_filter_default_to_mid_queue(monkeypatch):
     # Schedules with no model/issue_filter must default to Sonnet / mid-only.
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})


### PR DESCRIPTION
## What
One-line fix: `_VALID_ISSUE_FILTERS` in `scheduled-groom-dispatcher/index.py` gains `gated-reverify`, plus a regression test asserting the filter validates and reaches the box as `export GROOM_ISSUE_FILTER=gated-reverify`.

## Why
nousergon-data-PR681 restored the Sun 09:00 UTC weekly gated-reverify schedule (alpha-engine-config-I1891 / config-I1910), but only in `deploy.sh` — the Lambda's filter validation was never extended, so `_resolve_issue_filter` would have silently defaulted the weekly stale-gate lane to a **fourth mid-only groom** on its first fire this Sunday (2026-07-12). The driver itself already accepts the filter (`VALID_ISSUE_FILTERS` in alpha-engine-config `groom_driver.py`); the dispatcher was the only stale layer.

**Caught live today:** a manual gated-reverify dispatch returned `"issue_filter": "mid-only"` in the Lambda response; the mis-filtered box was terminated ~2 min after launch, before any groom activity (the in-progress marker + running mid run were verified unaffected).

## Tests
Dispatcher suite: **27 passed** (26 existing + 1 new) with the repo venv.

## Deploy
Code auto-deploys on merge via `deploy-scheduled-groom-dispatcher.yml` (no schedule/IAM change — no `--bootstrap` needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)