### PR TITLE
fix(eod): force on-demand for the post-interruption data-spot retry

### DIFF
--- a/infrastructure/lambdas/data-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/data-spot-dispatcher/index.py
@@ -223,10 +223,19 @@ echo "[data-spot] workload {workload} complete"
 """
 
 
-def _launch_instance() -> tuple[str, str]:
+def _launch_instance(force_on_demand: bool = False) -> tuple[str, str]:
     """Launch the data spot box; spot first, on-demand fallback on capacity
     exhaustion (a pre-open enrich the predictor reads next must not be starved by
-    a spot-capacity dip). Mirrors _launch_instance in scheduled-groom-dispatcher."""
+    a spot-capacity dip). Mirrors _launch_instance in scheduled-groom-dispatcher.
+
+    force_on_demand=True skips the spot attempt entirely. Set by the EOD SF's
+    bounded retry-on-relaunch (2026-07-14 incident: a data-spot box was
+    reclaimed by AWS — Server.SpotInstanceTermination — ~22min into a
+    post-market-data run, which the SF now retries once). A workload that
+    already lost one box to a spot interruption should not gamble on spot
+    again for its one retry attempt — the cost delta is a few cents for a
+    sub-hour c5.large-class box, negligible against the reconcile-reliability
+    this buys."""
     common = dict(
         image_id=AMI_ID,
         key_name=KEY_NAME,
@@ -237,6 +246,12 @@ def _launch_instance() -> tuple[str, str]:
         tag_name="alpha-engine-data-spot",
         region=REGION,
     )
+    if force_on_demand:
+        logger.info(
+            "force_on_demand=True (spot-interruption retry) — launching ON-DEMAND directly, skipping spot"
+        )
+        iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=False, **common)
+        return iid, "on-demand"
     try:
         iid = ec2_spot.launch(INSTANCE_TYPES, SUBNETS, spot=True, **common)
         return iid, "spot"
@@ -312,9 +327,12 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """Step Function handler — launch the data spot box for one workload.
 
     `event` carries {"workload": "morning-enrich" | "morning-arctic-append" |
-    "post-market-data" | "post-market-arctic-append"}. Returns, wrapped under a
-    `data_spot` key (mirrors the groom dispatcher's `groom` wrap so the SF's
-    JSONPath is $.<result>.Payload.data_spot.*):
+    "post-market-data" | "post-market-arctic-append", "force_on_demand": bool}.
+    `force_on_demand` (default False) is set by the EOD SF's post-interruption
+    retry (2026-07-14 incident) so the one retry attempt never gambles on spot
+    a second time. Returns, wrapped under a `data_spot` key (mirrors the groom
+    dispatcher's `groom` wrap so the SF's JSONPath is
+    $.<result>.Payload.data_spot.*):
 
       {"launched": true, "instance_id", "command_id", "workload", "run_token"}
       or {"launched": false, "reason": "disabled"} under the kill-switch.
@@ -325,13 +343,14 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """
     event = event or {}
     workload, collector_cmd = _resolve_workload(event)
+    force_on_demand = bool(event.get("force_on_demand", False))
 
     if not DISPATCH_ENABLED:
         logger.warning("DATA_SPOT_DISPATCH_ENABLED=false — data spot NOT launched")
         return {"data_spot": {"launched": False, "reason": "disabled", "workload": workload}}
 
     run_token = uuid.uuid4().hex
