### PR TITLE
Treat 429 as reachability proof in preflight probes — root-cause fix for config#2662

### DIFF
--- a/preflight.py
+++ b/preflight.py
@@ -320,6 +320,16 @@ class DataPreflight(BasePreflight):
                 f"key-metrics-ttm — the free tier no longer covers this endpoint. "
                 f"Subscribe or move the collector to a different provider."
             )
+        if resp.status_code == 429:
+            # Rate-limited ≠ unreachable/unauthorized — same contract as the
+            # polygon probe (config#2662): the probe validates reachability +
+            # auth only; quota pressure is the collector's to pace at fetch
+            # time. Proceed.
+            log.warning(
+                "preflight: FMP /stable returned 429 (rate-limited) — endpoint "
+                "REACHABLE, auth not rejected; proceeding."
+            )
+            return
         if resp.status_code >= 500:
             raise RuntimeError(
                 f"Pre-flight: FMP /stable returned HTTP {resp.status_code} — upstream outage."
@@ -342,7 +352,14 @@ class DataPreflight(BasePreflight):
 
         Catches expired API key, polygon outage, blocked egress. Does NOT
         catch rate-limit ceiling (next collector call will retry/fail
-        loudly by design).
+        loudly by design) — and per that contract, a 429 here is treated as
+        SUCCESS: the service answered (reachable) and did not reject auth
+        (429 ≠ 401/403); ``polygon_client._get`` owns Retry-After pacing at
+        fetch time. Before 2026-07-15 the generic ``!= 200`` catch-all below
+        contradicted this contract and aborted the whole workload on a 429
+        (config#2662 — a concurrent consumer exhausted the shared per-minute
+        quota, the probe died, and the DataSpot phase failed twice for a
+        condition the collector would have absorbed in seconds).
         """
         api_key = (get_secret("POLYGON_API_KEY", required=False, default="") or "").strip()
         resp = self._reachability_get(
@@ -354,6 +371,14 @@ class DataPreflight(BasePreflight):
                 f"Pre-flight: polygon.io auth failed (HTTP {resp.status_code}): "
                 f"POLYGON_API_KEY is invalid or revoked."
             )
+        if resp.status_code == 429:
+            log.warning(
+                "preflight: polygon.io returned 429 (rate-limited) — endpoint "
+                "REACHABLE, auth not rejected; proceeding. Collector-side "
+                "pacing (polygon_client._get: Retry-After + bounded backoff) "
+                "absorbs the limit at fetch time."
+            )
+            return
         if resp.status_code >= 500:
             raise RuntimeError(
                 f"Pre-flight: polygon.io returned HTTP {resp.status_code} on a reference-data call "
@@ -389,6 +414,17 @@ class DataPreflight(BasePreflight):
                     f"Pre-flight: FRED auth failed (HTTP 400): FRED_API_KEY is invalid. "
                     f"Response: {resp.text[:200]}"
                 )
+        if resp.status_code == 429:
+            # Rate-limited ≠ unreachable/unauthorized — same contract as the
+            # polygon probe (config#2662). Doubly so here: the FRED collector
+            # already owns 429 pacing (_fred_get_with_retry, the 2026-06-01
+            # TNX-storm fix) — a probe abort on the very condition the
+            # collector was hardened against would be self-defeating. Proceed.
+            log.warning(
+                "preflight: FRED returned 429 (rate-limited) — endpoint "
+                "REACHABLE, auth not rejected; proceeding."
+            )
+            return
         if resp.status_code >= 500:
             raise RuntimeError(
                 f"Pre-flight: FRED returned HTTP {resp.status_code} on DFF call "

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -69,6 +69,19 @@ class TestPolygonReachable:
             with pytest.raises(RuntimeError, match="auth failed"):
                 pf._check_polygon_reachable()
 
+    def test_429_rate_limited_passes(self):
+        # config#2662: a 429 is PROOF of reachability (service answered, auth
+        # not rejected) — the probe must NOT abort the workload; the
+        # collector's client (polygon_client._get) owns Retry-After pacing.
+        # The 2026-07-15 incident: this exact status killed the DataSpot
+        # phase twice for a condition the collector absorbs in seconds.
+        pf = self._setup()
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = MagicMock(
+                status_code=429, text='{"error": "max requests per minute"}'
+            )
+            pf._check_polygon_reachable()  # must not raise
+
     def test_500_outage(self):
         pf = self._setup()
         with patch("requests.get") as mock_get:
@@ -99,6 +112,36 @@ class TestPolygonReachable:
         assert mock_get.call_count == 2
 
 
+# ── FMP /stable reachability ─────────────────────────────────────────────────
+
+class TestFmpStableReachable:
+    def _setup(self):
+        env_patch = patch.dict("os.environ", {"FMP_API_KEY": "fake_key"}, clear=False)
+        env_patch.start()
+        self._env_patch = env_patch
+        return _make()
+
+    def teardown_method(self):
+        if hasattr(self, "_env_patch"):
+            self._env_patch.stop()
+
+    def test_200_with_list_body_passes(self):
+        pf = self._setup()
+        resp = MagicMock(status_code=200, text='[{"symbol": "AAPL"}]')
+        resp.json.return_value = [{"symbol": "AAPL"}]
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = resp
+            pf._check_fmp_stable_reachable()
+
+    def test_429_rate_limited_passes(self):
+        # config#2662: same contract as the polygon probe — 429 proves
+        # reachability; quota pressure is the collector's to pace.
+        pf = self._setup()
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=429, text="Limit Reach")
+            pf._check_fmp_stable_reachable()  # must not raise
+
+
 # ── FRED reachability ────────────────────────────────────────────────────────
 
 class TestFredReachable:
@@ -126,6 +169,14 @@ class TestFredReachable:
             )
             with pytest.raises(RuntimeError, match="auth failed.*invalid"):
                 pf._check_fred_reachable()
+
+    def test_429_rate_limited_passes(self):
+        # config#2662: same contract as the polygon probe — 429 proves
+        # reachability; _fred_get_with_retry owns pacing at fetch time.
+        pf = self._setup()
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=429, text="Too Many Requests")
+            pf._check_fred_reachable()  # must not raise
 
     def test_500_outage(self):
         pf = self._setup()


### PR DESCRIPTION
## Summary

Root-cause fix for alpha-engine-config-I2662 (nousergon/alpha-engine-config#2662) — at a deeper layer than the issue originally proposed. Brian asked whether the fail-soft + self-heal treatment is SOTA; the audit answer was: the architecture is, but one implementation layer betrays it, and it's the layer that caused the 2026-07-15 incident.

**The finding:** the entire stack already had institutional-grade rate-limit handling — `polygon_client._get` does client-side slot pacing + `Retry-After`-honoring bounded backoff on 429; `_fred_get_with_retry` does the same for FRED (built after the 2026-06-01 TNX 429-storm). The **only** place that dies on a 429 is the preflight reachability probe, whose own docstring scopes rate limits OUT of its contract ("next collector call will retry/fail loudly by design") but whose generic `!= 200` catch-all aborts the workload anyway. A 429 is *proof* of reachability — the service answered and did not reject auth (429 ≠ 401/403). On 2026-07-15 that one branch killed the `morning-arctic-append` workload twice (original + ChronicGapSelfHeal retry) for a condition the collector would have absorbed in seconds, producing two degraded ArcticDB days (fixed by config#2664 / PR840+PR841).

## Change

All three reachability probes in `preflight.py` (`_check_polygon_reachable`, `_check_fmp_stable_reachable`, `_check_fred_reachable`) now treat 429 as probe success: log a warning and proceed. Auth failures (401/403), payment failures (402), upstream outages (5xx), and unexpected statuses still abort exactly as before.

## Why this supersedes I2662's original proposal

I2662 proposed classifying the failure at the SF layer and skipping/delaying the ChronicGapSelfHeal retry. This fix is one layer deeper: with the probe no longer aborting on 429, the workload **never fails** for the rate-limit class — no fail-open Catch fires, no retry (doomed or otherwise) is dispatched, no degraded day is written. The SF-layer classification becomes unnecessary for this failure class. The fail-open path + fallback-quality self-heal (config#2664) remain as last-resort backstops for genuine outages (sustained 5xx, network partition) — for which the immediate SF retry is still redundant-but-harmless, since the next-morning heal now guarantees convergence.

Composed failure model after this PR:
- **Rate-limit pressure** → absorbed inside the workload (client pacing); not a failure at any layer.
- **Genuine transient outage** → fail-open (trading unaffected) + next-morning fallback-quality self-heal → auto-converges within 1–2 runs.
- **Sustained multi-day outage** → same, plus flow-doctor alerts each day; residual >5-trading-day window risk tracked as alpha-engine-config-I2672.

## Test plan

- [x] `pytest tests/test_preflight.py -v` — 32/32 passing (3 new 429-passes tests, one per probe; plus a new `TestFmpStableReachable` class — that probe previously had zero test coverage).
- [x] Full suite: `pytest tests/ -q` — 3158 passed, 11 skipped (pre-existing), 0 failed.
