### PR TITLE
feat(groom-dispatcher): enumerate-once queue manifests (observer phase)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -133,6 +133,12 @@
       "Effect": "Allow",
       "Action": "s3:PutObject",
       "Resource": "arn:aws:s3:::alpha-engine-research/groom/decisions/*"
+    },
+    {
+      "Sid": "WriteGroomQueueManifests",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/groom/queues/*"
     }
   ]
 }

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -788,14 +788,19 @@ def _load_recent_engagements() -> dict:
     return out
 
 
-def _enumerate_tier_stats_fresh(token: str) -> tuple[dict, dict, list]:
+def _enumerate_tier_stats_fresh(token: str) -> tuple[dict, dict, list, dict]:
     """Tier stats with config#1893 fresh-skip applied (P0 exempt).
 
-    Returns (counts, oldest_wait_hours, p0_tiers) for ge.decide_trigger().
-    """
+    Returns (counts, oldest_wait_hours, p0_tiers, tier_issues) —
+    the first three for ge.decide_trigger(); ``tier_issues`` maps tier →
+    the actual issue dicts behind each count (repo/number/title/labels/
+    updated_at), consumed by ``_write_queue_manifests`` (config#2152: the
+    enumerate-once queue manifest — counts and queue derive from the SAME
+    walk by construction, so they can never diverge)."""
     engagements = _load_recent_engagements()
     counts: dict[str, int] = {t: 0 for t in ge.TIERS}
     oldest: dict[str, float] = {t: 0.0 for t in ge.TIERS}
+    tier_issues: dict[str, list[dict]] = {t: [] for t in ge.TIERS}
     p0_tiers: set = set()
     now = datetime.now(ZoneInfo("UTC"))
     now_epoch = now.timestamp()
@@ -825,13 +830,61 @@ def _enumerate_tier_stats_fresh(token: str) -> tuple[dict, dict, list]:
                 if engaged and not is_p0 and ge.fresh_skip_active(engaged, updated_epoch, now_epoch):
                     continue
                 counts[tier] += 1
+                tier_issues[tier].append({
+                    "repo": repo, "number": it["number"],
+                    "title": it.get("title", ""), "labels": labels,
+                    "updated_at": str(it.get("updated_at", "")),
+                })
                 oldest[tier] = max(oldest[tier], (now_epoch - updated_epoch) / 3600.0)
                 if is_p0:
                     p0_tiers.add(tier)
             if len(batch) < 100:
                 break
             page += 1
-    return counts, oldest, sorted(p0_tiers)
+    return counts, oldest, sorted(p0_tiers), tier_issues
+
+
+def _write_queue_manifests(schedule_label: str, launches: list,
+                           tier_issues: dict) -> dict:
+    """config#2152 (queue manifest, OBSERVER phase): one manifest per launched
+    box at a deterministic key — ``groom/queues/{date}/trigger-{HHMM}-{issue_
+    filter}.json`` — carrying the exact issue list behind the launch decision.
+    The on-box driver discovers its manifest by (date, issue_filter, freshness)
+    and records a parity comparison in its run artifact; it does NOT consume
+    the manifest yet. Cutover (driver enumeration replaced by manifest +
+    revalidation) is gated on ≥3 days of clean parity — see I2152/I2154.
+
+    Best-effort during the observer phase ONLY: a write failure here must not
+    block the launches (the grooms are the primary deliverable), and the
+    failure IS recorded — the driver's parity check reports the missing
+    manifest in its run artifact (``manifest_parity``), which the I2152
+    cutover review reads. At cutover this becomes fail-loud like the trigger
+    record itself.
+
+    Returns {issue_filter: s3_key} for the trigger record / response payload.
+    """
+    now = datetime.now(ZoneInfo("UTC"))
+    keys: dict = {}
+    for d in launches:
+        if not d.launch:
+            continue
+        issues = [it for t in d.tiers for it in tier_issues.get(t, [])]
+        key = f"groom/queues/{now:%Y-%m-%d}/trigger-{now:%H%M}-{d.issue_filter}.json"
+        body = json.dumps({
+            "schema_version": 1, "schedule": schedule_label,
+            "issue_filter": d.issue_filter, "model": d.model,
+            "tiers": list(d.tiers), "decided_at": now.isoformat(),
+            "issue_count": len(issues), "issues": issues,
+        })
+        try:
+            boto3.client("s3", region_name=REGION).put_object(
+                Bucket=_RESEARCH_BUCKET, Key=key, Body=body.encode(),
+                ContentType="application/json")
+            keys[d.issue_filter] = key
+        except Exception as exc:  # noqa: BLE001 — observer phase; recording surface = driver manifest_parity (see docstring)
+            logger.warning("queue manifest write failed for %s (observer phase — "
+                           "driver parity will report it): %s", d.issue_filter, exc)
+    return keys
 
 
 def _write_trigger_record(schedule_label: str, launches: list, counts: dict) -> None:
@@ -938,7 +991,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         # own disjoint PR-sweep partition (config#2129) — no more "only the
         # first box sweeps".
         try:
-            counts, oldest, p0_tiers = _enumerate_tier_stats_fresh(_github_token())
+            counts, oldest, p0_tiers, tier_issues = _enumerate_tier_stats_fresh(_github_token())
             launches = ge.decide_trigger(counts, oldest, p0_tiers)
         except Exception as exc:  # noqa: BLE001 — fail-closed: skip this trigger rather than launching with stale (no-fresh-skip) legacy counts; recorded via ops-health page (config#2142)
             logger.warning("demand trigger unavailable (%s) — skipping trigger (legacy fallthrough retired, fresh-skip-less enumeration over-counts the queue)", exc)
@@ -948,6 +1001,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 return {"decide": {"launches": [], **err}}
             return {"groom": err}
         if launches is not None:
+            manifest_keys = _write_queue_manifests(schedule_label, launches, tier_issues)
             _write_trigger_record(schedule_label, launches, counts)
             entries = []
             for d in launches:
@@ -966,8 +1020,13 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 entries.append(entry)
             decisions_record = [d.as_record() for d in launches]
             if event.get("decide_only"):
+                # config#2152: manifests are written at DECIDE time (above) —
+                # the enumerate-once product of the same walk as the counts —
+                # so the two-phase SF path records them here too.
                 return {"decide": {"trigger": "demand-all", "counts": counts,
-                                   "decisions": decisions_record, "launches": entries}}
+                                   "decisions": decisions_record,
+                                   "queue_manifests": manifest_keys,
+                                   "launches": entries}}
             results = [
                 _launch_groom_spot(
                     run_mode, schedule_label, e["model"], e["issue_filter"], soft_limit_min,
@@ -977,7 +1036,9 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 for e in entries
             ]
             return {"groom": {"trigger": "demand-all", "counts": counts,
-                              "decisions": decisions_record, "launches": results}}
+                              "decisions": decisions_record,
+                              "queue_manifests": manifest_keys,
+                              "launches": results}}
 
     partition_index, partition_count = 0, 1
     if run_mode == "full" and not force_on_demand:

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -142,6 +142,12 @@ class _FakeS3:
     def get_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg names
         return {"Body": _FakeS3Body(self._objects[Key])}
 
+    def put_object(self, Bucket, Key, Body, **kw):  # noqa: N803 — boto3 kwarg names
+        # config#2152: records queue-manifest / trigger-record writes for
+        # assertions; stored alongside the seeded read objects.
+        self._objects[Key] = Body
+        return {}
+
 
 def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None, ssm_parameters=None,
          running_tier_instances=None):
@@ -726,10 +732,18 @@ def test_demand_gate_kill_switch(monkeypatch):
 # ── config#1933 SYMMETRIC triggers (Brian's ratified correction) ─────────────
 
 
-def _stub_fresh_stats(monkeypatch, idx, counts, oldest=None, p0=()):
+def _stub_fresh_stats(monkeypatch, idx, counts, oldest=None, p0=(), tier_issues=None):
+    # config#2152: default tier_issues fabricates N placeholder issues per tier
+    # so the count and the manifest queue stay consistent by construction —
+    # mirroring the real single-walk enumeration.
+    if tier_issues is None:
+        tier_issues = {t: [{"repo": "nousergon/alpha-engine-config", "number": 9000 + i,
+                            "title": f"{t} issue {i}", "labels": [f"complexity:{t}"],
+                            "updated_at": "2026-07-10T00:00:00Z"}
+                           for i in range(n)] for t, n in counts.items()}
     monkeypatch.setattr(idx, "_github_token", lambda: "tok")
     monkeypatch.setattr(idx, "_enumerate_tier_stats_fresh",
-                        lambda token: (counts, oldest or {}, list(p0)))
+                        lambda token: (counts, oldest or {}, list(p0), tier_issues))
     monkeypatch.setattr(idx, "_write_trigger_record", lambda *a, **k: None)
     monkeypatch.setattr(idx, "_notify_demand_skip", lambda *a, **k: None)
 
@@ -1010,3 +1024,49 @@ def test_load_recent_engagements_uses_lib_engaged_dispositions(monkeypatch):
     idx = _load(monkeypatch, s3_objects={key: art})
     engagements = idx._load_recent_engagements()
     assert ("nousergon/alpha-engine-config", 998) in engagements
+
+
+# ── config#2152: queue manifests (observer phase) ───────────────────────────────
+
+
+def test_symmetric_trigger_writes_queue_manifests(monkeypatch):
+    """Every launched box gets a manifest at the deterministic key carrying the
+    exact issue list behind its launch decision — counts and queue derive from
+    the same enumeration walk (config#2152 enumerate-once)."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    _stub_fresh_stats(monkeypatch, idx, {"low": 8, "mid": 9, "high": 10})
+    out = idx.handler(_demand_event("0 1 * * *"), None)
+    manifests = out["groom"]["queue_manifests"]
+    assert set(manifests) == {"low-only", "mid-only", "high-only"}
+    for filt, key in manifests.items():
+        assert key.startswith("groom/queues/") and key.endswith(f"-{filt}.json")
+        doc = json.loads(idx._test_s3._objects[key])
+        assert doc["schema_version"] == 1
+        assert doc["issue_filter"] == filt
+        assert doc["issue_count"] == len(doc["issues"])
+        assert all({"repo", "number", "title", "labels", "updated_at"} <= set(i)
+                   for i in doc["issues"])
+    # per-tier counts flow through to the per-filter manifests
+    assert json.loads(idx._test_s3._objects[manifests["high-only"]])["issue_count"] == 10
+
+
+def test_queue_manifest_write_failure_does_not_block_launch(monkeypatch):
+    """Observer phase: a manifest write failure is logged (driver-side parity
+    reports it) but the boxes still launch — grooms are the primary deliverable."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    _stub_fresh_stats(monkeypatch, idx, {"low": 8, "mid": 9, "high": 10})
+    def boom(**kw):
+        raise RuntimeError("AccessDenied: s3:PutObject")
+    monkeypatch.setattr(idx._test_s3, "put_object", boom)
+    out = idx.handler(_demand_event(), None)
+    assert out["groom"]["queue_manifests"] == {}
+    assert len(out["groom"]["launches"]) == 3
+
+
+def test_skipped_tier_gets_no_manifest(monkeypatch):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    _stub_fresh_stats(monkeypatch, idx, {"low": 2, "mid": 9, "high": 10})
+    out = idx.handler(_demand_event(), None)
+    # low (2 < floor 8) rides upward or skips — only launched filters get manifests
+    launched_filters = {l["issue_filter"] for l in out["groom"]["launches"]}
+    assert set(out["groom"]["queue_manifests"]) == launched_filters

--- a/tests/test_groom_dispatcher_engagement_iam_grants.py
+++ b/tests/test_groom_dispatcher_engagement_iam_grants.py
@@ -125,3 +125,31 @@ def test_list_bucket_grants_stay_prefix_scoped():
             f"unconditioned s3:ListBucket in statement {stmt.get('Sid')!r} — "
             "scope it with an s3:prefix condition."
         )
+
+
+# ── config#2152: write surfaces (queue manifests + decision records) ─────────
+
+WRITE_SURFACES = {
+    "decision_records": "groom/decisions/2026-07-10/trigger-1900.json",
+    "queue_manifests": "groom/queues/2026-07-10/trigger-1900-high-only.json",
+}
+
+
+def _put_object_allows_key(key: str) -> bool:
+    obj_arn = f"{RESEARCH_BUCKET_ARN}/{key}"
+    for stmt in _statements():
+        if stmt.get("Effect") != "Allow" or "s3:PutObject" not in _actions(stmt):
+            continue
+        if any(fnmatch.fnmatch(obj_arn, res) for res in _resources(stmt)):
+            return True
+    return False
+
+
+def test_every_write_surface_has_put_object_grant():
+    missing = {name: key for name, key in WRITE_SURFACES.items()
+               if not _put_object_allows_key(key)}
+    assert not missing, (
+        f"iam-policy.json grants no s3:PutObject covering: {missing} — "
+        "index.py's trigger/manifest writes will AccessDenied at run time "
+        "(config#2142/#2152 gap class)."
+    )


### PR DESCRIPTION
## Part of [EPIC] alpha-engine-config-I2154 Phase 3 head-start — alpha-engine-config-I2152

(Originally stacked on #733; that merged mid-session, so this is now a clean single commit on main.)

The dispatcher's fresh-skip-aware enumeration now captures the per-tier **issue lists** behind its counts (single walk — advertised counts and the queue cannot diverge by construction, killing the #2038/#2142 drift class at the root) and writes one **queue manifest** per launched box at a deterministic key `groom/queues/{date}/trigger-{HHMM}-{issue_filter}.json` (schema_version 1: issue_filter / model / tiers / decided_at / issue_count / issues[repo,number,title,labels,updated_at]).

**Observer phase semantics (deliberate):**
- The driver side (companion commit on alpha-engine-config-PR2158) discovers the manifest by (date, filter, freshness) and records `manifest_parity` in its run artifact — it does NOT consume it yet. No launch-path/env threading in this phase.
- Cutover (driver enumeration → manifest + revalidation, legacy removed) is gated on ≥3 days of clean parity per I2152 — evidence starts accruing on deploy, running concurrently with the 7/17 contract gate.
- Manifest write failure is non-blocking in this phase only (inline-commented; recording surface = driver `manifest_parity`); becomes fail-loud at cutover.

**IAM:** `WriteGroomQueueManifests` (PutObject `groom/queues/*`) — **already applied live** + `simulate-principal-policy` verified `allowed`. Guard test extended with a WRITE_SURFACES lockstep map.

## Tests
- Dispatcher `test_handler.py`: **48 passed** (new: manifests written per launched filter with correct issue lists; write failure never blocks launches; skipped tiers get no manifest).
- Repo suite: **2838 passed, 7 skipped** — re-run after rebasing onto post-#733 main.

Part of alpha-engine-config-I2152 (do not auto-close — cutover remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)