-    instance_id, market = _launch_instance()
+    instance_id, market = _launch_instance(force_on_demand=force_on_demand)
     logger.info("launched data-spot box %s (%s) for %s", instance_id, market, workload)
     # Once the box is up, ANY failure before the bootstrap command is delivered
     # would orphan it (no watchdog/trap yet). Terminate-on-error so a slow

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -808,21 +808,23 @@
     },
     "InitDataSpotRetryCounter": {
       "Type": "Pass",
-      "Comment": "Retry budget for a genuinely-interrupted (not merely slow) post-market-data spot workload — e.g. an AWS spot reclaim mid-job (root cause of the 2026-07-14 EOD FAILED incident: Server.SpotInstanceTermination ~22min into the run, well before the fetch completed). One relaunch-on-a-fresh-box retry before falling through to the existing fail-open path. Mirrors the InitSSMPollCounter counter idiom already used above for SSM-readiness polling.",
+      "Comment": "Retry budget for a genuinely-interrupted (not merely slow) post-market-data spot workload — e.g. an AWS spot reclaim mid-job (root cause of the 2026-07-14 EOD FAILED incident: Server.SpotInstanceTermination ~22min into the run, well before the fetch completed). One relaunch-on-a-fresh-box retry before falling through to the existing fail-open path. Mirrors the InitSSMPollCounter counter idiom already used above for SSM-readiness polling. force_on_demand starts false; IncrementDataSpotRetry flips it true so the one retry never gambles on spot a second time.",
       "Result": {
-        "attempts": 0
+        "attempts": 0,
+        "force_on_demand": false
       },
       "ResultPath": "$.data_spot_retry",
       "Next": "LaunchPostMarketDataSpot"
     },
     "LaunchPostMarketDataSpot": {
       "Type": "Task",
-      "Comment": "config#1767: invoke alpha-engine-data-spot-dispatcher to run PostMarketData (post-close fetch) on an ephemeral spot box, NOT on ae-trading. Arctic write follows in PostMarketArcticAppend, also on spot.",
+      "Comment": "config#1767: invoke alpha-engine-data-spot-dispatcher to run PostMarketData (post-close fetch) on an ephemeral spot box, NOT on ae-trading. Arctic write follows in PostMarketArcticAppend, also on spot. force_on_demand.$ is false on the first attempt and true on the post-interruption retry (2026-07-14 incident) — the dispatcher then skips spot entirely for that attempt.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-data-spot-dispatcher",
         "Payload": {
-          "workload": "post-market-data"
+          "workload": "post-market-data",
+          "force_on_demand.$": "$.data_spot_retry.force_on_demand"
         }
       },
       "TimeoutSeconds": 420,
@@ -949,8 +951,10 @@
     },
     "IncrementDataSpotRetry": {
       "Type": "Pass",
+      "Comment": "force_on_demand flips to true for the retry — a box already lost to spot interruption once must not gamble on spot again.",
       "Parameters": {
-        "attempts.$": "States.MathAdd($.data_spot_retry.attempts, 1)"
+        "attempts.$": "States.MathAdd($.data_spot_retry.attempts, 1)",
+        "force_on_demand": true
       },
       "ResultPath": "$.data_spot_retry",
       "Next": "LaunchPostMarketDataSpot"
@@ -962,21 +966,23 @@
     },
     "InitDataSpotArcticRetryCounter": {
       "Type": "Pass",
-      "Comment": "Retry budget for the Arctic-append sub-phase — the actual SPY-close WRITE that eod_reconcile.py's _spy_close hard-depends on. Mirrors InitDataSpotRetryCounter.",
+      "Comment": "Retry budget for the Arctic-append sub-phase — the actual SPY-close WRITE that eod_reconcile.py's _spy_close hard-depends on. Mirrors InitDataSpotRetryCounter, including force_on_demand.",
       "Result": {
-        "attempts": 0
+        "attempts": 0,
+        "force_on_demand": false
       },
       "ResultPath": "$.data_spot_arctic_retry",
       "Next": "LaunchPostMarketArcticAppendSpot"
     },
     "LaunchPostMarketArcticAppendSpot": {
       "Type": "Task",
-      "Comment": "config#1767: invoke alpha-engine-data-spot-dispatcher to run the EOD ArcticDB append on the spot box. Arctic/S3 write runs ON THE SPOT via its executor profile, not the trading box.",
+      "Comment": "config#1767: invoke alpha-engine-data-spot-dispatcher to run the EOD ArcticDB append on the spot box. Arctic/S3 write runs ON THE SPOT via its executor profile, not the trading box. force_on_demand.$ mirrors LaunchPostMarketDataSpot's post-interruption-retry behavior.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-data-spot-dispatcher",
         "Payload": {
-          "workload": "post-market-arctic-append"
+          "workload": "post-market-arctic-append",
+          "force_on_demand.$": "$.data_spot_arctic_retry.force_on_demand"
         }
       },
       "TimeoutSeconds": 420,
