### PR TITLE
fix(sf-watch): suppress agent dispatch on Friday shell-run preflight failures

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -504,11 +504,27 @@ def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str,
     # auto-dispatches a recovery agent (would waste a cycle and, once weekday/EOD
     # leave propose-only, risk an automated countermand of a human decision).
     operator_abort = _is_operator_abort(detail.get("status", ""), describe_resp)
-    dispatch_suppressed = "operator_abort" if operator_abort else None
+    # is_preflight: the Friday-PM dry pass of ne-weekly-freshness-pipeline
+    # (shell_run=true) is a deliberate rehearsal of Saturday's real run, not a
+    # production failure — a preflight FAILED/TIMED_OUT/ABORTED must never be
+    # indistinguishable from a genuine Saturday failure and summon the full
+    # diagnose-fix-merge-rerun agent against production. Prior to this fix
+    # is_preflight only gated the deterministic fast-path rerun (_maybe_fast_path
+    # reason="preflight"); the agent-dispatch path had no such gate at all, so a
+    # failed Friday shell-run WOULD have fired a genuine saturday-sf-failure
+    # dispatch (found 2026-07-10, before ever firing live).
+    is_preflight = _is_preflight(describe_resp)
+    if operator_abort:
+        dispatch_suppressed = "operator_abort"
+    elif is_preflight:
+        dispatch_suppressed = "preflight"
+    else:
+        dispatch_suppressed = None
     will_dispatch = (
         AGENT_DISPATCH_ENABLED
         and bool(cfg.get("has_listener", True))
         and not operator_abort
+        and not is_preflight
     )
     return {
         "detected_at": now_iso,
@@ -518,7 +534,7 @@ def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str,
         "execution_arn": detail.get("executionArn", ""),
         "failed_state": failed_state,
         "cause": cause or None,
-        "is_preflight": _is_preflight(describe_resp),
+        "is_preflight": is_preflight,
         # `lane` is filled by the dispatched agent (null until it classifies).
         # `action` reflects intent at write time (the log is written just BEFORE
         # the dispatch fires): "dispatch" only when an agent will genuinely be
@@ -528,9 +544,9 @@ def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str,
         "action": "dispatch" if will_dispatch else "observe",
         "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
         "has_listener": bool(cfg.get("has_listener", True)),
-        # config#1827: null unless the dispatch was withheld for a recorded
-        # reason; "operator_abort" makes the human-stop decision auditable in the
-        # watch-log and on the dashboard.
+        # config#1827/preflight: null unless the dispatch was withheld for a
+        # recorded reason; "operator_abort"/"preflight" make the withholding
+        # auditable in the watch-log and on the dashboard.
         "dispatch_suppressed": dispatch_suppressed,
     }
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -545,6 +545,77 @@ def test_programmatic_abort_still_dispatches(monkeypatch):
     assert written["events"][-1]["dispatch_suppressed"] is None
 
 
