### PR TITLE
Weekly SF: artifact-validated skip_predictor_training (freshness-gated branch-B skip)

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -124,6 +124,14 @@
       }
     },
     {
+      "Sid": "HeadPredictorWeightsManifest",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/predictor/weights/meta/manifest.json"
+    },
+    {
       "Sid": "AgentTelemetryMetrics",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1730,8 +1730,29 @@
           "States": {
             "CheckSkipPredictorTraining": {
               "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_predictor_training\": true} bypasses GBM retrain (and, per config#902, the now-bundled drift step that rides on the same spot) and converges to BranchBComplete.",
+              "Comment": "Skip-gate (config#2253 validated-skip upgrade). {\"skip_predictor_training\": true} bypasses GBM retrain (and, per config#902, the bundled drift step riding the same spot) AND the config#1083 model-zoo fan-out — but the skip claim is VALIDATED first: ValidatePredictorSkipWeightsFresh HeadObjects the live weights manifest (predictor/weights/meta/manifest.json — written UNCONDITIONALLY by every non-dry training run in alpha-engine-predictor training/meta_trainer.py, regardless of the promotion gate, unlike the live .pkl weights which only move on gate-pass) and CheckPredictorSkipWeightsFresh requires its LastModified DATE >= $.run_date — i.e. this run_date's training genuinely completed before the operator/watch-agent claimed it. Stale manifest → BranchBFailed (fail loud: silently honoring a false weights-are-already-live claim would hand Backtester stale weights AND swallow the very re-training the pipeline owed). EXCEPTION (first Choice rule): mode=backtest-eval (config#830 replay preset, which force-seeds this flag) routes straight to PredictorTrainingSkipped with NO freshness validation — that preset's contract is 'replay Backtester+Evaluator against existing artifacts, whatever their vintage', so a mid-week replay must not demand a same-day manifest. NOTE the manifest is the validation surface, NOT weights/meta/archive/{date}/: the dated archive is TRADING-DAY-keyed (config#1015 — Friday's close), while $.run_date is the Saturday calendar date, so an archive-prefix check would NEVER match on the standard Saturday recovery rerun this flag exists for. Cross-UTC-midnight recovery reruns: pass the ORIGINAL run_date explicitly (the watch charter's take-the-original-input rule already implies this for every date-keyed stage) and the lexicographic >= compare composes correctly.",
               "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.skip_predictor_training",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.skip_predictor_training",
+                      "BooleanEquals": true
+                    },
+                    {
+                      "Variable": "$.mode",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.mode",
+                      "StringEquals": "backtest-eval"
+                    }
+                  ],
+                  "Next": "PredictorTrainingSkipped"
+                },
                 {
                   "And": [
                     {
@@ -1743,10 +1764,84 @@
                       "BooleanEquals": true
                     }
                   ],
-                  "Next": "BranchBComplete"
+                  "Next": "ValidatePredictorSkipWeightsFresh"
                 }
               ],
               "Default": "PredictorTraining"
