### PR TITLE
Auto-heal ArcticDB days stuck on EOD yfinance-fallback quality

### DIFF
--- a/tests/test_universe_gap_self_heal.py
+++ b/tests/test_universe_gap_self_heal.py
@@ -20,6 +20,7 @@ import pytest
 from nousergon_lib.trading_calendar import previous_trading_day
 
 from weekly_collector import (
+    _detect_fallback_quality_universe_days,
     _detect_missing_universe_days,
     _self_heal_missing_universe_days,
 )
@@ -41,6 +42,23 @@ def _macro_lib_with_present(present: list[date]) -> MagicMock:
     df = pd.DataFrame(
         {"Close": [1.0] * len(present)},
         index=pd.DatetimeIndex(sorted(present)),
+    )
+    tail_obj = MagicMock()
+    tail_obj.data = df
+    lib = MagicMock()
+    lib.tail.return_value = tail_obj
+    return lib
+
+
+def _macro_lib_with_sources(sources_by_date: dict[date, str]) -> MagicMock:
+    """Build a macro/SPY tail mock carrying a ``source`` column, keyed by date."""
+    dates = sorted(sources_by_date)
+    df = pd.DataFrame(
+        {
+            "Close": [1.0] * len(dates),
+            "source": [sources_by_date[d] for d in dates],
+        },
+        index=pd.DatetimeIndex(dates),
     )
     tail_obj = MagicMock()
     tail_obj.data = df
@@ -88,16 +106,67 @@ class TestDetectMissingUniverseDays:
             assert _detect_missing_universe_days("bkt", TARGET, lookback_trading_days=5) == []
 
 
+class TestDetectFallbackQualityUniverseDays:
+    """config#2664: a day PRESENT in ArcticDB but stuck on EOD's yfinance
+    fallback because the next-morning Polygon overwrite never landed."""
+
+    def test_yfinance_sourced_day_flagged(self):
+        tds = _recent_tds(TARGET, 5)
+        stale = tds[0]
+        sources = {d: ("yfinance" if d == stale else "polygon") for d in tds}
+        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+            flagged = _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5)
+        assert flagged == [stale.strftime("%Y-%m-%d")]
+
+    def test_all_polygon_returns_empty(self):
+        tds = _recent_tds(TARGET, 5)
+        sources = {d: "polygon" for d in tds}
+        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+            assert _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5) == []
+
+    def test_absent_day_not_flagged_here(self):
+        # A day missing entirely is _detect_missing_universe_days's job, not
+        # this detector's — it can only flag days present in the index.
+        tds = _recent_tds(TARGET, 5)
+        present = tds[1:]  # drop the newest
+        sources = {d: "polygon" for d in present}
+        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+            flagged = _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5)
+        assert tds[0].strftime("%Y-%m-%d") not in flagged
+
+    def test_missing_source_column_is_noop(self):
+        tds = _recent_tds(TARGET, 5)
+        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_present(tds)):
+            assert _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5) == []
+
+    def test_reference_read_failure_is_noop(self):
+        with patch("store.arctic_store.get_macro_lib", side_effect=RuntimeError("arctic down")):
+            assert _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5) == []
+
+    def test_multiple_stale_days_newest_first(self):
+        tds = _recent_tds(TARGET, 5)
+        sources = {d: "polygon" for d in tds}
+        sources[tds[2]] = "yfinance"
+        sources[tds[0]] = "fred"
+        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+            flagged = _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5)
+        assert flagged == [tds[0].strftime("%Y-%m-%d"), tds[2].strftime("%Y-%m-%d")]
+
+
 # ── Heal orchestration ───────────────────────────────────────────────────────
 
 
 class TestSelfHealMissingUniverseDays:
-    def _patches(self, missing, append_status="ok"):
+    def _patches(self, missing, append_status="ok", fallback_quality=None):
         collect = MagicMock(return_value={"status": "ok"})
         append = MagicMock(return_value={"status": append_status})
         loader = MagicMock(return_value=({"AAA", "BBB"}, "2026-06-19"))
         return (
             patch("weekly_collector._detect_missing_universe_days", return_value=missing),
+            patch(
+                "weekly_collector._detect_fallback_quality_universe_days",
+                return_value=fallback_quality or [],
+            ),
             patch("collectors.daily_closes.collect", collect),
             patch("builders.daily_append.daily_append", append),
             patch("builders._constituents_loader.load_constituents_for_run_date", loader),
@@ -107,8 +176,8 @@ class TestSelfHealMissingUniverseDays:
         )
 
     def test_backfills_missing_day_via_collect_then_append(self):
