### PR TITLE
feat(sf): add States.Timeout/Lambda.Unknown retry to ThinkTankCoverage

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -927,7 +927,7 @@
             },
             "ThinkTankCoverage": {
               "Type": "Task",
-              "Comment": "Think Tank observe-mode coverage fill (alpha-engine-config-I2467). Invokes the thinktank Lambda in sf_cover mode to fill top-150 coverage gaps (new theses for uncovered names + stalest refresh) — the entire rank_ceiling universe, in one weekly run (2026-07-14 cadence split: the non-Saturday EventBridge 'maintenance' run no longer does intake at all, since the universe board this state's Scanner predecessor produces is itself Saturday-only; this state is now the SOLE coverage-growth/refresh owner). Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step.",
+              "Comment": "Think Tank observe-mode coverage fill (alpha-engine-config-I2467). Invokes the thinktank Lambda in sf_cover mode to fill top-150 coverage gaps (new theses for uncovered names + stalest refresh) — the entire rank_ceiling universe, in one weekly run. 2026-07-14 cadence consolidation: this is now the ONLY invocation path for the thinktank Lambda — the standalone EventBridge schedule is retired entirely (sf_cover mode's run_daily() already does theme reconciliation + a full events sweep over every covered name unconditionally, so a separate weekday invocation was pure duplicated work; the universe board this state's Scanner predecessor produces is itself Saturday-only, so a weekday intake pass never had new ranking data to act on). A full 150-name run can approach the 900s Lambda ceiling (observed 525-880s at only ~60 covered names, 2026-07-14 live-verify) — the States.Timeout/Lambda.Unknown retry below mirrors the sibling Research state's timeout bridge (no headroom lever left on Lambda at 900s; worst case on a retried run is a duplicate thesis version, never a silent skip, per thinktank_handler.py's documented failure contract — safe because the coverage ledger only persists once at the end of a run, so a mid-run timeout never partially commits). Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-thinktank:live",
@@ -945,6 +945,15 @@
                     "Lambda.ServiceException",
                     "Lambda.TooManyRequestsException",
                     "States.TaskFailed"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                },
+                {
+                  "ErrorEquals": [
+                    "States.Timeout",
+                    "Lambda.Unknown"
                   ],
                   "MaxAttempts": 1,
                   "IntervalSeconds": 60,


### PR DESCRIPTION
## Summary

Follow-up to nousergon-data-PR804 (merged, bumped `sf_cover_target`/`sf_cover_ceiling` 60→150). Mirrors the sibling `Research` state's timeout bridge.

The existing Retry block (`Lambda.ServiceException`/`TooManyRequestsException`/`States.TaskFailed`) does NOT cover `States.Timeout` — the actual risk now that the target covers the full 150-name universe in one weekly run: today's live-verify of the ZDR fix (alpha-engine-config-I2487) showed 525-880s runs at only ~60 covered names, already close to the 900s Lambda ceiling. A full 150-name run will very plausibly exceed it, especially the first catch-up week.

No Lambda-side headroom lever exists at 900s (the hard AWS maximum), so this adds the same bridge `Research`'s SF state already uses in production: 1 retry on `States.Timeout`/`Lambda.Unknown`, 60s interval. Safe because a retried run re-selects intake against the ledger written so far — worst case is a duplicate thesis version (never a silent skip, since the coverage ledger only persists once at the end of a run — a mid-run timeout never partially commits), matching `thinktank_handler.py`'s documented failure contract.

Companion PR: crucible-research (retires the standalone EventBridge schedule entirely, since `sf_cover` mode already does everything a weekday rule would have done).

## Test plan

- [x] `test_sf_scanner_wiring.py`, `test_sf_research_predictor_parallel_wiring.py`, `test_sf_payload_uniqueness.py`, `test_sf_definition_check_drift.py` — 191 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)