### PR TITLE
feat(infra): reconcile backstop for the config-runner dispatcher (I2653)

### DIFF
--- a/infrastructure/lambdas/config-runner-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/config-runner-dispatcher/deploy.sh
@@ -28,7 +28,7 @@
 # This script's FLAGLESS run is code-only; --bootstrap is operator-only.
 #
 # POST-BOOTSTRAP MANUAL STEPS (cannot be automated via this script — see
-# alpha-engine-config-I2572 for the full sequencing):
+# alpha-engine-config-I2572/I2653 for the full sequencing):
 #   1. Create the SSM params this Lambda/box read:
 #        /alpha-engine/config_runner/webhook_secret  (random string, shared
 #          with the GitHub webhook config below)
@@ -38,6 +38,13 @@
 #          runner registration tokens; the Actions permission does NOT cover
 #          this. Fine-grained PAT creation/scoping is a GitHub web-UI-only,
 #          human action — cannot be done via this script or the API.)
+#        /alpha-engine/config_runner/github_read_pat  (SEPARATE fine-grained
+#          PAT, owner=nousergon, repo=alpha-engine-config, Actions: Read
+#          ONLY — deliberately NOT the same PAT as above. This one is read
+#          by the Lambda's own execution role (behind a public Function URL)
+#          for the reconcile phase's read-only "list queued jobs" calls;
+#          keeping it separate and minimally-scoped means a Lambda-side
+#          issue can never expose Administration:write.)
 #   2. Register the GitHub webhook on nousergon/alpha-engine-config:
 #        event: workflow_job, content type: json, secret: (the same value as
 #        the SSM param above), URL: this script's printed Function URL.
@@ -45,9 +52,10 @@
 #
 # Usage:
 #   bash .../config-runner-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
-#   bash .../config-runner-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda + Function URL
+#   bash .../config-runner-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda + Function URL + reconcile schedule
 #   bash .../config-runner-dispatcher/deploy.sh --dry-run   # show actions, do not apply
 #   bash .../config-runner-dispatcher/deploy.sh --smoke     # invoke the WORKER phase once with a synthetic job id (fires a REAL spot box)
+#   bash .../config-runner-dispatcher/deploy.sh --reconcile-test # invoke the RECONCILE phase once directly (read-only unless it finds a genuinely stale job)
 
 set -euo pipefail
 
@@ -66,11 +74,13 @@ source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
 DRY_RUN=false
 BOOTSTRAP=false
 SMOKE=false
+RECONCILE_TEST=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
     --bootstrap) BOOTSTRAP=true ;;
     --smoke) SMOKE=true ;;
+    --reconcile-test) RECONCILE_TEST=true ;;
     -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
   esac
 done
@@ -198,6 +208,59 @@ if $BOOTSTRAP; then
     echo "     header for the full remaining manual steps."
     echo ""
   fi
