### PR TITLE
sf-watch dispatcher: defer-not-drop on concurrent skip + deferred re-evaluation + watch_log_key fallback

### DIFF
--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -19,6 +19,13 @@
 # ssm:SendCommand. The BOX reads its own run secrets (PAT) via ITS instance
 # profile, so this Lambda needs no secret access of its own.
 #
+# DEFER-NOT-DROP (config#2226): the Lambda additionally needs
+# scheduler:CreateSchedule/GetSchedule (scoped to schedule/default/
+# sf-watch-defer-*), iam:PassRole on alpha-engine-sf-watch-defer-scheduler-
+# role (the role EventBridge Scheduler assumes to re-invoke this Lambda —
+# created below in --bootstrap), and states:ListExecutions on the three ne-*
+# pipeline state machines for the deferred-invocation re-evaluation.
+#
 # Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
 # keeps the github-actions-lambda-deploy OIDC role's blast radius narrow — it
 # deliberately lacks iam:CreateRole/iam:PutRolePolicy (fleet-wide policy after
@@ -39,8 +46,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-sf-watch-spot-dispatcher"
 ROLE_NAME="alpha-engine-sf-watch-spot-dispatcher-role"
 POLICY_NAME="alpha-engine-sf-watch-spot-dispatcher-policy"
+# Role EventBridge Scheduler assumes to fire the one-shot defer-not-drop
+# re-invokes of this Lambda (config#2226). Created in --bootstrap only.
+DEFER_ROLE_NAME="alpha-engine-sf-watch-defer-scheduler-role"
+DEFER_POLICY_NAME="alpha-engine-sf-watch-defer-scheduler-policy"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+DEFER_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${DEFER_ROLE_NAME}"
+LAMBDA_ENV="Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=true,SF_WATCH_DEFER_ROLE_ARN=${DEFER_ROLE_ARN}}"
 
 DRY_RUN=false
 BOOTSTRAP=false
@@ -127,6 +140,33 @@ if $BOOTSTRAP; then
     --policy-name "${POLICY_NAME}" \
     --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
 
+  # --- 2a2. EventBridge Scheduler invoke role (defer-not-drop, config#2226) ---
+  # Assumed by scheduler.amazonaws.com to fire the one-shot deferred
+  # re-invokes; may ONLY invoke THIS function.
+  DEFER_TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${DEFER_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${DEFER_ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${DEFER_ROLE_NAME}" \
+      --assume-role-policy-document "${DEFER_TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${DEFER_ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${DEFER_POLICY_NAME}"
+  # Both the unqualified function ARN and :* (version/alias-qualified) — the
+  # schedule targets the unqualified ARN, but keep qualified invokes working
+  # if an alias is ever introduced.
+  DEFER_INVOKE_POLICY=$(cat <<EOF
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"lambda:InvokeFunction","Resource":["arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}","arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}:*"]}]}
+EOF
+)
+  run aws iam put-role-policy \
+    --role-name "${DEFER_ROLE_NAME}" \
+    --policy-name "${DEFER_POLICY_NAME}" \
+    --policy-document "${DEFER_INVOKE_POLICY}"
+
   if ! $DRY_RUN; then
     echo "  Waiting 10s for IAM role propagation..."
     sleep 10
@@ -144,7 +184,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 300 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=true}' \
+      --environment "${LAMBDA_ENV}" \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -172,7 +212,7 @@ echo "✓ Code deployed."
 echo "Updating Lambda environment..."
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment 'Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=true}' \
+  --environment "${LAMBDA_ENV}" \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
@@ -54,6 +54,36 @@
           "ec2:ResourceTag/Name": "alpha-engine-sf-watch-spot"
         }
       }
+    },
+    {
+      "Sid": "DeferNotDropOneShotSchedules",
+      "Effect": "Allow",
+      "Action": [
+        "scheduler:CreateSchedule",
+        "scheduler:GetSchedule"
+      ],
+      "Resource": "arn:aws:scheduler:*:*:schedule/default/sf-watch-defer-*"
+    },
+    {
+      "Sid": "PassDeferSchedulerRoleToScheduler",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-sf-watch-defer-scheduler-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "scheduler.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "DeferReevaluationListExecutions",
+      "Effect": "Allow",
+      "Action": "states:ListExecutions",
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
+      ]
     }
   ]
 }

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -35,6 +35,20 @@ own use of its full (repo, sha) key, not a partial one): two different
 run_dates failing independently for the same pipeline+cadence must each get
 their own box. Fail-safe OPEN on any API error.
 
