### PR TITLE
fix(sf): normalize $.model_zoo_error on Choice.Default edges before PublishModelZooFailureImmediate

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1983,7 +1983,18 @@
                   "Next": "ParseZooSpecs"
                 }
               ],
-              "Default": "PublishModelZooFailureImmediate"
+              "Default": "ExtractModelZooResolveError"
+            },
+            "ExtractModelZooResolveError": {
+              "Type": "Pass",
+              "Comment": "Normalize ResolveZooSpecs SSM non-Success poll into $.model_zoo_error. Mirrors ExtractPredictorError/ExtractResearchError/ExtractRAGIngestionError — CheckResolveZooStatus.Default does not populate $.model_zoo_error the way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's Message calls States.JsonToString($.model_zoo_error): a direct Choice->Task jump on this edge died with States.Runtime ('$.model_zoo_error could not be found'), masking the real zoo-resolve failure behind an opaque meta-error (observed live 2026-07-10, execution offcycle-shell-20260710-220932; config#2160 arc).",
+              "Parameters": {
+                "phase": "ModelZooResolve",
+                "source": "CheckResolveZooStatus.Default",
+                "poll.$": "$.resolve_zoo_poll"
+              },
+              "ResultPath": "$.model_zoo_error",
+              "Next": "PublishModelZooFailureImmediate"
             },
             "ResolveZooWait": {
               "Type": "Wait",
@@ -2254,7 +2265,18 @@
                   "Next": "BranchBComplete"
                 }
               ],
