### PR TITLE
Cut complexity:high groom tier over from Opus to Sonnet 5

### DIFF
--- a/infrastructure/lambdas/groom-liveness-probe/README.md
+++ b/infrastructure/lambdas/groom-liveness-probe/README.md
@@ -18,8 +18,8 @@ Schedule-aware, per-trigger accounting:
 1. Enumerate every scheduled groom trigger in the last `GROOM_LOOKBACK_HOURS`
    that has had `GROOM_CEILING_MIN + GROOM_MARGIN_MIN` to finish (so a still-running
    groom never false-alarms). The schedule mirrors the dispatcher's crons
-   (01:00 daily Opus high-only, 07:00 daily Sonnet mid-only, 19:00 daily Haiku
-   low-only) and is overridable via
+   (01:00 daily Sonnet high-only — config#2409, moved off Opus 2026-07-13;
+   07:00 daily Sonnet mid-only; 19:00 daily Haiku low-only) and is overridable via
    `GROOM_SCHEDULE` (JSON).
 2. Fetch recent `groom-digest`-labeled issues from `nousergon/alpha-engine-config`
    (success digests **and** loud-failure issues both carry the label).

--- a/infrastructure/lambdas/groom-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/groom-liveness-probe/deploy.sh
@@ -22,7 +22,7 @@
 # exact times non-load-bearing (generous LOOKBACK tolerates schedule drift):
 #   06:30 daily   cron(30 6 * * ? *)   # after the 19:00 groom matures (~01:45)
 #   14:30 daily   cron(30 14 * * ? *)  # after the 07:00 groom matures (~13:45)
-#                                      #   (the 01:00 Opus run matures ~07:45 —
+#                                      #   (the 01:00 high-only run matures ~07:45 —
 #                                      #   also covered by the 14:30 pass)
 #
 # Managed OUTSIDE CloudFormation — mirrors the sibling dispatchers (narrow OIDC

--- a/infrastructure/lambdas/groom-liveness-probe/index.py
+++ b/infrastructure/lambdas/groom-liveness-probe/index.py
@@ -93,14 +93,14 @@ _PAT_TIMEOUT_SEC = 15
 # clean-stop case: groom_driver.py files a groom-digest issue even on a
 # total==0 clean shutdown, so _missed()'s presence-in-window check (it never
 # inspects digest CONTENT) already treats that correctly as "not missed."
-#   cron(0 1 * * ? *)  → 01:00 daily (Opus, complexity:high only)
+#   cron(0 1 * * ? *)  → 01:00 daily (Sonnet, complexity:high only — config#2409, moved off Opus 2026-07-13)
 #   cron(0 7 * * ? *)  → 07:00 daily (Sonnet, complexity:mid only)
 #   cron(0 19 * * ? *) → 19:00 daily (Haiku, complexity:low only)
 # At CEILING_MIN=360/MARGIN_MIN=45 (6h45m) the windows can overlap slightly
-# (01:00→07:45 vs 07:00 Sonnet; 19:00→01:45 vs next-day 01:00 Opus) — _missed
+# (01:00→07:45 vs 07:00 Sonnet; 19:00→01:45 vs next-day 01:00 high-only) — _missed
 # attributes by trigger timestamp, not by exclusive window.
 _DEFAULT_SCHEDULE = [
-    {"hour": 1, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "01:00 daily (Opus high-only)"},
+    {"hour": 1, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "01:00 daily (Sonnet high-only)"},
     {"hour": 7, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "07:00 daily (Sonnet mid-only)"},
     {"hour": 19, "minute": 0, "dows": [0, 1, 2, 3, 4, 5, 6], "label": "19:00 daily (Haiku low-only)"},
 ]

--- a/infrastructure/lambdas/groom-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/groom-liveness-probe/test_handler.py
@@ -90,7 +90,7 @@ def test_only_mature_triggers_returned(monkeypatch):
     trigs = index._expected_triggers(now)
     ats = {t["at"] for t in trigs}
     assert _dt(2026, 6, 30, 7, 0) in ats   # 07:00 Tue Sonnet, matured
-    assert _dt(2026, 6, 30, 1, 0) in ats   # 01:00 Tue Opus, matured
+    assert _dt(2026, 6, 30, 1, 0) in ats   # 01:00 Tue high-only, matured
     assert _dt(2026, 6, 29, 19, 0) in ats  # 19:00 Mon Haiku, matured
     # Nothing in the immature zone (now - 6.75h .. now).
     assert all(t["at"] <= now - timedelta(minutes=405) for t in trigs)
