### PR TITLE
feat(groom): retire GHA groom execution — saturday-sf-success → spot dispatcher; manifest runs spot-first (config-I2175)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/README.md
@@ -1,26 +1,32 @@
 # saturday-sf-success-groom-dispatcher
 
-Runs the daily backlog groom **after a successful Saturday SF**, so the fresh
+Runs the backlog groom **after a successful Saturday SF**, so the fresh
 post-Director backlog (including the Director's just-filed weekly proposals) gets
-groomed immediately rather than waiting for the next scheduled 10pm-PT run.
+groomed immediately rather than waiting for the next scheduled slot.
 
-## How it fits
+## How it fits (config#2175 — GHA groom execution retired)
 
 ```
 ne-weekly-freshness-pipeline  ──SUCCEEDED──▶  EventBridge rule
   (status change event)                         alpha-engine-saturday-succeeded-groom
                                                         │ target
                                                         ▼
-                                          THIS Lambda (repository_dispatch)
-                                                        │ type: saturday-sf-success-groom
+                                          THIS Lambda (async boto3 invoke)
+                                                        │ InvocationType=Event
                                                         ▼
-                            nousergon/alpha-engine-config :: backlog-groom.yml
-                                          (on: repository_dispatch → FULL groom)
+                            alpha-engine-scheduled-groom-dispatcher (sibling dir)
+                              event {"run_mode": "full", "trigger": "demand-all",
+                                     "schedule": "saturday-sf-success"}
+                                                        │
+                                                        ▼
+                              0..3 EC2-spot groom boxes (per-tier demand gates)
 ```
 
-It mirrors the failure-side sibling `saturday-sf-watch-dispatcher` and **reuses the
-same SSM PAT** (`/alpha-engine/saturday_sf_watch/github_pat`) for the
-repository_dispatch — no new credential.
+The demand-all trigger evaluates the fresh post-SF backlog per tier — strictly
+better than the old unconditional single FULL groom this Lambda used to
+`repository_dispatch` to `nousergon/alpha-engine-config :: backlog-groom.yml`
+(workflow DELETED, config#2175). The GitHub PAT read + urllib dispatch machinery
+were removed with it — this Lambda needs **no GitHub credential**.
 
 ## Why this and not an in-SF task
 
@@ -33,8 +39,12 @@ identical to "run the groom once the Saturday SF completes."
 
 - **Fires only on `SUCCEEDED`** (the rule scopes it; the handler re-checks
   defensively so a mis-scoped rule can never fire on a non-success).
-- **Best-effort, non-fatal**: a GitHub/SSM outage logs WARN + is returned in the
-  result, never raises. The scheduled nightly groom is the backstop.
+- **Best-effort, non-fatal**: a Lambda-invoke outage logs WARN + is returned in
+  the result, never raises. The scheduled groom cadence is the backstop.
+- **Downstream gates still apply**: the scheduled dispatcher runs its own
+  pre-boot pace gate + per-tier demand gates on this trigger exactly as on its
+  cron slots — a post-SF trigger against a drained/over-pace backlog launches
+  nothing, by design.
 - **Kill-switch**: set the Lambda env `GROOM_DISPATCH_ENABLED=false` to disable
   without removing the rule.
 
@@ -44,22 +54,17 @@ identical to "run the groom once the Saturday SF completes."
 bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh --bootstrap  # first time: role + lambda + rule
 bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh              # update code only
 bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh --dry-run    # preview
-bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh --smoke      # ⚠ fires a REAL groom run
+bash infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh --smoke      # ⚠ fires a REAL groom trigger
 ```
 
-Merging the PR has **zero live effect** until an operator runs `--bootstrap`.
+Merging the PR has **zero live effect** until an operator runs `deploy.sh` (code)
+and re-applies the IAM policy (the config#2175 reroute swaps the SSM-PAT read for
+`lambda:InvokeFunction` on the scheduled dispatcher):
+
+```bash
+aws iam put-role-policy --role-name alpha-engine-saturday-sf-success-groom-dispatcher-role --policy-name alpha-engine-saturday-sf-success-groom-dispatcher-policy --policy-document file://infrastructure/lambdas/saturday-sf-success-groom-dispatcher/iam-policy.json
+```
+
 `--smoke` invokes the Lambda with a synthetic SUCCEEDED event and (since
-`GROOM_DISPATCH_ENABLED` defaults on) **triggers an actual groom run** — use
-intentionally.
-
-## Prerequisite in alpha-engine-config
-
-`backlog-groom.yml` must listen for the trigger:
-
-```yaml
-on:
-  repository_dispatch:
-    types: [saturday-sf-success-groom]
-```
-
-(added alongside the existing `schedule` + `workflow_dispatch` triggers).
+`GROOM_DISPATCH_ENABLED` defaults on) **triggers an actual demand-all groom
+evaluation** — use intentionally.

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/deploy.sh
@@ -2,10 +2,12 @@
 # deploy.sh — Create or update the alpha-engine-saturday-sf-success-groom-dispatcher
 # Lambda and wire its EventBridge trigger (Saturday SF SUCCEEDED only).
 #
-# On a successful Saturday SF, this Lambda repository_dispatches the backlog
-# groom (nousergon/alpha-engine-config :: backlog-groom.yml, type
-# `saturday-sf-success-groom`) so the fresh post-Director backlog gets groomed
-# immediately. Mirrors the failure-side sibling `saturday-sf-watch-dispatcher`.
+# On a successful Saturday SF, this Lambda async-invokes the sibling
+# `alpha-engine-scheduled-groom-dispatcher` with a demand-all trigger event
+# (config#2175 — GHA groom execution retired; was: repository_dispatch to the
+# deleted backlog-groom.yml workflow) so the fresh post-Director backlog gets
+# groomed immediately on EC2 spot. Mirrors the failure-side sibling
+# `saturday-sf-watch-dispatcher`'s deploy shape.
 #
 # Managed OUTSIDE CloudFormation — same rationale as the watch sibling +
 # sf-telegram-notifier (keeps the github-actions-lambda-deploy OIDC role's blast
@@ -151,7 +153,7 @@ EOF
 run aws events put-rule \
   --name "${RULE_NAME}" \
   --event-pattern "${EVENT_PATTERN}" \
-  --description "Saturday SF SUCCEEDED → backlog groom (repository_dispatch via groom dispatcher)" \
+  --description "Saturday SF SUCCEEDED → backlog groom (async invoke of scheduled-groom-dispatcher, config#2175)" \
   --region "${REGION}" \
   --query 'RuleArn' --output text
 

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/iam-policy.json
@@ -12,10 +12,10 @@
       "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-saturday-sf-success-groom-dispatcher:*"
     },
     {
-      "Sid": "GroomDispatchPAT",
+      "Sid": "InvokeScheduledGroomDispatcher",
       "Effect": "Allow",
-      "Action": ["ssm:GetParameter"],
-      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat"
+      "Action": ["lambda:InvokeFunction"],
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-scheduled-groom-dispatcher"
     }
   ]
 }

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/index.py
@@ -7,23 +7,28 @@ the fresh backlog state (including the Director's just-filed items) gets groomed
 immediately, rather than waiting for the next scheduled 10pm-PT run. Added while
 still building confidence that the daily groom is as thorough as intended.
 
-Wiring mirrors the failure-side sibling `saturday-sf-watch-dispatcher`: a
-dedicated EventBridge rule on the Saturday SF's SUCCEEDED status targets this
-Lambda, which sends a `repository_dispatch` (type `saturday-sf-success-groom`)
-to `nousergon/alpha-engine-config`, where `backlog-groom.yml` listens for it and
-runs a FULL groom. Reuses the same SSM-stored fine-grained PAT
-(`/alpha-engine/saturday_sf_watch/github_pat`) the watch sibling uses for
-repository_dispatch — no new credential.
+Wiring (config#2175 — GHA groom execution retired fleet-wide): a dedicated
+EventBridge rule on the Saturday SF's SUCCEEDED status targets this Lambda,
+which fires an ASYNC (InvocationType=Event) boto3 invoke of
+`alpha-engine-scheduled-groom-dispatcher` carrying a demand-all trigger event —
+the SAME EC2-spot path every scheduled groom already uses. Demand-all evaluates
+the fresh post-SF backlog per tier and launches 0..3 spot boxes, strictly
+better than the old unconditional single FULL GHA run this Lambda used to
+`repository_dispatch` to `backlog-groom.yml` (workflow deleted; the GitHub
+PAT read + urllib dispatch machinery went with it — this Lambda needs no
+GitHub credential at all now).
 
 Best-effort with a recording surface (CLAUDE.md no-silent-fails secondary
-carve-out): a GitHub/SSM outage logs WARN and is returned in the result but does
-NOT raise — triggering the groom is a convenience, NOT the Saturday pipeline's
-deliverable, and the scheduled nightly groom is the backstop. EventBridge's
-delivery retries + the Lambda error metric still record a hard failure.
+carve-out): a Lambda-invoke outage logs WARN and is returned in the result but
+does NOT raise — triggering the groom is a convenience, NOT the Saturday
+pipeline's deliverable, and the scheduled groom cadence is the backstop.
+EventBridge's delivery retries + the Lambda error metric still record a hard
+failure.
 
 Managed OUTSIDE CloudFormation (same rationale as the watch sibling): operator-
 deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live effect until
-bootstrapped.
+bootstrapped (and the reroute needs the iam-policy.json lambda:InvokeFunction
+grant re-applied — see README).
 """
 
 from __future__ import annotations
@@ -31,7 +36,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import urllib.request
 
 import boto3
 
@@ -42,58 +46,45 @@ REGION = os.environ.get("AWS_REGION", "us-east-1")
 # Kill-switch: set GROOM_DISPATCH_ENABLED=false on the Lambda to disable the
 # trigger without removing the EventBridge rule. Default ON (Brian wants it live).
 DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
-DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
-DISPATCH_EVENT_TYPE = os.environ.get("DISPATCH_EVENT_TYPE", "saturday-sf-success-groom")
-GITHUB_PAT_SSM_PARAM = os.environ.get(
-    "GITHUB_PAT_SSM_PARAM", "/alpha-engine/saturday_sf_watch/github_pat"
+# The scheduled-groom-dispatcher Lambda (this repo, sibling dir) — the single
+# fleet chokepoint for launching groom EC2-spot boxes (config#1432/#2175).
+GROOM_DISPATCHER_FUNCTION = os.environ.get(
+    "GROOM_DISPATCHER_FUNCTION", "alpha-engine-scheduled-groom-dispatcher"
 )
-_DISPATCH_TIMEOUT_SEC = 15
+# The demand-all trigger event (config#2175): the dispatcher enumerates the
+# fresh post-SF backlog per tier and launches 0..3 spot boxes — its own pace/
+# demand gates apply, exactly as on the cron-scheduled triggers.
+DISPATCH_EVENT = {
+    "run_mode": "full",
+    "trigger": "demand-all",
+    "schedule": "saturday-sf-success",
+}
 
 
-def _get_github_pat() -> str:
-    """Read the fine-grained PAT (SecureString) from SSM. Never logged."""
-    ssm = boto3.client("ssm", region_name=REGION)
-    resp = ssm.get_parameter(Name=GITHUB_PAT_SSM_PARAM, WithDecryption=True)
-    return resp["Parameter"]["Value"]
-
-
-def _dispatch_groom(execution_name: str, start_date) -> dict:
-    """Fire the repository_dispatch that triggers backlog-groom.yml. Best-effort:
-    records the outcome, never raises (secondary path)."""
+def _dispatch_groom(execution_name: str, start_date) -> dict:  # noqa: ARG001 — kept for handler-contract stability
+    """Async-invoke the scheduled-groom-dispatcher with the demand-all event.
+    Best-effort: records the outcome, never raises (secondary path — the
+    scheduled groom cadence is the backstop; recording surfaces are the WARN
+    log + this returned result)."""
     if not DISPATCH_ENABLED:
         return {"dispatched": False, "reason": "disabled"}
     try:
-        pat = _get_github_pat()
-        payload = {
-            "event_type": DISPATCH_EVENT_TYPE,
-            "client_payload": {
-                "trigger": "saturday-sf-success",
-                "execution_name": execution_name,
-                "start_date": start_date,
-            },
-        }
-        req = urllib.request.Request(
-            f"https://api.github.com/repos/{DISPATCH_REPO}/dispatches",
-            data=json.dumps(payload).encode("utf-8"),
-            method="POST",
-            headers={
-                "Authorization": f"Bearer {pat}",
-                "Accept": "application/vnd.github+json",
-                "Content-Type": "application/json",
-                "User-Agent": "saturday-sf-success-groom-dispatcher",
-            },
+        lam = boto3.client("lambda", region_name=REGION)
+        resp = lam.invoke(
+            FunctionName=GROOM_DISPATCHER_FUNCTION,
+            InvocationType="Event",  # async — never babysit the multi-hour groom
+            Payload=json.dumps(DISPATCH_EVENT).encode("utf-8"),
         )
-        with urllib.request.urlopen(req, timeout=_DISPATCH_TIMEOUT_SEC) as resp:
-            status_code = resp.status
+        status_code = resp["StatusCode"]
         logger.info(
-            "groom repository_dispatch sent to %s (type=%s, http=%s)",
-            DISPATCH_REPO,
-            DISPATCH_EVENT_TYPE,
+            "groom dispatcher invoked async: function=%s status=%s event=%s",
+            GROOM_DISPATCHER_FUNCTION,
             status_code,
+            DISPATCH_EVENT,
         )
         return {"dispatched": True, "status_code": status_code}
-    except Exception as exc:  # noqa: BLE001 — secondary path, recorded not raised
-        logger.warning("groom repository_dispatch failed (non-fatal): %s", exc)
+    except Exception as exc:  # noqa: BLE001 — secondary path, recorded not raised (see docstring)
+        logger.warning("groom dispatcher invoke failed (non-fatal): %s", exc)
         return {"dispatched": False, "error": f"{type(exc).__name__}: {exc}"}
 
 

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/requirements.txt
@@ -1,5 +1,5 @@
 # boto3 is provided by the Lambda python3.12 runtime; pinned here for an
 # explicit, reproducible package build (mirrors the watch-dispatcher sibling).
-# No alpha-engine/nousergon lib dependency — this Lambda only reads one SSM
-# parameter and POSTs a repository_dispatch via urllib.
+# No alpha-engine/nousergon lib dependency — this Lambda only async-invokes the
+# scheduled-groom-dispatcher Lambda via boto3 (config#2175).
 boto3>=1.34.0

--- a/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-success-groom-dispatcher/test_handler.py
@@ -1,9 +1,10 @@
 """Unit tests for the Saturday-SF success → groom dispatcher.
 
-No AWS / GitHub calls — SSM and urllib are monkeypatched. Validates: only
-SUCCEEDED dispatches; the kill-switch short-circuits; a SUCCEEDED event posts the
-correct repository_dispatch to alpha-engine-config; failures are recorded, not
-raised.
+No AWS calls — boto3 is monkeypatched. Validates: only SUCCEEDED dispatches;
+the kill-switch short-circuits; a SUCCEEDED event fires an ASYNC boto3 invoke
+of alpha-engine-scheduled-groom-dispatcher carrying the demand-all trigger
+event (config#2175 — no GitHub repository_dispatch, no PAT read); failures are
+recorded, not raised.
 """
 
 from __future__ import annotations
@@ -43,27 +44,18 @@ def test_disabled_flag_short_circuits(monkeypatch):
     assert out["groom"]["reason"] == "disabled"
 
 
-def test_succeeded_dispatches_correct_repository_dispatch(monkeypatch):
+def test_succeeded_invokes_groom_dispatcher_async(monkeypatch):
     idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
-    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
     captured = {}
 
-    class _Resp:
-        status = 204
+    class _FakeLambda:
+        def invoke(self, **kw):
+            captured.update(kw)
+            return {"StatusCode": 202}
 
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *a):
-            return False
-
-    def _fake_urlopen(req, timeout=0):
-        captured["url"] = req.full_url
-        captured["body"] = json.loads(req.data.decode())
-        captured["auth"] = req.headers.get("Authorization")
-        return _Resp()
-
-    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(
+        idx.boto3, "client", lambda name, **kw: {"lambda": _FakeLambda()}[name]
+    )
     event = {
         "detail": {
             "status": "SUCCEEDED",
@@ -73,21 +65,41 @@ def test_succeeded_dispatches_correct_repository_dispatch(monkeypatch):
     }
     out = idx.handler(event, None)
     assert out["groom"]["dispatched"] is True
-    assert out["groom"]["status_code"] == 204
-    assert captured["url"].endswith("/repos/nousergon/alpha-engine-config/dispatches")
-    assert captured["body"]["event_type"] == "saturday-sf-success-groom"
-    assert captured["body"]["client_payload"]["execution_name"] == "sat-run-1"
-    assert captured["auth"] == "Bearer tok"
+    assert out["groom"]["status_code"] == 202
+    assert captured["FunctionName"] == "alpha-engine-scheduled-groom-dispatcher"
+    # Async — this Lambda must never babysit the multi-hour groom.
+    assert captured["InvocationType"] == "Event"
+    payload = json.loads(captured["Payload"].decode())
+    # The exact config#2175 demand-all trigger event: the dispatcher enumerates
+    # the fresh post-SF backlog per tier (its own pace/demand gates apply).
+    assert payload == {
+        "run_mode": "full",
+        "trigger": "demand-all",
+        "schedule": "saturday-sf-success",
+    }
+
+
+def test_no_github_dispatch_machinery_remains():
+    # config#2175: the GitHub PAT read + urllib repository_dispatch are GONE —
+    # a reintroduction would silently resurrect the retired GHA groom path.
+    src = open(os.path.join(os.path.dirname(__file__), "index.py")).read()
+    assert "import urllib" not in src
+    assert "urlopen" not in src
+    assert "api.github.com" not in src
+    assert "github_pat" not in src.lower()
+    assert "ssm" not in src.lower()
 
 
 def test_dispatch_failure_is_recorded_not_raised(monkeypatch):
     idx = _load(monkeypatch, GROOM_DISPATCH_ENABLED="true")
-    monkeypatch.setattr(idx, "_get_github_pat", lambda: "tok")
 
-    def _boom(req, timeout=0):
-        raise RuntimeError("github down")
+    class _BoomLambda:
+        def invoke(self, **kw):
+            raise RuntimeError("lambda service down")
 
-    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
+    monkeypatch.setattr(
+        idx.boto3, "client", lambda name, **kw: {"lambda": _BoomLambda()}[name]
+    )
     out = idx.handler({"detail": {"status": "SUCCEEDED", "name": "x"}}, None)
     assert out["groom"]["dispatched"] is False
-    assert "github down" in out["groom"]["error"]
+    assert "lambda service down" in out["groom"]["error"]

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -923,6 +923,10 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     `pr_budget` is set only on the Opus high-only schedule (config#1769).
     `force_on_demand` (config#1645) is set only by the dispatch Step Function's
     own relaunch loop on its final bounded retry — no live schedule sets it.
+    `queue_manifest_key` (config#2152/#2175) marks an explicit operator queue
+    (drain runs): it bypasses the demand-count gates — which count GitHub
+    enumeration, meaningless for a manifest — but launches SPOT-FIRST and
+    still honors the pre-boot pace gate (weekly WET protection covers drains).
 
     Pre-boot pace gate (2026-07-04): if weekly Claude usage is running ahead
     of a linear pace through the current reset window, the launch is skipped
@@ -966,6 +970,18 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     # config#2152/#2147: manifest-consumption opt-in (drain runs / post-parity
     # cutover). FAIL LOUD on a malformed key — this string is embedded in the
     # box's root-shell bootstrap command line, so the character set is strict.
+    #
+    # config#2175 (gate/market split): a manifest run BYPASSES the demand-count
+    # gates below — the demand gate counts GitHub enumeration, meaningless for
+    # an explicit operator-built queue — but launches SPOT-FIRST like every
+    # other run (the lib's on-demand capacity fallback still applies).
+    # Previously drain runs had to set force_on_demand:true just to skip the
+    # gate, paying for an on-demand box as a side effect of `force_on_demand`
+    # conflating "skip demand gate" with "force on-demand market";
+    # force_on_demand keeps BOTH meanings for its one remaining caller (the
+    # dispatch SF's final bounded relaunch retry). The pre-boot PACE gate
+    # deliberately still applies to manifest runs — weekly WET protection
+    # covers drains too.
     queue_manifest_key = str(event.get("queue_manifest_key") or "")
     if queue_manifest_key and not re.fullmatch(r"[A-Za-z0-9._/-]{1,512}", queue_manifest_key):
         raise ValueError(f"invalid queue_manifest_key: {queue_manifest_key!r}")
@@ -999,7 +1015,8 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 return {"decide": {"launches": [], **skip}}
             return {"groom": skip}
 
-    if run_mode == "full" and not force_on_demand and str(event.get("trigger", "")) == "demand-all":
+    if (run_mode == "full" and not force_on_demand and not queue_manifest_key
+            and str(event.get("trigger", "")) == "demand-all"):
         # config#1933 SYMMETRIC triggers (Brian's ratified correction): every
         # scheduled trigger evaluates the FULL backlog and launches 0..3 boxes
         # — one per tier clearing the floor, thin tiers attached upward, the
@@ -1057,7 +1074,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                               "launches": results}}
 
     partition_index, partition_count = 0, 1
-    if run_mode == "full" and not force_on_demand:
+    if run_mode == "full" and not force_on_demand and not queue_manifest_key:
         decided = _demand_decision(issue_filter, schedule_label)
         if decided is not None:
             decision, counts = decided

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -1073,11 +1073,14 @@ def test_skipped_tier_gets_no_manifest(monkeypatch):
 
 
 # ── config#2152/#2147: queue_manifest_key passthrough (drain / cutover opt-in) ──
+# config#2175 gate/market split: a manifest run no longer needs (or wants)
+# force_on_demand — the key's presence bypasses the demand-count gates on its
+# own, and the box launches SPOT-FIRST like every other run.
 
 
 def test_manifest_key_reaches_bootstrap_env(monkeypatch):
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
-    out = idx.handler({"run_mode": "full", "schedule": "manual", "force_on_demand": True,
+    out = idx.handler({"run_mode": "full", "schedule": "manual",
                        "model": "claude-haiku-4-5", "issue_filter": "low-only",
                        "queue_manifest_key": "groom/queues/drain/2026-07-10-low.json"}, None)
     assert out["groom"]["launched"]
@@ -1097,6 +1100,85 @@ def test_malformed_manifest_key_fails_loud(monkeypatch):
     """The key lands on a root-shell command line — strict charset, fail loud."""
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     with pytest.raises(ValueError, match="invalid queue_manifest_key"):
-        idx.handler({"run_mode": "full", "schedule": "manual", "force_on_demand": True,
+        idx.handler({"run_mode": "full", "schedule": "manual",
                      "model": "claude-haiku-4-5", "issue_filter": "low-only",
                      "queue_manifest_key": "groom/x; rm -rf /"}, None)
+
+
+# ── config#2175: manifest runs skip demand gates + launch spot-first ─────────
+
+
+def test_manifest_key_skips_single_tier_demand_gate_and_launches_spot(monkeypatch):
+    """A manifest run with NO force_on_demand must (a) never run the demand-
+    count enumeration (the gate counts GitHub, meaningless for an explicit
+    operator queue) and (b) launch SPOT-FIRST — the old behavior forced
+    drains onto on-demand boxes purely to bypass the gate."""
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        return "i-drain"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    enumerated = []
+    monkeypatch.setattr(idx, "_enumerate_tier_stats",
+                        lambda token: enumerated.append(1) or ({}, {}, False))
+    out = idx.handler({"run_mode": "full", "schedule": "manual",
+                       "model": "claude-haiku-4-5", "issue_filter": "low-only",
+                       "queue_manifest_key": "groom/queues/drain/2026-07-10-low.json"}, None)
+    g = out["groom"]
+    assert g["launched"] is True
+    assert g["market"] == "spot"
+    assert seen == [True], "manifest run must try spot first, not force on-demand"
+    assert enumerated == [], "manifest run must never run demand-gate enumeration"
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "export GROOM_QUEUE_MANIFEST_KEY=groom/queues/drain/2026-07-10-low.json" in cmd
+
+
+def test_manifest_key_skips_demand_all_block(monkeypatch):
+    """queue_manifest_key + trigger=demand-all: the explicit queue wins — the
+    demand-all fan-out (which would enumerate GitHub and launch 0..3 boxes on
+    its own manifests) must be bypassed in favor of ONE box on the given key."""
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        return "i-drain"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    monkeypatch.setattr(idx, "_enumerate_tier_stats_fresh",
+                        lambda token: (_ for _ in ()).throw(
+                            AssertionError("manifest run must not enumerate demand-all")))
+    out = idx.handler({"run_mode": "full", "trigger": "demand-all", "schedule": "manual",
+                       "model": "claude-sonnet-5", "issue_filter": "mid-only",
+                       "queue_manifest_key": "groom/queues/drain/2026-07-10-mid.json"}, None)
+    g = out["groom"]
+    assert g["launched"] is True and g["market"] == "spot"
+    assert seen == [True]
+    assert len(idx._test_ssm.sent) == 1  # ONE box, not a demand-all fan-out
+
+
+def test_manifest_key_still_honors_pace_gate(monkeypatch):
+    """Deliberate (config#2175): the weekly WET pace gate applies to drains
+    too — a manifest bypasses the demand-COUNT gates only, never the budget."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"},
+                s3_objects={"claude_code_usage/groom/2026-07-13.json":
+                            _wet_doc(0.5 * 1_140_000_000)})
+    fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
+    monkeypatch.setattr(idx, "datetime", type("D", (), {
+        "now": staticmethod(lambda tz=None: fixed_now)}))
+    out = idx.handler({"run_mode": "full", "schedule": "manual",
+                       "model": "claude-haiku-4-5", "issue_filter": "low-only",
+                       "queue_manifest_key": "groom/queues/drain/2026-07-10-low.json"}, None)
+    assert out["groom"]["launched"] is False
+    assert out["groom"]["reason"] == "pace_gate_skip"
+    assert idx._test_ssm.sent == []
+
+
+def test_scheduled_demand_all_without_manifest_key_still_enumerates(monkeypatch):
+    """Scheduled (non-manifest) triggers are UNAFFECTED by the config#2175
+    split — demand-all still enumerates and fans out per tier."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    _stub_fresh_stats(monkeypatch, idx, {"low": 8, "mid": 9, "high": 10})
+    out = idx.handler(_demand_event(), None)
+    assert len(out["groom"]["launches"]) == 3


### PR DESCRIPTION
Part of **alpha-engine-config-I2175** (epic alpha-engine-config-I2154). Companion config PR (deletes `backlog-groom.yml`, updates the drain-manifest generator's printed commands) depends on **this PR deploying first** — merge this one before the alpha-engine-config PR, since the generator's new printed dispatch commands (no `force_on_demand`) rely on the manifest gate-bypass shipped here.

## saturday-sf-success-groom-dispatcher (deliverable 1)

- Replaces the GitHub `repository_dispatch` (which fired FULL grooms on GHA-hosted runners via the now-deleted `backlog-groom.yml`) with a direct **async boto3 invoke** (`InvocationType='Event'`) of `alpha-engine-scheduled-groom-dispatcher` carrying `{"run_mode": "full", "trigger": "demand-all", "schedule": "saturday-sf-success"}` — demand-all evaluates the fresh post-SF backlog per tier and launches 0..3 spot boxes (strictly better than the old unconditional single GHA run).
- GitHub PAT read + urllib dispatch machinery removed entirely (no GitHub credential needed); best-effort posture kept (invoke failure logs WARN + returns in the result, never raises — scheduled cadence is the backstop, per the module's existing no-silent-fails carve-out).
- `iam-policy.json`: SSM PAT grant dropped, `lambda:InvokeFunction` on the scheduled dispatcher added.
- README / deploy.sh / tests rewired to the new behavior (invoke recorded; regression guard that no GitHub dispatch machinery re-enters).

### ⚠️ Operator step (IAM — NOT applied by merge; deploy.sh only auto-deploys code)

```
aws iam put-role-policy --role-name alpha-engine-saturday-sf-success-groom-dispatcher-role --policy-name alpha-engine-saturday-sf-success-groom-dispatcher-policy --policy-document file://infrastructure/lambdas/saturday-sf-success-groom-dispatcher/iam-policy.json
```

Until applied, the rewired Lambda's invoke fails AccessDenied — recorded (WARN + `dispatched:false` result), never raised; the scheduled groom cadence covers the gap. Tracked on config-I2175 (re-exam 2026-07-12: verify the Saturday SF SUCCESS fires the spot path).

## scheduled-groom-dispatcher (deliverable 2 — gate/market split)

- A run with a non-empty `queue_manifest_key` now **bypasses the single-tier demand gate and the demand-all block** by itself (the gate counts GitHub enumeration — meaningless for an explicit operator manifest) while launching **SPOT-FIRST** (`_launch_instance(force_on_demand=False)` semantics; lib on-demand capacity fallback intact).
- `force_on_demand` keeps BOTH meanings (gate skip + on-demand market) unchanged for its one remaining caller — the dispatch SF's final bounded relaunch retry.
- The pre-boot **pace gate deliberately still applies** to manifest runs (weekly WET protection covers drains too) — covered by a dedicated test.

## Tests

- `saturday-sf-success-groom-dispatcher/test_handler.py`: 5 passed.
- `scheduled-groom-dispatcher/test_handler.py`: 64 passed (5 new: manifest skips single-tier gate + launches spot; manifest skips demand-all block; manifest still honors pace gate; scheduled demand-all unaffected; plus the 3 existing manifest tests updated to the new no-`force_on_demand` canonical form) — run in the deploy.sh-preflight-mirroring pinned env (pytest + krepis + nousergon-lib v0.101.0).
- Repo suite: `pytest tests/ -q` → **2848 passed, 7 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)