### PR TITLE
fix(ci-watch): deploy.sh preserves operator-owned CI_WATCH_DISPATCH_ENABLED; shared preserve helper (config#2264)

### DIFF
--- a/infrastructure/lambdas/_shared/preserve_env_flags.sh
+++ b/infrastructure/lambdas/_shared/preserve_env_flags.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# preserve_env_flags.sh — shared "preserve operator-owned env flags" helper,
+# sourced by dispatcher deploy.sh scripts.
+#
+# WHY (3rd instance of the operator-flag-clobber class — config#1818 saturday,
+# config#2236 spot, config#2264 ci-watch): dispatcher Lambdas carry OPERATOR-
+# OWNED runtime kill-switches (AGENT_DISPATCH_ENABLED, FAST_PATH_ENABLED,
+# SF_WATCH_DISPATCH_ENABLED, CI_WATCH_DISPATCH_ENABLED). A deploy script's
+# code-update path must READ the live value and carry it forward — never reset
+# it to the bootstrap default. 2026-07-05 incident: the saturday dispatcher's
+# update path hardcoded false; a routine redeploy silently disarmed autonomous
+# dispatch, and both 2026-07-06 preopen SF failures went un-dispatched with
+# the market open. Bootstrap (create-function) still applies each dispatcher's
+# hardcoded default — safe posture for a brand-NEW deployment only.
+#
+# Usage (from a deploy.sh that defines SCRIPT_DIR):
+#   source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+#   CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" CI_WATCH_DISPATCH_ENABLED true)
+#
+# The preserved value (true|false) is printed on stdout for command
+# substitution; the human-readable "preserving ..." receipt goes to stderr so
+# it still lands in deploy logs without polluting the captured value.
+
+# preserve_env_flag FUNCTION_NAME REGION VAR_NAME DEFAULT — echoes true|false.
+preserve_env_flag() {
+  local fn="$1" region="$2" var="$3" default="$4"
+  local val
+  # 2>/dev/null suppresses only the CLI's stderr chatter; a nonzero aws exit
+  # (e.g. function not found) still aborts the caller under set -e — same
+  # fail-loud posture as the pre-extraction inline blocks. A missing VAR on an
+  # existing function returns "None" with exit 0 and falls through to the
+  # per-dispatcher default below; the stderr receipt records the value applied.
+  val=$(aws lambda get-function-configuration \
+    --function-name "${fn}" \
+    --region "${region}" \
+    --query "Environment.Variables.${var}" --output text 2>/dev/null)
+  case "${val}" in true|false) ;; *) val="${default}" ;; esac
+  echo "  preserving ${var}=${val} (operator-owned)" >&2
+  echo "${val}"
+}

--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -42,6 +42,12 @@ ROLE_NAME="alpha-engine-ci-watch-dispatcher-role"
 POLICY_NAME="alpha-engine-ci-watch-dispatcher-policy"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# Bootstrap default (first-time deployment only) — sets CI_WATCH_DISPATCH_ENABLED=true
+# as the safe default. The update path (step 3) will read the live value and preserve it.
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=true}'
+
+# Shared operator-flag-preserve helper (config#1818/#2236/#2264 bug class).
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
 
 DRY_RUN=false
 BOOTSTRAP=false
@@ -145,7 +151,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 300 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=true}' \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -170,10 +176,16 @@ fi
 
 echo "✓ Code deployed."
 
-echo "Updating Lambda environment..."
+echo "Updating Lambda environment (preserving operator-owned CI_WATCH_DISPATCH_ENABLED)..."
+# CI_WATCH_DISPATCH_ENABLED is an OPERATOR-OWNED runtime kill-switch — the
+# update path must PRESERVE its live value, never reset it to the bootstrap
+# default. Mirrors the saturday/spot dispatcher fixes (config#1818/#2236): a
+# routine redeploy must not silently re-arm the operator's containment flag.
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" CI_WATCH_DISPATCH_ENABLED true)
+LAMBDA_ENV="Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=${CURRENT_DISPATCH}}"
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment 'Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=true}' \
+  --environment "${LAMBDA_ENV}" \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -35,6 +35,9 @@ RULE_NAME="alpha-engine-saturday-sf-watch-failed"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 
+# Shared operator-flag-preserve helper (config#1818/#2236/#2264 bug class).
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
 DRY_RUN=false
 BOOTSTRAP=false
 SMOKE=false
