### PR TITLE
feat(sf-watch): per-cadence mechanical dispatch ceiling + mid-run spot-reclaim coverage + alias retirement (config#2269, #2270, #2272)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/README.md
@@ -74,6 +74,30 @@ decision in `dispatch_suppressed` (never a silent skip); only the
 
 Neither carve-out suppresses the **first** failure of a pipeline/day.
 
+## Mechanical per-cadence dispatch ceiling (config#2269)
+
+The charter's attempt budget is honor-system (it depends on the dispatched
+agent reading + enriching the watch-log). The dispatcher ALSO enforces it
+mechanically: before each agent dispatch it counts prior budget-consuming
+events for this (cadence, pipeline, run_date) from its own watch-log —
+dispatcher-authored `action` values (`dispatch`, `fast_path_rerun`,
+`reclaim_relaunch`) plus the charter's in-place outcome rewrites of dispatch
+events (`fixed_merged_rerun`/`rerun`/`proposed`/`refused`/`escalated`), never
+the agent-enriched `agent_attempt` field, so an agent crash can't reset the
+count. At/over the ceiling the dispatch is suppressed
+(`dispatch_suppressed: attempt_budget_exhausted`) and a **LOUD** Telegram
+escalation pages — "the watch has given up on today; human needed" — instead
+of the silent receipt.
+
+Ceilings (env, config defaults — **not** operator flags, not preserved across
+redeploys; change via PR): `SF_WATCH_MAX_DISPATCHES_SATURDAY=8`,
+`SF_WATCH_MAX_DISPATCHES_WEEKDAY=2`, `SF_WATCH_MAX_DISPATCHES_EOD=2`
+(the charter's Brian-ruled per-cadence budgets, 2026-07-11). The ceiling
+composes with the config#2003 suppressions and the charter-side budget — it
+is the outermost runaway backstop, and it still applies when
+`EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=true` opts back into post-escalation
+dispatch.
+
 ## Why it's not a second notifier
 
 `alpha-engine-sf-telegram-notifier` already covers generic SF notification

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -125,7 +125,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 60 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,FAST_PATH_ENABLED=false,EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=false,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,FAST_PATH_ENABLED=false,EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=false,SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -210,9 +210,15 @@ CURRENT_FAST_PATH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" FAST_PATH_E
 # (config#1818/#2264 class: the update call REPLACES the whole Variables
 # map, so any operator-set flag missing here silently resets on redeploy).
 CURRENT_DISPATCH_AFTER_ESCALATION=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION false)
+# SF_WATCH_MAX_DISPATCHES_* (config#2269) are CONFIG DEFAULTS, not operator
+# kill-switches — deliberately NOT run through preserve_env_flag: the
+# canonical way to change a per-cadence dispatch ceiling is a PR editing
+# index.py's defaults + these pins together (a live env tweak SHOULD be reset
+# to the reviewed value on the next redeploy). Values mirror the charter's
+# Brian-ruled per-cadence budgets (saturday 8 / weekday 2 / eod 2).
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment "Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH},FAST_PATH_ENABLED=${CURRENT_FAST_PATH},EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=${CURRENT_DISPATCH_AFTER_ESCALATION},FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}" \
+  --environment "Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH},FAST_PATH_ENABLED=${CURRENT_FAST_PATH},EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=${CURRENT_DISPATCH_AFTER_ESCALATION},SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}" \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -133,8 +133,9 @@ if $BOOTSTRAP; then
   fi
 
   # EventBridge rule: terminal-failure statuses of ANY of the three fleet
-  # trading SFs (+ the transitional EOD alias). One rule, one target — keep
-  # the ARN list in lockstep with index.PIPELINES.
+  # trading SFs. One rule, one target — keep the ARN list in lockstep with
+  # index.PIPELINES. (The transitional alpha-engine-eod-pipeline alias was
+  # retired 2026-07-11 — config#2272; old SF deleted live.)
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   EVENT_PATTERN=$(cat <<EOF
 {
@@ -144,8 +145,7 @@ if $BOOTSTRAP; then
     "stateMachineArn": [
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-eod-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
     ],
     "status": ["FAILED", "TIMED_OUT", "ABORTED"]
   }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -39,8 +39,7 @@
       "Resource": [
         "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*",
         "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*"
+        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*"
       ]
     },
     {
@@ -59,8 +58,7 @@
       "Resource": [
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
       ]
     }
   ]

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -201,19 +201,9 @@ PIPELINES: dict[str, dict[str, object]] = {
         "dispatch_event_type": "eod-sf-failure",
         "has_listener": True,
     },
-    # TRANSITIONAL (remove at the SF-rename cutover — config#1408 / re-exam
-    # 2026-07-03). The EOD SF still runs under its OLD name `alpha-engine-eod-
-    # pipeline` (saturday/weekday already renamed; EOD lags). Until cutover, the
-    # LIVE failures arrive under the old ARN, so the registry must recognize it —
-    # otherwise the handler ignores the event (the 2026-06-29 dead-watch gap).
-    # Routes to the SAME eod cadence resources as ne-postclose-trading-pipeline.
-    "alpha-engine-eod-pipeline": {
-        "cadence_slug": "eod",
-        "label": "Post-close Trading",
-        "watch_prefix": "consolidated/eod_sf_watch",
-        "dispatch_event_type": "eod-sf-failure",
-        "has_listener": True,
-    },
+    # The transitional `alpha-engine-eod-pipeline` alias (config#1408) was
+    # retired 2026-07-11 (config#2272) after the dormant old state machine was
+    # DELETED live — zero executions since the 2026-06-29 ne-rename.
 }
 SCHEMA_VERSION = 1
 _CAUSE_MAX_CHARS = 600