+DEFER, NOT DROP (config#2226): when the lock finds a live box for the SAME
+key, the second failure is NOT dropped — the live box has no obligation to
+notice it (2026-07-11: a concurrent_skip left ne-weekly-freshness-pipeline
+FAILED with zero watch coverage). Instead the dispatcher creates a ONE-SHOT
+EventBridge Scheduler schedule (`ActionAfterCompletion=DELETE`) that
+re-invokes this same Lambda ~10 minutes later with the original payload plus
+`defer_generation` (capped at 3 — exhaustion returns `defer_exhausted`,
+which the GHA caller treats as launched!=true and files a P1). A deferred
+invocation (`defer_generation` >= 1) first RE-EVALUATES via
+`states:ListExecutions`: if the newest execution is RUNNING/SUCCEEDED the
+live box (or an operator) recovered the pipeline → `recovered`, no launch;
+if it is FAILED/TIMED_OUT/ABORTED the dispatch proceeds against that NEWEST
+failed execution's ARN (the original one may be stale by then).
+
 CAUSE FIELD IS BASE64: `cause` (the SF failure detail) is arbitrary AWS-
 supplied text, unlike every other event field here — it is NOT regex-
 validated and is base64-encoded before being embedded in the constructed SSM
@@ -56,11 +70,14 @@ has ZERO live effect until the new code + IAM are deployed AND
 from __future__ import annotations
 
 import base64
+import hashlib
+import json
 import logging
 import os
 import re
 import time
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import boto3
 from nousergon_lib import spot_dispatch
@@ -125,6 +142,36 @@ SF_WATCH_CONFIG_BRANCH = os.environ.get("SF_WATCH_CONFIG_BRANCH", "main")
 MAX_RUNTIME_SECONDS = int(os.environ.get("SF_WATCH_MAX_RUNTIME_SECONDS", "19200"))
 SSM_ONLINE_BUDGET_SEC = int(os.environ.get("SF_WATCH_SSM_ONLINE_BUDGET_SEC", "180"))
 CW_LOG_GROUP = os.environ.get("SF_WATCH_CW_LOG_GROUP", "/alpha-engine/sf-watch-spot")
+
+# ── Defer-not-drop config (config#2226) ──────────────────────────────────────
+# How far out the one-shot re-invoke schedule fires, and the generation cap
+# beyond which we stop deferring and fail LOUD (`defer_exhausted` — the GHA
+# caller files a P1 on any unexpected launched!=true reason).
+DEFER_DELAY_SECONDS = int(os.environ.get("SF_WATCH_DEFER_DELAY_SECONDS", "600"))
+DEFER_MAX_GENERATION = int(os.environ.get("SF_WATCH_DEFER_MAX_GENERATION", "3"))
+# Role EventBridge Scheduler assumes to invoke this Lambda. Set by deploy.sh
+# --bootstrap; when unset, constructed at call time from the account id parsed
+# out of context.invoked_function_arn (see _defer_relaunch).
+DEFER_ROLE_ARN = os.environ.get("SF_WATCH_DEFER_ROLE_ARN", "")
+DEFER_ROLE_NAME = "alpha-engine-sf-watch-defer-scheduler-role"
+DEFER_SCHEDULE_GROUP = os.environ.get("SF_WATCH_DEFER_SCHEDULE_GROUP", "default")
+
+# Operator-refire fallback (config#2226): the canonical watch_log_key is
+# minted ONLY by saturday-sf-watch-dispatcher's `_artifact_key(watch_prefix,
+# run_date)`. When an operator re-fires this Lambda by hand with an EMPTY
+# watch_log_key, synthesize `{prefix}/{run_date}.json` from this mirror of
+# that dispatcher's PIPELINES watch_prefix column. LOCKSTEP-GUARDED:
+# tests/test_sf_watch_defer_prefix_lockstep.py fails CI if this dict drifts
+# from saturday-sf-watch-dispatcher/index.py's PIPELINES.
+_WATCH_PREFIXES = {
+    "ne-weekly-freshness-pipeline": "consolidated/saturday_sf_watch",
+    "ne-preopen-trading-pipeline": "consolidated/weekday_sf_watch",
+    "ne-postclose-trading-pipeline": "consolidated/eod_sf_watch",
+    # TRANSITIONAL old EOD SF name — mirrors the same entry in
+    # saturday-sf-watch-dispatcher's PIPELINES (remove together at the
+    # config#1408 SF-rename cutover; the lockstep test enforces "together").
+    "alpha-engine-eod-pipeline": "consolidated/eod_sf_watch",
+}
 
 # Defense-in-depth allowlists for event fields embedded verbatim into the SSM
 # shell command below (mirrors ci-watch-dispatcher's _REPO_RE/_SHA_RE/etc).
@@ -295,7 +342,219 @@ def _terminate_instance(instance_id: str) -> None:
     spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="sf-watch")
 
 
