### PR TITLE
fix(data-spot-dispatcher): add missing deploy.sh + auto-deploy workflow (PR #643 gap)

### DIFF
--- a/.github/workflows/deploy-data-spot-dispatcher.yml
+++ b/.github/workflows/deploy-data-spot-dispatcher.yml
@@ -1,0 +1,84 @@
+name: Deploy data-spot-dispatcher
+
+# Auto-deploy the alpha-engine-data-spot-dispatcher Lambda CODE on merge to
+# main. Mirrors deploy-scheduled-groom-dispatcher.yml — same gap, same fix: a
+# merged code change to the dispatcher must not sit inert until someone
+# remembers to run deploy.sh by hand (the exact failure mode that broke the
+# 2026-07-08 EOD run, where the invoking SF def auto-deployed but the Lambda
+# did not exist).
+#
+# Separation of concerns: this deploys CODE only (deploy.sh with NO flag —
+# the flagless run is code-only; --bootstrap is what ADDS the IAM-role
+# creation, and stays operator-only: the github-actions-lambda-deploy OIDC
+# role deliberately has no iam:CreateRole / iam:PutRolePolicy, a fleet-wide
+# policy after 4 IAM-clobber incidents in 2 months — see
+# infrastructure/iam/README.md).
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/data-spot-dispatcher/**'
+      - '.github/workflows/deploy-data-spot-dispatcher.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-data-spot-dispatcher-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy data-spot-dispatcher Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy data-spot-dispatcher (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/data-spot-dispatcher/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-data-spot-dispatcher \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-data-spot-dispatcher.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/infrastructure/lambdas/data-spot-dispatcher/README.md
+++ b/infrastructure/lambdas/data-spot-dispatcher/README.md
@@ -66,15 +66,21 @@ failure must NOT block daemon start (weekday) or reconcile + instance-stop (EOD)
 
 ## Deployment
 
-Managed **outside CloudFormation** (same as `scheduled-groom-dispatcher`) —
-operator-deployed. Merging this PR has **zero live effect** until:
+Managed **outside CloudFormation** (same as `scheduled-groom-dispatcher`).
+**Caution: the invoking SF definitions auto-deploy on merge**, so merging a
+change that touches `step_function_daily.json` / `step_function_eod.json`
+alongside this Lambda goes live immediately on the SF side — the Lambda + IAM
+halves must exist BEFORE such a merge, or the SFs 404 on the invoke (this
+exact ordering inversion broke the 2026-07-08 EOD run; the original PR #643
+wrongly claimed merging had "zero live effect").
 
-1. the Lambda + `iam-policy.json` are deployed (create the
-   `alpha-engine-data-spot-dispatcher` function with the packaged `index.py` +
-   `requirements.txt`, attach `iam-policy.json`);
-2. the `alpha-engine-step-functions-role` policy is re-applied
-   (`infrastructure/iam/apply.sh`) so the SF can invoke the new Lambda;
-3. the daily + EOD Step Functions are re-deployed from the updated
-   `step_function_daily.json` / `step_function_eod.json`.
+First-time bootstrap (operator-only — creates the exec role from
+`iam-policy.json` + the function):
 
-This is the **live validation gate** — see the PR body for the exact steps.
+1. `bash infrastructure/lambdas/data-spot-dispatcher/deploy.sh --bootstrap`
+2. `bash infrastructure/iam/apply.sh --role alpha-engine-step-functions-role`
+   (applies the SF execution-role invoke grant)
+
+Code updates after bootstrap auto-deploy on merge via
+`.github/workflows/deploy-data-spot-dispatcher.yml` (path-filtered, flagless
+`deploy.sh` run — code-only, mirroring the groom-dispatcher twin).

--- a/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
@@ -21,7 +21,7 @@
 # the FIRST-TIME `--bootstrap` (which mints the execution role + creates the
 # function) MUST be run by an operator with IAM rights. The flagless run is
 # code-only (`update-function-code` + env converge) and is the CI auto-deploy
-# path once a deploy-data-spot-dispatcher.yml workflow exists.
+# path (.github/workflows/deploy-data-spot-dispatcher.yml, path-filtered).
 #
 # WHY THIS SCRIPT EXISTS (2026-07-08 EOD incident): config#1767 Phase 2 (#643)
 # shipped this Lambda's source + IAM policy + SF wiring + the SF-role invoke
@@ -54,11 +54,15 @@ ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 # the handler's in-code default, so they are intentionally NOT set here.
 PROD_ENV='Variables={LOG_LEVEL=INFO,DATA_SPOT_DISPATCH_ENABLED=true}'
 
-# Timeout must cover the handler's worst case: launch a spot + wait for its SSM
-# agent to come Online (DATA_SPOT_SSM_ONLINE_BUDGET_SEC default 300s) before the
-# async detached SSM send-command + immediate return. 300s matches that budget;
-# memory is small (the box does the heavy lifting, not the Lambda).
-FN_TIMEOUT=300
+# Timeout must cover the handler's worst case: launch a spot (RunInstances +
+# state poll, tens of seconds; longer on the on-demand fallback after capacity
+# retries) PLUS the full SSM-online wait (DATA_SPOT_SSM_ONLINE_BUDGET_SEC
+# default 300s) before the async detached SSM send-command + return. 300s
+# equals the SSM budget alone with ZERO launch headroom — the Lambda would time
+# out right as a slow box comes online and false-fail the (fail-open) data
+# phase. 600s matches the live function as bootstrapped 2026-07-08; memory is
+# small (the box does the heavy lifting, not the Lambda).
+FN_TIMEOUT=600
 FN_MEMORY=256
 
 DRY_RUN=false


### PR DESCRIPTION
## What

Adds the `deploy.sh` and path-filtered auto-deploy GHA that PR nousergon-data-PR643 should have shipped with, and corrects its README's false "merging has zero live effect" claim.

## Why

PR643 merged this morning (a `gate:live-run` draft flipped ready by ne-groomer with the gate label still attached) with its 3-step operator go-live unexecuted. The SF defs auto-deployed on merge; the Lambda they invoke did not exist and the SF-role IAM grant was unapplied. Tonight's `ne-postclose-trading-pipeline` 404'd on `LaunchPostMarketDataSpot` (fail-open) and `EODReconcile` hard-failed on the missing 2026-07-08 SPY close. Full incident thread: alpha-engine-config-I1446 + EPIC alpha-engine-config-I1464; box-lifecycle rerun gap filed as alpha-engine-config-I2000.

## Deltas

- `infrastructure/lambdas/data-spot-dispatcher/deploy.sh` — mirrors the scheduled-groom-dispatcher twin minus its SF/Scheduler sections. `--bootstrap` (operator-only) creates the exec role from `iam-policy.json` + the function; flagless run is code-only.
- `.github/workflows/deploy-data-spot-dispatcher.yml` — mirrors `deploy-scheduled-groom-dispatcher.yml`: code-only auto-deploy on merge under `github-actions-lambda-deploy` OIDC (no new IAM grant needed; `LambdaUpdate` on `alpha-engine-*` covers it).
- README Deployment section — documents the SF-defs-auto-deploy ordering constraint and the two bootstrap commands.

## Live state

Bootstrap + SF-role `apply.sh` were run live 2026-07-08 (Brian-authorized, incident recovery): role `alpha-engine-data-spot-dispatcher-role` + function `alpha-engine-data-spot-dispatcher` exist; `check-drift.py --role alpha-engine-step-functions-role` is clean. This PR makes the repo match live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)