### PR TITLE
feat(sf): health-check honesty — poll-to-terminal, degraded-notify routing, no runtime pip, fail-visible drift (config#2276)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -3573,7 +3573,7 @@
     },
     "SaturdayHealthCheck": {
       "Type": "Task",
-      "Comment": "Check data freshness after full pipeline — non-blocking (alerts on failure but does not halt). Runs from alpha-engine-dashboard post-2026-04-16 health_checker migration. config#2279: deliberately carries NO Retry ladder (declared class: health-observe) — it is best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs to the success notifier, so a retry ladder would only delay completion, never protect spend (the health-check masking class itself is config#2276 scope).",
+      "Comment": "Check data freshness after full pipeline — non-blocking (a failure degrades the completion email, it does not halt). Runs from alpha-engine-dashboard post-2026-04-16 health_checker migration. config#2279: deliberately carries NO Retry ladder (declared class: health-observe) — it is best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 timeout convention (both health-observe states): inner executionTimeout = script runtime budget (agent-enforced; its expiry surfaces as a terminal non-Success status the poll Choice turns into health_check_degraded — it is a runaway bound, no longer a silent kill-and-skip); SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout — time for the agent to PICK UP the command, not to run it); outer Task TimeoutSeconds = executionTimeout + 30 (bounds only the async SendCommand API call, which returns in <1s — pinned to inner+30 so the relation stays coherent if this ever flips to a .sync integration). Budget: executionTimeout raised 60→300 (config#2276): observed successful health_checker.py runs complete in ~2.7-2.8s (n=2 Success in the 30-day SSM history sampled 2026-07-11 — most runs FAILED sub-second on git-pull collisions, see CheckSaturdayHealthCheckStatus), so 300s is ~100x observed with headroom for S3-latency-bound freshness scans; under the poll loop a generous budget costs nothing on the happy path.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3588,19 +3588,19 @@
             "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
           ],
           "executionTimeout": [
-            "60"
+            "300"
           ]
         },
         "TimeoutSeconds": 60
       },
-      "TimeoutSeconds": 90,
+      "TimeoutSeconds": 330,
       "Catch": [
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Health check failure is non-blocking — continue to notify",
-          "Next": "NotifyComplete",
+          "Comment": "config#2276: health-check failure is non-blocking but must be VISIBLE — set health_check_degraded (threads into the completion-email selection) and continue to the sibling substrate check (independent observability paths; both must run). Pre-fix this jumped straight to NotifyComplete: a crash here sent the plain real-run SUCCESS email AND silently skipped WeeklySubstrateHealthCheck, ReportCard and the Director.",
+          "Next": "SaturdayHealthCheckDegraded",
           "ResultPath": "$.health_check_error"
         }
       ],
@@ -3639,8 +3639,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Non-blocking — continue to substrate check even if freshness polling fails. SaturdayHealthCheck (artifact freshness) and WeeklySubstrateHealthCheck (row-driven inventory validation) are independent observability paths; both must run.",
-          "Next": "WeeklySubstrateHealthCheck",
+          "Comment": "config#2276: non-blocking but VISIBLE — a freshness-poll infra failure sets health_check_degraded, then continues to the substrate check (SaturdayHealthCheck artifact freshness and WeeklySubstrateHealthCheck row-driven inventory validation are independent observability paths; both must run). Pre-fix this continued WITHOUT any flag — the outcome was simply lost.",
+          "Next": "SaturdayHealthCheckDegraded",
           "ResultPath": "$.health_check_error"
         }
       ],
@@ -3651,11 +3651,52 @@
         "StandardErrorContent.$": "$.StandardErrorContent"
       },
       "ResultPath": "$.health_check_poll",