-def _launch_sf_watch_spot(fields: dict) -> dict:
+def _defer_schedule_name(
+    cadence_slug: str, pipeline_name: str, run_date: str, generation: int
+) -> str:
+    """Deterministic one-shot schedule name for (key, generation) — the
+    determinism IS the idempotency lock: a duplicate defer attempt for the
+    same key+generation hits ConflictException and is treated as
+    already-deferred. EventBridge Scheduler caps Name at 64 chars; the
+    readable form overflows for ne-weekly-freshness-pipeline (66 chars), so
+    anything over the cap degrades to an equally-deterministic sha256 digest
+    of the key. BOTH forms keep the `sf-watch-defer-` prefix the IAM policy
+    scopes on (`schedule/default/sf-watch-defer-*`)."""
+    name = f"sf-watch-defer-{cadence_slug}-{pipeline_name}-{run_date}-g{generation}"
+    if len(name) <= 64:
+        return name
+    digest = hashlib.sha256(
+        f"{cadence_slug}|{pipeline_name}|{run_date}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"sf-watch-defer-{digest}-g{generation}"
+
+
+def _is_scheduler_conflict(exc: Exception) -> bool:
+    """True when the Scheduler API says the schedule already exists — matched
+    by exception class name AND botocore error code (covers both the real
+    boto3 ConflictException class and a generic ClientError carrying it)."""
+    if type(exc).__name__ == "ConflictException":
+        return True
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        return response.get("Error", {}).get("Code") == "ConflictException"
+    return False
+
+
+def _defer_relaunch(fields: dict, generation: int, context, existing: list[str]) -> dict:
+    """A live box holds the (cadence, pipeline, run_date) lock — DEFER this
+    dispatch instead of dropping it (config#2226): schedule a one-shot
+    EventBridge Scheduler re-invoke of this same Lambda in
+    DEFER_DELAY_SECONDS carrying the original payload + defer_generation.
+    Every failure mode returns a clean launched:false (synchronous contract),
+    but exhaustion and scheduling failures log ERROR so the drop is LOUD."""
+    if generation >= DEFER_MAX_GENERATION:
+        logger.error(
+            "sf-watch defer EXHAUSTED at generation %d for %s/%s@%s — a live box "
+            "(%s) still holds the lock and this failure will NOT be retried; the "
+            "synchronous caller must escalate (P1)",
+            generation, fields["cadence_slug"], fields["pipeline_name"],
+            fields["run_date"], existing,
+        )
+        return {"launched": False, "reason": "defer_exhausted",
+                "defer_generation": generation, "existing_instance_ids": existing}
+
+    next_generation = generation + 1
+    schedule_name = _defer_schedule_name(
+        fields["cadence_slug"], fields["pipeline_name"], fields["run_date"], next_generation
+    )
+
+    function_arn = str(getattr(context, "invoked_function_arn", "") or "")
+    if not function_arn:
+        logger.error(
+            "sf-watch defer FAILED for %s/%s@%s: no invoked_function_arn on the "
+            "Lambda context — cannot self-target the deferred re-invoke",
+            fields["cadence_slug"], fields["pipeline_name"], fields["run_date"],
+        )
+        return {"launched": False, "reason": "defer_schedule_failed",
+                "error": "no invoked_function_arn on context"}
+    # arn:aws:lambda:region:acct:function:name[:qualifier] — target the
+    # UNQUALIFIED function so the deferred invoke always runs the live code.
+    target_arn = ":".join(function_arn.split(":")[:7])
+    role_arn = DEFER_ROLE_ARN or (
+        f"arn:aws:iam::{function_arn.split(':')[4]}:role/{DEFER_ROLE_NAME}"
+    )
+
+    payload = {k: fields[k] for k in (
+        "pipeline_name", "cadence_slug", "run_date", "execution_arn",
+        "state_machine_arn", "failed_state", "watch_log_key", "is_preflight",
+        "cause",
+    )}
+    payload["defer_generation"] = next_generation
+    fire_at = datetime.now(timezone.utc) + timedelta(seconds=DEFER_DELAY_SECONDS)
+
+    try:
+        boto3.client("scheduler", region_name=REGION).create_schedule(
+            Name=schedule_name,
+            GroupName=DEFER_SCHEDULE_GROUP,
+            # at() with no ScheduleExpressionTimezone is UTC — matches fire_at.
+            ScheduleExpression=f"at({fire_at.strftime('%Y-%m-%dT%H:%M:%S')})",
+            FlexibleTimeWindow={"Mode": "OFF"},
+            ActionAfterCompletion="DELETE",  # one-shot: self-deletes after firing
+            Description=(
+                f"sf-watch defer-not-drop re-invoke (config#2226): "
+                f"{fields['cadence_slug']}/{fields['pipeline_name']}@"
+                f"{fields['run_date']} generation {next_generation}"
+            ),
+            Target={
+                "Arn": target_arn,
+                "RoleArn": role_arn,
+                "Input": json.dumps(payload),
+                # Bounded retry: the re-invoke is a re-CHECK, not the repair
+                # itself — a next-generation defer covers a missed window.
+                "RetryPolicy": {
+                    "MaximumRetryAttempts": 3,
+                    "MaximumEventAgeInSeconds": 3600,
+                },
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — synchronous contract: clean JSON verdict, never raise
+        if _is_scheduler_conflict(exc):
+            # Already-deferred swallow: a duplicate defer attempt for the same
+            # (key, generation) — the earlier schedule already covers this
+            # failure; recorded via this INFO log + the returned verdict.
+            logger.info(
+                "sf-watch defer schedule %s already exists — treating as "
+                "already-deferred", schedule_name,
+            )
+            return {"launched": False, "reason": "deferred",
+                    "defer_generation": next_generation,
+                    "schedule_name": schedule_name, "already_scheduled": True}
+        logger.error(
+            "sf-watch defer schedule creation FAILED for %s (%s: %s) — this "
+            "failure will NOT be retried; the synchronous caller must escalate",
+            schedule_name, type(exc).__name__, exc,
+        )
+        return {"launched": False, "reason": "defer_schedule_failed",
+                "error": f"{type(exc).__name__}: {exc}"}
+
+    logger.warning(
+        "sf-watch box already live for %s/%s@%s (%s) — DEFERRED (not dropped): "
+        "schedule %s re-invokes at %sZ (generation %d)",
+        fields["cadence_slug"], fields["pipeline_name"], fields["run_date"],
+        existing, schedule_name, fire_at.strftime("%Y-%m-%dT%H:%M:%S"), next_generation,
+    )
+    return {"launched": False, "reason": "deferred",
+            "defer_generation": next_generation, "schedule_name": schedule_name,
+            "existing_instance_ids": existing}
+
+
+def _state_machine_arn_from_execution(execution_arn: str) -> str:
+    """Derive the stateMachine ARN from an execution ARN:
+    arn:aws:states:R:A:execution:SM:NAME -> arn:aws:states:R:A:stateMachine:SM
+    (drop the trailing :NAME segment, swap the resource type)."""
+    without_name = execution_arn.rpartition(":")[0]
+    return without_name.replace(":execution:", ":stateMachine:", 1)
+
+
+def _reevaluate_after_defer(fields: dict) -> dict | None:
+    """On a DEFERRED invocation (defer_generation >= 1), re-check the state
+    machine before dispatching: the live box that forced the defer may have
+    recovered the pipeline meanwhile. Returns a terminal verdict dict
+    (`recovered`) to short-circuit the dispatch, or None to proceed — in the
+    proceed case, `fields["execution_arn"]` is retargeted at the NEWEST
+    failed execution (the originally-reported one may be stale by now).
+    Fail-safe toward LAUNCHING on any States API error (mirrors the
+    concurrency check's posture: a broken check never blocks a repair)."""
+    state_machine_arn = fields["state_machine_arn"] or _state_machine_arn_from_execution(
+        fields["execution_arn"]
+    )
+    try:
+        response = boto3.client("stepfunctions", region_name=REGION).list_executions(
+            stateMachineArn=state_machine_arn, maxResults=5
+        )
+        executions = response.get("executions") or []
+    except Exception as exc:  # noqa: BLE001 — fail-safe: a broken re-check must not block the repair dispatch (logged here)
+        logger.warning(
+            "deferred re-evaluation ListExecutions failed for %s (non-fatal, "
+            "dispatching anyway): %s: %s", state_machine_arn, type(exc).__name__, exc,
+        )
+        return None
+    if not executions:
+        # Zero executions on a machine we KNOW failed is a States-API anomaly,
+        # not a recovery signal — fail-safe toward launching (logged here).
+        logger.warning(
+            "deferred re-evaluation found NO executions for %s — dispatching "
+            "against the original execution_arn", state_machine_arn,
+        )
+        return None
+
+    latest = executions[0]  # ListExecutions returns newest-first
+    status = str(latest.get("status") or "")
+    if status in ("RUNNING", "SUCCEEDED", "PENDING_REDRIVE"):
+        # RUNNING/SUCCEEDED: the live box (or an operator) already recovered
+        # the pipeline. PENDING_REDRIVE: a redrive is in flight — launching a
+        # repair box now would duplicate it.
+        logger.info(
+            "deferred re-evaluation: latest execution %s is %s — recovered, "
+            "no dispatch needed", latest.get("executionArn"), status,
+        )
+        return {"launched": False, "reason": "recovered",
+                "latest_execution_arn": latest.get("executionArn"),
+                "latest_status": status}
+
+    # FAILED / TIMED_OUT / ABORTED — still broken; retarget the dispatch at
+    # the NEWEST failed execution so the repair agent diagnoses the current
+    # failure, not a stale one. The ARN comes from AWS but is embedded into a
+    # shell command downstream — hold it to the same allowlist as the event's.
+    newest_arn = str(latest.get("executionArn") or "")
+    if _ARN_RE.match(newest_arn):
+        if newest_arn != fields["execution_arn"]:
+            logger.info(
+                "deferred re-evaluation: retargeting dispatch from %s to newest "
+                "%s execution %s", fields["execution_arn"], status, newest_arn,
+            )
+            fields["execution_arn"] = newest_arn
+    else:
+        # Malformed-ARN swallow: keep the original validated execution_arn
+        # rather than embedding an unvalidated string into the SSM shell
+        # command; recorded via this WARNING log.
+        logger.warning(
+            "deferred re-evaluation: newest execution ARN %r fails the ARN "
+            "allowlist — keeping the original execution_arn", newest_arn,
+        )
+    return None
+
+
+def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0) -> dict:
     """Launch + bootstrap the SF-watch box. SYNCHRONOUS contract: every
     anticipated failure mode returns a clean, well-formed launched:false
     rather than raising — see module docstring."""
@@ -308,11 +567,10 @@ def _launch_sf_watch_spot(fields: dict) -> dict:
     )
     existing = _running_sf_watch_instance_ids(cadence_slug, pipeline_name, run_date)
     if existing:
-        logger.warning(
-            "sf-watch box already live for %s/%s@%s (%s) — skipping launch to "
-            "avoid a concurrent duplicate run", cadence_slug, pipeline_name, run_date, existing)
-        return {"launched": False, "reason": "concurrent_skip",
-                "existing_instance_ids": existing}
+        # DEFER, NOT DROP (config#2226): the live box has no obligation to
+        # notice THIS failure — schedule a one-shot re-invoke instead of
+        # silently dropping it (see module docstring).
+        return _defer_relaunch(fields, defer_generation, context, existing)
 
     run_token = uuid.uuid4().hex
     try:
@@ -372,18 +630,21 @@ def _launch_sf_watch_spot(fields: dict) -> dict:
     }
 
 
