### PR TITLE
feat(sf): advisory child pipeline + Sunday ModelZoo pipeline (I2544/I2545)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -197,6 +197,57 @@ Resources:
               LogGroupArn: !GetAtt PreopenTradingLogGroup.Arn
 
   # --------------------------------------------------------------------------
+  # Step Functions — Weekly Advisory Pipeline (alpha-engine-config-I2544)
+  # --------------------------------------------------------------------------
+  # Async child of SaturdayPipeline — the eval-judge chain / EvalRollingMean /
+  # RationaleClustering / ReplayConcordance / Counterfactual / AggregateCosts /
+  # ReportCard / Director, decoupled from the Saturday critical path.
+  # SaturdayPipeline's StartAdvisoryPipeline state fires this fire-and-forget
+  # (states:startExecution, NOT .sync) once DataPhase2 completes. NOT an
+  # EventBridge target — it has no cron trigger of its own. Same
+  # single-writer contract (config#2273) as SaturdayPipeline/WeekdayPipeline —
+  # see infrastructure/step_function_advisory.json's top-level Comment.
+  AdvisoryPipeline:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: ne-weekly-advisory-pipeline
+      RoleArn: !Ref StepFunctionsRoleArn
+      DefinitionS3Location:
+        Bucket: alpha-engine-research
+        Key: infrastructure/step_function_advisory.json
+      LoggingConfiguration:
+        Level: ERROR
+        IncludeExecutionData: true
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt WeeklyAdvisoryLogGroup.Arn
+
+  # --------------------------------------------------------------------------
+  # Step Functions — ModelZoo Sunday Pipeline (alpha-engine-config-I2545)
+  # --------------------------------------------------------------------------
+  # The model-zoo rotation (ResolveZooSpecs → ModelZooTrainMap →
+  # ModelZooSelect), moved off Saturday to its own Sunday 09:00 UTC trigger
+  # (Brian-ruled 2026-07-14 — see ModelZooSundayTrigger below). Ends with a
+  # re-invoke of the crucible-evaluator grading Lambda as the persistent-dash
+  # re-grade. Triggered directly by EventBridge — unlike AdvisoryPipeline
+  # above, this one IS an EventBridge target (it has no upstream SF to fire
+  # it fire-and-forget from).
+  ModelZooSundayPipeline:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: ne-modelzoo-sunday-pipeline
+      RoleArn: !Ref StepFunctionsRoleArn
+      DefinitionS3Location:
+        Bucket: alpha-engine-research
+        Key: infrastructure/step_function_modelzoo.json
+      LoggingConfiguration:
+        Level: ERROR
+        IncludeExecutionData: true
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt ModelZooSundayLogGroup.Arn
+
+  # --------------------------------------------------------------------------
   # EventBridge Rules — Pipeline Triggers
   # --------------------------------------------------------------------------
   SaturdayTrigger:
@@ -306,6 +357,34 @@ Resources:
               "trading_instance_id": ["${TradingInstanceId}"],
               "sns_topic_arn": "${AlertsTopic}",
               "pipeline_role": "daily"
+            }
+
+  # alpha-engine-config-I2545: ModelZoo Sunday trigger. Brian-ruled
+  # 2026-07-14 — 09:00 UTC gives a full day of retry headroom before Monday
+  # 12:45 UTC preopen (ne-preopen-trading-pipeline). Independent of
+  # SaturdayTrigger (no dependency edge in EventBridge; ordering is purely
+  # "the day after Saturday" by construction of the two separate cron
+  # expressions — no explicit day-of-week arithmetic needed since Sunday
+  # always immediately follows Saturday).
+  ModelZooSundayTrigger:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: alpha-engine-modelzoo-sunday
+      Description: Sunday 09:00 UTC — model-zoo rotation + persistent-dash re-grade (moved off Saturday, alpha-engine-config-I2545)
+      ScheduleExpression: 'cron(0 9 ? * SUN *)'
+      State: ENABLED
+      Targets:
+        # SINGLE TARGET PER RULE — see SaturdayTrigger's Targets comment for
+        # the 2026-05-26 duplicate-target incident that codified this
+        # invariant fleet-wide.
+        - Id: modelzoo-sunday-pipeline
+          Arn: !Ref ModelZooSundayPipeline
+          RoleArn: !Ref EventBridgeSfnRoleArn
+          Input: !Sub |
+            {
+              "ec2_instance_id": ["${MicroInstanceId}"],
+              "sns_topic_arn": "${AlertsTopic}",
+              "pipeline_role": "modelzoo-sunday"
             }
 
   # --------------------------------------------------------------------------
@@ -651,6 +730,22 @@ Resources:
       LogGroupName: /aws/stepfunctions/ne-preopen-trading-pipeline
       RetentionInDays: 30
 
+  # alpha-engine-config-I2544/I2545: log groups for the two new child SFs,
+  # same CFN-owned pattern (+ 30-day retention) as the two above — both new
+  # SFs are CFN AWS::StepFunctions::StateMachine resources (unlike the
+  # script-managed EOD pipeline), so their log groups are CFN resources too.
+  WeeklyAdvisoryLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/stepfunctions/ne-weekly-advisory-pipeline
+      RetentionInDays: 30
+
+  ModelZooSundayLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/stepfunctions/ne-modelzoo-sunday-pipeline
+      RetentionInDays: 30
+
   # The SF MutualExclusionGuard (L274) fails a duplicate-trigger execution with a
   # terminal `MutexConflict` Fail — visible today only in SF execution history +
   # the SNS HandleFailure email. These metric-filters + alarms add a CloudWatch
@@ -856,6 +951,14 @@ Outputs:
   WeekdayPipelineArn:
     Value: !Ref WeekdayPipeline
     Description: Weekday pipeline state machine ARN
+
+  AdvisoryPipelineArn:
+    Value: !Ref AdvisoryPipeline
+    Description: Weekly advisory child pipeline state machine ARN (alpha-engine-config-I2544)
+
+  ModelZooSundayPipelineArn:
+    Value: !Ref ModelZooSundayPipeline
+    Description: ModelZoo Sunday child pipeline state machine ARN (alpha-engine-config-I2545)
 
   ExecutionMutexTableName:
     Value: !Ref ExecutionMutexTable

--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -67,7 +67,9 @@ SAT_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
 DAILY_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
 EOD_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
 GROOM_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
-trap "rm -f '$SAT_STAMPED' '$DAILY_STAMPED' '$EOD_STAMPED' '$GROOM_STAMPED'" EXIT
+ADVISORY_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
+MODELZOO_STAMPED="$(mktemp --suffix=.json 2>/dev/null || mktemp)"
+trap "rm -f '$SAT_STAMPED' '$DAILY_STAMPED' '$EOD_STAMPED' '$GROOM_STAMPED' '$ADVISORY_STAMPED' '$MODELZOO_STAMPED'" EXIT
 python3 -c "
 import json, sys
 path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -109,6 +111,26 @@ if orig.startswith('[git:'):
 d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
 json.dump(d, open(path_out, 'w'), indent=2)
 " "$SCRIPT_DIR/step_function_groom.json" "$GROOM_STAMPED" "$GIT_SHA"
+python3 -c "
+import json, sys
+path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(path_in))
+orig = d.get('Comment', '')
+if orig.startswith('[git:'):
+    orig = orig.split(' ', 1)[1] if ' ' in orig else ''
+d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
+json.dump(d, open(path_out, 'w'), indent=2)
+" "$SCRIPT_DIR/step_function_advisory.json" "$ADVISORY_STAMPED" "$GIT_SHA"
+python3 -c "
+import json, sys
+path_in, path_out, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+d = json.load(open(path_in))
+orig = d.get('Comment', '')
+if orig.startswith('[git:'):
+    orig = orig.split(' ', 1)[1] if ' ' in orig else ''
+d['Comment'] = f'[git:{sha}] {orig}'.rstrip()
+json.dump(d, open(path_out, 'w'), indent=2)
+" "$SCRIPT_DIR/step_function_modelzoo.json" "$MODELZOO_STAMPED" "$GIT_SHA"
 
 echo ""
 echo "==> Uploading Step Function definitions to S3..."
@@ -116,6 +138,8 @@ aws s3 cp "$SAT_STAMPED" "s3://$BUCKET/infrastructure/step_function.json" --quie
 aws s3 cp "$DAILY_STAMPED" "s3://$BUCKET/infrastructure/step_function_daily.json" --quiet
 aws s3 cp "$EOD_STAMPED" "s3://$BUCKET/infrastructure/step_function_eod.json" --quiet
 aws s3 cp "$GROOM_STAMPED" "s3://$BUCKET/infrastructure/step_function_groom.json" --quiet
+aws s3 cp "$ADVISORY_STAMPED" "s3://$BUCKET/infrastructure/step_function_advisory.json" --quiet
+aws s3 cp "$MODELZOO_STAMPED" "s3://$BUCKET/infrastructure/step_function_modelzoo.json" --quiet
 echo "  Uploaded to s3://$BUCKET/infrastructure/"
 
 # ── 3. Update Step Function definitions (existence-aware) ────────────────────
@@ -135,6 +159,11 @@ SAT_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-p
 DAILY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline"
 EOD_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
 GROOM_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-dispatch"
+# alpha-engine-config-I2544/I2545: CFN-managed pair, same update-if-present/
+# defer-to-CFN-if-absent pattern as SAT_ARN/DAILY_ARN (both are
+# AWS::StepFunctions::StateMachine resources in the CFN template now).
+ADVISORY_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-weekly-advisory-pipeline"
+MODELZOO_ARN="arn:aws:states:$REGION:${ACCOUNT_ID}:stateMachine:ne-modelzoo-sunday-pipeline"
 # Shared SF execution role (the CFN StepFunctionsRoleArn default; all three
 # orchestration SFs run under it). Used only for the EOD create-if-absent path.
 SF_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-step-functions-role"
@@ -214,9 +243,13 @@ EOD_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":
 # includeExecutionData=true, the CFN-owned per-SF log groups).
 SAT_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-weekly-freshness-pipeline:*"}}]}'
 DAILY_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-preopen-trading-pipeline:*"}}]}'
+ADVISORY_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-weekly-advisory-pipeline:*"}}]}'
+MODELZOO_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-modelzoo-sunday-pipeline:*"}}]}'
 
 update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline" "$SAT_LOGGING_CONFIG"
 update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline" "$DAILY_LOGGING_CONFIG"
+update_or_defer_to_cfn "$ADVISORY_ARN" "$ADVISORY_STAMPED" "Weekly advisory child pipeline" "$ADVISORY_LOGGING_CONFIG"
+update_or_defer_to_cfn "$MODELZOO_ARN" "$MODELZOO_STAMPED" "ModelZoo Sunday child pipeline" "$MODELZOO_LOGGING_CONFIG"
 update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post-close trading pipeline" "$EOD_LOGGING_CONFIG"
 # CORRECTED 2026-07-12: was alpha-engine-groom-pipeline (the OLD name) — the EventBridge
 # Scheduler targets alpha-engine-groom-dispatch (created by the scheduled-groom-dispatcher

--- a/infrastructure/iam/alpha-engine-eventbridge-sfn-role.json
+++ b/infrastructure/iam/alpha-engine-eventbridge-sfn-role.json
@@ -6,7 +6,8 @@
             "Action": "states:StartExecution",
             "Resource": [
                 "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
-                "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline"
+                "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+                "arn:aws:states:us-east-1:711398986525:stateMachine:ne-modelzoo-sunday-pipeline"
             ]
         }
     ]

--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -151,6 +151,12 @@
       "Effect": "Allow",
       "Action": "ssm:GetCommandInvocation",
       "Resource": "*"
+    },
+    {
+      "Sid": "StartAdvisoryChildPipeline",
+      "Effect": "Allow",
+      "Action": "states:StartExecution",
+      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-advisory-pipeline"
     }
   ]
 }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -146,10 +146,14 @@ if $BOOTSTRAP; then
     echo "  Lambda exists, code will be updated in step 3"
   fi
 
-  # EventBridge rule: terminal-failure statuses of ANY of the three fleet
-  # trading SFs. One rule, one target — keep the ARN list in lockstep with
+  # EventBridge rule: terminal-failure statuses of ANY registered fleet SF.
+  # One rule, one target — keep the ARN list in lockstep with
   # index.PIPELINES. (The transitional alpha-engine-eod-pipeline alias was
-  # retired 2026-07-11 — config#2272; old SF deleted live.)
+  # retired 2026-07-11 — config#2272; old SF deleted live.) Widened
+  # 2026-07-14 (alpha-engine-config-I2544/I2545) to also cover the two new
+  # child SFs split out of the weekly pipeline — both registered in
+  # index.PIPELINES with has_listener:False (watch-log + Telegram fire;
+  # autonomous-agent dispatch deferred until their own charter exists).
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   EVENT_PATTERN=$(cat <<EOF
 {
@@ -159,7 +163,9 @@ if $BOOTSTRAP; then
     "stateMachineArn": [
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-advisory-pipeline",
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-modelzoo-sunday-pipeline"
     ],
     "status": ["FAILED", "TIMED_OUT", "ABORTED"]
   }

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -39,7 +39,9 @@
       "Resource": [
         "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*",
         "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:*",
-        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*"
+        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-advisory-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-modelzoo-sunday-pipeline:*"
       ]
     },
     {

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -201,6 +201,33 @@ PIPELINES: dict[str, dict[str, object]] = {
         "dispatch_event_type": "eod-sf-failure",
         "has_listener": True,
     },
+    # alpha-engine-config-I2544: async advisory child of ne-weekly-freshness-
+    # pipeline (eval-judge chain / ReportCard / Director), split out so a
+    # hang there no longer risks the Saturday critical path. has_listener:
+    # False (onboarding default, mirrors how a brand-new pipeline registers
+    # here BEFORE its alpha-engine-config repository_dispatch agent charter
+    # exists) — the watch-log artifact + Telegram receipt still fire
+    # unconditionally; only the AUTONOMOUS-AGENT dispatch is deferred until a
+    # charter for "weekly-advisory-sf-failure" is added and this flips to
+    # True. Non-trading-critical (advisory/observability tail only).
+    "ne-weekly-advisory-pipeline": {
+        "cadence_slug": "weekly-advisory",
+        "label": "Weekly Advisory (eval-judge/ReportCard/Director)",
+        "watch_prefix": "consolidated/weekly-advisory_sf_watch",
+        "dispatch_event_type": "weekly-advisory-sf-failure",
+        "has_listener": False,
+    },
+    # alpha-engine-config-I2545: ModelZoo rotation moved off Saturday to its
+    # own Sunday 09:00 UTC trigger. Same onboarding posture as the advisory
+    # pipeline above (has_listener: False until a dedicated agent charter
+    # exists) — watch-log + Telegram receipt fire unconditionally.
+    "ne-modelzoo-sunday-pipeline": {
+        "cadence_slug": "modelzoo-sunday",
+        "label": "ModelZoo Sunday Rotation",
+        "watch_prefix": "consolidated/modelzoo-sunday_sf_watch",
+        "dispatch_event_type": "modelzoo-sunday-sf-failure",
+        "has_listener": False,
+    },
     # The transitional `alpha-engine-eod-pipeline` alias (config#1408) was
     # retired 2026-07-11 (config#2272) after the dormant old state machine was
     # DELETED live — zero executions since the 2026-06-29 ne-rename.

--- a/infrastructure/lambdas/sf-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/index.py
@@ -161,6 +161,10 @@ EXPECTED_PIPELINE_NAMES = [
     "ne-postclose-trading-pipeline",
     # transitional alpha-engine-eod-pipeline alias retired 2026-07-11
     # (config#2272; dormant old SF deleted live).
+    # alpha-engine-config-I2544/I2545 (2026-07-14): added in lockstep with
+    # saturday-sf-watch-dispatcher's PIPELINES + its deploy.sh EVENT_PATTERN.
+    "ne-weekly-advisory-pipeline",
+    "ne-modelzoo-sunday-pipeline",
 ]
 
 WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
@@ -216,6 +220,11 @@ _WATCH_PREFIXES: dict[str, str] = {
     "ne-weekly-freshness-pipeline": "consolidated/saturday_sf_watch",
     "ne-preopen-trading-pipeline": "consolidated/weekday_sf_watch",
     "ne-postclose-trading-pipeline": "consolidated/eod_sf_watch",
+    # alpha-engine-config-I2544/I2545 (2026-07-14): added in lockstep with
+    # saturday-sf-watch-dispatcher's PIPELINES + sf-watch-spot-dispatcher's
+    # own _WATCH_PREFIXES copy (test_sf_watch_defer_prefix_lockstep.py).
+    "ne-weekly-advisory-pipeline": "consolidated/weekly-advisory_sf_watch",
+    "ne-modelzoo-sunday-pipeline": "consolidated/modelzoo-sunday_sf_watch",
 }
 # The statuses the watch's EventBridge rule matches (deploy.sh EVENT_PATTERN);
 # the saturday dispatcher itself applies the ABORTED operator-abort carve-out.

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -211,6 +211,11 @@ _WATCH_PREFIXES = {
     "ne-weekly-freshness-pipeline": "consolidated/saturday_sf_watch",
     "ne-preopen-trading-pipeline": "consolidated/weekday_sf_watch",
     "ne-postclose-trading-pipeline": "consolidated/eod_sf_watch",
+    # alpha-engine-config-I2544/I2545 (2026-07-14): the two child SFs split
+    # out of the weekly pipeline, added together with their
+    # saturday-sf-watch-dispatcher PIPELINES entries per the lockstep test.
+    "ne-weekly-advisory-pipeline": "consolidated/weekly-advisory_sf_watch",
+    "ne-modelzoo-sunday-pipeline": "consolidated/modelzoo-sunday_sf_watch",
     # The transitional alpha-engine-eod-pipeline alias was removed together
     # with saturday-sf-watch-dispatcher's PIPELINES entry on 2026-07-11
     # (config#2272) — the lockstep test enforces "together".

--- a/infrastructure/step-functions/check-definition-drift.py
+++ b/infrastructure/step-functions/check-definition-drift.py
@@ -79,6 +79,11 @@ SF_DEFINITIONS: tuple[dict, ...] = (
     {"sf_name": "ne-preopen-trading-pipeline", "definition_file": "step_function_daily.json"},
     {"sf_name": "ne-postclose-trading-pipeline", "definition_file": "step_function_eod.json"},
     {"sf_name": "alpha-engine-groom-pipeline", "definition_file": "step_function_groom.json"},
+    # alpha-engine-config-I2544/I2545: advisory + Sunday-modelzoo child SFs,
+    # split out of step_function.json (config#2273 single-writer contract
+    # applies to these two files identically — see deploy_step_function.sh).
+    {"sf_name": "ne-weekly-advisory-pipeline", "definition_file": "step_function_advisory.json"},
+    {"sf_name": "ne-modelzoo-sunday-pipeline", "definition_file": "step_function_modelzoo.json"},
 )
 
 _GIT_STAMP_RE = re.compile(r"^\[git:[0-9a-fA-F]{7,40}\]\s*")

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1,11 +1,11 @@
 {
-  "Comment": "Alpha Engine Saturday Pipeline — orchestrates weekly data collection, RAG ingestion, research, eval-judge + agent-justification triple, predictor training, backtesting, and evaluation sequentially with fail-fast error handling. MorningEnrich, DataPhase1 and RAGIngestion are independent SF states (RAG split 2026-05-06 after a RAG-side import bug failed under the DataPhase1 label, masking that the data layer was healthy; MorningEnrich split out of DataPhase1 2026-05-16 by the preflight-task-split so a phase1 failure never re-runs the completed ~28-min morning-enrich — plan alpha-engine-docs/private/preflight-task-split-260516.md). Backtester and Evaluator are independent SF states (split 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md — for failure isolation, per-stage email, and independent CW heartbeats). The eval-judge chain (EvalJudge → EvalRollingMean → RationaleClustering → ReplayConcordance → Counterfactual) runs after DataPhase2 and BEFORE PredictorTraining (reorder shipped 2026-05-07 evening) so its persisted S3 artifacts (decision_artifacts/_eval/, _clustering/, _concordance/, _counterfactual/) are available when Evaluator generates the weekly email — pre-reorder the judge chain ran AFTER Evaluator, so its results were never visible in the operator's primary review surface. Each spot-bearing state runs on its own spot — accepts +1 bootstrap cycle (~7 min) per split in exchange for failure isolation, redrive granularity, and per-step health markers. RAG still runs before Research so the knowledge base is fresh. Judge chain only reads decision_artifacts/ written by Research, so it has no dependency on Predictor or Backtester output. Backtester runs AFTER predictor training (depends on model weights); Evaluator runs after Backtester (reads same-cohort backtest artifacts). Supports partial execution via boolean skip_* flags on input (e.g. {\"skip_data_phase1\": true, \"skip_rag_ingestion\": true, \"skip_evaluator\": true}); a missing flag is treated as false, so scheduled runs are unaffected. config#2274: top-level TimeoutSeconds=43200 (12h) — the global hang ceiling. Recorded max full run is 3.04h (24-execution history sampled 2026-07-11); the longest LEGITIMATE composition is well under 12h even in the worst case (EvalJudgePoll's 21600s max_wait batch cap + the 7200s spot stages + retry ladders + offcycle/shell presets). Before this ceiling, a hung SSM WaitFor* poll loop (SSM control-plane degradation, e.g. the 2026-07-11 disk-full incident) polled toward the SF 1-year default, invisible to BOTH the deadman alarm (ExecutionsStarted only) and sf-watch (terminal statuses only). A ceiling breach yields status TIMED_OUT, which the sf-watch EventBridge rule already matches (saturday-sf-watch-dispatcher/deploy.sh EVENT_PATTERN) — a hang now pages and dispatches repair automatically. Per-poll-loop iteration caps deliberately skipped: the global ceiling is the load-bearing fix. config#2279: DECLARED RETRY CONVENTION for SSM states — every aws-sdk:ssm:sendCommand spot-stage state carries the 4+2 jittered ladder ([States.TaskFailed,States.Timeout]x4 + [States.ALL]x2, 30s base, backoff 2.0, MaxDelay 300, Jitter FULL); re-issue is idempotent for ALL stages because the send-state Retry fires only on pre-execution API failures (the launcher never ran; the WaitFor* poll loop owns post-delivery outcomes). The two tail health-check sends are the declared health-observe class (no Retry, fail-soft Catch). getCommandInvocation poll states carry the InvocationDoesNotExist eventual-consistency ladder. Enforced by tests/test_sf_retry_ladder_convention.py — a new SSM state must be added to a declared class there or CI fails. Lambda-state States.TaskFailed hardening is the sibling half (config#2250, data-PR752).",
+  "Comment": "Alpha Engine Saturday Pipeline \u2014 orchestrates weekly data collection, RAG ingestion, research, eval-judge + agent-justification triple, predictor training, backtesting, and evaluation sequentially with fail-fast error handling. MorningEnrich, DataPhase1 and RAGIngestion are independent SF states (RAG split 2026-05-06 after a RAG-side import bug failed under the DataPhase1 label, masking that the data layer was healthy; MorningEnrich split out of DataPhase1 2026-05-16 by the preflight-task-split so a phase1 failure never re-runs the completed ~28-min morning-enrich \u2014 plan alpha-engine-docs/private/preflight-task-split-260516.md). Backtester and Evaluator are independent SF states (split 2026-05-07 \u2014 plan: alpha-engine-docs/private/evaluator-split-260507.md \u2014 for failure isolation, per-stage email, and independent CW heartbeats). The eval-judge chain (EvalJudge \u2192 EvalRollingMean \u2192 RationaleClustering \u2192 ReplayConcordance \u2192 Counterfactual) runs after DataPhase2 and BEFORE PredictorTraining (reorder shipped 2026-05-07 evening) so its persisted S3 artifacts (decision_artifacts/_eval/, _clustering/, _concordance/, _counterfactual/) are available when Evaluator generates the weekly email \u2014 pre-reorder the judge chain ran AFTER Evaluator, so its results were never visible in the operator's primary review surface. Each spot-bearing state runs on its own spot \u2014 accepts +1 bootstrap cycle (~7 min) per split in exchange for failure isolation, redrive granularity, and per-step health markers. RAG still runs before Research so the knowledge base is fresh. Judge chain only reads decision_artifacts/ written by Research, so it has no dependency on Predictor or Backtester output. Backtester runs AFTER predictor training (depends on model weights); Evaluator runs after Backtester (reads same-cohort backtest artifacts). Supports partial execution via boolean skip_* flags on input (e.g. {\"skip_data_phase1\": true, \"skip_rag_ingestion\": true, \"skip_evaluator\": true}); a missing flag is treated as false, so scheduled runs are unaffected. config#2274: top-level TimeoutSeconds=43200 (12h) \u2014 the global hang ceiling. Recorded max full run is 3.04h (24-execution history sampled 2026-07-11); the longest LEGITIMATE composition is well under 12h even in the worst case (the 7200s spot stages + retry ladders + offcycle/shell presets). alpha-engine-config-I2544: the eval-judge chain's own EvalJudgePoll 21600s max_wait batch cap no longer bounds THIS ceiling \u2014 that chain (plus ReportCard/Director) now runs in the async ne-weekly-advisory-pipeline child SF (step_function_advisory.json), which carries its own 28800s (8h) top-level TimeoutSeconds sized to clear its own max_wait_seconds cap. Before this ceiling, a hung SSM WaitFor* poll loop (SSM control-plane degradation, e.g. the 2026-07-11 disk-full incident) polled toward the SF 1-year default, invisible to BOTH the deadman alarm (ExecutionsStarted only) and sf-watch (terminal statuses only). A ceiling breach yields status TIMED_OUT, which the sf-watch EventBridge rule already matches (saturday-sf-watch-dispatcher/deploy.sh EVENT_PATTERN) \u2014 a hang now pages and dispatches repair automatically. Per-poll-loop iteration caps deliberately skipped: the global ceiling is the load-bearing fix. config#2279: DECLARED RETRY CONVENTION for SSM states \u2014 every aws-sdk:ssm:sendCommand spot-stage state carries the 4+2 jittered ladder ([States.TaskFailed,States.Timeout]x4 + [States.ALL]x2, 30s base, backoff 2.0, MaxDelay 300, Jitter FULL); re-issue is idempotent for ALL stages because the send-state Retry fires only on pre-execution API failures (the launcher never ran; the WaitFor* poll loop owns post-delivery outcomes). The two tail health-check sends are the declared health-observe class (no Retry, fail-soft Catch). getCommandInvocation poll states carry the InvocationDoesNotExist eventual-consistency ladder. Enforced by tests/test_sf_retry_ladder_convention.py \u2014 a new SSM state must be added to a declared class there or CI fails. Lambda-state States.TaskFailed hardening is the sibling half (config#2250, data-PR752).",
   "StartAt": "InitializeInput",
   "TimeoutSeconds": 43200,
   "States": {
     "InitializeInput": {
       "Type": "Pass",
-      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + ec2_instance_id explicitly; manual runs for partial-execution testing often omit sns_topic_arn, which previously caused HandleFailure/NotifyComplete to error on missing JSONPath. States.JsonMerge with user-input as the second arg lets explicit values win. | 2026-05-17: also stamps run_date = date($$.Execution.StartTime) so every spot stage of one execution keys backtest/{date}/ off ONE date (fixes the Backtester=05-17 vs Evaluator=05-18 UTC-midnight split). User-passed run_date still wins. | 2026-05-18 (shell-run keystone): also seeds the dry-path control vars at their NON-DRY identity values — preflight_args=\"\" (empty spot-command suffix), research_dry=false, data_phase2_dry=false, regime_action=\"produce\". These exist on EVERY run so the spot States.Format / Lambda Payload .$ references always resolve; on the real Saturday run (no shell_run) they hold these identity values, making every spot command string byte-identical to pre-keystone and every Lambda Payload behaviourally identical (handlers default dry_run_llm/dry_run to false; regime action 'produce' is the pre-keystone hardcoded value). ApplyShellRunDefaults (shell_run=true only) overrides them with the dry values. innermost defaults blob is merged UNDER run_date which is merged UNDER sns_topic_arn which is merged UNDER the user input, so user/ApplyShellRunDefaults values always win. PROVENANCE (config#2281): the sns_topic_arn default in the JsonMerge floor hand-carries the account/region literal (arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts) as a FLOOR ONLY — $$.Execution.Input wins the merge, so the authoritative source is the CALLER: the EventBridge schedule's Input (CFN alpha-engine-orchestration.yaml should pass sns_topic_arn via !Sub/!Ref so account/region live in ONE place — that Input change rides the CFN file in alpha-engine-config, not this repo) or an operator StartExecution payload. The floor is retained DELIBERATELY: a bare manual console start with no input must still alert instead of dying in HandleFailure on a missing $.sns_topic_arn. tests/test_sf_sns_arn_single_source.py pins that no publish state hardcodes a TopicArn and no NEW copy of the literal can ship outside the two declared floors (here + NormalizeFailureContext).",
+      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + ec2_instance_id explicitly; manual runs for partial-execution testing often omit sns_topic_arn, which previously caused HandleFailure/NotifyComplete to error on missing JSONPath. States.JsonMerge with user-input as the second arg lets explicit values win. | 2026-05-17: also stamps run_date = date($$.Execution.StartTime) so every spot stage of one execution keys backtest/{date}/ off ONE date (fixes the Backtester=05-17 vs Evaluator=05-18 UTC-midnight split). User-passed run_date still wins. | 2026-05-18 (shell-run keystone): also seeds the dry-path control vars at their NON-DRY identity values \u2014 preflight_args=\"\" (empty spot-command suffix), research_dry=false, data_phase2_dry=false, regime_action=\"produce\". These exist on EVERY run so the spot States.Format / Lambda Payload .$ references always resolve; on the real Saturday run (no shell_run) they hold these identity values, making every spot command string byte-identical to pre-keystone and every Lambda Payload behaviourally identical (handlers default dry_run_llm/dry_run to false; regime action 'produce' is the pre-keystone hardcoded value). ApplyShellRunDefaults (shell_run=true only) overrides them with the dry values. innermost defaults blob is merged UNDER run_date which is merged UNDER sns_topic_arn which is merged UNDER the user input, so user/ApplyShellRunDefaults values always win. PROVENANCE (config#2281): the sns_topic_arn default in the JsonMerge floor hand-carries the account/region literal (arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts) as a FLOOR ONLY \u2014 $$.Execution.Input wins the merge, so the authoritative source is the CALLER: the EventBridge schedule's Input (CFN alpha-engine-orchestration.yaml should pass sns_topic_arn via !Sub/!Ref so account/region live in ONE place \u2014 that Input change rides the CFN file in alpha-engine-config, not this repo) or an operator StartExecution payload. The floor is retained DELIBERATELY: a bare manual console start with no input must still alert instead of dying in HandleFailure on a missing $.sns_topic_arn. tests/test_sf_sns_arn_single_source.py pins that no publish state hardcodes a TopicArn and no NEW copy of the literal can ship outside the two declared floors (here + NormalizeFailureContext).",
       "Parameters": {
         "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"preflight_args\":\"\",\"skip_weekly_run_day_gate\":false,\"research_dry\":false,\"data_phase2_dry\":false,\"regime_action\":\"produce\",\"pipeline_label\":\"\",\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
@@ -14,7 +14,7 @@
     },
     "CheckWeeklyRunDayGate": {
       "Type": "Choice",
-      "Comment": "config#1824 (Brian-ratified 2026-07-06): the weekly runs ONE DAY AFTER the week's last trading session, so the cron fires THU-SAT and this gate self-selects the single correct day. Applies ONLY to the scheduled weekly cadence (pipeline_role='weekly', set by the EventBridge CFN Input) — manual / recovery / watch-rerun / shell executions carry other roles (or none) and bypass automatically; skip_weekly_run_day_gate=true (defaulted false by InitializeInput) is the explicit operator bypass per the config#1617 skip-flag charter.",
+      "Comment": "config#1824 (Brian-ratified 2026-07-06): the weekly runs ONE DAY AFTER the week's last trading session, so the cron fires THU-SAT and this gate self-selects the single correct day. Applies ONLY to the scheduled weekly cadence (pipeline_role='weekly', set by the EventBridge CFN Input) \u2014 manual / recovery / watch-rerun / shell executions carry other roles (or none) and bypass automatically; skip_weekly_run_day_gate=true (defaulted false by InitializeInput) is the explicit operator bypass per the config#1617 skip-flag charter.",
       "Choices": [
         {
           "And": [
@@ -38,7 +38,7 @@
     },
     "WeeklyRunDayGate": {
       "Type": "Task",
-      "Comment": "Run-day gate (config#1824) — mirrors the weekday TradingDayGate (config#1430): predictor Lambda action=check_weekly_run_day is pure NYSE-calendar math with zero infra dependency, returning before preflight. True iff yesterday was the week's LAST trading session (Sat on normal weeks; Fri/Thu on holiday-shortened weeks — real precedent Fri 2026-07-03).",
+      "Comment": "Run-day gate (config#1824) \u2014 mirrors the weekday TradingDayGate (config#1430): predictor Lambda action=check_weekly_run_day is pure NYSE-calendar math with zero infra dependency, returning before preflight. True iff yesterday was the week's LAST trading session (Sat on normal weeks; Fri/Thu on holiday-shortened weeks \u2014 real precedent Fri 2026-07-03).",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
@@ -102,25 +102,25 @@
     },
     "WeeklyRunDaySkip": {
       "Type": "Succeed",
-      "Comment": "Designed no-op: scheduled THU-SAT firing on a non-run day. Succeed (never Fail) so SF-success metrics, the SF-watch agent, and page-25 treat this exactly like the weekday NotifyHolidaySkip — a green skip, not a failure. Cycle health remains artifact-freshness-as-authority (config#1724); this state produces no artifacts on purpose."
+      "Comment": "Designed no-op: scheduled THU-SAT firing on a non-run day. Succeed (never Fail) so SF-success metrics, the SF-watch agent, and page-25 treat this exactly like the weekday NotifyHolidaySkip \u2014 a green skip, not a failure. Cycle health remains artifact-freshness-as-authority (config#1724); this state produces no artifacts on purpose."
     },
     "WeeklyRunDayGateMalformed": {
       "Type": "Pass",
-      "Comment": "config#2275: floor $.weekly_run_day_gate_error before WeeklyRunDayGateFailed formats it into the SNS message — that state's Message.$ calls States.JsonToString($.weekly_run_day_gate_error), which would itself throw States.Runtime were the field absent. The Catch path sets it via ResultPath; this Choice path must floor it explicitly.",
+      "Comment": "config#2275: floor $.weekly_run_day_gate_error before WeeklyRunDayGateFailed formats it into the SNS message \u2014 that state's Message.$ calls States.JsonToString($.weekly_run_day_gate_error), which would itself throw States.Runtime were the field absent. The Catch path sets it via ResultPath; this Choice path must floor it explicitly.",
       "Result": {
         "Error": "WeeklyRunDayGateMalformedPayload",
-        "Cause": "check_weekly_run_day returned a payload without is_weekly_run_day — proceeding fail-open as a run day (mirrors the gate Catch posture)."
+        "Cause": "check_weekly_run_day returned a payload without is_weekly_run_day \u2014 proceeding fail-open as a run day (mirrors the gate Catch posture)."
       },
       "ResultPath": "$.weekly_run_day_gate_error",
       "Next": "WeeklyRunDayGateFailed"
     },
     "WeeklyRunDayGateFailed": {
       "Type": "Task",
-      "Comment": "Gate Lambda failed for infrastructure reasons — alert and PROCEED as run day (fail-open, mirroring the weekday TradingDayGateFailed). Worst case a broken predictor Lambda all week yields up to 3 alerted duplicate runs (distinct run_dates, idempotent artifact keys) — accepted: the same Lambda gates every weekday morning, so a multi-day outage is already loudly visible. Message fields are all structurally guaranteed (sns_topic_arn defaulted by InitializeInput; error set by the Catch ResultPath) per the config#1819 notifier-totality lesson.",
+      "Comment": "Gate Lambda failed for infrastructure reasons \u2014 alert and PROCEED as run day (fail-open, mirroring the weekday TradingDayGateFailed). Worst case a broken predictor Lambda all week yields up to 3 alerted duplicate runs (distinct run_dates, idempotent artifact keys) \u2014 accepted: the same Lambda gates every weekday morning, so a multi-day outage is already loudly visible. Message fields are all structurally guaranteed (sns_topic_arn defaulted by InitializeInput; error set by the Catch ResultPath) per the config#1819 notifier-totality lesson.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekly Pipeline — Run-Day Gate Failed (Proceeding)",
+        "Subject": "Alpha Engine Weekly Pipeline \u2014 Run-Day Gate Failed (Proceeding)",
         "Message.$": "States.Format('Weekly run-day gate Lambda failed (infra error, not a calendar decision). Pipeline proceeding as run day. Error: {}', States.JsonToString($.weekly_run_day_gate_error))"
       },
       "ResultPath": "$.weekly_run_day_gate_error_notify",
@@ -128,7 +128,7 @@
     },
     "CheckRunMode": {
       "Type": "Choice",
-      "Comment": "Cadence-preset gate (config#830). A single {\"mode\": \"backtest-eval\"} input expands (in ApplyBacktestEvalPreset) into the full skip-flag set that runs ONLY Backtester → Evaluator → NotifyComplete — the mid-week rerun shape that previously motivated a standalone state machine. This keeps ONE source of truth for the two stages (no verbatim-copied SF to drift) and one button instead of hand-passing ~17 skip flags. Missing/other mode → straight to CheckSkipLibPinDriftCheck, so scheduled Saturday runs and manual flag-driven partial runs are byte-identical to pre-config#830.",
+      "Comment": "Cadence-preset gate (config#830). A single {\"mode\": \"backtest-eval\"} input expands (in ApplyBacktestEvalPreset) into the full skip-flag set that runs ONLY Backtester \u2192 Evaluator \u2192 NotifyComplete \u2014 the mid-week rerun shape that previously motivated a standalone state machine. This keeps ONE source of truth for the two stages (no verbatim-copied SF to drift) and one button instead of hand-passing ~17 skip flags. Missing/other mode \u2192 straight to CheckSkipLibPinDriftCheck, so scheduled Saturday runs and manual flag-driven partial runs are byte-identical to pre-config#830.",
       "Choices": [
         {
           "And": [
@@ -148,7 +148,7 @@
     },
     "ApplyBacktestEvalPreset": {
       "Type": "Pass",
-      "Comment": "mode=backtest-eval ONLY (config#830). Seeds skip_* defaults that bypass every stage EXCEPT Backtester + Evaluator: the front half (lib-pin/morning-enrich/data-phase1/rag/regime/research/data-phase2/eval-judge chain/aggregate-costs/predictor-training), the post-backtest model block (predictor-backtest + portfolio-optimizer), parity, and the post-eval tail (health checks/report-card/director via skip_post_eval). skip_backtester / skip_evaluator are deliberately NOT set, so those two run. Merge order States.JsonMerge(preset, $, false) makes the preset the BASE and the live input ($) WIN — so an operator can still override any single flag (e.g. {\"mode\": \"backtest-eval\", \"skip_parity\": false}) and it takes effect. Mirrors InitializeInput's JsonMerge-defaults idiom.",
+      "Comment": "mode=backtest-eval ONLY (config#830). Seeds skip_* defaults that bypass every stage EXCEPT Backtester + Evaluator: the front half (lib-pin/morning-enrich/data-phase1/rag/regime/research/data-phase2/eval-judge chain/aggregate-costs/predictor-training), the post-backtest model block (predictor-backtest + portfolio-optimizer), parity, and the post-eval tail (health checks/report-card/director via skip_post_eval). skip_backtester / skip_evaluator are deliberately NOT set, so those two run. Merge order States.JsonMerge(preset, $, false) makes the preset the BASE and the live input ($) WIN \u2014 so an operator can still override any single flag (e.g. {\"mode\": \"backtest-eval\", \"skip_parity\": false}) and it takes effect. Mirrors InitializeInput's JsonMerge-defaults idiom.",
       "Parameters": {
         "merged.$": "States.JsonMerge(States.StringToJson('{\"skip_lib_pin_drift_check\":true,\"skip_morning_enrich\":true,\"skip_data_phase1\":true,\"skip_rag_ingestion\":true,\"skip_regime_substrate\":true,\"skip_regime_retrospective_eval\":true,\"skip_research\":true,\"skip_data_phase2\":true,\"skip_eval_judge\":true,\"skip_rationale_clustering\":true,\"skip_replay_concordance\":true,\"skip_counterfactual\":true,\"skip_aggregate_costs\":true,\"skip_predictor_training\":true,\"skip_predictor_backtest\":true,\"skip_portfolio_optimizer_backtest\":true,\"skip_parity\":true,\"skip_post_eval\":true}'),$,false)"
       },
@@ -157,7 +157,7 @@
     },
     "CheckSkipLibPinDriftCheck": {
       "Type": "Choice",
-      "Comment": "Skip-gate (L4517). {\"skip_lib_pin_drift_check\": true} bypasses the preventive cross-repo lib-pin drift check — e.g. an operator rerun where pins are known-good.",
+      "Comment": "Skip-gate (L4517). {\"skip_lib_pin_drift_check\": true} bypasses the preventive cross-repo lib-pin drift check \u2014 e.g. an operator rerun where pins are known-good.",
       "Choices": [
         {
           "And": [
@@ -177,7 +177,7 @@
     },
     "LibPinDriftCheck": {
       "Type": "Task",
-      "Comment": "Preventive cross-repo alpha-engine-lib pin-drift gate (L4517). Runs BEFORE any spot launch: asserts backtester-pin == predictor-pin (co-install parity — the only multi-repo co-install site, the 2026-05-12 silent-downgrade incident) AND every Saturday-SF repo's pin >= MIN_LIB_VERSION (v0.39.0 floor = data's lowest INTENTIONAL pin). has_drift=true halts in seconds with a named offender instead of a co-install break ~12 min into a spot. FAIL-OPEN: a GitHub-fetch/parse miss sets has_drift=false (the probe's own degraded mode), and the Catch routes any Lambda failure (incl. an unknown action before predictor PR A deploys) straight to the pipeline — so the checker NEVER false-halts the weekly run.",
+      "Comment": "Preventive cross-repo alpha-engine-lib pin-drift gate (L4517). Runs BEFORE any spot launch: asserts backtester-pin == predictor-pin (co-install parity \u2014 the only multi-repo co-install site, the 2026-05-12 silent-downgrade incident) AND every Saturday-SF repo's pin >= MIN_LIB_VERSION (v0.39.0 floor = data's lowest INTENTIONAL pin). has_drift=true halts in seconds with a named offender instead of a co-install break ~12 min into a spot. FAIL-OPEN: a GitHub-fetch/parse miss sets has_drift=false (the probe's own degraded mode), and the Catch routes any Lambda failure (incl. an unknown action before predictor PR A deploys) straight to the pipeline \u2014 so the checker NEVER false-halts the weekly run.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
@@ -201,7 +201,7 @@
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Comment": "config#2278: transient tier — most gate-infra flakes (GitHub/S3 fetch inside the Lambda surfacing as a crash/timeout) are transient; two backed-off retries make silent gate degradation rarer before the fail-open+alert Catch below engages.",
+          "Comment": "config#2278: transient tier \u2014 most gate-infra flakes (GitHub/S3 fetch inside the Lambda surfacing as a crash/timeout) are transient; two backed-off retries make silent gate degradation rarer before the fail-open+alert Catch below engages.",
           "MaxAttempts": 2,
           "IntervalSeconds": 10,
           "BackoffRate": 2.0
@@ -212,7 +212,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2278: still fail-open — the probe's own failure must not halt the weekly run — but no longer SILENT, and no longer skipping the sibling gate: route through the degraded-flag Pass + SNS alert, then into PipelineContractCheck (the old direct CheckMutexRole jump silently skipped gate 2 as well).",
+          "Comment": "config#2278: still fail-open \u2014 the probe's own failure must not halt the weekly run \u2014 but no longer SILENT, and no longer skipping the sibling gate: route through the degraded-flag Pass + SNS alert, then into PipelineContractCheck (the old direct CheckMutexRole jump silently skipped gate 2 as well).",
           "Next": "LibPinGateDegraded",
           "ResultPath": "$.libpin_drift_error"
         }
@@ -222,7 +222,7 @@
     },
     "LibPinDriftGate": {
       "Type": "Choice",
-      "Comment": "Hard-fail when the lib-pin probe reports has_drift=true (a confirmed co-install parity break or below-floor regression). Surfaces cross-repo pin drift loudly before the SF spends on any spot launch. Routes via ExtractLibPinDriftError (NOT straight to HandleFailure): a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — jumping here directly made HandleFailure itself die with States.Runtime ('$.error could not be found', 2026-07-03 offcycle-shell), swallowing the drift reason behind an opaque meta-error. Mirrors the existing Extract*Error normalizer convention. On pass, proceeds to PipelineContractCheck (L4595 / config#693) — the sibling pre-spend preflight gate — rather than straight to CheckMutexRole, composing both invariant probes into one preflight chain before any spot spend.",
+      "Comment": "Hard-fail when the lib-pin probe reports has_drift=true (a confirmed co-install parity break or below-floor regression). Surfaces cross-repo pin drift loudly before the SF spends on any spot launch. Routes via ExtractLibPinDriftError (NOT straight to HandleFailure): a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) \u2014 jumping here directly made HandleFailure itself die with States.Runtime ('$.error could not be found', 2026-07-03 offcycle-shell), swallowing the drift reason behind an opaque meta-error. Mirrors the existing Extract*Error normalizer convention. On pass, proceeds to PipelineContractCheck (L4595 / config#693) \u2014 the sibling pre-spend preflight gate \u2014 rather than straight to CheckMutexRole, composing both invariant probes into one preflight chain before any spot spend.",
       "Choices": [
         {
           "And": [
@@ -235,7 +235,7 @@
               "BooleanEquals": true
             }
           ],
-          "Comment": "config#2275: IsPresent-guarded — a partial gate payload (no has_drift) previously threw States.Runtime here, bypassing HandleFailure.",
+          "Comment": "config#2275: IsPresent-guarded \u2014 a partial gate payload (no has_drift) previously threw States.Runtime here, bypassing HandleFailure.",
           "Next": "ExtractLibPinDriftError"
         },
         {
@@ -243,7 +243,7 @@
             "Variable": "$.libpin_drift_result.Payload.has_drift",
             "IsPresent": true
           },
-          "Comment": "config#2278: a gate payload WITHOUT has_drift means the gate could not check — fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'.",
+          "Comment": "config#2278: a gate payload WITHOUT has_drift means the gate could not check \u2014 fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'.",
           "Next": "LibPinGateDegraded"
         }
       ],
@@ -251,7 +251,7 @@
     },
     "ExtractLibPinDriftError": {
       "Type": "Pass",
-      "Comment": "Normalize a confirmed lib-pin drift (LibPinDriftGate has_drift==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) — it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the drift offenders (2026-07-03 offcycle-shell). Carries the whole probe Payload (reason/offenders/pins/parity_ok/floor_ok/min_lib_version) so the FAILED SNS alert names the exact cross-repo pin mismatch a human must resolve. References only $.libpin_drift_result.Payload — guaranteed present because the gate already dereferenced Payload.has_drift to route here — so this normalizer cannot itself raise a missing-field States.Runtime. Mirrors the existing Extract*Error → HandleFailure convention; no new error channel. FAIL-LOUD PRESERVED: still → HandleFailure → FailExecution (the pipeline still hard-fails on real drift by design).",
+      "Comment": "Normalize a confirmed lib-pin drift (LibPinDriftGate has_drift==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so \u2014 unlike a Task Catch (ResultPath $.error) \u2014 it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the drift offenders (2026-07-03 offcycle-shell). Carries the whole probe Payload (reason/offenders/pins/parity_ok/floor_ok/min_lib_version) so the FAILED SNS alert names the exact cross-repo pin mismatch a human must resolve. References only $.libpin_drift_result.Payload \u2014 guaranteed present because the gate already dereferenced Payload.has_drift to route here \u2014 so this normalizer cannot itself raise a missing-field States.Runtime. Mirrors the existing Extract*Error \u2192 HandleFailure convention; no new error channel. FAIL-LOUD PRESERVED: still \u2192 HandleFailure \u2192 FailExecution (the pipeline still hard-fails on real drift by design).",
       "Parameters": {
         "phase": "LibPinDriftGate",
         "source": "LibPinDriftGate.has_drift",
@@ -262,7 +262,7 @@
     },
     "PipelineContractCheck": {
       "Type": "Task",
-      "Comment": "Preventive pre-spend PIPELINE_CONTRACT.yaml preflight gate (L4595 / config#693). Sibling to LibPinDriftCheck: runs immediately after it, BEFORE any spot launch, and asserts PIPELINE_CONTRACT.yaml is internally self-consistent AND every artifact_id it references exists in ARTIFACT_REGISTRY.yaml. A CI validator (validate_pipeline_contract.py) already catches this at PR time, but a config/SF-definition change made outside that CI could still spend a Saturday spot before failing; this probe re-runs the same invariants at SF start so a contract break halts in seconds. FAIL-OPEN: a GitHub-fetch/parse miss sets has_violation=false (the probe's own degraded mode, reason=fetch_failed), and the Catch routes any Lambda failure straight to the pipeline — so the checker NEVER false-halts the weekly run, mirroring LibPinDriftCheck's fail-open semantics exactly.",
+      "Comment": "Preventive pre-spend PIPELINE_CONTRACT.yaml preflight gate (L4595 / config#693). Sibling to LibPinDriftCheck: runs immediately after it, BEFORE any spot launch, and asserts PIPELINE_CONTRACT.yaml is internally self-consistent AND every artifact_id it references exists in ARTIFACT_REGISTRY.yaml. A CI validator (validate_pipeline_contract.py) already catches this at PR time, but a config/SF-definition change made outside that CI could still spend a Saturday spot before failing; this probe re-runs the same invariants at SF start so a contract break halts in seconds. FAIL-OPEN: a GitHub-fetch/parse miss sets has_violation=false (the probe's own degraded mode, reason=fetch_failed), and the Catch routes any Lambda failure straight to the pipeline \u2014 so the checker NEVER false-halts the weekly run, mirroring LibPinDriftCheck's fail-open semantics exactly.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
@@ -286,7 +286,7 @@
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Comment": "config#2278: transient tier — most gate-infra flakes (GitHub/S3 fetch inside the Lambda surfacing as a crash/timeout) are transient; two backed-off retries make silent gate degradation rarer before the fail-open+alert Catch below engages.",
+          "Comment": "config#2278: transient tier \u2014 most gate-infra flakes (GitHub/S3 fetch inside the Lambda surfacing as a crash/timeout) are transient; two backed-off retries make silent gate degradation rarer before the fail-open+alert Catch below engages.",
           "MaxAttempts": 2,
           "IntervalSeconds": 10,
           "BackoffRate": 2.0
@@ -297,7 +297,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2278: still fail-open — the probe's own failure must not halt the weekly run — but no longer silent: route through the degraded-flag Pass + SNS alert before proceeding to CheckMutexRole.",
+          "Comment": "config#2278: still fail-open \u2014 the probe's own failure must not halt the weekly run \u2014 but no longer silent: route through the degraded-flag Pass + SNS alert before proceeding to CheckMutexRole.",
           "Next": "PipelineContractGateDegraded",
           "ResultPath": "$.pipeline_contract_error"
         }
@@ -307,7 +307,7 @@
     },
     "PipelineContractGate": {
       "Type": "Choice",
-      "Comment": "Hard-fail when the pipeline-contract probe reports has_violation=true (a confirmed PIPELINE_CONTRACT.yaml self-consistency breach or dangling artifact_id). Surfaces the contract break loudly before the SF spends on any spot launch. Routes via ExtractPipelineContractError (NOT straight to HandleFailure), mirroring LibPinDriftGate: a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — a direct Choice→HandleFailure jump would die with States.Runtime ('$.error could not be found'), swallowing the violation list behind an opaque meta-error. config#1819: ExtractPipelineContractError itself hands off to NormalizeFailureContext (the single Catch/Next chokepoint), not HandleFailure directly.",
+      "Comment": "Hard-fail when the pipeline-contract probe reports has_violation=true (a confirmed PIPELINE_CONTRACT.yaml self-consistency breach or dangling artifact_id). Surfaces the contract break loudly before the SF spends on any spot launch. Routes via ExtractPipelineContractError (NOT straight to HandleFailure), mirroring LibPinDriftGate: a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) \u2014 a direct Choice\u2192HandleFailure jump would die with States.Runtime ('$.error could not be found'), swallowing the violation list behind an opaque meta-error. config#1819: ExtractPipelineContractError itself hands off to NormalizeFailureContext (the single Catch/Next chokepoint), not HandleFailure directly.",
       "Choices": [
         {
           "And": [
@@ -320,7 +320,7 @@
               "BooleanEquals": true
             }
           ],
-          "Comment": "config#2275: IsPresent-guarded — a partial gate payload (no has_violation) previously threw States.Runtime here, bypassing HandleFailure.",
+          "Comment": "config#2275: IsPresent-guarded \u2014 a partial gate payload (no has_violation) previously threw States.Runtime here, bypassing HandleFailure.",
           "Next": "ExtractPipelineContractError"
         },
         {
@@ -328,7 +328,7 @@
             "Variable": "$.pipeline_contract_result.Payload.has_violation",
             "IsPresent": true
           },
-          "Comment": "config#2278: a gate payload WITHOUT has_violation means the gate could not check — fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'.",
+          "Comment": "config#2278: a gate payload WITHOUT has_violation means the gate could not check \u2014 fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'.",
           "Next": "PipelineContractGateDegraded"
         }
       ],
@@ -336,7 +336,7 @@
     },
     "ExtractPipelineContractError": {
       "Type": "Pass",
-      "Comment": "Normalize a confirmed pipeline-contract violation (PipelineContractGate has_violation==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) — it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the violation list. Carries the whole probe Payload (has_violation/violations/boundary_count/reason) so the FAILED SNS alert names the exact contract breach a human must resolve. References only $.pipeline_contract_result.Payload — guaranteed present because the gate already dereferenced Payload.has_violation to route here — so this normalizer cannot itself raise a missing-field States.Runtime. Mirrors ExtractLibPinDriftError's convention, INCLUDING config#1819's chokepoint: this Pass already sets $.error itself, so it hands off to NormalizeFailureContext (the SOLE Catch/Next target for the whole failure path) rather than jumping straight to HandleFailure — that chokepoint still floor-defaults $.sns_topic_arn/$.pipeline_label and re-pins pipeline_label from $.shell_run, none of which this normalizer supplies. No new error channel. FAIL-LOUD PRESERVED: still → HandleFailure → FailExecution (the pipeline still hard-fails on a real contract violation by design).",
+      "Comment": "Normalize a confirmed pipeline-contract violation (PipelineContractGate has_violation==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so \u2014 unlike a Task Catch (ResultPath $.error) \u2014 it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the violation list. Carries the whole probe Payload (has_violation/violations/boundary_count/reason) so the FAILED SNS alert names the exact contract breach a human must resolve. References only $.pipeline_contract_result.Payload \u2014 guaranteed present because the gate already dereferenced Payload.has_violation to route here \u2014 so this normalizer cannot itself raise a missing-field States.Runtime. Mirrors ExtractLibPinDriftError's convention, INCLUDING config#1819's chokepoint: this Pass already sets $.error itself, so it hands off to NormalizeFailureContext (the SOLE Catch/Next target for the whole failure path) rather than jumping straight to HandleFailure \u2014 that chokepoint still floor-defaults $.sns_topic_arn/$.pipeline_label and re-pins pipeline_label from $.shell_run, none of which this normalizer supplies. No new error channel. FAIL-LOUD PRESERVED: still \u2192 HandleFailure \u2192 FailExecution (the pipeline still hard-fails on a real contract violation by design).",
       "Parameters": {
         "phase": "PipelineContractGate",
         "source": "PipelineContractGate.has_violation",
@@ -347,18 +347,18 @@
     },
     "LibPinGateDegraded": {
       "Type": "Pass",
-      "Comment": "config#2278: the lib-pin gate could not CHECK (Lambda failure after both retry tiers, or a payload without has_drift). Still fail-open — availability over gating for a weekly pipeline — but VISIBLE and rarer: gate_degraded=true threads into the completion email via CheckGateDegradedNotify, and PublishLibPinGateDegraded alerts NOW (mirroring WeeklyRunDayGateFailed's fail-open+alert shape). Proceeds into PipelineContractCheck so a lib-pin-gate infra flake no longer silently skips the SIBLING gate too.",
+      "Comment": "config#2278: the lib-pin gate could not CHECK (Lambda failure after both retry tiers, or a payload without has_drift). Still fail-open \u2014 availability over gating for a weekly pipeline \u2014 but VISIBLE and rarer: gate_degraded=true threads into the completion email via CheckGateDegradedNotify, and PublishLibPinGateDegraded alerts NOW (mirroring WeeklyRunDayGateFailed's fail-open+alert shape). Proceeds into PipelineContractCheck so a lib-pin-gate infra flake no longer silently skips the SIBLING gate too.",
       "Result": true,
       "ResultPath": "$.gate_degraded",
       "Next": "PublishLibPinGateDegraded"
     },
     "PublishLibPinGateDegraded": {
       "Type": "Task",
-      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline — never States.Format against input). Best-effort Catch: a publish failure must not halt the fail-open path this alert decorates; the caught TaskFailed still logs at ERROR and is matched by SnsPublishFailedMetricFilter.",
+      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline \u2014 never States.Format against input). Best-effort Catch: a publish failure must not halt the fail-open path this alert decorates; the caught TaskFailed still logs at ERROR and is matched by SnsPublishFailedMetricFilter.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekly Pipeline — Lib-Pin Gate DEGRADED (Proceeding Unchecked)",
+        "Subject": "Alpha Engine Weekly Pipeline \u2014 Lib-Pin Gate DEGRADED (Proceeding Unchecked)",
         "Message": "LibPinDriftCheck could not verify cross-repo pin parity (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the co-install break this gate exists to catch. The completion email will carry the gates-degraded marker. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.libpin_gate_degraded_notify",
@@ -367,7 +367,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Best-effort alert — a publish failure must not halt the fail-open path.",
+          "Comment": "Best-effort alert \u2014 a publish failure must not halt the fail-open path.",
           "ResultPath": "$.libpin_gate_degraded_notify_error",
           "Next": "PipelineContractCheck"
         }
@@ -387,7 +387,7 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekly Pipeline — Contract Gate DEGRADED (Proceeding Unchecked)",
+        "Subject": "Alpha Engine Weekly Pipeline \u2014 Contract Gate DEGRADED (Proceeding Unchecked)",
         "Message": "PipelineContractCheck could not verify PIPELINE_CONTRACT.yaml self-consistency (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the contract break this gate exists to catch. The completion email will carry the gates-degraded marker. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.pipeline_contract_gate_degraded_notify",
@@ -396,7 +396,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Best-effort alert — a publish failure must not halt the fail-open path.",
+          "Comment": "Best-effort alert \u2014 a publish failure must not halt the fail-open path.",
           "ResultPath": "$.pipeline_contract_gate_degraded_notify_error",
           "Next": "CheckMutexRole"
         }
@@ -405,7 +405,7 @@
     },
     "CheckMutexRole": {
       "Type": "Choice",
-      "Comment": "L274 SF MutualExclusionGuard — gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations — that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell. Trigger of record: 2026-05-26 duplicate-EventBridge-target incident (PR #322 closed the SPECIFIC dup-target shape via CI; this mutex closes the broader class).",
+      "Comment": "L274 SF MutualExclusionGuard \u2014 gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations \u2014 that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell. Trigger of record: 2026-05-26 duplicate-EventBridge-target incident (PR #322 closed the SPECIFIC dup-target shape via CI; this mutex closes the broader class).",
       "Choices": [
         {
           "And": [
@@ -442,13 +442,13 @@
     "ComputeMutexTtl": {
       "Type": "Pass",
       "QueryLanguage": "JSONata",
-      "Comment": "config#2280 — TTL epoch for the run-slot mutex item. JSONPath intrinsics cannot convert ISO-8601 to epoch (States.MathAdd needs a number the context object never provides), so this single Pass state opts into JSONata ($toMillis) to stamp mutex_ttl_epoch = epoch(Execution.StartTime) + 86400s (~24h) as a STRING (DynamoDB's N attribute is string-encoded on the wire). Chosen over (a) piggybacking a Lambda that runs before AcquireMutex — the only in-repo candidates (LibPinDriftCheck/PipelineContractCheck) are skip-gated, so the ttl attribute would be conditionally absent and a missing JSONPath in AcquireMutex's Item would throw States.Runtime into the States.ALL fail-open, silently disabling the mutex exactly on skip-flag runs — and over (b) a new epoch-computation Lambda (forbidden overhead). Only this state is JSONata; AcquireMutex stays JSONPath so its Catch/ResultPath semantics are untouched. Reached only via CheckMutexRole's cadence-role path, so $.mutex_ttl_epoch is ALWAYS present when AcquireMutex runs.",
+      "Comment": "config#2280 \u2014 TTL epoch for the run-slot mutex item. JSONPath intrinsics cannot convert ISO-8601 to epoch (States.MathAdd needs a number the context object never provides), so this single Pass state opts into JSONata ($toMillis) to stamp mutex_ttl_epoch = epoch(Execution.StartTime) + 86400s (~24h) as a STRING (DynamoDB's N attribute is string-encoded on the wire). Chosen over (a) piggybacking a Lambda that runs before AcquireMutex \u2014 the only in-repo candidates (LibPinDriftCheck/PipelineContractCheck) are skip-gated, so the ttl attribute would be conditionally absent and a missing JSONPath in AcquireMutex's Item would throw States.Runtime into the States.ALL fail-open, silently disabling the mutex exactly on skip-flag runs \u2014 and over (b) a new epoch-computation Lambda (forbidden overhead). Only this state is JSONata; AcquireMutex stays JSONPath so its Catch/ResultPath semantics are untouched. Reached only via CheckMutexRole's cadence-role path, so $.mutex_ttl_epoch is ALWAYS present when AcquireMutex runs.",
       "Output": "{% $merge([$states.input, {\"mutex_ttl_epoch\": $string($floor($toMillis($states.context.Execution.StartTime) / 1000) + 86400)}]) %}",
       "Next": "AcquireMutex"
     },
     "AcquireMutex": {
       "Type": "Task",
-      "Comment": "L274 + config#2280 — DynamoDB conditional PUT on the RUN-SLOT. mutex_key = '{state-machine-name}#{pipeline_role}#{run_date}' ($.run_date is stamped by InitializeInput before any gate). The old key's UTC minute bucket only caught duplicates landing in the SAME minute — an EventBridge internal retry >60s later, an operator re-paste a minute later, or a re-introduced duplicate rule at minute distance all got fresh keys and ran concurrently (double spot spend + artifact write races on the same run_date prefixes). Keying on run_date makes ANY second cadence execution of the same run-slot lose with ConditionalCheckFailedException → MutexConflict Fail, regardless of stagger. Staleness: a run-date key has no natural expiry (unlike the minute bucket), so items carry ttl_epoch (~24h, from ComputeMutexTtl) with table TTL enabled as the crashed-holder backstop; the PRIMARY stale-item mechanism is scripts/weekly_sf_rerun.py, which deletes the failed holder's item after verifying the holder execution is terminal (never steals from a RUNNING one). Recovery reruns themselves carry pipeline_role='watch-rerun' (non-cadence) and bypass this state entirely. Redrives resume the SAME execution and never re-enter this state. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
+      "Comment": "L274 + config#2280 \u2014 DynamoDB conditional PUT on the RUN-SLOT. mutex_key = '{state-machine-name}#{pipeline_role}#{run_date}' ($.run_date is stamped by InitializeInput before any gate). The old key's UTC minute bucket only caught duplicates landing in the SAME minute \u2014 an EventBridge internal retry >60s later, an operator re-paste a minute later, or a re-introduced duplicate rule at minute distance all got fresh keys and ran concurrently (double spot spend + artifact write races on the same run_date prefixes). Keying on run_date makes ANY second cadence execution of the same run-slot lose with ConditionalCheckFailedException \u2192 MutexConflict Fail, regardless of stagger. Staleness: a run-date key has no natural expiry (unlike the minute bucket), so items carry ttl_epoch (~24h, from ComputeMutexTtl) with table TTL enabled as the crashed-holder backstop; the PRIMARY stale-item mechanism is scripts/weekly_sf_rerun.py, which deletes the failed holder's item after verifying the holder execution is terminal (never steals from a RUNNING one). Recovery reruns themselves carry pipeline_role='watch-rerun' (non-cadence) and bypass this state entirely. Redrives resume the SAME execution and never re-enter this state. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
       "Resource": "arn:aws:states:::aws-sdk:dynamodb:putItem",
       "Parameters": {
         "TableName": "alpha-engine-sf-execution-mutex",
@@ -491,7 +491,7 @@
           "ErrorEquals": [
             "DynamoDB.ConditionalCheckFailedException"
           ],
-          "Comment": "Mutex held by another execution of the same run-slot (state-machine + pipeline_role + run_date) — the duplicate-trigger case we are explicitly protecting against, now at ANY stagger, not just same-minute. Fail loud so the dup is visible in SF execution history + SNS alert.",
+          "Comment": "Mutex held by another execution of the same run-slot (state-machine + pipeline_role + run_date) \u2014 the duplicate-trigger case we are explicitly protecting against, now at ANY stagger, not just same-minute. Fail loud so the dup is visible in SF execution history + SNS alert.",
           "Next": "MutexConflict",
           "ResultPath": "$.mutex_conflict"
         },
@@ -510,11 +510,11 @@
     "MutexConflict": {
       "Type": "Fail",
       "Error": "MutexConflict",
-      "Cause": "L274/config#2280: another SF execution with the same state-machine + pipeline_role + run_date already holds the run-slot mutex. Most likely causes: duplicate EventBridge target fan-out or a staggered duplicate trigger (internal retry / operator re-paste). Forensic: DynamoDB GetItem on the mutex_key in $.mutex_conflict names the holder's executionArn. If the holder is TERMINAL and a recovery rerun is intended, use scripts/weekly_sf_rerun.py — it verifies the holder is terminal, deletes the stale item, and starts a correctly-scoped watch-rerun; never delete the item while the holder is RUNNING."
+      "Cause": "L274/config#2280: another SF execution with the same state-machine + pipeline_role + run_date already holds the run-slot mutex. Most likely causes: duplicate EventBridge target fan-out or a staggered duplicate trigger (internal retry / operator re-paste). Forensic: DynamoDB GetItem on the mutex_key in $.mutex_conflict names the holder's executionArn. If the holder is TERMINAL and a recovery rerun is intended, use scripts/weekly_sf_rerun.py \u2014 it verifies the holder is terminal, deletes the stale item, and starts a correctly-scoped watch-rerun; never delete the item while the holder is RUNNING."
     },
     "CheckShellRun": {
       "Type": "Choice",
-      "Comment": "Friday-PM 'shell run' gate (ROADMAP 'Scheduled Friday-PM shell run'; spine landed #258, KEYSTONE landed feat/sf-shell-run-keystone). Input {\"shell_run\": true} (supplied by the event-driven alpha-engine-eod-success-friday-shell-trigger Lambda on Friday EOD-SF SUCCEEDED; the legacy cron rule alpha-engine-friday-shell-run was retired 2026-05-29 per ROADMAP L4055) routes to ApplyShellRunDefaults, which now sets the dry-path control vars (preflight_args=\" --preflight-only\" for the 7 spot states, Lambda dry flags for Research/DataPhase2/RegimeSubstrate/RegimeRetrospectiveEval) and hard-skips ONLY the 5 documented no-clean-dry-path exceptions — so the Friday run BOOTS + DRY-EXECUTES the workload instead of pure-skipping it (the keystone's whole point: exercise the real bootstrap/import/lib-pin/transport paths). shell_run absent OR false routes straight to CheckSkipMorningEnrich — BYTE-IDENTICAL to the pre-spine Saturday run (this is a strict superset; the real Sat 02:00 PT firing passes no shell_run, so this Choice always takes Default for it; with preflight_args defaulting to \"\" via InitializeInput every spot command string is char-for-char unchanged and every Lambda Payload behaviourally identical).",
+      "Comment": "Friday-PM 'shell run' gate (ROADMAP 'Scheduled Friday-PM shell run'; spine landed #258, KEYSTONE landed feat/sf-shell-run-keystone). Input {\"shell_run\": true} (supplied by the event-driven alpha-engine-eod-success-friday-shell-trigger Lambda on Friday EOD-SF SUCCEEDED; the legacy cron rule alpha-engine-friday-shell-run was retired 2026-05-29 per ROADMAP L4055) routes to ApplyShellRunDefaults, which now sets the dry-path control vars (preflight_args=\" --preflight-only\" for the 7 spot states, Lambda dry flags for Research/DataPhase2/RegimeSubstrate/RegimeRetrospectiveEval) and hard-skips ONLY the 5 documented no-clean-dry-path exceptions \u2014 so the Friday run BOOTS + DRY-EXECUTES the workload instead of pure-skipping it (the keystone's whole point: exercise the real bootstrap/import/lib-pin/transport paths). shell_run absent OR false routes straight to CheckSkipMorningEnrich \u2014 BYTE-IDENTICAL to the pre-spine Saturday run (this is a strict superset; the real Sat 02:00 PT firing passes no shell_run, so this Choice always takes Default for it; with preflight_args defaulting to \"\" via InitializeInput every spot command string is char-for-char unchanged and every Lambda Payload behaviourally identical).",
       "Choices": [
         {
           "And": [
@@ -534,7 +534,7 @@
     },
     "ApplyShellRunDefaults": {
       "Type": "Pass",
-      "Comment": "shell_run=true ONLY (keystone + skip-exception rewire — every substantive workload now boots + runs DRY; ZERO skip-exceptions remain). Merges the dry-path control blob OVER the current state (States.JsonMerge($, shellDefaults, false) — second arg wins, so shellDefaults wins over $) so shell_run=true ACTUALLY enforces dry mode for every keystone control var. The prior arg order (States.JsonMerge(shellDefaults, $, false)) silently fell back to non-dry because InitializeInput unconditionally seeds preflight_args=\"\" + research_dry=false + data_phase2_dry=false + regime_action=\"produce\" into $ — so $ wins meant the seeded non-dry identities won over the dry shellDefaults, and the 2026-05-22 Friday-PM shell-run dry-pass (first execution past the prior trap break) ran full-fat instead of --preflight-only. Skip flags are unaffected (they're not in shellDefaults; the #258 Choice-gated skip_* mechanism handles {\"shell_run\": true, \"skip_backtester\": true} downstream regardless of merge order). The previously-documented user-override-from-input case ({\"shell_run\": true, \"preflight_args\": \"\"} runs spots full-fat) is now intentionally LOST: in practice nobody passes both flags together — passing shell_run=true means you want dry mode for ALL keystone control vars; the comment line saying otherwise was a footgun masking the actual semantic intent. SPOT states (MorningEnrich, DataPhase1, RAGIngestion, PredictorTraining, Backtester, Parity, Evaluator) boot + run dry via preflight_args=\" --preflight-only\" (LEADING space inside the var; the spot states' final command is a States.Format whose {} is placed immediately after the mode token with NO literal space, so preflight_args=\"\" on the real run yields a byte-identical command — data #259 + #261 + predictor #175 + backtester #224 all expose --preflight-only verbatim, an orthogonal MODIFIER). LAMBDA states with a verified clean no-write dry path are routed dry, NOT skipped, via $.research_dry (the canonical shell-run LLM-dry signal, true here / false on the real run): the EvalJudge chain (EvalJudgeSubmit{FirstSaturday,Weekly}/Poll/Process — dry_run_llm via research #202) + RationaleClustering (research #202) + ReplayConcordance + Counterfactual (backtester #225) all take dry_run_llm.$=$.research_dry; DataPhase2 (dry_run=true — alternative.collect returns ok_dry_run BEFORE any fetch/S3 write), RegimeSubstrate + RegimeRetrospectiveEval (action=dry_run — produce_*(write=False) returns payload before any put_object). alpha-engine-config-I2515 Phase B removed the multi-agent Research state entirely (it was also routed dry via this same $.research_dry signal); its replacements SignalsEnvelope/ChallengerShadow carry no dry-run signal in their Payloads at all, mirroring ThinkTankCoverage's own no-dry-flag convention (both are cheap/idempotent enough — and date-keyed on $.run_date, which differs Friday-vs-Saturday — that a Friday shell-run invocation does not collide with the real Saturday artifact). The skip-exception rewire flipped the prior 5 skip→dry via the commands.$/States.Format($.preflight_args) Option-C mechanism (config#902 later collapsed the standalone DriftDetection spot state — drift is now bundled onto the PredictorTraining spot, so its Friday --preflight-only dry path folds into spot_train.sh --preflight-only rather than a separate drift state); the eval-judge / rationale-clustering / replay-concordance / counterfactual Lambdas now route dry via dry_run_llm.$=$.research_dry instead of being hard-skipped. ZERO skip-exceptions are force-set here. The #258 Choice-gated skip_* gates are LEFT INTACT and remain valid for targeted operator skips. The two health-check states have NO skip gate by design and run under shell_run (the bootstrap smoke) — their non-blocking Catch absorbs a stale-data sys.exit(1) so a missing-Friday-bar produces only a clearly-Friday-timestamped alert email, NOT a SF-fatal failure (ROADMAP owed-work item 5: a --shell-run-aware staleness tolerance in alpha-engine-dashboard/health_checker.py is a scoped cross-repo follow-on; not a SF-fatal spurious-fail, so deliberately out of this single-file SF PR).",
+      "Comment": "shell_run=true ONLY (keystone + skip-exception rewire \u2014 every substantive workload now boots + runs DRY; ZERO skip-exceptions remain). Merges the dry-path control blob OVER the current state (States.JsonMerge($, shellDefaults, false) \u2014 second arg wins, so shellDefaults wins over $) so shell_run=true ACTUALLY enforces dry mode for every keystone control var. The prior arg order (States.JsonMerge(shellDefaults, $, false)) silently fell back to non-dry because InitializeInput unconditionally seeds preflight_args=\"\" + research_dry=false + data_phase2_dry=false + regime_action=\"produce\" into $ \u2014 so $ wins meant the seeded non-dry identities won over the dry shellDefaults, and the 2026-05-22 Friday-PM shell-run dry-pass (first execution past the prior trap break) ran full-fat instead of --preflight-only. Skip flags are unaffected (they're not in shellDefaults; the #258 Choice-gated skip_* mechanism handles {\"shell_run\": true, \"skip_backtester\": true} downstream regardless of merge order). The previously-documented user-override-from-input case ({\"shell_run\": true, \"preflight_args\": \"\"} runs spots full-fat) is now intentionally LOST: in practice nobody passes both flags together \u2014 passing shell_run=true means you want dry mode for ALL keystone control vars; the comment line saying otherwise was a footgun masking the actual semantic intent. SPOT states (MorningEnrich, DataPhase1, RAGIngestion, PredictorTraining, Backtester, Parity, Evaluator) boot + run dry via preflight_args=\" --preflight-only\" (LEADING space inside the var; the spot states' final command is a States.Format whose {} is placed immediately after the mode token with NO literal space, so preflight_args=\"\" on the real run yields a byte-identical command \u2014 data #259 + #261 + predictor #175 + backtester #224 all expose --preflight-only verbatim, an orthogonal MODIFIER). LAMBDA states with a verified clean no-write dry path are routed dry, NOT skipped, via $.research_dry (the canonical shell-run LLM-dry signal, true here / false on the real run): the EvalJudge chain (EvalJudgeSubmit{FirstSaturday,Weekly}/Poll/Process \u2014 dry_run_llm via research #202) + RationaleClustering (research #202) + ReplayConcordance + Counterfactual (backtester #225) all take dry_run_llm.$=$.research_dry; DataPhase2 (dry_run=true \u2014 alternative.collect returns ok_dry_run BEFORE any fetch/S3 write), RegimeSubstrate + RegimeRetrospectiveEval (action=dry_run \u2014 produce_*(write=False) returns payload before any put_object). alpha-engine-config-I2515 Phase B removed the multi-agent Research state entirely (it was also routed dry via this same $.research_dry signal); its replacements SignalsEnvelope/ChallengerShadow carry no dry-run signal in their Payloads at all, mirroring ThinkTankCoverage's own no-dry-flag convention (both are cheap/idempotent enough \u2014 and date-keyed on $.run_date, which differs Friday-vs-Saturday \u2014 that a Friday shell-run invocation does not collide with the real Saturday artifact). The skip-exception rewire flipped the prior 5 skip\u2192dry via the commands.$/States.Format($.preflight_args) Option-C mechanism (config#902 later collapsed the standalone DriftDetection spot state \u2014 drift is now bundled onto the PredictorTraining spot, so its Friday --preflight-only dry path folds into spot_train.sh --preflight-only rather than a separate drift state); the eval-judge / rationale-clustering / replay-concordance / counterfactual Lambdas now route dry via dry_run_llm.$=$.research_dry instead of being hard-skipped. ZERO skip-exceptions are force-set here. The #258 Choice-gated skip_* gates are LEFT INTACT and remain valid for targeted operator skips. The two health-check states have NO skip gate by design and run under shell_run (the bootstrap smoke) \u2014 their non-blocking Catch absorbs a stale-data sys.exit(1) so a missing-Friday-bar produces only a clearly-Friday-timestamped alert email, NOT a SF-fatal failure (ROADMAP owed-work item 5: a --shell-run-aware staleness tolerance in alpha-engine-dashboard/health_checker.py is a scoped cross-repo follow-on; not a SF-fatal spurious-fail, so deliberately out of this single-file SF PR).",
       "Parameters": {
         "merged.$": "States.JsonMerge($,States.StringToJson('{\"preflight_args\":\" --preflight-only\",\"research_dry\":true,\"data_phase2_dry\":true,\"regime_action\":\"dry_run\",\"pipeline_label\":\" Preflight\"}'),false)"
       },
@@ -563,7 +563,7 @@
     },
     "MorningEnrich": {
       "Type": "Task",
-      "Comment": "Friday polygon-T+1 daily_closes fill (weekly_collector.py --morning-enrich) on a dedicated spot EC2. Split out of DataPhase1 by the preflight-task-split (2026-05-16): morning-enrich (~28 min) and phase1 are independent preflight-bearing actions, so a phase1 failure must never re-run this completed ~28-min step. Mirrors the RAGIngestion split precedent — its own spot, watchdog budget, per-state health marker, and a proper UNION entry preflight (preflight.py mode 'morning_enrich': polygon + FRED secrets + reachability + S3 writeable + ArcticDB libraries present; deliberately NO ArcticDB-freshness check — morning-enrich is part of what makes it fresh). ~7 min extra bootstrap vs the prior bundled design — accepted in exchange for never re-paying the 28-min morning-enrich on a downstream redrive.",
+      "Comment": "Friday polygon-T+1 daily_closes fill (weekly_collector.py --morning-enrich) on a dedicated spot EC2. Split out of DataPhase1 by the preflight-task-split (2026-05-16): morning-enrich (~28 min) and phase1 are independent preflight-bearing actions, so a phase1 failure must never re-run this completed ~28-min step. Mirrors the RAGIngestion split precedent \u2014 its own spot, watchdog budget, per-state health marker, and a proper UNION entry preflight (preflight.py mode 'morning_enrich': polygon + FRED secrets + reachability + S3 writeable + ArcticDB libraries present; deliberately NO ArcticDB-freshness check \u2014 morning-enrich is part of what makes it fresh). ~7 min extra bootstrap vs the prior bundled design \u2014 accepted in exchange for never re-paying the 28-min morning-enrich on a downstream redrive.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -733,7 +733,7 @@
     },
     "DataPhase1": {
       "Type": "Task",
-      "Comment": "Weekly Phase 1 data collection + universe-prune (weekly_collector.py --phase 1 then builders.prune_delisted_tickers) on a dedicated spot EC2. MorningEnrich was split into its own preceding SF state by the preflight-task-split (2026-05-16): a failure here no longer re-runs the completed ~28-min morning-enrich. RAG ingestion lives in the separate RAGIngestion state (split 2026-05-06). Entry preflight is preflight.py mode 'phase1' (a strict superset of morning_enrich's dependency set — phase1 additionally builds the universe).",
+      "Comment": "Weekly Phase 1 data collection + universe-prune (weekly_collector.py --phase 1 then builders.prune_delisted_tickers) on a dedicated spot EC2. MorningEnrich was split into its own preceding SF state by the preflight-task-split (2026-05-16): a failure here no longer re-runs the completed ~28-min morning-enrich. RAG ingestion lives in the separate RAGIngestion state (split 2026-05-06). Entry preflight is preflight.py mode 'phase1' (a strict superset of morning_enrich's dependency set \u2014 phase1 additionally builds the universe).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -856,7 +856,7 @@
     },
     "DataPhase1RetryGate": {
       "Type": "Choice",
-      "Comment": "SOTA bounded auto-retry (config#1059): a polled non-Success SSM status on this idempotent batch step is retriable, not terminal. Re-issue DataPhase1 ONCE on the same always-on instance ($.ec2_instance_id) before giving up — re-running is safe (the data job overwrites the same run_date S3 keys). Absent counter => first failure => re-issue; counter present (=1) => second failure => give up to ExtractDataPhase1Error. Keeps the scheduled execution alive through a transient blip so it succeeds first-pass (moves unattended_first_pass_rate).",
+      "Comment": "SOTA bounded auto-retry (config#1059): a polled non-Success SSM status on this idempotent batch step is retriable, not terminal. Re-issue DataPhase1 ONCE on the same always-on instance ($.ec2_instance_id) before giving up \u2014 re-running is safe (the data job overwrites the same run_date S3 keys). Absent counter => first failure => re-issue; counter present (=1) => second failure => give up to ExtractDataPhase1Error. Keeps the scheduled execution alive through a transient blip so it succeeds first-pass (moves unattended_first_pass_rate).",
       "Choices": [
         {
           "And": [
@@ -883,14 +883,14 @@
     },
     "ResearchPredictorParallel": {
       "Type": "Parallel",
-      "Comment": "Research and PredictorTraining are DATA-INDEPENDENT (no S3/db data flows between them — see CLAUDE.md Architecture). They previously ran sequentially ONLY to 'spread API load', a now-STALE rationale: predictor TRAINING (training/train_handler.py) reads ArcticDB + CPU LightGBM and makes NO Anthropic calls (the yfinance fallback was removed by predictor PR #6; train_handler yfinance docstrings are stale). Research's only heavy load is Anthropic. They do not contend on the rate-limited API, so they run in parallel here to decouple PredictorTraining from Research's variable <=75-min strict-retry runtime and shorten SF wall-clock. Branch A = the full Research-consuming chain (DataPhase2 + eval-judge chain + agent-justification triple), Branch B = the PredictorTraining quartet. PER-BRANCH ERROR ISOLATION: each branch ends in a branch-local Pass terminal (End:true) that records OK/FAILED as DATA — a branch NEVER throws, so SF Parallel's default cancel-all-siblings-on-error behaviour can never abandon or waste an in-flight (or completed+S3-promoted) sibling. The SF is failed AFTER the join by CheckBranchOutcomes if either branch recorded FAILED. The Parallel-level Catch is a defense-in-depth backstop for genuine SF-engine Parallel errors only (the branches themselves always succeed). (config#885: the Scanner→RAGIngestion→RegimeSubstrate→RegimeRetrospectiveEval chain was relocated FROM top-level INTO Branch A's head so PredictorTraining (Branch B) now forks parallel to it directly after DataPhase1 — Predictor ⊥ Scanner/RAG/Regime, all of which produce side-effect S3/ArcticDB artifacts, never SF-state JSON consumed by Branch B or any post-join state. Their in-branch error edges were rewired to the branch-fail path PublishResearchFailureImmediate→BranchAFailed.)",
+      "Comment": "Research and PredictorTraining are DATA-INDEPENDENT (no S3/db data flows between them \u2014 see CLAUDE.md Architecture). They previously ran sequentially ONLY to 'spread API load', a now-STALE rationale: predictor TRAINING (training/train_handler.py) reads ArcticDB + CPU LightGBM and makes NO Anthropic calls (the yfinance fallback was removed by predictor PR #6; train_handler yfinance docstrings are stale). Research's only heavy load is Anthropic. They do not contend on the rate-limited API, so they run in parallel here to decouple PredictorTraining from Research's variable <=75-min strict-retry runtime and shorten SF wall-clock. Branch A = the full Research-consuming chain (DataPhase2 + eval-judge chain + agent-justification triple), Branch B = the PredictorTraining quartet. PER-BRANCH ERROR ISOLATION: each branch ends in a branch-local Pass terminal (End:true) that records OK/FAILED as DATA \u2014 a branch NEVER throws, so SF Parallel's default cancel-all-siblings-on-error behaviour can never abandon or waste an in-flight (or completed+S3-promoted) sibling. The SF is failed AFTER the join by CheckBranchOutcomes if either branch recorded FAILED. The Parallel-level Catch is a defense-in-depth backstop for genuine SF-engine Parallel errors only (the branches themselves always succeed). (config#885: the Scanner\u2192RAGIngestion\u2192RegimeSubstrate\u2192RegimeRetrospectiveEval chain was relocated FROM top-level INTO Branch A's head so PredictorTraining (Branch B) now forks parallel to it directly after DataPhase1 \u2014 Predictor \u22a5 Scanner/RAG/Regime, all of which produce side-effect S3/ArcticDB artifacts, never SF-state JSON consumed by Branch B or any post-join state. Their in-branch error edges were rewired to the branch-fail path PublishResearchFailureImmediate\u2192BranchAFailed.)",
       "Branches": [
         {
           "StartAt": "Scanner",
           "States": {
             "Scanner": {
               "Type": "Task",
-              "Comment": "Standalone scanner Lambda (ROADMAP L1995 Phase 1 — alpha-engine-research #235). Reads constituents.json + feature store, runs run_quant_filter, writes the candidates.json universe-board artifact for THIS run_date (crucible-research PR425, merged). alpha-engine-config-I2515 Phase B: this write is now LOAD-BEARING — SignalsEnvelope, ChallengerShadow, and the relocated (post-RAG) ThinkTankCoverage all read the SAME-DAY board, closing the no-week-old-data invariant (config#1580 ruling). The multi-agent Research graph runner that previously consumed this artifact has been REMOVED from this SF; the champion path is scanner → predictor direct. Status contract OK / ERROR — no SKIPPED today (constituents.json + feature store are hard preconditions). dry_run_llm threads the Friday-Preflight shell-run signal so the Lambda boots+imports without S3 read on $.research_dry=true.",
+              "Comment": "Standalone scanner Lambda (ROADMAP L1995 Phase 1 \u2014 alpha-engine-research #235). Reads constituents.json + feature store, runs run_quant_filter, writes the candidates.json universe-board artifact for THIS run_date (crucible-research PR425, merged). alpha-engine-config-I2515 Phase B: this write is now LOAD-BEARING \u2014 SignalsEnvelope, ChallengerShadow, and the relocated (post-RAG) ThinkTankCoverage all read the SAME-DAY board, closing the no-week-old-data invariant (config#1580 ruling). The multi-agent Research graph runner that previously consumed this artifact has been REMOVED from this SF; the champion path is scanner \u2192 predictor direct. Status contract OK / ERROR \u2014 no SKIPPED today (constituents.json + feature store are hard preconditions). dry_run_llm threads the Friday-Preflight shell-run signal so the Lambda boots+imports without S3 read on $.research_dry=true.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-scanner:live",
@@ -917,7 +917,7 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Scanner failure must NOT halt the pipeline at the SF layer — Catch and Next now converge sensibly on the SAME state (CheckSkipRegimeSubstrate) under the config-I2515 Phase B reorder, since RegimeSubstrate is an independent macro/HMM fit with no scanner-board dependency. Genuine downstream impact of a missing board surfaces properly (not silently) at SignalsEnvelope, which is LOAD-BEARING and has NO non-blocking Catch — a scanner failure that leaves the board stale/missing will fail SignalsEnvelope's own invoke and correctly hard-fail Branch A instead of being swallowed here.",
+                  "Comment": "Scanner failure must NOT halt the pipeline at the SF layer \u2014 Catch and Next now converge sensibly on the SAME state (CheckSkipRegimeSubstrate) under the config-I2515 Phase B reorder, since RegimeSubstrate is an independent macro/HMM fit with no scanner-board dependency. Genuine downstream impact of a missing board surfaces properly (not silently) at SignalsEnvelope, which is LOAD-BEARING and has NO non-blocking Catch \u2014 a scanner failure that leaves the board stale/missing will fail SignalsEnvelope's own invoke and correctly hard-fail Branch A instead of being swallowed here.",
                   "Next": "CheckSkipRegimeSubstrate",
                   "ResultPath": "$.scanner_error"
                 }
@@ -927,7 +927,7 @@
             },
             "CheckSkipRegimeSubstrate": {
               "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_regime_substrate\": true} bypasses the regime substrate Lambda and jumps straight to SignalsEnvelope (config-I2515 Phase B: RAG/ThinkTank/RegimeRetrospectiveEval/DataPhase2 all now sit AFTER SignalsEnvelope in the reordered chain, so skipping substrate-compute must not skip the envelope itself — SignalsEnvelope reads whatever regime artifact already exists). Independent of skip flags for the rest of the chain — operators can skip the HMM refit while everything else still runs.",
+              "Comment": "Skip-gate. {\"skip_regime_substrate\": true} bypasses the regime substrate Lambda and jumps straight to SignalsEnvelope (config-I2515 Phase B: RAG/ThinkTank/RegimeRetrospectiveEval/DataPhase2 all now sit AFTER SignalsEnvelope in the reordered chain, so skipping substrate-compute must not skip the envelope itself \u2014 SignalsEnvelope reads whatever regime artifact already exists). Independent of skip flags for the rest of the chain \u2014 operators can skip the HMM refit while everything else still runs.",
               "Choices": [
                 {
                   "And": [
@@ -947,7 +947,7 @@
             },
             "RegimeSubstrate": {
               "Type": "Task",
-              "Comment": "Regime substrate Lambda — fits a weekly 3-state HMM + composite z-score + BOCPD on macro feature history (FRED-sourced VIX/HYOAS/TNX/TWO + SPY), writes s3://alpha-engine-research/regime/{YYMMDDHHMM}.json + latest.json sidecar. config-I2515 Phase B: now runs BEFORE SignalsEnvelope (moved ahead of RAG/ThinkTank) so the envelope's market_regime field reads a SAME-DAY regime label rather than a stale one. Observe-only at this stage — no production consumer besides the envelope reads the artifact yet. Failure is non-blocking (Catch routes to SignalsEnvelope, not HandleFailure) — a regime substrate failure must not halt the pipeline; SignalsEnvelope will read whatever regime artifact already exists.",
+              "Comment": "Regime substrate Lambda \u2014 fits a weekly 3-state HMM + composite z-score + BOCPD on macro feature history (FRED-sourced VIX/HYOAS/TNX/TWO + SPY), writes s3://alpha-engine-research/regime/{YYMMDDHHMM}.json + latest.json sidecar. config-I2515 Phase B: now runs BEFORE SignalsEnvelope (moved ahead of RAG/ThinkTank) so the envelope's market_regime field reads a SAME-DAY regime label rather than a stale one. Observe-only at this stage \u2014 no production consumer besides the envelope reads the artifact yet. Failure is non-blocking (Catch routes to SignalsEnvelope, not HandleFailure) \u2014 a regime substrate failure must not halt the pipeline; SignalsEnvelope will read whatever regime artifact already exists.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-predictor-regime-substrate:live",
@@ -982,7 +982,7 @@
             },
             "SignalsEnvelope": {
               "Type": "Task",
-              "Comment": "alpha-engine-config-I2515 Phase B: thin envelope producer replacing the removed multi-agent Research graph runner as the signals.json producer. Runs AFTER RegimeSubstrate (rationale b: same-day regime freshness) and BEFORE RAG/ThinkTankCoverage (rationale a: Scanner's universe-board write is now load-bearing for this and every downstream consumer — the no-week-old-data invariant, config#1580 ruling). Sources fields from the scanner board (universe membership + sector facts), the regime substrate (regime label), and neutral per-name defaults (mirrors the champion.py no_agent path) — same S3 key as the old signals.json for contract safety. The champion (scanner -> predictor direct) is the production path per config#1580; Think Tank is the challenger (observe-only, see ChallengerShadow). LOAD-BEARING: the executor hard-fails Monday without signals.json, so unlike ThinkTankCoverage/ChallengerShadow this Catch is NOT non-blocking — it routes to the Branch A failure path exactly as the removed Research state's hard-Catch did. IAM: alpha-engine-step-functions-role needs lambda:InvokeFunction on alpha-engine-research-signals-envelope* before first run — granted separately by the parent orchestrating session with operator consent, NOT part of this PR.",
+              "Comment": "alpha-engine-config-I2515 Phase B: thin envelope producer replacing the removed multi-agent Research graph runner as the signals.json producer. Runs AFTER RegimeSubstrate (rationale b: same-day regime freshness) and BEFORE RAG/ThinkTankCoverage (rationale a: Scanner's universe-board write is now load-bearing for this and every downstream consumer \u2014 the no-week-old-data invariant, config#1580 ruling). Sources fields from the scanner board (universe membership + sector facts), the regime substrate (regime label), and neutral per-name defaults (mirrors the champion.py no_agent path) \u2014 same S3 key as the old signals.json for contract safety. The champion (scanner -> predictor direct) is the production path per config#1580; Think Tank is the challenger (observe-only, see ChallengerShadow). LOAD-BEARING: the executor hard-fails Monday without signals.json, so unlike ThinkTankCoverage/ChallengerShadow this Catch is NOT non-blocking \u2014 it routes to the Branch A failure path exactly as the removed Research state's hard-Catch did. IAM: alpha-engine-step-functions-role needs lambda:InvokeFunction on alpha-engine-research-signals-envelope* before first run \u2014 granted separately by the parent orchestrating session with operator consent, NOT part of this PR.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-signals-envelope:live",
@@ -1026,7 +1026,7 @@
             },
             "ChallengerShadow": {
               "Type": "Task",
-              "Comment": "alpha-engine-config-I2515 Phase B: keeps the no_agent champion-baseline shadow (signals_shadow/no_agent/{trading_day}/signals.json, written by producers/runner.py::run_challengers) alive for the producer leaderboard (scoring/leaderboard_producers.py, hosted in the eval_rolling_mean Lambda, which survives this graph-runner removal) now that the weekly SF no longer hosts the multi-agent Research Lambda invocation that used to fire this mode as a side effect. The research-runner Lambda stays deployed for this + operator modes even though its weekly_run graph invocation is gone. NON-BLOCKING by design: _run_challengers_only (crucible-research lambda/handler.py:287) may carry preconditions tied to graph-run state (e.g. 'only valid for the latest run') that have not been re-verified for the envelope era — a precondition failure here must surface in logs without harming the pipeline, since this shadow feed is observe-only and never read by the executor or the live gate. Verifying/fixing those envelope-era preconditions is tracked follow-up work, not part of this PR.",
+              "Comment": "alpha-engine-config-I2515 Phase B: keeps the no_agent champion-baseline shadow (signals_shadow/no_agent/{trading_day}/signals.json, written by producers/runner.py::run_challengers) alive for the producer leaderboard (scoring/leaderboard_producers.py, hosted in the eval_rolling_mean Lambda, which survives this graph-runner removal) now that the weekly SF no longer hosts the multi-agent Research Lambda invocation that used to fire this mode as a side effect. The research-runner Lambda stays deployed for this + operator modes even though its weekly_run graph invocation is gone. NON-BLOCKING by design: _run_challengers_only (crucible-research lambda/handler.py:287) may carry preconditions tied to graph-run state (e.g. 'only valid for the latest run') that have not been re-verified for the envelope era \u2014 a precondition failure here must surface in logs without harming the pipeline, since this shadow feed is observe-only and never read by the executor or the live gate. Verifying/fixing those envelope-era preconditions is tracked follow-up work, not part of this PR.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-runner:live",
@@ -1082,7 +1082,7 @@
             },
             "RAGIngestion": {
               "Type": "Task",
-              "Comment": "Weekly RAG ingestion (SEC filings, 8-Ks, earnings, theses) on its own spot EC2. Same dispatcher (always-on micro) that ran DataPhase1; a fresh spot instance is launched here so this state has its own watchdog budget and per-state health marker. ~7 min extra bootstrap vs the prior bundled design — accepted in exchange for failure isolation. Origin of split: 2026-05-06 SF run where alpha-engine-lib v0.3.0 had bare `from rag.X` imports inside retrieval.py that fired during RRC dedup; failure was labeled DataPhase1 even though the data layer was healthy.",
+              "Comment": "Weekly RAG ingestion (SEC filings, 8-Ks, earnings, theses) on its own spot EC2. Same dispatcher (always-on micro) that ran DataPhase1; a fresh spot instance is launched here so this state has its own watchdog budget and per-state health marker. ~7 min extra bootstrap vs the prior bundled design \u2014 accepted in exchange for failure isolation. Origin of split: 2026-05-06 SF run where alpha-engine-lib v0.3.0 had bare `from rag.X` imports inside retrieval.py that fired during RRC dedup; failure was labeled DataPhase1 even though the data layer was healthy.",
               "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
               "Parameters": {
                 "DocumentName": "AWS-RunShellScript",
@@ -1232,7 +1232,7 @@
             },
             "ExtractRAGIngestionError": {
               "Type": "Pass",
-              "Comment": "Normalize RAGIngestion SSM non-Success poll into $.error. Mirrors ExtractDataPhase1Error — the soft-failure path from CheckRAGIngestionStatus.Default does not populate $.error, only Task Catch blocks do.",
+              "Comment": "Normalize RAGIngestion SSM non-Success poll into $.error. Mirrors ExtractDataPhase1Error \u2014 the soft-failure path from CheckRAGIngestionStatus.Default does not populate $.error, only Task Catch blocks do.",
               "Parameters": {
                 "phase": "RAGIngestion",
                 "source": "CheckRAGIngestionStatus.Default",
@@ -1243,7 +1243,7 @@
             },
             "ThinkTankCoverage": {
               "Type": "Task",
-              "Comment": "Think Tank observe-mode coverage top-up (alpha-engine-config-I2467). config-I2515 Phase B: MOVED to run AFTER the RAG ingestion chain (was between Scanner and RAG) so Think Tank's theses read the FRESH corpus instead of the week-old one — this also resolves alpha-engine-config-I2511. The daily EventBridge cadence (alpha-research-thinktank-daily) is the primary coverage-growth mechanism (5/day toward the full rank_ceiling=150 universe, handling staleness refresh gradually) and stays unchanged. This state's job is a narrower, reactive top-up — mode=gap_fill shores up whatever of the CURRENT top-60 the daily cadence hasn't caught up to yet by the time the fresh weekly scan lands, sized to the EXACT measured coverage_gap.uncovered_count (never a fixed constant, never padded with stale-refill — see crucible-research thinktank/run.py's gap_fill_only). Small and bounded by construction, so no sf_cover_target/sf_cover_ceiling numbers to keep in sync across repos. Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step. The Retry below (States.Timeout/Lambda.Unknown) stays as cheap defense-in-depth even though the gap-fill workload is small.",
+              "Comment": "Think Tank observe-mode coverage top-up (alpha-engine-config-I2467). config-I2515 Phase B: MOVED to run AFTER the RAG ingestion chain (was between Scanner and RAG) so Think Tank's theses read the FRESH corpus instead of the week-old one \u2014 this also resolves alpha-engine-config-I2511. The daily EventBridge cadence (alpha-research-thinktank-daily) is the primary coverage-growth mechanism (5/day toward the full rank_ceiling=150 universe, handling staleness refresh gradually) and stays unchanged. This state's job is a narrower, reactive top-up \u2014 mode=gap_fill shores up whatever of the CURRENT top-60 the daily cadence hasn't caught up to yet by the time the fresh weekly scan lands, sized to the EXACT measured coverage_gap.uncovered_count (never a fixed constant, never padded with stale-refill \u2014 see crucible-research thinktank/run.py's gap_fill_only). Small and bounded by construction, so no sf_cover_target/sf_cover_ceiling numbers to keep in sync across repos. Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step. The Retry below (States.Timeout/Lambda.Unknown) stays as cheap defense-in-depth even though the gap-fill workload is small.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-thinktank:live",
@@ -1289,7 +1289,7 @@
             },
             "CheckSkipRegimeRetrospectiveEval": {
               "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_regime_retrospective_eval\": true} bypasses the T1 retrospective HMM smoothing eval and jumps to CheckSkipDataPhase2 (config-I2515 Phase B: the removed multi-agent Research state used to sit between this chain and DataPhase2 — CheckSkipDataPhase2 is now the direct successor). Independent of skip_regime_substrate — operator can run substrate without eval (or vice versa during ad-hoc replays).",
+              "Comment": "Skip-gate. {\"skip_regime_retrospective_eval\": true} bypasses the T1 retrospective HMM smoothing eval and jumps to CheckSkipDataPhase2 (config-I2515 Phase B: the removed multi-agent Research state used to sit between this chain and DataPhase2 \u2014 CheckSkipDataPhase2 is now the direct successor). Independent of skip_regime_substrate \u2014 operator can run substrate without eval (or vice versa during ad-hoc replays).",
               "Choices": [
                 {
                   "And": [
@@ -1309,7 +1309,7 @@
             },
             "RegimeRetrospectiveEval": {
               "Type": "Task",
-              "Comment": "Stage C.2 T1 retrospective HMM smoothing eval — pairs the macro agent's historical regime calls against the HMM forward-backward smoother's labels (8-week lag, asymmetric loss penalizing bear-misses 2×). Writes s3://alpha-engine-research/regime/retrospective/{YYMMDDHHMM}.json + latest.json sidecar carrying n_pairings + rolling 26-week agreement rate. Observe-only — feeds the dashboard's Regime page, does NOT gate anything. Failure is non-blocking (Catch routes to CheckSkipDataPhase2, config-I2515 Phase B's new direct successor) — a retrospective-eval failure must not halt the pipeline. Returns n_pairings=0 cleanly during the cold-start window (~8 weeks after substrate Lambda starts running).",
+              "Comment": "Stage C.2 T1 retrospective HMM smoothing eval \u2014 pairs the macro agent's historical regime calls against the HMM forward-backward smoother's labels (8-week lag, asymmetric loss penalizing bear-misses 2\u00d7). Writes s3://alpha-engine-research/regime/retrospective/{YYMMDDHHMM}.json + latest.json sidecar carrying n_pairings + rolling 26-week agreement rate. Observe-only \u2014 feeds the dashboard's Regime page, does NOT gate anything. Failure is non-blocking (Catch routes to CheckSkipDataPhase2, config-I2515 Phase B's new direct successor) \u2014 a retrospective-eval failure must not halt the pipeline. Returns n_pairings=0 cleanly during the cold-start window (~8 weeks after substrate Lambda starts running).",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-predictor-regime-retrospective-eval:live",
@@ -1343,7 +1343,7 @@
             },
             "CheckSkipDataPhase2": {
               "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_data_phase2\": true} bypasses the Phase 2 Lambda and jumps to the eval-judge skip-gate (post-2026-05-07 reorder — judge chain runs before predictor training so its results are available to evaluator's email).",
+              "Comment": "Skip-gate. {\"skip_data_phase2\": true} bypasses the Phase 2 Lambda and jumps to the eval-judge skip-gate (post-2026-05-07 reorder \u2014 judge chain runs before predictor training so its results are available to evaluator's email).",
               "Choices": [
                 {
                   "And": [
@@ -1356,14 +1356,14 @@
                       "BooleanEquals": true
                     }
                   ],
-                  "Next": "CheckSkipEvalJudge"
+                  "Next": "StartAdvisoryPipeline"
                 }
               ],
               "Default": "DataPhase2"
             },
             "DataPhase2": {
               "Type": "Task",
-              "Comment": "Phase 2: alternative data for promoted tickers (Lambda). Successor is CheckSkipEvalJudge (post-2026-05-07 reorder) — judge + agent-justification triple run on Research's decision_artifacts/, no dependency on Predictor or Backtester output, so they run before predictor training to land their results in S3 before Evaluator generates the weekly email.",
+              "Comment": "Phase 2: alternative data for promoted tickers (Lambda). Successor is StartAdvisoryPipeline (alpha-engine-config-I2544: the eval-judge chain + ReportCard/Director now run in an async child SF) \u2014 judge + agent-justification triple run on Research's decision_artifacts/, no dependency on Predictor or Backtester output, so they run before predictor training to land their results in S3 before Evaluator generates the weekly email.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-data-collector:live",
@@ -1395,566 +1395,7 @@
                 }
               ],
               "ResultPath": "$.data_phase2_result",
-              "Next": "CheckSkipEvalJudge"
-            },
-            "CheckSkipEvalJudge": {
-              "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_eval_judge\": true} bypasses the LLM-as-judge eval step (typically used for ad-hoc reruns where eval cost is unwanted). Skipping the judge does NOT skip rationale clustering — they're independent observability paths (clustering reads decision_artifacts/, judge reads its own _eval/), so we route to CheckSkipRationaleClustering instead of bypassing both.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.skip_eval_judge",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.skip_eval_judge",
-                      "BooleanEquals": true
-                    }
-                  ],
-                  "Next": "CheckSkipRationaleClustering"
-                }
-              ],
-              "Default": "ComputeEvalCadence"
-            },
-            "ComputeEvalCadence": {
-              "Type": "Pass",
-              "Comment": "Extract day-of-month + ISO date + submit timestamp from the SF execution start time. day_of_month <= 07 ⇒ first Saturday of the month ⇒ force_sonnet_pass=true (monthly Sonnet sweep per ROADMAP §1626). All other Saturdays run Haiku-only batch + per-artifact Sonnet escalation tail inside the Process Lambda. submit_iso is propagated to EvalJudgePoll so it can compute elapsed-time against the 6h fail-soft cap.",
-              "Parameters": {
-                "day_of_month.$": "States.ArrayGetItem(States.StringSplit(States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0), '-'), 2)",
-                "eval_date.$": "States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0)",
-                "submit_iso.$": "$$.Execution.StartTime"
-              },
-              "ResultPath": "$.eval_cadence",
-              "Next": "CheckMonthlyCadence"
-            },
-            "CheckMonthlyCadence": {
-              "Type": "Choice",
-              "Comment": "First-Saturday-of-the-month detection via lexicographic compare on the zero-padded day-of-month string ('01'..'07' < '08'). Lexicographic ordering is correct here because all values are zero-padded 2-char strings.",
-              "Choices": [
-                {
-                  "Variable": "$.eval_cadence.day_of_month",
-                  "StringLessThan": "08",
-                  "Next": "EvalJudgeSubmitFirstSaturday"
-                }
-              ],
-              "Default": "EvalJudgeSubmitWeekly"
-            },
-            "EvalJudgeSubmitFirstSaturday": {
-              "Type": "Task",
-              "Comment": "Submit phase, monthly Sonnet sweep — force_sonnet_pass=true. Builds the (artifact × judge_model) batch payload covering both Haiku and Sonnet for every mapped artifact, submits as one Anthropic Message Batches API call, and writes the plan manifest to S3 keyed by batch_id. ROADMAP P1 §1642. 50% cost discount per Anthropic's batch contract; structurally bypasses the 15-min Lambda timeout class that nearly fired on the 2026-05-06 manual midweek SF run.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-eval-judge-submit:live",
-                "Payload": {
-                  "force_sonnet_pass": true,
-                  "date.$": "$.eval_cadence.eval_date",
-                  "dry_run_llm.$": "$.research_dry",
-                  "capture_lookback_days": 6
-                }
-              },
-              "TimeoutSeconds": 300,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Eval is observability per ROADMAP §1635 — submit failures must NOT halt the pipeline. EvalRollingMean still runs against historical data.",
-                  "Next": "EvalRollingMean",
-                  "ResultPath": "$.eval_judge_error"
-                }
-              ],
-              "ResultPath": "$.eval_judge_submit",
-              "Next": "EvalJudgePollChoice"
-            },
-            "EvalJudgeSubmitWeekly": {
-              "Type": "Task",
-              "Comment": "Submit phase, weekly Haiku-only batch + Sonnet escalation tail in Process. Submits Haiku entries for every mapped artifact in one batch; the Process Lambda runs Sonnet escalations synchronously after Haiku results arrive (typically 1-3 artifacts/run, well under Process's 15-min budget). Preserves the per-artifact <3 escalation gate so weekly cost stays bounded relative to the all-pairs first-Saturday batch.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-eval-judge-submit:live",
-                "Payload": {
-                  "force_sonnet_pass": false,
-                  "date.$": "$.eval_cadence.eval_date",
-                  "dry_run_llm.$": "$.research_dry",
-                  "capture_lookback_days": 6
-                }
-              },
-              "TimeoutSeconds": 300,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Eval is observability — submit failures must NOT halt the pipeline.",
-                  "Next": "EvalRollingMean",
-                  "ResultPath": "$.eval_judge_error"
-                }
-              ],
-              "ResultPath": "$.eval_judge_submit",
-              "Next": "EvalJudgePollChoice"
-            },
-            "EvalJudgePollChoice": {
-              "Type": "Choice",
-              "Comment": "Branch on Submit's processing_status. EMPTY (no captures or all empty-input skipped client-side) → route directly to Process so the empty-batch case still emits a clean SF result + downstream metric inputs. OK → enter the Wait/Poll loop. Anything else (ERROR, missing fields) routes to EvalRollingMean as a fail-soft.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.eval_judge_submit.Payload.status",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.eval_judge_submit.Payload.status",
-                      "StringEquals": "EMPTY"
-                    }
-                  ],
-                  "Next": "EvalJudgeProcess"
-                },
-                {
-                  "And": [
-                    {
-                      "Variable": "$.eval_judge_submit.Payload.status",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.eval_judge_submit.Payload.status",
-                      "StringEquals": "OK"
-                    }
-                  ],
-                  "Comment": "config#2275: IsPresent-guarded so a submit payload WITHOUT status actually reaches the fail-soft Default this state's own comment promises ('missing fields routes to EvalRollingMean') instead of throwing States.Runtime.",
-                  "Next": "EvalJudgePollWait"
-                }
-              ],
-              "Default": "EvalRollingMean"
-            },
-            "EvalJudgePollWait": {
-              "Type": "Wait",
-              "Comment": "60s pause between batch status polls. Anthropic's docs target sub-1h typical batch latency with 24h hard cap; 60s polls strike a balance between pickup latency and Lambda invocation cost over the typical wait.",
-              "Seconds": 60,
-              "Next": "EvalJudgePoll"
-            },
-            "EvalJudgePoll": {
-              "Type": "Task",
-              "Comment": "Poll phase. Calls anthropic.messages.batches.retrieve(batch_id) and returns processing_status + request_counts + elapsed_seconds. SF Choice that follows branches on processing_status: ended → Process; in_progress → loop back to Wait; exceeded_max_wait=true → fail-soft to EvalRollingMean.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-eval-judge-poll:live",
-                "Payload": {
-                  "batch_id.$": "$.eval_judge_submit.Payload.batch_id",
-                  "submit_iso.$": "$.eval_cadence.submit_iso",
-                  "max_wait_seconds": 21600,
-                  "dry_run_llm.$": "$.research_dry"
-                }
-              },
-              "TimeoutSeconds": 60,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 2,
-                  "IntervalSeconds": 30,
-                  "BackoffRate": 2.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "A poll-level failure is recoverable — Anthropic retains batch results 29 days, so a transient poll Lambda failure can be re-run by a human if needed. Route to EvalRollingMean so the rest of the pipeline isn't blocked.",
-                  "Next": "EvalRollingMean",
-                  "ResultPath": "$.eval_judge_error"
-                }
-              ],
-              "ResultPath": "$.eval_judge_poll",
-              "Next": "EvalJudgePollDecision"
-            },
-            "EvalJudgePollDecision": {
-              "Type": "Choice",
-              "Comment": "Branch on poll status. processing_status='ended' → run Process. exceeded_max_wait=true → fail-soft (batch results stay retrievable for 29 days; an operator can re-run the chain offline). Anything else → loop back to Wait. Includes the synthetic 'ended_empty' status (Submit short-circuited an empty plan) so the empty case still hits Process.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.eval_judge_poll.Payload.processing_status",
-                      "IsPresent": true
-                    },
-                    {
-                      "Or": [
-                        {
-                          "Variable": "$.eval_judge_poll.Payload.processing_status",
-                          "StringEquals": "ended"
-                        },
-                        {
-                          "Variable": "$.eval_judge_poll.Payload.processing_status",
-                          "StringEquals": "ended_empty"
-                        }
-                      ]
-                    }
-                  ],
-                  "Next": "EvalJudgeProcess"
-                },
-                {
-                  "And": [
-                    {
-                      "Variable": "$.eval_judge_poll.Payload.exceeded_max_wait",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.eval_judge_poll.Payload.exceeded_max_wait",
-                      "BooleanEquals": true
-                    }
-                  ],
-                  "Next": "EvalRollingMean"
-                },
-                {
-                  "And": [
-                    {
-                      "Not": {
-                        "Variable": "$.eval_judge_poll.Payload.processing_status",
-                        "IsPresent": true
-                      }
-                    },
-                    {
-                      "Not": {
-                        "Variable": "$.eval_judge_poll.Payload.exceeded_max_wait",
-                        "IsPresent": true
-                      }
-                    }
-                  ],
-                  "Comment": "config#2275: a poll payload carrying NEITHER processing_status NOR exceeded_max_wait is malformed — fail-soft to EvalRollingMean (eval is observability; mirrors this state's Catch posture) instead of States.Runtime, and instead of looping in Wait until the global ceiling.",
-                  "Next": "EvalRollingMean"
-                }
-              ],
-              "Default": "EvalJudgePollWait"
-            },
-            "EvalJudgeProcess": {
-              "Type": "Task",
-              "Comment": "Process phase. Streams the completed batch's results, parses each via the existing RubricEvalLLMOutput schema, persists per-artifact eval JSONs to decision_artifacts/_eval/{date}/, emits CW metrics under AlphaEngine/Eval, and runs the small synchronous Sonnet-escalation tail for any Haiku result that flagged a borderline dimension. Returns OK/PARTIAL/ERROR mirroring the legacy single-Lambda contract — no consumer (RationaleClustering, EvalRollingMean, dashboard) changes.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-eval-judge-process:live",
-                "Payload": {
-                  "batch_id.$": "$.eval_judge_submit.Payload.batch_id",
-                  "plan_s3_key.$": "$.eval_judge_submit.Payload.plan_s3_key",
-                  "dry_run_llm.$": "$.research_dry"
-                }
-              },
-              "TimeoutSeconds": 900,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Eval is observability — Process failures must NOT halt the pipeline. EvalRollingMean still runs against historical data.",
-                  "Next": "EvalRollingMean",
-                  "ResultPath": "$.eval_judge_error"
-                }
-              ],
-              "ResultPath": "$.eval_judge_result",
-              "Next": "EvalRollingMean"
-            },
-            "EvalRollingMean": {
-              "Type": "Task",
-              "Comment": "Rolling-4-week-mean derived metric Lambda (PR 4b) — runs after both eval-judge branches converge. Reads AlphaEngine/Eval/agent_quality_score for the trailing 28 days, computes the mean per (judged_agent_id, criterion, judge_model) combo, and emits agent_quality_score_4w_mean which a CloudWatch alarm fires against (per ROADMAP §1634). Runs every Saturday — even on weeks where eval-judge had infra failures, the mean across the prior 4 weeks of available data is still the most-current calibration signal.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-eval-rolling-mean:live",
-                "Payload": {
-                  "end_time_iso.$": "$$.Execution.StartTime"
-                }
-              },
-              "TimeoutSeconds": 300,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Eval observability layer — failures must NOT halt the pipeline.",
-                  "Next": "CheckSkipRationaleClustering",
-                  "ResultPath": "$.eval_rolling_mean_error"
-                }
-              ],
-              "ResultPath": "$.eval_rolling_mean_result",
-              "Next": "CheckSkipRationaleClustering"
-            },
-            "CheckSkipRationaleClustering": {
-              "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_rationale_clustering\": true} bypasses the cross-week rationale clustering Lambda (used during ad-hoc reruns where corpus is in a known-bad state, while iterating on extraction logic, or for post-incident reruns where stale outputs shouldn't hit CloudWatch). Standalone invocation of the Lambda is always available regardless of this flag.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.skip_rationale_clustering",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.skip_rationale_clustering",
-                      "BooleanEquals": true
-                    }
-                  ],
-                  "Next": "CheckSkipReplayConcordance"
-                }
-              ],
-              "Default": "RationaleClustering"
-            },
-            "RationaleClustering": {
-              "Type": "Task",
-              "Comment": "Cross-week rationale clustering Lambda (ROADMAP P0, 2026-05-05). Reads decision_artifacts/ for the trailing 8 weeks, clusters rationales per agent_id via TF-IDF char n-grams + greedy single-linkage with digit-normalization, emits CW metric agent_rationale_template_concentration (% of rationales in top-3 clusters; >0.7 indicates template-generation), and persists per-agent analysis JSON to decision_artifacts/_analysis/{agent_id}/{YYYY-WW}.json. Runs every Saturday after EvalRollingMean — same image-share + observability framing.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-rationale-clustering:live",
-                "Payload": {
-                  "end_time_iso.$": "$$.Execution.StartTime",
-                  "dry_run_llm.$": "$.research_dry"
-                }
-              },
-              "TimeoutSeconds": 900,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Eval observability layer — failures must NOT halt the pipeline.",
-                  "Next": "CheckSkipReplayConcordance",
-                  "ResultPath": "$.rationale_clustering_error"
-                }
-              ],
-              "ResultPath": "$.rationale_clustering_result",
-              "Next": "CheckSkipReplayConcordance"
-            },
-            "CheckSkipReplayConcordance": {
-              "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_replay_concordance\": true} bypasses the cheap-model concordance Lambda (used for ad-hoc reruns where Anthropic spend is unwanted, or while iterating on the comparison scorers in alpha-engine-backtester replay/comparison.py). Independent of skip_rationale_clustering and skip_counterfactual — the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.skip_replay_concordance",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.skip_replay_concordance",
-                      "BooleanEquals": true
-                    }
-                  ],
-                  "Next": "CheckSkipCounterfactual"
-                }
-              ],
-              "Default": "ReplayConcordance"
-            },
-            "ReplayConcordance": {
-              "Type": "Task",
-              "Comment": "Weekly cheap-model concordance Lambda (ROADMAP P0, agent-justification gate signal #3). Replays each captured DecisionArtifact in the trailing 8-week window under the configured target model(s) via langchain_anthropic.with_structured_output against the canonical agent_schemas Pydantic contract; aggregates agreement_score per (agent_id_base, target_model); emits CW metric agent_cheap_model_concordance; persists per-target summary JSON to decision_artifacts/_replay_summary/{YYYY-MM-DD}/{target_model}.json. Default target: claude-haiku-4-5 (Sonnet→Haiku concordance ≈ \"is the larger model earning its cost?\"). Runs every Saturday after RationaleClustering.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-replay-concordance:live",
-                "Payload": {
-                  "end_time_iso.$": "$$.Execution.StartTime",
-                  "target_models": [
-                    "claude-haiku-4-5"
-                  ],
-                  "window_days": 56,
-                  "max_artifacts": 150,
-                  "dry_run_llm.$": "$.research_dry"
-                }
-              },
-              "TimeoutSeconds": 900,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Eval observability layer — concordance failure must NOT halt the pipeline. Same Catch pattern as eval-judge / eval-rolling-mean / rationale-clustering.",
-                  "Next": "CheckSkipCounterfactual",
-                  "ResultPath": "$.replay_concordance_error"
-                }
-              ],
-              "ResultPath": "$.replay_concordance_result",
-              "Next": "CheckSkipCounterfactual"
-            },
-            "CheckSkipCounterfactual": {
-              "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_counterfactual\": true} bypasses the counterfactual rule fit Lambda (used for ad-hoc reruns while iterating on the per-agent feature extractors in alpha-engine-backtester replay/counterfactual.py). Independent of skip_rationale_clustering and skip_replay_concordance — the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag. Post-2026-05-07 reorder, exits to CheckSkipPredictorTraining (was SaturdayHealthCheck) — the judge chain now runs before predictor so its results are available to evaluator's email.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.skip_counterfactual",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.skip_counterfactual",
-                      "BooleanEquals": true
-                    }
-                  ],
-                  "Next": "CheckSkipAggregateCosts"
-                }
-              ],
-              "Default": "Counterfactual"
-            },
-            "Counterfactual": {
-              "Type": "Task",
-              "Comment": "Weekly counterfactual rule fit Lambda (ROADMAP P0, agent-justification gate signal #2 — does the agent reduce to a 3-deep decision tree?). Trains DecisionTreeClassifier(max_depth=3) per supported agent on (input → decision) pairs from the trailing 8-week decision_artifacts/ corpus; emits CW metric agent_counterfactual_rule_fit per (judged_agent_id); persists per-agent JSON to decision_artifacts/_counterfactual/{agent_id_base}/{YYYY-WW}.json including tree_text + feature_importances. v1 covers ic_cio + macro_economist; other agents emit UNSUPPORTED markers. $0 ongoing — no LLM calls. Post-2026-05-07 reorder, runs after ReplayConcordance and exits to CheckSkipPredictorTraining (was SaturdayHealthCheck), so its persisted artifacts are available to Evaluator downstream.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-replay-counterfactual:live",
-                "Payload": {
-                  "end_time_iso.$": "$$.Execution.StartTime",
-                  "window_days": 56,
-                  "max_depth": 3,
-                  "dry_run_llm.$": "$.research_dry"
-                }
-              },
-              "TimeoutSeconds": 600,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Eval observability layer — counterfactual failure must NOT halt the pipeline. Same Catch pattern as the rest of the agent-justification triple. Routes to CheckSkipAggregateCosts so the cost-telemetry aggregation step still runs even when counterfactual fails (the JSONLs the aggregator reads were written by Research / eval-judge / rationale-clustering / replay-concordance / counterfactual independently; a counterfactual failure doesn't invalidate the upstream cost rows).",
-                  "Next": "CheckSkipAggregateCosts",
-                  "ResultPath": "$.counterfactual_error"
-                }
-              ],
-              "ResultPath": "$.counterfactual_result",
-              "Next": "CheckSkipAggregateCosts"
-            },
-            "CheckSkipAggregateCosts": {
-              "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_aggregate_costs\": true} bypasses the daily cost-telemetry aggregation Lambda (used for ad-hoc reruns where the cost parquet for the date is already current, or when iterating on the aggregator script). Standalone invocation of the Lambda is always available via the deploy.sh aggregate_costs target. Independent of skip_rationale_clustering / skip_replay_concordance / skip_counterfactual — the four are independent observability paths.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.skip_aggregate_costs",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.skip_aggregate_costs",
-                      "BooleanEquals": true
-                    }
-                  ],
-                  "Next": "BranchAComplete"
-                }
-              ],
-              "Default": "AggregateCosts"
-            },
-            "AggregateCosts": {
-              "Type": "Task",
-              "Comment": "Daily cost-telemetry aggregation Lambda (ROADMAP L1146 — SF-wire scripts/aggregate_costs.py CLI). Reads decision_artifacts/_cost_raw/{run_date}/*.jsonl (written by Research / eval-judge / rationale-clustering / replay-concordance / counterfactual during the upstream chain), writes the daily parquet at decision_artifacts/_cost/{run_date}/cost.parquet, emits per-agent CW metrics under AlphaEngine/Cost. Placed at end of Branch A so all LLM-emitting upstream states have written their cost JSONL rows by the time the aggregator runs. Failure is non-blocking (Catch routes to BranchAComplete) — cost telemetry is observability, NOT a primary deliverable; aggregator failure does NOT regress the alpha pipeline. Status contract OK / SKIPPED / ERROR mirrors data #295 + L3277 audit — SKIPPED on no _cost_raw partitions for the date is a legitimate upstream no-op and treated as success.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-aggregate-costs:live",
-                "Payload": {
-                  "date.$": "$.run_date",
-                  "dry_run_llm.$": "$.research_dry"
-                }
-              },
-              "TimeoutSeconds": 600,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Cost-telemetry aggregation is observability — failure must NOT halt the pipeline. The next Saturday SF will retry over a fresh _cost_raw partition; the prior week's parquet (or the manual-trigger fallback via scripts/aggregate_costs.py) remains available.",
-                  "Next": "BranchAComplete",
-                  "ResultPath": "$.aggregate_costs_error"
-                }
-              ],
-              "ResultPath": "$.aggregate_costs_result",
-              "Next": "BranchAComplete"
+              "Next": "StartAdvisoryPipeline"
             },
             "ExtractSignalsEnvelopeError": {
               "Type": "Pass",
@@ -1969,11 +1410,11 @@
             },
             "PublishResearchFailureImmediate": {
               "Type": "Task",
-              "Comment": "Fire an immediate SNS failure alert when Branch A hard-fails (RAGIngestion or SignalsEnvelope), BEFORE the sibling PredictorTraining branch completes its full ~12-min train + the parent SF's parallel-join aggregation. Closes the 2026-05-24 operator-confusion gap where a mid-parallel failure surfaced only after the sibling branch's work completed (the salvage-at-join design is correct; the visibility lag was the actual problem). Shared across both RAG ingestion failures and SignalsEnvelope failures (config-I2515 Phase B: previously also shared with the now-removed Research state). Branch terminus is still BranchAFailed (Pass) so the salvage semantics are preserved: SF still fails at the join via CheckBranchOutcomes; the sibling branch's completed work still persists for the next redrive's skip-set. SNS publish failure is caught and routed forward — best-effort alert must NEVER prevent the branch from properly terminating.",
+              "Comment": "Fire an immediate SNS failure alert when Branch A hard-fails (RAGIngestion or SignalsEnvelope), BEFORE the sibling PredictorTraining branch completes its full ~12-min train + the parent SF's parallel-join aggregation. Closes the 2026-05-24 operator-confusion gap where a mid-parallel failure surfaced only after the sibling branch's work completed (the salvage-at-join design is correct; the visibility lag was the actual problem). Shared across both RAG ingestion failures and SignalsEnvelope failures (config-I2515 Phase B: previously also shared with the now-removed Research state). Branch terminus is still BranchAFailed (Pass) so the salvage semantics are preserved: SF still fails at the join via CheckBranchOutcomes; the sibling branch's completed work still persists for the next redrive's skip-set. SNS publish failure is caught and routed forward \u2014 best-effort alert must NEVER prevent the branch from properly terminating.",
               "Resource": "arn:aws:states:::sns:publish",
               "Parameters": {
                 "TopicArn.$": "$.sns_topic_arn",
-                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — Branch A FAILED (early signal — SF will fail at join)', $.pipeline_label)",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline \u2014 Branch A FAILED (early signal \u2014 SF will fail at join)', $.pipeline_label)",
                 "Message.$": "States.Format('Branch A (RAGIngestion or SignalsEnvelope) hard-failed inside ResearchPredictorParallel. The sibling PredictorTraining branch is still running and will complete its own work; the SF will fail at the parallel-join aggregation via CheckBranchOutcomes once both branches terminate. This is an EARLY-SIGNAL alert so you do not have to wait for the join. Error: {}', States.JsonToString($.error))"
               },
               "ResultPath": null,
@@ -1991,7 +1432,7 @@
             },
             "BranchAComplete": {
               "Type": "Pass",
-              "Comment": "Branch A (Scanner → RegimeSubstrate → SignalsEnvelope → ChallengerShadow → RAG chain → ThinkTankCoverage → RegimeRetrospectiveEval → DataPhase2 → eval-judge chain → EvalRollingMean → RationaleClustering → ReplayConcordance → Counterfactual → AggregateCosts) completed (config-I2515 Phase B reorder — the multi-agent Research graph runner was removed). Records branch_a_status=OK so the post-join AggregateBranchOutcomes can decide whether to halt the SF. End:true so the Parallel branch SUCCEEDS — it must never throw, because a thrown branch would cancel the sibling PredictorTraining branch (default SF Parallel semantics).",
+              "Comment": "Branch A (Scanner \u2192 RegimeSubstrate \u2192 SignalsEnvelope \u2192 ChallengerShadow \u2192 RAG chain \u2192 ThinkTankCoverage \u2192 RegimeRetrospectiveEval \u2192 DataPhase2 \u2192 StartAdvisoryPipeline) completed. alpha-engine-config-I2544: the eval-judge chain / EvalRollingMean / RationaleClustering / ReplayConcordance / Counterfactual / AggregateCosts / ReportCard / Director now run in the async ne-weekly-advisory-pipeline child SF, fired fire-and-forget by StartAdvisoryPipeline \u2014 they are NOT awaited here. Records branch_a_status=OK so the post-join AggregateBranchOutcomes can decide whether to halt the SF. End:true so the Parallel branch SUCCEEDS \u2014 it must never throw, because a thrown branch would cancel the sibling PredictorTraining branch (default SF Parallel semantics).",
               "Result": {
                 "branch_a_status": "OK"
               },
@@ -2000,13 +1441,65 @@
             },
             "BranchAFailed": {
               "Type": "Pass",
-              "Comment": "Branch A hard-failed (SignalsEnvelope failure — the LOAD-BEARING signals.json producer post config-I2515 Phase B — RAGIngestion failure, or DataPhase2 failure). Records branch_a_status=FAILED + the captured $.error as DATA and End:true — the branch SUCCEEDS in SF terms so the sibling PredictorTraining branch is NEVER abandoned by Parallel's cancel-siblings default. The SF is failed AFTER the join by CheckBranchOutcomes. Recovery: if Branch B completed + promoted weights to S3, the re-run uses {\"skip_predictor_training\": true} (weights are already live) and re-runs only Branch A.",
+              "Comment": "Branch A hard-failed (SignalsEnvelope failure \u2014 the LOAD-BEARING signals.json producer post config-I2515 Phase B \u2014 RAGIngestion failure, or DataPhase2 failure). Records branch_a_status=FAILED + the captured $.error as DATA and End:true \u2014 the branch SUCCEEDS in SF terms so the sibling PredictorTraining branch is NEVER abandoned by Parallel's cancel-siblings default. The SF is failed AFTER the join by CheckBranchOutcomes. Recovery: if Branch B completed + promoted weights to S3, the re-run uses {\"skip_predictor_training\": true} (weights are already live) and re-runs only Branch A.",
               "Parameters": {
                 "branch_a_status": "FAILED",
                 "branch_a_error.$": "$.error"
               },
               "ResultPath": "$.branch_a",
               "End": true
+            },
+            "StartAdvisoryPipeline": {
+              "Type": "Task",
+              "Comment": "alpha-engine-config-I2544: fire-and-forget dispatch of the advisory child SF (ne-weekly-advisory-pipeline \u2014 eval-judge chain, EvalRollingMean, RationaleClustering, ReplayConcordance, Counterfactual, AggregateCosts, ReportCard, Director), decoupled from the Saturday critical path. states:startExecution (NOT .sync) \u2014 the parent proceeds to BranchAComplete immediately; the child runs independently and is watched separately (saturday-sf-watch-dispatcher PIPELINES registration). Name is advisory-{run_date} \u2014 deterministic per run_date, which IS the idempotency mutex: a same-run_date retry (e.g. a redrive/rerun of this Saturday SF) hits StepFunctions.ExecutionAlreadyExistsException on the child's already-running-or-completed execution, caught below and treated as pass-through success (the child's own idempotent per-run_date semantics own that case, not a second concurrent child). Input.$ merges $ (the FULL current execution state at this point in Branch A) UNDER a small defaults floor via States.JsonMerge \u2014 mirrors InitializeInput/NormalizeFailureContext's own defaults-then-$-wins idiom \u2014 so the optional skip_eval_judge / skip_rationale_clustering / skip_replay_concordance / skip_counterfactual / skip_aggregate_costs flags (each independently absent on most runs) never throw States.Runtime for a missing JSONPath: a bare '\"skip_eval_judge.$\": \"$.skip_eval_judge\"' would throw whenever the flag was not explicitly passed.",
+              "Resource": "arn:aws:states:::states:startExecution",
+              "Parameters": {
+                "StateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-advisory-pipeline",
+                "Name.$": "States.Format('advisory-{}', $.run_date)",
+                "Input.$": "States.JsonMerge(States.StringToJson('{\"research_dry\":false,\"skip_eval_judge\":false,\"skip_rationale_clustering\":false,\"skip_replay_concordance\":false,\"skip_counterfactual\":false,\"skip_aggregate_costs\":false}'),$,false)"
+              },
+              "ResultPath": "$.advisory_dispatch_result",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "StepFunctions.ExecutionAlreadyExistsException"
+                  ],
+                  "Comment": "Duplicate advisory-{run_date} name on a rerun of the SAME run_date is the intentional idempotency mutex, not a genuine failure \u2014 a fresh Saturday SF re-execution for a run_date whose advisory child already started does not need (or want) a second concurrent child. Pass-through success.",
+                  "ResultPath": "$.advisory_dispatch_error",
+                  "Next": "BranchAComplete"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Fire-and-forget dispatch failure (IAM drift / throttle / malformed input) must NOT fail Branch A \u2014 the advisory pipeline is observability-only. Alert (not silent) then converge, mirroring the PublishResearchFailureImmediate / PublishPredictorFailureImmediate / PublishModelZooFailureImmediate early-signal-alert idiom already used in this Parallel state.",
+                  "Next": "PublishAdvisoryDispatchFailureAlert",
+                  "ResultPath": "$.advisory_dispatch_error"
+                }
+              ],
+              "Next": "BranchAComplete"
+            },
+            "PublishAdvisoryDispatchFailureAlert": {
+              "Type": "Task",
+              "Comment": "Alert-then-converge for a genuine StartAdvisoryPipeline dispatch failure (not the expected ExecutionAlreadyExistsException mutex case, which is caught separately above). Best-effort: an SNS publish failure must never prevent Branch A from terminating cleanly.",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline \u2014 Advisory child dispatch FAILED (eval-judge/ReportCard/Director will not run this week)', $.pipeline_label)",
+                "Message.$": "States.Format('StartAdvisoryPipeline failed to dispatch the advisory child SF (ne-weekly-advisory-pipeline). Branch A continues normally (trading-critical artifacts are unaffected) but the eval-judge chain / ReportCard / Director will NOT run for this run_date unless manually started. Error: {}', States.JsonToString($.advisory_dispatch_error))"
+              },
+              "ResultPath": null,
+              "Next": "BranchAComplete",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: a failed SNS publish must not prevent the branch from terminating cleanly.",
+                  "ResultPath": null,
+                  "Next": "BranchAComplete"
+                }
+              ]
             }
           }
         },
@@ -2015,7 +1508,7 @@
           "States": {
             "CheckSkipPredictorTraining": {
               "Type": "Choice",
-              "Comment": "Skip-gate (config#2253 validated-skip upgrade). {\"skip_predictor_training\": true} bypasses GBM retrain (and, per config#902, the bundled drift step riding the same spot) AND the config#1083 model-zoo fan-out — but the skip claim is VALIDATED first: ValidatePredictorSkipWeightsFresh HeadObjects the live weights manifest (predictor/weights/meta/manifest.json — written UNCONDITIONALLY by every non-dry training run in alpha-engine-predictor training/meta_trainer.py, regardless of the promotion gate, unlike the live .pkl weights which only move on gate-pass) and CheckPredictorSkipWeightsFresh requires its LastModified DATE >= $.run_date — i.e. this run_date's training genuinely completed before the operator/watch-agent claimed it. Stale manifest → BranchBFailed (fail loud: silently honoring a false weights-are-already-live claim would hand Backtester stale weights AND swallow the very re-training the pipeline owed). EXCEPTION (first Choice rule): mode=backtest-eval (config#830 replay preset, which force-seeds this flag) routes straight to PredictorTrainingSkipped with NO freshness validation — that preset's contract is 'replay Backtester+Evaluator against existing artifacts, whatever their vintage', so a mid-week replay must not demand a same-day manifest. NOTE the manifest is the validation surface, NOT weights/meta/archive/{date}/: the dated archive is TRADING-DAY-keyed (config#1015 — Friday's close), while $.run_date is the Saturday calendar date, so an archive-prefix check would NEVER match on the standard Saturday recovery rerun this flag exists for. Cross-UTC-midnight recovery reruns: pass the ORIGINAL run_date explicitly (the watch charter's take-the-original-input rule already implies this for every date-keyed stage) and the lexicographic >= compare composes correctly.",
+              "Comment": "Skip-gate (config#2253 validated-skip upgrade). {\"skip_predictor_training\": true} bypasses GBM retrain (and, per config#902, the bundled drift step riding the same spot) AND the config#1083 model-zoo fan-out \u2014 but the skip claim is VALIDATED first: ValidatePredictorSkipWeightsFresh HeadObjects the live weights manifest (predictor/weights/meta/manifest.json \u2014 written UNCONDITIONALLY by every non-dry training run in alpha-engine-predictor training/meta_trainer.py, regardless of the promotion gate, unlike the live .pkl weights which only move on gate-pass) and CheckPredictorSkipWeightsFresh requires its LastModified DATE >= $.run_date \u2014 i.e. this run_date's training genuinely completed before the operator/watch-agent claimed it. Stale manifest \u2192 BranchBFailed (fail loud: silently honoring a false weights-are-already-live claim would hand Backtester stale weights AND swallow the very re-training the pipeline owed). EXCEPTION (first Choice rule): mode=backtest-eval (config#830 replay preset, which force-seeds this flag) routes straight to PredictorTrainingSkipped with NO freshness validation \u2014 that preset's contract is 'replay Backtester+Evaluator against existing artifacts, whatever their vintage', so a mid-week replay must not demand a same-day manifest. NOTE the manifest is the validation surface, NOT weights/meta/archive/{date}/: the dated archive is TRADING-DAY-keyed (config#1015 \u2014 Friday's close), while $.run_date is the Saturday calendar date, so an archive-prefix check would NEVER match on the standard Saturday recovery rerun this flag exists for. Cross-UTC-midnight recovery reruns: pass the ORIGINAL run_date explicitly (the watch charter's take-the-original-input rule already implies this for every date-keyed stage) and the lexicographic >= compare composes correctly.",
               "Choices": [
                 {
                   "And": [
@@ -2056,7 +1549,7 @@
             },
             "ValidatePredictorSkipWeightsFresh": {
               "Type": "Task",
-              "Comment": "config#2253 artifact-presence validation for skip_predictor_training. HeadObject on the live weights manifest; ResultSelector lifts LastModified's DATE part (ISO-8601 'YYYY-MM-DDThh:mm:ssZ' → 'YYYY-MM-DD') for the lexicographic >= compare against $.run_date in CheckPredictorSkipWeightsFresh (both sides YYYY-MM-DD, so string ordering IS date ordering). Deliberately an aws-sdk:s3 integration, not a sendCommand/Lambda: (a) zero boot cost / no dependency on the always-on box, (b) aws-sdk:s3 is NOT in nousergon_lib pipeline_status SUBSTANTIVE_RESOURCES, so this stays console-invisible plumbing with no cross-repo registry entry required. IAM: s3:GetObject on the manifest key (Sid HeadPredictorWeightsManifest in infrastructure/iam/alpha-engine-step-functions-role.json — apply.sh before merge, iam-drift-check enforces). Any S3 error or an unexpected LastModified serialization (intrinsic parse failure) routes to BranchBFailed via Catch — fail loud, no silent swallow (recording surface: $.error → branch_b_error → post-join FAILED SNS).",
+              "Comment": "config#2253 artifact-presence validation for skip_predictor_training. HeadObject on the live weights manifest; ResultSelector lifts LastModified's DATE part (ISO-8601 'YYYY-MM-DDThh:mm:ssZ' \u2192 'YYYY-MM-DD') for the lexicographic >= compare against $.run_date in CheckPredictorSkipWeightsFresh (both sides YYYY-MM-DD, so string ordering IS date ordering). Deliberately an aws-sdk:s3 integration, not a sendCommand/Lambda: (a) zero boot cost / no dependency on the always-on box, (b) aws-sdk:s3 is NOT in nousergon_lib pipeline_status SUBSTANTIVE_RESOURCES, so this stays console-invisible plumbing with no cross-repo registry entry required. IAM: s3:GetObject on the manifest key (Sid HeadPredictorWeightsManifest in infrastructure/iam/alpha-engine-step-functions-role.json \u2014 apply.sh before merge, iam-drift-check enforces). Any S3 error or an unexpected LastModified serialization (intrinsic parse failure) routes to BranchBFailed via Catch \u2014 fail loud, no silent swallow (recording surface: $.error \u2192 branch_b_error \u2192 post-join FAILED SNS).",
               "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
               "Parameters": {
                 "Bucket": "alpha-engine-research",
@@ -2074,7 +1567,7 @@
                   "MaxAttempts": 2,
                   "IntervalSeconds": 5,
                   "BackoffRate": 2.0,
-                  "Comment": "Transient S3 5xx/throttle; a genuine 403/404 burns ~15s of retries then fails through to the Catch — acceptable on an operator-initiated recovery path."
+                  "Comment": "Transient S3 5xx/throttle; a genuine 403/404 burns ~15s of retries then fails through to the Catch \u2014 acceptable on an operator-initiated recovery path."
                 }
               ],
               "Catch": [
@@ -2090,7 +1583,7 @@
             },
             "CheckPredictorSkipWeightsFresh": {
               "Type": "Choice",
-              "Comment": "config#2253: manifest LastModified date >= run_date ⇒ a non-dry training run completed for this run_date ⇒ the skip claim is genuine → PredictorTrainingSkipped (branch reads as succeeded downstream). Otherwise the claim is false → PredictorSkipWeightsStale synthesizes $.error → BranchBFailed (the SF fails AFTER the join per CheckBranchOutcomes, so the sibling Research branch still completes and its artifacts persist). The StringMatches '20*-*-*' shape guard is load-bearing: no fleet SF has consumed the aws-sdk:s3 LastModified serialization before (the groom SF's headObject is existence-only), and if it ever arrived non-ISO (HTTP-date 'Sat, 11 Jul ...', epoch string) a bare lexicographic >= against 'YYYY-MM-DD' could SILENTLY wrong-pass — the guard converts that into the loud stale/malformed path whose Cause prints the raw value.",
+              "Comment": "config#2253: manifest LastModified date >= run_date \u21d2 a non-dry training run completed for this run_date \u21d2 the skip claim is genuine \u2192 PredictorTrainingSkipped (branch reads as succeeded downstream). Otherwise the claim is false \u2192 PredictorSkipWeightsStale synthesizes $.error \u2192 BranchBFailed (the SF fails AFTER the join per CheckBranchOutcomes, so the sibling Research branch still completes and its artifacts persist). The StringMatches '20*-*-*' shape guard is load-bearing: no fleet SF has consumed the aws-sdk:s3 LastModified serialization before (the groom SF's headObject is existence-only), and if it ever arrived non-ISO (HTTP-date 'Sat, 11 Jul ...', epoch string) a bare lexicographic >= against 'YYYY-MM-DD' could SILENTLY wrong-pass \u2014 the guard converts that into the loud stale/malformed path whose Cause prints the raw value.",
               "Choices": [
                 {
                   "And": [
@@ -2110,17 +1603,17 @@
             },
             "PredictorSkipWeightsStale": {
               "Type": "Pass",
-              "Comment": "config#2253: synthesize $.error for BranchBFailed's branch_b_error.$=$.error contract (a Choice.Default transition does not populate an error path the way a Task Catch does — same States.Runtime trap the ExtractModelZoo*Error states exist for, config#2160 arc). Names both dates so the FAILED SNS alert is self-diagnosing.",
+              "Comment": "config#2253: synthesize $.error for BranchBFailed's branch_b_error.$=$.error contract (a Choice.Default transition does not populate an error path the way a Task Catch does \u2014 same States.Runtime trap the ExtractModelZoo*Error states exist for, config#2160 arc). Names both dates so the FAILED SNS alert is self-diagnosing.",
               "Parameters": {
                 "Error": "PredictorSkipWeightsStale",
-                "Cause.$": "States.Format('skip_predictor_training=true but s3://alpha-engine-research/predictor/weights/meta/manifest.json LastModified date {} < run_date {} — no completed predictor training for this run_date; refusing to silently skip onto stale weights. Either re-run WITHOUT skip_predictor_training (training genuinely did not complete), or pass the ORIGINAL run_date explicitly if this is a cross-UTC-midnight recovery rerun.', $.predictor_skip_validation.manifest_last_modified_date, $.run_date)"
+                "Cause.$": "States.Format('skip_predictor_training=true but s3://alpha-engine-research/predictor/weights/meta/manifest.json LastModified date {} < run_date {} \u2014 no completed predictor training for this run_date; refusing to silently skip onto stale weights. Either re-run WITHOUT skip_predictor_training (training genuinely did not complete), or pass the ORIGINAL run_date explicitly if this is a cross-UTC-midnight recovery rerun.', $.predictor_skip_validation.manifest_last_modified_date, $.run_date)"
               },
               "ResultPath": "$.error",
               "Next": "BranchBFailed"
             },
             "PredictorTrainingSkipped": {
               "Type": "Pass",
-              "Comment": "config#2253 branch-B skip terminal. Reads as a SUCCEEDED branch to AggregateBranchOutcomes/CheckBranchOutcomes — the join reads ONLY $.parallel_result[1].branch_b.branch_b_status, and this records the identical branch_b_status=OK contract as BranchBComplete — plus an explicit skipped:true marker for execution-history forensics (no fabricated training payload beyond what routing requires). End:true so the sibling Research branch is never cancelled (the per-branch error-isolation invariant).",
+              "Comment": "config#2253 branch-B skip terminal. Reads as a SUCCEEDED branch to AggregateBranchOutcomes/CheckBranchOutcomes \u2014 the join reads ONLY $.parallel_result[1].branch_b.branch_b_status, and this records the identical branch_b_status=OK contract as BranchBComplete \u2014 plus an explicit skipped:true marker for execution-history forensics (no fabricated training payload beyond what routing requires). End:true so the sibling Research branch is never cancelled (the per-branch error-isolation invariant).",
               "Result": {
                 "branch_b_status": "OK",
                 "skipped": true
@@ -2150,7 +1643,7 @@
                     "States.TaskFailed",
                     "States.Timeout"
                   ],
-                  "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+                  "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
                   "MaxAttempts": 4,
                   "IntervalSeconds": 30,
                   "BackoffRate": 2.0,
@@ -2161,7 +1654,7 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
+                  "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
                   "MaxAttempts": 2,
                   "IntervalSeconds": 30,
                   "BackoffRate": 2.0,
@@ -2233,7 +1726,7 @@
                 {
                   "Variable": "$.predictor_poll.Status",
                   "StringEquals": "Success",
-                  "Next": "ResolveZooSpecs"
+                  "Next": "BranchBComplete"
                 },
                 {
                   "Variable": "$.predictor_poll.Status",
@@ -2266,11 +1759,11 @@
             },
             "PublishPredictorFailureImmediate": {
               "Type": "Task",
-              "Comment": "Fire an immediate SNS failure alert when PredictorTraining fails, BEFORE the sibling Research branch finishes its eval-judge / RollingMean / Counterfactual chain + the parent SF's parallel-join aggregation. Closes the 2026-05-24 operator-confusion gap where the predictor OOM surfaced only after the Research-eval chain completed (~10 min of misleading 'progress' visible while the run was already known-doomed). Branch terminus is still BranchBFailed (Pass) so the salvage semantics are preserved: SF still fails at the join via CheckBranchOutcomes; Research's eval-judge work still persists for the next redrive's skip-set. SNS publish failure is caught and routed forward — best-effort alert must NEVER prevent the branch from properly terminating.",
+              "Comment": "Fire an immediate SNS failure alert when PredictorTraining fails, BEFORE the sibling Research branch finishes its eval-judge / RollingMean / Counterfactual chain + the parent SF's parallel-join aggregation. Closes the 2026-05-24 operator-confusion gap where the predictor OOM surfaced only after the Research-eval chain completed (~10 min of misleading 'progress' visible while the run was already known-doomed). Branch terminus is still BranchBFailed (Pass) so the salvage semantics are preserved: SF still fails at the join via CheckBranchOutcomes; Research's eval-judge work still persists for the next redrive's skip-set. SNS publish failure is caught and routed forward \u2014 best-effort alert must NEVER prevent the branch from properly terminating.",
               "Resource": "arn:aws:states:::sns:publish",
               "Parameters": {
                 "TopicArn.$": "$.sns_topic_arn",
-                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — PredictorTraining FAILED (early signal — SF will fail at join)', $.pipeline_label)",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline \u2014 PredictorTraining FAILED (early signal \u2014 SF will fail at join)', $.pipeline_label)",
                 "Message.$": "States.Format('PredictorTraining branch failed inside ResearchPredictorParallel. The sibling Research branch is still running and will complete its eval-judge / RollingMean / Counterfactual work independently; the SF will fail at the parallel-join aggregation via CheckBranchOutcomes once both branches terminate. This is an EARLY-SIGNAL alert so you do not have to wait for the join. Error: {}', States.JsonToString($.error))"
               },
               "ResultPath": null,
@@ -2286,497 +1779,9 @@
                 }
               ]
             },
-            "ResolveZooSpecs": {
-              "Type": "Task",
-              "Comment": "config#1083 PARALLEL fan-out, step 1 (dispatcher SSM on the box, fast, NO spot): resolve the spec ids this rotation should train via list-rotation-specs, emitting a JSON array on stdout (the budget-N stalest active specs). The preamble (git pull + config stage) is redirected to stderr so StandardOutputContent is JUST the array, which ParseZooSpecs lifts into $.zoo_specs (the Map ItemsPath). BEST-EFFORT: a resolve/parse failure routes to PublishModelZooFailureImmediate then BranchBComplete (the champion already trained+promoted; the rotation must NEVER fail the Saturday SF).",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-              "Parameters": {
-                "DocumentName": "AWS-RunShellScript",
-                "InstanceIds.$": "$.ec2_instance_id",
-                "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','{ sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main; sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main; sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml; } 1>&2','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference','/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m training.model_zoo list-rotation-specs --bucket alpha-engine-research 2>/dev/null')",
-                  "executionTimeout": [
-                    "600"
-                  ]
-                },
-                "TimeoutSeconds": 600
-              },
-              "TimeoutSeconds": 660,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "States.TaskFailed",
-                    "States.Timeout"
-                  ],
-                  "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
-                  "MaxAttempts": 4,
-                  "IntervalSeconds": 30,
-                  "BackoffRate": 2.0,
-                  "MaxDelaySeconds": 300,
-                  "JitterStrategy": "FULL"
-                },
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
-                  "MaxAttempts": 2,
-                  "IntervalSeconds": 30,
-                  "BackoffRate": 2.0,
-                  "MaxDelaySeconds": 300,
-                  "JitterStrategy": "FULL"
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Best-effort: resolve failure must NEVER fail the branch. Alert (not silent) then converge to BranchBComplete.",
-                  "Next": "PublishModelZooFailureImmediate",
-                  "ResultPath": "$.model_zoo_error"
-                }
-              ],
-              "ResultPath": "$.resolve_zoo_result",
-              "Next": "WaitResolveZoo"
-            },
-            "WaitResolveZoo": {
-              "Type": "Task",
-              "Comment": "Poll the ResolveZooSpecs SSM command; capture StandardOutputContent (the JSON spec-id array).",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-              "Parameters": {
-                "CommandId.$": "$.resolve_zoo_result.Command.CommandId",
-                "InstanceId.$": "$.ec2_instance_id[0]"
-              },
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Ssm.InvocationDoesNotExistException",
-                    "Ssm.InvocationDoesNotExist"
-                  ],
-                  "MaxAttempts": 10,
-                  "IntervalSeconds": 30,
-                  "BackoffRate": 1.5
-                },
-                {
-                  "ErrorEquals": [
-                    "Ssm.SdkClientException",
-                    "States.Timeout"
-                  ],
-                  "MaxAttempts": 2,
-                  "IntervalSeconds": 5,
-                  "BackoffRate": 1.5
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Best-effort: poll failure routes via the alert, never to BranchBFailed.",
-                  "Next": "PublishModelZooFailureImmediate",
-                  "ResultPath": "$.model_zoo_error"
-                }
-              ],
-              "ResultSelector": {
-                "Status.$": "$.Status",
-                "ResponseCode.$": "$.ResponseCode",
-                "StatusDetails.$": "$.StatusDetails",
-                "StandardErrorContent.$": "$.StandardErrorContent",
-                "StandardOutputContent.$": "$.StandardOutputContent"
-              },
-              "ResultPath": "$.resolve_zoo_poll",
-              "Next": "CheckResolveZooStatus"
-            },
-            "CheckResolveZooStatus": {
-              "Type": "Choice",
-              "Comment": "Success leads to ParseZooSpecs (lift the JSON array); InProgress/Pending wait; anything else alerts then BranchBComplete (best-effort).",
-              "Choices": [
-                {
-                  "Variable": "$.resolve_zoo_poll.Status",
-                  "StringEquals": "InProgress",
-                  "Next": "ResolveZooWait"
-                },
-                {
-                  "Variable": "$.resolve_zoo_poll.Status",
-                  "StringEquals": "Pending",
-                  "Next": "ResolveZooWait"
-                },
-                {
-                  "Variable": "$.resolve_zoo_poll.Status",
-                  "StringEquals": "Success",
-                  "Next": "ParseZooSpecs"
-                }
-              ],
-              "Default": "ExtractModelZooResolveError"
-            },
-            "ExtractModelZooResolveError": {
-              "Type": "Pass",
-              "Comment": "Normalize ResolveZooSpecs SSM non-Success poll into $.model_zoo_error. Mirrors ExtractPredictorError/ExtractSignalsEnvelopeError/ExtractRAGIngestionError — CheckResolveZooStatus.Default does not populate $.model_zoo_error the way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's Message calls States.JsonToString($.model_zoo_error): a direct Choice->Task jump on this edge died with States.Runtime ('$.model_zoo_error could not be found'), masking the real zoo-resolve failure behind an opaque meta-error (observed live 2026-07-10, execution offcycle-shell-20260710-220932; config#2160 arc).",
-              "Parameters": {
-                "phase": "ModelZooResolve",
-                "source": "CheckResolveZooStatus.Default",
-                "poll.$": "$.resolve_zoo_poll"
-              },
-              "ResultPath": "$.model_zoo_error",
-              "Next": "PublishModelZooFailureImmediate"
-            },
-            "ResolveZooWait": {
-              "Type": "Wait",
-              "Seconds": 15,
-              "Next": "WaitResolveZoo"
-            },
-            "ParseZooSpecs": {
-              "Type": "Pass",
-              "Comment": "config#1083: lift the resolved JSON spec-id array (StandardOutputContent of ResolveZooSpecs) into $.zoo_specs for the Map ItemsPath. Reached ONLY after CheckResolveZooStatus=Success, where the SSM command exited 0 and stdout is the CLI json.dumps(ids) output - always a valid JSON array (possibly empty, which runs zero Map iterations; ModelZooSelect then handles the empty pool). A Pass state cannot carry a Catch (it cannot throw); the upstream poll-status gate is the failure boundary - any non-success ResolveZooSpecs outcome routes to PublishModelZooFailureImmediate BEFORE this state is reached.",
-              "Parameters": {
-                "zoo_specs.$": "States.StringToJson($.resolve_zoo_poll.StandardOutputContent)"
-              },
-              "ResultPath": "$.parsed_zoo",
-              "Next": "ModelZooTrainMap"
-            },
-            "ModelZooTrainMap": {
-              "Type": "Map",
-              "Comment": "config#1083 PARALLEL fan-out, step 2: train one challenger PER spec id, each on its OWN memory-isolated spot, concurrently. MaxConcurrency 4 bounds in-flight spots. PER-ITERATION ERROR ISOLATION (the key robustness property): each iteration ends in a branch-local Pass terminal (TrainSpecOK / TrainSpecFailed, both End:true) recording status as DATA so an iteration NEVER throws; a single challenger crashing (OOM / KeyError / spot interruption) does NOT abort its siblings; selection proceeds with the survivors. ToleratedFailurePercentage 100 is a defense-in-depth backstop (iterations already self-terminate as success). ItemSelector threads ec2_instance_id + preflight_args + the per-item spec id into each iteration.",
-              "ItemsPath": "$.parsed_zoo.zoo_specs",
-              "MaxConcurrency": 4,
-              "ToleratedFailurePercentage": 100,
-              "ItemSelector": {
-                "spec_id.$": "$$.Map.Item.Value",
-                "ec2_instance_id.$": "$.ec2_instance_id",
-                "preflight_args.$": "$.preflight_args"
-              },
-              "ItemProcessor": {
-                "ProcessorConfig": {
-                  "Mode": "INLINE"
-                },
-                "StartAt": "TrainSpecDispatch",
-                "States": {
-                  "TrainSpecDispatch": {
-                    "Type": "Task",
-                    "Comment": "Launch a dedicated spot for THIS spec via spot_train.sh --model-zoo-spec <id>. Dispatcher SSM on the box (the script launches the actual spot internally). Honors $.preflight_args for shell-run dry mode.",
-                    "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-                    "Parameters": {
-                      "DocumentName": "AWS-RunShellScript",
-                      "InstanceIds.$": "$.ec2_instance_id",
-                      "Parameters": {
-                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
-                        "executionTimeout": [
-                          "5400"
-                        ]
-                      },
-                      "TimeoutSeconds": 5400
-                    },
-                    "TimeoutSeconds": 5460,
-                    "Retry": [
-                      {
-                        "ErrorEquals": [
-                          "States.TaskFailed",
-                          "States.Timeout"
-                        ],
-                        "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
-                        "MaxAttempts": 4,
-                        "IntervalSeconds": 30,
-                        "BackoffRate": 2.0,
-                        "MaxDelaySeconds": 300,
-                        "JitterStrategy": "FULL"
-                      },
-                      {
-                        "ErrorEquals": [
-                          "States.ALL"
-                        ],
-                        "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
-                        "MaxAttempts": 2,
-                        "IntervalSeconds": 30,
-                        "BackoffRate": 2.0,
-                        "MaxDelaySeconds": 300,
-                        "JitterStrategy": "FULL"
-                      }
-                    ],
-                    "Catch": [
-                      {
-                        "ErrorEquals": [
-                          "States.ALL"
-                        ],
-                        "Comment": "This spec dispatch failed; record as data, do NOT throw (sibling iterations must proceed).",
-                        "Next": "TrainSpecFailed",
-                        "ResultPath": "$.error"
-                      }
-                    ],
-                    "ResultPath": "$.train_spec_result",
-                    "Next": "WaitTrainSpec"
-                  },
-                  "WaitTrainSpec": {
-                    "Type": "Task",
-                    "Comment": "Poll this spec SSM command until complete.",
-                    "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-                    "Parameters": {
-                      "CommandId.$": "$.train_spec_result.Command.CommandId",
-                      "InstanceId.$": "$.ec2_instance_id[0]"
-                    },
-                    "Retry": [
-                      {
-                        "ErrorEquals": [
-                          "Ssm.InvocationDoesNotExistException",
-                          "Ssm.InvocationDoesNotExist"
-                        ],
-                        "MaxAttempts": 10,
-                        "IntervalSeconds": 30,
-                        "BackoffRate": 1.5
-                      },
-                      {
-                        "ErrorEquals": [
-                          "Ssm.SdkClientException",
-                          "States.Timeout"
-                        ],
-                        "MaxAttempts": 2,
-                        "IntervalSeconds": 5,
-                        "BackoffRate": 1.5
-                      }
-                    ],
-                    "Catch": [
-                      {
-                        "ErrorEquals": [
-                          "States.ALL"
-                        ],
-                        "Comment": "Poll failure for this spec; record as data, never throw.",
-                        "Next": "TrainSpecFailed",
-                        "ResultPath": "$.error"
-                      }
-                    ],
-                    "ResultSelector": {
-                      "Status.$": "$.Status",
-                      "ResponseCode.$": "$.ResponseCode",
-                      "StatusDetails.$": "$.StatusDetails",
-                      "StandardErrorContent.$": "$.StandardErrorContent"
-                    },
-                    "ResultPath": "$.train_spec_poll",
-                    "Next": "CheckTrainSpecStatus"
-                  },
-                  "CheckTrainSpecStatus": {
-                    "Type": "Choice",
-                    "Comment": "Success leads to TrainSpecOK; InProgress/Pending wait; anything else (this spec spot OOM/errored) leads to TrainSpecFailed (recorded as data, NOT a throw, so siblings proceed - the per-spec isolation win).",
-                    "Choices": [
-                      {
-                        "Variable": "$.train_spec_poll.Status",
-                        "StringEquals": "InProgress",
-                        "Next": "TrainSpecWait"
-                      },
-                      {
-                        "Variable": "$.train_spec_poll.Status",
-                        "StringEquals": "Pending",
-                        "Next": "TrainSpecWait"
-                      },
-                      {
-                        "Variable": "$.train_spec_poll.Status",
-                        "StringEquals": "Success",
-                        "Next": "TrainSpecOK"
-                      }
-                    ],
-                    "Default": "TrainSpecFailed"
-                  },
-                  "TrainSpecWait": {
-                    "Type": "Wait",
-                    "Seconds": 60,
-                    "Next": "WaitTrainSpec"
-                  },
-                  "TrainSpecOK": {
-                    "Type": "Pass",
-                    "Comment": "This spec trained + registered its challenger. End:true so the Map iteration SUCCEEDS (never cancels sibling iterations).",
-                    "Parameters": {
-                      "spec_status": "OK",
-                      "spec_id.$": "$.spec_id"
-                    },
-                    "End": true
-                  },
-                  "TrainSpecFailed": {
-                    "Type": "Pass",
-                    "Comment": "This spec training failed (spot OOM / KeyError / interruption). Records status as DATA + End:true so the iteration SUCCEEDS in SF terms - the failure is isolated to THIS spec, siblings proceed, and ModelZooSelect simply finds this spec challenger absent from the registry (tolerated). The full failure log is on the box (predictor-model-zoo-spec.log) + durable in S3 via ssm_log_capture (config#272).",
-                    "Parameters": {
-                      "spec_status": "FAILED",
-                      "spec_id.$": "$.spec_id"
-                    },
-                    "End": true
-                  }
-                }
-              },
-              "ResultPath": "$.zoo_train_results",
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Backstop ONLY for a genuine Map-engine error (iterations never throw - they end success with status data). Best-effort: alert then BranchBComplete (the champion is already live). ModelZooSelect will still run on whatever registered.",
-                  "Next": "PublishModelZooFailureImmediate",
-                  "ResultPath": "$.model_zoo_error"
-                }
-              ],
-              "Next": "ModelZooSelect"
-            },
-            "ModelZooSelect": {
-              "Type": "Task",
-              "Comment": "config#1083 PARALLEL fan-out, step 3 (ONE spot, after the Map joins): select over whatever spec-* challengers registered for the date (failed Map iterations are simply absent - tolerated), write the leaderboard to BOTH the dated key AND latest.json, promote the winner if MODEL_ZOO_AUTO_PROMOTE_WINNER, and send the ONE consolidated digest. BEST-EFFORT: every failure path routes to PublishModelZooFailureImmediate then BranchBComplete (the champion already trained+promoted; the rotation must NEVER fail the Saturday SF). The base champion-arch retrain (PredictorTraining) ran first and competes in the same pool.",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
-              "Parameters": {
-                "DocumentName": "AWS-RunShellScript",
-                "InstanceIds.$": "$.ec2_instance_id",
-                "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_train.sh --model-zoo-select{}',$.preflight_args))",
-                  "executionTimeout": [
-                    "5400"
-                  ]
-                },
-                "TimeoutSeconds": 5400
-              },
-              "TimeoutSeconds": 5460,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "States.TaskFailed",
-                    "States.Timeout"
-                  ],
-                  "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
-                  "MaxAttempts": 4,
-                  "IntervalSeconds": 30,
-                  "BackoffRate": 2.0,
-                  "MaxDelaySeconds": 300,
-                  "JitterStrategy": "FULL"
-                },
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
-                  "MaxAttempts": 2,
-                  "IntervalSeconds": 30,
-                  "BackoffRate": 2.0,
-                  "MaxDelaySeconds": 300,
-                  "JitterStrategy": "FULL"
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Best-effort: a select failure must NEVER fail the branch. Alert (not silent) then converge to BranchBComplete.",
-                  "Next": "PublishModelZooFailureImmediate",
-                  "ResultPath": "$.model_zoo_error"
-                }
-              ],
-              "ResultPath": "$.model_zoo_result",
-              "Next": "WaitForModelZoo"
-            },
-            "WaitForModelZoo": {
-              "Type": "Task",
-              "Comment": "Poll the ModelZooSelect SSM command until complete.",
-              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
-              "Parameters": {
-                "CommandId.$": "$.model_zoo_result.Command.CommandId",
-                "InstanceId.$": "$.ec2_instance_id[0]"
-              },
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Ssm.InvocationDoesNotExistException",
-                    "Ssm.InvocationDoesNotExist"
-                  ],
-                  "MaxAttempts": 10,
-                  "IntervalSeconds": 30,
-                  "BackoffRate": 1.5
-                },
-                {
-                  "ErrorEquals": [
-                    "Ssm.SdkClientException",
-                    "States.Timeout"
-                  ],
-                  "MaxAttempts": 2,
-                  "IntervalSeconds": 5,
-                  "BackoffRate": 1.5
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Best-effort: poll failure must not fail the branch - but must not be SILENT either (the base retrain deferred its email to the zoo digest). Alert via PublishModelZooFailureImmediate, then converge to BranchBComplete.",
-                  "Next": "PublishModelZooFailureImmediate",
-                  "ResultPath": "$.model_zoo_error"
-                }
-              ],
-              "ResultSelector": {
-                "Status.$": "$.Status",
-                "ResponseCode.$": "$.ResponseCode",
-                "StatusDetails.$": "$.StatusDetails",
-                "StandardErrorContent.$": "$.StandardErrorContent"
-              },
-              "ResultPath": "$.model_zoo_poll",
-              "Next": "CheckModelZooStatus"
-            },
-            "CheckModelZooStatus": {
-              "Type": "Choice",
-              "Comment": "Any non-success routes to PublishModelZooFailureImmediate (SNS alert) then BranchBComplete - selection is best-effort and its failure is logged on the box (predictor-model-zoo-select.log); the champion is already live. The alert is required because PREDICTOR_DEFER_TRAINING_EMAIL=1 deferred the base retrain email to the zoo digest, so a silent zoo failure would otherwise mean zero email for the run.",
-              "Choices": [
-                {
-                  "Variable": "$.model_zoo_poll.Status",
-                  "StringEquals": "InProgress",
-                  "Next": "ModelZooWait"
-                },
-                {
-                  "Variable": "$.model_zoo_poll.Status",
-                  "StringEquals": "Pending",
-                  "Next": "ModelZooWait"
-                },
-                {
-                  "Variable": "$.model_zoo_poll.Status",
-                  "StringEquals": "Success",
-                  "Next": "BranchBComplete"
-                }
-              ],
-              "Default": "ExtractModelZooSelectError"
-            },
-            "ExtractModelZooSelectError": {
-              "Type": "Pass",
-              "Comment": "Normalize ModelZooSelect SSM non-Success poll into $.model_zoo_error. Mirrors ExtractPredictorError/ExtractSignalsEnvelopeError/ExtractRAGIngestionError — CheckModelZooStatus.Default does not populate $.model_zoo_error the way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's Message calls States.JsonToString($.model_zoo_error): a direct Choice->Task jump on this edge died with States.Runtime ('$.model_zoo_error could not be found'), masking the real zoo-select failure behind an opaque meta-error (observed live 2026-07-10, execution offcycle-shell-20260710-220932; config#2160 arc).",
-              "Parameters": {
-                "phase": "ModelZooSelect",
-                "source": "CheckModelZooStatus.Default",
-                "poll.$": "$.model_zoo_poll"
-              },
-              "ResultPath": "$.model_zoo_error",
-              "Next": "PublishModelZooFailureImmediate"
-            },
-            "PublishModelZooFailureImmediate": {
-              "Type": "Task",
-              "Comment": "Fire an SNS failure alert when the model-zoo rotation fails/times-out. REQUIRED for fallback safety: PredictorTraining now exports PREDICTOR_DEFER_TRAINING_EMAIL=1, so the base champion-arch retrain DEFERS its per-run training email to the consolidated zoo digest (sent at the end of run_rotation_and_select). If the zoo then fails, NEITHER email goes out — without this alert the run would be SILENT. Best-effort like the predictor early-signal alert: an SNS publish failure is caught and still routes to BranchBComplete (the champion already trained+promoted; the rotation is non-critical, so a zoo failure must NEVER fail the branch).",
-              "Resource": "arn:aws:states:::sns:publish",
-              "Parameters": {
-                "TopicArn.$": "$.sns_topic_arn",
-                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — ModelZooRotation FAILED (zoo digest email may be missing)', $.pipeline_label)",
-                "Message.$": "States.Format('The model-zoo rotation failed or timed out. The base champion-arch retrain already trained+promoted and DEFERRED its training email to the zoo digest (PREDICTOR_DEFER_TRAINING_EMAIL=1), so the consolidated digest email may NOT have been sent for this run — review predictor-model-zoo.log on the spot and predictor/model_zoo/leaderboard/. The branch will still complete (the champion is live); the rotation is best-effort. Error: {}', States.JsonToString($.model_zoo_error))"
-              },
-              "ResultPath": null,
-              "Next": "BranchBComplete",
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Best-effort: a failed SNS publish must not prevent the branch from completing. The champion is already live.",
-                  "ResultPath": null,
-                  "Next": "BranchBComplete"
-                }
-              ]
-            },
-            "ModelZooWait": {
-              "Type": "Wait",
-              "Seconds": 60,
-              "Next": "WaitForModelZoo"
-            },
             "BranchBComplete": {
               "Type": "Pass",
-              "Comment": "Branch B (PredictorTraining quartet) completed (training success; the L4544 model-zoo rotation, if it ran, is best-effort and converges here regardless of outcome). The skip_predictor_training path terminates at its own PredictorTrainingSkipped terminal (config#2253) with the same branch_b_status=OK contract plus a skipped:true marker. Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch.",
+              "Comment": "Branch B (PredictorTraining) completed (training success). alpha-engine-config-I2545: the model-zoo rotation (ResolveZooSpecs \u2192 ModelZooTrainMap \u2192 ModelZooSelect) moved OFF Saturday to its own Sunday 09:00 UTC trigger (ne-modelzoo-sunday-pipeline, triggered directly by EventBridge \u2014 NOT dispatched from here). The skip_predictor_training path terminates at its own PredictorTrainingSkipped terminal (config#2253) with the same branch_b_status=OK contract plus a skipped:true marker. Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch.",
               "Result": {
                 "branch_b_status": "OK"
               },
@@ -2785,7 +1790,7 @@
             },
             "BranchBFailed": {
               "Type": "Pass",
-              "Comment": "Branch B (PredictorTraining) failed/timed-out (SSM non-Success normalized by ExtractPredictorError, or a Task Catch). Records branch_b_status=FAILED + $.error as DATA, End:true so the branch SUCCEEDS and the sibling Research branch runs to its own completion — a completed Research branch's signals.json / decision_artifacts are NOT silently discarded. The SF is failed AFTER the join by CheckBranchOutcomes. NOTE: if PredictorTraining promoted weights to S3 before failing a later poll, those weights persist; the recovery re-run skips the genuinely-completed branch.",
+              "Comment": "Branch B (PredictorTraining) failed/timed-out (SSM non-Success normalized by ExtractPredictorError, or a Task Catch). Records branch_b_status=FAILED + $.error as DATA, End:true so the branch SUCCEEDS and the sibling Research branch runs to its own completion \u2014 a completed Research branch's signals.json / decision_artifacts are NOT silently discarded. The SF is failed AFTER the join by CheckBranchOutcomes. NOTE: if PredictorTraining promoted weights to S3 before failing a later poll, those weights persist; the recovery re-run skips the genuinely-completed branch.",
               "Parameters": {
                 "branch_b_status": "FAILED",
                 "branch_b_error.$": "$.error"
@@ -2802,7 +1807,7 @@
             "States.ALL"
           ],
           "MaxAttempts": 0,
-          "Comment": "MaxAttempts:0 — branches self-terminate as success and record failure as data; there is nothing to retry at the Parallel level. Explicit no-op Retry documents intent and prevents an accidental default retry from re-running a completed PredictorTraining."
+          "Comment": "MaxAttempts:0 \u2014 branches self-terminate as success and record failure as data; there is nothing to retry at the Parallel level. Explicit no-op Retry documents intent and prevents an accidental default retry from re-running a completed PredictorTraining."
         }
       ],
       "Catch": [
@@ -2810,7 +1815,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Backstop ONLY for a genuine SF-engine Parallel error (branches never throw — they end success with status data). Routes to the shared HandleFailure, mirroring the existing per-state Catch->HandleFailure convention; does NOT introduce a new error channel.",
+          "Comment": "Backstop ONLY for a genuine SF-engine Parallel error (branches never throw \u2014 they end success with status data). Routes to the shared HandleFailure, mirroring the existing per-state Catch->HandleFailure convention; does NOT introduce a new error channel.",
           "Next": "NormalizeFailureContext",
           "ResultPath": "$.error"
         }
@@ -2820,7 +1825,7 @@
     },
     "AggregateBranchOutcomes": {
       "Type": "Pass",
-      "Comment": "Parallel join sync point. $.parallel_result is the 2-element array of each branch's final effective input (branch order matches the Branches array: [0]=Research branch, [1]=PredictorTraining branch). Each branch terminal wrote its status under $.branch_a / $.branch_b, so hoist both statuses to a flat path for the Choice. This is the natural Backtester sync point — Backtester needs BOTH Research signal history AND PredictorTraining weights.",
+      "Comment": "Parallel join sync point. $.parallel_result is the 2-element array of each branch's final effective input (branch order matches the Branches array: [0]=Research branch, [1]=PredictorTraining branch). Each branch terminal wrote its status under $.branch_a / $.branch_b, so hoist both statuses to a flat path for the Choice. This is the natural Backtester sync point \u2014 Backtester needs BOTH Research signal history AND PredictorTraining weights.",
       "Parameters": {
         "branch_a_status.$": "$.parallel_result[0].branch_a.branch_a_status",
         "branch_b_status.$": "$.parallel_result[1].branch_b.branch_b_status"
@@ -2830,7 +1835,7 @@
     },
     "CheckBranchOutcomes": {
       "Type": "Choice",
-      "Comment": "Fail the SF AFTER the join if EITHER branch recorded FAILED — so the OTHER branch's completed work (Research signals.json / decision_artifacts, OR PredictorTraining's already-S3-promoted weights) persists and the recovery re-run's skip-set can skip whichever branch genuinely completed. Research-fail + Predictor-done → recovery re-run with {\"skip_predictor_training\": true}. Predictor-fail + Research-done → recovery re-run with {\"skip_research\": true, ... per the live-SF-derived skip-set practice}. Only when BOTH branches are OK does the pipeline continue to CheckSkipBacktester -> Backtester -> Parity -> Evaluator. (config#902: the standalone DriftDetection state was collapsed — drift is now bundled onto the PredictorTraining spot inside Branch B's spot_train.sh, running non-blocking after training succeeds — so the join routes straight to the backtester skip-gate.)",
+      "Comment": "Fail the SF AFTER the join if EITHER branch recorded FAILED \u2014 so the OTHER branch's completed work (Research signals.json / decision_artifacts, OR PredictorTraining's already-S3-promoted weights) persists and the recovery re-run's skip-set can skip whichever branch genuinely completed. Research-fail + Predictor-done \u2192 recovery re-run with {\"skip_predictor_training\": true}. Predictor-fail + Research-done \u2192 recovery re-run with {\"skip_research\": true, ... per the live-SF-derived skip-set practice}. Only when BOTH branches are OK does the pipeline continue to CheckSkipBacktester -> Backtester -> Parity -> Evaluator. (config#902: the standalone DriftDetection state was collapsed \u2014 drift is now bundled onto the PredictorTraining spot inside Branch B's spot_train.sh, running non-blocking after training succeeds \u2014 so the join routes straight to the backtester skip-gate.)",
       "Choices": [
         {
           "Or": [
@@ -2850,7 +1855,7 @@
     },
     "ExtractParallelBranchError": {
       "Type": "Pass",
-      "Comment": "Normalize a post-join branch failure into $.error for HandleFailure's States.Format/JsonToString template. Carries both branch statuses + each branch's recorded error so the FAILED SNS alert names which branch(es) failed and which completed (drives the recovery skip-set: a completed branch is skipped on the re-run). Mirrors the existing Extract*Error → HandleFailure convention; no new error channel.",
+      "Comment": "Normalize a post-join branch failure into $.error for HandleFailure's States.Format/JsonToString template. Carries both branch statuses + each branch's recorded error so the FAILED SNS alert names which branch(es) failed and which completed (drives the recovery skip-set: a completed branch is skipped on the re-run). Mirrors the existing Extract*Error \u2192 HandleFailure convention; no new error channel.",
       "Parameters": {
         "phase": "ResearchPredictorParallel",
         "source": "CheckBranchOutcomes",
@@ -2864,7 +1869,7 @@
     },
     "CheckSkipBacktester": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses BOTH the Backtester (backtest stage) and Parity states — it routes straight to CheckSkipEvaluator, skipping the whole backtest+parity pair (the parity stage was split into its own Parity SF state by the preflight-task-split 2026-05-16, plan alpha-engine-docs/private/preflight-task-split-260516.md; skip_backtester retains its original whole-pair semantics for backward compat). The Evaluator state still runs and gracefully degrades on missing same-cohort artifacts (evaluate.py logs a WARNING and continues — verified against the 2026-05-07 v1 validation run, where `Simulation artifact not found in S3: backtest/2026-05-07/sweep_df.parquet — evaluator will run without it` shows up cleanly). Routes to CheckSkipEvaluator so {\"skip_evaluator\": true} composes orthogonally: (a) neither flag → backtest+parity+evaluator run, (b) skip_backtester only → Evaluator runs against any pre-existing backtest/{date}/ artifacts, (c) skip_evaluator only → backtest+parity run without grading, (d) both → all skipped. To skip ONLY parity (keep the backtest), use {\"skip_parity\": true} on the new CheckSkipParity gate. Eval-judge chain downstream is preserved in all cases via CheckSkipEvaluator → CheckSkipEvalJudge (the 2026-05-03 silent-bypass fix is still pinned — both CheckSkipEvaluator paths converge to CheckSkipEvalJudge). The legacy {\"freeze_evaluator\": true} input is not honored; freeze-evaluator is a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
+      "Comment": "Skip-gate. {\"skip_backtester\": true} bypasses BOTH the Backtester (backtest stage) and Parity states \u2014 it routes straight to CheckSkipEvaluator, skipping the whole backtest+parity pair (the parity stage was split into its own Parity SF state by the preflight-task-split 2026-05-16, plan alpha-engine-docs/private/preflight-task-split-260516.md; skip_backtester retains its original whole-pair semantics for backward compat). The Evaluator state still runs and gracefully degrades on missing same-cohort artifacts (evaluate.py logs a WARNING and continues \u2014 verified against the 2026-05-07 v1 validation run, where `Simulation artifact not found in S3: backtest/2026-05-07/sweep_df.parquet \u2014 evaluator will run without it` shows up cleanly). Routes to CheckSkipEvaluator so {\"skip_evaluator\": true} composes orthogonally: (a) neither flag \u2192 backtest+parity+evaluator run, (b) skip_backtester only \u2192 Evaluator runs against any pre-existing backtest/{date}/ artifacts, (c) skip_evaluator only \u2192 backtest+parity run without grading, (d) both \u2192 all skipped. To skip ONLY parity (keep the backtest), use {\"skip_parity\": true} on the new CheckSkipParity gate. Eval-judge chain downstream is preserved in all cases via CheckSkipEvaluator \u2192 CheckSkipEvalJudge (the 2026-05-03 silent-bypass fix is still pinned \u2014 both CheckSkipEvaluator paths converge to CheckSkipEvalJudge). The legacy {\"freeze_evaluator\": true} input is not honored; freeze-evaluator is a spot CLI flag (--freeze-evaluator) invoked manually outside the SF.",
       "Choices": [
         {
           "And": [
@@ -2884,7 +1889,7 @@
     },
     "Backtester": {
       "Type": "Task",
-      "Comment": "Backtest SIMULATION-ONLY stage (10y simulate + param sweep) on spot instance, after predictor training. L4472 phase-split (2026-05-31, ROADMAP L4472): the monolithic Backtester state ran simulate+param_sweep+predictor-backtest+Phase4+optimizer/cov/gamma in ONE SSM command whose SUMMED runtime exceeded the SSM execution timeout on a fresh date (L4470). This state now runs ONLY the simulation pipeline via --mode=param-sweep; the predictor-backtest+Phase4 block runs in the new PredictorBacktest state and the optimizer/cov/gamma block in PortfolioOptimizerBacktest, each with its own SSM timeout + independent redrive. --no-pit-parity here so pit_parity runs exactly once (in PredictorBacktest, where it belongs). State name kept as Backtester (lower-churn — preserves the skip_backtester gate semantics; skip_backtester still skips the whole backtest-family by routing past CheckSkipParity to CheckSkipEvaluator). config#902 collapsed the standalone DriftDetection state that used to precede this one; entry flows now from CheckSkipBacktester directly. Mirrors the 2026-05-07/05-16 simulate/parity/evaluator split precedent (plans evaluator-split-260507.md + preflight-task-split-260516.md). All states key off the same backtest/{date}/ S3 prefix. If this state fails, PredictorBacktest is NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).",
+      "Comment": "Backtest SIMULATION-ONLY stage (10y simulate + param sweep) on spot instance, after predictor training. L4472 phase-split (2026-05-31, ROADMAP L4472): the monolithic Backtester state ran simulate+param_sweep+predictor-backtest+Phase4+optimizer/cov/gamma in ONE SSM command whose SUMMED runtime exceeded the SSM execution timeout on a fresh date (L4470). This state now runs ONLY the simulation pipeline via --mode=param-sweep; the predictor-backtest+Phase4 block runs in the new PredictorBacktest state and the optimizer/cov/gamma block in PortfolioOptimizerBacktest, each with its own SSM timeout + independent redrive. --no-pit-parity here so pit_parity runs exactly once (in PredictorBacktest, where it belongs). State name kept as Backtester (lower-churn \u2014 preserves the skip_backtester gate semantics; skip_backtester still skips the whole backtest-family by routing past CheckSkipParity to CheckSkipEvaluator). config#902 collapsed the standalone DriftDetection state that used to precede this one; entry flows now from CheckSkipBacktester directly. Mirrors the 2026-05-07/05-16 simulate/parity/evaluator split precedent (plans evaluator-split-260507.md + preflight-task-split-260516.md). All states key off the same backtest/{date}/ S3 prefix. If this state fails, PredictorBacktest is NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -2904,7 +1909,7 @@
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+          "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
           "MaxAttempts": 4,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -2915,7 +1920,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
+          "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
           "MaxAttempts": 2,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3009,7 +2014,7 @@
     },
     "CheckSkipPredictorBacktest": {
       "Type": "Choice",
-      "Comment": "Skip-gate (config#830 — closes the gap that made a Backtester→Evaluator-only run impossible on the weekly SF; PredictorBacktest had no skip gate). {\"skip_predictor_backtest\": true} bypasses the PredictorBacktest stage (the predictor-backtest + Phase4 + pit-parity block, L4472 split) and routes to CheckSkipPortfolioOptimizerBacktest. Set by mode=backtest-eval, where only backtester/evaluator CODE changed so the predictor backtest is not needed. Missing flag = run as normal, so scheduled Saturday runs are unaffected.",
+      "Comment": "Skip-gate (config#830 \u2014 closes the gap that made a Backtester\u2192Evaluator-only run impossible on the weekly SF; PredictorBacktest had no skip gate). {\"skip_predictor_backtest\": true} bypasses the PredictorBacktest stage (the predictor-backtest + Phase4 + pit-parity block, L4472 split) and routes to CheckSkipPortfolioOptimizerBacktest. Set by mode=backtest-eval, where only backtester/evaluator CODE changed so the predictor backtest is not needed. Missing flag = run as normal, so scheduled Saturday runs are unaffected.",
       "Choices": [
         {
           "And": [
@@ -3029,7 +2034,7 @@
     },
     "PredictorBacktest": {
       "Type": "Task",
-      "Comment": "Predictor-backtest + Phase 4a/b/c stage on a fresh spot SSM command, after the simulation-only Backtester state. L4472 phase-split (2026-05-31): runs spot_backtest.sh --mode=predictor-backtest, which executes the predictor_pipeline (GBM inference + 10y ArcticDB read + predictor param sweep) and Phase 4a/b/c — the block that, bundled with simulate + the optimizer sweeps in the old single Backtester state, summed past the SSM execution timeout on a fresh date (L4470). pit_parity runs HERE (default ON; Backtester + PortfolioOptimizerBacktest pass --no-pit-parity) so the observational walk-forward parity fires exactly once. Reads the backtest/{date}/ artifacts the Backtester state just wrote and writes its own predictor_sweep_df.parquet + predictor_stats.json to the same prefix. Per the L4472 executor-apply fix (backtester backtest.py::_run_predictor_pipeline gated on mode==all), this --mode=predictor-backtest run does NOT write the from_executor_optimizer.json recommendation artifact — the Backtester (param-sweep) state is its sole writer, so the assembler sees sim-based executor params (monolithic semantics preserved). If this state fails, PortfolioOptimizerBacktest is NOT entered (anti-auto-promote-garbage).",
+      "Comment": "Predictor-backtest + Phase 4a/b/c stage on a fresh spot SSM command, after the simulation-only Backtester state. L4472 phase-split (2026-05-31): runs spot_backtest.sh --mode=predictor-backtest, which executes the predictor_pipeline (GBM inference + 10y ArcticDB read + predictor param sweep) and Phase 4a/b/c \u2014 the block that, bundled with simulate + the optimizer sweeps in the old single Backtester state, summed past the SSM execution timeout on a fresh date (L4470). pit_parity runs HERE (default ON; Backtester + PortfolioOptimizerBacktest pass --no-pit-parity) so the observational walk-forward parity fires exactly once. Reads the backtest/{date}/ artifacts the Backtester state just wrote and writes its own predictor_sweep_df.parquet + predictor_stats.json to the same prefix. Per the L4472 executor-apply fix (backtester backtest.py::_run_predictor_pipeline gated on mode==all), this --mode=predictor-backtest run does NOT write the from_executor_optimizer.json recommendation artifact \u2014 the Backtester (param-sweep) state is its sole writer, so the assembler sees sim-based executor params (monolithic semantics preserved). If this state fails, PortfolioOptimizerBacktest is NOT entered (anti-auto-promote-garbage).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3049,7 +2054,7 @@
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+          "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
           "MaxAttempts": 4,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3060,7 +2065,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
+          "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
           "MaxAttempts": 2,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3154,7 +2159,7 @@
     },
     "CheckSkipPortfolioOptimizerBacktest": {
       "Type": "Choice",
-      "Comment": "Skip-gate (config#830 — closes the gap that made a Backtester→Evaluator-only run impossible on the weekly SF; PortfolioOptimizerBacktest had no skip gate). {\"skip_portfolio_optimizer_backtest\": true} bypasses the PortfolioOptimizerBacktest stage (the optimizer/cov/gamma block, L4472 split) and routes to CheckSkipParity. Set by mode=backtest-eval. Missing flag = run as normal, so scheduled Saturday runs are unaffected.",
+      "Comment": "Skip-gate (config#830 \u2014 closes the gap that made a Backtester\u2192Evaluator-only run impossible on the weekly SF; PortfolioOptimizerBacktest had no skip gate). {\"skip_portfolio_optimizer_backtest\": true} bypasses the PortfolioOptimizerBacktest stage (the optimizer/cov/gamma block, L4472 split) and routes to CheckSkipParity. Set by mode=backtest-eval. Missing flag = run as normal, so scheduled Saturday runs are unaffected.",
       "Choices": [
         {
           "And": [
@@ -3194,7 +2199,7 @@
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+          "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
           "MaxAttempts": 4,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3205,7 +2210,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
+          "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
           "MaxAttempts": 2,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3299,7 +2304,7 @@
     },
     "CheckSkipParity": {
       "Type": "Choice",
-      "Comment": "Skip-gate. {\"skip_parity\": true} bypasses ONLY the Parity state (backtester↔executor parity check) and routes to CheckSkipEvaluator — the completed backtest artifacts stay intact and Evaluator still runs against them. Missing flag = run as normal. Parity was split out of the old combined Backtester state by the preflight-task-split (2026-05-16, plan alpha-engine-docs/private/preflight-task-split-260516.md): backtest (~121 min) and parity are independent preflight-bearing actions, so a parity failure must never re-run the 121-min backtest. To skip the whole backtest+parity pair, use {\"skip_backtester\": true} on CheckSkipBacktester instead. Mirrors the skip_backtester / skip_evaluator shape.",
+      "Comment": "Skip-gate. {\"skip_parity\": true} bypasses ONLY the Parity state (backtester\u2194executor parity check) and routes to CheckSkipEvaluator \u2014 the completed backtest artifacts stay intact and Evaluator still runs against them. Missing flag = run as normal. Parity was split out of the old combined Backtester state by the preflight-task-split (2026-05-16, plan alpha-engine-docs/private/preflight-task-split-260516.md): backtest (~121 min) and parity are independent preflight-bearing actions, so a parity failure must never re-run the 121-min backtest. To skip the whole backtest+parity pair, use {\"skip_backtester\": true} on CheckSkipBacktester instead. Mirrors the skip_backtester / skip_evaluator shape.",
       "Choices": [
         {
           "And": [
@@ -3319,7 +2324,7 @@
     },
     "Parity": {
       "Type": "Task",
-      "Comment": "Backtester↔executor parity check on spot instance, after the backtest stage. Split out of the old combined Backtester state by the preflight-task-split (2026-05-16, plan alpha-engine-docs/private/preflight-task-split-260516.md): backtest (~121 min, 10y simulate + param sweep) and parity are independent preflight-bearing actions, so a parity failure must never re-run the 121-min backtest. spot_backtest.sh is invoked with --skip-stages=backtest,evaluator so this state runs ONLY the parity stage, reading the same backtest/{date}/ S3 prefix the Backtester state just wrote. ~7 min extra spot bootstrap vs the prior bundled design — accepted in exchange for never re-paying the 121-min backtest on a parity redrive. Timeout/heartbeat budget copied from the old combined Backtester state (not under-sized — same Retry/Catch/Timeout pattern). If this state fails, Evaluator is NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).",
+      "Comment": "Backtester\u2194executor parity check on spot instance, after the backtest stage. Split out of the old combined Backtester state by the preflight-task-split (2026-05-16, plan alpha-engine-docs/private/preflight-task-split-260516.md): backtest (~121 min, 10y simulate + param sweep) and parity are independent preflight-bearing actions, so a parity failure must never re-run the 121-min backtest. spot_backtest.sh is invoked with --skip-stages=backtest,evaluator so this state runs ONLY the parity stage, reading the same backtest/{date}/ S3 prefix the Backtester state just wrote. ~7 min extra spot bootstrap vs the prior bundled design \u2014 accepted in exchange for never re-paying the 121-min backtest on a parity redrive. Timeout/heartbeat budget copied from the old combined Backtester state (not under-sized \u2014 same Retry/Catch/Timeout pattern). If this state fails, Evaluator is NOT entered (preserves the 4/24 anti-auto-promote-garbage rule).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3339,7 +2344,7 @@
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+          "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
           "MaxAttempts": 4,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3350,7 +2355,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
+          "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
           "MaxAttempts": 2,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3464,7 +2469,7 @@
     },
     "Evaluator": {
       "Type": "Task",
-      "Comment": "Evaluator on a separate spot instance (split from Backtester 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md). Reads s3://alpha-engine-research/backtest/{RUN_DATE}/ artifacts produced by the prior Backtester state and runs evaluate.py --mode all --upload, which sends the per-signal grading email and auto-applies optimizer configs. Reuses spot_backtest.sh with --skip-stages=backtest,parity; the script is the canonical dispatch surface (existing CSV vocabulary). Live-apply mode by default; for diagnostic-only off-cycle runs, invoke spot_backtest.sh manually with --freeze-evaluator and --skip-stages=backtest,parity.",
+      "Comment": "Evaluator on a separate spot instance (split from Backtester 2026-05-07 \u2014 plan: alpha-engine-docs/private/evaluator-split-260507.md). Reads s3://alpha-engine-research/backtest/{RUN_DATE}/ artifacts produced by the prior Backtester state and runs evaluate.py --mode all --upload, which sends the per-signal grading email and auto-applies optimizer configs. Reuses spot_backtest.sh with --skip-stages=backtest,parity; the script is the canonical dispatch surface (existing CSV vocabulary). Live-apply mode by default; for diagnostic-only off-cycle runs, invoke spot_backtest.sh manually with --freeze-evaluator and --skip-stages=backtest,parity.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3484,7 +2489,7 @@
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Comment": "config#2279: declared spot-stage sendCommand convention — the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) — BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+          "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
           "MaxAttempts": 4,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3495,7 +2500,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2279: catch-all transient tier — same idempotency argument as the tier above.",
+          "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
           "MaxAttempts": 2,
           "IntervalSeconds": 30,
           "BackoffRate": 2.0,
@@ -3589,7 +2594,7 @@
     },
     "CheckSkipPostEval": {
       "Type": "Choice",
-      "Comment": "Post-Evaluator tail skip-gate (config#830). {\"skip_post_eval\": true} stops the run right after Evaluator — bypassing the four full-run-only tail stages (SaturdayHealthCheck → WeeklySubstrateHealthCheck → ReportCard → Director, none of which previously had a skip gate) and routing straight to CheckShellRunNotify so the SUCCESS SNS notify (and the shell-run-tagged variant) still fire. This is the one behavioral gap a standalone Backtester→Evaluator SF used to cover; closing it here lets the weekly SF reproduce that shape via mode=backtest-eval with no forked state machine. The tail stages are advisory/observability only (health checks are non-blocking; ReportCard/Director are non-fatal advisories), so stopping before them is safe for a mid-week backtester/evaluator code rerun. Missing flag = run the full tail as normal, so scheduled Saturday runs are unaffected. Both inbound edges (CheckEvaluatorStatus Success and CheckSkipEvaluator skip) converge here, preserving the prior 'Evaluator-skipped still notifies' behavior.",
+      "Comment": "Post-Evaluator tail skip-gate (config#830). {\"skip_post_eval\": true} stops the run right after Evaluator \u2014 bypassing the four full-run-only tail stages (SaturdayHealthCheck \u2192 WeeklySubstrateHealthCheck \u2192 ReportCard \u2192 Director, none of which previously had a skip gate) and routing straight to CheckShellRunNotify so the SUCCESS SNS notify (and the shell-run-tagged variant) still fire. This is the one behavioral gap a standalone Backtester\u2192Evaluator SF used to cover; closing it here lets the weekly SF reproduce that shape via mode=backtest-eval with no forked state machine. The tail stages are advisory/observability only (health checks are non-blocking; ReportCard/Director are non-fatal advisories), so stopping before them is safe for a mid-week backtester/evaluator code rerun. Missing flag = run the full tail as normal, so scheduled Saturday runs are unaffected. Both inbound edges (CheckEvaluatorStatus Success and CheckSkipEvaluator skip) converge here, preserving the prior 'Evaluator-skipped still notifies' behavior.",
       "Choices": [
         {
           "And": [
@@ -3609,7 +2614,7 @@
     },
     "SaturdayHealthCheck": {
       "Type": "Task",
-      "Comment": "Check data freshness after full pipeline — non-blocking (a failure degrades the completion email, it does not halt). Runs from alpha-engine-dashboard post-2026-04-16 health_checker migration. config#2279: deliberately carries NO Retry ladder (declared class: health-observe) — it is best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 timeout convention (both health-observe states): inner executionTimeout = script runtime budget (agent-enforced; its expiry surfaces as a terminal non-Success status the poll Choice turns into health_check_degraded — it is a runaway bound, no longer a silent kill-and-skip); SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout — time for the agent to PICK UP the command, not to run it); outer Task TimeoutSeconds = executionTimeout + 30 (bounds only the async SendCommand API call, which returns in <1s — pinned to inner+30 so the relation stays coherent if this ever flips to a .sync integration). Budget: executionTimeout raised 60→300 (config#2276): observed successful health_checker.py runs complete in ~2.7-2.8s (n=2 Success in the 30-day SSM history sampled 2026-07-11 — most runs FAILED sub-second on git-pull collisions, see CheckSaturdayHealthCheckStatus), so 300s is ~100x observed with headroom for S3-latency-bound freshness scans; under the poll loop a generous budget costs nothing on the happy path.",
+      "Comment": "Check data freshness after full pipeline \u2014 non-blocking (a failure degrades the completion email, it does not halt). Runs from alpha-engine-dashboard post-2026-04-16 health_checker migration. config#2279: deliberately carries NO Retry ladder (declared class: health-observe) \u2014 it is best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 timeout convention (both health-observe states): inner executionTimeout = script runtime budget (agent-enforced; its expiry surfaces as a terminal non-Success status the poll Choice turns into health_check_degraded \u2014 it is a runaway bound, no longer a silent kill-and-skip); SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout \u2014 time for the agent to PICK UP the command, not to run it); outer Task TimeoutSeconds = executionTimeout + 30 (bounds only the async SendCommand API call, which returns in <1s \u2014 pinned to inner+30 so the relation stays coherent if this ever flips to a .sync integration). Budget: executionTimeout raised 60\u2192300 (config#2276): observed successful health_checker.py runs complete in ~2.7-2.8s (n=2 Success in the 30-day SSM history sampled 2026-07-11 \u2014 most runs FAILED sub-second on git-pull collisions, see CheckSaturdayHealthCheckStatus), so 300s is ~100x observed with headroom for S3-latency-bound freshness scans; under the poll loop a generous budget costs nothing on the happy path.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3635,7 +2640,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2276: health-check failure is non-blocking but must be VISIBLE — set health_check_degraded (threads into the completion-email selection) and continue to the sibling substrate check (independent observability paths; both must run). Pre-fix this jumped straight to NotifyComplete: a crash here sent the plain real-run SUCCESS email AND silently skipped WeeklySubstrateHealthCheck, ReportCard and the Director.",
+          "Comment": "config#2276: health-check failure is non-blocking but must be VISIBLE \u2014 set health_check_degraded (threads into the completion-email selection) and continue to the sibling substrate check (independent observability paths; both must run). Pre-fix this jumped straight to NotifyComplete: a crash here sent the plain real-run SUCCESS email AND silently skipped WeeklySubstrateHealthCheck, ReportCard and the Director.",
           "Next": "SaturdayHealthCheckDegraded",
           "ResultPath": "$.health_check_error"
         }
@@ -3675,7 +2680,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2276: non-blocking but VISIBLE — a freshness-poll infra failure sets health_check_degraded, then continues to the substrate check (SaturdayHealthCheck artifact freshness and WeeklySubstrateHealthCheck row-driven inventory validation are independent observability paths; both must run). Pre-fix this continued WITHOUT any flag — the outcome was simply lost.",
+          "Comment": "config#2276: non-blocking but VISIBLE \u2014 a freshness-poll infra failure sets health_check_degraded, then continues to the substrate check (SaturdayHealthCheck artifact freshness and WeeklySubstrateHealthCheck row-driven inventory validation are independent observability paths; both must run). Pre-fix this continued WITHOUT any flag \u2014 the outcome was simply lost.",
           "Next": "SaturdayHealthCheckDegraded",
           "ResultPath": "$.health_check_error"
         }
@@ -3691,7 +2696,7 @@
     },
     "CheckSaturdayHealthCheckStatus": {
       "Type": "Choice",
-      "Comment": "config#2276: poll the freshness check to a TERMINAL status (mirrors the CheckMorningEnrichStatus wait-loop idiom, minus the re-issue gate — observe-only, one attempt). Pre-fix this stage was check-once: the single getCommandInvocation usually returned InProgress and the SF moved on, so (a) a hung/failing health_checker.py was invisible (green email regardless — verified live: most 30-day invocations FAILED sub-second and every run still emailed plain SUCCESS), and (b) WeeklySubstrateHealthCheck was dispatched while this command's git pull still held the dashboard repo's ref lock — the two concurrent `git pull`s produced the recurring 'Cannot fast-forward to multiple branches' / 'cannot lock ref' failures observed 2026-06-19→07-11. Sequential-to-terminal polling fixes both structurally. Terminal non-Success (Failed / TimedOut / Cancelled — incl. executionTimeout expiry and delivery timeout) → health_check_degraded. Loop bound: delivery TimeoutSeconds terminates a never-picked-up command and executionTimeout terminates a hung script, so the loop always reaches a terminal status; the SF top-level TimeoutSeconds (config#2274) backstops SSM control-plane pathology. $.health_check_poll.Status is safe to dereference un-guarded: the sole predecessor WaitForSaturdayHealthCheck pins Status via its ResultSelector (config#2275 rule 3b).",
+      "Comment": "config#2276: poll the freshness check to a TERMINAL status (mirrors the CheckMorningEnrichStatus wait-loop idiom, minus the re-issue gate \u2014 observe-only, one attempt). Pre-fix this stage was check-once: the single getCommandInvocation usually returned InProgress and the SF moved on, so (a) a hung/failing health_checker.py was invisible (green email regardless \u2014 verified live: most 30-day invocations FAILED sub-second and every run still emailed plain SUCCESS), and (b) WeeklySubstrateHealthCheck was dispatched while this command's git pull still held the dashboard repo's ref lock \u2014 the two concurrent `git pull`s produced the recurring 'Cannot fast-forward to multiple branches' / 'cannot lock ref' failures observed 2026-06-19\u219207-11. Sequential-to-terminal polling fixes both structurally. Terminal non-Success (Failed / TimedOut / Cancelled \u2014 incl. executionTimeout expiry and delivery timeout) \u2192 health_check_degraded. Loop bound: delivery TimeoutSeconds terminates a never-picked-up command and executionTimeout terminates a hung script, so the loop always reaches a terminal status; the SF top-level TimeoutSeconds (config#2274) backstops SSM control-plane pathology. $.health_check_poll.Status is safe to dereference un-guarded: the sole predecessor WaitForSaturdayHealthCheck pins Status via its ResultSelector (config#2275 rule 3b).",
       "Choices": [
         {
           "Variable": "$.health_check_poll.Status",
@@ -3725,14 +2730,14 @@
     },
     "SaturdayHealthCheckDegraded": {
       "Type": "Pass",
-      "Comment": "config#2276: the freshness health check could not run to Success (send/poll infra failure via Catch, or terminal non-Success command status via CheckSaturdayHealthCheckStatus.Default). Mirrors the LibPinGateDegraded shape (config#2278): an SF-controlled boolean that threads into the completion-email selection (CheckGateDegradedNotify) so the run emails 'SUCCESS (health checks DEGRADED)' instead of the plain real-run SUCCESS. Specifics live on the execution record: $.health_check_error (Catch path) / $.health_check_poll (status path). Continues to the sibling substrate check — a degraded freshness check must not skip the independent substrate/ReportCard/Director tail.",
+      "Comment": "config#2276: the freshness health check could not run to Success (send/poll infra failure via Catch, or terminal non-Success command status via CheckSaturdayHealthCheckStatus.Default). Mirrors the LibPinGateDegraded shape (config#2278): an SF-controlled boolean that threads into the completion-email selection (CheckGateDegradedNotify) so the run emails 'SUCCESS (health checks DEGRADED)' instead of the plain real-run SUCCESS. Specifics live on the execution record: $.health_check_error (Catch path) / $.health_check_poll (status path). Continues to the sibling substrate check \u2014 a degraded freshness check must not skip the independent substrate/ReportCard/Director tail.",
       "Result": true,
       "ResultPath": "$.health_check_degraded",
       "Next": "WeeklySubstrateHealthCheck"
     },
     "WeeklySubstrateHealthCheck": {
       "Type": "Task",
-      "Comment": "Phase 2 → 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) — agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (a failure degrades the completion email, it does not halt) — same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF runs --cadence daily on the daily-only subset (PR #178 — DailySubstrateHealthCheck state). config#2279: deliberately carries NO Retry ladder (declared class: health-observe) — best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 — NO runtime pip: the former in-pipeline `pip install --quiet --upgrade -r requirements.txt` (a live PyPI/network dependency inside an observability stage, with --upgrade able to float unpinned transitive deps past tested versions) was removed; the stage relies on the dashboard box's deploy-time venv sync — infrastructure/deploy-on-merge.sh in crucible-dashboard runs `.venv/bin/pip install -r requirements.txt` on every merge that diffs requirements.txt, and nousergon-lib is TAG-pinned there (@vX.Y.Z), so a lib bump always changes requirements.txt and always refreshes the same /home/ec2-user/alpha-engine-dashboard/.venv this command activates. Timeout convention + budget: see SaturdayHealthCheck's Comment — inner 240 (observed Success ~19-20s incl. the since-removed pip; ~12x headroom as a runaway bound), delivery 60, outer = inner + 30. The previous 240/180/240 set conflated the delivery timeout with an execution ceiling (inversion flagged by config#2276).",
+      "Comment": "Phase 2 \u2192 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) \u2014 agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (a failure degrades the completion email, it does not halt) \u2014 same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF runs --cadence daily on the daily-only subset (PR #178 \u2014 DailySubstrateHealthCheck state). config#2279: deliberately carries NO Retry ladder (declared class: health-observe) \u2014 best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 \u2014 NO runtime pip: the former in-pipeline `pip install --quiet --upgrade -r requirements.txt` (a live PyPI/network dependency inside an observability stage, with --upgrade able to float unpinned transitive deps past tested versions) was removed; the stage relies on the dashboard box's deploy-time venv sync \u2014 infrastructure/deploy-on-merge.sh in crucible-dashboard runs `.venv/bin/pip install -r requirements.txt` on every merge that diffs requirements.txt, and nousergon-lib is TAG-pinned there (@vX.Y.Z), so a lib bump always changes requirements.txt and always refreshes the same /home/ec2-user/alpha-engine-dashboard/.venv this command activates. Timeout convention + budget: see SaturdayHealthCheck's Comment \u2014 inner 240 (observed Success ~19-20s incl. the since-removed pip; ~12x headroom as a runaway bound), delivery 60, outer = inner + 30. The previous 240/180/240 set conflated the delivery timeout with an execution ceiling (inversion flagged by config#2276).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3761,7 +2766,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2276: substrate-check failure is non-blocking but VISIBLE — set health_check_degraded and continue to the ReportCard/Director tail (Lambdas, independent of the dashboard box). Per-row CloudWatch alarms catch row-level failures; this Catch only fires on infra/SSM failure. Pre-fix this jumped straight to NotifyComplete: plain SUCCESS email, ReportCard + Director silently skipped.",
+          "Comment": "config#2276: substrate-check failure is non-blocking but VISIBLE \u2014 set health_check_degraded and continue to the ReportCard/Director tail (Lambdas, independent of the dashboard box). Per-row CloudWatch alarms catch row-level failures; this Catch only fires on infra/SSM failure. Pre-fix this jumped straight to NotifyComplete: plain SUCCESS email, ReportCard + Director silently skipped.",
           "Next": "SubstrateHealthCheckDegraded",
           "ResultPath": "$.substrate_check_error"
         }
@@ -3801,7 +2806,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2276: non-blocking but VISIBLE — a substrate-poll infra failure sets health_check_degraded, then continues to ReportCard. Row-level alarms still page on failure regardless of polling outcome.",
+          "Comment": "config#2276: non-blocking but VISIBLE \u2014 a substrate-poll infra failure sets health_check_degraded, then continues to ReportCard. Row-level alarms still page on failure regardless of polling outcome.",
           "Next": "SubstrateHealthCheckDegraded",
           "ResultPath": "$.substrate_check_error"
         }
@@ -3817,12 +2822,12 @@
     },
     "CheckSubstrateHealthCheckStatus": {
       "Type": "Choice",
-      "Comment": "config#2276: poll the substrate check to a TERMINAL status — same shape and rationale as CheckSaturdayHealthCheckStatus (check-once masked a failing/hung checker AND raced the next consumer; see that state's Comment). A terminal non-Success lands on SubstrateHealthCheckDegraded. This is also where the constituents-drift sub-step became fail-VISIBLE (config#2276): its former `|| true` swallowed exit-1 (= alert-worthy Wikipedia-vs-ArcticDB drift, the exact 2026-05-23 BNY/P/SN incident surface) with no recording surface in the SF; now drift exit-1 fails the command → Status Failed → health_check_degraded → 'SUCCESS (health checks DEGRADED)' email, alongside the validator's own alerts.publish. $.substrate_check_poll.Status is safe un-guarded: sole predecessor WaitForWeeklySubstrateHealthCheck pins Status via ResultSelector (config#2275 rule 3b).",
+      "Comment": "config#2276: poll the substrate check to a TERMINAL status \u2014 same shape and rationale as CheckSaturdayHealthCheckStatus (check-once masked a failing/hung checker AND raced the next consumer; see that state's Comment). A terminal non-Success lands on SubstrateHealthCheckDegraded. This is also where the constituents-drift sub-step became fail-VISIBLE (config#2276): its former `|| true` swallowed exit-1 (= alert-worthy Wikipedia-vs-ArcticDB drift, the exact 2026-05-23 BNY/P/SN incident surface) with no recording surface in the SF; now drift exit-1 fails the command \u2192 Status Failed \u2192 health_check_degraded \u2192 'SUCCESS (health checks DEGRADED)' email, alongside the validator's own alerts.publish. $.substrate_check_poll.Status is safe un-guarded: sole predecessor WaitForWeeklySubstrateHealthCheck pins Status via ResultSelector (config#2275 rule 3b).",
       "Choices": [
         {
           "Variable": "$.substrate_check_poll.Status",
           "StringEquals": "Success",
-          "Next": "ReportCard"
+          "Next": "CheckShellRunNotify"
         },
         {
           "Or": [
@@ -3851,130 +2856,14 @@
     },
     "SubstrateHealthCheckDegraded": {
       "Type": "Pass",
-      "Comment": "config#2276: the substrate health check (or its constituents-drift sub-step) could not run to Success. Mirrors SaturdayHealthCheckDegraded / the LibPinGateDegraded shape (config#2278) — SF-controlled boolean into the completion-email selection. Shares $.health_check_degraded with the freshness twin DELIBERATELY (one flag family, one degraded Subject — which check degraded lives on the execution record: $.substrate_check_error / $.substrate_check_poll vs $.health_check_error / $.health_check_poll — avoiding a per-check combinatorial notifier explosion). Continues to ReportCard: the advisory Lambda tail is independent of the dashboard box and must not be skipped because an EC2 health command failed.",
+      "Comment": "config#2276: the substrate health check (or its constituents-drift sub-step) could not run to Success. Mirrors SaturdayHealthCheckDegraded / the LibPinGateDegraded shape (config#2278) \u2014 SF-controlled boolean into the completion-email selection. Shares $.health_check_degraded with the freshness twin DELIBERATELY (one flag family, one degraded Subject \u2014 which check degraded lives on the execution record: $.substrate_check_error / $.substrate_check_poll vs $.health_check_error / $.health_check_poll \u2014 avoiding a per-check combinatorial notifier explosion). Continues to CheckShellRunNotify (alpha-engine-config-I2544: ReportCard/Director now run in the async ne-weekly-advisory-pipeline child SF, dispatched earlier via StartAdvisoryPipeline \u2014 they are no longer part of this tail, so a degraded dashboard health check has nothing left to skip past here).",
       "Result": true,
       "ResultPath": "$.health_check_degraded",
-      "Next": "ReportCard"
-    },
-    "ReportCard": {
-      "Type": "Task",
-      "Comment": "Evaluator Report Card v2 (Layer B, Option B) — builds s3://alpha-engine-research/evaluator/{date}/report_card.json from the persisted per-module artifacts (the 7-tile MetricRecord substrate the Director will consume). Runs here, after the Evaluator + substrate health checks, so it reads fresh grades. NON-FATAL: its own Catch routes to CheckShellRunNotify so an advisory grading failure never breaks the run that produced the real trading artifacts. PREFLIGHT-AWARE (ROADMAP L4504): dry_run.$=$.research_dry (the canonical shell-run-dry signal — false on the real Saturday run, true on the Friday-PM Preflight Pipeline). On the preflight the handler still exercises the full read+compute path (container boot, lib/numpy/pandas imports, S3-read IAM/transport, the tile compute) but does NOT persist the degenerate, mostly-N/A preflight card — mirrors how the other advisory Lambdas (eval-judge / rationale-clustering / replay-concordance / counterfactual) run dry rather than skip, per the shell-run keystone's 'dry-execute, don't skip' principle.",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "FunctionName": "alpha-engine-evaluator:live",
-        "Payload": {
-          "date.$": "$.run_date",
-          "dry_run.$": "$.research_dry"
-        }
-      },
-      "TimeoutSeconds": 300,
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 30,
-          "BackoffRate": 1.0
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Comment": "Advisory grading is non-fatal — continue to the terminal notify regardless. config#2302: the run must still PAGE on entry (silent for 9 days pre-fix), so route through PublishReportCardDegraded before the terminal notify rather than swallowing the error.",
-          "Next": "PublishReportCardDegraded",
-          "ResultPath": "$.report_card_error"
-        }
-      ],
-      "ResultPath": "$.report_card_result",
-      "Next": "Director"
-    },
-    "PublishReportCardDegraded": {
-      "Type": "Task",
-      "Comment": "config#2302: ReportCard's Catch(States.ALL) used to route straight to CheckShellRunNotify with no alert — the 2026-07 incident where the evaluator Lambda died silently for 9 days. Mirrors PublishLibPinGateDegraded's shape exactly (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure can never block the non-fatal advisory-grading path this alert decorates). WARNING severity, not FAILED — the weekly run's real trading artifacts are unaffected; only the advisory grading layer degraded.",
-      "Resource": "arn:aws:states:::sns:publish",
-      "Parameters": {
-        "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekly Pipeline — ReportCard WARNING (Advisory Grading Degraded)",
-        "Message": "ReportCard (the Evaluator Report Card v2 Lambda) failed — see $.report_card_error on the execution record for detail. This is NON-FATAL: the weekly run's real trading artifacts are unaffected, but the advisory grading layer (report_card.json, and downstream Director) did not run. View pipeline status: https://console.nousergon.ai/pipeline-status"
-      },
-      "ResultPath": "$.report_card_degraded_notify",
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Comment": "Best-effort alert — a publish failure must not block the non-fatal advisory path this alert decorates.",
-          "ResultPath": "$.report_card_degraded_notify_error",
-          "Next": "CheckShellRunNotify"
-        }
-      ],
-      "Next": "CheckShellRunNotify"
-    },
-    "Director": {
-      "Type": "Task",
-      "Comment": "Director (Layer C, Part II) — the FINAL Saturday-SF task. A single structured Opus call over the fresh Report Card v2 (evaluator/{date}/report_card.json) produces an advisory DirectorWeeklyActionPlan at director/{date}/action_plan.json + updates the carry-over ledger. Runs only after a SUCCESSFUL ReportCard (a failed ReportCard skips straight to notify — no card to weigh). FLAG-GATED: the alpha-engine-evaluator-director Lambda is a no-op (status=disabled) until DIRECTOR_ENABLED is flipped on. NON-FATAL: its own Catch routes to CheckShellRunNotify so an advisory failure never breaks the run that produced the real trading artifacts. PREFLIGHT-AWARE (ROADMAP L4504): dry_run.$=$.research_dry. On the Friday-PM Preflight Pipeline (research_dry=true) the handler runs a no-Opus / no-write PROBE — it constructs the real Opus client (exercising the langchain-anthropic import + the SSM ANTHROPIC_API_KEY fetch / ReadAnthropicSecret IAM grant) and reads the carry-over ledger, then STOPS short of the paid .invoke() and writes NOTHING (no action_plan, no ledger mutation). This is load-bearing: the carry-over ledger is shared + non-date-scoped (director/carryover_ledger.json), so a preflight write would pollute the real Saturday run. A broken import / revoked key grant surfaces as a caught preflight failure ~18h before the real Saturday Director would hit it.",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "FunctionName": "alpha-engine-evaluator-director:live",
-        "Payload": {
-          "date.$": "$.run_date",
-          "dry_run.$": "$.research_dry"
-        }
-      },
-      "TimeoutSeconds": 300,
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 30,
-          "BackoffRate": 1.0
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Comment": "Advisory Director is non-fatal — continue to the terminal notify regardless. config#2302: the run must still PAGE on entry, so route through PublishDirectorDegraded before the terminal notify rather than swallowing the error.",
-          "Next": "PublishDirectorDegraded",
-          "ResultPath": "$.director_error"
-        }
-      ],
-      "ResultPath": "$.director_result",
-      "Next": "CheckShellRunNotify"
-    },
-    "PublishDirectorDegraded": {
-      "Type": "Task",
-      "Comment": "config#2302: Director's Catch(States.ALL) used to route straight to CheckShellRunNotify with no alert — same silent-swallow class as ReportCard's pre-fix Catch (the 2026-07 9-day-silent incident). Mirrors PublishLibPinGateDegraded's shape exactly (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure can never block the non-fatal advisory path this alert decorates). WARNING severity, not FAILED — the weekly run's real trading artifacts are unaffected; only the advisory Director layer degraded.",
-      "Resource": "arn:aws:states:::sns:publish",
-      "Parameters": {
-        "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekly Pipeline — Director WARNING (Advisory Action Plan Degraded)",
-        "Message": "Director (the Evaluator Director Lambda) failed — see $.director_error on the execution record for detail. This is NON-FATAL: the weekly run's real trading artifacts are unaffected, but the advisory Director layer (action_plan.json, carry-over ledger update) did not run. View pipeline status: https://console.nousergon.ai/pipeline-status"
-      },
-      "ResultPath": "$.director_degraded_notify",
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Comment": "Best-effort alert — a publish failure must not block the non-fatal advisory path this alert decorates.",
-          "ResultPath": "$.director_degraded_notify_error",
-          "Next": "CheckShellRunNotify"
-        }
-      ],
       "Next": "CheckShellRunNotify"
     },
     "CheckShellRunNotify": {
       "Type": "Choice",
-      "Comment": "Consolidated Friday-PM shell-run result notify. Reuses the EXISTING NotifyComplete SNS-publish substrate (same alpha-engine-alerts topic, same arn:aws:states:::sns:publish Resource) with a shell_run-tagged Subject/Message so the operator can tell a Friday dry-pass result apart from a real Saturday SUCCESS in their inbox. shell_run absent/false → NotifyComplete (BYTE-IDENTICAL to pre-spine). shell_run=true → NotifyShellRunComplete. No new SNS topic / Lambda / infra — the consolidated per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on; the spine delivers a single shell-run-tagged success signal by reusing NotifyComplete's pattern.",
+      "Comment": "Consolidated Friday-PM shell-run result notify. Reuses the EXISTING NotifyComplete SNS-publish substrate (same alpha-engine-alerts topic, same arn:aws:states:::sns:publish Resource) with a shell_run-tagged Subject/Message so the operator can tell a Friday dry-pass result apart from a real Saturday SUCCESS in their inbox. shell_run absent/false \u2192 NotifyComplete (BYTE-IDENTICAL to pre-spine). shell_run=true \u2192 NotifyShellRunComplete. No new SNS topic / Lambda / infra \u2014 the consolidated per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on; the spine delivers a single shell-run-tagged success signal by reusing NotifyComplete's pattern.",
       "Choices": [
         {
           "And": [
@@ -3994,7 +2883,7 @@
     },
     "CheckGateDegradedNotify": {
       "Type": "Choice",
-      "Comment": "config#2278 + config#2276: a green run that could not run its pre-spend gates (gate_degraded — set ONLY by the LibPinGateDegraded / PipelineContractGateDegraded Pass states) and/or its tail health checks (health_check_degraded — set ONLY by the SaturdayHealthCheckDegraded / SubstrateHealthCheckDegraded Pass states) must SAY SO in the completion email. Both are SF-controlled booleans, IsPresent-guarded per config#2275. Rules are ordered most-specific-first (both → gates-only → health-only); each routes to a SEPARATE hardcoded-constant notifier rather than States.Format-ing flags into NotifyComplete — preserving config#1819's Subject/Message-are-constants invariant. Composition note (config#2276): the two health checks share ONE flag (which check degraded lives on the execution record), so the enumeration is bounded at 3 degraded notifiers for the 2 flag families; a THIRD flag family should trigger a refactor to a data-driven degraded notifier, not a 7-way enumeration. Name retained from config#2278 (it is the wave-1 chain anchor referenced across tests/comments) — read it as the degraded-completion selector.",
+      "Comment": "config#2278 + config#2276: a green run that could not run its pre-spend gates (gate_degraded \u2014 set ONLY by the LibPinGateDegraded / PipelineContractGateDegraded Pass states) and/or its tail health checks (health_check_degraded \u2014 set ONLY by the SaturdayHealthCheckDegraded / SubstrateHealthCheckDegraded Pass states) must SAY SO in the completion email. Both are SF-controlled booleans, IsPresent-guarded per config#2275. Rules are ordered most-specific-first (both \u2192 gates-only \u2192 health-only); each routes to a SEPARATE hardcoded-constant notifier rather than States.Format-ing flags into NotifyComplete \u2014 preserving config#1819's Subject/Message-are-constants invariant. Composition note (config#2276): the two health checks share ONE flag (which check degraded lives on the execution record), so the enumeration is bounded at 3 degraded notifiers for the 2 flag families; a THIRD flag family should trigger a refactor to a data-driven degraded notifier, not a 7-way enumeration. Name retained from config#2278 (it is the wave-1 chain anchor referenced across tests/comments) \u2014 read it as the degraded-completion selector.",
       "Choices": [
         {
           "And": [
@@ -4048,12 +2937,12 @@
     },
     "NotifyCompleteGatesDegraded": {
       "Type": "Task",
-      "Comment": "config#2278: SUCCESS notifier for a run whose pre-spend gates were DEGRADED (failed open, unchecked). Mirrors NotifyComplete exactly — constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819) — with a Subject that says the gates were skipped.",
+      "Comment": "config#2278: SUCCESS notifier for a run whose pre-spend gates were DEGRADED (failed open, unchecked). Mirrors NotifyComplete exactly \u2014 constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819) \u2014 with a Subject that says the gates were skipped.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (pre-spend gates DEGRADED)",
-        "Message": "All steps completed successfully — BUT one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN; a gate-degraded alert fired earlier in this run. View pipeline status: https://console.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (pre-spend gates DEGRADED)",
+        "Message": "All steps completed successfully \u2014 BUT one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN; a gate-degraded alert fired earlier in this run. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -4061,7 +2950,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
+          "Comment": "config#1819 \u2014 best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
           "ResultPath": "$.notify_error",
           "Next": "NotifyCompleteDegraded"
         }
@@ -4070,12 +2959,12 @@
     },
     "NotifyCompleteHealthDegraded": {
       "Type": "Task",
-      "Comment": "config#2276: SUCCESS notifier for a run whose tail health checks were DEGRADED (crashed, timed out, or finished non-Success — including a fail-visible constituents-drift exit). Mirrors NotifyCompleteGatesDegraded exactly — constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
+      "Comment": "config#2276: SUCCESS notifier for a run whose tail health checks were DEGRADED (crashed, timed out, or finished non-Success \u2014 including a fail-visible constituents-drift exit). Mirrors NotifyCompleteGatesDegraded exactly \u2014 constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (health checks DEGRADED)",
-        "Message": "All steps completed successfully — BUT a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success; the run's freshness validation is NOT confirmed. Which check degraded is on the execution record: $.health_check_error / $.health_check_poll (freshness) vs $.substrate_check_error / $.substrate_check_poll (substrate). View pipeline status: https://console.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (health checks DEGRADED)",
+        "Message": "All steps completed successfully \u2014 BUT a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success; the run's freshness validation is NOT confirmed. Which check degraded is on the execution record: $.health_check_error / $.health_check_poll (freshness) vs $.substrate_check_error / $.substrate_check_poll (substrate). View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -4083,7 +2972,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
+          "Comment": "config#1819 \u2014 best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
           "ResultPath": "$.notify_error",
           "Next": "NotifyCompleteDegraded"
         }
@@ -4092,12 +2981,12 @@
     },
     "NotifyCompleteGatesAndHealthDegraded": {
       "Type": "Task",
-      "Comment": "config#2278 + config#2276: SUCCESS notifier for a run where BOTH the pre-spend gates failed open unchecked AND the tail health checks degraded — the Subject reflects both. Mirrors NotifyCompleteGatesDegraded exactly — constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
+      "Comment": "config#2278 + config#2276: SUCCESS notifier for a run where BOTH the pre-spend gates failed open unchecked AND the tail health checks degraded \u2014 the Subject reflects both. Mirrors NotifyCompleteGatesDegraded exactly \u2014 constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (gates + health checks DEGRADED)",
-        "Message": "All steps completed successfully — BUT (1) one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN (a gate-degraded alert fired earlier in this run), AND (2) a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success. Specifics are on the execution record: $.health_check_error / $.health_check_poll / $.substrate_check_error / $.substrate_check_poll. View pipeline status: https://console.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (gates + health checks DEGRADED)",
+        "Message": "All steps completed successfully \u2014 BUT (1) one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN (a gate-degraded alert fired earlier in this run), AND (2) a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success. Specifics are on the execution record: $.health_check_error / $.health_check_poll / $.substrate_check_error / $.substrate_check_poll. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -4105,7 +2994,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
+          "Comment": "config#1819 \u2014 best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
           "ResultPath": "$.notify_error",
           "Next": "NotifyCompleteDegraded"
         }
@@ -4114,11 +3003,11 @@
     },
     "NotifyShellRunComplete": {
       "Type": "Task",
-      "Comment": "Friday-PM Preflight Pipeline success notification via SNS. Mirrors NotifyComplete exactly (same topic, Resource, ResultPath, End) with a 'Saturday Preflight Pipeline' Subject so a green Friday dry-pass is distinguishable from a real Saturday SUCCESS in the operator inbox. The 'Preflight' label is the consumer-facing rename of what was internally called 'shell run' (2026-05-23 rename per Brian directive: the operational meaning is preflight validation of the Saturday SF; 'shell run' was internal mechanism-language that obscured the intent in alerts). A FAILED Preflight run still routes through HandleFailure, which now also surfaces 'Saturday Preflight Pipeline — FAILED' Subject via States.Format($.pipeline_label) — see HandleFailure's parameterized Subject. config#1819 (2026-06-12 incident class): Subject/Message here are both hardcoded constants (never States.Format against user input), so they can never violate the SNS Subject <=100-char/no-newline contract — but the sns:publish call itself can still throw for infra reasons (SNS throttling/IAM drift/transient outage), and a SUCCESS-path notifier failing an otherwise-succeeded pipeline is exactly the 2026-06-12 NotifyComplete incident shape. Catch below makes this best-effort: a publish failure is caught and the execution still ends SUCCEEDED (mirrors the existing PublishResearchFailureImmediate/PublishPredictorFailureImmediate/PublishModelZooFailureImmediate best-effort-notify idiom already used in ResearchPredictorParallel). The caught TaskFailed history event is still logged at the SF's existing Level:ERROR LoggingConfiguration (AWS logs TaskFailed at ERROR regardless of whether a Catch handles it) and picked up by the SnsPublishFailedMetricFilter/SnsPublishFailedAlarm CloudWatch alarm below — see that alarm's comment for the exact (repo-precedent, string-match) scoping and its known limitation.",
+      "Comment": "Friday-PM Preflight Pipeline success notification via SNS. Mirrors NotifyComplete exactly (same topic, Resource, ResultPath, End) with a 'Saturday Preflight Pipeline' Subject so a green Friday dry-pass is distinguishable from a real Saturday SUCCESS in the operator inbox. The 'Preflight' label is the consumer-facing rename of what was internally called 'shell run' (2026-05-23 rename per Brian directive: the operational meaning is preflight validation of the Saturday SF; 'shell run' was internal mechanism-language that obscured the intent in alerts). A FAILED Preflight run still routes through HandleFailure, which now also surfaces 'Saturday Preflight Pipeline \u2014 FAILED' Subject via States.Format($.pipeline_label) \u2014 see HandleFailure's parameterized Subject. config#1819 (2026-06-12 incident class): Subject/Message here are both hardcoded constants (never States.Format against user input), so they can never violate the SNS Subject <=100-char/no-newline contract \u2014 but the sns:publish call itself can still throw for infra reasons (SNS throttling/IAM drift/transient outage), and a SUCCESS-path notifier failing an otherwise-succeeded pipeline is exactly the 2026-06-12 NotifyComplete incident shape. Catch below makes this best-effort: a publish failure is caught and the execution still ends SUCCEEDED (mirrors the existing PublishResearchFailureImmediate/PublishPredictorFailureImmediate/PublishModelZooFailureImmediate best-effort-notify idiom already used in ResearchPredictorParallel). The caught TaskFailed history event is still logged at the SF's existing Level:ERROR LoggingConfiguration (AWS logs TaskFailed at ERROR regardless of whether a Catch handles it) and picked up by the SnsPublishFailedMetricFilter/SnsPublishFailedAlarm CloudWatch alarm below \u2014 see that alarm's comment for the exact (repo-precedent, string-match) scoping and its known limitation.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Preflight Pipeline — SUCCESS",
+        "Subject": "Alpha Engine Saturday Preflight Pipeline \u2014 SUCCESS",
         "Message": "Friday-PM Preflight Pipeline of the Saturday SF completed: all workload states ran in --preflight-only / dry mode, health/substrate checks ran. No Saturday-fatal bootstrap break detected for tomorrow's 02:00 PT real run. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
@@ -4127,7 +3016,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must NEVER fail an otherwise-succeeded pipeline (2026-06-12 NotifyComplete SNS.InvalidParameterException incident). Record the error as data and still Succeed; the underlying TaskFailed is independently visible via CloudWatch Logs (see SnsPublishFailedAlarm) regardless of this Catch.",
+          "Comment": "config#1819 \u2014 best-effort: a SUCCESS-path notifier must NEVER fail an otherwise-succeeded pipeline (2026-06-12 NotifyComplete SNS.InvalidParameterException incident). Record the error as data and still Succeed; the underlying TaskFailed is independently visible via CloudWatch Logs (see SnsPublishFailedAlarm) regardless of this Catch.",
           "ResultPath": "$.notify_error",
           "Next": "NotifyShellRunCompleteDegraded"
         }
@@ -4136,7 +3025,7 @@
     },
     "NotifyShellRunCompleteDegraded": {
       "Type": "Pass",
-      "Comment": "config#1819 — records the caught publish failure as execution DATA ($.notify_degraded, visible via GetExecutionHistory / the SF console) so an operator inspecting a degraded-but-SUCCEEDED execution can see why. NOT itself a CloudWatch alarm source: PassStateExited only logs at LoggingConfiguration Level:ALL, and this SF (like the other CFN-managed SFs) deliberately runs Level:ERROR for log volume/cost — see WeeklyFreshnessLogGroup comment. The real-time alarm signal for this failure class is the TaskFailed event from NotifyShellRunComplete's own Catch (logged at ERROR unconditionally) matched by SnsPublishFailedMetricFilter.",
+      "Comment": "config#1819 \u2014 records the caught publish failure as execution DATA ($.notify_degraded, visible via GetExecutionHistory / the SF console) so an operator inspecting a degraded-but-SUCCEEDED execution can see why. NOT itself a CloudWatch alarm source: PassStateExited only logs at LoggingConfiguration Level:ALL, and this SF (like the other CFN-managed SFs) deliberately runs Level:ERROR for log volume/cost \u2014 see WeeklyFreshnessLogGroup comment. The real-time alarm signal for this failure class is the TaskFailed event from NotifyShellRunComplete's own Catch (logged at ERROR unconditionally) matched by SnsPublishFailedMetricFilter.",
       "Parameters": {
         "degraded": true,
         "source": "NotifyShellRunComplete",
@@ -4147,11 +3036,11 @@
     },
     "NotifyComplete": {
       "Type": "Task",
-      "Comment": "Success notification via SNS. config#1819 (2026-06-12 incident class): Subject/Message here are both hardcoded constants (never States.Format against user input), so they can never violate the SNS Subject <=100-char/no-newline contract — but the sns:publish call itself can still throw for infra reasons (SNS throttling/IAM drift/transient outage/a future edit that parameterizes Subject and reintroduces the exact 2026-06-12 SNS.InvalidParameterException shape). A SUCCESS-path notifier failing an otherwise-succeeded pipeline is precisely that incident. Catch below makes this best-effort: a publish failure is caught and the execution still ends SUCCEEDED (mirrors the existing PublishResearchFailureImmediate/PublishPredictorFailureImmediate/PublishModelZooFailureImmediate best-effort-notify idiom already used in ResearchPredictorParallel). The caught TaskFailed history event is still logged at the SF's existing Level:ERROR LoggingConfiguration (AWS logs TaskFailed at ERROR regardless of whether a Catch handles it) and picked up by the SnsPublishFailedMetricFilter/SnsPublishFailedAlarm CloudWatch alarm below — see that alarm's comment for the exact (repo-precedent, string-match) scoping and its known limitation.",
+      "Comment": "Success notification via SNS. config#1819 (2026-06-12 incident class): Subject/Message here are both hardcoded constants (never States.Format against user input), so they can never violate the SNS Subject <=100-char/no-newline contract \u2014 but the sns:publish call itself can still throw for infra reasons (SNS throttling/IAM drift/transient outage/a future edit that parameterizes Subject and reintroduces the exact 2026-06-12 SNS.InvalidParameterException shape). A SUCCESS-path notifier failing an otherwise-succeeded pipeline is precisely that incident. Catch below makes this best-effort: a publish failure is caught and the execution still ends SUCCEEDED (mirrors the existing PublishResearchFailureImmediate/PublishPredictorFailureImmediate/PublishModelZooFailureImmediate best-effort-notify idiom already used in ResearchPredictorParallel). The caught TaskFailed history event is still logged at the SF's existing Level:ERROR LoggingConfiguration (AWS logs TaskFailed at ERROR regardless of whether a Catch handles it) and picked up by the SnsPublishFailedMetricFilter/SnsPublishFailedAlarm CloudWatch alarm below \u2014 see that alarm's comment for the exact (repo-precedent, string-match) scoping and its known limitation.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS",
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS",
         "Message": "All steps completed successfully. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
@@ -4160,7 +3049,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must NEVER fail an otherwise-succeeded pipeline (2026-06-12 NotifyComplete SNS.InvalidParameterException incident that motivated this fix). Record the error as data and still Succeed; the underlying TaskFailed is independently visible via CloudWatch Logs (see SnsPublishFailedAlarm) regardless of this Catch.",
+          "Comment": "config#1819 \u2014 best-effort: a SUCCESS-path notifier must NEVER fail an otherwise-succeeded pipeline (2026-06-12 NotifyComplete SNS.InvalidParameterException incident that motivated this fix). Record the error as data and still Succeed; the underlying TaskFailed is independently visible via CloudWatch Logs (see SnsPublishFailedAlarm) regardless of this Catch.",
           "ResultPath": "$.notify_error",
           "Next": "NotifyCompleteDegraded"
         }
@@ -4169,7 +3058,7 @@
     },
     "NotifyCompleteDegraded": {
       "Type": "Pass",
-      "Comment": "config#1819 — records the caught publish failure as execution DATA ($.notify_degraded, visible via GetExecutionHistory / the SF console) so an operator inspecting a degraded-but-SUCCEEDED execution can see why. NOT itself a CloudWatch alarm source: PassStateExited only logs at LoggingConfiguration Level:ALL, and this SF (like the other CFN-managed SFs) deliberately runs Level:ERROR for log volume/cost — see WeeklyFreshnessLogGroup comment. The real-time alarm signal for this failure class is the TaskFailed event from NotifyComplete's own Catch (logged at ERROR unconditionally) matched by SnsPublishFailedMetricFilter.",
+      "Comment": "config#1819 \u2014 records the caught publish failure as execution DATA ($.notify_degraded, visible via GetExecutionHistory / the SF console) so an operator inspecting a degraded-but-SUCCEEDED execution can see why. NOT itself a CloudWatch alarm source: PassStateExited only logs at LoggingConfiguration Level:ALL, and this SF (like the other CFN-managed SFs) deliberately runs Level:ERROR for log volume/cost \u2014 see WeeklyFreshnessLogGroup comment. The real-time alarm signal for this failure class is the TaskFailed event from NotifyComplete's own Catch (logged at ERROR unconditionally) matched by SnsPublishFailedMetricFilter.",
       "Parameters": {
         "degraded": true,
         "source": "NotifyComplete",
@@ -4180,7 +3069,7 @@
     },
     "ExtractMorningEnrichError": {
       "Type": "Pass",
-      "Comment": "Normalize MorningEnrich SSM non-Success poll into $.error. Mirrors ExtractDataPhase1Error — the soft-failure path from CheckMorningEnrichStatus.Default does not populate $.error, only Task Catch blocks do.",
+      "Comment": "Normalize MorningEnrich SSM non-Success poll into $.error. Mirrors ExtractDataPhase1Error \u2014 the soft-failure path from CheckMorningEnrichStatus.Default does not populate $.error, only Task Catch blocks do.",
       "Parameters": {
         "phase": "MorningEnrich",
         "source": "CheckMorningEnrichStatus.Default",
@@ -4191,7 +3080,7 @@
     },
     "ExtractDataPhase1Error": {
       "Type": "Pass",
-      "Comment": "Normalize DataPhase1 SSM non-Success poll into $.error so HandleFailure's States.Format template has something to serialize (the soft-failure path from CheckDataPhase1Status.Default does not populate $.error — only Task Catch blocks do).",
+      "Comment": "Normalize DataPhase1 SSM non-Success poll into $.error so HandleFailure's States.Format template has something to serialize (the soft-failure path from CheckDataPhase1Status.Default does not populate $.error \u2014 only Task Catch blocks do).",
       "Parameters": {
         "phase": "DataPhase1",
         "source": "CheckDataPhase1Status.Default",
@@ -4213,7 +3102,7 @@
     },
     "ExtractParityError": {
       "Type": "Pass",
-      "Comment": "Normalize Parity SSM non-Success poll into $.error. Mirrors ExtractBacktesterError — the soft-failure path from CheckParityStatus.Default does not populate $.error, only Task Catch blocks do.",
+      "Comment": "Normalize Parity SSM non-Success poll into $.error. Mirrors ExtractBacktesterError \u2014 the soft-failure path from CheckParityStatus.Default does not populate $.error, only Task Catch blocks do.",
       "Parameters": {
         "phase": "Parity",
         "source": "CheckParityStatus.Default",
@@ -4224,7 +3113,7 @@
     },
     "ExtractPredictorBacktestError": {
       "Type": "Pass",
-      "Comment": "Normalize PredictorBacktest SSM non-Success poll into $.error. Mirrors ExtractBacktesterError — the soft-failure path from CheckPredictorBacktestStatus.Default does not populate $.error, only Task Catch blocks do. Added by the L4472 phase-split.",
+      "Comment": "Normalize PredictorBacktest SSM non-Success poll into $.error. Mirrors ExtractBacktesterError \u2014 the soft-failure path from CheckPredictorBacktestStatus.Default does not populate $.error, only Task Catch blocks do. Added by the L4472 phase-split.",
       "Parameters": {
         "phase": "PredictorBacktest",
         "source": "CheckPredictorBacktestStatus.Default",
@@ -4235,7 +3124,7 @@
     },
     "ExtractPortfolioOptimizerBacktestError": {
       "Type": "Pass",
-      "Comment": "Normalize PortfolioOptimizerBacktest SSM non-Success poll into $.error. Mirrors ExtractBacktesterError — the soft-failure path from CheckPortfolioOptimizerBacktestStatus.Default does not populate $.error, only Task Catch blocks do. Added by the L4472 phase-split.",
+      "Comment": "Normalize PortfolioOptimizerBacktest SSM non-Success poll into $.error. Mirrors ExtractBacktesterError \u2014 the soft-failure path from CheckPortfolioOptimizerBacktestStatus.Default does not populate $.error, only Task Catch blocks do. Added by the L4472 phase-split.",
       "Parameters": {
         "phase": "PortfolioOptimizerBacktest",
         "source": "CheckPortfolioOptimizerBacktestStatus.Default",
@@ -4257,7 +3146,7 @@
     },
     "NormalizeFailureContext": {
       "Type": "Pass",
-      "Comment": "config#1819 notifier-totality fix. Single Catch/Next target for EVERY failure path before HandleFailure — structurally guarantees the fields HandleFailure's States.Format/JsonToString template consumes ($.error, $.pipeline_label, $.sns_topic_arn) are present, regardless of what any upstream Catch, Extract*Error normalizer, or manual Execution.Input supplied. Mirrors the InitializeInput JsonMerge-defaults idiom (defaults as the base/first-arg, current state $ as the override/second-arg — second-arg wins — so a real $.error from a Catch's ResultPath always survives). 2026-07-02 incident (offcycle-shell-20260703-005835): a manual-trigger input omitted pipeline_label and HandleFailure's States.Format('Saturday{} Pipeline failed...', $.pipeline_label, ...) threw States.Runtime, masking the true underlying error — this state closes that CLASS (not just this instance). error/sns_topic_arn get a floor default here for defense-in-depth against any FUTURE Catch that forgets its own ResultPath: $.error (every CURRENT path already sets $.error via a Task Catch ResultPath or an Extract*Error Pass, so this is a backstop, not a behavior change for today's paths). pipeline_label is ALSO re-pinned by NormalizeFailureContextRepin (next state) from $.shell_run rather than trusted verbatim — closes the Subject-injection shape (an arbitrary/oversized/newline-bearing manual pipeline_label reaching HandleFailure's States.Format Subject; SNS Subject must be <=100 chars with no newlines) at the root, the same class of bug as the 2026-06-12 NotifyComplete Subject crash (SNS.InvalidParameterException). PROVENANCE (config#2281): the sns_topic_arn literal in this JsonMerge is the failure-path FLOOR of last resort — the merge keeps any already-present $.sns_topic_arn (the execution-input-sourced value from InitializeInput); the literal engages only if the input context was lost upstream. Kept in lockstep with InitializeInput's floor by tests/test_sf_sns_arn_single_source.py.",
+      "Comment": "config#1819 notifier-totality fix. Single Catch/Next target for EVERY failure path before HandleFailure \u2014 structurally guarantees the fields HandleFailure's States.Format/JsonToString template consumes ($.error, $.pipeline_label, $.sns_topic_arn) are present, regardless of what any upstream Catch, Extract*Error normalizer, or manual Execution.Input supplied. Mirrors the InitializeInput JsonMerge-defaults idiom (defaults as the base/first-arg, current state $ as the override/second-arg \u2014 second-arg wins \u2014 so a real $.error from a Catch's ResultPath always survives). 2026-07-02 incident (offcycle-shell-20260703-005835): a manual-trigger input omitted pipeline_label and HandleFailure's States.Format('Saturday{} Pipeline failed...', $.pipeline_label, ...) threw States.Runtime, masking the true underlying error \u2014 this state closes that CLASS (not just this instance). error/sns_topic_arn get a floor default here for defense-in-depth against any FUTURE Catch that forgets its own ResultPath: $.error (every CURRENT path already sets $.error via a Task Catch ResultPath or an Extract*Error Pass, so this is a backstop, not a behavior change for today's paths). pipeline_label is ALSO re-pinned by NormalizeFailureContextRepin (next state) from $.shell_run rather than trusted verbatim \u2014 closes the Subject-injection shape (an arbitrary/oversized/newline-bearing manual pipeline_label reaching HandleFailure's States.Format Subject; SNS Subject must be <=100 chars with no newlines) at the root, the same class of bug as the 2026-06-12 NotifyComplete Subject crash (SNS.InvalidParameterException). PROVENANCE (config#2281): the sns_topic_arn literal in this JsonMerge is the failure-path FLOOR of last resort \u2014 the merge keeps any already-present $.sns_topic_arn (the execution-input-sourced value from InitializeInput); the literal engages only if the input context was lost upstream. Kept in lockstep with InitializeInput's floor by tests/test_sf_sns_arn_single_source.py.",
       "Parameters": {
         "merged.$": "States.JsonMerge(States.StringToJson('{\"error\":{\"phase\":\"Unknown\",\"source\":\"NormalizeFailureContext\",\"detail\":\"no $.error was set by the upstream Catch/normalizer\"},\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\",\"pipeline_label\":\"\"}'),$,false)"
       },
@@ -4266,7 +3155,7 @@
     },
     "NormalizeFailureContextRepin": {
       "Type": "Choice",
-      "Comment": "Re-derive $.pipeline_label from $.shell_run (a boolean the SF itself controls) instead of trusting whatever string a manual Execution.Input supplied for pipeline_label — closes the SNS Subject-injection vector at HandleFailure's States.Format('Alpha Engine Saturday{} Pipeline — FAILED', $.pipeline_label): an arbitrary/oversized/newline-bearing manual pipeline_label can no longer reach the Subject regardless of what NormalizeFailureContext's floor-default merge left in place. IsPresent guards make this Choice total — it cannot itself raise a missing-$.shell_run States.Runtime, unlike a bare States.Format/JsonToString would. shell_run=true -> ' Preflight' (matches ApplyShellRunDefaults' identity so a Friday shell-run failure still reads 'Saturday Preflight Pipeline — FAILED'); anything else (absent, false, or a non-boolean) -> '' (the real Saturday identity).",
+      "Comment": "Re-derive $.pipeline_label from $.shell_run (a boolean the SF itself controls) instead of trusting whatever string a manual Execution.Input supplied for pipeline_label \u2014 closes the SNS Subject-injection vector at HandleFailure's States.Format('Alpha Engine Saturday{} Pipeline \u2014 FAILED', $.pipeline_label): an arbitrary/oversized/newline-bearing manual pipeline_label can no longer reach the Subject regardless of what NormalizeFailureContext's floor-default merge left in place. IsPresent guards make this Choice total \u2014 it cannot itself raise a missing-$.shell_run States.Runtime, unlike a bare States.Format/JsonToString would. shell_run=true -> ' Preflight' (matches ApplyShellRunDefaults' identity so a Friday shell-run failure still reads 'Saturday Preflight Pipeline \u2014 FAILED'); anything else (absent, false, or a non-boolean) -> '' (the real Saturday identity).",
       "Choices": [
         {
           "And": [
@@ -4286,25 +3175,25 @@
     },
     "NormalizeFailureContextPreflightLabel": {
       "Type": "Pass",
-      "Comment": "shell_run=true path: pin pipeline_label to ' Preflight' (leading space, same convention as ApplyShellRunDefaults/preflight_args) so a Friday shell-run failure still surfaces 'Saturday Preflight Pipeline — FAILED', matching the pre-fix labeling behavior exactly.",
+      "Comment": "shell_run=true path: pin pipeline_label to ' Preflight' (leading space, same convention as ApplyShellRunDefaults/preflight_args) so a Friday shell-run failure still surfaces 'Saturday Preflight Pipeline \u2014 FAILED', matching the pre-fix labeling behavior exactly.",
       "Result": " Preflight",
       "ResultPath": "$.pipeline_label",
       "Next": "HandleFailure"
     },
     "NormalizeFailureContextRealLabel": {
       "Type": "Pass",
-      "Comment": "shell_run absent/false/non-boolean path (the real Saturday run, and any other cadence): pin pipeline_label to '' so HandleFailure surfaces the byte-identical pre-fix 'Alpha Engine Saturday Pipeline — FAILED' Subject. This OVERRIDES whatever pipeline_label value (if any) a manual Execution.Input or upstream state left in place — the label is now always SF-derived, never free-text passthrough, closing the Subject-injection vector structurally rather than by string-truncation (ASL has no substring/truncate intrinsic).",
+      "Comment": "shell_run absent/false/non-boolean path (the real Saturday run, and any other cadence): pin pipeline_label to '' so HandleFailure surfaces the byte-identical pre-fix 'Alpha Engine Saturday Pipeline \u2014 FAILED' Subject. This OVERRIDES whatever pipeline_label value (if any) a manual Execution.Input or upstream state left in place \u2014 the label is now always SF-derived, never free-text passthrough, closing the Subject-injection vector structurally rather than by string-truncation (ASL has no substring/truncate intrinsic).",
       "Result": "",
       "ResultPath": "$.pipeline_label",
       "Next": "HandleFailure"
     },
     "HandleFailure": {
       "Type": "Task",
-      "Comment": "Failure alert via SNS — pipeline halts. Subject + Message are parameterized via States.Format on $.pipeline_label so a Preflight Pipeline failure surfaces 'Saturday Preflight Pipeline — FAILED' (shell_run=true → ApplyShellRunDefaults sets $.pipeline_label=' Preflight') while a real Saturday SF failure surfaces 'Saturday Pipeline — FAILED' ($.pipeline_label='' from InitializeInput defaults). 2026-05-23 rename arc: 'shell_run' is internal mechanism-language; alerts surface the user-facing 'Preflight' label. config#1819 (2026-07-06): every path into this state now routes through NormalizeFailureContext -> NormalizeFailureContextRepin first (the ONLY Catch/Next target for the whole failure path), which structurally guarantees $.error/$.sns_topic_arn/$.pipeline_label are present AND re-pins pipeline_label from $.shell_run rather than trusting a manual Execution.Input's free-text value — so this Subject can never exceed the SNS 100-char/no-newline contract and this States.Format can never throw States.Runtime for a missing JSONPath, closing both the 2026-07-02 States.Runtime-masking incident and the Subject-injection shape of the 2026-06-12 NotifyComplete crash.",
+      "Comment": "Failure alert via SNS \u2014 pipeline halts. Subject + Message are parameterized via States.Format on $.pipeline_label so a Preflight Pipeline failure surfaces 'Saturday Preflight Pipeline \u2014 FAILED' (shell_run=true \u2192 ApplyShellRunDefaults sets $.pipeline_label=' Preflight') while a real Saturday SF failure surfaces 'Saturday Pipeline \u2014 FAILED' ($.pipeline_label='' from InitializeInput defaults). 2026-05-23 rename arc: 'shell_run' is internal mechanism-language; alerts surface the user-facing 'Preflight' label. config#1819 (2026-07-06): every path into this state now routes through NormalizeFailureContext -> NormalizeFailureContextRepin first (the ONLY Catch/Next target for the whole failure path), which structurally guarantees $.error/$.sns_topic_arn/$.pipeline_label are present AND re-pins pipeline_label from $.shell_run rather than trusting a manual Execution.Input's free-text value \u2014 so this Subject can never exceed the SNS 100-char/no-newline contract and this States.Format can never throw States.Runtime for a missing JSONPath, closing both the 2026-07-02 States.Runtime-masking incident and the Subject-injection shape of the 2026-06-12 NotifyComplete crash.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — FAILED', $.pipeline_label)",
+        "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline \u2014 FAILED', $.pipeline_label)",
         "Message.$": "States.Format('Saturday{} Pipeline failed. Error: {}. View the failing state + per-state detail at https://console.nousergon.ai/pipeline-status  (redrive-execution is a no-op on this pipeline: every Task Catch routes to this shared FailExecution state, so redrive just re-enters FailExecution and re-fails immediately with no retry. To retry MECHANICALLY: from a nousergon-data checkout run  python3 scripts/weekly_sf_rerun.py --dry-run  -- it derives the original run_date + the correct skip_* set from this failed execution and handles the run-slot mutex; review, then rerun with --start. Manual fallback: start a fresh execution with skip_* input flags set true for stages already completed, e.g. skip_morning_enrich / skip_data_phase1 / skip_backtester -- see infrastructure/README.md for the full flag list and rationale.)', $.pipeline_label, States.JsonToString($.error))"
       },
       "ResultPath": "$.failure_notify",

--- a/infrastructure/step_function_advisory.json
+++ b/infrastructure/step_function_advisory.json
@@ -1,0 +1,772 @@
+{
+  "Comment": "Alpha Engine Weekly Advisory Pipeline (alpha-engine-config-I2544, Phase 2 of the weekly-SF load-reduction plan) \u2014 the eval-judge chain (EvalJudge submit/poll/process \u2192 EvalRollingMean \u2192 RationaleClustering \u2192 ReplayConcordance \u2192 Counterfactual \u2192 AggregateCosts), PLUS ReportCard and Director, decoupled from the Saturday critical path into an async child SF. Started fire-and-forget (states:startExecution, NOT .sync) by the main ne-weekly-freshness-pipeline's StartAdvisoryPipeline state once DataPhase2 completes, named advisory-{run_date} for idempotency (a StartExecution retry against the same run_date's already-running/completed child gets StepFunctions.ExecutionAlreadyExistsException, treated as pass-through success by the parent). Internal state order and every lifted state's Payload/Retry/Catch semantics are PRESERVED byte-for-byte from step_function.json \u2014 only the terminal edges (BranchAComplete \u2192 ReportCard; CheckShellRunNotify \u2192 AdvisoryNotifyComplete) were rewired, since this child has no Parallel join and no shell-run/preflight identity of its own. Deploy path mirrors step_function.json's single-writer contract (config#2273): infrastructure/deploy_step_function.sh / deploy-infrastructure.sh upload this file's stamped bytes to the CFN-referenced S3 key before update-state-machine. Failure visibility: TopLevel TimeoutSeconds=28800 (8h \u2014 the eval-judge poll's own 6h fail-soft cap plus headroom for the Map/Lambda stages around it) yields TIMED_OUT on a hang, matched by the same saturday-sf-watch-dispatcher registration used for the fleet's other Step Functions (see PIPELINES in infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py). A genuine SF-engine-level error (vs. any lifted state's own, deliberately non-fatal failure path) is caught by the single-branch Parallel wrapper and alerted via AdvisoryHandleFailure \u2192 AdvisoryFailExecution, mirroring the parent SF's NormalizeFailureContext \u2192 HandleFailure \u2192 FailExecution shape in miniature.",
+  "StartAt": "InitializeAdvisoryInput",
+  "TimeoutSeconds": 28800,
+  "States": {
+    "InitializeAdvisoryInput": {
+      "Type": "Pass",
+      "Comment": "Layer defaults under the child execution input, mirroring the parent SF's InitializeInput idiom exactly (States.JsonMerge with user-input as the second/winning arg). run_date/research_dry/sns_topic_arn/pipeline_label are ALWAYS supplied by the parent's StartAdvisoryPipeline dispatch (Input.$ merges the parent's own $ into these floors before startExecution), but this state also makes a bare manual/console StartExecution of this child safe \u2014 the skip_* flags default false (run the full chain) and sns_topic_arn/pipeline_label get the same account-literal floor InitializeInput uses (config#2281 provenance note applies identically here).",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"research_dry\":false,\"skip_eval_judge\":false,\"skip_rationale_clustering\":false,\"skip_replay_concordance\":false,\"skip_counterfactual\":false,\"skip_aggregate_costs\":false,\"pipeline_label\":\"\",\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),$$.Execution.Input,false)"
+      },
+      "OutputPath": "$.merged",
+      "Next": "AdvisoryPipelineWrapper"
+    },
+    "AdvisoryPipelineWrapper": {
+      "Type": "Parallel",
+      "Comment": "Single-branch wrapper giving the advisory pipeline a machine-level catch-all WITHOUT altering any lifted state's own Payload/Retry/Catch (alpha-engine-config-I2544 explicitly requires preserving those semantics \u2014 every lifted Task already routes its own failures forward as non-fatal/observability-only, by original design; this Catch exists as a backstop for a genuine SF-engine-level error, not for any state's own business-logic failure path).",
+      "Branches": [
+        {
+          "StartAt": "CheckSkipEvalJudge",
+          "States": {
+            "CheckSkipEvalJudge": {
+              "Type": "Choice",
+              "Comment": "Skip-gate. {\"skip_eval_judge\": true} bypasses the LLM-as-judge eval step (typically used for ad-hoc reruns where eval cost is unwanted). Skipping the judge does NOT skip rationale clustering \u2014 they're independent observability paths (clustering reads decision_artifacts/, judge reads its own _eval/), so we route to CheckSkipRationaleClustering instead of bypassing both.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.skip_eval_judge",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.skip_eval_judge",
+                      "BooleanEquals": true
+                    }
+                  ],
+                  "Next": "CheckSkipRationaleClustering"
+                }
+              ],
+              "Default": "ComputeEvalCadence"
+            },
+            "ComputeEvalCadence": {
+              "Type": "Pass",
+              "Comment": "Extract day-of-month + ISO date + submit timestamp from the SF execution start time. day_of_month <= 07 \u21d2 first Saturday of the month \u21d2 force_sonnet_pass=true (monthly Sonnet sweep per ROADMAP \u00a71626). All other Saturdays run Haiku-only batch + per-artifact Sonnet escalation tail inside the Process Lambda. submit_iso is propagated to EvalJudgePoll so it can compute elapsed-time against the 6h fail-soft cap.",
+              "Parameters": {
+                "day_of_month.$": "States.ArrayGetItem(States.StringSplit(States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0), '-'), 2)",
+                "eval_date.$": "States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0)",
+                "submit_iso.$": "$$.Execution.StartTime"
+              },
+              "ResultPath": "$.eval_cadence",
+              "Next": "CheckMonthlyCadence"
+            },
+            "CheckMonthlyCadence": {
+              "Type": "Choice",
+              "Comment": "First-Saturday-of-the-month detection via lexicographic compare on the zero-padded day-of-month string ('01'..'07' < '08'). Lexicographic ordering is correct here because all values are zero-padded 2-char strings.",
+              "Choices": [
+                {
+                  "Variable": "$.eval_cadence.day_of_month",
+                  "StringLessThan": "08",
+                  "Next": "EvalJudgeSubmitFirstSaturday"
+                }
+              ],
+              "Default": "EvalJudgeSubmitWeekly"
+            },
+            "EvalJudgeSubmitFirstSaturday": {
+              "Type": "Task",
+              "Comment": "Submit phase, monthly Sonnet sweep \u2014 force_sonnet_pass=true. Builds the (artifact \u00d7 judge_model) batch payload covering both Haiku and Sonnet for every mapped artifact, submits as one Anthropic Message Batches API call, and writes the plan manifest to S3 keyed by batch_id. ROADMAP P1 \u00a71642. 50% cost discount per Anthropic's batch contract; structurally bypasses the 15-min Lambda timeout class that nearly fired on the 2026-05-06 manual midweek SF run.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-eval-judge-submit:live",
+                "Payload": {
+                  "force_sonnet_pass": true,
+                  "date.$": "$.eval_cadence.eval_date",
+                  "dry_run_llm.$": "$.research_dry",
+                  "capture_lookback_days": 6
+                }
+              },
+              "TimeoutSeconds": 300,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Eval is observability per ROADMAP \u00a71635 \u2014 submit failures must NOT halt the pipeline. EvalRollingMean still runs against historical data.",
+                  "Next": "EvalRollingMean",
+                  "ResultPath": "$.eval_judge_error"
+                }
+              ],
+              "ResultPath": "$.eval_judge_submit",
+              "Next": "EvalJudgePollChoice"
+            },
+            "EvalJudgeSubmitWeekly": {
+              "Type": "Task",
+              "Comment": "Submit phase, weekly Haiku-only batch + Sonnet escalation tail in Process. Submits Haiku entries for every mapped artifact in one batch; the Process Lambda runs Sonnet escalations synchronously after Haiku results arrive (typically 1-3 artifacts/run, well under Process's 15-min budget). Preserves the per-artifact <3 escalation gate so weekly cost stays bounded relative to the all-pairs first-Saturday batch.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-eval-judge-submit:live",
+                "Payload": {
+                  "force_sonnet_pass": false,
+                  "date.$": "$.eval_cadence.eval_date",
+                  "dry_run_llm.$": "$.research_dry",
+                  "capture_lookback_days": 6
+                }
+              },
+              "TimeoutSeconds": 300,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Eval is observability \u2014 submit failures must NOT halt the pipeline.",
+                  "Next": "EvalRollingMean",
+                  "ResultPath": "$.eval_judge_error"
+                }
+              ],
+              "ResultPath": "$.eval_judge_submit",
+              "Next": "EvalJudgePollChoice"
+            },
+            "EvalJudgePollChoice": {
+              "Type": "Choice",
+              "Comment": "Branch on Submit's processing_status. EMPTY (no captures or all empty-input skipped client-side) \u2192 route directly to Process so the empty-batch case still emits a clean SF result + downstream metric inputs. OK \u2192 enter the Wait/Poll loop. Anything else (ERROR, missing fields) routes to EvalRollingMean as a fail-soft.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.eval_judge_submit.Payload.status",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.eval_judge_submit.Payload.status",
+                      "StringEquals": "EMPTY"
+                    }
+                  ],
+                  "Next": "EvalJudgeProcess"
+                },
+                {
+                  "And": [
+                    {
+                      "Variable": "$.eval_judge_submit.Payload.status",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.eval_judge_submit.Payload.status",
+                      "StringEquals": "OK"
+                    }
+                  ],
+                  "Comment": "config#2275: IsPresent-guarded so a submit payload WITHOUT status actually reaches the fail-soft Default this state's own comment promises ('missing fields routes to EvalRollingMean') instead of throwing States.Runtime.",
+                  "Next": "EvalJudgePollWait"
+                }
+              ],
+              "Default": "EvalRollingMean"
+            },
+            "EvalJudgePollWait": {
+              "Type": "Wait",
+              "Comment": "60s pause between batch status polls. Anthropic's docs target sub-1h typical batch latency with 24h hard cap; 60s polls strike a balance between pickup latency and Lambda invocation cost over the typical wait.",
+              "Seconds": 60,
+              "Next": "EvalJudgePoll"
+            },
+            "EvalJudgePoll": {
+              "Type": "Task",
+              "Comment": "Poll phase. Calls anthropic.messages.batches.retrieve(batch_id) and returns processing_status + request_counts + elapsed_seconds. SF Choice that follows branches on processing_status: ended \u2192 Process; in_progress \u2192 loop back to Wait; exceeded_max_wait=true \u2192 fail-soft to EvalRollingMean.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-eval-judge-poll:live",
+                "Payload": {
+                  "batch_id.$": "$.eval_judge_submit.Payload.batch_id",
+                  "submit_iso.$": "$.eval_cadence.submit_iso",
+                  "max_wait_seconds": 21600,
+                  "dry_run_llm.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 60,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "A poll-level failure is recoverable \u2014 Anthropic retains batch results 29 days, so a transient poll Lambda failure can be re-run by a human if needed. Route to EvalRollingMean so the rest of the pipeline isn't blocked.",
+                  "Next": "EvalRollingMean",
+                  "ResultPath": "$.eval_judge_error"
+                }
+              ],
+              "ResultPath": "$.eval_judge_poll",
+              "Next": "EvalJudgePollDecision"
+            },
+            "EvalJudgePollDecision": {
+              "Type": "Choice",
+              "Comment": "Branch on poll status. processing_status='ended' \u2192 run Process. exceeded_max_wait=true \u2192 fail-soft (batch results stay retrievable for 29 days; an operator can re-run the chain offline). Anything else \u2192 loop back to Wait. Includes the synthetic 'ended_empty' status (Submit short-circuited an empty plan) so the empty case still hits Process.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.eval_judge_poll.Payload.processing_status",
+                      "IsPresent": true
+                    },
+                    {
+                      "Or": [
+                        {
+                          "Variable": "$.eval_judge_poll.Payload.processing_status",
+                          "StringEquals": "ended"
+                        },
+                        {
+                          "Variable": "$.eval_judge_poll.Payload.processing_status",
+                          "StringEquals": "ended_empty"
+                        }
+                      ]
+                    }
+                  ],
+                  "Next": "EvalJudgeProcess"
+                },
+                {
+                  "And": [
+                    {
+                      "Variable": "$.eval_judge_poll.Payload.exceeded_max_wait",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.eval_judge_poll.Payload.exceeded_max_wait",
+                      "BooleanEquals": true
+                    }
+                  ],
+                  "Next": "EvalRollingMean"
+                },
+                {
+                  "And": [
+                    {
+                      "Not": {
+                        "Variable": "$.eval_judge_poll.Payload.processing_status",
+                        "IsPresent": true
+                      }
+                    },
+                    {
+                      "Not": {
+                        "Variable": "$.eval_judge_poll.Payload.exceeded_max_wait",
+                        "IsPresent": true
+                      }
+                    }
+                  ],
+                  "Comment": "config#2275: a poll payload carrying NEITHER processing_status NOR exceeded_max_wait is malformed \u2014 fail-soft to EvalRollingMean (eval is observability; mirrors this state's Catch posture) instead of States.Runtime, and instead of looping in Wait until the global ceiling.",
+                  "Next": "EvalRollingMean"
+                }
+              ],
+              "Default": "EvalJudgePollWait"
+            },
+            "EvalJudgeProcess": {
+              "Type": "Task",
+              "Comment": "Process phase. Streams the completed batch's results, parses each via the existing RubricEvalLLMOutput schema, persists per-artifact eval JSONs to decision_artifacts/_eval/{date}/, emits CW metrics under AlphaEngine/Eval, and runs the small synchronous Sonnet-escalation tail for any Haiku result that flagged a borderline dimension. Returns OK/PARTIAL/ERROR mirroring the legacy single-Lambda contract \u2014 no consumer (RationaleClustering, EvalRollingMean, dashboard) changes.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-eval-judge-process:live",
+                "Payload": {
+                  "batch_id.$": "$.eval_judge_submit.Payload.batch_id",
+                  "plan_s3_key.$": "$.eval_judge_submit.Payload.plan_s3_key",
+                  "dry_run_llm.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 900,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Eval is observability \u2014 Process failures must NOT halt the pipeline. EvalRollingMean still runs against historical data.",
+                  "Next": "EvalRollingMean",
+                  "ResultPath": "$.eval_judge_error"
+                }
+              ],
+              "ResultPath": "$.eval_judge_result",
+              "Next": "EvalRollingMean"
+            },
+            "EvalRollingMean": {
+              "Type": "Task",
+              "Comment": "Rolling-4-week-mean derived metric Lambda (PR 4b) \u2014 runs after both eval-judge branches converge. Reads AlphaEngine/Eval/agent_quality_score for the trailing 28 days, computes the mean per (judged_agent_id, criterion, judge_model) combo, and emits agent_quality_score_4w_mean which a CloudWatch alarm fires against (per ROADMAP \u00a71634). Runs every Saturday \u2014 even on weeks where eval-judge had infra failures, the mean across the prior 4 weeks of available data is still the most-current calibration signal.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-eval-rolling-mean:live",
+                "Payload": {
+                  "end_time_iso.$": "$$.Execution.StartTime"
+                }
+              },
+              "TimeoutSeconds": 300,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Eval observability layer \u2014 failures must NOT halt the pipeline.",
+                  "Next": "CheckSkipRationaleClustering",
+                  "ResultPath": "$.eval_rolling_mean_error"
+                }
+              ],
+              "ResultPath": "$.eval_rolling_mean_result",
+              "Next": "CheckSkipRationaleClustering"
+            },
+            "CheckSkipRationaleClustering": {
+              "Type": "Choice",
+              "Comment": "Skip-gate. {\"skip_rationale_clustering\": true} bypasses the cross-week rationale clustering Lambda (used during ad-hoc reruns where corpus is in a known-bad state, while iterating on extraction logic, or for post-incident reruns where stale outputs shouldn't hit CloudWatch). Standalone invocation of the Lambda is always available regardless of this flag.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.skip_rationale_clustering",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.skip_rationale_clustering",
+                      "BooleanEquals": true
+                    }
+                  ],
+                  "Next": "CheckSkipReplayConcordance"
+                }
+              ],
+              "Default": "RationaleClustering"
+            },
+            "RationaleClustering": {
+              "Type": "Task",
+              "Comment": "Cross-week rationale clustering Lambda (ROADMAP P0, 2026-05-05). Reads decision_artifacts/ for the trailing 8 weeks, clusters rationales per agent_id via TF-IDF char n-grams + greedy single-linkage with digit-normalization, emits CW metric agent_rationale_template_concentration (% of rationales in top-3 clusters; >0.7 indicates template-generation), and persists per-agent analysis JSON to decision_artifacts/_analysis/{agent_id}/{YYYY-WW}.json. Runs every Saturday after EvalRollingMean \u2014 same image-share + observability framing.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-rationale-clustering:live",
+                "Payload": {
+                  "end_time_iso.$": "$$.Execution.StartTime",
+                  "dry_run_llm.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 900,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Eval observability layer \u2014 failures must NOT halt the pipeline.",
+                  "Next": "CheckSkipReplayConcordance",
+                  "ResultPath": "$.rationale_clustering_error"
+                }
+              ],
+              "ResultPath": "$.rationale_clustering_result",
+              "Next": "CheckSkipReplayConcordance"
+            },
+            "CheckSkipReplayConcordance": {
+              "Type": "Choice",
+              "Comment": "Skip-gate. {\"skip_replay_concordance\": true} bypasses the cheap-model concordance Lambda (used for ad-hoc reruns where Anthropic spend is unwanted, or while iterating on the comparison scorers in alpha-engine-backtester replay/comparison.py). Independent of skip_rationale_clustering and skip_counterfactual \u2014 the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.skip_replay_concordance",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.skip_replay_concordance",
+                      "BooleanEquals": true
+                    }
+                  ],
+                  "Next": "CheckSkipCounterfactual"
+                }
+              ],
+              "Default": "ReplayConcordance"
+            },
+            "ReplayConcordance": {
+              "Type": "Task",
+              "Comment": "Weekly cheap-model concordance Lambda (ROADMAP P0, agent-justification gate signal #3). Replays each captured DecisionArtifact in the trailing 8-week window under the configured target model(s) via langchain_anthropic.with_structured_output against the canonical agent_schemas Pydantic contract; aggregates agreement_score per (agent_id_base, target_model); emits CW metric agent_cheap_model_concordance; persists per-target summary JSON to decision_artifacts/_replay_summary/{YYYY-MM-DD}/{target_model}.json. Default target: claude-haiku-4-5 (Sonnet\u2192Haiku concordance \u2248 \"is the larger model earning its cost?\"). Runs every Saturday after RationaleClustering.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-replay-concordance:live",
+                "Payload": {
+                  "end_time_iso.$": "$$.Execution.StartTime",
+                  "target_models": [
+                    "claude-haiku-4-5"
+                  ],
+                  "window_days": 56,
+                  "max_artifacts": 150,
+                  "dry_run_llm.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 900,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Eval observability layer \u2014 concordance failure must NOT halt the pipeline. Same Catch pattern as eval-judge / eval-rolling-mean / rationale-clustering.",
+                  "Next": "CheckSkipCounterfactual",
+                  "ResultPath": "$.replay_concordance_error"
+                }
+              ],
+              "ResultPath": "$.replay_concordance_result",
+              "Next": "CheckSkipCounterfactual"
+            },
+            "CheckSkipCounterfactual": {
+              "Type": "Choice",
+              "Comment": "Skip-gate. {\"skip_counterfactual\": true} bypasses the counterfactual rule fit Lambda (used for ad-hoc reruns while iterating on the per-agent feature extractors in alpha-engine-backtester replay/counterfactual.py). Independent of skip_rationale_clustering and skip_replay_concordance \u2014 the three are independent agent-justification signals. Standalone invocation of the Lambda is always available regardless of this flag. Post-2026-05-07 reorder, exits to CheckSkipPredictorTraining (was SaturdayHealthCheck) \u2014 the judge chain now runs before predictor so its results are available to evaluator's email.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.skip_counterfactual",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.skip_counterfactual",
+                      "BooleanEquals": true
+                    }
+                  ],
+                  "Next": "CheckSkipAggregateCosts"
+                }
+              ],
+              "Default": "Counterfactual"
+            },
+            "Counterfactual": {
+              "Type": "Task",
+              "Comment": "Weekly counterfactual rule fit Lambda (ROADMAP P0, agent-justification gate signal #2 \u2014 does the agent reduce to a 3-deep decision tree?). Trains DecisionTreeClassifier(max_depth=3) per supported agent on (input \u2192 decision) pairs from the trailing 8-week decision_artifacts/ corpus; emits CW metric agent_counterfactual_rule_fit per (judged_agent_id); persists per-agent JSON to decision_artifacts/_counterfactual/{agent_id_base}/{YYYY-WW}.json including tree_text + feature_importances. v1 covers ic_cio + macro_economist; other agents emit UNSUPPORTED markers. $0 ongoing \u2014 no LLM calls. Post-2026-05-07 reorder, runs after ReplayConcordance and exits to CheckSkipPredictorTraining (was SaturdayHealthCheck), so its persisted artifacts are available to Evaluator downstream.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-replay-counterfactual:live",
+                "Payload": {
+                  "end_time_iso.$": "$$.Execution.StartTime",
+                  "window_days": 56,
+                  "max_depth": 3,
+                  "dry_run_llm.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 600,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Eval observability layer \u2014 counterfactual failure must NOT halt the pipeline. Same Catch pattern as the rest of the agent-justification triple. Routes to CheckSkipAggregateCosts so the cost-telemetry aggregation step still runs even when counterfactual fails (the JSONLs the aggregator reads were written by Research / eval-judge / rationale-clustering / replay-concordance / counterfactual independently; a counterfactual failure doesn't invalidate the upstream cost rows).",
+                  "Next": "CheckSkipAggregateCosts",
+                  "ResultPath": "$.counterfactual_error"
+                }
+              ],
+              "ResultPath": "$.counterfactual_result",
+              "Next": "CheckSkipAggregateCosts"
+            },
+            "CheckSkipAggregateCosts": {
+              "Type": "Choice",
+              "Comment": "Skip-gate. {\"skip_aggregate_costs\": true} bypasses the daily cost-telemetry aggregation Lambda (used for ad-hoc reruns where the cost parquet for the date is already current, or when iterating on the aggregator script). Standalone invocation of the Lambda is always available via the deploy.sh aggregate_costs target. Independent of skip_rationale_clustering / skip_replay_concordance / skip_counterfactual \u2014 the four are independent observability paths.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.skip_aggregate_costs",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.skip_aggregate_costs",
+                      "BooleanEquals": true
+                    }
+                  ],
+                  "Next": "ReportCard"
+                }
+              ],
+              "Default": "AggregateCosts"
+            },
+            "AggregateCosts": {
+              "Type": "Task",
+              "Comment": "Daily cost-telemetry aggregation Lambda (ROADMAP L1146 \u2014 SF-wire scripts/aggregate_costs.py CLI). Reads decision_artifacts/_cost_raw/{run_date}/*.jsonl (written by Research / eval-judge / rationale-clustering / replay-concordance / counterfactual during the upstream chain), writes the daily parquet at decision_artifacts/_cost/{run_date}/cost.parquet, emits per-agent CW metrics under AlphaEngine/Cost. Placed at end of Branch A so all LLM-emitting upstream states have written their cost JSONL rows by the time the aggregator runs. Failure is non-blocking (Catch routes to BranchAComplete) \u2014 cost telemetry is observability, NOT a primary deliverable; aggregator failure does NOT regress the alpha pipeline. Status contract OK / SKIPPED / ERROR mirrors data #295 + L3277 audit \u2014 SKIPPED on no _cost_raw partitions for the date is a legitimate upstream no-op and treated as success.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-research-aggregate-costs:live",
+                "Payload": {
+                  "date.$": "$.run_date",
+                  "dry_run_llm.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 600,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 60,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Cost-telemetry aggregation is observability \u2014 failure must NOT halt the pipeline. The next Saturday SF will retry over a fresh _cost_raw partition; the prior week's parquet (or the manual-trigger fallback via scripts/aggregate_costs.py) remains available.",
+                  "Next": "ReportCard",
+                  "ResultPath": "$.aggregate_costs_error"
+                }
+              ],
+              "ResultPath": "$.aggregate_costs_result",
+              "Next": "ReportCard"
+            },
+            "ReportCard": {
+              "Type": "Task",
+              "Comment": "Evaluator Report Card v2 (Layer B, Option B) \u2014 builds s3://alpha-engine-research/evaluator/{date}/report_card.json from the persisted per-module artifacts (the 7-tile MetricRecord substrate the Director will consume). Runs here, after the Evaluator + substrate health checks, so it reads fresh grades. NON-FATAL: its own Catch routes to CheckShellRunNotify so an advisory grading failure never breaks the run that produced the real trading artifacts. PREFLIGHT-AWARE (ROADMAP L4504): dry_run.$=$.research_dry (the canonical shell-run-dry signal \u2014 false on the real Saturday run, true on the Friday-PM Preflight Pipeline). On the preflight the handler still exercises the full read+compute path (container boot, lib/numpy/pandas imports, S3-read IAM/transport, the tile compute) but does NOT persist the degenerate, mostly-N/A preflight card \u2014 mirrors how the other advisory Lambdas (eval-judge / rationale-clustering / replay-concordance / counterfactual) run dry rather than skip, per the shell-run keystone's 'dry-execute, don't skip' principle. alpha-engine-config-I2556 (2026-07-14): Payload now carries \"snapshot\": true \u2014 this Saturday-cadence invocation is the WEEKLY FREEZE that writes the dated historical card (persistent report card with weekly snapshots). The Sunday ModelZoo child SF's re-grade tail (GradingLambdaReGrade, step_function_modelzoo.json) passes \"snapshot\": false \u2014 it only refreshes the standing latest.json, never a second same-week snapshot. Evaluator-side handler support for the flag ships separately (I2556, crucible-evaluator); an unrecognized event field is ignored harmlessly by the CURRENT handler, so wiring the payload ahead of that landing is safe and forward-correct.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-evaluator:live",
+                "Payload": {
+                  "date.$": "$.run_date",
+                  "dry_run.$": "$.research_dry",
+                  "snapshot": true
+                }
+              },
+              "TimeoutSeconds": 300,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Advisory grading is non-fatal \u2014 continue to the terminal notify regardless. config#2302: the run must still PAGE on entry (silent for 9 days pre-fix), so route through PublishReportCardDegraded before the terminal notify rather than swallowing the error.",
+                  "Next": "PublishReportCardDegraded",
+                  "ResultPath": "$.report_card_error"
+                }
+              ],
+              "ResultPath": "$.report_card_result",
+              "Next": "Director"
+            },
+            "PublishReportCardDegraded": {
+              "Type": "Task",
+              "Comment": "config#2302: ReportCard's Catch(States.ALL) used to route straight to CheckShellRunNotify with no alert \u2014 the 2026-07 incident where the evaluator Lambda died silently for 9 days. Mirrors PublishLibPinGateDegraded's shape exactly (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure can never block the non-fatal advisory-grading path this alert decorates). WARNING severity, not FAILED \u2014 the weekly run's real trading artifacts are unaffected; only the advisory grading layer degraded.",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject": "Alpha Engine Weekly Pipeline \u2014 ReportCard WARNING (Advisory Grading Degraded)",
+                "Message": "ReportCard (the Evaluator Report Card v2 Lambda) failed \u2014 see $.report_card_error on the execution record for detail. This is NON-FATAL: the weekly run's real trading artifacts are unaffected, but the advisory grading layer (report_card.json, and downstream Director) did not run. View pipeline status: https://console.nousergon.ai/pipeline-status"
+              },
+              "ResultPath": "$.report_card_degraded_notify",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort alert \u2014 a publish failure must not block the non-fatal advisory path this alert decorates.",
+                  "ResultPath": "$.report_card_degraded_notify_error",
+                  "Next": "AdvisoryNotifyComplete"
+                }
+              ],
+              "Next": "AdvisoryNotifyComplete"
+            },
+            "Director": {
+              "Type": "Task",
+              "Comment": "Director (Layer C, Part II) \u2014 the FINAL Saturday-SF task. A single structured Opus call over the fresh Report Card v2 (evaluator/{date}/report_card.json) produces an advisory DirectorWeeklyActionPlan at director/{date}/action_plan.json + updates the carry-over ledger. Runs only after a SUCCESSFUL ReportCard (a failed ReportCard skips straight to notify \u2014 no card to weigh). FLAG-GATED: the alpha-engine-evaluator-director Lambda is a no-op (status=disabled) until DIRECTOR_ENABLED is flipped on. NON-FATAL: its own Catch routes to CheckShellRunNotify so an advisory failure never breaks the run that produced the real trading artifacts. PREFLIGHT-AWARE (ROADMAP L4504): dry_run.$=$.research_dry. On the Friday-PM Preflight Pipeline (research_dry=true) the handler runs a no-Opus / no-write PROBE \u2014 it constructs the real Opus client (exercising the langchain-anthropic import + the SSM ANTHROPIC_API_KEY fetch / ReadAnthropicSecret IAM grant) and reads the carry-over ledger, then STOPS short of the paid .invoke() and writes NOTHING (no action_plan, no ledger mutation). This is load-bearing: the carry-over ledger is shared + non-date-scoped (director/carryover_ledger.json), so a preflight write would pollute the real Saturday run. A broken import / revoked key grant surfaces as a caught preflight failure ~18h before the real Saturday Director would hit it.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-evaluator-director:live",
+                "Payload": {
+                  "date.$": "$.run_date",
+                  "dry_run.$": "$.research_dry"
+                }
+              },
+              "TimeoutSeconds": 300,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Advisory Director is non-fatal \u2014 continue to the terminal notify regardless. config#2302: the run must still PAGE on entry, so route through PublishDirectorDegraded before the terminal notify rather than swallowing the error.",
+                  "Next": "PublishDirectorDegraded",
+                  "ResultPath": "$.director_error"
+                }
+              ],
+              "ResultPath": "$.director_result",
+              "Next": "AdvisoryNotifyComplete"
+            },
+            "PublishDirectorDegraded": {
+              "Type": "Task",
+              "Comment": "config#2302: Director's Catch(States.ALL) used to route straight to CheckShellRunNotify with no alert \u2014 same silent-swallow class as ReportCard's pre-fix Catch (the 2026-07 9-day-silent incident). Mirrors PublishLibPinGateDegraded's shape exactly (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure can never block the non-fatal advisory path this alert decorates). WARNING severity, not FAILED \u2014 the weekly run's real trading artifacts are unaffected; only the advisory Director layer degraded.",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject": "Alpha Engine Weekly Pipeline \u2014 Director WARNING (Advisory Action Plan Degraded)",
+                "Message": "Director (the Evaluator Director Lambda) failed \u2014 see $.director_error on the execution record for detail. This is NON-FATAL: the weekly run's real trading artifacts are unaffected, but the advisory Director layer (action_plan.json, carry-over ledger update) did not run. View pipeline status: https://console.nousergon.ai/pipeline-status"
+              },
+              "ResultPath": "$.director_degraded_notify",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort alert \u2014 a publish failure must not block the non-fatal advisory path this alert decorates.",
+                  "ResultPath": "$.director_degraded_notify_error",
+                  "Next": "AdvisoryNotifyComplete"
+                }
+              ],
+              "Next": "AdvisoryNotifyComplete"
+            },
+            "AdvisoryNotifyComplete": {
+              "Type": "Task",
+              "Comment": "Advisory child SF (alpha-engine-config-I2544) success notifier. Mirrors the parent Saturday SF's NotifyComplete exactly (config#1819: constants-only Subject/Message, best-effort Catch to AdvisoryNotifyCompleteDegraded) so a publish failure can never fail an otherwise-successful advisory run. Reached whether ReportCard/Director succeeded, degraded, or (ReportCard only) were skipped by a failure.",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject": "Alpha Engine Weekly Advisory Pipeline \u2014 SUCCESS",
+                "Message": "The weekly advisory child pipeline (eval-judge chain, EvalRollingMean, RationaleClustering, ReplayConcordance, Counterfactual, AggregateCosts, ReportCard, Director) completed. Any individual-stage degradation was already alerted separately (ReportCard/Director WARNING notices) \u2014 this confirms the child execution itself reached its terminal state. View pipeline status: https://console.nousergon.ai/pipeline-status"
+              },
+              "ResultPath": "$.notify_result",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "config#1819 \u2014 best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded child execution.",
+                  "ResultPath": "$.notify_error",
+                  "Next": "AdvisoryNotifyCompleteDegraded"
+                }
+              ],
+              "End": true
+            },
+            "AdvisoryNotifyCompleteDegraded": {
+              "Type": "Pass",
+              "Comment": "config#1819 \u2014 records the caught publish failure as execution DATA, mirroring the parent SF's NotifyCompleteDegraded.",
+              "Parameters": {
+                "degraded": true,
+                "source": "AdvisoryNotifyComplete",
+                "error.$": "$.notify_error"
+              },
+              "ResultPath": "$.notify_degraded",
+              "End": true
+            }
+          }
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "AdvisoryNormalizeFailureContext",
+          "ResultPath": "$.error"
+        }
+      ],
+      "End": true
+    },
+    "AdvisoryNormalizeFailureContext": {
+      "Type": "Pass",
+      "Comment": "Single Catch/Next funnel before AdvisoryHandleFailure, mirroring the parent SF's NormalizeFailureContext (config#1819 class) \u2014 guarantees $.error/$.sns_topic_arn are present regardless of what the wrapper Parallel's Catch populated.",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"error\":{\"phase\":\"Unknown\",\"source\":\"AdvisoryNormalizeFailureContext\",\"detail\":\"no $.error was set by the upstream Catch\"},\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),$,false)"
+      },
+      "OutputPath": "$.merged",
+      "Next": "AdvisoryHandleFailure"
+    },
+    "AdvisoryHandleFailure": {
+      "Type": "Task",
+      "Comment": "Failure alert via SNS \u2014 advisory child pipeline halted on a genuine SF-engine-level error escaping the wrapper Parallel (every lifted state's OWN failure path is non-fatal by design, so this is a rare backstop, not the common case). Subject is a hardcoded constant (no user-controlled pipeline_label threading here, unlike the parent \u2014 this child has no shell-run/preflight identity of its own), so it can never violate the SNS Subject <=100-char/no-newline contract (config#1819 class).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekly Advisory Pipeline \u2014 FAILED",
+        "Message.$": "States.Format('Weekly Advisory Pipeline (eval-judge chain / ReportCard / Director) failed at the SF-engine level (this is a backstop path \u2014 the advisory chain'\\''s own stages are individually non-fatal by design). Error: {}. This pipeline was started fire-and-forget by the main Saturday SF and does NOT block trading-critical artifacts. View pipeline status: https://console.nousergon.ai/pipeline-status', States.JsonToString($.error))"
+      },
+      "ResultPath": "$.failure_notify",
+      "Next": "AdvisoryFailExecution"
+    },
+    "AdvisoryFailExecution": {
+      "Type": "Fail",
+      "Error": "AdvisoryPipelineFailure",
+      "Cause": "The advisory child SF failed at the SF-engine level. Check CloudWatch Logs (/aws/stepfunctions/ne-weekly-advisory-pipeline) for details. This pipeline is non-trading-critical (eval-judge / ReportCard / Director advisory tail) \u2014 the main Saturday SF's trading-critical artifacts are unaffected."
+    }
+  }
+}

--- a/infrastructure/step_function_modelzoo.json
+++ b/infrastructure/step_function_modelzoo.json
@@ -1,0 +1,643 @@
+{
+  "Comment": "Alpha Engine ModelZoo Sunday Pipeline (alpha-engine-config-I2545, Phase 3 of the weekly-SF load-reduction plan) \u2014 the ModelZoo rotation (ResolveZooSpecs \u2192 ModelZooTrainMap \u2192 ModelZooSelect, up to 4 concurrent EC2-spot training boxes) moved OFF Saturday to its own Sunday 09:00 UTC trigger (Brian-ruled 2026-07-14: full-day retry headroom before Monday 12:45 UTC preopen). Triggered directly by EventBridge (ModelZooSundayTrigger, cron(0 9 ? * SUN *)) \u2014 NOT started by the Saturday SF, unlike the advisory child. Ends with a re-invoke of the crucible-evaluator grading Lambda (GradingLambdaReGrade) as the persistent-dash re-grade (Brian-ruled 2026-07-14: the grading Lambda is stateless/pull-based and keys to trading_day, so a Sunday run updates the SAME Friday card the Saturday run wrote \u2014 full re-grade, not tile-scoped, no new eval micromodule). Internal state order and every lifted state's Payload/Retry/Catch semantics are PRESERVED byte-for-byte from step_function.json \u2014 only the terminal edges (BranchBComplete \u2192 GradingLambdaReGrade) were rewired, since this child has no Parallel join of its own. run_date is the Sunday execution's own calendar date (see InitializeModelZooInput's Comment for why this is correct for the grading tail, and the flagged, NOT-closed cross-repo audit gap for the zoo Task states' own internal date handling). Deploy path mirrors step_function.json's single-writer contract (config#2273). Failure visibility: TopLevel TimeoutSeconds=21600 (6h \u2014 ResolveZooSpecs 11min + ModelZooTrainMap's 91min-per-spec ceiling at MaxConcurrency 4 + ModelZooSelect's 91min ceiling + the grading tail, with headroom; well inside the ~27h Sunday-09:00-UTC-to-Monday-12:45-UTC retry window) yields TIMED_OUT on a hang, matched by the saturday-sf-watch-dispatcher registration (see PIPELINES in infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py). A genuine SF-engine-level error is caught by the single-branch Parallel wrapper and alerted via ModelZooHandleFailure \u2192 ModelZooFailExecution, mirroring the parent SF's failure-handling shape in miniature. Retry-ladder convention (config#2279): the three lifted spot-stage sendCommand states (ResolveZooSpecs/TrainSpecDispatch/ModelZooSelect) keep their declared gold 4+2 jittered ladder verbatim \u2014 verified by tests/test_sf_retry_ladder_convention.py.",
+  "StartAt": "InitializeModelZooInput",
+  "TimeoutSeconds": 21600,
+  "States": {
+    "InitializeModelZooInput": {
+      "Type": "Pass",
+      "Comment": "Layer defaults under the child execution input, mirroring the parent SF's InitializeInput idiom. run_date is stamped from $$.Execution.StartTime \u2014 the SUNDAY execution's OWN calendar date, which is DELIBERATE and correct for the ONE consumer that reads $.run_date in this child (GradingLambdaReGrade): trading_day = last_closed_trading_day(now) is backward-looking (CLAUDE.md date convention), and neither Saturday nor Sunday is a trading day, so BOTH resolve to the identical last-closed Friday trading_day \u2014 a Sunday run correctly updates the SAME report_card.json the Saturday run wrote, per Brian's 2026-07-14 ruling. IMPORTANT CAVEAT (flagged, not resolved, by this build \u2014 see alpha-engine-config-I2545's original body, 'audit the promotion/alert code for date-coupling before moving'): the lifted ResolveZooSpecs / ModelZooTrainMap / ModelZooSelect Task states do NOT reference $.run_date at all in this SF (verified \u2014 none of their Payload/commands read it); their artifact dating is entirely internal to alpha-engine-predictor's box-side scripts (training.model_zoo / spot_train.sh --model-zoo-*). If those scripts derive 'today' via wall-clock date() rather than proper trading-day math, moving this rotation from Saturday to Sunday could misdate their artifacts \u2014 this is a cross-repo (alpha-engine-predictor) audit this SF-only change cannot verify and does NOT close; tracked as a follow-up rather than assumed safe.",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"preflight_args\":\"\",\"research_dry\":false,\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('{\"run_date\":\"{}\"}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
+      },
+      "OutputPath": "$.merged",
+      "Next": "ModelZooPipelineWrapper"
+    },
+    "ModelZooPipelineWrapper": {
+      "Type": "Parallel",
+      "Comment": "Single-branch wrapper giving the ModelZoo Sunday pipeline a machine-level catch-all WITHOUT altering any lifted state's own Payload/Retry/Catch (every lifted state's own failure path is already best-effort/non-fatal by original design \u2014 'the rotation must NEVER fail the branch'). This Catch is a backstop for a genuine SF-engine-level error only.",
+      "Branches": [
+        {
+          "StartAt": "ResolveZooSpecs",
+          "States": {
+            "ResolveZooSpecs": {
+              "Type": "Task",
+              "Comment": "config#1083 PARALLEL fan-out, step 1 (dispatcher SSM on the box, fast, NO spot): resolve the spec ids this rotation should train via list-rotation-specs, emitting a JSON array on stdout (the budget-N stalest active specs). The preamble (git pull + config stage) is redirected to stderr so StandardOutputContent is JUST the array, which ParseZooSpecs lifts into $.zoo_specs (the Map ItemsPath). BEST-EFFORT: a resolve/parse failure routes to PublishModelZooFailureImmediate then BranchBComplete (the champion already trained+promoted; the rotation must NEVER fail the Saturday SF).",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+              "Parameters": {
+                "DocumentName": "AWS-RunShellScript",
+                "InstanceIds.$": "$.ec2_instance_id",
+                "Parameters": {
+                  "commands.$": "States.Array('set -eo pipefail','{ sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main; sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main; sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml; } 1>&2','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference','/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m training.model_zoo list-rotation-specs --bucket alpha-engine-research 2>/dev/null')",
+                  "executionTimeout": [
+                    "600"
+                  ]
+                },
+                "TimeoutSeconds": 600
+              },
+              "TimeoutSeconds": 660,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "States.TaskFailed",
+                    "States.Timeout"
+                  ],
+                  "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+                  "MaxAttempts": 4,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0,
+                  "MaxDelaySeconds": 300,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0,
+                  "MaxDelaySeconds": 300,
+                  "JitterStrategy": "FULL"
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: resolve failure must NEVER fail the branch. Alert (not silent) then converge to BranchBComplete.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultPath": "$.resolve_zoo_result",
+              "Next": "WaitResolveZoo"
+            },
+            "WaitResolveZoo": {
+              "Type": "Task",
+              "Comment": "Poll the ResolveZooSpecs SSM command; capture StandardOutputContent (the JSON spec-id array).",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+              "Parameters": {
+                "CommandId.$": "$.resolve_zoo_result.Command.CommandId",
+                "InstanceId.$": "$.ec2_instance_id[0]"
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Ssm.InvocationDoesNotExistException",
+                    "Ssm.InvocationDoesNotExist"
+                  ],
+                  "MaxAttempts": 10,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
+                  "BackoffRate": 1.5
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: poll failure routes via the alert, never to BranchBFailed.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultSelector": {
+                "Status.$": "$.Status",
+                "ResponseCode.$": "$.ResponseCode",
+                "StatusDetails.$": "$.StatusDetails",
+                "StandardErrorContent.$": "$.StandardErrorContent",
+                "StandardOutputContent.$": "$.StandardOutputContent"
+              },
+              "ResultPath": "$.resolve_zoo_poll",
+              "Next": "CheckResolveZooStatus"
+            },
+            "CheckResolveZooStatus": {
+              "Type": "Choice",
+              "Comment": "Success leads to ParseZooSpecs (lift the JSON array); InProgress/Pending wait; anything else alerts then BranchBComplete (best-effort).",
+              "Choices": [
+                {
+                  "Variable": "$.resolve_zoo_poll.Status",
+                  "StringEquals": "InProgress",
+                  "Next": "ResolveZooWait"
+                },
+                {
+                  "Variable": "$.resolve_zoo_poll.Status",
+                  "StringEquals": "Pending",
+                  "Next": "ResolveZooWait"
+                },
+                {
+                  "Variable": "$.resolve_zoo_poll.Status",
+                  "StringEquals": "Success",
+                  "Next": "ParseZooSpecs"
+                }
+              ],
+              "Default": "ExtractModelZooResolveError"
+            },
+            "ExtractModelZooResolveError": {
+              "Type": "Pass",
+              "Comment": "Normalize ResolveZooSpecs SSM non-Success poll into $.model_zoo_error. Mirrors ExtractPredictorError/ExtractSignalsEnvelopeError/ExtractRAGIngestionError \u2014 CheckResolveZooStatus.Default does not populate $.model_zoo_error the way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's Message calls States.JsonToString($.model_zoo_error): a direct Choice->Task jump on this edge died with States.Runtime ('$.model_zoo_error could not be found'), masking the real zoo-resolve failure behind an opaque meta-error (observed live 2026-07-10, execution offcycle-shell-20260710-220932; config#2160 arc).",
+              "Parameters": {
+                "phase": "ModelZooResolve",
+                "source": "CheckResolveZooStatus.Default",
+                "poll.$": "$.resolve_zoo_poll"
+              },
+              "ResultPath": "$.model_zoo_error",
+              "Next": "PublishModelZooFailureImmediate"
+            },
+            "ResolveZooWait": {
+              "Type": "Wait",
+              "Seconds": 15,
+              "Next": "WaitResolveZoo"
+            },
+            "ParseZooSpecs": {
+              "Type": "Pass",
+              "Comment": "config#1083: lift the resolved JSON spec-id array (StandardOutputContent of ResolveZooSpecs) into $.zoo_specs for the Map ItemsPath. Reached ONLY after CheckResolveZooStatus=Success, where the SSM command exited 0 and stdout is the CLI json.dumps(ids) output - always a valid JSON array (possibly empty, which runs zero Map iterations; ModelZooSelect then handles the empty pool). A Pass state cannot carry a Catch (it cannot throw); the upstream poll-status gate is the failure boundary - any non-success ResolveZooSpecs outcome routes to PublishModelZooFailureImmediate BEFORE this state is reached.",
+              "Parameters": {
+                "zoo_specs.$": "States.StringToJson($.resolve_zoo_poll.StandardOutputContent)"
+              },
+              "ResultPath": "$.parsed_zoo",
+              "Next": "ModelZooTrainMap"
+            },
+            "ModelZooTrainMap": {
+              "Type": "Map",
+              "Comment": "config#1083 PARALLEL fan-out, step 2: train one challenger PER spec id, each on its OWN memory-isolated spot, concurrently. MaxConcurrency 4 bounds in-flight spots. PER-ITERATION ERROR ISOLATION (the key robustness property): each iteration ends in a branch-local Pass terminal (TrainSpecOK / TrainSpecFailed, both End:true) recording status as DATA so an iteration NEVER throws; a single challenger crashing (OOM / KeyError / spot interruption) does NOT abort its siblings; selection proceeds with the survivors. ToleratedFailurePercentage 100 is a defense-in-depth backstop (iterations already self-terminate as success). ItemSelector threads ec2_instance_id + preflight_args + the per-item spec id into each iteration.",
+              "ItemsPath": "$.parsed_zoo.zoo_specs",
+              "MaxConcurrency": 4,
+              "ToleratedFailurePercentage": 100,
+              "ItemSelector": {
+                "spec_id.$": "$$.Map.Item.Value",
+                "ec2_instance_id.$": "$.ec2_instance_id",
+                "preflight_args.$": "$.preflight_args"
+              },
+              "ItemProcessor": {
+                "ProcessorConfig": {
+                  "Mode": "INLINE"
+                },
+                "StartAt": "TrainSpecDispatch",
+                "States": {
+                  "TrainSpecDispatch": {
+                    "Type": "Task",
+                    "Comment": "Launch a dedicated spot for THIS spec via spot_train.sh --model-zoo-spec <id>. Dispatcher SSM on the box (the script launches the actual spot internally). Honors $.preflight_args for shell-run dry mode.",
+                    "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+                    "Parameters": {
+                      "DocumentName": "AWS-RunShellScript",
+                      "InstanceIds.$": "$.ec2_instance_id",
+                      "Parameters": {
+                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
+                        "executionTimeout": [
+                          "5400"
+                        ]
+                      },
+                      "TimeoutSeconds": 5400
+                    },
+                    "TimeoutSeconds": 5460,
+                    "Retry": [
+                      {
+                        "ErrorEquals": [
+                          "States.TaskFailed",
+                          "States.Timeout"
+                        ],
+                        "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+                        "MaxAttempts": 4,
+                        "IntervalSeconds": 30,
+                        "BackoffRate": 2.0,
+                        "MaxDelaySeconds": 300,
+                        "JitterStrategy": "FULL"
+                      },
+                      {
+                        "ErrorEquals": [
+                          "States.ALL"
+                        ],
+                        "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
+                        "MaxAttempts": 2,
+                        "IntervalSeconds": 30,
+                        "BackoffRate": 2.0,
+                        "MaxDelaySeconds": 300,
+                        "JitterStrategy": "FULL"
+                      }
+                    ],
+                    "Catch": [
+                      {
+                        "ErrorEquals": [
+                          "States.ALL"
+                        ],
+                        "Comment": "This spec dispatch failed; record as data, do NOT throw (sibling iterations must proceed).",
+                        "Next": "TrainSpecFailed",
+                        "ResultPath": "$.error"
+                      }
+                    ],
+                    "ResultPath": "$.train_spec_result",
+                    "Next": "WaitTrainSpec"
+                  },
+                  "WaitTrainSpec": {
+                    "Type": "Task",
+                    "Comment": "Poll this spec SSM command until complete.",
+                    "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+                    "Parameters": {
+                      "CommandId.$": "$.train_spec_result.Command.CommandId",
+                      "InstanceId.$": "$.ec2_instance_id[0]"
+                    },
+                    "Retry": [
+                      {
+                        "ErrorEquals": [
+                          "Ssm.InvocationDoesNotExistException",
+                          "Ssm.InvocationDoesNotExist"
+                        ],
+                        "MaxAttempts": 10,
+                        "IntervalSeconds": 30,
+                        "BackoffRate": 1.5
+                      },
+                      {
+                        "ErrorEquals": [
+                          "Ssm.SdkClientException",
+                          "States.Timeout"
+                        ],
+                        "MaxAttempts": 2,
+                        "IntervalSeconds": 5,
+                        "BackoffRate": 1.5
+                      }
+                    ],
+                    "Catch": [
+                      {
+                        "ErrorEquals": [
+                          "States.ALL"
+                        ],
+                        "Comment": "Poll failure for this spec; record as data, never throw.",
+                        "Next": "TrainSpecFailed",
+                        "ResultPath": "$.error"
+                      }
+                    ],
+                    "ResultSelector": {
+                      "Status.$": "$.Status",
+                      "ResponseCode.$": "$.ResponseCode",
+                      "StatusDetails.$": "$.StatusDetails",
+                      "StandardErrorContent.$": "$.StandardErrorContent"
+                    },
+                    "ResultPath": "$.train_spec_poll",
+                    "Next": "CheckTrainSpecStatus"
+                  },
+                  "CheckTrainSpecStatus": {
+                    "Type": "Choice",
+                    "Comment": "Success leads to TrainSpecOK; InProgress/Pending wait; anything else (this spec spot OOM/errored) leads to TrainSpecFailed (recorded as data, NOT a throw, so siblings proceed - the per-spec isolation win).",
+                    "Choices": [
+                      {
+                        "Variable": "$.train_spec_poll.Status",
+                        "StringEquals": "InProgress",
+                        "Next": "TrainSpecWait"
+                      },
+                      {
+                        "Variable": "$.train_spec_poll.Status",
+                        "StringEquals": "Pending",
+                        "Next": "TrainSpecWait"
+                      },
+                      {
+                        "Variable": "$.train_spec_poll.Status",
+                        "StringEquals": "Success",
+                        "Next": "TrainSpecOK"
+                      }
+                    ],
+                    "Default": "TrainSpecFailed"
+                  },
+                  "TrainSpecWait": {
+                    "Type": "Wait",
+                    "Seconds": 60,
+                    "Next": "WaitTrainSpec"
+                  },
+                  "TrainSpecOK": {
+                    "Type": "Pass",
+                    "Comment": "This spec trained + registered its challenger. End:true so the Map iteration SUCCEEDS (never cancels sibling iterations).",
+                    "Parameters": {
+                      "spec_status": "OK",
+                      "spec_id.$": "$.spec_id"
+                    },
+                    "End": true
+                  },
+                  "TrainSpecFailed": {
+                    "Type": "Pass",
+                    "Comment": "This spec training failed (spot OOM / KeyError / interruption). Records status as DATA + End:true so the iteration SUCCEEDS in SF terms - the failure is isolated to THIS spec, siblings proceed, and ModelZooSelect simply finds this spec challenger absent from the registry (tolerated). The full failure log is on the box (predictor-model-zoo-spec.log) + durable in S3 via ssm_log_capture (config#272).",
+                    "Parameters": {
+                      "spec_status": "FAILED",
+                      "spec_id.$": "$.spec_id"
+                    },
+                    "End": true
+                  }
+                }
+              },
+              "ResultPath": "$.zoo_train_results",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Backstop ONLY for a genuine Map-engine error (iterations never throw - they end success with status data). Best-effort: alert then BranchBComplete (the champion is already live). ModelZooSelect will still run on whatever registered.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "Next": "ModelZooSelect"
+            },
+            "ModelZooSelect": {
+              "Type": "Task",
+              "Comment": "config#1083 PARALLEL fan-out, step 3 (ONE spot, after the Map joins): select over whatever spec-* challengers registered for the date (failed Map iterations are simply absent - tolerated), write the leaderboard to BOTH the dated key AND latest.json, promote the winner if MODEL_ZOO_AUTO_PROMOTE_WINNER, and send the ONE consolidated digest. BEST-EFFORT: every failure path routes to PublishModelZooFailureImmediate then BranchBComplete (the champion already trained+promoted; the rotation must NEVER fail the Saturday SF). The base champion-arch retrain (PredictorTraining) ran first and competes in the same pool.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+              "Parameters": {
+                "DocumentName": "AWS-RunShellScript",
+                "InstanceIds.$": "$.ec2_instance_id",
+                "Parameters": {
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_train.sh --model-zoo-select{}',$.preflight_args))",
+                  "executionTimeout": [
+                    "5400"
+                  ]
+                },
+                "TimeoutSeconds": 5400
+              },
+              "TimeoutSeconds": 5460,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "States.TaskFailed",
+                    "States.Timeout"
+                  ],
+                  "Comment": "config#2279: declared spot-stage sendCommand convention \u2014 the 4+2 jittered ladder (mirrors MorningEnrich/DataPhase1/RAGIngestion, the gold standard). SAFE to widen here: this state's Retry fires only when the SendCommand API call itself failed (throttle/5xx/dead dispatch box) \u2014 BEFORE the launcher command ever ran, so no spot was launched and no partial S3 writes exist; post-delivery outcomes are owned by the WaitFor* poll loop + Check*Status gate, which this ladder never re-enters.",
+                  "MaxAttempts": 4,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0,
+                  "MaxDelaySeconds": 300,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "config#2279: catch-all transient tier \u2014 same idempotency argument as the tier above.",
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0,
+                  "MaxDelaySeconds": 300,
+                  "JitterStrategy": "FULL"
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: a select failure must NEVER fail the branch. Alert (not silent) then converge to BranchBComplete.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultPath": "$.model_zoo_result",
+              "Next": "WaitForModelZoo"
+            },
+            "WaitForModelZoo": {
+              "Type": "Task",
+              "Comment": "Poll the ModelZooSelect SSM command until complete.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+              "Parameters": {
+                "CommandId.$": "$.model_zoo_result.Command.CommandId",
+                "InstanceId.$": "$.ec2_instance_id[0]"
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Ssm.InvocationDoesNotExistException",
+                    "Ssm.InvocationDoesNotExist"
+                  ],
+                  "MaxAttempts": 10,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
+                  "BackoffRate": 1.5
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: poll failure must not fail the branch - but must not be SILENT either (the base retrain deferred its email to the zoo digest). Alert via PublishModelZooFailureImmediate, then converge to BranchBComplete.",
+                  "Next": "PublishModelZooFailureImmediate",
+                  "ResultPath": "$.model_zoo_error"
+                }
+              ],
+              "ResultSelector": {
+                "Status.$": "$.Status",
+                "ResponseCode.$": "$.ResponseCode",
+                "StatusDetails.$": "$.StatusDetails",
+                "StandardErrorContent.$": "$.StandardErrorContent"
+              },
+              "ResultPath": "$.model_zoo_poll",
+              "Next": "CheckModelZooStatus"
+            },
+            "CheckModelZooStatus": {
+              "Type": "Choice",
+              "Comment": "Any non-success routes to PublishModelZooFailureImmediate (SNS alert) then BranchBComplete - selection is best-effort and its failure is logged on the box (predictor-model-zoo-select.log); the champion is already live. The alert is required because PREDICTOR_DEFER_TRAINING_EMAIL=1 deferred the base retrain email to the zoo digest, so a silent zoo failure would otherwise mean zero email for the run.",
+              "Choices": [
+                {
+                  "Variable": "$.model_zoo_poll.Status",
+                  "StringEquals": "InProgress",
+                  "Next": "ModelZooWait"
+                },
+                {
+                  "Variable": "$.model_zoo_poll.Status",
+                  "StringEquals": "Pending",
+                  "Next": "ModelZooWait"
+                },
+                {
+                  "Variable": "$.model_zoo_poll.Status",
+                  "StringEquals": "Success",
+                  "Next": "GradingLambdaReGrade"
+                }
+              ],
+              "Default": "ExtractModelZooSelectError"
+            },
+            "ExtractModelZooSelectError": {
+              "Type": "Pass",
+              "Comment": "Normalize ModelZooSelect SSM non-Success poll into $.model_zoo_error. Mirrors ExtractPredictorError/ExtractSignalsEnvelopeError/ExtractRAGIngestionError \u2014 CheckModelZooStatus.Default does not populate $.model_zoo_error the way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's Message calls States.JsonToString($.model_zoo_error): a direct Choice->Task jump on this edge died with States.Runtime ('$.model_zoo_error could not be found'), masking the real zoo-select failure behind an opaque meta-error (observed live 2026-07-10, execution offcycle-shell-20260710-220932; config#2160 arc).",
+              "Parameters": {
+                "phase": "ModelZooSelect",
+                "source": "CheckModelZooStatus.Default",
+                "poll.$": "$.model_zoo_poll"
+              },
+              "ResultPath": "$.model_zoo_error",
+              "Next": "PublishModelZooFailureImmediate"
+            },
+            "PublishModelZooFailureImmediate": {
+              "Type": "Task",
+              "Comment": "Fire an SNS failure alert when the model-zoo rotation fails/times-out. REQUIRED for fallback safety: PredictorTraining now exports PREDICTOR_DEFER_TRAINING_EMAIL=1, so the base champion-arch retrain DEFERS its per-run training email to the consolidated zoo digest (sent at the end of run_rotation_and_select). If the zoo then fails, NEITHER email goes out \u2014 without this alert the run would be SILENT. Best-effort like the predictor early-signal alert: an SNS publish failure is caught and still routes to BranchBComplete (the champion already trained+promoted; the rotation is non-critical, so a zoo failure must NEVER fail the branch).",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline \u2014 ModelZooRotation FAILED (zoo digest email may be missing)', $.pipeline_label)",
+                "Message.$": "States.Format('The model-zoo rotation failed or timed out. The base champion-arch retrain already trained+promoted and DEFERRED its training email to the zoo digest (PREDICTOR_DEFER_TRAINING_EMAIL=1), so the consolidated digest email may NOT have been sent for this run \u2014 review predictor-model-zoo.log on the spot and predictor/model_zoo/leaderboard/. The branch will still complete (the champion is live); the rotation is best-effort. Error: {}', States.JsonToString($.model_zoo_error))"
+              },
+              "ResultPath": null,
+              "Next": "GradingLambdaReGrade",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort: a failed SNS publish must not prevent the branch from completing. The champion is already live.",
+                  "ResultPath": null,
+                  "Next": "GradingLambdaReGrade"
+                }
+              ]
+            },
+            "ModelZooWait": {
+              "Type": "Wait",
+              "Seconds": 60,
+              "Next": "WaitForModelZoo"
+            },
+            "GradingLambdaReGrade": {
+              "Type": "Task",
+              "Comment": "Persistent-dash re-grade (Brian's 2026-07-14 ruling on alpha-engine-config-I2545): the crucible-evaluator grading Lambda is stateless / full-rebuild-per-invoke and keys its report_card.json to trading_day, NOT calendar date \u2014 a Sunday invocation resolves to the SAME Friday trading_day the Saturday run's ReportCard already wrote, updating that card in place with whatever the zoo rotation just changed (e.g. a newly promoted champion). No new eval micromodule needed; this is a full re-grade, not tile-scoped. Same FunctionName/ Payload shape as the parent Saturday SF's ReportCard state (step_function.json) by design \u2014 same Lambda, same contract. dry_run.$=$.research_dry so a dry-run invocation of this SF (manual testing) doesn't persist a degenerate card, mirroring ReportCard's own preflight-aware convention. NON-FATAL (I2545 build item 2): its Catch routes to PublishGradingDegradedAlert rather than failing the zoo run \u2014 the rotation/promotion already completed and must not be invalidated by an advisory grading failure. alpha-engine-config-I2556 (2026-07-14): Payload now carries \"snapshot\": false \u2014 this Sunday re-grade only refreshes the standing latest.json, never a second same-week dated snapshot (the Saturday advisory child SF's ReportCard, step_function_advisory.json, is the one weekly-freeze invocation that passes \"snapshot\": true). Evaluator-side handler support ships separately (I2556, crucible-evaluator); an unrecognized event field is ignored harmlessly by the CURRENT handler.",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Parameters": {
+                "FunctionName": "alpha-engine-evaluator:live",
+                "Payload": {
+                  "date.$": "$.run_date",
+                  "dry_run.$": "$.research_dry",
+                  "snapshot": false
+                }
+              },
+              "TimeoutSeconds": 300,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "MaxAttempts": 1,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.0
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Advisory re-grade is non-fatal \u2014 the zoo rotation/promotion already completed and must not be invalidated by a grading failure. Alert (not silent) then converge to the terminal notify.",
+                  "Next": "PublishGradingDegradedAlert",
+                  "ResultPath": "$.report_card_error"
+                }
+              ],
+              "ResultPath": "$.report_card_result",
+              "Next": "ModelZooSundayNotifyComplete"
+            },
+            "PublishGradingDegradedAlert": {
+              "Type": "Task",
+              "Comment": "Mirrors the parent SF's PublishReportCardDegraded shape exactly (config#2302 discipline: hardcoded Subject/Message constants, best-effort Catch). WARNING severity \u2014 the model-zoo rotation/promotion is unaffected; only the persistent-dash re-grade degraded.",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject": "Alpha Engine ModelZoo Sunday Pipeline \u2014 ReportCard re-grade WARNING",
+                "Message": "The Sunday persistent-dash re-grade (ReportCard Lambda re-invoked after the model-zoo rotation) failed \u2014 see $.report_card_error on the execution record for detail. This is NON-FATAL: the model-zoo rotation/promotion already completed; only the dashboard's trading_day card was not refreshed with this run's outcome. View pipeline status: https://console.nousergon.ai/pipeline-status"
+              },
+              "ResultPath": "$.report_card_degraded_notify",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "Best-effort alert \u2014 a publish failure must not block the non-fatal advisory path this alert decorates.",
+                  "ResultPath": "$.report_card_degraded_notify_error",
+                  "Next": "ModelZooSundayNotifyComplete"
+                }
+              ],
+              "Next": "ModelZooSundayNotifyComplete"
+            },
+            "ModelZooSundayNotifyComplete": {
+              "Type": "Task",
+              "Comment": "Sunday ModelZoo child SF (alpha-engine-config-I2545) success notifier. Mirrors the parent Saturday SF's NotifyComplete exactly (config#1819: constants-only Subject/Message, best-effort Catch).",
+              "Resource": "arn:aws:states:::sns:publish",
+              "Parameters": {
+                "TopicArn.$": "$.sns_topic_arn",
+                "Subject": "Alpha Engine ModelZoo Sunday Pipeline \u2014 SUCCESS",
+                "Message": "The Sunday model-zoo rotation (resolve \u2192 train \u2192 select, with auto-promote if MODEL_ZOO_AUTO_PROMOTE_WINNER) and the persistent-dash re-grade completed. Any individual-stage degradation was already alerted separately. View pipeline status: https://console.nousergon.ai/pipeline-status"
+              },
+              "ResultPath": "$.notify_result",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Comment": "config#1819 \u2014 best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded child execution.",
+                  "ResultPath": "$.notify_error",
+                  "Next": "ModelZooSundayNotifyCompleteDegraded"
+                }
+              ],
+              "End": true
+            },
+            "ModelZooSundayNotifyCompleteDegraded": {
+              "Type": "Pass",
+              "Comment": "config#1819 \u2014 records the caught publish failure as execution DATA, mirroring the parent SF's NotifyCompleteDegraded.",
+              "Parameters": {
+                "degraded": true,
+                "source": "ModelZooSundayNotifyComplete",
+                "error.$": "$.notify_error"
+              },
+              "ResultPath": "$.notify_degraded",
+              "End": true
+            }
+          }
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ModelZooNormalizeFailureContext",
+          "ResultPath": "$.error"
+        }
+      ],
+      "End": true
+    },
+    "ModelZooNormalizeFailureContext": {
+      "Type": "Pass",
+      "Comment": "Single Catch/Next funnel before ModelZooHandleFailure, mirroring the parent SF's NormalizeFailureContext (config#1819 class).",
+      "Parameters": {
+        "merged.$": "States.JsonMerge(States.StringToJson('{\"error\":{\"phase\":\"Unknown\",\"source\":\"ModelZooNormalizeFailureContext\",\"detail\":\"no $.error was set by the upstream Catch\"},\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),$,false)"
+      },
+      "OutputPath": "$.merged",
+      "Next": "ModelZooHandleFailure"
+    },
+    "ModelZooHandleFailure": {
+      "Type": "Task",
+      "Comment": "Failure alert via SNS \u2014 ModelZoo Sunday child pipeline halted on a genuine SF-engine-level error escaping the wrapper Parallel (every lifted state's OWN failure path is best-effort/non-fatal by design). Hardcoded Subject constant (config#1819 class).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine ModelZoo Sunday Pipeline \u2014 FAILED",
+        "Message.$": "States.Format('ModelZoo Sunday Pipeline failed at the SF-engine level (this is a backstop path \u2014 the rotation'\\''s own stages are individually best-effort by design). Error: {}. Full-day retry headroom exists before Monday 12:45 UTC preopen (Brian'\\''s 2026-07-14 trigger-time ruling). View pipeline status: https://console.nousergon.ai/pipeline-status', States.JsonToString($.error))"
+      },
+      "ResultPath": "$.failure_notify",
+      "Next": "ModelZooFailExecution"
+    },
+    "ModelZooFailExecution": {
+      "Type": "Fail",
+      "Error": "ModelZooPipelineFailure",
+      "Cause": "The ModelZoo Sunday child SF failed at the SF-engine level. Check CloudWatch Logs (/aws/stepfunctions/ne-modelzoo-sunday-pipeline) for details. Full-day retry headroom exists before Monday 12:45 UTC preopen \u2014 a fresh execution can be started manually before then."
+    }
+  }
+}

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -177,47 +177,40 @@ STAGES: tuple[Stage, ...] = (
     Stage(
         "data_phase2", "skip_data_phase2",
         "CheckSkipDataPhase2", "DataPhase2",
-        frozenset({"CheckSkipEvalJudge"}),
-    ),
-    Stage(
-        "eval_judge", "skip_eval_judge",
-        "CheckSkipEvalJudge", "ComputeEvalCadence",
-        frozenset({"CheckSkipRationaleClustering"}),
-    ),
-    Stage(
-        "rationale_clustering", "skip_rationale_clustering",
-        "CheckSkipRationaleClustering", "RationaleClustering",
-        frozenset({"CheckSkipReplayConcordance"}),
-    ),
-    Stage(
-        "replay_concordance", "skip_replay_concordance",
-        "CheckSkipReplayConcordance", "ReplayConcordance",
-        frozenset({"CheckSkipCounterfactual"}),
-    ),
-    Stage(
-        "counterfactual", "skip_counterfactual",
-        "CheckSkipCounterfactual", "Counterfactual",
-        frozenset({"CheckSkipAggregateCosts"}),
-    ),
-    Stage(
-        "aggregate_costs", "skip_aggregate_costs",
-        "CheckSkipAggregateCosts", "AggregateCosts",
-        frozenset({"BranchAComplete"}),
+        # alpha-engine-config-I2544: DataPhase2's witness used to be
+        # CheckSkipEvalJudge (the eval-judge chain's own skip-gate, entered
+        # unconditionally right after DataPhase2). That whole chain — plus
+        # ReportCard/Director — was LIFTED into the async
+        # ne-weekly-advisory-pipeline child SF; DataPhase2's successor in
+        # THIS SF is now StartAdvisoryPipeline (fire-and-forget dispatch).
+        # The eval_judge/rationale_clustering/replay_concordance/
+        # counterfactual/aggregate_costs Stage entries that used to follow
+        # are REMOVED — their skip_* flags govern a state machine
+        # (step_function_advisory.json) this script does not rerun; a
+        # StartExecution of the CHILD SF is a separate, not-yet-built
+        # recovery surface (the child re-derives its own defaults on every
+        # fresh dispatch, so there is nothing here to "skip re-running").
+        frozenset({"StartAdvisoryPipeline"}),
     ),
     # --- ResearchPredictorParallel branch B -------------------------------
     Stage(
         "predictor_training", "skip_predictor_training",
         "CheckSkipPredictorTraining", "PredictorTraining",
-        # ResolveZooSpecs entered <=> training succeeded (model-zoo rotation
-        # downstream is best-effort and cannot hard-fail the branch);
-        # PredictorTrainingSkipped <=> skip flag honored after the
-        # ValidatePredictorSkipWeightsFresh freshness proof. On the rerun
-        # the SF re-proves weights/meta freshness for run_date before
-        # honoring the flag — the helper does not need to.
-        frozenset({"ResolveZooSpecs", "PredictorTrainingSkipped"}),
+        # alpha-engine-config-I2545: BranchBComplete entered <=> training
+        # succeeded (the model-zoo rotation that used to run right after,
+        # ResolveZooSpecs, was moved to its OWN Sunday-triggered child SF —
+        # it no longer sits between CheckPredictorStatus's Success edge and
+        # BranchBComplete in THIS SF); PredictorTrainingSkipped <=> skip
+        # flag honored after the ValidatePredictorSkipWeightsFresh
+        # freshness proof. On the rerun the SF re-proves weights/meta
+        # freshness for run_date before honoring the flag — the helper
+        # does not need to.
+        frozenset({"BranchBComplete", "PredictorTrainingSkipped"}),
         note=(
-            "skip_predictor_training also skips the best-effort model-zoo"
-            " rotation (the flag ends branch B; zoo has no separate gate)."
+            "skip_predictor_training ends branch B directly at"
+            " BranchBComplete — the model-zoo rotation now runs"
+            " independently on ne-modelzoo-sunday-pipeline and has no gate"
+            " in this SF at all."
         ),
     ),
     # --- post-parallel tail ------------------------------------------------
@@ -268,9 +261,12 @@ BRANCH_A_STAGES = frozenset({
     # alpha-engine-config-I2515 Phase B: "research" removed (the
     # multi-agent Research state — and its skip_research flag /
     # CheckSkipResearch gate — no longer exists).
+    # alpha-engine-config-I2544: eval_judge/rationale_clustering/
+    # replay_concordance/counterfactual/aggregate_costs removed — that
+    # chain now lives in the async ne-weekly-advisory-pipeline child SF,
+    # out of scope for this (main-SF-only) rerun helper.
     "rag_ingestion", "regime_substrate", "regime_retrospective_eval",
-    "data_phase2", "eval_judge", "rationale_clustering",
-    "replay_concordance", "counterfactual", "aggregate_costs",
+    "data_phase2",
 })
 # Stages whose gate is only reachable THROUGH CheckSkipBacktester's run path
 # (the skip route overshoots them — see Stage("backtester").note).

--- a/tests/fixtures/weekly_sf_rerun/parallel_branch_failure.json
+++ b/tests/fixtures/weekly_sf_rerun/parallel_branch_failure.json
@@ -1,633 +1,579 @@
 {
- "events": [
-  {
-   "type": "ExecutionStarted",
-   "executionStartedEventDetails": {
-    "input": "{\"ec2_instance_id\": [\"i-09b539c844515d549\"], \"sns_topic_arn\": \"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\", \"pipeline_role\": \"weekly\"}"
-   },
-   "id": 1,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "InitializeInput",
-    "input": "{}"
-   },
-   "id": 2,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateExited",
-   "stateExitedEventDetails": {
-    "name": "InitializeInput",
-    "output": "{\"ec2_instance_id\": [\"i-09b539c844515d549\"], \"sns_topic_arn\": \"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\", \"pipeline_role\": \"weekly\", \"run_date\": \"2026-07-11\", \"preflight_args\": \"\", \"research_dry\": false, \"data_phase2_dry\": false, \"regime_action\": \"produce\", \"pipeline_label\": \"\", \"skip_weekly_run_day_gate\": false}"
-   },
-   "id": 3,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckWeeklyRunDayGate",
-    "input": "{}"
-   },
-   "id": 4,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "WeeklyRunDayGate",
-    "input": "{}"
-   },
-   "id": 5,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "WeeklyRunDayGate",
-    "output": "{}"
-   },
-   "id": 6,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "WeeklyRunDayGateChoice",
-    "input": "{}"
-   },
-   "id": 7,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckRunMode",
-    "input": "{}"
-   },
-   "id": 8,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckSkipLibPinDriftCheck",
-    "input": "{}"
-   },
-   "id": 9,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "LibPinDriftCheck",
-    "input": "{}"
-   },
-   "id": 10,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "LibPinDriftCheck",
-    "output": "{}"
-   },
-   "id": 11,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "LibPinDriftGate",
-    "input": "{}"
-   },
-   "id": 12,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "PipelineContractCheck",
-    "input": "{}"
-   },
-   "id": 13,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "PipelineContractCheck",
-    "output": "{}"
-   },
-   "id": 14,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "PipelineContractGate",
-    "input": "{}"
-   },
-   "id": 15,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckMutexRole",
-    "input": "{}"
-   },
-   "id": 16,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ComputeMutexTtl",
-    "input": "{}"
-   },
-   "id": 17,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateExited",
-   "stateExitedEventDetails": {
-    "name": "ComputeMutexTtl",
-    "output": "{}"
-   },
-   "id": 18,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "AcquireMutex",
-    "input": "{}"
-   },
-   "id": 19,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "AcquireMutex",
-    "output": "{}"
-   },
-   "id": 20,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckShellRun",
-    "input": "{}"
-   },
-   "id": 21,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckSkipMorningEnrich",
-    "input": "{}"
-   },
-   "id": 22,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "MorningEnrich",
-    "input": "{}"
-   },
-   "id": 23,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "MorningEnrich",
-    "output": "{}"
-   },
-   "id": 24,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "WaitForMorningEnrich",
-    "input": "{}"
-   },
-   "id": 25,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "WaitForMorningEnrich",
-    "output": "{}"
-   },
-   "id": 26,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckMorningEnrichStatus",
-    "input": "{}"
-   },
-   "id": 27,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckSkipDataPhase1",
-    "input": "{}"
-   },
-   "id": 28,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "DataPhase1",
-    "input": "{}"
-   },
-   "id": 29,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "DataPhase1",
-    "output": "{}"
-   },
-   "id": 30,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "WaitForDataPhase1",
-    "input": "{}"
-   },
-   "id": 31,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "WaitForDataPhase1",
-    "output": "{}"
-   },
-   "id": 32,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckDataPhase1Status",
-    "input": "{}"
-   },
-   "id": 33,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ParallelStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ResearchPredictorParallel",
-    "input": "{}"
-   },
-   "id": 34,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "Scanner",
-    "input": "{}"
-   },
-   "id": 35,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "Scanner",
-    "output": "{}"
-   },
-   "id": 36,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckSkipRAGIngestion",
-    "input": "{}"
-   },
-   "id": 37,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "RAGIngestion",
-    "input": "{}"
-   },
-   "id": 38,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "RAGIngestion",
-    "output": "{}"
-   },
-   "id": 39,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "WaitForRAGIngestion",
-    "input": "{}"
-   },
-   "id": 40,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "WaitForRAGIngestion",
-    "output": "{}"
-   },
-   "id": 41,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckRAGIngestionStatus",
-    "input": "{}"
-   },
-   "id": 42,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "RAGIngestionRetryGate",
-    "input": "{}"
-   },
-   "id": 43,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ExtractRAGIngestionError",
-    "input": "{}"
-   },
-   "id": 44,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "PublishResearchFailureImmediate",
-    "input": "{}"
-   },
-   "id": 45,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "PublishResearchFailureImmediate",
-    "output": "{}"
-   },
-   "id": 46,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "BranchAFailed",
-    "input": "{}"
-   },
-   "id": 47,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckSkipPredictorTraining",
-    "input": "{}"
-   },
-   "id": 48,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "PredictorTraining",
-    "input": "{}"
-   },
-   "id": 49,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "PredictorTraining",
-    "output": "{}"
-   },
-   "id": 50,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "WaitForPredictorTraining",
-    "input": "{}"
-   },
-   "id": 51,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "WaitForPredictorTraining",
-    "output": "{}"
-   },
-   "id": 52,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckPredictorStatus",
-    "input": "{}"
-   },
-   "id": 53,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ResolveZooSpecs",
-    "input": "{}"
-   },
-   "id": 54,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "ResolveZooSpecs",
-    "output": "{}"
-   },
-   "id": 55,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ParseZooSpecs",
-    "input": "{}"
-   },
-   "id": 56,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "MapStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ModelZooTrainMap",
-    "input": "{}"
-   },
-   "id": 57,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ModelZooSelect",
-    "input": "{}"
-   },
-   "id": 58,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "ModelZooSelect",
-    "output": "{}"
-   },
-   "id": 59,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "BranchBComplete",
-    "input": "{}"
-   },
-   "id": 60,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "AggregateBranchOutcomes",
-    "input": "{}"
-   },
-   "id": 61,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "CheckBranchOutcomes",
-    "input": "{}"
-   },
-   "id": 62,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "ExtractParallelBranchError",
-    "input": "{}"
-   },
-   "id": 63,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "NormalizeFailureContext",
-    "input": "{}"
-   },
-   "id": 64,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ChoiceStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "NormalizeFailureContextRepin",
-    "input": "{}"
-   },
-   "id": 65,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "PassStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "NormalizeFailureContextRealLabel",
-    "input": "{}"
-   },
-   "id": 66,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "HandleFailure",
-    "input": "{}"
-   },
-   "id": 67,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "TaskStateExited",
-   "stateExitedEventDetails": {
-    "name": "HandleFailure",
-    "output": "{}"
-   },
-   "id": 68,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "FailStateEntered",
-   "stateEnteredEventDetails": {
-    "name": "FailExecution",
-    "input": "{}"
-   },
-   "id": 69,
-   "timestamp": "2026-07-11T09:00:00Z"
-  },
-  {
-   "type": "ExecutionFailed",
-   "executionFailedEventDetails": {
-    "error": "PipelineFailure",
-    "cause": "..."
-   },
-   "id": 70,
-   "timestamp": "2026-07-11T09:00:00Z"
-  }
- ]
+  "events": [
+    {
+      "type": "ExecutionStarted",
+      "executionStartedEventDetails": {
+        "input": "{\"ec2_instance_id\": [\"i-09b539c844515d549\"], \"sns_topic_arn\": \"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\", \"pipeline_role\": \"weekly\"}"
+      },
+      "id": 1,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "InitializeInput",
+        "input": "{}"
+      },
+      "id": 2,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateExited",
+      "stateExitedEventDetails": {
+        "name": "InitializeInput",
+        "output": "{\"ec2_instance_id\": [\"i-09b539c844515d549\"], \"sns_topic_arn\": \"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\", \"pipeline_role\": \"weekly\", \"run_date\": \"2026-07-11\", \"preflight_args\": \"\", \"research_dry\": false, \"data_phase2_dry\": false, \"regime_action\": \"produce\", \"pipeline_label\": \"\", \"skip_weekly_run_day_gate\": false}"
+      },
+      "id": 3,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckWeeklyRunDayGate",
+        "input": "{}"
+      },
+      "id": 4,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "WeeklyRunDayGate",
+        "input": "{}"
+      },
+      "id": 5,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "WeeklyRunDayGate",
+        "output": "{}"
+      },
+      "id": 6,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "WeeklyRunDayGateChoice",
+        "input": "{}"
+      },
+      "id": 7,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckRunMode",
+        "input": "{}"
+      },
+      "id": 8,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckSkipLibPinDriftCheck",
+        "input": "{}"
+      },
+      "id": 9,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "LibPinDriftCheck",
+        "input": "{}"
+      },
+      "id": 10,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "LibPinDriftCheck",
+        "output": "{}"
+      },
+      "id": 11,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "LibPinDriftGate",
+        "input": "{}"
+      },
+      "id": 12,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "PipelineContractCheck",
+        "input": "{}"
+      },
+      "id": 13,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "PipelineContractCheck",
+        "output": "{}"
+      },
+      "id": 14,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "PipelineContractGate",
+        "input": "{}"
+      },
+      "id": 15,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckMutexRole",
+        "input": "{}"
+      },
+      "id": 16,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "ComputeMutexTtl",
+        "input": "{}"
+      },
+      "id": 17,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateExited",
+      "stateExitedEventDetails": {
+        "name": "ComputeMutexTtl",
+        "output": "{}"
+      },
+      "id": 18,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "AcquireMutex",
+        "input": "{}"
+      },
+      "id": 19,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "AcquireMutex",
+        "output": "{}"
+      },
+      "id": 20,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckShellRun",
+        "input": "{}"
+      },
+      "id": 21,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckSkipMorningEnrich",
+        "input": "{}"
+      },
+      "id": 22,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "MorningEnrich",
+        "input": "{}"
+      },
+      "id": 23,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "MorningEnrich",
+        "output": "{}"
+      },
+      "id": 24,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "WaitForMorningEnrich",
+        "input": "{}"
+      },
+      "id": 25,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "WaitForMorningEnrich",
+        "output": "{}"
+      },
+      "id": 26,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckMorningEnrichStatus",
+        "input": "{}"
+      },
+      "id": 27,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckSkipDataPhase1",
+        "input": "{}"
+      },
+      "id": 28,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "DataPhase1",
+        "input": "{}"
+      },
+      "id": 29,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "DataPhase1",
+        "output": "{}"
+      },
+      "id": 30,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "WaitForDataPhase1",
+        "input": "{}"
+      },
+      "id": 31,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "WaitForDataPhase1",
+        "output": "{}"
+      },
+      "id": 32,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckDataPhase1Status",
+        "input": "{}"
+      },
+      "id": 33,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ParallelStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "ResearchPredictorParallel",
+        "input": "{}"
+      },
+      "id": 34,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "Scanner",
+        "input": "{}"
+      },
+      "id": 35,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "Scanner",
+        "output": "{}"
+      },
+      "id": 36,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckSkipRAGIngestion",
+        "input": "{}"
+      },
+      "id": 37,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "RAGIngestion",
+        "input": "{}"
+      },
+      "id": 38,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "RAGIngestion",
+        "output": "{}"
+      },
+      "id": 39,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "WaitForRAGIngestion",
+        "input": "{}"
+      },
+      "id": 40,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "WaitForRAGIngestion",
+        "output": "{}"
+      },
+      "id": 41,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckRAGIngestionStatus",
+        "input": "{}"
+      },
+      "id": 42,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "RAGIngestionRetryGate",
+        "input": "{}"
+      },
+      "id": 43,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "ExtractRAGIngestionError",
+        "input": "{}"
+      },
+      "id": 44,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "PublishResearchFailureImmediate",
+        "input": "{}"
+      },
+      "id": 45,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "PublishResearchFailureImmediate",
+        "output": "{}"
+      },
+      "id": 46,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "BranchAFailed",
+        "input": "{}"
+      },
+      "id": 47,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckSkipPredictorTraining",
+        "input": "{}"
+      },
+      "id": 48,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "PredictorTraining",
+        "input": "{}"
+      },
+      "id": 49,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "PredictorTraining",
+        "output": "{}"
+      },
+      "id": 50,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "WaitForPredictorTraining",
+        "input": "{}"
+      },
+      "id": 51,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "WaitForPredictorTraining",
+        "output": "{}"
+      },
+      "id": 52,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckPredictorStatus",
+        "input": "{}"
+      },
+      "id": 53,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "BranchBComplete",
+        "input": "{}"
+      },
+      "id": 54,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "AggregateBranchOutcomes",
+        "input": "{}"
+      },
+      "id": 55,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "CheckBranchOutcomes",
+        "input": "{}"
+      },
+      "id": 56,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "ExtractParallelBranchError",
+        "input": "{}"
+      },
+      "id": 57,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "NormalizeFailureContext",
+        "input": "{}"
+      },
+      "id": 58,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ChoiceStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "NormalizeFailureContextRepin",
+        "input": "{}"
+      },
+      "id": 59,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "PassStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "NormalizeFailureContextRealLabel",
+        "input": "{}"
+      },
+      "id": 60,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "HandleFailure",
+        "input": "{}"
+      },
+      "id": 61,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "HandleFailure",
+        "output": "{}"
+      },
+      "id": 62,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "FailStateEntered",
+      "stateEnteredEventDetails": {
+        "name": "FailExecution",
+        "input": "{}"
+      },
+      "id": 63,
+      "timestamp": "2026-07-11T09:00:00Z"
+    },
+    {
+      "type": "ExecutionFailed",
+      "executionFailedEventDetails": {
+        "error": "PipelineFailure",
+        "cause": "..."
+      },
+      "id": 64,
+      "timestamp": "2026-07-11T09:00:00Z"
+    }
+  ]
 }

--- a/tests/fixtures/weekly_sf_rerun/tail_stage_failure.json
+++ b/tests/fixtures/weekly_sf_rerun/tail_stage_failure.json
@@ -495,192 +495,21 @@
       "id": 55
     },
     {
-      "type": "ChoiceStateEntered",
+      "type": "TaskStateEntered",
       "stateEnteredEventDetails": {
-        "name": "CheckSkipEvalJudge",
+        "name": "StartAdvisoryPipeline",
         "input": "{}"
       },
       "id": 56,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
-      "type": "PassStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "ComputeEvalCadence",
-        "input": "{}"
+      "type": "TaskStateExited",
+      "stateExitedEventDetails": {
+        "name": "StartAdvisoryPipeline",
+        "output": "{}"
       },
       "id": 57,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "ChoiceStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "CheckMonthlyCadence",
-        "input": "{}"
-      },
-      "id": 58,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "EvalJudgeSubmitWeekly",
-        "input": "{}"
-      },
-      "id": 59,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "EvalJudgeSubmitWeekly",
-        "output": "{}"
-      },
-      "id": 60,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "EvalJudgeProcess",
-        "input": "{}"
-      },
-      "id": 61,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "EvalJudgeProcess",
-        "output": "{}"
-      },
-      "id": 62,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "EvalRollingMean",
-        "input": "{}"
-      },
-      "id": 63,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "EvalRollingMean",
-        "output": "{}"
-      },
-      "id": 64,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "ChoiceStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "CheckSkipRationaleClustering",
-        "input": "{}"
-      },
-      "id": 65,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "RationaleClustering",
-        "input": "{}"
-      },
-      "id": 66,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "RationaleClustering",
-        "output": "{}"
-      },
-      "id": 67,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "ChoiceStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "CheckSkipReplayConcordance",
-        "input": "{}"
-      },
-      "id": 68,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "ReplayConcordance",
-        "input": "{}"
-      },
-      "id": 69,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "ReplayConcordance",
-        "output": "{}"
-      },
-      "id": 70,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "ChoiceStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "CheckSkipCounterfactual",
-        "input": "{}"
-      },
-      "id": 71,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "Counterfactual",
-        "input": "{}"
-      },
-      "id": 72,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "Counterfactual",
-        "output": "{}"
-      },
-      "id": 73,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "ChoiceStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "CheckSkipAggregateCosts",
-        "input": "{}"
-      },
-      "id": 74,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "AggregateCosts",
-        "input": "{}"
-      },
-      "id": 75,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "AggregateCosts",
-        "output": "{}"
-      },
-      "id": 76,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -689,7 +518,7 @@
         "name": "BranchAComplete",
         "input": "{}"
       },
-      "id": 77,
+      "id": 58,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -698,7 +527,7 @@
         "name": "CheckSkipPredictorTraining",
         "input": "{}"
       },
-      "id": 78,
+      "id": 59,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -707,7 +536,7 @@
         "name": "PredictorTraining",
         "input": "{}"
       },
-      "id": 79,
+      "id": 60,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -716,7 +545,7 @@
         "name": "PredictorTraining",
         "output": "{}"
       },
-      "id": 80,
+      "id": 61,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -725,43 +554,7 @@
         "name": "CheckPredictorStatus",
         "input": "{}"
       },
-      "id": 81,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "ResolveZooSpecs",
-        "input": "{}"
-      },
-      "id": 82,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "ResolveZooSpecs",
-        "output": "{}"
-      },
-      "id": 83,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "ModelZooSelect",
-        "input": "{}"
-      },
-      "id": 84,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateExited",
-      "stateExitedEventDetails": {
-        "name": "ModelZooSelect",
-        "output": "{}"
-      },
-      "id": 85,
+      "id": 62,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -770,7 +563,7 @@
         "name": "BranchBComplete",
         "input": "{}"
       },
-      "id": 86,
+      "id": 63,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -779,7 +572,7 @@
         "name": "AggregateBranchOutcomes",
         "input": "{}"
       },
-      "id": 87,
+      "id": 64,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -788,7 +581,7 @@
         "name": "CheckBranchOutcomes",
         "input": "{}"
       },
-      "id": 88,
+      "id": 65,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -797,7 +590,7 @@
         "name": "CheckSkipBacktester",
         "input": "{}"
       },
-      "id": 89,
+      "id": 66,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -806,7 +599,7 @@
         "name": "Backtester",
         "input": "{}"
       },
-      "id": 90,
+      "id": 67,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -815,7 +608,7 @@
         "name": "Backtester",
         "output": "{}"
       },
-      "id": 91,
+      "id": 68,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -824,7 +617,7 @@
         "name": "CheckBacktesterStatus",
         "input": "{}"
       },
-      "id": 92,
+      "id": 69,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -833,7 +626,7 @@
         "name": "CheckSkipPredictorBacktest",
         "input": "{}"
       },
-      "id": 93,
+      "id": 70,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -842,7 +635,7 @@
         "name": "PredictorBacktest",
         "input": "{}"
       },
-      "id": 94,
+      "id": 71,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -851,7 +644,7 @@
         "name": "PredictorBacktest",
         "output": "{}"
       },
-      "id": 95,
+      "id": 72,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -860,7 +653,7 @@
         "name": "CheckPredictorBacktestStatus",
         "input": "{}"
       },
-      "id": 96,
+      "id": 73,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -869,7 +662,7 @@
         "name": "CheckSkipPortfolioOptimizerBacktest",
         "input": "{}"
       },
-      "id": 97,
+      "id": 74,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -878,7 +671,7 @@
         "name": "PortfolioOptimizerBacktest",
         "input": "{}"
       },
-      "id": 98,
+      "id": 75,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -887,7 +680,7 @@
         "name": "PortfolioOptimizerBacktest",
         "output": "{}"
       },
-      "id": 99,
+      "id": 76,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -896,7 +689,7 @@
         "name": "CheckPortfolioOptimizerBacktestStatus",
         "input": "{}"
       },
-      "id": 100,
+      "id": 77,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -905,7 +698,7 @@
         "name": "CheckSkipParity",
         "input": "{}"
       },
-      "id": 101,
+      "id": 78,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -914,7 +707,7 @@
         "name": "Parity",
         "input": "{}"
       },
-      "id": 102,
+      "id": 79,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -923,7 +716,7 @@
         "name": "Parity",
         "output": "{}"
       },
-      "id": 103,
+      "id": 80,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -932,7 +725,7 @@
         "name": "WaitForParity",
         "input": "{}"
       },
-      "id": 104,
+      "id": 81,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -941,7 +734,7 @@
         "name": "WaitForParity",
         "output": "{}"
       },
-      "id": 105,
+      "id": 82,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -950,7 +743,7 @@
         "name": "CheckParityStatus",
         "input": "{}"
       },
-      "id": 106,
+      "id": 83,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -959,7 +752,7 @@
         "name": "ExtractParityError",
         "input": "{}"
       },
-      "id": 107,
+      "id": 84,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -968,7 +761,7 @@
         "name": "NormalizeFailureContext",
         "input": "{}"
       },
-      "id": 108,
+      "id": 85,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -977,7 +770,7 @@
         "name": "NormalizeFailureContextRepin",
         "input": "{}"
       },
-      "id": 109,
+      "id": 86,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -986,7 +779,7 @@
         "name": "NormalizeFailureContextRealLabel",
         "input": "{}"
       },
-      "id": 110,
+      "id": 87,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -995,7 +788,7 @@
         "name": "HandleFailure",
         "input": "{}"
       },
-      "id": 111,
+      "id": 88,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -1004,7 +797,7 @@
         "name": "HandleFailure",
         "output": "{}"
       },
-      "id": 112,
+      "id": 89,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -1013,7 +806,7 @@
         "name": "FailExecution",
         "input": "{}"
       },
-      "id": 113,
+      "id": 90,
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
@@ -1022,7 +815,7 @@
         "error": "PipelineFailure",
         "cause": "..."
       },
-      "id": 114,
+      "id": 91,
       "timestamp": "2026-07-11T09:00:00Z"
     }
   ]

--- a/tests/test_deploy_step_function_eventbridge_input.py
+++ b/tests/test_deploy_step_function_eventbridge_input.py
@@ -63,7 +63,14 @@ _DEPLOY_SCRIPTS = (
 # now flows directly into WeekdayTrigger.
 _TRIGGER_SUCCESSORS = {
     "SaturdayTrigger": "WeekdayTrigger",
-    "WeekdayTrigger": "ResearchAlerts",
+    # alpha-engine-config-I2545: ModelZooSundayTrigger was inserted between
+    # WeekdayTrigger and ResearchAlerts in the CFN template — update this
+    # chain in the SAME PR as any future insertion between two entries here
+    # (an unregistered gap silently merges the two neighboring blocks and
+    # masks a genuine multi-target regression, exactly the failure mode
+    # this successor-chain exists to prevent).
+    "WeekdayTrigger": "ModelZooSundayTrigger",
+    "ModelZooSundayTrigger": "ResearchAlerts",
 }
 
 

--- a/tests/test_sf_advisory_pipeline_wiring.py
+++ b/tests/test_sf_advisory_pipeline_wiring.py
@@ -1,0 +1,271 @@
+"""Pins the ne-weekly-advisory-pipeline child SF (alpha-engine-config-I2544).
+
+Origin: Phase 2 of the weekly-SF load-reduction plan — the eval-judge chain
+(EvalJudge submit/poll/process -> EvalRollingMean -> RationaleClustering ->
+ReplayConcordance -> Counterfactual -> AggregateCosts), PLUS ReportCard and
+Director, were lifted OUT of the main ne-weekly-freshness-pipeline's Branch A
+/ top-level tail into this async child SF (infrastructure/
+step_function_advisory.json), fired fire-and-forget (states:startExecution,
+NOT .sync) by the main SF's StartAdvisoryPipeline state once DataPhase2
+completes (see test_sf_research_predictor_parallel_wiring.py for that side).
+
+Every lifted state's Payload/Retry/Catch semantics were REQUIRED to be
+preserved byte-for-byte (I2544 build instruction) — this file re-pins the
+same behavioral assertions that used to live in
+test_sf_research_predictor_parallel_wiring.py's TestBranchAContents /
+TestPerBranchErrorIsolation classes, now pointed at this file, PLUS new
+coverage for the child-SF-only scaffolding (InitializeAdvisoryInput's
+defaults floor, the single-branch Parallel catch-all wrapper, the terminal
+notify pair, and the child's own top-level TimeoutSeconds).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_advisory.json"
+
+_LIFTED_TAIL_STATES = {
+    "CheckSkipEvalJudge", "ComputeEvalCadence", "CheckMonthlyCadence",
+    "EvalJudgeSubmitFirstSaturday", "EvalJudgeSubmitWeekly",
+    "EvalJudgePollChoice", "EvalJudgePollWait", "EvalJudgePoll",
+    "EvalJudgePollDecision", "EvalJudgeProcess", "EvalRollingMean",
+    "CheckSkipRationaleClustering", "RationaleClustering",
+    "CheckSkipReplayConcordance", "ReplayConcordance",
+    "CheckSkipCounterfactual", "Counterfactual",
+    "CheckSkipAggregateCosts", "AggregateCosts",
+    "ReportCard", "PublishReportCardDegraded", "Director",
+    "PublishDirectorDegraded",
+}
+
+
+def _own_targets(st: dict) -> list[str]:
+    out: list[str] = []
+
+    def rec(o) -> None:
+        if isinstance(o, dict):
+            for k, v in o.items():
+                if k in ("Branches", "ItemProcessor", "Iterator"):
+                    continue
+                if k in ("Next", "Default") and isinstance(v, str):
+                    out.append(v)
+                elif k == "Catch":
+                    for c in v:
+                        out.append(c["Next"])
+                else:
+                    rec(v)
+        elif isinstance(o, list):
+            for it in o:
+                rec(it)
+
+    rec(st)
+    return out
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    return sf["States"]
+
+
+@pytest.fixture(scope="module")
+def wrapper(states) -> dict:
+    return states["AdvisoryPipelineWrapper"]
+
+
+@pytest.fixture(scope="module")
+def inner(wrapper) -> dict:
+    return wrapper["Branches"][0]["States"]
+
+
+class TestJsonParsesAndTopLevel:
+    def test_json_parses(self, sf):
+        assert isinstance(sf, dict)
+        assert sf["StartAt"] in sf["States"]
+
+    def test_start_at_initializes_input(self, sf):
+        assert sf["StartAt"] == "InitializeAdvisoryInput"
+
+    def test_top_level_timeout_clears_eval_judge_poll_cap(self, sf):
+        # Also pinned in test_sf_global_timeout.py; re-pinned here for
+        # locality with the rest of this SF's coverage.
+        assert sf["TimeoutSeconds"] == 28800
+
+    def test_initialize_advisory_input_defaults_floor(self, states):
+        init = states["InitializeAdvisoryInput"]
+        assert init["Type"] == "Pass"
+        merge_expr = init["Parameters"]["merged.$"]
+        for flag in (
+            "research_dry", "skip_eval_judge", "skip_rationale_clustering",
+            "skip_replay_concordance", "skip_counterfactual",
+            "skip_aggregate_costs",
+        ):
+            assert f'"{flag}":false' in merge_expr
+        assert "$$.Execution.Input" in merge_expr
+        assert init["Next"] == "AdvisoryPipelineWrapper"
+
+
+class TestWrapperParallelCatchAll:
+    """Single-branch Parallel retrofit for a machine-level catch-all,
+    WITHOUT altering any lifted state's own (deliberately non-fatal)
+    Catch semantics."""
+
+    def test_wrapper_is_single_branch_parallel(self, wrapper):
+        assert wrapper["Type"] == "Parallel"
+        assert len(wrapper["Branches"]) == 1
+
+    def test_wrapper_starts_at_check_skip_eval_judge(self, wrapper):
+        assert wrapper["Branches"][0]["StartAt"] == "CheckSkipEvalJudge"
+
+    def test_wrapper_catch_routes_to_failure_funnel(self, wrapper):
+        catches = wrapper["Catch"]
+        assert any(
+            c["ErrorEquals"] == ["States.ALL"]
+            and c["Next"] == "AdvisoryNormalizeFailureContext"
+            and c["ResultPath"] == "$.error"
+            for c in catches
+        )
+
+    def test_failure_funnel_reaches_fail_state(self, states):
+        assert states["AdvisoryNormalizeFailureContext"]["Next"] == (
+            "AdvisoryHandleFailure"
+        )
+        assert states["AdvisoryHandleFailure"]["Next"] == "AdvisoryFailExecution"
+        assert states["AdvisoryFailExecution"]["Type"] == "Fail"
+
+
+class TestLiftedStatesPresent:
+    @pytest.mark.parametrize("name", sorted(_LIFTED_TAIL_STATES))
+    def test_lifted_state_present(self, inner, name):
+        assert name in inner
+
+
+class TestEvalJudgeChainSemanticsPreserved:
+    """Re-pins the behavioral assertions that used to live in
+    test_sf_research_predictor_parallel_wiring.py::TestBranchAContents /
+    TestPerBranchErrorIsolation before the I2544 lift."""
+
+    def test_eval_chain_entry_skip_gate(self, inner):
+        assert inner["CheckSkipEvalJudge"]["Default"] == "ComputeEvalCadence"
+        assert inner["CheckSkipEvalJudge"]["Choices"][0]["Next"] == (
+            "CheckSkipRationaleClustering"
+        )
+
+    def test_eval_judge_quartet_preserved(self, inner):
+        assert inner["EvalJudgePollChoice"]["Type"] == "Choice"
+        assert inner["EvalJudgePollWait"]["Type"] == "Wait"
+        assert inner["EvalJudgePollWait"]["Next"] == "EvalJudgePoll"
+        assert inner["EvalJudgePoll"]["Next"] == "EvalJudgePollDecision"
+
+    def test_eval_chain_fail_soft_catches_preserved_in_advisory_pipeline(self, inner):
+        """The eval/agent-justification observability Catches must stay
+        fail-soft (route forward within the wrapper branch) — never to
+        AdvisoryNormalizeFailureContext/AdvisoryHandleFailure. They were
+        never SF-halting pre-lift and must not become so post-lift."""
+        for n in (
+            "EvalJudgeSubmitWeekly", "EvalJudgeProcess", "EvalRollingMean",
+            "RationaleClustering", "ReplayConcordance", "Counterfactual",
+        ):
+            for c in inner[n].get("Catch", []):
+                assert c["Next"] not in (
+                    "AdvisoryNormalizeFailureContext", "AdvisoryHandleFailure",
+                ), f"{n} observability Catch escaped to the machine-level failure funnel"
+
+    def test_aggregate_costs_now_feeds_report_card(self, inner):
+        """alpha-engine-config-I2544: the old branch terminal
+        (BranchAComplete) that used to follow AggregateCosts is replaced by
+        ReportCard — this child SF has no Parallel join of its own."""
+        assert inner["CheckSkipAggregateCosts"]["Choices"][0]["Next"] == "ReportCard"
+        assert inner["AggregateCosts"]["Next"] == "ReportCard"
+        assert inner["AggregateCosts"]["Catch"][0]["Next"] == "ReportCard"
+
+
+class TestReportCardAndDirectorWiring:
+    def test_report_card_success_feeds_director(self, inner):
+        assert inner["ReportCard"]["Next"] == "Director"
+
+    def test_report_card_failure_skips_director(self, inner):
+        """Director's own Comment says it 'runs only after a SUCCESSFUL
+        ReportCard' — preserved from the parent SF verbatim."""
+        assert inner["ReportCard"]["Catch"][0]["Next"] == (
+            "PublishReportCardDegraded"
+        )
+        assert inner["PublishReportCardDegraded"]["Next"] == (
+            "AdvisoryNotifyComplete"
+        )
+        assert inner["PublishReportCardDegraded"]["Catch"][0]["Next"] == (
+            "AdvisoryNotifyComplete"
+        )
+
+    def test_director_success_and_failure_converge_on_notify(self, inner):
+        assert inner["Director"]["Next"] == "AdvisoryNotifyComplete"
+        assert inner["Director"]["Catch"][0]["Next"] == "PublishDirectorDegraded"
+        assert inner["PublishDirectorDegraded"]["Next"] == "AdvisoryNotifyComplete"
+        assert inner["PublishDirectorDegraded"]["Catch"][0]["Next"] == (
+            "AdvisoryNotifyComplete"
+        )
+
+    def test_report_card_and_director_payload_shape_unchanged(self, inner):
+        """Same FunctionName/Payload shape as the (now-removed) main SF
+        states — dry_run.$=$.research_dry preflight-aware convention
+        preserved."""
+        assert inner["ReportCard"]["Parameters"]["FunctionName"] == (
+            "alpha-engine-evaluator:live"
+        )
+        assert inner["ReportCard"]["Parameters"]["Payload"]["dry_run.$"] == (
+            "$.research_dry"
+        )
+        assert inner["Director"]["Parameters"]["FunctionName"] == (
+            "alpha-engine-evaluator-director:live"
+        )
+        assert inner["Director"]["Parameters"]["Payload"]["dry_run.$"] == (
+            "$.research_dry"
+        )
+
+    def test_report_card_snapshot_flag_true(self, inner):
+        """alpha-engine-config-I2556 (persistent report card with weekly
+        snapshots): this Saturday-cadence ReportCard invocation is the
+        WEEKLY FREEZE — snapshot=true writes the dated historical card.
+        The Sunday ModelZoo child SF's re-grade tail passes snapshot=false
+        (see test_sf_modelzoo_pipeline_wiring.py)."""
+        assert inner["ReportCard"]["Parameters"]["Payload"]["snapshot"] is True
+
+
+class TestTerminalNotify:
+    def test_notify_complete_is_constants_only(self, inner):
+        """config#1819 discipline: Subject/Message must be hardcoded
+        constants, never States.Format against unbounded input."""
+        n = inner["AdvisoryNotifyComplete"]
+        assert n["Resource"] == "arn:aws:states:::sns:publish"
+        assert "Subject.$" not in n["Parameters"]
+        assert "Message.$" not in n["Parameters"]
+        assert n["End"] is True
+        assert n["Catch"][0]["Next"] == "AdvisoryNotifyCompleteDegraded"
+
+    def test_notify_complete_degraded_records_data(self, inner):
+        d = inner["AdvisoryNotifyCompleteDegraded"]
+        assert d["Type"] == "Pass"
+        assert d["End"] is True
+        assert d["Parameters"]["degraded"] is True
+
+
+class TestNoDanglingTargets:
+    def test_inner_no_dangling(self, wrapper):
+        names = set(wrapper["Branches"][0]["States"])
+        assert wrapper["Branches"][0]["StartAt"] in names
+        for n, st in wrapper["Branches"][0]["States"].items():
+            for t in _own_targets(st):
+                assert t in names, f"dangling: {n} -> {t}"
+
+    def test_top_level_no_dangling(self, states):
+        top = set(states)
+        for n, st in states.items():
+            for t in _own_targets(st):
+                assert t in top, f"top-level dangling: {n} -> {t}"

--- a/tests/test_sf_aggregate_costs_wiring.py
+++ b/tests/test_sf_aggregate_costs_wiring.py
@@ -1,21 +1,26 @@
-"""Pins the AggregateCosts Lambda wiring in the Saturday Step Functions JSON.
+"""Pins the AggregateCosts Lambda wiring in the weekly advisory child SF.
 
 ROADMAP L1146 — SF-wire ``scripts/aggregate_costs.py`` CLI. The
 companion alpha-engine-research PR adds the
 ``alpha-engine-research-aggregate-costs:live`` Lambda; this test only
 asserts the SF wiring.
 
-Pin the chain end of Branch A:
+alpha-engine-config-I2544 (2026-07-14): AggregateCosts (and the whole
+eval-judge chain it terminates) was LIFTED out of the main SF's Branch A
+into the async ne-weekly-advisory-pipeline child SF, fired fire-and-forget
+right after DataPhase2. Its own Payload/Retry/Catch/Next semantics are
+preserved byte-for-byte; the only rewired edge is the terminal target,
+since this child SF has no Parallel join / branch terminal of its own:
 
     ... Counterfactual → CheckSkipAggregateCosts → AggregateCosts
-                                                 → BranchAComplete
+                                                 → ReportCard
 
-The aggregator must sit AFTER the entire LLM chain (Research /
-eval-judge / rationale-clustering / replay-concordance / counterfactual)
-so every upstream LLM-emitting state has finished writing its
-``_cost_raw/{date}/*.jsonl`` rows by the time the aggregator runs.
-Catches regressions like: a future SF refactor that drops the new
-state, or reroutes Counterfactual back to BranchAComplete bypassing
+(pre-lift this was ``→ BranchAComplete``). The aggregator must still sit
+AFTER the entire LLM chain (eval-judge / rationale-clustering / replay-
+concordance / counterfactual) so every upstream LLM-emitting state has
+finished writing its ``_cost_raw/{date}/*.jsonl`` rows by the time the
+aggregator runs. Catches regressions like: a future SF refactor that drops
+the new state, or reroutes Counterfactual back to ReportCard bypassing
 the aggregator.
 """
 
@@ -28,7 +33,7 @@ import pytest
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_advisory.json"
 
 
 @pytest.fixture(scope="module")
@@ -97,13 +102,14 @@ class TestLambdaTarget:
 
 
 class TestFailureIsolation:
-    def test_catch_routes_to_branch_a_complete(self, states):
+    def test_catch_routes_to_report_card(self, states):
         # Cost telemetry is observability — aggregator failure must NOT
         # halt the pipeline. Mirrors the rationale-clustering Catch.
+        # alpha-engine-config-I2544: was BranchAComplete pre-lift.
         catches = states["AggregateCosts"]["Catch"]
         assert len(catches) >= 1
         assert any(
-            c["Next"] == "BranchAComplete"
+            c["Next"] == "ReportCard"
             and "States.ALL" in c["ErrorEquals"]
             for c in catches
         )
@@ -135,8 +141,9 @@ class TestEdges:
         # Counterfactual failure must STILL run the aggregator —
         # upstream LLM cost rows are independent of counterfactual's
         # success. (The aggregator's own Catch routes to
-        # BranchAComplete so a downstream failure-of-failure can't
-        # ladder back into the failed counterfactual error path.)
+        # ReportCard (alpha-engine-config-I2544: was BranchAComplete
+        # pre-lift) so a downstream failure-of-failure can't ladder back
+        # into the failed counterfactual error path.)
         cf = states["Counterfactual"]
         catches = cf["Catch"]
         assert any(
@@ -163,16 +170,18 @@ class TestEdges:
         assert len(skip_choices) == 1
         assert skip_choices[0]["Next"] == "CheckSkipAggregateCosts"
 
-    def test_aggregate_costs_success_routes_to_branch_a_complete(self, states):
-        assert states["AggregateCosts"]["Next"] == "BranchAComplete"
+    def test_aggregate_costs_success_routes_to_report_card(self, states):
+        # alpha-engine-config-I2544: was BranchAComplete pre-lift.
+        assert states["AggregateCosts"]["Next"] == "ReportCard"
 
-    def test_check_skip_aggregate_costs_skip_routes_to_branch_a_complete(
+    def test_check_skip_aggregate_costs_skip_routes_to_report_card(
         self, states,
     ):
+        # alpha-engine-config-I2544: was BranchAComplete pre-lift.
         skip = states["CheckSkipAggregateCosts"]
         skip_choices = skip["Choices"]
         assert len(skip_choices) == 1
-        assert skip_choices[0]["Next"] == "BranchAComplete"
+        assert skip_choices[0]["Next"] == "ReportCard"
 
     def test_check_skip_aggregate_costs_default_is_aggregate_costs(self, states):
         assert states["CheckSkipAggregateCosts"]["Default"] == "AggregateCosts"

--- a/tests/test_sf_choice_guards.py
+++ b/tests/test_sf_choice_guards.py
@@ -47,10 +47,17 @@ import pytest
 
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 _WEEKLY = _REPO_ROOT / "infrastructure" / "step_function.json"
+# alpha-engine-config-I2544/I2545: the two child SFs split out of the
+# weekly SF carry their own Choice states (the eval-judge chain's
+# CheckSkipEvalJudge/EvalJudgePollChoice/etc. and the modelzoo fan-out's
+# CheckResolveZooStatus/CheckModelZooStatus/etc.) and are in scope for the
+# SAME config#2275 guard-or-floor discipline.
+_ADVISORY = _REPO_ROOT / "infrastructure" / "step_function_advisory.json"
+_MODELZOO = _REPO_ROOT / "infrastructure" / "step_function_modelzoo.json"
 
 
-def _load() -> dict:
-    return json.loads(_WEEKLY.read_text())
+def _load(path: pathlib.Path = _WEEKLY) -> dict:
+    return json.loads(path.read_text())
 
 
 # ---------------------------------------------------------------------------
@@ -75,18 +82,21 @@ def _iter_scopes(definition: dict):
 
 
 def _initialize_input_floors(definition: dict) -> set[str]:
-    """Keys InitializeInput guarantees on $ for every execution: the embedded
-    JsonMerge defaults literal, plus the States.Format-injected run_date.
-    Parsed MECHANICALLY from the state so the floor set can never drift from
-    the definition."""
-    params = definition["States"]["InitializeInput"]["Parameters"]["merged.$"]
+    """Keys the SF's initializer Pass state (its StartAt — InitializeInput
+    on the weekly SF, InitializeAdvisoryInput / InitializeModelZooInput on
+    the two I2544/I2545 child SFs) guarantees on $ for every execution: the
+    FIRST embedded JsonMerge defaults literal, plus any States.Format-
+    injected run_date. Parsed MECHANICALLY from the state so the floor set
+    can never drift from the definition."""
+    init_state_name = definition["StartAt"]
+    params = definition["States"][init_state_name]["Parameters"]["merged.$"]
     start = params.index("States.StringToJson('") + len("States.StringToJson('")
     end = params.index("')", start)
     literal = params[start:end].replace('\\"', '"')
     floors = set(json.loads(literal))
     if "run_date" in params:
         floors.add("run_date")
-    assert "sns_topic_arn" in floors, "InitializeInput defaults parse failed"
+    assert "sns_topic_arn" in floors, f"{init_state_name} defaults parse failed"
     return floors
 
 
@@ -182,8 +192,22 @@ def _leaf_violations(rule: dict, guards: frozenset[str], context: str,
     return violations
 
 
-def test_every_choice_variable_is_guarded_or_floored():
-    definition = _load()
+# alpha-engine-config-I2544/I2545 (2026-07-14): the weekly SF's Choice count
+# dropped from 51 -> 40 when the eval-judge chain (8 Choices:
+# CheckSkipEvalJudge/CheckMonthlyCadence/EvalJudgePollChoice/
+# EvalJudgePollDecision/CheckSkipRationaleClustering/
+# CheckSkipReplayConcordance/CheckSkipCounterfactual/CheckSkipAggregateCosts)
+# and the modelzoo fan-out (3 Choices: CheckResolveZooStatus/
+# CheckModelZooStatus/CheckTrainSpecStatus — the last inside
+# ModelZooTrainMap's Map iterator) moved to the two new child SFs, which
+# carry the SAME config#2275 guard-or-floor discipline (see
+# _MIN_CHOICES_SEEN below and the two new per-file tests).
+_MIN_CHOICES_SEEN = {_WEEKLY: 35, _ADVISORY: 8, _MODELZOO: 3}
+
+
+@pytest.mark.parametrize("sf_path", [_WEEKLY, _ADVISORY, _MODELZOO], ids=lambda p: p.stem)
+def test_every_choice_variable_is_guarded_or_floored(sf_path):
+    definition = _load(sf_path)
     top_floors = _initialize_input_floors(definition)
     violations: list[str] = []
     choices_seen = 0
@@ -206,11 +230,15 @@ def test_every_choice_variable_is_guarded_or_floored():
                 violations.extend(
                     _leaf_violations(rule, frozenset(), context, floored)
                 )
-    assert choices_seen >= 40, f"walker regressed: only {choices_seen} Choice states found"
+    min_expected = _MIN_CHOICES_SEEN[sf_path]
+    assert choices_seen >= min_expected, (
+        f"walker regressed on {sf_path.name}: only {choices_seen} Choice "
+        f"states found (expected >= {min_expected})"
+    )
     assert not violations, (
-        "config#2275 regression — Choice dereferences that can States.Runtime "
-        "on an absent field (guard with And:[{IsPresent}, ...] or floor "
-        "upstream):\n" + "\n".join(violations)
+        f"config#2275 regression on {sf_path.name} — Choice dereferences "
+        "that can States.Runtime on an absent field (guard with "
+        "And:[{IsPresent}, ...] or floor upstream):\n" + "\n".join(violations)
     )
 
 
@@ -303,10 +331,10 @@ def _choice_target(definition: dict, choice_name: str, data) -> str:
          "LibPinGateDegraded"),  # fail-open, VISIBLY (config#2278)
         ("PipelineContractGate", {"pipeline_contract_result": {"Payload": {}}},
          "PipelineContractGateDegraded"),  # fail-open, VISIBLY (config#2278)
-        ("EvalJudgePollChoice", {"eval_judge_submit": {"Payload": {}}},
-         "EvalRollingMean"),  # eval is observability — fail-soft
-        ("EvalJudgePollDecision", {"eval_judge_poll": {"Payload": {}}},
-         "EvalRollingMean"),  # malformed poll payload — fail-soft, no Wait loop
+        # NOTE: the EvalJudgePollChoice/EvalJudgePollDecision drill cases
+        # moved to test_partial_payload_routes_to_explicit_path_advisory
+        # below — alpha-engine-config-I2544 lifted the eval-judge chain into
+        # step_function_advisory.json.
         # Healthy-path sanity: the guards must not change live semantics.
         ("WeeklyRunDayGateChoice",
          {"weekly_run_day_gate": {"Payload": {"is_weekly_run_day": False}}},
@@ -314,13 +342,30 @@ def _choice_target(definition: dict, choice_name: str, data) -> str:
         ("LibPinDriftGate",
          {"libpin_drift_result": {"Payload": {"has_drift": True}}},
          "ExtractLibPinDriftError"),
+    ],
+)
+def test_partial_payload_routes_to_explicit_path(choice, partial_input, expected_route):
+    definition = _load()
+    assert _choice_target(definition, choice, partial_input) == expected_route
+
+
+@pytest.mark.parametrize(
+    ("choice", "partial_input", "expected_route"),
+    [
+        ("EvalJudgePollChoice", {"eval_judge_submit": {"Payload": {}}},
+         "EvalRollingMean"),  # eval is observability — fail-soft
+        ("EvalJudgePollDecision", {"eval_judge_poll": {"Payload": {}}},
+         "EvalRollingMean"),  # malformed poll payload — fail-soft, no Wait loop
+        # Healthy-path sanity: the guards must not change live semantics.
         ("EvalJudgePollDecision",
          {"eval_judge_poll": {"Payload": {"processing_status": "polling"}}},
          "EvalJudgePollWait"),
     ],
 )
-def test_partial_payload_routes_to_explicit_path(choice, partial_input, expected_route):
-    definition = _load()
+def test_partial_payload_routes_to_explicit_path_advisory(choice, partial_input, expected_route):
+    """alpha-engine-config-I2544: same drill, re-pointed at the advisory
+    child SF the eval-judge chain now lives in."""
+    definition = _load(_ADVISORY)
     assert _choice_target(definition, choice, partial_input) == expected_route
 
 

--- a/tests/test_sf_definition_check_drift.py
+++ b/tests/test_sf_definition_check_drift.py
@@ -78,13 +78,16 @@ def fake_repo(cd, tmp_path, monkeypatch):
 # ── codified map against the real repo ──────────────────────────────────────
 
 
-def test_map_covers_all_four_orchestrated_state_machines(cd):
+def test_map_covers_all_six_orchestrated_state_machines(cd):
     names = {e["sf_name"] for e in cd.SF_DEFINITIONS}
     assert names == {
         "ne-weekly-freshness-pipeline",
         "ne-preopen-trading-pipeline",
         "ne-postclose-trading-pipeline",
         "alpha-engine-groom-pipeline",
+        # alpha-engine-config-I2544/I2545: advisory + Sunday-modelzoo child SFs.
+        "ne-weekly-advisory-pipeline",
+        "ne-modelzoo-sunday-pipeline",
     }
 
 

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -27,7 +27,18 @@ import pytest
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+# alpha-engine-config-I2544 (2026-07-14): the entire eval-judge chain (+
+# EvalRollingMean/RationaleClustering/ReplayConcordance/Counterfactual/
+# AggregateCosts) was LIFTED out of step_function.json's Branch A into the
+# async ne-weekly-advisory-pipeline child SF, fired fire-and-forget by the
+# main SF's StartAdvisoryPipeline state once DataPhase2 completes (see
+# test_sf_research_predictor_parallel_wiring.py for that side). Every
+# lifted state's Payload/Retry/Catch/Next semantics were preserved
+# byte-for-byte, so this file's per-state assertions are unchanged EXCEPT
+# for pointing at the new file and retiring the now-inapplicable
+# same-state-machine "before PredictorTraining" ordering claim (see
+# TestJudgeChainBeforePredictor below).
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_advisory.json"
 
 
 @pytest.fixture(scope="module")
@@ -37,20 +48,16 @@ def sf() -> dict:
 
 @pytest.fixture(scope="module")
 def states(sf) -> dict:
-    """Flattened state view: top-level states UNION every Parallel
-    branch's states.
+    """Flattened state view: top-level states UNION the single-branch
+    Parallel wrapper's states.
 
-    Post the 2026-05-16 Research || PredictorTraining SF Parallel
-    restructure (plan
-    alpha-engine-docs/private/research-predictor-parallel-260516.md) the
-    entire eval-judge + agent-justification chain moved INSIDE Branch A
-    of the ResearchPredictorParallel state, and PredictorTraining moved
-    into Branch B. Every per-state shape assertion in this file (payload,
-    retry, timeout, Catch posture, in-chain Next edges) is still true —
-    the states just nest one level deeper. Flattening keeps those
-    assertions intact while the few tests that pinned the OLD
-    cross-boundary edges (Counterfactual → CheckSkipPredictorTraining)
-    are updated to the new branch-local terminal + post-join semantics.
+    Originally (pre-I2544) the entire eval-judge + agent-justification
+    chain lived INSIDE Branch A of the main SF's ResearchPredictorParallel
+    state; flattening kept every per-state shape assertion (payload,
+    retry, timeout, Catch posture, in-chain Next edges) valid regardless
+    of nesting depth. Post-I2544 the chain lives inside
+    AdvisoryPipelineWrapper's own single-branch Parallel (the machine-
+    level catch-all retrofit) — same flattening trick, same reason.
     """
     flat: dict = dict(sf["States"])
     for st in sf["States"].values():
@@ -100,116 +107,15 @@ class TestStatesPresent:
 # ── Backtester success → evaluator skip-gate ──────────────────────────────
 
 
-class TestBacktesterTransition:
-    def test_success_routes_to_evaluator_skip_gate(self, states):
-        # Post-2026-05-07 split: Backtester success routed to
-        # CheckSkipEvaluator (the gate in front of the standalone
-        # Evaluator state).
-        #
-        # Post-2026-05-16 preflight-task-split P1: the parity stage was
-        # split out of the combined Backtester state into its own Parity
-        # quartet, reached via CheckSkipParity.
-        #
-        # Post-2026-05-31 L4472 phase-split: the backtest stage is further
-        # decomposed by --mode into Backtester (simulate) → PredictorBacktest
-        # → PortfolioOptimizerBacktest → CheckSkipParity. CheckSkipEvaluator
-        # (the eval-judge gate) stays reachable transitively through the whole
-        # chain; pinned here by walking each status gate's Success edge.
-        # Post-config#830: skip-gates (CheckSkipPredictorBacktest /
-        # CheckSkipPortfolioOptimizerBacktest) precede the predictor + optimizer
-        # stages so mode=backtest-eval can bypass them; each defaults to running
-        # its stage, so the chain to CheckSkipEvaluator is unchanged on a normal run.
-        bt = states["CheckBacktesterStatus"]
-        success_choice = next(
-            c for c in bt["Choices"] if c.get("StringEquals") == "Success"
-        )
-        assert success_choice["Next"] == "CheckSkipPredictorBacktest"
-        assert states["CheckSkipPredictorBacktest"]["Default"] == "PredictorBacktest"
-
-        def _success(check):
-            return next(
-                c for c in states[check]["Choices"]
-                if c.get("StringEquals") == "Success"
-            )["Next"]
-
-        # Walk the L4472 split chain (through the config#830 skip-gates) to the
-        # parity skip-gate.
-        assert _success("CheckPredictorBacktestStatus") == "CheckSkipPortfolioOptimizerBacktest"
-        assert states["CheckSkipPortfolioOptimizerBacktest"]["Default"] == "PortfolioOptimizerBacktest"
-        assert _success("CheckPortfolioOptimizerBacktestStatus") == "CheckSkipParity"
-
-        # skip_parity short-circuit reaches the Evaluator gate directly.
-        skip_parity = states["CheckSkipParity"]
-        assert skip_parity["Choices"][0]["Next"] == "CheckSkipEvaluator"
-        # Default = run Parity; Parity success → CheckSkipEvaluator.
-        assert skip_parity["Default"] == "Parity"
-        parity_success = next(
-            c
-            for c in states["CheckParityStatus"]["Choices"]
-            if c.get("StringEquals") == "Success"
-        )
-        assert parity_success["Next"] == "CheckSkipEvaluator"
-
-
-# ── Skip gate ─────────────────────────────────────────────────────────────
-
-
-class TestSkipBacktesterPreservesEvalJudge:
-    """Pins the 2026-05-03 fix (eval-judge always reachable from a
-    skip_backtester=true operator) AND the 2026-05-07 simplification
-    (skip_backtester decouples from skip_evaluator). The skip-path now
-    routes to CheckSkipEvaluator, which by construction always converges
-    to CheckSkipEvalJudge regardless of which branch it takes. So the
-    silent-bypass-to-SaturdayHealthCheck class is still impossible while
-    the operator gets independent skip flags.
-
-    Caught by SF eval-pipeline-validation-5 (2026-05-03) when Research
-    succeeded + new-format captures landed on S3 but the eval-judge state
-    silently never fired because skip_backtester=true had been
-    short-circuiting past it.
-    """
-
-    def test_skip_backtester_routes_to_evaluator_gate_not_health(self, states):
-        skip = states["CheckSkipBacktester"]
-        choice = skip["Choices"][0]
-        # The skip-true branch hits CheckSkipEvaluator (decoupled flag
-        # 2026-05-07). CheckSkipEvaluator's both branches still converge
-        # to CheckSkipEvalJudge, so eval-judge stays reachable.
-        assert choice["Next"] == "CheckSkipEvaluator"
-        # Critically NOT routed to SaturdayHealthCheck — that was the
-        # 2026-05-03 silent-bypass bug.
-        assert choice["Next"] != "SaturdayHealthCheck"
-
-    def test_evaluator_skip_gate_always_reaches_health_check(self, states):
-        """Both branches of CheckSkipEvaluator must converge into the
-        post-eval tail — the skip path and the run path
-        (Evaluator → CheckEvaluatorStatus → Success) both exit to
-        CheckSkipPostEval, the config#830 tail skip-gate, which defaults
-        to SaturdayHealthCheck (full observability tail).
-
-        Post-2026-05-07 reorder: the eval-judge chain runs UPSTREAM of
-        Evaluator (after DataPhase2, before PredictorTraining), so the
-        question this class previously asked (does eval-judge stay
-        reachable from any skip-flag combination?) is now answered at
-        the upstream junction (CheckSkipDataPhase2 → CheckSkipEvalJudge
-        regardless of skip_data_phase2). At THIS junction, both
-        branches simply exit to the tail; no judge gate downstream to protect.
-
-        config#830: CheckSkipPostEval lets a mid-week mode=backtest-eval run
-        stop after Evaluator (skip the advisory tail), but it DEFAULTS to
-        SaturdayHealthCheck so a normal Saturday run still runs the full tail.
-        """
-        gate = states["CheckSkipEvaluator"]
-        skip_choice = gate["Choices"][0]
-        assert skip_choice["Next"] == "CheckSkipPostEval"
-        assert gate["Default"] == "Evaluator"
-        # Run path success also exits to the tail gate (judge already ran upstream).
-        assert (
-            states["CheckEvaluatorStatus"]["Choices"][0]["Next"]
-            == "CheckSkipPostEval"
-        )
-        # The tail gate defaults to the full health-check tail (normal run).
-        assert states["CheckSkipPostEval"]["Default"] == "SaturdayHealthCheck"
+# RETIRED (alpha-engine-config-I2544, 2026-07-14): TestBacktesterTransition
+# and TestSkipBacktesterPreservesEvalJudge used to pin that the Backtester/
+# Evaluator chain (main SF, post-Parallel-join tail) always stayed reachable
+# to / reachable from the eval-judge chain's skip gates. That invariant is
+# now MOOT — the eval-judge chain lives in a completely separate,
+# asynchronously-dispatched child SF (ne-weekly-advisory-pipeline) with no
+# ordering/reachability relationship to Backtester/Evaluator at all; the
+# main SF's Backtester->Evaluator->CheckSkipPostEval chain (unchanged by
+# this lift) is covered by tests/test_sf_evaluator_wiring.py.
 
 
 class TestSkipEvalJudge:
@@ -794,16 +700,17 @@ class TestJudgeChainBeforePredictor:
     they can be pulled into the weekly email.
     """
 
-    def test_data_phase2_exits_to_judge_skip_gate_not_predictor(self, states):
-        """DataPhase2's success path enters the judge chain, not
-        predictor training. This is the load-bearing invariant — if
-        someone ever rewires DataPhase2.Next to CheckSkipPredictorTraining
-        (the pre-reorder target), the judge chain bypass is silent."""
-        assert states["DataPhase2"]["Next"] == "CheckSkipEvalJudge"
-        assert (
-            states["CheckSkipDataPhase2"]["Choices"][0]["Next"]
-            == "CheckSkipEvalJudge"
-        )
+    # NOTE (alpha-engine-config-I2544, 2026-07-14): the same-state-machine
+    # "DataPhase2 → judge chain → PredictorTraining" ordering claim this
+    # class originally pinned no longer applies — the judge chain now runs
+    # in a SEPARATE, asynchronously-dispatched child SF with no completion
+    # dependency from PredictorTraining (Branch B) at all; the main SF's
+    # DataPhase2 → StartAdvisoryPipeline → BranchAComplete wiring is
+    # covered by test_sf_research_predictor_parallel_wiring.py::
+    # TestBranchAContents::test_advisory_dispatch_after_dataphase2_in_branch_a.
+    # test_data_phase2_exits_to_judge_skip_gate_not_predictor was retired
+    # here (DataPhase2/CheckSkipDataPhase2 are main-SF-only states, out of
+    # this file's scope post-lift).
 
     def test_counterfactual_exits_to_aggregate_costs_gate(self, states):
         """Counterfactual's three exit edges (Next + Catch + the
@@ -829,20 +736,7 @@ class TestJudgeChainBeforePredictor:
             == "CheckSkipAggregateCosts"
         )
 
-    def test_evaluator_exits_directly_to_health_check(self, states):
-        """Evaluator's success path no longer enters the judge chain
-        (judge ran upstream). It exits to the post-eval tail gate
-        (CheckSkipPostEval, config#830), which defaults to SaturdayHealthCheck."""
-        success = next(
-            c for c in states["CheckEvaluatorStatus"]["Choices"]
-            if c.get("StringEquals") == "Success"
-        )
-        assert success["Next"] == "CheckSkipPostEval"
-        # And the skip-evaluator path also goes to CheckSkipPostEval
-        # (the previous pre-reorder target was CheckSkipEvalJudge).
-        assert (
-            states["CheckSkipEvaluator"]["Choices"][0]["Next"]
-            == "CheckSkipPostEval"
-        )
-        # The tail gate defaults to the full health-check tail on a normal run.
-        assert states["CheckSkipPostEval"]["Default"] == "SaturdayHealthCheck"
+    # test_evaluator_exits_directly_to_health_check RETIRED (alpha-engine-
+    # config-I2544): Evaluator/CheckEvaluatorStatus/CheckSkipEvaluator are
+    # main-SF-only states, out of this (advisory-SF) file's scope post-lift
+    # — covered by tests/test_sf_evaluator_wiring.py instead.

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -73,6 +73,10 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+# alpha-engine-config-I2544: the eval-judge chain's dry-path control-var
+# wiring lives here now (lifted verbatim — Payload/Retry/Catch semantics
+# preserved byte-for-byte).
+_ADVISORY_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_advisory.json"
 _CFN_PATH = (
     _REPO_ROOT / "infrastructure" / "cloudformation"
     / "alpha-engine-orchestration.yaml"
@@ -100,14 +104,12 @@ _EXPECTED_SKIPS = {
     # own unconditional posture — it is now a same-day-freshness producer,
     # not an ad-hoc-rerun-optional step).
     "skip_data_phase2",
-    "skip_eval_judge",
-    "skip_rationale_clustering",
-    "skip_replay_concordance",
-    "skip_counterfactual",
-    # Added 2026-05-25 (ROADMAP L1146 — SF-wire aggregate_costs.py CLI).
-    # Observability skip; independent of the three above per the
-    # CheckSkipAggregateCosts comment.
-    "skip_aggregate_costs",
+    # skip_eval_judge/skip_rationale_clustering/skip_replay_concordance/
+    # skip_counterfactual/skip_aggregate_costs retired here:
+    # alpha-engine-config-I2544 lifted the whole eval-judge chain (+
+    # ReportCard/Director) into the async ne-weekly-advisory-pipeline
+    # child SF — these gates no longer exist in THIS SF at all. See
+    # test_sf_advisory_pipeline_wiring.py for their coverage there.
     "skip_predictor_training",
     # config#902: skip_drift_detection was removed — the DriftDetection state
     # (and its CheckSkipDriftDetection gate) were collapsed when drift was
@@ -197,7 +199,13 @@ _DRY_LAMBDA_STATES = {
     "DataPhase2": ("dry_run.$", "$.data_phase2_dry"),
     "RegimeSubstrate": ("action.$", "$.regime_action"),
     "RegimeRetrospectiveEval": ("action.$", "$.regime_action"),
-    # Skip-exception rewire — eval-judge chain + agent-justification triple.
+}
+
+# alpha-engine-config-I2544: the eval-judge chain + agent-justification
+# triple moved to the async advisory child SF (step_function_advisory.json)
+# — same dry-flag wiring, verified against that file by
+# TestAdvisoryByteIdenticalAbsentPath below instead of this file's `sf`.
+_ADVISORY_DRY_LAMBDA_STATES = {
     "EvalJudgeSubmitFirstSaturday": ("dry_run_llm.$", "$.research_dry"),
     "EvalJudgeSubmitWeekly": ("dry_run_llm.$", "$.research_dry"),
     "EvalJudgePoll": ("dry_run_llm.$", "$.research_dry"),
@@ -722,22 +730,60 @@ class TestByteIdenticalAbsentPath:
         )
 
 
+class TestAdvisoryByteIdenticalAbsentPath:
+    """alpha-engine-config-I2544: same dry-flag-follows-control-var
+    invariant as TestByteIdenticalAbsentPath, re-pointed at the eval-judge
+    chain's new home (the advisory child SF's wrapper Parallel branch).
+    research_dry is threaded into the child's input by the parent SF's
+    StartAdvisoryPipeline dispatch (see
+    test_sf_research_predictor_parallel_wiring.py), so the same absent-path
+    identity argument holds."""
+
+    @pytest.fixture(scope="class")
+    def advisory_sf(self) -> dict:
+        return json.loads(_ADVISORY_SF_PATH.read_text())
+
+    def _state(self, advisory_sf: dict, name: str) -> dict:
+        states = advisory_sf["States"]
+        if name in states:
+            return states[name]
+        wrapper = states["AdvisoryPipelineWrapper"]
+        inner = wrapper["Branches"][0]["States"]
+        if name in inner:
+            return inner[name]
+        raise KeyError(name)
+
+    @pytest.mark.parametrize(
+        "name,payload_key,ref", sorted(
+            (n, k, r) for n, (k, r) in _ADVISORY_DRY_LAMBDA_STATES.items()
+        )
+    )
+    def test_dry_lambda_payload_references_control_var(
+        self, advisory_sf, name, payload_key, ref
+    ):
+        st = self._state(advisory_sf, name)
+        payload = st["Parameters"]["Payload"]
+        assert payload.get(payload_key) == ref, (
+            f"{name}.Payload[{payload_key}] must be {ref} (so the dry flag "
+            f"follows the control var); got {payload.get(payload_key)!r}"
+        )
+
+
 class TestConsolidatedNotify:
     def test_substrate_check_routes_to_notify_gate(self, states):
-        # The substrate check flows into two non-fatal advisory states (evaluator
-        # Report Card v2, then the Director) before the notify gate. ReportCard's
-        # SUCCESS Next feeds the Director; its Catch routes to
-        # PublishReportCardDegraded (config#2302: a WARNING page — advisory grading
-        # failed silently for 9 days pre-fix) which then continues to
-        # CheckShellRunNotify. The Director's own Next lands on CheckShellRunNotify;
-        # its Catch routes to PublishDirectorDegraded (same config#2302 shape) which
-        # then continues to CheckShellRunNotify. The path to the notify gate is
-        # preserved whether grading/advisory succeed or fail. On the Friday preflight
-        # the states still RUN (dry, see test_advisory_tail_runs_dry_on_preflight) —
-        # they are not skipped — so the success edge is identical on real + preflight
-        # runs.
-        # config#2276: the substrate poll resolves to a terminal status
-        # first; its Success edge is what feeds ReportCard.
+        # alpha-engine-config-I2544: ReportCard + Director were LIFTED out
+        # of this SF's tail into the async ne-weekly-advisory-pipeline child
+        # SF (dispatched earlier via StartAdvisoryPipeline, right after
+        # DataPhase2 — see test_sf_research_predictor_parallel_wiring.py).
+        # The substrate check's Success edge (and its Degraded fallback)
+        # now converge DIRECTLY on the notify gate — there is nothing left
+        # in this SF's tail to route through. Their own ReportCard->Director
+        # ->notify wiring (unchanged, byte-for-byte preserved) is covered by
+        # test_sf_advisory_pipeline_wiring.py::TestReportCardAndDirectorWiring
+        # and its preflight-dry-run coverage by
+        # test_sf_advisory_pipeline_wiring.py::
+        # TestReportCardAndDirectorWiring::test_report_card_and_director_payload_shape_unchanged.
+        # config#2276: the substrate poll resolves to a terminal status first.
         assert (
             states["WaitForWeeklySubstrateHealthCheck"]["Next"]
             == "CheckSubstrateHealthCheckStatus"
@@ -747,43 +793,25 @@ class TestConsolidatedNotify:
             for r in states["CheckSubstrateHealthCheckStatus"]["Choices"]
             if r.get("StringEquals") == "Success"
         )
-        assert substrate_success["Next"] == "ReportCard"
-        report_card = states["ReportCard"]
-        assert report_card["Next"] == "Director"
-        assert all(c["Next"] == "PublishReportCardDegraded" for c in report_card["Catch"])
-        assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
-        director = states["Director"]
-        assert director["Next"] == "CheckShellRunNotify"
-        assert all(c["Next"] == "PublishDirectorDegraded" for c in director["Catch"])
-        assert states["PublishDirectorDegraded"]["Next"] == "CheckShellRunNotify"
+        assert substrate_success["Next"] == "CheckShellRunNotify"
+        assert states["SubstrateHealthCheckDegraded"]["Next"] == "CheckShellRunNotify"
+        assert "ReportCard" not in states
+        assert "Director" not in states
 
-    def test_advisory_tail_runs_dry_on_preflight(self, states):
-        """ROADMAP L4504: ReportCard + Director were added after the shell-run
-        keystone and were given NO dry path — their payloads only carried {date},
-        and the Director Lambda gates solely on DIRECTOR_ENABLED. Left ungated,
-        the Friday-PM Preflight Pipeline would run ReportCard for real (writing a
-        degenerate, mostly-N/A card) and, once DIRECTOR_ENABLED is flipped on,
-        fire a REAL Opus Director call that merges that plan into the SHARED,
-        non-date-scoped carry-over ledger (director/carryover_ledger.json),
-        polluting the state the real Saturday run reads.
-
-        Fix (keystone-consistent: dry-execute, don't skip): both payloads thread
-        dry_run.$=$.research_dry — the canonical shell-run-dry signal, false on the
-        real Saturday run / true on the preflight. The handlers then run a no-write
-        (ReportCard) / no-Opus-no-write probe (Director) on the preflight, still
-        exercising container boot / imports / IAM / S3-read. Mirrors the other
-        advisory Lambdas (eval-judge / rationale-clustering / replay-concordance /
-        counterfactual) which all run dry via $.research_dry rather than skipping.
-        """
+    def test_advisory_tail_dry_run_coverage_relocated(self, states):
+        """ROADMAP L4504 / alpha-engine-config-I2544: the ReportCard/
+        Director dry-execute-on-preflight invariant (both payloads thread
+        dry_run.$=$.research_dry so the Friday preflight runs a no-write /
+        no-Opus probe rather than polluting the shared carry-over ledger)
+        is unchanged, but ReportCard/Director no longer live in THIS SF —
+        see test_sf_advisory_pipeline_wiring.py::TestReportCardAndDirectorWiring
+        ::test_report_card_and_director_payload_shape_unchanged for the
+        re-pointed assertion."""
         for state_name in ("ReportCard", "Director"):
-            payload = states[state_name]["Parameters"]["Payload"]
-            assert payload.get("dry_run.$") == "$.research_dry", (
-                f"{state_name}.Payload must thread dry_run.$=$.research_dry so the "
-                f"Friday preflight runs it dry (no write / no Opus call); got "
-                f"{payload.get('dry_run.$')!r}"
+            assert state_name not in states, (
+                f"{state_name} still present at top level — alpha-engine-"
+                "config-I2544 lifted it into step_function_advisory.json"
             )
-            # date must still flow so the dry run keys off the same RUN_DATE.
-            assert payload.get("date.$") == "$.run_date"
 
     def test_shell_run_notify_reuses_sns_substrate(self, states):
         """NotifyShellRunComplete surfaces the user-facing 'Saturday

--- a/tests/test_sf_global_timeout.py
+++ b/tests/test_sf_global_timeout.py
@@ -27,6 +27,7 @@ import re
 
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 _WEEKLY = _REPO_ROOT / "infrastructure" / "step_function.json"
+_ADVISORY = _REPO_ROOT / "infrastructure" / "step_function_advisory.json"
 _WATCH_DEPLOY = (
     _REPO_ROOT / "infrastructure" / "lambdas" / "saturday-sf-watch-dispatcher" / "deploy.sh"
 )
@@ -34,6 +35,10 @@ _WATCH_DEPLOY = (
 
 def _definition() -> dict:
     return json.loads(_WEEKLY.read_text())
+
+
+def _advisory_definition() -> dict:
+    return json.loads(_ADVISORY.read_text())
 
 
 def test_weekly_definition_has_global_timeout():
@@ -51,20 +56,44 @@ def test_weekly_definition_has_global_timeout():
 
 
 def test_global_timeout_clears_longest_legitimate_composition():
+    # alpha-engine-config-I2544: the eval-judge chain (and its
+    # max_wait_seconds batch-poll cap) moved to the async
+    # ne-weekly-advisory-pipeline child SF — this file no longer contains
+    # that wait at all, so the weekly SF's own ceiling is now bounded by the
+    # spot-stage/retry-ladder composition alone (see the top-level Comment).
     definition = _definition()
     timeout = definition["TimeoutSeconds"]
-    # The single longest in-definition wait: the eval-judge Anthropic batch
-    # poll cap. The ceiling must clear it with real headroom for the spot
-    # stages around it (recorded full-run max 3.04h ≈ 11000s).
     text = _WEEKLY.read_text()
     max_waits = [int(m) for m in re.findall(r'"max_wait_seconds":\s*(\d+)', text)]
-    assert max_waits, "eval-judge max_wait_seconds cap not found — update this test"
-    assert timeout >= max(max_waits) + 4 * 3600, (
-        "global ceiling too tight: a legitimate slow Anthropic batch plus "
-        "normal stage time would TIMED_OUT a healthy run"
+    assert not max_waits, (
+        "a max_wait_seconds cap reappeared in step_function.json — the "
+        "eval-judge chain that owned this pattern was moved to "
+        "step_function_advisory.json by alpha-engine-config-I2544; if a new "
+        "in-SF wait was legitimately added here, restore the "
+        "clears-the-longest-wait assertion this test used to make"
     )
     assert timeout <= 24 * 3600, (
         "global ceiling above 24h stops being a same-day hang signal"
+    )
+
+
+def test_advisory_global_timeout_clears_its_own_eval_judge_poll_cap():
+    """alpha-engine-config-I2544: the advisory child SF inherits the
+    eval-judge chain's max_wait_seconds cap — its OWN top-level
+    TimeoutSeconds must clear it with headroom, mirroring the parent SF's
+    config#2274 discipline in miniature."""
+    definition = _advisory_definition()
+    timeout = definition["TimeoutSeconds"]
+    assert isinstance(timeout, int)
+    text = _ADVISORY.read_text()
+    max_waits = [int(m) for m in re.findall(r'"max_wait_seconds":\s*(\d+)', text)]
+    assert max_waits, "eval-judge max_wait_seconds cap not found in the advisory child SF"
+    assert timeout >= max(max_waits) + 3600, (
+        "advisory child SF's ceiling too tight: a legitimate slow Anthropic "
+        "batch plus ReportCard/Director would TIMED_OUT a healthy run"
+    )
+    assert timeout <= 24 * 3600, (
+        "advisory child SF's ceiling above 24h stops being a same-day hang signal"
     )
 
 
@@ -78,3 +107,6 @@ def test_timed_out_routes_into_sf_watch():
     statuses = {s.strip().strip('"') for s in match.group(1).split(",")}
     assert "TIMED_OUT" in statuses
     assert "ne-weekly-freshness-pipeline" in deploy
+    # alpha-engine-config-I2544/I2545: both new child SFs are watch-registered too.
+    assert "ne-weekly-advisory-pipeline" in deploy
+    assert "ne-modelzoo-sunday-pipeline" in deploy

--- a/tests/test_sf_health_check_honesty_wiring.py
+++ b/tests/test_sf_health_check_honesty_wiring.py
@@ -54,10 +54,15 @@ CHECKS = [
      "CheckSaturdayHealthCheckStatus", "SaturdayHealthCheckPollWait",
      "SaturdayHealthCheckDegraded", "$.health_check_poll",
      "WeeklySubstrateHealthCheck", 300),
+    # alpha-engine-config-I2544 (2026-07-14): "proceeds-to" was ReportCard
+    # pre-lift — ReportCard/Director now live in the async
+    # ne-weekly-advisory-pipeline child SF, dispatched earlier via
+    # StartAdvisoryPipeline. This tail has nothing left to proceed into
+    # except the notify gate.
     ("WeeklySubstrateHealthCheck", "WaitForWeeklySubstrateHealthCheck",
      "CheckSubstrateHealthCheckStatus", "SubstrateHealthCheckPollWait",
      "SubstrateHealthCheckDegraded", "$.substrate_check_poll",
-     "ReportCard", 240),
+     "CheckShellRunNotify", 240),
 ]
 _IDS = [c[0] for c in CHECKS]
 

--- a/tests/test_sf_logging_config_check_drift.py
+++ b/tests/test_sf_logging_config_check_drift.py
@@ -38,7 +38,7 @@ def _fake_run(returncode=0, stdout="", stderr=""):
 # ── Discovery against the real repo state ───────────────────────────────────
 
 
-def test_discovers_all_four_orchestrated_state_machines(cd):
+def test_discovers_all_six_orchestrated_state_machines(cd):
     entries = cd._discover_expected_logging_configs()
     names = {e["sf_name"] for e in entries}
     assert names == {
@@ -46,6 +46,13 @@ def test_discovers_all_four_orchestrated_state_machines(cd):
         "ne-preopen-trading-pipeline",
         "ne-postclose-trading-pipeline",
         "alpha-engine-groom-dispatch",
+        # alpha-engine-config-I2544/I2545: both are CFN
+        # AWS::StepFunctions::StateMachine resources with a
+        # LoggingConfiguration block, auto-discovered via
+        # _discover_expected_from_cfn's regex walk of the CFN template —
+        # no code change needed in check-drift.py itself.
+        "ne-weekly-advisory-pipeline",
+        "ne-modelzoo-sunday-pipeline",
     }
 
 

--- a/tests/test_sf_modelzoo_pipeline_wiring.py
+++ b/tests/test_sf_modelzoo_pipeline_wiring.py
@@ -1,0 +1,280 @@
+"""Pins the ne-modelzoo-sunday-pipeline child SF (alpha-engine-config-I2545).
+
+Origin: Phase 3 of the weekly-SF load-reduction plan — the config#1083
+model-zoo fan-out (ResolveZooSpecs -> Map -> ModelZooSelect) was moved OFF
+Saturday's Branch B into its own Sunday-09:00-UTC-triggered child SF
+(infrastructure/step_function_modelzoo.json), Brian-ruled 2026-07-14. Ends
+with a re-invoke of the crucible-evaluator grading Lambda as the
+persistent-dash re-grade (same ruling: the grading Lambda is stateless/
+pull-based and keys to trading_day, so a Sunday run updates the SAME Friday
+card the Saturday run wrote).
+
+Re-pins the behavioral assertions that used to live in
+test_sf_research_predictor_parallel_wiring.py::TestBranchBContents before
+the I2545 lift, plus new coverage for the child-SF-only scaffolding.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_modelzoo.json"
+
+_LIFTED_ZOO_STATES = {
+    "ResolveZooSpecs", "WaitResolveZoo", "CheckResolveZooStatus",
+    "ExtractModelZooResolveError", "ResolveZooWait", "ParseZooSpecs",
+    "ModelZooTrainMap", "ModelZooSelect", "WaitForModelZoo",
+    "CheckModelZooStatus", "ExtractModelZooSelectError",
+    "PublishModelZooFailureImmediate", "ModelZooWait",
+    "GradingLambdaReGrade", "PublishGradingDegradedAlert",
+}
+
+
+def _own_targets(st: dict) -> list[str]:
+    out: list[str] = []
+
+    def rec(o) -> None:
+        if isinstance(o, dict):
+            for k, v in o.items():
+                if k in ("Branches", "ItemProcessor", "Iterator"):
+                    continue
+                if k in ("Next", "Default") and isinstance(v, str):
+                    out.append(v)
+                elif k == "Catch":
+                    for c in v:
+                        out.append(c["Next"])
+                else:
+                    rec(v)
+        elif isinstance(o, list):
+            for it in o:
+                rec(it)
+
+    rec(st)
+    return out
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def states(sf) -> dict:
+    return sf["States"]
+
+
+@pytest.fixture(scope="module")
+def wrapper(states) -> dict:
+    return states["ModelZooPipelineWrapper"]
+
+
+@pytest.fixture(scope="module")
+def inner(wrapper) -> dict:
+    return wrapper["Branches"][0]["States"]
+
+
+class TestJsonParsesAndTopLevel:
+    def test_json_parses(self, sf):
+        assert isinstance(sf, dict)
+        assert sf["StartAt"] in sf["States"]
+
+    def test_start_at_initializes_input(self, sf):
+        assert sf["StartAt"] == "InitializeModelZooInput"
+
+    def test_top_level_timeout(self, sf):
+        assert sf["TimeoutSeconds"] == 21600
+        assert sf["TimeoutSeconds"] <= 24 * 3600
+
+    def test_initialize_modelzoo_input_derives_run_date_from_own_execution(self, states):
+        """The Sunday execution's OWN calendar date is used for $.run_date —
+        deliberate, since trading_day = last_closed_trading_day(now) is
+        backward-looking and both Saturday and Sunday resolve to the same
+        last-closed Friday (see this state's Comment for the full rationale
+        + the flagged, NOT-closed cross-repo audit gap on the zoo Task
+        states' own internal date handling)."""
+        init = states["InitializeModelZooInput"]
+        assert init["Type"] == "Pass"
+        merge_expr = init["Parameters"]["merged.$"]
+        assert "$$.Execution.StartTime" in merge_expr
+        assert "$$.Execution.Input" in merge_expr
+        assert '"research_dry":false' in merge_expr
+        assert init["Next"] == "ModelZooPipelineWrapper"
+
+
+class TestWrapperParallelCatchAll:
+    def test_wrapper_is_single_branch_parallel(self, wrapper):
+        assert wrapper["Type"] == "Parallel"
+        assert len(wrapper["Branches"]) == 1
+
+    def test_wrapper_starts_at_resolve_zoo_specs(self, wrapper):
+        assert wrapper["Branches"][0]["StartAt"] == "ResolveZooSpecs"
+
+    def test_wrapper_catch_routes_to_failure_funnel(self, wrapper):
+        catches = wrapper["Catch"]
+        assert any(
+            c["ErrorEquals"] == ["States.ALL"]
+            and c["Next"] == "ModelZooNormalizeFailureContext"
+            and c["ResultPath"] == "$.error"
+            for c in catches
+        )
+
+    def test_failure_funnel_reaches_fail_state(self, states):
+        assert states["ModelZooNormalizeFailureContext"]["Next"] == (
+            "ModelZooHandleFailure"
+        )
+        assert states["ModelZooHandleFailure"]["Next"] == "ModelZooFailExecution"
+        assert states["ModelZooFailExecution"]["Type"] == "Fail"
+
+
+class TestLiftedStatesPresent:
+    @pytest.mark.parametrize("name", sorted(_LIFTED_ZOO_STATES))
+    def test_lifted_state_present(self, inner, name):
+        assert name in inner
+
+
+class TestZooFanoutSemanticsPreserved:
+    """Re-pins the behavioral assertions that used to live in
+    test_sf_research_predictor_parallel_wiring.py::TestBranchBContents
+    before the I2545 lift."""
+
+    def test_zoo_fanout_pipeline_wiring(self, inner):
+        resolve = inner["ResolveZooSpecs"]
+        assert resolve["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
+        rcmd = resolve["Parameters"]["Parameters"]["commands.$"]
+        assert "list-rotation-specs" in rcmd
+        assert resolve["Next"] == "WaitResolveZoo"
+        check_resolve = inner["CheckResolveZooStatus"]
+        rnexts = {c["StringEquals"]: c["Next"] for c in check_resolve["Choices"]}
+        assert rnexts["Success"] == "ParseZooSpecs"
+        assert check_resolve["Default"] == "ExtractModelZooResolveError"
+        extract_resolve = inner["ExtractModelZooResolveError"]
+        assert extract_resolve["Type"] == "Pass"
+        assert extract_resolve["ResultPath"] == "$.model_zoo_error"
+        assert extract_resolve["Next"] == "PublishModelZooFailureImmediate"
+        parse = inner["ParseZooSpecs"]
+        assert parse["Type"] == "Pass"
+        assert "StringToJson" in parse["Parameters"]["zoo_specs.$"]
+        assert "Catch" not in parse
+        assert parse["Next"] == "ModelZooTrainMap"
+
+    def test_model_zoo_train_map_per_spec_isolation(self, inner):
+        m = inner["ModelZooTrainMap"]
+        assert m["Type"] == "Map"
+        assert m["ItemsPath"] == "$.parsed_zoo.zoo_specs"
+        assert isinstance(m["MaxConcurrency"], int) and m["MaxConcurrency"] >= 1
+        assert m["ToleratedFailurePercentage"] == 100
+        assert m["ItemSelector"]["spec_id.$"] == "$$.Map.Item.Value"
+        assert m["ItemSelector"]["ec2_instance_id.$"] == "$.ec2_instance_id"
+        proc = m["ItemProcessor"]["States"]
+        dcmd = proc["TrainSpecDispatch"]["Parameters"]["Parameters"]["commands.$"]
+        assert "--model-zoo-spec" in dcmd
+        assert "$.spec_id" in dcmd
+        for term in ("TrainSpecOK", "TrainSpecFailed"):
+            assert proc[term]["Type"] == "Pass"
+            assert proc[term]["End"] is True
+        cts = proc["CheckTrainSpecStatus"]
+        assert cts["Default"] == "TrainSpecFailed"
+        assert m["Next"] == "ModelZooSelect"
+
+    def test_model_zoo_map_iterator_no_dangling(self, inner):
+        proc = inner["ModelZooTrainMap"]["ItemProcessor"]
+        names = set(proc["States"])
+        assert proc["StartAt"] in names
+        for n, st in proc["States"].items():
+            for t in _own_targets(st):
+                assert t in names, f"Map iterator dangling: {n} -> {t}"
+
+    def test_model_zoo_select_is_best_effort(self, inner):
+        sel = inner["ModelZooSelect"]
+        assert sel["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
+        scmd = sel["Parameters"]["Parameters"]["commands.$"]
+        assert "--model-zoo-select" in scmd
+        assert sel["Next"] == "WaitForModelZoo"
+        check = inner["CheckModelZooStatus"]
+        assert check["Default"] == "ExtractModelZooSelectError"
+        extract_select = inner["ExtractModelZooSelectError"]
+        assert extract_select["Next"] == "PublishModelZooFailureImmediate"
+        nexts = {c["StringEquals"]: c["Next"] for c in check["Choices"]}
+        assert nexts["InProgress"] == "ModelZooWait"
+        assert nexts["Pending"] == "ModelZooWait"
+        # alpha-engine-config-I2545: Success now feeds the grading tail
+        # (was BranchBComplete before the lift — no Parallel join here).
+        assert nexts["Success"] == "GradingLambdaReGrade"
+        assert inner["ModelZooWait"]["Next"] == "WaitForModelZoo"
+
+    def test_model_zoo_failure_alert_converges_on_grading_tail(self, inner):
+        """alpha-engine-config-I2545: every best-effort ModelZoo failure
+        path converges on GradingLambdaReGrade (was BranchBComplete
+        pre-lift) — the persistent-dash re-grade must still run even if
+        the rotation itself degraded."""
+        alert = inner["PublishModelZooFailureImmediate"]
+        assert alert["Resource"] == "arn:aws:states:::sns:publish"
+        assert alert["Next"] == "GradingLambdaReGrade"
+        assert all(c["Next"] == "GradingLambdaReGrade" for c in alert["Catch"])
+        assert "PREDICTOR_DEFER_TRAINING_EMAIL" in alert["Parameters"]["Message.$"]
+
+
+class TestGradingLambdaReGradeTail:
+    def test_grading_lambda_payload_shape_matches_report_card(self, inner):
+        """Same FunctionName/Payload shape as the parent SF's ReportCard
+        state (and the advisory child's own ReportCard) — same Lambda,
+        same contract, per Brian's 2026-07-14 ruling."""
+        g = inner["GradingLambdaReGrade"]
+        assert g["Resource"] == "arn:aws:states:::lambda:invoke"
+        assert g["Parameters"]["FunctionName"] == "alpha-engine-evaluator:live"
+        assert g["Parameters"]["Payload"]["date.$"] == "$.run_date"
+        assert g["Parameters"]["Payload"]["dry_run.$"] == "$.research_dry"
+
+    def test_grading_lambda_snapshot_flag_false(self, inner):
+        """alpha-engine-config-I2556 (persistent report card with weekly
+        snapshots): this Sunday re-grade only refreshes the standing
+        latest.json — snapshot=false, never a second same-week dated
+        snapshot (the advisory child SF's ReportCard owns that, with
+        snapshot=true)."""
+        g = inner["GradingLambdaReGrade"]
+        assert g["Parameters"]["Payload"]["snapshot"] is False
+
+    def test_grading_lambda_non_blocking(self, inner):
+        """I2545 build item 2: a grading failure must not fail the zoo run."""
+        g = inner["GradingLambdaReGrade"]
+        assert g["Catch"][0]["Next"] == "PublishGradingDegradedAlert"
+        assert g["Next"] == "ModelZooSundayNotifyComplete"
+        alert = inner["PublishGradingDegradedAlert"]
+        assert alert["Next"] == "ModelZooSundayNotifyComplete"
+        assert all(
+            c["Next"] == "ModelZooSundayNotifyComplete" for c in alert["Catch"]
+        )
+
+
+class TestTerminalNotify:
+    def test_notify_complete_is_constants_only(self, inner):
+        n = inner["ModelZooSundayNotifyComplete"]
+        assert n["Resource"] == "arn:aws:states:::sns:publish"
+        assert "Subject.$" not in n["Parameters"]
+        assert "Message.$" not in n["Parameters"]
+        assert n["End"] is True
+        assert n["Catch"][0]["Next"] == "ModelZooSundayNotifyCompleteDegraded"
+
+    def test_notify_complete_degraded_records_data(self, inner):
+        d = inner["ModelZooSundayNotifyCompleteDegraded"]
+        assert d["Type"] == "Pass"
+        assert d["End"] is True
+        assert d["Parameters"]["degraded"] is True
+
+
+class TestNoDanglingTargets:
+    def test_inner_no_dangling(self, wrapper):
+        names = set(wrapper["Branches"][0]["States"])
+        assert wrapper["Branches"][0]["StartAt"] in names
+        for n, st in wrapper["Branches"][0]["States"].items():
+            for t in _own_targets(st):
+                assert t in names, f"dangling: {n} -> {t}"
+
+    def test_top_level_no_dangling(self, states):
+        top = set(states)
+        for n, st in states.items():
+            for t in _own_targets(st):
+                assert t in top, f"top-level dangling: {n} -> {t}"

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -42,6 +42,11 @@ _INFRA = _REPO_ROOT / "infrastructure"
 _SF_SATURDAY = _INFRA / "step_function.json"
 _SF_WEEKDAY = _INFRA / "step_function_daily.json"
 _SF_EOD = _INFRA / "step_function_eod.json"
+# alpha-engine-config-I2544/I2545: the two child SFs split out of the
+# Saturday SF each get their OWN closed payload-key registry (build
+# instruction: "new SFs get their own payload-key registries").
+_SF_ADVISORY = _INFRA / "step_function_advisory.json"
+_SF_MODELZOO = _INFRA / "step_function_modelzoo.json"
 
 _SF_ROLE_POLICY = _INFRA / "iam" / "alpha-engine-step-functions-role.json"
 
@@ -89,42 +94,12 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # shadow alive for the producer leaderboard post graph-runner removal.
     "ChallengerShadow": frozenset({"mode", "date.$"}),
     "DataPhase2": frozenset({"dry_run.$", "phase"}),
-    "EvalJudgeSubmitFirstSaturday": frozenset(
-        {"date.$", "dry_run_llm.$", "force_sonnet_pass", "capture_lookback_days"}
-    ),
-    "EvalJudgeSubmitWeekly": frozenset(
-        {"date.$", "dry_run_llm.$", "force_sonnet_pass", "capture_lookback_days"}
-    ),
-    "EvalJudgePoll": frozenset(
-        {"batch_id.$", "dry_run_llm.$", "max_wait_seconds", "submit_iso.$"}
-    ),
-    "EvalJudgeProcess": frozenset(
-        {"batch_id.$", "dry_run_llm.$", "plan_s3_key.$"}
-    ),
-    "EvalRollingMean": frozenset({"end_time_iso.$"}),
-    "RationaleClustering": frozenset({"dry_run_llm.$", "end_time_iso.$"}),
-    "ReplayConcordance": frozenset(
-        {
-            "dry_run_llm.$",
-            "end_time_iso.$",
-            "max_artifacts",
-            "target_models",
-            "window_days",
-        }
-    ),
-    "Counterfactual": frozenset(
-        {"dry_run_llm.$", "end_time_iso.$", "max_depth", "window_days"}
-    ),
-    "AggregateCosts": frozenset({"date.$", "dry_run_llm.$"}),
-    # Evaluator Report Card v2 (Layer B) — alpha-engine-evaluator:live. Builds
-    # evaluator/{date}/report_card.json; non-fatal (own Catch → notify gate).
-    # dry_run.$=$.research_dry → no-write on the Friday preflight (ROADMAP L4504).
-    "ReportCard": frozenset({"date.$", "dry_run.$"}),
-    # Director (Layer C, Part II) — alpha-engine-evaluator-director:live. Final
-    # advisory task; reads the fresh report card, writes director/{date}/
-    # action_plan.json; flag-gated (DIRECTOR_ENABLED) + non-fatal (own Catch).
-    # dry_run.$=$.research_dry → no-Opus / no-write probe on the preflight (L4504).
-    "Director": frozenset({"date.$", "dry_run.$"}),
+    # alpha-engine-config-I2544: the eval-judge chain (EvalJudgeSubmit*/
+    # EvalJudgePoll/EvalJudgeProcess/EvalRollingMean/RationaleClustering/
+    # ReplayConcordance/Counterfactual/AggregateCosts) PLUS ReportCard/
+    # Director were LIFTED out of this SF into the async
+    # ne-weekly-advisory-pipeline child SF — see _ADVISORY_PAYLOAD_KEYS
+    # below (step_function_advisory.json has its own closed registry).
 }
 
 # config#1811: the liveness-aware SSM poll iteration — one shared payload
@@ -249,6 +224,135 @@ class TestSaturdaySFPayloadFieldSetsClosed:
             f"Missing: {sorted(expected - actual)}. If the change is "
             "deliberate, update _SATURDAY_PAYLOAD_KEYS in this test file "
             "in the SAME PR."
+        )
+
+
+# alpha-engine-config-I2544: the advisory child SF's own closed registry —
+# every Lambda Payload key-set lifted verbatim from the pre-lift
+# _SATURDAY_PAYLOAD_KEYS entries (Payload/Retry/Catch semantics preserved
+# byte-for-byte per the build instruction).
+_ADVISORY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
+    "EvalJudgeSubmitFirstSaturday": frozenset(
+        {"date.$", "dry_run_llm.$", "force_sonnet_pass", "capture_lookback_days"}
+    ),
+    "EvalJudgeSubmitWeekly": frozenset(
+        {"date.$", "dry_run_llm.$", "force_sonnet_pass", "capture_lookback_days"}
+    ),
+    "EvalJudgePoll": frozenset(
+        {"batch_id.$", "dry_run_llm.$", "max_wait_seconds", "submit_iso.$"}
+    ),
+    "EvalJudgeProcess": frozenset(
+        {"batch_id.$", "dry_run_llm.$", "plan_s3_key.$"}
+    ),
+    "EvalRollingMean": frozenset({"end_time_iso.$"}),
+    "RationaleClustering": frozenset({"dry_run_llm.$", "end_time_iso.$"}),
+    "ReplayConcordance": frozenset(
+        {
+            "dry_run_llm.$",
+            "end_time_iso.$",
+            "max_artifacts",
+            "target_models",
+            "window_days",
+        }
+    ),
+    "Counterfactual": frozenset(
+        {"dry_run_llm.$", "end_time_iso.$", "max_depth", "window_days"}
+    ),
+    "AggregateCosts": frozenset({"date.$", "dry_run_llm.$"}),
+    # alpha-engine-config-I2556 (2026-07-14, persistent report card with
+    # weekly snapshots): this Saturday-cadence invocation is the WEEKLY
+    # FREEZE — snapshot=true writes the dated historical card. The Sunday
+    # ModelZoo child SF's re-grade tail (_MODELZOO_PAYLOAD_KEYS below)
+    # passes snapshot=false (standing latest.json refresh only).
+    "ReportCard": frozenset({"date.$", "dry_run.$", "snapshot"}),
+    "Director": frozenset({"date.$", "dry_run.$"}),
+}
+
+# alpha-engine-config-I2545: the ModelZoo Sunday child SF's own closed
+# registry — the model-zoo fan-out states carry no static-dict Lambda
+# Payloads (they're all SSM sendCommand Tasks, out of scope for
+# _enumerate_lambda_payloads), so this registry covers only the NEW
+# GradingLambdaReGrade tail (same shape as ReportCard above). I2556:
+# snapshot=false — a Sunday re-grade refreshes latest.json only, never a
+# second same-week dated snapshot (the advisory SF's ReportCard owns that).
+_MODELZOO_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
+    "GradingLambdaReGrade": frozenset({"date.$", "dry_run.$", "snapshot"}),
+}
+
+
+class TestAdvisorySFPayloadFieldSetsClosed:
+    """Same chokepoint as Saturday but for the advisory child SF's Lambda
+    Payloads (alpha-engine-config-I2544)."""
+
+    @pytest.fixture(scope="class")
+    def actual_payloads(self) -> dict[str, frozenset[str]]:
+        return _enumerate_lambda_payloads(json.loads(_SF_ADVISORY.read_text()))
+
+    def test_every_lambda_payload_is_in_registry(self, actual_payloads):
+        extra = set(actual_payloads) - set(_ADVISORY_PAYLOAD_KEYS)
+        assert not extra, (
+            f"Advisory SF has Lambda invoke states with Payloads NOT in "
+            f"_ADVISORY_PAYLOAD_KEYS: {sorted(extra)}."
+        )
+
+    def test_no_registry_entry_missing_from_sf(self, actual_payloads):
+        missing = set(_ADVISORY_PAYLOAD_KEYS) - set(actual_payloads)
+        assert not missing, (
+            f"_ADVISORY_PAYLOAD_KEYS has entries for states no longer in "
+            f"the advisory SF: {sorted(missing)}."
+        )
+
+    @pytest.mark.parametrize("state_name", sorted(_ADVISORY_PAYLOAD_KEYS))
+    def test_payload_keys_match_registry(self, actual_payloads, state_name):
+        if state_name not in actual_payloads:
+            pytest.skip(
+                f"{state_name} not present in SF — covered by "
+                "test_no_registry_entry_missing_from_sf"
+            )
+        expected = _ADVISORY_PAYLOAD_KEYS[state_name]
+        actual = actual_payloads[state_name]
+        assert actual == expected, (
+            f"Advisory SF state {state_name!r} Payload keys drifted from "
+            f"registry. Extras: {sorted(actual - expected)} | "
+            f"Missing: {sorted(expected - actual)}."
+        )
+
+
+class TestModelZooSFPayloadFieldSetsClosed:
+    """Same chokepoint as Saturday but for the ModelZoo Sunday child SF's
+    Lambda Payloads (alpha-engine-config-I2545)."""
+
+    @pytest.fixture(scope="class")
+    def actual_payloads(self) -> dict[str, frozenset[str]]:
+        return _enumerate_lambda_payloads(json.loads(_SF_MODELZOO.read_text()))
+
+    def test_every_lambda_payload_is_in_registry(self, actual_payloads):
+        extra = set(actual_payloads) - set(_MODELZOO_PAYLOAD_KEYS)
+        assert not extra, (
+            f"ModelZoo SF has Lambda invoke states with Payloads NOT in "
+            f"_MODELZOO_PAYLOAD_KEYS: {sorted(extra)}."
+        )
+
+    def test_no_registry_entry_missing_from_sf(self, actual_payloads):
+        missing = set(_MODELZOO_PAYLOAD_KEYS) - set(actual_payloads)
+        assert not missing, (
+            f"_MODELZOO_PAYLOAD_KEYS has entries for states no longer in "
+            f"the modelzoo SF: {sorted(missing)}."
+        )
+
+    @pytest.mark.parametrize("state_name", sorted(_MODELZOO_PAYLOAD_KEYS))
+    def test_payload_keys_match_registry(self, actual_payloads, state_name):
+        if state_name not in actual_payloads:
+            pytest.skip(
+                f"{state_name} not present in SF — covered by "
+                "test_no_registry_entry_missing_from_sf"
+            )
+        expected = _MODELZOO_PAYLOAD_KEYS[state_name]
+        actual = actual_payloads[state_name]
+        assert actual == expected, (
+            f"ModelZoo SF state {state_name!r} Payload keys drifted from "
+            f"registry. Extras: {sorted(actual - expected)} | "
+            f"Missing: {sorted(expected - actual)}."
         )
 
 
@@ -599,14 +703,18 @@ class TestEODSFTopLevelFieldsClosed:
 # (crucible-predictor spot_train.sh runs monitoring.drift_detector non-blocking
 # after training succeeds, on the same instance), so it no longer launches its
 # own spot. DriftDetection dropped out of the flat-level spot set.
-_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 10
+# 10 → 9 on alpha-engine-config-I2545 (2026-07-14): ModelZooSelect (the last
+# remaining flat-level model-zoo spot launcher) moved to the new Sunday-
+# triggered ne-modelzoo-sunday-pipeline child SF (step_function_modelzoo.json)
+# — see TestModelZooSFSpotStateCount below for its own closed count.
+_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 9
 
 
-def _saturday_spot_states() -> list[str]:
+def _spot_states(sf_path: Path) -> list[str]:
     """Find every Task state whose `commands` contains
     `bash infrastructure/spot_*.sh` — these are the spot-instance
-    launchers and must equal the documented 8."""
-    sf = json.loads(_SF_SATURDAY.read_text())
+    launchers."""
+    sf = json.loads(sf_path.read_text())
     out: list[str] = []
     for name, st in _flatten_states(sf).items():
         if st.get("Type") != "Task":
@@ -631,14 +739,15 @@ def _saturday_spot_states() -> list[str]:
 
 
 class TestSaturdaySFSpotStateCount:
-    """Closes the spot-state set as exactly 8. Pre-rewire
-    test_sf_friday_shell_run_wiring.py parametrizes over the 8 expected
-    names but doesn't assert there are EXACTLY 8 — an orphaned legacy
+    """Closes the spot-state set as exactly 9 (see the count-history
+    changelog comment above `_EXPECTED_SATURDAY_SPOT_STATE_COUNT`).
+    Pre-rewire test_sf_friday_shell_run_wiring.py parametrizes over the
+    expected names but doesn't assert an EXACT count — an orphaned legacy
     spot state from an incomplete refactor would slip through.
     """
 
-    def test_exactly_eight_spot_states_in_saturday_sf(self):
-        spots = _saturday_spot_states()
+    def test_exactly_nine_spot_states_in_saturday_sf(self):
+        spots = _spot_states(_SF_SATURDAY)
         assert len(spots) == _EXPECTED_SATURDAY_SPOT_STATE_COUNT, (
             f"Saturday SF should have EXACTLY "
             f"{_EXPECTED_SATURDAY_SPOT_STATE_COUNT} spot-launching states; "
@@ -646,3 +755,23 @@ class TestSaturdaySFSpotStateCount:
             "legacy state slipped through an incomplete refactor or a "
             "deliberate spot-state addition needs the test bump."
         )
+
+
+# alpha-engine-config-I2545: the ModelZoo Sunday child SF's own closed spot-
+# state count. ModelZooSelect is the sole flat-level spot launcher moved
+# here from the Saturday SF (TrainSpecDispatch, the per-spec launcher, lives
+# in ModelZooTrainMap's Map ItemProcessor — _flatten_states does not descend
+# into a Map, same exclusion _saturday_spot_states/_spot_states has always
+# applied to the Saturday SF's own ModelZooTrainMap).
+_EXPECTED_MODELZOO_SPOT_STATE_COUNT = 1
+
+
+class TestModelZooSFSpotStateCount:
+    def test_exactly_one_spot_state_in_modelzoo_sf(self):
+        spots = _spot_states(_SF_MODELZOO)
+        assert len(spots) == _EXPECTED_MODELZOO_SPOT_STATE_COUNT, (
+            f"ModelZoo SF should have EXACTLY "
+            f"{_EXPECTED_MODELZOO_SPOT_STATE_COUNT} spot-launching state "
+            f"(ModelZooSelect); found {len(spots)}: {sorted(spots)}."
+        )
+        assert spots == ["ModelZooSelect"]

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -80,20 +80,23 @@ _BRANCH_A_STATES = {
     # ChallengerShadow (keeps the no_agent champion-baseline shadow alive).
     # ThinkTankCoverage moved to run AFTER RAG so its theses read the fresh
     # corpus. ExtractResearchError was renamed ExtractSignalsEnvelopeError.
+    #
+    # alpha-engine-config-I2544: the eval-judge chain (CheckSkipEvalJudge
+    # through AggregateCosts) PLUS ReportCard/Director were LIFTED out of
+    # Branch A into the async ne-weekly-advisory-pipeline child SF
+    # (step_function_advisory.json — see test_sf_advisory_pipeline_wiring.py
+    # for their coverage there). DataPhase2 now routes straight into
+    # StartAdvisoryPipeline (fire-and-forget dispatch), which converges on
+    # BranchAComplete like every other Branch A terminal edge.
     "Scanner", "CheckSkipRegimeSubstrate", "RegimeSubstrate",
     "SignalsEnvelope", "ChallengerShadow",
     "ThinkTankCoverage", "CheckSkipRAGIngestion", "RAGIngestion",
     "WaitForRAGIngestion", "CheckRAGIngestionStatus", "RAGIngestionWait",
     "RAGIngestionRetryGate", "RAGIngestionReissue", "ExtractRAGIngestionError",
     "CheckSkipRegimeRetrospectiveEval", "RegimeRetrospectiveEval",
-    "CheckSkipDataPhase2", "DataPhase2", "CheckSkipEvalJudge",
-    "ComputeEvalCadence", "CheckMonthlyCadence",
-    "EvalJudgeSubmitFirstSaturday", "EvalJudgeSubmitWeekly",
-    "EvalJudgePollChoice", "EvalJudgePollWait", "EvalJudgePoll",
-    "EvalJudgePollDecision", "EvalJudgeProcess", "EvalRollingMean",
-    "CheckSkipRationaleClustering", "RationaleClustering",
-    "CheckSkipReplayConcordance", "ReplayConcordance",
-    "CheckSkipCounterfactual", "Counterfactual", "ExtractSignalsEnvelopeError",
+    "CheckSkipDataPhase2", "DataPhase2",
+    "StartAdvisoryPipeline", "PublishAdvisoryDispatchFailureAlert",
+    "ExtractSignalsEnvelopeError",
     "PublishResearchFailureImmediate",
     "BranchAComplete", "BranchAFailed",
 }
@@ -101,18 +104,18 @@ _BRANCH_B_STATES = {
     "CheckSkipPredictorTraining", "PredictorTraining",
     "WaitForPredictorTraining", "CheckPredictorStatus", "PredictorWait",
     "ExtractPredictorError", "PublishPredictorFailureImmediate",
-    # config#1083 parallel model-zoo fan-out: ResolveZooSpecs -> Map -> Select.
-    "ResolveZooSpecs", "WaitResolveZoo", "CheckResolveZooStatus",
-    "ResolveZooWait", "ExtractModelZooResolveError", "ParseZooSpecs",
-    "ModelZooTrainMap", "ModelZooSelect",
-    "WaitForModelZoo", "CheckModelZooStatus", "ModelZooWait",
-    "ExtractModelZooSelectError", "PublishModelZooFailureImmediate",
     # config#2253 validated skip path: skip_predictor_training=true routes
     # through a manifest-freshness HeadObject before the branch may read
     # as succeeded (backtest-eval preset bypasses validation by design).
     "ValidatePredictorSkipWeightsFresh", "CheckPredictorSkipWeightsFresh",
     "PredictorSkipWeightsStale", "PredictorTrainingSkipped",
     "BranchBComplete", "BranchBFailed",
+    # alpha-engine-config-I2545: the config#1083 model-zoo fan-out
+    # (ResolveZooSpecs -> Map -> Select) was LIFTED out of Branch B into
+    # its own Sunday-triggered ne-modelzoo-sunday-pipeline child SF
+    # (step_function_modelzoo.json — see test_sf_modelzoo_pipeline_wiring.py
+    # for their coverage there). CheckPredictorStatus's Success edge now
+    # routes straight to BranchBComplete.
 }
 
 
@@ -239,17 +242,20 @@ class TestResearchAndPredictorAreSiblingBranches:
         assert "PredictorTraining" not in branch_a
 
     def test_no_research_to_predictor_serial_edge_anywhere(self, sf):
-        """Defensive: no state's Next/Default/Catch may point Research →
-        PredictorTraining or chain them sequentially. The old serial edge
-        was CheckSkipCounterfactual/Counterfactual → CheckSkipPredictor
-        Training; that must now be a branch-local terminal."""
+        """Defensive: no state's Next/Default/Catch may point Branch A work →
+        PredictorTraining or chain them sequentially — Branch A must never
+        route into Branch B's StartAt. alpha-engine-config-I2544: the old
+        serial-edge suspects (CheckSkipCounterfactual/Counterfactual) moved
+        to the async advisory child SF along with the rest of the eval-judge
+        chain, so this now checks EVERY remaining Branch A state generically
+        rather than naming specific lifted states."""
         a = sf["States"]["ResearchPredictorParallel"]["Branches"][0][
             "States"
         ]
-        for n in ("Counterfactual", "CheckSkipCounterfactual"):
-            assert "CheckSkipPredictorTraining" not in _own_targets(a[n]), (
-                f"{n} still routes to CheckSkipPredictorTraining — Research "
-                f"and PredictorTraining are re-serialized."
+        for n, st in a.items():
+            assert "CheckSkipPredictorTraining" not in _own_targets(st), (
+                f"{n} routes to CheckSkipPredictorTraining — Branch A and "
+                f"PredictorTraining (Branch B) are re-serialized."
             )
 
 
@@ -272,17 +278,45 @@ class TestBranchAContents:
         assert branch_a["RegimeRetrospectiveEval"]["Next"] == "CheckSkipDataPhase2"
         assert branch_a["CheckSkipDataPhase2"]["Default"] == "DataPhase2"
 
-    def test_eval_chain_after_dataphase2_in_branch_a(self, branch_a):
-        assert branch_a["DataPhase2"]["Next"] == "CheckSkipEvalJudge"
-        assert branch_a["CheckSkipEvalJudge"]["Default"] == "ComputeEvalCadence"
-
-    def test_eval_judge_quartet_preserved(self, branch_a):
-        assert branch_a["EvalJudgePollChoice"]["Type"] == "Choice"
-        assert branch_a["EvalJudgePollWait"]["Type"] == "Wait"
-        assert branch_a["EvalJudgePollWait"]["Next"] == "EvalJudgePoll"
-        assert (
-            branch_a["EvalJudgePoll"]["Next"] == "EvalJudgePollDecision"
+    def test_advisory_dispatch_after_dataphase2_in_branch_a(self, branch_a):
+        """alpha-engine-config-I2544: DataPhase2's successor is now
+        StartAdvisoryPipeline (fire-and-forget dispatch of the eval-judge
+        chain + ReportCard/Director into the async child SF), not the
+        eval-judge chain's own CheckSkipEvalJudge skip-gate — that gate now
+        lives in step_function_advisory.json (see
+        test_sf_advisory_pipeline_wiring.py)."""
+        assert branch_a["DataPhase2"]["Next"] == "StartAdvisoryPipeline"
+        assert branch_a["CheckSkipDataPhase2"]["Choices"][0]["Next"] == (
+            "StartAdvisoryPipeline"
         )
+        assert branch_a["StartAdvisoryPipeline"]["Next"] == "BranchAComplete"
+
+    def test_start_advisory_pipeline_dispatch_shape(self, branch_a):
+        """alpha-engine-config-I2544: fire-and-forget (states:startExecution,
+        NOT .sync) dispatch, named advisory-{run_date} for idempotency —
+        a same-run_date retry hits ExecutionAlreadyExists, treated as
+        pass-through success (not a genuine failure)."""
+        d = branch_a["StartAdvisoryPipeline"]
+        assert d["Type"] == "Task"
+        assert d["Resource"] == "arn:aws:states:::states:startExecution"
+        assert d["Parameters"]["StateMachineArn"] == (
+            "arn:aws:states:us-east-1:711398986525:stateMachine:"
+            "ne-weekly-advisory-pipeline"
+        )
+        assert d["Parameters"]["Name.$"] == "States.Format('advisory-{}', $.run_date)"
+        already_exists = next(
+            c for c in d["Catch"]
+            if c["ErrorEquals"] == ["StepFunctions.ExecutionAlreadyExistsException"]
+        )
+        assert already_exists["Next"] == "BranchAComplete"
+        catch_all = next(
+            c for c in d["Catch"] if c["ErrorEquals"] == ["States.ALL"]
+        )
+        assert catch_all["Next"] == "PublishAdvisoryDispatchFailureAlert"
+        alert = branch_a["PublishAdvisoryDispatchFailureAlert"]
+        assert alert["Resource"] == "arn:aws:states:::sns:publish"
+        assert alert["Next"] == "BranchAComplete"
+        assert all(c["Next"] == "BranchAComplete" for c in alert["Catch"])
 
 
 class TestBranchBContents:
@@ -465,139 +499,19 @@ class TestBranchBContents:
             "WaitForPredictorTraining"
         )
 
-    def test_predictor_success_routes_to_resolve_zoo_specs(self, branch_b):
-        # config#1083: champion-retrain success now flows into the parallel
-        # model-zoo fan-out, starting with ResolveZooSpecs (skip path still →
-        # BranchBComplete).
+    def test_predictor_success_routes_to_branch_b_complete(self, branch_b):
+        """alpha-engine-config-I2545: the config#1083 model-zoo fan-out
+        (ResolveZooSpecs -> Map -> Select) was lifted out of Branch B into
+        its own Sunday-triggered child SF (step_function_modelzoo.json —
+        see test_sf_modelzoo_pipeline_wiring.py). Champion-retrain success
+        now routes DIRECTLY to BranchBComplete, same as the skip path."""
         success = [
             c["Next"]
             for c in branch_b["CheckPredictorStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == ["ResolveZooSpecs"]
-
-    def test_zoo_fanout_pipeline_wiring(self, branch_b):
-        """config#1083: ResolveZooSpecs → (poll) → ParseZooSpecs → ModelZooTrainMap
-        (Map, per-spec spot) → ModelZooSelect → (poll) → BranchBComplete. Every
-        failure path is best-effort (routes via the alert, never BranchBFailed)."""
-        # ResolveZooSpecs dispatches list-rotation-specs on the box.
-        resolve = branch_b["ResolveZooSpecs"]
-        assert resolve["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
-        rcmd = resolve["Parameters"]["Parameters"]["commands.$"]
-        assert "list-rotation-specs" in rcmd
-        assert all(c["Next"] != "BranchBFailed" for c in resolve["Catch"])
-        assert resolve["Next"] == "WaitResolveZoo"
-        # Resolve poll → CheckResolveZooStatus: Success → ParseZooSpecs.
-        check_resolve = branch_b["CheckResolveZooStatus"]
-        rnexts = {c["StringEquals"]: c["Next"] for c in check_resolve["Choices"]}
-        assert rnexts["Success"] == "ParseZooSpecs"
-        # Default routes through ExtractModelZooResolveError (mirrors
-        # ExtractPredictorError/ExtractSignalsEnvelopeError/ExtractRAGIngestionError)
-        # — a Choice.Default transition does not populate $.model_zoo_error the
-        # way a Task Catch's ResultPath does, and PublishModelZooFailureImmediate's
-        # Message calls States.JsonToString($.model_zoo_error); a direct
-        # Choice->Task jump on this edge died with States.Runtime, masking the
-        # real zoo-resolve failure (observed live 2026-07-10, config#2160 arc).
-        assert check_resolve["Default"] == "ExtractModelZooResolveError"
-        extract_resolve = branch_b["ExtractModelZooResolveError"]
-        assert extract_resolve["Type"] == "Pass"
-        assert extract_resolve["ResultPath"] == "$.model_zoo_error"
-        assert extract_resolve["Parameters"]["poll.$"] == "$.resolve_zoo_poll"
-        assert extract_resolve["Next"] == "PublishModelZooFailureImmediate"
-        # ParseZooSpecs lifts the JSON array into $.parsed_zoo.zoo_specs.
-        parse = branch_b["ParseZooSpecs"]
-        assert parse["Type"] == "Pass"
-        assert "StringToJson" in parse["Parameters"]["zoo_specs.$"]
-        assert "Catch" not in parse  # a Pass cannot carry a Catch (AWS schema)
-        assert parse["Next"] == "ModelZooTrainMap"
-
-    def test_model_zoo_train_map_per_spec_isolation(self, branch_b):
-        """THE robustness property: the Map fans out one spot PER spec, and each
-        iteration self-terminates as success (recording status as data), so one
-        challenger crashing never aborts its siblings."""
-        m = branch_b["ModelZooTrainMap"]
-        assert m["Type"] == "Map"
-        assert m["ItemsPath"] == "$.parsed_zoo.zoo_specs"
-        assert isinstance(m["MaxConcurrency"], int) and m["MaxConcurrency"] >= 1
-        # Backstop tolerance so a Map-engine error never aborts survivors.
-        assert m["ToleratedFailurePercentage"] == 100
-        # Each item carries the spec id + shared SSM context.
-        assert m["ItemSelector"]["spec_id.$"] == "$$.Map.Item.Value"
-        assert m["ItemSelector"]["ec2_instance_id.$"] == "$.ec2_instance_id"
-        proc = m["ItemProcessor"]["States"]
-        # The dispatch invokes the per-spec spot mode with the item's spec id.
-        dcmd = proc["TrainSpecDispatch"]["Parameters"]["Parameters"]["commands.$"]
-        assert "--model-zoo-spec" in dcmd
-        assert "$.spec_id" in dcmd
-        assert "$.preflight_args" in dcmd
-        # PER-ITERATION ISOLATION: both terminals are End:true Pass states
-        # recording status as DATA — the iteration NEVER throws.
-        for term in ("TrainSpecOK", "TrainSpecFailed"):
-            assert proc[term]["Type"] == "Pass"
-            assert proc[term]["End"] is True
-        # A failed/cancelled/timed-out spec routes to TrainSpecFailed (data),
-        # NOT a throw — siblings proceed.
-        cts = proc["CheckTrainSpecStatus"]
-        assert cts["Default"] == "TrainSpecFailed"
-        # The dispatch + poll Catches record failure as data (TrainSpecFailed),
-        # never throwing out of the iteration.
-        assert all(c["Next"] == "TrainSpecFailed" for c in proc["TrainSpecDispatch"]["Catch"])
-        assert all(c["Next"] == "TrainSpecFailed" for c in proc["WaitTrainSpec"]["Catch"])
-        # The Map state's own Catch is a best-effort backstop, never BranchBFailed.
-        assert all(c["Next"] != "BranchBFailed" for c in m["Catch"])
-        assert m["Next"] == "ModelZooSelect"
-
-    def test_model_zoo_select_is_best_effort(self, branch_b):
-        """config#1083: ModelZooSelect runs the selection on ONE spot after the
-        Map joins; every failure path converges to BranchBComplete via the alert,
-        never BranchBFailed (the champion already trained+promoted)."""
-        sel = branch_b["ModelZooSelect"]
-        assert sel["Parameters"]["InstanceIds.$"] == "$.ec2_instance_id"
-        scmd = sel["Parameters"]["Parameters"]["commands.$"]
-        assert "--model-zoo-select" in scmd
-        assert "$.preflight_args" in scmd
-        assert any(
-            c["Next"] == "PublishModelZooFailureImmediate" and "States.ALL" in c["ErrorEquals"]
-            for c in sel["Catch"]
-        )
-        assert all(c["Next"] != "BranchBFailed" for c in sel["Catch"])
-        assert sel["Next"] == "WaitForModelZoo"
-        # Select poll Catch is best-effort; routes via the alert, never BranchBFailed.
-        wait = branch_b["WaitForModelZoo"]
-        assert all(c["Next"] != "BranchBFailed" for c in wait["Catch"])
-        check = branch_b["CheckModelZooStatus"]
-        # Default routes through ExtractModelZooSelectError — same rationale
-        # as ExtractModelZooResolveError above: CheckModelZooStatus.Default
-        # does not populate $.model_zoo_error, and a direct jump to
-        # PublishModelZooFailureImmediate died with States.Runtime (observed
-        # live 2026-07-10, config#2160 arc).
-        assert check["Default"] == "ExtractModelZooSelectError"
-        extract_select = branch_b["ExtractModelZooSelectError"]
-        assert extract_select["Type"] == "Pass"
-        assert extract_select["ResultPath"] == "$.model_zoo_error"
-        assert extract_select["Parameters"]["poll.$"] == "$.model_zoo_poll"
-        assert extract_select["Next"] == "PublishModelZooFailureImmediate"
-        nexts = {c["StringEquals"]: c["Next"] for c in check["Choices"]}
-        assert nexts["InProgress"] == "ModelZooWait"
-        assert nexts["Pending"] == "ModelZooWait"
-        assert nexts["Success"] == "BranchBComplete"
-        assert branch_b["ModelZooWait"]["Next"] == "WaitForModelZoo"
-        # The alert state is itself best-effort.
-        alert = branch_b["PublishModelZooFailureImmediate"]
-        assert alert["Resource"] == "arn:aws:states:::sns:publish"
-        assert alert["Next"] == "BranchBComplete"
-        assert all(c["Next"] == "BranchBComplete" for c in alert["Catch"])
-        assert "PREDICTOR_DEFER_TRAINING_EMAIL" in alert["Parameters"]["Message.$"]
-
-    def test_model_zoo_map_iterator_no_dangling(self, branch_b):
-        """The Map's iterator namespace is self-consistent (all Next/Default/Catch
-        targets resolve within the iterator's own States)."""
-        proc = branch_b["ModelZooTrainMap"]["ItemProcessor"]
-        names = set(proc["States"])
-        assert proc["StartAt"] in names
-        for n, st in proc["States"].items():
-            for t in _own_targets(st):
-                assert t in names, f"Map iterator dangling: {n} -> {t}"
+        assert success == ["BranchBComplete"]
+        assert "ResolveZooSpecs" not in branch_b
 
     def test_branch_b_ssm_can_resolve_instance_id(self, branch_b):
         """Branch B's SSM calls reference $.ec2_instance_id — which is
@@ -746,24 +660,12 @@ class TestPerBranchErrorIsolation:
             == "ExtractPredictorError"
         )
 
-    def test_eval_chain_fail_soft_catches_preserved(self, branch_a):
-        """The eval/agent-justification observability Catches must stay
-        fail-soft (route forward within the branch), NOT to BranchAFailed
-        — they were never SF-halting and must not become so."""
-        for n in (
-            "EvalJudgeSubmitWeekly",
-            "EvalJudgeProcess",
-            "EvalRollingMean",
-            "RationaleClustering",
-            "ReplayConcordance",
-            "Counterfactual",
-        ):
-            for c in branch_a[n].get("Catch", []):
-                assert c["Next"] != "BranchAFailed", (
-                    f"{n} observability Catch became a hard branch fail — "
-                    f"it must stay fail-soft (forward within Branch A)."
-                )
-                assert c["Next"] != "HandleFailure"
+    # NOTE: the eval-judge / agent-justification fail-soft-Catch coverage
+    # (EvalJudgeSubmitWeekly, EvalJudgeProcess, EvalRollingMean,
+    # RationaleClustering, ReplayConcordance, Counterfactual) moved to
+    # test_sf_advisory_pipeline_wiring.py's
+    # test_eval_chain_fail_soft_catches_preserved_in_advisory_pipeline
+    # (alpha-engine-config-I2544 — these states no longer live in Branch A).
 
 
 class TestPostJoinAggregationAndFailure:

--- a/tests/test_sf_retry_ladder_convention.py
+++ b/tests/test_sf_retry_ladder_convention.py
@@ -33,16 +33,18 @@ import pathlib
 
 import pytest
 
-_WEEKLY = pathlib.Path(__file__).parent.parent / "infrastructure" / "step_function.json"
+_INFRA = pathlib.Path(__file__).parent.parent / "infrastructure"
+_WEEKLY = _INFRA / "step_function.json"
+# alpha-engine-config-I2545: ResolveZooSpecs/TrainSpecDispatch/ModelZooSelect
+# moved to their own Sunday-triggered child SF — same declared retry-ladder
+# convention applies there too (see MODELZOO_SPOT_STAGE_SEND_STATES below).
+_MODELZOO = _INFRA / "step_function_modelzoo.json"
 
 SPOT_STAGE_SEND_STATES = {
     "MorningEnrich",
     "DataPhase1",
     "RAGIngestion",
     "PredictorTraining",
-    "ResolveZooSpecs",
-    "TrainSpecDispatch",
-    "ModelZooSelect",
     "Backtester",
     "PredictorBacktest",
     "PortfolioOptimizerBacktest",
@@ -52,6 +54,14 @@ SPOT_STAGE_SEND_STATES = {
 HEALTH_OBSERVE_SEND_STATES = {
     "SaturdayHealthCheck",
     "WeeklySubstrateHealthCheck",
+}
+# alpha-engine-config-I2545: same gold 4+2 jittered ladder, verified
+# byte-for-byte preserved by the lift — declared here as this child SF's
+# OWN closed registry.
+MODELZOO_SPOT_STAGE_SEND_STATES = {
+    "ResolveZooSpecs",
+    "TrainSpecDispatch",
+    "ModelZooSelect",
 }
 
 GOLD_LADDER = [
@@ -74,8 +84,8 @@ GOLD_LADDER = [
 ]
 
 
-def _iter_states():
-    definition = json.loads(_WEEKLY.read_text())
+def _iter_states(path: pathlib.Path = _WEEKLY):
+    definition = json.loads(path.read_text())
 
     def _walk(states):
         for name, state in states.items():
@@ -91,10 +101,10 @@ def _iter_states():
     yield from _walk(definition["States"])
 
 
-def _ssm_states(suffix: str) -> dict[str, dict]:
+def _ssm_states(suffix: str, path: pathlib.Path = _WEEKLY) -> dict[str, dict]:
     return {
         name: state
-        for name, state in _iter_states()
+        for name, state in _iter_states(path)
         if state.get("Resource", "").endswith(f"aws-sdk:ssm:{suffix}")
     }
 
@@ -121,12 +131,38 @@ def test_every_send_command_state_is_classified():
     assert not missing, f"declared states no longer exist: {sorted(missing)}"
 
 
+def test_every_modelzoo_send_command_state_is_classified():
+    """alpha-engine-config-I2545: same chokepoint, scoped to the ModelZoo
+    Sunday child SF's own closed registry."""
+    send_states = set(_ssm_states("sendCommand", _MODELZOO))
+    unclassified = send_states - MODELZOO_SPOT_STAGE_SEND_STATES
+    assert not unclassified, (
+        f"config#2279/I2545: new sendCommand state(s) {sorted(unclassified)} "
+        "in the ModelZoo Sunday child SF must be added to "
+        "MODELZOO_SPOT_STAGE_SEND_STATES (or a new declared class)."
+    )
+    missing = MODELZOO_SPOT_STAGE_SEND_STATES - send_states
+    assert not missing, f"declared states no longer exist: {sorted(missing)}"
+
+
 @pytest.mark.parametrize("name", sorted(SPOT_STAGE_SEND_STATES))
 def test_spot_stage_carries_gold_ladder(name):
     states = _ssm_states("sendCommand")
     assert _normalized_ladder(states[name]) == GOLD_LADDER, (
         f"config#2279: {name} drifted from the declared spot-stage 4+2 "
         "jittered ladder"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(MODELZOO_SPOT_STAGE_SEND_STATES))
+def test_modelzoo_spot_stage_carries_gold_ladder(name):
+    """alpha-engine-config-I2545: verifies the lift preserved the gold
+    ladder byte-for-byte on the three states moved to the ModelZoo Sunday
+    child SF."""
+    states = _ssm_states("sendCommand", _MODELZOO)
+    assert _normalized_ladder(states[name]) == GOLD_LADDER, (
+        f"config#2279/I2545: {name} drifted from the declared spot-stage "
+        "4+2 jittered ladder"
     )
 
 
@@ -147,11 +183,14 @@ def test_health_observe_has_no_retry_but_fail_soft_catch(name):
     assert "config#2279" in state.get("Comment", "")
 
 
-def test_every_poll_state_has_invocation_does_not_exist_ladder():
+@pytest.mark.parametrize("path", [_WEEKLY, _MODELZOO], ids=lambda p: p.stem)
+def test_every_poll_state_has_invocation_does_not_exist_ladder(path):
     """SendCommand→GetCommandInvocation eventual consistency: every poll
-    state must retry the not-yet-visible-invocation error class."""
+    state must retry the not-yet-visible-invocation error class.
+    alpha-engine-config-I2545: also covers the ModelZoo Sunday child SF's
+    own poll states (WaitResolveZoo/WaitTrainSpec/WaitForModelZoo)."""
     offenders = []
-    for name, state in _ssm_states("getCommandInvocation").items():
+    for name, state in _ssm_states("getCommandInvocation", path).items():
         rules = state.get("Retry", [])
         covered = any(
             any(e.startswith("Ssm.InvocationDoesNotExist") for e in rule["ErrorEquals"])
@@ -160,13 +199,15 @@ def test_every_poll_state_has_invocation_does_not_exist_ladder():
         if not covered:
             offenders.append(name)
     assert not offenders, (
-        f"poll state(s) without the InvocationDoesNotExist ladder: {offenders}"
+        f"{path.name}: poll state(s) without the InvocationDoesNotExist "
+        f"ladder: {offenders}"
     )
 
 
-def test_convention_is_declared_in_definition_comment():
-    definition = json.loads(_WEEKLY.read_text())
+@pytest.mark.parametrize("path", [_WEEKLY, _MODELZOO], ids=lambda p: p.stem)
+def test_convention_is_declared_in_definition_comment(path):
+    definition = json.loads(path.read_text())
     assert "config#2279" in definition["Comment"], (
-        "the retry convention declaration was dropped from the definition's "
-        "top-level Comment"
+        f"{path.name}: the retry convention declaration was dropped from "
+        "the definition's top-level Comment"
     )

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -96,38 +96,24 @@ class TestChainOrdering:
         # unchanged NotifyComplete, so the REAL Saturday run (no shell_run
         # input) still ends at NotifyComplete — strict superset preserved.
         #
-        # Two non-fatal advisory states (evaluator Report Card v2, then the
-        # Director) sit between the substrate poll and the notify gate. ReportCard's
-        # SUCCESS edge feeds the Director (which weighs the fresh card); ReportCard's
-        # Catch routes to PublishReportCardDegraded (config#2302: a WARNING alert —
-        # advisory grading failed silently for 9 days pre-fix) which then continues to
-        # notify (no card to weigh). The Director's own Next lands on CheckShellRunNotify;
-        # its Catch routes to PublishDirectorDegraded (same config#2302 WARNING-alert
-        # shape) which then continues to notify. Every path still preserves the success
-        # edge. On the Friday preflight both states RUN (dry, via
-        # dry_run.$=$.research_dry — ROADMAP L4504), they are not skipped, so the wiring
-        # is identical on real + preflight runs.
-        # config#2276: the substrate poll now resolves to a terminal status
-        # first; its Success edge is what feeds ReportCard (pinned below in
+        # alpha-engine-config-I2544 (2026-07-14): ReportCard + Director
+        # (previously sitting between the substrate poll and the notify
+        # gate) were LIFTED into the async ne-weekly-advisory-pipeline
+        # child SF, dispatched earlier via StartAdvisoryPipeline right
+        # after DataPhase2. Their own success/degraded wiring (unchanged,
+        # byte-for-byte preserved) is covered by
+        # test_sf_advisory_pipeline_wiring.py::TestReportCardAndDirectorWiring.
+        # The substrate poll's Success edge now feeds CheckShellRunNotify
+        # DIRECTLY (pinned below in
         # test_wait_for_substrate_routes_via_status_choice).
-        assert states["ReportCard"]["Next"] == "Director"
-        assert all(
-            c["Next"] == "PublishReportCardDegraded" for c in states["ReportCard"]["Catch"]
-        )
-        assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
-        assert states["Director"]["Next"] == "CheckShellRunNotify"
-        assert all(
-            c["Next"] == "PublishDirectorDegraded" for c in states["Director"]["Catch"]
-        )
-        assert states["PublishDirectorDegraded"]["Next"] == "CheckShellRunNotify"
         # config#2278: the real-run success edge now passes through the
         # gate-degraded completion Choice before NotifyComplete.
         assert states["CheckShellRunNotify"]["Default"] == "CheckGateDegradedNotify"
         assert states["CheckGateDegradedNotify"]["Default"] == "NotifyComplete"
 
     def test_wait_for_substrate_routes_via_status_choice(self, states):
-        # config#2276: the substrate poll resolves to a terminal status
-        # before ReportCard, so a failing/hung checker is visible.
+        # alpha-engine-config-I2544: the substrate poll's Success edge now
+        # feeds CheckShellRunNotify directly (was ReportCard pre-lift).
         assert (
             states["WaitForWeeklySubstrateHealthCheck"]["Next"]
             == "CheckSubstrateHealthCheckStatus"
@@ -136,7 +122,7 @@ class TestChainOrdering:
         success = next(
             r for r in choice["Choices"] if r.get("StringEquals") == "Success"
         )
-        assert success["Next"] == "ReportCard"
+        assert success["Next"] == "CheckShellRunNotify"
 
 
 class TestCatchSemantics:
@@ -165,13 +151,14 @@ class TestCatchSemantics:
         for c in catches:
             assert c["Next"] == "SubstrateHealthCheckDegraded"
 
-    def test_substrate_degraded_continues_to_advisory_tail(self, states):
+    def test_substrate_degraded_continues_to_notify_gate(self, states):
+        """alpha-engine-config-I2544: ReportCard/Director no longer sit in
+        this SF's tail (see test_sf_advisory_pipeline_wiring.py) — a
+        degraded substrate check now continues straight to the notify
+        gate, same as the healthy path."""
         degraded = states["SubstrateHealthCheckDegraded"]
         assert degraded["Type"] == "Pass"
-        assert degraded["Next"] == "ReportCard", (
-            "A degraded substrate check must not skip the ReportCard/Director "
-            "Lambda tail — it is independent of the dashboard box."
-        )
+        assert degraded["Next"] == "CheckShellRunNotify"
 
 
 class TestCommandShape:

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -87,11 +87,12 @@ class TestDerivePlan:
             # skip_research retired: alpha-engine-config-I2515 Phase B
             # removed the multi-agent Research state entirely.
             "skip_data_phase2",
-            "skip_eval_judge",
-            "skip_rationale_clustering",
-            "skip_replay_concordance",
-            "skip_counterfactual",
-            "skip_aggregate_costs",
+            # skip_eval_judge/skip_rationale_clustering/
+            # skip_replay_concordance/skip_counterfactual/
+            # skip_aggregate_costs retired here: alpha-engine-config-I2544
+            # lifted that whole chain into the async
+            # ne-weekly-advisory-pipeline child SF — this (main-SF-only)
+            # rerun helper no longer tracks or emits those flags at all.
             "skip_predictor_training",
             "skip_predictor_backtest",
             "skip_portfolio_optimizer_backtest",


### PR DESCRIPTION
## Summary

STACKED ON PR814 (merge that first; this PR's base is its branch — after PR814 merges, retarget this to main via the GitHub UI or I'll do it).

Implements the weekly-SF load plan's remaining phases (alpha-engine-config-I2544 + I2545, both ruled 2026-07-14) plus the persistent-report-card caller wiring (I2556):

**`ne-weekly-advisory-pipeline`** (new, `step_function_advisory.json`): the eval-judge chain, EvalRollingMean, RationaleClustering, ReplayConcordance, Counterfactual, AggregateCosts, ReportCard (`snapshot: true` — the weekly freeze) and Director, lifted intact from the main SF. Fired fire-and-forget from Branch A after DataPhase2 (`StartAdvisoryPipeline`, execution-name idempotency: duplicate-name Catch treated as already-running). 8h top-level timeout, own SNS failure route. The main SF's join no longer waits on the 6h eval-judge poll cap.

**`ne-modelzoo-sunday-pipeline`** (new, `step_function_modelzoo.json`): the ModelZoo Resolve/TrainMap/Select chain lifted from Branch B, triggered EventBridge `cron(0 9 ? * SUN *)` per Brian's ruling, tailed by a grading-Lambda re-grade (`snapshot: false` — refreshes the persistent dash's latest). 6h timeout.

**Main SF**: Branch A ends DataPhase2 → StartAdvisoryPipeline; Branch B ends at PredictorTraining. Combined with PR814, Saturday's main SF drops the pipeline's two biggest tails (measured baseline on config-I2543: Research 24.1 min was Branch A's largest single item; the eval tail's 6h cap and ModelZoo's 4-spot fan-out now run off the critical path entirely).

**Watch coverage**: both new SFs registered in all four in-repo watch surfaces (saturday-sf-watch-dispatcher PIPELINES + EVENT_PATTERN, sf-watch-spot-dispatcher, sf-watch-liveness-probe) as `has_listener: False` (Telegram-visible, agent dispatch deferred pending charter).

**Codified IAM**: SF role gains `states:StartExecution` on the advisory ARN; the EventBridge-SFN role gains the modelzoo ARN. Live applies + state-machine creation + watch-Lambda redeploys are enumerated for the operator session (not fired by merge alone for NEW state machines).

Follow-up filed by this work: **alpha-engine-config-I2562** — the lifted ModelZoo Task states carry no `$.run_date` reference; their date handling is internal to predictor box-side scripts and needs a Sunday-fire audit there.

## Test plan

- [x] `tests/`: 3095 passed, 11 skipped, 0 failed (2 new wiring test files; 16 existing updated). Watch-Lambda dirs: saturday-sf-watch-dispatcher 71 passed, sf-watch-liveness-probe 45 passed; sf-watch-spot-dispatcher's 44 failures verified pre-existing on the unmodified base (hermetic-import stub gap, unrelated).
- [ ] Post-merge: live IAM applies + SF creation + watch redeploys (operator-consented), then first advisory run Saturday 7/18 + first Sunday zoo run 7/20.

Part of alpha-engine-config-I2544 / I2545 / I2556 / I2515. Companions: crucible-backtester-PR521 (merged), crucible-evaluator-PR121 (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)