@@ -198,20 +201,10 @@ echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 # 2026-07-06 preopen SF failures (dispatched=False on both) while the market
 # was open. Bootstrap (create-function above) still defaults false — safe
 # rollout posture for a NEW deployment only.
-CURRENT_DISPATCH=$(aws lambda get-function-configuration \
-  --function-name "${FUNCTION_NAME}" \
-  --region "${REGION}" \
-  --query 'Environment.Variables.AGENT_DISPATCH_ENABLED' --output text 2>/dev/null)
-case "${CURRENT_DISPATCH}" in true|false) ;; *) CURRENT_DISPATCH=false ;; esac
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" AGENT_DISPATCH_ENABLED false)
 # FAST_PATH_ENABLED (config#1900) is operator-owned exactly like
 # AGENT_DISPATCH_ENABLED — preserve the live value across redeploys.
-CURRENT_FAST_PATH=$(aws lambda get-function-configuration \
-  --function-name "${FUNCTION_NAME}" \
-  --region "${REGION}" \
-  --query 'Environment.Variables.FAST_PATH_ENABLED' --output text 2>/dev/null)
-case "${CURRENT_FAST_PATH}" in true|false) ;; *) CURRENT_FAST_PATH=false ;; esac
-echo "  preserving AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH} (operator-owned)"
-echo "  preserving FAST_PATH_ENABLED=${CURRENT_FAST_PATH} (operator-owned)"
+CURRENT_FAST_PATH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" FAST_PATH_ENABLED false)
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
   --environment "Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH},FAST_PATH_ENABLED=${CURRENT_FAST_PATH},FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}" \

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -57,6 +57,9 @@ DEFER_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${DEFER_ROLE_NAME}"
 # as the safe default. The update path (step 3) will read the live value and preserve it.
 LAMBDA_ENV_BOOTSTRAP="Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=true,SF_WATCH_DEFER_ROLE_ARN=${DEFER_ROLE_ARN}}"
 
+# Shared operator-flag-preserve helper (config#1818/#2236/#2264 bug class).
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
 DRY_RUN=false
 BOOTSTRAP=false
 SMOKE=false
@@ -216,12 +219,7 @@ echo "Updating Lambda environment (preserving operator-owned SF_WATCH_DISPATCH_E
 # the update path must PRESERVE its live value, never reset it to bootstrap defaults.
 # This mirrors the saturday-sf-watch-dispatcher fix (config#1818): a routine redeploy
 # should not silently re-arm/disarm the operator's incident-response flag.
-CURRENT_DISPATCH=$(aws lambda get-function-configuration \
-  --function-name "${FUNCTION_NAME}" \
-  --region "${REGION}" \
-  --query 'Environment.Variables.SF_WATCH_DISPATCH_ENABLED' --output text 2>/dev/null)
-case "${CURRENT_DISPATCH}" in true|false) ;; *) CURRENT_DISPATCH=true ;; esac
-echo "  preserving SF_WATCH_DISPATCH_ENABLED=${CURRENT_DISPATCH} (operator-owned)"
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" SF_WATCH_DISPATCH_ENABLED true)
 LAMBDA_ENV="Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=${CURRENT_DISPATCH},SF_WATCH_DEFER_ROLE_ARN=${DEFER_ROLE_ARN}}"
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \

--- a/tests/test_sf_watch_deploy_flag_preserve.py
+++ b/tests/test_sf_watch_deploy_flag_preserve.py
@@ -1,47 +1,81 @@
-"""config#1818 — the sf-watch dispatcher deploy script must preserve the
-operator-owned AGENT_DISPATCH_ENABLED flag across redeploys.
+"""config#1818 / config#2236 / config#2264 — dispatcher deploy scripts must
+preserve operator-owned kill-switch flags across redeploys.
 
