### PR TITLE
fix(config-runner): FIFO dispatch order in reconcile — oldest stale job first (config-I2692)

### DIFF
--- a/infrastructure/lambdas/config-runner-dispatcher/index.py
+++ b/infrastructure/lambdas/config-runner-dispatcher/index.py
@@ -597,8 +597,15 @@ def _reconcile() -> dict:
         logger.error("reconcile: failed to list queued runs: %s: %s", type(exc).__name__, exc)
         return {"reconciled": 0, "reason": "list_runs_failed", "error": str(exc)}
 
-    dispatched = []
-    skipped = []
+    # Collect ALL stale queued jobs first, then dispatch OLDEST-FIRST.
+    # GitHub lists runs newest-first; dispatching in listing order let a
+    # constant churn of fresh runs (e.g. the 2026-07-15 Dependabot-drain
+    # rebase wave) win every quota-constrained launch race while the oldest
+    # job starved indefinitely (PR2690's pytest sat queued 95+ min while
+    # newer jobs got every available spot slot). FIFO makes quota pressure
+    # degrade to bounded latency for everyone instead of unbounded latency
+    # for the unluckiest.
+    stale_jobs: list[tuple[float, str]] = []
     for run in runs_resp.get("workflow_runs", []):
         try:
             jobs_resp = _gh_api_get(
@@ -615,18 +622,22 @@ def _reconcile() -> dict:
             age_seconds = (now - created_at).total_seconds()
             if age_seconds < RECONCILE_STALE_SECONDS:
                 continue  # still within the reactive path's normal dispatch latency
-            job_id = str(job["id"])
-            try:
-                existing = _running_config_runner_instance_ids(job_id)
-            except SpotProbeError:
-                existing = []  # degrade to "dispatch anyway" — the launch's own dedup/tag logic is authoritative
-            if existing:
-                skipped.append(job_id)
-                continue
-            logger.info("reconcile: job %s queued %.0fs with no in-flight box — dispatching",
-                       job_id, age_seconds)
-            dispatched.append({"job_id": job_id, "age_seconds": age_seconds,
-                               "result": _launch_config_runner_spot(job_id)})
+            stale_jobs.append((age_seconds, str(job["id"])))
+
+    dispatched = []
+    skipped = []
+    for age_seconds, job_id in sorted(stale_jobs, reverse=True):  # oldest first
+        try:
+            existing = _running_config_runner_instance_ids(job_id)
+        except SpotProbeError:
+            existing = []  # degrade to "dispatch anyway" — the launch's own dedup/tag logic is authoritative
+        if existing:
+            skipped.append(job_id)
+            continue
+        logger.info("reconcile: job %s queued %.0fs with no in-flight box — dispatching",
+                   job_id, age_seconds)
+        dispatched.append({"job_id": job_id, "age_seconds": age_seconds,
+                           "result": _launch_config_runner_spot(job_id)})
 
     logger.info("reconcile: dispatched=%d skipped=%d bootstrap_and_reap=%s",
                 len(dispatched), len(skipped), br_stats)

--- a/infrastructure/lambdas/config-runner-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/config-runner-dispatcher/test_handler.py
@@ -615,3 +615,36 @@ def test_reconcile_list_runs_failure_returns_clean_result_not_raise(monkeypatch)
     out = idx.handler({"reconcile": True}, None)
     assert out["reconciled"] == 0
     assert out["reason"] == "list_runs_failed"
+
+
+def test_reconcile_dispatches_oldest_job_first(monkeypatch):
+    # FIFO fairness: under quota pressure the OLDEST stale job must get the
+    # first launch attempt — newest-first listing order let fresh churn
+    # starve old jobs indefinitely (PR2690, 2026-07-15).
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        return f"i-{len(launched)}"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"CONFIG_RUNNER_DISPATCH_ENABLED": "true"})
+
+    old = (datetime.now(timezone.utc) - timedelta(seconds=5000)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    newer = (datetime.now(timezone.utc) - timedelta(seconds=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def fake_get(path):
+        if path.endswith("&per_page=50") or "/actions/runs?" in path:
+            return {"workflow_runs": [{"id": 1}, {"id": 2}]}
+        if "/runs/1/jobs" in path:
+            # newest-first listing: run 1 (listed first) has the NEWER job
+            return {"jobs": [{"id": 111, "status": "queued", "created_at": newer,
+                              "labels": ["self-hosted", "alpha-engine-config-spot"]}]}
+        if "/runs/2/jobs" in path:
+            return {"jobs": [{"id": 222, "status": "queued", "created_at": old,
+                              "labels": ["self-hosted", "alpha-engine-config-spot"]}]}
+        raise AssertionError(f"unexpected GH GET {path}")
+
+    monkeypatch.setattr(idx, "_gh_api_get", fake_get)
+    out = idx.handler({"reconcile": True}, None)
+    order = [d["job_id"] for d in out["dispatched"]]
+    assert order == ["222", "111"], f"oldest job must dispatch first, got {order}"


### PR DESCRIPTION
## Summary
Starvation fix observed live on PR2690: GitHub lists queued runs newest-first, so under spot-quota pressure the reconcile's dispatch loop let constant fresh-run churn (Dependabot-drain rebase CI) win every launch slot while the oldest job sat queued 95+ minutes. Now: collect all stale queued jobs, dispatch **oldest-first** — quota pressure degrades to bounded latency for every job instead of unbounded latency for the unluckiest.

One functional change + one new ordering test (30 pass). I'll deploy via deploy.sh after merge (no auto-deploy exists for this Lambda — same as PR847).

🤖 Generated with [Claude Code](https://claude.com/claude-code)