### PR TITLE
fix(groom): dispatcher reads fresh-skip constants from nousergon-lib, not local hardcodes (config#2038)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -754,14 +754,24 @@ def _demand_decision(issue_filter: str, schedule_label: str):
 
 
 def _load_recent_engagements() -> dict:
-    """(repo, number) -> engagement horizon epoch from the last 3 days' S3 run
-    artifacts (same schema the driver's config#1893 fresh-skip reads).
-    Fail-safe {} — a read error only means counting a few extra issues."""
+    """(repo, number) -> engagement horizon epoch from the last
+    ``ge.ENGAGEMENT_LOOKBACK_DAYS`` days' S3 run artifacts (same schema the
+    driver's config#1893 fresh-skip reads).
+    Fail-safe {} — a read error only means counting a few extra issues.
+
+    config#2038: the lookback (was a hardcoded ``range(3)``) and the engaged-
+    disposition set (was a hardcoded tuple literal) had silently drifted from
+    groom_driver.py's own constants (4-day lookback, same 4 dispositions) —
+    this module already imports ``nousergon_lib.groom_eligibility`` as the
+    declared single source of truth for exactly this class of drift; the two
+    values just weren't pulled from it yet. Read them from ``ge`` so they
+    can't re-drift.
+    """
     out: dict = {}
     try:
         s3 = boto3.client("s3", region_name=REGION)
         now = datetime.now(ZoneInfo("UTC"))
-        for d in range(3):
+        for d in range(ge.ENGAGEMENT_LOOKBACK_DAYS):
             date = (now - timedelta(days=d)).strftime("%Y-%m-%d")
             resp = s3.list_objects_v2(Bucket=_RESEARCH_BUCKET, Prefix=f"groom/{date}/")
             for obj in resp.get("Contents", []) or []:
@@ -774,7 +784,7 @@ def _load_recent_engagements() -> dict:
                 horizon = (datetime.fromisoformat(run_start.replace("Z", "+00:00")).timestamp()
                            + int(art.get("elapsed_min", 0)) * 60 + ge.FRESH_SKIP_SLACK_SEC)
                 for rec in art.get("issues", []):
-                    if rec.get("disposition") in ("closed", "pr_opened", "commented", "labeled"):
+                    if rec.get("disposition") in ge.ENGAGED_DISPOSITIONS:
                         k = (rec.get("repo", ""), rec.get("number"))
                         out[k] = max(out.get(k, 0.0), horizon)
     except Exception as exc:  # noqa: BLE001

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -1,5 +1,5 @@
 # boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
 boto3>=1.34.0
 # config#1742 T2 — flow-doctor forum routing + ec2_spot launch chokepoint.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.93.0
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.97.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -13,6 +13,7 @@ surface the miss).
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 import types
@@ -130,6 +131,12 @@ class _FakeS3:
     def get_paginator(self, name):
         assert name == "list_objects_v2"
         return _FakeS3Paginator(self._objects)
+
+    def list_objects_v2(self, Bucket, Prefix):  # noqa: N803 — boto3 kwarg names
+        # config#2038: _load_recent_engagements calls this directly (no
+        # paginator) — single-page return is sufficient for these tests.
+        keys = [k for k in self._objects if k.startswith(Prefix)]
+        return {"Contents": [{"Key": k} for k in keys]}
 
     def get_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg names
         return {"Body": _FakeS3Body(self._objects[Key])}
@@ -769,3 +776,51 @@ def test_non_demand_events_keep_legacy_behavior(monkeypatch):
     out = idx.handler({"run_mode": "full", "model": "claude-haiku-4-5",
                        "issue_filter": "gated-reverify"}, None)
     assert out["groom"]["launched"] and not called
