### PR TITLE
fix(groom): Map-iteration failure must not starve the end-of-SF sweep (config#2311)

### DIFF
--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -70,6 +70,14 @@
         "max_retries": 2,
         "fod": {"force_on_demand": false, "launch_decided": true}
       },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Comment": "config#2311: a Standard Map's default ToleratedFailurePercentage=0 means ANY iteration reaching FailExecution fails the whole Map — that's still correct 'fail loud' per-lane semantics (Fleet-SF Watch must see it), but it must NOT also starve the end-of-SF sweep the way it did on 2026-07-11 (a single transient Ssm.SdkClientException 2h43m into a Haiku launch killed that iteration, the Map, and skipped DispatchEndOfSfSweep entirely — the wiring test's own 'unconditional coverage' invariant was violated in production on this exact path). Route through RecordMapLaunchFailure so the sweep still fires, then re-assert FAILED via CheckMapLaunchOutcome/GroomMapLaunchFailed after the sweep dispatch completes — preserving both properties instead of trading one for the other.",
+          "Next": "RecordMapLaunchFailure",
+          "ResultPath": "$.mapLaunchError"
+        }
+      ],
       "ItemProcessor": {
         "ProcessorConfig": {"Mode": "INLINE"},
         "StartAt": "LaunchGroomSpot",
@@ -128,7 +136,7 @@
           },
           "PollGroomCommand": {
             "Type": "Task",
-            "Comment": "Poll the async SSM command to a terminal state. No attempt-cap/counter here (mirrors the fleet's existing poll-loop convention, e.g. step_function_eod.json's PostMarketData/WaitForPostMarketData) — the underlying command is itself bounded by groom_spot_bootstrap.sh's own hard watchdog (MAX_RUNTIME_SECONDS, default 21600s/6h) plus the spot-orphan-reaper's 6.5h fleet cap, so this loop always resolves to a terminal SSM status without needing its own ceiling.",
+            "Comment": "Poll the async SSM command to a terminal state. No attempt-cap/counter here (mirrors the fleet's existing poll-loop convention, e.g. step_function_eod.json's PostMarketData/WaitForPostMarketData) — the underlying command is itself bounded by groom_spot_bootstrap.sh's own hard watchdog (MAX_RUNTIME_SECONDS, default 21600s/6h) plus the spot-orphan-reaper's 6.5h fleet cap, so this loop always resolves to a terminal SSM status without needing its own ceiling. config#2311/#761: retries transient SDK/network errors (Ssm.SdkClientException, States.Timeout) too — this loop fires every ~15s across a run that can span hours, so a single momentary connectivity blip has a near-certain chance of occurring somewhere in the window; uncaught, it previously fell straight through to HandleFailure and killed the whole iteration 2h43m into an otherwise-healthy run (2026-07-11 live incident). Mirrors the retry shape the fleet already uses for Ssm.SdkClientException elsewhere (see DescribeInstanceInfo in step_function_eod.json/step_function_daily.json) — this specific retry block was fixed fleet-wide across all 23 getCommandInvocation states by #761, landed independently/concurrently with this PR's structural fix below.",
             "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
             "Parameters": {
               "CommandId.$": "$.groomLaunch.Payload.groom.command_id",
@@ -342,6 +350,17 @@
       "ResultPath": "$.mapOutcome",
       "Next": "DispatchEndOfSfSweep"
     },
+    "RecordMapLaunchFailure": {
+      "Type": "Pass",
+      "Comment": "config#2311 no-silent-caps: shape an explicit failed:true record into $.mapFailure (mirrors RecordSweepDispatchFailure's $.sweep shape) so a Map-iteration failure is visible in the execution output. The raw error stays alongside in $.mapLaunchError. Falls through to the SAME DispatchEndOfSfSweep the healthy paths use — the sweep is unconditional regardless of how this state was reached — then CheckMapLaunchOutcome re-asserts FAILED once the sweep dispatch is done.",
+      "Parameters": {
+        "failed": true,
+        "reason": "map_iteration_failed",
+        "error.$": "$.mapLaunchError"
+      },
+      "ResultPath": "$.mapFailure",
+      "Next": "DispatchEndOfSfSweep"
+    },
     "DispatchEndOfSfSweep": {
       "Type": "Task",
       "Comment": "config#2201: ONE Haiku run_mode=sweep spot box per trigger cycle, launched AFTER every groom box has fully wound down (this state is only reached when every Map iteration hit its own GroomSucceeded/GroomSkipped — any FailExecution fails the whole Map, and hence the execution, before reaching here) — and equally via AllSkipped when zero groom boxes launched. Payload is a LITERAL launch_decided event (no pace/demand re-check — the sweep is unconditional by design; issue_filter is inert for run_mode=sweep but the launch path validates it, so the mid-only default is passed explicitly). The dispatcher tags sweep boxes groom-issue-filter=sweep — distinct from every groom tier tag — so its config#1979 concurrent guard skips ONLY when a prior cycle's sweep box is still live (launched:false, reason=concurrent_tier_skip, recorded in $.sweep), never colliding with a live mid-only groom box. Fire-and-forget: the Lambda returns as soon as the async SSM command is delivered; no polling loop here (Brian removed the wait — the sweep box self-terminates and writes its own S3 run artifact + completion marker). NON-FATAL: a sweep-launch failure must never fail the groom SF execution — Catch records it in the execution output (no-silent-caps) + SNS-notifies, then the SF still succeeds.",
@@ -374,7 +393,7 @@
         }
       ],
       "ResultPath": "$.sweep",
