### PR TITLE
fix(data): bound _fetch_yfinance_closes to the requested date (config#2475)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -2221,12 +2221,31 @@ def _fetch_yfinance_closes(
     ``collectors/prices.py`` (nousergon-data#455) and
     ``collectors/metron_market_data.py`` (config#1029). The replacement
     recording surface is the aggregated ``log_yf_coverage`` call below.
+
+    Bounded to the close **on-or-before** ``date_str`` (mirrors
+    ``_fetch_fred_closes``'s ``observation_end=date_str`` semantics), NOT
+    ``period="5d"`` anchored to wall-clock now. The unbounded form always
+    returned yfinance's most-recent bar regardless of the requested date —
+    the identical defect fixed in ``_fetch_fred_window``/``_fetch_fred_closes``
+    (2026-05, L4492) for FRED, which "clobbered every historical date in the
+    rolling window with today's latest close." This function had the same
+    bug: every historical (non-today) caller — chiefly the L1 cross-source
+    observer's per-window-date SPY check (``sources/cross_source_gate.py``,
+    config#1277) — got today's yfinance close mislabeled with the requested
+    historical date, producing a false QUARANTINE on nearly every date in the
+    56-business-day window (alpha-engine-config#2475).
     """
     try:
         import yfinance as yf
     except ImportError:
         logger.warning("yfinance not available for daily closes fallback")
         return 0
+
+    requested = datetime.strptime(date_str, "%Y-%m-%d").date()
+    # 9 calendar days comfortably spans any weekend/holiday gap back to the
+    # nearest prior trading day, matching FRED's on-or-before resolution.
+    window_start = requested - timedelta(days=9)
+    window_end = requested + timedelta(days=1)  # yfinance ``end`` is exclusive
 
     count = 0
     covered: set[str] = set()
@@ -2240,7 +2259,8 @@ def _fetch_yfinance_closes(
             tickers_arg = batch[0] if len(batch) == 1 else batch
             raw = yf.download(
                 tickers=tickers_arg,
-                period="5d",
+                start=window_start.isoformat(),
+                end=window_end.isoformat(),
                 interval="1d",
                 auto_adjust=False,
                 progress=False,
@@ -2256,6 +2276,9 @@ def _fetch_yfinance_closes(
                     if df.index.tz is not None:
                         df.index = df.index.tz_convert("UTC").tz_localize(None)
                     df = df.dropna(subset=["Close"])
+                    # On-or-before ``date_str`` — a batched/backfilled fetch
+                    # must never resolve to a bar AFTER the requested date.
+                    df = df[df.index <= pd.Timestamp(requested)]
                     if df.empty:
                         continue
 

--- a/tests/test_daily_closes_vwap.py
+++ b/tests/test_daily_closes_vwap.py
@@ -104,3 +104,64 @@ def test_yfinance_fallback_multi_ticker_vwap_none():
     assert count == 2
     for row in records:
         assert row["VWAP"] is None, f"VWAP should be None (not proxy) for {row['ticker']}"
+
+
+def test_yfinance_fetch_returns_requested_date_not_latest_bar():
+    """Regression for alpha-engine-config#2475.
+
+    ``_fetch_yfinance_closes`` must return the close ON-OR-BEFORE the
+    requested ``date_str``, not yfinance's most-recent bar. The old
+    ``period="5d"`` + ``iloc[-1]`` implementation always returned the latest
+    available close regardless of what date was requested — the same defect
+    already fixed for FRED in ``_fetch_fred_closes``/``_fetch_fred_window``
+    (2026-05, L4492). This mislabeled a later close with an earlier date,
+    which made the L1 cross-source observer (config#1277) falsely QUARANTINE
+    SPY on nearly every historical date in its rolling window.
+    """
+    records = []
+    fake_frame = _make_yf_frame([
+        ("2026-06-29", 100.0, 101.0, 99.0, 100.5, 1_000_000),
+        ("2026-06-30", 102.0, 103.0, 101.0, 102.5, 1_200_000),
+        ("2026-07-01", 200.0, 201.0, 199.0, 200.5, 900_000),  # a later "latest" bar
+    ])
+
+    mock_yf = MagicMock()
+    mock_yf.download.return_value = fake_frame
+
+    with patch.dict("sys.modules", {"yfinance": mock_yf}):
+        count = daily_closes._fetch_yfinance_closes(["SPY"], "2026-06-30", records)
+
+    assert count == 1
+    assert records[0]["Close"] == 102.5, (
+        "must return the close for the REQUESTED date (2026-06-30), not "
+        "yfinance's latest available bar (2026-07-01 close=200.5)"
+    )
+
+    call_kwargs = mock_yf.download.call_args.kwargs
+    assert "period" not in call_kwargs, (
+        "must not use period= (anchored to wall-clock now, ignores the "
+        "requested date) — use a start/end window bounded by date_str"
+    )
+    assert call_kwargs.get("start") == "2026-06-21"
+    assert call_kwargs.get("end") == "2026-07-01"
+
+
+def test_yfinance_fetch_falls_back_to_prior_trading_day():
+    """A requested date with no exact yfinance bar (weekend/holiday) resolves
+    to the nearest prior trading day, mirroring FRED's on-or-before semantics
+    — not skipped, and not a later bar."""
+    records = []
+    fake_frame = _make_yf_frame([
+        ("2026-07-02", 300.0, 301.0, 299.0, 300.5, 1_000_000),  # Thursday
+        ("2026-07-06", 305.0, 306.0, 304.0, 305.5, 1_100_000),  # next Monday
+    ])
+
+    mock_yf = MagicMock()
+    mock_yf.download.return_value = fake_frame
+
+    with patch.dict("sys.modules", {"yfinance": mock_yf}):
+        # 2026-07-04 (Saturday) has no bar — should resolve to 07-02, not 07-06.
+        count = daily_closes._fetch_yfinance_closes(["SPY"], "2026-07-04", records)
+
+    assert count == 1
+    assert records[0]["Close"] == 300.5


### PR DESCRIPTION
## Summary

- `_fetch_yfinance_closes` (`collectors/daily_closes.py`) ignored its `date_str` parameter and always returned yfinance's most-recent close (`period="5d"` + `iloc[-1]`), mislabeled with whatever date was actually requested — the same defect already fixed for FRED in `_fetch_fred_closes`/`_fetch_fred_window` (2026-05, L4492), never applied to yfinance.
- This made the L1 cross-source observer (`alpha-engine-config#1277`) falsely QUARANTINE SPY on nearly every historical date in its 56-business-day rolling window, forever — 9 duplicate `flow-doctor:fix` issues filed today alone (`nousergon-data#744-746`, `#785-787`, `#793-795`).
- Verified stored `Close` values are **not** corrupted — `cross_source_observer.annotate_records` never overwrites the priority-coalesced value, only the (false) observer annotation columns. The real cost is a corrupted false-quarantine rate feeding `config#1277`'s Aug-11 Option B/C enforcement decision.
- Fix bounds the yfinance fetch to a window ending at `date_str` and selects the close on-or-before that date, mirroring the existing FRED on-or-before pattern.

Closes nousergon/alpha-engine-config#2475

## Test plan

- [x] Full local suite: `3043 passed, 7 skipped, 0 failed`
- [x] New regression tests: `test_yfinance_fetch_returns_requested_date_not_latest_bar`, `test_yfinance_fetch_falls_back_to_prior_trading_day`
- [x] Existing yfinance/VWAP tests unmodified in behavior, still pass