+
+  # --- 2c. Reconcile backstop schedule (config-I2653) ---
+  # A self-hosted runner registered via a plain registration token binds to
+  # the repo's WHOLE label pool, not the specific job that triggered its
+  # launch (GitHub has no per-job reservation API — verified against
+  # GitHub's own docs; an earlier JIT-runner-config fix attempt for this
+  # issue was wrong, JIT mints the same kind of "any matching job"
+  # registration, just more securely). Under concurrent load a dispatched
+  # runner can grab an unrelated queued job, permanently stranding the job
+  # that triggered its launch — GitHub sends `queued` exactly once per job.
+  # This EventBridge Scheduler rule invokes the Lambda's RECONCILE phase
+  # every 60s as a self-healing backstop; see index.py's module docstring
+  # phase 3 for the full mechanism.
+  RECONCILE_SCHED_ROLE_NAME="alpha-engine-config-runner-reconcile-scheduler-role"
+  RECONCILE_SCHED_POLICY_NAME="invoke-config-runner-dispatcher"
+  RECONCILE_SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${RECONCILE_SCHED_ROLE_NAME}"
+  RECONCILE_SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${RECONCILE_SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${RECONCILE_SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME}'s reconcile phase every 60s (config-I2653)" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${RECONCILE_SCHED_ROLE_NAME}"
+  fi
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  RECONCILE_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":[\"${FN_ARN}\",\"${FN_ARN}:*\"]}]}"
+  echo "  Applying Scheduler invoke policy: ${RECONCILE_SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+    --policy-name "${RECONCILE_SCHED_POLICY_NAME}" \
+    --policy-document "${RECONCILE_INVOKE_POLICY}"
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  RECONCILE_SCHED_NAME="alpha-engine-config-runner-reconcile"
+  RECONCILE_TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${RECONCILE_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"reconcile\\\":true}\"}"
+  if aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  Updating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler update-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  else
+    echo "  Creating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler create-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  fi
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: Scheduler rule ${RECONCILE_SCHED_NAME} not found after create/update" >&2; exit 1; }
+  fi
 fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
@@ -246,5 +309,23 @@ if $SMOKE; then
     --region "${REGION}" \
     "${RESP}" >/dev/null
   cat "${RESP}"
+  echo ""
+fi
+
+# ----- 5. Reconcile test (synthetic reconcile-phase event, direct invoke) ---
+
+if $RECONCILE_TEST; then
+  echo ""
+  echo "Testing the RECONCILE phase via direct invoke..."
+  echo "Read-only unless it finds a genuinely stale (>90s) queued job with no in-flight box — in which case it dispatches a REAL spot box for it (which is the correct/intended behavior, not a side effect to worry about)."
+  RESP2=$(mktemp)
+  trap "rm -f '${RESP2}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"reconcile":true}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP2}" >/dev/null
+  cat "${RESP2}"
   echo ""
 fi

--- a/infrastructure/lambdas/config-runner-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/config-runner-dispatcher/iam-policy.json
@@ -18,6 +18,12 @@
       "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/config_runner/webhook_secret"
     },
     {
+      "Sid": "ReadGithubReadOnlyPatForReconcileListing",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/config_runner/github_read_pat"
+    },
+    {
       "Sid": "SelfInvokeAsyncForTwoPhaseDispatch",
       "Effect": "Allow",
       "Action": "lambda:InvokeFunction",

--- a/infrastructure/lambdas/config-runner-dispatcher/index.py
+++ b/infrastructure/lambdas/config-runner-dispatcher/index.py
@@ -18,7 +18,7 @@ setup-python, pytest, etc.) is untouched, only `runs-on:` changes, and
 GitHub's own Actions service handles job dispatch + Check Run status
 natively, exactly as it does for hosted runners.
 
-MECHANISM (two-phase single Lambda, self-invoked async — see module-level
+MECHANISM (three-phase single Lambda, self-invoked async — see module-level
 `handler` for the branch):
   1. WEBHOOK RECEIVER phase: GitHub calls this Lambda's Function URL directly
      on every `workflow_job` event for alpha-engine-config (repo-level
@@ -42,6 +42,23 @@ MECHANISM (two-phase single Lambda, self-invoked async — see module-level
      on-box watchdog). Mirrors `ci-watch-dispatcher/index.py`'s
      launch/wait/dispatch shape via the shared `nousergon_lib.spot_dispatch`
      primitives (config#2106) — NOT reinvented here.
+  3. RECONCILE phase (EventBridge Scheduler, ~every 60s — config-I2653): a
+     self-hosted runner registered via a plain registration token binds to
+     the repo's WHOLE label pool, not the specific job that triggered its
+     launch — GitHub has no API to reserve a job for a not-yet-connected
+     runner (confirmed against GitHub's own docs before implementing this;
+     an earlier JIT-runner-config diagnosis for this issue was WRONG — JIT
+     is a more secure way to mint the same "any matching job" registration,
+     it does not bind to one job either). Under concurrent load a dispatched
+     runner can grab an unrelated queued job, leaving the job that triggered
+     its launch permanently stuck — GitHub sends the `queued` webhook exactly
+     ONCE per job, so there is no other path back to it without this backstop.
+     `_reconcile()` lists queued jobs matching our label that have sat queued
+     longer than `CONFIG_RUNNER_RECONCILE_STALE_SECONDS` with no in-flight
+     box (the existing job-id-tag dedup check), and dispatches a fresh runner
+     for each. Same "coverage beats dedupe" posture as the SpotProbeError
+     handling below — doesn't prevent the occasional mismatch, guarantees no
+     job stays stranded indefinitely.
 
 CONCURRENCY LOCK: keyed on `Name=alpha-engine-config-runner-spot` +
 `config-runner-job-id=<workflow_job.id>` — one job, one box, 1:1 (unlike
@@ -83,6 +100,9 @@ import hmac
 import json
 import logging
 import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
 
 import boto3
 from nousergon_lib import spot_dispatch
@@ -160,6 +180,49 @@ CONFIG_RUNNER_CONFIG_BRANCH = os.environ.get("CONFIG_RUNNER_CONFIG_BRANCH", "mai
 MAX_RUNTIME_SECONDS = int(os.environ.get("CONFIG_RUNNER_MAX_RUNTIME_SECONDS", "1800"))
 SSM_ONLINE_BUDGET_SEC = int(os.environ.get("CONFIG_RUNNER_SSM_ONLINE_BUDGET_SEC", "180"))
 CW_LOG_GROUP = os.environ.get("CONFIG_RUNNER_CW_LOG_GROUP", "/alpha-engine/config-runner-spot")
+
+# Reconcile backstop (config-I2653): a queued job older than this with no
+# in-flight box (per the same job-id-tag dedup check the reactive path uses)
+# gets a fresh dispatch. ~2-3x the typical observed dispatch+SSM-online
+# latency (15-40s) — comfortably past normal in-flight dispatches, without
+# waiting so long that a genuinely-orphaned job sits stuck for minutes.
+RECONCILE_STALE_SECONDS = int(os.environ.get("CONFIG_RUNNER_RECONCILE_STALE_SECONDS", "90"))
+RECONCILE_MAX_QUEUED_RUNS = int(os.environ.get("CONFIG_RUNNER_RECONCILE_MAX_QUEUED_RUNS", "50"))
+
+CONFIG_RUNNER_READ_PAT_SSM = os.environ.get(
+    "CONFIG_RUNNER_READ_PAT_SSM", "/alpha-engine/config_runner/github_read_pat"
+)
+_gh_read_pat_cache: str | None = None
+
+
+def _gh_read_pat() -> str:
+    """A SEPARATE, dedicated, least-privilege PAT (Actions: Read ONLY —
+    cannot register runners, cannot touch repo settings) — deliberately NOT
+    the Administration:write PAT the box uses to register runners. This
+    Lambda sits behind a public, unauthenticated Function URL (HMAC
+    verification protects the WEBHOOK path, not a credential the Lambda's
+    own execution role can read); granting it read access to the powerful
+    registration PAT would widen blast radius for no reason the reconcile
+    logic actually needs (it only ever lists queued runs/jobs)."""
+    global _gh_read_pat_cache
+    if _gh_read_pat_cache is None:
+        _gh_read_pat_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=CONFIG_RUNNER_READ_PAT_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _gh_read_pat_cache
+
+
+def _gh_api_get(path: str) -> dict:
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Authorization": f"Bearer {_gh_read_pat()}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - fixed https://api.github.com host
+        return json.loads(resp.read())
 
 
 def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
@@ -352,11 +415,77 @@ def _launch_config_runner_spot(job_id: str) -> dict:
     }
 
 
+def _reconcile() -> dict:
+    """Scheduled backstop (~every 60s, config-I2653): dispatch a fresh runner
+    for any queued job matching our label that's had no in-flight box for
+    RECONCILE_STALE_SECONDS. See module docstring phase 3 for the full
+    rationale — this is NOT redundant with the reactive webhook path; it is
+    the only mechanism that can recover a job whose one-shot `queued`
+    webhook already fired but whose dispatched runner grabbed a different
+    job instead."""
+    if not DISPATCH_ENABLED:
+        logger.info("reconcile: CONFIG_RUNNER_DISPATCH_ENABLED=false — skipping")
+        return {"reconciled": 0, "reason": "disabled"}
+
+    now = datetime.now(timezone.utc)
+    try:
+        runs_resp = _gh_api_get(
+            f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs"
+            f"?status=queued&per_page={RECONCILE_MAX_QUEUED_RUNS}"
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        # Best-effort: a failed reconcile pass just means "no backstop this
+        # minute" — the NEXT scheduled invocation tries again. Never raise
+        # (this is EventBridge-invoked; an unhandled exception would just
+        # generate a Lambda-error-metric page for a transient GitHub API
+        # blip with no actionable fix).
+        logger.error("reconcile: failed to list queued runs: %s: %s", type(exc).__name__, exc)
+        return {"reconciled": 0, "reason": "list_runs_failed", "error": str(exc)}
+
+    dispatched = []
+    skipped = []
+    for run in runs_resp.get("workflow_runs", []):
+        try:
+            jobs_resp = _gh_api_get(
+                f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs/{run['id']}/jobs"
+            )
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+            logger.error("reconcile: failed to list jobs for run %s: %s: %s",
+                         run.get("id"), type(exc).__name__, exc)
+            continue
+        for job in jobs_resp.get("jobs", []):
+            if job.get("status") != "queued" or TARGET_LABEL not in (job.get("labels") or []):
+                continue
+            created_at = datetime.fromisoformat(job["created_at"].replace("Z", "+00:00"))
+            age_seconds = (now - created_at).total_seconds()
+            if age_seconds < RECONCILE_STALE_SECONDS:
+                continue  # still within the reactive path's normal dispatch latency
+            job_id = str(job["id"])
+            try:
+                existing = _running_config_runner_instance_ids(job_id)
+            except SpotProbeError:
+                existing = []  # degrade to "dispatch anyway" — the launch's own dedup/tag logic is authoritative
+            if existing:
+                skipped.append(job_id)
+                continue
+            logger.info("reconcile: job %s queued %.0fs with no in-flight box — dispatching",
+                       job_id, age_seconds)
+            dispatched.append({"job_id": job_id, "age_seconds": age_seconds,
+                               "result": _launch_config_runner_spot(job_id)})
+
+    logger.info("reconcile: dispatched=%d skipped=%d", len(dispatched), len(skipped))
+    return {"reconciled": len(dispatched), "dispatched": dispatched, "skipped": skipped}
+
+
 def handler(event: dict, context) -> dict:
-    """Two-phase entrypoint — see module docstring. A Function URL delivery
-    carries `requestContext` (the API Gateway v2-shaped proxy event); the
-    async self-invoked worker payload does not."""
+    """Three-phase entrypoint — see module docstring. A Function URL
+    delivery carries `requestContext` (the API Gateway v2-shaped proxy
+    event); the EventBridge-scheduled reconcile trigger carries
+    `{"reconcile": true}`; the async self-invoked worker payload carries
+    `config_runner_job_id`."""
     event = event or {}
+    if event.get("reconcile"):
+        return _reconcile()
     if "requestContext" in event:
         return _handle_webhook(event)
 

--- a/infrastructure/lambdas/config-runner-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/config-runner-dispatcher/test_handler.py
@@ -1,13 +1,17 @@
-"""Unit tests for the two-phase (webhook receiver / worker) config-runner
-spot dispatcher.
+"""Unit tests for the three-phase (webhook receiver / worker / reconcile)
+config-runner spot dispatcher.
 
 Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
 before importing index (mirrors ci-watch-dispatcher/test_handler.py). Covers:
 webhook HMAC signature verification, event/action/label/repo filtering, the
-async self-invoke on a matching queued job, the kill-switch, and the worker
+async self-invoke on a matching queued job, the kill-switch, the worker
 phase's launch/dedup/tag/SSM-dispatch behavior (spot-first with on-demand
 fallback, job-id-scoped concurrency lock, terminate-on-post-launch-failure,
-config#2267-style dedupe_degraded on a probe failure).
+config#2267-style dedupe_degraded on a probe failure), and the reconcile
+backstop (config-I2653 — dispatches a fresh runner for any queued job
+matching our label that's sat stale with no in-flight box; ``urllib.request``
+is monkeypatched per-test rather than stubbed in sys.modules, since it's
+stdlib and always resolvable).
 """
 
 from __future__ import annotations
@@ -84,7 +88,10 @@ class _FakeEc2:
 class _FakeSsm:
     def __init__(self):
         self.sent = []
-        self.params = {"/alpha-engine/config_runner/webhook_secret": WEBHOOK_SECRET}
+        self.params = {
+            "/alpha-engine/config_runner/webhook_secret": WEBHOOK_SECRET,
+            "/alpha-engine/config_runner/github_read_pat": "test-read-only-pat",
+        }
 
     def get_parameter(self, Name, WithDecryption=True):  # noqa: N803
         return {"Parameter": {"Value": self.params[Name]}}
@@ -377,3 +384,132 @@ def test_worker_missing_job_id_returns_invalid_event(monkeypatch):
     out = idx.handler({}, None)
     assert out["launched"] is False
     assert out["reason"] == "invalid_event"
+
+
+# ── Phase 3: reconcile backstop (config-I2653) ───────────────────────────────
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_gh_api_stub(idx, monkeypatch, runs_by_path):
+    """runs_by_path: {url_path_suffix: response_dict}. Any request whose URL
+    ends with a registered suffix returns that canned response."""
+    def _fake_urlopen(req, timeout=10):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+        for suffix, payload in runs_by_path.items():
+            if url.endswith(suffix):
+                return _FakeHttpResponse(payload)
+        raise AssertionError(f"unexpected GH API call: {url}")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+
+
+def _iso(seconds_ago: float) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_reconcile_dispatches_stale_orphaned_job(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-rescued",  # noqa: E731
+        env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {
+            "workflow_runs": [{"id": 555}],
+        },
+        "/actions/runs/555/jobs": {
+            "jobs": [{
+                "id": 999, "status": "queued",
+                "labels": ["self-hosted", "alpha-engine-config-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 1
+    assert out["dispatched"][0]["job_id"] == "999"
+    assert out["dispatched"][0]["result"]["launched"] is True
+
+
+def test_reconcile_skips_job_within_normal_dispatch_window(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [{
+                "id": 1, "status": "queued",
+                "labels": ["self-hosted", "alpha-engine-config-spot"],
+                "created_at": _iso(10),  # well under the 90s default threshold
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["dispatched"] == []
+
+
+def test_reconcile_skips_job_already_covered_by_an_in_flight_box(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"777": ["i-already-covering-it"]},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 2}]},
+        "/actions/runs/2/jobs": {
+            "jobs": [{
+                "id": 777, "status": "queued",
+                "labels": ["self-hosted", "alpha-engine-config-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["skipped"] == ["777"]
+
+
+def test_reconcile_ignores_jobs_without_our_label(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 3}]},
+        "/actions/runs/3/jobs": {
+            "jobs": [{
+                "id": 3, "status": "queued", "labels": ["ubuntu-latest"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+
+
+def test_reconcile_disabled_flag_short_circuits(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "false"})
+    out = idx.handler({"reconcile": True}, None)
+    assert out == {"reconciled": 0, "reason": "disabled"}
+
+
+def test_reconcile_list_runs_failure_returns_clean_result_not_raise(monkeypatch):
+    idx = _load(monkeypatch, env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+
+    def _boom(req, timeout=10):  # noqa: ARG001
+        raise idx.urllib.error.URLError("network blip")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["reason"] == "list_runs_failed"


### PR DESCRIPTION
## Summary

Adds a third phase to `alpha-engine-config-runner-dispatcher`: an EventBridge-scheduled sweep (~every 60s) that lists queued jobs matching our self-hosted label and dispatches a fresh runner for any that have sat stale (>90s, no in-flight box) — a self-healing backstop for the job-pool race where a dispatched runner grabs a different queued job than the one that triggered its launch, permanently stranding the original job (GitHub sends the `queued` webhook exactly once per job — no other path back to it exists without this).

**Corrects a wrong diagnosis on `alpha-engine-config-I2653`** — verified against GitHub's own docs before implementing: JIT runner config does NOT bind a runner to a specific job, it's just a more secure way to mint the same "any matching job" registration a plain token gives you. The only GitHub-native mechanism that actually reserves a job for a runner is Actions Runner Controller's runner-scale-set protocol, a materially bigger (Kubernetes-oriented) architecture, out of scope here.

**Security-scoped deliberately** (caught by the auto-mode classifier on the first draft, fixed before this PR): the reconcile phase's read-only "list queued jobs" calls use a SEPARATE, dedicated PAT (`/alpha-engine/config_runner/github_read_pat`, `Actions: Read` ONLY) — never the `Administration: write` PAT the box uses to register runners. That powerful PAT stays reachable only from the isolated EC2 instance profile; the Lambda (behind a public Function URL) never touches it.

## Blocked on (gate:operator)

A new fine-grained PAT (`Actions: Read` only, repo=alpha-engine-config) needs creating via the GitHub web UI — same human-only constraint as the original registration PAT. Store at `/alpha-engine/config_runner/github_read_pat`.

## Test plan

- [x] 23 unit tests (17 existing + 6 new reconcile tests), all hermetic
- [x] gitleaks clean
- [ ] Once the new PAT exists and this is bootstrapped: `deploy.sh --reconcile-test` for a manual verification pass, then let the schedule run live

🤖 Generated with [Claude Code](https://claude.com/claude-code)