@@ -1027,7 +1017,8 @@ def _maybe_dispatch_agent(
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge handler — fires only on a registered fleet SF terminal failure
     (FAILED / TIMED_OUT / ABORTED), per the dedicated rule
-    ``alpha-engine-sf-watch-failed`` (scoped to the three SFs in ``PIPELINES``).
+    ``alpha-engine-saturday-sf-watch-failed`` (scoped to the three SFs in
+    ``PIPELINES``; rule name pinned in deploy.sh's RULE_NAME).
     """
     detail = event.get("detail") or {}
     sm_arn = detail.get("stateMachineArn") or ""

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -49,6 +49,23 @@ DISPATCH SUPPRESSED`), recording the decision via `dispatch_suppressed`
    dispatch-every-failure behavior with
    `EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=true`.
 Neither carve-out suppresses the FIRST failure of a pipeline/day.
+
+**Mechanical per-cadence dispatch ceiling (config#2269).** The charter's
+attempt budget is honor-system — it depends on the dispatched agent reading
+the watch-log AND enriching it with `agent_attempt`. This dispatcher now ALSO
+enforces the budget mechanically: before each agent dispatch it counts PRIOR
+budget-consuming events for this (cadence, pipeline, run_date) from its OWN
+watch-log (see ``_BUDGET_CONSUMING_ACTIONS`` — dispatcher-authored ``action``
+values plus the agent's in-place outcome rewrites of those same events; NEVER
+the agent-enriched ``agent_attempt`` field, so an agent crash can neither
+reset nor starve the count). At/over the per-cadence ceiling
+(``SF_WATCH_MAX_DISPATCHES_{SATURDAY,WEEKDAY,EOD}``, defaults 8/2/2 per
+Brian's 2026-07-11 per-cadence ruling) the dispatch is suppressed with
+``dispatch_suppressed: attempt_budget_exhausted`` and a LOUD Telegram
+escalation fires — budget exhaustion means "the watch has given up on today;
+human needed", which must page, never the silent receipt. This ceiling
+COMPOSES with (never replaces) the config#2003 suppressions and the
+charter-side budget: it is the outermost runaway backstop.
 """
 
 from __future__ import annotations
@@ -103,6 +120,24 @@ FAST_PATH_ENABLED = (
 DISPATCH_AFTER_ESCALATION = (
     os.environ.get("EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION", "false").lower() == "true"
 )
+# config#2269 — mechanical per-cadence dispatch ceiling. Hard runaway backstop
+# on agent dispatches per (cadence, pipeline, run_date), mirroring the
+# charter's Brian-ruled per-cadence budgets (2026-07-11): saturday tolerates
+# distinct-new-root-causes, hard backstop 8/run_date; weekday/eod cap 2.
+# These are CONFIG DEFAULTS, not operator kill-switches: deploy.sh pins them
+# and deliberately does NOT run them through the preserve_env_flag helper —
+# the canonical way to change a ceiling is a PR editing these defaults +
+# deploy.sh, not a live env tweak that a redeploy should preserve.
+# int() raising on a malformed env value is deliberate fail-loud: a broken
+# ceiling config must surface at deploy/import time, never default silently.
+SF_WATCH_MAX_DISPATCHES: dict[str, int] = {
+    "saturday": int(os.environ.get("SF_WATCH_MAX_DISPATCHES_SATURDAY", "8")),
+    "weekday": int(os.environ.get("SF_WATCH_MAX_DISPATCHES_WEEKDAY", "2")),
+    "eod": int(os.environ.get("SF_WATCH_MAX_DISPATCHES_EOD", "2")),
+}
+# A cadence slug not in the map (e.g. a future pipeline registered before its
+# budget is ruled) gets the CONSERVATIVE weekday/eod cap, never the saturday 8.
+_DEFAULT_MAX_DISPATCHES = 2
 # repository_dispatch target — the private alpha-engine-config repo hosts the
 # agent GHA workflow (on: repository_dispatch, types: [*-sf-failure]).
 DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
@@ -280,6 +315,54 @@ def _already_escalated_today(existing_events: list[dict]) -> bool:
     SECOND agent by default — see `DISPATCH_AFTER_ESCALATION` for the
     operator-owned override."""
     return any(ev.get("action") == "escalated" for ev in existing_events)
+
+
+# config#2269 — watch-log `action` values that CONSUMED a dispatch/rerun out
+# of the day's budget. Chosen from what this dispatcher itself writes plus the
+# charter's documented in-place enrichment of those same events, so the count
+# is correct whether the dispatched agent crashed OR completed:
+#   dispatch           — written by THIS Lambda at dispatch intent (the state
+#                        an event stays in when the agent crashes before
+#                        enriching — the exact starvation case config#2269
+#                        exists to close).
+#   fixed_merged_rerun / rerun / proposed / refused / escalated
+#                      — the charter's STEP 6 outcome values, which REWRITE
+#                        the matching dispatch event's `action` IN PLACE (one
+#                        event, one action — never a double count).
+#   dispatched         — defensive: post-hoc/manual enrichment variant already
+#                        present in historical fixtures.
+#   fast_path_rerun    — this Lambda's own deterministic rerun (config#1900);
+#                        charter STEP 2 counts these against the same budget.
+#   reclaim_relaunch   — sf-watch-liveness-probe's mid-run spot-reclaim
+#                        relaunch record (config#2270; same shared counter).
+# Deliberately NOT keyed on `agent_attempt`: that field is agent-enriched, so
+# an agent crash would make the count starvable (unbounded re-dispatch).
+# `observe` events never consume budget.
+_BUDGET_CONSUMING_ACTIONS = frozenset({
+    "dispatch",
+    "dispatched",
+    "fixed_merged_rerun",
+    "rerun",
+    "proposed",
+    "refused",
+    "escalated",
+    "fast_path_rerun",
+    "reclaim_relaunch",
+})
+
+
+def _prior_dispatch_count(existing_events: list[dict]) -> int:
+    """How many of today's already-recorded events consumed the dispatch
+    budget (config#2269). Counts dispatcher-authored `action` values (and
+    their documented in-place agent rewrites) ONLY — see
+    ``_BUDGET_CONSUMING_ACTIONS``."""
+    return sum(1 for ev in existing_events if ev.get("action") in _BUDGET_CONSUMING_ACTIONS)
+
+
+def _max_dispatches(cadence_slug: str) -> int:
+    """Per-cadence dispatch ceiling (config#2269) — 8 for saturday, 2 for
+    weekday/eod, conservative 2 for any unruled future cadence."""
+    return SF_WATCH_MAX_DISPATCHES.get(cadence_slug, _DEFAULT_MAX_DISPATCHES)
 
 
 def _is_preflight(describe_resp: dict | None) -> bool:
@@ -614,10 +697,18 @@ def _build_event_record(
     #   already_escalated_today   — a human is already engaged for this
     #                               pipeline/day (an `action: escalated` event
     #                               already landed in today's watch-log).
+    # config#2269: checked LAST in the chain below — the ceiling is the
+    #   outermost runaway backstop and must fire even when the operator opted
+    #   back into post-escalation dispatch (DISPATCH_AFTER_ESCALATION=true).
+    #   The count uses dispatcher-authored fields only (never agent_attempt)
+    #   so an agent crash can't reset it — see _BUDGET_CONSUMING_ACTIONS.
     operator_abort = _is_operator_abort(detail.get("status", ""), describe_resp)
     is_preflight = _is_preflight(describe_resp)
     operator_recovery_rerun = _is_operator_recovery_rerun(execution_name)
     already_escalated = bool(existing_events) and _already_escalated_today(existing_events)
+    prior_dispatches = _prior_dispatch_count(existing_events or [])
+    dispatch_ceiling = _max_dispatches(str(cfg.get("cadence_slug", "")))
+    budget_exhausted = prior_dispatches >= dispatch_ceiling
     if operator_abort:
         dispatch_suppressed = "operator_abort"
     elif is_preflight:
@@ -626,6 +717,8 @@ def _build_event_record(
         dispatch_suppressed = "operator_recovery_rerun"
     elif already_escalated and not DISPATCH_AFTER_ESCALATION:
         dispatch_suppressed = "already_escalated_today"
+    elif budget_exhausted:
+        dispatch_suppressed = "attempt_budget_exhausted"
     else:
         dispatch_suppressed = None
     will_dispatch = (
@@ -633,7 +726,7 @@ def _build_event_record(
         and bool(cfg.get("has_listener", True))
         and dispatch_suppressed is None
     )
-    return {
+    record: dict = {
         "detected_at": now_iso,
         "status": detail.get("status", "UNKNOWN"),
         "state_machine": (detail.get("stateMachineArn") or "").rsplit(":", 1)[-1],
@@ -656,6 +749,12 @@ def _build_event_record(
         # auditable in the watch-log and on the dashboard.
         "dispatch_suppressed": dispatch_suppressed,
     }
+    if dispatch_suppressed == "attempt_budget_exhausted":
+        # config#2269: make the exhaustion auditable in the watch-log itself
+        # (additive fields — S3 schema contract allows ADD only).
+        record["prior_dispatch_count"] = prior_dispatches
+        record["dispatch_ceiling"] = dispatch_ceiling
+    return record
 
 
 def _write_watch_log(
@@ -806,6 +905,50 @@ def _notify(record: dict, key: str, pipeline_name: str, dispatch: dict) -> bool:
         return False
 
 
+def _escalate_budget_exhausted(record: dict, key: str, pipeline_name: str, run_date: str) -> bool:
+    """LOUD Telegram escalation when the mechanical dispatch ceiling suppresses
+    a dispatch (config#2269). Deliberately NOT the silent ``_notify`` receipt:
+    budget exhaustion means "the watch has given up on today; human needed" —
+    it must page (``silent=False, severity="error"``, mirroring the watch
+    plane's loud path, e.g. sf-watch-liveness-probe's ``_alert``). Deduped per
+    (pipeline, run_date) so a runaway fail-loop pages a human ONCE, not on
+    every subsequent suppressed failure. Best-effort delivery surface: a
+    Telegram outage logs WARNING and is returned in the handler result — the
+    watch-log record (primary) already landed, and the suppression itself
+    never depends on the page being delivered."""
+    label = _pipeline_label(pipeline_name)
+    text = "\n".join([
+        "\U0001f6a8 *Fleet-SF Watch — ATTEMPT BUDGET EXHAUSTED*",
+        f"{label} SF: {record.get('status', 'UNKNOWN')} — dispatch #"
+        f"{record.get('prior_dispatch_count', '?')} today already hit the "
+        f"{record.get('dispatch_ceiling', '?')}-attempt ceiling for run_date {run_date}.",
+        f"Failed state: `{record.get('failed_state')}`" if record.get("failed_state") else "",
+        f"Cause: `{record['cause']}`" if record.get("cause") else "",
+        f"Watch log: `s3://{WATCH_BUCKET}/{key}`",
+        "_The watch has GIVEN UP on today for this pipeline — no further agent "
+        "dispatches or reruns will fire. Human needed (config#2269)._",
+    ]).replace("\n\n", "\n")
+    try:
+        return notify_via_flow_doctor(
+            text,
+            silent=False,
+            severity="error",
+            dedup_key=f"{_FLOW_NAME}:budget_exhausted:{pipeline_name}:{run_date}",
+            flow_name=_FLOW_NAME,
+            topics=PIPELINE_OBSERVER_TELEGRAM_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={
+                "pipeline": pipeline_name,
+                "run_date": run_date,
+                "prior_dispatch_count": record.get("prior_dispatch_count"),
+                "dispatch_ceiling": record.get("dispatch_ceiling"),
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface; suppression already recorded in the watch-log
+        logger.warning("budget-exhausted escalation Telegram send failed (non-fatal): %s", exc)
+        return False
+
+
 def _get_github_pat() -> str:
     """Read the dedicated fine-grained PAT (SecureString) from SSM. Never logged."""
     ssm = boto3.client("ssm", region_name=REGION)
@@ -922,6 +1065,13 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         dispatch = {"dispatched": False, "reason": "fast_path_rerun"}
     else:
         dispatch = _maybe_dispatch_agent(record, run_date, key, cfg, sm_name, sm_arn)  # secondary
+    # config#2269: budget exhaustion pages LOUD (a human must take over the
+    # day) — instead of the silent receipt below, never in addition to it
+    # (attempt_budget_exhausted is deliberately NOT in
+    # _TELEGRAM_ON_SUPPRESSED_REASONS).
+    budget_escalated = False
+    if record.get("dispatch_suppressed") == "attempt_budget_exhausted":
+        budget_escalated = _escalate_budget_exhausted(record, key, sm_name, run_date)
     # Telegram only when recovery work actually started (not observe-only).
     telegram_sent = _notify(record, key, sm_name, dispatch)               # secondary — best-effort
 
@@ -937,6 +1087,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "failed_state": record.get("failed_state"),
         "watch_log_key": key,
         "telegram_sent": telegram_sent,
+        "budget_escalated": budget_escalated,
         "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
         "fast_path_enabled": FAST_PATH_ENABLED,
         "fast_path": fast_path,

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -1162,3 +1162,233 @@ def test_load_existing_valid_watch_log_accumulates():
     s3.get_object.return_value = {"Body": body}
     out = index._load_existing(s3, "consolidated/saturday_sf_watch/2026-07-11.json")
     assert out == existing
+
+
+# ── config#2269: mechanical per-cadence dispatch ceiling ─────────────────────
+# The charter's attempt budget is honor-system; the dispatcher enforces it
+# mechanically by counting PRIOR budget-consuming events (dispatcher-authored
+# `action` values, never agent-enriched `agent_attempt`) for the
+# (cadence, pipeline, run_date). At/over the per-cadence ceiling (saturday 8,
+# weekday/eod 2) the dispatch is suppressed with a LOUD Telegram escalation.
+
+
+def _dispatch_events(n: int, action: str = "dispatch") -> list[dict]:
+    return [{"action": action, "execution_name": f"exec-{i:03d}"} for i in range(n)]
+
+
+def _existing_doc(events: list[dict]) -> dict:
+    return {"schema_version": 1, "run_date": "2023-11-14", "events": events}
+
+
+def test_per_cadence_ceiling_defaults_mirror_charter_budgets():
+    """Pins the Brian-ruled 2026-07-11 per-cadence budgets: saturday 8,
+    weekday 2, eod 2 (env-overridable via SF_WATCH_MAX_DISPATCHES_*)."""
+    assert index.SF_WATCH_MAX_DISPATCHES == {"saturday": 8, "weekday": 2, "eod": 2}
+    assert index._max_dispatches("saturday") == 8
+    assert index._max_dispatches("weekday") == 2
+    assert index._max_dispatches("eod") == 2
+    # Unruled future cadence gets the conservative cap, never saturday's 8.
+    assert index._max_dispatches("some-future-cadence") == 2
+
+
+def test_saturday_failure_at_8_prior_dispatches_suppressed_and_paged_loud(monkeypatch):
+    """Saturday's hard runaway backstop: with 8 prior dispatch events already
+    in today's watch-log, the next qualifying failure must NOT dispatch —
+    suppressed with `attempt_budget_exhausted` AND a LOUD (silent=False,
+    severity=error) Telegram escalation, never the silent receipt."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    fired = {"called": False}
+
+    def fake_urlopen(req, timeout=None):
+        fired["called"] = True
+        return _FakeResp()
+
+    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
+    factory, _, s3 = _make_clients(existing=_existing_doc(_dispatch_events(8)))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=SATURDAY_ARN), None)
+
+    assert result["agent_dispatch"] == {
+        "dispatched": False, "reason": "attempt_budget_exhausted",
+    }
+    assert fired["called"] is False
+    assert result["budget_escalated"] is True
+
+    # Watch-log STILL written (fail-loud) and carries the auditable reason +
+    # the counts that justified it.
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    ev = written["events"][-1]
+    assert ev["dispatch_suppressed"] == "attempt_budget_exhausted"
+    assert ev["prior_dispatch_count"] == 8
+    assert ev["dispatch_ceiling"] == 8
+    assert ev["action"] == "observe"
+
+    # LOUD page — not the silent receipt.
+    index.notify_via_flow_doctor.assert_called_once()
+    kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    text = index.notify_via_flow_doctor.call_args.args[0]
+    assert kwargs["silent"] is False
+    assert kwargs["severity"] == "error"
+    assert "ATTEMPT BUDGET EXHAUSTED" in text
+    assert "Human needed" in text
+
+
+def test_saturday_below_ceiling_passes_through(monkeypatch):
+    """7 prior dispatches on saturday (ceiling 8) → the 8th dispatch fires."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, _, s3 = _make_clients(existing=_existing_doc(_dispatch_events(7)))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=SATURDAY_ARN), None)
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["budget_escalated"] is False
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    assert written["events"][-1]["dispatch_suppressed"] is None
+
+
+@pytest.mark.parametrize("sm_arn", [WEEKDAY_ARN, EOD_ARN])
+def test_weekday_and_eod_third_failure_with_2_prior_dispatches_suppressed(monkeypatch, sm_arn):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    fired = {"called": False}
+
+    def fake_urlopen(req, timeout=None):
+        fired["called"] = True
+        return _FakeResp()
+
+    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
+    factory, _, s3 = _make_clients(existing=_existing_doc(_dispatch_events(2)))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=sm_arn), None)
+    assert result["agent_dispatch"] == {
+        "dispatched": False, "reason": "attempt_budget_exhausted",
+    }
+    assert fired["called"] is False
+    assert result["budget_escalated"] is True
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    ev = written["events"][-1]
+    assert ev["dispatch_suppressed"] == "attempt_budget_exhausted"
+    assert ev["prior_dispatch_count"] == 2
+    assert ev["dispatch_ceiling"] == 2
+
+
+def test_weekday_below_ceiling_passes_through(monkeypatch):
+    """1 prior dispatch on weekday (ceiling 2) → the 2nd dispatch fires."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, _, _ = _make_clients(existing=_existing_doc(_dispatch_events(1)))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["budget_escalated"] is False
+
+
+def test_fast_path_rerun_events_count_toward_the_budget(monkeypatch):
+    """config#2269 deliverable 2: dispatcher fast-path reruns consume the SAME
+    budget — one dispatch + one fast_path_rerun on weekday (ceiling 2)
+    exhausts it."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    events = [{"action": "dispatch"}, {"action": "fast_path_rerun"}]
+    factory, _, _ = _make_clients(existing=_existing_doc(events))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"] == {
+        "dispatched": False, "reason": "attempt_budget_exhausted",
+    }
+
+
+def test_agent_outcome_rewritten_events_still_count(monkeypatch):
+    """The charter REWRITES a dispatch event's `action` in place with its
+    outcome (fixed_merged_rerun/rerun/proposed/...). The mechanical count must
+    survive that rewrite — otherwise a HEALTHY agent would reset the budget
+    (the inverse of the agent-crash starvation the counter guards against).
+    Uses outcomes that don't trip the separate already_escalated_today
+    suppression, so this pins the budget reason specifically."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    events = [
+        {"action": "fixed_merged_rerun", "agent_attempt": 1},
+        {"action": "rerun", "agent_attempt": 2},
+    ]
+    factory, _, _ = _make_clients(existing=_existing_doc(events))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"] == {
+        "dispatched": False, "reason": "attempt_budget_exhausted",
+    }
+
+
+def test_observe_events_never_consume_budget(monkeypatch):
+    """Pure observe records (kill-switch-off days, suppressed repeats) must
+    not eat the budget — only genuine dispatches/reruns do."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, _, _ = _make_clients(
+        existing=_existing_doc(_dispatch_events(5, action="observe"))
+    )
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"]["dispatched"] is True
+
+
+def test_budget_ceiling_also_blocks_fast_path(monkeypatch):
+    """Composition guard: an exhausted budget suppresses the deterministic
+    fast path too (it consumes the same budget), not just the agent dispatch."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "FAST_PATH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    factory, sf, _ = _make_clients(existing=_existing_doc(_dispatch_events(2)))
+    sf.describe_execution.return_value = {
+        "input": WEEKDAY_INPUT, "error": "DailyPipelineFailure", "cause": "steps failed",
+    }
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    sf.start_execution.assert_not_called()
+    assert result["fast_path"] == {"fast_path": False, "reason": "attempt_budget_exhausted"}
+    assert result["agent_dispatch"] == {
+        "dispatched": False, "reason": "attempt_budget_exhausted",
+    }
+
+
+def test_budget_ceiling_applies_even_with_dispatch_after_escalation_opt_in(monkeypatch):
+    """The ceiling is the OUTERMOST backstop: EOD_SF_WATCH_DISPATCH_AFTER_
+    ESCALATION=true opts back into post-escalation dispatch, but can never
+    override the mechanical ceiling (escalated events themselves consumed
+    dispatches, so they count)."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "DISPATCH_AFTER_ESCALATION", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    events = [
+        {"action": "escalated", "agent_attempt": 1},
+        {"action": "dispatch"},
+    ]
+    factory, _, _ = _make_clients(existing=_existing_doc(events))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=EOD_ARN), None)
+    assert result["agent_dispatch"] == {
+        "dispatched": False, "reason": "attempt_budget_exhausted",
+    }
+
+
+def test_budget_escalation_telegram_failure_is_non_fatal(monkeypatch):
+    """The loud page is a delivery surface: its outage must not mask the
+    suppression (watch-log already recorded it) nor crash the handler."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
+    index.notify_via_flow_doctor.side_effect = RuntimeError("bot down")
+    factory, _, s3 = _make_clients(existing=_existing_doc(_dispatch_events(2)))
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["budget_escalated"] is False
+    assert result["agent_dispatch"]["reason"] == "attempt_budget_exhausted"
+    s3.put_object.assert_called_once()  # primary deliverable survived

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -459,12 +459,14 @@ def test_registry_and_eventbridge_rule_are_in_lockstep():
     )
 
 
