### PR TITLE
feat(canary): weekly synthetic drill through both watch dispatch pipes (config#2223)

### DIFF
--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -6,12 +6,14 @@
 # GitHub-hosted Actions runners, burning the org's metered Actions-minutes
 # budget — currently gated to Saturday-only as a stopgap. This Lambda moves it
 # to EC2 spot, mirroring the PROVEN scheduled-groom-dispatcher pattern in THIS
-# repo, but MUCH SIMPLER: no Step Function, no EventBridge Scheduler rules —
-# CI-watch is invoked directly via a SYNCHRONOUS `lambda invoke` from a GHA job
-# (built by a sibling agent in alpha-engine-config's sf-watch.yml) once per
-# real CI failure event, not on a cron cadence. So --bootstrap here only needs
-# to create: (1) this Lambda's OWN execution role + inline policy, (2) the
-# Lambda function itself. No SF, no Scheduler execution role, no SCHED_NAMES.
+# repo, but MUCH SIMPLER: no Step Function — CI-watch is invoked directly via
+# a SYNCHRONOUS `lambda invoke` from a GHA job (built by a sibling agent in
+# alpha-engine-config's sf-watch.yml) once per real CI failure event, not on a
+# cron cadence. --bootstrap creates: (1) this Lambda's OWN execution role +
+# inline policy, (2) the Lambda function itself, (3) the weekly canary drill
+# Scheduler rule + its dedicated invoke role (config#2223, step 2c) — the one
+# standing schedule, which fires a synthetic `is_drill` payload through the
+# same pipe.
 #
 # IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
 # (scoped to alpha-engine-ci-watch-executor-role — a NEW, dedicated role a
@@ -30,7 +32,7 @@
 #
 # Usage:
 #   bash .../ci-watch-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
-#   bash .../ci-watch-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda function
+#   bash .../ci-watch-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM roles + Lambda function + weekly canary drill schedule (config#2223)
 #   bash .../ci-watch-dispatcher/deploy.sh --dry-run   # show actions, do not apply
 #   bash .../ci-watch-dispatcher/deploy.sh --smoke     # invoke once with a synthetic event (fires a REAL spot box)
 
@@ -40,8 +42,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-ci-watch-dispatcher"
 ROLE_NAME="alpha-engine-ci-watch-dispatcher-role"
 POLICY_NAME="alpha-engine-ci-watch-dispatcher-policy"
+# Role EventBridge Scheduler assumes to fire the weekly canary drill
+# (config#2223). Created in --bootstrap only; may ONLY invoke THIS function.
+# (sf-watch-spot-dispatcher reuses its existing defer-scheduler role for the
+# same purpose; ci-watch has no prior scheduler role, hence a dedicated one.)
+CANARY_SCHED_ROLE_NAME="alpha-engine-ci-watch-canary-scheduler-role"
+CANARY_SCHED_POLICY_NAME="invoke-ci-watch-dispatcher"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+CANARY_SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${CANARY_SCHED_ROLE_NAME}"
 # Bootstrap default (first-time deployment only) — sets CI_WATCH_DISPATCH_ENABLED=true
 # as the safe default. The update path (step 3) will read the live value and preserve it.
 LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=true}'