@@ -109,8 +109,8 @@ def test_saturday_0700_included(monkeypatch):
     assert _dt(2026, 6, 27, 7, 0) in {t["at"] for t in trigs}
 
 
-def test_0100_opus_schedule_included(monkeypatch):
-    """The 01:00 UTC Opus/complexity:high schedule must be tracked."""
+def test_0100_high_only_schedule_included(monkeypatch):
+    """The 01:00 UTC dedicated complexity:high schedule must be tracked."""
     monkeypatch.setattr(index, "CEILING_MIN", 360)
     monkeypatch.setattr(index, "MARGIN_MIN", 45)
     monkeypatch.setattr(index, "LOOKBACK_HOURS", 30)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -50,14 +50,23 @@ flexible-time-window) mirror `infrastructure/run_weekly_offcycle.sh`.
 
 | Scheduler rule | Expression (UTC) | PT | Day mask | run_mode | model | issue_filter |
 |---|---|---|---|---|---|---|
-| `…-0100-daily-opus-high` | `cron(0 1 * * ? *)` | 6pm | daily (all 7) | full | claude-opus-4-8 | high-only |
+| `…-0100-daily-opus-high`¹ | `cron(0 1 * * ? *)` | 6pm | daily (all 7) | full | claude-sonnet-5 | high-only |
 | `…-0700-daily-mid` | `cron(0 7 * * ? *)` | 12am | daily (all 7) | full | claude-sonnet-5 | mid-only |
 | `…-1900-daily-low` | `cron(0 19 * * ? *)` | 12pm | daily (all 7) | full | claude-haiku-4-5 | low-only |
 | `…-sun0900-weekly-gated-reverify` | `cron(0 9 ? * SUN *)` | 2am | Sun only | full | claude-haiku-4-5 | gated-reverify |
 