+            },
+            "ValidatePredictorSkipWeightsFresh": {
+              "Type": "Task",
+              "Comment": "config#2253 artifact-presence validation for skip_predictor_training. HeadObject on the live weights manifest; ResultSelector lifts LastModified's DATE part (ISO-8601 'YYYY-MM-DDThh:mm:ssZ' → 'YYYY-MM-DD') for the lexicographic >= compare against $.run_date in CheckPredictorSkipWeightsFresh (both sides YYYY-MM-DD, so string ordering IS date ordering). Deliberately an aws-sdk:s3 integration, not a sendCommand/Lambda: (a) zero boot cost / no dependency on the always-on box, (b) aws-sdk:s3 is NOT in nousergon_lib pipeline_status SUBSTANTIVE_RESOURCES, so this stays console-invisible plumbing with no cross-repo registry entry required. IAM: s3:GetObject on the manifest key (Sid HeadPredictorWeightsManifest in infrastructure/iam/alpha-engine-step-functions-role.json — apply.sh before merge, iam-drift-check enforces). Any S3 error or an unexpected LastModified serialization (intrinsic parse failure) routes to BranchBFailed via Catch — fail loud, no silent swallow (recording surface: $.error → branch_b_error → post-join FAILED SNS).",
+              "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
+              "Parameters": {
+                "Bucket": "alpha-engine-research",
+                "Key": "predictor/weights/meta/manifest.json"
+              },
+              "ResultSelector": {
+                "manifest_last_modified_date.$": "States.ArrayGetItem(States.StringSplit($.LastModified, 'T'), 0)"
+              },
+              "ResultPath": "$.predictor_skip_validation",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "States.TaskFailed"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
+                  "BackoffRate": 2.0,
+                  "Comment": "Transient S3 5xx/throttle; a genuine 403/404 burns ~15s of retries then fails through to the Catch — acceptable on an operator-initiated recovery path."
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Next": "BranchBFailed",
+                  "ResultPath": "$.error"
+                }
+              ],
+              "Next": "CheckPredictorSkipWeightsFresh"
+            },
+            "CheckPredictorSkipWeightsFresh": {
+              "Type": "Choice",
+              "Comment": "config#2253: manifest LastModified date >= run_date ⇒ a non-dry training run completed for this run_date ⇒ the skip claim is genuine → PredictorTrainingSkipped (branch reads as succeeded downstream). Otherwise the claim is false → PredictorSkipWeightsStale synthesizes $.error → BranchBFailed (the SF fails AFTER the join per CheckBranchOutcomes, so the sibling Research branch still completes and its artifacts persist). The StringMatches '20*-*-*' shape guard is load-bearing: no fleet SF has consumed the aws-sdk:s3 LastModified serialization before (the groom SF's headObject is existence-only), and if it ever arrived non-ISO (HTTP-date 'Sat, 11 Jul ...', epoch string) a bare lexicographic >= against 'YYYY-MM-DD' could SILENTLY wrong-pass — the guard converts that into the loud stale/malformed path whose Cause prints the raw value.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.predictor_skip_validation.manifest_last_modified_date",
+                      "StringMatches": "20*-*-*"
+                    },
+                    {
+                      "Variable": "$.predictor_skip_validation.manifest_last_modified_date",
+                      "StringGreaterThanEqualsPath": "$.run_date"
+                    }
+                  ],
+                  "Next": "PredictorTrainingSkipped"
+                }
+              ],
+              "Default": "PredictorSkipWeightsStale"
+            },
+            "PredictorSkipWeightsStale": {
+              "Type": "Pass",
+              "Comment": "config#2253: synthesize $.error for BranchBFailed's branch_b_error.$=$.error contract (a Choice.Default transition does not populate an error path the way a Task Catch does — same States.Runtime trap the ExtractModelZoo*Error states exist for, config#2160 arc). Names both dates so the FAILED SNS alert is self-diagnosing.",
+              "Parameters": {
+                "Error": "PredictorSkipWeightsStale",
+                "Cause.$": "States.Format('skip_predictor_training=true but s3://alpha-engine-research/predictor/weights/meta/manifest.json LastModified date {} < run_date {} — no completed predictor training for this run_date; refusing to silently skip onto stale weights. Either re-run WITHOUT skip_predictor_training (training genuinely did not complete), or pass the ORIGINAL run_date explicitly if this is a cross-UTC-midnight recovery rerun.', $.predictor_skip_validation.manifest_last_modified_date, $.run_date)"
+              },
+              "ResultPath": "$.error",
+              "Next": "BranchBFailed"
+            },
+            "PredictorTrainingSkipped": {
+              "Type": "Pass",
+              "Comment": "config#2253 branch-B skip terminal. Reads as a SUCCEEDED branch to AggregateBranchOutcomes/CheckBranchOutcomes — the join reads ONLY $.parallel_result[1].branch_b.branch_b_status, and this records the identical branch_b_status=OK contract as BranchBComplete — plus an explicit skipped:true marker for execution-history forensics (no fabricated training payload beyond what routing requires). End:true so the sibling Research branch is never cancelled (the per-branch error-isolation invariant).",
+              "Result": {
+                "branch_b_status": "OK",
+                "skipped": true
+              },
+              "ResultPath": "$.branch_b",
+              "End": true
             },
             "PredictorTraining": {
               "Type": "Task",
@@ -2307,7 +2402,7 @@
             },
             "BranchBComplete": {
               "Type": "Pass",
-              "Comment": "Branch B (PredictorTraining quartet) completed (training success OR skipped via skip_predictor_training; the L4544 model-zoo rotation, if it ran, is best-effort and converges here regardless of outcome). Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch.",
+              "Comment": "Branch B (PredictorTraining quartet) completed (training success; the L4544 model-zoo rotation, if it ran, is best-effort and converges here regardless of outcome). The skip_predictor_training path terminates at its own PredictorTrainingSkipped terminal (config#2253) with the same branch_b_status=OK contract plus a skipped:true marker. Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch.",
               "Result": {
                 "branch_b_status": "OK"
               },

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -87,6 +87,11 @@ _BRANCH_B_STATES = {
     "ModelZooTrainMap", "ModelZooSelect",
     "WaitForModelZoo", "CheckModelZooStatus", "ModelZooWait",
     "ExtractModelZooSelectError", "PublishModelZooFailureImmediate",
+    # config#2253 validated skip path: skip_predictor_training=true routes
+    # through a manifest-freshness HeadObject before the branch may read
+    # as succeeded (backtest-eval preset bypasses validation by design).
+    "ValidatePredictorSkipWeightsFresh", "CheckPredictorSkipWeightsFresh",
+    "PredictorSkipWeightsStale", "PredictorTrainingSkipped",
     "BranchBComplete", "BranchBFailed",
 }
 
@@ -274,13 +279,156 @@ class TestBranchBContents:
         assert name in branch_b
 
     def test_skip_predictor_training_gate_preserved(self, branch_b):
-        c = branch_b["CheckSkipPredictorTraining"]["Choices"][0]
-        variables = {cond["Variable"] for cond in c["And"]}
-        assert variables == {"$.skip_predictor_training"}
-        # skip → branch-local completion (NOT the old CheckSkipDrift edge)
-        assert c["Next"] == "BranchBComplete"
-        assert branch_b["CheckSkipPredictorTraining"]["Default"] == (
-            "PredictorTraining"
+        """config#2253: the skip gate is now a TWO-rule Choice. Rule order
+        is load-bearing (ASL evaluates in order, first match wins):
+        rule 0 = backtest-eval preset (skip AND mode) → straight to the
+        skip terminal, NO freshness validation (the config#830 replay
+        preset's contract is 'existing artifacts, whatever their vintage');
+        rule 1 = plain skip → the manifest-freshness validation task.
+        Absent flag still defaults to PredictorTraining (scheduled runs
+        unaffected)."""
+        gate = branch_b["CheckSkipPredictorTraining"]
+        assert len(gate["Choices"]) == 2
+        preset_rule, plain_rule = gate["Choices"]
+        # Rule 0: skip + mode=backtest-eval — must come FIRST or the plain
+        # skip rule would shadow it and mid-week replays would hard-fail
+        # on a stale manifest.
+        preset_vars = {cond["Variable"] for cond in preset_rule["And"]}
+        assert preset_vars == {"$.skip_predictor_training", "$.mode"}
+        assert any(
+            cond.get("StringEquals") == "backtest-eval"
+            for cond in preset_rule["And"]
+        )
+        assert preset_rule["Next"] == "PredictorTrainingSkipped"
+        # Rule 1: plain skip → validated-skip path (present-and-true; a
+        # missing flag must never match).
+        plain_vars = {cond["Variable"] for cond in plain_rule["And"]}
+        assert plain_vars == {"$.skip_predictor_training"}
+        assert any(
+            cond.get("IsPresent") is True for cond in plain_rule["And"]
+        )
+        assert any(
+            cond.get("BooleanEquals") is True for cond in plain_rule["And"]
+        )
+        assert plain_rule["Next"] == "ValidatePredictorSkipWeightsFresh"
+        assert gate["Default"] == "PredictorTraining"
+
+    def test_validated_skip_path_wiring(self, branch_b):
+        """config#2253: the plain-skip path must VALIDATE the operator's
+        weights-are-already-live claim against the live weights manifest
+        before the branch may read as succeeded.
+
+        Surface choice is load-bearing: manifest.json is written
+        UNCONDITIONALLY by every non-dry training run (promotion-gate
+        independent), while weights/meta/archive/{date}/ is TRADING-DAY
+        keyed (config#1015 — Friday) and would NEVER match the Saturday
+        calendar $.run_date this validation compares against."""
+        v = branch_b["ValidatePredictorSkipWeightsFresh"]
+        assert v["Type"] == "Task"
+        assert v["Resource"] == "arn:aws:states:::aws-sdk:s3:headObject"
+        assert v["Parameters"]["Bucket"] == "alpha-engine-research"
+        assert v["Parameters"]["Key"] == (
+            "predictor/weights/meta/manifest.json"
+        )
+        # ResultSelector lifts the DATE part of LastModified so the Choice
+        # can do a lexicographic (== chronological for YYYY-MM-DD) compare.
+        sel = v["ResultSelector"]["manifest_last_modified_date.$"]
+        assert "States.StringSplit($.LastModified, 'T')" in sel
+        assert v["ResultPath"] == "$.predictor_skip_validation"
+        # Fail loud: any S3/serialization error is a branch failure, not a
+        # silent fall-through to either skipping OR re-training.
+        assert [c["Next"] for c in v["Catch"]] == ["BranchBFailed"]
+        assert all(c["ResultPath"] == "$.error" for c in v["Catch"])
+        assert v["Next"] == "CheckPredictorSkipWeightsFresh"
+
+    def test_validated_skip_freshness_choice(self, branch_b):
+        """manifest date >= run_date → skip terminal; stale → synthesized
+        $.error → BranchBFailed (never a silent skip onto stale weights,
+        never an implicit re-run of the 1h training spot the operator
+        asked to skip)."""
+        c = branch_b["CheckPredictorSkipWeightsFresh"]
+        assert c["Type"] == "Choice"
+        (fresh,) = c["Choices"]
+        conds = {
+            k: v for cond in fresh["And"] for k, v in cond.items()
+            if k != "Variable"
+        }
+        assert all(
+            cond["Variable"]
+            == "$.predictor_skip_validation.manifest_last_modified_date"
+            for cond in fresh["And"]
+        )
+        # Shape guard: no fleet SF consumed the aws-sdk:s3 LastModified
+        # serialization before — a non-ISO value (HTTP-date/epoch) must
+        # fail LOUD, not silently wrong-pass a lexicographic compare.
+        assert conds["StringMatches"] == "20*-*-*"
+        assert conds["StringGreaterThanEqualsPath"] == "$.run_date"
+        assert fresh["Next"] == "PredictorTrainingSkipped"
+        assert c["Default"] == "PredictorSkipWeightsStale"
+        # The stale Pass synthesizes $.error (a Choice.Default transition
+        # does not populate an error path — the config#2160 States.Runtime
+        # trap) and routes to BranchBFailed.
+        stale = branch_b["PredictorSkipWeightsStale"]
+        assert stale["Type"] == "Pass"
+        assert stale["ResultPath"] == "$.error"
+        assert stale["Parameters"]["Error"] == "PredictorSkipWeightsStale"
+        assert "$.run_date" in stale["Parameters"]["Cause.$"]
+        assert stale["Next"] == "BranchBFailed"
+
+    def test_skip_terminal_reads_as_succeeded_branch(self, branch_b):
+        """THE aggregator seam (config#2253): AggregateBranchOutcomes reads
+        ONLY $.parallel_result[1].branch_b.branch_b_status, so the skip
+        terminal must record the IDENTICAL success contract as
+        BranchBComplete — same ResultPath, same branch_b_status=OK — plus
+        an explicit skipped marker (and nothing fabricated beyond that).
+        End:true preserves the per-branch error-isolation invariant."""
+        skipped = branch_b["PredictorTrainingSkipped"]
+        assert skipped["Type"] == "Pass"
+        assert skipped["End"] is True
+        assert skipped["ResultPath"] == "$.branch_b"
+        assert skipped["Result"]["branch_b_status"] == "OK"
+        assert skipped["Result"]["skipped"] is True
+        # Exactly the success contract + the marker — nothing else.
+        assert set(skipped["Result"]) == {"branch_b_status", "skipped"}
+        # Contract equivalence with the real success terminal.
+        complete = branch_b["BranchBComplete"]
+        assert (
+            skipped["Result"]["branch_b_status"]
+            == complete["Result"]["branch_b_status"]
+        )
+        assert skipped["ResultPath"] == complete["ResultPath"]
+
+    def test_validation_head_object_key_is_iam_granted(self, branch_b):
+        """Cross-guard: the manifest key the SF HeadObjects must be granted
+        to the SF role in infrastructure/iam/alpha-engine-step-functions-
+        role.json (Sid HeadPredictorWeightsManifest) — the aws-sdk:s3 task
+        runs AS the state machine role, and a missing grant only surfaces
+        live as an AccessDenied on the recovery path (the worst time)."""
+        iam_path = (
+            _REPO_ROOT / "infrastructure" / "iam"
+            / "alpha-engine-step-functions-role.json"
+        )
+        policy = json.loads(iam_path.read_text())
+        key = branch_b["ValidatePredictorSkipWeightsFresh"]["Parameters"]["Key"]
+        bucket = branch_b["ValidatePredictorSkipWeightsFresh"]["Parameters"][
+            "Bucket"
+        ]
+        expected_arn = f"arn:aws:s3:::{bucket}/{key}"
+        grants = [
+            s for s in policy["Statement"]
+            if s.get("Effect") == "Allow"
+            and "s3:GetObject" in (
+                s["Action"] if isinstance(s["Action"], list) else [s["Action"]]
+            )
+            and expected_arn in (
+                s["Resource"]
+                if isinstance(s["Resource"], list) else [s["Resource"]]
+            )
+        ]
+        assert grants, (
+            f"SF role policy lacks s3:GetObject on {expected_arn} — the "
+            f"ValidatePredictorSkipWeightsFresh HeadObject would "
+            f"AccessDenied live."
         )
 
     def test_predictor_status_poll_quartet_preserved(self, branch_b):
@@ -822,10 +970,28 @@ class TestNoDanglingTargetsAnywhere:
                         f"Branch{bi} dangling: {n} -> {t}"
                     )
 
-    def test_exactly_one_end_terminal_class_per_branch(self, parallel):
+    def test_branch_terminal_sets_pinned(self, parallel):
+        """Pin the CLOSED set of End:true terminals per branch, and require
+        every terminal to record its branch status as data (the Parallel
+        error-isolation contract). Branch B gained a third terminal in
+        config#2253: PredictorTrainingSkipped (validated-skip success)."""
+        expected = [
+            ("$.branch_a", {"BranchAComplete", "BranchAFailed"}),
+            (
+                "$.branch_b",
+                {
+                    "BranchBComplete",
+                    "BranchBFailed",
+                    "PredictorTrainingSkipped",
+                },
+            ),
+        ]
         for bi, b in enumerate(parallel["Branches"]):
             ends = {
                 k for k, v in b["States"].items() if v.get("End") is True
             }
-            # Each branch has exactly its 2 Complete/Failed terminals.
-            assert len(ends) == 2, (bi, ends)
+            result_path, names = expected[bi]
+            assert ends == names, (bi, ends)
+            for k in ends:
+                assert b["States"][k]["Type"] == "Pass", (bi, k)
+                assert b["States"][k]["ResultPath"] == result_path, (bi, k)


### PR DESCRIPTION
## What (alpha-engine-config-I2253)
`skip_predictor_training` already existed as a bare unvalidated Choice (data-PR70/251) — today's duplicate branch-B reruns happened because the CHARTER lacked the vocabulary (fixed in alpha-engine-config-PR2254), and the flag had no artifact validation. This PR adds the validation the issue's closes-when requires:

- `CheckSkipPredictorTraining` → two-rule Choice (order load-bearing): `mode=backtest-eval` + skip → unvalidated skip (config#830 preset contract: replay against artifacts of any vintage); plain skip → freshness validation; absent flag → run (scheduled runs byte-identical).
- `ValidatePredictorSkipWeightsFresh`: `aws-sdk:s3:headObject` on `predictor/weights/meta/manifest.json` — written unconditionally by every non-dry training run (meta_trainer.py:4406) and NOT trading-day-keyed (the dated archive is Friday-keyed and would never match Saturday run_date — issue body corrected on this).
- `CheckPredictorSkipWeightsFresh`: manifest LastModified date ≥ run_date, with an ISO shape guard so a non-ISO SDK serialization can't silently wrong-pass; stale → `PredictorSkipWeightsStale` (synthesizes $.error per the config#2160 Choice.Default trap) → BranchBFailed. Fail loud everywhere.
- `PredictorTrainingSkipped` terminal Pass emits the exact BranchBComplete success contract + `skipped:true` — pinned by `test_skip_terminal_reads_as_succeeded_branch`; aggregator reads only branch_b_status (evidence in test).

## Deploy
Merge-button-only: deploy-infrastructure.yml restamps the SF on every push to main. IAM (Sid HeadPredictorWeightsManifest, single-object s3:GetObject) applied live in-session 2026-07-11 pre-PR per the repo's apply.sh flow — iam-drift-check should be green.

## Tests
2871 passed / 7 pre-existing env skips. ASL validated via validate-state-machine-definition. Drift-registry: no lib change needed (aws-sdk headObject not a SUBSTANTIVE_RESOURCE; verified by replicating the dashboard drift walk).

Companions: crucible-predictor-PR358 (promotion idempotency — the belt), alpha-engine-config-PR2254 (charter skip vocabulary — what actually stops the recurrence). Closes alpha-engine-config-I2253 jointly with PR2254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)