+      "Next": "CheckSaturdayHealthCheckStatus"
+    },
+    "CheckSaturdayHealthCheckStatus": {
+      "Type": "Choice",
+      "Comment": "config#2276: poll the freshness check to a TERMINAL status (mirrors the CheckMorningEnrichStatus wait-loop idiom, minus the re-issue gate — observe-only, one attempt). Pre-fix this stage was check-once: the single getCommandInvocation usually returned InProgress and the SF moved on, so (a) a hung/failing health_checker.py was invisible (green email regardless — verified live: most 30-day invocations FAILED sub-second and every run still emailed plain SUCCESS), and (b) WeeklySubstrateHealthCheck was dispatched while this command's git pull still held the dashboard repo's ref lock — the two concurrent `git pull`s produced the recurring 'Cannot fast-forward to multiple branches' / 'cannot lock ref' failures observed 2026-06-19→07-11. Sequential-to-terminal polling fixes both structurally. Terminal non-Success (Failed / TimedOut / Cancelled — incl. executionTimeout expiry and delivery timeout) → health_check_degraded. Loop bound: delivery TimeoutSeconds terminates a never-picked-up command and executionTimeout terminates a hung script, so the loop always reaches a terminal status; the SF top-level TimeoutSeconds (config#2274) backstops SSM control-plane pathology. $.health_check_poll.Status is safe to dereference un-guarded: the sole predecessor WaitForSaturdayHealthCheck pins Status via its ResultSelector (config#2275 rule 3b).",
+      "Choices": [
+        {
+          "Variable": "$.health_check_poll.Status",
+          "StringEquals": "Success",
+          "Next": "WeeklySubstrateHealthCheck"
+        },
+        {
+          "Or": [
+            {
+              "Variable": "$.health_check_poll.Status",
+              "StringEquals": "InProgress"
+            },
+            {
+              "Variable": "$.health_check_poll.Status",
+              "StringEquals": "Pending"
+            },
+            {
+              "Variable": "$.health_check_poll.Status",
+              "StringEquals": "Delayed"
+            }
+          ],
+          "Next": "SaturdayHealthCheckPollWait"
+        }
+      ],
+      "Default": "SaturdayHealthCheckDegraded"
+    },
+    "SaturdayHealthCheckPollWait": {
+      "Type": "Wait",
+      "Seconds": 30,
+      "Next": "WaitForSaturdayHealthCheck"
+    },
+    "SaturdayHealthCheckDegraded": {
+      "Type": "Pass",
+      "Comment": "config#2276: the freshness health check could not run to Success (send/poll infra failure via Catch, or terminal non-Success command status via CheckSaturdayHealthCheckStatus.Default). Mirrors the LibPinGateDegraded shape (config#2278): an SF-controlled boolean that threads into the completion-email selection (CheckGateDegradedNotify) so the run emails 'SUCCESS (health checks DEGRADED)' instead of the plain real-run SUCCESS. Specifics live on the execution record: $.health_check_error (Catch path) / $.health_check_poll (status path). Continues to the sibling substrate check — a degraded freshness check must not skip the independent substrate/ReportCard/Director tail.",
+      "Result": true,
+      "ResultPath": "$.health_check_degraded",
       "Next": "WeeklySubstrateHealthCheck"
     },
     "WeeklySubstrateHealthCheck": {
       "Type": "Task",
-      "Comment": "Phase 2 → 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) — agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (alerts on failure but does not halt pipeline) — same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF runs --cadence daily on the daily-only subset (PR #178 — DailySubstrateHealthCheck state). config#2279: deliberately carries NO Retry ladder (declared class: health-observe) — best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs to the success notifier, so a retry ladder would only delay completion, never protect spend.",
+      "Comment": "Phase 2 → 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) — agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (a failure degrades the completion email, it does not halt) — same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF runs --cadence daily on the daily-only subset (PR #178 — DailySubstrateHealthCheck state). config#2279: deliberately carries NO Retry ladder (declared class: health-observe) — best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 — NO runtime pip: the former in-pipeline `pip install --quiet --upgrade -r requirements.txt` (a live PyPI/network dependency inside an observability stage, with --upgrade able to float unpinned transitive deps past tested versions) was removed; the stage relies on the dashboard box's deploy-time venv sync — infrastructure/deploy-on-merge.sh in crucible-dashboard runs `.venv/bin/pip install -r requirements.txt` on every merge that diffs requirements.txt, and nousergon-lib is TAG-pinned there (@vX.Y.Z), so a lib bump always changes requirements.txt and always refreshes the same /home/ec2-user/alpha-engine-dashboard/.venv this command activates. Timeout convention + budget: see SaturdayHealthCheck's Comment — inner 240 (observed Success ~19-20s incl. the since-removed pip; ~12x headroom as a runaway bound), delivery 60, outer = inner + 30. The previous 240/180/240 set conflated the delivery timeout with an execution ceiling (inversion flagged by config#2276).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3666,27 +3707,26 @@
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main",
             "cd /home/ec2-user/alpha-engine-dashboard",
             "source .venv/bin/activate",
-            "pip install --quiet --upgrade -r requirements.txt",
             "trap 'aws s3 cp /var/log/substrate-health-check.log \"s3://alpha-engine-research/_ssm_logs/substrate-health-check/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
             "python -m nousergon_lib.transparency --cadence weekly --alert 2>&1 | tee /var/log/substrate-health-check.log",
             "echo '--- constituents drift check ---' | tee -a /var/log/substrate-health-check.log",
             "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-data && /home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m validators.constituents_drift_check 2>&1 | tee -a /var/log/substrate-health-check.log || true"
+            "cd /home/ec2-user/alpha-engine-data && /home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m validators.constituents_drift_check 2>&1 | tee -a /var/log/substrate-health-check.log"
           ],
           "executionTimeout": [
             "240"
           ]
         },
-        "TimeoutSeconds": 180
+        "TimeoutSeconds": 60
       },
-      "TimeoutSeconds": 240,
+      "TimeoutSeconds": 270,
       "Catch": [
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Substrate check failure is non-blocking — continue to notify. Per-row CloudWatch alarms catch row-level failures; this Catch only fires on infra/SSM failure.",
-          "Next": "NotifyComplete",
+          "Comment": "config#2276: substrate-check failure is non-blocking but VISIBLE — set health_check_degraded and continue to the ReportCard/Director tail (Lambdas, independent of the dashboard box). Per-row CloudWatch alarms catch row-level failures; this Catch only fires on infra/SSM failure. Pre-fix this jumped straight to NotifyComplete: plain SUCCESS email, ReportCard + Director silently skipped.",
+          "Next": "SubstrateHealthCheckDegraded",
           "ResultPath": "$.substrate_check_error"
         }
       ],
