### PR TITLE
fix(deploy): saturday-sf-watch-dispatcher test-gate self-provisions pytest+deps (config#2295)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -58,7 +58,15 @@ run() {
   fi
 }
 
-# ----- 0. Validate handler + run unit tests ----------------------------------
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+# PKG and TEST_DEPS are both created up front (mirrors ci-watch-dispatcher/
+# deploy.sh) so ONE trap covers both — a pytest-install failure below still
+# cleans up.
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
 
 python3 -c "
 import ast
@@ -67,16 +75,28 @@ ast.parse(src)
 print('index.py syntax OK')
 "
 
+# ----- 0b. Preflight handler unit tests --------------------------------------
+# The gate now runs on bare CI runners (deploy-saturday-sf-watch-dispatcher.yml,
+# config#2295), not just operator laptops where pytest/boto3 were ambient — so
+# it must self-provision its own test deps or it dies "No module named pytest"
+# (2026-07-12 incident; same class the fleet already hit 2026-07-02/-04 and
+# fixed the same way in ci-watch-dispatcher, spot-orphan-reaper, groom-liveness-
+# probe, et al). test_handler.py does a REAL `import index` (no sys.modules
+# stubs), which pulls boto3, the local flow_doctor_telegram (found via the
+# test's sys.path parent insert), and nousergon_lib.flow_doctor_fleet. pytest +
+# boto3 + the pinned nousergon-lib + krepis are installed into a scratch
+# TEST_DEPS dir — NOT the caller's global site-packages, not bundled into the
+# Lambda zip.
 if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + boto3 + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest boto3 "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
   echo "Running handler unit tests..."
-  python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
 fi
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
-
-LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PKG=$(mktemp -d)
-trap "rm -rf '$PKG'" EXIT
 
 echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
 bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"


### PR DESCRIPTION
## Root cause
The new auto-deploy workflow `deploy-saturday-sf-watch-dispatcher.yml` (#767, config#2295) runs `deploy.sh` on a **bare** ubuntu runner. The script's step-0 handler test-gate called `python3 -m pytest "${SCRIPT_DIR}/test_handler.py"` with **pytest never installed** on the runner → `No module named pytest`, exit 1.

The failure is at the validation gate — **before** packaging and before any `aws lambda update-function-code` — so **no partial live Lambda state** was applied ([failed run](https://github.com/nousergon/nousergon-data/actions/runs/29175979074)).

`deploy.sh` here was written with the *naive* gate form. Every sibling dispatcher already self-provisions its test deps for exactly this reason — `ci-watch-dispatcher`, `spot-orphan-reaper`, `groom-liveness-probe`, `scheduled-groom-dispatcher`, `usage-pace-alert` — the same `No module named pytest` incident class the fleet hit on 2026-07-02 / -04.

## The SOTA fix and why this layer
`deploy.sh` is the single source of truth for **how this Lambda deploys** (its test-gate included) and is run **both** by operators locally **and** by CI. The fix belongs here, not in the workflow YAML — a workflow-only `pip install` would leave operator-laptop runs broken and diverge from the 6+ sibling scripts.

The gate now creates a scratch `TEST_DEPS` dir up front (one `trap` covers both `PKG` and `TEST_DEPS`, mirroring `ci-watch-dispatcher/deploy.sh`) and installs `pytest + boto3 + krepis + the pinned nousergon-lib` into it, running pytest with `PYTHONPATH="${TEST_DEPS}"`. `test_handler.py` does a **real** `import index` (no `sys.modules` stubs), so `boto3` and `nousergon_lib.flow_doctor_fleet` must be importable — hence the full set, not just pytest. Deps land in a scratch dir, never the caller's global site-packages and never the Lambda zip.

## Guard / test that now covers this class
The gate itself is the guard, and it now runs **hermetically self-provisioned** so it can never again silently no-op or die on a bare runner. Validated locally against the exact pinned deps: **71 passed**.

## Fail-loud rationale
No error-handling weakened. The gate still hard-fails (`set -euo pipefail`) on any real test failure or install failure — the change only makes the *dependencies* present, it does not swallow, `|| true`, or skip anything.