### PR TITLE
Wire DynamoDB dedup store for data-collector Flow Doctor alerts

### DIFF
--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -27,8 +27,18 @@ notify:
     subsystem: data_pipeline
     default_root_cause_category: code_bug
 store:
-  type: sqlite
-  path: /tmp/flow_doctor.db
+  # DynamoDB, not local SQLite — dedup cooldowns must survive across
+  # separate process/instance/Lambda invocations, which /tmp SQLite
+  # cannot. Without this, every fresh invocation starts with an empty
+  # dedup store and re-alerts on the same signature (observed 2026-07-13:
+  # 8 duplicate L1-observer quarantine emails for one cell in 2 minutes).
+  # Table provisioned out-of-band (PAY_PER_REQUEST, matches
+  # flow_doctor.storage.dynamodb.DynamoDBStorage.init_schema's schema);
+  # runtime role only needs CRUD, not CreateTable — see
+  # infrastructure/iam/alpha-engine-data-role.json.
+  type: dynamodb
+  table_name: flow-doctor-store
+  region: us-east-1
 dedup_cooldown_minutes: 60
 rate_limits:
   max_alerts_per_day: 10

--- a/infrastructure/iam/alpha-engine-data-role.json
+++ b/infrastructure/iam/alpha-engine-data-role.json
@@ -1,0 +1,43 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3Access",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research",
+        "arn:aws:s3:::alpha-engine-research/*"
+      ]
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Sid": "FlowDoctorDedupStore",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:DescribeTable"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:us-east-1:711398986525:table/flow-doctor-store",
+        "arn:aws:dynamodb:us-east-1:711398986525:table/flow-doctor-store/index/*"
+      ]
+    }
+  ]
+}

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -59,17 +59,20 @@ def stub_flow_doctor_env(monkeypatch):
 
 @pytest.fixture
 def temp_flow_doctor_yaml(tmp_path):
-    """Write a copy of the production flow-doctor.yaml with store.path
-    redirected into the test's tmp_path. Returns the temp yaml path.
+    """Write a copy of the production flow-doctor.yaml with store forced
+    to a local sqlite file in the test's tmp_path. Returns the temp yaml path.
 
-    The production yaml hardcodes /tmp/flow_doctor.db (Lambda ephemeral
-    convention) which isn't writable in every CI/sandbox env. Tests that
-    actually invoke flow_doctor.init() need a redirectable path.
+    Production uses a shared DynamoDB store (survives across invocations,
+    unlike /tmp SQLite) so dedup cooldowns actually work fleet-wide. Tests
+    that invoke flow_doctor.init() must NOT hit live AWS — they only
+    verify handler-wiring shape, not persistence behavior — so the store
+    is overridden to an isolated sqlite file regardless of the production
+    store type.
     """
     import yaml as yamllib
     with open(REPO_ROOT / "flow-doctor.yaml") as f:
         cfg = yamllib.safe_load(f)
-    cfg["store"]["path"] = str(tmp_path / "flow_doctor_test.db")
+    cfg["store"] = {"type": "sqlite", "path": str(tmp_path / "flow_doctor_test.db")}
     yaml_path = tmp_path / "flow-doctor.yaml"
     with open(yaml_path, "w") as f:
         yamllib.safe_dump(cfg, f)


### PR DESCRIPTION
## Summary

- Fixes 8 duplicate `[Flow Doctor] [ERROR] data-collector` emails received 2026-07-13 for a single L1 cross-source-observer quarantine (SPY, 2026-07-02) within a 2-minute window.
- Root cause: `flow-doctor.yaml`'s dedup store was local `/tmp` SQLite, which cannot survive across separate process/EC2-instance/Lambda invocations — every fresh invocation started with an empty dedup store and re-alerted on the same signature, defeating the configured 60-minute cooldown.
- Repoints the store at `flow_doctor.storage.dynamodb.DynamoDBStorage` (already shipped in the `flow-doctor` PyPI package, never wired up anywhere in the fleet) against a newly-provisioned shared `flow-doctor-store` DynamoDB table.
- Codifies `alpha-engine-data-role`'s IAM into `infrastructure/iam/alpha-engine-data-role.json` (previously applied ad hoc via `aws iam put-role-policy`, untracked by this repo's existing single-writer IAM pattern) and grants scoped DynamoDB CRUD (no CreateTable/DeleteTable — least privilege, table provisioned out-of-band).
- Fixes `tests/test_flow_doctor_wiring.py`'s `temp_flow_doctor_yaml` fixture, which assumed a sqlite-only `store.path` shape — now force-overrides to an isolated sqlite file for tests regardless of production store type, so wiring tests never touch live AWS.

## Live-applied in this session (deployable via merge button alone)

- `flow-doctor-store` DynamoDB table created (us-east-1, PAY_PER_REQUEST) — **live**.
- `alpha-engine-data-role`'s IAM policy applied — **live**. Old ad-hoc `alpha-engine-data-policy` inline policy removed (superseded).
- Nothing is deferred to a post-merge manual step; merging just makes the already-provisioned infra the one the code path uses.

## Test plan

- [x] `pytest tests/test_flow_doctor_wiring.py -v` — 15/15 passed
- [x] Full suite: `pytest tests/ -x -q` — 3039 passed, 7 skipped, 0 failed
- [x] Live smoke test: two independently-constructed `FlowDoctor` clients against the real `flow-doctor-store` table, identical message — second `.report()` call returned `None` (deduped), confirming the exact failure mode is fixed. Smoke-test rows deleted from the live table afterward.

Closes nousergon/alpha-engine-config#2417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