-2026-07-05: the update path hardcoded false; a routine redeploy silently
-disarmed autonomous dispatch, and both 2026-07-06 preopen SF failures went
-un-dispatched (dispatched=False) with the market open.
+2026-07-05: the saturday dispatcher's update path hardcoded false; a routine
+redeploy silently disarmed autonomous dispatch, and both 2026-07-06 preopen SF
+failures went un-dispatched (dispatched=False) with the market open. The same
+clobber class recurred in sf-watch-spot-dispatcher (config#2236, re-arm
+direction) and ci-watch-dispatcher (config#2264, re-arm direction). 3rd
+instance = consolidation: the preserve logic now lives in ONE shared sourced
+helper, infrastructure/lambdas/_shared/preserve_env_flags.sh.
 """
 
+from pathlib import Path
+
+LAMBDAS_DIR = Path(__file__).parent.parent / "infrastructure/lambdas"
+HELPER_REL = "_shared/preserve_env_flags.sh"
+SOURCE_LINE = 'source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"'
+
+# dispatcher -> list of (flag_name, bootstrap_default, preserved_shell_var)
+OPERATOR_FLAGS = {
+    "saturday-sf-watch-dispatcher": [
+        ("AGENT_DISPATCH_ENABLED", "false", "CURRENT_DISPATCH"),
+        ("FAST_PATH_ENABLED", "false", "CURRENT_FAST_PATH"),
+    ],
+    "sf-watch-spot-dispatcher": [
+        ("SF_WATCH_DISPATCH_ENABLED", "true", "CURRENT_DISPATCH"),
+    ],
+    "ci-watch-dispatcher": [
+        ("CI_WATCH_DISPATCH_ENABLED", "true", "CURRENT_DISPATCH"),
+    ],
+}
+
+
+def test_shared_helper_reads_live_value():
+    """The shared helper must query the LIVE function config and validate the
+    value, falling back to the caller-supplied default only for non-boolean
+    reads (missing var / fresh bootstrap)."""
+    src = (LAMBDAS_DIR / HELPER_REL).read_text()
+    assert "preserve_env_flag()" in src, "helper must define preserve_env_flag()"
+    assert "aws lambda get-function-configuration" in src, \
+        "helper must query the live function configuration"
+    assert '--query "Environment.Variables.${var}"' in src, \
+        "helper must read the flag's live value"
+    assert 'case "${val}" in true|false) ;; *) val="${default}" ;; esac' in src, \
+        "helper must validate true|false and fall back to the default"
+
+
 def test_deploy_update_path_preserves_operator_dispatch_flag():
-    """config#1818/config#2236: AGENT_DISPATCH_ENABLED and SF_WATCH_DISPATCH_ENABLED
-    are operator-owned — deploy scripts' UPDATE paths must read the live value and
-    carry it, never reset to bootstrap defaults. 2026-07-05 incident: the hardcoded
-    false in the saturday dispatcher's update path silently disarmed autonomous
-    dispatch during a routine redeploy; both 2026-07-06 preopen failures went
-    un-dispatched with the market open. Same bug class in spot dispatcher (config#2236)."""
-    from pathlib import Path
+    """config#1818/#2236/#2264: operator-owned flags — every dispatcher deploy
+    script's UPDATE path must read the live value (via the shared helper) and
+    carry it, never reset to bootstrap defaults."""
+    for dispatcher, flags in OPERATOR_FLAGS.items():
+        src = (LAMBDAS_DIR / dispatcher / "deploy.sh").read_text()
 
-    for dispatcher in ["saturday-sf-watch-dispatcher", "sf-watch-spot-dispatcher"]:
-        src = (
-            Path(__file__).parent.parent
-            / f"infrastructure/lambdas/{dispatcher}/deploy.sh"
-        ).read_text()
+        # Each deploy.sh sources the ONE shared helper — no hand-copied forks.
+        assert SOURCE_LINE in src, \
+            f"{dispatcher}: must source the shared {HELPER_REL} helper"
+        assert "aws lambda get-function-configuration" not in src, \
+            f"{dispatcher}: live read belongs in the shared helper, not inline"
 
-        if dispatcher == "saturday-sf-watch-dispatcher":
-            flag_name = "AGENT_DISPATCH_ENABLED"
-        else:
-            flag_name = "SF_WATCH_DISPATCH_ENABLED"
+        for flag_name, default_val, shell_var in flags:
+            # The update path reads the current live value via the helper...
+            call = (
+                f'{shell_var}=$(preserve_env_flag "${{FUNCTION_NAME}}" '
+                f'"${{REGION}}" {flag_name} {default_val})'
+            )
+            assert call in src, \
+                f"{dispatcher}: update path must preserve {flag_name} via the helper"
+            # ...and the env applied on update carries the preserved value.
+            assert f"{flag_name}=${{{shell_var}}}" in src, \
+                f"{dispatcher}: update env must use the preserved {flag_name} value"
 
-        # The update path reads the current live value...
-        assert "CURRENT_DISPATCH=$(aws lambda get-function-configuration" in src, \
-            f"{dispatcher}: update path must query live value"
-        assert f"{flag_name}=${{CURRENT_DISPATCH}}" in src, \
-            f"{dispatcher}: update path must use preserved value"
-
-        # ...and exactly ONE hardcoded false/true in bootstrap (create-function).
-        # Saturday dispatcher uses false default; spot uses true default.
-        default_val = "false" if dispatcher == "saturday-sf-watch-dispatcher" else "true"
-        hardcoded_count = src.count(f"{flag_name}={default_val}")
-        assert hardcoded_count >= 1, \
-            f"{dispatcher}: must have at least one hardcoded {flag_name}={default_val} (bootstrap)"
-
-        # Verify the hardcoded value is in the bootstrap section, not update
-        create_pos = src.index("create-function")
-        default_pos = src.index(f"{flag_name}={default_val}")
-        update_pos = src.index("Updating Lambda environment")
-        assert default_pos < update_pos, \
-            f"{dispatcher}: hardcoded {flag_name}={default_val} may only exist in bootstrap, not update path"
+            # The hardcoded default may only exist in the bootstrap
+            # (create-function) posture, never in the update path's env.
+            assert "create-function" in src, f"{dispatcher}: bootstrap block missing"
+            hardcoded = f"{flag_name}={default_val}"
+            assert src.count(hardcoded) >= 1, \
+                f"{dispatcher}: must keep one hardcoded {hardcoded} (bootstrap default)"
+            update_pos = src.index("Updating Lambda environment")
+            assert src.rindex(hardcoded) < update_pos, \
+                f"{dispatcher}: hardcoded {hardcoded} may only exist pre-update (bootstrap)"


### PR DESCRIPTION
## What
3rd instance of the operator-flag-clobber class (config#1818, config#2236): `ci-watch-dispatcher/deploy.sh`'s update path hardcoded `CI_WATCH_DISPATCH_ENABLED=true` on every redeploy, silently re-arming a deliberately-flipped kill-switch.

- Ports the PR751 preserve pattern to ci-watch-dispatcher (live env read on update; defaults bootstrap-only).
- 3rd instance = consolidation: new `infrastructure/lambdas/_shared/preserve_env_flags.sh` sourced by all THREE dispatcher deploy.sh scripts (saturday x2 flags, spot x1, ci-watch x1) — byte-identical inline blocks lifted to one helper; per-script env assembly stays local.
- `tests/test_sf_watch_deploy_flag_preserve.py` rewritten table-driven across all three dispatchers + forbids future inline hand-copies.

## Verification
- New/changed tests pass; `bash -n` clean on all four scripts; helper smoke-tested under bash 5 and macOS bash 3.2 (live=false stays false / live=true stays true / missing→default).

Closes nousergon/alpha-engine-config#2264 (alpha-engine-config-I2264; epic alpha-engine-config-I2282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)