### PR TITLE
feat(metron): add trailingEps/forwardEps to fundamentals collector

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -111,6 +111,8 @@ FUNDAMENTALS_PREFIX = "market_data/fundamentals/"
 # v3 (metron Holdings balance-sheet band): added the absolute balance-sheet fields
 # (totalDebt / totalCash / ebitda / freeCashflow) the Holdings "Balance Sheet" columns
 # need — cash balance, debt balance, net debt, and net-debt/EBITDA leverage.
+# v4 (metron-ops#163): added trailingEps/forwardEps so the Holdings Valuation band can
+# show raw EPS alongside P/E, not just the ratio.
 FUNDAMENTALS_INFO_KEYS = [
     "trailingPE", "forwardPE", "trailingPegRatio", "enterpriseToEbitda",
     "priceToBook", "priceToSalesTrailing12Months",
@@ -118,6 +120,7 @@ FUNDAMENTALS_INFO_KEYS = [
     "returnOnEquity", "returnOnAssets", "grossMargins", "operatingMargins",
     "totalDebt", "totalCash", "ebitda", "freeCashflow",
     "beta", "dividendYield", "marketCap", "sector", "industry",
+    "trailingEps", "forwardEps",
 ]
 # Technicals — per-held-symbol indicators computed from the close_history this module
 # already publishes daily (zero new fetches). Slow-moving (RSI14 / 50d-200d MA / 52w
@@ -171,7 +174,7 @@ FX_HISTORY_SCHEMA_VERSION = 1
 SECTORS_SCHEMA_VERSION = 2  # v2: additive `countries` map (yf_symbol → country of domicile)
 EARNINGS_SCHEMA_VERSION = 1
 MACRO_SCHEMA_VERSION = 2  # v2: added next_release (per series) + release_events (metron-ops#49)
-FUNDAMENTALS_SCHEMA_VERSION = 3  # v3: + totalDebt/totalCash/ebitda/freeCashflow (balance sheet)
+FUNDAMENTALS_SCHEMA_VERSION = 4  # v4: + trailingEps/forwardEps (metron-ops#163)
 INTRADAY_SCHEMA_VERSION = 3  # v3: additive `fund_proxies` map (mutual-fund tracking-proxy ETF quotes)
 TECHNICALS_SCHEMA_VERSION = 2  # v2: + pct_from_52wk_high (tearsheet parity with Holdings)
 SECURITY_PERFORMANCE_SCHEMA_VERSION = 1

--- a/tests/test_metron_holdings_metrics.py
+++ b/tests/test_metron_holdings_metrics.py
@@ -38,10 +38,10 @@ def _body(obj: dict) -> dict:
 
 # ── Fundamentals v2: P/B + P/S are published ─────────────────────────────────
 
-def test_fundamentals_schema_v3_includes_multiples_and_balance_sheet():
-    assert mmd.FUNDAMENTALS_SCHEMA_VERSION == 3
+def test_fundamentals_schema_v4_includes_multiples_balance_sheet_and_eps():
+    assert mmd.FUNDAMENTALS_SCHEMA_VERSION == 4
     for k in ("priceToBook", "priceToSalesTrailing12Months", "totalDebt", "totalCash",
-              "ebitda", "freeCashflow"):
+              "ebitda", "freeCashflow", "trailingEps", "forwardEps"):
         assert k in mmd.FUNDAMENTALS_INFO_KEYS
 
     s3 = MagicMock()
@@ -53,7 +53,7 @@ def test_fundamentals_schema_v3_includes_multiples_and_balance_sheet():
 
     assert result["status"] == "ok"
     art = _puts(s3)[f"{mmd.FUNDAMENTALS_PREFIX}latest.json"]
-    assert art["schema_version"] == 3
+    assert art["schema_version"] == 4
     aapl = art["fundamentals"]["AAPL"]
     assert aapl["priceToBook"] == 6.0 and aapl["priceToSalesTrailing12Months"] == 7.5
     assert aapl["totalDebt"] == 1.1e11 and aapl["totalCash"] == 6.0e10 and aapl["ebitda"] == 1.3e11


### PR DESCRIPTION
## Summary
Phase 2 of `metron-ops#163` (Holdings Valuation band: show raw inputs alongside multiples). Raw EPS wasn't collected anywhere upstream — P/E arrives pre-computed from yfinance's `trailingPE`/`forwardPE` without its EPS/price components ever being fetched. Adds `trailingEps`/`forwardEps` to `FUNDAMENTALS_INFO_KEYS` (`collectors/metron_market_data.py`), bumps `FUNDAMENTALS_SCHEMA_VERSION` 3→4 per the existing versioning convention.

No producer-side conversion needed — `_yfinance_fundamentals` already passes every `FUNDAMENTALS_INFO_KEYS` entry through as-is.

## Dependency
Companion Metron-side PR wires `eps`/`fwd_eps` through `TickerFundamentals` → API → Holdings table (opening next).

## Test plan
- [x] `pytest tests/` — 2828 passed, 7 skipped (pre-existing), 0 failures
- [x] Updated `tests/test_metron_holdings_metrics.py`'s schema-version pin (3→4) + EPS key coverage assertion