### PR TITLE
fix(groom): wire dispatcher pace gate to usage_pacing.json SSoT (config-I2461)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/README.md
@@ -115,20 +115,29 @@ but injection protection is cheap).
   `Errors` metric during bootstrap-ops to page on it.)
 - **Kill-switch**: set the Lambda env `GROOM_DISPATCH_ENABLED=false` to disable
   without deleting the Scheduler rules.
-- **Pre-boot pace gate (2026-07-04)**: before launching the spot box, compares
-  reset-aligned weekly Claude usage (WET) against how much of the current
-  weekly window has elapsed (`krepis.usage_pacing.pace_check` — same gate
+- **Pre-boot pace gate (2026-07-04; ceiling wired to the SSoT config-I2461,
+  2026-07-14)**: before launching the spot box, compares reset-aligned weekly
+  Claude usage (WET) against how much of the current weekly window has
+  elapsed (`krepis.usage_pacing.pace_check` — same gate
   `alpha-engine-config/scripts/groom_budget.py` runs on-box); a launch running
   ahead of pace is skipped entirely (`launched: false, reason: "pace_gate_skip"`,
   routed through the existing `CheckLaunched`→`GroomSkipped` Step Function
   branch, no SF changes needed) **and sends its own Telegram ping** — the only
   place a pre-boot skip is ever visible, since a run that never boots has no
   on-box `groom_run.sh` to notify the way the on-box budget-gate skip does.
-  Fail-safe on any S3/read error — never blocks a scheduled groom (and never
-  pings on a fail-safe pass-through either). `GROOM_PACE_GATE_ENABLED=false`
-  disables just this gate (independent of `GROOM_DISPATCH_ENABLED`);
-  `GROOM_WEEKLY_WET_CEILING` / `CCUSAGE_BUCKET` override the calibrated
-  defaults.
+  The ceiling/anchor are read LIVE from `s3://alpha-engine-research/config/
+  usage_pacing.json` (`_load_pacing_config()`) — the SAME SSoT `groom_budget.py`
+  and the `usage-pace-alert` Lambda already read, recalibrated daily by
+  `alpha-engine-config/scripts/record_usage_pacing_sample.py`. `GROOM_WEEKLY_
+  WET_CEILING` / the `WEEKLY_RESET_ANCHOR` constant are FALLBACK ONLY, used
+  iff that S3 read fails (previously this Lambda was permanently pinned to
+  the 850M literal regardless of recalibration — config-I2461 — which
+  false-tripped the gate on every trigger once the SSoT was recalibrated
+  upward). Fail-safe on any S3/read error — never blocks a scheduled groom
+  (and never pings on a fail-safe pass-through either). `GROOM_PACE_GATE_
+  ENABLED=false` disables just this gate (independent of
+  `GROOM_DISPATCH_ENABLED`); `CCUSAGE_BUCKET` / `PACING_CONFIG_KEY` override
+  the S3 location.
 - **Narrow IAM**: the box reads its own run secrets from SSM via its own
   instance profile — this Lambda needs none of those. Its own IAM grants are
   EC2 launch/terminate, `iam:PassRole` for the executor role, SSM

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -106,16 +106,24 @@ _RESEARCH_BUCKET = "alpha-engine-research"
 # Kill-switch independent of GROOM_DISPATCH_ENABLED — lets ops disable JUST the
 # pace gate (e.g. during a known burst) without touching the dispatch trigger.
 PACE_GATE_ENABLED = os.environ.get("GROOM_PACE_GATE_ENABLED", "true").lower() == "true"
-# Calibrated 2026-07-08 — MUST track alpha-engine-config/scripts/groom_budget.py's
-# WEEKLY_WET_CEILING; re-calibrate both together against /usage every few days.
+# FALLBACK ONLY (config-I2461) — used iff the S3 SSoT read below fails. The
+# live ceiling/anchor come from ``s3://alpha-engine-research/config/usage_pacing.json``
+# (``_load_pacing_config``), the SAME object ``groom_budget.py``'s
+# ``read_pacing_config()`` and the ``usage-pace-alert`` Lambda's
+# ``_load_pacing_config()`` already read — this Lambda was, until now, the one
+# consumer still pinned to this literal/env-var regardless of recalibration,
+# which silently diverged from the SSoT and false-tripped the pace gate.
 WEEKLY_WET_CEILING = int(os.environ.get("GROOM_WEEKLY_WET_CEILING", "850000000"))
 _PT = ZoneInfo("America/Los_Angeles")
-# MUST match groom_budget.py's WEEKLY_RESET_ANCHOR/WEEKLY_PERIOD exactly — both
-# derive the SAME reset-aligned window from one observed reset instant.
+# FALLBACK ONLY — same S3-read-failure posture as WEEKLY_WET_CEILING above.
 WEEKLY_RESET_ANCHOR = datetime(2026, 7, 12, 21, 0)   # PT, naive — Sunday 9pm PT
 WEEKLY_PERIOD = timedelta(days=7)
 CCUSAGE_BUCKET = os.environ.get("CCUSAGE_BUCKET", "alpha-engine-research")
 CCUSAGE_PREFIX = "claude_code_usage/"
+# SSoT (config#2043) — written by alpha-engine-config's set_usage_pacing_config.py,
+# also read by that repo's groom_budget.py, the usage-pace-alert Lambda, and
+# alpha-engine-dashboard view 36. See _load_pacing_config().
+PACING_CONFIG_KEY = os.environ.get("PACING_CONFIG_KEY", "config/usage_pacing.json")
 # Self-expiring operator override — MUST track groom_budget.py::OVERRIDE_UNTIL_PARAM.
 OVERRIDE_UNTIL_PARAM = "/alpha-engine/groom/dynamic_budget_override_until"
 
@@ -208,6 +216,21 @@ def _read_weekly_wet(window_start: datetime) -> float:
     return total
 
 
+def _load_pacing_config() -> "tuple[float, datetime]":
+    """(weekly_wet_ceiling, weekly_reset_anchor_pt) from the SSoT S3 object
+    (config-I2461). RAISES on any read/parse failure — callers must catch and
+    fall back to WEEKLY_WET_CEILING/WEEKLY_RESET_ANCHOR (this function does NOT
+    fall back itself, mirroring groom_budget.py::read_pacing_config and the
+    usage-pace-alert Lambda's ``_load_pacing_config``, both of which read this
+    SAME object)."""
+    s3 = boto3.client("s3", region_name=REGION)
+    obj = s3.get_object(Bucket=CCUSAGE_BUCKET, Key=PACING_CONFIG_KEY)
+    doc = json.loads(obj["Body"].read())
+    ceiling = float(doc["weekly_wet_ceiling"])
+    anchor = datetime.fromisoformat(doc["weekly_reset_anchor_pt"])
+    return ceiling, anchor
+
+
 def _parse_override_until(raw: str) -> "datetime | None":
     """PT-naive datetime from the SSM value; None if blank/unparseable."""
     raw = (raw or "").strip()
@@ -246,16 +269,28 @@ def _pace_gate_status() -> dict:
                 "override_until": override_until.isoformat(),
                 "reason": "operator override active — pace gate suspended",
             }
