### PR TITLE
fix(groom): skip demand-all trigger on enumeration error instead of legacy fallthrough

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -899,9 +899,9 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         try:
             counts, oldest, p0_tiers = _enumerate_tier_stats_fresh(_github_token())
             launches = ge.decide_trigger(counts, oldest, p0_tiers)
-        except Exception as exc:  # noqa: BLE001 — fail-safe to legacy slot launch
-            logger.warning("demand trigger unavailable (%s) — legacy launch", exc)
-            launches = None
+        except Exception as exc:  # noqa: BLE001 — fail-safe: skip this trigger rather than launching with stale (no-fresh-skip) legacy counts
+            logger.warning("demand trigger unavailable (%s) — skipping trigger (legacy fallthrough retired, fresh-skip-less enumeration over-counts the queue)", exc)
+            return {"groom": {"launched": False, "reason": "demand_all_failed", "error": str(exc)}}
         if launches is not None:
             _write_trigger_record(schedule_label, launches, counts)
             results = []

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -748,16 +748,16 @@ def test_symmetric_trigger_thin_pool_downgrades_model(monkeypatch):
     assert ls[0]["model"] == "claude-sonnet-5"
 
 
-def test_symmetric_trigger_fail_safe_to_legacy(monkeypatch):
+def test_symmetric_trigger_skips_on_enumeration_error(monkeypatch):
+    """demand-all enumeration failure now returns early — no legacy fallthrough."""
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     def boom(token):
         raise RuntimeError("github down")
     monkeypatch.setattr(idx, "_github_token", lambda: "tok")
     monkeypatch.setattr(idx, "_enumerate_tier_stats_fresh", boom)
-    # legacy path also needs stubbing past the per-slot gate
-    monkeypatch.setattr(idx, "_demand_decision", lambda f, s: None)
     out = idx.handler(_demand_event(), None)
-    assert out["groom"]["launched"]  # legacy unconditional launch
+    assert not out["groom"]["launched"]
+    assert out["groom"]["reason"] == "demand_all_failed"
 
 
 def test_non_demand_events_keep_legacy_behavior(monkeypatch):


### PR DESCRIPTION
The demand-all symmetric trigger path (config#1933) fell through to the legacy per-slot decision when enumeration threw. The legacy path uses _enumerate_tier_stats which does NOT apply fresh-skip, over-counting the queue. This caused the 2026-07-09 floor breach (alpha-engine-config run 29006704920): the Lambda counted mid=20 and launched a Sonnet box, but the driver found only 5 actionable issues.

Fix: return early with launched=False on demand-all failure instead of falling through to the legacy path. The next scheduled trigger retries freshly rather than launching a box against stale counts.

Companion PR: nousergon/alpha-engine-config-PR2032