### PR TITLE
[P1/mid] feat(groom): skip launching a groom box for a tier already running

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -461,6 +461,57 @@ def _send_bootstrap(instance_id: str, run_mode: str, run_url: str, model: str, i
     return resp["Command"]["CommandId"]
 
 
+GROOM_TIER_TAG_KEY = "groom-issue-filter"
+
+
+def _running_tier_instance_ids(issue_filter: str) -> list[str]:
+    """Instance ids for a LIVE (pending/running) groom-spot box already working
+    THIS ``issue_filter`` tier (config#1979). Two concurrent boxes on the same
+    tier would race the identical GitHub issue queue and double-spend WET on
+    duplicate work — config#1969's adaptive re-queue now makes a full-coverage
+    run legitimately take longer (a run can now genuinely work its ENTIRE
+    queue rather than stopping early), raising the odds a prior trigger's box
+    for a tier is still running when the next trigger re-evaluates the same
+    tier. Fail-safe: any API error returns ``[]`` (never blocks a launch on a
+    broken check — this guard is an optimization, not a correctness gate,
+    mirroring every other pre-launch gate in this file)."""
+    try:
+        ec2 = boto3.client("ec2", region_name=REGION)
+        resp = ec2.describe_instances(Filters=[
+            {"Name": "tag:Name", "Values": ["alpha-engine-groom-spot"]},
+            {"Name": f"tag:{GROOM_TIER_TAG_KEY}", "Values": [issue_filter]},
+            {"Name": "instance-state-name", "Values": ["pending", "running"]},
+        ])
+        return [i["InstanceId"] for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
+    except Exception as exc:  # noqa: BLE001 — fail-safe: never block a launch
+        logger.warning("concurrent-tier check failed (non-fatal, launching anyway): %s: %s",
+                       type(exc).__name__, exc)
+        return []
+
+
+def _notify_concurrent_skip(issue_filter: str, existing_ids: list[str], schedule_label: str) -> None:
+    """Best-effort loud ping for a concurrent-same-tier skip — never raises."""
+    text = (
+        "⚪ Backlog groom slot SKIPPED — a box for this tier is already running "
+        f"(config#1979). issue_filter={issue_filter}, existing instance(s): "
+        f"{', '.join(existing_ids)}. schedule={schedule_label}. Zero spot/WET "
+        "spend; this slot's queue rides the next trigger once the running box "
+        "finishes."
+    )
+    try:
+        notify_via_flow_doctor(
+            text, silent=True, severity="info",
+            dedup_key=f"{_FLOW_NAME}:concurrent_tier_skip:{issue_filter}",
+            flow_name=_FLOW_NAME, topics=_GROOM_LIFECYCLE_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={"schedule": schedule_label, "issue_filter": issue_filter,
+                     "existing_instance_ids": existing_ids},
+            silent_topic=FleetTelegramTopic.GROOM,
+        )
+    except Exception as exc:  # noqa: BLE001 — secondary observability
+        logger.warning("concurrent-tier skip Telegram failed (non-fatal): %s", exc)
+
+
 def _terminate_instance(instance_id: str) -> None:
     """Best-effort terminate of a just-launched box whose post-launch steps
     failed. Without this the box orphans: it received no bootstrap, so neither
@@ -486,6 +537,19 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         logger.warning("GROOM_DISPATCH_ENABLED=false — groom spot NOT launched")
         return {"launched": False, "reason": "disabled"}
 
+    # config#1979: skip if a box for THIS SAME tier is already live — a prior
+    # trigger's run that's still working its queue (now more likely to run
+    # long thanks to config#1969's adaptive re-queue) must not get a second,
+    # concurrent box racing the identical GitHub issue queue.
+    existing = _running_tier_instance_ids(issue_filter)
+    if existing:
+        logger.warning(
+            "tier %s already has a live groom box (%s) — skipping launch to avoid "
+            "a concurrent same-tier run", issue_filter, existing)
+        _notify_concurrent_skip(issue_filter, existing, schedule_label)
+        return {"launched": False, "reason": "concurrent_tier_skip",
+                "issue_filter": issue_filter, "existing_instance_ids": existing}
+
     # config#1645: a fresh token per launch ATTEMPT (not per schedule) — the
     # dispatch Step Function's relaunch loop calls this Lambda again with a new
     # execution, so each attempt gets its own S3 completion-marker key. A dead
@@ -493,6 +557,15 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
     run_token = uuid.uuid4().hex
     instance_id, market = _launch_instance(force_on_demand=force_on_demand)
     logger.info("launched groom box %s (%s)", instance_id, market)
+    # config#1979: tag the box with its tier so the NEXT trigger's guard check
+    # (above) can find it. Best-effort — a tag-write failure must not abort an
+    # already-launched box (mirrors the fail-safe posture of the check itself).
+    try:
+        boto3.client("ec2", region_name=REGION).create_tags(
+            Resources=[instance_id], Tags=[{"Key": GROOM_TIER_TAG_KEY, "Value": issue_filter}])
+    except Exception as exc:  # noqa: BLE001 — non-fatal, mirrors _running_tier_instance_ids
+        logger.warning("groom-issue-filter tag write failed (non-fatal): %s: %s",
+                       type(exc).__name__, exc)
     # Once the box is up, ANY failure before the bootstrap command is delivered
     # would orphan it (no watchdog/trap yet). Terminate-on-error so a slow
     # SSM-online, an SSM SendCommand error, etc. tears the box down instead of

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -57,8 +57,12 @@ class _FakeWaiter:
 
 
 class _FakeEc2:
-    def __init__(self):
+    def __init__(self, running_tier_instances=None):
         self.terminated = []
+        self.tags_created = []
+        # config#1979: (issue_filter -> [instance_ids]) already "live" for the
+        # concurrent-tier guard's describe_instances check to find.
+        self._running_tier_instances = dict(running_tier_instances or {})
 
     def get_waiter(self, name):
         return _FakeWaiter()
@@ -66,6 +70,16 @@ class _FakeEc2:
     def terminate_instances(self, InstanceIds):  # noqa: N803 — boto3 kwarg name
         self.terminated.extend(InstanceIds)
         return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
+
+    def create_tags(self, Resources, Tags):  # noqa: N803 — boto3 kwarg names
+        self.tags_created.append((Resources, Tags))
+        return {}
+
+    def describe_instances(self, Filters):  # noqa: N803 — boto3 kwarg name
+        by_name = {f["Name"]: f["Values"] for f in Filters}
+        issue_filter = by_name.get("tag:groom-issue-filter", [None])[0]
+        ids = self._running_tier_instances.get(issue_filter, [])
+        return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
 
 
 class _FakeSsm:
@@ -121,11 +135,12 @@ class _FakeS3:
         return {"Body": _FakeS3Body(self._objects[Key])}
 
 
-def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None, ssm_parameters=None):
+def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None, ssm_parameters=None,
+         running_tier_instances=None):
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
     ssm = _FakeSsm(ssm_parameters)
-    ec2 = _FakeEc2()
+    ec2 = _FakeEc2(running_tier_instances=running_tier_instances)
     s3 = _FakeS3(s3_objects)
     clients = {"ec2": ec2, "ssm": ssm, "s3": s3}
     if launch_impl is None:
@@ -535,6 +550,64 @@ def test_post_launch_failure_terminates_instance_no_orphan(monkeypatch):
         idx.handler({"run_mode": "full"}, None)
     # The just-launched box was terminated (not orphaned) before the re-raise.
     assert idx._test_ec2.terminated == ["i-orphan"]
+
+
+# ── config#1979: concurrent-same-tier guard ───────────────────────────────────
+def test_concurrent_tier_skip_when_same_tier_already_running(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-new"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"mid-only": ["i-already-running"]},
+    )
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    g = out["groom"]
+    assert g["launched"] is False
+    assert g["reason"] == "concurrent_tier_skip"
+    assert g["existing_instance_ids"] == ["i-already-running"]
+    assert launched == []  # never even attempted a spot launch — zero spend
+
+
+def test_different_tier_running_does_not_block_launch(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"high-only": ["i-other-tier"]},
+    )
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    assert out["groom"]["launched"] is True
+    assert out["groom"]["instance_id"] == "i-new"
+
+
+def test_launched_instance_gets_tagged_with_its_tier(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+    )
+    idx.handler({"run_mode": "full", "issue_filter": "high-only", "schedule": "x"}, None)
+    assert idx._test_ec2.tags_created == [
+        (["i-new"], [{"Key": "groom-issue-filter", "Value": "high-only"}])
+    ]
+
+
+def test_concurrent_tier_check_fails_safe_and_still_launches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom(Filters):  # noqa: N803 — boto3 kwarg name
+        raise RuntimeError("EC2 API hiccup")
+
+    idx._test_ec2.describe_instances = _boom
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    # A broken check must never block a launch — it's an optimization, not a
+    # correctness gate (mirrors the pace gate / demand gate fail-safe posture).
+    assert out["groom"]["launched"] is True
 
 
 # ── config#1933: demand-driven dispatch (enumerate-then-decide) ──────────────


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

## Summary

Closes alpha-engine-config#1979.

config#1969 (adaptive re-queue, same session) makes full-coverage groom runs legitimately take much longer — a run now genuinely works through its ENTIRE queue instead of stopping early (verified: 18/18 issues covered in ~62 min vs the pre-fix 3/9 in ~39 min). This raises the real risk that a prior trigger's box for a tier (e.g. `mid-only`) is STILL RUNNING when the next scheduled trigger re-evaluates the same tier and launches a second, concurrent box — racing the identical GitHub issue queue and double-spending WET on duplicate work.

`_launch_groom_spot()` now checks `_running_tier_instance_ids(issue_filter)` (`ec2:DescribeInstances` filtered on `tag:Name=alpha-engine-groom-spot` + `tag:groom-issue-filter=<tier>` + state in pending/running) BEFORE any spot spend; if a box for the same tier is already live, the launch is skipped (`reason=concurrent_tier_skip`) with a best-effort Telegram ping, mirroring the existing pace-gate/demand-gate skip pattern. Every launched instance is tagged `groom-issue-filter=<issue_filter>` right after launch so the next trigger's check can find it. Fail-safe: any API error in the check returns `[]` and never blocks a launch.

**Zero new IAM permissions needed** — `ec2:CreateTags` and `ec2:DescribeInstances` are already granted with `Resource: "*"` in `iam-policy.json` (verified).

## Test plan
- [x] `pytest test_handler.py -q` — 42 passed (4 new: skip-when-running, different-tier-not-blocked, tag-on-launch, fail-safe-on-API-error)
- [x] `python3 -m py_compile index.py` — compiles clean
- [ ] Brian: review + merge; auto-deploys via `deploy-scheduled-groom-dispatcher.yml` (code-only, path-triggered) — no manual post-merge step

🤖 Generated with [Claude Code](https://claude.com/claude-code)