-        p_det, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(["2026-06-24"])
-        with p_det, p_col, p_app, p_ldr, p_b3:
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(["2026-06-24"])
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
             summary = _self_heal_missing_universe_days(
                 "bkt", TARGET, config={}, dry_run=False, max_heal_days=1
             )
@@ -121,17 +190,17 @@ class TestSelfHealMissingUniverseDays:
         assert "SPY" in append.call_args.kwargs["expected_tickers"]
 
     def test_no_missing_days_is_clean_noop(self):
-        p_det, p_col, p_app, p_ldr, p_b3, collect, append = self._patches([])
-        with p_det, p_col, p_app, p_ldr, p_b3:
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches([])
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
             summary = _self_heal_missing_universe_days("bkt", TARGET, config={})
         assert summary["healed_days"] == [] and summary["missing_days"] == []
         append.assert_not_called()
 
     def test_caps_heal_at_max_per_run_defers_the_rest(self):
-        p_det, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(
             ["2026-06-24", "2026-06-23", "2026-06-22"]
         )
-        with p_det, p_col, p_app, p_ldr, p_b3:
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
             summary = _self_heal_missing_universe_days(
                 "bkt", TARGET, config={}, max_heal_days=1
             )
@@ -140,10 +209,62 @@ class TestSelfHealMissingUniverseDays:
         assert append.call_count == 1
 
     def test_append_failure_recorded_not_raised(self):
-        p_det, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(
             ["2026-06-24"], append_status="failed"
         )
-        with p_det, p_col, p_app, p_ldr, p_b3:
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
             summary = _self_heal_missing_universe_days("bkt", TARGET, config={}, max_heal_days=1)
         assert summary["healed_days"] == []
         assert summary["errors"] and "status=failed" in summary["errors"][0]["reason"]
