### PR TITLE
Fix config#2205: refresh stale SlotDecision partition-fields comment

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -943,10 +943,11 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                     continue
                 logger.info("demand trigger LAUNCH — %s (filter=%s model=%s)",
                             d.reason, d.issue_filter, d.model)
-                # config#2201: SlotDecision still carries partition_index/
-                # partition_count (lib fields kept for pin-lockstep compat —
-                # deferred lib cleanup), but they are no longer consumed:
-                # the end-of-SF sweep box replaced per-box partitioned sweeps.
+                # config#2201: SlotDecision no longer carries partition_index/
+                # partition_count at all — those fields were fully removed
+                # from nousergon-lib's SlotDecision (confirmed on the lib's
+                # current default branch, pin >= v0.109.0). The end-of-SF
+                # sweep box replaced per-box partitioned sweeps.
                 entry = {"model": d.model, "issue_filter": d.issue_filter}
                 if pr_budget is not None and "high" in d.tiers:
                     entry["pr_budget"] = pr_budget


### PR DESCRIPTION
## Summary

- `scheduled-groom-dispatcher/index.py`'s `decide_trigger` LAUNCH-path comment claimed `SlotDecision` "still carries `partition_index`/`partition_count` (lib fields kept for pin-lockstep compat — deferred lib cleanup)".
- Verified against `nousergon-lib`'s current default branch: `SlotDecision` (in `groom_eligibility.py`) is a frozen dataclass with exactly `launch`, `tiers`, `issue_filter`, `model`, `reason` — the partition fields are fully removed, not deferred.
- This Lambda's pin is already `v0.109.0` (well past the removal), so the comment was simply stale.
- Comment-only change, no behavior modification.

This is the **comment-refresh remainder of alpha-engine-config-I2205**. That issue asked for two things: (1) bump this Lambda's `nousergon-lib` pin, and (2) refresh this stale comment. Deliverable (1) already shipped via nousergon-data-PR748 (merged, pin at v0.109.0+). This PR is just deliverable (2).

## Test plan

- [x] Ran `test_handler.py` via the shared hermetic gate (`infrastructure/lambdas/_shared/run_handler_tests.sh`, same mechanism `deploy.sh` uses) with the pinned `nousergon-lib` install: **68 passed**, 0 failures — confirms the comment-only edit is a true no-op.

Closes nousergon/alpha-engine-config#2205 (alpha-engine-config-I2205).

🤖 Generated with [Claude Code](https://claude.com/claude-code)