### PR TITLE
fix: canary-replay-dispatcher deploy.sh put-targets JSON escaping

### DIFF
--- a/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
@@ -163,9 +163,12 @@ if $BOOTSTRAP; then
     --query 'RuleArn' --output text
 
   FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  # JSON array form, not shorthand — shorthand's `Input={...}` cannot embed
+  # nested JSON (the CLI's shorthand parser chokes on the unescaped `"`,
+  # live-caught on first bootstrap: config#2246).
   run aws events put-targets \
     --rule "${RULE_NAME}" \
-    --targets "Id=1,Arn=${FN_ARN},Input={\"mode\":\"scheduled\"}" \
+    --targets "[{\"Id\":\"1\",\"Arn\":\"${FN_ARN}\",\"Input\":\"{\\\"mode\\\":\\\"scheduled\\\"}\"}]" \
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"


### PR DESCRIPTION
## Summary
- Small follow-up found live during today's config-I2246 (Saturday-replay canary) deploy.
- `deploy.sh --bootstrap`'s `put-targets` call used AWS CLI shorthand syntax with an embedded JSON `Input` value — shorthand cannot parse nested JSON (`Expected: '=', received: '"'`). Switched to the JSON-array form.
- The live EventBridge rule's target was already wired manually as a workaround during the deploy this PR documents (confirmed: `alpha-engine-canary-replay-thursday` rule has its target correctly set, dispatcher Lambda is Active, IAM role/profile created, liveness-probe deployed+verified, both EventBridge rules enabled). This PR just prevents the same failure hitting the next `--bootstrap` run (region migration, role recreation, etc.).

## Test plan
- [x] `bash -n deploy.sh` — syntax OK.
- [x] Verified the fixed `--targets` value round-trips through `json.loads` for both the outer array and the escaped inner `Input` string.
- [x] Live-verified: the corrected shape is exactly what I applied manually via `aws events put-targets` during today's deploy, which succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)