+
+    # ── config#2664: fallback-quality days folded into the same heal ────────
+
+    def test_fallback_quality_day_healed_via_same_path(self):
+        """A day with no absence gap, only a stale (yfinance) source, still
+        gets collect+append re-run — the exact overwrite MorningEnrich itself
+        relies on (skip_if_exists defaults False)."""
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(
+            [], fallback_quality=["2026-07-14"]
+        )
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
+            summary = _self_heal_missing_universe_days(
+                "bkt", TARGET, config={}, max_heal_days=1
+            )
+        assert [h["date"] for h in summary["healed_days"]] == ["2026-07-14"]
+        assert [h["kind"] for h in summary["healed_days"]] == ["fallback_quality"]
+        assert summary["fallback_quality_days"] == ["2026-07-14"]
+        assert collect.call_args.kwargs["run_date"] == "2026-07-14"
+        assert append.call_args.kwargs["date_str"] == "2026-07-14"
+
+    def test_missing_days_healed_before_fallback_quality_days(self):
+        """Missing (absent) days are the more severe gap — they consume the
+        per-run budget before fallback-quality days get a turn."""
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(
+            ["2026-06-24"], fallback_quality=["2026-07-14"]
+        )
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
+            summary = _self_heal_missing_universe_days(
+                "bkt", TARGET, config={}, max_heal_days=1
+            )
+        assert [h["date"] for h in summary["healed_days"]] == ["2026-06-24"]
+        assert [h["kind"] for h in summary["healed_days"]] == ["missing"]
+        assert summary["deferred_days"] == ["2026-07-14"]
+
+    def test_budget_covers_both_kinds_in_same_run(self):
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches(
+            ["2026-06-24"], fallback_quality=["2026-07-14"]
+        )
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
+            summary = _self_heal_missing_universe_days(
+                "bkt", TARGET, config={}, max_heal_days=2
+            )
+        assert [h["date"] for h in summary["healed_days"]] == ["2026-06-24", "2026-07-14"]
+        assert [h["kind"] for h in summary["healed_days"]] == ["missing", "fallback_quality"]
+        assert summary["deferred_days"] == []
+
+    def test_neither_missing_nor_fallback_quality_is_clean_noop(self):
+        p_det, p_fq, p_col, p_app, p_ldr, p_b3, collect, append = self._patches([])
+        with p_det, p_fq, p_col, p_app, p_ldr, p_b3:
+            summary = _self_heal_missing_universe_days("bkt", TARGET, config={})
+        assert summary["fallback_quality_days"] == []
+        append.assert_not_called()

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -1581,6 +1581,71 @@ def _detect_missing_universe_days(
     return [d.strftime("%Y-%m-%d") for d in missing]
 
 
+def _detect_fallback_quality_universe_days(
+    bucket: str,
+    target_date: str,
+    lookback_trading_days: int = _UNIVERSE_GAP_HEAL_LOOKBACK_TD,
+) -> list[str]:
+    """Trading days strictly before ``target_date`` PRESENT in ArcticDB but
+    still on EOD's yfinance-fallback quality — never received the next
+    morning's Polygon VWAP-corrected overwrite (alpha-engine-config#2664).
+
+    Every trading day is written twice: EOD same-evening writes a
+    yfinance-sourced row (``source="yfinance"``, ``VWAP=NaN``); the next
+    morning's MorningArcticAppend is supposed to overwrite it with a
+    Polygon-sourced row (``source="polygon"``). ``_detect_missing_universe_days``
+    only catches a day with NO row at all — if the Polygon overwrite fails
+    (e.g. a rate limit; 2026-07-15 incident) the day is PRESENT, so that
+    detector never flags it, and nothing else in the pipeline ever revisits
+    a day that already has a row. This closes that hole using the same
+    fixed-key macro/SPY proxy as the missing-day detector (avoids
+    reconstitution-churn false positives, and costs no extra ArcticDB read —
+    reads the ``source`` column off the same ``tail`` call).
+
+    Returns the affected days as ``YYYY-MM-DD`` strings, newest first.
+    Best-effort: any read failure, or a schema without a ``source`` column
+    (pre-provenance-tagging history), returns ``[]`` — degrades to
+    missing-day-only healing rather than mis-flagging.
+    """
+    from datetime import date as _date
+
+    import pandas as pd
+
+    from nousergon_lib.trading_calendar import previous_trading_day
+
+    target = _date.fromisoformat(target_date)
+    expected: list[_date] = []
+    d = previous_trading_day(target)
+    for _ in range(lookback_trading_days):
+        expected.append(d)
+        d = previous_trading_day(d)
+
+    try:
+        from store.arctic_store import get_macro_lib
+
+        macro_lib = get_macro_lib(bucket)
+        df = macro_lib.tail("SPY", n=lookback_trading_days + 6).data
+    except Exception as exc:  # best-effort reference read
+        logger.warning(
+            "universe-gap detect: macro/SPY index read failed (%s) — "
+            "skipping fallback-quality heal; freshness monitor remains the backstop.",
+            exc,
+        )
+        return []
+
+    if "source" not in df.columns:
+        return []
+
+    by_date = {pd.Timestamp(ix).date(): src for ix, src in df["source"].items()}
+
+    fallback_days = [
+        d for d in expected
+        if d in by_date and pd.notna(by_date[d]) and str(by_date[d]).lower() != "polygon"
+    ]
+    fallback_days.sort(reverse=True)  # newest first
+    return [d.strftime("%Y-%m-%d") for d in fallback_days]
+
+
 def _self_heal_missing_universe_days(
     bucket: str,
     target_date: str,
@@ -1589,9 +1654,20 @@ def _self_heal_missing_universe_days(
     lookback_trading_days: int = _UNIVERSE_GAP_HEAL_LOOKBACK_TD,
     max_heal_days: int = _UNIVERSE_GAP_HEAL_MAX_PER_RUN,
 ) -> dict:
-    """Backfill trading days missing from the ArcticDB universe (config#1228).
+    """Backfill trading days missing OR fallback-quality in the ArcticDB
+    universe (config#1228; fallback-quality healing added config#2664).
 
-    For each missing day (newest first, capped at ``max_heal_days`` per run):
+    Two distinct conditions are healed through the same path, most-severe
+    first (missing days, then present-but-fallback-quality days), each
+    newest-first within its own group, capped at ``max_heal_days`` combined
+    per run:
+      - **Missing**: no row at all for that day (a skipped weekday/EOD SF).
+      - **Fallback-quality**: EOD wrote a yfinance-sourced row, but the next
+        morning's Polygon VWAP-correction pass never landed (e.g. a rate
+        limit) — the day is present, so nothing else ever revisits it
+        (see :func:`_detect_fallback_quality_universe_days`).
+
+    For each day to heal:
       1. Resolve that day's constituents via ``load_constituents_for_run_date``
          (run_date-direct, #468-correct — never the latest_weekly pointer),
          plus the fixed macro keys.
@@ -1599,8 +1675,10 @@ def _self_heal_missing_universe_days(
          (``daily_closes.collect``; ``auto`` source so FRED/yfinance backfill
          any Polygon gaps — completeness matters more than VWAP purity here).
       3. Splice the day into ArcticDB via ``daily_append(date_str=day)`` — an
-         idempotent mid-series insert (re-running a partially-healed day is a
-         no-op-equivalent rewrite).
+         idempotent mid-series insert. ``skip_if_exists`` defaults to False
+         (not passed here), so a fallback-quality day's existing row is
+         overwritten exactly like MorningEnrich's own polygon-over-yfinance
+         overwrite — no separate write path needed for the two conditions.
 
     Best-effort and per-day isolated: one day's failure is recorded and the
     loop continues. NEVER raises — returns a summary the caller logs. The
@@ -1611,23 +1689,38 @@ def _self_heal_missing_universe_days(
         "scan_window_td": lookback_trading_days,
         "max_per_run": max_heal_days,
         "missing_days": [],
+        "fallback_quality_days": [],
         "healed_days": [],
         "deferred_days": [],
         "errors": [],
     }
 
     missing = _detect_missing_universe_days(bucket, target_date, lookback_trading_days)
+    fallback_quality = _detect_fallback_quality_universe_days(
+        bucket, target_date, lookback_trading_days
+    )
     summary["missing_days"] = missing
-    if not missing:
-        logger.info("universe-gap heal: no prior trading-day gaps before %s.", target_date)
+    summary["fallback_quality_days"] = fallback_quality
+
+    # Mutually exclusive by construction (fallback-quality requires an
+    # existing row; missing requires none) — de-dup is defensive only.
+    # Missing days are the more severe gap, so they get healed first.
+    combined = missing + [d for d in fallback_quality if d not in missing]
+    if not combined:
+        logger.info(
+            "universe-gap heal: no prior trading-day gaps or fallback-quality "
+            "rows before %s.",
+            target_date,
+        )
         return summary
 
-    to_heal = missing[:max_heal_days]
-    summary["deferred_days"] = missing[max_heal_days:]
+    to_heal = combined[:max_heal_days]
+    summary["deferred_days"] = combined[max_heal_days:]
     logger.warning(
-        "universe-gap heal: %d trading day(s) missing from ArcticDB before %s (%s); "
-        "healing %s this run%s.",
-        len(missing), target_date, missing, to_heal,
+        "universe-gap heal: %d day(s) need healing before %s — %d missing (%s), "
+        "%d fallback-quality (%s); healing %s this run%s.",
+        len(combined), target_date, len(missing), missing,
+        len(fallback_quality), fallback_quality, to_heal,
         f", deferring {summary['deferred_days']} to subsequent runs" if summary["deferred_days"] else "",
     )
 
@@ -1640,6 +1733,7 @@ def _self_heal_missing_universe_days(
     s3 = boto3.client("s3")
 
     for day in to_heal:
+        kind = "missing" if day in missing else "fallback_quality"
         try:
             try:
                 tickers_set, weekly_date = load_constituents_for_run_date(
@@ -1658,7 +1752,9 @@ def _self_heal_missing_universe_days(
             # Mirror MorningEnrich's universe scope: constituents + macro keys.
             tickers = list(dict.fromkeys(tickers + _MACRO_DAILY_TICKERS))
             if not tickers:
-                summary["errors"].append({"date": day, "reason": "no constituents resolved"})
+                summary["errors"].append(
+                    {"date": day, "kind": kind, "reason": "no constituents resolved"}
+                )
                 continue
 
             # 1+2: stage the day's OHLCV (Polygon T+1, auto-chain fallback).
@@ -1680,22 +1776,28 @@ def _self_heal_missing_universe_days(
             status = append_result.get("status", "unknown")
             if status in ("ok", "ok_dry_run"):
                 summary["healed_days"].append(
-                    {"date": day, "tickers": len(tickers), "weekly_date": str(weekly_date)}
+                    {
+                        "date": day,
+                        "kind": kind,
+                        "tickers": len(tickers),
+                        "weekly_date": str(weekly_date),
+                    }
                 )
                 logger.info(
-                    "universe-gap heal: backfilled %s (%d tickers, status=%s).",
-                    day, len(tickers), status,
+                    "universe-gap heal: backfilled %s (%s, %d tickers, status=%s).",
+                    day, kind, len(tickers), status,
                 )
             else:
                 summary["errors"].append(
-                    {"date": day, "reason": f"daily_append status={status}"}
+                    {"date": day, "kind": kind, "reason": f"daily_append status={status}"}
                 )
                 logger.warning(
-                    "universe-gap heal: daily_append for %s returned status=%s.", day, status
+                    "universe-gap heal: daily_append for %s (%s) returned status=%s.",
+                    day, kind, status,
                 )
         except Exception as exc:
-            logger.warning("universe-gap heal: failed to backfill %s (%s).", day, exc)
-            summary["errors"].append({"date": day, "reason": str(exc)})
+            logger.warning("universe-gap heal: failed to backfill %s (%s, %s).", day, kind, exc)
+            summary["errors"].append({"date": day, "kind": kind, "reason": str(exc)})
 
     return summary
 


### PR DESCRIPTION
## Summary

Closes nousergon/alpha-engine-config#2664 (alpha-engine-config-I2664). `_detect_missing_universe_days` (config#1228's existing self-heal) only catches an ArcticDB day with **no row at all**. A day EOD already wrote — yfinance-sourced, `VWAP=NaN` — whose next-morning Polygon quality-upgrade pass then fails (e.g. the 2026-07-15 Polygon 429 incident) is *present*, so that detector never flags it, and nothing else in the pipeline ever revisits it. Result: a transient failure produces a **permanent, silent data-quality degradation** with zero automated recovery path.

- Adds `_detect_fallback_quality_universe_days` (`weekly_collector.py`), reading the `source` column already persisted on every ArcticDB row (`OHLCV_COLS + [PROVENANCE_COL] + FEATURES`, `store/arctic_store.py`) — no schema change, no extra ArcticDB read (reuses the same `macro_lib.tail("SPY", ...)` call the existing missing-day detector already makes).
- Merges its results into `_self_heal_missing_universe_days`'s existing heal loop: missing days heal first (more severe — no row at all), then fallback-quality days, sharing the same per-run `max_heal_days` budget.
- No write-path change needed — `daily_append`'s existing `skip_if_exists=False` default (not passed by the self-heal caller) already overwrites an existing row exactly like MorningEnrich's own polygon-over-yfinance overwrite. This is purely a **detection** gap being closed.
- Each healed/errored day is now tagged `kind: "missing" | "fallback_quality"` in the returned summary for observability.

## Why

Root-caused while investigating why 2026-07-15's `ne-preopen-trading-pipeline` `MorningArcticAppend` failure (Polygon HTTP 429, alpha-engine-config-I2662) left 07-14's row permanently on yfinance quality. The system's fail-open design (config#1767) is correct — a data-phase failure must never block `RunDaemon` — but fail-open is only safe when paired with a genuine auto-heal, and this specific failure mode (present-but-degraded row) had none.

## Test plan

- [x] `pytest tests/test_universe_gap_self_heal.py -v` — 19/19 passing (4 new detector tests, 4 new orchestration tests, 4 existing tests updated for the new mock plumbing, all passing).
- [x] `pytest tests/test_weekly_collector_morning_enrich.py tests/test_sf_chronic_gap_heal_wiring.py -v` — 59/59 passing, no regressions.
- [x] Full suite: `pytest tests/ -q` — 3148 passed, 11 skipped (pre-existing, environment-gated), 0 failed.
- [x] No lint gate configured in this repo's CI (`ci.yml` runs pytest only).
