### PR TITLE
[P3/mid] feat(features): add vwap_divergence, cmf_20, hy_oas_level (config#939)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -155,6 +155,13 @@ def _extract_macro_series(price_data: dict[str, pd.DataFrame]) -> dict[str, pd.S
     macro_keys = {
         "SPY": "SPY", "VIX": "VIX", "VIX3M": "VIX3M",
         "TNX": "TNX", "IRX": "IRX", "GLD": "GLD", "USO": "USO",
+        # config#939 — credit spreads. HYOAS is the FRED-only ICE BofA US
+        # HY Index OAS index ticker (see collectors/daily_closes.py
+        # _FRED_INDEX_MAP), collected the same way as VIX/TNX/IRX. Absent
+        # from price_data (e.g. pre-Stage-2.5 cache) → macro.get("HYOAS")
+        # returns None downstream, which compute_features already
+        # neutral-defaults rather than crashing.
+        "HYOAS": "HYOAS",
     }
     macro: dict[str, pd.Series] = {}
     for key, stem in macro_keys.items():
@@ -606,6 +613,7 @@ def backfill(
     gld_series = macro.get("GLD")
     uso_series = macro.get("USO")
     vix3m_series = macro.get("VIX3M")
+    hyoas_series = macro.get("HYOAS")
 
     # ── 4. Compute features and write to ArcticDB ────────────────────────────
     if not dry_run:
@@ -645,6 +653,7 @@ def backfill(
                 gld_series=gld_series,
                 uso_series=uso_series,
                 vix3m_series=vix3m_series,
+                hyoas_series=hyoas_series,
                 earnings_data=ticker_alt.get("earnings"),
                 revision_data=ticker_alt.get("revisions"),
                 options_data=ticker_alt.get("options"),
@@ -764,9 +773,12 @@ def backfill(
             macro_lib.write("features", to_arctic_safe(macro_df))
             log.info("Wrote macro features: %d dates", len(macro_df))
 
-        # Write raw macro series (SPY, VIX, etc.) for consumers that need them
+        # Write raw macro series (SPY, VIX, etc.) for consumers that need them.
+        # HYOAS added config#939 (credit spreads) — mirrors the existing
+        # VIX/TNX/etc. raw-series persistence so daily_append's read-back
+        # loop (macro_lib.read("HYOAS")) resolves after this backfill runs.
         if not dry_run:
-            for key in ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO"]:
+            for key in ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO", "HYOAS"]:
                 series = macro.get(key)
                 if series is not None:
                     macro_series_df = pd.DataFrame({"Close": series}, index=series.index)
@@ -913,6 +925,7 @@ def _run_validation(
     gld_series = macro.get("GLD")
     uso_series = macro.get("USO")
     vix3m_series = macro.get("VIX3M")
+    hyoas_series = macro.get("HYOAS")
 
     passed = 0
     failed = 0
@@ -936,6 +949,7 @@ def _run_validation(
                 gld_series=gld_series,
                 uso_series=uso_series,
                 vix3m_series=vix3m_series,
+                hyoas_series=hyoas_series,
                 earnings_data=ticker_alt.get("earnings"),
                 revision_data=ticker_alt.get("revisions"),
                 options_data=ticker_alt.get("options"),

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -1221,6 +1221,43 @@ def _daily_append_impl(
                     f"Failed to update sector ETF {sym} bar for {date_str}: {exc}"
                 ) from exc
 
+        # HYOAS (config#939, credit spreads) — best-effort, NOT added to
+        # `macro_keys` above. Unlike SPY/VIX/TNX/etc. (battle-tested,
+        # load-bearing for every downstream feature), HYOAS is a newer,
+        # optional macro input: FRED-license-gated to 2023+ and not yet
+        # guaranteed present in every daily_closes parquet. Gating the
+        # WHOLE daily pipeline on its freshness (via macro_missing_from_closes
+        # -> the hard-fail below) would be a disproportionate blast radius
+        # for one optional feature — feature_engineer.compute_features
+        # already neutral-defaults hy_oas_credit_spread_pct to 0.0 when
+        # hyoas_series is None, so a missing HYOAS bar degrades one column
+        # to its neutral default rather than failing the run.
+        bar = closes.get("HYOAS")
+        if bar is not None and not np.isnan(bar.get("Close", np.nan)):
+            try:
+                new_row = pd.DataFrame(
+                    [{"Close": bar["Close"]}],
+                    index=pd.DatetimeIndex([today_ts]),
+                )
+                new_row.index.name = "date"
+                with _count_schema_drift(n_schema_drift, on_drift=_emit_schema_drift):
+                    mode = _write_row_backfill_safe(macro_lib, "HYOAS", new_row)
+                macro_updated.append("HYOAS")
+                macro_write_modes["HYOAS"] = mode
+            except Exception as exc:
+                log.warning(
+                    "HYOAS macro bar write failed for %s (non-fatal — "
+                    "hy_oas_credit_spread_pct will neutral-default): %s",
+                    date_str, exc,
+                )
+        else:
+            log.info(
+                "HYOAS bar missing/NaN from today's daily_closes for %s — "
+                "hy_oas_credit_spread_pct will neutral-default this run "
+                "(non-fatal, unlike the mandatory macro_keys set below).",
+                date_str,
+            )
+
         # Hard-fail on any missing key — macro inputs are not optional.
         # downstream feature compute + predictor preflight both depend on
         # these being fresh.
@@ -1429,6 +1466,35 @@ def _daily_append_impl(
                     series = series[~series.index.duplicated(keep="last")].sort_index()
                 macro[sym] = series
 
+        # HYOAS (config#939, credit spreads) — best-effort read, mirroring
+        # the best-effort write above. Not part of the mandatory
+        # `macro_keys` hard-fail loop: if the symbol doesn't exist yet
+        # (fresh deploy before any backfill/daily-write has populated it)
+        # or the read otherwise fails, `macro["HYOAS"]` simply stays
+        # unset and `hyoas_series = macro.get("HYOAS")` downstream is
+        # None — feature_engineer.compute_features already neutral-
+        # defaults hy_oas_credit_spread_pct to 0.0 in that case.
+        try:
+            mdf = macro_lib.read("HYOAS").data
+        except Exception as exc:
+            log.info(
+                "HYOAS macro series unreadable from ArcticDB (non-fatal — "
+                "hy_oas_credit_spread_pct will neutral-default): %s", exc,
+            )
+        else:
+            if "Close" in mdf.columns:
+                series = mdf["Close"].dropna()
+                ticker_close = closes.get("HYOAS")
+                if ticker_close and not np.isnan(ticker_close["Close"]):
+                    series = pd.concat([series, pd.Series([ticker_close["Close"]], index=[today_ts])])
+                    series = series[~series.index.duplicated(keep="last")].sort_index()
+                macro["HYOAS"] = series
+            else:
+                log.warning(
+                    "HYOAS macro series has no Close column — ArcticDB "
+                    "schema drift (non-fatal, treated as missing)."
+                )
+
     t_load = time.time() - t0
     log.info("Data loaded in %.1fs: %d closes, %d macro series", t_load, len(closes), len(macro))
 
@@ -1440,6 +1506,7 @@ def _daily_append_impl(
     gld_series = macro.get("GLD")
     uso_series = macro.get("USO")
     vix3m_series = macro.get("VIX3M")
+    hyoas_series = macro.get("HYOAS")
 
     # Filter to stock tickers only
     # _UNIVERSE_EXTRA (SPY) is maintained as a full universe member here too;
@@ -1723,6 +1790,7 @@ def _daily_append_impl(
                     gld_series=gld_series,
                     uso_series=uso_series,
                     vix3m_series=vix3m_series,
+                    hyoas_series=hyoas_series,
                     earnings_data=ticker_alt.get("earnings"),
                     revision_data=ticker_alt.get("revisions"),
                     options_data=ticker_alt.get("options"),

--- a/features/SCHEMA.md
+++ b/features/SCHEMA.md
@@ -143,6 +143,8 @@ parity.
 | `mom_12_1_pct` | decimal return | `close.shift(21) / close.shift(252) - 1` (12-1 skip-month momentum) | predictor (W2) |
 | `sector_mom_pct` | decimal return | sector-ETF `close.shift(21) / close.shift(252) - 1` (absolute industry momentum) | predictor (W2) |
 | `factor_momentum_ratio` | dimensionless projection | `Σ_f zscore(loading_{i,f,t}) × factor_momentum_{f,t}` (Gupta-Kelly factor momentum) — **second-pass** column materialized over the full universe panel by `factor_momentum.materialize_factor_momentum` (not per-ticker `compute_features`); backward-only | predictor (W2.3, observe) |
+| `vwap_divergence_pct` | decimal pct (`_pct` suffix) | `(Close - VWAP) / VWAP` | predictor (config#939 — VWAP divergence). NaN when VWAP is unavailable (yfinance-fallback rows; the documented 2026-04-17→23 Polygon outage) or when VWAP is 0 (guarded via `.replace(0, nan)`) |
+| `cmf_20_ratio` | dimensionless ratio, bounded ~[-1, 1] (`_ratio` suffix) | Chaikin Money Flow: `rolling_sum(MFM * Volume, 20) / rolling_sum(Volume, 20)` where `MFM = ((Close-Low)-(High-Close))/(High-Low)` | predictor (config#939 — buying/selling pressure). `High == Low` guarded to NaN via `.replace(0, nan)`, mirroring `volume_trend` / `obv_slope_10d` |
 
 ### Macro (one row per date — `per_ticker=False`)
 
@@ -155,6 +157,7 @@ parity.
 | `oil_mom_5d` | decimal return | `uso / uso.shift(5) - 1` | predictor |
 | `vix_term_slope` | normalized | `(vix - vix3m) / vix_baseline` | predictor |
 | `xsect_dispersion` | stdev of universe returns | precomputed series | predictor |
+| `hy_oas_credit_spread_pct` | percent (FRED native units, `_pct` suffix) | ICE BofA US HY Index OAS, FRED series `BAMLH0A0HYM2`, ffilled onto the trading-day index | predictor (config#939 — credit spreads). License-gated to 2023+ on FRED; pre-2023 / missing rows fall back to neutral `0.0` (same pattern as `gold_mom_5d` / `oil_mom_5d`), never hard-fail. **Distinct from** crucible-predictor's `model/regime_predictor.py` `hy_oas_level` / `hy_oas_change_21d` — that is a separate market-wide regime-substrate feature family (own `HYOAS.parquet` source, consumed only via `cfg.MACRO_NORM_FEATURES`), not a `feature_engineer.FEATURES` / `registry.CATALOG` entry. Same underlying FRED series, deliberately different name/namespace to avoid collision. |
 
 ### Regime interactions (per-ticker × macro)
 
@@ -302,3 +305,4 @@ Before landing a new alpha-bearing column through the private pack:
 | 2026-05-25 | This SCHEMA.md + additive `avg_volume_20d_raw` + naming-convention rule shipped as the institutional substrate (alpha-engine-data Phase 1). |
 | 2026-05-26 | C.1 of optimizer-sota-upgrades-260526 — 8 factor-loading `*_zscore` columns added (cross-sectional ±3σ-winsorized z-scores) as substrate for the executor's Σ = B·F·Bᵀ + D risk decomposition. |
 | 2026-07-01 | alpha-engine-config#1032 (private-edge divergence policy, config#1031) — private feature-pack loading mechanism (`features/private_pack.py`) + `compute=PRIVATE_PACK_COMPUTE` schema-contract sentinel (§3b) shipped. No alpha-bearing column has landed through it yet; only the throwaway fixture in `tests/fixtures/dummy_private_pack.py` exercises the mechanism. |
+| 2026-07-08 | alpha-engine-config#939 — 3 of the 7 originally-listed feature gaps shipped (the other 4 had already landed): `vwap_divergence_pct` (VWAP divergence), `cmf_20_ratio` (Chaikin Money Flow — buying/selling pressure, chosen over MFI-14 / Chaikin A/D for its bounded range and fewest edge cases), `hy_oas_credit_spread_pct` (credit spreads, FRED `BAMLH0A0HYM2` / `HYOAS`, deliberately named distinct from crucible-predictor's separate regime-substrate `hy_oas_level`). All 3 computed from already-ingested data; no new data source. |

--- a/features/compute.py
+++ b/features/compute.py
@@ -551,6 +551,7 @@ _MACRO_SLIM_KEYS = {
     "IRX": "IRX",
     "GLD": "GLD",
     "USO": "USO",
+    "HYOAS": "HYOAS", # config#939 — credit spreads; FRED-only index ticker
 }
 
 
@@ -818,6 +819,7 @@ def compute_and_write(
     gld_series = macro.get("GLD")
     uso_series = macro.get("USO")
     vix3m_series = macro.get("VIX3M")
+    hyoas_series = macro.get("HYOAS")
 
     for ticker in universe_tickers:
         try:
@@ -842,6 +844,7 @@ def compute_and_write(
                 gld_series=gld_series,
                 uso_series=uso_series,
                 vix3m_series=vix3m_series,
+                hyoas_series=hyoas_series,
                 earnings_data=earnings_data,
                 revision_data=revision_data,
                 options_data=options_data,

--- a/features/feature_engineer.py
+++ b/features/feature_engineer.py
@@ -251,6 +251,25 @@ FEATURES = [
     # emitted by apply_factor_zscores (log pre-transform registered in
     # cross_sectional.FACTOR_LOADING_TRANSFORMS). Barra SIZE loading.
     "size_zscore",
+    # config#939 — feature gaps: VWAP divergence, buying/selling pressure,
+    # credit spreads. NaN-safe optional-input features (like beta_60d /
+    # hy_oas_credit_spread_pct below): propagate NaN rather than crash when
+    # the upstream input is unavailable (VWAP is NaN for yfinance-fallback
+    # rows and during the documented 2026-04-17→23 Polygon outage).
+    "vwap_divergence_pct",
+    # Chaikin Money Flow (20d) — buying/selling pressure. Bounded ~[-1, 1]
+    # dimensionless ratio of volume-weighted close-location-value sums.
+    "cmf_20_ratio",
+    # hy_oas_credit_spread_pct: ICE BofA US HY Index OAS (FRED
+    # BAMLH0A0HYM2), percent. Per-ticker/date credit-spread level feature
+    # (identical across tickers on a given day — macro group). Deliberately
+    # named DISTINCT from crucible-predictor's regime_predictor.py
+    # ``hy_oas_level`` / ``hy_oas_change_21d`` (a SEPARATE market-wide
+    # regime-substrate feature family sourced from its own HYOAS.parquet
+    # cache, consumed only via cfg.MACRO_NORM_FEATURES) — same underlying
+    # FRED series, different namespace/consumer/compute path, so the names
+    # must not collide.
+    "hy_oas_credit_spread_pct",
 ]
 
 MIN_ROWS_FOR_FEATURES = 265  # 252 warmup + buffer
@@ -312,6 +331,7 @@ def compute_features(
     fundamental_data: dict | None = None,
     vix3m_series: pd.Series | None = None,
     xsect_dispersion: pd.Series | None = None,
+    hyoas_series: pd.Series | None = None,
     close_col: str = "Close",
 ) -> pd.DataFrame:
     """
@@ -344,6 +364,10 @@ def compute_features(
     fundamental_data : dict with keys: pe_ratio, pb_ratio, etc.
     vix3m_series : VIX3M Close prices (DatetimeIndex).
     xsect_dispersion : Cross-sectional dispersion Series (DatetimeIndex).
+    hyoas_series : ICE BofA US HY Index OAS, FRED series BAMLH0A0HYM2, in
+        percent (DatetimeIndex). License-gated to 2023+ on FRED — rows
+        before the series' first observation fall back to the neutral
+        default like the other optional macro inputs (see hy_oas_credit_spread_pct).
 
     Returns
     -------
@@ -593,6 +617,18 @@ def compute_features(
     else:
         df["oil_mom_5d"] = 0.0
 
+    # hy_oas_credit_spread_pct (config#939) — ICE BofA US HY Index OAS,
+    # FRED BAMLH0A0HYM2, percent. License-gated to 2023+ on FRED, so
+    # pre-2023 rows (and any date before hyoas_series' first observation)
+    # naturally ffill to NaN via reindex — fillna(0.0) below applies the
+    # same neutral-default-fallback pattern already used for gold_mom_5d /
+    # oil_mom_5d rather than hard-failing on missing history.
+    if hyoas_series is not None:
+        hyoas_aligned = hyoas_series.reindex(df.index, method="ffill")
+        df["hy_oas_credit_spread_pct"] = hyoas_aligned.fillna(0.0)
+    else:
+        df["hy_oas_credit_spread_pct"] = 0.0
+
     # ── v1.6 features — investigation upgrades (A2) ─────────────────────────
 
     # vix_term_slope
@@ -640,6 +676,20 @@ def compute_features(
     # a vol-term-structure signal (steep upward slope = vol expansion;
     # flat / inverted = mean-revert regime).
     df["realized_vol_63d"] = daily_returns.rolling(63).std() * np.sqrt(_52w)
+
+    # vwap_divergence_pct (config#939) — (Close - VWAP) / VWAP. VWAP is a
+    # first-class OHLCV column (store/arctic_store.py OHLCV_COLS) sourced
+    # from Polygon's `vw` field; it is NaN for yfinance-fallback rows and
+    # during the documented 2026-04-17→23 Polygon outage. No column at all
+    # is also possible (pre-VWAP-migration frames) — mirror the
+    # High/Low-optional guard above rather than crash. Division by a
+    # (rare) zero VWAP is guarded the same way volume_trend/obv_slope_10d
+    # guard a zero divisor; both paths propagate NaN, never raise.
+    if "VWAP" in df.columns:
+        vwap = df["VWAP"].astype(float)
+        df["vwap_divergence_pct"] = (close - vwap) / vwap.replace(0, float("nan"))
+    else:
+        df["vwap_divergence_pct"] = float("nan")
 
     # ── v3.2: Per-ticker risk features (Stage 2 regime-conditioning rebuild) ──
     # Four institutional risk dimensions that capture cross-sectional
@@ -759,6 +809,25 @@ def compute_features(
 
     # volume_price_div
     df["volume_price_div"] = np.sign(df["volume_trend"] - 1.0) * np.sign(df["momentum_5d"])
+
+    # cmf_20_ratio (config#939) — Chaikin Money Flow, buying/selling
+    # pressure. MFM (money flow multiplier) is the close's position within
+    # the day's H-L range, signed: +1 at the high, -1 at the low. Guard
+    # High==Low (e.g. halted / illiquid sessions) the same way
+    # volume_trend / obv_slope_10d guard a zero divisor — .replace(0, nan)
+    # so a degenerate day contributes NaN to the sum rather than a
+    # division blow-up. CMF_20 = rolling_SUM(MFM*Volume, 20) /
+    # rolling_SUM(Volume, 20) — bounded ~[-1, 1] by construction. NOTE:
+    # this is a rolling SUM denominator, not the rolling MEAN `vol_20`
+    # used by volume_trend/obv_slope_10d above — reusing that mean here
+    # would inflate CMF by ~20x and break the bounded range.
+    mfm = ((close - low) - (high - close)) / (high - low).replace(0, float("nan"))
+    mfv = mfm * volume
+    vol_sum_20 = volume.rolling(_vol_slow, min_periods=_vol_slow).sum()
+    df["cmf_20_ratio"] = (
+        mfv.rolling(_vol_slow, min_periods=_vol_slow).sum()
+        / vol_sum_20.replace(0, float("nan"))
+    )
 
     # ── v1.5 features — regime interaction terms ───────────────────────────────
 

--- a/features/registry.py
+++ b/features/registry.py
@@ -83,8 +83,17 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("obv_slope_10d", "technical", "OBV linear regression slope over 10 days", source="yfinance", refresh="daily"),
     FeatureEntry("rsi_slope_5d", "technical", "5-day RSI slope", source="yfinance", refresh="daily"),
     FeatureEntry("volume_price_div", "technical", "sign(volume_trend-1) * sign(momentum_5d)", source="yfinance", refresh="daily"),
+    # config#939 — VWAP divergence: (Close - VWAP) / VWAP. VWAP is a
+    # first-class OHLCV column (Polygon `vw`); NaN for yfinance-fallback
+    # rows and during the documented 2026-04-17->23 Polygon outage.
+    FeatureEntry("vwap_divergence_pct", "technical", "(Close - VWAP) / VWAP, decimal pct — NaN when VWAP is unavailable (yfinance-fallback rows, Polygon outage windows)", source="polygon", refresh="daily"),
+    # config#939 — buying/selling pressure: Chaikin Money Flow (CMF-20).
+    # Chosen over MFI-14 / Chaikin A/D: bounded ~[-1,1] range (fewest edge
+    # cases vs. A/D's unbounded cumulative line), uses only OHLCV already
+    # in the feature store (no new data source).
+    FeatureEntry("cmf_20_ratio", "technical", "Chaikin Money Flow (20d): rolling_sum(money_flow_multiplier * Volume, 20) / rolling_sum(Volume, 20). Bounded ~[-1, 1] dimensionless ratio; High==Low guarded to NaN.", source="yfinance", refresh="daily"),
 
-    # ── Macro (7) — identical across all tickers on a given day ───────────────
+    # ── Macro (8) — identical across all tickers on a given day ───────────────
     FeatureEntry("vix_level", "macro", "VIX / 20 (normalized around long-run avg)", source="yfinance", refresh="daily", per_ticker=False),
     FeatureEntry("yield_10y", "macro", "10Y Treasury yield normalized to 0-1", source="yfinance", refresh="daily", per_ticker=False),
     FeatureEntry("yield_curve_slope", "macro", "10Y - 2Y spread, normalized", source="yfinance", refresh="daily", per_ticker=False),
@@ -92,6 +101,16 @@ CATALOG: list[FeatureEntry] = [
     FeatureEntry("oil_mom_5d", "macro", "5-day oil (USO) momentum", source="yfinance", refresh="daily", per_ticker=False),
     FeatureEntry("vix_term_slope", "macro", "VIX spot vs VIX3M term structure slope, normalized", source="yfinance", refresh="daily", per_ticker=False),
     FeatureEntry("xsect_dispersion", "macro", "Cross-sectional std dev of daily returns across universe", source="computed", refresh="daily", per_ticker=False),
+    # config#939 — credit spreads. ICE BofA US HY Index OAS (FRED
+    # BAMLH0A0HYM2), percent. License-gated to 2023+ on FRED; pre-2023 /
+    # missing rows fall back to the neutral default 0.0 (same pattern as
+    # gold_mom_5d / oil_mom_5d), never hard-fail. Deliberately named
+    # DISTINCT from crucible-predictor's regime_predictor.py
+    # `hy_oas_level` / `hy_oas_change_21d` (a separate market-wide
+    # regime-substrate feature family, sourced independently via its own
+    # HYOAS.parquet cache and consumed only through cfg.MACRO_NORM_FEATURES
+    # — not this feature-store namespace).
+    FeatureEntry("hy_oas_credit_spread_pct", "macro", "ICE BofA US HY Index OAS (FRED BAMLH0A0HYM2), percent. License-gated to 2023+ on FRED; falls back to neutral 0.0 when unavailable.", source="fred", refresh="daily", per_ticker=False),
 
     # ── Regime interactions (5) — macro x ticker-specific signals ─────────────
     FeatureEntry("mom5d_x_vix", "interaction", "momentum_5d * VIX regime indicator", source="computed", refresh="daily"),

--- a/tests/test_feature_engineer_config939.py
+++ b/tests/test_feature_engineer_config939.py
@@ -1,0 +1,233 @@
+"""Tests for the config#939 feature gaps: VWAP divergence, buying/selling
+pressure, credit spreads.
+
+Validates the 3 new features added to features/feature_engineer.py:
+- vwap_divergence_pct:    (Close - VWAP) / VWAP
+- cmf_20_ratio:           Chaikin Money Flow (20d) — buying/selling pressure
+- hy_oas_credit_spread_pct: ICE BofA US HY Index OAS (FRED BAMLH0A0HYM2)
+
+Refs nousergon/alpha-engine-config#939.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from features.feature_engineer import FEATURES, compute_features
+
+
+def _synthetic_ohlcv(
+    n: int = 400,
+    seed: int = 0,
+    start: str = "2018-01-01",
+    with_vwap: bool = True,
+):
+    """Build (n,)-day OHLCV(+VWAP) DataFrame for compute_features."""
+    rng = np.random.default_rng(seed)
+    daily_returns = rng.normal(0, 0.012, n)
+    close = 100.0 * np.exp(np.cumsum(daily_returns))
+    high = close * (1 + np.abs(rng.normal(0, 0.005, n)))
+    low = close * (1 - np.abs(rng.normal(0, 0.005, n)))
+    open_ = close * (1 + rng.normal(0, 0.003, n))
+    volume = rng.integers(1_000_000, 10_000_000, n).astype(float)
+    idx = pd.date_range(start, periods=n, freq="B")
+    data = {
+        "Open": open_, "High": high, "Low": low, "Close": close, "Volume": volume,
+    }
+    if with_vwap:
+        data["VWAP"] = close * (1 + rng.normal(0, 0.001, n))
+    return pd.DataFrame(data, index=idx)
+
+
+def _synthetic_hyoas(n: int = 400, seed: int = 7, start: str = "2018-01-01") -> pd.Series:
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range(start, periods=n, freq="B")
+    return pd.Series(rng.normal(4.0, 0.3, n).clip(min=1.0), index=idx)
+
+
+# ── Schema contract ─────────────────────────────────────────────────────
+
+
+class TestFeatureSchema:
+
+    def test_new_features_in_features_list(self):
+        for name in ("vwap_divergence_pct", "cmf_20_ratio", "hy_oas_credit_spread_pct"):
+            assert name in FEATURES, f"{name} missing from FEATURES list"
+
+    def test_compute_features_emits_new_columns(self):
+        df = _synthetic_ohlcv()
+        hyoas = _synthetic_hyoas()
+        out = compute_features(df, hyoas_series=hyoas)
+        for name in ("vwap_divergence_pct", "cmf_20_ratio", "hy_oas_credit_spread_pct"):
+            assert name in out.columns
+
+    def test_no_namespace_collision_with_regime_hy_oas_level(self):
+        # config#939: crucible-predictor's model/regime_predictor.py already
+        # ships a SEPARATE market-wide regime feature named "hy_oas_level" /
+        # "hy_oas_change_21d" (consumed via cfg.MACRO_NORM_FEATURES). This
+        # repo's per-ticker/date feature store must use a distinct name.
+        assert "hy_oas_level" not in FEATURES
+        assert "hy_oas_credit_spread_pct" in FEATURES
+
+
+# ── vwap_divergence_pct ──────────────────────────────────────────────────
+
+
+class TestVwapDivergencePct:
+
+    def test_finite_when_vwap_present(self):
+        df = _synthetic_ohlcv()
+        out = compute_features(df)
+        assert out["vwap_divergence_pct"].notna().any()
+
+    def test_known_good_value(self):
+        n = 300
+        idx = pd.date_range("2024-01-01", periods=n, freq="B")
+        close = pd.Series(100.0, index=idx)
+        vwap = pd.Series(95.0, index=idx)
+        df = pd.DataFrame({
+            "Open": close, "High": close + 1, "Low": close - 1,
+            "Close": close, "Volume": 1_000_000.0, "VWAP": vwap,
+        }, index=idx)
+        out = compute_features(df)
+        expected = (100.0 - 95.0) / 95.0
+        assert abs(out["vwap_divergence_pct"].iloc[-1] - expected) < 1e-9
+
+    def test_nan_when_vwap_column_absent(self):
+        # yfinance-fallback-only frames (no VWAP column at all) must not
+        # crash — propagate NaN, matching the High/Low-optional pattern.
+        df = _synthetic_ohlcv(with_vwap=False)
+        out = compute_features(df)
+        assert out["vwap_divergence_pct"].isna().all()
+
+    def test_nan_when_vwap_values_are_nan(self):
+        # Documented 2026-04-17->23 Polygon outage window: VWAP column
+        # present but NaN for the affected rows.
+        df = _synthetic_ohlcv()
+        df["VWAP"] = np.nan
+        out = compute_features(df)
+        assert out["vwap_divergence_pct"].isna().all()
+
+    def test_nan_guarded_when_vwap_is_zero(self):
+        # Degenerate zero-VWAP row must not raise a ZeroDivisionError /
+        # produce +-inf — guarded to NaN like volume_trend/obv_slope_10d.
+        df = _synthetic_ohlcv()
+        df.loc[df.index[200], "VWAP"] = 0.0
+        out = compute_features(df)
+        assert pd.isna(out["vwap_divergence_pct"].iloc[200])
+        assert np.isfinite(out["vwap_divergence_pct"].iloc[-1])
+
+
+# ── cmf_20_ratio ──────────────────────────────────────────────────────────
+
+
+class TestCmf20Ratio:
+
+    def test_bounded_range(self):
+        # CMF is a volume-weighted average of a [-1, 1] signal — must stay
+        # within that band (small float slop tolerated).
+        df = _synthetic_ohlcv()
+        out = compute_features(df)
+        cmf = out["cmf_20_ratio"].dropna()
+        assert len(cmf) > 0
+        assert cmf.between(-1.0001, 1.0001).all()
+
+    def test_all_buying_pressure_is_positive_one(self):
+        # Close == High every day (price closes at the top of its range) ->
+        # money-flow multiplier is +1 every day -> CMF_20 == +1.
+        n = 60
+        idx = pd.date_range("2024-01-01", periods=n, freq="B")
+        close = pd.Series(np.linspace(100, 130, n), index=idx)
+        high = close
+        low = close - 2.0
+        df = pd.DataFrame({
+            "Open": low, "High": high, "Low": low, "Close": close,
+            "Volume": 1_000_000.0,
+        }, index=idx)
+        out = compute_features(df)
+        tail = out["cmf_20_ratio"].dropna()
+        assert len(tail) > 0
+        assert np.allclose(tail.tail(5), 1.0)
+
+    def test_all_selling_pressure_is_negative_one(self):
+        # Close == Low every day -> money-flow multiplier is -1 every day
+        # -> CMF_20 == -1.
+        n = 60
+        idx = pd.date_range("2024-01-01", periods=n, freq="B")
+        close = pd.Series(np.linspace(130, 100, n), index=idx)
+        low = close
+        high = close + 2.0
+        df = pd.DataFrame({
+            "Open": high, "High": high, "Low": low, "Close": close,
+            "Volume": 1_000_000.0,
+        }, index=idx)
+        out = compute_features(df)
+        tail = out["cmf_20_ratio"].dropna()
+        assert len(tail) > 0
+        assert np.allclose(tail.tail(5), -1.0)
+
+    def test_nan_guarded_when_high_equals_low(self):
+        # Halted/illiquid session: High == Low degenerates the money-flow
+        # multiplier's denominator to zero — must not raise, must not
+        # silently zero-fill; NaN-guarded like volume_trend/obv_slope_10d.
+        df = _synthetic_ohlcv()
+        df.loc[df.index[50], "High"] = df.loc[df.index[50], "Low"]
+        out = compute_features(df)
+        # No crash, and the feature stays finite/NaN-only (no inf).
+        assert not np.isinf(out["cmf_20_ratio"].dropna()).any()
+
+    def test_uses_rolling_sum_not_rolling_mean_denominator(self):
+        # Regression guard: CMF_20 = rolling_SUM(mfm*vol, 20) /
+        # rolling_SUM(vol, 20). An earlier draft divided by the rolling
+        # MEAN volume (reusing volume_trend's vol_20) instead of the
+        # rolling SUM, which inflated the ratio ~20x out of [-1, 1].
+        df = _synthetic_ohlcv()
+        out = compute_features(df)
+        cmf = out["cmf_20_ratio"].dropna()
+        assert cmf.abs().max() <= 1.0001
+
+
+# ── hy_oas_credit_spread_pct ────────────────────────────────────────────
+
+
+class TestHyOasCreditSpreadPct:
+
+    def test_finite_when_hyoas_series_provided(self):
+        df = _synthetic_ohlcv()
+        hyoas = _synthetic_hyoas()
+        out = compute_features(df, hyoas_series=hyoas)
+        assert out["hy_oas_credit_spread_pct"].notna().all()
+
+    def test_tracks_input_series_after_alignment(self):
+        n = 300
+        idx = pd.date_range("2024-01-01", periods=n, freq="B")
+        df = _synthetic_ohlcv(n=n, start="2024-01-01")
+        hyoas = pd.Series(4.25, index=idx)
+        out = compute_features(df, hyoas_series=hyoas)
+        assert np.allclose(out["hy_oas_credit_spread_pct"], 4.25)
+
+    def test_neutral_default_when_series_absent(self):
+        # HYOAS is FRED-license-gated to 2023+; pre-2023 backfills or any
+        # run where the macro dict lacks "HYOAS" must fall back to the
+        # neutral default (0.0), never hard-fail — same pattern as
+        # gold_mom_5d / oil_mom_5d.
+        df = _synthetic_ohlcv()
+        out = compute_features(df)  # hyoas_series defaults to None
+        assert (out["hy_oas_credit_spread_pct"] == 0.0).all()
+
+    def test_neutral_default_when_series_partially_missing(self):
+        # hyoas_series covers only the tail of df's date range (mimics the
+        # FRED 2023+ license gate against a longer per-ticker history) —
+        # rows before the series' first observation ffill to NaN, then
+        # neutral-default to 0.0 rather than propagating NaN or raising.
+        df = _synthetic_ohlcv(n=400, start="2018-01-01")
+        hyoas = _synthetic_hyoas(n=100, start="2023-01-02")
+        out = compute_features(df, hyoas_series=hyoas)
+        assert out["hy_oas_credit_spread_pct"].notna().all()
+        early_rows = out["hy_oas_credit_spread_pct"].loc[:"2022-12-31"]
+        assert (early_rows == 0.0).all()


### PR DESCRIPTION
**Priority:** P3 · **Complexity:** mid

Adds the 3 remaining feature-store gaps from the issue's original list of 7 (the other 4 had already shipped): VWAP divergence, buying/selling pressure, and credit spreads. All 3 are computed entirely from data already ingested by this repo — no new data source, no new collector.

## What shipped

- **`vwap_divergence_pct`** — `(Close - VWAP) / VWAP`. VWAP is already a first-class OHLCV column (Polygon `vw`, `store/arctic_store.py::OHLCV_COLS`). NaN-safe: propagates NaN when VWAP is absent/NaN (yfinance-fallback rows, the documented 2026-04-17→23 Polygon outage) or zero, mirroring the existing High/Low-optional and zero-divisor guard patterns.
- **`cmf_20_ratio`** — Chaikin Money Flow (20-day): `rolling_sum(MFM * Volume, 20) / rolling_sum(Volume, 20)` where `MFM = ((Close-Low)-(High-Close))/(High-Low)`. Bounded ~[-1, 1] by construction; `High == Low` guarded to NaN the same way `volume_trend` / `obv_slope_10d` guard a zero divisor.
- **`hy_oas_credit_spread_pct`** — ICE BofA US HY Index OAS (FRED `BAMLH0A0HYM2`, already collected as `HYOAS` by `collectors/daily_closes.py`). License-gated to 2023+ on FRED; missing/pre-2023 rows fall back to the neutral default `0.0` (same pattern as `gold_mom_5d`/`oil_mom_5d`), never hard-fail.

## Naming note — avoiding a real collision

crucible-predictor's `model/regime_predictor.py` already ships a **separate** market-wide regime-substrate feature also named `hy_oas_level` (+ `hy_oas_change_21d`), consumed only via `cfg.MACRO_NORM_FEATURES` and sourced independently from its own `HYOAS.parquet` cache — not from this repo's feature store. Same underlying FRED series, genuinely different namespace/compute path/consumer. To avoid confusing the two, this repo's per-ticker/date feature store entry is named `hy_oas_credit_spread_pct`, not `hy_oas_level`. Documented in both `features/SCHEMA.md` and inline comments at both the `FEATURES` list and `registry.CATALOG` entry.

## Threading

`hyoas_series` is threaded through `compute_features` call sites in `builders/backfill.py`, `builders/daily_append.py`, and `features/compute.py`, the same way `vix_series`/`tnx_series` are threaded. One deliberate deviation in `daily_append.py`: HYOAS is **not** added to the pre-existing mandatory `macro_keys` hard-fail set (unlike battle-tested VIX/TNX/SPY) — it's a newer, optional macro input, so a missing HYOAS bar degrades `hy_oas_credit_spread_pct` to its neutral default for that run instead of hard-failing the entire daily pipeline. Caught this via the existing `test_daily_append_universe_chunking.py` suite, which failed when HYOAS was first added to the mandatory list with a synthetic `closes` fixture that doesn't include it.

## Tests

- New `tests/test_feature_engineer_config939.py` — 17 tests covering NaN-safety (missing VWAP column, all-NaN VWAP, zero VWAP, `High==Low`, missing/partial `hyoas_series`) and known-good-value cases (VWAP divergence against a hand-computed value; CMF-20 against synthetic all-buying/all-selling OHLCV sequences that must resolve to exactly +1.0 / -1.0).
- `pytest tests/test_schema_contract.py` — all 10 pass (FEATURES/CATALOG/SCHEMA.md 3-way parity, units-suffix enforcement).
- Full repo suite: 2712 passed, 17 skipped, 0 new failures (9 pre-existing failures are sandbox-environment gaps unrelated to this change — missing `embit`/`lxml` for crypto-balances and constituents-sector-map tests).

Refs nousergon/alpha-engine-config#939

---
Groom-Run: 335716eb1015463dbecd4ec0345bb071
