### PR TITLE
feat(sf-deploy): single-writer protocol for the weekly-SF definition + repo/S3/live drift check; stale doc corrections (config#2273, config#2281)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -136,16 +136,24 @@ Resources:
       DefinitionS3Location:
         Bucket: alpha-engine-research
         Key: infrastructure/step_function.json
-      # Alternative: inline definition via DefinitionString
-      # Using S3 location so the JSON files in the repo are the source of truth.
-      # Deploy script uploads JSON to S3 then updates the state machine.
-      # LoggingConfiguration is OWNED HERE (declarative SoT). The deploy
-      # script's update-state-machine call passes only --definition, which is a
-      # partial update (omitted loggingConfiguration is left unchanged), so this
-      # CFN-set logging is NOT wiped on each deploy. Logging the SF execution
-      # FailedEvents (level=ERROR) is what carries the L274 MutexConflict Cause
-      # into the log group for the metric filter below. The ne-* rename
-      # (config#1381) re-created these SFs without logging — this restores it.
+      # SINGLE-WRITER CONTRACT (config#2273): the repo file
+      # infrastructure/step_function.json is the sole source of truth for
+      # this definition. DefinitionS3Location is only READ at stack-create /
+      # resource-replacement time; both deploy paths
+      # (deploy-infrastructure.sh on merge, deploy_step_function.sh for
+      # manual/bootstrap) upload the stamped repo bytes to this exact S3
+      # key BEFORE update-state-machine, so a CFN restamp can only ever
+      # re-deploy the same bytes — CFN is not an independent writer in
+      # practice. Drift backstop across all three copies (repo / S3 / live):
+      # infrastructure/step-functions/check-definition-drift.py.
+      # LoggingConfiguration is DECLARED here (declarative SoT for the
+      # shape) and ASSERTED explicitly (--logging-configuration) by the
+      # deploy scripts on every update since config#2273 — never left to
+      # partial-update preservation (the recreate-drops-logging class is
+      # config#1464). Logging the SF execution FailedEvents (level=ERROR)
+      # is what carries the L274 MutexConflict Cause into the log group
+      # for the metric filter below. The ne-* rename (config#1381)
+      # re-created these SFs without logging — this restores it.
       LoggingConfiguration:
         Level: ERROR
         IncludeExecutionData: true

--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -153,10 +153,22 @@ sf_exists() {
 # Regression: 2026-06-04 — the Director SF state pushed the ASL over the line.
 
 # CFN-managed SF: update if present, else defer creation to CloudFormation (step 4).
+# The 4th arg is a JSON LoggingConfiguration string, passed EXPLICITLY on every
+# update (config#2273 deliverable 3): never rely on partial-update semantics to
+# preserve the CFN-set logging — a recreate-dropped config (config#1464 class,
+# hit live by the ne-* rename config#1381) is self-healed by the next deploy
+# instead of lingering until step-functions/check-drift.py pages. The SHAPE
+# stays declared in cloudformation/alpha-engine-orchestration.yaml (SoT); the
+# literals below must mirror it. Same mechanics as the EOD precedent
+# (config#1416) in update_or_create below.
 update_or_defer_to_cfn() {
-    local arn="$1" stamped="$2" label="$3"
+    local arn="$1" stamped="$2" label="$3" logging="${4:-}"
+    local logging_args=()
+    if [ -n "$logging" ]; then
+        logging_args=(--logging-configuration "$logging")
+    fi
     if sf_exists "$arn"; then
-        aws stepfunctions update-state-machine --state-machine-arn "$arn" --definition "file://$stamped" --query "updateDate" --output text
+        aws stepfunctions update-state-machine --state-machine-arn "$arn" --definition "file://$stamped" "${logging_args[@]}" --query "updateDate" --output text
         echo "  $label updated."
     else
         echo "  $label absent — CloudFormation will create it from S3 in step 4 (rename cutover)."
@@ -197,8 +209,14 @@ aws logs create-log-group --log-group-name "$EOD_LOG_GROUP_NAME" --region "$REGI
 aws logs put-retention-policy --log-group-name "$EOD_LOG_GROUP_NAME" --retention-in-days 30 --region "$REGION"
 EOD_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"'"$EOD_LOG_GROUP_ARN"'"}}]}'
 
-update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline"
-update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline"
+# CFN-pair logging configs — mirror the LoggingConfiguration blocks CFN
+# declares on SaturdayPipeline / WeekdayPipeline (level=ERROR,
+# includeExecutionData=true, the CFN-owned per-SF log groups).
+SAT_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-weekly-freshness-pipeline:*"}}]}'
+DAILY_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-preopen-trading-pipeline:*"}}]}'
+
+update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline" "$SAT_LOGGING_CONFIG"
+update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline" "$DAILY_LOGGING_CONFIG"
 update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post-close trading pipeline" "$EOD_LOGGING_CONFIG"
 update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-pipeline" "Backlog groom pipeline"
 

--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -30,7 +30,12 @@
 #
 # After deployment:
 #   1. Run a test execution from the Step Functions console
-#   2. Monitor first automated Saturday run (00:00 UTC)
+#   2. Monitor the next automated weekly run — schedule SoT is the CFN
+#      SaturdayTrigger ScheduleExpression in
+#      cloudformation/alpha-engine-orchestration.yaml plus the SF's
+#      WeeklyRunDayGate self-selection (config#1824); the cron is
+#      deliberately NOT copied here, it has gone stale in this file before
+#      (config#2281)
 #   3. After 2 successful weeks, run with --disable-old-crons
 
 set -euo pipefail
@@ -312,7 +317,10 @@ echo ""
 echo "=== Deployment Complete ==="
 echo ""
 echo "  State machine:  $SM_ARN"
-echo "  EventBridge:    $EVENTBRIDGE_RULE (Saturday 00:00 UTC)"
+# Schedule SoT is the CFN SaturdayTrigger rule (ScheduleExpression +
+# WeeklyRunDayGate self-selection, config#1824) — point there rather than
+# hand-copying the cron into a second place that goes stale (config#2281).
+echo "  EventBridge:    $EVENTBRIDGE_RULE (schedule: CFN-owned — SoT is the SaturdayTrigger ScheduleExpression in infrastructure/cloudformation/alpha-engine-orchestration.yaml, plus the SF's WeeklyRunDayGate self-selecting the single run day)"
 echo "  SNS topic:      $SNS_TOPIC_ARN"
 echo ""
 echo "To test manually:"

--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -2,6 +2,16 @@
 # deploy_step_function.sh — Create/update the Saturday pipeline Step Functions
 # state machine, IAM role, SNS topic, and EventBridge trigger.
 #