@@ -3725,8 +3765,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Non-blocking — continue even if polling fails. Row-level alarms still page on failure regardless of polling outcome.",
-          "Next": "NotifyComplete",
+          "Comment": "config#2276: non-blocking but VISIBLE — a substrate-poll infra failure sets health_check_degraded, then continues to ReportCard. Row-level alarms still page on failure regardless of polling outcome.",
+          "Next": "SubstrateHealthCheckDegraded",
           "ResultPath": "$.substrate_check_error"
         }
       ],
@@ -3737,6 +3777,47 @@
         "StandardErrorContent.$": "$.StandardErrorContent"
       },
       "ResultPath": "$.substrate_check_poll",
+      "Next": "CheckSubstrateHealthCheckStatus"
+    },
+    "CheckSubstrateHealthCheckStatus": {
+      "Type": "Choice",
+      "Comment": "config#2276: poll the substrate check to a TERMINAL status — same shape and rationale as CheckSaturdayHealthCheckStatus (check-once masked a failing/hung checker AND raced the next consumer; see that state's Comment). A terminal non-Success lands on SubstrateHealthCheckDegraded. This is also where the constituents-drift sub-step became fail-VISIBLE (config#2276): its former `|| true` swallowed exit-1 (= alert-worthy Wikipedia-vs-ArcticDB drift, the exact 2026-05-23 BNY/P/SN incident surface) with no recording surface in the SF; now drift exit-1 fails the command → Status Failed → health_check_degraded → 'SUCCESS (health checks DEGRADED)' email, alongside the validator's own alerts.publish. $.substrate_check_poll.Status is safe un-guarded: sole predecessor WaitForWeeklySubstrateHealthCheck pins Status via ResultSelector (config#2275 rule 3b).",
+      "Choices": [
+        {
+          "Variable": "$.substrate_check_poll.Status",
+          "StringEquals": "Success",
+          "Next": "ReportCard"
+        },
+        {
+          "Or": [
+            {
+              "Variable": "$.substrate_check_poll.Status",
+              "StringEquals": "InProgress"
+            },
+            {
+              "Variable": "$.substrate_check_poll.Status",
+              "StringEquals": "Pending"
+            },
+            {
+              "Variable": "$.substrate_check_poll.Status",
+              "StringEquals": "Delayed"
+            }
+          ],
+          "Next": "SubstrateHealthCheckPollWait"
+        }
+      ],
+      "Default": "SubstrateHealthCheckDegraded"
+    },
+    "SubstrateHealthCheckPollWait": {
+      "Type": "Wait",
+      "Seconds": 30,
+      "Next": "WaitForWeeklySubstrateHealthCheck"
+    },
+    "SubstrateHealthCheckDegraded": {
+      "Type": "Pass",
+      "Comment": "config#2276: the substrate health check (or its constituents-drift sub-step) could not run to Success. Mirrors SaturdayHealthCheckDegraded / the LibPinGateDegraded shape (config#2278) — SF-controlled boolean into the completion-email selection. Shares $.health_check_degraded with the freshness twin DELIBERATELY (one flag family, one degraded Subject — which check degraded lives on the execution record: $.substrate_check_error / $.substrate_check_poll vs $.health_check_error / $.health_check_poll — avoiding a per-check combinatorial notifier explosion). Continues to ReportCard: the advisory Lambda tail is independent of the dashboard box and must not be skipped because an EC2 health command failed.",
+      "Result": true,
+      "ResultPath": "$.health_check_degraded",
       "Next": "ReportCard"
     },
     "ReportCard": {
@@ -3833,8 +3914,29 @@
     },
     "CheckGateDegradedNotify": {
       "Type": "Choice",
-      "Comment": "config#2278: a green run that could not run its pre-spend gates must SAY SO in the completion email. gate_degraded is set ONLY by the LibPinGateDegraded / PipelineContractGateDegraded Pass states (an SF-controlled boolean; IsPresent-guarded per config#2275). Routes to a SEPARATE hardcoded-constant notifier rather than States.Format-ing the flag into NotifyComplete — preserving config#1819's Subject/Message-are-constants invariant.",
+      "Comment": "config#2278 + config#2276: a green run that could not run its pre-spend gates (gate_degraded — set ONLY by the LibPinGateDegraded / PipelineContractGateDegraded Pass states) and/or its tail health checks (health_check_degraded — set ONLY by the SaturdayHealthCheckDegraded / SubstrateHealthCheckDegraded Pass states) must SAY SO in the completion email. Both are SF-controlled booleans, IsPresent-guarded per config#2275. Rules are ordered most-specific-first (both → gates-only → health-only); each routes to a SEPARATE hardcoded-constant notifier rather than States.Format-ing flags into NotifyComplete — preserving config#1819's Subject/Message-are-constants invariant. Composition note (config#2276): the two health checks share ONE flag (which check degraded lives on the execution record), so the enumeration is bounded at 3 degraded notifiers for the 2 flag families; a THIRD flag family should trigger a refactor to a data-driven degraded notifier, not a 7-way enumeration. Name retained from config#2278 (it is the wave-1 chain anchor referenced across tests/comments) — read it as the degraded-completion selector.",
       "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.gate_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.gate_degraded",
+              "BooleanEquals": true
+            },
+            {
+              "Variable": "$.health_check_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.health_check_degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "NotifyCompleteGatesAndHealthDegraded"
+        },
         {
           "And": [
             {
@@ -3847,6 +3949,19 @@
             }
           ],
           "Next": "NotifyCompleteGatesDegraded"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.health_check_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.health_check_degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "NotifyCompleteHealthDegraded"
         }
       ],
       "Default": "NotifyComplete"