+# ── preflight dispatch carve-out (found 2026-07-10, before ever firing live) ──
+# The Friday-PM dry pass of ne-weekly-freshness-pipeline (shell_run=true in the
+# execution input) is a deliberate rehearsal, not a production failure. Prior
+# to this fix, is_preflight only suppressed the deterministic fast-path rerun
+# (_maybe_fast_path) — the agent-dispatch path had no equivalent gate, so a
+# FAILED Friday shell-run would fire a genuine saturday-sf-failure
+# repository_dispatch, indistinguishable from a real Saturday production
+# failure, and summon the full diagnose-fix-merge-rerun agent.
+
+
+def test_preflight_suppresses_agent_dispatch(monkeypatch):
+    """A Friday shell-run (preflight) failure must NOT auto-dispatch a recovery
+    agent even when the flag + listener are on — mirrors the operator-abort
+    carve-out (config#1827) exactly, but for a rehearsal run rather than a
+    human stop. Watch-log still written (fail-loud preserved); no Telegram."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    fired = {"called": False}
+
+    def fake_urlopen(req, timeout=None):
+        fired["called"] = True
+        return _FakeResp()
+
+    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
+    describe = {
+        "input": json.dumps({"shell_run": True}),
+        "error": "States.TaskFailed",
+        "cause": "RAGIngestion failed",
+    }
+    factory, _, s3 = _make_clients(describe=describe)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+
+    # Dispatch suppressed — no repository_dispatch HTTP call fired.
+    assert result["agent_dispatch"] == {"dispatched": False, "reason": "preflight"}
+    assert result["action"] == "observe"
+    assert fired["called"] is False
+    # Watch-log STILL written (fail-loud) and carries the auditable reason.
+    s3.put_object.assert_called_once()
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    ev = written["events"][-1]
+    assert ev["is_preflight"] is True
+    assert ev["dispatch_suppressed"] == "preflight"
+    assert ev["action"] == "observe"
+    assert result["telegram_sent"] is False
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_preflight_also_still_gated_from_fast_path(monkeypatch):
+    """Over-suppression is impossible to get backwards here: a preflight FAILED
+    must not fall through to the fast path either (fast path has its own
+    is_preflight check, config#1900) — confirms both recovery layers agree a
+    preflight failure gets NO automated action, only the watch-log record.
+    Uses the weekday pipeline since it's the only one with a `fast_path` scope
+    configured — the is_preflight gate itself is cadence-agnostic."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "FAST_PATH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    describe = {
+        "input": json.dumps({"shell_run": True, "trading_instance_id": ["i-0"]}),
+        "error": "States.TaskFailed",
+        "cause": "transient",
+    }
+    factory, _, s3 = _make_clients(describe=describe)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["fast_path"] == {"fast_path": False, "reason": "preflight"}
+    assert result["agent_dispatch"] == {"dispatched": False, "reason": "preflight"}
+
+
 # ── config#1900: deterministic zero-token fast path ──────────────────────────
 # A weekday failure whose history EXACTLY matches a known-transient signature
 # (data-spot host death / SendCommand invalid-instance) is recovered by a plain


### PR DESCRIPTION
## Summary

`saturday-sf-watch-dispatcher`'s `is_preflight` flag (set when an `ne-weekly-freshness-pipeline` execution's input carries `shell_run: true` — the Friday-PM dry pass of Saturday's real run, kicked off by `eod-success-friday-shell-trigger` once Friday's EOD SF succeeds) only ever gated the deterministic fast-path rerun (`_maybe_fast_path`, config#1900). The agent-dispatch path (`_maybe_dispatch_agent`) had **no equivalent gate** — a FAILED/TIMED_OUT/ABORTED preflight execution would fire a genuine `saturday-sf-failure` `repository_dispatch`, indistinguishable from a real Saturday production failure, and summon the full diagnose→fix→merge→rerun resilience agent against production for what was only a rehearsal run.

Found while auditing Fleet-SF Watch ahead of today's (2026-07-10, Friday) scheduled shell-run — **not yet fired live**; the fix landed before the run completed.

## Fix

Fold `is_preflight` into `dispatch_suppressed` exactly parallel to the existing `operator_abort` carve-out (config#1827) in `_build_event_record`: a preflight failure now sets `dispatch_suppressed="preflight"`, which `_maybe_dispatch_agent` already respects (early-return on any truthy `dispatch_suppressed`), and `_watch_is_acting`/`_notify` already treat as "no automated action, no Telegram" the same way they do for operator aborts. The watch-log artifact still records the event (fail-loud preserved) — only the automated action is withheld.

No other consumer needs a change: `sf-watch-spot-dispatcher` (the EC2-spot launch Lambda) simply never gets invoked for a preflight failure now, since the originating `repository_dispatch` never fires; `sf-telegram-notifier`'s loud failure alert is a fully separate path, unaffected.

## Tests

Added `test_preflight_suppresses_agent_dispatch` (mirrors `test_operator_abort_suppresses_dispatch_but_still_records`) and `test_preflight_also_still_gated_from_fast_path` (confirms both recovery layers agree). Full suite: `42 passed`.

```
cd infrastructure/lambdas/saturday-sf-watch-dispatcher && python3 -m pytest test_handler.py -q
42 passed in 0.12s
```

## Deploy — NOT automatic on merge, needs an explicit operator step

This Lambda is **operator-deployed only by design** (`deploy.sh`'s own header: "Merging the PR has ZERO live effect until an operator runs this... keeps the github-actions-lambda-deploy OIDC role's blast radius narrow"), mirroring `sf-telegram-notifier`/`spot-orphan-reaper`. Merging this PR alone does **not** update the live Lambda code — `bash infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh` (code-update path, no `--bootstrap`) must be run by an operator after merge to actually close the live gap.

**Time-sensitive:** today's Friday shell-run fires sometime after the EOD SF succeeds (~1pm PT). Flagging directly to Brian for an explicit go-ahead on running the deploy today, per standing policy against unilaterally deploying live prod Lambda changes.

## Test plan
- [x] Full `test_handler.py` suite green (42 passed) locally before push
- [ ] CI green on this PR
- [ ] Operator runs `deploy.sh` post-merge (explicit go-ahead required — see above)