### PR TITLE
feat(infra): config-runner-dispatcher Lambda for self-hosted GHA runner (I2572)

### DIFF
--- a/infrastructure/lambdas/config-runner-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/config-runner-dispatcher/deploy.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-config-runner-dispatcher Lambda.
+#
+# WHY (alpha-engine-config-I2572): a hard GHA audit (2026-07-14) found
+# alpha-engine-config's own CI/validation workflows (scripts-tests.yml,
+# changelog.yml, the validate-*.yaml set, etc.) are the dominant steady-state
+# draw on the org's metered private-repo GHA-minutes quota (~1.6k min/30d
+# projected). This Lambda receives GitHub's `workflow_job` webhook directly
+# (a Function URL, not a `lambda invoke` from a GHA job — there is no
+# GHA-hosted leg left to invoke it once the target workflows' runs-on points
+# at a self-hosted runner) and launches an EC2-spot box that registers as an
+# EPHEMERAL self-hosted runner for exactly one queued job, then
+# self-terminates. --bootstrap creates: (1) this Lambda's own execution role
+# + inline policy, (2) the Lambda function itself, (3) its public Function
+# URL + the resource policy allowing GitHub to invoke it.
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
+# (scoped to alpha-engine-config-runner-executor-role — a NEW, dedicated role
+# a sibling agent is creating in alpha-engine-config) + ssm:SendCommand +
+# ssm:GetParameter (its OWN webhook secret — unlike ci-watch-dispatcher, this
+# Lambda verifies GitHub's HMAC signature itself) + lambda:InvokeFunction on
+# itself (the two-phase webhook-receiver/worker self-invoke — see index.py's
+# module docstring for why the launch work cannot run inline in the
+# webhook-receiving invocation).
+#
+# Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
+# keeps the github-actions-lambda-deploy OIDC role's blast radius narrow.
+# This script's FLAGLESS run is code-only; --bootstrap is operator-only.
+#
+# POST-BOOTSTRAP MANUAL STEPS (cannot be automated via this script — see
+# alpha-engine-config-I2572 for the full sequencing):
+#   1. Create the SSM params this Lambda/box read:
+#        /alpha-engine/config_runner/webhook_secret  (random string, shared
+#          with the GitHub webhook config below)
+#        /alpha-engine/config_runner/github_pat  (fine-grained PAT, owner=
+#          nousergon, repo=alpha-engine-config, Administration: Read and
+#          write + Contents: read — Administration:write is REQUIRED to mint
+#          runner registration tokens; the Actions permission does NOT cover
+#          this. Fine-grained PAT creation/scoping is a GitHub web-UI-only,
+#          human action — cannot be done via this script or the API.)
+#   2. Register the GitHub webhook on nousergon/alpha-engine-config:
+#        event: workflow_job, content type: json, secret: (the same value as
+#        the SSM param above), URL: this script's printed Function URL.
+#      Can be done via `gh api repos/nousergon/alpha-engine-config/hooks`.
+#
+# Usage:
+#   bash .../config-runner-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../config-runner-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda + Function URL
+#   bash .../config-runner-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../config-runner-dispatcher/deploy.sh --smoke     # invoke the WORKER phase once with a synthetic job id (fires a REAL spot box)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-config-runner-dispatcher"
+ROLE_NAME="alpha-engine-config-runner-dispatcher-role"
+POLICY_NAME="alpha-engine-config-runner-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# Bootstrap default (first-time deployment only) — safe default ON, mirrors
+# every other fleet dispatcher's kill-switch convention.
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,CONFIG_RUNNER_DISPATCH_ENABLED=true}'
+
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+    if ! $DRY_RUN; then
+      aws lambda wait function-active --function-name "${FUNCTION_NAME}" --region "${REGION}"
+    fi
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2b. Function URL (GitHub webhooks can't sign SigV4 — auth is the
+  # handler's own HMAC verification against the shared webhook secret) ---
+  if ! aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --query 'FunctionUrl' --output text >/dev/null 2>&1; then
+    echo "  Creating Function URL (AuthType=NONE; handler-level HMAC verification is the real auth boundary)"
+    run aws lambda create-function-url-config \
+      --function-name "${FUNCTION_NAME}" \
+      --auth-type NONE \
+      --region "${REGION}" \
+      --query 'FunctionUrl' --output text
+    echo "  Granting public InvokeFunctionUrl permission"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "AllowPublicFunctionUrlInvoke" \
+      --action lambda:InvokeFunctionUrl \
+      --principal "*" \
+      --function-url-auth-type NONE \
+      --region "${REGION}" >/dev/null
+  else
+    echo "  Function URL already configured"
+  fi
+
+  if ! $DRY_RUN; then
+    FN_URL=$(aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --region "${REGION}" --query 'FunctionUrl' --output text)
+    echo ""
+    echo "  Function URL: ${FN_URL}"
+    echo "  -> register as the GitHub webhook target for nousergon/alpha-engine-config"
+    echo "     (event: workflow_job, content type: json, secret: matches"
+    echo "     /alpha-engine/config_runner/webhook_secret) — see this script's"
+    echo "     header for the full remaining manual steps."
+    echo ""
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment (preserving operator-owned CONFIG_RUNNER_DISPATCH_ENABLED)..."
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" CONFIG_RUNNER_DISPATCH_ENABLED true)
+LAMBDA_ENV="Variables={LOG_LEVEL=INFO,CONFIG_RUNNER_DISPATCH_ENABLED=${CURRENT_DISPATCH}}"
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment "${LAMBDA_ENV}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+# ----- 4. Smoke (synthetic worker-phase event, direct invoke) ---------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing the WORKER phase via direct invoke (synthetic job id)..."
+  echo "⚠ this fires a REAL spot box + REAL config_runner_spot_bootstrap.sh run."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"config_runner_job_id":"smoke-test-0"}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi

--- a/infrastructure/lambdas/config-runner-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/config-runner-dispatcher/iam-policy.json
@@ -1,0 +1,133 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-config-runner-dispatcher:*"
+    },
+    {
+      "Sid": "ReadWebhookSecret",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/config_runner/webhook_secret"
+    },
+    {
+      "Sid": "SelfInvokeAsyncForTwoPhaseDispatch",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-config-runner-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-config-runner-dispatcher:*"
+      ]
+    },
+    {
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "alpha-engine-config-runner-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-config-runner-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassConfigRunnerExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-config-runner-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunConfigRunnerBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateConfigRunnerSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-config-runner-spot"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/config-runner-dispatcher/index.py
+++ b/infrastructure/lambdas/config-runner-dispatcher/index.py
@@ -1,0 +1,367 @@
+"""alpha-engine-config-runner-dispatcher — launch an EPHEMERAL GitHub Actions
+self-hosted runner on a dedicated EC2 spot box, once per queued CI/validation
+job in nousergon/alpha-engine-config. alpha-engine-config-I2572.
+
+WHY: a hard GHA audit (2026-07-14) found alpha-engine-config's own CI/
+validation workflows (scripts-tests.yml, changelog.yml, the validate-*.yaml
+set, etc.) — NOT the heavy agentic workloads ci-watch/sf-watch/groom already
+moved to spot — are now the dominant steady-state draw on the org's metered
+private-repo GHA-minutes quota (~1.6k min/30d projected, ~93% of all
+private-repo GHA spend fleet-wide). Those are frequent (dozens/day) and
+short-lived (<1 min avg) — a poor fit for the ci-watch/sf-watch pattern (a
+thin GHA-hosted dispatch leg synchronously invoking a Lambda that runs a
+bespoke script over SSM, outside the Actions protocol entirely): replicating
+that shape per-workflow would mean hand-rolling GitHub Checks-API status
+reporting ~13 times over. Registering a REAL ephemeral self-hosted runner is
+simpler AND more correct here — the existing workflow YAML (checkout,
+setup-python, pytest, etc.) is untouched, only `runs-on:` changes, and
+GitHub's own Actions service handles job dispatch + Check Run status
+natively, exactly as it does for hosted runners.
+
+MECHANISM (two-phase single Lambda, self-invoked async — see module-level
+`handler` for the branch):
+  1. WEBHOOK RECEIVER phase: GitHub calls this Lambda's Function URL directly
+     on every `workflow_job` event for alpha-engine-config (repo-level
+     webhook, event type `workflow_job`). Verifies the HMAC signature, filters
+     to `action=queued` + our `alpha-engine-config-spot` label, then
+     self-invokes ASYNC (`InvocationType=Event`) with a minimal worker
+     payload and returns 200 immediately. GitHub's webhook delivery timeout
+     is short (single-digit seconds) — the actual spot launch below can take
+     30-90s+, so it MUST NOT block the HTTP response, or every delivery would
+     show as a spurious timeout in GitHub's UI even though the box still
+     launches (Lambda execution isn't cancelled by a disconnected client, but
+     a clean signal matters for operability).
+  2. WORKER phase (the self-invoked async call): does the actual dispatch —
+     `spot_dispatch.launch_with_fallback()` (spot-first, on-demand fallback
+     on capacity exhaustion), wait for SSM-online, then an async detached SSM
+     command that clones alpha-engine-config and `exec`s
+     `infrastructure/config_runner_spot_bootstrap.sh` (built by a sibling
+     agent in alpha-engine-config) — which installs+registers the actual
+     `actions-runner` binary in `--ephemeral` mode, runs exactly one job, and
+     self-terminates (InstanceInitiatedShutdownBehavior=terminate + its own
+     on-box watchdog). Mirrors `ci-watch-dispatcher/index.py`'s
+     launch/wait/dispatch shape via the shared `nousergon_lib.spot_dispatch`
+     primitives (config#2106) — NOT reinvented here.
+
+CONCURRENCY LOCK: keyed on `Name=alpha-engine-config-runner-spot` +
+`config-runner-job-id=<workflow_job.id>` — one job, one box, 1:1 (unlike
+ci-watch's repo+sha lock, a GitHub Actions job id is already the unique
+discriminator; no broader key needed). A duplicate `queued` delivery for the
+same job (GitHub webhooks are at-least-once) is a clean no-op skip.
+
+IAM PROFILE: `alpha-engine-config-runner-executor-profile`, a NEW dedicated
+instance profile (infrastructure/iam/config-runner-executor-role-*.json in
+alpha-engine-config) scoped to read exactly one SSM param (the runner-
+registration PAT) — deliberately not `alpha-engine-ci-watch-executor-profile`
+or any other existing profile, so this new/less-proven workload's blast
+radius stays contained. Every AWS credential the actual CI STEPS need (S3
+sync, OIDC role assumption, etc.) continues to flow through GitHub's own
+per-workflow OIDC mechanism, unrelated to this instance's own role.
+
+FAIL-SOFT ON THE WEBHOOK RECEIVER PHASE, FAIL-LOUD ON THE WORKER PHASE: an
+unrecognized/malformed webhook delivery is a clean 200 no-op (GitHub sends
+many event types/actions we don't care about — treating them as errors would
+just generate webhook-delivery noise for no reason). The worker phase mirrors
+ci-watch's SYNCHRONOUS-style clean-failure contract even though its own
+caller is async (nothing reads the return value) — CloudWatch Logs is the
+observability surface for worker-phase failures; a genuinely unexpected
+internal bug still propagates as a Python exception (visible as a Lambda
+error metric).
+
+Managed OUTSIDE CloudFormation (same as every other fleet dispatcher):
+operator-deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live
+effect until the new code + IAM + Function URL + GitHub webhook registration
+are applied AND the (separately-tracked, human-only) runner-registration PAT
+with Administration:write on alpha-engine-config exists in SSM — see
+alpha-engine-config-I2572 for the full rollout sequencing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+
+import boto3
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotLaunchError, SpotProbeError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: CONFIG_RUNNER_DISPATCH_ENABLED=false disables the launch
+# without touching the GitHub webhook wiring — mirrors every other fleet
+# dispatcher's safety valve. Default ON.
+DISPATCH_ENABLED = os.environ.get("CONFIG_RUNNER_DISPATCH_ENABLED", "true").lower() == "true"
+
+TARGET_REPO_FULL_NAME = "nousergon/alpha-engine-config"
+TARGET_LABEL = "alpha-engine-config-spot"
+
+# ── Spot launch config (env-overridable; same default-VPC/AMI/security-group
+# as the fleet's other spot dispatchers — only the IAM profile + tag differ).
+# IAM LOCKSTEP (mirrors ci-watch-dispatcher): these defaults are ENUMERATED
+# in this Lambda's scoped ec2:RunInstances policy (sibling iam-policy.json).
+# Changing them without re-applying that policy makes RunInstances fail with
+# UnauthorizedOperation at the next dispatch. Keep them in sync.
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "CONFIG_RUNNER_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "CONFIG_RUNNER_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("CONFIG_RUNNER_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("CONFIG_RUNNER_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("CONFIG_RUNNER_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+IAM_PROFILE = os.environ.get(
+    "CONFIG_RUNNER_IAM_PROFILE", "alpha-engine-config-runner-executor-profile"
+)
+VOLUME_SIZE_GB = int(os.environ.get("CONFIG_RUNNER_VOLUME_SIZE_GB", "30"))
+
+CONFIG_RUNNER_TAG_NAME = "alpha-engine-config-runner-spot"
+CONFIG_RUNNER_JOB_ID_TAG_KEY = "config-runner-job-id"
+
+# This Lambda's OWN secret (unlike ci-watch-dispatcher, which needs none) —
+# the webhook HMAC secret, read once per cold start and cached at module
+# scope (same pattern as every fleet Lambda that reads a param once, not
+# per-invocation, to keep p50 latency low on the hot webhook-verification path).
+WEBHOOK_SECRET_SSM = os.environ.get(
+    "CONFIG_RUNNER_WEBHOOK_SECRET_SSM", "/alpha-engine/config_runner/webhook_secret"
+)
+_webhook_secret_cache: str | None = None
+
+
+def _webhook_secret() -> str:
+    global _webhook_secret_cache
+    if _webhook_secret_cache is None:
+        _webhook_secret_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=WEBHOOK_SECRET_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _webhook_secret_cache
+
+
+CONFIG_RUNNER_GH_PAT_SSM = os.environ.get(
+    "CONFIG_RUNNER_GH_PAT_SSM", "/alpha-engine/config_runner/github_pat"
+)
+CONFIG_RUNNER_CONFIG_BRANCH = os.environ.get("CONFIG_RUNNER_CONFIG_BRANCH", "main")
+MAX_RUNTIME_SECONDS = int(os.environ.get("CONFIG_RUNNER_MAX_RUNTIME_SECONDS", "1800"))
+SSM_ONLINE_BUDGET_SEC = int(os.environ.get("CONFIG_RUNNER_SSM_ONLINE_BUDGET_SEC", "180"))
+CW_LOG_GROUP = os.environ.get("CONFIG_RUNNER_CW_LOG_GROUP", "/alpha-engine/config-runner-spot")
+
+
+def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
+    """Constant-time HMAC-SHA256 verification of GitHub's
+    `X-Hub-Signature-256` header against the shared webhook secret."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(
+        _webhook_secret().encode("utf-8"), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def _decode_body(event: dict) -> bytes:
+    body = event.get("body") or ""
+    if event.get("isBase64Encoded"):
+        import base64
+
+        return base64.b64decode(body)
+    return body.encode("utf-8")
+
+
+def _response(status: int, body: dict) -> dict:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _handle_webhook(event: dict) -> dict:
+    """Phase 1: verify + filter a raw GitHub `workflow_job` webhook delivery.
+    Always returns fast (no spot-launch work happens in this phase) — a
+    matching event triggers an async self-invoke of the worker phase."""
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    raw_body = _decode_body(event)
+
+    if not _verify_signature(raw_body, headers.get("x-hub-signature-256")):
+        logger.warning("webhook signature verification failed — rejecting delivery")
+        return _response(401, {"error": "invalid signature"})
+
+    if headers.get("x-github-event") != "workflow_job":
+        # `ping` (sent on webhook creation) and anything else we didn't
+        # subscribe to — clean no-op, not an error.
+        return _response(200, {"ignored": "not a workflow_job event"})
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        logger.error("malformed webhook JSON body: %s", exc)
+        return _response(400, {"error": "malformed JSON"})
+
+    action = payload.get("action")
+    repo_full_name = (payload.get("repository") or {}).get("full_name")
+    job = payload.get("workflow_job") or {}
+    labels = job.get("labels") or []
+    job_id = job.get("id")
+
+    if (
+        action != "queued"
+        or repo_full_name != TARGET_REPO_FULL_NAME
+        or TARGET_LABEL not in labels
+        or job_id is None
+    ):
+        return _response(200, {"ignored": True, "action": action, "repo": repo_full_name})
+
+    if not DISPATCH_ENABLED:
+        logger.warning("CONFIG_RUNNER_DISPATCH_ENABLED=false — job %s NOT dispatched", job_id)
+        return _response(200, {"launched": False, "reason": "disabled", "job_id": job_id})
+
+    logger.info("queued job %s matches — self-invoking worker phase async", job_id)
+    boto3.client("lambda", region_name=REGION).invoke(
+        FunctionName=os.environ["AWS_LAMBDA_FUNCTION_NAME"],
+        InvocationType="Event",
+        Payload=json.dumps({"config_runner_job_id": str(job_id)}).encode("utf-8"),
+    )
+    return _response(200, {"accepted": True, "job_id": job_id})
+
+
+def _running_config_runner_instance_ids(job_id: str) -> list[str]:
+    return spot_dispatch.running_instance_ids(
+        CONFIG_RUNNER_TAG_NAME,
+        {CONFIG_RUNNER_JOB_ID_TAG_KEY: job_id},
+        region=REGION,
+    )
+
+
+def _bootstrap_command(job_id: str) -> str:
+    """The async SSM RunShellScript prelude: minimal-install, fetch the PAT,
+    clone alpha-engine-config, exec its config_runner_spot_bootstrap.sh
+    entrypoint. Mirrors ci-watch-dispatcher's prelude exactly (same fail()
+    trap shape) — the difference is entirely in what runs AFTER the clone."""
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+export HOME=/root
+fail() {{ echo "[config-runner-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 >/dev/null 2>&1 || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {CONFIG_RUNNER_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/alpha-engine-config
+git clone --depth 1 --branch {CONFIG_RUNNER_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{TARGET_REPO_FULL_NAME}.git" \
+  /home/ec2-user/alpha-engine-config || fail "clone failed"
+cd /home/ec2-user/alpha-engine-config
+exec bash infrastructure/config_runner_spot_bootstrap.sh --job-id "{job_id}"
+"""
+
+
+def _launch_config_runner_spot(job_id: str) -> dict:
+    dedupe_degraded = False
+    try:
+        existing = _running_config_runner_instance_ids(job_id)
+    except SpotProbeError as exc:
+        # Coverage beats dedupe (same policy as ci-watch-dispatcher, config#2267
+        # site 1): a failed probe must never leave a real queued job uncovered.
+        dedupe_degraded = True
+        existing = []
+        logger.error(
+            "config-runner concurrency probe FAILED for job %s — proceeding "
+            "with dedupe_degraded=true: %s: %s", job_id, type(exc).__name__, exc,
+        )
+    if existing:
+        logger.warning("config-runner box already live for job %s (%s) — skipping",
+                       job_id, existing)
+        return {"launched": False, "reason": "concurrent_skip", "existing_instance_ids": existing}
+
+    try:
+        instance_id, market = spot_dispatch.launch_with_fallback(
+            INSTANCE_TYPES, SUBNETS,
+            image_id=AMI_ID,
+            key_name=KEY_NAME,
+            security_group_ids=[SECURITY_GROUP],
+            iam_instance_profile=IAM_PROFILE,
+            volume_size_gb=VOLUME_SIZE_GB,
+            tag_name=CONFIG_RUNNER_TAG_NAME,
+            region=REGION,
+        )
+    except SpotLaunchError as exc:
+        logger.error("config-runner spot launch failed for job %s: %s: %s",
+                     job_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "launch_failed", "error": str(exc)}
+
+    logger.info("launched config-runner box %s (%s) for job %s%s", instance_id, market, job_id,
+                " dedupe_degraded=true" if dedupe_degraded else "")
+
+    try:
+        boto3.client("ec2", region_name=REGION).create_tags(
+            Resources=[instance_id],
+            Tags=[{"Key": CONFIG_RUNNER_JOB_ID_TAG_KEY, "Value": job_id}],
+        )
+    except Exception as exc:  # noqa: BLE001 — load-bearing tag write; terminate + fail loud on failure
+        spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="config-runner")
+        logger.error("config-runner discriminator tag write FAILED for %s (job %s) — "
+                     "box terminated, dispatch failed: %s: %s",
+                     instance_id, job_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "tag_write_failed", "instance_id": instance_id,
+                "error": str(exc), "dedupe_degraded": dedupe_degraded}
+
+    try:
+        spot_dispatch.wait_ssm_online(
+            instance_id, region=REGION, ssm_online_budget_sec=SSM_ONLINE_BUDGET_SEC
+        )
+        command_id = spot_dispatch.send_async_command(
+            instance_id,
+            _bootstrap_command(job_id),
+            comment=f"config-runner (job {job_id})",
+            region=REGION,
+            cw_log_group=CW_LOG_GROUP,
+            execution_timeout_seconds=MAX_RUNTIME_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001 — post-launch failure; terminate the orphan
+        spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="config-runner")
+        logger.error("config-runner post-launch step failed for %s (job %s): %s: %s",
+                     instance_id, job_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "post_launch_failed", "instance_id": instance_id,
+                "error": str(exc), "dedupe_degraded": dedupe_degraded}
+
+    logger.info("config-runner dispatched: instance=%s market=%s command=%s job_id=%s",
+               instance_id, market, command_id, job_id)
+    return {
+        "launched": True,
+        "reason": "launched",
+        "instance_id": instance_id,
+        "market": market,
+        "command_id": command_id,
+        "job_id": job_id,
+        "dedupe_degraded": dedupe_degraded,
+    }
+
+
+def handler(event: dict, context) -> dict:
+    """Two-phase entrypoint — see module docstring. A Function URL delivery
+    carries `requestContext` (the API Gateway v2-shaped proxy event); the
+    async self-invoked worker payload does not."""
+    event = event or {}
+    if "requestContext" in event:
+        return _handle_webhook(event)
+
+    job_id = event.get("config_runner_job_id")
+    if not job_id:
+        logger.error("worker-phase invocation missing config_runner_job_id: %r", event)
+        return {"launched": False, "reason": "invalid_event"}
+    return _launch_config_runner_spot(str(job_id))

--- a/infrastructure/lambdas/config-runner-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/config-runner-dispatcher/requirements.txt
@@ -1,0 +1,10 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
+# spot-launch capacity-resilience chokepoint) — same primitives ci-watch-
+# dispatcher/sf-watch-spot-dispatcher use. Pinned to the latest tag at the
+# time this Lambda was written (v0.106.0 is the floor: first version whose
+# running_instance_ids raises SpotProbeError instead of failing open,
+# config#2267 site 1 — index.py imports and handles that exception).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.110.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/config-runner-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/config-runner-dispatcher/test_handler.py
@@ -1,0 +1,379 @@
+"""Unit tests for the two-phase (webhook receiver / worker) config-runner
+spot dispatcher.
+
+Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
+before importing index (mirrors ci-watch-dispatcher/test_handler.py). Covers:
+webhook HMAC signature verification, event/action/label/repo filtering, the
+async self-invoke on a matching queued job, the kill-switch, and the worker
+phase's launch/dedup/tag/SSM-dispatch behavior (spot-first with on-demand
+fallback, job-id-scoped concurrency lock, terminate-on-post-launch-failure,
+config#2267-style dedupe_degraded on a probe failure).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_stdlib
+import json
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+WEBHOOK_SECRET = "test-webhook-secret"
+
+
+class _SpotLaunchError(Exception):
+    pass
+
+
+class _SpotCapacityExhausted(_SpotLaunchError):
+    pass
+
+
+def _install_stubs(launch_impl, boto_clients):
+    ec2_spot_mod = types.ModuleType("nousergon_lib.ec2_spot")
+    ec2_spot_mod.SpotLaunchError = _SpotLaunchError
+    ec2_spot_mod.SpotCapacityExhausted = _SpotCapacityExhausted
+    ec2_spot_mod.launch = launch_impl
+    sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
+
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: boto_clients[name]
+    sys.modules["boto3"] = boto3_mod
+
+
+class _FakeWaiter:
+    def wait(self, **kw):
+        return None
+
+
+class _FakeEc2:
+    def __init__(self, running_job_ids=None, create_tags_failures=0):
+        self.terminated = []
+        self.tags_created = []
+        self.create_tags_attempts = 0
+        self._create_tags_failures = create_tags_failures
+        self._running_job_ids = dict(running_job_ids or {})  # {job_id: [instance_ids]}
+
+    def get_waiter(self, name):
+        return _FakeWaiter()
+
+    def terminate_instances(self, InstanceIds):  # noqa: N803
+        self.terminated.extend(InstanceIds)
+        return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
+
+    def create_tags(self, Resources, Tags):  # noqa: N803
+        self.create_tags_attempts += 1
+        if self.create_tags_attempts <= self._create_tags_failures:
+            raise RuntimeError(f"CreateTags throttled (attempt {self.create_tags_attempts})")
+        self.tags_created.append((Resources, Tags))
+        return {}
+
+    def describe_instances(self, Filters):  # noqa: N803
+        by_name = {f["Name"]: f["Values"] for f in Filters}
+        job_id = by_name.get("tag:config-runner-job-id", [None])[0]
+        ids = self._running_job_ids.get(job_id, [])
+        return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
+
+
+class _FakeSsm:
+    def __init__(self):
+        self.sent = []
+        self.params = {"/alpha-engine/config_runner/webhook_secret": WEBHOOK_SECRET}
+
+    def get_parameter(self, Name, WithDecryption=True):  # noqa: N803
+        return {"Parameter": {"Value": self.params[Name]}}
+
+    def describe_instance_information(self, **kw):
+        return {"InstanceInformationList": [{"PingStatus": "Online"}]}
+
+    def send_command(self, **kw):
+        self.sent.append(kw)
+        return {"Command": {"CommandId": "cmd-123"}}
+
+
+class _FakeLambda:
+    def __init__(self):
+        self.invocations = []
+
+    def invoke(self, **kw):
+        self.invocations.append(kw)
+        return {"StatusCode": 202}
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None, running_job_ids=None,
+          create_tags_failures=0):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "alpha-engine-config-runner-dispatcher")
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    ssm = _FakeSsm()
+    ec2 = _FakeEc2(running_job_ids=running_job_ids, create_tags_failures=create_tags_failures)
+    lam = _FakeLambda()
+    clients = {"ec2": ec2, "ssm": ssm, "lambda": lam}
+    if launch_impl is None:
+        launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
+    _install_stubs(launch_impl, clients)
+
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+
+    assert_hermetic_imports_satisfied(__file__)
+    import importlib
+
+    if "nousergon_lib.spot_dispatch" in sys.modules:
+        importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
+    else:
+        import nousergon_lib.spot_dispatch  # noqa: F401 — first import picks up the current stub
+
+    _sd = sys.modules["nousergon_lib.spot_dispatch"]
+    if not hasattr(_sd, "SpotProbeError"):
+        _sd.SpotProbeError = type("SpotProbeError", (Exception,), {})
+
+    import index
+
+    importlib.reload(index)
+    index._test_ssm = ssm
+    index._test_ec2 = ec2
+    index._test_lambda = lam
+    return index
+
+
+def _sign(body_bytes: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    return "sha256=" + hmac_stdlib.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+
+
+def _webhook_event(payload: dict, *, event_type: str = "workflow_job", secret: str = WEBHOOK_SECRET) -> dict:
+    body = json.dumps(payload)
+    body_bytes = body.encode("utf-8")
+    return {
+        "requestContext": {"http": {"method": "POST"}},
+        "headers": {
+            "x-github-event": event_type,
+            "x-hub-signature-256": _sign(body_bytes, secret),
+        },
+        "body": body,
+        "isBase64Encoded": False,
+    }
+
+
+def _job_payload(**overrides):
+    base = {
+        "action": "queued",
+        "repository": {"full_name": "nousergon/alpha-engine-config"},
+        "workflow_job": {"id": 987654321, "labels": ["self-hosted", "alpha-engine-config-spot"]},
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Phase 1: webhook receiver ────────────────────────────────────────────────
+
+
+def test_webhook_valid_queued_job_self_invokes_and_returns_200(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["accepted"] is True
+    assert body["job_id"] == 987654321
+    assert len(idx._test_lambda.invocations) == 1
+    inv = idx._test_lambda.invocations[0]
+    assert inv["InvocationType"] == "Event"
+    assert inv["FunctionName"] == "alpha-engine-config-runner-dispatcher"
+    worker_payload = json.loads(inv["Payload"])
+    assert worker_payload == {"config_runner_job_id": "987654321"}
+
+
+def test_webhook_invalid_signature_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(), secret="wrong-secret"), None)
+    assert resp["statusCode"] == 401
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_signature_header_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    event = _webhook_event(_job_payload())
+    del event["headers"]["x-hub-signature-256"]
+    resp = idx.handler(event, None)
+    assert resp["statusCode"] == 401
+
+
+def test_webhook_non_workflow_job_event_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event({"zen": "hello"}, event_type="ping"), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_non_queued_action_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(action="completed")), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_wrong_repo_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(repository={"full_name": "nousergon/some-other-repo"})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_our_label_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(workflow_job={"id": 1, "labels": ["ubuntu-latest"]})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_disabled_flag_skips_invoke(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "false"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["launched"] is False
+    assert body["reason"] == "disabled"
+    assert idx._test_lambda.invocations == []
+
+
+# ── Phase 2: worker (async self-invoked) ─────────────────────────────────────
+
+
+def test_worker_valid_job_launches_spot_and_sends_async_ssm(monkeypatch):
+    calls = {}
+
+    def _launch(types_, subnets, **kw):
+        calls["spot"] = kw.get("spot")
+        calls["profile"] = kw.get("iam_instance_profile")
+        calls["tag_name"] = kw.get("tag_name")
+        return "i-abc"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"config_runner_job_id": "987654321"}, None)
+    assert out["launched"] is True
+    assert out["instance_id"] == "i-abc"
+    assert out["market"] == "spot"
+    assert out["command_id"] == "cmd-123"
+    assert calls["profile"] == "alpha-engine-config-runner-executor-profile"
+    assert calls["tag_name"] == "alpha-engine-config-runner-spot"
+    assert idx._test_ec2.tags_created == [
+        (["i-abc"], [{"Key": "config-runner-job-id", "Value": "987654321"}])
+    ]
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "exec bash infrastructure/config_runner_spot_bootstrap.sh --job-id \"987654321\"" in cmd
+    assert "export HOME=/root" in cmd
+
+
+def test_worker_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        if kw.get("spot"):
+            raise _SpotCapacityExhausted("no capacity")
+        return "i-ondemand"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"config_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["market"] == "on-demand"
+    assert seen == [True, False]
+
+
+def test_worker_total_launch_exhaustion_returns_clean_false(monkeypatch):
+    def _launch(types_, subnets, **kw):
+        raise _SpotCapacityExhausted("exhausted")
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"config_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_concurrency_skip_when_job_already_running(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-new"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-already-running"]},
+    )
+    out = idx.handler({"config_runner_job_id": "55"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "concurrent_skip"
+    assert out["existing_instance_ids"] == ["i-already-running"]
+    assert launched == []
+
+
+def test_worker_different_job_id_is_not_blocked(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-other-job"]},
+    )
+    out = idx.handler({"config_runner_job_id": "56"}, None)
+    assert out["launched"] is True
+
+
+def test_worker_probe_failure_launches_with_dedupe_degraded(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-degraded",  # noqa: E731
+        env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _probe_down(*a, **kw):
+        raise idx.SpotProbeError("probe failed: ThrottlingException")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler({"config_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["dedupe_degraded"] is True
+
+
+def test_worker_persistent_tag_write_failure_terminates_and_fails(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-untaggable",  # noqa: E731
+        env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"},
+        create_tags_failures=99,
+    )
+    out = idx.handler({"config_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "tag_write_failed"
+    assert idx._test_ec2.terminated == ["i-untaggable"]
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_post_launch_ssm_failure_terminates_instance(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-orphan",  # noqa: E731
+        env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom_send(**kw):
+        raise RuntimeError("SSM SendCommand failed")
+
+    idx._test_ssm.send_command = _boom_send
+    out = idx.handler({"config_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "post_launch_failed"
+    assert idx._test_ec2.terminated == ["i-orphan"]
+
+
+def test_worker_missing_job_id_returns_invalid_event(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -62,6 +62,11 @@ _LAMBDA_PIN_EXEMPTIONS = {
         "v0.106.0",
         "nousergon_lib.spot_dispatch chokepoint (config#2267: SpotProbeError handling)",
     ),
+    "config-runner-dispatcher": (
+        "v0.110.0",
+        "nousergon_lib.spot_dispatch chokepoint (alpha-engine-config-I2572: same SpotProbeError "
+        "handling as ci-watch-dispatcher, pinned to the latest tag at time of writing)",
+    ),
     "data-spot-dispatcher": (
         "v0.83.0",
         "ec2_spot launch chokepoint (config#1767)",


### PR DESCRIPTION
## Summary

Two-phase Lambda (`alpha-engine-config-runner-dispatcher`): a Function URL receives GitHub's `workflow_job` webhook directly, verifies its HMAC signature, filters to `action=queued` + our `alpha-engine-config-spot` label, then self-invokes async to do the actual EC2-spot launch via the shared `nousergon_lib.spot_dispatch` primitives — same shape as `ci-watch-dispatcher`/`sf-watch-spot-dispatcher`, generalized to a real self-hosted-runner workload instead of a bespoke SSM-invoked agent job.

Companion PR: nousergon/alpha-engine-config#2585 (EC2-side bootstrap script + IAM role this Lambda's SSM command targets).

## Why the async self-invoke

GitHub's webhook delivery timeout is short (single-digit seconds); a spot launch + SSM dispatch can take 30-90s+. Without decoupling, every delivery would show as a spurious timeout in GitHub's UI even though the box still launches — the receiver phase does only signature verification + filtering, then hands off.

## Blocked on (gate:operator)

Same blocker as the companion PR: a fine-grained PAT with Administration:write on `alpha-engine-config` must be created via the GitHub web UI before this can be exercised end-to-end (`deploy.sh --smoke` would otherwise just fail at the box's PAT-fetch step). `deploy.sh --bootstrap` (IAM role + Lambda + Function URL) can be applied independently of the PAT.

## Test plan

- [x] `deploy.sh` syntax check
- [x] 17 unit tests, hermetic (webhook signature verification, event/action/label/repo filtering, async self-invoke, spot launch + on-demand fallback, job-id-scoped concurrency lock, terminate-on-post-launch-failure, dedupe-degraded-on-probe-failure)
- [ ] Live: `deploy.sh --bootstrap` (operator step)
- [ ] Live: register the GitHub webhook on `alpha-engine-config` pointing at the printed Function URL
- [ ] Live: `config-runner-smoke-test.yml` in the companion repo, once the PAT exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)