### PR TITLE
Suppress Fleet-SF Watch Telegram on observe-only failures

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
@@ -14,9 +14,10 @@ Lambda:
    `s3://alpha-engine-research/consolidated/saturday_sf_watch/{run_date}.json`
    (the contract the M3 dashboard page reads; repeated failures in one Saturday
    accumulate).
-3. Sends a **distinct, SILENT** Telegram receipt naming the failed state + the
-   artifact location (the `sf-telegram-notifier` already pinged loud on the same
-   FAILED event — this is the additive watch record, not a duplicate alert).
+3. Sends a **distinct, SILENT** Telegram receipt **only when recovery work
+   actually starts** (agent dispatched or fast-path rerun). Observe-only paths
+   are recorded in the watch-log only — `sf-telegram-notifier` already alerted
+   on the failure; a Fleet-SF Watch ping with no action is noise.
 
 ## M2 — agent dispatch (behind a flag, default OFF)
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -19,8 +19,10 @@ ARN to the single EventBridge rule (deploy.sh), widen the IAM ARNs.
 `alpha-engine-sf-telegram-notifier` (subscribes to all three SFs / all statuses,
 pings loud on FAILED with the cause). This Lambda's distinct responsibilities are:
 the **per-pipeline, terminal-failure-only** trigger (the seam the agent dispatch
-hangs off), the **watch-log artifact** the dashboard page reads, and a
-**distinct, SILENT** Telegram record (the notifier already buzzed loud).
+hangs off), the **watch-log artifact** the dashboard page reads, and — ONLY when
+it actually takes recovery action (agent dispatch or fast-path rerun) — a
+**distinct, SILENT** Telegram receipt (sf-telegram-notifier already buzzed loud
+on the failure; observe-only paths are watch-log-only, no Fleet-SF Watch ping).
 
 **Fail-loud (CLAUDE.md no-silent-fails).** The watch-log artifact write is the
 primary deliverable → it RAISES on failure so a broken producer surfaces via the
@@ -566,15 +568,27 @@ def _pipeline_label(pipeline_name: str) -> str:
     return pipeline_name.removeprefix("ne-").removesuffix("-pipeline") or pipeline_name
 
 
-def _notify(record: dict, key: str, pipeline_name: str) -> bool:
-    """Distinct, SILENT Telegram record. The sf-telegram-notifier already pinged
-    loud on this FAILED event; this is the additive watch receipt (which state,
-    where the artifact is, current dispatch mode). Best-effort — never raises.
-    The header + footer reflect the LIVE ``AGENT_DISPATCH_ENABLED`` state AND
-    whether this specific pipeline has a wired listener (config#1535 — the
-    receipt must never claim "autonomous fix ACTIVE" when no workflow is
-    actually listening for this pipeline's dispatch_event_type, same spirit as
-    the 2026-06-26 stale-text bug this pattern originally fixed)."""
+def _watch_is_acting(record: dict, dispatch: dict) -> bool:
+    """True only when this invocation actually started recovery work.
+
+    Observe-only paths (kill-switch off, no listener, operator abort, fast-path
+    miss with dispatch disabled, etc.) still land in the watch-log but must NOT
+    ping Telegram — sf-telegram-notifier already alerted on the failure, and a
+    Fleet-SF Watch receipt with no action is noise (especially for pipelines
+    removed from the agent surface, e.g. groom post config#1795)."""
+    if record.get("action") == "fast_path_rerun":
+        return True
+    return dispatch.get("dispatched") is True
+
+
+def _notify(record: dict, key: str, pipeline_name: str, dispatch: dict) -> bool:
+    """Distinct, SILENT Telegram receipt — ONLY when ``_watch_is_acting``.
+
+    The sf-telegram-notifier already pinged loud on this FAILED event; this
+    receipt names what the watch is doing (fast-path rerun or agent dispatch).
+    Best-effort — never raises. Returns False (no send) on observe-only paths."""
+    if not _watch_is_acting(record, dispatch):
+        return False
     cfg = PIPELINES.get(pipeline_name) or {}
     has_listener = bool(cfg.get("has_listener", True))
     cadence = _pipeline_label(pipeline_name)
