### PR TITLE
fix(yfinance-noise): route remaining large-universe collectors through the yf_quiet chokepoint

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -52,6 +52,7 @@ import pandas as pd
 import requests
 
 from nousergon_lib.secrets import get_secret
+from nousergon_lib.yfinance_quiet import log_yf_coverage, yf_quiet
 
 logger = logging.getLogger(__name__)
 
@@ -2166,12 +2167,22 @@ def _fetch_fred_closes(
     return count
 
 
+@yf_quiet
 def _fetch_yfinance_closes(
     tickers: list[str],
     date_str: str,
     records: list[dict],
 ) -> int:
-    """Fetch closes from yfinance for tickers not covered by polygon."""
+    """Fetch closes from yfinance for tickers not covered by polygon.
+
+    Runs under ``yf_quiet`` (nousergon_lib.yfinance_quiet): a delisted/renamed
+    ticker (e.g. JHG, BLD 2026-07-10) makes yfinance log its own per-symbol
+    "possibly delisted" ERROR, which Flow Doctor turns into one report per
+    symbol per worded variant — the same recurring bug class already fixed in
+    ``collectors/prices.py`` (nousergon-data#455) and
+    ``collectors/metron_market_data.py`` (config#1029). The replacement
+    recording surface is the aggregated ``log_yf_coverage`` call below.
+    """
     try:
         import yfinance as yf
     except ImportError:
@@ -2179,6 +2190,7 @@ def _fetch_yfinance_closes(
         return 0
 
     count = 0
+    covered: set[str] = set()
     batches = [tickers[i:i + _YFINANCE_BATCH_SIZE]
                for i in range(0, len(tickers), _YFINANCE_BATCH_SIZE)]
 
@@ -2235,10 +2247,12 @@ def _fetch_yfinance_closes(
                         "source": "yfinance",
                     })
                     count += 1
+                    covered.add(ticker)
                 except Exception as e:
                     logger.warning("yfinance close extract failed for %s: %s", ticker, e)
         except Exception as e:
             logger.warning("yfinance batch failed: %s", e)
 
     logger.info("yfinance fallback: %d/%d tickers captured", count, len(tickers))
+    log_yf_coverage(logger, "daily_closes", tickers, covered)
     return count

--- a/collectors/short_interest.py
+++ b/collectors/short_interest.py
@@ -49,6 +49,8 @@ from datetime import datetime, timezone
 
 import boto3
 
+from nousergon_lib.yfinance_quiet import log_yf_coverage, quiet_yfinance
+
 logger = logging.getLogger(__name__)
 
 
@@ -124,45 +126,58 @@ def collect(
     payload: dict[str, dict] = {}
     ok_count = 0
     err_count = 0
+    covered: set[str] = set()
     started = time.time()
 
-    for i, ticker in enumerate(fetch_list):
-        if i > 0 and inter_request_delay > 0:
-            time.sleep(inter_request_delay)
-        row = {
-            "short_pct_float": None,
-            "short_ratio": None,
-            "shares_short": None,
-        }
-        try:
-            info = yf.Ticker(ticker).info
-            short_pct = info.get("shortPercentOfFloat")
-            short_ratio = info.get("shortRatio")
-            shares_short = info.get("sharesShort")
+    # yfinance logs its own per-symbol ERROR ("possibly delisted", etc.) on a
+    # failed ``Ticker.info`` fetch, independent of this loop's own try/except.
+    # At an expected ~50% ok-ratio across a ~900-ticker universe (see
+    # ``_MIN_OK_RATIO`` docstring above), that is up to ~450 ERROR log lines
+    # per run, each a distinct Flow Doctor report (the same storm bug class
+    # fixed in ``collectors/prices.py`` (nousergon-data#455) and
+    # ``collectors/metron_market_data.py`` (config#1029) — see
+    # ``krepis.yfinance_quiet`` for the full history). ``quiet_yfinance``
+    # demotes those internal records; ``log_yf_coverage`` below is the
+    # replacement aggregated recording surface.
+    with quiet_yfinance():
+        for i, ticker in enumerate(fetch_list):
+            if i > 0 and inter_request_delay > 0:
+                time.sleep(inter_request_delay)
+            row = {
+                "short_pct_float": None,
+                "short_ratio": None,
+                "shares_short": None,
+            }
+            try:
+                info = yf.Ticker(ticker).info
+                short_pct = info.get("shortPercentOfFloat")
+                short_ratio = info.get("shortRatio")
+                shares_short = info.get("sharesShort")
 
-            # yfinance exposes shortPercentOfFloat as a 0-1 ratio; convert
-            # to percent for the executor / scoring layer's threshold semantics.
-            if short_pct is not None:
-                row["short_pct_float"] = round(float(short_pct) * 100, 2)
-            if short_ratio is not None:
-                row["short_ratio"] = round(float(short_ratio), 2)
-            if shares_short is not None:
-                row["shares_short"] = int(shares_short)
+                # yfinance exposes shortPercentOfFloat as a 0-1 ratio; convert
+                # to percent for the executor / scoring layer's threshold semantics.
+                if short_pct is not None:
+                    row["short_pct_float"] = round(float(short_pct) * 100, 2)
+                if short_ratio is not None:
+                    row["short_ratio"] = round(float(short_ratio), 2)
+                if shares_short is not None:
+                    row["shares_short"] = int(shares_short)
 
-            if any(v is not None for v in row.values()):
-                ok_count += 1
-        except Exception as exc:
-            err_count += 1
-            logger.debug("short interest fetch failed for %s: %s", ticker, exc)
+                if any(v is not None for v in row.values()):
+                    ok_count += 1
+                    covered.add(ticker)
+            except Exception as exc:
+                err_count += 1
+                logger.debug("short interest fetch failed for %s: %s", ticker, exc)
 
-        payload[ticker] = row
+            payload[ticker] = row
 
-        if (i + 1) % 100 == 0:
-            elapsed = time.time() - started
-            logger.info(
-                "short interest progress: %d/%d (%d ok, %d err) in %.0fs",
-                i + 1, len(fetch_list), ok_count, err_count, elapsed,
-            )
+            if (i + 1) % 100 == 0:
+                elapsed = time.time() - started
+                logger.info(
+                    "short interest progress: %d/%d (%d ok, %d err) in %.0fs",
+                    i + 1, len(fetch_list), ok_count, err_count, elapsed,
+                )
 
     elapsed = time.time() - started
     ok_ratio = ok_count / max(len(fetch_list), 1)
@@ -170,6 +185,7 @@ def collect(
         "short interest done: %d/%d ok (%.1f%%), %d errors, %.0fs",
         ok_count, len(fetch_list), ok_ratio * 100, err_count, elapsed,
     )
+    log_yf_coverage(logger, "short_interest", fetch_list, covered)
 
     result = {
         "date": run_date,

--- a/collectors/universe_classification.py
+++ b/collectors/universe_classification.py
@@ -63,6 +63,8 @@ from datetime import datetime, timezone
 
 import boto3
 
+from nousergon_lib.yfinance_quiet import log_yf_coverage, quiet_yfinance
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_BUCKET = "alpha-engine-research"
@@ -151,32 +153,42 @@ def collect(
     payload: dict[str, dict] = {}
     ok_count = 0
     err_count = 0
+    covered: set[str] = set()
     started = time.time()
 
-    for i, ticker in enumerate(fetch_list):
-        if i > 0 and inter_request_delay > 0:
-            time.sleep(inter_request_delay)
-        row = {field: None for field in _INFO_FIELDS.values()}
-        try:
-            info = yf.Ticker(ticker).info or {}
-            for info_key, field in _INFO_FIELDS.items():
-                v = info.get(info_key)
-                if v:
-                    row[field] = str(v)
-            if any(v is not None for v in row.values()):
-                ok_count += 1
-        except Exception as exc:
-            err_count += 1
-            logger.debug("classification fetch failed for %s: %s", ticker, exc)
+    # See collectors/short_interest.py for the full rationale: yfinance logs
+    # its own per-symbol ERROR on a failed ``Ticker.info`` fetch regardless of
+    # this loop's own try/except, which storms Flow Doctor across a
+    # ~900-ticker universe (the bug class fixed in ``collectors/prices.py``
+    # (nousergon-data#455) / ``collectors/metron_market_data.py``
+    # (config#1029)). ``quiet_yfinance`` demotes those records;
+    # ``log_yf_coverage`` below is the replacement aggregated surface.
+    with quiet_yfinance():
+        for i, ticker in enumerate(fetch_list):
+            if i > 0 and inter_request_delay > 0:
+                time.sleep(inter_request_delay)
+            row = {field: None for field in _INFO_FIELDS.values()}
+            try:
+                info = yf.Ticker(ticker).info or {}
+                for info_key, field in _INFO_FIELDS.items():
+                    v = info.get(info_key)
+                    if v:
+                        row[field] = str(v)
+                if any(v is not None for v in row.values()):
+                    ok_count += 1
+                    covered.add(ticker)
+            except Exception as exc:
+                err_count += 1
+                logger.debug("classification fetch failed for %s: %s", ticker, exc)
 
-        payload[ticker] = row
+            payload[ticker] = row
 
-        if (i + 1) % 100 == 0:
-            elapsed = time.time() - started
-            logger.info(
-                "universe classification progress: %d/%d (%d ok, %d err) in %.0fs",
-                i + 1, len(fetch_list), ok_count, err_count, elapsed,
-            )
+            if (i + 1) % 100 == 0:
+                elapsed = time.time() - started
+                logger.info(
+                    "universe classification progress: %d/%d (%d ok, %d err) in %.0fs",
+                    i + 1, len(fetch_list), ok_count, err_count, elapsed,
+                )
 
     elapsed = time.time() - started
     ok_ratio = ok_count / max(len(fetch_list), 1)
@@ -184,6 +196,7 @@ def collect(
         "universe classification done: %d/%d ok (%.1f%%), %d errors, %.0fs",
         ok_count, len(fetch_list), ok_ratio * 100, err_count, elapsed,
     )
+    log_yf_coverage(logger, "universe_classification", fetch_list, covered)
 
     artifact = {
         "schema_version": UNIVERSE_CLASSIFICATION_SCHEMA_VERSION,

--- a/data/snapshotter/analyst_daily.py
+++ b/data/snapshotter/analyst_daily.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from typing import Any, Sequence
 
 from nousergon_lib.sources import AnalystSnapshot, AnalystSource
+from nousergon_lib.yfinance_quiet import quiet_yfinance
 
 logger = logging.getLogger(__name__)
 
@@ -177,28 +178,36 @@ def snapshot_universe(
         "n_source_calls_succeeded": 0,
         "n_tickers_with_zero_coverage": 0,
     }
-    for ticker in tickers:
-        snapshots = snapshot_one_ticker(ticker, sources)
-        stats["n_source_calls_attempted"] += len(sources)
-        stats["n_source_calls_succeeded"] += len(snapshots)
-        if not snapshots:
-            stats["n_tickers_with_zero_coverage"] += 1
-        if dry_run:
-            logger.info(
-                "[DRY RUN] would snapshot %s with %d sources",
-                ticker, len(snapshots),
+    # ``quiet_yfinance`` is pure-stdlib and demotes only the "yfinance"
+    # logger, so wrapping here is safe regardless of which adapters are in
+    # ``sources``. Without it, a delisted/unpriceable ticker anywhere in the
+    # universe makes yfinance log its own per-symbol ERROR — the same storm
+    # bug class fixed in ``collectors/prices.py`` (nousergon-data#455) and
+    # ``collectors/metron_market_data.py`` (config#1029); ``stats`` above
+    # (returned to the caller to log) is the aggregated coverage surface.
+    with quiet_yfinance():
+        for ticker in tickers:
+            snapshots = snapshot_one_ticker(ticker, sources)
+            stats["n_source_calls_attempted"] += len(sources)
+            stats["n_source_calls_succeeded"] += len(snapshots)
+            if not snapshots:
+                stats["n_tickers_with_zero_coverage"] += 1
+            if dry_run:
+                logger.info(
+                    "[DRY RUN] would snapshot %s with %d sources",
+                    ticker, len(snapshots),
+                )
+                stats["n_documents_written"] += 1
+                continue
+            write_snapshot_document(
+                ticker=ticker,
+                snapshot_date=snapshot_date,
+                snapshots=snapshots,
+                s3_client=s3_client,
+                bucket=bucket,
+                prefix=prefix,
             )
             stats["n_documents_written"] += 1
-            continue
-        write_snapshot_document(
-            ticker=ticker,
-            snapshot_date=snapshot_date,
-            snapshots=snapshots,
-            s3_client=s3_client,
-            bucket=bucket,
-            prefix=prefix,
-        )
-        stats["n_documents_written"] += 1
     return stats
 
 


### PR DESCRIPTION
## Summary

Root-causes today's `data-collector` Flow Doctor ERROR alerts (JHG, BLD — "possibly delisted; no price data found (period=5d)"). This is the **third recurrence** of a known bug class: yfinance logs its own per-symbol ERROR independent of the caller's own try/except, and Flow Doctor turns each into its own report/email. Previously fixed in `collectors/metron_market_data.py` (config#1029, the PCKM storm) and `collectors/prices.py` (nousergon-data#455, the PCAR recurrence) via the `nousergon_lib.yfinance_quiet` chokepoint (`quiet_yfinance` / `yf_quiet` / `log_yf_coverage`).

**Paging site:** `collectors/daily_closes.py::_fetch_yfinance_closes` (the MorningEnrich daily-closes yfinance fallback) was never converted to the chokepoint.

Audited the rest of the repo for the same unwrapped shape rather than patching only the alerting site — the defect is systemic (any collector iterating a dynamic ticker universe through raw `yf.download`/`yf.Ticker` carries the same storm risk). Converted every other **large/dynamic-universe** consumer found:

- `collectors/daily_closes.py` — `@yf_quiet` + `log_yf_coverage` (the alerting site)
- `collectors/short_interest.py` — full ~900-ticker S&P500+400 universe, ~50% expected ok-ratio by design (`_MIN_OK_RATIO`) — the highest latent-storm risk found in this sweep, up to ~450 distinct ERROR lines per Saturday run
- `collectors/universe_classification.py` — same full-universe shape
- `data/snapshotter/analyst_daily.py` — `quiet_yfinance()` around the per-ticker snapshot loop in `snapshot_universe` (source-agnostic wrap; harmless when yfinance isn't in the adapter list for a given run)

**Deliberately not touched in this PR** (small, fixed, non-delisting-prone ticker lists — real risk assessed as negligible, tracked as a follow-up rather than silently dropped):
- `collectors/macro.py::_fetch_market_prices` (6 futures/ETF tickers: CL=F, GC=F, HG=F, SPY, QQQ, IWM)
- `weekly_collector.py::_self_heal_chronic_polygon_gaps` (4 configured chronic-*polygon-coverage-gap* tickers — actively-traded names with a data-quality quirk, not delisted names)
- `collectors/alternative.py::collect()` (promoted/tracked tickers only, ~25)
- `builders/migrate_universe_crsp_basis.py` (manual one-off migration tool, not in the automated pipeline)

Follow-up: nousergon-data-I(TBD after filing).

## Test plan
- [x] `pytest tests/ -k "short_interest or universe_classification or analyst_daily or analyst_snapshot or daily_closes or flow_doctor_wiring"` — 159 passed
- [x] Full suite: `pytest tests/` — 2833 passed, 7 pre-existing skips, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)