### PR TITLE
fix(rag): coerce pgvector Vector→float32 in filing change detection (weekly-freshness 2026-07-11)

### DIFF
--- a/rag/pipelines/filing_change_detection.py
+++ b/rag/pipelines/filing_change_detection.py
@@ -26,6 +26,31 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+def _embedding_to_f32(embedding) -> np.ndarray:
+    """Coerce a pgvector ``vector`` column value to a float32 ndarray.
+
+    ``nousergon_lib.rag.db.get_connection`` registers pgvector's psycopg2
+    codec, whose contract is that ``vector`` columns come back as numpy
+    arrays. Depending on the pgvector/psycopg2 build that resolves on the
+    weekly data spot, that same codec can instead hand back a
+    ``pgvector.Vector`` object — which has NO numpy interop (no
+    ``__array__``/``__len__``/``__iter__``), so ``np.array(v, dtype=...)``
+    falls through to ``float(v)`` and raises
+    ``TypeError: float() argument must be ... not 'Vector'`` (the
+    2026-07-11 weekly-freshness break at Step 8/9, filing change detection).
+
+    Normalize via pgvector's documented ``Vector.to_numpy()`` before the
+    array cast so the "laziness" signal computes identically regardless of
+    which representation the codec returns. This stays FAIL-LOUD: a raw
+    string here means the codec silently failed to register, and
+    ``np.asarray('[...]', dtype=np.float32)`` still raises rather than
+    silently mis-parsing it.
+    """
+    if hasattr(embedding, "to_numpy"):  # pgvector.Vector — not numpy-coercible
+        embedding = embedding.to_numpy()
+    return np.asarray(embedding, dtype=np.float32)
+
+
 def _load_filing_embeddings() -> dict[str, list[dict]]:
     """Load all 10-K and 10-Q filing embeddings grouped by ticker.
 
@@ -59,7 +84,7 @@ def _load_filing_embeddings() -> dict[str, list[dict]]:
                 "sections": defaultdict(list),
             }
         if embedding is not None:
-            vec = np.array(embedding, dtype=np.float32)
+            vec = _embedding_to_f32(embedding)
             grouped[key]["embeddings"].append(vec)
             if section_label:
                 grouped[key]["sections"][section_label].append(vec)

--- a/tests/test_filing_change_detection_pgvector.py
+++ b/tests/test_filing_change_detection_pgvector.py
@@ -1,0 +1,82 @@
+"""Guard: filing change detection tolerates every pgvector column
+representation.
+
+Regression (2026-07-11 weekly-freshness break): the RAG weekly ingestion
+crashed at Step 8/9 (filing change detection) with
+
+    File ".../rag/pipelines/filing_change_detection.py", line 62,
+        in _load_filing_embeddings
+      vec = np.array(embedding, dtype=np.float32)
+    TypeError: float() argument must be a string or a real number, not 'Vector'
+
+``nousergon_lib.rag.db.get_connection`` registers pgvector's psycopg2 codec
+to return numpy arrays, but the pgvector/psycopg2 build resolved on the spot
+handed back a ``pgvector.Vector`` object instead. ``pgvector.Vector`` has no
+numpy interop, so ``np.array(v, dtype=np.float32)`` calls ``float(v)`` and
+detonates. ``_embedding_to_f32`` normalizes both representations via
+pgvector's documented ``.to_numpy()`` while staying fail-loud on a genuinely
+unexpected value.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rag.pipelines.filing_change_detection import _embedding_to_f32
+
+
+class _VectorLike:
+    """Mimics ``pgvector.Vector``: exposes ``.to_numpy()`` and, crucially,
+    NO ``__array__``/``__len__``/``__iter__`` — so a naive
+    ``np.array(obj, dtype=np.float32)`` raises exactly as prod did."""
+
+    def __init__(self, values):
+        self._values = list(values)
+
+    def to_numpy(self):
+        return np.array(self._values, dtype=np.float32)
+
+
+def test_naive_cast_reproduces_the_regression():
+    # Lock the failure mode the fix defends against: a to_numpy-only object
+    # is NOT coercible by np.array directly.
+    with pytest.raises(TypeError):
+        np.array(_VectorLike([1.0, 2.0, 3.0]), dtype=np.float32)
+
+
+def test_vector_like_object_is_coerced():
+    out = _embedding_to_f32(_VectorLike([1.0, 2.0, 3.0]))
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.float32
+    np.testing.assert_array_equal(out, np.array([1, 2, 3], dtype=np.float32))
+
+
+def test_ndarray_passthrough():
+    # The register_vector "happy path" — value already an ndarray (float64).
+    out = _embedding_to_f32(np.array([1.5, 2.5], dtype=np.float64))
+    assert out.dtype == np.float32
+    np.testing.assert_array_equal(out, np.array([1.5, 2.5], dtype=np.float32))
+
+
+def test_list_is_coerced():
+    out = _embedding_to_f32([0.1, 0.2, 0.3])
+    assert out.dtype == np.float32
+    assert out.shape == (3,)
+
+
+def test_raw_string_fails_loud():
+    # A raw string means the codec silently didn't register — must surface,
+    # never be silently re-parsed.
+    with pytest.raises((ValueError, TypeError)):
+        _embedding_to_f32("[1,2,3]")
+
+
+def test_real_pgvector_vector_if_available():
+    # When pgvector is installed (it is in CI via requirements.txt →
+    # nousergon-lib[rag]), lock the exact prod type, not just the stub.
+    pgvector = pytest.importorskip("pgvector")
+    Vector = pgvector.Vector
+    out = _embedding_to_f32(Vector([4.0, 5.0, 6.0]))
+    assert out.dtype == np.float32
+    np.testing.assert_array_equal(out, np.array([4, 5, 6], dtype=np.float32))


