### PR TITLE
feat(sf-watch-liveness-probe): probe the live EC2-spot dispatch leg — dispatcher health, kill-switch reporting, launch-config existence (config#2265)

### DIFF
--- a/infrastructure/lambdas/sf-watch-liveness-probe/README.md
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/README.md
@@ -26,6 +26,20 @@ Read-only, schedule-aware config-drift check:
    failure to expose it.
 4. The target dispatcher Lambda is `Active` with a successful last code
    update.
+5. **EC2-spot dispatch leg** (the LIVE repair path since the 2026-07-10 spot
+   migration, config#2001/#2106): `alpha-engine-sf-watch-spot-dispatcher` and
+   `alpha-engine-ci-watch-dispatcher` exist and are `Active`. Their
+   kill-switch env values (`SF_WATCH_DISPATCH_ENABLED` /
+   `CI_WATCH_DISPATCH_ENABLED`) are read and **reported** in the probe
+   record/log — never alerted on: a deliberate operator disable is state, not
+   an incident.
+6. **Launch-config existence** (the deregistered-AMI silent-break guard,
+   config#2265): the AMI, security group, and subnets the spot dispatcher
+   would launch with — read from its DEPLOYED live env (`SF_WATCH_AMI_ID` /
+   `SF_WATCH_SECURITY_GROUP` / `SF_WATCH_SUBNETS`, pinned by that Lambda's
+   `deploy.sh` and lockstep-tested against its in-code defaults) — still
+   exist in EC2. A missing expected env key is itself a loud finding, never a
+   skip.
 
 Silent-unless-broken (mirrors the groom-liveness-probe's philosophy, one
 layer up): a clean check logs and returns, no Telegram noise. Any problem
@@ -35,9 +49,11 @@ alert state clears automatically once the check is clean again.
 
 **Fail-loud:** every AWS describe/list call is the PRIMARY input — an error
 code other than the specific "doesn't exist" ones being checked for RAISES,
-surfacing via the Lambda error metric + a CW alarm rather than silently
-skipping the one check that verifies nothing else is silently broken. The
-Telegram send and dedup-state write are best-effort.
+surfacing via the Lambda `Errors` metric, alarmed by the watch-plane
+CloudWatch alarms provisioned in `infrastructure/setup_watch_plane_alarms.sh`
+(the dead-probe backstop) — rather than silently skipping the one check that
+verifies nothing else is silently broken. The Telegram send and dedup-state
+write are best-effort.
 
 ## Deploy (operator-gated, outside CloudFormation)
 
@@ -49,8 +65,8 @@ bash deploy.sh --smoke       # invoke once (read-only; pings only on a REAL prob
 ```
 
 Merging the PR has **zero** live effect until an operator runs `--bootstrap`.
-Recommend wiring a CloudWatch alarm on this function's `Errors` metric (the
-fail-loud contract assumes one).
+The CloudWatch alarm on this function's `Errors` metric (which the fail-loud
+contract assumes) is provisioned by `infrastructure/setup_watch_plane_alarms.sh`.
 
 Cadence (UTC): `cron(45 6 * * ? *)` and `cron(45 14 * * ? *)` — offset 15 min
 from the groom-liveness-probe's cadence purely to avoid simultaneous

--- a/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
@@ -43,7 +43,21 @@
       "Sid": "ReadDispatcherLambdaHealth",
       "Effect": "Allow",
       "Action": ["lambda:GetFunctionConfiguration"],
-      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-saturday-sf-watch-dispatcher"
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-saturday-sf-watch-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-sf-watch-spot-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ci-watch-dispatcher"
+      ]
+    },
+    {
+      "Sid": "ReadSpotLaunchConfigEc2DescribeNotResourceScopable",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeImages",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets"
+      ],
+      "Resource": "*"
     },
     {
       "Sid": "LivenessDedupState",

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -27,6 +27,24 @@ and asserts, read-only:
      2026-06-29 dead-ARN class directly, instead of waiting for a real failure
      to expose it.
   4. The target Lambda is Active with a successful last code update.
+  5. The EC2-spot dispatch leg — the LIVE repair path since the 2026-07-10
+     spot migration (config#2001/#2106): alpha-engine-sf-watch-spot-dispatcher
+     and alpha-engine-ci-watch-dispatcher exist and are Active. Their
+     kill-switch env values (SF_WATCH_DISPATCH_ENABLED /
+     CI_WATCH_DISPATCH_ENABLED) are READ AND REPORTED in the probe record so a
+     disabled watch is visible — but never alerted on: a deliberate operator
+     disable is state, not an incident (config#2265; sweep obligation lives
+     with config#2257).
+  6. The spot launch config still exists, read from the DEPLOYED spot
+     dispatcher's live env (SF_WATCH_AMI_ID / SF_WATCH_SECURITY_GROUP /
+     SF_WATCH_SUBNETS — pinned by that Lambda's deploy.sh, so the env is the
+     observable source of truth; this probe deliberately duplicates NO
+     constants): DescribeImages / DescribeSecurityGroups / DescribeSubnets.
+     A deregistered AMI or deleted SG/subnet would break every future spot
+     launch with ZERO signal until the next real failure needed a repair —
+     the exact "healthy idle vs silently broken idle" class that bit twice on
+     2026-07-10. A missing expected env key is itself a LOUD finding, never a
+     skip.
 
 Silent-unless-broken (mirrors the groom probe and Fleet-SF Watch's own
 failure-driven design): a clean check logs and returns, no Telegram noise. Any
@@ -37,8 +55,10 @@ the alert state clears automatically the moment the check is clean again.
 **Fail-loud (CLAUDE.md no-silent-fails).** Every AWS describe/list call here is
 the PRIMARY input: an UNEXPECTED API error (anything other than the specific
 "this resource doesn't exist" codes we're explicitly checking for) RAISES, so a
-broken probe surfaces via the Lambda error metric + CW alarm rather than
-silently skipping the one check that verifies nothing else is silently broken.
+broken probe surfaces via the Lambda Errors metric — alarmed by the watch-plane
+CloudWatch alarms provisioned in infrastructure/setup_watch_plane_alarms.sh
+(the dead-probe backstop) — rather than silently skipping the one check that
+verifies nothing else is silently broken.
 The Telegram alert itself is a secondary delivery surface: its own failure is
 logged + returned, not raised.
 """
@@ -86,6 +106,27 @@ EXPECTED_PIPELINE_NAMES = [
 WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
 STATE_KEY = os.environ.get("SF_WATCH_LIVENESS_STATE_KEY", "consolidated/sf_watch_liveness/alerted.json")
 
+# ── EC2-spot dispatch leg (the LIVE repair path since 2026-07-10) ────────────
+SPOT_DISPATCHER_FUNCTION = os.environ.get(
+    "SF_WATCH_SPOT_DISPATCHER_FUNCTION", "alpha-engine-sf-watch-spot-dispatcher"
+)
+CI_WATCH_DISPATCHER_FUNCTION = os.environ.get(
+    "CI_WATCH_DISPATCHER_FUNCTION", "alpha-engine-ci-watch-dispatcher"
+)
+# (function name, kill-switch env key). The kill-switch value is REPORTED in
+# the probe record, never alerted on — a deliberate operator disable is state,
+# not an incident.
+SPOT_LEG_DISPATCHERS: list[tuple[str, str]] = [
+    (SPOT_DISPATCHER_FUNCTION, "SF_WATCH_DISPATCH_ENABLED"),
+    (CI_WATCH_DISPATCHER_FUNCTION, "CI_WATCH_DISPATCH_ENABLED"),
+]
+# Launch-config keys read from the DEPLOYED spot dispatcher's live env (its
+# deploy.sh pins them — a lockstep test in sf-watch-spot-dispatcher/
+# test_handler.py holds deploy.sh's pins equal to that index.py's defaults).
+# Reading the live env instead of re-declaring the values here means this
+# probe can never drift from what the dispatcher will actually launch with.
+LAUNCH_CONFIG_ENV_KEYS = ("SF_WATCH_AMI_ID", "SF_WATCH_SECURITY_GROUP", "SF_WATCH_SUBNETS")
+
 
 def _error_code(exc: Exception) -> str:
     return str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
@@ -105,6 +146,10 @@ def _lambda_client():
 
 def _s3_client():
     return boto3.client("s3", region_name=REGION)
+
+
+def _ec2_client():
+    return boto3.client("ec2", region_name=REGION)
 
 
 def _check_rule() -> list[str]:
@@ -179,6 +224,108 @@ def _check_lambda_healthy() -> list[str]:
     return problems
 
 
+def _check_launch_config(env: dict[str, str]) -> list[str]:
+    """The deregistered-AMI silent-break guard: assert the AMI/SG/subnets the
+    DEPLOYED spot dispatcher would launch with still exist. Uses Filters (not
+    ImageIds/GroupIds/SubnetIds) so a missing resource comes back as an EMPTY
+    result set instead of a per-service error code to pattern-match; unexpected
+    API errors therefore always RAISE (fail-loud)."""
+    problems: list[str] = []
+
+    missing_keys = sorted(k for k in LAUNCH_CONFIG_ENV_KEYS if not (env.get(k) or "").strip())
+    if missing_keys:
+        # Fail-loud on env absence: an unreadable launch config is itself the
+        # finding (deploy.sh pins these keys; their absence means the deployed
+        # env drifted from deploy.sh). Deliberately STOP here rather than probe
+        # EC2 with unknown ids — the problem line above is the recording surface.
+        problems.append(
+            f"spot dispatcher '{SPOT_DISPATCHER_FUNCTION}' live env is MISSING launch-config "
+            f"key(s) {missing_keys} — AMI/SG/subnet existence is UNVERIFIABLE (its deploy.sh "
+            "pins these; redeploy it)"
+        )
+        return problems
+
+    ami = env["SF_WATCH_AMI_ID"].strip()
+    sg = env["SF_WATCH_SECURITY_GROUP"].strip()
+    subnets = sorted({s.strip() for s in env["SF_WATCH_SUBNETS"].split(",") if s.strip()})
+
+    ec2 = _ec2_client()
+
+    # IncludeDeprecated: an old-but-still-registered AMI must NOT false-alarm —
+    # only a deregistered/deleted one (which every future spot launch would
+    # fail on) is a finding.
+    images = ec2.describe_images(
+        Filters=[{"Name": "image-id", "Values": [ami]}], IncludeDeprecated=True
+    ).get("Images", [])
+    if not images:
+        problems.append(
+            f"spot AMI '{ami}' NOT FOUND (deregistered/deleted) — every future "
+            "sf-watch spot launch would fail"
+        )
+    elif images[0].get("State") != "available":
+        problems.append(f"spot AMI '{ami}' state={images[0].get('State')}, not available")
+
+    groups = ec2.describe_security_groups(
+        Filters=[{"Name": "group-id", "Values": [sg]}]
+    ).get("SecurityGroups", [])
+    if not groups:
+        problems.append(f"spot security group '{sg}' NOT FOUND")
+
+    found_subnets = {
+        s.get("SubnetId")
+        for s in ec2.describe_subnets(
+            Filters=[{"Name": "subnet-id", "Values": subnets}]
+        ).get("Subnets", [])
+    }
+    missing_subnets = sorted(set(subnets) - found_subnets)
+    if missing_subnets:
+        problems.append(f"spot subnet(s) NOT FOUND: {missing_subnets}")
+
+    return problems
+
+
+def _check_spot_dispatch_leg() -> tuple[list[str], dict[str, str]]:
+    """The live EC2-spot repair path (config#2001/#2106): both dispatcher
+    Lambdas exist + Active, kill-switch env values read + REPORTED (never
+    alerted — see module docstring), and the spot dispatcher's launch config
+    verified against live EC2 state."""
+    problems: list[str] = []
+    kill_switches: dict[str, str] = {}
+    lam = _lambda_client()
+
+    for fn_name, switch_key in SPOT_LEG_DISPATCHERS:
+        try:
+            cfg = lam.get_function_configuration(FunctionName=fn_name)
+        except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+            if _error_code(exc) == "ResourceNotFoundException":
+                problems.append(
+                    f"spot-leg dispatcher Lambda '{fn_name}' does NOT EXIST — "
+                    "the live repair path cannot launch"
+                )
+                kill_switches[switch_key] = "UNREADABLE(function missing)"
+                # Launch-config check deliberately skipped for a missing spot
+                # dispatcher: there is no env to read, and the does-NOT-EXIST
+                # problem line above is the loud recording surface for it.
+                continue
+            raise
+        if cfg.get("State") != "Active":
+            problems.append(
+                f"spot-leg dispatcher Lambda '{fn_name}' state={cfg.get('State')}, not Active"
+            )
+        if cfg.get("LastUpdateStatus") != "Successful":
+            problems.append(
+                f"spot-leg dispatcher Lambda '{fn_name}' LastUpdateStatus={cfg.get('LastUpdateStatus')}"
+            )
+        env = (cfg.get("Environment") or {}).get("Variables") or {}
+        # REPORTED, never alerted: absence of the key means the dispatcher's
+        # own in-code default applies ("true").
+        kill_switches[switch_key] = env.get(switch_key, "unset(default:true)")
+        if fn_name == SPOT_DISPATCHER_FUNCTION:
+            problems.extend(_check_launch_config(env))
+
+    return problems, kill_switches
+
+
 def _problem_fingerprint(problems: list[str]) -> str:
     return hashlib.sha256("\n".join(sorted(problems)).encode()).hexdigest()[:16]
 
@@ -212,7 +359,7 @@ def _save_alerted_fingerprint(s3, fingerprint: str | None) -> None:
         logger.warning("could not persist sf-watch liveness state %s: %s", STATE_KEY, exc)
 
 
-def _alert(problems: list[str]) -> bool:
+def _alert(problems: list[str], kill_switches: dict[str, str] | None = None) -> bool:
     lines = [
         "\U0001f6f0️ *Fleet-SF Watch Liveness Probe — WIRING PROBLEM*",
         f"{len(problems)} issue(s) found with the Fleet-SF Watch trigger itself "
@@ -221,8 +368,9 @@ def _alert(problems: list[str]) -> bool:
     for p in problems:
         lines.append(f"• {p}")
     lines.append(
-        "_Fleet-SF Watch may not catch a real pipeline failure right now. "
-        "Check the EventBridge rule + saturday-sf-watch-dispatcher Lambda._"
+        "_Fleet-SF Watch may not catch (or repair) a real pipeline failure right "
+        "now. Check the EventBridge rule, the saturday-sf-watch-dispatcher "
+        "Lambda, and the sf-watch/ci-watch spot dispatchers._"
     )
     text = "\n".join(lines)
     try:
@@ -234,7 +382,7 @@ def _alert(problems: list[str]) -> bool:
             flow_name=_FLOW_NAME,
             topics=_OPS_TOPICS,
             db_basename=_DB_BASENAME,
-            context={"problems": len(problems)},
+            context={"problems": len(problems), "kill_switches": kill_switches or {}},
         )
     except Exception as exc:  # noqa: BLE001 — delivery surface; finding still returned
         logger.warning("sf-watch liveness alert Telegram send failed (non-fatal): %s", exc)
@@ -244,8 +392,15 @@ def _alert(problems: list[str]) -> bool:
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """Scheduled (EventBridge) entrypoint. Read-only; raises on an unexpected
     AWS API failure so the check can never silently no-op."""
-    problems = _check_rule() + _check_state_machines_exist() + _check_lambda_healthy()
+    spot_problems, kill_switches = _check_spot_dispatch_leg()
+    problems = (
+        _check_rule() + _check_state_machines_exist() + _check_lambda_healthy() + spot_problems
+    )
     fingerprint = _problem_fingerprint(problems) if problems else None
+
+    # Always surfaced (record + log), never alerted: a deliberate operator
+    # disable is state, not an incident.
+    logger.info("sf-watch liveness: dispatch kill-switches: %s", kill_switches)
 
     s3 = _s3_client()
     already = _load_alerted_fingerprint(s3)
@@ -253,7 +408,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     alerted = False
     if problems and fingerprint != already:
         logger.warning("sf-watch liveness: %d NEW problem(s): %s", len(problems), problems)
-        alerted = _alert(problems)
+        alerted = _alert(problems, kill_switches)
         if alerted:
             _save_alerted_fingerprint(s3, fingerprint)
     elif problems:
@@ -263,4 +418,9 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         if already is not None:
             _save_alerted_fingerprint(s3, None)  # clear dedup state now that it's healthy again
 
-    return {"problems": problems, "alerted": alerted, "clean": not problems}
+    return {
+        "problems": problems,
+        "alerted": alerted,
+        "clean": not problems,
+        "kill_switches": kill_switches,
+    }

--- a/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
@@ -1,9 +1,15 @@
 """Unit tests for sf-watch-liveness-probe index.handler.
 
-Mocks flow-doctor notify (no live Telegram) and boto3 events/stepfunctions/lambda/s3
+Mocks flow-doctor notify (no live Telegram) and boto3 events/stepfunctions/lambda/s3/ec2
 clients. Asserts: a clean environment alerts nothing, each individual wiring problem is
 detected, problems are deduplicated by content (not re-alerted every run), and the dedup
 state clears once the environment goes clean again.
+
+EC2-spot dispatch leg (config#2265): both spot-leg dispatcher Lambdas must exist and be
+Active; kill-switch env values are REPORTED in the probe record but never alerted on
+(a deliberate operator disable is state, not an incident); the launch config
+(AMI/SG/subnets) read from the spot dispatcher's live env must still exist in EC2, and a
+MISSING launch-config env key is itself a loud finding, never a skip.
 """
 
 from __future__ import annotations
@@ -73,13 +79,89 @@ def _make_sfn_client(*, missing_names=()):
     return sfn
 
 
-def _make_lambda_client(*, missing=False, state="Active", last_update="Successful"):
+# Healthy live env for the spot dispatcher — ids here are test fixtures; the
+# REAL values live in sf-watch-spot-dispatcher/deploy.sh (pins) and index.py
+# (defaults), held equal by that Lambda's own lockstep test.
+HEALTHY_SPOT_ENV = {
+    "LOG_LEVEL": "INFO",
+    "SF_WATCH_DISPATCH_ENABLED": "true",
+    "SF_WATCH_AMI_ID": "ami-test0000000000001",
+    "SF_WATCH_SECURITY_GROUP": "sg-test000000000001",
+    "SF_WATCH_SUBNETS": "subnet-testaaa,subnet-testbbb",
+}
+HEALTHY_CI_ENV = {"LOG_LEVEL": "INFO", "CI_WATCH_DISPATCH_ENABLED": "true"}
+
+
+def _make_lambda_client(
+    *,
+    missing=False,
+    state="Active",
+    last_update="Successful",
+    spot_missing=False,
+    spot_state="Active",
+    spot_env=HEALTHY_SPOT_ENV,
+    ci_missing=False,
+    ci_env=HEALTHY_CI_ENV,
+):
+    """One fake serves all three probed functions: the legacy EventBridge
+    dispatcher (missing/state/last_update) plus the two spot-leg dispatchers."""
     lam = MagicMock()
-    if missing:
-        lam.get_function_configuration.side_effect = FakeClientError("ResourceNotFoundException")
-    else:
-        lam.get_function_configuration.return_value = {"State": state, "LastUpdateStatus": last_update}
+
+    def get_config(FunctionName):  # noqa: N803 — boto3 kwarg name
+        if FunctionName == index.EXPECTED_TARGET_FUNCTION:
+            if missing:
+                raise FakeClientError("ResourceNotFoundException")
+            return {"State": state, "LastUpdateStatus": last_update}
+        if FunctionName == index.SPOT_DISPATCHER_FUNCTION:
+            if spot_missing:
+                raise FakeClientError("ResourceNotFoundException")
+            return {
+                "State": spot_state,
+                "LastUpdateStatus": "Successful",
+                "Environment": {"Variables": dict(spot_env)},
+            }
+        if FunctionName == index.CI_WATCH_DISPATCHER_FUNCTION:
+            if ci_missing:
+                raise FakeClientError("ResourceNotFoundException")
+            return {
+                "State": "Active",
+                "LastUpdateStatus": "Successful",
+                "Environment": {"Variables": dict(ci_env)},
+            }
+        raise AssertionError(f"probe queried an unexpected Lambda: {FunctionName}")
+
+    lam.get_function_configuration.side_effect = get_config
     return lam
+
+
+def _make_ec2_client(
+    *,
+    ami_ids=(HEALTHY_SPOT_ENV["SF_WATCH_AMI_ID"],),
+    ami_state="available",
+    sg_ids=(HEALTHY_SPOT_ENV["SF_WATCH_SECURITY_GROUP"],),
+    subnet_ids=tuple(HEALTHY_SPOT_ENV["SF_WATCH_SUBNETS"].split(",")),
+):
+    """Mirrors the Filters-based lookups: a missing resource comes back as an
+    EMPTY result set, exactly like the real DescribeImages/SecurityGroups/
+    Subnets calls with an id filter."""
+    ec2 = MagicMock()
+
+    def describe_images(Filters, IncludeDeprecated=False):  # noqa: N803
+        requested = set(Filters[0]["Values"])
+        return {"Images": [{"ImageId": i, "State": ami_state} for i in sorted(requested & set(ami_ids))]}
+
+    def describe_security_groups(Filters):  # noqa: N803
+        requested = set(Filters[0]["Values"])
+        return {"SecurityGroups": [{"GroupId": g} for g in sorted(requested & set(sg_ids))]}
+
+    def describe_subnets(Filters):  # noqa: N803
+        requested = set(Filters[0]["Values"])
+        return {"Subnets": [{"SubnetId": s} for s in sorted(requested & set(subnet_ids))]}
+
+    ec2.describe_images.side_effect = describe_images
+    ec2.describe_security_groups.side_effect = describe_security_groups
+    ec2.describe_subnets.side_effect = describe_subnets
+    return ec2
 
 
 def _make_s3_client(*, existing_fingerprint=None):
@@ -93,10 +175,18 @@ def _make_s3_client(*, existing_fingerprint=None):
     return s3
 
 
-def _clients_factory(events, sfn, lam, s3):
+def _clients_factory(events, sfn, lam, s3, ec2=None):
+    ec2 = ec2 if ec2 is not None else _make_ec2_client()
+
     def factory(name, region_name=None):
-        return {"events": events, "stepfunctions": sfn, "lambda": lam, "s3": s3}[name]
+        return {"events": events, "stepfunctions": sfn, "lambda": lam, "s3": s3, "ec2": ec2}[name]
     return factory
+
+
+HEALTHY_KILL_SWITCHES = {
+    "SF_WATCH_DISPATCH_ENABLED": "true",
+    "CI_WATCH_DISPATCH_ENABLED": "true",
+}
 
 
 @pytest.fixture(autouse=True)
@@ -113,7 +203,12 @@ def test_all_clean_alerts_nothing():
     s3 = _make_s3_client()
     with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
         result = index.handler({}, None)
-    assert result == {"problems": [], "alerted": False, "clean": True}
+    assert result == {
+        "problems": [],
+        "alerted": False,
+        "clean": True,
+        "kill_switches": HEALTHY_KILL_SWITCHES,
+    }
     index.notify_via_flow_doctor.assert_not_called()
 
 
@@ -190,6 +285,173 @@ def test_unhealthy_lambda_alerts():
     with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
         result = index.handler({}, None)
     assert any("not Active" in p for p in result["problems"])
+
+
+# ── EC2-spot dispatch leg (config#2265) ──────────────────────────────────────
+
+
+def test_spot_dispatcher_missing_alerts_and_skips_launch_config_probe():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client(spot_missing=True)
+    s3 = _make_s3_client()
+    ec2 = _make_ec2_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3, ec2)):
+        result = index.handler({}, None)
+    assert any(
+        "spot-leg dispatcher Lambda" in p and index.SPOT_DISPATCHER_FUNCTION in p and "does NOT EXIST" in p
+        for p in result["problems"]
+    )
+    assert result["alerted"] is True
+    assert result["kill_switches"]["SF_WATCH_DISPATCH_ENABLED"] == "UNREADABLE(function missing)"
+    # No env to read → no launch-config EC2 probing (the does-NOT-EXIST alert
+    # is the recording surface).
+    ec2.describe_images.assert_not_called()
+
+
+def test_ci_watch_dispatcher_missing_alerts():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client(ci_missing=True)
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any(
+        index.CI_WATCH_DISPATCHER_FUNCTION in p and "does NOT EXIST" in p for p in result["problems"]
+    )
+    assert result["alerted"] is True
+    assert result["kill_switches"]["CI_WATCH_DISPATCH_ENABLED"] == "UNREADABLE(function missing)"
+
+
+def test_spot_dispatcher_not_active_alerts():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client(spot_state="Pending")
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert any(
+        index.SPOT_DISPATCHER_FUNCTION in p and "not Active" in p for p in result["problems"]
+    )
+
+
+def test_kill_switch_false_is_reported_not_alerted():
+    """A deliberate operator disable is STATE, not an incident: the value must
+    land in the probe record while the run stays clean and silent."""
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client(
+        spot_env={**HEALTHY_SPOT_ENV, "SF_WATCH_DISPATCH_ENABLED": "false"},
+        ci_env={**HEALTHY_CI_ENV, "CI_WATCH_DISPATCH_ENABLED": "false"},
+    )
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert result["clean"] is True
+    assert result["alerted"] is False
+    assert result["kill_switches"] == {
+        "SF_WATCH_DISPATCH_ENABLED": "false",
+        "CI_WATCH_DISPATCH_ENABLED": "false",
+    }
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_kill_switch_unset_reported_as_default_true():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client(ci_env={"LOG_LEVEL": "INFO"})
+    s3 = _make_s3_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
+        result = index.handler({}, None)
+    assert result["clean"] is True
+    assert result["kill_switches"]["CI_WATCH_DISPATCH_ENABLED"] == "unset(default:true)"
+
+
+def test_missing_ami_alerts():
+    """The deregistered-AMI silent-break guard — the headline check of the
+    spot leg (config#2265 closes-when drill (a))."""
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    ec2 = _make_ec2_client(ami_ids=())
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3, ec2)):
+        result = index.handler({}, None)
+    assert any(
+        HEALTHY_SPOT_ENV["SF_WATCH_AMI_ID"] in p and "NOT FOUND" in p for p in result["problems"]
+    )
+    assert result["alerted"] is True
+    index.notify_via_flow_doctor.assert_called_once()
+
+
+def test_ami_not_available_state_alerts():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    ec2 = _make_ec2_client(ami_state="failed")
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3, ec2)):
+        result = index.handler({}, None)
+    assert any("state=failed, not available" in p for p in result["problems"])
+
+
+def test_missing_security_group_alerts():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    ec2 = _make_ec2_client(sg_ids=())
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3, ec2)):
+        result = index.handler({}, None)
+    assert any(
+        HEALTHY_SPOT_ENV["SF_WATCH_SECURITY_GROUP"] in p and "NOT FOUND" in p
+        for p in result["problems"]
+    )
+
+
+def test_missing_subnet_alerts_naming_only_the_missing_ones():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    ec2 = _make_ec2_client(subnet_ids=("subnet-testaaa",))  # subnet-testbbb gone
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3, ec2)):
+        result = index.handler({}, None)
+    assert any(
+        "subnet(s) NOT FOUND" in p and "subnet-testbbb" in p and "subnet-testaaa" not in p
+        for p in result["problems"]
+    )
+
+
+def test_missing_launch_config_env_key_alerts_not_skips():
+    """Fail-loud on env absence: an unreadable launch config is itself the
+    finding — the probe must never silently skip the AMI/SG/subnet checks."""
+    stripped = {k: v for k, v in HEALTHY_SPOT_ENV.items() if k != "SF_WATCH_AMI_ID"}
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client(spot_env=stripped)
+    s3 = _make_s3_client()
+    ec2 = _make_ec2_client()
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3, ec2)):
+        result = index.handler({}, None)
+    assert any(
+        "MISSING launch-config" in p and "SF_WATCH_AMI_ID" in p for p in result["problems"]
+    )
+    assert result["alerted"] is True
+    # Unknown ids are not probed — the MISSING-key alert is the recording surface.
+    ec2.describe_images.assert_not_called()
+
+
+def test_unexpected_ec2_error_is_not_swallowed():
+    events = _make_events_client()
+    sfn = _make_sfn_client()
+    lam = _make_lambda_client()
+    s3 = _make_s3_client()
+    ec2 = _make_ec2_client()
+    ec2.describe_images.side_effect = FakeClientError("UnauthorizedOperation")
+    with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3, ec2)):
+        with pytest.raises(FakeClientError):
+            index.handler({}, None)
 
 
 def test_repeat_problem_is_suppressed_not_realerted():

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -53,9 +53,24 @@ DEFER_POLICY_NAME="alpha-engine-sf-watch-defer-scheduler-policy"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 DEFER_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${DEFER_ROLE_NAME}"
+# Launch-config pins (config#2265): the DEPLOYED env is the observable source
+# of truth the sf-watch-liveness-probe reads (it verifies these AMI/SG/subnet
+# ids still exist twice daily and alerts loud if any key is MISSING from the
+# live env). Values MUST equal index.py's in-code defaults — a lockstep test
+# in test_handler.py (test_deploy_sh_launch_config_pins_match_index_defaults)
+# enforces it. JSON form (not the Variables={...} shorthand) because the
+# subnet list itself contains commas.
+LAUNCH_AMI_ID="ami-0c421724a94bba6d6"
+LAUNCH_SECURITY_GROUP="sg-03cd3c4bd91e610b0"
+LAUNCH_SUBNETS="subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,subnet-c670118d,subnet-7cff7c43,subnet-e07166ec"
+lambda_env_json() {
+  # $1 = SF_WATCH_DISPATCH_ENABLED value (true|false)
+  printf '{"Variables":{"LOG_LEVEL":"INFO","SF_WATCH_DISPATCH_ENABLED":"%s","SF_WATCH_DEFER_ROLE_ARN":"%s","SF_WATCH_AMI_ID":"%s","SF_WATCH_SECURITY_GROUP":"%s","SF_WATCH_SUBNETS":"%s"}}' \
+    "$1" "${DEFER_ROLE_ARN}" "${LAUNCH_AMI_ID}" "${LAUNCH_SECURITY_GROUP}" "${LAUNCH_SUBNETS}"
+}
 # Bootstrap default (first-time deployment only) — sets SF_WATCH_DISPATCH_ENABLED=true
 # as the safe default. The update path (step 3) will read the live value and preserve it.
-LAMBDA_ENV_BOOTSTRAP="Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=true,SF_WATCH_DEFER_ROLE_ARN=${DEFER_ROLE_ARN}}"
+LAMBDA_ENV_BOOTSTRAP="$(lambda_env_json true)"
 
 # Shared operator-flag-preserve helper (config#1818/#2236/#2264 bug class).
 source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
@@ -220,7 +235,9 @@ echo "Updating Lambda environment (preserving operator-owned SF_WATCH_DISPATCH_E
 # This mirrors the saturday-sf-watch-dispatcher fix (config#1818): a routine redeploy
 # should not silently re-arm/disarm the operator's incident-response flag.
 CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" SF_WATCH_DISPATCH_ENABLED true)
-LAMBDA_ENV="Variables={LOG_LEVEL=INFO,SF_WATCH_DISPATCH_ENABLED=${CURRENT_DISPATCH},SF_WATCH_DEFER_ROLE_ARN=${DEFER_ROLE_ARN}}"
+# Launch-config pins ride every update so the liveness probe always finds them
+# in the live env (see the lambda_env_json comment near the top, config#2265).
+LAMBDA_ENV="$(lambda_env_json "${CURRENT_DISPATCH}")"
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
   --environment "${LAMBDA_ENV}" \

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -722,3 +722,39 @@ def test_disabled_flag_short_circuits(monkeypatch):
     assert out["launched"] is False
     assert out["reason"] == "disabled"
     assert idx._test_ssm.sent == []
+
+
+def test_deploy_sh_launch_config_pins_match_index_defaults(monkeypatch):
+    """LOCKSTEP GUARD (config#2265): deploy.sh pins SF_WATCH_AMI_ID /
+    SF_WATCH_SECURITY_GROUP / SF_WATCH_SUBNETS into the deployed Lambda env —
+    the observable source of truth sf-watch-liveness-probe reads to verify the
+    launch config (AMI/SG/subnets) still exists twice daily. The pins MUST
+    equal this module's own in-code defaults, or the probe would verify a
+    DIFFERENT launch config than the one an env-stripped dispatcher would
+    actually launch with. Mirrors the probe's own EXPECTED_PIPELINE_NAMES
+    source-text lockstep guard."""
+    for var in ("SF_WATCH_AMI_ID", "SF_WATCH_SECURITY_GROUP", "SF_WATCH_SUBNETS"):
+        monkeypatch.delenv(var, raising=False)
+    idx = _load(monkeypatch)
+
+    deploy_sh = open(os.path.join(os.path.dirname(__file__), "deploy.sh")).read()
+    pins = {}
+    for var in ("LAUNCH_AMI_ID", "LAUNCH_SECURITY_GROUP", "LAUNCH_SUBNETS"):
+        m = re.search(rf'^{var}="([^"]+)"$', deploy_sh, re.M)
+        assert m is not None, (
+            f"deploy.sh no longer pins {var} — the liveness probe would alert "
+            "a MISSING launch-config key on every run after the next deploy"
+        )
+        pins[var] = m.group(1)
+
+    assert pins["LAUNCH_AMI_ID"] == idx.AMI_ID
+    assert pins["LAUNCH_SECURITY_GROUP"] == idx.SECURITY_GROUP
+    assert [s.strip() for s in pins["LAUNCH_SUBNETS"].split(",")] == idx.SUBNETS
+
+    # And the env JSON template actually carries all three pins into the
+    # deployed env (both the bootstrap create AND the every-deploy update use
+    # lambda_env_json).
+    for env_key in ("SF_WATCH_AMI_ID", "SF_WATCH_SECURITY_GROUP", "SF_WATCH_SUBNETS"):
+        assert f'\\"{env_key}\\"' in deploy_sh or f'"{env_key}"' in deploy_sh, (
+            f"deploy.sh's lambda_env_json no longer sets {env_key}"
+        )

--- a/tests/test_sf_watch_deploy_flag_preserve.py
+++ b/tests/test_sf_watch_deploy_flag_preserve.py
@@ -66,14 +66,25 @@ def test_deploy_update_path_preserves_operator_dispatch_flag():
             )
             assert call in src, \
                 f"{dispatcher}: update path must preserve {flag_name} via the helper"
-            # ...and the env applied on update carries the preserved value.
-            assert f"{flag_name}=${{{shell_var}}}" in src, \
+            # ...and the env applied on update carries the preserved value —
+            # either inline (`Variables={...,FLAG=${VAR},...}`) or through a
+            # JSON env-builder taking the preserved var as its argument
+            # (sf-watch-spot-dispatcher's lambda_env_json, config#2265).
+            inline_carry = f"{flag_name}=${{{shell_var}}}" in src
+            builder_carry = (
+                f'lambda_env_json "${{{shell_var}}}"' in src
+                and f'"{flag_name}":"%s"' in src
+            )
+            assert inline_carry or builder_carry, \
                 f"{dispatcher}: update env must use the preserved {flag_name} value"
 
             # The hardcoded default may only exist in the bootstrap
             # (create-function) posture, never in the update path's env.
             assert "create-function" in src, f"{dispatcher}: bootstrap block missing"
-            hardcoded = f"{flag_name}={default_val}"
+            hardcoded = (
+                f"{flag_name}={default_val}" if inline_carry
+                else f"lambda_env_json {default_val}"
+            )
             assert src.count(hardcoded) >= 1, \
                 f"{dispatcher}: must keep one hardcoded {hardcoded} (bootstrap default)"
             update_pos = src.index("Updating Lambda environment")


### PR DESCRIPTION
## What
Since the 2026-07-10 EC2-spot migration the ACTUAL repair path (spot dispatcher Lambdas → box) had ZERO liveness coverage — the probe only checked the legacy EventBridge leg, so the live leg could rot (deregistered AMI, deleted SG/subnet, broken Lambda, lost invoke grant) behind a green probe.

- `sf-watch-liveness-probe/index.py`: new checks — both spot dispatchers exist/Active/LastUpdateStatus=Successful; kill-switch env values READ AND REPORTED (never alerted — operator state, not incident); launch config (AMI/SG/subnets) read from the DEPLOYED spot dispatcher's live env (zero duplicated constants) and existence-verified via filtered Describes (missing resource → loud alert; real API error → raise). Missing expected env key alerts, fail-loud.
- `sf-watch-spot-dispatcher/deploy.sh`: pins `SF_WATCH_AMI_ID`/`SF_WATCH_SECURITY_GROUP`/`SF_WATCH_SUBNETS` into the function env on create AND every update via a JSON `lambda_env_json()` builder (subnet list has commas — the `Variables={}` shorthand can't carry it). Without this the probe's env read would false-alarm from day one. Lockstep guard test pins deploy.sh values == index.py code defaults.
- `iam-policy.json`: + `lambda:GetFunctionConfiguration` on the two dispatchers, + `ec2:DescribeImages/SecurityGroups/Subnets` (Describe* not resource-scopable).
- Tests: 22 probe tests (11 new — incl. the closes-when drills: bogus AMI → alert, missing dispatcher → alert, kill-switch=false → reported-not-alerted), 30 spot-dispatcher tests (1 new lockstep), flag-preserve guard updated to accept the JSON env-builder carry form.

## Rebase note (was: stacked on PR755)
Includes PR755's shared preserve-helper commit (same file); merge #755 first, this PR then reduces to its own commit. The flag-preserve guard test update here is the reconciliation of the two changes.

## Deploy sequencing (operator note, tracked on the ISSUE not buried here)
Probe deploys via its operator-gated deploy.sh; deploy AFTER the spot dispatcher's next auto-deploy pins the env (else one false missing-env-key alert cycle). IAM delta + deploy step queued on alpha-engine-config-I2265, which stays open until the probe is live and drilled.

Refs nousergon/alpha-engine-config#2265 (alpha-engine-config-I2265; epic alpha-engine-config-I2282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