@@ -156,6 +165,55 @@ if $BOOTSTRAP; then
       --query 'FunctionArn' --output text
   else
     echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2c. Weekly canary drill schedule (config#2223) ---
+  # Exercises the WHOLE dispatch pipe (Lambda IAM -> scoped RunInstances ->
+  # SSM -> bootstrap start) without a real CI failure. The box short-circuits
+  # before the agent and writes the _canary heartbeat the Fleet Status page
+  # escalates on when missed. 30 min after the sf-watch drill (15:00 UTC) so
+  # the two drills never contend. Idempotent create-or-update, mirrors
+  # sf-watch-liveness-probe/deploy.sh's scheduler style.
+  CANARY_SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${CANARY_SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${CANARY_SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${CANARY_SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${CANARY_SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} for the weekly canary drill (config#2223)" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${CANARY_SCHED_ROLE_NAME}"
+  fi
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  CANARY_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":[\"${FN_ARN}\",\"${FN_ARN}:*\"]}]}"
+  echo "  Applying Scheduler invoke policy: ${CANARY_SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${CANARY_SCHED_ROLE_NAME}" \
+    --policy-name "${CANARY_SCHED_POLICY_NAME}" \
+    --policy-document "${CANARY_INVOKE_POLICY}"
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  CANARY_SCHED_NAME="alpha-engine-ci-watch-canary-drill-weekly"
+  CANARY_CRON="cron(30 15 ? * WED *)"
+  # Static Input: the drill's ENTIRE identity (repo/sha/run_id/...) is
+  # synthesized in index.py so no payload can carry a real (repo, sha) into
+  # a drill (see index.py DRILL_REPO isolation invariant).
+  CANARY_TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${CANARY_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"is_drill\\\":\\\"true\\\"}\"}"
+  if aws scheduler get-schedule --name "${CANARY_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  Updating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
+    run aws scheduler update-schedule --name "${CANARY_SCHED_NAME}" \
+      --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  else
+    echo "  Creating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
+    run aws scheduler create-schedule --name "${CANARY_SCHED_NAME}" \
+      --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  fi
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${CANARY_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: Scheduler rule ${CANARY_SCHED_NAME} not found after create/update" >&2; exit 1; }
   fi
 fi
 

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -62,11 +62,13 @@ until the new code + IAM are deployed AND a sibling agent's GHA workflow
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import re
 import time
 import uuid
+from datetime import datetime, timezone
 
 import boto3
 from nousergon_lib import spot_dispatch
@@ -123,6 +125,34 @@ VOLUME_SIZE_GB = int(os.environ.get("CI_WATCH_VOLUME_SIZE_GB", "40"))
 CI_WATCH_TAG_NAME = "alpha-engine-ci-watch-spot"
 CI_WATCH_REPO_TAG_KEY = "ci-watch-repo"
 CI_WATCH_SHA_TAG_KEY = "ci-watch-sha"
+# Canary drill discriminator (config#2223): set on drill boxes ONLY. The tag
+# KEY is deliberately the same one sf-watch-spot-dispatcher uses
+# (sf-watch-drill) — one fleet-wide drill marker every consumer can filter
+# on, not a per-dispatcher variant.
+CI_WATCH_DRILL_TAG_KEY = "sf-watch-drill"
+
+# ── Canary drill identity (config#2223) ──────────────────────────────────────
+# DRILL-vs-REAL ISOLATION INVARIANT: a drill's (repo, sha) lock key is ALWAYS
+# synthesized in code — never taken from the payload. DRILL_REPO is not a
+# real fleet repository: the only real caller of this Lambda is sf-watch.yml's
+# `ci-watch-dispatch` job relaying nousergon-lib's notify-ci-failure.yml
+# repository_dispatch, which always carries the actual `owner/repo` of a live
+# fleet repo — so the (repo, sha) concurrency lock and the completion-marker
+# key `ci_watch/_control/completed/{repo-with-slash-flattened}-{sha}.json`
+# (which therefore contains "drill-") can never collide with, dedupe-block,
+# or reclaim-confuse a real dispatch. The sha is a deterministic per-UTC-day
+# digest so a duplicate drill on the same day dedupes against itself only.
+# Pinned by test_drill_identity_can_never_collide_with_a_real_dispatch.
+DRILL_REPO = "nousergon/ci-watch-drill"
+DRILL_RUN_URL = "https://drill.invalid/ci-watch-canary"
+DRILL_WORKFLOW = "canary-drill"
+
+
+def _drill_sha(now: datetime) -> str:
+    """Deterministic per-UTC-day 40-hex drill sha (matches _SHA_RE)."""
+    return hashlib.sha256(
+        f"ci-watch-drill-{now:%Y-%m-%d}".encode("utf-8")
+    ).hexdigest()[:40]
 
 # Discriminator tag write (config#2267 site 2, same defect class as
 # sf-watch-spot-dispatcher's): the (repo, sha) tags are LOAD-BEARING —
@@ -161,6 +191,7 @@ _SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
 _RUN_ID_RE = re.compile(r"^[0-9]+$")
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9_./-]{1,200}$")
 _WORKFLOW_RE = re.compile(r"^[A-Za-z0-9 _./:()-]{1,200}$")
+_BOOL_RE = re.compile(r"^(true|false)$")
 
 
 class _InvalidEvent(ValueError):
@@ -174,10 +205,30 @@ def _require(event: dict, key: str, pattern: "re.Pattern[str]") -> str:
     return val
 
 
-def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str]:
+def _optional(event: dict, key: str, pattern: "re.Pattern[str]", default: str = "") -> str:
+    val = str(event.get(key) or "").strip()
+    if not val:
+        return default
+    if not pattern.match(val):
+        raise _InvalidEvent(f"malformed {key!r} in event: {val!r}")
+    return val
+
+
+def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str, str]:
     """Validate the GHA payload's CI fields; raises _InvalidEvent on any
     missing/malformed field (caught once, at the handler, and converted to a
-    clean launched:false — see module docstring's synchronous contract)."""
+    clean launched:false — see module docstring's synchronous contract).
+
+    is_drill (config#2223): "true" on the weekly synthetic canary drill the
+    EventBridge Scheduler rule fires (see deploy.sh --bootstrap). A drill's
+    ENTIRE identity is synthesized in code — repo/sha/run_id/run_url/
+    workflow/branch from the payload are IGNORED — so no payload can carry a
+    real (repo, sha) into a drill's lock/marker keys. See the DRILL_REPO
+    isolation invariant above."""
+    is_drill = _optional(event, "is_drill", _BOOL_RE, default="false")
+    if is_drill == "true":
+        return (DRILL_REPO, _drill_sha(datetime.now(timezone.utc)), "0",
+                DRILL_RUN_URL, DRILL_WORKFLOW, "main", is_drill)
     repo = _require(event, "repo", _REPO_RE)
     sha = _require(event, "sha", _SHA_RE)
     run_id = _require(event, "run_id", _RUN_ID_RE)
@@ -189,11 +240,12 @@ def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str]:
         # under `set -u` it could expand as a positional param (same gotcha
         # groom's run_url note documents) and abort the prelude.
         raise _InvalidEvent(f"missing/malformed 'run_url' in event: {run_url!r}")
-    return repo, sha, run_id, run_url, workflow, branch
+    return repo, sha, run_id, run_url, workflow, branch, is_drill
 
 
 def _bootstrap_command(repo: str, sha: str, run_id: str, run_url: str,
-                       workflow: str, branch: str, run_token: str) -> str:
+                       workflow: str, branch: str, run_token: str,
+                       is_drill: str = "false") -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec the
     ci_watch_spot_bootstrap.sh entrypoint (built by a sibling agent in
     alpha-engine-config). Any prelude failure shuts the box down so a botched
@@ -225,7 +277,8 @@ git clone --depth 1 --branch {CI_WATCH_CONFIG_BRANCH} \
 cd /home/ec2-user/alpha-engine-config
 exec bash infrastructure/ci_watch_spot_bootstrap.sh \
   --ci-repo "{repo}" --ci-sha "{sha}" --ci-run-id "{run_id}" \
-  --ci-run-url "{run_url}" --ci-workflow "{workflow}" --ci-branch "{branch}"
+  --ci-run-url "{run_url}" --ci-workflow "{workflow}" --ci-branch "{branch}" \
+  --is-drill "{is_drill}"
 """
 
 
@@ -254,11 +307,13 @@ def _wait_ssm_online(instance_id: str) -> None:
 
 
 def _send_bootstrap(instance_id: str, repo: str, sha: str, run_id: str, run_url: str,
-                    workflow: str, branch: str, run_token: str) -> str:
+                    workflow: str, branch: str, run_token: str,
+                    is_drill: str = "false") -> str:
     """Fire the async, detached SSM command that runs CI-watch + self-terminates."""
     return spot_dispatch.send_async_command(
         instance_id,
-        _bootstrap_command(repo, sha, run_id, run_url, workflow, branch, run_token),
+        _bootstrap_command(repo, sha, run_id, run_url, workflow, branch, run_token,
+                           is_drill=is_drill),
         comment=f"ci-watch ({repo}@{sha[:12]}, run {run_id}, token {run_token[:12]})",
         region=REGION,
         cw_log_group=CW_LOG_GROUP,
@@ -290,17 +345,21 @@ def _terminate_instance(instance_id: str) -> None:
     spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="ci-watch")
 
 
-def _create_discriminator_tags(instance_id: str, repo: str, sha: str) -> str | None:
+def _create_discriminator_tags(instance_id: str, repo: str, sha: str,
+                               is_drill: bool = False) -> str | None:
     """Write the load-bearing (repo, sha) discriminator tags (config#2267
     site 2) with a bounded retry. Returns None on success, or the final
     ``"ExcName: msg"`` string after TAG_WRITE_ATTEMPTS failures — the caller
     terminates the box and fails the dispatch (the tags are what make the
     box visible to the dedupe guard and the spot-orphan-reaper; an untagged
-    box must not run)."""
+    box must not run). A canary drill box (config#2223) additionally carries
+    ``sf-watch-drill=true`` so fleet consumers can tell it apart."""
     tags = [
         {"Key": CI_WATCH_REPO_TAG_KEY, "Value": repo},
         {"Key": CI_WATCH_SHA_TAG_KEY, "Value": sha},
     ]
+    if is_drill:
+        tags.append({"Key": CI_WATCH_DRILL_TAG_KEY, "Value": "true"})
     last_error = ""
     for attempt in range(1, TAG_WRITE_ATTEMPTS + 1):
         try:
@@ -320,7 +379,8 @@ def _create_discriminator_tags(instance_id: str, repo: str, sha: str) -> str | N
 
 
 def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
-                          workflow: str, branch: str) -> dict:
+                          workflow: str, branch: str,
+                          is_drill: str = "false") -> dict:
     """Launch + bootstrap the CI-watch box. SYNCHRONOUS contract: every
     anticipated failure mode returns a clean, well-formed launched:false
     rather than raising — see module docstring."""
@@ -374,7 +434,8 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
     # TagSpecifications — is blocked on krepis.ec2_spot.launch, the fleet's
     # RunInstances chokepoint, growing an extra-tags parameter; until then
     # this retry+terminate closes the hole loudly.)
-    tag_error = _create_discriminator_tags(instance_id, repo, sha)
+    tag_error = _create_discriminator_tags(instance_id, repo, sha,
+                                           is_drill=is_drill == "true")
     if tag_error is not None:
         _terminate_instance(instance_id)
         logger.error(
@@ -393,7 +454,8 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
     # error to unwrap).
     try:
         _wait_ssm_online(instance_id)
-        command_id = _send_bootstrap(instance_id, repo, sha, run_id, run_url, workflow, branch, run_token)
+        command_id = _send_bootstrap(instance_id, repo, sha, run_id, run_url,
+                                     workflow, branch, run_token, is_drill=is_drill)
     except Exception as exc:  # noqa: BLE001 — converted to a clean launched:false
         _terminate_instance(instance_id)
         logger.error("ci-watch post-launch step failed for %s: %s: %s",
@@ -418,6 +480,7 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
         "run_id": run_id,
         "run_token": run_token,
         "dedupe_degraded": dedupe_degraded,
+        "is_drill": is_drill == "true",
     }
     if dedupe_degraded:
         verdict["dedupe_probe_error"] = dedupe_probe_error
@@ -425,9 +488,18 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
 
 
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
-    """Synchronous handler invoked once per real CI failure event — NOT on a
-    schedule. `event` carries {"repo", "sha", "run_id", "run_url", "workflow",
-    "branch"} from the GHA job's `lambda invoke` payload (RequestResponse).
+    """Synchronous handler invoked once per real CI failure event. `event`
+    carries {"repo", "sha", "run_id", "run_url", "workflow", "branch"} from
+    the GHA job's `lambda invoke` payload (RequestResponse).
+
+    CANARY DRILL (config#2223): the ONE scheduled caller is the weekly
+    EventBridge Scheduler rule (`alpha-engine-ci-watch-canary-drill-weekly`,
+    created by deploy.sh --bootstrap) invoking with `{"is_drill": "true"}`.
+    The dispatch pipe runs FOR REAL (spot launch, SSM, bootstrap start) but
+    the box short-circuits before the agent (alpha-engine-config's
+    ci_watch_run.sh drill guard), writes the
+    `consolidated/ci_watch/_canary/{date}.json` heartbeat, and
+    self-terminates. Drill isolation: see DRILL_REPO.
 
     Returns {"launched": bool, "reason": str, "instance_id": ..., ...} —
     read DIRECTLY by the GHA job as its success signal. Every anticipated
@@ -437,13 +509,14 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """
     event = event or {}
     try:
-        repo, sha, run_id, run_url, workflow, branch = _resolve_event_fields(event)
+        repo, sha, run_id, run_url, workflow, branch, is_drill = _resolve_event_fields(event)
     except _InvalidEvent as exc:
         logger.error("invalid ci-watch event: %s", exc)
         return {"launched": False, "reason": "invalid_event", "error": str(exc)}
 
     logger.info(
-        "ci-watch trigger: repo=%s sha=%s run_id=%s workflow=%s branch=%s",
-        repo, sha, run_id, workflow, branch,
+        "ci-watch trigger: repo=%s sha=%s run_id=%s workflow=%s branch=%s is_drill=%s",
+        repo, sha, run_id, workflow, branch, is_drill,
     )
-    return _launch_ci_watch_spot(repo, sha, run_id, run_url, workflow, branch)
+    return _launch_ci_watch_spot(repo, sha, run_id, run_url, workflow, branch,
+                                 is_drill=is_drill)

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -436,3 +436,106 @@ def test_disabled_flag_short_circuits(monkeypatch):
     assert out["launched"] is False
     assert out["reason"] == "disabled"
     assert idx._test_ssm.sent == []
+
+
+# ── config#2223: weekly synthetic canary drill ───────────────────────────────
+
+
+def test_drill_synthesizes_isolated_identity_and_launches(monkeypatch):
+    """The happy path the weekly canary exists to verify: `{"is_drill":
+    "true"}` (the EventBridge Scheduler rule's entire static Input)
+    round-trips the REAL launch pipe with a code-synthesized drill identity —
+    DRILL_REPO + per-day sha — plus the sf-watch-drill discriminator tag."""
+    from datetime import datetime, timezone
+
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"is_drill": "true"}, None)
+    expected_sha = idx._drill_sha(datetime.now(timezone.utc))
+    assert out["launched"] is True
+    assert out["is_drill"] is True
+    assert out["repo"] == idx.DRILL_REPO == "nousergon/ci-watch-drill"
+    assert out["sha"] == expected_sha
+    assert idx._test_ec2.tags_created == [
+        (["i-stub"], [
+            {"Key": "ci-watch-repo", "Value": idx.DRILL_REPO},
+            {"Key": "ci-watch-sha", "Value": expected_sha},
+            {"Key": "sf-watch-drill", "Value": "true"},
+        ])
+    ]
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--is-drill "true"' in cmd
+    assert f'--ci-repo "{idx.DRILL_REPO}"' in cmd
+    assert f'--ci-sha "{expected_sha}"' in cmd
+
+
+def test_drill_identity_can_never_collide_with_a_real_dispatch(monkeypatch):
+    """Pins the structural isolation invariant (index.DRILL_REPO comment):
+    the drill sha is allowlist-valid but per-day-deterministic, DRILL_REPO is
+    not a real fleet repository, and the slash-flattened completion-marker
+    stem contains 'drill-' — so a drill can never dedupe-block a real
+    dispatch and its marker key never collides with a real one."""
+    from datetime import datetime, timezone
+
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    sha = idx._drill_sha(datetime.now(timezone.utc))
+    assert idx._SHA_RE.match(sha)
+    # ci_watch_run.sh's completion key stem is "{repo//\//-}-{sha}" — for a
+    # drill that is "nousergon-ci-watch-drill-<sha>", which contains "drill-".
+    marker_stem = f"{idx.DRILL_REPO.replace('/', '-')}-{sha}"
+    assert "drill-" in marker_stem
+    # Deterministic within a day — a duplicate drill dedupes against itself.
+    assert sha == idx._drill_sha(datetime.now(timezone.utc))
+
+
+def test_drill_ignores_payload_supplied_identity(monkeypatch):
+    """ISOLATION INVARIANT: even a payload that smuggles a real (repo, sha)
+    into a drill gets the code-synthesized drill identity — no payload can
+    point a drill at a real dispatch's lock/marker keys."""
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler({
+        "is_drill": "true",
+        "repo": "nousergon/alpha-engine-config",
+        "sha": "abc1234def5678900000000000000000000abcd",
+        "run_id": "123456789",
+        "run_url": "https://github.com/nousergon/alpha-engine-config/actions/runs/123456789",
+        "workflow": "Fleet CI",
+        "branch": "main",
+    }, None)
+    assert out["launched"] is True
+    assert out["repo"] == idx.DRILL_REPO
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--ci-repo "nousergon/alpha-engine-config"' not in cmd
+
+
+def test_drill_same_day_duplicate_dedupes_against_itself_only(monkeypatch):
+    from datetime import datetime, timezone
+
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    sha = idx._drill_sha(datetime.now(timezone.utc))
+    idx2 = _load(
+        monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={(idx.DRILL_REPO, sha): ["i-drill-live"]},
+    )
+    out = idx2.handler({"is_drill": "true"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "concurrent_skip"
+    assert idx2._test_ssm.sent == []
+
+
+def test_malformed_is_drill_returns_clean_false(monkeypatch):
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"is_drill": "yes-please"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+    assert idx._test_ssm.sent == []
+
+
+def test_non_drill_dispatch_carries_no_drill_tag_and_is_drill_false(monkeypatch):
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert out["is_drill"] is False
+    (_, tags), = idx._test_ec2.tags_created
+    assert all(t["Key"] != "sf-watch-drill" for t in tags)
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--is-drill "false"' in cmd

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -603,6 +603,33 @@ def _handle_reclaim_event(event: dict) -> dict:
     key_ctx = {"instance_id": instance_id, "cadence": cadence,
                "pipeline": pipeline, "run_date": run_date}
     marker_key = f"{COMPLETION_MARKER_PREFIX}{cadence}-{pipeline}-{run_date}.json"
+
+    # Canary-drill isolation (config#2223): a drill box's run_date tag is
+    # ALWAYS "drill-YYYY-MM-DD" (synthesized by sf-watch-spot-dispatcher —
+    # a real run_date is bare YYYY-MM-DD, so the two can never collide). A
+    # drill is not a repair: its death — clean OR mid-run — must NEVER
+    # consume the reclaim-relaunch budget, spend an on-demand relaunch, or
+    # page "unreconstructable dispatch fields" (a drill writes no watch-log
+    # at all, so that escalation would fire on every reclaimed drill). A
+    # drill that died before writing its completion marker surfaces through
+    # the DESIGNED canary channel instead: the missing
+    # consolidated/*/_canary/{date}.json heartbeat escalates the Fleet
+    # Status dot to YELLOW/RED (crucible-dashboard fleet_status.py).
+    if run_date.startswith("drill-"):
+        completed = _completion_marker_exists(marker_key)
+        if completed:
+            logger.info("reclaim check: drill box %s (%s/%s@%s) finished cleanly",
+                        instance_id, cadence, pipeline, run_date)
+        else:
+            logger.warning(
+                "reclaim check: drill box %s (%s/%s@%s) died WITHOUT a "
+                "completion marker — no relaunch/escalation for drills; the "
+                "missed _canary heartbeat is the alerting surface (config#2223)",
+                instance_id, cadence, pipeline, run_date,
+            )
+        return {**base, "watch_box": True, "drill": True,
+                "completed": completed, "relaunched": False}
+
     if _completion_marker_exists(marker_key):
         logger.info("reclaim check: %s finished cleanly (marker %s present)",
                     instance_id, marker_key)

--- a/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/test_handler.py
@@ -828,3 +828,63 @@ def test_watch_prefixes_follow_the_cadence_convention_the_reclaim_checker_derive
             f"watch_prefix {watch_prefix!r} for cadence {cadence_slug!r} breaks "
             "the convention the reclaim checker's key derivation relies on"
         )
+
+
+# ── config#2223: canary-drill isolation in the reclaim checker ───────────────
+# A drill box's run-date tag is always "drill-YYYY-MM-DD" (synthesized by
+# sf-watch-spot-dispatcher; a real run_date is bare YYYY-MM-DD). Drills are
+# not repairs: their deaths must never relaunch, consume the reclaim budget,
+# or page — a failed drill's alerting surface is the missing _canary
+# heartbeat (Fleet Status escalation), by design.
+
+DRILL_TAGS = {
+    "Name": "alpha-engine-sf-watch-spot",
+    "sf-watch-cadence": "saturday",
+    "sf-watch-pipeline": "ne-weekly-freshness-pipeline",
+    "sf-watch-run-date": "drill-2026-07-15",
+    "sf-watch-drill": "true",
+}
+DRILL_MARKER_KEY = ("sf_watch/_control/completed/"
+                    "saturday-ne-weekly-freshness-pipeline-drill-2026-07-15.json")
+
+
+def test_reclaim_of_completed_drill_box_is_clean_no_relaunch_no_page():
+    ec2 = _make_reclaim_ec2(tags=DRILL_TAGS)
+    s3 = _make_reclaim_s3(marker_exists=True)
+    result, _, s3, lam = _run_reclaim(_reclaim_event(), ec2=ec2, s3=s3)
+    assert result["watch_box"] is True
+    assert result["drill"] is True
+    assert result["completed"] is True
+    assert result["relaunched"] is False
+    assert s3.head_object.call_args.kwargs["Key"] == DRILL_MARKER_KEY
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_of_dead_drill_box_never_relaunches_or_escalates():
+    """A drill reclaimed/killed mid-run has NO completion marker and NO
+    watch-log — the pre-drill code would have paged 'dispatch fields
+    UNRECONSTRUCTABLE' and/or burned the exactly-one relaunch on a synthetic
+    run. The drill branch exits before any of that; the missed _canary
+    heartbeat (Fleet Status YELLOW/RED) is the designed signal."""
+    ec2 = _make_reclaim_ec2(tags=DRILL_TAGS)
+    s3 = _make_reclaim_s3(marker_exists=False)
+    result, _, s3, lam = _run_reclaim(_reclaim_event(), ec2=ec2, s3=s3)
+    assert result["watch_box"] is True
+    assert result["drill"] is True
+    assert result["completed"] is False
+    assert result["relaunched"] is False
+    # Exits BEFORE the watch-log read — a drill has no watch-log to consult.
+    s3.get_object.assert_not_called()
+    s3.put_object.assert_not_called()
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_real_reclaim_path_unaffected_by_drill_branch():
+    """A real (bare YYYY-MM-DD) run_date must never enter the drill branch."""
+    s3 = _make_reclaim_s3(watch_log=_watch_log_doc([_dispatch_log_event()]))
+    result, _, s3, lam = _run_reclaim(_reclaim_event(), s3=s3)
+    assert "drill" not in result
+    assert result["relaunched"] is True
+    lam.invoke.assert_called_once()

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -7,10 +7,12 @@
 # runner for saturday-sf-failure, burning the org's metered Actions-minutes
 # budget — exactly the exposure config#2001 was filed to eliminate. This
 # Lambda moves it to EC2 spot, mirroring ci-watch-dispatcher's PROVEN pattern
-# byte-for-byte in shape: no Step Function, no EventBridge Scheduler rules —
-# invoked directly via a SYNCHRONOUS `lambda invoke` from a GHA job (built in
-# alpha-engine-config's sf-watch.yml, `sf-watch-dispatch` job) once per real
-# saturday-sf-failure event, not on a cron cadence.
+# byte-for-byte in shape: no Step Function — invoked directly via a
+# SYNCHRONOUS `lambda invoke` from a GHA job (built in alpha-engine-config's
+# sf-watch.yml, `sf-watch-dispatch` job) once per real saturday-sf-failure
+# event, not on a cron cadence. The ONE standing schedule is the weekly
+# canary drill (config#2223, step 2c below), which fires a synthetic
+# `is_drill` payload through the same pipe.
 #
 # IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
 # (scoped to alpha-engine-sf-watch-executor-role — a NEW, dedicated role
@@ -36,7 +38,7 @@
 #
 # Usage:
 #   bash .../sf-watch-spot-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
-#   bash .../sf-watch-spot-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda function
+#   bash .../sf-watch-spot-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM roles + Lambda function + weekly canary drill schedule (config#2223)
 #   bash .../sf-watch-spot-dispatcher/deploy.sh --dry-run   # show actions, do not apply
 #   bash .../sf-watch-spot-dispatcher/deploy.sh --smoke     # invoke once with a synthetic event (fires a REAL spot box)
 
@@ -209,6 +211,56 @@ EOF
       --query 'FunctionArn' --output text
   else
     echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2c. Weekly canary drill schedule (config#2223) ---
+  # Exercises the WHOLE dispatch pipe (Lambda IAM -> scoped RunInstances ->
+  # SSM -> bootstrap start) without a real SF failure. The box short-circuits
+  # before the agent and writes the _canary heartbeat the Fleet Status page
+  # escalates on when missed. Reuses the defer-scheduler role (created in 2a2
+  # above) — its policy is exactly "invoke THIS function", which is all the
+  # canary schedule needs; no new role. Idempotent create-or-update, mirrors
+  # sf-watch-liveness-probe/deploy.sh's scheduler style.
+  CANARY_SCHED_NAME="alpha-engine-sf-watch-canary-drill-weekly"
+  CANARY_CRON="cron(0 15 ? * WED *)"
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  # Static Input: run_date is deliberately ABSENT — the handler ALWAYS
+  # synthesizes a drill-scoped run_date (drill-YYYY-MM-DD) so no payload can
+  # carry a real run_date into a drill (see index.py DRILL_RUN_DATE_PREFIX).
+  # The execution_arn is synthetic but ARN-shaped (allowlist-valid); the
+  # drill never touches it.
+  CANARY_TARGET=$(python3 - <<PY
+import json
+payload = {
+    "is_drill": "true",
+    "pipeline_name": "ne-weekly-freshness-pipeline",
+    "cadence_slug": "saturday",
+    "execution_arn": "arn:aws:states:${REGION}:${ACCOUNT_ID}:execution:ne-weekly-freshness-pipeline:canary-drill",
+    "cause": "synthetic weekly canary drill of the dispatch pipe (config#2223) - not a real failure",
+}
+print(json.dumps({
+    "Arn": "${FN_ARN}",
+    "RoleArn": "${DEFER_ROLE_ARN}",
+    "Input": json.dumps(payload),
+}))
+PY
+)
+  if aws scheduler get-schedule --name "${CANARY_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  Updating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
+    run aws scheduler update-schedule --name "${CANARY_SCHED_NAME}" \
+      --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  else
+    echo "  Creating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
+    run aws scheduler create-schedule --name "${CANARY_SCHED_NAME}" \
+      --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  fi
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${CANARY_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: Scheduler rule ${CANARY_SCHED_NAME} not found after create/update" >&2; exit 1; }
   fi
 fi
 

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -140,6 +140,26 @@ SF_WATCH_TAG_NAME = "alpha-engine-sf-watch-spot"
 SF_WATCH_CADENCE_TAG_KEY = "sf-watch-cadence"
 SF_WATCH_PIPELINE_TAG_KEY = "sf-watch-pipeline"
 SF_WATCH_RUN_DATE_TAG_KEY = "sf-watch-run-date"
+# Canary drill discriminator (config#2223): set on drill boxes ONLY, so any
+# fleet consumer (dashboard live-box signal, ad-hoc audits) can tell a
+# synthetic drill box from a real repair box with one tag read. The SAME tag
+# key is used by ci-watch-dispatcher — one fleet-wide drill marker.
+SF_WATCH_DRILL_TAG_KEY = "sf-watch-drill"
+
+# DRILL RUN_DATE PREFIX (config#2223). DRILL-vs-REAL ISOLATION INVARIANT: a
+# drill's effective run_date is ALWAYS synthesized as f"drill-{utc-date}" —
+# it can NEVER match _RUN_DATE_RE (real run_dates are bare YYYY-MM-DD), so
+# every surface keyed on run_date is structurally collision-free between
+# drills and real dispatches: the (cadence, pipeline, run_date) concurrency
+# lock, the completion-marker key sf_watch/_control/completed/
+# {cadence}-{pipeline}-{run_date}.json (what spot-orphan-reaper and the
+# sf-watch-liveness-probe reclaim checker derive from the tags), the
+# watch-log key consolidated/{cadence}_sf_watch/{run_date}.json, and the
+# saturday dispatcher's config#2269 per-(cadence, pipeline, run_date)
+# mechanical attempt ceiling. A drill therefore can never dedupe-block,
+# budget-consume, or reclaim-relaunch against a real dispatch. Pinned by
+# test_drill_run_date_can_never_collide_with_a_real_run_date.
+DRILL_RUN_DATE_PREFIX = "drill-"
 
 # Discriminator tag write (config#2267 site 2): the tags are LOAD-BEARING —
 # without them the next failure's dedupe guard is blind (duplicate box) and
@@ -236,7 +256,17 @@ def _resolve_event_fields(event: dict) -> dict:
     clean launched:false — see module docstring's synchronous contract)."""
     pipeline_name = _require(event, "pipeline_name", _PIPELINE_RE)
     cadence_slug = _require(event, "cadence_slug", _CADENCE_RE)
-    run_date = _require(event, "run_date", _RUN_DATE_RE)
+    # is_drill (config#2223): "true" on the weekly synthetic canary drill the
+    # EventBridge Scheduler rule fires (see deploy.sh --bootstrap). A drill's
+    # effective run_date is ALWAYS synthesized here — never taken from the
+    # payload — so no payload (scheduler Input, operator refire, anything)
+    # can ever carry a real run_date into a drill's lock/marker/watch-log
+    # keys. See the DRILL_RUN_DATE_PREFIX isolation invariant above.
+    is_drill = _optional(event, "is_drill", _BOOL_RE, default="false")
+    if is_drill == "true":
+        run_date = f"{DRILL_RUN_DATE_PREFIX}{datetime.now(timezone.utc):%Y-%m-%d}"
+    else:
+        run_date = _require(event, "run_date", _RUN_DATE_RE)
     execution_arn = _require(event, "execution_arn", _ARN_RE)
     state_machine_arn = _optional(event, "state_machine_arn", _ARN_RE)
     failed_state = _optional(event, "failed_state", _FAILED_STATE_RE)
@@ -260,6 +290,7 @@ def _resolve_event_fields(event: dict) -> dict:
         "failed_state": failed_state,
         "watch_log_key": watch_log_key,
         "is_preflight": is_preflight,
+        "is_drill": is_drill,
         "force_on_demand": force_on_demand,
         "cause": cause,
     }
@@ -300,7 +331,7 @@ exec bash infrastructure/sf_watch_spot_bootstrap.sh \
   --state-machine-arn "{fields['state_machine_arn']}" --execution-arn "{fields['execution_arn']}" \
   --run-date "{fields['run_date']}" --failed-state "{fields['failed_state']}" \
   --cause-b64 "{cause_b64}" --watch-log-key "{fields['watch_log_key']}" \
-  --is-preflight "{fields['is_preflight']}"
+  --is-preflight "{fields['is_preflight']}" --is-drill "{fields['is_drill']}"
 """
 
 
@@ -378,18 +409,23 @@ def _terminate_instance(instance_id: str) -> None:
 
 
 def _create_discriminator_tags(
-    instance_id: str, cadence_slug: str, pipeline_name: str, run_date: str
+    instance_id: str, cadence_slug: str, pipeline_name: str, run_date: str,
+    is_drill: bool = False,
 ) -> str | None:
     """Write the load-bearing discriminator tags (config#2267 site 2) with a
     bounded retry. Returns None on success, or the final ``"ExcName: msg"``
     string after TAG_WRITE_ATTEMPTS failures — the caller terminates the box
     and fails the dispatch (the tags are what make the box visible to the
-    dedupe guard and the spot-orphan-reaper; an untagged box must not run)."""
+    dedupe guard and the spot-orphan-reaper; an untagged box must not run).
+    A canary drill box (config#2223) additionally carries
+    ``sf-watch-drill=true`` so fleet consumers can tell it apart."""
     tags = [
         {"Key": SF_WATCH_CADENCE_TAG_KEY, "Value": cadence_slug},
         {"Key": SF_WATCH_PIPELINE_TAG_KEY, "Value": pipeline_name},
         {"Key": SF_WATCH_RUN_DATE_TAG_KEY, "Value": run_date},
     ]
+    if is_drill:
+        tags.append({"Key": SF_WATCH_DRILL_TAG_KEY, "Value": "true"})
     last_error = ""
     for attempt in range(1, TAG_WRITE_ATTEMPTS + 1):
         try:
@@ -482,7 +518,7 @@ def _defer_relaunch(fields: dict, generation: int, context, existing: list[str])
     payload = {k: fields[k] for k in (
         "pipeline_name", "cadence_slug", "run_date", "execution_arn",
         "state_machine_arn", "failed_state", "watch_log_key", "is_preflight",
-        "force_on_demand", "cause",
+        "is_drill", "force_on_demand", "cause",
     )}
     payload["defer_generation"] = next_generation
     fire_at = datetime.now(timezone.utc) + timedelta(seconds=DEFER_DELAY_SECONDS)
@@ -652,7 +688,21 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
             "duplicate box is possible): %s",
             cadence_slug, pipeline_name, run_date, dedupe_probe_error,
         )
+    is_drill = fields.get("is_drill") == "true"
     if existing:
+        if is_drill:
+            # A drill is NOT a repair: defer-not-drop (config#2226) exists so
+            # a REAL failure is never silently dropped — a duplicate drill
+            # for the same day carries no coverage obligation, so it skips
+            # cleanly instead of minting a one-shot re-invoke schedule
+            # (config#2223).
+            logger.info(
+                "sf-watch canary drill already live for %s/%s@%s (%s) — "
+                "skipping (no defer for drills)",
+                cadence_slug, pipeline_name, run_date, existing,
+            )
+            return {"launched": False, "reason": "drill_concurrent_skip",
+                    "existing_instance_ids": existing, "is_drill": True}
         # DEFER, NOT DROP (config#2226): the live box has no obligation to
         # notice THIS failure — schedule a one-shot re-invoke instead of
         # silently dropping it (see module docstring).
@@ -679,7 +729,9 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
     # TagSpecifications — is blocked on krepis.ec2_spot.launch, the fleet's
     # RunInstances chokepoint, growing an extra-tags parameter; until then
     # this retry+terminate closes the hole loudly.)
-    tag_error = _create_discriminator_tags(instance_id, cadence_slug, pipeline_name, run_date)
+    tag_error = _create_discriminator_tags(
+        instance_id, cadence_slug, pipeline_name, run_date, is_drill=is_drill
+    )
     if tag_error is not None:
         _terminate_instance(instance_id)
         logger.error(
@@ -724,6 +776,7 @@ def _launch_sf_watch_spot(fields: dict, context=None, defer_generation: int = 0)
         "run_token": run_token,
         "dedupe_degraded": dedupe_degraded,
         "force_on_demand": force_on_demand,
+        "is_drill": is_drill,
     }
     if dedupe_degraded:
         verdict["dedupe_probe_error"] = dedupe_probe_error
@@ -746,6 +799,15 @@ def handler(event: dict, context) -> dict:
     watch-log; the budget-visible `action: reclaim_relaunch` watch-log event
     (counted by the saturday dispatcher's config#2269 attempt ceiling) is
     written by the PROBE before it invokes here.
+
+    CANARY DRILL (config#2223): a weekly EventBridge Scheduler rule
+    (`alpha-engine-sf-watch-canary-drill-weekly`, created by deploy.sh
+    --bootstrap) invokes this same handler with `is_drill: "true"` and a
+    synthetic execution_arn. The dispatch pipe runs FOR REAL (spot launch,
+    SSM, bootstrap start) but the box short-circuits before the agent
+    (alpha-engine-config's sf_watch_run.sh drill guard), writes the
+    `consolidated/{cadence}_sf_watch/_canary/{date}.json` heartbeat, and
+    self-terminates. Drill isolation: see DRILL_RUN_DATE_PREFIX.
 
     Returns {"launched": bool, "reason": str, "instance_id": ..., ...} — read
     DIRECTLY by the GHA job as its success signal. Every anticipated failure

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -907,3 +907,133 @@ def test_deploy_sh_launch_config_pins_match_index_defaults(monkeypatch):
         assert f'\\"{env_key}\\"' in deploy_sh or f'"{env_key}"' in deploy_sh, (
             f"deploy.sh's lambda_env_json no longer sets {env_key}"
         )
+
+
+# ── config#2223: weekly synthetic canary drill ───────────────────────────────
+
+
+def _drill_event(**overrides):
+    """Mirror of the static EventBridge Scheduler Input deploy.sh's --bootstrap
+    wires (run_date deliberately absent — the handler ALWAYS synthesizes it)."""
+    base = {
+        "is_drill": "true",
+        "pipeline_name": "ne-weekly-freshness-pipeline",
+        "cadence_slug": "saturday",
+        "execution_arn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:canary-drill",
+        "cause": "synthetic weekly canary drill of the dispatch pipe (config#2223) - not a real failure",
+    }
+    base.update(overrides)
+    return base
+
+
+def _expected_drill_run_date():
+    from datetime import datetime, timezone
+    return f"drill-{datetime.now(timezone.utc):%Y-%m-%d}"
+
+
+def test_drill_event_launches_with_drill_scoped_run_date_and_drill_tag(monkeypatch):
+    """The happy path the weekly canary exists to verify: a drill payload
+    round-trips the REAL launch pipe (spot launch + tags + SSM bootstrap),
+    with the drill-scoped run_date threaded everywhere a real run_date would
+    be, plus the sf-watch-drill discriminator tag."""
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_drill_event(), None)
+    drill_date = _expected_drill_run_date()
+    assert out["launched"] is True
+    assert out["is_drill"] is True
+    assert out["run_date"] == drill_date
+    # Tags: the normal discriminator triple (run_date drill-scoped) PLUS the
+    # drill marker tag fleet consumers filter on.
+    assert idx._test_ec2.tags_created == [
+        (["i-stub"], [
+            {"Key": "sf-watch-cadence", "Value": "saturday"},
+            {"Key": "sf-watch-pipeline", "Value": "ne-weekly-freshness-pipeline"},
+            {"Key": "sf-watch-run-date", "Value": drill_date},
+            {"Key": "sf-watch-drill", "Value": "true"},
+        ])
+    ]
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--is-drill "true"' in cmd
+    assert f'--run-date "{drill_date}"' in cmd
+    # The synthesized watch_log_key is drill-scoped too (never a real key).
+    assert f'--watch-log-key "consolidated/saturday_sf_watch/{drill_date}.json"' in cmd
+
+
+def test_drill_run_date_is_synthesized_never_taken_from_payload(monkeypatch):
+    """ISOLATION INVARIANT (see index.DRILL_RUN_DATE_PREFIX): even a payload
+    that smuggles a real run_date into a drill gets the code-synthesized
+    drill run_date — no payload can point a drill at a real dispatch's
+    lock/marker/watch-log keys."""
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_drill_event(run_date="2026-07-11"), None)
+    assert out["launched"] is True
+    assert out["run_date"] == _expected_drill_run_date()
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--run-date "2026-07-11"' not in cmd
+
+
+def test_drill_run_date_can_never_collide_with_a_real_run_date(monkeypatch):
+    """Pins the structural non-collision every drill-vs-real isolation claim
+    rests on (index.DRILL_RUN_DATE_PREFIX comment): a real run_date always
+    matches _RUN_DATE_RE, a drill run_date never does — so the concurrency
+    lock, completion-marker key, watch-log key, and the saturday dispatcher's
+    config#2269 per-run_date budget can never mix the two."""
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    drill_date = _expected_drill_run_date()
+    assert drill_date.startswith(idx.DRILL_RUN_DATE_PREFIX)
+    assert idx._RUN_DATE_RE.match("2026-07-11")
+    assert not idx._RUN_DATE_RE.match(drill_date)
+
+
+def test_drill_concurrent_skip_never_defers(monkeypatch):
+    """A drill is not a repair: a live drill box for the same day skips
+    cleanly — it must NOT mint a defer-not-drop one-shot schedule (that
+    machinery exists so REAL failures are never dropped)."""
+    drill_date = _expected_drill_run_date()
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", drill_date): ["i-drill-live"],
+        },
+    )
+    out = idx.handler(_drill_event(), _FakeContext())
+    assert out["launched"] is False
+    assert out["reason"] == "drill_concurrent_skip"
+    assert out["is_drill"] is True
+    assert out["existing_instance_ids"] == ["i-drill-live"]
+    assert idx._test_scheduler.created == []
+    assert idx._test_ssm.sent == []
+
+
+def test_real_dispatch_is_not_blocked_by_a_live_drill_box(monkeypatch):
+    """The other direction of the isolation invariant: a live drill box holds
+    only the drill-scoped lock key, so a real failure for the same
+    (cadence, pipeline) on the same day still launches."""
+    drill_date = _expected_drill_run_date()
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        running_instances={
+            ("saturday", "ne-weekly-freshness-pipeline", drill_date): ["i-drill-live"],
+        },
+    )
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+
+
+def test_malformed_is_drill_returns_clean_false(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_drill_event(is_drill="yes-please"), None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+    assert idx._test_ssm.sent == []
+
+
+def test_non_drill_dispatch_carries_no_drill_tag_and_is_drill_false(monkeypatch):
+    idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+    assert out["is_drill"] is False
+    (_, tags), = idx._test_ec2.tags_created
+    assert all(t["Key"] != "sf-watch-drill" for t in tags)
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert '--is-drill "false"' in cmd


### PR DESCRIPTION
Data half of the dispatch canary: boolean-validated `is_drill` in both spot dispatchers; drill identity is ALWAYS code-synthesized (`drill-YYYY-MM-DD` run_date / synthetic repo+sha) so it structurally cannot collide with real concurrency locks, completion markers, watch-logs, or the config#2269 budget (invariant-pinned tests both directions); `sf-watch-drill=true` box tag; reclaim checker ignores drill deaths (missed heartbeat is the drill's failure surface, never a relaunch/page). Weekly EventBridge Scheduler drills (Wed 15:00/15:30 UTC) created idempotently via each deploy.sh --bootstrap. IAM verified strict-subset — zero policy changes.

**Merge order: after alpha-engine-config-PR (the drill flags land in the repo the box clones); before first drill, run both deploy.sh --bootstrap + probe code deploy** (queued on the in-session apply list). 103 tests green under lib v0.106.0.

Refs nousergon/alpha-engine-config#2223 (epic I2282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)