### PR TITLE
Add ThinkTankCoverage state to Saturday SF (observe-mode, after Scanner)

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -11,6 +11,7 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-rationale-clustering*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-aggregate-costs*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-scanner*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-thinktank*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-concordance*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-replay-counterfactual*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -923,6 +923,43 @@
                 }
               ],
               "ResultPath": "$.scanner_result",
+              "Next": "ThinkTankCoverage"
+            },
+            "ThinkTankCoverage": {
+              "Type": "Task",
+              "Comment": "Think Tank observe-mode coverage fill (alpha-engine-config-I2467). Invokes the thinktank Lambda in sf_cover mode to fill top-60 coverage gaps (new theses for uncovered names + stalest refresh). Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-thinktank:live",
+                "Payload": {
+                  "mode": "sf_cover",
+                  "sf_cover_target": 60,
+                  "sf_cover_ceiling": 60,
+                  "run_date.$": "$.run_date"
+                }
+              },
+              "TimeoutSeconds": 900,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException",
+                    "States.TaskFailed"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": ["States.ALL"],
+                  "Comment": "Observe-mode non-blocking: think tank failure must NOT halt the pipeline. Routes forward to CheckSkipRAGIngestion.",
+                  "Next": "CheckSkipRAGIngestion",
+                  "ResultPath": "$.thinktank_error"
+                }
+              ],
+              "ResultPath": "$.thinktank_result",
               "Next": "CheckSkipRAGIngestion"
             },
             "CheckSkipRAGIngestion": {

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -79,6 +79,7 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # config#1824 weekly run-day gate (pure calendar; mirrors LibPinDriftCheck shape).
     "WeeklyRunDayGate": frozenset({"action"}),
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),
+    "ThinkTankCoverage": frozenset({"mode", "sf_cover_target", "sf_cover_ceiling", "run_date.$"}),
     "RegimeSubstrate": frozenset({"action.$"}),
     "RegimeRetrospectiveEval": frozenset({"action.$"}),
     "Research": frozenset({"dry_run_llm.$", "force", "weekly_run", "skip_dry_run_gate"}),
@@ -489,17 +490,6 @@ class TestEODSFTopLevelFieldsClosed:
             "substrate_check_error",
             "substrate_check_poll",
             "substrate_check_result",
-            # config#2326: poll-to-terminal-status honesty fix (ports
-            # config#2276's weekly-SF pattern) — SubstrateHealthCheckDegraded
-            # sets $.health_check_degraded (SF-controlled boolean, shared name
-            # with the weekly SF's flag though the two SFs have no notifier in
-            # common); PublishSubstrateHealthCheckDegradedAlert (the EOD SF's
-            # dedicated best-effort degraded-alert notifier, since EOD has no
-            # success-path notifier to thread the flag into) emits its own
-            # ResultPath + fail-open Catch ResultPath.
-            "health_check_degraded",
-            "substrate_health_check_degraded_notify",
-            "substrate_health_check_degraded_notify_error",
             "trading_instance_id",
             # L274 SF MutualExclusionGuard (2026-05-27) — CheckMutexRole
             # reads $.pipeline_role; AcquireMutex emits $.mutex_result on
@@ -539,6 +529,10 @@ class TestEODSFTopLevelFieldsClosed:
             "skip_refresh_executor_deploy",
             "refresh_executor_deploy_result",
             "refresh_executor_deploy_poll",
+            # substrate health check (EOD SF) — fail-notify paths
+            "health_check_degraded",
+            "substrate_health_check_degraded_notify",
+            "substrate_health_check_degraded_notify_error",
         }
     )
 

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -60,7 +60,7 @@ _BRANCH_A_STATES = {
     # RegimeRetrospectiveEval chain was relocated FROM top level INTO
     # Branch A's head (Scanner is Branch A's StartAt) so PredictorTraining
     # (Branch B) forks parallel to it directly after DataPhase1.
-    "Scanner", "CheckSkipRAGIngestion", "RAGIngestion",
+    "Scanner", "ThinkTankCoverage", "CheckSkipRAGIngestion", "RAGIngestion",
     "WaitForRAGIngestion", "CheckRAGIngestionStatus", "RAGIngestionWait",
     "RAGIngestionRetryGate", "RAGIngestionReissue", "ExtractRAGIngestionError",
     "CheckSkipRegimeSubstrate", "RegimeSubstrate",
@@ -840,7 +840,7 @@ class TestInboundRewireAndDownstreamUnchanged:
         (and its skip-gate + non-blocking Catch) continue to
         CheckSkipResearch IN-BRANCH — never the parent Parallel (invalid
         branch→parent) nor top-level HandleFailure (cross-branch cancel)."""
-        assert branch_a["Scanner"]["Next"] == "CheckSkipRAGIngestion"
+        assert branch_a["Scanner"]["Next"] == "ThinkTankCoverage"
         assert (
             branch_a["RegimeRetrospectiveEval"]["Next"] == "CheckSkipResearch"
         )

--- a/tests/test_sf_scanner_wiring.py
+++ b/tests/test_sf_scanner_wiring.py
@@ -171,8 +171,8 @@ class TestEdges:
         par = sf["States"]["ResearchPredictorParallel"]
         assert par["Branches"][0]["StartAt"] == "Scanner"
 
-    def test_scanner_success_routes_to_check_skip_rag(self, states):
-        assert states["Scanner"]["Next"] == "CheckSkipRAGIngestion"
+    def test_scanner_success_routes_to_thinktank_coverage(self, states):
+        assert states["Scanner"]["Next"] == "ThinkTankCoverage"
 
 
 # ── Result paths (state-merge contract) ───────────────────────────────────


### PR DESCRIPTION
Adds a new `ThinkTankCoverage` Lambda state to Branch A of `ResearchPredictorParallel` in the Saturday SF, running after Scanner.

- Invokes `alpha-engine-research-thinktank:live` with `mode: sf_cover` to fill top-60 coverage gaps
- Non-blocking Catch routes forward to CheckSkipRAGIngestion on failure (observe-mode)
- Updates wiring tests to reflect Scanner `Next` change and new state in Branch A state set

Merge order: research PR first (defines the Lambda handler), then data PR (wires it into the SF).