### PR TITLE
feat(sf): bump ThinkTankCoverage sf_cover_target/ceiling 60 -> 150

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -927,14 +927,14 @@
             },
             "ThinkTankCoverage": {
               "Type": "Task",
-              "Comment": "Think Tank observe-mode coverage fill (alpha-engine-config-I2467). Invokes the thinktank Lambda in sf_cover mode to fill top-60 coverage gaps (new theses for uncovered names + stalest refresh). Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step.",
+              "Comment": "Think Tank observe-mode coverage fill (alpha-engine-config-I2467). Invokes the thinktank Lambda in sf_cover mode to fill top-150 coverage gaps (new theses for uncovered names + stalest refresh) — the entire rank_ceiling universe, in one weekly run (2026-07-14 cadence split: the non-Saturday EventBridge 'maintenance' run no longer does intake at all, since the universe board this state's Scanner predecessor produces is itself Saturday-only; this state is now the SOLE coverage-growth/refresh owner). Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-thinktank:live",
                 "Payload": {
                   "mode": "sf_cover",
-                  "sf_cover_target": 60,
-                  "sf_cover_ceiling": 60,
+                  "sf_cover_target": 150,
+                  "sf_cover_ceiling": 150,
                   "run_date.$": "$.run_date"
                 }
               },


### PR DESCRIPTION
## Summary

Part of the 2026-07-14 SOTA cadence split for the think-tank pipeline (follow-up to the ZDR incident, alpha-engine-config-I2487).

Saturday's `ThinkTankCoverage` step becomes the SOLE coverage-growth and staleness-refresh owner for the think-tank Lambda — the companion crucible-research PR retires the weekday EventBridge rule's intake entirely, since the universe board this state's Scanner predecessor produces is itself Saturday-only. Bumping `sf_cover_target`/`sf_cover_ceiling` to the full `rank_ceiling=150` (was 60) lets one weekly run cover the entire universe rather than the top-60 slice the old daily 5/day steady-state was slowly building toward.

Companion PRs:
- alpha-engine-config: `daily_new_names` → 0
- crucible-research: schedule Mon/Wed/Fri + handler docstring

## Test plan

- [x] `test_sf_scanner_wiring.py`, `test_sf_research_predictor_parallel_wiring.py`, `test_sf_payload_uniqueness.py`, `test_sf_definition_check_drift.py` — 191 passed locally (payload-key-set pins are unaffected — only the values changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)