### PR DESCRIPTION
## Incident
`ne-weekly-freshness-pipeline` (Saturday) execution failed 2026-07-11. Terminal `FailExecution` was raised by `ResearchPredictorParallel` → **Branch A (RAGIngestion)**. (Branch B / ModelZoo ended OK — its select step is observe-first/non-fatal.) The RAG weekly ingestion died at **Step 8/9: filing change detection**; the spot relaunch-decision was `not-reclaim:other`, i.e. a real error, not a spot interruption.

## Root cause
`rag/pipelines/filing_change_detection.py::_load_filing_embeddings` did:
```python
vec = np.array(embedding, dtype=np.float32)   # embedding = rag.chunks.embedding
```
`nousergon_lib.rag.db.get_connection` registers pgvector's psycopg2 codec whose documented contract is "`vector` columns come back as numpy arrays". On the weekly data spot the resolved pgvector/psycopg2 build handed back a **`pgvector.Vector` object** instead. `pgvector.Vector` has **no numpy interop** (`__array__`/`__len__`/`__iter__` all absent), so numpy falls through to `float(Vector)`:
```
TypeError: float() argument must be a string or a real number, not 'Vector'
```
Confirmed by reproduction: `np.array(pgvector.Vector([1,2,3]), dtype=np.float32)` raises this exact error; `Vector.to_numpy()` is the documented extraction path.

## Fix — SOTA at the correct layer
`filing_change_detection.py:62` is the **only** raw-embedding materialization site in the whole system — retrieval (`nousergon_lib.rag.retrieval`) computes cosine **in-SQL** (`c.embedding <=> %s::vector`) and reads back only scalar similarities, never the raw vector. So the read here is the correct place to normalize the representation.

`_embedding_to_f32` calls pgvector's documented `Vector.to_numpy()` when present, then `np.asarray(..., dtype=np.float32)`; ndarray (the register_vector happy path) and list pass straight through. The change-score / laziness computation is **byte-for-byte identical** — this repairs *deserialization only* (Lane B/C data plumbing). It does not change any score, weight, threshold, or what the signal concludes.

## Fail-loud rationale
The prohibition on quieter failures is honored. A raw **string** reaching this helper would mean the codec silently failed to register — `np.asarray('[...]', dtype=np.float32)` still **raises** rather than silently re-parsing it. No `except`, no swallow, no skip-gate widening. The only behavior change is: a value that pgvector *did* return correctly (as a `Vector`) is now consumed correctly.

## Guard covering this failure class
`tests/test_filing_change_detection_pgvector.py`:
- `test_naive_cast_reproduces_the_regression` — locks that a `to_numpy`-only object detonates a naive `np.array(..., float32)` (the exact prod failure mode).
- coercion correct for **real `pgvector.Vector`** (installed in CI via `requirements.txt` → `nousergon-lib[rag]`), a stub Vector, ndarray, and list.
- `test_raw_string_fails_loud` — asserts a raw string still raises (registration-failure must surface).

Local: 6/6 pass. `py_compile` clean. Ruff is not a CI gate here; no new ruff findings introduced.

## Residual gap (tracked separately)
This normalizes the single current consumer. The broader class — the db.py codec's "returns ndarray" guarantee is representation-fragile — is being lifted to the `nousergon_lib.rag` chokepoint under a follow-up issue so future consumers can't reintroduce the naive cast.