### PR TITLE
Add ci-watch-dispatcher Lambda + CI-watch-aware orphan-reaper alert (config#2001/#2004)

### DIFF
--- a/.github/workflows/deploy-ci-watch-dispatcher.yml
+++ b/.github/workflows/deploy-ci-watch-dispatcher.yml
@@ -1,0 +1,87 @@
+name: Deploy ci-watch-dispatcher
+
+# Auto-deploy the alpha-engine-ci-watch-dispatcher Lambda CODE on merge to
+# main. Mirrors deploy-scheduled-groom-dispatcher.yml — same gap, same fix: a
+# merged code fix must not sit inert until someone remembers to run deploy.sh
+# by hand. This closes that gap for the CODE path only.
+#
+# Separation of concerns: this deploys CODE only (deploy.sh with NO flag —
+# this script's default/flagless run IS already code-only; --bootstrap is
+# what ADDS the IAM-role-creation + Lambda-function-creation on top, not the
+# reverse). Simpler than the groom sibling: CI-watch has NO Step Function and
+# NO EventBridge Scheduler rules to keep operator-only — it's invoked
+# synchronously by a GHA job in alpha-engine-config's sf-watch.yml, so there
+# is no schedule/cadence surface for this workflow to ever need to touch. The
+# github-actions-lambda-deploy OIDC role deliberately has no iam:CreateRole /
+# iam:PutRolePolicy (fleet-wide policy after 4 IAM-clobber incidents in 2
+# months; see infrastructure/iam/README.md) — an IAM/profile change still
+# requires an operator to run `deploy.sh --bootstrap` by hand.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/ci-watch-dispatcher/**'
+      - '.github/workflows/deploy-ci-watch-dispatcher.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-ci-watch-dispatcher-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy ci-watch-dispatcher Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy ci-watch-dispatcher (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-ci-watch-dispatcher \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-ci-watch-dispatcher.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-ci-watch-dispatcher Lambda.
+#
+# WHY (config#1432-style migration, see index.py's module docstring): Fleet CI
+# Watch (`sf-watch`, alpha-engine-config) diagnoses+fixes fleet CI failures on
+# GitHub-hosted Actions runners, burning the org's metered Actions-minutes
+# budget — currently gated to Saturday-only as a stopgap. This Lambda moves it
+# to EC2 spot, mirroring the PROVEN scheduled-groom-dispatcher pattern in THIS
+# repo, but MUCH SIMPLER: no Step Function, no EventBridge Scheduler rules —
+# CI-watch is invoked directly via a SYNCHRONOUS `lambda invoke` from a GHA job
+# (built by a sibling agent in alpha-engine-config's sf-watch.yml) once per
+# real CI failure event, not on a cron cadence. So --bootstrap here only needs
+# to create: (1) this Lambda's OWN execution role + inline policy, (2) the
+# Lambda function itself. No SF, no Scheduler execution role, no SCHED_NAMES.
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
+# (scoped to alpha-engine-ci-watch-executor-role — a NEW, dedicated role a
+# sibling agent is creating in alpha-engine-config, deliberately NOT the
+# shared trading alpha-engine-executor-role) + ssm:SendCommand. The BOX reads
+# its own run secrets (PAT) via ITS instance profile, so this Lambda needs no
+# secret access of its own.
+#
+# Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
+# keeps the github-actions-lambda-deploy OIDC role's blast radius narrow — it
+# deliberately lacks iam:CreateRole/iam:PutRolePolicy (fleet-wide policy after
+# 4 IAM-clobber incidents in 2 months; see infrastructure/iam/README.md if
+# present). This script's FLAGLESS run is already code-only (this is what the
+# GHA auto-deploy workflow calls); --bootstrap is what ADDS IAM-role-creation +
+# Lambda-function-creation on top, operator-run only, never in CI.
+#
+# Usage:
+#   bash .../ci-watch-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../ci-watch-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda function
+#   bash .../ci-watch-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../ci-watch-dispatcher/deploy.sh --smoke     # invoke once with a synthetic event (fires a REAL spot box)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-ci-watch-dispatcher"
+ROLE_NAME="alpha-engine-ci-watch-dispatcher-role"
+POLICY_NAME="alpha-engine-ci-watch-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+# PKG and TEST_DEPS are both created up front (mirrors scheduled-groom-
+# dispatcher/deploy.sh) so ONE trap covers both — a pytest-install failure
+# below still cleans up.
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+# Hermetic for AWS: boto3 + nousergon_lib.ec2_spot are stubbed in sys.modules
+# before `import index` (see test_handler.py). The pinned nousergon-lib +
+# krepis are installed for real into a scratch TEST_DEPS dir — NOT the
+# caller's global site-packages, not bundled into the Lambda zip.
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # --- 2a. Lambda execution role + inline policy ---
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  # --- 2b. Lambda function ---
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 300 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=true}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=true}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+# ----- 4. Smoke (synthetic event, direct invoke) -----------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (synthetic CI-failure event)..."
+  echo "⚠ this fires a REAL spot box + REAL ci_watch_spot_bootstrap.sh run."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"repo":"nousergon/alpha-engine-config","sha":"0000000000000000000000000000000000000000","run_id":"999999999","run_url":"https://github.com/nousergon/alpha-engine-config/actions/runs/999999999","workflow":"smoke-test","branch":"main"}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi

--- a/infrastructure/lambdas/ci-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/ci-watch-dispatcher/iam-policy.json
@@ -1,0 +1,59 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-ci-watch-dispatcher:*"
+    },
+    {
+      "Sid": "LaunchCiWatchSpot",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateTags",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassCiWatchExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-ci-watch-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunCiWatchBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateCiWatchSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-ci-watch-spot"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -171,7 +171,16 @@ def _bootstrap_command(repo: str, sha: str, run_id: str, run_url: str,
     """The async SSM RunShellScript body: fetch PAT, clone config, exec the
     ci_watch_spot_bootstrap.sh entrypoint (built by a sibling agent in
     alpha-engine-config). Any prelude failure shuts the box down so a botched
-    launch never idles (mirrors groom's prelude fail() trap exactly)."""
+    launch never idles (mirrors groom's prelude fail() trap exactly).
+
+    ``ci_watch_spot_bootstrap.sh`` takes its CI fields as CLI FLAGS
+    (``--ci-repo``/``--ci-sha``/...), not environment variables — invoke it
+    that way, not via `export`. ``run_token`` is deliberately NOT threaded
+    into the box: the bootstrap/run-script side keys its S3 completion
+    marker directly on repo+sha (no per-attempt dispatch token, unlike
+    groom's ``GROOM_RUN_TOKEN``), so there is no in-box consumer for it — it
+    stays a Lambda-side-only correlation id (see the SSM Comment field in
+    ``_send_bootstrap``, and the handler's returned JSON)."""
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
 # SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
@@ -188,14 +197,9 @@ git clone --depth 1 --branch {CI_WATCH_CONFIG_BRANCH} \
   "https://x-access-token:${{PAT}}@github.com/{CI_WATCH_CONFIG_REPO}.git" \
   /home/ec2-user/alpha-engine-config || fail "clone failed"
 cd /home/ec2-user/alpha-engine-config
-export CI_WATCH_REPO={repo}
-export CI_WATCH_SHA={sha}
-export CI_WATCH_RUN_ID={run_id}
-export CI_WATCH_RUN_URL="{run_url}"
-export CI_WATCH_WORKFLOW="{workflow}"
-export CI_WATCH_BRANCH={branch}
-export CI_WATCH_RUN_TOKEN={run_token}
-exec bash infrastructure/ci_watch_spot_bootstrap.sh
+exec bash infrastructure/ci_watch_spot_bootstrap.sh \
+  --ci-repo "{repo}" --ci-sha "{sha}" --ci-run-id "{run_id}" \
+  --ci-run-url "{run_url}" --ci-workflow "{workflow}" --ci-branch "{branch}"
 """
 
 
@@ -251,7 +255,7 @@ def _send_bootstrap(instance_id: str, repo: str, sha: str, run_id: str, run_url:
     resp = ssm.send_command(
         InstanceIds=[instance_id],
         DocumentName="AWS-RunShellScript",
-        Comment=f"ci-watch ({repo}@{sha[:12]}, run {run_id})",
+        Comment=f"ci-watch ({repo}@{sha[:12]}, run {run_id}, token {run_token[:12]})",
         Parameters={
             "commands": [_bootstrap_command(repo, sha, run_id, run_url, workflow, branch, run_token)],
             "executionTimeout": [str(MAX_RUNTIME_SECONDS)],

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -1,0 +1,401 @@
+"""alpha-engine-ci-watch-dispatcher — launch the Fleet CI Watch diagnose+fix
+agent on a dedicated EC2 spot box, once per real CI failure event.
+
+WHY SPOT, NOT GITHUB ACTIONS: `sf-watch` (Fleet CI Watch, lives in
+`nousergon/alpha-engine-config`) diagnoses+fixes fleet CI failures and merge
+conflicts. Running that agent on GitHub-hosted Actions runners burned the
+org's metered Actions-minutes budget — the same defect class that motivated
+`scheduled-groom-dispatcher` (config#1432) — so CI-watch is currently gated to
+Saturday-only. This Lambda moves it to EC2 spot, mirroring that PROVEN
+dispatcher pattern, but SIMPLER: CI-watch fires once per real CI failure event
+via a SYNCHRONOUS `lambda invoke` from a GHA job (not a schedule), so none of
+groom's tier/model/demand-gate/pace-gate complexity applies here.
+
+Mechanism (mirrors `scheduled-groom-dispatcher/index.py`, reusing the same
+fleet chokepoint — no lib change):
+  1. `nousergon_lib.ec2_spot.launch()` rotates instance_type x subnet on
+     capacity error; on SpotCapacityExhausted across all pools we relaunch
+     ON-DEMAND (spot=False) so a capacity dip never silently drops a CI fix.
+  2. Wait for the instance to run + its SSM agent to come Online.
+  3. Fire an async, detached `ssm send-command` (AWS-RunShellScript) carrying
+     a small prelude: fetch the PAT from SSM, clone alpha-engine-config, then
+     `exec infrastructure/ci_watch_spot_bootstrap.sh` (built by a sibling
+     agent in alpha-engine-config). The box self-terminates
+     (InstanceInitiatedShutdownBehavior=terminate + its own on-box watchdog).
+
+SYNCHRONOUS CONTRACT (the key divergence from groom's fail-loud posture): a
+GHA job invokes this Lambda with RequestResponse (not async) and branches
+directly on the returned JSON. Every anticipated failure mode — concurrency
+skip, spot+on-demand launch exhaustion, a malformed event, a post-launch SSM
+failure — returns a clean, well-formed `{"launched": false, "reason": ...}`
+rather than raising. Groom's Lambda deliberately RAISES on these same failure
+classes because the caller there is EventBridge (retry-on-error is the
+correct behavior for a scheduled job); CI-watch's caller is a synchronous GHA
+step that needs an unambiguous JSON verdict to branch on, not a Lambda
+invocation error to unwrap. Only a genuinely unexpected internal bug should
+still propagate as a Python exception.
+
+CONCURRENCY LOCK — narrower than groom's per-tier lock (config#1979):
+keyed on `Name=alpha-engine-ci-watch-spot` + `ci-watch-repo=<repo>` +
+`ci-watch-sha=<sha>` (NOT bare repo). Two different commits on the same repo
+failing CI independently must each get their own box — a repo-only lock
+would starve the second commit's fix. Fail-safe OPEN on any API error (same
+posture as groom's `_running_tier_instance_ids`) — this guard is an
+optimization against duplicate spend, never a correctness gate.
+
+IAM PROFILE — deliberately NOT `alpha-engine-executor-profile` (shared with
+the live trading executor). Uses `alpha-engine-ci-watch-executor-profile`, a
+dedicated instance profile a sibling agent is creating in
+`alpha-engine-config`'s IAM json files, so a CI-watch box's blast radius
+never touches trading credentials.
+
+Managed OUTSIDE CloudFormation (same as scheduled-groom-dispatcher): operator-
+deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live effect
+until the new code + IAM are deployed AND a sibling agent's GHA workflow
+(`sf-watch.yml` in alpha-engine-config) is wired to invoke this Lambda.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+import uuid
+
+import boto3
+from nousergon_lib import ec2_spot
+from nousergon_lib.ec2_spot import SpotCapacityExhausted, SpotLaunchError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: CI_WATCH_DISPATCH_ENABLED=false disables the launch without
+# touching the GHA invoke wiring — mirrors every other fleet dispatcher's
+# safety valve. Default ON.
+DISPATCH_ENABLED = os.environ.get("CI_WATCH_DISPATCH_ENABLED", "true").lower() == "true"
+
+# ── Spot launch config (env-overridable; defaults mirror scheduled-groom-
+# dispatcher/data-spot-dispatcher — same default-VPC/AMI/security-group, only
+# the IAM profile differs for blast-radius isolation). ────────────────────────
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "CI_WATCH_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "CI_WATCH_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("CI_WATCH_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("CI_WATCH_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("CI_WATCH_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+# NEW, dedicated profile — deliberately NOT alpha-engine-executor-profile (the
+# live trading executor's profile). See module docstring.
+IAM_PROFILE = os.environ.get("CI_WATCH_IAM_PROFILE", "alpha-engine-ci-watch-executor-profile")
+VOLUME_SIZE_GB = int(os.environ.get("CI_WATCH_VOLUME_SIZE_GB", "40"))
+
+CI_WATCH_TAG_NAME = "alpha-engine-ci-watch-spot"
+CI_WATCH_REPO_TAG_KEY = "ci-watch-repo"
+CI_WATCH_SHA_TAG_KEY = "ci-watch-sha"
+
+# The box reads its own run secrets (PAT) via its instance profile in the
+# common case, but the PRELUDE below (run before the profile-backed bootstrap
+# script takes over) still needs the PAT to clone the private config repo —
+# same shape as groom's prelude. Reuses the SAME shared SSM param the other
+# spot dispatchers already read (data-spot-dispatcher, scheduled-groom-
+# dispatcher) rather than assuming a new dedicated param exists.
+CI_WATCH_GH_PAT_SSM = os.environ.get(
+    "CI_WATCH_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+CI_WATCH_CONFIG_REPO = os.environ.get("CI_WATCH_CONFIG_REPO", "nousergon/alpha-engine-config")
+CI_WATCH_CONFIG_BRANCH = os.environ.get("CI_WATCH_CONFIG_BRANCH", "main")
+# Hard ceiling for the on-box SSM command (matches the bootstrap watchdog). CI
+# fixes are a much shorter-lived workload than a full groom sweep; 2h default,
+# env-overridable if a sibling agent's bootstrap script needs more headroom.
+MAX_RUNTIME_SECONDS = int(os.environ.get("CI_WATCH_MAX_RUNTIME_SECONDS", "7200"))
+SSM_ONLINE_BUDGET_SEC = int(os.environ.get("CI_WATCH_SSM_ONLINE_BUDGET_SEC", "180"))
+CW_LOG_GROUP = os.environ.get("CI_WATCH_CW_LOG_GROUP", "/alpha-engine/ci-watch-spot")
+
+# Defense-in-depth allowlists for event fields embedded verbatim into the SSM
+# shell command below (mirrors groom's _MODEL_RE / data-spot's _WORKLOAD_RE).
+# These come from a GHA job (not raw external user input), but the same cheap
+# regex check rules out shell-metacharacter injection outright.
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+_RUN_ID_RE = re.compile(r"^[0-9]+$")
+_BRANCH_RE = re.compile(r"^[A-Za-z0-9_./-]{1,200}$")
+_WORKFLOW_RE = re.compile(r"^[A-Za-z0-9 _./:()-]{1,200}$")
+
+
+class _InvalidEvent(ValueError):
+    """A required event field is missing or fails its allowlist."""
+
+
+def _require(event: dict, key: str, pattern: "re.Pattern[str]") -> str:
+    val = str(event.get(key) or "").strip()
+    if not pattern.match(val):
+        raise _InvalidEvent(f"missing/malformed {key!r} in event: {val!r}")
+    return val
+
+
+def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str]:
+    """Validate the GHA payload's CI fields; raises _InvalidEvent on any
+    missing/malformed field (caught once, at the handler, and converted to a
+    clean launched:false — see module docstring's synchronous contract)."""
+    repo = _require(event, "repo", _REPO_RE)
+    sha = _require(event, "sha", _SHA_RE)
+    run_id = _require(event, "run_id", _RUN_ID_RE)
+    workflow = _require(event, "workflow", _WORKFLOW_RE)
+    branch = _require(event, "branch", _BRANCH_RE)
+    run_url = str(event.get("run_url") or "").strip()
+    if not run_url.startswith("https://") or "$" in run_url:
+        # `$` would be embedded into the double-quoted bootstrap export below;
+        # under `set -u` it could expand as a positional param (same gotcha
+        # groom's run_url note documents) and abort the prelude.
+        raise _InvalidEvent(f"missing/malformed 'run_url' in event: {run_url!r}")
+    return repo, sha, run_id, run_url, workflow, branch
+
+
+def _bootstrap_command(repo: str, sha: str, run_id: str, run_url: str,
+                       workflow: str, branch: str, run_token: str) -> str:
+    """The async SSM RunShellScript body: fetch PAT, clone config, exec the
+    ci_watch_spot_bootstrap.sh entrypoint (built by a sibling agent in
+    alpha-engine-config). Any prelude failure shuts the box down so a botched
+    launch never idles (mirrors groom's prelude fail() trap exactly)."""
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+# SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
+export HOME=/root
+fail() {{ echo "[ci-watch-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 python3.12-pip >/dev/null 2>&1 \
+  || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {CI_WATCH_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/alpha-engine-config
+git clone --depth 1 --branch {CI_WATCH_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{CI_WATCH_CONFIG_REPO}.git" \
+  /home/ec2-user/alpha-engine-config || fail "clone failed"
+cd /home/ec2-user/alpha-engine-config
+export CI_WATCH_REPO={repo}
+export CI_WATCH_SHA={sha}
+export CI_WATCH_RUN_ID={run_id}
+export CI_WATCH_RUN_URL="{run_url}"
+export CI_WATCH_WORKFLOW="{workflow}"
+export CI_WATCH_BRANCH={branch}
+export CI_WATCH_RUN_TOKEN={run_token}
+exec bash infrastructure/ci_watch_spot_bootstrap.sh
+"""
+
+
+def _launch_instance() -> tuple[str, str]:
+    """Launch the CI-watch box; spot first, on-demand fallback on capacity
+    exhaustion. Raises SpotLaunchError (or the SpotCapacityExhausted subclass)
+    if BOTH the spot attempt and the on-demand fallback are exhausted/fail —
+    caught once by the caller and converted to a clean launched:false."""
+    common = dict(
+        image_id=AMI_ID,
+        key_name=KEY_NAME,
+        security_group_ids=[SECURITY_GROUP],
+        iam_instance_profile=IAM_PROFILE,
+        volume_size_gb=VOLUME_SIZE_GB,
+        shutdown_behavior="terminate",
+        tag_name=CI_WATCH_TAG_NAME,
+        region=REGION,
+    )
+    try:
+        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=True, **common)
+        return iid, "spot"
+    except SpotCapacityExhausted:
+        logger.warning(
+            "spot capacity exhausted across all type x subnet pools — relaunching ON-DEMAND"
+        )
+        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=False, **common)
+        return iid, "on-demand"
+
+
+def _wait_ssm_online(instance_id: str) -> None:
+    """Block until the instance is running AND its SSM agent registers Online."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    ssm = boto3.client("ssm", region_name=REGION)
+    ec2.get_waiter("instance_running").wait(
+        InstanceIds=[instance_id], WaiterConfig={"Delay": 5, "MaxAttempts": 40}
+    )
+    deadline = time.time() + SSM_ONLINE_BUDGET_SEC
+    while time.time() < deadline:
+        info = ssm.describe_instance_information(
+            Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
+        ).get("InstanceInformationList", [])
+        if info and info[0].get("PingStatus") == "Online":
+            logger.info("SSM agent Online for %s", instance_id)
+            return
+        time.sleep(5)
+    raise RuntimeError(f"SSM agent not Online after {SSM_ONLINE_BUDGET_SEC}s for {instance_id}")
+
+
+def _send_bootstrap(instance_id: str, repo: str, sha: str, run_id: str, run_url: str,
+                    workflow: str, branch: str, run_token: str) -> str:
+    """Fire the async, detached SSM command that runs CI-watch + self-terminates."""
+    ssm = boto3.client("ssm", region_name=REGION)
+    resp = ssm.send_command(
+        InstanceIds=[instance_id],
+        DocumentName="AWS-RunShellScript",
+        Comment=f"ci-watch ({repo}@{sha[:12]}, run {run_id})",
+        Parameters={
+            "commands": [_bootstrap_command(repo, sha, run_id, run_url, workflow, branch, run_token)],
+            "executionTimeout": [str(MAX_RUNTIME_SECONDS)],
+        },
+        TimeoutSeconds=600,  # time to START delivering before giving up
+        CloudWatchOutputConfig={
+            "CloudWatchLogGroupName": CW_LOG_GROUP,
+            "CloudWatchOutputEnabled": True,
+        },
+    )
+    return resp["Command"]["CommandId"]
+
+
+def _running_ci_watch_instance_ids(repo: str, sha: str) -> list[str]:
+    """Instance ids for a LIVE (pending/running) ci-watch box already working
+    THIS exact (repo, sha) — deliberately NARROWER than groom's per-tier lock
+    (config#1979): two different commits on the same repo failing CI
+    independently must each get their own box. Fail-safe: any API error
+    returns [] (never blocks a launch on a broken check — an optimization,
+    not a correctness gate, mirroring every other pre-launch guard in the
+    fleet)."""
+    try:
+        ec2 = boto3.client("ec2", region_name=REGION)
+        resp = ec2.describe_instances(Filters=[
+            {"Name": "tag:Name", "Values": [CI_WATCH_TAG_NAME]},
+            {"Name": f"tag:{CI_WATCH_REPO_TAG_KEY}", "Values": [repo]},
+            {"Name": f"tag:{CI_WATCH_SHA_TAG_KEY}", "Values": [sha]},
+            {"Name": "instance-state-name", "Values": ["pending", "running"]},
+        ])
+        return [i["InstanceId"] for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
+    except Exception as exc:  # noqa: BLE001 — fail-safe: never block a launch
+        logger.warning("concurrency check failed (non-fatal, launching anyway): %s: %s",
+                       type(exc).__name__, exc)
+        return []
+
+
+def _terminate_instance(instance_id: str) -> None:
+    """Best-effort terminate of a just-launched box whose post-launch steps
+    failed. Without this the box orphans: it received no bootstrap, so
+    neither the on-box watchdog nor the EXIT trap (both armed BY the
+    bootstrap) is running to tear it down. Never masks the original error
+    (logged, not raised) — mirrors groom's `_terminate_instance` exactly."""
+    try:
+        boto3.client("ec2", region_name=REGION).terminate_instances(InstanceIds=[instance_id])
+        logger.warning("terminated ci-watch box %s after post-launch failure (no orphan)", instance_id)
+    except Exception as exc:  # noqa: BLE001 — cleanup; caller still returns a clean result
+        logger.error(
+            "FAILED to terminate %s after a post-launch error (%s) — MANUAL cleanup needed",
+            instance_id, exc,
+        )
+
+
+def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
+                          workflow: str, branch: str) -> dict:
+    """Launch + bootstrap the CI-watch box. SYNCHRONOUS contract: every
+    anticipated failure mode returns a clean, well-formed launched:false
+    rather than raising — see module docstring."""
+    if not DISPATCH_ENABLED:
+        logger.warning("CI_WATCH_DISPATCH_ENABLED=false — ci-watch spot NOT launched")
+        return {"launched": False, "reason": "disabled"}
+
+    existing = _running_ci_watch_instance_ids(repo, sha)
+    if existing:
+        logger.warning(
+            "ci-watch box already live for %s@%s (%s) — skipping launch to avoid a "
+            "concurrent duplicate run", repo, sha, existing)
+        return {"launched": False, "reason": "concurrent_skip",
+                "existing_instance_ids": existing}
+
+    run_token = uuid.uuid4().hex
+    try:
+        instance_id, market = _launch_instance()
+    except SpotLaunchError as exc:
+        logger.error("ci-watch spot launch failed: %s: %s", type(exc).__name__, exc)
+        return {"launched": False, "reason": "launch_failed", "error": str(exc)}
+
+    logger.info("launched ci-watch box %s (%s) for %s@%s", instance_id, market, repo, sha)
+    # config#1979-style tag so the NEXT trigger's guard check (above) can find
+    # it. Best-effort — a tag-write failure must not abort an already-launched
+    # box (mirrors groom's fail-safe posture on its own tier tag).
+    try:
+        boto3.client("ec2", region_name=REGION).create_tags(
+            Resources=[instance_id],
+            Tags=[
+                {"Key": CI_WATCH_REPO_TAG_KEY, "Value": repo},
+                {"Key": CI_WATCH_SHA_TAG_KEY, "Value": sha},
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001 — non-fatal, mirrors groom's tier-tag write
+        logger.warning("ci-watch repo/sha tag write failed (non-fatal): %s: %s",
+                       type(exc).__name__, exc)
+
+    # Once the box is up, ANY failure before the bootstrap command is
+    # delivered would orphan it (no watchdog/trap yet). Terminate-on-error —
+    # but, unlike groom, return a clean result rather than re-raising (this
+    # Lambda's synchronous caller needs a JSON verdict, not an invocation
+    # error to unwrap).
+    try:
+        _wait_ssm_online(instance_id)
+        command_id = _send_bootstrap(instance_id, repo, sha, run_id, run_url, workflow, branch, run_token)
+    except Exception as exc:  # noqa: BLE001 — converted to a clean launched:false
+        _terminate_instance(instance_id)
+        logger.error("ci-watch post-launch step failed for %s: %s: %s",
+                     instance_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "post_launch_failed",
+                "instance_id": instance_id, "error": str(exc)}
+
+    logger.info(
+        "ci-watch dispatched: instance=%s market=%s command=%s repo=%s sha=%s run_id=%s "
+        "run_token=%s", instance_id, market, command_id, repo, sha, run_id, run_token,
+    )
+    return {
+        "launched": True,
+        "reason": "launched",
+        "instance_id": instance_id,
+        "market": market,
+        "command_id": command_id,
+        "repo": repo,
+        "sha": sha,
+        "run_id": run_id,
+        "run_token": run_token,
+    }
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Synchronous handler invoked once per real CI failure event — NOT on a
+    schedule. `event` carries {"repo", "sha", "run_id", "run_url", "workflow",
+    "branch"} from the GHA job's `lambda invoke` payload (RequestResponse).
+
+    Returns {"launched": bool, "reason": str, "instance_id": ..., ...} —
+    read DIRECTLY by the GHA job as its success signal. Every anticipated
+    failure (malformed event, concurrency skip, spot+on-demand launch
+    exhaustion, post-launch SSM failure) is a clean return, never an
+    exception — see module docstring's synchronous contract.
+    """
+    event = event or {}
+    try:
+        repo, sha, run_id, run_url, workflow, branch = _resolve_event_fields(event)
+    except _InvalidEvent as exc:
+        logger.error("invalid ci-watch event: %s", exc)
+        return {"launched": False, "reason": "invalid_event", "error": str(exc)}
+
+    logger.info(
+        "ci-watch trigger: repo=%s sha=%s run_id=%s workflow=%s branch=%s",
+        repo, sha, run_id, workflow, branch,
+    )
+    return _launch_ci_watch_spot(repo, sha, run_id, run_url, workflow, branch)

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -1,0 +1,8 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.ec2_spot re-exports krepis.ec2_spot (the spot-launch capacity-
+# resilience chokepoint) — SAME pin as scheduled-groom-dispatcher/data-spot-dispatcher.
+# No [flow-doctor] extra needed — this Lambda sends no Telegram of its own (the
+# synchronous GHA caller reads the return value directly; see index.py docstring).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.97.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -153,11 +153,21 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
     ]
     sent = idx._test_ssm.sent[0]
     cmd = sent["Parameters"]["commands"][0]
+    # ci_watch_spot_bootstrap.sh (alpha-engine-config) takes its CI fields as
+    # CLI FLAGS, not env vars — assert the actual invocation shape, not an
+    # `export CI_WATCH_*` form the bootstrap script never reads.
     assert "exec bash infrastructure/ci_watch_spot_bootstrap.sh" in cmd
-    assert "export CI_WATCH_REPO=nousergon/alpha-engine-config" in cmd
-    assert "export CI_WATCH_SHA=abc1234def5678900000000000000000000abcd" in cmd
-    assert 'export CI_WATCH_RUN_URL="https://github.com' in cmd
+    assert '--ci-repo "nousergon/alpha-engine-config"' in cmd
+    assert '--ci-sha "abc1234def5678900000000000000000000abcd"' in cmd
+    assert '--ci-run-url "https://github.com' in cmd
     assert "export HOME=/root" in cmd
+    # run_token is NOT threaded into the box (no in-box consumer — the
+    # completion marker keys directly on repo+sha) — only a Lambda-side
+    # correlation id, surfaced via the SSM Comment field instead.
+    assert "run_token" not in cmd
+    assert "CI_WATCH_RUN_TOKEN" not in cmd
+    assert "token" in sent["Comment"]
+
     assert sent["Parameters"]["executionTimeout"] == [str(idx.MAX_RUNTIME_SECONDS)]
 
 

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -1,0 +1,322 @@
+"""Unit tests for the synchronous CI-failure -> ci-watch-spot dispatcher.
+
+Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
+BEFORE importing index (mirrors scheduled-groom-dispatcher/test_handler.py).
+Validates: a valid event launches a spot box and fires an async SSM command;
+the on-demand fallback on spot capacity exhaustion; a total launch failure
+(spot AND on-demand exhausted) returns a clean launched:false rather than
+raising; the (repo, sha)-scoped concurrency lock (narrower than groom's
+per-tier lock — two different shas on the same repo must NOT block each
+other); a post-launch SSM-send failure terminates the box and returns
+launched:false; a malformed event returns launched:false rather than raising;
+the kill-switch short-circuit.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ── Stub nousergon_lib.ec2_spot + boto3 before importing index ─────────────────
+class _SpotLaunchError(Exception):
+    pass
+
+
+class _SpotCapacityExhausted(_SpotLaunchError):
+    pass
+
+
+def _install_stubs(launch_impl, boto_clients):
+    ec2_spot_mod = types.ModuleType("nousergon_lib.ec2_spot")
+    ec2_spot_mod.SpotLaunchError = _SpotLaunchError
+    ec2_spot_mod.SpotCapacityExhausted = _SpotCapacityExhausted
+    ec2_spot_mod.launch = launch_impl
+    sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
+
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: boto_clients[name]
+    sys.modules["boto3"] = boto3_mod
+
+
+class _FakeWaiter:
+    def wait(self, **kw):
+        return None
+
+
+class _FakeEc2:
+    def __init__(self, running_instances=None):
+        self.terminated = []
+        self.tags_created = []
+        # {(repo, sha) -> [instance_ids]} already "live" for the concurrency
+        # guard's describe_instances check to find.
+        self._running_instances = dict(running_instances or {})
+
+    def get_waiter(self, name):
+        return _FakeWaiter()
+
+    def terminate_instances(self, InstanceIds):  # noqa: N803 — boto3 kwarg name
+        self.terminated.extend(InstanceIds)
+        return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
+
+    def create_tags(self, Resources, Tags):  # noqa: N803 — boto3 kwarg names
+        self.tags_created.append((Resources, Tags))
+        return {}
+
+    def describe_instances(self, Filters):  # noqa: N803 — boto3 kwarg name
+        by_name = {f["Name"]: f["Values"] for f in Filters}
+        repo = by_name.get("tag:ci-watch-repo", [None])[0]
+        sha = by_name.get("tag:ci-watch-sha", [None])[0]
+        ids = self._running_instances.get((repo, sha), [])
+        return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
+
+
+class _FakeSsm:
+    def __init__(self):
+        self.sent = []
+
+    def describe_instance_information(self, **kw):
+        return {"InstanceInformationList": [{"PingStatus": "Online"}]}
+
+    def send_command(self, **kw):
+        self.sent.append(kw)
+        return {"Command": {"CommandId": "cmd-123"}}
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None):
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    ssm = _FakeSsm()
+    ec2 = _FakeEc2(running_instances=running_instances)
+    clients = {"ec2": ec2, "ssm": ssm}
+    if launch_impl is None:
+        launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
+    _install_stubs(launch_impl, clients)
+    # Derive the stub requirement from index.py's live import graph and fail
+    # loud on drift here, rather than as a ModuleNotFoundError at deploy time
+    # (config#1746 pattern — see scheduled-groom-dispatcher/test_handler.py).
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+
+    assert_hermetic_imports_satisfied(__file__)
+    import index
+    import importlib
+
+    importlib.reload(index)
+    index._test_ssm = ssm  # expose for assertions
+    index._test_ec2 = ec2
+    return index
+
+
+def _event(**overrides):
+    base = {
+        "repo": "nousergon/alpha-engine-config",
+        "sha": "abc1234def5678900000000000000000000abcd",
+        "run_id": "123456789",
+        "run_url": "https://github.com/nousergon/alpha-engine-config/actions/runs/123456789",
+        "workflow": "Fleet CI",
+        "branch": "main",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
+    calls = {}
+
+    def _launch(types_, subnets, **kw):
+        calls["spot"] = kw.get("spot")
+        calls["profile"] = kw.get("iam_instance_profile")
+        calls["tag_name"] = kw.get("tag_name")
+        return "i-abc"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert out["reason"] == "launched"
+    assert out["instance_id"] == "i-abc"
+    assert out["market"] == "spot"
+    assert out["command_id"] == "cmd-123"
+    assert out["repo"] == "nousergon/alpha-engine-config"
+    assert calls["spot"] is True
+    assert calls["profile"] == "alpha-engine-ci-watch-executor-profile"
+    assert calls["tag_name"] == "alpha-engine-ci-watch-spot"
+    # The instance is tagged with its repo+sha for the concurrency guard.
+    assert idx._test_ec2.tags_created == [
+        (["i-abc"], [{"Key": "ci-watch-repo", "Value": "nousergon/alpha-engine-config"},
+                     {"Key": "ci-watch-sha", "Value": "abc1234def5678900000000000000000000abcd"}])
+    ]
+    sent = idx._test_ssm.sent[0]
+    cmd = sent["Parameters"]["commands"][0]
+    assert "exec bash infrastructure/ci_watch_spot_bootstrap.sh" in cmd
+    assert "export CI_WATCH_REPO=nousergon/alpha-engine-config" in cmd
+    assert "export CI_WATCH_SHA=abc1234def5678900000000000000000000abcd" in cmd
+    assert 'export CI_WATCH_RUN_URL="https://github.com' in cmd
+    assert "export HOME=/root" in cmd
+    assert sent["Parameters"]["executionTimeout"] == [str(idx.MAX_RUNTIME_SECONDS)]
+
+
+def test_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        if kw.get("spot"):
+            raise _SpotCapacityExhausted("no capacity in any pool")
+        return "i-ondemand"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert out["market"] == "on-demand"
+    assert out["instance_id"] == "i-ondemand"
+    assert seen == [True, False]  # tried spot, then on-demand
+
+
+def test_total_launch_exhaustion_returns_clean_false_not_raise(monkeypatch):
+    # SYNCHRONOUS contract (index.py docstring): unlike groom's fail-loud
+    # posture, spot AND on-demand both exhausted must be a clean return, not
+    # an exception — the GHA caller needs a JSON verdict to branch on.
+    def _launch(types_, subnets, **kw):
+        raise _SpotCapacityExhausted("exhausted everywhere")
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert "exhausted everywhere" in out["error"]
+    assert idx._test_ssm.sent == []
+
+
+def test_non_capacity_launch_error_returns_clean_false(monkeypatch):
+    def _launch(types_, subnets, **kw):
+        raise _SpotLaunchError("RunInstances denied")
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+
+
+def test_concurrency_skip_when_same_repo_and_sha_already_running(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-new"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("nousergon/alpha-engine-config", "abc1234def5678900000000000000000000abcd"): ["i-already-running"],
+        },
+    )
+    out = idx.handler(_event(), None)
+    assert out["launched"] is False
+    assert out["reason"] == "concurrent_skip"
+    assert out["existing_instance_ids"] == ["i-already-running"]
+    assert launched == []  # never even attempted a spot launch — zero spend
+
+
+def test_different_sha_same_repo_is_not_blocked(monkeypatch):
+    # This is the whole point of the (repo, sha) granularity — a bare-repo
+    # lock (like groom's per-tier lock) would wrongly starve a second commit's
+    # independent CI failure on the same repo.
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("nousergon/alpha-engine-config", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"): ["i-other-sha"],
+        },
+    )
+    out = idx.handler(_event(sha="abc1234def5678900000000000000000000abcd"), None)
+    assert out["launched"] is True
+    assert out["instance_id"] == "i-new"
+
+
+def test_different_repo_same_sha_is_not_blocked(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("nousergon/other-repo", "abc1234def5678900000000000000000000abcd"): ["i-other-repo"],
+        },
+    )
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+
+
+def test_concurrency_check_fails_safe_and_still_launches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom(Filters):  # noqa: N803 — boto3 kwarg name
+        raise RuntimeError("EC2 API hiccup")
+
+    idx._test_ec2.describe_instances = _boom
+    out = idx.handler(_event(), None)
+    # A broken check must never block a launch — optimization, not a
+    # correctness gate (mirrors groom's fail-safe posture on its own guard).
+    assert out["launched"] is True
+
+
+def test_post_launch_ssm_failure_terminates_instance_returns_clean_false(monkeypatch):
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: "i-orphan",  # noqa: E731
+        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom_send(**kw):
+        raise RuntimeError("SSM SendCommand failed")
+
+    idx._test_ssm.send_command = _boom_send
+    out = idx.handler(_event(), None)
+    assert out["launched"] is False
+    assert out["reason"] == "post_launch_failed"
+    assert out["instance_id"] == "i-orphan"
+    # The just-launched box was terminated (not orphaned), and the handler
+    # still returned a clean result instead of raising.
+    assert idx._test_ec2.terminated == ["i-orphan"]
+
+
+def test_malformed_event_returns_clean_false_not_raise(monkeypatch):
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(sha="not-a-sha"), None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+    assert idx._test_ssm.sent == []
+
+
+def test_missing_field_returns_clean_false(monkeypatch):
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    event = _event()
+    del event["repo"]
+    out = idx.handler(event, None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+
+
+def test_run_url_with_dollar_sign_rejected(monkeypatch):
+    # Under `set -u` in the double-quoted prelude export, a `$`-bearing
+    # run_url could expand as a positional param and abort the prelude
+    # (same gotcha groom's own run_url note documents).
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(run_url="https://example.com/$2Fbad"), None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+
+
+def test_disabled_flag_short_circuits(monkeypatch):
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "false"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is False
+    assert out["reason"] == "disabled"
+    assert idx._test_ssm.sent == []

--- a/infrastructure/lambdas/spot-orphan-reaper/README.md
+++ b/infrastructure/lambdas/spot-orphan-reaper/README.md
@@ -58,6 +58,21 @@ box whose watchdog failed) lingers up to 6.5h before the backstop fires instead 
 value is a process-quality signal worth investigating — the most likely cause is a
 launcher that shipped without arming its watchdog.
 
+## CI-watch incomplete-reap alert (additive, ci-watch-dispatcher migration)
+
+Every other tagged workload's reap path above is unchanged. Specifically for
+boxes tagged `Name=alpha-engine-ci-watch-spot`, this reaper ALSO checks — right
+before terminating — whether the sibling `ci_watch_run.sh` wrote its S3
+completion marker (`s3://alpha-engine-research/ci_watch/_control/completed/
+<repo>-<sha>.json`, written on every one of its exit paths). If the marker is
+absent, the reap fired because the diagnose+fix agent never reached a normal
+exit — `main` could still be red with nobody told — so this Lambda sends one
+best-effort Telegram ping via `krepis.telegram.send_message` (through the
+`nousergon_lib.telegram` re-export). Fail-safe direction is deliberately the
+OPPOSITE of the reap decision itself: any inability to confirm completion (a
+genuine 404 or an unrelated S3 error) still fires the alert — an occasional
+false positive is safer than silently missing a real incomplete run.
+
 ## Deploying
 
 ```bash
@@ -91,6 +106,8 @@ The role's inline policy (`iam-policy.json`):
 - `ec2:DescribeInstances *` — global read for the scan
 - `ec2:TerminateInstances` scoped to instances with `tag:Name` matching `alpha-engine-*` — defence in depth so even a buggy reaper run cannot terminate anything outside the alpha-engine tag prefix
 - `cloudwatch:PutMetricData` scoped to namespace `AlphaEngine/Infra`
+- `s3:HeadObject` scoped to `s3://alpha-engine-research/ci_watch/_control/completed/*` — the CI-watch incomplete-reap marker check (above)
+- `ssm:GetParameter` scoped to the two Telegram secrets (`/alpha-engine/TELEGRAM_BOT_TOKEN`, `/alpha-engine/TELEGRAM_CHAT_ID`) — resolved by `krepis.secrets.get_secret` inside `send_message`
 - Standard Lambda logging perms
 
 ## Changing the cap

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -6,6 +6,15 @@
 # scripts. Hourly scan terminates any alpha-engine-* tagged spot instance
 # whose age exceeds its per-tag-prefix budget + 30-min grace.
 #
+# ci-watch-dispatcher migration (new dependency): index.py now imports
+# nousergon_lib.telegram (re-exports krepis.telegram.send_message) for the
+# CI-watch incomplete-reap alert. nousergon-lib pulls in pydantic (pydantic-
+# core ships a compiled, platform-specific wheel — verified: a bare macOS
+# `pip install --target` produces a darwin/arm64 .so that is NOT Lambda-safe),
+# so packaging now goes through lambda_pip_install.sh (Docker linux/amd64),
+# mirroring scheduled-groom-dispatcher/deploy.sh exactly, instead of the old
+# single-file `zip index.py`.
+#
 # Managed outside CloudFormation — same rationale as the
 # changelog-cloudwatch-mirror Lambda (keeps the github-actions-lambda-deploy
 # OIDC role's blast radius narrow; this Lambda has destructive ec2:Terminate
@@ -53,7 +62,13 @@ run() {
   fi
 }
 
-# ----- 0. Validate handler ---------------------------------------------------
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+# PKG and TEST_DEPS are both created up front (mirrors scheduled-groom-
+# dispatcher/deploy.sh) so ONE trap covers both.
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 
 python3 -c "
 import ast, sys
@@ -62,9 +77,18 @@ ast.parse(src)
 print('index.py syntax OK')
 "
 
+# ----- 0b. Preflight handler unit tests --------------------------------------
+# Hermetic for AWS: boto3 + nousergon_lib.telegram are stubbed in sys.modules
+# before `import index` (see test_handler.py). The pinned nousergon-lib is
+# installed for real into a scratch TEST_DEPS dir (config#1746 hermetic-
+# import-guard pattern) — NOT the caller's global site-packages, not bundled
+# into the Lambda zip.
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${NOUSERGON_LIB_REQ}"
   echo "Running handler unit tests..."
-  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
 # ----- 1. Bootstrap (first-time only) ---------------------------------------
@@ -94,11 +118,12 @@ if $BOOTSTRAP; then
     sleep 10
   fi
 
-  PKG=$(mktemp -d)
-  trap "rm -rf '$PKG'" EXIT
+  LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  echo "  Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+  bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
   cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
   ZIP="${PKG}/function.zip"
-  (cd "${PKG}" && zip -q "function.zip" index.py)
+  (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
   echo "  Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
 
   ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
@@ -145,11 +170,12 @@ fi
 # ----- 2. Update function code (always) -------------------------------------
 
 if ! $BOOTSTRAP; then
-  PKG=$(mktemp -d)
-  trap "rm -rf '$PKG'" EXIT
+  LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+  bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
   cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
   ZIP="${PKG}/function.zip"
-  (cd "${PKG}" && zip -q "function.zip" index.py)
+  (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
   echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
 
   echo "Updating Lambda function code: ${FUNCTION_NAME}"

--- a/infrastructure/lambdas/spot-orphan-reaper/iam-policy.json
+++ b/infrastructure/lambdas/spot-orphan-reaper/iam-policy.json
@@ -30,6 +30,21 @@
       }
     },
     {
+      "Sid": "CheckCiWatchCompletionMarker",
+      "Effect": "Allow",
+      "Action": "s3:HeadObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/ci_watch/_control/completed/*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    },
+    {
       "Sid": "LambdaLogging",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/spot-orphan-reaper/index.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/index.py
@@ -37,6 +37,21 @@ Hourly EventBridge cron scans running `alpha-engine-*` spot instances and
 terminates any older than the threshold. Emits CloudWatch custom metric
 `AlphaEngine/Infra/spot_orphans_terminated` (sum) with a `name` dimension (the
 box's Name tag) purely for observability — it does NOT feed the reap decision.
+
+CI-WATCH INCOMPLETE-REAP ALERT (additive, ci-watch-dispatcher migration): when
+the terminated box is specifically tagged `Name=alpha-engine-ci-watch-spot`,
+this reaper is no longer just a generic backstop — a CI-watch box reaped by
+the fleet-wide age cap (rather than its own on-box completion path) can mean
+the diagnose+fix agent never finished, leaving `main` red with nobody told.
+Before terminating such a box, check for the sibling `ci_watch_run.sh`'s S3
+completion marker (`s3://alpha-engine-research/ci_watch/_control/completed/
+<repo>-<sha>.json`, written on every one of its exit paths); if absent, fire
+one best-effort Telegram ping via `krepis.telegram.send_message` (through the
+`nousergon_lib.telegram` re-export — the same base primitive
+`flow_doctor_telegram.py` itself falls back to, reused directly here since
+this Lambda sends exactly one alert shape and doesn't need the full forum-
+topic/dedup machinery). This check is purely additive to every OTHER tagged
+spot workload's reap path, which is untouched.
 """
 
 from __future__ import annotations
@@ -46,11 +61,17 @@ import os
 from datetime import datetime, timedelta, timezone
 
 import boto3
+from nousergon_lib.telegram import send_message
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
+# ci-watch-dispatcher migration: the ONE tag value that gets the extra
+# incomplete-reap check below. No other workload's reap path is affected.
+CI_WATCH_TAG_NAME = "alpha-engine-ci-watch-spot"
+CI_WATCH_COMPLETION_BUCKET = os.environ.get("CI_WATCH_COMPLETION_BUCKET", "alpha-engine-research")
+CI_WATCH_COMPLETION_PREFIX = "ci_watch/_control/completed/"
 # The longest on-box watchdog in the fleet. Keep >= the largest launcher
 # MAX_RUNTIME_SECONDS (today: backlog groom = 21600s / 6h). This is the ONLY
 # number that ties the reaper to the workloads, and it is a single ceiling, not a
@@ -81,8 +102,64 @@ def _scan_spot_instances(ec2) -> list[dict]:
                     "name": tags.get("Name", ""),
                     "launch_time": inst["LaunchTime"],
                     "instance_type": inst.get("InstanceType", ""),
+                    # Only meaningful for CI_WATCH_TAG_NAME boxes; empty for
+                    # every other workload's instances (harmless no-op there).
+                    "ci_watch_repo": tags.get("ci-watch-repo", ""),
+                    "ci_watch_sha": tags.get("ci-watch-sha", ""),
                 })
     return out
+
+
+def _ci_watch_completion_marker_exists(s3, repo: str, sha: str) -> bool:
+    """True iff the sibling ``ci_watch_run.sh`` wrote its S3 completion marker
+    for this (repo, sha) before the reaper's fleet-wide age cap fired.
+
+    Fail-safe direction (deliberately the OPPOSITE of every other guard in
+    this file): any inability to confirm completion — a genuine 404 (marker
+    truly absent) OR an unrelated S3 error (throttle, auth hiccup) — is
+    treated as "not confirmed complete", so the alert still fires. An
+    occasional false-positive ping from a rare S3 hiccup is the safer
+    failure direction than silently swallowing a genuine incomplete CI-watch
+    run (recording surface: the logger.warning below)."""
+    if not repo or not sha:
+        # Box was reaped before its repo/sha tags ever landed (e.g. tag-write
+        # failed right after launch) — cannot look up a marker either way.
+        return False
+    key = f"{CI_WATCH_COMPLETION_PREFIX}{repo}-{sha}.json"
+    try:
+        s3.head_object(Bucket=CI_WATCH_COMPLETION_BUCKET, Key=key)
+        return True
+    except Exception as exc:  # noqa: BLE001 — see fail-safe-direction note above
+        logger.warning(
+            "ci-watch completion marker not confirmed for %s@%s (key=%s): %s",
+            repo, sha, key, exc,
+        )
+        return False
+
+
+def _notify_ci_watch_incomplete_reap(instance_id: str, repo: str, sha: str) -> None:
+    """Best-effort Telegram ping — a CI-watch box reaped without its
+    completion marker can mean the diagnose+fix agent never finished, leaving
+    `main` red with nobody told. Reuses ``krepis.telegram.send_message``
+    directly (via the ``nousergon_lib.telegram`` re-export) rather than the
+    full ``flow_doctor_telegram`` forum-topic wrapper other Lambdas use — this
+    Lambda sends exactly one alert shape, so the dedup/topic-routing
+    machinery is unneeded weight. ``send_message`` itself never raises (see
+    its own docstring), but this is still wrapped defensively: the reap
+    already completed by the time this runs, so nothing here may ever mask
+    or retry that outcome (recording surface: the logger.warning below)."""
+    key = f"{CI_WATCH_COMPLETION_PREFIX}{repo}-{sha}.json"
+    text = (
+        "🟠 CI-watch box reaped WITHOUT completing "
+        f"(repo={repo or 'unknown'}, sha={sha or 'unknown'}, instance={instance_id}) "
+        f"— main may still be red. No completion marker at "
+        f"s3://{CI_WATCH_COMPLETION_BUCKET}/{key} before the orphan-reaper's "
+        "fleet-wide age cap fired."
+    )
+    try:
+        send_message(text, disable_notification=False)
+    except Exception as exc:  # noqa: BLE001 — secondary observability only
+        logger.warning("ci-watch incomplete-reap Telegram send failed (non-fatal): %s", exc)
 
 
 def _emit_metric(cw, name: str, count: int) -> None:
@@ -110,6 +187,7 @@ def handler(event: dict, context) -> dict:
     """
     ec2 = boto3.client("ec2", region_name=REGION)
     cw = boto3.client("cloudwatch", region_name=REGION)
+    s3 = boto3.client("s3", region_name=REGION)
     now = datetime.now(timezone.utc)
     threshold = timedelta(seconds=REAP_AFTER_SECONDS)
 
@@ -122,6 +200,7 @@ def handler(event: dict, context) -> dict:
     orphans: list[dict] = []
     terminated: list[str] = []
     per_name_terminated: dict[str, int] = {}
+    ci_watch_incomplete_reaps: list[str] = []
 
     for inst in instances:
         age = now - inst["launch_time"]
@@ -150,6 +229,15 @@ def handler(event: dict, context) -> dict:
                 inst["instance_id"], inst["name"], int(age.total_seconds()),
                 REAP_AFTER_SECONDS, inst["instance_type"],
             )
+            # ci-watch-dispatcher migration (additive — every other tag's reap
+            # path above is unchanged): a ci-watch box reaped by the fleet-wide
+            # age cap, rather than its own on-box completion path, can mean the
+            # diagnose+fix agent never finished.
+            if inst["name"] == CI_WATCH_TAG_NAME:
+                repo, sha = inst["ci_watch_repo"], inst["ci_watch_sha"]
+                if not _ci_watch_completion_marker_exists(s3, repo, sha):
+                    _notify_ci_watch_incomplete_reap(inst["instance_id"], repo, sha)
+                    ci_watch_incomplete_reaps.append(inst["instance_id"])
         except Exception as exc:
             logger.error(
                 "terminate_instances failed for %s: %s", inst["instance_id"], exc,
@@ -165,4 +253,5 @@ def handler(event: dict, context) -> dict:
         "dry_run": DRY_RUN,
         "reap_after_seconds": REAP_AFTER_SECONDS,
         "orphan_detail": orphans,
+        "ci_watch_incomplete_reaps": ci_watch_incomplete_reaps,
     }

--- a/infrastructure/lambdas/spot-orphan-reaper/index.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/index.py
@@ -125,7 +125,11 @@ def _ci_watch_completion_marker_exists(s3, repo: str, sha: str) -> bool:
         # Box was reaped before its repo/sha tags ever landed (e.g. tag-write
         # failed right after launch) — cannot look up a marker either way.
         return False
-    key = f"{CI_WATCH_COMPLETION_PREFIX}{repo}-{sha}.json"
+    # repo is "owner/name" (a literal "/") — ci_watch_run.sh flattens that to
+    # "-" before writing its marker key (so the S3 key has no unintended
+    # nested "directory" per repo); mirror the SAME escaping here or every
+    # lookup 404s against a key that was never written.
+    key = f"{CI_WATCH_COMPLETION_PREFIX}{repo.replace('/', '-')}-{sha}.json"
     try:
         s3.head_object(Bucket=CI_WATCH_COMPLETION_BUCKET, Key=key)
         return True

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -1,0 +1,8 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# ci-watch-dispatcher migration (new): nousergon_lib.telegram re-exports
+# krepis.telegram.send_message — a single best-effort Telegram ping for the
+# CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
+# sends exactly one alert shape, not the full multi-topic forum substrate
+# other Lambdas route through. Same pin as scheduled-groom-dispatcher.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.97.0

--- a/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
@@ -1,16 +1,24 @@
 """Unit tests for the alpha-engine-spot-orphan-reaper Lambda handler.
 
-Mocks boto3 EC2 + CloudWatch clients so tests run without AWS calls. Locks the
-single-global-cap semantics (config#1492): no per-workload budget table — every
-alpha-engine spot is reaped only after the one fleet-wide threshold
-(MAX_SPOT_BUDGET_SECONDS + GRACE_SECONDS). Includes the exact regression that
-motivated the redesign: a live 6h groom box must NOT be reaped at 2.5–3h.
+Mocks boto3 EC2 + CloudWatch + S3 clients so tests run without AWS calls.
+Locks the single-global-cap semantics (config#1492): no per-workload budget
+table — every alpha-engine spot is reaped only after the one fleet-wide
+threshold (MAX_SPOT_BUDGET_SECONDS + GRACE_SECONDS). Includes the exact
+regression that motivated the redesign: a live 6h groom box must NOT be
+reaped at 2.5-3h.
+
+Also covers the ci-watch-dispatcher migration's additive incomplete-reap
+alert: ``nousergon_lib.telegram`` is stubbed in sys.modules before `import
+index` (config#1746 hermetic-import-guard pattern — same as scheduled-groom-
+dispatcher/ci-watch-dispatcher's test files) so this suite stays network-free.
 """
 
 from __future__ import annotations
 
 import importlib
+import os
 import sys
+import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -20,9 +28,21 @@ import pytest
 # Ensure the handler module is importable from the test file
 SCRIPT_DIR = Path(__file__).parent
 sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(SCRIPT_DIR.parent))
 
 # Default threshold = MAX_SPOT_BUDGET_SECONDS (21600) + GRACE_SECONDS (1800) = 23400s.
 THRESHOLD = 23400
+
+
+class _FakeSendMessage:
+    """Records every call so tests can assert on the alert text/args."""
+
+    def __init__(self):
+        self.calls: list[tuple[tuple, dict]] = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return True
 
 
 @pytest.fixture
@@ -32,17 +52,38 @@ def index_module(monkeypatch):
     monkeypatch.setenv("MAX_SPOT_BUDGET_SECONDS", "21600")
     monkeypatch.setenv("GRACE_SECONDS", "1800")
     monkeypatch.setenv("DRY_RUN", "false")
+
+    # Stub nousergon_lib.telegram (index.py's one git-only import) — derived
+    # from index.py's live import graph and asserted below, so a future new
+    # import that this stub doesn't cover fails loud here, not at deploy time.
+    fake_send_message = _FakeSendMessage()
+    tel_mod = types.ModuleType("nousergon_lib.telegram")
+    tel_mod.send_message = fake_send_message
+    sys.modules["nousergon_lib.telegram"] = tel_mod
+
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+
+    assert_hermetic_imports_satisfied(__file__)
+
     if "index" in sys.modules:
         del sys.modules["index"]
-    return importlib.import_module("index")
+    mod = importlib.import_module("index")
+    mod._test_send_message = fake_send_message  # expose for assertions
+    return mod
 
 
-def _spot(instance_id: str, name: str, age_seconds: int, instance_type: str = "c5.large"):
+def _spot(instance_id: str, name: str, age_seconds: int, instance_type: str = "c5.large",
+         ci_watch_repo: str | None = None, ci_watch_sha: str | None = None):
     """Build a mock describe-instances entry."""
+    tags = [{"Key": "Name", "Value": name}]
+    if ci_watch_repo is not None:
+        tags.append({"Key": "ci-watch-repo", "Value": ci_watch_repo})
+    if ci_watch_sha is not None:
+        tags.append({"Key": "ci-watch-sha", "Value": ci_watch_sha})
     return {
         "InstanceId": instance_id,
         "InstanceType": instance_type,
-        "Tags": [{"Key": "Name", "Value": name}],
+        "Tags": tags,
         "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
     }
 
@@ -55,14 +96,24 @@ def _describe_instances_paginator(spots: list[dict]):
     return paginator
 
 
-def _run(index_module, spots):
+class _NotFound(Exception):
+    pass
+
+
+def _run(index_module, spots, s3_marker_exists: bool = False):
     ec2 = MagicMock()
     ec2.get_paginator.return_value = _describe_instances_paginator(spots)
     cw = MagicMock()
+    s3 = MagicMock()
+    if s3_marker_exists:
+        s3.head_object.return_value = {}
+    else:
+        s3.head_object.side_effect = _NotFound("404 Not Found")
+    clients = {"ec2": ec2, "cloudwatch": cw, "s3": s3}
     with patch.object(index_module.boto3, "client",
-                      side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+                      side_effect=lambda svc, **kw: clients[svc]):
         out = index_module.handler({}, None)
-    return out, ec2, cw
+    return out, ec2, cw, s3
 
 
 class TestThresholdConfig:
@@ -84,25 +135,28 @@ class TestHandler:
         # REGRESSION (config#1492): the 6h groom box was killed at 2.5h by the old
         # per-workload default. Under the single cap a 3h-old groom is safe.
         spots = [_spot("i-groom", "alpha-engine-groom-spot", age_seconds=10800)]
-        out, ec2, _ = _run(index_module, spots)
+        out, ec2, _cw, _s3 = _run(index_module, spots)
         assert out["orphans_detected"] == 0
         ec2.terminate_instances.assert_not_called()
 
     def test_orphaned_groom_past_threshold_is_reaped(self, index_module):
         # A groom box that outlived its own 6h watchdog + grace is a genuine orphan.
         spots = [_spot("i-groom", "alpha-engine-groom-spot", age_seconds=THRESHOLD + 600)]
-        out, ec2, cw = _run(index_module, spots)
+        out, ec2, cw, _s3 = _run(index_module, spots)
         assert out["orphans_detected"] == 1
         assert out["terminated"] == ["i-groom"]
         ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-groom"])
         cw.put_metric_data.assert_called_once()
+        # NOT a ci-watch box — the incomplete-reap alert must never fire.
+        assert out["ci_watch_incomplete_reaps"] == []
+        assert index_module._test_send_message.calls == []
 
     def test_no_orphans_when_all_young(self, index_module):
         spots = [
             _spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=600),
             _spot("i-0002", "alpha-engine-data-weekly-20260511", age_seconds=7800),
         ]
-        out, ec2, cw = _run(index_module, spots)
+        out, ec2, cw, _s3 = _run(index_module, spots)
         assert out["scanned"] == 2
         assert out["orphans_detected"] == 0
         assert out["terminated"] == []
@@ -111,13 +165,13 @@ class TestHandler:
 
     def test_boundary_just_under_threshold_is_safe(self, index_module):
         spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD - 60)]
-        out, ec2, _ = _run(index_module, spots)
+        out, ec2, _cw, _s3 = _run(index_module, spots)
         assert out["orphans_detected"] == 0
         ec2.terminate_instances.assert_not_called()
 
     def test_boundary_just_over_threshold_is_reaped(self, index_module):
         spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD + 60)]
-        out, ec2, _ = _run(index_module, spots)
+        out, ec2, _cw, _s3 = _run(index_module, spots)
         assert out["orphans_detected"] == 1
         assert out["terminated"] == ["i-0001"]
 
@@ -125,12 +179,16 @@ class TestHandler:
         monkeypatch.setenv("MAX_SPOT_BUDGET_SECONDS", "21600")
         monkeypatch.setenv("GRACE_SECONDS", "1800")
         monkeypatch.setenv("DRY_RUN", "true")
+        fake_send_message = _FakeSendMessage()
+        tel_mod = types.ModuleType("nousergon_lib.telegram")
+        tel_mod.send_message = fake_send_message
+        sys.modules["nousergon_lib.telegram"] = tel_mod
         if "index" in sys.modules:
             del sys.modules["index"]
         index_module = importlib.import_module("index")
 
         spots = [_spot("i-0001", "alpha-engine-backtest-20260511", age_seconds=THRESHOLD + 600)]
-        out, ec2, _ = _run(index_module, spots)
+        out, ec2, _cw, _s3 = _run(index_module, spots)
         assert out["dry_run"] is True
         assert out["orphans_detected"] == 1
         assert out["terminated"] == []
@@ -148,10 +206,79 @@ class TestHandler:
             {"TerminatingInstances": [{"InstanceId": "i-0002"}]},
         ]
         cw = MagicMock()
+        s3 = MagicMock()
+        clients = {"ec2": ec2, "cloudwatch": cw, "s3": s3}
         with patch.object(index_module.boto3, "client",
-                          side_effect=lambda svc, **kw: ec2 if svc == "ec2" else cw):
+                          side_effect=lambda svc, **kw: clients[svc]):
             out = index_module.handler({}, None)
 
         assert out["orphans_detected"] == 2
         assert out["terminated"] == ["i-0002"]
         assert ec2.terminate_instances.call_count == 2
+
+
+class TestCiWatchIncompleteReapAlert:
+    """ci-watch-dispatcher migration: additive alert scoped to ONLY
+    Name=alpha-engine-ci-watch-spot boxes — every other tag's reap path
+    (covered above) must stay byte-for-byte unaffected."""
+
+    def test_reaped_without_marker_fires_alert(self, index_module):
+        spots = [_spot("i-ciwatch", "alpha-engine-ci-watch-spot", age_seconds=THRESHOLD + 600,
+                       ci_watch_repo="nousergon/alpha-engine-config", ci_watch_sha="abc123def456")]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=False)
+        assert out["terminated"] == ["i-ciwatch"]
+        assert out["ci_watch_incomplete_reaps"] == ["i-ciwatch"]
+        s3.head_object.assert_called_once_with(
+            Bucket="alpha-engine-research",
+            Key="ci_watch/_control/completed/nousergon/alpha-engine-config-abc123def456.json",
+        )
+        assert len(index_module._test_send_message.calls) == 1
+        (text,), kwargs = index_module._test_send_message.calls[0]
+        assert "reaped WITHOUT completing" in text
+        assert "nousergon/alpha-engine-config" in text
+        assert "abc123def456" in text
+        assert kwargs["disable_notification"] is False
+
+    def test_reaped_with_marker_present_does_not_alert(self, index_module):
+        spots = [_spot("i-ciwatch", "alpha-engine-ci-watch-spot", age_seconds=THRESHOLD + 600,
+                       ci_watch_repo="nousergon/alpha-engine-config", ci_watch_sha="abc123def456")]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=True)
+        assert out["terminated"] == ["i-ciwatch"]
+        assert out["ci_watch_incomplete_reaps"] == []
+        assert index_module._test_send_message.calls == []
+
+    def test_s3_error_still_fires_alert_fail_safe_direction(self, index_module):
+        # Any inability to CONFIRM completion (a real 404 OR an unrelated S3
+        # error) must fire the alert — the safer failure direction (an
+        # occasional false-positive beats silently missing a real incomplete
+        # run). Covered here via a generic exception (throttle/auth-shaped).
+        spots = [_spot("i-ciwatch", "alpha-engine-ci-watch-spot", age_seconds=THRESHOLD + 600,
+                       ci_watch_repo="nousergon/alpha-engine-config", ci_watch_sha="abc123def456")]
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value = _describe_instances_paginator(spots)
+        cw = MagicMock()
+        s3 = MagicMock()
+        s3.head_object.side_effect = RuntimeError("S3 throttled")
+        clients = {"ec2": ec2, "cloudwatch": cw, "s3": s3}
+        with patch.object(index_module.boto3, "client",
+                          side_effect=lambda svc, **kw: clients[svc]):
+            out = index_module.handler({}, None)
+        assert out["ci_watch_incomplete_reaps"] == ["i-ciwatch"]
+        assert len(index_module._test_send_message.calls) == 1
+
+    def test_missing_repo_sha_tags_treated_as_incomplete(self, index_module):
+        # A box reaped before its repo/sha tags ever landed (e.g. the
+        # dispatcher's tag-write failed) — cannot look up a marker, so the
+        # safer direction is to alert rather than silently skip.
+        spots = [_spot("i-ciwatch", "alpha-engine-ci-watch-spot", age_seconds=THRESHOLD + 600)]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=True)
+        assert out["ci_watch_incomplete_reaps"] == ["i-ciwatch"]
+        s3.head_object.assert_not_called()  # nothing to look up without repo+sha
+        assert len(index_module._test_send_message.calls) == 1
+
+    def test_other_tags_never_trigger_s3_lookup_or_alert(self, index_module):
+        spots = [_spot("i-groom", "alpha-engine-groom-spot", age_seconds=THRESHOLD + 600)]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=False)
+        assert out["ci_watch_incomplete_reaps"] == []
+        s3.head_object.assert_not_called()
+        assert index_module._test_send_message.calls == []

--- a/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
@@ -230,7 +230,10 @@ class TestCiWatchIncompleteReapAlert:
         assert out["ci_watch_incomplete_reaps"] == ["i-ciwatch"]
         s3.head_object.assert_called_once_with(
             Bucket="alpha-engine-research",
-            Key="ci_watch/_control/completed/nousergon/alpha-engine-config-abc123def456.json",
+            # repo's "/" is flattened to "-" (matches ci_watch_run.sh's own
+            # escaping when it WRITES the marker) — this key must reflect that,
+            # not a literal nested "nousergon/alpha-engine-config-..." path.
+            Key="ci_watch/_control/completed/nousergon-alpha-engine-config-abc123def456.json",
         )
         assert len(index_module._test_send_message.calls) == 1
         (text,), kwargs = index_module._test_send_message.calls[0]


### PR DESCRIPTION
## Summary

Second half of the Fleet CI Watch EC2-spot migration (companion PR: nousergon/alpha-engine-config `feat/ci-watch-ec2-spot-migration`). Restores `ci-main-failure` coverage — currently Saturday-gated since alpha-engine-config-I2004 (2026-07-08, GHA-minutes budget) — by moving execution off GitHub-hosted runners onto EC2 spot, mirroring the already-proven `scheduled-groom-dispatcher` pattern (config#1432) but simplified: no Step Function/EventBridge Scheduler, since CI-watch is invoked once per real CI failure via a **synchronous** `lambda invoke` from a GHA job, not a schedule.

Ruled by Brian 2026-07-10 on alpha-engine-config-I2001 (comment): build the EC2-spot migration, restore `ci-main-failure` only.

## What's new

- `infrastructure/lambdas/ci-watch-dispatcher/` — new Lambda (`index.py`, `iam-policy.json`, `deploy.sh`, `test_handler.py`, `requirements.txt`). Synchronous contract: every anticipated failure (concurrency skip, spot+on-demand exhaustion, malformed event, post-launch SSM failure) returns a clean `{"launched": false, "reason": ...}` rather than raising — the caller is a GHA job that branches directly on the JSON, not EventBridge retry-on-error. Concurrency lock is scoped `(repo, sha)`, narrower than groom's per-tier lock, so two different commits on the same repo failing independently each get their own box.
- `.github/workflows/deploy-ci-watch-dispatcher.yml` — code-only auto-deploy on merge, mirrors `deploy-scheduled-groom-dispatcher.yml`.
- `infrastructure/lambdas/spot-orphan-reaper/` — additive: when the reaper terminates an `alpha-engine-ci-watch-spot`-tagged box past the age ceiling, it now checks for the S3 completion marker `ci_watch_run.sh` (companion PR) writes on every exit path, and fires one extra Telegram line if absent ("reaped without completing — main may still be red"). Every other tag's reap path is unaffected.

## Design notes / deviations caught in review

- Uses a **dedicated** `alpha-engine-ci-watch-executor-role`/`-profile` (already provisioned live) for the spot box — deliberately not the shared `alpha-engine-executor-role` used by the live trading executor, to keep this newer, cross-~10-repo autonomous workload's blast radius contained.
- No Step Function / bounded-relaunch wrapper (unlike groom): CI-watch's natural retry is the next CI failure/rerun re-firing the dispatch, so groom's scheduled-cadence relaunch machinery isn't needed. The reaper alert (above) is the cheap backstop for a silently-dead box instead.
- Caught in cross-repo review after the initial build: the Lambda's SSM prelude was exporting `CI_WATCH_*`-prefixed env vars and exec'ing the sibling bootstrap script with no arguments, but that script actually parses `--ci-repo`/`--ci-sha`/etc. CLI flags — fixed to invoke correctly (see commit `7cc7220`). Also fixed: the reaper's completion-marker S3 key didn't escape the repo name's `/` the way the writer does, which would have 404'd on every single successful run and false-alerted every time (commit `ea4d42c`).
- `nousergon-lib` (via `krepis`) is a genuinely new pip dependency for this Lambda and for the reaper — pulls in a platform-specific compiled wheel, so packaging goes through the existing `lambda_pip_install.sh` (Docker linux/amd64) rather than a bare host `pip install --target`.

## Deployed / provisioned this session (operator step, not GHA-automated — this repo's `github-actions-lambda-deploy` OIDC role deliberately has no `iam:CreateRole`/`iam:PutRolePolicy`, fleet policy after prior IAM-clobber incidents, see `infrastructure/iam/README.md`)

- `alpha-engine-ci-watch-dispatcher-role` + inline policy — live.
- `alpha-engine-ci-watch-dispatcher` Lambda, code deployed, `Active` — live.
- Merging this PR only affects future CODE updates via the new `deploy-ci-watch-dispatcher.yml` (code-only, path-filtered) — the function/role already exist.

## Not yet done — before this is actually load-bearing

- [ ] End-to-end smoke test (`deploy.sh --smoke`) — deliberately NOT run this session since it launches a real spot box + a real autonomous agent run against a live repo. Should be run once, deliberately, after both PRs are reviewed.
- [ ] Diff the SSM-stored `/alpha-engine/saturday_sf_watch/github_pat`'s scopes against the GHA-secret `SATURDAY_SF_WATCH_PAT` used today — don't assume parity (config#1792 precedent: a PAT silently missing `workflow` scope degrades a run to propose-only).
- [ ] Follow-up issue to file at completion: consolidate the near-duplicate tag-lock + spot-launch + post-launch-cleanup logic between this Lambda and `scheduled-groom-dispatcher` into a shared `nousergon-lib` helper (second-adoption signal, deliberately not bundled into this change).

## Test plan

- [x] `test_handler.py` for `ci-watch-dispatcher` (13/13), `spot-orphan-reaper` (14/14 incl. 5 new), `scheduled-groom-dispatcher` (44/44, untouched, proves no regression) — all run individually with the real pinned `nousergon-lib`/`krepis` installed (matches `deploy.sh`'s own preflight, not a bare hermetic stub).
- [x] `deploy.sh --bootstrap` run live this session — role + Lambda created and verified `Active`.
- [ ] Smoke test (see above) — intentionally deferred.

Depends on / companion to: nousergon/alpha-engine-config#TBD (`feat/ci-watch-ec2-spot-migration`) — that PR's `ci_watch_spot_bootstrap.sh`/`scripts/ci_watch_run.sh` are what this Lambda's SSM command actually execs on the box.