+# SINGLE-WRITER CONTRACT (config#2273): the repo file
+# infrastructure/step_function.json is the sole source of truth for the
+# ne-weekly-freshness-pipeline definition. Every deploy path (this script
+# for manual/bootstrap use, deploy-infrastructure.sh on merge) uploads the
+# stamped repo bytes to the CFN-referenced S3 key BEFORE calling
+# update-state-machine from those same bytes, and passes
+# --logging-configuration explicitly. CFN's DefinitionS3Location is only
+# read at stack-create/replacement, so keeping the S3 object in lockstep
+# means CFN can never restamp different bytes — see section 3 below.
+#
 # Prerequisites:
 #   1. AWS CLI configured with admin credentials
 #   2. SSM agent installed on the always-on EC2 instance
@@ -104,7 +114,39 @@ echo "  Role ARN: $ROLE_ARN"
 echo "  Inline policy is codified in infrastructure/iam/${ROLE_NAME}.json"
 echo "  Apply via: ./infrastructure/iam/apply.sh $ROLE_NAME"
 
-# ── 3. State Machine ───────────────────────────────────────────────────────
+# ── 3. State Machine — SINGLE-WRITER CONTRACT (config#2273) ────────────────
+#
+# The repo file infrastructure/step_function.json is the SOLE source of
+# truth for the ne-weekly-freshness-pipeline definition. Three copies of
+# the definition exist — the repo file, the S3 object CFN's
+# DefinitionS3Location references, and the live state machine — and the
+# deploy path is the ONLY thing allowed to move any of them. Every deploy
+# therefore does ALL of:
+#
+#   (a) stamp the repo file with the current git SHA (the same idempotent
+#       [git:<sha>] Comment stamp as deploy-infrastructure.sh, so this
+#       manual/bootstrap path and the on-merge CI path emit byte-identical
+#       artifacts for the same commit);
+#   (b) upload the stamped bytes to the CFN-referenced S3 key
+#       (WEEKLY_SF_S3_BUCKET/WEEKLY_SF_S3_KEY below — MUST stay equal to
+#       the SaturdayPipeline DefinitionS3Location in
+#       cloudformation/alpha-engine-orchestration.yaml). CFN only reads
+#       that object at stack-create / resource-replacement time; keeping
+#       it in lockstep means a future CFN restamp re-deploys the SAME
+#       bytes instead of silently rolling the live definition back to a
+#       stale object — CFN stops being an independent writer in practice;
+#   (c) update-state-machine from the SAME stamped bytes, passing
+#       --logging-configuration EXPLICITLY — reconstructed from the shape
+#       CFN declares on the SaturdayPipeline resource (level=ERROR,
+#       includeExecutionData=true, the WeeklyFreshnessLogGroup log group)
+#       — never relying on partial-update preservation (the
+#       recreate-drops-logging bug class is config#1464; the ne-* rename
+#       config#1381 hit it live).
+#
+# Drift backstop: infrastructure/step-functions/check-definition-drift.py
+# compares repo file vs live definition vs S3 staged copy (normalized)
+# and exits non-zero on any divergence. Shape-guard for THIS section:
+# tests/test_deploy_step_function_single_writer.py.
 
 echo "Creating/updating state machine: $STATE_MACHINE_NAME..."
 
@@ -114,36 +156,62 @@ if [ ! -f "$ASL_FILE" ]; then
   exit 1
 fi
 
-# Read the ASL definition
-DEFINITION=$(cat "$ASL_FILE")
+# CFN-referenced definition location (SaturdayPipeline DefinitionS3Location).
+# tests/test_deploy_step_function_single_writer.py pins these to the CFN
+# template so the script and CFN can never point at different objects.
+WEEKLY_SF_S3_BUCKET="alpha-engine-research"
+WEEKLY_SF_S3_KEY="infrastructure/step_function.json"
 
-# Check if state machine exists
+# Git SHA stamp — identical mechanics to deploy-infrastructure.sh so the
+# deploy-drift preflight can compare the live Comment stamp against
+# origin/main regardless of which deploy path last wrote the definition.
+GIT_SHA="${GITHUB_SHA:-$(git -C "$SCRIPT_DIR/.." rev-parse HEAD 2>/dev/null || echo unknown)}"
+echo "  Stamping definition with GIT_SHA=${GIT_SHA}"
+STAMPED_ASL="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
+trap 'rm -f "$STAMPED_ASL"' EXIT
+python3 -c "
+import json, sys
+path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(path_in))
+orig = d.get('Comment', '')
+# Strip any existing [git:…] prefix so re-stamping is idempotent
+if orig.startswith('[git:'):
+    orig = orig.split(' ', 1)[1] if ' ' in orig else ''
+d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
+json.dump(d, open(path_out, 'w'), indent=2)
+" "$ASL_FILE" "$STAMPED_ASL" "$GIT_SHA"
+
+# (b) S3 upload FIRST — the CFN read-source must never lag the live machine.
+echo "  Uploading stamped definition to s3://${WEEKLY_SF_S3_BUCKET}/${WEEKLY_SF_S3_KEY}..."
+aws s3 cp "$STAMPED_ASL" "s3://${WEEKLY_SF_S3_BUCKET}/${WEEKLY_SF_S3_KEY}" --quiet --region "$REGION"
+
+# (c) Explicit LoggingConfiguration — shape mirrors the CFN SaturdayPipeline
+# LoggingConfiguration declaration (CFN stays the declarative SoT for the
+# SHAPE; asserting it on every update self-heals a recreate-dropped config
+# instead of leaving the gap to the drift checker).
+LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws/stepfunctions/${STATE_MACHINE_NAME}:*"
+LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"'"$LOG_GROUP_ARN"'"}}]}'
+
+# --definition via file:// — an inline "$(cat ...)" arg blows ARG_MAX once
+# the ASL grows (2026-06-04 regression in deploy-infrastructure.sh; the
+# weekly ASL is ~130 KB and growing).
 SM_ARN="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:${STATE_MACHINE_NAME}"
 if aws stepfunctions describe-state-machine --state-machine-arn "$SM_ARN" --region "$REGION" &>/dev/null; then
   echo "  Updating existing state machine..."
   aws stepfunctions update-state-machine \
     --state-machine-arn "$SM_ARN" \
-    --definition "$DEFINITION" \
+    --definition "file://$STAMPED_ASL" \
     --role-arn "$ROLE_ARN" \
+    --logging-configuration "$LOGGING_CONFIG" \
     --region "$REGION" > /dev/null
 else
   echo "  Creating new state machine..."
   aws stepfunctions create-state-machine \
     --name "$STATE_MACHINE_NAME" \
-    --definition "$DEFINITION" \
+    --definition "file://$STAMPED_ASL" \
     --role-arn "$ROLE_ARN" \
     --type STANDARD \
-    --logging-configuration '{
-      "level": "ERROR",
-      "includeExecutionData": true,
-      "destinations": [
-        {
-          "cloudWatchLogsLogGroup": {
-            "logGroupArn": "arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/'"$STATE_MACHINE_NAME"':*"
-          }
-        }
-      ]
-    }' \
+    --logging-configuration "$LOGGING_CONFIG" \
     --region "$REGION" > /dev/null
   SM_ARN="arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:${STATE_MACHINE_NAME}"
 fi

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -1,10 +1,27 @@
 #!/usr/bin/env bash