-        window_start, _next_reset = reset_window(now_pt, WEEKLY_RESET_ANCHOR, WEEKLY_PERIOD)
+
+        try:
+            ceiling, anchor = _load_pacing_config()
+            ceiling_source = "ssot"
+        except Exception as e:  # noqa: BLE001 — config-I2461 fallback path
+            ceiling, anchor = WEEKLY_WET_CEILING, WEEKLY_RESET_ANCHOR
+            ceiling_source = f"fallback ({type(e).__name__})"
+            logger.warning("pacing SSoT read failed, using fallback ceiling %.0f: %s: %s",
+                           ceiling, type(e).__name__, e)
+
+        window_start, _next_reset = reset_window(now_pt, anchor, WEEKLY_PERIOD)
         wet = _read_weekly_wet(window_start)
-        used_frac = wet / WEEKLY_WET_CEILING if WEEKLY_WET_CEILING else 0.0
-        status = pace_check(used_frac, now_pt, WEEKLY_RESET_ANCHOR, WEEKLY_PERIOD)
+        used_frac = wet / ceiling if ceiling else 0.0
+        status = pace_check(used_frac, now_pt, anchor, WEEKLY_PERIOD)
         return {
             "exceeded": status.exceeded,
             "used_frac": round(status.used_frac, 4),
             "elapsed_frac": round(status.elapsed_frac, 4),
             "overrun": round(status.overrun, 4),
             "wet": round(wet, 1),
+            "ceiling": ceiling,
+            "ceiling_source": ceiling_source,
         }
     except Exception as e:  # noqa: BLE001 — fail-safe: never block a scheduled groom
         logger.warning("pace gate check failed (non-fatal, launching anyway): %s: %s",

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -409,6 +409,82 @@ def test_pace_gate_fails_safe_and_still_launches_on_s3_error(monkeypatch):
     assert notified == []  # fail-safe path never trips (exceeded=False), no ping
 
 
+# ── SSoT ceiling wiring (config-I2461) ──────────────────────────────────────
+def _pacing_doc(ceiling: float, anchor_iso: str = "2026-07-12T21:00:00") -> bytes:
+    import json
+    return json.dumps({
+        "schema_version": 2, "weekly_wet_ceiling": ceiling,
+        "weekly_reset_anchor_pt": anchor_iso,
+    }).encode()
+
+
+def test_pace_gate_reads_ceiling_from_ssot_not_hardcoded_fallback(monkeypatch):
+    # Real-world regression (2026-07-13/14): the SSoT was recalibrated to
+    # ~2.06B WET, but this Lambda stayed pinned to the 850M literal and
+    # false-tripped pace_gate_skip on every trigger. Seed a WET level that
+    # is UNDER pace against the recalibrated SSoT ceiling but would be WAY
+    # over pace against the stale 850M fallback (208.6M/850M = 24.5% used
+    # at only 16% elapsed — reproduces the live config-I2461 numbers) —
+    # asserting launch proves the ceiling came from the SSoT, not the fallback.
+    wet = 208_628_197.0
+    idx = _load(
+        monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        s3_objects={
+            "claude_code_usage/groom/2026-07-14.json": _wet_doc(wet),
+            "config/usage_pacing.json": _pacing_doc(2_055_816_944.44),
+        },
+    )
+    fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(hours=27)  # ~16% elapsed
+    # This test's own _load_pacing_config() call needs fromisoformat — unlike
+    # the other pace-gate tests, which never reach that code path when the
+    # SSoT object is absent (fallback raises before touching datetime again).
+    monkeypatch.setattr(idx, "datetime", type("D", (), {
+        "now": staticmethod(lambda tz=None: fixed_now),
+        "fromisoformat": staticmethod(idx.datetime.fromisoformat)}))
+    notified = _spy_notify(monkeypatch, idx)
+    out = idx.handler({"run_mode": "full", "schedule": "0 7 * * *"}, None)
+    assert out["groom"]["launched"] is True
+    assert notified == []
+
+
+def test_pace_gate_falls_back_to_constant_when_ssot_object_missing(monkeypatch):
+    # No "config/usage_pacing.json" object seeded -> _load_pacing_config()
+    # raises (KeyError on the fake S3's dict lookup) -> falls back to the
+    # WEEKLY_WET_CEILING module constant, same behavior as before config-I2461.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"},
+                s3_objects={"claude_code_usage/groom/2026-07-13.json":
+                            _wet_doc(0.5 * 1_140_000_000)})
+    fixed_now = idx.WEEKLY_RESET_ANCHOR + idx.timedelta(days=1)
+    monkeypatch.setattr(idx, "datetime", type("D", (), {
+        "now": staticmethod(lambda tz=None: fixed_now)}))
+    out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
+    assert out["groom"]["launched"] is False
+    assert out["groom"]["reason"] == "pace_gate_skip"
+
+
+def test_pacing_config_schema_contract_matches_shared_ssot_shape(monkeypatch):
+    # config-I2461 requirement #2: this Lambda and alpha-engine-config's
+    # groom_budget.py::read_pacing_config() / usage-pace-alert's
+    # _load_pacing_config() must all parse the IDENTICAL SSoT document shape
+    # (schema_version, weekly_wet_ceiling, weekly_reset_anchor_pt) into the
+    # SAME (ceiling, anchor) values — a schema drift in any one consumer's
+    # field names/types would silently diverge `used_frac` across consumers.
+    # This fixture is the literal live SSoT shape observed 2026-07-13.
+    idx = _load(monkeypatch, s3_objects={
+        "config/usage_pacing.json": json.dumps({
+            "schema_version": 2,
+            "weekly_wet_ceiling": 2055816944.4444444,
+            "weekly_reset_anchor_pt": "2026-07-12T21:00:00",
+            "calibrated_date": "2026-07-13",
+            "calibration_basis": "daily calibration sample",
+            "fit_method": "raw", "n_samples": 1, "cv": None, "converged": False,
+        }).encode(),
+    })
+    ceiling, anchor = idx._load_pacing_config()
+    assert ceiling == 2055816944.4444444
+    assert anchor == idx.datetime(2026, 7, 12, 21, 0)
+
+
 def test_gated_reverify_schedule_forwards_filter(monkeypatch):
     # config#1891 Sunday lane: "gated-reverify" must pass validation — it was
     # missing from _VALID_ISSUE_FILTERS (PR #681 added only the schedule), so


