### PR TITLE
feat: Saturday-replay canary dispatch + data probe (config#2246)

### DIFF
--- a/.github/workflows/canary-replay.yml
+++ b/.github/workflows/canary-replay.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Configure AWS credentials
         id: aws_creds
         continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::711398986525:role/github-actions-canary-replay-dispatch
           aws-region: us-east-1

--- a/.github/workflows/canary-replay.yml
+++ b/.github/workflows/canary-replay.yml
@@ -1,0 +1,90 @@
+name: Canary Replay
+
+# Per-PR gate for alpha-engine-config#2246 (Saturday-replay canary). Gated
+# on the `canary:replay` label (auto-applied by label-canary-replay.yml on
+# weekly-critical paths). Thin GHA shim on this PUBLIC repo (free/unmetered
+# hosted runner) — the actual probe workload runs on EC2 spot, dispatched
+# via alpha-engine-canary-replay-dispatcher (this repo). Brian's binding
+# ruling: the canary ALWAYS runs all 3 probes together regardless of which
+# repo's PR triggered it, so this shim supplies ITS OWN branch as data_ref
+# and lets research_ref default to main on the dispatcher side.
+#
+# Fork PRs have no OIDC trust to this account — configure-aws-credentials
+# fails cleanly and the job exits 0 rather than failing a check a fork
+# contributor cannot fix.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  canary:
+    if: contains(github.event.pull_request.labels.*.name, 'canary:replay')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Configure AWS credentials
+        id: aws_creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-canary-replay-dispatch
+          aws-region: us-east-1
+
+      - name: Skip (no OIDC trust — fork PR)
+        if: steps.aws_creds.outcome == 'failure'
+        run: |
+          echo "No OIDC trust available (fork PR) — skipping canary replay gate."
+
+      - name: Dispatch canary
+        if: steps.aws_creds.outcome == 'success'
+        id: dispatch
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg mode "pr" \
+            --arg repo "nousergon/nousergon-data" \
+            --arg pr_number "${{ github.event.pull_request.number }}" \
+            --arg sha "${{ github.event.pull_request.head.sha }}" \
+            --arg data_ref "${{ github.event.pull_request.head.ref }}" \
+            '{mode: $mode, repo: $repo, pr_number: $pr_number, sha: $sha, data_ref: $data_ref}')
+
+          RESP=$(mktemp)
+          aws lambda invoke --function-name alpha-engine-canary-replay-dispatcher \
+            --payload "$PAYLOAD" --cli-binary-format raw-in-base64-out \
+            --region us-east-1 "$RESP" >/dev/null
+          cat "$RESP"
+
+          LAUNCHED=$(jq -r '.launched' "$RESP")
+          if [ "$LAUNCHED" != "true" ]; then
+            echo "::error::canary-replay-dispatcher declined to launch: $(cat "$RESP")"
+            exit 1
+          fi
+          MARKER_KEY=$(jq -r '.marker_key' "$RESP")
+          echo "marker_key=${MARKER_KEY}" >> "$GITHUB_OUTPUT"
+
+      - name: Poll for completion marker
+        if: steps.aws_creds.outcome == 'success'
+        run: |
+          MARKER_KEY="${{ steps.dispatch.outputs.marker_key }}"
+          DEADLINE=$((SECONDS + 1200))
+          while [ "$SECONDS" -lt "$DEADLINE" ]; do
+            if aws s3api head-object --bucket alpha-engine-research --key "$MARKER_KEY" --region us-east-1 >/dev/null 2>&1; then
+              aws s3 cp "s3://alpha-engine-research/${MARKER_KEY}" marker.json --region us-east-1 --quiet
+              cat marker.json
+              STATUS=$(jq -r '.overall_status' marker.json)
+              echo "canary overall_status=${STATUS}"
+              if [ "$STATUS" = "PASS" ]; then
+                exit 0
+              else
+                echo "::error::canary replay FAILED — see marker.json above for per-probe detail"
+                exit 1
+              fi
+            fi
+            sleep 20
+          done
+          echo "::error::timed out waiting for canary completion marker at ${MARKER_KEY}"
+          exit 1

--- a/.github/workflows/canary-replay.yml
+++ b/.github/workflows/canary-replay.yml
@@ -43,13 +43,23 @@ jobs:
       - name: Dispatch canary
         if: steps.aws_creds.outcome == 'success'
         id: dispatch
+        env:
+          # Passed via env (shell-escaped), never spliced directly into the
+          # run: script — head.ref/head.sha are attacker-controlled on a
+          # pull_request trigger (fork branch names/commits), and direct
+          # ${{ }} interpolation into a run: block is a script-injection
+          # vector CodeQL flags (github.com/nousergon/crucible-research
+          # code-scanning finding on the sibling workflow's first draft).
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_DATA_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           PAYLOAD=$(jq -n \
             --arg mode "pr" \
             --arg repo "nousergon/nousergon-data" \
-            --arg pr_number "${{ github.event.pull_request.number }}" \
-            --arg sha "${{ github.event.pull_request.head.sha }}" \
-            --arg data_ref "${{ github.event.pull_request.head.ref }}" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg sha "$PR_SHA" \
+            --arg data_ref "$PR_DATA_REF" \
             '{mode: $mode, repo: $repo, pr_number: $pr_number, sha: $sha, data_ref: $data_ref}')
 
           RESP=$(mktemp)

--- a/.github/workflows/label-canary-replay.yml
+++ b/.github/workflows/label-canary-replay.yml
@@ -1,0 +1,38 @@
+name: Label canary:replay
+
+# Auto-labels a PR `canary:replay` when it touches weekly-critical paths —
+# the label is what gates canary-replay.yml (alpha-engine-config#2246).
+# Path list MUST stay in lockstep with what
+# alpha-engine-config/infrastructure/canary_replay_spot_bootstrap.sh's
+# probe 1 actually exercises: a change to any of these could regress what
+# the Saturday weekly-SF's filing-change-detection step executes.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            weekly_critical:
+              - 'rag/pipelines/**'
+              - 'infrastructure/lambdas/canary-replay-dispatcher/**'
+              - 'infrastructure/lambdas/canary-replay-liveness-probe/**'
+              - '.github/workflows/label-canary-replay.yml'
+              - '.github/workflows/canary-replay.yml'
+      - name: Apply canary:replay label
+        if: steps.filter.outputs.weekly_critical == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit "${{ github.event.pull_request.number }}" --add-label canary:replay

--- a/.github/workflows/label-canary-replay.yml
+++ b/.github/workflows/label-canary-replay.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |

--- a/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-canary-replay-dispatcher Lambda
+# (alpha-engine-config#2246, Saturday-replay canary).
+#
+# --bootstrap creates: (1) this Lambda's OWN execution role + inline policy,
+# (2) the Lambda function itself, (3) the Thursday EventBridge cron rule
+# (classic `events put-rule`, NOT EventBridge Scheduler — this Lambda takes no
+# per-invocation identity the way ci-watch-dispatcher's weekly drill needs,
+# a plain rule->Lambda target is the simpler, correct fit, mirroring
+# eod-backstop/deploy.sh's shape).
+#
+# SAFE ROLLOUT (mirrors eod-backstop): the EventBridge rule is created
+# DISABLED. Enable it deliberately AFTER canary-replay-liveness-probe is
+# deployed and verified live (it is the ONLY thing watching the scheduled
+# path — nothing else notices a silent Thursday failure):
+#   aws events enable-rule --name alpha-engine-canary-replay-thursday --region us-east-1
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
+# (scoped to alpha-engine-canary-replay-executor-role — a NEW, dedicated role
+# a sibling agent creates in alpha-engine-config, deliberately NOT the shared
+# trading/dashboard executor role) + ssm:SendCommand. The BOX reads its own
+# run secrets via ITS instance profile, so this Lambda needs no secret
+# access of its own.
+#
+# Managed OUTSIDE CloudFormation (same as every sibling dispatcher): keeps the
+# github-actions-lambda-deploy OIDC role's blast radius narrow. This script's
+# FLAGLESS run is code-only (the CI auto-deploy path); --bootstrap is
+# operator-only, never in CI.
+#
+# Usage:
+#   bash .../canary-replay-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../canary-replay-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda function + Thursday rule (DISABLED)
+#   bash .../canary-replay-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../canary-replay-dispatcher/deploy.sh --smoke     # invoke once with a synthetic scheduled event (fires a REAL spot box)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-canary-replay-dispatcher"
+ROLE_NAME="alpha-engine-canary-replay-dispatcher-role"
+POLICY_NAME="alpha-engine-canary-replay-dispatcher-policy"
+RULE_NAME="alpha-engine-canary-replay-thursday"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# Bootstrap default (first-time deployment only) — safe default. The update
+# path (step 3) reads the live value and preserves it (config#1818/#2236 bug
+# class: a routine redeploy must not silently re-arm an operator kill-switch).
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,CANARY_REPLAY_DISPATCH_ENABLED=true}'
+
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Installing pytest into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # --- 2a. Lambda execution role + inline policy ---
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  # --- 2b. Lambda function ---
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 300 \
+      --memory-size 256 \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2c. Thursday EventBridge cron rule (DISABLED at first deploy — see
+  # header. 09:00 UTC Thursday, ahead of Saturday's weekly run with a full
+  # business day of slack to investigate a failure before Saturday.) ---
+  echo "  Creating EventBridge rule: ${RULE_NAME} (DISABLED)"
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --schedule-expression 'cron(0 9 ? * THU *)' \
+    --state DISABLED \
+    --description "Saturday-replay canary (config#2246) weekly trigger, 09:00 UTC Thursday. DISABLED until canary-replay-liveness-probe is deployed and verified live." \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN},Input={\"mode\":\"scheduled\"}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+
+  echo "  NOTE: rule is DISABLED. Enable AFTER canary-replay-liveness-probe is verified live:"
+  echo "        aws events enable-rule --name ${RULE_NAME} --region ${REGION}"
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment (preserving operator-owned CANARY_REPLAY_DISPATCH_ENABLED)..."
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" CANARY_REPLAY_DISPATCH_ENABLED true)
+LAMBDA_ENV="Variables={LOG_LEVEL=INFO,CANARY_REPLAY_DISPATCH_ENABLED=${CURRENT_DISPATCH}}"
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment "${LAMBDA_ENV}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+# ----- 4. Smoke (synthetic scheduled event, direct invoke) -------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (synthetic scheduled event)..."
+  echo "⚠ this fires a REAL spot box + REAL canary_replay_spot_bootstrap.sh run"
+  echo "  (live LLM calls against the real held-ticker archive, ~\$1 in Anthropic cost)."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"mode":"scheduled"}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi

--- a/infrastructure/lambdas/canary-replay-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/canary-replay-dispatcher/iam-policy.json
@@ -1,0 +1,118 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-canary-replay-dispatcher:*"
+    },
+    {
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "alpha-engine-canary-replay-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-canary-replay-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassCanaryReplayExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-canary-replay-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunCanaryReplayBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateCanaryReplaySpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-canary-replay-spot"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/canary-replay-dispatcher/index.py
+++ b/infrastructure/lambdas/canary-replay-dispatcher/index.py
@@ -1,0 +1,425 @@
+"""alpha-engine-canary-replay-dispatcher — launch the Saturday-replay canary
+(alpha-engine-config#2246) on a dedicated EC2 spot box.
+
+WHY: the Friday dry-preflight is structurally blind to every bug class that
+fails Saturday's live run — `--preflight-only`/`--dry-run` never execute
+`rag.pipelines.filing_change_detection` (data) or the real held-thesis-
+update / qual-analyst / structured-output-retry paths (research) against
+live data. This canary actually replays those 3 paths, on a schedule AND
+per-PR, so a regression is caught before Saturday instead of during it.
+
+TWO CALLERS, ONE DISPATCH PATH:
+  1. EventBridge (Thursday cron) invokes this Lambda directly with
+     `{"mode": "scheduled"}` — `research_ref`/`data_ref` default to `main`.
+  2. A thin GHA shim on `crucible-research`/`nousergon-data` (gated by the
+     `canary:replay` label) invokes this Lambda SYNCHRONOUSLY with
+     `{"mode": "pr", "research_ref": ..., "data_ref": ..., "pr_number": ...}`
+     — whichever repo's PR triggered the run supplies its own branch ref;
+     the OTHER repo defaults to `main`. Brian's binding ruling on #2246: the
+     canary ALWAYS runs all 3 probes together regardless of which repo
+     changed — a per-repo PR still exercises the full weekly-critical path.
+
+Mechanism (mirrors ci-watch-dispatcher/index.py's PROVEN async spot-dispatch
+shape via the shared `nousergon_lib.spot_dispatch` primitives — every
+dispatcher in this fleet is deliberately ASYNC: none bets a gating operation
+on Lambda's 900s hard ceiling under spot-capacity/LLM-latency variance):
+  1. `spot_dispatch.launch_with_fallback()` — spot first, on-demand fallback
+     on capacity exhaustion across all pools.
+  2. Wait for the instance to run + its SSM agent to come Online.
+  3. Fire an async, detached `ssm send-command` (AWS-RunShellScript) that
+     fetches the fleet PAT from SSM, clones alpha-engine-config, then
+     `exec`s `infrastructure/canary_replay_spot_bootstrap.sh` (built by a
+     sibling agent in that repo) with the resolved refs/run-token/mode. The
+     box self-terminates (InstanceInitiatedShutdownBehavior=terminate + its
+     own on-box watchdog — config#1472 shape).
+
+DETERMINISTIC run_token (the key divergence from ci-watch-dispatcher's
+random uuid4): the SCHEDULED path derives `sched-{isoyear}w{isoweek:02d}`
+from the current UTC date, and the PR path derives
+`pr-{repo-with-slash-flattened}-{pr_number}-{sha[:12]}` from the event —
+both WITHOUT any IPC. This lets `canary-replay-liveness-probe` (the
+Thursday-path watchdog) independently compute the SAME S3 completion-marker
+key it needs to poll, with no coupling to this Lambda beyond the shared
+derivation function. It also gives natural at-most-one-live-marker
+idempotency: a retried Thursday dispatch in the same ISO week, or a
+re-pushed commit on the same PR/sha, overwrites the same key rather than
+littering orphan markers.
+
+SYNCHRONOUS CONTRACT (mirrors ci-watch-dispatcher): every anticipated
+failure mode — concurrency skip, spot+on-demand launch exhaustion, a
+malformed event, a post-launch SSM failure — returns a clean, well-formed
+`{"launched": false, "reason": ...}` rather than raising, so the per-PR
+GHA job's synchronous `aws lambda invoke` gets an unambiguous JSON verdict
+to branch on. Only a genuinely unexpected internal bug propagates as an
+exception (which EventBridge's Thursday caller then retries, the correct
+behavior for a scheduled invocation).
+
+IAM PROFILE — deliberately NOT the shared trading-executor or dashboard
+profile. Uses `alpha-engine-canary-replay-executor-profile` (a sibling
+agent in alpha-engine-config), because the per-PR trigger path means this
+box is reachable from PR content a contributor (not just a scheduled
+trigger) can influence — blast-radius isolation matters more here than for
+ci-watch/sf-watch.
+
+Managed OUTSIDE CloudFormation (same as every sibling dispatcher):
+operator-deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live
+effect until the new code + IAM are deployed AND the GHA workflows/
+EventBridge rule are wired.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+
+import boto3
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import (
+    SpotLaunchError,
+    SpotProbeError,
+)
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: mirrors every other fleet dispatcher's safety valve. Default ON.
+DISPATCH_ENABLED = os.environ.get("CANARY_REPLAY_DISPATCH_ENABLED", "true").lower() == "true"
+
+# ── Spot launch config (env-overridable; IAM LOCKSTEP — see iam-policy.json's
+# scoped ec2:RunInstances condition, which enumerates these same values;
+# changing a default here WITHOUT updating iam-policy.json breaks RunInstances
+# with UnauthorizedOperation at the next dispatch) ───────────────────────────
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "CANARY_REPLAY_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "CANARY_REPLAY_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("CANARY_REPLAY_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("CANARY_REPLAY_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("CANARY_REPLAY_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+IAM_PROFILE = os.environ.get(
+    "CANARY_REPLAY_IAM_PROFILE", "alpha-engine-canary-replay-executor-profile"
+)
+VOLUME_SIZE_GB = int(os.environ.get("CANARY_REPLAY_VOLUME_SIZE_GB", "40"))
+
+CANARY_REPLAY_TAG_NAME = "alpha-engine-canary-replay-spot"
+CANARY_REPLAY_RUN_TOKEN_TAG_KEY = "canary-replay-run-token"
+
+TAG_WRITE_ATTEMPTS = int(os.environ.get("CANARY_REPLAY_TAG_WRITE_ATTEMPTS", "3"))
+TAG_WRITE_RETRY_DELAY_SEC = float(os.environ.get("CANARY_REPLAY_TAG_WRITE_RETRY_DELAY_SEC", "2"))
+
+CANARY_REPLAY_GH_PAT_SSM = os.environ.get(
+    "CANARY_REPLAY_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+CANARY_REPLAY_CONFIG_REPO = os.environ.get(
+    "CANARY_REPLAY_CONFIG_REPO", "nousergon/alpha-engine-config"
+)
+CANARY_REPLAY_CONFIG_BRANCH = os.environ.get("CANARY_REPLAY_CONFIG_BRANCH", "main")
+# Nominal probe runtime ~5-10 min; generous headroom without the fleet's
+# usual 2h dispatcher-level ceiling — this box's own work is small and
+# bounded, unlike groom/ci-watch/sf-watch. Matches
+# canary_replay_spot_bootstrap.sh's own MAX_RUNTIME_SECONDS default.
+MAX_RUNTIME_SECONDS = int(os.environ.get("CANARY_REPLAY_MAX_RUNTIME_SECONDS", "2400"))
+SSM_ONLINE_BUDGET_SEC = int(os.environ.get("CANARY_REPLAY_SSM_ONLINE_BUDGET_SEC", "180"))
+CW_LOG_GROUP = os.environ.get("CANARY_REPLAY_CW_LOG_GROUP", "/alpha-engine/canary-replay-spot")
+
+# Defense-in-depth allowlists for event fields embedded verbatim into the SSM
+# shell command below (mirrors ci-watch-dispatcher's _REPO_RE/_SHA_RE). These
+# come from a GHA job (not raw external user input), but the same cheap
+# regex check rules out shell-metacharacter injection outright.
+_REF_RE = re.compile(r"^[A-Za-z0-9_./-]{1,200}$")
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+_PR_NUMBER_RE = re.compile(r"^[0-9]+$")
+_MODE_RE = re.compile(r"^(scheduled|pr)$")
+
+
+class _InvalidEvent(ValueError):
+    """A required event field is missing or fails its allowlist."""
+
+
+def _require(event: dict, key: str, pattern: "re.Pattern[str]") -> str:
+    val = str(event.get(key) or "").strip()
+    if not pattern.match(val):
+        raise _InvalidEvent(f"missing/malformed {key!r} in event: {val!r}")
+    return val
+
+
+def _optional(event: dict, key: str, pattern: "re.Pattern[str]", default: str) -> str:
+    val = str(event.get(key) or "").strip()
+    if not val:
+        return default
+    if not pattern.match(val):
+        raise _InvalidEvent(f"malformed {key!r} in event: {val!r}")
+    return val
+
+
+def _scheduled_run_token(now: datetime) -> str:
+    """Deterministic per-ISO-week token — see module docstring. A retried
+    Thursday dispatch in the same week overwrites the same marker key
+    rather than orphaning a new one."""
+    iso_year, iso_week, _ = now.isocalendar()
+    return f"sched-{iso_year}w{iso_week:02d}"
+
+
+def _pr_run_token(repo: str, pr_number: str, sha: str) -> str:
+    """Deterministic per-(repo, PR, sha) token — see module docstring. A
+    re-pushed commit gets a fresh token (new sha); re-running CI on the SAME
+    commit (e.g. a manual re-run) overwrites the same marker key."""
+    return f"pr-{repo.replace('/', '-')}-{pr_number}-{sha[:12]}"
+
+
+def _resolve_event_fields(event: dict) -> tuple[str, str, str, str]:
+    """Validate the caller's payload; raises _InvalidEvent on any
+    missing/malformed field (caught once, at the handler, and converted to a
+    clean launched:false — see module docstring's synchronous contract).
+
+    Returns (mode, research_ref, data_ref, run_token).
+    """
+    mode = _require(event, "mode", _MODE_RE)
+    research_ref = _optional(event, "research_ref", _REF_RE, default="main")
+    data_ref = _optional(event, "data_ref", _REF_RE, default="main")
+
+    if mode == "scheduled":
+        run_token = _scheduled_run_token(datetime.now(timezone.utc))
+        return mode, research_ref, data_ref, run_token
+
+    # mode == "pr"
+    repo = _require(event, "repo", _REPO_RE)
+    pr_number = _require(event, "pr_number", _PR_NUMBER_RE)
+    sha = _require(event, "sha", _SHA_RE)
+    run_token = _pr_run_token(repo, pr_number, sha)
+    return mode, research_ref, data_ref, run_token
+
+
+def _bootstrap_command(research_ref: str, data_ref: str, run_token: str, mode: str) -> str:
+    """The async SSM RunShellScript body: fetch PAT, clone config, exec
+    canary_replay_spot_bootstrap.sh (built by a sibling agent in
+    alpha-engine-config). Any prelude failure shuts the box down so a
+    botched launch never idles (mirrors ci-watch-dispatcher's prelude
+    fail() trap exactly)."""
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+export HOME=/root
+fail() {{ echo "[canary-replay-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 python3.12-pip >/dev/null 2>&1 \
+  || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {CANARY_REPLAY_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/alpha-engine-config
+git clone --depth 1 --branch {CANARY_REPLAY_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{CANARY_REPLAY_CONFIG_REPO}.git" \
+  /home/ec2-user/alpha-engine-config || fail "clone failed"
+cd /home/ec2-user/alpha-engine-config
+exec bash infrastructure/canary_replay_spot_bootstrap.sh \
+  --research-ref "{research_ref}" --data-ref "{data_ref}" \
+  --run-token "{run_token}" --mode "{mode}"
+"""
+
+
+def _launch_instance() -> tuple[str, str]:
+    """Launch the canary-replay box; spot first, on-demand fallback on
+    capacity exhaustion. Raises SpotLaunchError if both are exhausted —
+    caught once by the caller and converted to a clean launched:false."""
+    return spot_dispatch.launch_with_fallback(
+        INSTANCE_TYPES, SUBNETS,
+        image_id=AMI_ID,
+        key_name=KEY_NAME,
+        security_group_ids=[SECURITY_GROUP],
+        iam_instance_profile=IAM_PROFILE,
+        volume_size_gb=VOLUME_SIZE_GB,
+        tag_name=CANARY_REPLAY_TAG_NAME,
+        region=REGION,
+    )
+
+
+def _wait_ssm_online(instance_id: str) -> None:
+    spot_dispatch.wait_ssm_online(
+        instance_id, region=REGION, ssm_online_budget_sec=SSM_ONLINE_BUDGET_SEC
+    )
+
+
+def _send_bootstrap(instance_id: str, research_ref: str, data_ref: str,
+                    run_token: str, mode: str) -> str:
+    """Fire the async, detached SSM command that runs the canary + self-terminates."""
+    return spot_dispatch.send_async_command(
+        instance_id,
+        _bootstrap_command(research_ref, data_ref, run_token, mode),
+        comment=f"canary-replay ({mode}, token {run_token[:24]})",
+        region=REGION,
+        cw_log_group=CW_LOG_GROUP,
+        execution_timeout_seconds=MAX_RUNTIME_SECONDS,
+    )
+
+
+def _running_canary_instance_ids(run_token: str) -> list[str]:
+    """Instance ids for a LIVE (pending/running) canary box already working
+    THIS exact run_token — prevents a double-dispatch for the same
+    ISO-week/PR-sha. Raises SpotProbeError when the probe itself fails; the
+    caller degrades to launch-with-dedupe_degraded, never a silent
+    fail-open []."""
+    return spot_dispatch.running_instance_ids(
+        CANARY_REPLAY_TAG_NAME,
+        {CANARY_REPLAY_RUN_TOKEN_TAG_KEY: run_token},
+        region=REGION,
+    )
+
+
+def _terminate_instance(instance_id: str) -> None:
+    spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="canary-replay")
+
+
+def _create_discriminator_tag(instance_id: str, run_token: str) -> str | None:
+    """Write the load-bearing run_token discriminator tag with a bounded
+    retry. Returns None on success, or the final error string after
+    TAG_WRITE_ATTEMPTS failures — the caller terminates the box and fails
+    the dispatch (an untagged box is invisible to the dedupe guard AND to
+    canary-replay-liveness-probe's marker-key derivation)."""
+    tags = [{"Key": CANARY_REPLAY_RUN_TOKEN_TAG_KEY, "Value": run_token}]
+    last_error = ""
+    for attempt in range(1, TAG_WRITE_ATTEMPTS + 1):
+        try:
+            boto3.client("ec2", region_name=REGION).create_tags(
+                Resources=[instance_id], Tags=tags
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 — bounded retry; final failure is FATAL to the dispatch
+            last_error = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "canary-replay discriminator tag write attempt %d/%d failed for %s: %s",
+                attempt, TAG_WRITE_ATTEMPTS, instance_id, last_error,
+            )
+            if attempt < TAG_WRITE_ATTEMPTS:
+                time.sleep(TAG_WRITE_RETRY_DELAY_SEC)
+    return last_error
+
+
+def _launch_canary_replay_spot(mode: str, research_ref: str, data_ref: str,
+                               run_token: str) -> dict:
+    """Launch + bootstrap the canary box. SYNCHRONOUS contract: every
+    anticipated failure mode returns a clean, well-formed launched:false
+    rather than raising — see module docstring."""
+    if not DISPATCH_ENABLED:
+        logger.warning("CANARY_REPLAY_DISPATCH_ENABLED=false — canary spot NOT launched")
+        return {"launched": False, "reason": "disabled", "run_token": run_token}
+
+    dedupe_degraded = False
+    dedupe_probe_error = ""
+    try:
+        existing = _running_canary_instance_ids(run_token)
+    except SpotProbeError as exc:
+        dedupe_degraded = True
+        dedupe_probe_error = f"{type(exc).__name__}: {exc}"
+        existing = []
+        logger.error(
+            "canary-replay concurrency probe FAILED for token=%s — proceeding to "
+            "launch with dedupe_degraded=true: %s", run_token, dedupe_probe_error,
+        )
+    if existing:
+        logger.warning(
+            "canary-replay box already live for token=%s (%s) — skipping launch",
+            run_token, existing,
+        )
+        return {"launched": False, "reason": "concurrent_skip",
+                "existing_instance_ids": existing, "run_token": run_token}
+
+    try:
+        instance_id, market = _launch_instance()
+    except SpotLaunchError as exc:
+        logger.error("canary-replay spot launch failed: %s: %s", type(exc).__name__, exc)
+        return {"launched": False, "reason": "launch_failed", "error": str(exc),
+                "run_token": run_token}
+
+    logger.info("launched canary-replay box %s (%s) for token=%s%s", instance_id, market,
+                run_token, " dedupe_degraded=true" if dedupe_degraded else "")
+
+    tag_error = _create_discriminator_tag(instance_id, run_token)
+    if tag_error is not None:
+        _terminate_instance(instance_id)
+        logger.error(
+            "canary-replay discriminator tag write FAILED after %d attempts for %s "
+            "(token=%s) — box terminated, dispatch failed: %s",
+            TAG_WRITE_ATTEMPTS, instance_id, run_token, tag_error,
+        )
+        return {"launched": False, "reason": "tag_write_failed",
+                "instance_id": instance_id, "error": tag_error,
+                "run_token": run_token, "dedupe_degraded": dedupe_degraded}
+
+    try:
+        _wait_ssm_online(instance_id)
+        command_id = _send_bootstrap(instance_id, research_ref, data_ref, run_token, mode)
+    except Exception as exc:  # noqa: BLE001 — converted to a clean launched:false
+        _terminate_instance(instance_id)
+        logger.error("canary-replay post-launch step failed for %s: %s: %s",
+                     instance_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "post_launch_failed",
+                "instance_id": instance_id, "error": str(exc),
+                "run_token": run_token, "dedupe_degraded": dedupe_degraded}
+
+    logger.info(
+        "canary-replay dispatched: instance=%s market=%s command=%s mode=%s "
+        "research_ref=%s data_ref=%s run_token=%s dedupe_degraded=%s",
+        instance_id, market, command_id, mode, research_ref, data_ref, run_token,
+        dedupe_degraded,
+    )
+    verdict = {
+        "launched": True,
+        "reason": "launched",
+        "instance_id": instance_id,
+        "market": market,
+        "command_id": command_id,
+        "mode": mode,
+        "research_ref": research_ref,
+        "data_ref": data_ref,
+        "run_token": run_token,
+        "marker_key": f"tmp/canary/{run_token}.json",
+        "dedupe_degraded": dedupe_degraded,
+    }
+    if dedupe_degraded:
+        verdict["dedupe_probe_error"] = dedupe_probe_error
+    return verdict
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Entrypoint for both callers — see module docstring. `event` carries
+    `{"mode": "scheduled"}` (EventBridge Thursday cron) or
+    `{"mode": "pr", "repo", "pr_number", "sha", "research_ref"?, "data_ref"?}`
+    (GHA per-PR shim, synchronous invoke).
+
+    Returns {"launched": bool, "reason": str, "run_token": str, ...} — the
+    per-PR GHA job reads this DIRECTLY as its success signal and then polls
+    `marker_key` for the probe verdict. Every anticipated failure (malformed
+    event, concurrency skip, spot+on-demand launch exhaustion, post-launch
+    SSM failure) is a clean return, never an exception — see module
+    docstring's synchronous contract.
+    """
+    event = event or {}
+    try:
+        mode, research_ref, data_ref, run_token = _resolve_event_fields(event)
+    except _InvalidEvent as exc:
+        logger.error("invalid canary-replay event: %s", exc)
+        return {"launched": False, "reason": "invalid_event", "error": str(exc)}
+
+    logger.info(
+        "canary-replay trigger: mode=%s research_ref=%s data_ref=%s run_token=%s",
+        mode, research_ref, data_ref, run_token,
+    )
+    return _launch_canary_replay_spot(mode, research_ref, data_ref, run_token)

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -1,0 +1,9 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.spot_dispatch (config#2106) — same pin as ci-watch-dispatcher/
+# config-runner-dispatcher. v0.106.0 is the first version whose
+# running_instance_ids raises SpotProbeError instead of failing open; index.py
+# imports and handles that exception. EXEMPTED from root-pin lockstep in
+# tests/test_lib_pin_lockstep.py (same contract reason as ci-watch-dispatcher).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.106.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/canary-replay-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/canary-replay-dispatcher/test_handler.py
@@ -1,0 +1,232 @@
+"""Unit tests for the canary-replay dispatcher (alpha-engine-config#2246).
+
+Hermetic: ``nousergon_lib.spot_dispatch`` and ``boto3`` are stubbed in
+sys.modules BEFORE importing index — this repo's own
+``nousergon-lib/tests/test_spot_dispatch.py`` already covers
+``spot_dispatch``'s internal retry/fallback mechanics; these tests validate
+ONLY this Lambda's orchestration: event validation + deterministic
+run_token derivation, the concurrency dedupe guard, spot-launch failure
+handling, discriminator-tag retry-then-terminate, post-launch-failure
+terminate, and the kill-switch short-circuit.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+
+class _SpotLaunchError(Exception):
+    pass
+
+
+class _SpotProbeError(Exception):
+    pass
+
+
+def _install_stubs(
+    launch_with_fallback_impl=None,
+    running_instance_ids_impl=None,
+    send_async_command_impl=None,
+    create_tags_failures=0,
+    wait_ssm_online_raises=None,
+):
+    spot_dispatch_mod = types.ModuleType("nousergon_lib.spot_dispatch")
+    spot_dispatch_mod.SpotLaunchError = _SpotLaunchError
+    spot_dispatch_mod.SpotProbeError = _SpotProbeError
+
+    spot_dispatch_mod.launch_with_fallback = launch_with_fallback_impl or (
+        lambda *a, **kw: ("i-abc123", "spot")
+    )
+    spot_dispatch_mod.running_instance_ids = running_instance_ids_impl or (lambda *a, **kw: [])
+
+    def _wait_ssm_online(instance_id, **kw):
+        if wait_ssm_online_raises:
+            raise wait_ssm_online_raises
+
+    spot_dispatch_mod.wait_ssm_online = _wait_ssm_online
+    spot_dispatch_mod.send_async_command = send_async_command_impl or (
+        lambda *a, **kw: "cmd-xyz"
+    )
+
+    terminated: list[str] = []
+
+    def _terminate_on_failure(instance_id, **kw):
+        terminated.append(instance_id)
+
+    spot_dispatch_mod.terminate_on_failure = _terminate_on_failure
+
+    nousergon_lib_mod = types.ModuleType("nousergon_lib")
+    nousergon_lib_mod.spot_dispatch = spot_dispatch_mod
+    sys.modules["nousergon_lib"] = nousergon_lib_mod
+    sys.modules["nousergon_lib.spot_dispatch"] = spot_dispatch_mod
+
+    tags_created: list[tuple] = []
+    create_tags_attempts = {"n": 0}
+
+    class _FakeEc2:
+        def create_tags(self, Resources, Tags):  # noqa: N803 — boto3 kwarg names
+            create_tags_attempts["n"] += 1
+            if create_tags_attempts["n"] <= create_tags_failures:
+                raise RuntimeError(f"CreateTags throttled (attempt {create_tags_attempts['n']})")
+            tags_created.append((Resources, Tags))
+            return {}
+
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: _FakeEc2()
+    sys.modules["boto3"] = boto3_mod
+
+    return terminated, tags_created
+
+
+def _reload_index():
+    sys.path.insert(0, os.path.dirname(__file__))
+    if "index" in sys.modules:
+        del sys.modules["index"]
+    import index  # noqa: PLC0415
+
+    return importlib.reload(index)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    import time
+
+    monkeypatch.setattr(time, "sleep", lambda *a, **kw: None)
+
+
+class TestEventValidation:
+    def test_scheduled_mode_defaults_refs_to_main(self):
+        _install_stubs()
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is True
+        assert result["research_ref"] == "main"
+        assert result["data_ref"] == "main"
+        assert result["run_token"].startswith("sched-")
+
+    def test_scheduled_run_token_is_deterministic_per_iso_week(self):
+        from datetime import datetime, timezone
+
+        _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)  # a Thursday
+        assert index._scheduled_run_token(now) == "sched-2026w29"
+
+    def test_pr_mode_requires_repo_pr_number_sha(self):
+        _install_stubs()
+        index = _reload_index()
+        result = index.handler({"mode": "pr"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "invalid_event"
+
+    def test_pr_mode_derives_deterministic_run_token(self):
+        _install_stubs()
+        index = _reload_index()
+        result = index.handler(
+            {
+                "mode": "pr",
+                "repo": "nousergon/crucible-research",
+                "pr_number": "42",
+                "sha": "abc1234567890abc1234567890abc1234567890",
+                "research_ref": "feat/some-branch",
+            },
+            None,
+        )
+        assert result["launched"] is True
+        assert result["run_token"] == "pr-nousergon-crucible-research-42-abc123456789"
+        assert result["research_ref"] == "feat/some-branch"
+        assert result["data_ref"] == "main"
+
+    def test_invalid_mode_returns_clean_launched_false(self):
+        _install_stubs()
+        index = _reload_index()
+        result = index.handler({"mode": "bogus"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "invalid_event"
+
+    def test_malformed_ref_rejected(self):
+        _install_stubs()
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled", "research_ref": "; rm -rf /"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "invalid_event"
+
+
+class TestConcurrencyDedupe:
+    def test_existing_box_for_same_token_skips_launch(self):
+        _install_stubs(running_instance_ids_impl=lambda *a, **kw: ["i-existing"])
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "concurrent_skip"
+        assert result["existing_instance_ids"] == ["i-existing"]
+
+    def test_probe_error_degrades_but_still_launches(self):
+        def _raise(*a, **kw):
+            raise _SpotProbeError("probe boom")
+
+        _install_stubs(running_instance_ids_impl=_raise)
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is True
+        assert result["dedupe_degraded"] is True
+        assert "probe boom" in result["dedupe_probe_error"]
+
+
+class TestLaunchFailures:
+    def test_spot_launch_failure_returns_clean_launched_false(self):
+        def _raise(*a, **kw):
+            raise _SpotLaunchError("no capacity anywhere")
+
+        _install_stubs(launch_with_fallback_impl=_raise)
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "launch_failed"
+
+    def test_tag_write_retries_then_terminates_on_final_failure(self):
+        terminated, tags_created = _install_stubs(create_tags_failures=99)
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "tag_write_failed"
+        assert terminated == ["i-abc123"]
+
+    def test_tag_write_succeeds_after_transient_failures(self):
+        terminated, tags_created = _install_stubs(create_tags_failures=2)
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is True
+        assert terminated == []
+        assert len(tags_created) == 1
+
+    def test_ssm_online_failure_terminates_box_and_returns_clean_failure(self):
+        terminated, _ = _install_stubs(wait_ssm_online_raises=TimeoutError("ssm never came online"))
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "post_launch_failed"
+        assert terminated == ["i-abc123"]
+
+
+class TestKillSwitch:
+    def test_dispatch_disabled_env_short_circuits(self, monkeypatch):
+        _install_stubs()
+        monkeypatch.setenv("CANARY_REPLAY_DISPATCH_ENABLED", "false")
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["launched"] is False
+        assert result["reason"] == "disabled"
+
+
+class TestMarkerKey:
+    def test_launched_verdict_carries_the_marker_key_a_poller_would_read(self):
+        _install_stubs()
+        index = _reload_index()
+        result = index.handler({"mode": "scheduled"}, None)
+        assert result["marker_key"] == f"tmp/canary/{result['run_token']}.json"

--- a/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-canary-replay-liveness-probe
+# Lambda (alpha-engine-config#2246).
+#
+# --bootstrap creates: (1) this Lambda's OWN execution role + inline policy,
+# (2) the Lambda function itself, (3) a frequent EventBridge cron rule
+# (every 15 min) — created ENABLED, unlike the dispatcher's rule: this
+# Lambda is read-only and self-gates on its own check window + the
+# dispatcher rule's live State (see index.py's disabled-dispatcher
+# carve-out), so running it before the dispatcher goes live is harmless —
+# it simply no-ops every tick.
+#
+# DEPLOY ORDER (operator, see canary-replay-dispatcher/deploy.sh's header):
+#   1. Bootstrap + deploy THIS Lambda first.
+#   2. Confirm it's alive (CloudWatch logs show ticks; --smoke below invokes
+#      it directly with a synthetic in-window event).
+#   3. THEN enable the dispatcher's Thursday rule:
+#      aws events enable-rule --name alpha-engine-canary-replay-thursday --region us-east-1
+#
+# Usage:
+#   bash .../canary-replay-liveness-probe/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../canary-replay-liveness-probe/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda function + 15-min rule (ENABLED)
+#   bash .../canary-replay-liveness-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../canary-replay-liveness-probe/deploy.sh --smoke     # invoke once directly (read-only; pages ONLY if genuinely in-window with a bad/missing marker)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-canary-replay-liveness-probe"
+ROLE_NAME="alpha-engine-canary-replay-liveness-probe-role"
+POLICY_NAME="alpha-engine-canary-replay-liveness-probe-policy"
+RULE_NAME="alpha-engine-canary-replay-liveness-probe-tick"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  echo "Installing pytest into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # --- 2a. Lambda execution role + inline policy ---
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  # --- 2b. Lambda function ---
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2c. 15-min EventBridge cron rule — ENABLED (see header: this Lambda
+  # self-gates and is harmless to run before the dispatcher goes live) ---
+  echo "  Creating EventBridge rule: ${RULE_NAME} (ENABLED)"
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --schedule-expression 'rate(15 minutes)' \
+    --state ENABLED \
+    --description "Saturday-replay canary liveness probe tick (config#2246) — self-gates on its own check window + the dispatcher rule's live State." \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (direct invoke, read-only) -----------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke..."
+  echo "(read-only — pages ONLY if genuinely in-window with a bad/missing marker)"
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi

--- a/infrastructure/lambdas/canary-replay-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/iam-policy.json
@@ -1,0 +1,48 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-canary-replay-liveness-probe:*"
+    },
+    {
+      "Sid": "ReadCanaryCompletionMarker",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/tmp/canary/*"
+    },
+    {
+      "Sid": "ReadDispatchRuleStateForDisabledCarveOut",
+      "Effect": "Allow",
+      "Action": "events:DescribeRule",
+      "Resource": "arn:aws:events:us-east-1:711398986525:rule/alpha-engine-canary-replay-thursday"
+    },
+    {
+      "Sid": "AlertsDedupMarkerReadWrite",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/_alerts/_dedup/*"
+    },
+    {
+      "Sid": "PublishToAlertsSnsTopic",
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    },
+    {
+      "Sid": "ReadTelegramCreds",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    }
+  ]
+}

--- a/infrastructure/lambdas/canary-replay-liveness-probe/index.py
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/index.py
@@ -1,0 +1,220 @@
+"""alpha-engine-canary-replay-liveness-probe — the Thursday-path watchdog
+FOR the Saturday-replay canary itself (alpha-engine-config#2246).
+
+WHY: the Thursday canary is the ONLY thing that would otherwise notice a
+regression before Saturday — but nothing watches the canary's OWN dispatch.
+If ``canary-replay-dispatcher`` silently fails to launch, or the spot box
+dies before writing its completion marker, the canary's absence looks
+identical to "nothing scheduled today" from the outside. This probe is the
+external observer of that producer (mirrors the groom/sf-watch liveness
+probes' philosophy — a schedule-driven check external to the thing it's
+watching, since a dead process cannot reliably report its own death).
+
+MUCH SIMPLER than sf-watch-liveness-probe/ci-watch-dispatcher's liveness
+counterpart: this canary has exactly ONE scheduled trigger (the Thursday
+EventBridge rule) and ONE deterministic completion-marker key per ISO week
+(``_scheduled_run_token`` — duplicated here in lockstep from
+canary-replay-dispatcher/index.py rather than imported, since Lambdas
+deploy independently; a lockstep test in this file pins the two copies
+equal). No dispatch-pipe wiring to verify, no reclaim/relaunch machinery,
+no per-pipeline sweep — just: did this week's canary run, and did it pass?
+
+SELF-GATING SCHEDULE: runs on a tight recurring cron (every 15 min) rather
+than a single precisely-timed one-shot, and no-ops outside the check
+window — [CHECK_START_MINUTES_AFTER_DISPATCH, CHECK_WINDOW_HOURS] after the
+most recent Thursday 09:00 UTC dispatch. This absorbs spot-boot + probe
+runtime variance without needing exact timing, and naturally re-checks a
+transient S3 read hiccup on the next tick.
+
+PAGE ON: (a) the marker never appears within the window (canary silently
+failed to dispatch, or the box died before writing it), or (b) the marker
+appears with ``overall_status: FAIL`` (a real probe regression — the
+canary did its job). Uses ``nousergon_lib.alerts.publish``'s built-in
+``dedup_key`` (keyed on run_token, which is already unique per ISO week) —
+no hand-rolled fingerprint/clear state needed; next week's token naturally
+resets dedup.
+
+DISABLED-DISPATCHER CARVE-OUT: before treating a missing marker as an
+incident, this probe reads the Thursday EventBridge rule's live State. A
+DISABLED dispatcher rule means no dispatch was ever supposed to fire — a
+deliberate operator disable is state, not an incident (mirrors
+sf-watch-liveness-probe's kill-switch posture). This is also the deploy
+SEQUENCING mechanism: this Lambda + its own (harmless, read-only) schedule
+can go live FIRST while the dispatcher's rule is still DISABLED — it will
+no-op cleanly every week instead of paging — and the dispatcher rule is
+enabled only once this probe is confirmed live (deploy.sh header).
+
+Fail-loud (CLAUDE.md no-silent-fails): an S3 read error OTHER than a clean
+"object doesn't exist" RAISES, surfacing via the Lambda Errors metric,
+rather than being silently read as "no marker yet."
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from nousergon_lib import alerts
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+MARKER_BUCKET = os.environ.get("CANARY_REPLAY_MARKER_BUCKET", "alpha-engine-research")
+DISPATCH_RULE_NAME = os.environ.get(
+    "CANARY_REPLAY_DISPATCH_RULE_NAME", "alpha-engine-canary-replay-thursday"
+)
+
+DISPATCH_HOUR_UTC = int(os.environ.get("CANARY_REPLAY_DISPATCH_HOUR_UTC", "9"))
+# Nominal probe runtime is ~5-10 min + ~1-2 min spot boot; 30 min floor gives
+# ample margin before the FIRST check, so a normal run is never flagged
+# mid-flight.
+CHECK_START_MINUTES_AFTER_DISPATCH = int(
+    os.environ.get("CANARY_REPLAY_CHECK_START_MINUTES", "30")
+)
+# 20h ceiling keeps checking (idempotently) until Friday ~05:00 UTC —
+# comfortably before Saturday's weekly run, so a late-discovered failure
+# still leaves a full business day to investigate.
+CHECK_WINDOW_HOURS = float(os.environ.get("CANARY_REPLAY_CHECK_WINDOW_HOURS", "20"))
+
+
+def _scheduled_run_token(dispatch_time: datetime) -> str:
+    """MUST stay in lockstep with canary-replay-dispatcher/index.py's
+    identically-named function — a regression test in this file pins both
+    copies' source text equal."""
+    iso_year, iso_week, _ = dispatch_time.isocalendar()
+    return f"sched-{iso_year}w{iso_week:02d}"
+
+
+def _most_recent_thursday_dispatch(now: datetime) -> datetime:
+    """The most recent Thursday DISPATCH_HOUR_UTC:00 at-or-before `now`."""
+    days_since_thursday = (now.weekday() - 3) % 7  # Monday=0 .. Thursday=3 .. Sunday=6
+    candidate = (now - timedelta(days=days_since_thursday)).replace(
+        hour=DISPATCH_HOUR_UTC, minute=0, second=0, microsecond=0
+    )
+    if candidate > now:
+        candidate -= timedelta(days=7)
+    return candidate
+
+
+def _error_code(exc: Exception) -> str:
+    return str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+
+
+def _dispatch_rule_enabled() -> bool:
+    """True iff the Thursday dispatch rule is ENABLED. A missing rule reads
+    as disabled (nothing to check yet — the rule is created before this
+    Lambda's own schedule per deploy.sh's bootstrap order, but a defensive
+    read here costs nothing). Any OTHER describe_rule error RAISES
+    (fail-loud — misreading this as 'disabled' would silently suppress a
+    real incident)."""
+    try:
+        rule = boto3.client("events", region_name=REGION).describe_rule(Name=DISPATCH_RULE_NAME)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) == "ResourceNotFoundException":
+            return False
+        raise
+    return rule.get("State") == "ENABLED"
+
+
+def _read_marker(run_token: str) -> dict | None:
+    """The completion marker for `run_token`, or None if it genuinely
+    doesn't exist yet. Any OTHER S3 error RAISES (fail-loud — see module
+    docstring)."""
+    key = f"tmp/canary/{run_token}.json"
+    try:
+        obj = boto3.client("s3", region_name=REGION).get_object(Bucket=MARKER_BUCKET, Key=key)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"NoSuchKey", "404"}:
+            return None
+        raise
+    return json.loads(obj["Body"].read())
+
+
+ALERTS_SNS_TOPIC_ARN = os.environ.get(
+    "CANARY_REPLAY_ALERTS_SNS_TOPIC_ARN",
+    f"arn:aws:sns:{REGION}:711398986525:alpha-engine-alerts",
+)
+
+
+def _page(message: str, run_token: str) -> None:
+    # Explicit sns_topic_arn avoids alerts.publish's default dynamic
+    # sts:GetCallerIdentity resolution — tighter, more auditable IAM policy
+    # for this Lambda (see iam-policy.json).
+    alerts.publish(
+        message,
+        severity="critical",
+        source="canary-replay-liveness-probe",
+        dedup_key=f"canary-replay:{run_token}",
+        sns_topic_arn=ALERTS_SNS_TOPIC_ARN,
+    )
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Scheduled entrypoint. Read-only + self-gating — see module docstring.
+    Raises on an unexpected AWS API failure so the check can never silently
+    no-op on a real error."""
+    now = datetime.now(timezone.utc)
+    dispatch_time = _most_recent_thursday_dispatch(now)
+    elapsed = now - dispatch_time
+    window_start = timedelta(minutes=CHECK_START_MINUTES_AFTER_DISPATCH)
+    window_end = timedelta(hours=CHECK_WINDOW_HOURS)
+
+    if not (window_start <= elapsed <= window_end):
+        logger.info(
+            "canary-replay liveness: outside check window (dispatch=%s, elapsed=%s) — no-op",
+            dispatch_time.isoformat(), elapsed,
+        )
+        return {"checked": False, "reason": "outside_check_window",
+                "elapsed_seconds": elapsed.total_seconds()}
+
+    if not _dispatch_rule_enabled():
+        # Deliberate operator disable (or not-yet-enabled during rollout) is
+        # STATE, not an incident — see module docstring's disabled-dispatcher
+        # carve-out. No dispatch was ever supposed to fire this week.
+        logger.info(
+            "canary-replay liveness: dispatch rule '%s' is disabled — nothing "
+            "to check this week", DISPATCH_RULE_NAME,
+        )
+        return {"checked": False, "reason": "dispatch_rule_disabled"}
+
+    run_token = _scheduled_run_token(dispatch_time)
+    marker = _read_marker(run_token)
+
+    if marker is None:
+        logger.warning(
+            "canary-replay liveness: NO completion marker for %s after %s — paging",
+            run_token, elapsed,
+        )
+        _page(
+            f"\U0001f6a8 Saturday-replay canary — NO completion marker for `{run_token}` "
+            f"{elapsed} after its Thursday {DISPATCH_HOUR_UTC:02d}:00 UTC dispatch. The "
+            "canary either failed to launch or its spot box died before finishing. "
+            "Check alpha-engine-canary-replay-dispatcher's CloudWatch logs.",
+            run_token,
+        )
+        return {"checked": True, "run_token": run_token, "marker_found": False, "paged": True}
+
+    overall_status = marker.get("overall_status")
+    if overall_status != "PASS":
+        failed_probes = [p.get("name") for p in marker.get("probes", []) if p.get("status") != "PASS"]
+        logger.warning(
+            "canary-replay liveness: %s completed with overall_status=%s (failed probes: %s) — paging",
+            run_token, overall_status, failed_probes,
+        )
+        _page(
+            f"\U0001f6a8 Saturday-replay canary `{run_token}` completed with "
+            f"overall_status={overall_status!r} — failed probe(s): {failed_probes}. "
+            "This is exactly the bug class the canary exists to catch BEFORE "
+            "Saturday's weekly run — investigate before then.",
+            run_token,
+        )
+        return {"checked": True, "run_token": run_token, "marker_found": True,
+                "overall_status": overall_status, "paged": True}
+
+    logger.info("canary-replay liveness: %s PASS — all clean", run_token)
+    return {"checked": True, "run_token": run_token, "marker_found": True,
+            "overall_status": "PASS", "paged": False}

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -1,0 +1,8 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.alerts.publish — the fleet-wide SNS+Telegram paging chokepoint,
+# with built-in dedup_key support (used here keyed on run_token, which is
+# already unique per ISO week — no hand-rolled fingerprint/clear state needed).
+# Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
+# this Lambda uses no spot_dispatch feature requiring a newer tag.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.86.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/test_handler.py
@@ -1,0 +1,278 @@
+"""Unit tests for canary-replay-liveness-probe (alpha-engine-config#2246).
+
+Hermetic: ``boto3`` and ``nousergon_lib.alerts`` are stubbed in sys.modules
+BEFORE importing index. Validates: the self-gating check window (no-op
+before/after), the deterministic Thursday-dispatch-time derivation, the
+paging-on-missing-marker and paging-on-FAIL-marker paths, the clean-pass
+no-page path, fail-loud on an unexpected S3 error, and the
+``_scheduled_run_token`` lockstep with canary-replay-dispatcher/index.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import types
+from datetime import datetime, timezone
+
+import pytest
+
+
+class _FakeS3:
+    def __init__(self, objects: dict[str, bytes] | None = None, raise_error: Exception | None = None):
+        self._objects = dict(objects or {})
+        self._raise_error = raise_error
+
+    def get_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg names
+        if self._raise_error is not None:
+            raise self._raise_error
+        if Key not in self._objects:
+            err = type("ClientError", (Exception,), {})()
+            err.response = {"Error": {"Code": "NoSuchKey"}}
+            raise err
+        body = types.SimpleNamespace(read=lambda: self._objects[Key])
+        return {"Body": body}
+
+
+class _FakeEvents:
+    def __init__(self, rule_state: str | None = "ENABLED"):
+        self._rule_state = rule_state
+
+    def describe_rule(self, Name):  # noqa: N803 — boto3 kwarg names
+        if self._rule_state is None:
+            err = type("ClientError", (Exception,), {})()
+            err.response = {"Error": {"Code": "ResourceNotFoundException"}}
+            raise err
+        return {"Name": Name, "State": self._rule_state}
+
+
+def _install_stubs(s3_objects=None, s3_raises=None, dispatch_rule_state="ENABLED"):
+    published: list[dict] = []
+
+    clients = {
+        "s3": _FakeS3(s3_objects, s3_raises),
+        "events": _FakeEvents(dispatch_rule_state),
+    }
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: clients[name]
+    sys.modules["boto3"] = boto3_mod
+
+    alerts_mod = types.ModuleType("nousergon_lib.alerts")
+
+    def _publish(message, **kw):
+        published.append({"message": message, **kw})
+
+    alerts_mod.publish = _publish
+
+    nousergon_lib_mod = types.ModuleType("nousergon_lib")
+    nousergon_lib_mod.alerts = alerts_mod
+    sys.modules["nousergon_lib"] = nousergon_lib_mod
+    sys.modules["nousergon_lib.alerts"] = alerts_mod
+
+    return published
+
+
+def _reload_index():
+    sys.path.insert(0, os.path.dirname(__file__))
+    if "index" in sys.modules:
+        del sys.modules["index"]
+    import index  # noqa: PLC0415
+
+    return importlib.reload(index)
+
+
+class TestScheduledRunTokenLockstep:
+    def test_matches_dispatcher_derivation(self):
+        """Pins this Lambda's duplicated _scheduled_run_token against
+        canary-replay-dispatcher's — both must derive the SAME key for the
+        same instant, or the probe would poll a marker key the dispatcher
+        never writes."""
+        _install_stubs()
+        index = _reload_index()
+
+        dispatcher_dir = os.path.join(
+            os.path.dirname(__file__), "..", "canary-replay-dispatcher"
+        )
+        sys.path.insert(0, dispatcher_dir)
+        if "dispatcher_index" in sys.modules:
+            del sys.modules["dispatcher_index"]
+
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "dispatcher_index", os.path.join(dispatcher_dir, "index.py")
+        )
+        # dispatcher's index.py imports nousergon_lib.spot_dispatch at module
+        # load — stub it minimally just for this import.
+        spot_dispatch_mod = types.ModuleType("nousergon_lib.spot_dispatch")
+        spot_dispatch_mod.SpotLaunchError = Exception
+        spot_dispatch_mod.SpotProbeError = Exception
+        spot_dispatch_mod.launch_with_fallback = lambda *a, **kw: None
+        spot_dispatch_mod.running_instance_ids = lambda *a, **kw: []
+        spot_dispatch_mod.wait_ssm_online = lambda *a, **kw: None
+        spot_dispatch_mod.send_async_command = lambda *a, **kw: None
+        spot_dispatch_mod.terminate_on_failure = lambda *a, **kw: None
+        sys.modules["nousergon_lib"].spot_dispatch = spot_dispatch_mod
+        sys.modules["nousergon_lib.spot_dispatch"] = spot_dispatch_mod
+
+        dispatcher_index = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(dispatcher_index)
+
+        for now in [
+            datetime(2026, 7, 16, 9, 0, tzinfo=timezone.utc),
+            datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 12, 31, 23, 59, tzinfo=timezone.utc),
+        ]:
+            assert index._scheduled_run_token(now) == dispatcher_index._scheduled_run_token(now)
+
+
+class TestCheckWindowGating:
+    def test_before_window_start_is_a_noop(self, monkeypatch):
+        _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 9, 10, tzinfo=timezone.utc)  # Thursday, 10 min after dispatch
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["checked"] is False
+        assert result["reason"] == "outside_check_window"
+
+    def test_after_window_end_is_a_noop(self, monkeypatch):
+        _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 18, 8, 0, tzinfo=timezone.utc)  # Saturday morning
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["checked"] is False
+
+    def test_inside_window_checks(self, monkeypatch):
+        published = _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)  # 1h after Thursday dispatch
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["checked"] is True
+        assert result["marker_found"] is False
+        assert result["paged"] is True
+        assert len(published) == 1
+
+
+def _make_fixed_datetime(fixed_now):
+    class _FD(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+    return _FD
+
+
+class TestMarkerOutcomes:
+    def test_missing_marker_pages(self, monkeypatch):
+        published = _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["marker_found"] is False
+        assert result["paged"] is True
+        assert "NO completion marker" in published[0]["message"]
+
+    def test_fail_marker_pages_with_probe_detail(self, monkeypatch):
+        run_token = "sched-2026w29"
+        marker = {
+            "run_id": run_token,
+            "overall_status": "FAIL",
+            "probes": [
+                {"name": "filing_change_detection", "status": "PASS"},
+                {"name": "thesis_update", "status": "FAIL"},
+            ],
+        }
+        published = _install_stubs(
+            s3_objects={f"tmp/canary/{run_token}.json": json.dumps(marker).encode()}
+        )
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["marker_found"] is True
+        assert result["overall_status"] == "FAIL"
+        assert result["paged"] is True
+        assert "thesis_update" in published[0]["message"]
+
+    def test_pass_marker_does_not_page(self, monkeypatch):
+        run_token = "sched-2026w29"
+        marker = {"run_id": run_token, "overall_status": "PASS", "probes": []}
+        published = _install_stubs(
+            s3_objects={f"tmp/canary/{run_token}.json": json.dumps(marker).encode()}
+        )
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["marker_found"] is True
+        assert result["overall_status"] == "PASS"
+        assert result["paged"] is False
+        assert published == []
+
+    def test_unexpected_s3_error_raises(self, monkeypatch):
+        _install_stubs(s3_raises=RuntimeError("S3 is having a bad day"))
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        with pytest.raises(RuntimeError, match="bad day"):
+            index.handler({}, None)
+
+
+class TestDispatchTimeDerivation:
+    def test_thursday_after_dispatch_hour_uses_today(self):
+        _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 15, 0, tzinfo=timezone.utc)  # Thursday afternoon
+        result = index._most_recent_thursday_dispatch(now)
+        assert result == datetime(2026, 7, 16, 9, 0, tzinfo=timezone.utc)
+
+    def test_wednesday_uses_previous_thursday(self):
+        _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)  # Wednesday
+        result = index._most_recent_thursday_dispatch(now)
+        assert result == datetime(2026, 7, 9, 9, 0, tzinfo=timezone.utc)
+
+    def test_thursday_before_dispatch_hour_uses_previous_week(self):
+        _install_stubs()
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 5, 0, tzinfo=timezone.utc)  # Thursday, before 09:00
+        result = index._most_recent_thursday_dispatch(now)
+        assert result == datetime(2026, 7, 9, 9, 0, tzinfo=timezone.utc)
+
+
+class TestDisabledDispatcherCarveOut:
+    def test_disabled_rule_is_state_not_incident_no_page(self, monkeypatch):
+        published = _install_stubs(dispatch_rule_state="DISABLED")
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["checked"] is False
+        assert result["reason"] == "dispatch_rule_disabled"
+        assert published == []
+
+    def test_missing_rule_also_treated_as_nothing_to_check(self, monkeypatch):
+        published = _install_stubs(dispatch_rule_state=None)
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["checked"] is False
+        assert result["reason"] == "dispatch_rule_disabled"
+        assert published == []
+
+    def test_enabled_rule_proceeds_to_check_and_pages_on_missing_marker(self, monkeypatch):
+        published = _install_stubs(dispatch_rule_state="ENABLED")
+        index = _reload_index()
+        now = datetime(2026, 7, 16, 10, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "datetime", _make_fixed_datetime(now))
+        result = index.handler({}, None)
+        assert result["checked"] is True
+        assert result["paged"] is True
+        assert len(published) == 1

--- a/rag/pipelines/filing_change_detection.py
+++ b/rag/pipelines/filing_change_detection.py
@@ -213,6 +213,18 @@ def main():
     parser.add_argument("--output-s3", action="store_true", help="Write results to S3")
     parser.add_argument("--output-local", type=str, help="Write results to local file")
     parser.add_argument("--bucket", type=str, default="alpha-engine-research")
+    parser.add_argument(
+        "--key-prefix",
+        type=str,
+        default="",
+        help=(
+            "Prefix the dated S3 key with this (e.g. 'canary/{run_id}/') and "
+            "never touch the real 'latest.json' pointer. Used by the "
+            "Saturday-replay canary (alpha-engine-config#2246) to exercise "
+            "this pipeline against the live pgvector corpus without "
+            "clobbering the production pointer."
+        ),
+    )
     args = parser.parse_args()
 
     results = compute_filing_changes()
@@ -233,19 +245,23 @@ def main():
     if args.output_s3:
         import boto3
         s3 = boto3.client("s3")
-        key = f"rag/filing_changes/{date.today().isoformat()}.json"
+        key = f"rag/filing_changes/{args.key_prefix}{date.today().isoformat()}.json"
         s3.put_object(
             Bucket=args.bucket, Key=key,
             Body=json.dumps(output, indent=2).encode(),
             ContentType="application/json",
         )
-        # Also write latest pointer
-        s3.put_object(
-            Bucket=args.bucket, Key="rag/filing_changes/latest.json",
-            Body=json.dumps(output, indent=2).encode(),
-            ContentType="application/json",
-        )
-        logger.info("Written to s3://%s/%s (+ latest)", args.bucket, key)
+        if args.key_prefix:
+            # Canary/staging run — never touch the real pointer consumers read.
+            logger.info("Written to s3://%s/%s (key-prefix set, latest.json untouched)", args.bucket, key)
+        else:
+            # Also write latest pointer
+            s3.put_object(
+                Bucket=args.bucket, Key="rag/filing_changes/latest.json",
+                Body=json.dumps(output, indent=2).encode(),
+                ContentType="application/json",
+            )
+            logger.info("Written to s3://%s/%s (+ latest)", args.bucket, key)
 
     # Print summary
     print(f"\n{'='*60}")
@@ -269,6 +285,16 @@ def main():
                 rf_sim = r["section_similarities"].get("Risk Factors", "N/A")
                 print(f"  {r['ticker']} {r['doc_type']}: RF_sim={rf_sim} "
                       f"({r['prev_date']}→{r['curr_date']})")
+
+    # Grep-able single-line summary for orchestrating shell scripts (the
+    # Saturday-replay canary's spot bootstrap in particular — see
+    # alpha-engine-config#2246).
+    print("RESULT_JSON=" + json.dumps({
+        "status": "OK",
+        "n_analyzed": output["n_analyzed"],
+        "n_lazy": output["n_lazy"],
+        "n_risk_factor_changes": output["n_risk_factor_changes"],
+    }))
 
 
 if __name__ == "__main__":

--- a/tests/test_filing_change_detection_key_prefix.py
+++ b/tests/test_filing_change_detection_key_prefix.py
@@ -1,0 +1,68 @@
+"""Guard: ``filing_change_detection.py --key-prefix`` writes to a scoped S3
+key and never touches the production ``latest.json`` pointer.
+
+Added for the Saturday-replay canary (alpha-engine-config#2246): the
+canary must exercise this pipeline against the live pgvector corpus
+without any chance of shadowing what the real weekly-SF's Step 8/9
+Step writes and downstream consumers read.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_main(argv, mock_s3):
+    from rag.pipelines import filing_change_detection
+
+    with (
+        patch.object(sys, "argv", ["filing_change_detection.py", *argv]),
+        patch.object(filing_change_detection, "compute_filing_changes", return_value=[]),
+        patch("boto3.client", return_value=mock_s3),
+    ):
+        filing_change_detection.main()
+
+
+class TestKeyPrefixDefaultsToCurrentBehavior:
+    def test_no_key_prefix_writes_dated_key_and_latest(self):
+        mock_s3 = MagicMock()
+        _run_main(["--output-s3"], mock_s3)
+
+        put_keys = [c.kwargs["Key"] for c in mock_s3.put_object.call_args_list]
+        assert any(k.startswith("rag/filing_changes/") and k != "rag/filing_changes/latest.json" for k in put_keys)
+        assert "rag/filing_changes/latest.json" in put_keys
+        assert mock_s3.put_object.call_count == 2
+
+
+class TestKeyPrefixIsolatesCanaryWrites:
+    def test_key_prefix_scopes_the_dated_key(self):
+        mock_s3 = MagicMock()
+        _run_main(["--output-s3", "--key-prefix", "canary/run-123/"], mock_s3)
+
+        put_keys = [c.kwargs["Key"] for c in mock_s3.put_object.call_args_list]
+        assert any(k.startswith("rag/filing_changes/canary/run-123/") for k in put_keys)
+
+    def test_key_prefix_never_writes_latest_json(self):
+        mock_s3 = MagicMock()
+        _run_main(["--output-s3", "--key-prefix", "canary/run-123/"], mock_s3)
+
+        put_keys = [c.kwargs["Key"] for c in mock_s3.put_object.call_args_list]
+        assert "rag/filing_changes/latest.json" not in put_keys
+        assert mock_s3.put_object.call_count == 1
+
+
+class TestResultJsonLine:
+    def test_result_json_line_is_printed(self, capsys):
+        mock_s3 = MagicMock()
+        _run_main(["--output-s3", "--key-prefix", "canary/run-123/"], mock_s3)
+
+        out = capsys.readouterr().out
+        result_lines = [line for line in out.splitlines() if line.startswith("RESULT_JSON=")]
+        assert len(result_lines) == 1
+
+        import json
+        payload = json.loads(result_lines[0][len("RESULT_JSON="):])
+        assert payload["status"] == "OK"
+        assert payload["n_analyzed"] == 0

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -58,6 +58,11 @@ _LAMBDA_PIN_RE = re.compile(
 # documented in each Lambda's requirements.txt header comment.
 # Key: lambda directory name, Value: (pin version, contract reason)
 _LAMBDA_PIN_EXEMPTIONS = {
+    "canary-replay-dispatcher": (
+        "v0.106.0",
+        "nousergon_lib.spot_dispatch chokepoint (alpha-engine-config#2246: same SpotProbeError "
+        "handling as ci-watch-dispatcher)",
+    ),
     "ci-watch-dispatcher": (
         "v0.106.0",
         "nousergon_lib.spot_dispatch chokepoint (config#2267: SpotProbeError handling)",


### PR DESCRIPTION
## Summary
- Part 2/3 of the Saturday-replay canary build (alpha-engine-config-I2246): data-repo probe + AWS dispatch.
- `rag/pipelines/filing_change_detection.py --key-prefix` — the canary's probe 1, staged so it never touches the real `latest.json` pointer.
- `infrastructure/lambdas/canary-replay-dispatcher/` (new) — async EC2-spot dispatch Lambda, both the Thursday-scheduled and per-PR trigger paths, mirroring `ci-watch-dispatcher`'s proven shape.
- `infrastructure/lambdas/canary-replay-liveness-probe/` (new) — the external watchdog for the Thursday path; self-gates on its own check window AND the dispatcher rule's live state (a deliberate operator disable is never mistaken for an incident).
- `.github/workflows/label-canary-replay.yml` + `canary-replay.yml` — per-PR gate, mirrors the sibling `crucible-research` workflow.

**No live AWS effect from merging this PR alone** — both Lambdas are `deploy.sh --bootstrap`'d as a deliberate, separate operator step (tracked in config-I2246), same convention as every sibling dispatcher in this repo. The Thursday EventBridge rule ships DISABLED at bootstrap; enabling it is an explicit follow-up after the liveness probe is verified live.

Depends on (merge order doesn't matter for CI, but the full pipe needs all 3):
- alpha-engine-config PR (`canary_replay_spot_bootstrap.sh` + IAM policies for the new executor role)
- crucible-research PR (`agents/canary_replay.py` + its own per-PR gate)

## Test plan
- [x] `pytest infrastructure/lambdas/canary-replay-dispatcher/test_handler.py` — 14/14 passing (event validation, deterministic run_token derivation, concurrency dedupe, launch-failure handling, tag-write retry/terminate, kill-switch).
- [x] `pytest infrastructure/lambdas/canary-replay-liveness-probe/test_handler.py` — 14/14 passing (check-window gating, dispatch-time derivation, marker outcomes, disabled-dispatcher carve-out, run_token lockstep with the dispatcher).
- [x] `pytest tests/test_filing_change_detection_key_prefix.py` — 4/4 passing.
- [x] Full repo suite: 3158 passed, 11 skipped, 0 failed (includes the `nousergon-lib` pin-lockstep exemption added for `canary-replay-dispatcher`).
- [ ] Live spot-box run + `deploy.sh --bootstrap` (operator step, tracked in config-I2246 — not run from this session per standing infra-change confirmation practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)