### PR TITLE
fix(data-spot-dispatcher): add missing deploy.sh + guard it (config#1767 / EOD 2026-07-08)

### DIFF
--- a/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-data-spot-dispatcher Lambda.
+#
+# This Lambda is the SF-invokable launcher for the data-heavy weekday/EOD enrich
+# workloads on an ephemeral EC2 spot box (config#1767 Phase 2). It is invoked
+# DIRECTLY by the two existing orchestration Step Functions —
+# `ne-preopen-trading-pipeline` (MorningEnrich + MorningArcticAppend) and
+# `ne-postclose-trading-pipeline` (PostMarketData + PostMarketArcticAppend) — so,
+# UNLIKE scheduled-groom-dispatcher, there is NO wrapping Step Function and NO
+# EventBridge Scheduler to wire here. This script manages only the Lambda and its
+# execution role. The SF EXECUTION-role delta (sf-execution-iam-policy.json —
+# `lambda:InvokeFunction` on this function) lives in
+# `infrastructure/iam/alpha-engine-step-functions-role.json` and is applied
+# SEPARATELY by `infrastructure/iam/apply.sh` (the human-gated IAM path), NOT here.
+#
+# Managed OUTSIDE CloudFormation — same rationale as the sibling dispatchers
+# (scheduled-groom-dispatcher, spot-orphan-reaper): keep the
+# github-actions-lambda-deploy OIDC role's blast radius narrow. That OIDC role
+# deliberately LACKS iam:CreateRole / iam:PutRolePolicy (a fleet-wide policy
+# after repeated IAM-clobber incidents — see infrastructure/iam/README.md), so
+# the FIRST-TIME `--bootstrap` (which mints the execution role + creates the
+# function) MUST be run by an operator with IAM rights. The flagless run is
+# code-only (`update-function-code` + env converge) and is the CI auto-deploy
+# path once a deploy-data-spot-dispatcher.yml workflow exists.
+#
+# WHY THIS SCRIPT EXISTS (2026-07-08 EOD incident): config#1767 Phase 2 (#643)
+# shipped this Lambda's source + IAM policy + SF wiring + the SF-role invoke
+# grant, but NO deploy.sh — so step 1 of the README rollout ("create the Lambda +
+# execution role") had no runnable tooling and was skipped. The SF re-deploy
+# (auto, on merge) and the SF-role IAM re-apply (manual) both landed, but the
+# function itself was never created: LaunchPostMarketDataSpot got a 403 (grant
+# not yet applied) and then, once the grant WAS applied, a 404
+# ResourceNotFoundException (function absent). Fail-open let the pipeline
+# continue, but the post-market SPY close was never fetched and EODReconcile
+# correctly failed loud. This script is the missing, repeatable step-1 tooling.
+#
+# Usage:
+#   bash infrastructure/lambdas/data-spot-dispatcher/deploy.sh             # update code + env only (CI auto-deploy path)
+#   bash infrastructure/lambdas/data-spot-dispatcher/deploy.sh --bootstrap # operator-only: create/update the execution role + create the Lambda
+#   bash infrastructure/lambdas/data-spot-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-data-spot-dispatcher"
+ROLE_NAME="alpha-engine-data-spot-dispatcher-role"
+POLICY_NAME="alpha-engine-data-spot-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+# Canonical function env — defined ONCE so the create / update paths can never
+# drift out of lockstep. DATA_SPOT_DISPATCH_ENABLED is the kill-switch the
+# handler reads (index.py: DISPATCH_ENABLED); every other DATA_SPOT_* knob uses
+# the handler's in-code default, so they are intentionally NOT set here.
+PROD_ENV='Variables={LOG_LEVEL=INFO,DATA_SPOT_DISPATCH_ENABLED=true}'
+
+# Timeout must cover the handler's worst case: launch a spot + wait for its SSM
+# agent to come Online (DATA_SPOT_SSM_ONLINE_BUDGET_SEC default 300s) before the
+# async detached SSM send-command + immediate return. 300s matches that budget;
+# memory is small (the box does the heavy lifting, not the Lambda).
+FN_TIMEOUT=300
+FN_MEMORY=256
+
+DRY_RUN=false
+BOOTSTRAP=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dir + validate handler syntax ------------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 1. Package: pip install deps (Lambda-safe) + zip handler --------------
+# index.py imports nousergon_lib.ec2_spot (the config#1767 spot-launch
+# chokepoint) + boto3 + krepis, all pinned in requirements.txt — so the deps are
+# bundled via the shared Lambda-safe installer (same as scheduled-groom-
+# dispatcher, whose requirements.txt carries the SAME nousergon-lib pin).
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only, operator-run) --------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # --- 2a. Lambda execution role + inline policy ---
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --description "Execution role for ${FUNCTION_NAME} — launch the data-enrich spot box + fire async SSM (config#1767)" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  # --- 2b. Lambda function ---
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout "${FN_TIMEOUT}" \
+      --memory-size "${FN_MEMORY}" \
+      --environment "${PROD_ENV}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+fi
+
+# ----- 3. Update function code (always, idempotent) --------------------------
+# On a not-yet-bootstrapped function this update-function-code FAILS LOUD with a
+# 404 (set -e aborts) — deliberately: a flagless run cannot silently "succeed"
+# when the function was never created. Run --bootstrap first.
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Converge function env (always) -------------------------------------
+# update-function-code does not touch env, so converge the canonical env on
+# every deploy (this is how DATA_SPOT_DISPATCH_ENABLED lands on an already-
+# created function and how any interim override is reset to the canonical value).
+
+echo "Converging Lambda environment..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment "${PROD_ENV}" \
+  --timeout "${FN_TIMEOUT}" \
+  --memory-size "${FN_MEMORY}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+echo "✓ Env converged: ${PROD_ENV}"
+
+echo ""
+echo "Done. Next (operator): re-run the affected pipeline once to validate end to"
+echo "end — e.g. a plain EOD rerun (idempotent, no skip flags) confirms"
+echo "LaunchPostMarketDataSpot now invokes the function and the SPY close lands."