### PR DESCRIPTION
## Summary
- `scheduled-groom-dispatcher`'s pre-boot pace gate was permanently pinned to a hardcoded `850000000` WET ceiling, never reading `s3://alpha-engine-research/config/usage_pacing.json` — the SSoT `groom_budget.py` and the `usage-pace-alert` Lambda already read.
- Once the SSoT was recalibrated to ~2.06B WET (2026-07-13), the stale 850M fallback made every trigger since 2026-07-13 19:00 UTC compute a wildly inflated `used_frac` and false-trip `pace_gate_skip` — **no backlog groom tier launched for 3 consecutive overnight cycles** (19:00 UTC 7/13, 01:00 UTC 7/14, 07:00 UTC 7/14), confirmed via the live Step Function decision payloads.
- Fix: `_load_pacing_config()` reads `weekly_wet_ceiling`/`weekly_reset_anchor_pt` live from the S3 SSoT; `GROOM_WEEKLY_WET_CEILING` env var / `WEEKLY_RESET_ANCHOR` constant are now FALLBACK ONLY, used iff the S3 read genuinely fails — preserving the existing fail-safe posture.

Closes nousergon/alpha-engine-config#2461.

## Test plan
- [x] `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --dry-run` — preflight `run_handler_tests.sh` gate: 73 passed (72 pre-existing unchanged + 1 new SSoT-wiring test + 2 supporting tests: fallback-when-SSoT-missing, schema-contract).
- [x] New regression test reproduces the exact live false-trip numbers (208.6M WET / 850M fallback = 24.5% used vs 16% elapsed at ~16% into the window) and asserts launch succeeds once the ceiling comes from the SSoT instead.
- [x] Schema-contract test pins the shared SSoT document shape against the literal live object captured 2026-07-13, so a future field/type drift in any one of the three consumers is caught here.
- [ ] Operator: as an immediate mitigation while this deploys, the pace gate has been suspended fleet-wide via the existing self-expiring `/alpha-engine/groom/dynamic_budget_override_until` SSM override (set through 2026-07-17). No action needed to merge/deploy this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)