-# infrastructure/spot_data_weekly.sh — Run weekly data workloads on a spot EC2.
+# infrastructure/spot_data_weekly.sh — Launch a weekly data workload on its
+# own fresh spot EC2 (c5.large-class), run it, emit a heartbeat on success,
+# and self-terminate.
 #
-# Bundles DataPhase1 + RAGIngestion on a single spot: launches c5.large,
-# clones alpha-engine-data, runs `python weekly_collector.py --phase 1`
-# followed by `bash rag/pipelines/run_weekly_ingestion.sh`, emits a
-# heartbeat on success, and self-terminates.
+# ONE SPOT PER WORKLOAD (preflight-task-split, 2026-05-16): the weekly SF
+# (ne-weekly-freshness-pipeline) SSM-invokes this script on the launching
+# host once per data state, and each invocation launches its OWN spot for
+# exactly one workload:
+#
+#   SF state MorningEnrich → --morning-enrich-only
+#       (Saturday-morning polygon T+1 fill: weekly_collector.py --morning-enrich)
+#   SF state DataPhase1    → --phase1-only
+#       (full price-cache refresh: weekly_collector.py --phase 1)
+#   SF state RAGIngestion  → --rag-only
+#       (rag/pipelines/run_weekly_ingestion.sh)
+#
+# Each SF state polls its own spot's completion independently (Wait /
+# CheckStatus / RetryGate / Reissue loop in step_function.json), so a
+# phase1 failure no longer re-pays the ~28-min morning-enrich, and a RAG
+# failure doesn't invalidate the price data. The pre-split single-spot
+# bundle survives only as MANUAL rerun modes: --data-only (morning-enrich
+# + phase1) and the no-flag default "full" (morning-enrich + phase1 + RAG
+# on one spot) — the SF never uses them.
 #
 # Origin: moved off ae-dashboard (t3.micro, 1 GB RAM) after the 2026-04-16
 # OOM incident (features/compute.py in the DAILY code path exhausted micro
@@ -13,12 +30,6 @@
 # fragile-by-design. This spot pattern mirrors the Backtester +
 # PredictorTraining launchers so all heavy weekly compute lives on
 # fresh, self-terminating instances instead of the always-on micro.
-#
-# Bundling rationale: Phase 1 and RAG ingestion are sequential SF steps
-# that share the same repo + venv. One spot per bundle saves ~7 min of
-# bootstrap overhead and one spot request. Trade-off: any failure fails
-# both — acceptable since partial Saturday failures typically require a
-# full-pipeline rerun anyway.
 #
 # **2026-05-27 — SSH/SCP → SSM transport migration (ROADMAP L342 PR 2).**
 # Communication with the spot is now via `aws ssm send-command`
@@ -35,7 +46,11 @@
 # audit.
 #
 # Usage:
-#   ./infrastructure/spot_data_weekly.sh                   # phase1 + rag
+#   ./infrastructure/spot_data_weekly.sh --morning-enrich-only  # one spot: morning enrich (SF: MorningEnrich)
+#   ./infrastructure/spot_data_weekly.sh --phase1-only          # one spot: DataPhase1 (SF: DataPhase1)
+#   ./infrastructure/spot_data_weekly.sh --rag-only             # one spot: RAG ingestion (SF: RAGIngestion)
+#   ./infrastructure/spot_data_weekly.sh --data-only            # manual rerun: morning-enrich + phase1
+#   ./infrastructure/spot_data_weekly.sh                        # manual full bundle: enrich + phase1 + rag
 #   ./infrastructure/spot_data_weekly.sh --smoke-only      # quick validation, then terminate
 #   ./infrastructure/spot_data_weekly.sh --preflight-only  # boot + DataPhase1/MorningEnrich preflight, exit 0 (NO fetch/write)
 #   ./infrastructure/spot_data_weekly.sh --rag-only --preflight-only  # boot + RAG-path preflight, exit 0 (NO fetch/write)