-def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+def handler(event: dict, context) -> dict:
     """Synchronous handler invoked once per real saturday-sf-failure event —
-    NOT on a schedule. `event` carries {"pipeline_name", "cadence_slug",
+    NOT on a cron schedule. `event` carries {"pipeline_name", "cadence_slug",
     "state_machine_arn", "execution_arn", "run_date", "failed_state", "cause",
     "watch_log_key", "is_preflight"} from the GHA job's `lambda invoke`
-    payload (RequestResponse).
+    payload (RequestResponse). A DEFERRED re-invoke (config#2226 — fired by
+    the one-shot EventBridge Scheduler schedule this handler created on a
+    concurrency skip) carries the same payload plus `defer_generation` >= 1
+    and first re-evaluates the state machine before dispatching.
 
     Returns {"launched": bool, "reason": str, "instance_id": ..., ...} — read
     DIRECTLY by the GHA job as its success signal. Every anticipated failure
-    (malformed event, concurrency skip, spot+on-demand launch exhaustion,
-    post-launch SSM failure) is a clean return, never an exception — see
-    module docstring's synchronous contract.
+    (malformed event, defer-scheduling failure, defer exhaustion,
+    spot+on-demand launch exhaustion, post-launch SSM failure) is a clean
+    return, never an exception — see module docstring's synchronous contract.
     """
     event = event or {}
     try:
@@ -392,9 +653,42 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         logger.error("invalid sf-watch event: %s", exc)
         return {"launched": False, "reason": "invalid_event", "error": str(exc)}
 
+    try:
+        defer_generation = int(str(event.get("defer_generation") or 0))
+        if defer_generation < 0:
+            raise ValueError(defer_generation)
+    except ValueError:
+        logger.error("invalid sf-watch event: malformed defer_generation %r",
+                     event.get("defer_generation"))
+        return {"launched": False, "reason": "invalid_event",
+                "error": f"malformed defer_generation: {event.get('defer_generation')!r}"}
+
+    if not fields["watch_log_key"]:
+        # Operator-refire fallback (config#2226): synthesize the canonical
+        # per-pipeline key exactly as saturday-sf-watch-dispatcher's
+        # _artifact_key mints it (lockstep-guarded — see _WATCH_PREFIXES).
+        prefix = _WATCH_PREFIXES.get(fields["pipeline_name"])
+        if prefix:
+            fields["watch_log_key"] = f"{prefix}/{fields['run_date']}.json"
+            logger.info("empty watch_log_key — synthesized %s", fields["watch_log_key"])
+        else:
+            # Unknown-pipeline swallow: watch_log_key is OPTIONAL in the box's
+            # contract (the bootstrap tolerates an empty flag), so an
+            # unregistered pipeline proceeds without one; recorded via this
+            # WARNING log.
+            logger.warning(
+                "empty watch_log_key and pipeline %r has no registered watch "
+                "prefix — dispatching without one", fields["pipeline_name"],
+            )
+
     logger.info(
-        "sf-watch trigger: pipeline=%s cadence=%s run_date=%s execution_arn=%s",
+        "sf-watch trigger: pipeline=%s cadence=%s run_date=%s execution_arn=%s "
+        "defer_generation=%d",
         fields["pipeline_name"], fields["cadence_slug"], fields["run_date"],
-        fields["execution_arn"],
+        fields["execution_arn"], defer_generation,
     )