-      "Next": "GroomDispatchComplete"
+      "Next": "CheckMapLaunchOutcome"
     },
     "RecordSweepDispatchFailure": {
       "Type": "Pass",
@@ -400,15 +419,32 @@
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
-          "Next": "GroomDispatchComplete",
+          "Next": "CheckMapLaunchOutcome",
           "ResultPath": "$.sweep_notify_error"
         }
       ],
-      "Next": "GroomDispatchComplete"
+      "Next": "CheckMapLaunchOutcome"
+    },
+    "CheckMapLaunchOutcome": {
+      "Type": "Choice",
+      "Comment": "config#2311: every path (MapLaunches success, AllSkipped, RecordMapLaunchFailure) converges here AFTER the end-of-SF sweep has already been attempted, so the sweep's unconditional-coverage guarantee holds regardless of which branch set this. IsPresent (not BooleanEquals — the field is absent on the two healthy paths, and referencing an absent path in a non-IsPresent rule is a States.Runtime error) routes a genuine Map-iteration failure to GroomMapLaunchFailed so the execution still terminates FAILED for Fleet-SF Watch, instead of the pre-fix behavior where reaching this point meant the failure was silently absorbed.",
+      "Choices": [
+        {
+          "Variable": "$.mapFailure",
+          "IsPresent": true,
+          "Next": "GroomMapLaunchFailed"
+        }
+      ],
+      "Default": "GroomDispatchComplete"
+    },
+    "GroomMapLaunchFailed": {
+      "Type": "Fail",
+      "Error": "GroomMapLaunchFailure",
+      "Cause": "One or more groom launch lanes failed (see $.mapFailure / the per-lane SNS alert). The end-of-SF PR sweep was still dispatched unconditionally (see $.sweep) — this execution is marked FAILED so Fleet-SF Watch alerts on the underlying lane failure."
     },
     "GroomDispatchComplete": {
       "Type": "Succeed",
-      "Comment": "Terminal success for BOTH paths (config#2201): every co-launched iteration reached its own GroomSucceeded/GroomSkipped (a Standard Map state's default ToleratedFailurePercentage=0 means ANY iteration reaching its own FailExecution fails the whole Map — and hence this whole execution — instead, the correct 'fail loud' extension of the old single-box behavior to N co-launched boxes), OR the zero-launches AllSkipped path — and in EITHER case the end-of-SF sweep dispatch was attempted, with its outcome recorded in $.sweep (launched box, concurrent-sweep skip, kill-switch skip, or dispatched:false failure record)."
+      "Comment": "Terminal success (config#2201/config#2311): every co-launched iteration reached its own GroomSucceeded/GroomSkipped, OR the zero-launches AllSkipped path — and in EITHER case the end-of-SF sweep dispatch was attempted, with its outcome recorded in $.sweep (launched box, concurrent-sweep skip, kill-switch skip, or dispatched:false failure record). A genuine Map-iteration failure never reaches here — CheckMapLaunchOutcome routes it to GroomMapLaunchFailed instead, after the sweep still fires."
     },
     "HandleDecideFailure": {
       "Type": "Task",

--- a/tests/test_sf_groom_end_of_sf_sweep_wiring.py
+++ b/tests/test_sf_groom_end_of_sf_sweep_wiring.py
@@ -1,19 +1,30 @@
-"""Pins config#2201 end-of-SF sweep wiring in the groom-dispatch SF.
+"""Pins config#2201/#2311 end-of-SF sweep wiring in the groom-dispatch SF.
 
 Brian design 2026-07-10: ONE Haiku run_mode=sweep spot box per trigger cycle,
 dispatched by the SF AFTER the groom Map fully winds down — and equally on the
 zero-launches path — replacing the config#2129 per-box partitioned sweeps.
 
+config#2311 (2026-07-11 live incident): a THIRD path — a genuine MapLaunches
+iteration failure (e.g. an uncaught Ssm.SdkClientException 2h43m into a poll
+loop) — previously skipped DispatchEndOfSfSweep entirely, contradicting the
+"unconditional coverage" invariant below. Fixed via a Catch on MapLaunches
+routing through RecordMapLaunchFailure -> DispatchEndOfSfSweep -> (after the
+sweep fires) CheckMapLaunchOutcome -> GroomMapLaunchFailed, so the execution
+still ends FAILED for Fleet-SF Watch without starving the sweep.
+
 This test catches regressions like:
-- either path (Map wind-down / zero-launches AllSkipped) no longer reaching
-  DispatchEndOfSfSweep (the unconditional-coverage property is the whole
-  point: the drain-the-backlog end state must never starve the PR sweep)
+- any of the three paths (Map success / zero-launches AllSkipped / Map
+  iteration failure) no longer reaching DispatchEndOfSfSweep (the
+  unconditional-coverage property is the whole point: the drain-the-backlog
+  end state must never starve the PR sweep)
 - the sweep payload drifting off the launch_decided sweep contract the
   dispatcher expects (run_mode=sweep + launch_decided + a lib-valid
   issue_filter — 'sweep' itself is a TAG value, never a filter)
 - the Catch being dropped or rerouted to a Fail state (a sweep-launch failure
   must be recorded + notified but NEVER fail the groom SF execution)
 - the failure record / SNS notify losing the no-silent-caps guarantees
+- a genuine Map-launch failure silently stopping being reported as FAILED
+  (the sweep fix must not also swallow real lane-failure alerting)
 """
 
 from __future__ import annotations
@@ -69,10 +80,12 @@ def test_sweep_payload_is_the_launch_decided_sweep_contract(states):
 
 def test_sweep_launch_failure_is_nonfatal_recorded_and_notified(states):
     """Catch → record (Pass, dispatched:false into $.sweep) → best-effort SNS
-    → the SAME terminal Succeed the success path uses. No route to any Fail
-    state anywhere on the sweep dispatch's failure path (no-silent-caps: the
-    skip is recorded in the execution output, never converted into an
-    execution failure)."""
+    → CheckMapLaunchOutcome (config#2311: no longer directly to the terminal
+    Succeed — the outcome check re-asserts FAILED if a Map-launch failure was
+    ALSO recorded, independent of the sweep's own outcome). A sweep-launch
+    failure alone must still never route to Fail (no-silent-caps: the skip is
+    recorded in the execution output, never converted into an execution
+    failure by itself)."""
     st = states["DispatchEndOfSfSweep"]
     catches = st["Catch"]
     assert len(catches) == 1