-def test_live_old_named_eod_is_registered_during_rename_transition():
-    """Until the SF-rename cutover (config#1408 / re-exam 2026-07-03) the EOD SF
-    still runs as `alpha-engine-eod-pipeline`. Drop this assertion when the old
-    ARN is removed from the registry + rule at cutover."""
-    assert "alpha-engine-eod-pipeline" in index.PIPELINES
-    assert index.PIPELINES["alpha-engine-eod-pipeline"]["cadence_slug"] == "eod"
+def test_transitional_eod_alias_is_retired():
+    """config#2272 (2026-07-11): the dormant `alpha-engine-eod-pipeline` state
+    machine was deleted live and the transitional alias retired from every
+    hand-maintained list — it must never quietly reappear in the registry
+    (drift seed) nor in the deploy.sh rule (the lockstep test above covers the
+    rule side)."""
+    assert "alpha-engine-eod-pipeline" not in index.PIPELINES
+    assert "alpha-engine-eod-pipeline" not in _deploy_sh_rule_arns()
 
 
 # ── config#1827: operator-abort dispatch carve-out ──────────────────────────

--- a/infrastructure/lambdas/sf-watch-liveness-probe/README.md
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/README.md
@@ -47,6 +47,36 @@ fires a LOUD alert, deduplicated by the **content** of the problem set (a
 hash, not a timestamp) — a standing issue doesn't re-ping every run, and the
 alert state clears automatically once the check is clean again.
 