@@ -3859,6 +3974,50 @@
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (pre-spend gates DEGRADED)",
         "Message": "All steps completed successfully — BUT one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN; a gate-degraded alert fired earlier in this run. View pipeline status: https://console.nousergon.ai/pipeline-status"
+      },
+      "ResultPath": "$.notify_result",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
+          "ResultPath": "$.notify_error",
+          "Next": "NotifyCompleteDegraded"
+        }
+      ],
+      "End": true
+    },
+    "NotifyCompleteHealthDegraded": {
+      "Type": "Task",
+      "Comment": "config#2276: SUCCESS notifier for a run whose tail health checks were DEGRADED (crashed, timed out, or finished non-Success — including a fail-visible constituents-drift exit). Mirrors NotifyCompleteGatesDegraded exactly — constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (health checks DEGRADED)",
+        "Message": "All steps completed successfully — BUT a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success; the run's freshness validation is NOT confirmed. Which check degraded is on the execution record: $.health_check_error / $.health_check_poll (freshness) vs $.substrate_check_error / $.substrate_check_poll (substrate). View pipeline status: https://console.nousergon.ai/pipeline-status"
+      },
+      "ResultPath": "$.notify_result",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
+          "ResultPath": "$.notify_error",
+          "Next": "NotifyCompleteDegraded"
+        }
+      ],
+      "End": true
+    },
+    "NotifyCompleteGatesAndHealthDegraded": {
+      "Type": "Task",
+      "Comment": "config#2278 + config#2276: SUCCESS notifier for a run where BOTH the pre-spend gates failed open unchecked AND the tail health checks degraded — the Subject reflects both. Mirrors NotifyCompleteGatesDegraded exactly — constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (gates + health checks DEGRADED)",
+        "Message": "All steps completed successfully — BUT (1) one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN (a gate-degraded alert fired earlier in this run), AND (2) a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success. Specifics are on the execution record: $.health_check_error / $.health_check_poll / $.substrate_check_error / $.substrate_check_poll. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -720,9 +720,18 @@ class TestConsolidatedNotify:
         # grading/advisory succeed or fail. On the Friday preflight the states
         # still RUN (dry, see test_advisory_tail_runs_dry_on_preflight) — they are
         # not skipped — so the success edge is identical on real + preflight runs.
+        # config#2276: the substrate poll resolves to a terminal status
+        # first; its Success edge is what feeds ReportCard.
         assert (
-            states["WaitForWeeklySubstrateHealthCheck"]["Next"] == "ReportCard"
+            states["WaitForWeeklySubstrateHealthCheck"]["Next"]
+            == "CheckSubstrateHealthCheckStatus"
         )
+        substrate_success = next(
+            r
+            for r in states["CheckSubstrateHealthCheckStatus"]["Choices"]
+            if r.get("StringEquals") == "Success"
+        )
+        assert substrate_success["Next"] == "ReportCard"
         report_card = states["ReportCard"]
         assert report_card["Next"] == "Director"
         assert all(c["Next"] == "CheckShellRunNotify" for c in report_card["Catch"])

--- a/tests/test_sf_health_check_honesty_wiring.py
+++ b/tests/test_sf_health_check_honesty_wiring.py
@@ -1,0 +1,284 @@
+"""config#2276 — the weekly-SF tail health checks must be honest: they may
+fail SOFT, but never SILENTLY.
+
+Pre-fix, the two post-pipeline health stages could no-op while the run
+emailed the plain real-run SUCCESS:
+
+  1. ``SaturdayHealthCheck`` / ``WeeklySubstrateHealthCheck`` Catches routed
+     DIRECTLY to ``NotifyComplete`` — bypassing BOTH ``CheckShellRunNotify``
+     and ``CheckGateDegradedNotify`` (config#2278), so a health-check crash
+     on a gates-degraded or preflight run sent the plain real-run SUCCESS
+     email, and silently skipped the ReportCard/Director advisory tail.
+  2. Each ``WaitFor*`` poll was CHECK-ONCE: the single getCommandInvocation
+     usually returned InProgress and the SF moved on — a hung/failing
+     health_checker.py was invisible, and the substrate command was
+     dispatched while the freshness command's ``git pull`` still held the
+     dashboard repo's ref lock (the recurring live 'Cannot fast-forward to
+     multiple branches' / 'cannot lock ref' sub-second failures observed
+     2026-06-19 → 2026-07-11 — every one of which still emailed SUCCESS).
+  3. ``WeeklySubstrateHealthCheck`` ran ``pip install --quiet --upgrade -r
+     requirements.txt`` mid-pipeline (live PyPI dependency inside an
+     observability stage) and swallowed the constituents-drift sub-step
+     with ``|| true``.
+
+Shape pinned here (mirrors test_sf_prespend_gate_alerting.py / config#2278):
+  * poll-to-terminal-status loop per check (WaitFor → Check*Status Choice →
+    Success edge | in-flight Wait loop | Default → *Degraded Pass);
+  * every Catch on the four health states routes through its *Degraded
+    Pass (``health_check_degraded: true``) and CONTINUES the tail;
+  * ``health_check_degraded`` threads into the completion-email selection:
+    CheckShellRunNotify → CheckGateDegradedNotify → constants-only degraded
+    notifiers (gates+health / gates / health), Default NotifyComplete;
+  * no runtime pip; no ``|| true`` drift swallow; timeout convention
+    (inner executionTimeout = budget, delivery 60, outer = inner + 30).
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+_WEEKLY = pathlib.Path(__file__).parent.parent / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_WEEKLY.read_text())["States"]
+
+
+CHECKS = [
+    # (send state, wait state, status choice, poll wait, degraded pass,
+    #  poll result path, degraded proceeds-to, inner executionTimeout)
+    ("SaturdayHealthCheck", "WaitForSaturdayHealthCheck",
+     "CheckSaturdayHealthCheckStatus", "SaturdayHealthCheckPollWait",
+     "SaturdayHealthCheckDegraded", "$.health_check_poll",
+     "WeeklySubstrateHealthCheck", 300),
+    ("WeeklySubstrateHealthCheck", "WaitForWeeklySubstrateHealthCheck",
+     "CheckSubstrateHealthCheckStatus", "SubstrateHealthCheckPollWait",
+     "SubstrateHealthCheckDegraded", "$.substrate_check_poll",
+     "ReportCard", 240),
+]
+_IDS = [c[0] for c in CHECKS]
+
+
+# ---------------------------------------------------------------------------
+# Catch routing + degraded flag
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("send", "wait", "status", "_pw", "degraded", "_poll", "proceed", "_t"),
+    CHECKS, ids=_IDS)
+def test_send_and_wait_catches_route_through_degraded_pass(
+    states, send, wait, status, _pw, degraded, _poll, proceed, _t
+):
+    for name in (send, wait):
+        catches = states[name]["Catch"]
+        assert catches, f"{name} must keep its fail-soft Catch"
+        for c in catches:
+            assert c["ErrorEquals"] == ["States.ALL"]
+            assert c["Next"] == degraded, (
+                f"{name} Catch must set the degraded flag via {degraded}, "
+                f"not {c['Next']!r} — a direct jump to a notifier is the "
+                "silent-skip masking config#2276 closed"
+            )
+
+    degraded_state = states[degraded]
+    assert degraded_state["Type"] == "Pass"
+    assert degraded_state["Result"] is True
+    assert degraded_state["ResultPath"] == "$.health_check_degraded"
+    # Fail-soft: degrade then PROCEED with the rest of the tail — the two
+    # checks are independent, and ReportCard/Director are Lambdas that must
+    # not be skipped because an EC2 health command failed.
+    assert degraded_state["Next"] == proceed
+
+
+def test_only_health_degraded_passes_set_health_check_degraded(states):
+    """The completion-email marker must be SF-controlled: exactly the two
+    health-degraded Pass states may write $.health_check_degraded (mirror of
+    the $.gate_degraded writers pin in test_sf_prespend_gate_alerting.py)."""
+    writers = [
+        name for name, st in states.items()
+        if st.get("ResultPath") == "$.health_check_degraded"
+    ]
+    assert sorted(writers) == [
+        "SaturdayHealthCheckDegraded", "SubstrateHealthCheckDegraded",
+    ]
+
+
+def test_no_health_state_catch_targets_notify_complete_directly(states):
+    """The exact pre-fix defect: any of the four health states' Catch
+    jumping straight to a success notifier."""
+    for send, wait, *_ in CHECKS:
+        for name in (send, wait):
+            targets = [c["Next"] for c in states[name].get("Catch", [])]
+            assert "NotifyComplete" not in targets
+            # even the selection-chain entry is wrong as a Catch target —
+            # the degraded Pass must come first so the flag is set
+            assert "CheckShellRunNotify" not in targets
+
+
+# ---------------------------------------------------------------------------
+# poll-to-terminal-status loop (the check-once fix)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("send", "wait", "status", "poll_wait", "degraded", "poll", "proceed", "_t"),
+    CHECKS, ids=_IDS)
+def test_poll_resolves_to_terminal_status(
+    states, send, wait, status, poll_wait, degraded, poll, proceed, _t
+):
+    assert states[send]["Next"] == wait
+    assert states[wait]["Next"] == status, (
+        f"{wait} must feed the terminal-status Choice — check-once polling "
+        "is how a failing health checker stayed invisible (config#2276)"
+    )
+
+    choice = states[status]
+    rules = choice["Choices"]
+    success = next(r for r in rules if r.get("StringEquals") == "Success")
+    assert success["Variable"] == f"{poll}.Status"
+    assert success["Next"] == proceed
+
+    in_flight = next(r for r in rules if "Or" in r)
+    looped = {op["StringEquals"] for op in in_flight["Or"]}
+    assert looped == {"InProgress", "Pending", "Delayed"}, (
+        f"{status} must loop on exactly the non-terminal statuses; got {looped}"
+    )
+    assert in_flight["Next"] == poll_wait
+    assert states[poll_wait]["Type"] == "Wait"
+    assert states[poll_wait]["Next"] == wait
+
+    # THE drill edge: a terminal non-Success (Failed / TimedOut / Cancelled
+    # — incl. executionTimeout expiry killing a hung checker) must land on
+    # the degraded Pass, not fall through to a plain notifier.
+    assert choice["Default"] == degraded
+
+
+# ---------------------------------------------------------------------------
+# degraded flag threads into the completion-email selection
+# ---------------------------------------------------------------------------
+
+def _notify_target(states, data: dict) -> str:
+    """Evaluate the CheckShellRunNotify → CheckGateDegradedNotify selection
+    with ASL short-circuit semantics against a partial payload."""
+    def eval_rule(rule):
+        if "And" in rule:
+            return all(eval_rule(op) for op in rule["And"])
+        var, present = rule["Variable"].lstrip("$."), rule["Variable"].lstrip("$.") in data
+        if "IsPresent" in rule:
+            return present == rule["IsPresent"]
+        assert present, f"unguarded dereference of {var} in drill payload {data}"
+        return data[var] == rule["BooleanEquals"]
+
+    cur = "CheckShellRunNotify"
+    while states[cur]["Type"] == "Choice":
+        for rule in states[cur]["Choices"]:
+            if eval_rule(rule):
+                cur = rule["Next"]
+                break
+        else:
+            cur = states[cur]["Default"]
+    return cur
+
+
+@pytest.mark.parametrize(("payload", "expected"), [
+    # both flag families set → subject reflects both
+    ({"gate_degraded": True, "health_check_degraded": True},
+     "NotifyCompleteGatesAndHealthDegraded"),
+    ({"gate_degraded": True}, "NotifyCompleteGatesDegraded"),
+    ({"health_check_degraded": True}, "NotifyCompleteHealthDegraded"),
+    ({}, "NotifyComplete"),  # clean run byte-identical
+    # a preflight run still gets the shell-run notifier regardless of flags
+    ({"shell_run": True, "health_check_degraded": True},
+     "NotifyShellRunComplete"),
+])
+def test_degraded_flags_select_the_right_completion_notifier(
+    states, payload, expected
+):
+    assert _notify_target(states, payload) == expected
+
+
+@pytest.mark.parametrize("notifier", [
+    "NotifyCompleteHealthDegraded", "NotifyCompleteGatesAndHealthDegraded",
+])
+def test_degraded_notifiers_mirror_config_1819_shape(states, notifier):
+    st = states[notifier]
+    assert st["Resource"] == "arn:aws:states:::sns:publish"
+    assert st["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"
+    # config#1819: constants only — no States.Format against state fields.
+    assert "Subject.$" not in st["Parameters"]
+    assert "Message.$" not in st["Parameters"]
+    subject = st["Parameters"]["Subject"]
+    assert "SUCCESS" in subject and "DEGRADED" in subject
+    assert 0 < len(subject) <= 100
+    assert "\n" not in subject
+    assert "health checks" in subject
+    assert st["End"] is True
+    (catch,) = st["Catch"]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "NotifyCompleteDegraded"  # config#1819 idiom
+
+
+def test_both_flags_subject_names_both_families(states):
+    subject = states["NotifyCompleteGatesAndHealthDegraded"]["Parameters"]["Subject"]
+    assert "gates" in subject and "health checks" in subject
+
+
+# ---------------------------------------------------------------------------
+# command hygiene: no runtime pip, no || true drift swallow
+# ---------------------------------------------------------------------------
+
+def _all_command_arrays(states):
+    for name, st in states.items():
+        cmds = (st.get("Parameters", {}) or {}).get("Parameters", {}).get("commands")
+        if cmds:
+            yield name, cmds
+
+
+def test_no_runtime_pip_install_anywhere_in_definition(states):
+    """config#2276: deps come from the dashboard box's deploy-time venv sync
+    (crucible-dashboard infrastructure/deploy-on-merge.sh pip-installs on
+    requirements.txt diff; nousergon-lib is tag-pinned so a lib bump always
+    diffs requirements.txt). A live PyPI/network dependency mid-pipeline is
+    forbidden — --upgrade could also float unpinned transitive deps past
+    tested versions."""
+    offenders = [
+        name for name, cmds in _all_command_arrays(states)
+        if "pip install" in " ".join(cmds)
+    ]
+    assert not offenders, f"runtime pip install in: {offenders}"
+
+
+def test_constituents_drift_step_is_fail_visible(states):
+    cmds = states["WeeklySubstrateHealthCheck"]["Parameters"]["Parameters"]["commands"]
+    (drift_line,) = [c for c in cmds if "constituents_drift_check" in c]
+    assert "|| true" not in drift_line, (
+        "config#2276: the drift check exits 1 on alert-worthy drift (the "
+        "2026-05-23 BNY/P/SN incident surface) — '|| true' swallowed exactly "
+        "that signal; under set -eo pipefail its failure must fail the "
+        "command so the poll Choice degrades the completion email"
+    )
+    # the log-upload trap's own '|| true' is fine (best-effort log shipping,
+    # inline-commented failure mode) — pin that the drift WORK line is the
+    # only place we assert on.
+    assert cmds[0].startswith("set -eo pipefail")
+
+
+# ---------------------------------------------------------------------------
+# timeout convention
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("send", "_w", "_s", "_pw", "_d", "_p", "_pr", "inner"),
+    CHECKS, ids=_IDS)
+def test_timeout_convention(states, send, _w, _s, _pw, _d, _p, _pr, inner):
+    """config#2276 convention: inner executionTimeout = script budget
+    (agent-enforced; expiry surfaces as terminal non-Success → degraded);
+    SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout);
+    outer Task TimeoutSeconds = inner + 30."""
+    st = states[send]
+    ssm_params = st["Parameters"]["Parameters"]
+    assert ssm_params["executionTimeout"] == [str(inner)]
+    assert st["Parameters"]["TimeoutSeconds"] == 60
+    assert st["TimeoutSeconds"] == inner + 30

--- a/tests/test_sf_prespend_gate_alerting.py
+++ b/tests/test_sf_prespend_gate_alerting.py
@@ -120,7 +120,16 @@ def test_gate_degraded_threads_into_completion_email(states):
     assert states["CheckShellRunNotify"]["Default"] == "CheckGateDegradedNotify"
 
     choice = states["CheckGateDegradedNotify"]
-    (rule,) = choice["Choices"]
+    # config#2276 extended this Choice with health_check_degraded rules
+    # (most-specific-first ordering, pinned in
+    # tests/test_sf_health_check_honesty_wiring.py). The gates-ONLY rule —
+    # exactly the two gate_degraded operands — must still exist and still
+    # route to the gates-degraded notifier.
+    rule = next(
+        r for r in choice["Choices"]
+        if [c["Variable"] for c in r.get("And", [])]
+        == ["$.gate_degraded", "$.gate_degraded"]
+    )
     guard, comparison = rule["And"]
     assert guard == {"Variable": "$.gate_degraded", "IsPresent": True}
     assert comparison == {"Variable": "$.gate_degraded", "BooleanEquals": True}

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -49,19 +49,38 @@ class TestStatePresence:
 
 
 class TestChainOrdering:
-    """Wiring goes: SaturdayHealthCheck → WaitForSat → Substrate → WaitForSubstrate → Notify."""
+    """Wiring goes: SaturdayHealthCheck → WaitForSat → CheckSatStatus →
+    Substrate → WaitForSubstrate → CheckSubStatus → Notify (config#2276
+    turned each check-once poll into a poll-to-terminal-status loop)."""
 
-    def test_wait_for_saturday_health_check_routes_to_substrate(self, states):
+    def test_wait_for_saturday_health_check_routes_to_status_choice(self, states):
         wait_state = states["WaitForSaturdayHealthCheck"]
-        assert wait_state["Next"] == "WeeklySubstrateHealthCheck", (
-            "WaitForSaturdayHealthCheck must hand off to the substrate check, "
-            "not skip directly to NotifyComplete."
+        assert wait_state["Next"] == "CheckSaturdayHealthCheckStatus", (
+            "WaitForSaturdayHealthCheck must hand off to the terminal-status "
+            "Choice (config#2276 poll loop), not fire-and-forget onward."
         )
 
-    def test_wait_for_saturday_catch_routes_to_substrate(self, states):
+    def test_saturday_status_success_routes_to_substrate(self, states):
+        choice = states["CheckSaturdayHealthCheckStatus"]
+        success = next(
+            r for r in choice["Choices"] if r.get("StringEquals") == "Success"
+        )
+        assert success["Next"] == "WeeklySubstrateHealthCheck", (
+            "A successful freshness check must hand off to the substrate "
+            "check, not skip directly to NotifyComplete."
+        )
+
+    def test_wait_for_saturday_catch_routes_to_degraded_then_substrate(self, states):
         catches = states["WaitForSaturdayHealthCheck"]["Catch"]
-        assert any(c["Next"] == "WeeklySubstrateHealthCheck" for c in catches), (
-            "If freshness polling fails, substrate check must still run — "
+        assert any(c["Next"] == "SaturdayHealthCheckDegraded" for c in catches), (
+            "If freshness polling fails, the degraded flag must be set — "
+            "pre-config#2276 this continued silently."
+        )
+        assert (
+            states["SaturdayHealthCheckDegraded"]["Next"]
+            == "WeeklySubstrateHealthCheck"
+        ), (
+            "A degraded freshness check must still run the substrate check — "
             "they're independent observability paths."
         )
 
@@ -85,9 +104,9 @@ class TestChainOrdering:
         # path still preserves the success edge. On the Friday preflight both states
         # RUN (dry, via dry_run.$=$.research_dry — ROADMAP L4504), they are not
         # skipped, so the wiring is identical on real + preflight runs.
-        assert (
-            states["WaitForWeeklySubstrateHealthCheck"]["Next"] == "ReportCard"
-        )
+        # config#2276: the substrate poll now resolves to a terminal status
+        # first; its Success edge is what feeds ReportCard (pinned below in
+        # test_wait_for_substrate_routes_via_status_choice).
         assert states["ReportCard"]["Next"] == "Director"
         assert all(c["Next"] == "CheckShellRunNotify" for c in states["ReportCard"]["Catch"])
         assert states["Director"]["Next"] == "CheckShellRunNotify"
@@ -97,28 +116,53 @@ class TestChainOrdering:
         assert states["CheckShellRunNotify"]["Default"] == "CheckGateDegradedNotify"
         assert states["CheckGateDegradedNotify"]["Default"] == "NotifyComplete"
 
+    def test_wait_for_substrate_routes_via_status_choice(self, states):
+        # config#2276: the substrate poll resolves to a terminal status
+        # before ReportCard, so a failing/hung checker is visible.
+        assert (
+            states["WaitForWeeklySubstrateHealthCheck"]["Next"]
+            == "CheckSubstrateHealthCheckStatus"
+        )
+        choice = states["CheckSubstrateHealthCheckStatus"]
+        success = next(
+            r for r in choice["Choices"] if r.get("StringEquals") == "Success"
+        )
+        assert success["Next"] == "ReportCard"
+
 
 class TestCatchSemantics:
-    """Substrate failures must NOT halt the pipeline.
+    """Substrate failures must NOT halt the pipeline — but must be VISIBLE.
 
     Per-row CloudWatch alarms own paging; the SF Catch only fires on
-    infra-level failures (SSM unreachable, EC2 down). Either way, the
-    failure path must terminate at NotifyComplete, not HandleFailure.
+    infra-level failures (SSM unreachable, EC2 down). config#2276: the
+    failure path sets $.health_check_degraded (SubstrateHealthCheckDegraded
+    Pass) and CONTINUES to the advisory tail — never HandleFailure, and
+    never the plain-SUCCESS NotifyComplete either (that was the silent-skip
+    masking this issue closed). Full degraded-flag threading is pinned in
+    tests/test_sf_health_check_honesty_wiring.py.
     """
 