+
+
+# ── config#2038: engagement lookback + disposition set must come from the lib ──
+
+
+def test_load_recent_engagements_uses_lib_lookback_window(monkeypatch):
+    """A run artifact just inside ge.ENGAGEMENT_LOOKBACK_DAYS ago must be
+    picked up — this would be dropped by the old hardcoded range(3) whenever
+    the lib's lookback is > 3 (config#2038's actual drift: 4 vs 3)."""
+    from datetime import datetime, timedelta
+    from zoneinfo import ZoneInfo
+
+    import nousergon_lib.groom_eligibility as ge
+
+    now = datetime.now(ZoneInfo("UTC"))
+    farthest = now - timedelta(days=ge.ENGAGEMENT_LOOKBACK_DAYS - 1)
+    art = json.dumps({
+        "run_start": farthest.isoformat().replace("+00:00", "Z"),
+        "elapsed_min": 5,
+        "issues": [{"repo": "nousergon/alpha-engine-config", "number": 999,
+                    "disposition": "commented"}],
+    }).encode()
+    key = f"groom/{farthest.strftime('%Y-%m-%d')}/run1.json"
+    idx = _load(monkeypatch, s3_objects={key: art})
+    engagements = idx._load_recent_engagements()
+    assert ("nousergon/alpha-engine-config", 999) in engagements
+
+
+def test_load_recent_engagements_uses_lib_engaged_dispositions(monkeypatch):
+    """A "labeled" disposition (config#1928/#1890 — label-only edits are the
+    NORM for blocked dispositions) must count as engaged — this comes from
+    ge.ENGAGED_DISPOSITIONS, not a local hardcoded tuple that could drift."""
+    from datetime import datetime, timezone
+
+    import nousergon_lib.groom_eligibility as ge
+
+    assert "labeled" in ge.ENGAGED_DISPOSITIONS
+    now = datetime.now(timezone.utc)
+    art = json.dumps({
+        "run_start": now.isoformat().replace("+00:00", "Z"),
+        "elapsed_min": 5,
+        "issues": [{"repo": "nousergon/alpha-engine-config", "number": 998,
+                    "disposition": "labeled"}],
+    }).encode()
+    key = f"groom/{now.strftime('%Y-%m-%d')}/run1.json"
+    idx = _load(monkeypatch, s3_objects={key: art})
+    engagements = idx._load_recent_engagements()
+    assert ("nousergon/alpha-engine-config", 998) in engagements


### PR DESCRIPTION
Part of config#2038 (3-repo fix: nousergon-lib#175 → alpha-engine-config#2039 → this PR).

## Summary
`scheduled-groom-dispatcher/index.py::_load_recent_engagements()` hardcoded its own copy of the engagement-lookback window (`range(3)`) and the engaged-disposition tuple, despite already importing `nousergon_lib.groom_eligibility as ge` as the declared single source of truth for exactly this class of drift (config#1933's docstring names the PR683 incident this module exists to prevent). Both had silently diverged from `alpha-engine-config/scripts/groom_driver.py`'s values (4-day lookback, same 4 dispositions).

**Observed live** 2026-07-09 19:00 UTC: this Lambda's pre-boot fresh-skip-aware enumeration said 19 actionable low-complexity issues (`groom/decisions/2026-07-09/trigger-1900.json`) → launched a spot box; the on-box driver's own (correct) fresh-skip found only 8 three minutes later (`fresh_skipped: 11` in `groom/2026-07-09/bfd250d5....json`) — a box launched for a queue ~60% smaller than the dispatcher's own count advertised.

## Fix
- `_load_recent_engagements()`: `range(3)` → `range(ge.ENGAGEMENT_LOOKBACK_DAYS)`; hardcoded disposition tuple → `ge.ENGAGED_DISPOSITIONS`.
- Bumps `requirements.txt`'s `nousergon-lib` pin `v0.93.0` → `v0.97.0`.
- Adds `list_objects_v2` to the test file's `_FakeS3` (previously only `get_paginator` was faked — this function calls it directly) + two new tests proving the lookback and disposition set actually come from the lib (verified locally: the lookback test correctly FAILS against the pre-fix `index.py`).

## Dependency — merge order
1. **nousergon-lib#175** must merge first (auto-publishes to PyPI + auto-tags `v0.97.0` on merge to `main`).
2. **alpha-engine-config#2039** (contract test extension) — independent of this PR, no ordering constraint between the two.
3. **This PR** — the `v0.97.0` git tag must exist before `ci.yml`'s `pip install -r requirements.txt` can resolve it. **CI here will fail (tag not found) until #1 merges.**

## Test plan
- [x] `pytest test_handler.py` — 44 passed (42 existing + 2 new), verified locally against nousergon-lib#175's branch (git tag doesn't exist yet, so installed via local `pip install -e`).
- [x] Verified `test_load_recent_engagements_uses_lib_lookback_window` correctly FAILS against the pre-fix `index.py` (git-stashed the index.py change, re-ran: `AssertionError: assert (...) in {}`) — proves the test isn't a no-op.