### PR TITLE
chore: add standard fleet dependabot.yml (weekly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Standard fleet Dependabot config (weekly, grouped minor+patch) — alpha-engine-config-I2525
+# Majors ride separate individual PRs deliberately (scrutiny before merge).
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds the standard fleet Dependabot config (weekly cadence, grouped minor+patch, majors as individual PRs). Ecosystems detected for this repo: pip, github-actions.

Part of the 2026-07-14 software-factory audit rollout — alpha-engine-config-I2525 (https://github.com/nousergon/alpha-engine-config/issues/2525).

Resulting Dependabot update PRs fall under the standing self-merge exception only when CI is green and no deliberate pin/lockstep collides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)