--- a/tests/test_sf_data_spot_relocation_wiring.py
+++ b/tests/test_sf_data_spot_relocation_wiring.py
@@ -318,8 +318,28 @@ class TestEODFailureIsolation:
 # ══════════════════════════════════════════════════════════════════════════
 class TestDispatcherLambdaAndIam:
     def test_dispatcher_package_present(self):
-        for f in ("index.py", "iam-policy.json", "sf-execution-iam-policy.json", "requirements.txt"):
+        # deploy.sh is load-bearing, NOT optional: like every sibling dispatcher
+        # (scheduled-groom-dispatcher, spot-orphan-reaper), the function is
+        # operator-deployed OUTSIDE CloudFormation, so a runnable deploy script
+        # IS the deployment mechanism. #643 (config#1767 Phase 2) shipped this
+        # dispatcher's source + IAM + SF wiring but NO deploy.sh, so step 1 of
+        # the README rollout ("create the Lambda + role") had no tooling and was
+        # skipped — the live function was never created and the 2026-07-08 EOD
+        # LaunchPostMarketDataSpot got a 404 ResourceNotFoundException. This guard
+        # fails loud so a data-spot dispatcher can never again merge un-deployable.
+        for f in ("index.py", "iam-policy.json", "sf-execution-iam-policy.json",
+                  "requirements.txt", "deploy.sh"):
             assert (_DISPATCHER / f).exists(), f"data-spot-dispatcher/{f} missing"
+
+    def test_dispatcher_deploy_sh_creates_the_function(self):
+        # A deploy.sh that exists but doesn't actually create the Lambda would
+        # re-open the same gap. Pin the two commands that make it a real,
+        # first-time-capable deployer for THIS function.
+        deploy = (_DISPATCHER / "deploy.sh").read_text()
+        assert "alpha-engine-data-spot-dispatcher" in deploy, \
+            "deploy.sh must target the alpha-engine-data-spot-dispatcher function"
+        assert "aws lambda create-function" in deploy, \
+            "deploy.sh must be able to CREATE the function (first-time bootstrap), not only update it"
 
     def test_workload_map_preserves_collector_contract(self):
         # M0 contract: the spot workloads run the SAME weekly_collector.py entry


### PR DESCRIPTION
## Root cause (2026-07-08 `ne-postclose-trading-pipeline` FailExecution)

