### PR TITLE
feat(watch-dispatch): launch-path hardening — fail-loud probe/tags/watch-log-read + scoped RunInstances IAM (config#2267 sites 1/2/4, config#2271)

### DIFF
--- a/infrastructure/lambdas/ci-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/ci-watch-dispatcher/iam-policy.json
@@ -12,11 +12,70 @@
       "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-ci-watch-dispatcher:*"
     },
     {
-      "Sid": "LaunchCiWatchSpot",
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "alpha-engine-ci-watch-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-ci-watch-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
       "Effect": "Allow",
       "Action": [
-        "ec2:RunInstances",
-        "ec2:CreateTags",
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceStatus"
       ],

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -41,9 +41,12 @@ CONCURRENCY LOCK — narrower than groom's per-tier lock (config#1979):
 keyed on `Name=alpha-engine-ci-watch-spot` + `ci-watch-repo=<repo>` +
 `ci-watch-sha=<sha>` (NOT bare repo). Two different commits on the same repo
 failing CI independently must each get their own box — a repo-only lock
-would starve the second commit's fix. Fail-safe OPEN on any API error (same
-posture as groom's `_running_tier_instance_ids`) — this guard is an
-optimization against duplicate spend, never a correctness gate.
+would starve the second commit's fix. A FAILED probe (SpotProbeError,
+config#2267 site 1) does NOT fail-open silently: the dispatch proceeds —
+coverage beats dedupe; a probe failure must never leave a real CI failure
+uncovered — but the degradation is recorded loudly (`dedupe_degraded: true`
+in the returned verdict + an ERROR log naming the probe error). This guard
+is an optimization against duplicate spend, never a correctness gate.
 
 IAM PROFILE — deliberately NOT `alpha-engine-executor-profile` (shared with
 the live trading executor). Uses `alpha-engine-ci-watch-executor-profile`, a
@@ -62,11 +65,16 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 import uuid
 
 import boto3
 from nousergon_lib import spot_dispatch
-from nousergon_lib.spot_dispatch import SpotCapacityExhausted, SpotLaunchError
+from nousergon_lib.spot_dispatch import (  # SpotProbeError: nousergon-lib >= 0.106.0
+    SpotCapacityExhausted,
+    SpotLaunchError,
+    SpotProbeError,
+)
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -81,6 +89,13 @@ DISPATCH_ENABLED = os.environ.get("CI_WATCH_DISPATCH_ENABLED", "true").lower() =
 # ── Spot launch config (env-overridable; defaults mirror scheduled-groom-
 # dispatcher/data-spot-dispatcher — same default-VPC/AMI/security-group, only
 # the IAM profile differs for blast-radius isolation). ────────────────────────
+# IAM LOCKSTEP (config#2271): the INSTANCE_TYPES default below, AMI_ID,
+# SUBNETS, and SECURITY_GROUP are ENUMERATED in this Lambda's scoped
+# ec2:RunInstances policy (sibling iam-policy.json — JSON carries no
+# comments, so this is the canonical cross-reference). Changing any of these
+# defaults (or their env overrides at deploy time) WITHOUT updating
+# iam-policy.json + re-applying it will make RunInstances fail with
+# UnauthorizedOperation at the next dispatch. Keep them in sync.
 INSTANCE_TYPES = [
     t.strip()
     for t in os.environ.get(
@@ -108,6 +123,16 @@ VOLUME_SIZE_GB = int(os.environ.get("CI_WATCH_VOLUME_SIZE_GB", "40"))
 CI_WATCH_TAG_NAME = "alpha-engine-ci-watch-spot"
 CI_WATCH_REPO_TAG_KEY = "ci-watch-repo"
 CI_WATCH_SHA_TAG_KEY = "ci-watch-sha"
+
+# Discriminator tag write (config#2267 site 2, same defect class as
+# sf-watch-spot-dispatcher's): the (repo, sha) tags are LOAD-BEARING —
+# without them the next failure's dedupe guard is blind (duplicate box) and
+# spot-orphan-reaper cannot derive the completion-marker key (guaranteed
+# false "incomplete reap" page for a healthy run). Bounded retry, then
+# terminate-the-box-and-fail-the-dispatch on final failure. Retry delay is
+# env-overridable so tests run at 0.
+TAG_WRITE_ATTEMPTS = int(os.environ.get("CI_WATCH_TAG_WRITE_ATTEMPTS", "3"))
+TAG_WRITE_RETRY_DELAY_SEC = float(os.environ.get("CI_WATCH_TAG_WRITE_RETRY_DELAY_SEC", "2"))
 
 # The box reads its own run secrets (PAT) via its instance profile in the
 # common case, but the PRELUDE below (run before the profile-backed bootstrap
@@ -245,10 +270,10 @@ def _running_ci_watch_instance_ids(repo: str, sha: str) -> list[str]:
     """Instance ids for a LIVE (pending/running) ci-watch box already working
     THIS exact (repo, sha) — deliberately NARROWER than groom's per-tier lock
     (config#1979): two different commits on the same repo failing CI
-    independently must each get their own box. Fail-safe: any API error
-    returns [] (never blocks a launch on a broken check — an optimization,
-    not a correctness gate, mirroring every other pre-launch guard in the
-    fleet)."""
+    independently must each get their own box. Raises SpotProbeError
+    (nousergon-lib >= 0.106.0, config#2267 site 1) when the probe itself
+    fails — the caller degrades to launch-with-dedupe_degraded, never a
+    silent fail-open []."""
     return spot_dispatch.running_instance_ids(
         CI_WATCH_TAG_NAME,
         {CI_WATCH_REPO_TAG_KEY: repo, CI_WATCH_SHA_TAG_KEY: sha},
@@ -265,6 +290,35 @@ def _terminate_instance(instance_id: str) -> None:
     spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="ci-watch")
 
 
+def _create_discriminator_tags(instance_id: str, repo: str, sha: str) -> str | None:
+    """Write the load-bearing (repo, sha) discriminator tags (config#2267
+    site 2) with a bounded retry. Returns None on success, or the final
+    ``"ExcName: msg"`` string after TAG_WRITE_ATTEMPTS failures — the caller
+    terminates the box and fails the dispatch (the tags are what make the
+    box visible to the dedupe guard and the spot-orphan-reaper; an untagged
+    box must not run)."""
+    tags = [
+        {"Key": CI_WATCH_REPO_TAG_KEY, "Value": repo},
+        {"Key": CI_WATCH_SHA_TAG_KEY, "Value": sha},
+    ]
+    last_error = ""
+    for attempt in range(1, TAG_WRITE_ATTEMPTS + 1):
+        try:
+            boto3.client("ec2", region_name=REGION).create_tags(
+                Resources=[instance_id], Tags=tags
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 — bounded retry; final failure is FATAL to the dispatch (caller terminates + fails)
+            last_error = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "ci-watch discriminator tag write attempt %d/%d failed for %s: %s",
+                attempt, TAG_WRITE_ATTEMPTS, instance_id, last_error,
+            )
+            if attempt < TAG_WRITE_ATTEMPTS:
+                time.sleep(TAG_WRITE_RETRY_DELAY_SEC)
+    return last_error
+
+
 def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
                           workflow: str, branch: str) -> dict:
     """Launch + bootstrap the CI-watch box. SYNCHRONOUS contract: every
@@ -274,7 +328,27 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
         logger.warning("CI_WATCH_DISPATCH_ENABLED=false — ci-watch spot NOT launched")
         return {"launched": False, "reason": "disabled"}
 
-    existing = _running_ci_watch_instance_ids(repo, sha)
+    dedupe_degraded = False
+    dedupe_probe_error = ""
+    try:
+        existing = _running_ci_watch_instance_ids(repo, sha)
+    except SpotProbeError as exc:
+        # Degraded-probe swallow (config#2267 site 1 POLICY): failure mode
+        # swallowed = a possible duplicate box (the probe could not rule one
+        # out); the primary deliverable — watch coverage of a REAL CI failure
+        # — survives, and coverage beats dedupe: a probe failure must never
+        # leave a real CI failure uncovered. Recording surfaces: this ERROR
+        # log + `dedupe_degraded: true` in the returned verdict the GHA
+        # caller archives.
+        dedupe_degraded = True
+        dedupe_probe_error = f"{type(exc).__name__}: {exc}"
+        existing = []
+        logger.error(
+            "ci-watch concurrency probe FAILED for %s@%s — proceeding to "
+            "launch with dedupe_degraded=true (coverage beats dedupe; a "
+            "duplicate box is possible): %s",
+            repo, sha, dedupe_probe_error,
+        )
     if existing:
         logger.warning(
             "ci-watch box already live for %s@%s (%s) — skipping launch to avoid a "
@@ -289,21 +363,28 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
         logger.error("ci-watch spot launch failed: %s: %s", type(exc).__name__, exc)
         return {"launched": False, "reason": "launch_failed", "error": str(exc)}
 
-    logger.info("launched ci-watch box %s (%s) for %s@%s", instance_id, market, repo, sha)
-    # config#1979-style tag so the NEXT trigger's guard check (above) can find
-    # it. Best-effort — a tag-write failure must not abort an already-launched
-    # box (mirrors groom's fail-safe posture on its own tier tag).
-    try:
-        boto3.client("ec2", region_name=REGION).create_tags(
-            Resources=[instance_id],
-            Tags=[
-                {"Key": CI_WATCH_REPO_TAG_KEY, "Value": repo},
-                {"Key": CI_WATCH_SHA_TAG_KEY, "Value": sha},
-            ],
+    logger.info("launched ci-watch box %s (%s) for %s@%s%s", instance_id, market, repo, sha,
+                " dedupe_degraded=true" if dedupe_degraded else "")
+    # config#1979-style tags so the NEXT trigger's guard check (above) — and
+    # the fleet spot-orphan-reaper's completion-marker lookup — can find the
+    # box. LOAD-BEARING, not cosmetic (config#2267 site 2): bounded retry,
+    # then TERMINATE the box and fail the dispatch on final failure — a box
+    # invisible to the dedupe guard and the reaper must not run. (The root
+    # fix — discriminator tags atomic with launch via RunInstances
+    # TagSpecifications — is blocked on krepis.ec2_spot.launch, the fleet's
+    # RunInstances chokepoint, growing an extra-tags parameter; until then
+    # this retry+terminate closes the hole loudly.)
+    tag_error = _create_discriminator_tags(instance_id, repo, sha)
+    if tag_error is not None:
+        _terminate_instance(instance_id)
+        logger.error(
+            "ci-watch discriminator tag write FAILED after %d attempts for %s "
+            "(%s@%s) — box terminated, dispatch failed: %s",
+            TAG_WRITE_ATTEMPTS, instance_id, repo, sha, tag_error,
         )
-    except Exception as exc:  # noqa: BLE001 — non-fatal, mirrors groom's tier-tag write
-        logger.warning("ci-watch repo/sha tag write failed (non-fatal): %s: %s",
-                       type(exc).__name__, exc)
+        return {"launched": False, "reason": "tag_write_failed",
+                "instance_id": instance_id, "error": tag_error,
+                "dedupe_degraded": dedupe_degraded}
 
     # Once the box is up, ANY failure before the bootstrap command is
     # delivered would orphan it (no watchdog/trap yet). Terminate-on-error —
@@ -318,13 +399,15 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
         logger.error("ci-watch post-launch step failed for %s: %s: %s",
                      instance_id, type(exc).__name__, exc)
         return {"launched": False, "reason": "post_launch_failed",
-                "instance_id": instance_id, "error": str(exc)}
+                "instance_id": instance_id, "error": str(exc),
+                "dedupe_degraded": dedupe_degraded}
 
     logger.info(
         "ci-watch dispatched: instance=%s market=%s command=%s repo=%s sha=%s run_id=%s "
-        "run_token=%s", instance_id, market, command_id, repo, sha, run_id, run_token,
+        "run_token=%s dedupe_degraded=%s", instance_id, market, command_id, repo, sha,
+        run_id, run_token, dedupe_degraded,
     )
-    return {
+    verdict = {
         "launched": True,
         "reason": "launched",
         "instance_id": instance_id,
@@ -334,7 +417,11 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
         "sha": sha,
         "run_id": run_id,
         "run_token": run_token,
+        "dedupe_degraded": dedupe_degraded,
     }
+    if dedupe_degraded:
+        verdict["dedupe_probe_error"] = dedupe_probe_error
+    return verdict
 
 
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -2,10 +2,12 @@
 boto3>=1.34.0
 # nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
 # spot-launch capacity-resilience chokepoint) — SAME pin as
-# scheduled-groom-dispatcher/data-spot-dispatcher. v0.100.0 is the first
-# version carrying spot_dispatch (bumped from v0.97.0 alongside the
-# groom/ci-watch dispatcher refactor onto it). No [flow-doctor] extra needed
-# — this Lambda sends no Telegram of its own (the synchronous GHA caller
-# reads the return value directly; see index.py docstring).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.100.0
+# sf-watch-spot-dispatcher. v0.106.0 is the first version whose
+# running_instance_ids raises SpotProbeError instead of failing open
+# (config#2267 site 1) — index.py imports and handles that exception, so
+# this pin GATES on the nousergon-lib v0.106.0 tag existing (lib PR must
+# merge + tag before this deploys). No [flow-doctor] extra needed — this
+# Lambda sends no Telegram of its own (the synchronous GHA caller reads the
+# return value directly; see index.py docstring).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.106.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -9,7 +9,10 @@ raising; the (repo, sha)-scoped concurrency lock (narrower than groom's
 per-tier lock — two different shas on the same repo must NOT block each
 other); a post-launch SSM-send failure terminates the box and returns
 launched:false; a malformed event returns launched:false rather than raising;
-the kill-switch short-circuit.
+the kill-switch short-circuit; and the config#2267 launch-path hardening — a
+failed concurrency probe launches WITH dedupe_degraded:true recorded
+(site 1), and the load-bearing discriminator tag write is retried then
+terminate-and-fail on final failure (site 2).
 """
 
 from __future__ import annotations
@@ -51,9 +54,12 @@ class _FakeWaiter:
 
 
 class _FakeEc2:
-    def __init__(self, running_instances=None):
+    def __init__(self, running_instances=None, create_tags_failures=0):
         self.terminated = []
         self.tags_created = []
+        self.create_tags_attempts = 0
+        # First N create_tags calls raise (config#2267 site 2 retry tests).
+        self._create_tags_failures = create_tags_failures
         # {(repo, sha) -> [instance_ids]} already "live" for the concurrency
         # guard's describe_instances check to find.
         self._running_instances = dict(running_instances or {})
@@ -66,6 +72,9 @@ class _FakeEc2:
         return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
 
     def create_tags(self, Resources, Tags):  # noqa: N803 — boto3 kwarg names
+        self.create_tags_attempts += 1
+        if self.create_tags_attempts <= self._create_tags_failures:
+            raise RuntimeError(f"CreateTags throttled (attempt {self.create_tags_attempts})")
         self.tags_created.append((Resources, Tags))
         return {}
 
@@ -89,11 +98,15 @@ class _FakeSsm:
         return {"Command": {"CommandId": "cmd-123"}}
 
 
-def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None):
+def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None,
+          create_tags_failures=0):
+    # config#2267 site 2 retry loop sleeps between attempts — zero it out.
+    monkeypatch.setenv("CI_WATCH_TAG_WRITE_RETRY_DELAY_SEC", "0")
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
     ssm = _FakeSsm()
-    ec2 = _FakeEc2(running_instances=running_instances)
+    ec2 = _FakeEc2(running_instances=running_instances,
+                   create_tags_failures=create_tags_failures)
     clients = {"ec2": ec2, "ssm": ssm}
     if launch_impl is None:
         launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
@@ -119,6 +132,16 @@ def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None):
         importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
     else:
         import nousergon_lib.spot_dispatch  # noqa: F401 — first import picks up the current stub
+
+    # SpotProbeError back-fill (config#2267 site 1): index.py imports it and
+    # its requirements pin nousergon-lib v0.106.0 (the first version carrying
+    # it), but a local/shared environment may still have an OLDER installed
+    # lib. Inject a name-compatible stand-in so the suite runs under both —
+    # under >= 0.106.0 the real class is present and this is a no-op. (Reload
+    # above re-executes the module, so re-check every _load call.)
+    _sd = sys.modules["nousergon_lib.spot_dispatch"]
+    if not hasattr(_sd, "SpotProbeError"):
+        _sd.SpotProbeError = type("SpotProbeError", (Exception,), {})
 
     import index
 
@@ -276,7 +299,13 @@ def test_different_repo_same_sha_is_not_blocked(monkeypatch):
     assert out["launched"] is True
 
 
-def test_concurrency_check_fails_safe_and_still_launches(monkeypatch):
+def test_concurrency_check_failure_still_launches(monkeypatch):
+    # config#2267 site 1 POLICY: a broken probe must never block a launch —
+    # coverage beats dedupe. (Under nousergon-lib >= 0.106.0 the raw
+    # describe_instances error surfaces as SpotProbeError and the launch is
+    # flagged dedupe_degraded; under the old fail-open lib it degrades to []
+    # silently. Either way the box launches — the explicit degraded-flag
+    # contract is pinned separately below.)
     idx = _load(
         monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
         env={"CI_WATCH_DISPATCH_ENABLED": "true"},
@@ -287,9 +316,71 @@ def test_concurrency_check_fails_safe_and_still_launches(monkeypatch):
 
     idx._test_ec2.describe_instances = _boom
     out = idx.handler(_event(), None)
-    # A broken check must never block a launch — optimization, not a
-    # correctness gate (mirrors groom's fail-safe posture on its own guard).
     assert out["launched"] is True
+
+
+def test_probe_failure_launches_with_dedupe_degraded_recorded(monkeypatch):
+    """config#2267 site 1: SpotProbeError from the concurrency probe →
+    proceed to launch, with dedupe_degraded:true + the probe error recorded
+    in the returned verdict (lib-version-agnostic via a direct monkeypatch
+    of the probe primitive)."""
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-degraded",  # noqa: E731
+        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+    )
+
+    def _probe_down(*args, **kwargs):
+        raise idx.SpotProbeError("concurrency probe failed for tag_name='alpha-engine-ci-watch-spot': ThrottlingException: rate exceeded")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert out["dedupe_degraded"] is True
+    # The verdict names the probe error — the GHA caller archives it.
+    assert "ThrottlingException" in out["dedupe_probe_error"]
+    # A healthy probe keeps the flag False.
+    idx2 = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out2 = idx2.handler(_event(), None)
+    assert out2["launched"] is True
+    assert out2["dedupe_degraded"] is False
+    assert "dedupe_probe_error" not in out2
+
+
+def test_transient_tag_write_failure_is_retried_then_launch_succeeds(monkeypatch):
+    """config#2267 site 2: create_tags failing twice then succeeding on the
+    third (final) attempt keeps the dispatch alive — the tags land."""
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-retagged",  # noqa: E731
+        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        create_tags_failures=2,
+    )
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert idx._test_ec2.create_tags_attempts == 3
+    assert idx._test_ec2.tags_created  # third attempt landed the tags
+    assert idx._test_ec2.terminated == []
+
+
+def test_persistent_tag_write_failure_terminates_box_and_fails_dispatch(monkeypatch):
+    """config#2267 site 2: the (repo, sha) discriminator tags are
+    LOAD-BEARING — after the bounded retry is exhausted the box is
+    TERMINATED (it is invisible to the dedupe guard and the orphan-reaper's
+    completion check) and the dispatch fails loudly with a clean
+    launched:false."""
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-untaggable",  # noqa: E731
+        env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        create_tags_failures=99,
+    )
+    out = idx.handler(_event(), None)
+    assert out["launched"] is False
+    assert out["reason"] == "tag_write_failed"
+    assert out["instance_id"] == "i-untaggable"
+    assert "CreateTags throttled" in out["error"]
+    assert idx._test_ec2.create_tags_attempts == idx.TAG_WRITE_ATTEMPTS
+    # The untagged box was terminated, and no bootstrap was ever sent to it.
+    assert idx._test_ec2.terminated == ["i-untaggable"]
+    assert idx._test_ssm.sent == []
 
 
 def test_post_launch_ssm_failure_terminates_instance_returns_clean_false(monkeypatch):

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -481,18 +481,43 @@ def _artifact_key(watch_prefix: str, run_date: str) -> str:
 
 def _load_existing(s3, key: str) -> dict:
     """Read the existing watch-log for this date (so repeated failures in one
-    run accumulate), or a fresh skeleton. A missing object (404/403) is the
-    common first-failure-of-the-day case, NOT an error."""
+    run accumulate), or a fresh skeleton. ONLY a true absence (404/NoSuchKey)
+    is the common first-failure-of-the-day case; every OTHER read error —
+    403/AccessDenied above all — RAISES (config#2267 site 4: treating a 403
+    as "absent" made an IAM read regression reset the attempt budget on
+    every failure, unbounded re-dispatch masquerading as first-failure-of-
+    the-day; the watch-plane alarms are the backstop for the resulting
+    Lambda error)."""
+    fresh = {"schema_version": SCHEMA_VERSION, "events": []}
     try:
         obj = s3.get_object(Bucket=WATCH_BUCKET, Key=key)
+    except Exception as exc:  # noqa: BLE001 — only genuine absence is swallowed; everything else re-raises
+        response = getattr(exc, "response", None)
+        code = ""
+        if isinstance(response, dict):
+            code = str(response.get("Error", {}).get("Code", ""))
+        if code in {"NoSuchKey", "404"}:
+            return fresh
+        logger.error("could not read existing watch-log %s (code=%s): %s", key, code, exc)
+        raise
+    try:
         data = json.loads(obj["Body"].read())
-        if isinstance(data, dict) and isinstance(data.get("events"), list):
-            return data
-    except Exception as exc:  # noqa: BLE001 — absence is expected; bad blob is recoverable
-        code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
-        if code not in {"NoSuchKey", "404", "403"}:
-            logger.warning("could not read existing watch-log %s: %s", key, exc)
-    return {"schema_version": SCHEMA_VERSION, "events": []}
+    except (ValueError, TypeError) as exc:
+        # Malformed-blob swallow: failure mode swallowed = a corrupted/
+        # unparseable existing watch-log (loses that day's accumulated event
+        # history, NOT the current event — the fresh skeleton still records
+        # it and the artifact write stays the fail-loud primary deliverable).
+        # Recording surface: this WARNING log.
+        logger.warning("existing watch-log %s is unparseable — starting a "
+                       "fresh skeleton: %s", key, exc)
+        return fresh
+    if isinstance(data, dict) and isinstance(data.get("events"), list):
+        return data
+    # Wrong-shape swallow: same failure mode + recording surface as the
+    # unparseable case above — a valid-JSON blob that is not a watch-log.
+    logger.warning("existing watch-log %s has an unexpected shape — starting "
+                   "a fresh skeleton", key)
+    return fresh
 
 
 def _build_event_record(detail: dict, describe_resp: dict | None, run_date: str, cfg: dict) -> dict:

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -835,3 +835,82 @@ def test_fast_path_preflight_excluded(fast_path_on):
 
     sf.start_execution.assert_not_called()
     assert result["fast_path"]["reason"] == "preflight"
+
+
+# ── _load_existing fail-loud contract (config#2267 site 4) ───────────────────
+# Only a TRUE absence (404/NoSuchKey) may mean "first failure of the day";
+# 403/AccessDenied and every other read error must RAISE — the old
+# 403-as-absent behavior reset the attempt budget on every failure (unbounded
+# re-dispatch) while an IAM read regression masqueraded as first-failure.
+
+
+def test_load_existing_404_means_fresh_skeleton():
+    s3 = MagicMock()
+    s3.get_object.side_effect = FakeClientError("404")
+    out = index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+    assert out == {"schema_version": index.SCHEMA_VERSION, "events": []}
+
+
+def test_load_existing_nosuchkey_means_fresh_skeleton():
+    s3 = MagicMock()
+    s3.get_object.side_effect = FakeClientError("NoSuchKey")
+    out = index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+    assert out == {"schema_version": index.SCHEMA_VERSION, "events": []}
+
+
+def test_load_existing_403_raises_instead_of_resetting_attempt_budget():
+    s3 = MagicMock()
+    s3.get_object.side_effect = FakeClientError("403")
+    with pytest.raises(FakeClientError):
+        index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+
+
+def test_load_existing_access_denied_raises():
+    s3 = MagicMock()
+    s3.get_object.side_effect = FakeClientError("AccessDenied")
+    with pytest.raises(FakeClientError):
+        index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+
+
+def test_load_existing_other_client_error_raises():
+    s3 = MagicMock()
+    s3.get_object.side_effect = FakeClientError("Throttling")
+    with pytest.raises(FakeClientError):
+        index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+
+
+def test_load_existing_non_client_error_raises():
+    # An exception with no botocore-shaped .response (e.g. a socket error)
+    # must also raise — it is not absence.
+    s3 = MagicMock()
+    s3.get_object.side_effect = RuntimeError("connection reset")
+    with pytest.raises(RuntimeError):
+        index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+
+
+def test_load_existing_unparseable_blob_starts_fresh():
+    s3 = MagicMock()
+    body = MagicMock()
+    body.read.return_value = b"{not-json"
+    s3.get_object.return_value = {"Body": body}
+    out = index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+    assert out == {"schema_version": index.SCHEMA_VERSION, "events": []}
+
+
+def test_load_existing_wrong_shape_starts_fresh():
+    s3 = MagicMock()
+    body = MagicMock()
+    body.read.return_value = json.dumps(["not", "a", "watch-log"]).encode()
+    s3.get_object.return_value = {"Body": body}
+    out = index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+    assert out == {"schema_version": index.SCHEMA_VERSION, "events": []}
+
+
+def test_load_existing_valid_watch_log_accumulates():
+    existing = {"schema_version": index.SCHEMA_VERSION, "events": [{"prior": True}]}
+    s3 = MagicMock()
+    body = MagicMock()
+    body.read.return_value = json.dumps(existing).encode()
+    s3.get_object.return_value = {"Body": body}
+    out = index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
+    assert out == existing

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
@@ -12,11 +12,70 @@
       "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-sf-watch-spot-dispatcher:*"
     },
     {
-      "Sid": "LaunchSfWatchSpot",
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "alpha-engine-sf-watch-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-sf-watch-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
       "Effect": "Allow",
       "Action": [
-        "ec2:RunInstances",
-        "ec2:CreateTags",
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceStatus"
       ],

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -33,7 +33,11 @@ CONCURRENCY LOCK: keyed on `Name=alpha-engine-sf-watch-spot` +
 `sf-watch-run-date=<run_date>` — the FULL identifying key (mirrors ci-watch's
 own use of its full (repo, sha) key, not a partial one): two different
 run_dates failing independently for the same pipeline+cadence must each get
-their own box. Fail-safe OPEN on any API error.
+their own box. A FAILED probe (SpotProbeError, config#2267 site 1) does NOT
+fail-open silently: the dispatch proceeds — coverage beats dedupe; a probe
+failure must never leave a real SF failure uncovered — but the degradation
+is recorded loudly (`dedupe_degraded: true` in the returned verdict + an
+ERROR log naming the probe error).
 
 DEFER, NOT DROP (config#2226): when the lock finds a live box for the SAME
 key, the second failure is NOT dropped — the live box has no obligation to
@@ -81,7 +85,11 @@ from datetime import datetime, timedelta, timezone
 
 import boto3
 from nousergon_lib import spot_dispatch
-from nousergon_lib.spot_dispatch import SpotCapacityExhausted, SpotLaunchError
+from nousergon_lib.spot_dispatch import (  # SpotProbeError: nousergon-lib >= 0.106.0
+    SpotCapacityExhausted,
+    SpotLaunchError,
+    SpotProbeError,
+)
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -96,6 +104,13 @@ DISPATCH_ENABLED = os.environ.get("SF_WATCH_DISPATCH_ENABLED", "true").lower() =
 # ── Spot launch config (env-overridable; defaults mirror ci-watch-dispatcher/
 # scheduled-groom-dispatcher — same default-VPC/AMI/security-group, only the
 # IAM profile differs for blast-radius isolation). ────────────────────────────
+# IAM LOCKSTEP (config#2271): the INSTANCE_TYPES default below, AMI_ID,
+# SUBNETS, and SECURITY_GROUP are ENUMERATED in this Lambda's scoped
+# ec2:RunInstances policy (sibling iam-policy.json — JSON carries no
+# comments, so this is the canonical cross-reference). Changing any of these
+# defaults (or their env overrides at deploy time) WITHOUT updating
+# iam-policy.json + re-applying it will make RunInstances fail with
+# UnauthorizedOperation at the next dispatch. Keep them in sync.
 INSTANCE_TYPES = [
     t.strip()
     for t in os.environ.get(
@@ -125,6 +140,15 @@ SF_WATCH_TAG_NAME = "alpha-engine-sf-watch-spot"
 SF_WATCH_CADENCE_TAG_KEY = "sf-watch-cadence"
 SF_WATCH_PIPELINE_TAG_KEY = "sf-watch-pipeline"
 SF_WATCH_RUN_DATE_TAG_KEY = "sf-watch-run-date"
+
+# Discriminator tag write (config#2267 site 2): the tags are LOAD-BEARING —
+# without them the next failure's dedupe guard is blind (duplicate box) and
+# spot-orphan-reaper cannot derive the completion-marker key (guaranteed
+# false "incomplete reap" page for a healthy run). Bounded retry, then
+# terminate-the-box-and-fail-the-dispatch on final failure. Retry delay is
+# env-overridable so tests run at 0.
+TAG_WRITE_ATTEMPTS = int(os.environ.get("SF_WATCH_TAG_WRITE_ATTEMPTS", "3"))
+TAG_WRITE_RETRY_DELAY_SEC = float(os.environ.get("SF_WATCH_TAG_WRITE_RETRY_DELAY_SEC", "2"))
 
 # The box reads its own run secrets (PAT) via its instance profile in the
 # common case, but the PRELUDE below (run before the profile-backed bootstrap
@@ -319,8 +343,10 @@ def _running_sf_watch_instance_ids(cadence_slug: str, pipeline_name: str, run_da
     THIS exact (cadence_slug, pipeline_name, run_date) — the full identifying
     key (mirrors ci-watch-dispatcher's own use of its full (repo, sha) key):
     two different run_dates failing independently for the same
-    pipeline+cadence must each get their own box. Fail-safe: any API error
-    returns [] (never blocks a launch on a broken check)."""
+    pipeline+cadence must each get their own box. Raises SpotProbeError
+    (nousergon-lib >= 0.106.0, config#2267 site 1) when the probe itself
+    fails — the caller degrades to launch-with-dedupe_degraded, never a
+    silent fail-open []."""
     return spot_dispatch.running_instance_ids(
         SF_WATCH_TAG_NAME,
         {
@@ -340,6 +366,37 @@ def _terminate_instance(instance_id: str) -> None:
     (logged, not raised) — mirrors ci-watch-dispatcher's `_terminate_instance`
     exactly."""
     spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="sf-watch")
+
+
+def _create_discriminator_tags(
+    instance_id: str, cadence_slug: str, pipeline_name: str, run_date: str
+) -> str | None:
+    """Write the load-bearing discriminator tags (config#2267 site 2) with a
+    bounded retry. Returns None on success, or the final ``"ExcName: msg"``
+    string after TAG_WRITE_ATTEMPTS failures — the caller terminates the box
+    and fails the dispatch (the tags are what make the box visible to the
+    dedupe guard and the spot-orphan-reaper; an untagged box must not run)."""
+    tags = [
+        {"Key": SF_WATCH_CADENCE_TAG_KEY, "Value": cadence_slug},
+        {"Key": SF_WATCH_PIPELINE_TAG_KEY, "Value": pipeline_name},
+        {"Key": SF_WATCH_RUN_DATE_TAG_KEY, "Value": run_date},
+    ]
+    last_error = ""
+    for attempt in range(1, TAG_WRITE_ATTEMPTS + 1):
+        try:
+            boto3.client("ec2", region_name=REGION).create_tags(
+                Resources=[instance_id], Tags=tags
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 — bounded retry; final failure is FATAL to the dispatch (caller terminates + fails)
+            last_error = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "sf-watch discriminator tag write attempt %d/%d failed for %s: %s",
+                attempt, TAG_WRITE_ATTEMPTS, instance_id, last_error,
+            )
+            if attempt < TAG_WRITE_ATTEMPTS:
+                time.sleep(TAG_WRITE_RETRY_DELAY_SEC)
+    return last_error
 
 
 def _defer_schedule_name(
@@ -565,7 +622,27 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
     cadence_slug, pipeline_name, run_date = (
         fields["cadence_slug"], fields["pipeline_name"], fields["run_date"],
     )
-    existing = _running_sf_watch_instance_ids(cadence_slug, pipeline_name, run_date)
+    dedupe_degraded = False
+    dedupe_probe_error = ""
+    try:
+        existing = _running_sf_watch_instance_ids(cadence_slug, pipeline_name, run_date)
+    except SpotProbeError as exc:
+        # Degraded-probe swallow (config#2267 site 1 POLICY): failure mode
+        # swallowed = a possible duplicate box (the probe could not rule one
+        # out); the primary deliverable — watch coverage of a REAL SF failure
+        # — survives, and coverage beats dedupe: a probe failure must never
+        # leave a real SF failure uncovered. Recording surfaces: this ERROR
+        # log + `dedupe_degraded: true` in the returned verdict the GHA
+        # caller archives.
+        dedupe_degraded = True
+        dedupe_probe_error = f"{type(exc).__name__}: {exc}"
+        existing = []
+        logger.error(
+            "sf-watch concurrency probe FAILED for %s/%s@%s — proceeding to "
+            "launch with dedupe_degraded=true (coverage beats dedupe; a "
+            "duplicate box is possible): %s",
+            cadence_slug, pipeline_name, run_date, dedupe_probe_error,
+        )
     if existing:
         # DEFER, NOT DROP (config#2226): the live box has no obligation to
         # notice THIS failure — schedule a one-shot re-invoke instead of
@@ -579,24 +656,30 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
         logger.error("sf-watch spot launch failed: %s: %s", type(exc).__name__, exc)
         return {"launched": False, "reason": "launch_failed", "error": str(exc)}
 
-    logger.info("launched sf-watch box %s (%s) for %s/%s@%s",
-               instance_id, market, cadence_slug, pipeline_name, run_date)
+    logger.info("launched sf-watch box %s (%s) for %s/%s@%s%s",
+               instance_id, market, cadence_slug, pipeline_name, run_date,
+               " dedupe_degraded=true" if dedupe_degraded else "")
     # config#1979-style tags so the NEXT trigger's guard check (above) — and
-    # the fleet spot-orphan-reaper's incomplete-reap alert — can find them.
-    # Best-effort — a tag-write failure must not abort an already-launched
-    # box (mirrors ci-watch-dispatcher's fail-safe posture on its own tags).
-    try:
-        boto3.client("ec2", region_name=REGION).create_tags(
-            Resources=[instance_id],
-            Tags=[
-                {"Key": SF_WATCH_CADENCE_TAG_KEY, "Value": cadence_slug},
-                {"Key": SF_WATCH_PIPELINE_TAG_KEY, "Value": pipeline_name},
-                {"Key": SF_WATCH_RUN_DATE_TAG_KEY, "Value": run_date},
-            ],
+    # the fleet spot-orphan-reaper's completion-marker lookup — can find the
+    # box. LOAD-BEARING, not cosmetic (config#2267 site 2): bounded retry,
+    # then TERMINATE the box and fail the dispatch on final failure — a box
+    # invisible to the dedupe guard and the reaper must not run. (The root
+    # fix — discriminator tags atomic with launch via RunInstances
+    # TagSpecifications — is blocked on krepis.ec2_spot.launch, the fleet's
+    # RunInstances chokepoint, growing an extra-tags parameter; until then
+    # this retry+terminate closes the hole loudly.)
+    tag_error = _create_discriminator_tags(instance_id, cadence_slug, pipeline_name, run_date)
+    if tag_error is not None:
+        _terminate_instance(instance_id)
+        logger.error(
+            "sf-watch discriminator tag write FAILED after %d attempts for %s "
+            "(%s/%s@%s) — box terminated, dispatch failed: %s",
+            TAG_WRITE_ATTEMPTS, instance_id, cadence_slug, pipeline_name,
+            run_date, tag_error,
         )
-    except Exception as exc:  # noqa: BLE001 — non-fatal, mirrors ci-watch's tag write
-        logger.warning("sf-watch discriminator tag write failed (non-fatal): %s: %s",
-                       type(exc).__name__, exc)
+        return {"launched": False, "reason": "tag_write_failed",
+                "instance_id": instance_id, "error": tag_error,
+                "dedupe_degraded": dedupe_degraded}
 
     # Once the box is up, ANY failure before the bootstrap command is
     # delivered would orphan it (no watchdog/trap yet). Terminate-on-error —
@@ -610,14 +693,15 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
         logger.error("sf-watch post-launch step failed for %s: %s: %s",
                      instance_id, type(exc).__name__, exc)
         return {"launched": False, "reason": "post_launch_failed",
-                "instance_id": instance_id, "error": str(exc)}
+                "instance_id": instance_id, "error": str(exc),
+                "dedupe_degraded": dedupe_degraded}
 
     logger.info(
         "sf-watch dispatched: instance=%s market=%s command=%s cadence=%s pipeline=%s "
-        "run_date=%s run_token=%s", instance_id, market, command_id, cadence_slug,
-        pipeline_name, run_date, run_token,
+        "run_date=%s run_token=%s dedupe_degraded=%s", instance_id, market, command_id,
+        cadence_slug, pipeline_name, run_date, run_token, dedupe_degraded,
     )
-    return {
+    verdict = {
         "launched": True,
         "reason": "launched",
         "instance_id": instance_id,
@@ -627,7 +711,11 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
         "pipeline_name": pipeline_name,
         "run_date": run_date,
         "run_token": run_token,
+        "dedupe_degraded": dedupe_degraded,
     }
+    if dedupe_degraded:
+        verdict["dedupe_probe_error"] = dedupe_probe_error
+    return verdict
 
 
 def handler(event: dict, context) -> dict:

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -2,9 +2,12 @@
 boto3>=1.34.0
 # nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
 # spot-launch capacity-resilience chokepoint) — SAME pin as
-# scheduled-groom-dispatcher/ci-watch-dispatcher. v0.100.0 is the first
-# version carrying spot_dispatch. No [flow-doctor] extra needed — this
+# ci-watch-dispatcher. v0.106.0 is the first version whose
+# running_instance_ids raises SpotProbeError instead of failing open
+# (config#2267 site 1) — index.py imports and handles that exception, so
+# this pin GATES on the nousergon-lib v0.106.0 tag existing (lib PR must
+# merge + tag before this deploys). No [flow-doctor] extra needed — this
 # Lambda sends no Telegram of its own (the synchronous GHA caller reads the
 # return value directly; see index.py docstring).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.100.0
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.106.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -15,8 +15,11 @@ invocation re-evaluates via ListExecutions (recovered / retarget-newest-
 failed / defer-again / fail-safe-launch); the empty-watch_log_key synthesis
 fallback; a post-launch SSM-send failure terminates the box and returns
 launched:false; a malformed event returns launched:false rather than
-raising; the kill-switch short-circuit; and the cause-field base64
-command-injection guard.
+raising; the kill-switch short-circuit; the cause-field base64
+command-injection guard; and the config#2267 launch-path hardening — a
+failed concurrency probe launches WITH dedupe_degraded:true recorded
+(site 1), and the load-bearing discriminator tag write is retried then
+terminate-and-fail on final failure (site 2).
 """
 
 from __future__ import annotations
@@ -62,9 +65,12 @@ class _FakeWaiter:
 
 
 class _FakeEc2:
-    def __init__(self, running_instances=None):
+    def __init__(self, running_instances=None, create_tags_failures=0):
         self.terminated = []
         self.tags_created = []
+        self.create_tags_attempts = 0
+        # First N create_tags calls raise (config#2267 site 2 retry tests).
+        self._create_tags_failures = create_tags_failures
         # {(cadence_slug, pipeline_name, run_date) -> [instance_ids]} already
         # "live" for the concurrency guard's describe_instances check to find.
         self._running_instances = dict(running_instances or {})
@@ -77,6 +83,9 @@ class _FakeEc2:
         return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
 
     def create_tags(self, Resources, Tags):  # noqa: N803 — boto3 kwarg names
+        self.create_tags_attempts += 1
+        if self.create_tags_attempts <= self._create_tags_failures:
+            raise RuntimeError(f"CreateTags throttled (attempt {self.create_tags_attempts})")
         self.tags_created.append((Resources, Tags))
         return {}
 
@@ -145,11 +154,14 @@ class _FakeContext:
 
 
 def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None,
-          scheduler=None, sfn=None):
+          scheduler=None, sfn=None, create_tags_failures=0):
+    # config#2267 site 2 retry loop sleeps between attempts — zero it out.
+    monkeypatch.setenv("SF_WATCH_TAG_WRITE_RETRY_DELAY_SEC", "0")
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
     ssm = _FakeSsm()
-    ec2 = _FakeEc2(running_instances=running_instances)
+    ec2 = _FakeEc2(running_instances=running_instances,
+                   create_tags_failures=create_tags_failures)
     scheduler = scheduler if scheduler is not None else _FakeScheduler()
     sfn = sfn if sfn is not None else _FakeSfn()
     clients = {"ec2": ec2, "ssm": ssm, "scheduler": scheduler, "stepfunctions": sfn}
@@ -172,6 +184,16 @@ def _load(monkeypatch, *, launch_impl=None, env=None, running_instances=None,
         importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
     else:
         import nousergon_lib.spot_dispatch  # noqa: F401 — first import picks up the current stub
+
+    # SpotProbeError back-fill (config#2267 site 1): index.py imports it and
+    # its requirements pin nousergon-lib v0.106.0 (the first version carrying
+    # it), but a local/shared environment may still have an OLDER installed
+    # lib. Inject a name-compatible stand-in so the suite runs under both —
+    # under >= 0.106.0 the real class is present and this is a no-op. (Reload
+    # above re-executes the module, so re-check every _load call.)
+    _sd = sys.modules["nousergon_lib.spot_dispatch"]
+    if not hasattr(_sd, "SpotProbeError"):
+        _sd.SpotProbeError = type("SpotProbeError", (Exception,), {})
 
     import index
 
@@ -644,7 +666,13 @@ def test_different_pipeline_same_cadence_and_date_is_not_blocked(monkeypatch):
     assert out["launched"] is True
 
 
-def test_concurrency_check_fails_safe_and_still_launches(monkeypatch):
+def test_concurrency_check_failure_still_launches(monkeypatch):
+    # config#2267 site 1 POLICY: a broken probe must never block a launch —
+    # coverage beats dedupe. (Under nousergon-lib >= 0.106.0 the raw
+    # describe_instances error surfaces as SpotProbeError and the launch is
+    # flagged dedupe_degraded; under the old fail-open lib it degrades to []
+    # silently. Either way the box launches — the explicit degraded-flag
+    # contract is pinned separately below.)
     idx = _load(
         monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
         env={"SF_WATCH_DISPATCH_ENABLED": "true"},
@@ -655,9 +683,70 @@ def test_concurrency_check_fails_safe_and_still_launches(monkeypatch):
 
     idx._test_ec2.describe_instances = _boom
     out = idx.handler(_event(), None)
-    # A broken check must never block a launch — optimization, not a
-    # correctness gate.
     assert out["launched"] is True
+
+
+def test_probe_failure_launches_with_dedupe_degraded_recorded(monkeypatch):
+    """config#2267 site 1: SpotProbeError from the concurrency probe →
+    proceed to launch, with dedupe_degraded:true + the probe error recorded
+    in the returned verdict (lib-version-agnostic via a direct monkeypatch
+    of the probe primitive)."""
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-degraded",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+    )
+
+    def _probe_down(*args, **kwargs):
+        raise idx.SpotProbeError("concurrency probe failed for tag_name='alpha-engine-sf-watch-spot': ThrottlingException: rate exceeded")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert out["dedupe_degraded"] is True
+    # The verdict names the probe error — the GHA caller archives it.
+    assert "ThrottlingException" in out["dedupe_probe_error"]
+    # A healthy probe keeps the flag False.
+    idx2 = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out2 = idx2.handler(_event(), None)
+    assert out2["launched"] is True
+    assert out2["dedupe_degraded"] is False
+    assert "dedupe_probe_error" not in out2
+
+
+def test_transient_tag_write_failure_is_retried_then_launch_succeeds(monkeypatch):
+    """config#2267 site 2: create_tags failing twice then succeeding on the
+    third (final) attempt keeps the dispatch alive — the tags land."""
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-retagged",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        create_tags_failures=2,
+    )
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert idx._test_ec2.create_tags_attempts == 3
+    assert idx._test_ec2.tags_created  # third attempt landed the tags
+    assert idx._test_ec2.terminated == []
+
+
+def test_persistent_tag_write_failure_terminates_box_and_fails_dispatch(monkeypatch):
+    """config#2267 site 2: the discriminator tags are LOAD-BEARING — after
+    the bounded retry is exhausted the box is TERMINATED (it is invisible to
+    the dedupe guard and the orphan-reaper's completion check) and the
+    dispatch fails loudly with a clean launched:false."""
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-untaggable",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        create_tags_failures=99,
+    )
+    out = idx.handler(_event(), None)
+    assert out["launched"] is False
+    assert out["reason"] == "tag_write_failed"
+    assert out["instance_id"] == "i-untaggable"
+    assert "CreateTags throttled" in out["error"]
+    assert idx._test_ec2.create_tags_attempts == idx.TAG_WRITE_ATTEMPTS
+    # The untagged box was terminated, and no bootstrap was ever sent to it.
+    assert idx._test_ec2.terminated == ["i-untaggable"]
+    assert idx._test_ssm.sent == []
 
 
 def test_post_launch_ssm_failure_terminates_instance_returns_clean_false(monkeypatch):

--- a/infrastructure/lambdas/spot-orphan-reaper/index.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/index.py
@@ -177,9 +177,15 @@ def _completion_marker_exists(s3, kind: WatchKind, watch_tags: dict[str, str]) -
     failure direction than silently swallowing a genuine incomplete run
     (recording surface: the logger.warning below)."""
     if not all(watch_tags.get(key) for key in kind.discriminator_tag_keys):
-        # Box was reaped before its discriminator tags ever landed (e.g. the
-        # dispatcher's post-launch tag-write failed) — cannot look up a
-        # marker either way.
+        # Box was reaped before its discriminator tags ever landed — cannot
+        # look up a marker either way. INVARIANT (config#2267 site 2): the
+        # sf-watch/ci-watch dispatchers now TERMINATE a box whose
+        # discriminator tag write fails after bounded retries, so a
+        # long-lived tagless WATCH_KINDS box should no longer exist — hitting
+        # this branch means either the narrow launch→tag race window (the
+        # tags are still post-launch create_tags, not atomic RunInstances
+        # TagSpecifications — that root fix is blocked on krepis.ec2_spot)
+        # or a genuine anomaly worth the alert this False triggers.
         return False
     key = _completion_key(kind, watch_tags)
     try:


### PR DESCRIPTION
## What (four coordinated hardenings, both watch dispatchers)
1. **Probe fail-loud (site 1):** consumes nousergon-lib v0.106.0's `SpotProbeError`; on probe failure the dispatch PROCEEDS (coverage beats dedupe — a probe failure must never leave a real SF/CI failure uncovered) with `dedupe_degraded: true` in the verdict + ERROR log. Both lambdas' lib pins v0.100.0 → v0.106.0.
2. **Load-bearing tags (site 2):** `create_tags` bounded-retry (3x); final failure TERMINATES the just-launched box and fails the dispatch (`reason: tag_write_failed`) — missing discriminator tags meant a dedupe hole + guaranteed false incomplete-reap. The atomic root fix (tags in RunInstances TagSpecifications) is blocked on krepis.ec2_spot.launch growing an extra-tags param — filed separately, noted inline + at the reaper's missing-tags branch.
3. **Watch-log read honesty (site 4):** `_load_existing` treats ONLY 404/NoSuchKey as absent; 403/AccessDenied and other errors RAISE — an IAM read regression can no longer reset the attempt budget while masquerading as first-failure-of-day. 9 new tests.
4. **Scoped RunInstances (config#2271):** both dispatcher policies rewritten — instance stanza conditioned on RequestTag/Name + InstanceType allowlist; AMI pinned; subnets/SG/key-pair enumerated; `CreateTags` gated on `ec2:CreateAction=RunInstances` + own-box ResourceTag. Lockstep comments above each `INSTANCE_TYPES`. **IAM not applied live yet** — queued with the operator apply list on alpha-engine-config-I2271.

## Why draft (gate:dependency)
CI's handler-test job pip-installs each lambda's requirements — the `v0.106.0` git pin fails until nousergon-lib-PR184 merges AND the tag is cut. Expected red; un-draft after the tag exists. Tests verified locally under BOTH v0.100.0 (back-fill shim) and a v0.106.0 build: spot 32 + ci-watch 16 + saturday 51 + reaper 18 green.

## Sequencing
Rebase over PR755/PR757 if they merge first (shared files: spot dispatcher test_handler.py/deploy.sh region).

Refs nousergon/alpha-engine-config#2267, nousergon/alpha-engine-config#2271 (epic alpha-engine-config-I2282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
