### PR TITLE
fix(groom-dispatcher): grant engagement-scan S3 reads + fail loud on enumeration failure

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -77,6 +77,27 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/claude_code_usage/*"
     },
     {
+      "Sid": "ListGroomRunArtifactsForFreshSkip",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": "groom/*"
+        }
+      }
+    },
+    {
+      "Sid": "ReadGroomRunArtifactsForFreshSkip",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/groom/*"
+    },
+    {
       "Sid": "TelegramSecretsSSM",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -658,6 +658,34 @@ def _write_decision_record(slot_tier: str, decision, counts: dict,
         logger.warning("decision record write failed (non-fatal): %s", exc)
 
 
+def _notify_demand_trigger_failed(exc: Exception, schedule_label: str) -> None:
+    """Loud page for a failed trigger evaluation — never raises (config#2142).
+
+    A demand-all trigger that cannot enumerate (GitHub or the S3 engagement
+    scan down) is skipped fail-closed — meaning NO groom boxes launch for
+    that slot. That must page ops-health, not sit in CloudWatch: the
+    predecessor failure mode (engagement scan AccessDenied logged at WARNING
+    only) ran undetected on 8 consecutive triggers, 2026-07-08 → 07-10.
+    """
+    text = (
+        "🔴 Backlog groom trigger FAILED — demand-all enumeration errored, "
+        f"trigger SKIPPED fail-closed (schedule={schedule_label}). NO groom "
+        f"boxes launched for this slot. Error: {exc}. If this repeats on the "
+        "next trigger, grooms are fully stalled — investigate the dispatcher "
+        "Lambda's GitHub/S3 access (cf. config#2142)."
+    )
+    try:
+        notify_via_flow_doctor(
+            text, silent=False, severity="warning",
+            dedup_key=f"{_FLOW_NAME}:demand_trigger_failed:{schedule_label}",
+            flow_name=_FLOW_NAME, topics=_GROOM_LIFECYCLE_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={"schedule": schedule_label, "error": str(exc)},
+        )
+    except Exception as notify_exc:  # noqa: BLE001 — secondary observability
+        logger.warning("trigger-failed Telegram failed (non-fatal): %s", notify_exc)
+
+
 def _notify_demand_skip(decision, counts: dict, schedule_label: str) -> None:
     """Best-effort ping for a demand-gate skip — never raises."""
     text = (
@@ -707,7 +735,15 @@ def _load_recent_engagements() -> dict:
     """(repo, number) -> engagement horizon epoch from the last
     ``ge.ENGAGEMENT_LOOKBACK_DAYS`` days' S3 run artifacts (same schema the
     driver's config#1893 fresh-skip reads).
-    Fail-safe {} — a read error only means counting a few extra issues.
+
+    RAISES on any read failure (config#2142). This was previously fail-safe
+    ``{}`` ("skip nothing — counting a few extra issues"), which masked a
+    total AccessDenied on the ``groom/{date}/`` engagement scan for every
+    trigger from ship (2026-07-08) to 2026-07-10: fresh-skip enumeration ran
+    with an empty map on 8 consecutive triggers with zero pipeline signal,
+    inflating every advertised per-tier count. The trigger handler's own
+    catch is the recording surface: it skips the trigger (fail-closed, no
+    launch on over-counted queues) AND pages ops-health.
 
     config#2038: the lookback (was a hardcoded ``range(3)``) and the engaged-
     disposition set (was a hardcoded tuple literal) had silently drifted from
@@ -718,27 +754,24 @@ def _load_recent_engagements() -> dict:
     can't re-drift.
     """
     out: dict = {}
-    try:
-        s3 = boto3.client("s3", region_name=REGION)
-        now = datetime.now(ZoneInfo("UTC"))
-        for d in range(ge.ENGAGEMENT_LOOKBACK_DAYS):
-            date = (now - timedelta(days=d)).strftime("%Y-%m-%d")
-            resp = s3.list_objects_v2(Bucket=_RESEARCH_BUCKET, Prefix=f"groom/{date}/")
-            for obj in resp.get("Contents", []) or []:
-                if not obj["Key"].endswith(".json"):
-                    continue
-                art = json.loads(s3.get_object(Bucket=_RESEARCH_BUCKET, Key=obj["Key"])["Body"].read())
-                run_start = art.get("run_start", "")
-                if not run_start:
-                    continue
-                horizon = (datetime.fromisoformat(run_start.replace("Z", "+00:00")).timestamp()
-                           + int(art.get("elapsed_min", 0)) * 60 + ge.FRESH_SKIP_SLACK_SEC)
-                for rec in art.get("issues", []):
-                    if rec.get("disposition") in ge.ENGAGED_DISPOSITIONS:
-                        k = (rec.get("repo", ""), rec.get("number"))
-                        out[k] = max(out.get(k, 0.0), horizon)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("engagement load failed (non-fatal — skip nothing): %s", exc)
+    s3 = boto3.client("s3", region_name=REGION)
+    now = datetime.now(ZoneInfo("UTC"))
+    for d in range(ge.ENGAGEMENT_LOOKBACK_DAYS):
+        date = (now - timedelta(days=d)).strftime("%Y-%m-%d")
+        resp = s3.list_objects_v2(Bucket=_RESEARCH_BUCKET, Prefix=f"groom/{date}/")
+        for obj in resp.get("Contents", []) or []:
+            if not obj["Key"].endswith(".json"):
+                continue
+            art = json.loads(s3.get_object(Bucket=_RESEARCH_BUCKET, Key=obj["Key"])["Body"].read())
+            run_start = art.get("run_start", "")
+            if not run_start:
+                continue
+            horizon = (datetime.fromisoformat(run_start.replace("Z", "+00:00")).timestamp()
+                       + int(art.get("elapsed_min", 0)) * 60 + ge.FRESH_SKIP_SLACK_SEC)
+            for rec in art.get("issues", []):
+                if rec.get("disposition") in ge.ENGAGED_DISPOSITIONS:
+                    k = (rec.get("repo", ""), rec.get("number"))
+                    out[k] = max(out.get(k, 0.0), horizon)
     return out
 
 
@@ -859,8 +892,9 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         try:
             counts, oldest, p0_tiers = _enumerate_tier_stats_fresh(_github_token())
             launches = ge.decide_trigger(counts, oldest, p0_tiers)
-        except Exception as exc:  # noqa: BLE001 — fail-safe: skip this trigger rather than launching with stale (no-fresh-skip) legacy counts
+        except Exception as exc:  # noqa: BLE001 — fail-closed: skip this trigger rather than launching with stale (no-fresh-skip) legacy counts; recorded via ops-health page (config#2142)
             logger.warning("demand trigger unavailable (%s) — skipping trigger (legacy fallthrough retired, fresh-skip-less enumeration over-counts the queue)", exc)
+            _notify_demand_trigger_failed(exc, schedule_label)
             return {"groom": {"launched": False, "reason": "demand_all_failed", "error": str(exc)}}
         if launches is not None:
             _write_trigger_record(schedule_label, launches, counts)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -773,8 +773,13 @@ def test_symmetric_trigger_thin_pool_downgrades_model(monkeypatch):
 
 
 def test_symmetric_trigger_skips_on_enumeration_error(monkeypatch):
-    """demand-all enumeration failure now returns early — no legacy fallthrough."""
+    """demand-all enumeration failure now returns early — no legacy fallthrough.
+
+    config#2142: the skip must also PAGE ops-health (a skipped trigger means
+    NO groom boxes launch for the slot — the predecessor CloudWatch-only
+    warning hid a dead engagement scan for 8 consecutive triggers)."""
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    notifications = _spy_notify(monkeypatch, idx)
     def boom(token):
         raise RuntimeError("github down")
     monkeypatch.setattr(idx, "_github_token", lambda: "tok")
@@ -782,6 +787,24 @@ def test_symmetric_trigger_skips_on_enumeration_error(monkeypatch):
     out = idx.handler(_demand_event(), None)
     assert not out["groom"]["launched"]
     assert out["groom"]["reason"] == "demand_all_failed"
+    assert len(notifications) == 1
+    text, kw = notifications[0]
+    assert "FAILED" in text and "github down" in text
+    assert kw["severity"] == "warning" and kw["silent"] is False
+
+
+def test_load_recent_engagements_raises_on_s3_access_denied(monkeypatch):
+    """config#2142: an engagement-scan read failure must RAISE, never degrade
+    to an empty map. The old fail-safe ``{}`` ("skip nothing") silently
+    disabled fresh-skip on every trigger from ship (2026-07-08) to 2026-07-10
+    when the role lacked ListBucket on groom/{date}/ — the dispatcher
+    advertised pre-skip counts (e.g. high=26) that deflated on-box (10)."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    def denied(Bucket, Prefix):  # noqa: N803 — boto3 kwarg names
+        raise RuntimeError("AccessDenied: s3:ListBucket")
+    monkeypatch.setattr(idx._test_s3, "list_objects_v2", denied)
+    with pytest.raises(RuntimeError, match="AccessDenied"):
+        idx._load_recent_engagements()
 
 
 def test_non_demand_events_keep_legacy_behavior(monkeypatch):

--- a/tests/test_groom_dispatcher_engagement_iam_grants.py
+++ b/tests/test_groom_dispatcher_engagement_iam_grants.py
@@ -1,0 +1,127 @@
+"""
+tests/test_groom_dispatcher_engagement_iam_grants.py — the scheduled-groom-
+dispatcher Lambda's codified IAM policy must cover every S3 surface its
+pre-boot enumeration reads.
+
+Regression target: config#2142 (2026-07-10) — the fresh-skip-aware
+enumeration shipped in the config#2038 arc (`_load_recent_engagements` →
+``list_objects_v2(Prefix="groom/{date}/")`` + ``get_object`` on the run
+artifacts) WITHOUT matching IAM statements. The role's only ``s3:ListBucket``
+grant was condition-scoped to ``claude_code_usage/*`` (the pace gate), so the
+engagement scan hit AccessDenied on every trigger from ship (2026-07-08) to
+2026-07-10 — swallowed by a "non-fatal, skip nothing" fallback, silently
+disabling fresh-skip and inflating every advertised per-tier count.
+
+This is the static policy/code-drift half of the fix (mirrors
+test_groom_sf_iam_lambda_grants.py's role for the groom SF role); the
+runtime half is that `_load_recent_engagements` now RAISES and the trigger
+handler pages ops-health. The policy file is applied idempotently by
+deploy.sh (`aws iam put-role-policy`), so guarding the file guards the role.
+"""
+
+import fnmatch
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_FILE = (REPO_ROOT / "infrastructure" / "lambdas"
+               / "scheduled-groom-dispatcher" / "iam-policy.json")
+
+RESEARCH_BUCKET_ARN = "arn:aws:s3:::alpha-engine-research"
+
+# One representative key per S3 read surface index.py's pre-boot phases touch.
+# Adding a new S3 read to index.py without extending the policy AND this map
+# is exactly the config#2142 gap — keep them in lockstep.
+READ_SURFACES = {
+    # pace gate (_pace_gate_status)
+    "claude_code_usage": "claude_code_usage/groom/2026-07-10.json",
+    # engagement scan (_load_recent_engagements, config#1893/#2038)
+    "groom_run_artifacts": "groom/2026-07-10/abc123.json",
+}
+
+
+def _statements() -> list[dict]:
+    doc = json.loads(POLICY_FILE.read_text())
+    return doc["Statement"]
+
+
+def _actions(stmt: dict) -> set[str]:
+    a = stmt.get("Action", [])
+    return {a} if isinstance(a, str) else set(a)
+
+
+def _resources(stmt: dict) -> list[str]:
+    r = stmt.get("Resource", [])
+    return [r] if isinstance(r, str) else list(r)
+
+
+def _prefix_patterns(stmt: dict) -> list[str]:
+    """s3:prefix patterns from the statement's condition ('' -> unconditioned)."""
+    cond = stmt.get("Condition")
+    if not cond:
+        return ["*"]
+    patterns: list[str] = []
+    for op, kv in cond.items():
+        if not op.startswith(("StringLike", "StringEquals")):
+            continue
+        for key, val in kv.items():
+            if key.lower() == "s3:prefix":
+                patterns.extend([val] if isinstance(val, str) else val)
+    return patterns
+
+
+def _list_bucket_allows_prefix(key: str) -> bool:
+    for stmt in _statements():
+        if stmt.get("Effect") != "Allow" or "s3:ListBucket" not in _actions(stmt):
+            continue
+        if RESEARCH_BUCKET_ARN not in _resources(stmt):
+            continue
+        # ListObjectsV2 sends the *prefix* as the s3:prefix context key — match
+        # the key's prefix chain against the statement's patterns.
+        prefix = key.rsplit("/", 1)[0] + "/"
+        if any(fnmatch.fnmatch(prefix, pat) or fnmatch.fnmatch(key, pat)
+               for pat in _prefix_patterns(stmt)):
+            return True
+    return False
+
+
+def _get_object_allows_key(key: str) -> bool:
+    obj_arn = f"{RESEARCH_BUCKET_ARN}/{key}"
+    for stmt in _statements():
+        if stmt.get("Effect") != "Allow" or "s3:GetObject" not in _actions(stmt):
+            continue
+        if any(fnmatch.fnmatch(obj_arn, res) for res in _resources(stmt)):
+            return True
+    return False
+
+
+def test_every_read_surface_has_list_bucket_grant():
+    missing = {name: key for name, key in READ_SURFACES.items()
+               if not _list_bucket_allows_prefix(key)}
+    assert not missing, (
+        f"iam-policy.json grants no s3:ListBucket covering: {missing} — "
+        "index.py's pre-boot enumeration will AccessDenied at run time "
+        "(config#2142 regression)."
+    )
+
+
+def test_every_read_surface_has_get_object_grant():
+    missing = {name: key for name, key in READ_SURFACES.items()
+               if not _get_object_allows_key(key)}
+    assert not missing, (
+        f"iam-policy.json grants no s3:GetObject covering: {missing} — "
+        "index.py's pre-boot enumeration will AccessDenied at run time "
+        "(config#2142 regression)."
+    )
+
+
+def test_list_bucket_grants_stay_prefix_scoped():
+    """Deliberate ceiling: never widen ListBucket to the whole research
+    bucket unconditioned — grants stay prefix-scoped per read surface."""
+    for stmt in _statements():
+        if "s3:ListBucket" not in _actions(stmt):
+            continue
+        assert _prefix_patterns(stmt) != ["*"], (
+            f"unconditioned s3:ListBucket in statement {stmt.get('Sid')!r} — "
+            "scope it with an s3:prefix condition."
+        )


### PR DESCRIPTION
## Problem

The scheduled-groom-dispatcher's fresh-skip-aware enumeration (config#2038 arc) has been dead since ship: `_load_recent_engagements` failed `AccessDenied` on `s3:ListBucket` at **every trigger 2026-07-08 01:00 UTC → 2026-07-10 19:00 UTC** (8 consecutive), because the role's only ListBucket grant is prefix-scoped to `claude_code_usage/*`. The failure was swallowed (`non-fatal — skip nothing`), so every trigger decision ran with fresh-skip silently disabled — advertised counts like `high=26` deflated to a real on-box queue of 10, making groom coverage look broken when the runs were actually draining their true queues.

Full forensics: alpha-engine-config-I2142.

## Changes

1. **`iam-policy.json`** — two new statements: `s3:ListBucket` with `s3:prefix = groom/*` condition, `s3:GetObject` on `groom/*`. Prefix-scoped per the existing pattern; no unconditioned widening.
2. **`index.py` fail-loud (no-silent-swallows)** — `_load_recent_engagements` now raises; the demand-all handler's existing fail-closed trigger-skip additionally **pages ops-health** (severity=warning, non-silent) via `_notify_demand_trigger_failed`. A skipped trigger = zero groom boxes for the slot; that must page, not sit in CloudWatch.
3. **Regression guards** — `tests/test_groom_dispatcher_engagement_iam_grants.py` keeps the policy in lockstep with every S3 read surface in `index.py` (the exact gap class here and in config#2010); `test_handler.py` gains raise-on-denied + page-on-skip coverage.

## Deploy / IAM state

- **IAM already applied live in-session** (operator `put-role-policy`, per the fleet rule that the deploy GHA is code-only) and verified via `simulate-principal-policy`: ListBucket(prefix `groom/2026-07-10/`) → **allowed**, GetObject(real run-artifact key) → **allowed**, pace-gate prefix still **allowed**. Merge deploys the code change via `deploy-scheduled-groom-dispatcher.yml`.
- **Observation gate (on the issue, not this PR):** next scheduled trigger (01:00 UTC) must show no `engagement load failed` warning and decision counts ≈ on-box `total_issues`.

## Tests

- `test_handler.py`: 45 passed (pinned-dep run mirroring deploy.sh preflight).
- `tests/`: 2836 passed, 7 skipped.

Closes alpha-engine-config-I2142 (native: Closes nousergon/alpha-engine-config#2142)

🤖 Generated with [Claude Code](https://claude.com/claude-code)