`EODReconcile` fatally raised `RuntimeError: ArcticDB has no SPY close for 2026-07-08 (latest: 2026-07-07)` — a **downstream** effect. The true root cause is at the deploy layer:

**config#1767 Phase 2 (#643) shipped the `alpha-engine-data-spot-dispatcher` Lambda with no `deploy.sh`.** Every sibling dispatcher (`scheduled-groom-dispatcher`, `spot-orphan-reaper`) has one, because these Lambdas are **operator-deployed outside CloudFormation** — the runnable `deploy.sh` *is* the deployment mechanism. #643 added the Lambda source, `iam-policy.json`, the SF `LaunchPostMarketDataSpot`/`MorningEnrich` wiring, and the SF-role `lambda:InvokeFunction` grant — but the tooling to perform README rollout **step 1 ("create the Lambda + execution role")** never existed, so it was skipped. The live function was **never created**.

Diagnostic cascade (both trading SFs invoke this Lambda directly):
- **20:01** original run → `LaunchPostMarketDataSpot` **403 AccessDenied** (SF-role invoke grant not yet applied). Lambda returns AccessDenied *before* an existence check.
- An operator then re-applied the grant via `infrastructure/iam/apply.sh` (README step 2).
- **20:18** rerun → same state now **404 `ResourceNotFoundException: Function not found: …data-spot-dispatcher`** — permission passed, existence check failed. **The function does not exist.**
- The data-spot is **fail-open by design** (config#1767 #4), so the pipeline continued, the post-market SPY close was never fetched into ArcticDB, and `EODReconcile` **correctly failed loud**.

## The SOTA fix at the correct layer

- **Add `infrastructure/lambdas/data-spot-dispatcher/deploy.sh`** — a faithful, simplified mirror of `scheduled-groom-dispatcher/deploy.sh`:
  - `--bootstrap` (operator-only): mints the execution role from `iam-policy.json`, then `aws lambda create-function`.
  - flagless run: code-only (`update-function-code` + env converge) — the CI auto-deploy path.
  - **No wrapping SF / no EventBridge** — this dispatcher is invoked *directly* by the daily + EOD SFs, and the SF-role grant is applied separately via `apply.sh`.
- **Fail-loud, no swallow:** on a not-yet-bootstrapped function the flagless `update-function-code` aborts (`set -e`) on 404 rather than pretending to succeed.
- **Guard that would have blocked #643:** `test_dispatcher_package_present` now **requires `deploy.sh`** (plus `test_dispatcher_deploy_sh_creates_the_function` pins that it can `create-function`). A data-spot dispatcher can never again merge un-deployable.

Lane B/C (HOW-it-runs). Touches only `infrastructure/lambdas/` + `tests/` — no `executor/`, no research/model/risk logic.

## Validation
- `pytest tests/` → **2787 passed, 11 skipped** (pre-existing sibling-checkout/structural skips); the two new dispatcher guards run and pass.
- `bash -n deploy.sh` OK. `deploy.sh` is never executed by CI (CI globs `test_handler.py`, not `deploy.sh`); its `--bootstrap` path is operator-run — the same validation bar as every sibling `deploy.sh`.

## ⚠️ This merge does NOT fix the live incident
Creating the function is **human/operator-gated** (the `github-actions-lambda-deploy` OIDC role deliberately lacks `iam:CreateRole`). **Operator action required** and **time-sensitive** (the *same* 404 will hit tomorrow's pre-open `MorningEnrich`):

```
cd nousergon-data
bash infrastructure/lambdas/data-spot-dispatcher/deploy.sh --bootstrap
aws lambda get-function --function-name alpha-engine-data-spot-dispatcher --query 'Configuration.[FunctionName,State]'
# then a PLAIN EOD rerun (idempotent, NO skip flags, never redrive):
aws stepfunctions start-execution \
  --state-machine-arn arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline \
  --name watch-rerun-2026-07-08-3 \
  --input '{"trading_instance_id":["i-018eb3307a21329bf"],"ec2_instance_id":["i-09b539c844515d549"],"sns_topic_arn":"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts","run_date":"2026-07-08","triggered_by":"daemon_shutdown","pipeline_role":"eod"}'
```