### PR TITLE
fix(sf): export AWS_REGION in ChronicGapSelfHeal inline SSM commands

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -206,7 +206,7 @@
     },
     "ChronicGapSelfHeal": {
       "Type": "Task",
-      "Comment": "Best-effort chronic-polygon-gap yfinance self-heal (BF-B/BRK-B/MOG-A/PSTG — polygon doesn't reliably serve them) + polygon-recovery / constituents-drift alarms. SPLIT OUT of MorningEnrich 2026-06-11: inline, an unbounded yf.download hang ran out MorningEnrich's SSM executionTimeout and SIGKILLed the whole command, discarding ~20 min of completed daily_append and failing the weekday pipeline (no predictions that day). Per the standing rule (a best-effort downstream step must never force re-running a completed upstream task — same rule that split MorningEnrich out of DataPhase1), this runs as its OWN FAIL-SOFT state: short executionTimeout, and the Catch + CheckChronicGapStatus Default both route to PredictorInference so a heal failure/hang can never block the trading path. Runs before PredictorInference so the healed chronic rows are fresh for inference; postflight remains the load-bearing freshness gate.",
+      "Comment": "Best-effort chronic-polygon-gap yfinance self-heal (BF-B/BRK-B/MOG-A/PSTG — polygon doesn't reliably serve them) + polygon-recovery / constituents-drift alarms. SPLIT OUT of MorningEnrich 2026-06-11: inline, an unbounded yf.download hang ran out MorningEnrich's SSM executionTimeout and SIGKILLed the whole command, discarding ~20 min of completed daily_append and failing the weekday pipeline (no predictions that day). Per the standing rule (a best-effort downstream step must never force re-running a completed upstream task — same rule that split MorningEnrich out of DataPhase1), this runs as its OWN FAIL-SOFT state: short executionTimeout, and the Catch + CheckChronicGapStatus Default both route to PredictorInference so a heal failure/hang can never block the trading path. Runs before PredictorInference so the healed chronic rows are fresh for inference; postflight remains the load-bearing freshness gate. 2026-07-10: unlike MorningEnrich/MorningArcticAppend, this state was never migrated off ae-trading by the config#1807 spot-decoupling (it was split out earlier, 2026-06-11, as its own inline SSM Task) and never picked up the #247 AWS_REGION re-export fix (2026-05-16) that spot_data_weekly.sh and the data-spot-dispatcher's bootstrap command both carry — weekly_collector.py's DataPreflight hard-requires AWS_REGION via nousergon_lib.preflight.check_env_vars(), and ae-trading's SSM shell has no .env / ~/.aws/config source for it. Because this Task is fail-soft (Catch below), the failure never surfaced as a pipeline break — only as a daily flow-doctor CONFIG alert (nousergon-data#710, #722). Explicit export added below; see tests/test_step_function_chronic_gap_heal_region.py.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -216,6 +216,8 @@
             "set -eo pipefail",
             "export FLOW_DOCTOR_ENABLED=1",
             "export ALPHA_ENGINE_DEPLOYED=1",
+            "export AWS_REGION=us-east-1",
+            "export AWS_DEFAULT_REGION=us-east-1",
             "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
             "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-data",

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -227,6 +227,27 @@ class TestSsmCommandShape:
         assert "export FLOW_DOCTOR_ENABLED=1" in joined
         assert "export ALPHA_ENGINE_DEPLOYED=1" in joined
 
+    def test_heal_exports_aws_region(self, states):
+        # 2026-07-10: ChronicGapSelfHeal is the one on-trading inline-SSM Task
+        # that runs weekly_collector.py directly (not through spot_data_weekly.sh's
+        # ENV_SOURCE or the data-spot-dispatcher's bootstrap command, both of
+        # which already carry the #247 fix). ae-trading's SSM shell has no .env /
+        # ~/.aws/config, so without an explicit export here
+        # nousergon_lib.preflight.check_env_vars("AWS_REGION") hard-fails before
+        # any collection work runs. Because the state is fail-soft (Catch below),
+        # this silently broke the daily heal without failing the pipeline —
+        # surfaced only via daily flow-doctor CONFIG alerts (nousergon-data#710,
+        # #722). Same regression class as test_spot_env_source_aws_region.py.
+        joined = "\n".join(extract_commands(states[_HEAL]))
+        assert "export AWS_REGION=" in joined, (
+            f"{_HEAL} must export AWS_REGION before invoking weekly_collector.py "
+            "— see nousergon-data#710/#722."
+        )
+        assert "export AWS_DEFAULT_REGION=" in joined, (
+            f"{_HEAL} must also export AWS_DEFAULT_REGION for boto3 clients that "
+            "read the default-region var."
+        )
+
     def test_heal_has_bounded_execution_timeout(self, states):
         et = states[_HEAL]["Parameters"]["Parameters"]["executionTimeout"]
         # SSM executionTimeout is a single-element string list.


### PR DESCRIPTION
## Summary
- `ChronicGapSelfHeal` invokes `weekly_collector.py --chronic-gap-heal` directly on ae-trading via inline SSM commands. Unlike `spot_data_weekly.sh` and the data-spot-dispatcher's bootstrap command (both fixed for the same regression in PR #247, 2026-05-16), this state never exported `AWS_REGION`/`AWS_DEFAULT_REGION`.
- Root cause: this state was split out of MorningEnrich on 2026-06-11 as its own inline SF Task, and was never migrated off ae-trading by the config#1807 spot-decoupling (2026-07-06) — MorningEnrich/MorningArcticAppend moved to the ephemeral data-spot dispatcher, which already carries the export; ChronicGapSelfHeal stayed behind and was never audited against the original fix.
- Because the state is fail-soft (`Catch: States.ALL` → proceeds to PredictorInference), this broke the daily chronic-gap self-heal (BF-B/BRK-B/MOG-A/PSTG) silently — the pipeline never failed, it only surfaced as a daily flow-doctor CONFIG alert: closes nousergon-data#710, closes nousergon-data#722.
- Added a regression test (`test_heal_exports_aws_region` in `test_sf_chronic_gap_heal_wiring.py`) asserting the exports stay present, mirroring `test_spot_env_source_aws_region.py`'s pattern for the sibling scripts.

**Already deployed live** (2026-07-10, this session) via `infrastructure/step_function_daily.json`'s own operator-deploy path (`infrastructure/deploy_step_function_daily.sh` → `aws stepfunctions update-state-machine`) — this repo's Step Function definitions aren't wired to CI/CD, so per standing convention the fix was applied in-session rather than left as a manual post-merge step. This PR brings the tracked source back in sync with the live state machine; merging has no further deploy action to take.

## Test plan
- [x] `~/Development/alpha-engine-data/.venv/bin/python3 -m pytest` (using main checkout's venv against the worktree) — 2829 passed, 7 skipped, 0 failed
- [x] `test_sf_chronic_gap_heal_wiring.py` + `test_spot_env_source_aws_region.py` + `test_flow_doctor_wiring.py` — all green
- [x] Live `ne-preopen-trading-pipeline` definition verified to match this PR's `step_function_daily.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)