-    def test_substrate_check_catch_is_non_blocking(self, states):
+    def test_substrate_check_catch_is_non_blocking_but_visible(self, states):
         catches = states["WeeklySubstrateHealthCheck"]["Catch"]
         assert len(catches) >= 1
         for c in catches:
-            assert c["Next"] == "NotifyComplete", (
-                f"Substrate Catch must continue to NotifyComplete, not "
-                f"{c['Next']!r} — the substrate check is observability, not gating."
+            assert c["Next"] == "SubstrateHealthCheckDegraded", (
+                f"Substrate Catch must set the degraded flag, not go to "
+                f"{c['Next']!r} — observability, not gating; visible, not silent."
             )
 
-    def test_substrate_wait_catch_is_non_blocking(self, states):
+    def test_substrate_wait_catch_is_non_blocking_but_visible(self, states):
         catches = states["WaitForWeeklySubstrateHealthCheck"]["Catch"]
         for c in catches:
-            assert c["Next"] == "NotifyComplete"
+            assert c["Next"] == "SubstrateHealthCheckDegraded"
+
+    def test_substrate_degraded_continues_to_advisory_tail(self, states):
+        degraded = states["SubstrateHealthCheckDegraded"]
+        assert degraded["Type"] == "Pass"
+        assert degraded["Next"] == "ReportCard", (
+            "A degraded substrate check must not skip the ReportCard/Director "
+            "Lambda tail — it is independent of the dashboard box."
+        )
 
 
 class TestCommandShape:
@@ -158,6 +202,14 @@ class TestCommandShape:
         # Stale repo on the dispatcher would run an outdated lib pin.
         joined = " ".join(commands)
         assert "git" in joined and "pull" in joined
+
+    def test_no_runtime_pip_install(self, commands):
+        # config#2276: deps are synced at deploy time (crucible-dashboard
+        # infrastructure/deploy-on-merge.sh pip-installs on requirements.txt
+        # diff; nousergon-lib is tag-pinned there) — a live PyPI dependency
+        # mid-pipeline is forbidden.
+        joined = " ".join(commands)
+        assert "pip install" not in joined
 
 
 class TestResultPathIsolation:


### PR DESCRIPTION
## What
Live root-cause finding during implementation: **12 of 16 health-check invocations over 30 days FAILED while every run emailed plain SUCCESS** — the WaitFor* states were check-once, and the SF dispatched the substrate check while the Saturday check's git pull held the dashboard repo ref lock (recurring since 6/19). The issue's original deliverables all land, plus the load-bearing fix:

- **Poll-to-terminal loops** for both health checks (serializes them — kills the git race; observe-only, no re-issue).
- **Degraded-notify routing:** all four Catches route via `health_check_degraded` Pass states that CONTINUE the tail (a box hiccup no longer skips ReportCard/Director), then a most-specific-first notify selection: gates+health / gates / health degraded subjects. One flag family, 3 notifiers, config#1819 constants-only invariant preserved.
- **No runtime pip** — stage relies on the dashboard venv, synced at deploy time by construction (deploy-on-merge pip-installs on every requirements.txt diff; lib is tag-pinned so bumps always diff it).
- **Fail-visible constituents drift** (`|| true` removed) and a stated timeout convention (Saturday budget 60→300s as a runaway bound — observed success is ~3s; delivery timeout 60s uniform; outer = inner+30).

## Tests
New 18-test wiring suite; 3 existing pins minimally updated to the new topology (the old Catch→NotifyComplete pins WERE the defect). Full suite 2992 passed; validate-state-machine-definition OK. Deploys via single-writer on merge.

Spin-offs filed: alpha-engine-config-I2326 (EOD sibling has the same shape), I2330 (dashboard-role `_ssm_logs/health-check/*` PutObject denied — log shipping silently dead).

Refs nousergon/alpha-engine-config#2276 (epic alpha-engine-config-I2283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)