### PR TITLE
feat(observability): CloudWatch Errors/Throttles alarms for the four watch-plane Lambdas (config#2266)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -26,7 +26,10 @@ on the failure; observe-only paths are watch-log-only, no Fleet-SF Watch ping).
 
 **Fail-loud (CLAUDE.md no-silent-fails).** The watch-log artifact write is the
 primary deliverable → it RAISES on failure so a broken producer surfaces via the
-Lambda error metric + CW alarm. Enrichment (DescribeExecution /
+Lambda Errors metric and the ``alpha-engine-watch-plane-saturday-sf-watch-
+dispatcher-errors`` CloudWatch alarm (provisioned by
+``infrastructure/setup_watch_plane_alarms.sh``, routed to the independent
+``alpha-engine-alarm-backstop`` SNS topic — config#2266). Enrichment (DescribeExecution /
 GetExecutionHistory), the Telegram record, and the agent dispatch are secondary
 observability hung off the primary path: their failure is logged at WARNING and
 recorded in the artifact — the artifact still records that a failure was detected.
@@ -556,9 +559,11 @@ def _write_watch_log(
 ) -> str:
     """Append the event to the date's watch-log and write it back. PRIMARY
     deliverable — RAISES on failure (fail-loud: a broken producer must surface
-    via the Lambda error metric + CW alarm, never silently). ``doc`` lets the
-    handler pass the already-loaded document (the fast path reads prior events
-    from it first) so load-append-write stays a single read."""
+    via the Lambda Errors metric + the alpha-engine-watch-plane-*-errors CW
+    alarm from infrastructure/setup_watch_plane_alarms.sh, never silently).
+    ``doc`` lets the handler pass the already-loaded document (the fast path
+    reads prior events from it first) so load-append-write stays a single
+    read."""
     key = _artifact_key(watch_prefix, run_date)
     if doc is None:
         doc = _load_existing(s3, key)

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# setup_watch_plane_alarms.sh — CloudWatch Errors/Throttles alarms for the four
+# watch-plane Lambdas (config#2266).
+#
+# Why this exists: the watch-plane Lambdas (saturday-sf-watch-dispatcher,
+# sf-watch-spot-dispatcher, ci-watch-dispatcher, sf-watch-liveness-probe) are
+# the components whose JOB is to notice fleet failures — and their docstrings
+# asserted that their own failures "surface via the Lambda error metric + CW
+# alarm". Until this script, NO such alarm existed: an unhandled dispatcher
+# exception incremented an AWS/Lambda Errors metric nobody watched, so the
+# fail-loud raise in _write_watch_log (the PRIMARY watch record) failed
+# silently in practice. The watch's own failure mode was exactly the
+# unmonitored one. This script makes the docstring claim true.
+#
+# INDEPENDENT alerting channel: the watch plane IS a primary failure-detection
+# channel, so its own failures must page via the INDEPENDENT backstop topic
+# (alpha-engine-alarm-backstop), NOT alpha-engine-alerts — the same
+# independence argument as setup_pipeline_deadman_alarms.sh (config#856 infra
+# item b): a blackout of the primary alert channel must not also silence the
+# alarms that watch the watchers.
+#
+# Topic ownership (single-writer convention): setup_pipeline_deadman_alarms.sh
+# is the backstop topic's SOLE provisioner (create-topic + email subscription).
+# This script only CONSUMES the topic and fails fast if it is missing —
+# mirrors the fail-fast-on-missing-topic convention in
+# setup_substrate_alarms.sh / setup_changelog_observability_alarms.sh.
+#
+# Metric semantics: unlike the deadman alarms (which alarm on ABSENCE of
+# activity and therefore need TreatMissingData=breaching), these alarm on
+# PRESENCE of errors. AWS/Lambda emits no Errors datapoint during quiet
+# periods, so missing data is the healthy steady state here —
+# TreatMissingData=notBreaching is correct, and breaching would page
+# continuously on every idle 5-minute window.
+#
+# Window: Period=300 (5 min), EvaluationPeriods=1, Threshold=1,
+# GreaterThanOrEqualToThreshold, Statistic=Sum — a single error or throttle in
+# any 5-minute window pages immediately. These functions are low-volume and
+# failure-driven; there is no acceptable nonzero error rate.
+#
+# Idempotent: put-metric-alarm upserts by name. Safe to re-run.
+#
+# Usage:
+#   ./infrastructure/setup_watch_plane_alarms.sh [--dry-run]
+
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
+
+# Deliberately NOT alpha-engine-alerts — see header comment. Provisioned by
+# setup_pipeline_deadman_alarms.sh (sole owner); consumed here.
+BACKSTOP_TOPIC_NAME="alpha-engine-alarm-backstop"
+BACKSTOP_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${BACKSTOP_TOPIC_NAME}"
+
+# The four watch-plane Lambdas (deployed names verified against each
+# infrastructure/lambdas/<dir>/deploy.sh FUNCTION_NAME).
+declare -A WATCH_PLANE_FUNCTIONS=(
+  ["saturday-sf-watch-dispatcher"]="alpha-engine-saturday-sf-watch-dispatcher"
+  ["sf-watch-spot-dispatcher"]="alpha-engine-sf-watch-spot-dispatcher"
+  ["ci-watch-dispatcher"]="alpha-engine-ci-watch-dispatcher"
+  ["sf-watch-liveness-probe"]="alpha-engine-sf-watch-liveness-probe"
+)
+
+echo "Configuring watch-plane Lambda alarms"
+echo "  Region:         $REGION"
+echo "  Backstop topic: $BACKSTOP_TOPIC_ARN"
+
+run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+
+# --- 1. Fail fast if the backstop topic is missing ---------------------------
+# setup_pipeline_deadman_alarms.sh owns topic creation + the email
+# subscription; wiring alarms to a nonexistent topic would create silently
+# dangling alarms — the exact failure class this script exists to close.
+
+echo ""
+echo "==> Verifying backstop SNS topic exists..."
+if ! $DRY_RUN && ! aws sns get-topic-attributes --topic-arn "$BACKSTOP_TOPIC_ARN" --region "$REGION" >/dev/null 2>&1; then
+  echo "ERROR: backstop SNS topic $BACKSTOP_TOPIC_ARN not found. Run" >&2
+  echo "       infrastructure/setup_pipeline_deadman_alarms.sh first (it is the" >&2
+  echo "       topic's sole provisioner). Aborting before creating dangling alarms." >&2
+  exit 1
+fi
+
+# --- 2. Per-Lambda Errors + Throttles alarms ---------------------------------
+
+echo ""
+echo "==> Creating per-Lambda watch-plane alarms..."
+for label in "${!WATCH_PLANE_FUNCTIONS[@]}"; do
+  fn_name="${WATCH_PLANE_FUNCTIONS[$label]}"
+
+  for metric in Errors Throttles; do
+    metric_lc=$(echo "$metric" | tr '[:upper:]' '[:lower:]')
+    alarm_name="alpha-engine-watch-plane-${label}-${metric_lc}"
+
+    echo "  -> $alarm_name (FunctionName=$fn_name, metric=$metric)"
+    run aws cloudwatch put-metric-alarm \
+      --region "$REGION" \
+      --alarm-name "$alarm_name" \
+      --alarm-description "Watch-plane backstop: fires when ${fn_name} records any ${metric} in a 5-minute window. This Lambda is part of the fleet's failure-detection plane — its own unhandled failure (e.g. the fail-loud raise in _write_watch_log) is otherwise exactly the unmonitored failure mode (config#2266). Routes to the INDEPENDENT ${BACKSTOP_TOPIC_NAME} topic (not alpha-engine-alerts) so a blackout of the primary alert channel cannot also silence the alarm that watches the watchers. Provisioned by infrastructure/setup_watch_plane_alarms.sh." \
+      --namespace "AWS/Lambda" \
+      --metric-name "$metric" \
+      --dimensions "Name=FunctionName,Value=${fn_name}" \
+      --statistic "Sum" \
+      --period 300 \
+      --evaluation-periods 1 \
+      --datapoints-to-alarm 1 \
+      --threshold 1 \
+      --comparison-operator "GreaterThanOrEqualToThreshold" \
+      --treat-missing-data "notBreaching" \
+      --alarm-actions "$BACKSTOP_TOPIC_ARN" \
+      --ok-actions "$BACKSTOP_TOPIC_ARN" >/dev/null
+  done
+done
+
+echo ""
+echo "Done — $(( ${#WATCH_PLANE_FUNCTIONS[@]} * 2 )) watch-plane alarms upserted, routed to $BACKSTOP_TOPIC_ARN."
+echo ""
+echo "Validation:"
+echo "  aws cloudwatch describe-alarms --region $REGION \\"
+echo "    --alarm-name-prefix alpha-engine-watch-plane- \\"
+echo "    --query 'MetricAlarms[].[AlarmName,StateValue]' --output table"

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -1,0 +1,167 @@
+"""Pins the watch-plane Lambda alarm setup script (config#2266).
+
+setup_watch_plane_alarms.sh puts CloudWatch Errors + Throttles alarms on each
+of the four watch-plane Lambdas — the components whose job is to notice fleet
+failures, and whose own failures were previously the one unmonitored failure
+mode (docstrings claimed an "error metric + CW alarm" backstop that did not
+exist). These tests pin the load-bearing shape:
+
+- All four watch-plane Lambdas must be covered — dropping one silently
+  reopens the "who watches the watcher" gap for that function.
+- Alarms must route to the INDEPENDENT alpha-engine-alarm-backstop topic,
+  never alpha-engine-alerts (the watch plane IS a primary channel; its own
+  failures must page via the independent one — setup_pipeline_deadman_alarms.sh
+  precedent).
+- TreatMissingData must be "notBreaching" — the OPPOSITE of the deadman
+  alarms: these alarm on presence of errors, and AWS/Lambda emits no Errors
+  datapoint during quiet periods, so missing data is the healthy steady state
+  ("breaching" would page continuously on every idle window).
+- The topic must be verified before any put-metric-alarm call (fail-fast
+  before dangling alarms), and this script must NOT provision the topic —
+  setup_pipeline_deadman_alarms.sh is its sole owner.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "infrastructure" / "setup_watch_plane_alarms.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _SCRIPT.read_text()
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT.is_file()
+    assert _SCRIPT.stat().st_mode & 0o111, "script must be chmod +x"
+
+
+def test_bash_syntax_is_valid():
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash not available")
+    result = subprocess.run([bash, "-n", str(_SCRIPT)], capture_output=True)
+    assert result.returncode == 0, result.stderr.decode()
+
+
+class TestWatchPlaneCoverage:
+    """All four watch-plane Lambdas must be alarmed."""
+
+    @pytest.mark.parametrize(
+        "fn_name",
+        [
+            "alpha-engine-saturday-sf-watch-dispatcher",
+            "alpha-engine-sf-watch-spot-dispatcher",
+            "alpha-engine-ci-watch-dispatcher",
+            "alpha-engine-sf-watch-liveness-probe",
+        ],
+    )
+    def test_lambda_is_present(self, script_text, fn_name):
+        assert fn_name in script_text, (
+            f"{fn_name} must be in the watch-plane alarm target set — dropping "
+            "it silently reopens the 'who watches the watcher' gap (config#2266)."
+        )
+
+    def test_four_functions_declared(self, script_text):
+        block = script_text[
+            script_text.find("declare -A WATCH_PLANE_FUNCTIONS=(") : script_text.find(
+                ")", script_text.find("declare -A WATCH_PLANE_FUNCTIONS=(")
+            )
+        ]
+        assert block.count('"alpha-engine-') == 4
+
+    def test_both_errors_and_throttles_alarmed(self, script_text):
+        assert "for metric in Errors Throttles" in script_text
+
+
+class TestIndependentBackstopTopic:
+    def test_routes_to_backstop_topic(self, script_text):
+        assert 'BACKSTOP_TOPIC_NAME="alpha-engine-alarm-backstop"' in script_text
+        assert '--alarm-actions "$BACKSTOP_TOPIC_ARN"' in script_text
+        assert '--ok-actions "$BACKSTOP_TOPIC_ARN"' in script_text
+
+    def test_never_routes_to_primary_alerts_topic(self, script_text):
+        # alpha-engine-alerts may appear in prose comments (contrasting it) but
+        # must never be constructed as an ARN / used as a routing variable.
+        assert ":alpha-engine-alerts" not in script_text
+        assert 'SNS_TOPIC_ARN="arn:aws:sns' not in script_text
+
+    def test_topic_verified_before_alarm_wiring(self, script_text):
+        verify_pos = script_text.find("aws sns get-topic-attributes")
+        first_alarm_pos = script_text.find("aws cloudwatch put-metric-alarm")
+        assert verify_pos != -1
+        assert first_alarm_pos != -1
+        assert verify_pos < first_alarm_pos
+
+    def test_does_not_provision_the_topic(self, script_text):
+        # Single-writer convention: setup_pipeline_deadman_alarms.sh is the
+        # backstop topic's sole provisioner; this script only consumes it.
+        assert "aws sns create-topic" not in script_text
+        assert "aws sns subscribe" not in script_text
+
+
+class TestAlarmSemantics:
+    def test_lambda_namespace_and_dimension(self, script_text):
+        assert '--namespace "AWS/Lambda"' in script_text
+        assert "Name=FunctionName,Value=" in script_text
+
+    def test_fires_at_one_error(self, script_text):
+        assert '--comparison-operator "GreaterThanOrEqualToThreshold"' in script_text
+        assert "--threshold 1" in script_text
+        assert '--statistic "Sum"' in script_text
+
+    def test_treat_missing_data_is_not_breaching(self, script_text):
+        # Opposite of the deadman alarms: these alarm on PRESENCE of errors,
+        # and AWS/Lambda emits no Errors datapoint when idle — "breaching"
+        # would page continuously on every quiet 5-minute window.
+        assert '--treat-missing-data "notBreaching"' in script_text
+        assert '--treat-missing-data "breaching"' not in script_text
+
+    def test_five_minute_single_period_window(self, script_text):
+        assert "--period 300" in script_text
+        assert "--evaluation-periods 1" in script_text
+        assert "--datapoints-to-alarm 1" in script_text
+
+    def test_alarm_naming_convention(self, script_text):
+        assert 'alarm_name="alpha-engine-watch-plane-${label}-${metric_lc}"' in script_text
+
+
+class TestRegionDefault:
+    def test_region_defaults_to_us_east_1(self, script_text):
+        assert 'REGION="${AWS_REGION:-us-east-1}"' in script_text
+
+
+class TestDryRun:
+    def test_supports_dry_run_flag(self, script_text):
+        assert '"${1:-}" == "--dry-run"' in script_text
+
+    def test_dry_run_gates_mutating_calls_via_run_helper(self, script_text):
+        assert "run() {" in script_text
+        alarm_block = script_text[script_text.find("Creating per-Lambda") :]
+        assert "run aws cloudwatch put-metric-alarm" in alarm_block
+
+
+class TestDocstringsNowTruthful:
+    """config#2266 deliverable 3: the dispatcher docstrings that claimed the
+    alarm must now point at the script that actually provisions it."""
+
+    def test_saturday_dispatcher_docstring_names_the_alarm_script(self):
+        index_py = (
+            _REPO_ROOT
+            / "infrastructure"
+            / "lambdas"
+            / "saturday-sf-watch-dispatcher"
+            / "index.py"
+        ).read_text()
+        assert index_py.count("setup_watch_plane_alarms.sh") >= 2, (
+            "Both fail-loud docstrings (module header + _write_watch_log) must "
+            "name the alarm-provisioning script — the pre-#2266 wording claimed "
+            "a CW alarm that did not exist."
+        )


### PR DESCRIPTION
## What
The watch-plane Lambdas' docstrings claimed failures "surface via the Lambda error metric + CW alarm" — no such alarm existed, so the fail-loud raise in `_write_watch_log` (the PRIMARY watch record) failed silently in practice.

- New `infrastructure/setup_watch_plane_alarms.sh` (mirrors `setup_pipeline_deadman_alarms.sh`): Errors + Throttles alarms per Lambda (Sum/300s/1 period/>=1, TreatMissingData=notBreaching — these alarm on PRESENCE of errors, unlike the deadman absence alarms), all routed to the INDEPENDENT `alpha-engine-alarm-backstop` topic; fails fast if the topic is missing (single-writer: the deadman script remains its sole provisioner).
- `saturday-sf-watch-dispatcher/index.py`: the two false docstrings now name the real alarm + provisioning script.
- Guard test `tests/test_watch_plane_alarms_script.py` pins the script shape (4 functions, backstop-only routing, notBreaching, no topic provisioning, dry-run gating).

## Live-apply status (found during this arc)
**The backstop layer from data-PR610 (merged 2026-07-03) was NEVER applied live** — no `alpha-engine-alarm-backstop` topic and ZERO deadman alarms exist (verified 2026-07-11). Live apply of BOTH scripts is queued pending Brian's explicit go-ahead (auto-mode boundary on prod-infra mutation); the observation gate stays on alpha-engine-config-I2266, which remains open until `describe-alarms` shows the alarms live. This PR is merge-safe independently (tracked scripts + docstrings only, no deploy-surface change).

Refs nousergon/alpha-engine-config#2266 (alpha-engine-config-I2266; epic alpha-engine-config-I2282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)