### PR TITLE
fix(sf): remove .env source from spot-dispatch SSM commands

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -408,7 +408,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only{}',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only{}',$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -569,7 +569,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only{}',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only{}',$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -773,7 +773,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$.preflight_args))",
                   "executionTimeout": [
                     "3600"
                   ]

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -219,7 +219,6 @@
             "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",
-            "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
             "source .venv/bin/activate",
             "trap 'aws s3 cp /var/log/chronic-gap-heal.log \"s3://alpha-engine-research/_ssm_logs/chronic-gap-heal/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "bash scripts/ensure_lib_pin.sh /home/ec2-user/alpha-engine-data 2>&1 | tee -a /var/log/chronic-gap-heal.log",

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -14,7 +14,6 @@
     "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
   ],
   "DriftDetection": [
@@ -40,7 +39,6 @@
     "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
   ],
   "Parity": [
@@ -87,7 +85,6 @@
     "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
   ]
 }


### PR DESCRIPTION
The dashboard role now carries scoped `ec2:RunInstances`, `CreateTags`, `iam:PassRole`, and `s3:PutObject` grants (applied 2026-07-08). The four spot-dispatch commands can now launch via instance profile.

**Commands updated:**
- `step_function.json`: MorningEnrich, DataPhase1, RAGIngestion
- `step_function_daily.json`: LaunchDailyDataSpot

**Deploy state:** both SFs already deployed live from local edits. This PR syncs the repo to match.

**Verification:** Thu 7/9 daily spot launch (~12:45 UTC), Sat 7/11 weekly spot launch (~09:00 UTC).

Refs: config#1828, config#1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)