@@ -90,11 +103,12 @@ def test_sweep_launch_failure_is_nonfatal_recorded_and_notified(states):
     notify = states["NotifySweepDispatchFailure"]
     assert notify["Resource"] == "arn:aws:states:::sns:publish"
     assert "$.sweepDispatchError" in notify["Parameters"]["Message.$"]
-    assert notify["Next"] == "GroomDispatchComplete"
-    assert notify["Catch"][0]["Next"] == "GroomDispatchComplete"
+    assert notify["Next"] == "CheckMapLaunchOutcome"
+    assert notify["Catch"][0]["Next"] == "CheckMapLaunchOutcome"
 
     assert states["GroomDispatchComplete"]["Type"] == "Succeed"
-    # No sweep-path state may terminate in a Fail.
+    # A sweep-dispatch failure alone (Catch -> Record -> Notify) must never
+    # itself route directly to a Fail state.
     for name in ("DispatchEndOfSfSweep", "RecordSweepDispatchFailure",
                  "NotifySweepDispatchFailure"):
         st = states[name]
@@ -103,14 +117,15 @@ def test_sweep_launch_failure_is_nonfatal_recorded_and_notified(states):
             if nxt is None:
                 continue
             assert states[nxt].get("Type") != "Fail", (
-                f"{name} routes to Fail state {nxt} — the end-of-SF sweep "
-                "must never fail the groom SF execution (config#2201)")
+                f"{name} routes to Fail state {nxt} — a sweep-dispatch "
+                "failure alone must never fail the groom SF execution "
+                "(config#2201)")
 
 
 def test_sweep_success_path_records_result_and_succeeds(states):
     st = states["DispatchEndOfSfSweep"]
     assert st["ResultPath"] == "$.sweep"