-              "Default": "PublishModelZooFailureImmediate"
+              "Default": "ExtractModelZooSelectError"
+            },
+            "ExtractModelZooSelectError": {
+              "Type": "Pass",
+              "Comment": "Normalize ModelZooSelect SSM non-Success poll into $.model_zoo_error. Mirrors ExtractPredictorError/ExtractResearchError/ExtractRAGIngestionError — CheckModelZooStatus.Default does not populate $.model_zoo_error the way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's Message calls States.JsonToString($.model_zoo_error): a direct Choice->Task jump on this edge died with States.Runtime ('$.model_zoo_error could not be found'), masking the real zoo-select failure behind an opaque meta-error (observed live 2026-07-10, execution offcycle-shell-20260710-220932; config#2160 arc).",
+              "Parameters": {
+                "phase": "ModelZooSelect",
+                "source": "CheckModelZooStatus.Default",
+                "poll.$": "$.model_zoo_poll"
+              },
+              "ResultPath": "$.model_zoo_error",
+              "Next": "PublishModelZooFailureImmediate"
             },
             "PublishModelZooFailureImmediate": {
               "Type": "Task",

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -83,9 +83,10 @@ _BRANCH_B_STATES = {
     "ExtractPredictorError", "PublishPredictorFailureImmediate",
     # config#1083 parallel model-zoo fan-out: ResolveZooSpecs -> Map -> Select.
     "ResolveZooSpecs", "WaitResolveZoo", "CheckResolveZooStatus",
-    "ResolveZooWait", "ParseZooSpecs", "ModelZooTrainMap", "ModelZooSelect",
+    "ResolveZooWait", "ExtractModelZooResolveError", "ParseZooSpecs",
+    "ModelZooTrainMap", "ModelZooSelect",
     "WaitForModelZoo", "CheckModelZooStatus", "ModelZooWait",
-    "PublishModelZooFailureImmediate",
+    "ExtractModelZooSelectError", "PublishModelZooFailureImmediate",
     "BranchBComplete", "BranchBFailed",
 }
 
@@ -325,7 +326,19 @@ class TestBranchBContents:
         check_resolve = branch_b["CheckResolveZooStatus"]
         rnexts = {c["StringEquals"]: c["Next"] for c in check_resolve["Choices"]}
         assert rnexts["Success"] == "ParseZooSpecs"
-        assert check_resolve["Default"] == "PublishModelZooFailureImmediate"
+        # Default routes through ExtractModelZooResolveError (mirrors
+        # ExtractPredictorError/ExtractResearchError/ExtractRAGIngestionError)
+        # — a Choice.Default transition does not populate $.model_zoo_error the
+        # way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's
+        # Message calls States.JsonToString($.model_zoo_error); a direct
+        # Choice->Task jump on this edge died with States.Runtime, masking the
+        # real zoo-resolve failure (observed live 2026-07-10, config#2160 arc).
+        assert check_resolve["Default"] == "ExtractModelZooResolveError"
+        extract_resolve = branch_b["ExtractModelZooResolveError"]
+        assert extract_resolve["Type"] == "Pass"
+        assert extract_resolve["ResultPath"] == "$.model_zoo_error"
+        assert extract_resolve["Parameters"]["poll.$"] == "$.resolve_zoo_poll"
+        assert extract_resolve["Next"] == "PublishModelZooFailureImmediate"
         # ParseZooSpecs lifts the JSON array into $.parsed_zoo.zoo_specs.
         parse = branch_b["ParseZooSpecs"]
         assert parse["Type"] == "Pass"
@@ -388,7 +401,17 @@ class TestBranchBContents:
         wait = branch_b["WaitForModelZoo"]
         assert all(c["Next"] != "BranchBFailed" for c in wait["Catch"])
         check = branch_b["CheckModelZooStatus"]
-        assert check["Default"] == "PublishModelZooFailureImmediate"
+        # Default routes through ExtractModelZooSelectError — same rationale
+        # as ExtractModelZooResolveError above: CheckModelZooStatus.Default
+        # does not populate $.model_zoo_error, and a direct jump to
+        # PublishModelZooFailureImmediate died with States.Runtime (observed
+        # live 2026-07-10, config#2160 arc).
+        assert check["Default"] == "ExtractModelZooSelectError"
+        extract_select = branch_b["ExtractModelZooSelectError"]
+        assert extract_select["Type"] == "Pass"
+        assert extract_select["ResultPath"] == "$.model_zoo_error"
+        assert extract_select["Parameters"]["poll.$"] == "$.model_zoo_poll"
+        assert extract_select["Next"] == "PublishModelZooFailureImmediate"
         nexts = {c["StringEquals"]: c["Next"] for c in check["Choices"]}
         assert nexts["InProgress"] == "ModelZooWait"
         assert nexts["Pending"] == "ModelZooWait"


### PR DESCRIPTION
## Why

\`CheckResolveZooStatus\` and \`CheckModelZooStatus\` (Choice states inside \`ResearchPredictorParallel\`'s model-zoo fan-out, config#1083) both had \`Default\` routing straight to \`PublishModelZooFailureImmediate\`, whose \`Message\` template calls \`States.JsonToString($.model_zoo_error)\`. A Choice \`Default\` transition does not populate that field the way a Task \`Catch\`'s \`ResultPath\` does, so this edge died with \`States.Runtime\` (\`"$.model_zoo_error could not be found"\`), masking the real underlying model-zoo failure behind an opaque meta-crash instead of the intended best-effort alert-then-continue behavior.

Observed live 2026-07-10 (execution \`offcycle-shell-20260710-220932\`, part of the config#2144/2149/2155/2160/2162 weekly-preflight arc) — the first real exercise of this \`Default\` edge, since every other inbound path to \`PublishModelZooFailureImmediate\` is a Task \`Catch\` that already sets \`$.model_zoo_error\` correctly.

## What

Mirrors the ALREADY-established sibling idiom used by \`ExtractPredictorError\`/\`ExtractResearchError\`/\`ExtractRAGIngestionError\`: inserts \`ExtractModelZooResolveError\` and \`ExtractModelZooSelectError\` Pass states between each Choice's \`Default\` and \`PublishModelZooFailureImmediate\`, each setting \`$.model_zoo_error\` from the actual poll object already available at that point. Audited \`PublishResearchFailureImmediate\`/\`PublishPredictorFailureImmediate\` — both already have this guard on every inbound edge, so this gap was specific to the model-zoo addition, not a fleet-wide pattern.

Updated \`test_sf_research_predictor_parallel_wiring.py\`'s two assertions that had pinned the buggy wiring as expected (\`Default == "PublishModelZooFailureImmediate"\`) to assert the corrected routing, plus positive checks on the new Extract states, and added both new state names to the branch's exhaustive state-name set.

## Verification

- \`aws stepfunctions validate-state-machine-definition\`: OK, no diagnostics
- Full nousergon-data suite: 2848 passed, 7 pre-existing skips, 0 failed

## Deploy note

This repo's \`step_function.json\` is operator-deployed (\`infrastructure/deploy_step_function.sh\`), not GHA-auto-deploy-on-merge. Will run the deploy script in-session immediately after merge so this isn't a dangling manual step.

## Test plan
- [x] Local suite + ASL validation green
- [ ] CI green on this PR
- [ ] Deployed live via deploy_step_function.sh, confirmed via describe-state-machine
- [ ] Next shell-run rehearsal gets past ModelZooRotation without a States.Runtime crash