### PR TITLE
[P2/mid] fix(ci): make pip-audit blocking with reviewed ignore-list

### DIFF
--- a/.github/pip-audit-ignore.txt
+++ b/.github/pip-audit-ignore.txt
@@ -1,0 +1,13 @@
+# pip-audit ignore list (nousergon/alpha-engine-config#2342)
+# Every entry below MUST carry a dated rationale comment directly above it.
+# No blanket suppression — each accepted advisory is named individually.
+# Format:
+#   # <rationale> — accepted 2026-07-12, revisit <YYYY-MM-DD or "when a fix is released">
+#   <VULN-ID>
+#
+# No entries as of 2026-07-12: `pip-audit` against the fully-resolved
+# requirements.txt (127 packages, including arcticdb and the git-pinned
+# nousergon-lib[arcticdb,flow-doctor,rag,contracts]@v0.86.0) reported zero
+# known vulnerabilities. This file exists so the ignore-file plumbing in
+# ci.yml has something to read; add entries here if/when pip-audit finds
+# something that can't be safely bumped.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,13 @@ jobs:
       - name: Security audit
         run: |
           pip install pip-audit
-          pip-audit || true
+          IGNORE_ARGS=()
+          if [ -f .github/pip-audit-ignore.txt ]; then
+            while IFS= read -r vuln_id; do
+              IGNORE_ARGS+=(--ignore-vuln "$vuln_id")
+            done < <(grep -vE '^\s*#|^\s*$' .github/pip-audit-ignore.txt)
+          fi
+          pip-audit "${IGNORE_ARGS[@]}"
 
   # Alert (Telegram) ONLY on genuine post-merge breakage of the default
   # branch. PR-branch reds (mid-fix commits, cross-repo lib-tag merge-order


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** mid

`pip-audit || true` in CI meant the security audit could never fail a PR. This makes it blocking, with a reviewed, dated ignore-list for currently-accepted advisories (see `.github/pip-audit-ignore.txt`).

Findings handled: ran `pip-audit` locally against the fully-resolved `requirements.txt` (127 packages on Python 3.12, matching CI — including `arcticdb` and the git-pinned `nousergon-lib[arcticdb,flow-doctor,rag,contracts]@v0.86.0`). Result: zero known vulnerabilities found, so there was nothing to bump and nothing to ignore. `.github/pip-audit-ignore.txt` is created with the required header format but no entries — the plumbing is in place for the next time pip-audit finds something that can't be safely auto-fixed. Full local test suite (`pytest tests/`, changelog lambda tests, and the glob-derived per-lambda handler suite) all pass against this environment.

Part of nousergon/alpha-engine-config#2342 (fleet-wide sweep across 7 repos).

---
Groom-Run: 0b534c31baab4492ab02f08506455e62