-    return _launch_sf_watch_spot(fields)
+    if defer_generation >= 1:
+        verdict = _reevaluate_after_defer(fields)
+        if verdict is not None:
+            return verdict
+    return _launch_sf_watch_spot(fields, context, defer_generation)

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -7,17 +7,25 @@ itself imports the REAL nousergon_lib.spot_dispatch, which resolves its own
 Validates: a valid event launches a spot box and fires an async SSM command;
 the on-demand fallback on spot capacity exhaustion; a total launch failure
 (spot AND on-demand exhausted) returns a clean launched:false rather than
-raising; the (cadence_slug, pipeline_name, run_date)-scoped concurrency lock;
-a post-launch SSM-send failure terminates the box and returns launched:false;
-a malformed event returns launched:false rather than raising; the kill-switch
-short-circuit; and the cause-field base64 command-injection guard.
+raising; the (cadence_slug, pipeline_name, run_date)-scoped concurrency lock
+DEFERS (not drops) via a one-shot EventBridge Scheduler re-invoke, with a
+loud generation cap, ConflictException-as-already-deferred, and a clean
+defer_schedule_failed on Scheduler API errors (config#2226); a deferred
+invocation re-evaluates via ListExecutions (recovered / retarget-newest-
+failed / defer-again / fail-safe-launch); the empty-watch_log_key synthesis
+fallback; a post-launch SSM-send failure terminates the box and returns
+launched:false; a malformed event returns launched:false rather than
+raising; the kill-switch short-circuit; and the cause-field base64
+command-injection guard.
 """
 
 from __future__ import annotations
 
 import base64
 import importlib
+import json
 import os
+import re
 import sys
 import types
 
@@ -93,12 +101,58 @@ class _FakeSsm:
         return {"Command": {"CommandId": "cmd-123"}}
 
 
-def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None):
+class ConflictException(Exception):
+    """Name-matched stand-in for scheduler.exceptions.ConflictException —
+    index._is_scheduler_conflict matches on the exception CLASS NAME (the
+    real boto3 factory-built class carries the same name)."""
+
+
+class _FakeScheduler:
+    def __init__(self, create_error=None):
+        self.created = []
+        self.create_error = create_error
+
+    def create_schedule(self, **kw):
+        if self.create_error is not None:
+            raise self.create_error
+        self.created.append(kw)
+        return {
+            "ScheduleArn": f"arn:aws:scheduler:us-east-1:711398986525:schedule/default/{kw['Name']}"
+        }
+
+
+class _FakeSfn:
+    def __init__(self, executions=None, error=None):
+        self.calls = []
+        # newest-first, mirroring the real ListExecutions ordering.
+        self.executions = list(executions or [])
+        self.error = error
+
+    def list_executions(self, **kw):
+        self.calls.append(kw)
+        if self.error is not None:
+            raise self.error
+        return {"executions": self.executions}
+
+
+class _FakeContext:
+    """Minimal Lambda context — index reads only invoked_function_arn (for
+    the defer schedule's self-target + account-derived scheduler role ARN)."""
+    invoked_function_arn = (
+        "arn:aws:lambda:us-east-1:711398986525:function:"
+        "alpha-engine-sf-watch-spot-dispatcher"
+    )
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None,
+          scheduler=None, sfn=None):
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
     ssm = _FakeSsm()
     ec2 = _FakeEc2(running_instances=running_instances)
-    clients = {"ec2": ec2, "ssm": ssm}
+    scheduler = scheduler if scheduler is not None else _FakeScheduler()
+    sfn = sfn if sfn is not None else _FakeSfn()
+    clients = {"ec2": ec2, "ssm": ssm, "scheduler": scheduler, "stepfunctions": sfn}
     if launch_impl is None:
         launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
     _install_stubs(launch_impl, clients)
@@ -124,6 +178,8 @@ def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None):
     importlib.reload(index)
     index._test_ssm = ssm  # expose for assertions
     index._test_ec2 = ec2
+    index._test_scheduler = scheduler
+    index._test_sfn = sfn
     return index
 
 
@@ -258,7 +314,10 @@ def test_non_capacity_launch_error_returns_clean_false(monkeypatch):
     assert out["reason"] == "launch_failed"
 
 
-def test_concurrency_skip_when_same_cadence_pipeline_run_date_already_running(monkeypatch):
+def test_concurrent_skip_now_defers_via_one_shot_schedule(monkeypatch):
+    # config#2226 — DEFER, NOT DROP: a live box for the same full key no
+    # longer drops the second failure; it schedules a one-shot EventBridge
+    # Scheduler re-invoke of this same Lambda ~10min out.
     launched = []
 
     def _launch(types_, subnets, **kw):
@@ -271,11 +330,290 @@ def test_concurrency_skip_when_same_cadence_pipeline_run_date_already_running(mo
             ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-already-running"],
         },
     )
-    out = idx.handler(_event(), None)
+    out = idx.handler(_event(), _FakeContext())
     assert out["launched"] is False
-    assert out["reason"] == "concurrent_skip"
+    assert out["reason"] == "deferred"
+    assert out["defer_generation"] == 1
     assert out["existing_instance_ids"] == ["i-already-running"]
     assert launched == []  # never even attempted a spot launch — zero spend