+## Mid-run spot-reclaim checker (config#2270)
+
+This Lambda is **also** the EventBridge target for `EC2 Spot Instance
+Interruption Warning` and `EC2 Instance State-change Notification`
+(state=terminated) — the handler branches on event shape (the scheduled probe
+payload is `{}`). The EC2 events carry only an instance-id (the rules cannot
+be tag-scoped), so the checker `DescribeTags` the instance (tags stay
+queryable post-termination for a while):
+
+- `Name` tag ≠ `alpha-engine-sf-watch-spot` → quiet exit (log only).
+- Watch box **with** its completion marker
+  (`s3://…/sf_watch/_control/completed/{cadence}-{pipeline}-{run_date}.json`,
+  the spot-orphan-reaper's key shape) → clean run, exit.
+- Watch box **without** a marker → died mid-repair: re-invoke
+  `alpha-engine-sf-watch-spot-dispatcher` **once** (async) with the dispatch
+  fields reconstructed from the discriminator tags + the newest watch-log
+  event, plus `force_on_demand: "true"` (a reclaim already proved spot
+  unreliable for this run). The decision is recorded FIRST as an
+  `action: reclaim_relaunch` watch-log event — the exactly-one bound, and the
+  event the saturday dispatcher's config#2269 mechanical attempt ceiling
+  counts — then a **silent** Telegram note fires ("watch box reclaimed
+  mid-repair — relaunched on-demand").
+- A **second** death for the same (cadence, pipeline, run_date), an untagged
+  watch-box death, or an unreconstructable dispatch → **LOUD** escalation
+  (human needed), never a second relaunch.
+
+The interruption warning and the terminated notification both fire for one
+reclaim — the second notification of the **same** instance is recognized via
+the recorded `dead_instance_id` and exits quietly.
+
 **Fail-loud:** every AWS describe/list call is the PRIMARY input — an error
 code other than the specific "doesn't exist" ones being checked for RAISES,
 surfacing via the Lambda `Errors` metric, alarmed by the watch-plane
@@ -59,7 +89,7 @@ write are best-effort.
 
 ```
 bash deploy.sh --dry-run     # show actions
-bash deploy.sh --bootstrap   # first-time: create role + Lambda + 2 Scheduler rules
+bash deploy.sh --bootstrap   # first-time: role + Lambda + 2 Scheduler rules + 2 EC2 reclaim EventBridge rules (config#2270)
 bash deploy.sh               # update code only
 bash deploy.sh --smoke       # invoke once (read-only; pings only on a REAL problem)
 ```

--- a/infrastructure/lambdas/sf-watch-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/deploy.sh
@@ -14,10 +14,14 @@
 # groom-liveness-probe's philosophy one layer up).
 #
 # IAM (iam-policy.json): logs + ssm:GetParameter (Telegram creds) +
-# events:DescribeRule/ListTargetsByRule + states:DescribeStateMachine (scoped to
-# the 5 registered pipeline ARNs) + lambda:GetFunctionConfiguration (scoped to
-# the dispatcher) + s3 Get/Put on the dedup state key. Entirely read-only — no
-# launch/send/write-anywhere-else permissions.
+# events:DescribeRule/ListTargetsByRule + states:DescribeStateMachine (scoped
+# to the registered pipeline ARNs) + lambda:GetFunctionConfiguration (scoped
+# to the dispatchers) + s3 Get/Put on the dedup state key. The probe path is
+# read-only; the mid-run reclaim-checker branch (config#2270) additionally
+# needs ec2:DescribeTags (Describe* — not resource-scopable), s3:GetObject on
+# the sf_watch/_control/completed/ markers, s3 Get/Put on the watch-log
+# prefixes (the reclaim_relaunch record), and lambda:InvokeFunction scoped to
+# alpha-engine-sf-watch-spot-dispatcher.
 #
 # Cadence (UTC): twice daily, offset 15 min from the groom-liveness-probe's own
 # cadence (06:30/14:30) purely to avoid simultaneous invocation, not for any
@@ -32,7 +36,7 @@
 #
 # Usage:
 #   bash .../sf-watch-liveness-probe/deploy.sh             # update code only
-#   bash .../sf-watch-liveness-probe/deploy.sh --bootstrap # first-time create + wire schedules
+#   bash .../sf-watch-liveness-probe/deploy.sh --bootstrap # first-time create + wire schedules + EC2 reclaim rules (config#2270)
 #   bash .../sf-watch-liveness-probe/deploy.sh --dry-run   # show actions, do not apply
 #   bash .../sf-watch-liveness-probe/deploy.sh --smoke     # invoke once (read-only check; pings only on a real problem)
 
@@ -180,6 +184,47 @@ if $BOOTSTRAP; then
       echo "    Deleting orphaned Scheduler rule: ${live}"
       run aws scheduler delete-schedule --name "${live}" --region "${REGION}"
     fi
+  done
+
+  # EventBridge rules for the mid-run spot-reclaim checker (config#2270).
+  # NOTE: neither EC2 event type can be TAG-scoped in the rule pattern (the
+  # events carry only instance-id) — the handler filters by the box's
+  # Name=alpha-engine-sf-watch-spot tag and exits quietly for everything else.
+  # put-rule/put-targets are idempotent upserts (mirrors the sibling
+  # saturday-sf-watch-dispatcher bootstrap style); add-permission tolerates
+  # the already-exists rerun.
+  RECLAIM_RULE_NAMES=(
+    "alpha-engine-sf-watch-spot-interruption"
+    "alpha-engine-sf-watch-instance-terminated"
+  )
+  RECLAIM_RULE_PATTERNS=(
+    '{"source":["aws.ec2"],"detail-type":["EC2 Spot Instance Interruption Warning"]}'
+    '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["terminated"]}}'
+  )
+  RECLAIM_RULE_DESCRIPTIONS=(
+    "EC2 spot interruption warning -> sf-watch mid-run reclaim checker (config#2270)"
+    "EC2 instance terminated -> sf-watch mid-run reclaim checker (config#2270)"
+  )
+  for i in "${!RECLAIM_RULE_NAMES[@]}"; do
+    rule="${RECLAIM_RULE_NAMES[$i]}"
+    echo "  Creating/updating EventBridge rule: ${rule}"
+    run aws events put-rule \
+      --name "${rule}" \
+      --event-pattern "${RECLAIM_RULE_PATTERNS[$i]}" \
+      --description "${RECLAIM_RULE_DESCRIPTIONS[$i]}" \
+      --region "${REGION}" \
+      --query 'RuleArn' --output text
+    run aws events put-targets \
+      --rule "${rule}" \
+      --targets "Id=1,Arn=${FN_ARN}" \
+      --region "${REGION}"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "eventbridge-${rule}" \
+      --action lambda:InvokeFunction \
+      --principal events.amazonaws.com \
+      --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${rule}" \
+      --region "${REGION}" 2>/dev/null || true
   done
 fi
 

--- a/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
@@ -35,8 +35,7 @@
       "Resource": [
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
       ]
     },
     {

--- a/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
@@ -55,7 +55,8 @@
       "Action": [
         "ec2:DescribeImages",
         "ec2:DescribeSecurityGroups",
-        "ec2:DescribeSubnets"
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags"
       ],
       "Resource": "*"
     },
@@ -64,6 +65,24 @@
       "Effect": "Allow",
       "Action": ["s3:GetObject", "s3:PutObject"],
       "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/sf_watch_liveness/*"
+    },
+    {
+      "Sid": "ReclaimCheckerCompletionMarkers",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/sf_watch/_control/completed/*"
+    },
+    {
+      "Sid": "ReclaimCheckerWatchLogRW",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/*_sf_watch/*"
+    },
+    {
+      "Sid": "ReclaimCheckerInvokeSpotDispatcher",
+      "Effect": "Allow",
+      "Action": ["lambda:InvokeFunction"],
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-sf-watch-spot-dispatcher"
     }
   ]
 }

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -125,7 +125,8 @@ EXPECTED_PIPELINE_NAMES = [
     "ne-weekly-freshness-pipeline",
     "ne-preopen-trading-pipeline",
     "ne-postclose-trading-pipeline",
-    "alpha-engine-eod-pipeline",  # transitional alias, config#1408 / re-exam 2026-07-03
+    # transitional alpha-engine-eod-pipeline alias retired 2026-07-11
+    # (config#2272; dormant old SF deleted live).
 ]
 
 WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -52,6 +52,31 @@ problem fires a LOUD alert, deduplicated by the CONTENT of the problem set
 (a hash), not a timestamp — so a standing issue doesn't re-ping every run, and
 the alert state clears automatically the moment the check is clean again.
 
+**Mid-run spot-reclaim checker (config#2270).** This Lambda is ALSO the
+EventBridge target for `EC2 Spot Instance Interruption Warning` and
+`EC2 Instance State-change Notification` (state=terminated) events — the
+handler branches on event shape (the scheduled probe payload is `{}`; the EC2
+events carry `source: aws.ec2`). A spot reclaim MID-REPAIR used to kill the
+watch box with no completion marker, no failure marker, and no relaunch —
+detection was the >=6.5h spot-orphan-reaper ping. The checker lives HERE
+(rather than a new Lambda) per the issue's candidate-home evaluation: this is
+already the external observer of the watch plane. Flow: the EC2 events carry
+only an instance-id (no tags — the rules cannot be tag-scoped), so the
+checker DescribeTags the instance (tags stay queryable post-termination for a
+while) → non-watch boxes (`Name` != alpha-engine-sf-watch-spot) exit quietly
+→ for a watch box it heads the S3 completion marker
+`sf_watch/_control/completed/{cadence}-{pipeline}-{run_date}.json` (the same
+key the spot-orphan-reaper derives) → marker present = clean run, exit;
+marker ABSENT = the box died mid-run: re-invoke
+alpha-engine-sf-watch-spot-dispatcher ONCE with the original dispatch fields
+(reconstructed from the discriminator tags + the newest watch-log event) and
+`force_on_demand: true` — the groom-SF bounded-relaunch pattern
+(config#1645 / nousergon-data#658). Exactly-one bound: the relaunch decision
+is recorded as an `action: reclaim_relaunch` watch-log event (which the
+saturday dispatcher's config#2269 mechanical attempt ceiling counts) BEFORE
+the invoke; a second death for the same (cadence, pipeline, run_date)
+escalates LOUD instead of relaunching again (second death = human).
+
 **Fail-loud (CLAUDE.md no-silent-fails).** Every AWS describe/list call here is
 the PRIMARY input: an UNEXPECTED API error (anything other than the specific
 "this resource doesn't exist" codes we're explicitly checking for) RAISES, so a
@@ -126,6 +151,23 @@ SPOT_LEG_DISPATCHERS: list[tuple[str, str]] = [
 # Reading the live env instead of re-declaring the values here means this
 # probe can never drift from what the dispatcher will actually launch with.
 LAUNCH_CONFIG_ENV_KEYS = ("SF_WATCH_AMI_ID", "SF_WATCH_SECURITY_GROUP", "SF_WATCH_SUBNETS")
+
+# ── Mid-run spot-reclaim checker (config#2270) ───────────────────────────────
+# Tag names/keys mirror sf-watch-spot-dispatcher/index.py (SF_WATCH_TAG_NAME +
+# the three SF_WATCH_*_TAG_KEY discriminators) and spot-orphan-reaper's
+# WATCH_KINDS sf-watch entry — the same triple every watch-plane consumer keys
+# on. The completion-marker key shape below is the reaper's `_completion_key`
+# shape for the sf-watch kind.
+SF_WATCH_SPOT_TAG_NAME = "alpha-engine-sf-watch-spot"
+SF_WATCH_CADENCE_TAG_KEY = "sf-watch-cadence"
+SF_WATCH_PIPELINE_TAG_KEY = "sf-watch-pipeline"
+SF_WATCH_RUN_DATE_TAG_KEY = "sf-watch-run-date"
+COMPLETION_MARKER_PREFIX = "sf_watch/_control/completed/"
+RECLAIM_INTERRUPTION_DETAIL_TYPE = "EC2 Spot Instance Interruption Warning"
+RECLAIM_STATE_CHANGE_DETAIL_TYPE = "EC2 Instance State-change Notification"
+RECLAIM_DETAIL_TYPES = frozenset(
+    {RECLAIM_INTERRUPTION_DETAIL_TYPE, RECLAIM_STATE_CHANGE_DETAIL_TYPE}
+)
 
 
 def _error_code(exc: Exception) -> str:
@@ -389,9 +431,296 @@ def _alert(problems: list[str], kill_switches: dict[str, str] | None = None) -> 
         return False
 
 
+# ── Mid-run spot-reclaim checker (config#2270) ───────────────────────────────
+
+
+def _is_reclaim_event(event: dict) -> bool:
+    """True iff this invocation is an EC2 reclaim/termination EventBridge
+    event rather than the scheduled probe (whose payload is ``{}``)."""
+    return (
+        isinstance(event, dict)
+        and event.get("source") == "aws.ec2"
+        and event.get("detail-type") in RECLAIM_DETAIL_TYPES
+    )
+
+
+def _instance_tags(instance_id: str) -> dict[str, str]:
+    """Tags for ``instance_id`` via DescribeTags — still queryable for a
+    while after termination, unlike the instance record itself. Raises on any
+    API error (fail-loud: the tags are the PRIMARY input of the reclaim
+    check; an unreadable tag set must surface via the Lambda Errors metric,
+    never silently classify a dead watch box as 'not ours')."""
+    resp = _ec2_client().describe_tags(
+        Filters=[{"Name": "resource-id", "Values": [instance_id]}]
+    )
+    return {t.get("Key", ""): t.get("Value", "") for t in resp.get("Tags", [])}
+
+
+def _completion_marker_exists(marker_key: str) -> bool:
+    """HeadObject on the run's completion marker. Only a true absence
+    (404/NoSuchKey/NotFound) means "no marker"; any OTHER error RAISES —
+    misreading an S3 hiccup as 'absent' would fire a duplicate relaunch, and
+    misreading it as 'present' would silently drop coverage (the config#2267
+    site-4 lesson, applied to this read)."""
+    try:
+        _s3_client().head_object(Bucket=WATCH_BUCKET, Key=marker_key)
+        return True
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        raise
+
+
+def _load_watch_log(s3, watch_log_key: str) -> dict | None:
+    """The day's watch-log doc, or None when it truly doesn't exist (404).
+    Any other read error RAISES (fail-loud — the exactly-one relaunch bound
+    depends on this read). A present-but-unparseable doc also returns None:
+    without a readable event history the checker can neither reconstruct the
+    dispatch fields nor verify the exactly-one bound, and the None path below
+    escalates LOUDLY instead of relaunching — that escalation is the
+    recording surface for this swallow (failure mode swallowed: a corrupted
+    watch-log blob; the reclaim finding itself still pages)."""
+    try:
+        obj = s3.get_object(Bucket=WATCH_BUCKET, Key=watch_log_key)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"404", "NoSuchKey"}:
+            return None
+        raise
+    try:
+        doc = json.loads(obj["Body"].read())
+    except (ValueError, TypeError) as exc:
+        logger.warning("watch-log %s unparseable during reclaim check: %s", watch_log_key, exc)
+        return None
+    if isinstance(doc, dict) and isinstance(doc.get("events"), list):
+        return doc
+    logger.warning("watch-log %s has an unexpected shape during reclaim check", watch_log_key)
+    return None
+
+
+def _record_reclaim_relaunch(s3, watch_log_key: str, doc: dict, record: dict) -> None:
+    """Append the relaunch decision to the day's watch-log and write it back.
+    PRIMARY deliverable of the relaunch path — RAISES on failure, and runs
+    BEFORE the dispatcher invoke: if this write fails, NO relaunch fires (the
+    Lambda error pages via the watch-plane alarms) — the safe failure
+    direction, since a relaunch without its record would break the
+    exactly-one bound and permit unbounded relaunches."""
+    doc["updated_at"] = record["detected_at"]
+    doc["events"].append(record)
+    s3.put_object(
+        Bucket=WATCH_BUCKET,
+        Key=watch_log_key,
+        Body=json.dumps(doc, indent=2, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _reclaim_escalate(text: str, dedup_key: str, context_info: dict) -> bool:
+    """LOUD reclaim-path escalation (second death / unreconstructable dispatch
+    fields = human needed). Best-effort delivery surface — a Telegram outage
+    logs WARNING and is returned, never masks the finding (which is already
+    in the CloudWatch log + returned verdict)."""
+    try:
+        return notify_via_flow_doctor(
+            text,
+            silent=False,
+            severity="error",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context=context_info,
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface; finding still logged + returned
+        logger.warning("reclaim escalation Telegram send failed (non-fatal): %s", exc)
+        return False
+
+
+def _reclaim_note(text: str, dedup_key: str, context_info: dict) -> bool:
+    """Silent Telegram note for a successful bounded relaunch (mirrors the
+    dispatcher's silent 'watch is acting' receipt). Best-effort."""
+    try:
+        return notify_via_flow_doctor(
+            text,
+            silent=True,
+            severity="info",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context=context_info,
+            silent_topic=FleetTelegramTopic.OPS_HEALTH,
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface; relaunch already fired + recorded
+        logger.warning("reclaim relaunch Telegram note failed (non-fatal): %s", exc)
+        return False
+
+
+def _handle_reclaim_event(event: dict) -> dict:
+    """Mid-run spot-reclaim checker (config#2270) — see module docstring."""
+    detail = event.get("detail") or {}
+    detail_type = str(event.get("detail-type") or "")
+    instance_id = str(detail.get("instance-id") or "")
+    if not instance_id:
+        # Rule contract violation — the EventBridge patterns always carry an
+        # instance-id. Fail loud rather than silently ignoring a malformed
+        # event that might be a real watch-box death.
+        raise ValueError(f"EC2 reclaim event without instance-id (detail-type={detail_type!r})")
+    base = {"reclaim_event": True, "detail_type": detail_type, "instance_id": instance_id}
+
+    # Defense in depth: the terminated rule's pattern filters state=terminated;
+    # a stopping/running state-change reaching us anyway is not a death.
+    if detail_type == RECLAIM_STATE_CHANGE_DETAIL_TYPE and str(detail.get("state") or "") != "terminated":
+        logger.info("reclaim check: ignoring non-terminated state-change for %s", instance_id)
+        return {**base, "handled": False, "reason": "not_terminated"}
+
+    tags = _instance_tags(instance_id)
+    if tags.get("Name") != SF_WATCH_SPOT_TAG_NAME:
+        # Every instance in the account hits these rules (they cannot be
+        # tag-scoped) — non-watch boxes exit quietly, log only.
+        logger.info("reclaim check: %s is not an sf-watch box (Name=%r) — ignoring",
+                    instance_id, tags.get("Name"))
+        return {**base, "watch_box": False}
+
+    cadence = tags.get(SF_WATCH_CADENCE_TAG_KEY, "")
+    pipeline = tags.get(SF_WATCH_PIPELINE_TAG_KEY, "")
+    run_date = tags.get(SF_WATCH_RUN_DATE_TAG_KEY, "")
+    if not (cadence and pipeline and run_date):
+        # A watch box died inside the narrow launch→tag window (or a tag write
+        # regressed): no discriminators means no marker key and no dispatch
+        # fields — a human must look. LOUD, never a quiet drop.
+        alerted = _reclaim_escalate(
+            "\U0001f6a8 *SF-Watch reclaim checker — UNTAGGED watch box died*\n"
+            f"Watch box `{instance_id}` terminated without its cadence/pipeline/"
+            "run-date discriminator tags — cannot verify completion or relaunch. "
+            "Check the sf-watch-spot-dispatcher tag-write path (config#2267 site 2).",
+            dedup_key=f"{_FLOW_NAME}:reclaim_untagged:{instance_id}",
+            context_info={"instance_id": instance_id, "tags": tags},
+        )
+        return {**base, "watch_box": True, "handled": False,
+                "reason": "missing_discriminator_tags", "escalated": alerted}
+
+    key_ctx = {"instance_id": instance_id, "cadence": cadence,
+               "pipeline": pipeline, "run_date": run_date}
+    marker_key = f"{COMPLETION_MARKER_PREFIX}{cadence}-{pipeline}-{run_date}.json"
+    if _completion_marker_exists(marker_key):
+        logger.info("reclaim check: %s finished cleanly (marker %s present)",
+                    instance_id, marker_key)
+        return {**base, "watch_box": True, "completed": True}
+
+    # No completion marker: the box died MID-RUN.
+    watch_log_key = f"consolidated/{cadence}_sf_watch/{run_date}.json"
+    s3 = _s3_client()
+    doc = _load_watch_log(s3, watch_log_key)
+    events = (doc or {}).get("events", [])
+    relaunches = [ev for ev in events if ev.get("action") == "reclaim_relaunch"]
+
+    if any(ev.get("dead_instance_id") == instance_id for ev in relaunches):
+        # The interruption WARNING and the terminated state-change both fire
+        # for one reclaim — the second notification of the SAME death is a
+        # duplicate, not a second death.
+        logger.info("reclaim check: death of %s already handled — duplicate notification",
+                    instance_id)
+        return {**base, "watch_box": True, "completed": False,
+                "duplicate_notification": True}
+
+    if relaunches:
+        # Exactly-one bound: a DIFFERENT box already died and was relaunched
+        # for this (cadence, pipeline, run_date) — second death = human.
+        alerted = _reclaim_escalate(
+            "\U0001f6a8 *SF-Watch reclaim checker — SECOND watch-box death*\n"
+            f"{cadence}/{pipeline}@{run_date}: relaunched box `{instance_id}` "
+            "ALSO died without a completion marker (prior relaunch: "
+            f"`{relaunches[-1].get('dead_instance_id', '?')}` → on-demand). "
+            "The bounded relaunch budget is spent — human needed (config#2270).",
+            dedup_key=f"{_FLOW_NAME}:reclaim_second_death:{pipeline}:{run_date}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": False,
+                "reason": "second_death", "escalated": alerted}
+
+    # First mid-run death for this key: reconstruct the dispatch fields. The
+    # tags carry (cadence, pipeline, run_date); the execution context comes
+    # from the NEWEST watch-log event carrying an execution_arn — the failure
+    # this box was dispatched for (the dispatcher writes the log BEFORE
+    # dispatching, so a dispatched box always has one... unless the log is
+    # missing/corrupted, in which case escalate LOUD instead of guessing).
+    source_ev = next((ev for ev in reversed(events) if ev.get("execution_arn")), None)
+    if source_ev is None:
+        alerted = _reclaim_escalate(
+            "\U0001f6a8 *SF-Watch reclaim checker — watch box died mid-run, "
+            "dispatch fields UNRECONSTRUCTABLE*\n"
+            f"{cadence}/{pipeline}@{run_date}: box `{instance_id}` died without "
+            f"a completion marker, and the watch-log `{watch_log_key}` has no "
+            "usable event to rebuild the dispatch from — relaunch manually "
+            "(config#2270).",
+            dedup_key=f"{_FLOW_NAME}:reclaim_no_source:{pipeline}:{run_date}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": False,
+                "reason": "no_source_event", "escalated": alerted}
+
+    payload = {
+        "pipeline_name": pipeline,
+        "cadence_slug": cadence,
+        "run_date": run_date,
+        "execution_arn": source_ev.get("execution_arn", ""),
+        "state_machine_arn": f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{pipeline}",
+        "failed_state": source_ev.get("failed_state") or "",
+        "cause": source_ev.get("cause") or "",
+        "watch_log_key": watch_log_key,
+        "is_preflight": "true" if source_ev.get("is_preflight") else "false",
+        # The whole point: a spot reclaim already proved spot unreliable for
+        # this run — relaunch straight to on-demand (lib >= 0.106.0
+        # launch_with_fallback(force_on_demand=True), config#1645 pattern).
+        "force_on_demand": "true",
+    }
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    record = {
+        "detected_at": now_iso,
+        # Counted by the saturday dispatcher's config#2269 mechanical attempt
+        # ceiling (_BUDGET_CONSUMING_ACTIONS) — the relaunch consumes the same
+        # shared budget as agent dispatches and fast-path reruns.
+        "action": "reclaim_relaunch",
+        "source": _FLOW_NAME,
+        "dead_instance_id": instance_id,
+        "reclaim_detail_type": detail_type,
+        "cadence_slug": cadence,
+        "pipeline": pipeline,
+        "run_date": run_date,
+        "execution_arn": source_ev.get("execution_arn", ""),
+        "force_on_demand": True,
+    }
+    # Record FIRST (exactly-one bound), then invoke — both fail-loud.
+    _record_reclaim_relaunch(s3, watch_log_key, doc, record)
+    _lambda_client().invoke(
+        FunctionName=SPOT_DISPATCHER_FUNCTION,
+        InvocationType="Event",
+        Payload=json.dumps(payload).encode("utf-8"),
+    )
+    logger.warning(
+        "reclaim check: watch box %s (%s/%s@%s) died mid-repair — relaunch "
+        "dispatched with force_on_demand", instance_id, cadence, pipeline, run_date,
+    )
+    noted = _reclaim_note(
+        "\U0001f6f0️ *SF-Watch reclaim checker — bounded relaunch*\n"
+        f"Watch box `{instance_id}` ({cadence}/{pipeline}@{run_date}) was "
+        "reclaimed mid-repair — relaunched ON-DEMAND (attempt 1/1; a second "
+        "death escalates loud, config#2270).",
+        dedup_key=f"{_FLOW_NAME}:reclaim_relaunch:{pipeline}:{run_date}:{instance_id}",
+        context_info=key_ctx,
+    )
+    return {**base, "watch_box": True, "completed": False, "relaunched": True,
+            "telegram_sent": noted, "watch_log_key": watch_log_key}
+
+
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
-    """Scheduled (EventBridge) entrypoint. Read-only; raises on an unexpected
+    """Scheduled (EventBridge) entrypoint — plus the mid-run spot-reclaim
+    checker branch (config#2270) when invoked by the EC2 reclaim/termination
+    EventBridge rules. Read-only on the probe path; raises on an unexpected
     AWS API failure so the check can never silently no-op."""
+    if _is_reclaim_event(event or {}):
+        return _handle_reclaim_event(event)
     spot_problems, kill_switches = _check_spot_dispatch_leg()
     problems = (
         _check_rule() + _check_state_machines_exist() + _check_lambda_healthy() + spot_problems

--- a/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
@@ -520,3 +520,311 @@ def test_unexpected_error_is_not_swallowed():
     with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
         with pytest.raises(FakeClientError):
             index.handler({}, None)
+
+
+# ── config#2270: mid-run spot-reclaim checker ────────────────────────────────
+# EC2 reclaim/termination EventBridge events route to a checker branch in this
+# same handler: non-watch boxes exit quietly; a watch box with its completion
+# marker is a clean run; a watch box WITHOUT a marker died mid-repair — invoke
+# the spot dispatcher once with force_on_demand (recorded as an
+# `action: reclaim_relaunch` watch-log event, the exactly-one bound); a second
+# death for the same key escalates LOUD instead.
+
+WATCH_TAGS = {
+    "Name": "alpha-engine-sf-watch-spot",
+    "sf-watch-cadence": "saturday",
+    "sf-watch-pipeline": "ne-weekly-freshness-pipeline",
+    "sf-watch-run-date": "2026-07-11",
+}
+EXEC_ARN = ("arn:aws:states:us-east-1:711398986525:execution:"
+            "ne-weekly-freshness-pipeline:run-1")
+WATCH_LOG_KEY = "consolidated/saturday_sf_watch/2026-07-11.json"
+MARKER_KEY = ("sf_watch/_control/completed/"
+              "saturday-ne-weekly-freshness-pipeline-2026-07-11.json")
+
+
+def _reclaim_event(detail_type="EC2 Spot Instance Interruption Warning",
+                   instance_id="i-dead", **detail_overrides):
+    detail = {"instance-id": instance_id}
+    detail.update(detail_overrides)
+    return {"source": "aws.ec2", "detail-type": detail_type, "detail": detail}
+
+
+def _make_reclaim_ec2(tags=WATCH_TAGS):
+    ec2 = _make_ec2_client()
+    ec2.describe_tags.return_value = {
+        "Tags": [{"Key": k, "Value": v, "ResourceId": "i-dead"} for k, v in tags.items()]
+    }
+    return ec2
+
+
+def _make_reclaim_s3(*, marker_exists=False, watch_log=None):
+    """s3 mock for the reclaim path: head_object → completion marker;
+    get_object/put_object → the watch-log doc."""
+    s3 = MagicMock()
+    if marker_exists:
+        s3.head_object.return_value = {}
+    else:
+        s3.head_object.side_effect = FakeClientError("404")
+    if watch_log is None:
+        s3.get_object.side_effect = FakeClientError("NoSuchKey")
+    else:
+        body = MagicMock()
+        body.read.return_value = json.dumps(watch_log).encode()
+        s3.get_object.return_value = {"Body": body}
+    return s3
+
+
+def _watch_log_doc(events):
+    return {"schema_version": 1, "run_date": "2026-07-11", "events": events}
+
+
+def _dispatch_log_event(**overrides):
+    ev = {
+        "detected_at": "2026-07-11T09:15:00+00:00",
+        "action": "dispatch",
+        "status": "FAILED",
+        "execution_arn": EXEC_ARN,
+        "failed_state": "RAGIngestion",
+        "cause": "States.TaskFailed: RAGIngestion failed",
+        "is_preflight": False,
+    }
+    ev.update(overrides)
+    return ev
+
+
+def _run_reclaim(event, *, ec2=None, s3=None, lam=None):
+    ec2 = ec2 if ec2 is not None else _make_reclaim_ec2()
+    s3 = s3 if s3 is not None else _make_reclaim_s3()
+    lam = lam if lam is not None else MagicMock()
+    factory = _clients_factory(_make_events_client(), _make_sfn_client(), lam, s3, ec2)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(event, None)
+    return result, ec2, s3, lam
+
+
+def test_reclaim_event_for_non_watch_box_exits_quietly():
+    """Every instance in the account hits the (untag-scopable) rules — a box
+    whose Name tag isn't the watch tag is ignored with a log line only: no
+    S3 reads, no invoke, no Telegram."""
+    ec2 = _make_reclaim_ec2(tags={"Name": "alpha-engine-data-spot"})
+    result, _, s3, lam = _run_reclaim(_reclaim_event(), ec2=ec2)
+    assert result["reclaim_event"] is True
+    assert result["watch_box"] is False
+    s3.head_object.assert_not_called()
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_event_with_completion_marker_is_clean_exit():
+    s3 = _make_reclaim_s3(marker_exists=True)
+    result, _, s3, lam = _run_reclaim(_reclaim_event(), s3=s3)
+    assert result["watch_box"] is True
+    assert result["completed"] is True
+    s3.head_object.assert_called_once()
+    assert s3.head_object.call_args.kwargs["Key"] == MARKER_KEY
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_without_marker_relaunches_on_demand_once_with_record_and_note():
+    """First mid-run death: exactly one dispatcher invoke (Event type) with
+    force_on_demand + the fields reconstructed from tags + the newest
+    watch-log event; the reclaim_relaunch record is written BEFORE the
+    invoke; a silent Telegram note fires."""
+    s3 = _make_reclaim_s3(watch_log=_watch_log_doc([_dispatch_log_event()]))
+    result, _, s3, lam = _run_reclaim(_reclaim_event(), s3=s3)
+
+    assert result["watch_box"] is True
+    assert result["completed"] is False
+    assert result["relaunched"] is True
+
+    lam.invoke.assert_called_once()
+    kwargs = lam.invoke.call_args.kwargs
+    assert kwargs["FunctionName"] == index.SPOT_DISPATCHER_FUNCTION
+    assert kwargs["InvocationType"] == "Event"
+    payload = json.loads(kwargs["Payload"])
+    assert payload == {
+        "pipeline_name": "ne-weekly-freshness-pipeline",
+        "cadence_slug": "saturday",
+        "run_date": "2026-07-11",
+        "execution_arn": EXEC_ARN,
+        "state_machine_arn": ("arn:aws:states:us-east-1:711398986525:"
+                              "stateMachine:ne-weekly-freshness-pipeline"),
+        "failed_state": "RAGIngestion",
+        "cause": "States.TaskFailed: RAGIngestion failed",
+        "watch_log_key": WATCH_LOG_KEY,
+        "is_preflight": "false",
+        "force_on_demand": "true",
+    }
+
+    # The relaunch decision landed in the watch-log (the exactly-one bound +
+    # the event the saturday dispatcher's config#2269 ceiling counts).
+    s3.put_object.assert_called_once()
+    assert s3.put_object.call_args.kwargs["Key"] == WATCH_LOG_KEY
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    ev = written["events"][-1]
+    assert ev["action"] == "reclaim_relaunch"
+    assert ev["dead_instance_id"] == "i-dead"
+    assert ev["force_on_demand"] is True
+    assert ev["execution_arn"] == EXEC_ARN
+
+    # Silent note — the loud alert already happened at the SF failure itself.
+    index.notify_via_flow_doctor.assert_called_once()
+    note_kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert note_kwargs["silent"] is True
+    text = index.notify_via_flow_doctor.call_args.args[0]
+    assert "reclaimed mid-repair" in text
+    assert "ON-DEMAND" in text
+
+
+def test_second_death_escalates_loud_and_never_reinvokes():
+    """Exactly-one bound: a prior reclaim_relaunch for this key (different
+    box) means the relaunched box ALSO died — LOUD escalation, no second
+    dispatcher invoke, no second watch-log relaunch record."""
+    prior = {
+        "action": "reclaim_relaunch",
+        "dead_instance_id": "i-original-box",
+        "execution_arn": EXEC_ARN,
+    }
+    s3 = _make_reclaim_s3(watch_log=_watch_log_doc([_dispatch_log_event(), prior]))
+    result, _, s3, lam = _run_reclaim(
+        _reclaim_event(instance_id="i-relaunched-box"), s3=s3
+    )
+    assert result["relaunched"] is False
+    assert result["reason"] == "second_death"
+    lam.invoke.assert_not_called()
+    s3.put_object.assert_not_called()
+    index.notify_via_flow_doctor.assert_called_once()
+    esc_kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert esc_kwargs["silent"] is False
+    assert esc_kwargs["severity"] == "error"
+    assert "SECOND watch-box death" in index.notify_via_flow_doctor.call_args.args[0]
+
+
+def test_duplicate_notification_of_same_death_is_quiet():
+    """The interruption WARNING and the terminated state-change both fire for
+    ONE reclaim — the second notification for the SAME instance-id must
+    neither re-invoke nor escalate."""
+    prior = {
+        "action": "reclaim_relaunch",
+        "dead_instance_id": "i-dead",
+        "execution_arn": EXEC_ARN,
+    }
+    s3 = _make_reclaim_s3(watch_log=_watch_log_doc([_dispatch_log_event(), prior]))
+    result, _, s3, lam = _run_reclaim(
+        _reclaim_event(detail_type="EC2 Instance State-change Notification",
+                       instance_id="i-dead", state="terminated"),
+        s3=s3,
+    )
+    assert result["duplicate_notification"] is True
+    lam.invoke.assert_not_called()
+    s3.put_object.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_with_missing_discriminator_tags_escalates_loud():
+    """A watch box that died inside the launch→tag window: no marker key, no
+    dispatch fields — must page a human, never drop quietly."""
+    ec2 = _make_reclaim_ec2(tags={"Name": "alpha-engine-sf-watch-spot"})
+    result, _, _, lam = _run_reclaim(_reclaim_event(), ec2=ec2)
+    assert result["watch_box"] is True
+    assert result["reason"] == "missing_discriminator_tags"
+    lam.invoke.assert_not_called()
+    esc_kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert esc_kwargs["silent"] is False
+    assert esc_kwargs["severity"] == "error"
+
+
+def test_reclaim_with_no_usable_watch_log_event_escalates_loud():
+    """No watch-log (or none of its events carries an execution_arn) → the
+    dispatch cannot be reconstructed — LOUD escalation, no blind invoke."""
+    s3 = _make_reclaim_s3(watch_log=None)  # 404: no watch-log at all
+    result, _, s3, lam = _run_reclaim(_reclaim_event(), s3=s3)
+    assert result["relaunched"] is False
+    assert result["reason"] == "no_source_event"
+    lam.invoke.assert_not_called()
+    esc_kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert esc_kwargs["silent"] is False
+
+
+def test_non_terminated_state_change_is_ignored():
+    result, ec2, s3, lam = _run_reclaim(
+        _reclaim_event(detail_type="EC2 Instance State-change Notification",
+                       state="stopping")
+    )
+    assert result["handled"] is False
+    assert result["reason"] == "not_terminated"
+    ec2.describe_tags.assert_not_called()
+    lam.invoke.assert_not_called()
+
+
+def test_reclaim_event_without_instance_id_raises():
+    """Rule contract violation — fail loud, never silently ignore what might
+    be a real watch-box death."""
+    event = {"source": "aws.ec2",
+             "detail-type": "EC2 Spot Instance Interruption Warning",
+             "detail": {}}
+    with pytest.raises(ValueError, match="instance-id"):
+        index.handler(event, None)
+
+
+def test_marker_head_unexpected_error_is_not_swallowed():
+    """Only a true 404 means 'no marker' — an S3 hiccup must RAISE, never be
+    misread as absent (duplicate relaunch) or present (dropped coverage)."""
+    s3 = _make_reclaim_s3()
+    s3.head_object.side_effect = FakeClientError("AccessDenied")
+    with pytest.raises(FakeClientError):
+        _run_reclaim(_reclaim_event(), s3=s3)
+
+
+def test_scheduled_probe_event_never_routes_to_reclaim_branch():
+    """The scheduled probe payload is {} — it must run the wiring checks, not
+    the reclaim checker (pinned by test_all_clean_alerts_nothing running the
+    full check set; this pins the discriminator directly)."""
+    assert index._is_reclaim_event({}) is False
+    assert index._is_reclaim_event({"source": "aws.ec2"}) is False
+    assert index._is_reclaim_event(_reclaim_event()) is True
+    assert index._is_reclaim_event(
+        _reclaim_event(detail_type="EC2 Instance State-change Notification")
+    ) is True
+
+
+def _sibling_dispatcher_cadence_prefix_pairs() -> set[tuple[str, str]]:
+    """(cadence_slug, watch_prefix) pairs out of the sibling dispatcher's
+    PIPELINES — ast-extracted (the inner dicts carry non-literal values)."""
+    import ast
+
+    path = Path(__file__).parent.parent / "saturday-sf-watch-dispatcher" / "index.py"
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and getattr(node.target, "id", "") == "PIPELINES":
+            pipelines = node.value
+            break
+    else:
+        raise AssertionError("PIPELINES not found in sibling dispatcher")
+    pairs = set()
+    for cfg in pipelines.values:
+        fields = {
+            k.value: v.value
+            for k, v in zip(cfg.keys, cfg.values)
+            if isinstance(k, ast.Constant) and isinstance(v, ast.Constant)
+        }
+        pairs.add((fields["cadence_slug"], fields["watch_prefix"]))
+    return pairs
+
+
+def test_watch_prefixes_follow_the_cadence_convention_the_reclaim_checker_derives():
+    """LOCKSTEP GUARD (config#2270): the reclaim checker derives the watch-log
+    key as consolidated/{cadence_slug}_sf_watch/{run_date}.json from the box's
+    cadence tag. That derivation is only sound while EVERY dispatcher
+    watch_prefix equals consolidated/{cadence_slug}_sf_watch — if a pipeline
+    ever breaks the convention, this test forces the checker to grow a real
+    mapping instead of silently reading a wrong key."""
+    pairs = _sibling_dispatcher_cadence_prefix_pairs()
+    assert pairs, "no (cadence_slug, watch_prefix) pairs extracted"
+    for cadence_slug, watch_prefix in pairs:
+        assert watch_prefix == f"consolidated/{cadence_slug}_sf_watch", (
+            f"watch_prefix {watch_prefix!r} for cadence {cadence_slug!r} breaks "
+            "the convention the reclaim checker's key derivation relies on"
+        )

--- a/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
@@ -269,12 +269,12 @@ def test_dead_state_machine_arn_alerts():
     """The exact 2026-06-29 bug class: registered in the rule, but the SF
     itself no longer exists (deleted/renamed)."""
     events = _make_events_client()
-    sfn = _make_sfn_client(missing_names={"alpha-engine-eod-pipeline"})
+    sfn = _make_sfn_client(missing_names={"ne-postclose-trading-pipeline"})
     lam = _make_lambda_client()
     s3 = _make_s3_client()
     with patch("index.boto3.client", side_effect=_clients_factory(events, sfn, lam, s3)):
         result = index.handler({}, None)
-    assert any("NO live Step Function" in p and "alpha-engine-eod-pipeline" in p for p in result["problems"])
+    assert any("NO live Step Function" in p and "ne-postclose-trading-pipeline" in p for p in result["problems"])
 
 
 def test_unhealthy_lambda_alerts():

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -191,10 +191,9 @@ _WATCH_PREFIXES = {
     "ne-weekly-freshness-pipeline": "consolidated/saturday_sf_watch",
     "ne-preopen-trading-pipeline": "consolidated/weekday_sf_watch",
     "ne-postclose-trading-pipeline": "consolidated/eod_sf_watch",
-    # TRANSITIONAL old EOD SF name — mirrors the same entry in
-    # saturday-sf-watch-dispatcher's PIPELINES (remove together at the
-    # config#1408 SF-rename cutover; the lockstep test enforces "together").
-    "alpha-engine-eod-pipeline": "consolidated/eod_sf_watch",
+    # The transitional alpha-engine-eod-pipeline alias was removed together
+    # with saturday-sf-watch-dispatcher's PIPELINES entry on 2026-07-11
+    # (config#2272) — the lockstep test enforces "together".
 }
 
 # Defense-in-depth allowlists for event fields embedded verbatim into the SSM

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -243,6 +243,12 @@ def _resolve_event_fields(event: dict) -> dict:
     failed_state = _optional(event, "failed_state", _FAILED_STATE_RE)
     watch_log_key = _optional(event, "watch_log_key", _WATCH_LOG_KEY_RE)
     is_preflight = _optional(event, "is_preflight", _BOOL_RE, default="false")
+    # force_on_demand (config#2270): set "true" by the sf-watch-liveness-probe
+    # reclaim checker's bounded relaunch — a spot reclaim already proved spot
+    # unreliable for this run, so the relaunch skips spot entirely (threaded
+    # to launch_with_fallback(force_on_demand=...), present in the pinned
+    # nousergon-lib v0.106.0). Boolean-validated like is_preflight.
+    force_on_demand = _optional(event, "force_on_demand", _BOOL_RE, default="false")
     # cause: deliberately unvalidated — arbitrary AWS text, base64-encoded
     # before it ever reaches a shell command (see _bootstrap_command).
     cause = str(event.get("cause") or "")
@@ -255,6 +261,7 @@ def _resolve_event_fields(event: dict) -> dict:
         "failed_state": failed_state,
         "watch_log_key": watch_log_key,
         "is_preflight": is_preflight,
+        "force_on_demand": force_on_demand,
         "cause": cause,
     }
 
@@ -298,11 +305,13 @@ exec bash infrastructure/sf_watch_spot_bootstrap.sh \
 """
 
 
-def _launch_instance() -> tuple[str, str]:
+def _launch_instance(force_on_demand: bool = False) -> tuple[str, str]:
     """Launch the SF-watch box; spot first, on-demand fallback on capacity
-    exhaustion. Raises SpotLaunchError (or the SpotCapacityExhausted
-    subclass) if BOTH the spot attempt and the on-demand fallback are
-    exhausted/fail — caught once by the caller and converted to a clean
+    exhaustion — or straight to on-demand when ``force_on_demand`` (the
+    config#2270 reclaim relaunch; ``launch_with_fallback`` grew the kwarg in
+    nousergon-lib v0.106.0, this Lambda's pinned version). Raises
+    SpotLaunchError (or the SpotCapacityExhausted subclass) if every attempt
+    is exhausted/fails — caught once by the caller and converted to a clean
     launched:false."""
     return spot_dispatch.launch_with_fallback(
         INSTANCE_TYPES, SUBNETS,
@@ -313,6 +322,7 @@ def _launch_instance() -> tuple[str, str]:
         volume_size_gb=VOLUME_SIZE_GB,
         tag_name=SF_WATCH_TAG_NAME,
         region=REGION,
+        force_on_demand=force_on_demand,
     )
 
 
@@ -473,7 +483,7 @@ def _defer_relaunch(fields: dict, generation: int, context, existing: list[str])
     payload = {k: fields[k] for k in (
         "pipeline_name", "cadence_slug", "run_date", "execution_arn",
         "state_machine_arn", "failed_state", "watch_log_key", "is_preflight",
-        "cause",
+        "force_on_demand", "cause",
     )}
     payload["defer_generation"] = next_generation
     fire_at = datetime.now(timezone.utc) + timedelta(seconds=DEFER_DELAY_SECONDS)
@@ -650,8 +660,10 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
         return _defer_relaunch(fields, defer_generation, context, existing)
 
     run_token = uuid.uuid4().hex
+    # config#2270: the reclaim checker's bounded relaunch skips spot entirely.
+    force_on_demand = fields.get("force_on_demand") == "true"
     try:
-        instance_id, market = _launch_instance()
+        instance_id, market = _launch_instance(force_on_demand=force_on_demand)
     except SpotLaunchError as exc:
         logger.error("sf-watch spot launch failed: %s: %s", type(exc).__name__, exc)
         return {"launched": False, "reason": "launch_failed", "error": str(exc)}
@@ -712,6 +724,7 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
         "run_date": run_date,
         "run_token": run_token,
         "dedupe_degraded": dedupe_degraded,
+        "force_on_demand": force_on_demand,
     }
     if dedupe_degraded:
         verdict["dedupe_probe_error"] = dedupe_probe_error
@@ -726,7 +739,14 @@ def handler(event: dict, context) -> dict:
     payload (RequestResponse). A DEFERRED re-invoke (config#2226 — fired by
     the one-shot EventBridge Scheduler schedule this handler created on a
     concurrency skip) carries the same payload plus `defer_generation` >= 1
-    and first re-evaluates the state machine before dispatching.
+    and first re-evaluates the state machine before dispatching. The
+    sf-watch-liveness-probe's mid-run reclaim checker (config#2270) invokes
+    this same handler (async Event) with the payload plus
+    `force_on_demand: "true"` — note this Lambda records its dispatch
+    decisions ONLY in the returned verdict + CloudWatch logs, never in the
+    watch-log; the budget-visible `action: reclaim_relaunch` watch-log event
+    (counted by the saturday dispatcher's config#2269 attempt ceiling) is
+    written by the PROBE before it invokes here.
 
     Returns {"launched": bool, "reason": str, "instance_id": ..., ...} — read
     DIRECTLY by the GHA job as its success signal. Every anticipated failure

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -402,7 +402,6 @@ def test_defer_schedule_name_deterministic_and_within_aws_cap(monkeypatch):
         ("saturday", "ne-weekly-freshness-pipeline"),
         ("weekday", "ne-preopen-trading-pipeline"),
         ("eod", "ne-postclose-trading-pipeline"),
-        ("eod", "alpha-engine-eod-pipeline"),
     ):
         for gen in (1, 2, 3):
             name = idx._defer_schedule_name(cadence, pipeline, "2026-07-11", gen)

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -805,6 +805,67 @@ def test_missing_optional_fields_still_launches(monkeypatch):
     assert out["launched"] is True
 
 
+# ── config#2270: force_on_demand relaunch (mid-run spot-reclaim coverage) ────
+
+
+def test_force_on_demand_threads_through_to_launch(monkeypatch):
+    """The reclaim checker's relaunch payload carries force_on_demand:"true" —
+    launch_with_fallback (nousergon-lib v0.106.0) must go STRAIGHT to
+    on-demand, never trying spot first."""
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        return "i-ondemand-relaunch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(force_on_demand="true"), None)
+    assert out["launched"] is True
+    assert out["market"] == "on-demand"
+    assert out["force_on_demand"] is True
+    assert seen == [False]  # single attempt, spot=False — no spot try at all
+
+
+def test_force_on_demand_defaults_false_spot_first(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        return "i-spot"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert out["market"] == "spot"
+    assert out["force_on_demand"] is False
+    assert seen == [True]
+
+
+def test_force_on_demand_malformed_returns_clean_false(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(force_on_demand="yes-please"), None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+    assert idx._test_ssm.sent == []
+
+
+def test_defer_payload_carries_force_on_demand(monkeypatch):
+    """A deferred re-invoke must not lose the on-demand escalation: the
+    one-shot schedule's payload carries force_on_demand through, so the
+    relaunch stays on-demand when it finally fires."""
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", "2026-07-11"): ["i-still-dying"],
+        },
+    )
+    out = idx.handler(_event(force_on_demand="true"), _FakeContext())
+    assert out["reason"] == "deferred"
+    (sched,) = idx._test_scheduler.created
+    payload = json.loads(sched["Target"]["Input"])
+    assert payload["force_on_demand"] == "true"
+
+
 def test_disabled_flag_short_circuits(monkeypatch):
     idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "false"})
     out = idx.handler(_event(), None)

--- a/tests/test_sf_watch_defer_prefix_lockstep.py
+++ b/tests/test_sf_watch_defer_prefix_lockstep.py
@@ -70,9 +70,9 @@ def _saturday_pipeline_prefixes() -> dict[str, str]:
 def test_spot_dispatcher_watch_prefixes_match_saturday_dispatcher_exactly():
     """EXACT equality, both directions: a pipeline added/removed/renamed (or a
     prefix changed) in saturday-sf-watch-dispatcher's PIPELINES must land in
-    the spot dispatcher's _WATCH_PREFIXES in the same PR — including the
-    TRANSITIONAL alpha-engine-eod-pipeline alias, which must be REMOVED from
-    both together at the config#1408 SF-rename cutover."""
+    the spot dispatcher's _WATCH_PREFIXES in the same PR — exactly how the
+    TRANSITIONAL alpha-engine-eod-pipeline alias was removed from both
+    together at the config#2272 retirement (2026-07-11)."""
     assert _spot_dispatcher_prefixes() == _saturday_pipeline_prefixes()
 
 


### PR DESCRIPTION
## Wave 2 of the SF-Fleet-Watch SOTA epic (alpha-engine-config-I2282) — two commits

### Commit 1 — I2269 mechanical ceiling + I2270 reclaim coverage
**Ceiling (saturday-sf-watch-dispatcher):** `SF_WATCH_MAX_DISPATCHES_{SATURDAY,WEEKDAY,EOD}` (8/2/2 per Brian's per-cadence ruling; unruled cadence → 2). Counts dispatcher-authored budget-consuming events from the watch-log — **including the charter's in-place `action` outcome rewrites** (`fixed_merged_rerun|rerun|proposed|refused|escalated`): counting only `dispatched` would let a HEALTHY agent reset the ceiling. Never keyed on agent-enriched fields, so agent crashes can't starve it either. Exhaustion → `dispatch_suppressed: attempt_budget_exhausted` + LOUD page (never the silent receipt). Outermost backstop; composes with the PR705 suppressions + charter budget. Env vars are config defaults, deliberately NOT operator-preserved (comment in deploy.sh).
**Reclaim coverage (liveness probe + spot dispatcher):** probe handler branches on EC2 events (interruption warning + terminated) for `Name=alpha-engine-sf-watch-spot` boxes; completion-marker HEAD (404-only-means-absent) → dead-mid-run ⇒ exactly-one bounded relaunch: `reclaim_relaunch` watch-log record written FIRST (single writer, keyed on dead_instance_id — keeps the bound even if the probe dies mid-invoke; counts against the I2269 ceiling), then async re-invoke of the spot dispatcher with `force_on_demand: true` (verified present in lib v0.106.0's `launch_with_fallback`) + silent Telegram note. Second death or unreconstructable dispatch fields → LOUD escalation, no blind relaunch. New EventBridge rules ship idempotently via the probe's deploy.sh bootstrap; probe IAM extended (DescribeTags, marker read, watch-log RW, InvokeFunction on the spot dispatcher). New lockstep guard pins the watch-prefix key derivation.

### Commit 2 (cherry-pickable) — I2272 alias retirement
`alpha-engine-eod-pipeline` (state machine DELETED live 2026-07-11 after zero-references verification) removed from all six surfaces: dispatcher PIPELINES/EVENT_PATTERN/IAM (×2 ARNs), probe EXPECTED list/IAM, spot-dispatcher allowlist. Docstring rule-name fix. Alias-presence test flipped to an absence regression guard.

## Tests
71 + 34 + 37 handler tests (29 new) + 4 lockstep/guard, all green under pinned lib v0.106.0; bash -n clean.

## Post-merge operator steps (tracked on the issues, not buried here)
Nothing auto-deploys (all three Lambdas operator-deployed; parity gap config#2295). Queued for the in-session apply under the standing arc authorization: dispatcher `deploy.sh --bootstrap` (ceiling envs + rule pattern minus alias) → probe `deploy.sh --bootstrap` (reclaim rules + IAM) → spot dispatcher code-only `deploy.sh`; then probe `--smoke`.

Closes nousergon/alpha-engine-config#2272. Refs nousergon/alpha-engine-config#2269, nousergon/alpha-engine-config#2270 (both close after live deploy + verification; epic alpha-engine-config-I2282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)