-    assert st["Next"] == "GroomDispatchComplete"
+    assert st["Next"] == "CheckMapLaunchOutcome"
 
 
 def test_sweep_is_fire_and_forget_no_polling_loop(states):
@@ -133,3 +148,83 @@ def test_no_groom_box_partition_fields_remain_in_sf(doc):
     raw = json.dumps(doc)
     assert "partition_index" not in raw
     assert "partition_count" not in raw
+
+
+def test_poll_groom_command_retries_transient_ssm_sdk_errors(states):
+    """config#2311: a single Ssm.SdkClientException (bare network blip) must
+    not kill a lane outright — this loop fires every ~15s across a run that
+    can span hours, so a transient blip somewhere in that window is a
+    near-certainty, not an edge case (this is what actually happened live on
+    2026-07-11, 2h43m into an otherwise-healthy run)."""
+    poll = states["MapLaunches"]["ItemProcessor"]["States"]["PollGroomCommand"]
+    retries = poll["Retry"]
+    error_sets = [set(r["ErrorEquals"]) for r in retries]
+    assert {"Ssm.InvocationDoesNotExistException", "Ssm.InvocationDoesNotExist"} in error_sets
+    sdk_retry = next(
+        (r for r in retries if "Ssm.SdkClientException" in r["ErrorEquals"]), None
+    )
+    assert sdk_retry is not None, "no Retry entry covers Ssm.SdkClientException"
+    assert "States.Timeout" in sdk_retry["ErrorEquals"]
+    assert sdk_retry["MaxAttempts"] >= 1
+
+
+def test_map_launch_failure_still_reaches_sweep(states):
+    """config#2311: the third path — a genuine MapLaunches iteration failure
+    — must reach DispatchEndOfSfSweep exactly like the success and
+    zero-launches paths, closing the gap that caused the 2026-07-11 live
+    incident (the sweep never dispatched that cycle)."""
+    catches = states["MapLaunches"]["Catch"]
+    assert len(catches) == 1
+    assert catches[0]["ErrorEquals"] == ["States.ALL"]
+    assert catches[0]["Next"] == "RecordMapLaunchFailure"
+    assert catches[0]["ResultPath"] == "$.mapLaunchError"
+
+    record = states["RecordMapLaunchFailure"]
+    assert record["Type"] == "Pass"
+    assert record["ResultPath"] == "$.mapFailure"
+    assert record["Parameters"]["failed"] is True
+    assert record["Parameters"]["error.$"] == "$.mapLaunchError"
+    assert record["Next"] == "DispatchEndOfSfSweep"
+
+
+def test_map_launch_failure_still_terminates_execution_failed(states):
+    """config#2311: closing the sweep gap must NOT also swallow real
+    lane-failure alerting — Fleet-SF Watch's EventBridge pattern listens for
+    the execution's own terminal status, so a genuine Map-iteration failure
+    must still end the execution FAILED, just AFTER the sweep has already
+    been dispatched (not instead of it)."""
+    # Every path that can ultimately terminate the execution successfully
+    # must funnel through CheckMapLaunchOutcome first — DispatchEndOfSfSweep's
+    # OWN success Next, and NotifySweepDispatchFailure's Next/Catch (the tail
+    # of the sweep-failure sub-path). DispatchEndOfSfSweep's Catch is exempt
+    # here — that's the sweep's OWN failure path, which correctly detours
+    # through RecordSweepDispatchFailure/NotifySweepDispatchFailure first.
+    assert states["DispatchEndOfSfSweep"]["Next"] == "CheckMapLaunchOutcome"
+    notify = states["NotifySweepDispatchFailure"]
+    nexts = [notify.get("Next")] + [c.get("Next") for c in notify.get("Catch", [])]
+    for nxt in nexts:
+        assert nxt == "CheckMapLaunchOutcome", (
+            f"NotifySweepDispatchFailure routes to {nxt} instead of "
+            "CheckMapLaunchOutcome — a Map-launch failure recorded in "
+            "$.mapFailure would be lost")
+
+    check = states["CheckMapLaunchOutcome"]
+    assert check["Type"] == "Choice"
+    choices = check["Choices"]
+    assert len(choices) == 1
+    assert choices[0]["Variable"] == "$.mapFailure"
+    assert choices[0]["IsPresent"] is True
+    assert choices[0]["Next"] == "GroomMapLaunchFailed"
+    assert check["Default"] == "GroomDispatchComplete"
+
+    fail = states["GroomMapLaunchFailed"]
+    assert fail["Type"] == "Fail"
+
+
+def test_healthy_paths_do_not_route_through_fail_state(states):
+    """The two healthy paths (Map success, AllSkipped) must still reach the
+    terminal Succeed — CheckMapLaunchOutcome's IsPresent check must not
+    misfire when $.mapFailure was never set."""
+    assert states["MapLaunches"]["Next"] == "DispatchEndOfSfSweep"
+    assert states["AllSkipped"]["Next"] == "DispatchEndOfSfSweep"
+    assert states["GroomDispatchComplete"]["Type"] == "Succeed"


