### PR TITLE
feat(metron): add bookValue/revenuePerShare/enterpriseValue to fundamentals collector

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -113,6 +113,9 @@ FUNDAMENTALS_PREFIX = "market_data/fundamentals/"
 # need — cash balance, debt balance, net debt, and net-debt/EBITDA leverage.
 # v4 (metron-ops#163): added trailingEps/forwardEps so the Holdings Valuation band can
 # show raw EPS alongside P/E, not just the ratio.
+# v5 (metron-ops#178): added bookValue/revenuePerShare/enterpriseValue — every Valuation
+# multiple now has its raw input(s) in the same band (P/B -> book value/share, P/S ->
+# revenue/share, EV/EBITDA -> enterprise value).
 FUNDAMENTALS_INFO_KEYS = [
     "trailingPE", "forwardPE", "trailingPegRatio", "enterpriseToEbitda",
     "priceToBook", "priceToSalesTrailing12Months",
@@ -121,6 +124,7 @@ FUNDAMENTALS_INFO_KEYS = [
     "totalDebt", "totalCash", "ebitda", "freeCashflow",
     "beta", "dividendYield", "marketCap", "sector", "industry",
     "trailingEps", "forwardEps",
+    "bookValue", "revenuePerShare", "enterpriseValue",
 ]
 # Technicals — per-held-symbol indicators computed from the close_history this module
 # already publishes daily (zero new fetches). Slow-moving (RSI14 / 50d-200d MA / 52w
@@ -174,7 +178,7 @@ FX_HISTORY_SCHEMA_VERSION = 1
 SECTORS_SCHEMA_VERSION = 2  # v2: additive `countries` map (yf_symbol → country of domicile)
 EARNINGS_SCHEMA_VERSION = 1
 MACRO_SCHEMA_VERSION = 2  # v2: added next_release (per series) + release_events (metron-ops#49)
-FUNDAMENTALS_SCHEMA_VERSION = 4  # v4: + trailingEps/forwardEps (metron-ops#163)
+FUNDAMENTALS_SCHEMA_VERSION = 5  # v5: + bookValue/revenuePerShare/enterpriseValue (metron-ops#178)
 INTRADAY_SCHEMA_VERSION = 3  # v3: additive `fund_proxies` map (mutual-fund tracking-proxy ETF quotes)
 TECHNICALS_SCHEMA_VERSION = 2  # v2: + pct_from_52wk_high (tearsheet parity with Holdings)
 SECURITY_PERFORMANCE_SCHEMA_VERSION = 1

--- a/tests/test_metron_holdings_metrics.py
+++ b/tests/test_metron_holdings_metrics.py
@@ -38,10 +38,11 @@ def _body(obj: dict) -> dict:
 
 # ── Fundamentals v2: P/B + P/S are published ─────────────────────────────────
 
-def test_fundamentals_schema_v4_includes_multiples_balance_sheet_and_eps():
-    assert mmd.FUNDAMENTALS_SCHEMA_VERSION == 4
+def test_fundamentals_schema_v5_includes_multiples_balance_sheet_eps_and_valuation_inputs():
+    assert mmd.FUNDAMENTALS_SCHEMA_VERSION == 5
     for k in ("priceToBook", "priceToSalesTrailing12Months", "totalDebt", "totalCash",
-              "ebitda", "freeCashflow", "trailingEps", "forwardEps"):
+              "ebitda", "freeCashflow", "trailingEps", "forwardEps",
+              "bookValue", "revenuePerShare", "enterpriseValue"):
         assert k in mmd.FUNDAMENTALS_INFO_KEYS
 
     s3 = MagicMock()
@@ -53,7 +54,7 @@ def test_fundamentals_schema_v4_includes_multiples_balance_sheet_and_eps():
 
     assert result["status"] == "ok"
     art = _puts(s3)[f"{mmd.FUNDAMENTALS_PREFIX}latest.json"]
-    assert art["schema_version"] == 4
+    assert art["schema_version"] == 5
     aapl = art["fundamentals"]["AAPL"]
     assert aapl["priceToBook"] == 6.0 and aapl["priceToSalesTrailing12Months"] == 7.5
     assert aapl["totalDebt"] == 1.1e11 and aapl["totalCash"] == 6.0e10 and aapl["ebitda"] == 1.3e11


### PR DESCRIPTION
## Summary
metron-ops#178: every Holdings Valuation-band ratio should show its raw inputs in the same band. Adds `bookValue`, `revenuePerShare`, `enterpriseValue` to `FUNDAMENTALS_INFO_KEYS` (`collectors/metron_market_data.py`) — inputs behind P/B, P/S, and EV/EBITDA respectively. Bumps `FUNDAMENTALS_SCHEMA_VERSION` 4→5.

No producer-side conversion needed — `_yfinance_fundamentals` already passes every `FUNDAMENTALS_INFO_KEYS` entry through as-is.

## Dependency
Companion Metron-side PR wires these through `TickerFundamentals` → API → the Holdings Valuation-band columns (opening next).

## Test plan
- [x] `pytest tests/` — 2828 passed, 7 skipped (pre-existing), 0 failures
- [x] Updated `tests/test_metron_holdings_metrics.py`'s schema-version pin (4→5) + new-key coverage assertion