### PR TITLE
chore(groom-dispatcher): bump nousergon-lib pin to v0.104.0

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -5,10 +5,12 @@ boto3>=1.34.0
 # directly through v0.97.0). v0.101.0 is the first version carrying
 # SlotDecision.partition_index/partition_count (config#2129) — this Lambda's
 # decide_only/launch_decided operations read those fields off ge.decide_
-# trigger()'s output and WILL AttributeError against v0.100.0. MERGE ORDER:
-# nousergon-lib-PR179 must merge (and auto-tag v0.101.0 via .github/workflows/
-# auto-tag.yml) BEFORE this PR merges — this pin bump is what makes that
-# ordering an explicit, CI-enforced gate rather than a silent runtime crash
-# on the next demand-all trigger.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.101.0
+# trigger()'s output and WILL AttributeError against v0.100.0.
+# v0.104.0 (config#2146 / alpha-engine-config-I2230, 2026-07-11) adds
+# groom:stalled/triage:session to BASE_EXCLUDE_LABELS — keeps this Lambda's
+# pre-boot per-tier actionable-issue count in parity with groom_driver.py's
+# own (already-fixed) mirrored copy, which is what actually governs on-box
+# enumeration. Mechanical pin-only bump — no behavior change on this Lambda's
+# own code.
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.104.0
 krepis>=0.10.2


### PR DESCRIPTION
## Summary
- Mechanical pin-only bump, `v0.101.0` → `v0.104.0`, in `scheduled-groom-dispatcher/requirements.txt`. No code change on this Lambda.
- Picks up `groom_eligibility.BASE_EXCLUDE_LABELS`'s new `groom:stalled`/`triage:session` exclusion (`nousergon-lib-PR182`, merged+published) — keeps this dispatcher's pre-boot per-tier actionable-issue count in parity with `groom_driver.py`'s own mirrored copy (`alpha-engine-config-PR2229`, already merged and live), the invariant the two-consumer contract test enforces.
- Closes `alpha-engine-config-I2230`.

## Test plan
- [x] Tag exists and is installable: `v0.104.0` confirmed live on PyPI/GitHub after `nousergon-lib-PR182` merged
- CI: `ci.yml` install/smoke coverage for this Lambda

Eligible for the standing mechanical-pin-bump self-merge exception (CI green, no other changes riding along) once checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)