### PR TITLE
Fix config#2664: fallback-quality detector read the wrong ArcticDB library

### DIFF
--- a/tests/test_universe_gap_self_heal.py
+++ b/tests/test_universe_gap_self_heal.py
@@ -108,20 +108,27 @@ class TestDetectMissingUniverseDays:
 
 class TestDetectFallbackQualityUniverseDays:
     """config#2664: a day PRESENT in ArcticDB but stuck on EOD's yfinance
-    fallback because the next-morning Polygon overwrite never landed."""
+    fallback because the next-morning Polygon overwrite never landed.
+
+    Reads SPY's ``source`` column from the UNIVERSE library (not macro) —
+    verified live 2026-07-15 that ``macro_lib.tail("SPY").data`` carries
+    only a bare ``Close`` column with no ``source``/OHLCV, so an earlier
+    version of this detector that read macro_lib silently always returned
+    ``[]``. Only ``store.arctic_store.get_universe_lib`` is patched here.
+    """
 
     def test_yfinance_sourced_day_flagged(self):
         tds = _recent_tds(TARGET, 5)
         stale = tds[0]
         sources = {d: ("yfinance" if d == stale else "polygon") for d in tds}
-        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+        with patch("store.arctic_store.get_universe_lib", return_value=_macro_lib_with_sources(sources)):
             flagged = _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5)
         assert flagged == [stale.strftime("%Y-%m-%d")]
 
     def test_all_polygon_returns_empty(self):
         tds = _recent_tds(TARGET, 5)
         sources = {d: "polygon" for d in tds}
-        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+        with patch("store.arctic_store.get_universe_lib", return_value=_macro_lib_with_sources(sources)):
             assert _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5) == []
 
     def test_absent_day_not_flagged_here(self):
@@ -130,17 +137,17 @@ class TestDetectFallbackQualityUniverseDays:
         tds = _recent_tds(TARGET, 5)
         present = tds[1:]  # drop the newest
         sources = {d: "polygon" for d in present}
-        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+        with patch("store.arctic_store.get_universe_lib", return_value=_macro_lib_with_sources(sources)):
             flagged = _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5)
         assert tds[0].strftime("%Y-%m-%d") not in flagged
 
     def test_missing_source_column_is_noop(self):
         tds = _recent_tds(TARGET, 5)
-        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_present(tds)):
+        with patch("store.arctic_store.get_universe_lib", return_value=_macro_lib_with_present(tds)):
             assert _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5) == []
 
     def test_reference_read_failure_is_noop(self):
-        with patch("store.arctic_store.get_macro_lib", side_effect=RuntimeError("arctic down")):
+        with patch("store.arctic_store.get_universe_lib", side_effect=RuntimeError("arctic down")):
             assert _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5) == []
 
     def test_multiple_stale_days_newest_first(self):
@@ -148,9 +155,24 @@ class TestDetectFallbackQualityUniverseDays:
         sources = {d: "polygon" for d in tds}
         sources[tds[2]] = "yfinance"
         sources[tds[0]] = "fred"
-        with patch("store.arctic_store.get_macro_lib", return_value=_macro_lib_with_sources(sources)):
+        with patch("store.arctic_store.get_universe_lib", return_value=_macro_lib_with_sources(sources)):
             flagged = _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5)
         assert flagged == [tds[0].strftime("%Y-%m-%d"), tds[2].strftime("%Y-%m-%d")]
+
+    def test_does_not_touch_macro_lib(self):
+        """Regression guard for the exact bug caught 2026-07-15 live-testing:
+        this detector must never read macro_lib (Close-only, no source)."""
+        tds = _recent_tds(TARGET, 5)
+        sources = {d: "polygon" for d in tds}
+        sources[tds[0]] = "yfinance"
+        with (
+            patch("store.arctic_store.get_universe_lib", return_value=_macro_lib_with_sources(sources)) as p_uni,
+            patch("store.arctic_store.get_macro_lib") as p_macro,
+        ):
+            flagged = _detect_fallback_quality_universe_days("bkt", TARGET, lookback_trading_days=5)
+        assert flagged == [tds[0].strftime("%Y-%m-%d")]
+        p_uni.assert_called_once()
+        p_macro.assert_not_called()
 
 
 # ── Heal orchestration ───────────────────────────────────────────────────────

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -1598,9 +1598,15 @@ def _detect_fallback_quality_universe_days(
     (e.g. a rate limit; 2026-07-15 incident) the day is PRESENT, so that
     detector never flags it, and nothing else in the pipeline ever revisits
     a day that already has a row. This closes that hole using the same
-    fixed-key macro/SPY proxy as the missing-day detector (avoids
-    reconstitution-churn false positives, and costs no extra ArcticDB read —
-    reads the ``source`` column off the same ``tail`` call).
+    fixed-key SPY proxy as the missing-day detector (avoids
+    reconstitution-churn false positives) — but reads it from the
+    **universe** library, not macro. SPY exists in both: ``macro_lib`` holds
+    only a bare ``Close`` reference copy (no ``source``/OHLCV — that's all
+    ``_detect_missing_universe_days`` needs, since it only checks index
+    presence); the full ``OHLCV_COLS + [PROVENANCE_COL] + FEATURES`` schema
+    with ``source`` lives in ``universe_lib`` (verified live 2026-07-15:
+    ``macro_lib.tail("SPY").data`` columns == ``['Close']`` only — reading
+    ``source`` off it would silently always return ``[]``).
 
     Returns the affected days as ``YYYY-MM-DD`` strings, newest first.
     Best-effort: any read failure, or a schema without a ``source`` column
@@ -1621,13 +1627,13 @@ def _detect_fallback_quality_universe_days(
         d = previous_trading_day(d)
 
     try:
-        from store.arctic_store import get_macro_lib
+        from store.arctic_store import get_universe_lib
 
-        macro_lib = get_macro_lib(bucket)
-        df = macro_lib.tail("SPY", n=lookback_trading_days + 6).data
+        universe_lib = get_universe_lib(bucket)
+        df = universe_lib.tail("SPY", n=lookback_trading_days + 6).data
     except Exception as exc:  # best-effort reference read
         logger.warning(
-            "universe-gap detect: macro/SPY index read failed (%s) — "
+            "universe-gap detect: universe/SPY source read failed (%s) — "
             "skipping fallback-quality heal; freshness monitor remains the backstop.",
             exc,
         )


### PR DESCRIPTION
## Summary

Follow-up to #840 (nousergon-data-PR840, merged). Brian asked to verify the merged fix actually works against live production data before considering config#2664 (alpha-engine-config-I2664) closed — that verification caught a real defect in what was shipped.

`_detect_fallback_quality_universe_days` read SPY's `source` column off **`macro_lib`**. Live testing showed `macro_lib.tail("SPY").data` carries only a bare `Close` column — no `source`, no OHLCV. That's all `_detect_missing_universe_days` (the existing detector this was modeled on) ever needed, since it only checks index presence. The full `OHLCV_COLS + [PROVENANCE_COL] + FEATURES` schema — the one that actually carries `source` — lives in **`universe_lib`**. As merged in #840, the new detector silently always returned `[]`: a complete no-op that never healed anything, despite all tests passing (the tests mocked `get_macro_lib` directly, so they never exercised the real schema mismatch).

## Fix

- `_detect_fallback_quality_universe_days` now reads from `get_universe_lib(bucket)` instead of `get_macro_lib(bucket)`.
- Updated all 7 tests in `TestDetectFallbackQualityUniverseDays` to patch `get_universe_lib`.
- Added `test_does_not_touch_macro_lib` — a regression guard asserting the detector never calls `get_macro_lib`, so this exact mistake can't silently recur.

## Live verification (production ArcticDB, read-only)

```
missing_days: []
fallback_quality_days: ['2026-07-14', '2026-07-13']
```

Confirms the real 2026-07-15 incident data (`universe_lib` SPY row for 07-14: `source="yfinance"`) is now correctly detected — and surfaced a second affected day (07-13) that was previously invisible even to a human inspecting the incident. Ran directly against production S3/ArcticDB from a local venv (read-only detector call, no writes, no EC2 touched — the trading box was mid-market-hours and excluded per standing policy).

## Test plan

- [x] `pytest tests/test_universe_gap_self_heal.py -v` — 20/20 passing (was 19; +1 regression guard).
- [x] `pytest tests/test_universe_gap_self_heal.py tests/test_weekly_collector_morning_enrich.py tests/test_sf_chronic_gap_heal_wiring.py -v` — 79/79 passing.
- [x] Full suite: `pytest tests/ -q` — 3154 passed, 11 skipped (pre-existing), 0 failed.
- [x] Live read-only verification against production ArcticDB (above).
