### PR TITLE
fix(deploy): update groom-dispatch instead of orphaned groom-pipeline + IAM grant

### DIFF
--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -134,7 +134,7 @@ echo "==> Updating Step Function definitions..."
 SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline"
 DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline"
 EOD_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
-GROOM_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-pipeline"
+GROOM_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-dispatch"
 # Shared SF execution role (the CFN StepFunctionsRoleArn default; all three
 # orchestration SFs run under it). Used only for the EOD create-if-absent path.
 SF_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-step-functions-role"
@@ -218,7 +218,12 @@ DAILY_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations
 update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline" "$SAT_LOGGING_CONFIG"
 update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline" "$DAILY_LOGGING_CONFIG"
 update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post-close trading pipeline" "$EOD_LOGGING_CONFIG"
-update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-pipeline" "Backlog groom pipeline"
+# CORRECTED 2026-07-12: was alpha-engine-groom-pipeline (the OLD name) — the EventBridge
+# Scheduler targets alpha-engine-groom-dispatch (created by the scheduled-groom-dispatcher
+# deploy.sh --bootstrap). Every deploy between config#2129 (2026-07-01) and this fix was
+# updating the orphaned groom-pipeline name instead of the live groom-dispatch, which is
+# why PRs #761 and #763's SF definition fixes had zero live effect on actual groom runs.
+update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-dispatch" "Backlog groom dispatch"
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────
 echo ""

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -123,6 +123,7 @@
       ],
       "Resource": [
         "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-*-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-groom-dispatch",
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-*-pipeline"
       ]
     },

--- a/infrastructure/step-functions/check-drift.py
+++ b/infrastructure/step-functions/check-drift.py
@@ -30,7 +30,7 @@ not a hypothetical one):
     (`ne-postclose-trading-pipeline`) is NOT in CloudFormation (script-
     managed); its `EOD_LOGGING_CONFIG` literal there is the source of truth,
     passed explicitly on every `update-state-machine` / `create-state-machine`
-    call. The backlog-groom SF (`alpha-engine-groom-pipeline`) is also
+    call. The backlog-groom SF (`alpha-engine-groom-dispatch`) is also
     script-managed but its `update_or_create` call deliberately omits a
     logging arg ("preserving its current no-logging behavior exactly", per
     that script's comment) — so this guard's codified expectation for groom

--- a/tests/test_deploy_infrastructure_sf_coverage.py
+++ b/tests/test_deploy_infrastructure_sf_coverage.py
@@ -122,7 +122,12 @@ def _sf_names_deployed_by_script() -> set[str]:
     """
     script = _DEPLOY.read_text()
     return set(
-        re.findall(r"stateMachine:((?:alpha-engine|ne)-[a-z0-9-]+pipeline)", script)
+        # Match BOTH pipeline names (ne-*-pipeline) and the groom-dispatch SF
+        # (alpha-engine-groom-dispatch). The regex was originally [a-z0-9-]+pipeline
+        # to match all pipeline-named SFs; alpha-engine-groom-dispatch is the only
+        # orchestration SF that doesn't use the -pipeline suffix. If a future SF
+        # joins it, add an alternation here.
+        re.findall(r"stateMachine:(alpha-engine-groom-dispatch|(?:alpha-engine|ne)-[a-z0-9-]+pipeline)", script)
     )
 
 

--- a/tests/test_sf_logging_config_check_drift.py
+++ b/tests/test_sf_logging_config_check_drift.py
@@ -45,7 +45,7 @@ def test_discovers_all_four_orchestrated_state_machines(cd):
         "ne-weekly-freshness-pipeline",
         "ne-preopen-trading-pipeline",
         "ne-postclose-trading-pipeline",
-        "alpha-engine-groom-pipeline",
+        "alpha-engine-groom-dispatch",
     }
 
 
@@ -81,7 +81,7 @@ def test_groom_sf_expects_no_logging(cd):
     logging arg on purpose — this guard's codified expectation must match
     that, not silently assume logging is wanted everywhere."""
     entries = {e["sf_name"]: e for e in cd._discover_expected_logging_configs()}
-    groom = entries["alpha-engine-groom-pipeline"]
+    groom = entries["alpha-engine-groom-dispatch"]
     assert groom["expected_level"] == "OFF"
 
 
@@ -204,7 +204,7 @@ def test_check_sf_missing_state_machine_on_aws(cd):
 
 def test_check_sf_groom_no_drift_when_live_is_off(cd):
     entry = {
-        "sf_name": "alpha-engine-groom-pipeline",
+        "sf_name": "alpha-engine-groom-dispatch",
         "source_file": _REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh",
         "expected_level": "OFF",
         "expected_include_execution_data": None,


### PR DESCRIPTION
## Problem

The deploy-infrastructure.sh script deploys the groom Step Function definition to alpha-engine-groom-pipeline, but the EventBridge Scheduler triggers alpha-engine-groom-dispatch - a different state machine (created by scheduled-groom-dispatcher/deploy.sh --bootstrap).

This deploy-wiring bug means every infrastructure deploy since the config#2129 two-phase restructure (2026-07-01) has been updating the orphaned SF while the live SF never received its definition updates. This is why PRs #761 (Ssm.SdkClientException retry) and #763 (Map-iteration failure sweep fix) had zero live effect on groom runs. The 2026-07-11 19:00Z groom-liveness failure was a direct consequence.

## Fix
1. GROOM_ARN in deploy-infrastructure.sh: alpha-engine-groom-pipeline -> alpha-engine-groom-dispatch
2. IAM policy: added alpha-engine-groom-dispatch to InfraDeploySFDefinition resource list
3. Tests: updated assertions and regex for new SF name
4. Live alpha-engine-groom-dispatch already manually updated with current definition

## Post-merge operator action required
The IAM policy change must be applied post-merge:
  bash infrastructure/iam/apply.sh github-actions-lambda-deploy

## Impact
~11 day deploy gap (config#2129 on 2026-07-01 to this fix).