@@ -740,13 +754,14 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     fast_path = _maybe_fast_path(record, doc.get("events", []), cfg, sm_arn, describe_resp, run_date)
 
     _write_watch_log(s3, cfg["watch_prefix"], run_date, record, doc=doc)  # PRIMARY — fail-loud
-    telegram_sent = _notify(record, key, sm_name)                         # secondary — best-effort
     # M2: fire the agent AFTER the watch-log lands (agent reads fresh context).
     # A successful fast-path rerun REPLACES the agent dispatch for this event.
     if fast_path.get("fast_path"):
         dispatch = {"dispatched": False, "reason": "fast_path_rerun"}
     else:
         dispatch = _maybe_dispatch_agent(record, run_date, key, cfg, sm_name, sm_arn)  # secondary
+    # Telegram only when recovery work actually started (not observe-only).
+    telegram_sent = _notify(record, key, sm_name, dispatch)               # secondary — best-effort
 
     logger.info(
         "Fleet-SF Watch recorded: sf=%s run_date=%s failed_state=%s key=%s telegram=%s fast_path=%s dispatched=%s",

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -114,24 +114,41 @@ def test_failed_writes_watch_log_and_returns_state():
     assert ev["agent_dispatch_enabled"] is False
 
 
-def test_telegram_is_silent_and_records_artifact_location():
+def test_observe_only_does_not_telegram():
+    """AGENT_DISPATCH_ENABLED=false → watch-log written, no Fleet-SF Watch ping."""
     factory, _, _ = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
-        index.handler(_event("FAILED"), None)
+        result = index.handler(_event("FAILED"), None)
+    index.notify_via_flow_doctor.assert_not_called()
+    assert result["telegram_sent"] is False
+
+
+def test_telegram_fires_when_dispatch_enabled(monkeypatch):
+    """When the agent is actually dispatched, send the silent watch receipt."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
     index.notify_via_flow_doctor.assert_called_once()
     text = index.notify_via_flow_doctor.call_args.args[0]
     kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert result["telegram_sent"] is True
     assert kwargs["silent"] is True  # notifier already buzzed loud
-    assert "Fleet-SF Watch — OBSERVE" in text
+    assert "Fleet-SF Watch — AUTO-FIX" in text
     assert "Weekly Freshness SF: FAILED" in text  # pipeline-aware label
     assert "Failed state: `RAGIngestion`" in text
     assert "consolidated/saturday_sf_watch/2023-11-14.json" in text
-    assert "observe-only" in text
+    assert "autonomous fix ACTIVE" in text
 
 
-def test_watch_log_path_is_code_fenced():
+def test_watch_log_path_is_code_fenced(monkeypatch):
     """config#1584: underscored S3 keys must survive Telegram legacy Markdown
     (which treats bare ``_`` as italic delimiters) — wrap in backticks."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
     factory, _, _ = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
         index.handler(_event("FAILED"), None)
@@ -192,7 +209,10 @@ def test_describe_error_still_writes_artifact():
     s3.put_object.assert_called_once()
 
 
-def test_telegram_failure_is_non_fatal():
+def test_telegram_failure_is_non_fatal(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
     index.notify_via_flow_doctor.side_effect = RuntimeError("bot down")
     factory, _, s3 = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
@@ -209,8 +229,7 @@ def test_preflight_shell_run_marks_record():
         index.handler(_event("FAILED"), None)
     written = json.loads(s3.put_object.call_args.kwargs["Body"])
     assert written["events"][0]["is_preflight"] is True
-    text = index.notify_via_flow_doctor.call_args.args[0]
-    assert "Weekly Freshness Preflight SF" in text
+    index.notify_via_flow_doctor.assert_not_called()
 
 
 def test_unregistered_sf_is_ignored():
@@ -228,8 +247,7 @@ def test_weekday_sf_routes_to_weekday_prefix_and_label():
     assert result["state_machine"] == "ne-preopen-trading-pipeline"
     assert result["watch_log_key"] == "consolidated/weekday_sf_watch/2023-11-14.json"
     assert s3.put_object.call_args.kwargs["Key"].startswith("consolidated/weekday_sf_watch/")
-    text = index.notify_via_flow_doctor.call_args.args[0]
-    assert "Pre-open Trading SF: FAILED" in text
+    index.notify_via_flow_doctor.assert_not_called()
 
 
 def test_eod_sf_routes_to_eod_prefix():
@@ -237,8 +255,7 @@ def test_eod_sf_routes_to_eod_prefix():
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED", sm_arn=EOD_ARN), None)
     assert result["watch_log_key"] == "consolidated/eod_sf_watch/2023-11-14.json"
-    text = index.notify_via_flow_doctor.call_args.args[0]
-    assert "Post-close Trading SF: FAILED" in text
+    index.notify_via_flow_doctor.assert_not_called()
 
 
 @pytest.mark.parametrize("status", ["TIMED_OUT", "ABORTED"])
@@ -395,10 +412,7 @@ def test_no_listener_pipeline_never_dispatches_even_when_globally_enabled(monkey
     assert result["agent_dispatch"] == {"dispatched": False, "reason": "no_listener"}
     assert result["action"] == "observe"
     assert fired["called"] is False
-    text = index.notify_via_flow_doctor.call_args.args[0]
-    assert "Fleet-SF Watch — OBSERVE" in text
-    assert "autonomous fix ACTIVE" not in text
-    assert "observe-only for this pipeline" in text
+    index.notify_via_flow_doctor.assert_not_called()
 
 
 def test_saturday_still_dispatches_when_enabled(monkeypatch):
@@ -459,8 +473,8 @@ def test_live_old_named_eod_is_registered_during_rename_transition():
 def test_operator_abort_suppresses_dispatch_but_still_records(monkeypatch):
     """A deliberate operator abort (status ABORTED + error == "OperatorAbort")
     must NOT auto-dispatch a recovery agent even when the flag + listener are on,
-    yet MUST still write the watch-log and fire the Telegram receipt (fail-loud
-    preserved — only the autonomous ACTION on a human decision is withheld)."""
+    yet MUST still write the watch-log (fail-loud preserved — only the autonomous
+    ACTION on a human decision is withheld; no Fleet-SF Watch Telegram ping)."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
     fired = {"called": False}
@@ -490,12 +504,8 @@ def test_operator_abort_suppresses_dispatch_but_still_records(monkeypatch):
     assert ev["status"] == "ABORTED"
     assert ev["dispatch_suppressed"] == "operator_abort"
     assert ev["action"] == "observe"
-    # Telegram receipt STILL fired, labelled OBSERVE with the operator-abort note.
-    assert result["telegram_sent"] is True
-    text = index.notify_via_flow_doctor.call_args.args[0]
-    assert "Fleet-SF Watch — OBSERVE" in text
-    assert "autonomous fix ACTIVE" not in text
-    assert "operator abort" in text.lower()
+    assert result["telegram_sent"] is False
+    index.notify_via_flow_doctor.assert_not_called()
 
 
 def test_genuine_failed_still_dispatches(monkeypatch):
@@ -633,6 +643,10 @@ def test_fast_path_reruns_on_host_death_signature(fast_path_on):
     assert result["fast_path"]["fast_path"] is True
     assert result["fast_path"]["signature"] == "data_spot_host_death"
     assert result["agent_dispatch"] == {"dispatched": False, "reason": "fast_path_rerun"}
+    assert result["telegram_sent"] is True
+    index.notify_via_flow_doctor.assert_called_once()
+    text = index.notify_via_flow_doctor.call_args.args[0]
+    assert "Fleet-SF Watch — AUTO-RERUN" in text
     ev = _put_body(s3)["events"][-1]
     assert ev["action"] == "fast_path_rerun"
     assert ev["lane"] == "A"


### PR DESCRIPTION
## Summary
- Fleet-SF Watch dispatcher Telegram receipts now fire **only when recovery actually starts** (agent `repository_dispatch` or zero-token fast-path rerun).
- Observe-only paths (kill-switch off, no listener, operator abort, pipelines outside the watch surface) still append to the watch-log artifact; `sf-telegram-notifier` remains the generic failure alert.
- Aligns with groom removal from Fleet-SF Watch scope (config#1795): watch-branded pings no longer fire when the watch is not acting.

## Test plan
- [x] `python3 -m pytest infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py -q` (40 passed locally)
- [ ] CI green