@@ -1103,8 +1109,10 @@
     },
     "IncrementDataSpotArcticRetry": {
       "Type": "Pass",
+      "Comment": "force_on_demand flips to true for the retry — mirrors IncrementDataSpotRetry.",
       "Parameters": {
-        "attempts.$": "States.MathAdd($.data_spot_arctic_retry.attempts, 1)"
+        "attempts.$": "States.MathAdd($.data_spot_arctic_retry.attempts, 1)",
+        "force_on_demand": true
       },
       "ResultPath": "$.data_spot_arctic_retry",
       "Next": "LaunchPostMarketArcticAppendSpot"

--- a/tests/test_sf_data_spot_relocation_wiring.py
+++ b/tests/test_sf_data_spot_relocation_wiring.py
@@ -224,6 +224,9 @@ class TestEODSpotStatesPresent:
         assert st["Parameters"]["Payload"]["workload"] in {
             "post-market-data", "post-market-arctic-append"
         }
+        # 2026-07-14: force_on_demand.$ threads the retry-budget's on-demand
+        # override into the dispatcher (see TestEODDataSpotRetryBudget).
+        assert set(st["Parameters"]["Payload"]) == {"workload", "force_on_demand.$"}
 
     @pytest.mark.parametrize("name", _POLL)
     def test_poll_state_polls_ssm(self, eod, name):
@@ -334,14 +337,25 @@ class TestEODDataSpotRetryBudget:
         assert eod["CheckSkipPostMarketData"]["Default"] == "InitDataSpotRetryCounter"
         assert eod["InitDataSpotRetryCounter"]["Type"] == "Pass"
         assert eod["InitDataSpotRetryCounter"]["ResultPath"] == "$.data_spot_retry"
-        assert eod["InitDataSpotRetryCounter"]["Result"] == {"attempts": 0}
+        assert eod["InitDataSpotRetryCounter"]["Result"] == {"attempts": 0, "force_on_demand": False}
         assert eod["InitDataSpotRetryCounter"]["Next"] == "LaunchPostMarketDataSpot"
 
         assert eod["CheckPostMarketDataSpotStatus"]["Choices"][0]["Next"] == "InitDataSpotArcticRetryCounter"
         assert eod["InitDataSpotArcticRetryCounter"]["Type"] == "Pass"
         assert eod["InitDataSpotArcticRetryCounter"]["ResultPath"] == "$.data_spot_arctic_retry"
-        assert eod["InitDataSpotArcticRetryCounter"]["Result"] == {"attempts": 0}
+        assert eod["InitDataSpotArcticRetryCounter"]["Result"] == {"attempts": 0, "force_on_demand": False}
         assert eod["InitDataSpotArcticRetryCounter"]["Next"] == "LaunchPostMarketArcticAppendSpot"
+
+    @pytest.mark.parametrize(
+        "launch_state,counter_field",
+        [
+            ("LaunchPostMarketDataSpot", "data_spot_retry"),
+            ("LaunchPostMarketArcticAppendSpot", "data_spot_arctic_retry"),
+        ],
+    )
+    def test_launch_threads_force_on_demand_from_retry_counter(self, eod, launch_state, counter_field):
+        payload = eod[launch_state]["Parameters"]["Payload"]
+        assert payload["force_on_demand.$"] == f"$.{counter_field}.force_on_demand"
 
     @pytest.mark.parametrize(
         "budget_state,counter_field,increment_state,relaunch_state",
@@ -369,6 +383,8 @@ class TestEODDataSpotRetryBudget:
         assert inc["Type"] == "Pass"
         assert inc["ResultPath"] == counter_field.rsplit(".", 1)[0]
         assert inc["Parameters"]["attempts.$"] == f"States.MathAdd({counter_field}, 1)"
+        # The one retry must never gamble on spot a second time.
+        assert inc["Parameters"]["force_on_demand"] is True
         # The retry relaunches on a FRESH box — same launch state, not a
         # separate "retry launch" — a plain Lambda invoke each time.
         assert inc["Next"] == relaunch_state


### PR DESCRIPTION
## Summary

Follow-up hardening on the just-merged `nousergon-data-PR813` (bounded retry for a spot-reclaimed EOD data-spot workload). Brian asked directly whether PR813 was fully SOTA — it wasn't quite: the retry re-invoked the SAME spot-first dispatch path, so two consecutive AWS spot interruptions (rare, but real) would still exhaust the retry budget and reproduce the original "EOD Pipeline — FAILED" page.

**Fix:** thread a `force_on_demand` flag from the retry-budget counters (`InitDataSpotRetryCounter`/`InitDataSpotArcticRetryCounter` start it `false`; `IncrementDataSpotRetry`/`IncrementDataSpotArcticRetry` flip it `true`) into the dispatcher Lambda's Payload, and make `_launch_instance()` skip the spot attempt entirely when set. A box that already lost one run to a spot interruption should not gamble on spot again for its one retry — the cost delta is a few cents for a sub-hour c5.large-class box.

## Test plan

- [x] `infrastructure/step_function_eod.json` parses; no dangling targets; `force_on_demand.$` is always floored by its Init* counter before the Launch* state is reachable (no `States.Runtime` risk)
- [x] Verified `_launch_instance`'s branch logic directly (mocked `ec2_spot.launch`) since `data-spot-dispatcher` has no existing unit test file — confirmed `force_on_demand=True` skips spot entirely
- [x] Updated `tests/test_sf_data_spot_relocation_wiring.py` for the new Payload field + Result shape
- [x] Full local suite: `3060 passed, 7 pre-existing skips, 0 failures`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)