+
+    (sched,) = idx._test_scheduler.created
+    assert sched["Name"] == out["schedule_name"]
+    # Deterministic name: readable form when <=64 chars, sha256-digest form
+    # otherwise (this key's readable form is 66 chars — over the AWS cap).
+    assert sched["Name"] == idx._defer_schedule_name(
+        "saturday", "ne-weekly-freshness-pipeline", "2026-07-11", 1
+    )
+    assert sched["Name"].startswith("sf-watch-defer-")  # IAM policy prefix scope
+    assert sched["Name"].endswith("-g1")
+    assert len(sched["Name"]) <= 64
+    assert sched["GroupName"] == "default"
+    assert sched["FlexibleTimeWindow"] == {"Mode": "OFF"}
+    assert sched["ActionAfterCompletion"] == "DELETE"  # one-shot self-delete
+    assert re.fullmatch(r"at\(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\)",
+                        sched["ScheduleExpression"])
+    # Target: this same Lambda (unqualified), via the dedicated scheduler
+    # role (derived from the context account when the env var is unset).
+    assert sched["Target"]["Arn"] == _FakeContext.invoked_function_arn
+    assert sched["Target"]["RoleArn"] == (
+        "arn:aws:iam::711398986525:role/alpha-engine-sf-watch-defer-scheduler-role"
+    )
+    # Input: the ORIGINAL validated payload + the incremented generation.
+    payload = json.loads(sched["Target"]["Input"])
+    assert payload["defer_generation"] == 1
+    for key, value in _event().items():
+        assert payload[key] == value
+
+
+def test_defer_schedule_name_deterministic_and_within_aws_cap(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    # eod/ne-postclose readable form is 62 chars — stays fully readable.
+    assert idx._defer_schedule_name(
+        "eod", "ne-postclose-trading-pipeline", "2026-07-11", 1
+    ) == "sf-watch-defer-eod-ne-postclose-trading-pipeline-2026-07-11-g1"
+    # saturday/ne-weekly readable form is 66 chars — over the AWS 64-char
+    # Name cap, so it degrades to the deterministic sha256-digest form.
+    saturday = idx._defer_schedule_name(
+        "saturday", "ne-weekly-freshness-pipeline", "2026-07-11", 1)
+    assert saturday != "sf-watch-defer-saturday-ne-weekly-freshness-pipeline-2026-07-11-g1"
+    for cadence, pipeline in (
+        ("saturday", "ne-weekly-freshness-pipeline"),
+        ("weekday", "ne-preopen-trading-pipeline"),
+        ("eod", "ne-postclose-trading-pipeline"),
+        ("eod", "alpha-engine-eod-pipeline"),
+    ):
+        for gen in (1, 2, 3):
+            name = idx._defer_schedule_name(cadence, pipeline, "2026-07-11", gen)
+            assert len(name) <= 64, (cadence, pipeline, name)
+            assert name.startswith("sf-watch-defer-")  # IAM prefix scope
+            assert name.endswith(f"-g{gen}")
+            # Deterministic — same inputs, same name (the idempotency lock).
+            assert name == idx._defer_schedule_name(cadence, pipeline, "2026-07-11", gen)
+    # Distinct keys never collide.
+    names = {
+        idx._defer_schedule_name(c, p, d, g)
+        for c, p in (("saturday", "ne-weekly-freshness-pipeline"),
+                     ("eod", "ne-postclose-trading-pipeline"))
+        for d in ("2026-07-11", "2026-07-12") for g in (1, 2)
+    }
+    assert len(names) == 8
+
+
+def test_defer_cap_exhausts_loudly_no_further_schedule(monkeypatch):
+    # Incoming defer_generation >= 3 with the lock still held: do NOT
+    # schedule again — return defer_exhausted (the GHA caller files a P1 on
+    # any unexpected launched!=true reason).
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-still-running"],
+        },
+        sfn=_FakeSfn(executions=[{
+            "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1",
+            "status": "FAILED",
+        }]),
+    )
+    out = idx.handler(_event(defer_generation=3), _FakeContext())
+    assert out["launched"] is False
+    assert out["reason"] == "defer_exhausted"
+    assert out["defer_generation"] == 3
+    assert idx._test_scheduler.created == []
+    assert idx._test_ssm.sent == []
+
+
+def test_deferred_invocation_latest_succeeded_returns_recovered(monkeypatch):
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(True) or "i-new",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(executions=[
+            {"executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-2",
+             "status": "SUCCEEDED"},
+            {"executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1",
+             "status": "FAILED"},
+        ]),
+    )
+    out = idx.handler(_event(defer_generation=1), _FakeContext())
+    assert out["launched"] is False
+    assert out["reason"] == "recovered"
+    assert out["latest_status"] == "SUCCEEDED"
+    assert launched == []
+    assert idx._test_scheduler.created == []
+    # ListExecutions hit the event's state_machine_arn, unfiltered, capped at 5.
+    (call,) = idx._test_sfn.calls
+    assert call == {
+        "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "maxResults": 5,
+    }
+
+
+def test_deferred_invocation_latest_running_returns_recovered(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(executions=[
+            {"executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-2",
+             "status": "RUNNING"},
+        ]),
+    )
+    out = idx.handler(_event(defer_generation=2), _FakeContext())
+    assert out["launched"] is False
+    assert out["reason"] == "recovered"
+    assert idx._test_ssm.sent == []
+
+
+def test_deferred_invocation_latest_failed_launches_against_newest_execution_arn(monkeypatch):
+    newest = ("arn:aws:states:us-east-1:711398986525:execution:"
+              "ne-weekly-freshness-pipeline:run-9-newest-failure")
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(executions=[
+            {"executionArn": newest, "status": "FAILED"},
+            {"executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1",
+             "status": "FAILED"},
+        ]),
+    )
+    out = idx.handler(_event(defer_generation=1), _FakeContext())
+    assert out["launched"] is True
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    # The dispatch was RETARGETED at the newest failed execution — the
+    # originally-reported run-1 may be stale by the time the defer fires.
+    assert f'--execution-arn "{newest}"' in cmd
+    assert 'run-1"' not in cmd
+
+
+def test_deferred_invocation_derives_state_machine_arn_when_event_omits_it(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(executions=[
+            {"executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-2",
+             "status": "SUCCEEDED"},
+        ]),
+    )
+    out = idx.handler(_event(defer_generation=1, state_machine_arn=""), _FakeContext())
+    assert out["reason"] == "recovered"
+    # Derived from execution_arn: swap :execution: -> :stateMachine:, drop
+    # the trailing execution-name segment.
+    (call,) = idx._test_sfn.calls
+    assert call["stateMachineArn"] == (
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline"
+    )
+
+
+def test_deferred_invocation_latest_failed_with_live_box_defers_next_generation(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-still-running"],
+        },
+        sfn=_FakeSfn(executions=[
+            {"executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-2",
+             "status": "TIMED_OUT"},
+        ]),
+    )
+    out = idx.handler(_event(defer_generation=1), _FakeContext())
+    assert out["launched"] is False
+    assert out["reason"] == "deferred"
+    assert out["defer_generation"] == 2
+    (sched,) = idx._test_scheduler.created
+    assert sched["Name"].endswith("-g2")
+    payload = json.loads(sched["Target"]["Input"])
+    assert payload["defer_generation"] == 2
+
+
+def test_states_api_error_fails_safe_toward_launching(monkeypatch):
+    # Mirrors the concurrency check's posture: a broken re-check must never
+    # block the repair dispatch.
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(error=RuntimeError("States API hiccup")),
+    )
+    out = idx.handler(_event(defer_generation=1), _FakeContext())
+    assert out["launched"] is True
+
+
+def test_conflict_exception_treated_as_already_deferred(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-already-running"],
+        },
+        scheduler=_FakeScheduler(create_error=ConflictException("schedule exists")),
+    )
+    out = idx.handler(_event(), _FakeContext())
+    # Clean return, never a raise: an earlier defer for the same
+    # (key, generation) already covers this failure.
+    assert out["launched"] is False
+    assert out["reason"] == "deferred"
+    assert out["already_scheduled"] is True
+    assert out["defer_generation"] == 1
+
+
+def test_scheduler_api_error_returns_defer_schedule_failed(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-already-running"],
+        },
+        scheduler=_FakeScheduler(create_error=RuntimeError("Scheduler API down")),
+    )
+    out = idx.handler(_event(), _FakeContext())
+    # SYNCHRONOUS contract holds even when the defer path itself breaks.
+    assert out["launched"] is False
+    assert out["reason"] == "defer_schedule_failed"
+    assert "Scheduler API down" in out["error"]
+
+
+def test_defer_role_arn_env_override_wins(monkeypatch):
+    idx = _load(
+        monkeypatch,
+        env={"SF_WATCH_DISPATCH_ENABLED": "true",
+             "SF_WATCH_DEFER_ROLE_ARN": "arn:aws:iam::711398986525:role/custom-defer-role"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-already-running"],
+        },
+    )
+    out = idx.handler(_event(), _FakeContext())
+    assert out["reason"] == "deferred"
+    (sched,) = idx._test_scheduler.created
+    assert sched["Target"]["RoleArn"] == "arn:aws:iam::711398986525:role/custom-defer-role"
+
+
+def test_empty_watch_log_key_is_synthesized_from_pipeline_prefix(monkeypatch):
+    # Operator-refire fallback: the canonical key is minted only by
+    # saturday-sf-watch-dispatcher; a hand-fired event with an empty
+    # watch_log_key gets the same {prefix}/{run_date}.json synthesized.
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(watch_log_key=""), _FakeContext())
+    assert out["launched"] is True
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--watch-log-key "consolidated/saturday_sf_watch/2026-07-11.json"' in cmd
+
+
+def test_empty_watch_log_key_unknown_pipeline_dispatches_without_key(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(
+        _event(
+            pipeline_name="some-future-pipeline",
+            watch_log_key="",
+            execution_arn="arn:aws:states:us-east-1:711398986525:execution:some-future-pipeline:run-1",
+            state_machine_arn="arn:aws:states:us-east-1:711398986525:stateMachine:some-future-pipeline",
+        ),
+        _FakeContext(),
+    )
+    # watch_log_key is optional in the box contract — unknown pipeline still
+    # dispatches, with the flag empty.
+    assert out["launched"] is True
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--watch-log-key ""' in cmd
+
+
+def test_malformed_defer_generation_returns_clean_false(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(defer_generation="not-a-number"), _FakeContext())
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+    assert idx._test_ssm.sent == []
 
 
 def test_different_run_date_same_pipeline_cadence_is_not_blocked(monkeypatch):

--- a/tests/test_sf_watch_defer_prefix_lockstep.py
+++ b/tests/test_sf_watch_defer_prefix_lockstep.py
@@ -1,0 +1,86 @@
+"""config#2226 — sf-watch-spot-dispatcher's `_WATCH_PREFIXES` must stay in
+LOCKSTEP with saturday-sf-watch-dispatcher's `PIPELINES` watch prefixes.
+
+The canonical watch_log_key is minted ONLY by saturday-sf-watch-dispatcher's
+`_artifact_key(watch_prefix, run_date)`. The spot dispatcher mirrors the
+{pipeline_name: watch_prefix} column so an operator re-fire with an EMPTY
+watch_log_key can synthesize the same `{prefix}/{run_date}.json` key. A
+silent drift between the two would route the repair agent's watch log to a
+wrong/orphaned S3 prefix with zero pipeline signal — so drift fails CI here.
+
+Both dicts are extracted STATICALLY (ast over the source text — the same
+source-derived pattern as tests/test_sf_watch_deploy_flag_preserve.py):
+importing either index.py would drag in boto3 clients and each Lambda's own
+pinned nousergon-lib, which this repo-level pytest process does not carry.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_LAMBDAS = Path(__file__).parent.parent / "infrastructure" / "lambdas"
+_SPOT_DISPATCHER = _LAMBDAS / "sf-watch-spot-dispatcher" / "index.py"
+_SATURDAY_DISPATCHER = _LAMBDAS / "saturday-sf-watch-dispatcher" / "index.py"
+
+
+def _module_assign_value(path: Path, name: str) -> ast.expr:
+    """The AST value node of module-level `name = ...` / `name: T = ...`."""
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if name in targets:
+                return node.value
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == name:
+                assert node.value is not None, f"{name} annotated but unassigned in {path}"
+                return node.value
+    raise AssertionError(f"module-level assignment {name!r} not found in {path}")
+
+
+def _spot_dispatcher_prefixes() -> dict[str, str]:
+    value = _module_assign_value(_SPOT_DISPATCHER, "_WATCH_PREFIXES")
+    prefixes = ast.literal_eval(value)
+    assert isinstance(prefixes, dict) and prefixes, "_WATCH_PREFIXES must be a non-empty dict"
+    return prefixes
+
+
+def _saturday_pipeline_prefixes() -> dict[str, str]:
+    """{pipeline_name: watch_prefix} out of PIPELINES — extracted key-by-key
+    (the inner dicts carry non-literal values like frozenset(), so a whole-
+    dict literal_eval is not possible)."""
+    value = _module_assign_value(_SATURDAY_DISPATCHER, "PIPELINES")
+    assert isinstance(value, ast.Dict), "PIPELINES must be a dict literal"
+    prefixes: dict[str, str] = {}
+    for key_node, cfg_node in zip(value.keys, value.values):
+        assert isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)
+        assert isinstance(cfg_node, ast.Dict), f"PIPELINES[{key_node.value!r}] must be a dict literal"
+        for inner_key, inner_value in zip(cfg_node.keys, cfg_node.values):
+            if isinstance(inner_key, ast.Constant) and inner_key.value == "watch_prefix":
+                assert isinstance(inner_value, ast.Constant) and isinstance(inner_value.value, str)
+                prefixes[key_node.value] = inner_value.value
+                break
+        else:
+            raise AssertionError(f"PIPELINES[{key_node.value!r}] has no watch_prefix")
+    assert prefixes, "PIPELINES yielded no watch prefixes"
+    return prefixes
+
+
+def test_spot_dispatcher_watch_prefixes_match_saturday_dispatcher_exactly():
+    """EXACT equality, both directions: a pipeline added/removed/renamed (or a
+    prefix changed) in saturday-sf-watch-dispatcher's PIPELINES must land in
+    the spot dispatcher's _WATCH_PREFIXES in the same PR — including the
+    TRANSITIONAL alpha-engine-eod-pipeline alias, which must be REMOVED from
+    both together at the config#1408 SF-rename cutover."""
+    assert _spot_dispatcher_prefixes() == _saturday_pipeline_prefixes()
+
+
+def test_synthesized_key_shape_matches_artifact_key():
+    """The spot dispatcher synthesizes f"{prefix}/{run_date}.json" — the same
+    shape as saturday-sf-watch-dispatcher's `_artifact_key`. Guard the shape
+    at the source level so a format change there is caught here."""
+    saturday_src = _SATURDAY_DISPATCHER.read_text()
+    assert 'return f"{watch_prefix}/{run_date}.json"' in saturday_src
+    spot_src = _SPOT_DISPATCHER.read_text()
+    assert '''f"{prefix}/{fields['run_date']}.json"''' in spot_src


### PR DESCRIPTION
## What (dispatcher half of alpha-engine-config-I2226)
2026-07-11: a second weekly-SF failure arrived while the repair box for the first was still live; the dispatcher logged `concurrent_skip` and DROPPED it — pipeline sat FAILED with zero watch coverage.

- **Defer, not drop**: concurrent skip now creates a one-shot EventBridge Scheduler schedule re-invoking this Lambda in 10 min with `defer_generation: n+1` (`ActionAfterCompletion=DELETE`, deterministic name, ConflictException = already-deferred). Generation cap 3 → `defer_exhausted` + ERROR (fail-loud; GHA caller files P1 on unexpected reasons). Scheduler API errors never break the synchronous return contract.
- **Deferred re-evaluation**: `defer_generation>=1` → ListExecutions; latest RUNNING/SUCCEEDED/PENDING_REDRIVE → `recovered` (no launch); latest FAILED/TIMED_OUT/ABORTED → launch retargeted at the NEWEST failed execution; live box still present → defer again within cap; States API error fails safe toward launching.
- **watch_log_key fallback**: operator re-fires arrived with an empty key (the canonical minting lives upstream) — now synthesized from `_WATCH_PREFIXES`, with an AST-based lockstep test against saturday-sf-watch-dispatcher's PIPELINES so drift fails CI.
- Schedule-name 64-char limit handled (weekly pipeline's literal name is 66 chars): deterministic sha16 fallback, IAM prefix preserved, human key in Description.

## Why draft (gate:decision)
Merge-button-only requires the IAM pre-applied; the batch is queued for Brian's review in-session (5 commands, listed below). Flip to ready once applied.

```
1. put-role-policy alpha-engine-sf-watch-spot-dispatcher-role  <- updated iam-policy.json (scheduler:CreateSchedule/GetSchedule scoped sf-watch-defer-*, iam:PassRole on defer role conditioned to scheduler.amazonaws.com, states:ListExecutions on the 3 ne-* SMs)
2. create-role alpha-engine-sf-watch-defer-scheduler-role      (trust scheduler.amazonaws.com)
3. put-role-policy on it: lambda:InvokeFunction on this dispatcher only
4. lambda update-function-configuration: += SF_WATCH_DEFER_ROLE_ARN (kill-switch verified true before)
5. put-role-policy alpha-engine-sf-watch-executor-role += lambda:InvokeFunction on the dispatcher (closes the STEP 5.7 charter-handoff seam found by cross-tracing config-PR2234 against the box role — without it the handoff 403s)
```

## Tests
Repo suite 2863 passed / 7 skipped; all 18 per-lambda suites green in CI-mirror isolation (this lambda: 15→29 tests); new lockstep test.

Pairs with alpha-engine-config-PR2234 (charter exit contract) — independent, either merge order. Closes alpha-engine-config-I2226 jointly with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)