--- a/infrastructure/step-functions/check-definition-drift.py
+++ b/infrastructure/step-functions/check-definition-drift.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""check-definition-drift.py — Diff the codified Step Function DEFINITIONS
+(repo `infrastructure/step_function*.json`) against live AWS state AND the
+S3 staged copies CloudFormation reads from.
+
+**Background (alpha-engine-config#2273).** The weekly SF definition existed
+as THREE copies with no reconciliation: the repo file (source of truth), the
+S3 object CFN's ``DefinitionS3Location`` references (read at stack-create /
+resource-replacement time), and the live state machine. Historically
+``deploy_step_function.sh`` updated the live machine from the LOCAL file
+without refreshing the S3 object — so a stale S3 copy sat armed, and any
+future CFN restamp/replacement would silently ROLL BACK the live definition
+to whatever the S3 object held. config#2273 codified the single-writer
+contract (every deploy path uploads the stamped repo bytes to the CFN key
+before ``update-state-machine`` from those same bytes); this script is the
+drift BACKSTOP that pages when any of the three copies diverges anyway
+(out-of-band console edit, aborted deploy, drive-by S3 write).
+
+Sibling of `infrastructure/step-functions/check-drift.py` (the
+LoggingConfiguration drift guard, config#1464) — same shape: standalone,
+regex/JSON parsing of repo sources, live state via the AWS CLI, exit 0/1/2.
+
+**Normalization.** Deploys stamp the top-level ``Comment`` with a
+``[git:<sha>] `` prefix (see deploy-infrastructure.sh); the repo file is
+unstamped. The comparison strips that stamp from both sides and compares
+canonical JSON (sorted keys) — so a stamp-only difference is NOT drift, but
+any real Comment/state/field change is.
+
+Drift cases (all exit non-zero):
+  * Live definition differs from the repo file (normalized) — the live
+    machine was written from something other than the repo HEAD bytes.
+  * S3 staged copy differs from the repo file (normalized) — the CFN
+    read-source is stale; a CFN restamp would deploy those stale bytes.
+  * A codified state machine isn't found on AWS at all (missing-in-aws).
+  * The S3 staged object is missing entirely.
+  * A repo definition file is missing or malformed JSON (source-error).
+
+Usage:
+  ./infrastructure/step-functions/check-definition-drift.py               # every codified SF
+  ./infrastructure/step-functions/check-definition-drift.py --name NAME   # one (by SF name)
+
+Requires AWS creds with states:DescribeStateMachine on the target state
+machines and s3:GetObject on s3://alpha-engine-research/infrastructure/*.
+Wiring: standalone by design, callable from liveness sweeps / operator
+sessions — mirrors its check-drift.py siblings rather than adding a new
+GHA schedule (fleet direction is EC2-spot sweeps, not GHA-hosted crons).
+Shape-guarded by tests/test_sf_definition_check_drift.py (mocked CLI — no
+real AWS access in CI).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+REPO_ROOT = SCRIPT_DIR.parent.parent
+INFRA_DIR = REPO_ROOT / "infrastructure"
+
+# Fallback defaults used only to build the ARN this script queries AWS with
+# (mirrors step-functions/check-drift.py's same constants).
+DEFAULT_REGION = "us-east-1"
+DEFAULT_ACCOUNT_ID = "711398986525"
+
+# The S3 bucket/prefix every deploy path stages definitions to — MUST match
+# deploy-infrastructure.sh ($BUCKET) and the CFN DefinitionS3Location keys.
+S3_BUCKET = "alpha-engine-research"
+S3_PREFIX = "infrastructure/"
+
+# repo definition file -> live state machine name. Mirrors the ARN mapping in
+# deploy-infrastructure.sh step 3. A renamed/removed file or SF fails loud
+# below (source-error / missing-in-aws) rather than silently dropping out.
+SF_DEFINITIONS: tuple[dict, ...] = (
+    {"sf_name": "ne-weekly-freshness-pipeline", "definition_file": "step_function.json"},
+    {"sf_name": "ne-preopen-trading-pipeline", "definition_file": "step_function_daily.json"},
+    {"sf_name": "ne-postclose-trading-pipeline", "definition_file": "step_function_eod.json"},
+    {"sf_name": "alpha-engine-groom-pipeline", "definition_file": "step_function_groom.json"},
+)
+
+_GIT_STAMP_RE = re.compile(r"^\[git:[0-9a-fA-F]{7,40}\]\s*")
+
+
+def _normalized_dict(definition: dict) -> dict:
+    """Deep copy with the git-stamp stripped from the top-level Comment —
+    the ONLY tolerated difference between the repo file and deployed copies."""
+    d = json.loads(json.dumps(definition))  # deep copy — never mutate input
+    comment = d.get("Comment")
+    if isinstance(comment, str):
+        d["Comment"] = _GIT_STAMP_RE.sub("", comment)
+    return d
+
+
+def _normalize(definition: dict) -> str:
+    """Canonical form for comparison: git-stamp stripped from the top-level
+    Comment, keys sorted, whitespace-free dump."""
+    return json.dumps(_normalized_dict(definition), sort_keys=True, separators=(",", ":"))
+
+
+def _diff_summary(expected: dict, actual: dict) -> str:
+    """Human-oriented pointer at WHERE two definitions diverge (top-level
+    keys; differing state names when States is the divergent key). Callers
+    pass stamp-stripped (_normalized_dict) copies so the git stamp never
+    reads as a Comment divergence."""
+    expected, actual = _normalized_dict(expected), _normalized_dict(actual)
+    parts: list[str] = []
+    keys = sorted(set(expected) | set(actual))
+    for key in keys:
+        if json.dumps(expected.get(key), sort_keys=True) == json.dumps(actual.get(key), sort_keys=True):
+            continue
+        if key == "States" and isinstance(expected.get(key), dict) and isinstance(actual.get(key), dict):
+            exp_states, act_states = expected[key], actual[key]
+            differing = sorted(
+                name
+                for name in set(exp_states) | set(act_states)
+                if json.dumps(exp_states.get(name), sort_keys=True)
+                != json.dumps(act_states.get(name), sort_keys=True)
+            )
+            shown = ", ".join(differing[:5]) + (" …" if len(differing) > 5 else "")
+            parts.append(f"States ({len(differing)} differing: {shown})")
+        else:
+            parts.append(key)
+    return "; ".join(parts) if parts else "<no top-level divergence found — nested/ordering?>"
+
+
+def _aws_cli(*args: str, allow_missing_patterns: tuple[str, ...] = ()):
+    """Run an AWS CLI command; return raw stdout, None when the error matches
+    an allow_missing pattern, or hard-exit 2 on any other failure (a broken
+    CLI/creds state must never read as 'no drift')."""
+    result = subprocess.run(
+        ["aws", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        if any(pat in result.stderr for pat in allow_missing_patterns):
+            return None
+        sys.stderr.write(
+            f"AWS CLI failed: aws {' '.join(args)}\n"
+            f"stderr: {result.stderr}\n"
+        )
+        sys.exit(2)
+    return result.stdout
+
+
+def _fetch_live_definition(sf_name: str) -> dict | None:
+    """Live definition dict, or None when the state machine doesn't exist."""
+    arn = f"arn:aws:states:{DEFAULT_REGION}:{DEFAULT_ACCOUNT_ID}:stateMachine:{sf_name}"
+    out = _aws_cli(
+        "stepfunctions",
+        "describe-state-machine",
+        "--state-machine-arn",
+        arn,
+        "--output",
+        "json",
+        allow_missing_patterns=("StateMachineDoesNotExist", "ResourceNotFoundException"),
+    )
+    if out is None:
+        return None
+    desc = json.loads(out)
+    return json.loads(desc["definition"])
+
+
+def _fetch_s3_definition(key: str) -> dict | None:
+    """S3 staged definition dict, or None when the object doesn't exist."""
+    out = _aws_cli(
+        "s3",
+        "cp",
+        f"s3://{S3_BUCKET}/{key}",
+        "-",
+        allow_missing_patterns=("Not Found", "NoSuchKey", "404", "does not exist"),
+    )
+    if out is None:
+        return None
+    return json.loads(out)
+
+
+def _check_sf(entry: dict) -> list[str]:
+    sf_name = entry["sf_name"]
+    definition_path = INFRA_DIR / entry["definition_file"]
+    source_rel = definition_path.relative_to(REPO_ROOT)
+
+    if not definition_path.is_file():
+        return [
+            f"{sf_name}: codified definition {source_rel} not found — has the "
+            f"file been renamed without updating SF_DEFINITIONS in this script?"
+        ]
+    try:
+        repo_def = json.loads(definition_path.read_text())
+    except json.JSONDecodeError as exc:
+        return [f"{sf_name}: {source_rel} is not valid JSON ({exc})"]
+
+    repo_norm = _normalize(repo_def)
+    findings: list[str] = []
+
+    # ── live vs repo ─────────────────────────────────────────────────────
+    live_def = _fetch_live_definition(sf_name)
+    if live_def is None:
+        findings.append(
+            f"{sf_name}: codified in {source_rel} but state machine not found "
+            f"on AWS (renamed/recreated without updating the source, or vice "
+            f"versa?)"
+        )
+    elif _normalize(live_def) != repo_norm:
+        findings.append(
+            f"{sf_name}: definition drift (LIVE vs {source_rel}) — the live "
+            f"state machine was not written from the repo bytes. Diverges at: "
+            f"{_diff_summary(repo_def, live_def)}"
+        )
+
+    # ── S3 staged copy vs repo ───────────────────────────────────────────
+    s3_key = f"{S3_PREFIX}{entry['definition_file']}"
+    s3_def = _fetch_s3_definition(s3_key)
+    if s3_def is None:
+        findings.append(
+            f"{sf_name}: staged copy s3://{S3_BUCKET}/{s3_key} is missing — "
+            f"a CFN stack-create/replacement would fail (or read nothing); "
+            f"run a deploy to restore it."
+        )
+    else:
+        try:
+            s3_drifted = _normalize(s3_def) != repo_norm
+        except (TypeError, ValueError) as exc:
+            findings.append(f"{sf_name}: s3://{S3_BUCKET}/{s3_key} unparseable ({exc})")
+            s3_drifted = False
+        if s3_drifted:
+            findings.append(
+                f"{sf_name}: definition drift (S3 staged copy vs {source_rel}) "
+                f"— s3://{S3_BUCKET}/{s3_key} is stale; a future CFN "
+                f"restamp/replacement would silently roll the live definition "
+                f"back to those bytes (config#2273). Diverges at: "
+                f"{_diff_summary(repo_def, s3_def)}"
+            )
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--name", help="Check one state machine by name (default: every codified one)"
+    )
+    args = parser.parse_args()
+
+    entries = list(SF_DEFINITIONS)
+
+    if args.name:
+        entries = [e for e in entries if e["sf_name"] == args.name]
+        if not entries:
+            sys.stderr.write(
+                f"ERROR: no codified definition mapping for state machine "
+                f"'{args.name}'\n"
+            )
+            return 2
+
+    total_findings: list[str] = []
+    for entry in entries:
+        total_findings.extend(_check_sf(entry))
+
+    if total_findings:
+        print(f"SF definition drift detected ({len(total_findings)} finding(s)):")
+        for f in total_findings:
+            print(f"  - {f}")
+        return 1
+
+    sf_names = ", ".join(e["sf_name"] for e in entries)
+    print(f"OK: repo, live, and S3 staged definitions all match for {sf_names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/step-functions/check-drift.py
+++ b/infrastructure/step-functions/check-drift.py
@@ -20,10 +20,12 @@ not a hypothetical one):
   * `infrastructure/cloudformation/alpha-engine-orchestration.yaml` —
     declares `LoggingConfiguration` for the two CFN-owned state machines
     (`SaturdayPipeline` / `ne-weekly-freshness-pipeline` and
-    `WeekdayPipeline` / `ne-preopen-trading-pipeline`). The CFN comment on
-    those resources spells out why this is safe from the deploy-vs-drift
-    trap: the deploy script's `update-state-machine` call passes only
-    `--definition`, so it never wipes this CFN-set config.
+    `WeekdayPipeline` / `ne-preopen-trading-pipeline`). Since config#2273
+    the deploy scripts ALSO pass `--logging-configuration` explicitly on
+    every `update-state-machine` call, mirroring these CFN-declared shapes
+    — so an update self-heals a recreate-dropped config rather than
+    relying on partial-update preservation; this script remains the
+    backstop for out-of-band drift.
   * `infrastructure/deploy-infrastructure.sh` — the EOD SF
     (`ne-postclose-trading-pipeline`) is NOT in CloudFormation (script-
     managed); its `EOD_LOGGING_CONFIG` literal there is the source of truth,

--- a/tests/test_deploy_step_function_single_writer.py
+++ b/tests/test_deploy_step_function_single_writer.py
@@ -1,0 +1,256 @@
+"""Single-writer shape-guard for the weekly SF definition deploy path
+(alpha-engine-config#2273).
+
+Root cause this pins: the ne-weekly-freshness-pipeline definition existed as
+THREE copies — the repo file, the S3 object CFN's ``DefinitionS3Location``
+references, and the live state machine — with TWO writers reading two
+different sources. ``deploy_step_function.sh`` updated the live machine from
+the LOCAL file without refreshing the S3 object (and without
+``--logging-configuration``), so a stale S3 copy sat armed: any CFN
+restamp/replacement would silently roll the live definition back to old
+bytes, and a recreate would drop execution logging (the config#1464 class,
+hit live by the ne-* rename config#1381).
+
+The codified contract (this test fails loudly the moment any leg is removed):
+
+  1. The repo file is the SOLE source of truth. ``deploy_step_function.sh``
+     uploads the stamped repo bytes to EXACTLY the S3 bucket/key CFN's
+     ``SaturdayPipeline.DefinitionS3Location`` declares — no path may exist
+     where CFN and the script can write/read different bytes.
+  2. The S3 upload happens BEFORE any update/create-state-machine call.
+  3. The SAME stamped artifact feeds both the S3 upload and the
+     ``--definition`` apply.
+  4. Every update/create passes ``--logging-configuration`` EXPLICITLY,
+     matching the CFN-declared shape (ERROR / includeExecutionData / the
+     CFN-owned log group) — never relying on partial-update preservation.
+  5. ``deploy-infrastructure.sh`` (the on-merge writer) passes explicit
+     logging configs for the CFN-managed pair too, mirroring its EOD
+     precedent (config#1416).
+
+Raw-text parsing per the existing test_deploy_step_function_eventbridge_input
+precedent — CFN's !Ref / !Sub / !GetAtt tags require a custom YAML loader.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+_DEPLOY_SF = _INFRA / "deploy_step_function.sh"
+_DEPLOY_INFRA = _INFRA / "deploy-infrastructure.sh"
+_CFN = _INFRA / "cloudformation" / "alpha-engine-orchestration.yaml"
+
+_TOP_LEVEL_KEY_RE = re.compile(r"^  ([A-Za-z0-9]+):\s*$", re.MULTILINE)
+
+
+def _script_text() -> str:
+    assert _DEPLOY_SF.is_file(), f"missing {_DEPLOY_SF}"
+    return _DEPLOY_SF.read_text()
+
+
+def _cfn_block(logical_id: str) -> str:
+    """Slice one top-level CFN resource block out of the template text."""
+    text = _CFN.read_text()
+    matches = list(_TOP_LEVEL_KEY_RE.finditer(text))
+    for i, m in enumerate(matches):
+        if m.group(1) == logical_id:
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            return text[m.end():end]
+    raise AssertionError(f"CFN resource {logical_id} not found in {_CFN}")
+
+
+def _cfn_definition_s3_location() -> tuple[str, str]:
+    block = _cfn_block("SaturdayPipeline")
+    bucket = re.search(r"Bucket:\s*(\S+)", block)
+    key = re.search(r"Key:\s*(\S+)", block)
+    assert bucket and key, "SaturdayPipeline has no parseable DefinitionS3Location"
+    return bucket.group(1), key.group(1)
+
+
+def _shell_var(text: str, name: str) -> str:
+    m = re.search(rf'^{name}="([^"]+)"', text, re.MULTILINE)
+    assert m, f"deploy_step_function.sh must define {name}=\"...\""
+    return m.group(1)
+
+
+# ── 1. script's S3 target == CFN's DefinitionS3Location ─────────────────────
+
+
+def test_script_uploads_to_exact_cfn_definition_s3_location() -> None:
+    """The single-writer invariant: the script's upload target and CFN's
+    read-source are the same object, pinned to the same literals."""
+    text = _script_text()
+    cfn_bucket, cfn_key = _cfn_definition_s3_location()
+    assert _shell_var(text, "WEEKLY_SF_S3_BUCKET") == cfn_bucket, (
+        "deploy_step_function.sh WEEKLY_SF_S3_BUCKET must equal the CFN "
+        "SaturdayPipeline DefinitionS3Location Bucket (config#2273)."
+    )
+    assert _shell_var(text, "WEEKLY_SF_S3_KEY") == cfn_key, (
+        "deploy_step_function.sh WEEKLY_SF_S3_KEY must equal the CFN "
+        "SaturdayPipeline DefinitionS3Location Key (config#2273)."
+    )
+    assert re.search(
+        r'aws s3 cp "\$\w+" "s3://\$\{WEEKLY_SF_S3_BUCKET\}/\$\{WEEKLY_SF_S3_KEY\}"',
+        text,
+    ), (
+        "deploy_step_function.sh must upload the stamped definition to "
+        "s3://${WEEKLY_SF_S3_BUCKET}/${WEEKLY_SF_S3_KEY} — removing the "
+        "upload re-arms the stale-S3 CFN-rollback hazard (config#2273)."
+    )
+
+
+# ── 2. ordering: upload before any state-machine write ──────────────────────
+
+
+def test_s3_upload_precedes_state_machine_write() -> None:
+    text = _script_text()
+    upload_at = text.find("aws s3 cp")
+    write_m = re.search(r"aws stepfunctions (update|create)-state-machine", text)
+    assert upload_at != -1, "expected an `aws s3 cp` upload of the definition"
+    assert write_m, "expected an update/create-state-machine apply"
+    assert upload_at < write_m.start(), (
+        "the S3 upload must run BEFORE update/create-state-machine so the "
+        "CFN read-source never lags the live machine (config#2273)."
+    )
+
+
+# ── 3. same stamped bytes to S3 and to --definition ─────────────────────────
+
+
+def test_same_stamped_artifact_uploaded_and_applied() -> None:
+    text = _script_text()
+    upload_m = re.search(r'aws s3 cp "\$(\w+)" "s3://', text)
+    assert upload_m, "expected `aws s3 cp \"$<var>\" \"s3://...\"`"
+    stamped_var = upload_m.group(1)
+
+    definition_args = re.findall(r'--definition "file://\$(\w+)"', text)
+    assert definition_args, (
+        "update/create-state-machine must pass --definition via file:// "
+        "(inline $(cat ...) blows ARG_MAX on the ~130 KB weekly ASL — the "
+        "2026-06-04 regression class)."
+    )
+    assert all(v == stamped_var for v in definition_args), (
+        f"every --definition must apply the SAME stamped artifact uploaded "
+        f"to S3 (${stamped_var}); got {definition_args} — diverging here "
+        f"recreates the two-writers-two-sources bug (config#2273)."
+    )
+
+
+def test_no_inline_cat_definition_path_remains() -> None:
+    text = _script_text()
+    assert not re.search(r'DEFINITION=\$\(cat\b', text), (
+        "the inline DEFINITION=$(cat ...) read path must not come back — it "
+        "bypasses the stamped artifact and blows ARG_MAX (config#2273)."
+    )
+
+
+def test_definition_is_stamped_from_the_repo_file() -> None:
+    text = _script_text()
+    assert re.search(r'ASL_FILE="\$SCRIPT_DIR/step_function\.json"', text), (
+        "the deploy must read the repo file infrastructure/step_function.json "
+        "— it is the sole source of truth (config#2273)."
+    )
+    assert '"$ASL_FILE" "$STAMPED_ASL" "$GIT_SHA"' in text, (
+        "the git-SHA stamp step (repo file -> stamped artifact) is missing — "
+        "both deploy paths must emit byte-identical stamped artifacts for the "
+        "same commit (mirrors deploy-infrastructure.sh)."
+    )
+
+
+# ── 4. explicit logging configuration on every write ────────────────────────
+
+
+def _state_machine_write_calls(text: str) -> list[str]:
+    """Each update/create-state-machine invocation's argument text (up to the
+    terminating `--region` arg)."""
+    calls = []
+    for m in re.finditer(r"aws stepfunctions (?:update|create)-state-machine", text):
+        tail = text[m.end():]
+        region_at = tail.find("--region")
+        calls.append(tail[: region_at if region_at != -1 else len(tail)])
+    return calls
+
+
+def test_every_state_machine_write_passes_explicit_logging_configuration() -> None:
+    text = _script_text()
+    calls = _state_machine_write_calls(text)
+    assert calls, "expected update/create-state-machine calls"
+    for call in calls:
+        assert "--logging-configuration" in call, (
+            "every update/create-state-machine call must pass "
+            "--logging-configuration explicitly — partial-update preservation "
+            "is exactly what a recreate silently drops (config#2273 "
+            "deliverable 3; bug class config#1464)."
+        )
+
+
+def test_logging_config_matches_cfn_declared_shape() -> None:
+    """The script reconstructs the CFN-declared LoggingConfiguration; pin the
+    shape AND that the log group is the CFN-owned WeeklyFreshnessLogGroup."""
+    text = _script_text()
+    assert '"level":"ERROR"' in text
+    assert '"includeExecutionData":true' in text
+
+    # CFN-declared shape for the weekly SF.
+    sat_block = _cfn_block("SaturdayPipeline")
+    assert re.search(r"Level:\s*ERROR", sat_block)
+    assert re.search(r"IncludeExecutionData:\s*true", sat_block)
+
+    log_group_block = _cfn_block("WeeklyFreshnessLogGroup")
+    cfn_log_group = re.search(r"LogGroupName:\s*(\S+)", log_group_block)
+    assert cfn_log_group, "WeeklyFreshnessLogGroup has no LogGroupName"
+
+    # The script builds the ARN as .../aws/stepfunctions/${STATE_MACHINE_NAME};
+    # resolve the variable and compare against the CFN log group name.
+    sm_name = _shell_var(text, "STATE_MACHINE_NAME")
+    assert f"/aws/stepfunctions/{sm_name}" == cfn_log_group.group(1), (
+        "the script's logging destination must be the CFN-owned "
+        "WeeklyFreshnessLogGroup — a diverging log group silently breaks the "
+        "L274 MutexConflict metric-filter chain (config#729)."
+    )
+    assert re.search(
+        r"log-group:/aws/stepfunctions/\$\{STATE_MACHINE_NAME\}", text
+    ), "LOG_GROUP_ARN must target /aws/stepfunctions/${STATE_MACHINE_NAME}"
+
+
+# ── 5. the on-merge writer (deploy-infrastructure.sh) — CFN pair logging ────
+
+
+def test_deploy_infrastructure_passes_logging_for_cfn_managed_pair() -> None:
+    text = _DEPLOY_INFRA.read_text()
+    assert re.search(
+        r'update_or_defer_to_cfn "\$SAT_ARN"\s+"\$SAT_STAMPED"\s+"[^"]+"\s+"\$SAT_LOGGING_CONFIG"',
+        text,
+    ), (
+        "deploy-infrastructure.sh must pass $SAT_LOGGING_CONFIG to the weekly "
+        "SF update (config#2273 deliverable 3)."
+    )
+    assert re.search(
+        r'update_or_defer_to_cfn "\$DAILY_ARN"\s+"\$DAILY_STAMPED"\s+"[^"]+"\s+"\$DAILY_LOGGING_CONFIG"',
+        text,
+    ), (
+        "deploy-infrastructure.sh must pass $DAILY_LOGGING_CONFIG to the "
+        "preopen SF update (config#2273 deliverable 3)."
+    )
+    # The helper must actually forward it.
+    helper = text.split("update_or_defer_to_cfn() {", 1)[1].split("\n}", 1)[0]
+    assert "--logging-configuration" in helper, (
+        "update_or_defer_to_cfn must forward the logging arg via "
+        "--logging-configuration."
+    )
+
+
+def test_deploy_infrastructure_logging_literals_target_cfn_owned_log_groups() -> None:
+    text = _DEPLOY_INFRA.read_text()
+    # Capture the full assignment line — the literal embeds '"$VAR"' shell
+    # quote-breaks, so a naive '([^']+)' capture stops early.
+    sat = re.search(r"^SAT_LOGGING_CONFIG='(.+)'$", text, re.MULTILINE)
+    daily = re.search(r"^DAILY_LOGGING_CONFIG='(.+)'$", text, re.MULTILINE)
+    assert sat and daily, "expected SAT_LOGGING_CONFIG / DAILY_LOGGING_CONFIG literals"
+    assert "/aws/stepfunctions/ne-weekly-freshness-pipeline" in sat.group(1)
+    assert "/aws/stepfunctions/ne-preopen-trading-pipeline" in daily.group(1)
+    for blob in (sat.group(1), daily.group(1)):
+        assert '"level":"ERROR"' in blob
+        assert '"includeExecutionData":true' in blob

--- a/tests/test_sf_definition_check_drift.py
+++ b/tests/test_sf_definition_check_drift.py
@@ -1,0 +1,263 @@
+"""Tests for infrastructure/step-functions/check-definition-drift.py
+(alpha-engine-config#2273).
+
+Covers the SF DEFINITION drift guard: the codified file->state-machine map,
+git-stamp normalization (a stamp-only difference is NOT drift), and the
+compare-against-live + compare-against-S3-staged-copy logic (mocked
+`aws` CLI calls — no real AWS access). Mirrors the sibling
+test_sf_logging_config_check_drift.py's module-load + mocked-subprocess
+pattern.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "infrastructure" / "step-functions" / "check-definition-drift.py"
+
+
+@pytest.fixture(scope="module")
+def cd():
+    spec = importlib.util.spec_from_file_location("sf_definition_check_drift", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_SAMPLE_DEF = {
+    "Comment": "weekly pipeline",
+    "StartAt": "A",
+    "States": {
+        "A": {"Type": "Pass", "Next": "B"},
+        "B": {"Type": "Succeed"},
+    },
+}
+
+
+def _fake_run(returncode=0, stdout="", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def _dispatcher(live_def=None, s3_def=None, sf_missing=False, s3_missing=False):
+    """subprocess.run side_effect routing describe-state-machine vs s3 cp."""
+
+    def run(cmd, **kwargs):
+        if "stepfunctions" in cmd:
+            if sf_missing:
+                return _fake_run(255, "", "StateMachineDoesNotExist")
+            return _fake_run(0, json.dumps({"definition": json.dumps(live_def)}))
+        if "s3" in cmd:
+            if s3_missing:
+                return _fake_run(1, "", "fatal error: An error occurred (404) when calling the HeadObject operation: Not Found")
+            return _fake_run(0, json.dumps(s3_def))
+        raise AssertionError(f"unexpected aws call: {cmd}")
+
+    return run
+
+
+@pytest.fixture()
+def fake_repo(cd, tmp_path, monkeypatch):
+    """Point the module at a tmp repo holding one definition file."""
+    infra = tmp_path / "infrastructure"
+    infra.mkdir()
+    (infra / "fake.json").write_text(json.dumps(_SAMPLE_DEF, indent=2))
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cd, "INFRA_DIR", infra)
+    return {"sf_name": "fake-sf", "definition_file": "fake.json"}
+
+
+# ── codified map against the real repo ──────────────────────────────────────
+
+
+def test_map_covers_all_four_orchestrated_state_machines(cd):
+    names = {e["sf_name"] for e in cd.SF_DEFINITIONS}
+    assert names == {
+        "ne-weekly-freshness-pipeline",
+        "ne-preopen-trading-pipeline",
+        "ne-postclose-trading-pipeline",
+        "alpha-engine-groom-pipeline",
+    }
+
+
+def test_every_mapped_definition_file_exists(cd):
+    for entry in cd.SF_DEFINITIONS:
+        path = cd.INFRA_DIR / entry["definition_file"]
+        assert path.is_file(), f"{entry['sf_name']} maps to missing {path}"
+
+
+def test_map_covers_every_sf_definition_file_in_infrastructure(cd):
+    """A new step_function*.json must be added to the drift map — same
+    deploy-coverage class as test_deploy_infrastructure_sf_coverage.py."""
+    mapped = {e["definition_file"] for e in cd.SF_DEFINITIONS}
+    on_disk = {p.name for p in cd.INFRA_DIR.glob("step_function*.json")}
+    assert on_disk == mapped, (
+        f"drift map out of sync with infrastructure/: on disk {sorted(on_disk)} "
+        f"vs mapped {sorted(mapped)} — add the new SF to SF_DEFINITIONS."
+    )
+
+
+def test_s3_constants_match_deploy_script(cd):
+    """The staged-copy location must be the one the deploy paths write."""
+    deploy = (_REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh").read_text()
+    assert f'BUCKET="{cd.S3_BUCKET}"' in deploy
+    assert cd.S3_PREFIX == "infrastructure/"
+
+
+# ── normalization ───────────────────────────────────────────────────────────
+
+
+def test_normalize_strips_git_stamp(cd):
+    stamped = dict(_SAMPLE_DEF, Comment="[git:abc1234] weekly pipeline")
+    assert cd._normalize(stamped) == cd._normalize(_SAMPLE_DEF)
+
+
+def test_normalize_detects_real_comment_change(cd):
+    changed = dict(_SAMPLE_DEF, Comment="[git:abc1234] a DIFFERENT comment")
+    assert cd._normalize(changed) != cd._normalize(_SAMPLE_DEF)
+
+
+def test_normalize_is_order_insensitive(cd):
+    reordered = json.loads(json.dumps(_SAMPLE_DEF))
+    reordered["States"] = dict(reversed(list(reordered["States"].items())))
+    assert cd._normalize(reordered) == cd._normalize(_SAMPLE_DEF)
+
+
+def test_normalize_does_not_mutate_input(cd):
+    stamped = dict(_SAMPLE_DEF, Comment="[git:abc1234] weekly pipeline")
+    cd._normalize(stamped)
+    assert stamped["Comment"] == "[git:abc1234] weekly pipeline"
+
+
+# ── _check_sf — mocked AWS CLI ──────────────────────────────────────────────
+
+
+def _stamped(d):
+    out = json.loads(json.dumps(d))
+    out["Comment"] = f"[git:deadbeef] {out.get('Comment', '')}".rstrip()
+    return out
+
+
+def test_check_sf_clean_when_all_three_copies_match(cd, fake_repo):
+    with patch.object(
+        cd.subprocess,
+        "run",
+        side_effect=_dispatcher(live_def=_stamped(_SAMPLE_DEF), s3_def=_stamped(_SAMPLE_DEF)),
+    ):
+        findings = cd._check_sf(fake_repo)
+    assert findings == []
+
+
+def test_check_sf_detects_live_drift_and_names_the_state(cd, fake_repo):
+    drifted = json.loads(json.dumps(_SAMPLE_DEF))
+    drifted["States"]["B"] = {"Type": "Fail"}
+    with patch.object(
+        cd.subprocess,
+        "run",
+        side_effect=_dispatcher(live_def=_stamped(drifted), s3_def=_stamped(_SAMPLE_DEF)),
+    ):
+        findings = cd._check_sf(fake_repo)
+    assert len(findings) == 1
+    assert "LIVE" in findings[0]
+    assert "B" in findings[0]
+
+
+def test_check_sf_detects_stale_s3_staged_copy(cd, fake_repo):
+    stale = json.loads(json.dumps(_SAMPLE_DEF))
+    stale["States"]["A"] = {"Type": "Pass", "Next": "B", "ResultPath": "$.x"}
+    with patch.object(
+        cd.subprocess,
+        "run",
+        side_effect=_dispatcher(live_def=_stamped(_SAMPLE_DEF), s3_def=_stamped(stale)),
+    ):
+        findings = cd._check_sf(fake_repo)
+    assert len(findings) == 1
+    assert "S3 staged copy" in findings[0]
+    assert "CFN" in findings[0]  # the rollback hazard must be spelled out
+
+
+def test_check_sf_stamp_only_difference_is_not_drift(cd, fake_repo):
+    """The exact false-positive class: live+S3 carry the deploy git stamp,
+    the repo file does not."""
+    with patch.object(
+        cd.subprocess,
+        "run",
+        side_effect=_dispatcher(live_def=_stamped(_SAMPLE_DEF), s3_def=_SAMPLE_DEF),
+    ):
+        findings = cd._check_sf(fake_repo)
+    assert findings == []
+
+
+def test_check_sf_missing_state_machine_on_aws(cd, fake_repo):
+    with patch.object(
+        cd.subprocess,
+        "run",
+        side_effect=_dispatcher(s3_def=_stamped(_SAMPLE_DEF), sf_missing=True),
+    ):
+        findings = cd._check_sf(fake_repo)
+    assert len(findings) == 1
+    assert "not found" in findings[0]
+
+
+def test_check_sf_missing_s3_staged_object(cd, fake_repo):
+    with patch.object(
+        cd.subprocess,
+        "run",
+        side_effect=_dispatcher(live_def=_stamped(_SAMPLE_DEF), s3_missing=True),
+    ):
+        findings = cd._check_sf(fake_repo)
+    assert len(findings) == 1
+    assert "missing" in findings[0]
+
+
+def test_check_sf_missing_repo_file(cd, fake_repo):
+    entry = {"sf_name": "fake-sf", "definition_file": "nope.json"}
+    findings = cd._check_sf(entry)
+    assert len(findings) == 1
+    assert "not found" in findings[0]
+
+
+def test_aws_cli_hard_exits_on_unexpected_failure(cd):
+    """A broken CLI/creds state must never read as 'no drift'."""
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(255, "", "AccessDenied")):
+        with pytest.raises(SystemExit) as exc:
+            cd._aws_cli("stepfunctions", "describe-state-machine")
+    assert exc.value.code == 2
+
+
+# ── main() exit codes ───────────────────────────────────────────────────────
+
+
+def test_main_returns_zero_when_clean(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_check_sf", lambda entry: [])
+    monkeypatch.setattr("sys.argv", ["check-definition-drift.py"])
+    assert cd.main() == 0
+
+
+def test_main_returns_one_on_drift(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_check_sf", lambda entry: [f"{entry['sf_name']}: drifted"])
+    monkeypatch.setattr("sys.argv", ["check-definition-drift.py"])
+    assert cd.main() == 1
+
+
+def test_main_name_filter_no_match_returns_two(cd, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["check-definition-drift.py", "--name", "does-not-exist"])
+    assert cd.main() == 2
+
+
+def test_main_name_filter_scopes_to_one_sf(cd, monkeypatch):
+    checked = []
+    monkeypatch.setattr(cd, "_check_sf", lambda entry: checked.append(entry["sf_name"]) or [])
+    monkeypatch.setattr(
+        "sys.argv", ["check-definition-drift.py", "--name", "ne-weekly-freshness-pipeline"]
+    )
+    assert cd.main() == 0
+    assert checked == ["ne-weekly-freshness-pipeline"]


### PR DESCRIPTION
## config#2273 — single-writer contract (P1)
The definition had two writers reading two sources: CFN's `DefinitionS3Location` (S3 object) vs `deploy_step_function.sh` (local file, no S3 refresh, no logging config) — a stale S3 object sat armed to silently roll back the live definition on any CFN restamp, and a recreate would drop execution logging (the config#1464 class).

- **Single-write protocol:** repo file = sole SoT; BOTH deploy paths now move repo → S3 → live in lockstep with identical `[git:<sha>]` stamping. `deploy_step_function.sh` §3 rewritten (upload-before-write, `file://` not ARG_MAX-prone inline, explicit `--logging-configuration` mirroring CFN). `deploy-infrastructure.sh` (the PRIMARY on-merge writer — discovery during implementation) now passes explicit logging for the CFN pair too (EOD precedent config#1416), self-healing recreate-dropped configs.
- **Drift check:** new `infrastructure/step-functions/check-definition-drift.py` (mirrors the config#1464 check-drift family) — repo vs LIVE vs S3 staged, normalized compare, all four SFs, loud exit-nonzero. **Verified read-only against live: exit 0, all four currently in lockstep.** Standalone by design (callable from liveness sweeps; deliberately no new GHA schedule). Sweep wiring tracked as an epic follow-up.
- 29 new tests (single-writer shape guards + mocked drift scenarios); full repo suite 2922 passed.

## config#2281 items 2+3
`spot_data_weekly.sh` header rewritten to the actual one-spot-per-workload reality; `deploy_step_function.sh` schedule echo now points at CFN as SoT (no hand-copied cron literals).

## Notes for review
- `deploy-infrastructure.sh` hunks don't overlap open data-PR682 (different region).
- If logging config HAS drifted when a deploy runs, the explicit set becomes a real mutation — fails loud if the GHA role lacks `logs:*LogDelivery` grants (correct posture; noted per the red-by-design rule, expected green normally).

Refs nousergon/alpha-engine-config#2273, nousergon/alpha-engine-config#2281 (epic alpha-engine-config-I2283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)