### PR TITLE
fix(eod): retry spot-reclaimed data-spot workload, skip EODReconcile on exhausted data gap

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -804,7 +804,16 @@
           "Next": "CheckSkipCaptureSnapshot"
         }
       ],
-      "Default": "LaunchPostMarketDataSpot"
+      "Default": "InitDataSpotRetryCounter"
+    },
+    "InitDataSpotRetryCounter": {
+      "Type": "Pass",
+      "Comment": "Retry budget for a genuinely-interrupted (not merely slow) post-market-data spot workload — e.g. an AWS spot reclaim mid-job (root cause of the 2026-07-14 EOD FAILED incident: Server.SpotInstanceTermination ~22min into the run, well before the fetch completed). One relaunch-on-a-fresh-box retry before falling through to the existing fail-open path. Mirrors the InitSSMPollCounter counter idiom already used above for SSM-readiness polling.",
+      "Result": {
+        "attempts": 0
+      },
+      "ResultPath": "$.data_spot_retry",
+      "Next": "LaunchPostMarketDataSpot"
     },
     "LaunchPostMarketDataSpot": {
       "Type": "Task",
@@ -901,12 +910,12 @@
     },
     "CheckPostMarketDataSpotStatus": {
       "Type": "Choice",
-      "Comment": "Success -> the Arctic append spot workload; InProgress/Pending/Delayed -> wait; ANY other terminal status -> ExtractDataSpotError -> CONTINUE (fail-open: an EOD data failure must not block reconcile + instance-stop, config#1767 #4). Inverse of the OLD on-trading CheckPostMarketStatus which HandleFailure'd.",
+      "Comment": "Success -> the Arctic append spot workload retry-counter init; InProgress/Pending/Delayed -> wait; ANY other terminal status -> CheckDataSpotRetryBudget (one relaunch retry before the existing fail-open path). Inverse of the OLD on-trading CheckPostMarketStatus which HandleFailure'd.",
       "Choices": [
         {
           "Variable": "$.postmarket_poll.Status",
           "StringEquals": "Success",
-          "Next": "LaunchPostMarketArcticAppendSpot"
+          "Next": "InitDataSpotArcticRetryCounter"
         },
         {
           "Variable": "$.postmarket_poll.Status",
@@ -924,12 +933,41 @@
           "Next": "PostMarketDataSpotWait"
         }
       ],
+      "Default": "CheckDataSpotRetryBudget"
+    },
+    "CheckDataSpotRetryBudget": {
+      "Type": "Choice",
+      "Comment": "A terminal non-Success status on the post-market-data spot poll (Failed/Cancelled/TimedOut/the SSM Undeliverable class an already-reclaimed spot instance produces) is presumed transient AWS spot interruption until proven otherwise — retry once on a freshly-launched box before accepting failure. Bounded at 1 retry: a second consecutive interruption is no longer 'transient blip' territory and falls through to the existing fail-open path rather than looping indefinitely. $.data_spot_retry is always initialized by InitDataSpotRetryCounter before this state is reachable.",
+      "Choices": [
+        {
+          "Variable": "$.data_spot_retry.attempts",
+          "NumericLessThan": 1,
+          "Next": "IncrementDataSpotRetry"
+        }
+      ],
       "Default": "ExtractDataSpotError"
+    },
+    "IncrementDataSpotRetry": {
+      "Type": "Pass",
+      "Parameters": {
+        "attempts.$": "States.MathAdd($.data_spot_retry.attempts, 1)"
+      },
+      "ResultPath": "$.data_spot_retry",
+      "Next": "LaunchPostMarketDataSpot"
     },
     "PostMarketDataSpotWait": {
       "Type": "Wait",
       "Seconds": 15,
       "Next": "PollPostMarketDataSpot"
+    },
+    "InitDataSpotArcticRetryCounter": {
+      "Type": "Pass",
+      "Comment": "Retry budget for the Arctic-append sub-phase — the actual SPY-close WRITE that eod_reconcile.py's _spy_close hard-depends on. Mirrors InitDataSpotRetryCounter.",
+      "Result": {
+        "attempts": 0
+      },
+      "ResultPath": "$.data_spot_arctic_retry",
+      "Next": "LaunchPostMarketArcticAppendSpot"
     },
     "LaunchPostMarketArcticAppendSpot": {
       "Type": "Task",
@@ -1026,7 +1064,7 @@
     },
     "CheckPostMarketArcticAppendSpotStatus": {
       "Type": "Choice",
-      "Comment": "Success -> continue to snapshot/reconcile/stop; InProgress/Pending/Delayed -> wait; ANY other terminal status -> ExtractDataSpotError -> CONTINUE (fail-open).",
+      "Comment": "Success -> continue to snapshot/reconcile/stop; InProgress/Pending/Delayed -> wait; ANY other terminal status -> CheckDataSpotArcticRetryBudget (one relaunch retry before the existing fail-open path).",
       "Choices": [
         {
           "Variable": "$.postmarket_arctic_poll.Status",
@@ -1049,7 +1087,27 @@
           "Next": "PostMarketArcticAppendSpotWait"
         }
       ],
+      "Default": "CheckDataSpotArcticRetryBudget"
+    },
+    "CheckDataSpotArcticRetryBudget": {
+      "Type": "Choice",
+      "Comment": "Same one-retry-then-give-up policy as CheckDataSpotRetryBudget, applied to the Arctic-append sub-phase. $.data_spot_arctic_retry is always initialized by InitDataSpotArcticRetryCounter before this state is reachable.",
+      "Choices": [
+        {
+          "Variable": "$.data_spot_arctic_retry.attempts",
+          "NumericLessThan": 1,
+          "Next": "IncrementDataSpotArcticRetry"
+        }
+      ],
       "Default": "ExtractDataSpotError"
+    },
+    "IncrementDataSpotArcticRetry": {
+      "Type": "Pass",
+      "Parameters": {
+        "attempts.$": "States.MathAdd($.data_spot_arctic_retry.attempts, 1)"
+      },
+      "ResultPath": "$.data_spot_arctic_retry",
+      "Next": "LaunchPostMarketArcticAppendSpot"
     },
     "PostMarketArcticAppendSpotWait": {
       "Type": "Wait",
@@ -1117,7 +1175,7 @@
     },
     "CheckSkipEODReconcile": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4607). Input {\"skip_eod_reconcile\": true} routes past EODReconcile to the next gate (CheckSkipDailySubstrateHealthCheck); missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Comment": "Per-task rerun gate (L4607). Input {\"skip_eod_reconcile\": true} routes past EODReconcile to the next gate (CheckSkipDailySubstrateHealthCheck); missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work. EXTENDED 2026-07-14: a $.data_spot_error present at this point means the post-market data-spot phase failed even after its retry budget (CheckDataSpotRetryBudget / CheckDataSpotArcticRetryBudget) was exhausted — today's SPY/OHLCV close was never written to ArcticDB, so eod_reconcile.py's _spy_close hard-fail (by design, no fallback — see executor/eod_reconcile.py in alpha-engine) is GUARANTEED, not merely possible. Route to SkipEODReconcileDataGap instead of letting that guaranteed crash fall through HandleFailure -> FailExecution, which mislabels a known, retry-exhausted, self-healing data gap as a pipeline defect (root-caused 2026-07-14: AWS spot reclaim mid-job, Server.SpotInstanceTermination, previously paged as a misleading generic 'EOD Pipeline — FAILED').",
       "Choices": [
         {
           "And": [
@@ -1139,9 +1197,36 @@
             }
           ],
           "Next": "CheckSkipDailySubstrateHealthCheck"
+        },
+        {
+          "Variable": "$.data_spot_error",
+          "IsPresent": true,
+          "Next": "SkipEODReconcileDataGap"
         }
       ],
       "Default": "EODReconcile"