-> **Tier-split cadence (config#1760, 2026-07-05):** three disjoint queues — Haiku
-> on `complexity:low`, Sonnet on `complexity:mid` (+ unlabeled), Opus on
-> `complexity:high`. Requires `alpha-engine-config` driver filters (#1761) on
+> ¹ config#2409 (2026-07-13): the high-only slot's MODEL moved off Opus onto
+> Sonnet; the Scheduler rule NAME is left as `-opus-high` deliberately — a
+> rename would require an operator-run `--bootstrap` (see the warning above)
+> purely for a cosmetic AWS identifier, which isn't worth the live-schedule
+> churn. Rename opportunistically the next time this cadence table changes
+> for a substantive reason.
+
+> **Tier-split cadence (config#1760/#2409):** three disjoint queues — Haiku
+> on `complexity:low`, Sonnet on `complexity:mid` (+ unlabeled) and on
+> `complexity:high` (moved off Opus 2026-07-13 — see config#2409; the split
+> is queue-isolation/dedicated-attention, not a model-capability step up).
+> Requires `alpha-engine-config` driver filters (#1761) on
 > the box's cloned `main` before `--bootstrap` deploys these schedules live.
 
 > **Sat-skip removed 2026-07-02, uniform 3x/day/7-days, no exceptions.** The
@@ -83,15 +92,15 @@ day-of-week year)` with `?` for an unspecified day field.
 ## Schedule-input routing
 
 Each schedule passes a JSON input, e.g. `{"run_mode": "full", "model":
-"claude-opus-4-8", "issue_filter": "high-only", "pr_budget": 100, "schedule": "0 1 * * *"}`.
-The Opus schedule alone carries `pr_budget: 100` (config#1769) — forwarded as
-`GROOM_PR_BUDGET` on the spot box; Haiku/Sonnet stay at the bootstrap default (50).
+"claude-sonnet-5", "issue_filter": "high-only", "pr_budget": 100, "schedule": "0 1 * * *"}`.
+The dedicated high-only schedule alone carries `pr_budget: 100` (config#1769) — forwarded as
+`GROOM_PR_BUDGET` on the spot box; Haiku/mid-Sonnet stay at the bootstrap default (50).
 The Lambda resolves each field (unknown/missing values degrade to a safe
 default — `full` / `claude-sonnet-5` / `default`) and exports `GROOM_MODEL` +
 `GROOM_ISSUE_FILTER` in the SSM bootstrap prelude ahead of invoking
 `groom_spot_bootstrap.sh --mode <run_mode>`, which forwards them into
 `scripts/groom_run.sh` → `scripts/groom_driver.py` (`--issue-filter` selects
-the Sonnet default queue vs. the Opus `complexity:high`-only queue; `--model`
+the mid default queue vs. the dedicated `complexity:high`-only queue; `--model`
 is passed straight to the `claude -p` invocation). `model` is validated against
 a conservative allowlist regex before being embedded in the shell command
 (defense-in-depth — the event is Lambda-config-controlled, not raw user input,

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -38,7 +38,9 @@
 # the groom cadence needing to track it.
 # Off-peak tier-split cadence (2026-07-07): avoid Anthropic Max weekday peak
 # (5–11am PT / 12:00–18:00 UTC PDT) and Brian's interactive hours where possible.
-#   01:00 daily     cron(0 1 * * ? *)         FULL   Opus,   high-only      # 6pm PT, every day
+# config#2409 (2026-07-13): the 01:00 high-only slot moved off Opus onto Sonnet
+# — dedicated queue/budget/off-peak schedule, no longer a distinct model tier.
+#   01:00 daily     cron(0 1 * * ? *)         FULL   Sonnet, high-only      # 6pm PT, every day
 #   07:00 daily     cron(0 7 * * ? *)         FULL   Sonnet, mid-only       # 12am PT, every day
 #   19:00 daily     cron(0 19 * * ? *)        FULL   Haiku,  low-only       # 12pm PT, every day
 #   Sun 09:00       cron(0 9 ? * SUN *)       FULL   Haiku,  gated-reverify # weekly stale-gate lane (config#1891)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -324,7 +324,7 @@ def _resolve_soft_limit_min(event: dict) -> int | None:
 def _resolve_pr_budget(event: dict) -> int | None:
     """Optional per-schedule PR budget override (config#1769).
 
-    Only the Opus high-only schedule sets this today; missing/invalid → None
+    Only the dedicated high-only schedule sets this today; missing/invalid → None
     (groom_spot_bootstrap.sh's GROOM_PR_BUDGET default of 50 applies).
     """
     raw = event.get("pr_budget")
@@ -468,12 +468,25 @@ def _running_tier_instance_ids(tier_tag: str) -> list[str]:
     for a lane is still running when the next trigger re-evaluates the same
     lane. Fail-safe: any API error returns ``[]`` (never blocks a launch on a
     broken check — this guard is an optimization, not a correctness gate,
-    mirroring every other pre-launch gate in this file)."""
-    return spot_dispatch.running_instance_ids(
-        "alpha-engine-groom-spot",
-        {GROOM_TIER_TAG_KEY: tier_tag},
-        region=REGION,
-    )
+    mirroring every other pre-launch gate in this file). config#2267 (lib
+    v0.106.0): ``spot_dispatch.running_instance_ids`` now RAISES
+    ``SpotProbeError`` instead of fail-open-returning ``[]`` itself (closing a
+    different gap for callers that want to KNOW a probe failed); this caller
+    still wants fail-SAFE for launch-blocking purposes, so it catches here and
+    logs loudly instead of silently swallowing."""
+    try:
+        return spot_dispatch.running_instance_ids(
+            "alpha-engine-groom-spot",
+            {GROOM_TIER_TAG_KEY: tier_tag},
+            region=REGION,
+        )
+    except spot_dispatch.SpotProbeError as exc:
+        logger.warning(
+            "concurrency probe failed for tier_tag=%s — failing safe, NOT "
+            "blocking this launch (guard is an optimization, not a "
+            "correctness gate): %s", tier_tag, exc,
+        )
+        return []
 
 
 def _notify_concurrent_skip(tier_tag: str, existing_ids: list[str], schedule_label: str) -> None:
@@ -932,11 +945,11 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge Scheduler handler — launches the groom spot box on cadence.
 
     `event` is the schedule's JSON input, e.g. {"run_mode": "full", "model":
-    "claude-opus-4-8", "issue_filter": "high-only", "schedule": "0 1 * * *"}.
+    "claude-sonnet-5", "issue_filter": "high-only", "schedule": "0 1 * * *"}.
     `model`/`issue_filter` default to the Sonnet mid-tier queue when absent
     (the two pre-existing Sonnet schedules don't set them). `soft_limit_min` is
     a manual-invoke-ONLY bounded-test override — no live schedule sets it.
-    `pr_budget` is set only on the Opus high-only schedule (config#1769).
+    `pr_budget` is set only on the dedicated high-only schedule (config#1769).
     `force_on_demand` (config#1645) is set only by the dispatch Step Function's
     own relaunch loop on its final bounded retry — no live schedule sets it.
     `queue_manifest_key` (config#2152/#2175) marks an explicit operator queue
@@ -1106,7 +1119,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 return {"groom": skip}
             # Launch with the DECIDED bundle + cheapest adequate model — the
             # schedule's model is only the slot default; high never runs
-            # below Opus, and a bundle without high never pays for it.
+            # below its own tier's model, and a bundle without high never pays for it.
             issue_filter = decision.issue_filter
             model = decision.model
             logger.info("demand gate LAUNCH — %s (filter=%s model=%s)",

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -12,5 +12,9 @@ boto3>=1.34.0
 # own (already-fixed) mirrored copy, which is what actually governs on-box
 # enumeration. Mechanical pin-only bump — no behavior change on this Lambda's
 # own code.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.104.0
+# v0.109.0 (config#2409, 2026-07-13) flips TIER_MODELS["high"] claude-opus-4-8
+# -> claude-sonnet-5 — this Lambda picks it up automatically via
+# ge.decide_slot()/decide_trigger()'s SlotDecision.model; no code change here,
+# behavior change only (see test_handler.py updates in this same commit).
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.109.0
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -252,19 +252,20 @@ def test_sweep_run_mode_is_forwarded(monkeypatch):
 
 
 def test_high_only_schedule_forwards_model_and_issue_filter(monkeypatch):
-    # The Opus (6pm PT) schedule's event carries model + issue_filter —
-    # these must reach the box as exported env vars ahead of the bootstrap exec.
+    # The high-only (01:00 UTC / 6pm PT) schedule's event carries model +
+    # issue_filter — these must reach the box as exported env vars ahead of
+    # the bootstrap exec.
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler(
-        {"run_mode": "full", "model": "claude-opus-4-8", "issue_filter": "high-only",
+        {"run_mode": "full", "model": "claude-sonnet-5", "issue_filter": "high-only",
          "schedule": "0 1 * * *"},
         None,
     )
     g = out["groom"]
-    assert g["model"] == "claude-opus-4-8"
+    assert g["model"] == "claude-sonnet-5"
     assert g["issue_filter"] == "high-only"
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert "export GROOM_MODEL=claude-opus-4-8" in cmd
+    assert "export GROOM_MODEL=claude-sonnet-5" in cmd
     assert "export GROOM_ISSUE_FILTER=high-only" in cmd
     assert cmd.index("export GROOM_MODEL") < cmd.index("groom_spot_bootstrap.sh")
 
@@ -274,7 +275,7 @@ def test_high_only_schedule_forwards_pr_budget(monkeypatch):
     out = idx.handler(
         {
             "run_mode": "full",
-            "model": "claude-opus-4-8",
+            "model": "claude-sonnet-5",
             "issue_filter": "high-only",
             "schedule": "0 1 * * *",
             "pr_budget": 100,
@@ -291,7 +292,7 @@ def test_deploy_schedule_high_only_carries_pr_budget():
         Path(__file__).resolve().parent / "deploy.sh"
     ).read_text()
     assert '"pr_budget":100' in deploy_sh or '"pr_budget": 100' in deploy_sh
-    # Haiku/Sonnet schedules must NOT inherit the Opus override.
+    # Haiku/Sonnet-mid schedules must NOT inherit the high-only override.
     low_line = next(
         line for line in deploy_sh.splitlines()
         if "low-only" in line and "SCHED_INPUTS" not in line
@@ -666,10 +667,10 @@ def test_demand_gate_skips_light_queue_with_zero_launch(monkeypatch):
 
 
 def test_demand_gate_bundles_and_downgrades_model(monkeypatch):
-    # Opus slot, no high issues, starving low+mid -> ONE Sonnet run.
+    # high slot, no high issues, starving low+mid -> ONE Sonnet run.
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     _stub_stats(monkeypatch, idx, {"low": 5, "mid": 6, "high": 0})
-    out = idx.handler({"run_mode": "full", "model": "claude-opus-4-8",
+    out = idx.handler({"run_mode": "full", "model": "claude-sonnet-5",
                        "issue_filter": "high-only", "schedule": "0 1 * * *"}, None)
     g = out["groom"]
     assert g["launched"] and g["issue_filter"] == "mid+low"
@@ -758,7 +759,7 @@ def test_symmetric_trigger_brians_8_9_10_launches_three_boxes(monkeypatch):
     g = out["groom"]
     assert g["trigger"] == "demand-all"
     launched = {(l["issue_filter"], l["model"]) for l in g["launches"]}
-    assert launched == {("high-only", "claude-opus-4-8"),
+    assert launched == {("high-only", "claude-sonnet-5"),
                         ("mid-only", "claude-sonnet-5"),
                         ("low-only", "claude-haiku-4-5")}
     cmds = [c["Parameters"]["commands"][0] for c in idx._test_ssm.sent]
@@ -952,7 +953,7 @@ def test_launch_decided_bypasses_pace_gate(monkeypatch):
     monkeypatch.setattr(idx, "datetime", type("D", (), {
         "now": staticmethod(lambda tz=None: fixed_now)}))
     out = idx.handler({
-        "run_mode": "full", "schedule": "0 1 * * *", "model": "claude-opus-4-8",
+        "run_mode": "full", "schedule": "0 1 * * *", "model": "claude-sonnet-5",
         "issue_filter": "high-only", "launch_decided": True,
     }, None)
     assert out["groom"]["launched"] is True

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -99,8 +99,9 @@ _LAMBDA_PIN_EXEMPTIONS = {
         "flow-doctor forum-topic routing (config#1742)",
     ),
     "scheduled-groom-dispatcher": (
-        "v0.104.0",
-        "spot_dispatch + SlotDecision + label-exclude parity (config#2146/2106/2129)",
+        "v0.109.0",
+        "spot_dispatch + SlotDecision + label-exclude parity (config#2146/2106/2129); "
+        "bumped for TIER_MODELS[\"high\"] Opus->Sonnet (config#2409)",
     ),
     "sf-telegram-notifier": (
         "v0.83.0",


### PR DESCRIPTION
## Summary

Cut the `complexity:high` groom tier over from Opus to Sonnet 5. Third leg of
nousergon/nousergon-lib#192 + nousergon/alpha-engine-config#2410 — see
nousergon/alpha-engine-config#2409 for full rationale/risk discussion.

## Changes

- `infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt`: bump
  the `nousergon-lib` pin `v0.104.0` → `v0.109.0` (carries
  `TIER_MODELS["high"]` `claude-opus-4-8` → `claude-sonnet-5`). This pin is
  independent of the root `requirements.txt`/`Dockerfile`/
  `requirements-daily-news.txt` lockstep group (`tests/test_lib_pin_lockstep.py`)
  — no other file in this repo needs to move.
- `test_handler.py`: updated hardcoded `claude-opus-4-8` expectations for
  high-only launches to `claude-sonnet-5`.
- Comment/docstring/README sweep for now-stale "Opus" framing across
  `index.py`, `deploy.sh`, `README.md` (both lambdas), and
  `groom-liveness-probe/test_handler.py`. Deliberately did **NOT** rename the
  live EventBridge Scheduler rule `alpha-engine-scheduled-groom-0100-daily-opus-high`
  — see the README footnote added in this PR: a rename requires an
  operator-run `--bootstrap` for a purely cosmetic AWS identifier, which
  isn't worth the live-schedule churn (and would violate the "PR must be
  deployable via merge button alone" rule, since renaming here wouldn't take
  live effect on merge anyway). Rename opportunistically next time this
  cadence table changes for a substantive reason.

## Bug found + fixed (surfaced by the pin bump, unrelated to TIER_MODELS)

`nousergon-lib` v0.106.0 (config#2267) changed
`spot_dispatch.running_instance_ids()` to **RAISE** `SpotProbeError` on a
degraded EC2 API instead of fail-open-returning `[]`. This Lambda's pin was
frozen at v0.104.0 since before that shipped, so
`_running_tier_instance_ids()`'s own documented contract — *"Fail-safe: any
API error returns `[]`, never blocks a launch on a broken check"* — had
silently gone false: an EC2 `DescribeInstances` hiccup would now crash the
whole Lambda invocation instead of degrading gracefully. Added the missing
`SpotProbeError` catch to restore the documented fail-safe contract (logs
loudly, returns `[]`, does not block the launch).

## Testing

Both lambdas' suites run green against an isolated per-lambda venv
(mirrors `ci.yml`'s own per-lambda `requirements.txt` install):
- `scheduled-groom-dispatcher`: 70/70 (installed the local
  `nousergon-lib` worktree in place of the not-yet-published `v0.109.0` tag,
  since that tag doesn't exist until nousergon-lib#192 merges + publishes).
- `groom-liveness-probe`: 12/12 (pin untouched, comment-only changes).

## Dependency

**DRAFT, `gate:dependency`** — blocked on nousergon/nousergon-lib#192
merging AND publishing to PyPI (the git tag `v0.109.0` this pin points at
doesn't exist until then — this PR's own CI will fail to install until it
does). Will mark ready once verified live.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JAtYBA7WpjYhzjdJ4d2fHM