### PR DESCRIPTION
## Summary
- 2026-07-11 12:00 PT groom-dispatch execution (`596a5292-b0fb-4e43-8e13-9196d10ee161`) ran healthily for 2h43m then FAILED on an uncaught `Ssm.SdkClientException` (bare 2s network timeout), which killed the whole `MapLaunches` Map and skipped `DispatchEndOfSfSweep` entirely — the end-of-SF Haiku PR sweep (config#2201, shipped same day via #738) never dispatched that cycle.
- **Note on scope (updated after rebase):** the `Ssm.SdkClientException` retry-coverage half of this fix was independently shipped fleet-wide (all 23 `getCommandInvocation` states across all 4 SFs) by **#761**, merged concurrently while this PR was in flight. This branch has been rebased onto that merge and no longer duplicates it — `PollGroomCommand`'s retry block now reflects #761's shipped values as-is. **The remaining and primary contribution of this PR is the structural fix #761 did NOT address:** `MapLaunches` had no top-level `Catch`, so ANY iteration failure (transient or genuine) skipped `DispatchEndOfSfSweep` outright, contradicting the sweep's own documented "unconditional coverage" invariant. That gap is independent of retry-hardening — even with #761's retries in place, a genuine non-transient lane failure (spot exhaustion, `GroomRetriesExhausted`, etc.) would still skip the sweep without this fix.
- `MapLaunches`: added a `Catch` routing through a new `RecordMapLaunchFailure` state so the sweep still dispatches unconditionally on ANY lane failure, then a new `CheckMapLaunchOutcome` choice re-asserts FAILED via `GroomMapLaunchFailed` **after** the sweep has fired — so the fix doesn't trade sweep-coverage for losing Fleet-SF Watch's failure alerting on real lane failures.
- Extended `test_sf_groom_end_of_sf_sweep_wiring.py` with coverage for the third path (Map failure) and updated the two pre-existing tests whose expected `Next` targets shifted.

## Issue reconciliation
- Closes nousergon/alpha-engine-config#2311 (this PR's primary tracking issue).
- config#2312 (my own follow-up for the fleet-wide retry gap) has already been closed as a duplicate of **#761** + **config-I2308** (a more precisely-scoped, independently-filed version of the same finding, covering the adjacent zero-retry `sendCommand` dispatch states too) — both landed from a concurrent session working the same live incident.

## Test plan
- [x] `pytest tests/test_sf_groom_end_of_sf_sweep_wiring.py` — 11/11 passing (7 pre-existing + 4 new)
- [x] `pytest tests/test_sf_groom_relaunch_wiring.py tests/test_groom_sf_iam_lambda_grants.py` — 7/7 passing, unaffected
- [x] `pytest tests/` (full repo suite, pre-rebase) — 2897 passed, 7 skipped (pre-existing/unrelated), 0 failed
- [x] Rebased cleanly onto #761 (single conflict in `PollGroomCommand`'s Retry array, resolved by adopting #761's shipped values) — re-verified JSON structural validity + all targeted tests green post-rebase
- [x] CI green: `test` pass, `gate-label-guard` pass, 0 CodeQL/review comments
- [ ] Next live groom-dispatch execution confirms the sweep still dispatches end-to-end (auto-deploys on merge via `deploy-infrastructure.yml`, no path filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)