### PR TITLE
Fix sf-telegram-notifier IAM resource pattern to cover ne-* pipelines

### DIFF
--- a/infrastructure/lambdas/sf-telegram-notifier/iam-policy.json
+++ b/infrastructure/lambdas/sf-telegram-notifier/iam-policy.json
@@ -27,7 +27,10 @@
       "Sid": "DescribeExecutionForFailureCause",
       "Effect": "Allow",
       "Action": ["states:DescribeExecution", "states:GetExecutionHistory"],
-      "Resource": "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-*:*"
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-*:*",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-*:*"
+      ]
     },
     {
       "Sid": "ArtifactAttestationRead",


### PR DESCRIPTION
## Summary
- `DescribeExecutionForFailureCause` in `infrastructure/lambdas/sf-telegram-notifier/iam-policy.json` only matched `arn:...:execution:alpha-engine-*:*`
- The three trading pipelines were renamed to `ne-weekly-freshness-pipeline` / `ne-preopen-trading-pipeline` / `ne-postclose-trading-pipeline` (config#1381), so the notifier has been unable to fetch `states:GetExecutionHistory`/`states:DescribeExecution` failure detail for **any** trading-pipeline failure since that rename
- Confirmed live 2026-07-13: `AccessDeniedException` on `GetExecutionHistory` for `ne-postclose-trading-pipeline:eod-2026-07-13-...`
- Live IAM policy already patched via `aws iam put-role-policy` to unblock immediately; this PR lands the identical change in the tracked source of truth so the next `deploy.sh` run doesn't drift back

Closes alpha-engine-config-I2466

## Test plan
- [x] `python -m pytest infrastructure/lambdas/sf-telegram-notifier/test_handler.py -q` — 21 passed
- [x] Verified live IAM policy matches this file's content (`aws iam get-role-policy --role-name alpha-engine-sf-telegram-notifier-role --policy-name alpha-engine-sf-telegram-notifier-policy`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>