### PR TITLE
fix(sf): retry Ssm.SdkClientException across all fleet getCommandInvocation polls

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -468,6 +468,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 30,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -628,6 +637,15 @@
           ],
           "MaxAttempts": 10,
           "IntervalSeconds": 30,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
           "BackoffRate": 1.5
         }
       ],
@@ -832,6 +850,15 @@
                   ],
                   "MaxAttempts": 10,
                   "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
                   "BackoffRate": 1.5
                 }
               ],
@@ -1900,6 +1927,15 @@
                   "MaxAttempts": 10,
                   "IntervalSeconds": 30,
                   "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
+                  "BackoffRate": 1.5
                 }
               ],
               "Catch": [
@@ -2035,6 +2071,15 @@
                   ],
                   "MaxAttempts": 10,
                   "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
                   "BackoffRate": 1.5
                 }
               ],
@@ -2180,6 +2225,15 @@
                         "MaxAttempts": 10,
                         "IntervalSeconds": 30,
                         "BackoffRate": 1.5
+                      },
+                      {
+                        "ErrorEquals": [
+                          "Ssm.SdkClientException",
+                          "States.Timeout"
+                        ],
+                        "MaxAttempts": 2,
+                        "IntervalSeconds": 5,
+                        "BackoffRate": 1.5
                       }
                     ],
                     "Catch": [
@@ -2318,6 +2372,15 @@
                   ],
                   "MaxAttempts": 10,
                   "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
                   "BackoffRate": 1.5
                 }
               ],
@@ -2565,6 +2628,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 30,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -2687,6 +2759,15 @@
           ],
           "MaxAttempts": 10,
           "IntervalSeconds": 30,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
           "BackoffRate": 1.5
         }
       ],
@@ -2811,6 +2892,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 30,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -2933,6 +3023,15 @@
           ],
           "MaxAttempts": 10,
           "IntervalSeconds": 30,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
           "BackoffRate": 1.5
         }
       ],
@@ -3057,6 +3156,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 30,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -3175,6 +3283,15 @@
           "MaxAttempts": 5,
           "IntervalSeconds": 5,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -3250,6 +3367,15 @@
             "Ssm.InvocationDoesNotExist"
           ],
           "MaxAttempts": 5,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
           "IntervalSeconds": 5,
           "BackoffRate": 1.5
         }

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1272,6 +1272,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 10,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -1387,6 +1396,15 @@
           ],
           "MaxAttempts": 10,
           "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
           "BackoffRate": 1.5
         }
       ],

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -262,6 +262,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 10,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -383,6 +392,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 10,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -503,6 +521,15 @@
           "MaxAttempts": 5,
           "IntervalSeconds": 5,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -612,6 +639,15 @@
           ],
           "MaxAttempts": 10,
           "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
           "BackoffRate": 1.5
         }
       ],
@@ -772,6 +808,15 @@
           "MaxAttempts": 10,
           "IntervalSeconds": 10,
           "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.5
         }
       ],
       "Catch": [
@@ -887,6 +932,15 @@
           ],
           "MaxAttempts": 10,
           "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
           "BackoffRate": 1.5
         }
       ],

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -140,6 +140,15 @@
                 "MaxAttempts": 10,
                 "IntervalSeconds": 10,
                 "BackoffRate": 1.5
+              },
+              {
+                "ErrorEquals": [
+                  "Ssm.SdkClientException",
+                  "States.Timeout"
+                ],
+                "MaxAttempts": 2,
+                "IntervalSeconds": 5,
+                "BackoffRate": 1.5
               }
             ],
             "Catch": [


### PR DESCRIPTION
## Summary
- Backlog groom dispatch just failed live: `{"Error":"Ssm.SdkClientException","Cause":"Unable to execute HTTP request: connection timed out after 2000 ms: ssm.us-east-1.amazonaws.com..."}` from `step_function_groom.json`'s `PollGroomCommand` state.
- Root cause: `Ssm.SdkClientException` is AWS's documented transient-network error class for direct `aws-sdk:ssm:*` Step Functions integrations — not a real SSM-agent/instance problem. The fleet already retries it correctly on `DescribeInstanceInfo` (`step_function_daily.json`/`step_function_eod.json`), but every `getCommandInvocation` poll state across **all 4** fleet Step Functions only retried `Ssm.InvocationDoesNotExistException`/`Ssm.InvocationDoesNotExist`, so any transient SdkClientException fell straight to `Catch:States.ALL -> HandleFailure`, producing a false pipeline failure.
- Adds a second Retry entry (`Ssm.SdkClientException`, `States.Timeout`; MaxAttempts=2, IntervalSeconds=5, BackoffRate=1.5 — mirroring the existing `DescribeInstanceInfo` convention) to all 23 `getCommandInvocation` states: 9 in `step_function.json` (weekly), 1 in `step_function_groom.json`, 2 in `step_function_daily.json`, 6 in `step_function_eod.json`.
- Purely additive JSON diff — no existing Retry/Catch/state wiring touched.

## Test plan
- [x] Full repo test suite: `2893 passed, 7 skipped` (venv-activated, `pytest tests/`)
- [x] `tests/test_sf_invocationdoesnotexist_retry.py` — still green (asserts both existing error forms are retried; unaffected by the additive second Retry entry)
- [x] `tests/test_deploy_infrastructure_sf_coverage.py` — confirms all 4 SF defs deploy via `deploy-infrastructure.yml` on merge (no manual post-merge step needed)
- [x] JSON-validated all 4 modified files; verified via structural walk (incl. Map `ItemProcessor` and Parallel `Branches`) that all 23 `getCommandInvocation` states now carry the fix and none were missed

Deploys automatically on merge — merge button alone is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)