+    },
+    "SkipEODReconcileDataGap": {
+      "Type": "Task",
+      "Comment": "Loud, distinctly-labeled alert for a known/self-healing condition — NOT a silent swallow (feedback_no_silent_fails): the data-spot phase exhausted its retry budget, so today's SPY close is genuinely absent from ArcticDB and EODReconcile is skipped rather than left to crash into the generic HandleFailure/FailExecution path. Recovery is expected to be automatic/operator-driven: alpha-engine-data's chronic-gap-heal backfills the missing daily bar on its next run, after which an operator-replay execution with skip_post_market_data=true reruns EODReconcile alone.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Reconcile SKIPPED (data gap, self-healing)",
+        "Message.$": "States.Format('EOD reconcile SKIPPED for {}: post-market data-spot phase failed after its retry budget was exhausted (most likely an AWS spot interruption) — no NAV/alpha row will be written today. Detail: {}. Chronic-gap-heal will backfill the missing ArcticDB close; then rerun EODReconcile via an operator-replay execution with skip_post_market_data=true.', $.run_date, States.JsonToString($.data_spot_error))"
+      },
+      "ResultPath": "$.eod_skip_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Defense-in-depth, mirrors HandleFailure's own Catch: an SNS-side failure must not block the substrate check + instance-stop cost-guard.",
+          "ResultPath": null,
+          "Next": "CheckSkipDailySubstrateHealthCheck"
+        }
+      ],
+      "Next": "CheckSkipDailySubstrateHealthCheck"
     },
     "CheckSkipDailySubstrateHealthCheck": {
       "Type": "Choice",

--- a/tests/test_sf_data_spot_relocation_wiring.py
+++ b/tests/test_sf_data_spot_relocation_wiring.py
@@ -280,8 +280,14 @@ class TestEODFailureIsolation:
                 assert c["Next"] not in _HALT
 
     def test_status_default_is_fail_open_not_handlefailure(self, eod):
-        for name in ("CheckPostMarketDataSpotStatus", "CheckPostMarketArcticAppendSpotStatus"):
-            assert eod[name]["Default"] == "ExtractDataSpotError"
+        # 2026-07-14 (root cause: AWS spot reclaim mid-job, Server.SpotInstanceTermination):
+        # a terminal non-Success poll status now routes through a one-shot
+        # retry-budget Choice BEFORE falling through to the fail-open
+        # ExtractDataSpotError normalizer — see TestEODDataSpotRetryBudget.
+        assert eod["CheckPostMarketDataSpotStatus"]["Default"] == "CheckDataSpotRetryBudget"
+        assert eod["CheckPostMarketArcticAppendSpotStatus"]["Default"] == "CheckDataSpotArcticRetryBudget"
+        assert eod["CheckDataSpotRetryBudget"]["Default"] == "ExtractDataSpotError"
+        assert eod["CheckDataSpotArcticRetryBudget"]["Default"] == "ExtractDataSpotError"
 
     def test_error_normalizer_continues_to_reconcile_path(self, eod):
         assert eod["ExtractDataSpotError"]["Next"] == "PublishDataSpotFailureImmediate"
@@ -295,9 +301,12 @@ class TestEODFailureIsolation:
         data_states = [
             "LaunchPostMarketDataSpot", "CheckPostMarketDataSpotLaunched",
             "PollPostMarketDataSpot", "CheckPostMarketDataSpotStatus", "PostMarketDataSpotWait",
+            "CheckDataSpotRetryBudget", "IncrementDataSpotRetry",
+            "InitDataSpotArcticRetryCounter",
             "LaunchPostMarketArcticAppendSpot", "CheckPostMarketArcticAppendSpotLaunched",
             "PollPostMarketArcticAppendSpot", "CheckPostMarketArcticAppendSpotStatus",
             "PostMarketArcticAppendSpotWait",
+            "CheckDataSpotArcticRetryBudget", "IncrementDataSpotArcticRetry",
             "ExtractDataSpotError", "PublishDataSpotFailureImmediate",
         ]
         for name in data_states:
@@ -311,6 +320,110 @@ class TestEODFailureIsolation:
         assert eod["CheckSkipPostMarketData"]["Choices"][0]["Next"] == self._CONTINUE
         for gate in ("CheckPostMarketDataSpotLaunched", "CheckPostMarketArcticAppendSpotLaunched"):
             assert eod[gate]["Default"] == self._CONTINUE
+
+
+class TestEODDataSpotRetryBudget:
+    """2026-07-14 incident fix: a spot-reclaimed data-spot workload (AWS
+    Server.SpotInstanceTermination — first observed 2026-07-14, ~22min into a
+    post-market-data run) gets ONE relaunch-on-a-fresh-box retry before the
+    pipeline accepts the failure and falls through to the pre-existing
+    fail-open path. Bounded, not unbounded — a second consecutive
+    interruption still falls through, so this can never loop indefinitely."""
+
+    def test_retry_counters_initialized_before_first_launch(self, eod):
+        assert eod["CheckSkipPostMarketData"]["Default"] == "InitDataSpotRetryCounter"
+        assert eod["InitDataSpotRetryCounter"]["Type"] == "Pass"
+        assert eod["InitDataSpotRetryCounter"]["ResultPath"] == "$.data_spot_retry"
+        assert eod["InitDataSpotRetryCounter"]["Result"] == {"attempts": 0}
+        assert eod["InitDataSpotRetryCounter"]["Next"] == "LaunchPostMarketDataSpot"
+
+        assert eod["CheckPostMarketDataSpotStatus"]["Choices"][0]["Next"] == "InitDataSpotArcticRetryCounter"
+        assert eod["InitDataSpotArcticRetryCounter"]["Type"] == "Pass"
+        assert eod["InitDataSpotArcticRetryCounter"]["ResultPath"] == "$.data_spot_arctic_retry"
+        assert eod["InitDataSpotArcticRetryCounter"]["Result"] == {"attempts": 0}
+        assert eod["InitDataSpotArcticRetryCounter"]["Next"] == "LaunchPostMarketArcticAppendSpot"
+
+    @pytest.mark.parametrize(
+        "budget_state,counter_field,increment_state,relaunch_state",
+        [
+            ("CheckDataSpotRetryBudget", "$.data_spot_retry.attempts",
+             "IncrementDataSpotRetry", "LaunchPostMarketDataSpot"),
+            ("CheckDataSpotArcticRetryBudget", "$.data_spot_arctic_retry.attempts",
+             "IncrementDataSpotArcticRetry", "LaunchPostMarketArcticAppendSpot"),
+        ],
+    )
+    def test_one_retry_then_give_up(
+        self, eod, budget_state, counter_field, increment_state, relaunch_state
+    ):
+        st = eod[budget_state]
+        assert st["Type"] == "Choice"
+        assert len(st["Choices"]) == 1
+        cond = st["Choices"][0]
+        assert cond["Variable"] == counter_field
+        assert cond["NumericLessThan"] == 1
+        assert cond["Next"] == increment_state
+        # Retry budget exhausted -> the pre-existing fail-open path, never a HALT.
+        assert st["Default"] == "ExtractDataSpotError"
+
+        inc = eod[increment_state]
+        assert inc["Type"] == "Pass"
+        assert inc["ResultPath"] == counter_field.rsplit(".", 1)[0]
+        assert inc["Parameters"]["attempts.$"] == f"States.MathAdd({counter_field}, 1)"
+        # The retry relaunches on a FRESH box — same launch state, not a
+        # separate "retry launch" — a plain Lambda invoke each time.
+        assert inc["Next"] == relaunch_state
+
+
+class TestEODReconcileSkippedOnDataGap:
+    """2026-07-14 incident fix, part 2: even with the retry budget above, the
+    data-spot phase can still end in $.data_spot_error (retry exhausted). That
+    condition GUARANTEES eod_reconcile.py's _spy_close hard-fail (no fallback
+    by design — today's SPY close was never written to ArcticDB), so
+    CheckSkipEODReconcile must route around EODReconcile entirely instead of
+    letting a guaranteed crash fall through to the generic HandleFailure ->
+    FailExecution path (which mislabels a known, self-healing data gap as a
+    pipeline defect — the false 'EOD Pipeline — FAILED' page from 2026-07-14)."""
+
+    def test_data_gap_branch_precedes_default(self, eod):
+        st = eod["CheckSkipEODReconcile"]
+        assert st["Type"] == "Choice"
+        gap_choices = [c for c in st["Choices"] if c.get("Variable") == "$.data_spot_error"]
+        assert len(gap_choices) == 1
+        assert gap_choices[0]["IsPresent"] is True
+        assert gap_choices[0]["Next"] == "SkipEODReconcileDataGap"
+        # The pre-existing operator-replay skip_eod_reconcile branch is untouched.
+        assert st["Default"] == "EODReconcile"
+
+    def test_skip_state_is_sns_publish_not_a_swallow(self, eod):
+        # feedback_no_silent_fails: a skip must still be LOUD — a distinct,
+        # accurately-worded SNS publish, not a bare Pass-through.
+        st = eod["SkipEODReconcileDataGap"]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::sns:publish"
+        subject = st["Parameters"]["Subject"]
+        assert 0 < len(subject) <= 100
+        assert "\n" not in subject
+        assert "SKIPPED" in subject
+        assert "FAILED" not in subject, (
+            "must read as a known/self-healing skip, not the generic pipeline-"
+            "failed alert it replaces"
+        )
+        message_fmt = st["Parameters"]["Message.$"]
+        assert "States.JsonToString($.data_spot_error)" in message_fmt
+
+    def test_skip_state_never_reaches_a_halt(self, eod):
+        for tgt in _all_targets(eod["SkipEODReconcileDataGap"]):
+            assert tgt not in _HALT
+        assert eod["SkipEODReconcileDataGap"]["Next"] == "CheckSkipDailySubstrateHealthCheck"
+
+    def test_skip_states_own_sns_failure_still_continues(self, eod):
+        # Mirrors HandleFailure's defense-in-depth: an SNS-side failure here
+        # must not block the substrate check + instance-stop cost-guard.
+        catches = eod["SkipEODReconcileDataGap"].get("Catch", [])
+        assert any(
+            c["ErrorEquals"] == ["States.ALL"] and c["Next"] == "CheckSkipDailySubstrateHealthCheck"
+            for c in catches
+        )
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -43,7 +43,11 @@ _CHAIN = [
     # FIRST (right after the SSM-readiness gate), so the entire EOD run executes
     # latest origin/main by construction. Skipping it resumes at the first work gate.
     ("CheckSkipRefreshExecutorDeploy", "RefreshExecutorDeploy", "skip_refresh_executor_deploy", "CheckSkipPostMarketData"),
-    ("CheckSkipPostMarketData", "LaunchPostMarketDataSpot", "skip_post_market_data", "CheckSkipCaptureSnapshot"),
+    # 2026-07-14: CheckSkipPostMarketData's Default now runs through
+    # InitDataSpotRetryCounter (the new spot-interruption retry-budget init)
+    # before LaunchPostMarketDataSpot — pinned separately in
+    # TestEODDataSpotRetryBudget (test_sf_data_spot_relocation_wiring.py).
+    ("CheckSkipPostMarketData", "InitDataSpotRetryCounter", "skip_post_market_data", "CheckSkipCaptureSnapshot"),
     ("CheckSkipCaptureSnapshot", "CaptureSnapshot", "skip_capture_snapshot", "CheckSkipEODReconcile"),
     ("CheckSkipEODReconcile", "EODReconcile", "skip_eod_reconcile", "CheckSkipDailySubstrateHealthCheck"),
     ("CheckSkipDailySubstrateHealthCheck", "DailySubstrateHealthCheck", "skip_daily_substrate_health_check", "StopTradingInstance"),
@@ -102,10 +106,12 @@ class TestEntryEdgesRouteThroughGates:
 
     def test_post_market_spot_success_enters_arctic_append_spot(self, states):
         # config#1767: the post-market fetch now runs on spot; its poll Success
-        # enters the Arctic-append spot launch (both run on spot).
+        # enters the Arctic-append retry-counter init (2026-07-14), which then
+        # launches the Arctic-append spot workload (both run on spot).
         succ = [c["Next"] for c in states["CheckPostMarketDataSpotStatus"]["Choices"]
                 if c.get("StringEquals") == "Success"]
-        assert succ == ["LaunchPostMarketArcticAppendSpot"]
+        assert succ == ["InitDataSpotArcticRetryCounter"]
+        assert states["InitDataSpotArcticRetryCounter"]["Next"] == "LaunchPostMarketArcticAppendSpot"
 
     def test_arctic_append_spot_success_enters_snapshot_gate(self, states):
         # config#1767: the EOD Arctic append also runs on spot; its Success
@@ -180,10 +186,12 @@ class TestPaths:
     def test_skip_refresh_resumes_at_data_spot(self, states):
         # config#1549: skipping only the deploy refresh (e.g. an operator rerun
         # on a box already known fresh) resumes at the first work task, which is
-        # now the spot data-phase launch (config#1767).
+        # now the spot data-phase retry-counter init (config#1767; counter init
+        # added 2026-07-14) then the spot launch itself.
         order = self._walk(states, skip_flags={"skip_refresh_executor_deploy"})
         assert "RefreshExecutorDeploy" not in order
-        assert order[0] == "LaunchPostMarketDataSpot"
+        assert order[0] == "InitDataSpotRetryCounter"
+        assert order[1] == "LaunchPostMarketDataSpot"
         assert order[-1] == "StopTradingInstance"
 
     def test_skip_data_phase_resumes_at_snapshot(self, states):

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -484,6 +484,14 @@ class TestEODSFTopLevelFieldsClosed:
             "postmarket_arctic_launch",
             "data_spot_error",
             "data_spot_failure_notify",
+            # 2026-07-14 incident fix: bounded (1x) relaunch-on-a-fresh-box
+            # retry for a spot-reclaimed data-spot workload, plus a distinct
+            # loud skip of EODReconcile when the retry is exhausted (today's
+            # SPY close genuinely never landed in ArcticDB, so eod_reconcile.py's
+            # _spy_close hard-fail would otherwise be guaranteed).
+            "data_spot_retry",
+            "data_spot_arctic_retry",
+            "eod_skip_notify",
             "snapshot_poll",
             "snapshot_result",
             "stop_result",


### PR DESCRIPTION
## Summary

Root-causes and fixes the 2026-07-14 `ne-postclose-trading-pipeline` FAILED alert (report `019f624e00884ee11ecaff274d6b`).

**Root cause:** the EOD data-spot phase (post-market-data fetch + Arctic-append writing today's SPY close) is architecturally fail-open by design (config#1767 deliverable #4) so a data-phase blip never blocks reconcile+instance-stop — but `executor/eod_reconcile.py::_spy_close` (in `alpha-engine`) is an intentional hard-fail with zero fallback ("EOD alpha is meaningless without a reliable SPY reference"). On 2026-07-14 the data-spot instance (`i-0c7d895ba30125a7b`) was reclaimed by AWS mid-job — confirmed via `describe-instances` (`Server.SpotInstanceTermination`) and CloudTrail (`RunInstances` by `alpha-engine-data-spot-dispatcher` at 20:01Z, reclaimed 20:23Z, ~22min into the run) — before it finished writing today's SPY close. The SF correctly took the fail-open continue path, but `EODReconcile` then ran unconditionally and hard-crashed on the missing close, turning a transient AWS spot event into a full pipeline failure via `HandleFailure` → `FailExecution` — exactly the outcome the fail-open design exists to prevent, just one step later. Two independently-reasonable designs (fail-open data phase; hard-fail SPY consumer) composed unsoundly the first time the data phase actually failed.

**Fix (same layer, no `eod_reconcile.py` change — its hard-fail is correct policy, just reached via the wrong path):**

1. **Bounded (1×) retry-on-relaunch** for a spot-interrupted `post-market-data`/`post-market-arctic-append` workload — mirrors the existing `InitSSMPollCounter` idiom already used for SSM-readiness polling elsewhere in this file. Most spot reclaims are transient; a fresh-box relaunch fixes the proximate cause instead of accepting data loss.
2. **`CheckSkipEODReconcile` now routes to a new `SkipEODReconcileDataGap`** SNS state (loud, distinctly-worded, not a silent swallow) instead of `EODReconcile` when `$.data_spot_error` is present after the retry budget is exhausted — today's SPY close is then *guaranteed* absent, so the crash is guaranteed too. This turns a misleading generic "EOD Pipeline — FAILED" page into an accurate "reconcile skipped, data gap, self-healing via chronic-gap-heal + operator-replay" alert, while the trading instance still stops normally.

## Test plan

- [x] `infrastructure/step_function_eod.json` parses; no dangling `Next`/`Default`/`Choice`/`Catch` targets (scripted check)
- [x] Updated `tests/test_sf_data_spot_relocation_wiring.py` (new `TestEODDataSpotRetryBudget`, `TestEODReconcileSkippedOnDataGap`), `tests/test_sf_eod_skipgate_wiring.py`, `tests/test_sf_payload_uniqueness.py` (closed top-level field registry) for the new states
- [x] Full local suite: `3058 passed, 7 pre-existing skips, 0 failures`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)