### PR TITLE
fix(data): SPY excluded from daily_append freshness safety net (config-I2703)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -527,6 +527,24 @@ def _scan_universe_and_emit_freshness_receipt(
     scan tripped on the same 8 stragglers (one 25d stale) and halted
     the SF.
 
+    ``_UNIVERSE_EXTRA`` members (currently: SPY) are HARD-PINNED benchmark
+    symbols, never churn-eligible — they are excluded from ``_SKIP_TICKERS``
+    membership here via the same ``(... not in _SKIP_TICKERS or ... in
+    _UNIVERSE_EXTRA)`` carve-out the write-path predicate
+    (``_daily_append_admits`` in tests/test_spy_universe_member.py; see
+    ``stock_tickers`` below) already uses. 2026-07-15 P0 (config-I2703):
+    this scan (and the missing-from-closes check below) had DRIFTED from
+    that write-path predicate — they filtered on bare ``_SKIP_TICKERS``
+    with no ``_UNIVERSE_EXTRA`` carve-out, so SPY (in ``_SKIP_TICKERS`` by
+    design, see features/compute.py) was silently excluded from BOTH
+    freshness accounting paths every run, logged as an "S&P churn-out
+    straggler, awaiting prune" — even though SPY is a permanent member,
+    never a prune candidate, and is the executor's benchmark hard-fail
+    dependency (eod_reconcile._spy_close). A genuine SPY write failure
+    would have gone undetected by this gate. Fixed by aligning all three
+    ``expected_tickers``-scoping call sites (write / missing-from-closes /
+    freshness-scan) on the identical predicate.
+
     Returns scan metadata (also embedded in the receipt) for logging
     by the caller. Skipped automatically on dry_run.
     """
@@ -540,7 +558,7 @@ def _scan_universe_and_emit_freshness_receipt(
     if expected_tickers is not None:
         expected_set = {
             t.lstrip("^") for t in expected_tickers
-            if t.lstrip("^") not in _SKIP_TICKERS
+            if (t.lstrip("^") not in _SKIP_TICKERS or t.lstrip("^") in _UNIVERSE_EXTRA)
             and not _is_sector_etf(t.lstrip("^"))
         }
         syms = [s for s in all_syms if s in expected_set]
@@ -1396,10 +1414,17 @@ def _daily_append_impl(
         # closes contains everything: stocks + macro keys + sector ETFs.
         # Reduce to the stock set so the diff is apples-to-apples with
         # universe_lib's contents (which holds only stocks). Same predicate
-        # as the line ~274 stock_tickers filter — keep them in lockstep.
+        # as the ``stock_tickers`` write-path filter below — keep them in
+        # lockstep (the ``_UNIVERSE_EXTRA`` carve-out is REQUIRED here: SPY
+        # is in ``_SKIP_TICKERS`` but IS written to `universe`, so without
+        # the carve-out SPY would always compute as "missing from closes"
+        # even on days it's genuinely present — config-I2703 fixed the
+        # sibling gap where this same omission made the freshness scan
+        # blind to SPY entirely).
         closes_stock_keys = {
             t for t in closes
-            if t not in _SKIP_TICKERS and not _is_sector_etf(t)
+            if (t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA)
+            and not _is_sector_etf(t)
         }
         # Scope "expected" to the intersection of ArcticDB universe and the
         # caller's request list. A ticker dropped from S&P this week (still
@@ -1408,11 +1433,15 @@ def _daily_append_impl(
         # design, not a data gap. Without this, every S&P churn week trips
         # the threshold (2026-05-02: 8 churn-out tickers + 4 chronic =
         # 12 > 5 → SF halt). With it, only tickers we both want to track
-        # AND have history for can flag the alarm.
+        # AND have history for can flag the alarm. ``_UNIVERSE_EXTRA``
+        # members are excepted from the ``_SKIP_TICKERS`` exclusion (same
+        # carve-out as ``closes_stock_keys`` above and the write-path
+        # ``stock_tickers`` filter) — SPY is a hard-pinned benchmark, never
+        # a churn-eligible S&P straggler (config-I2703).
         if expected_tickers is not None:
             expected_stocks = {
                 t.lstrip("^") for t in expected_tickers
-                if t.lstrip("^") not in _SKIP_TICKERS
+                if (t.lstrip("^") not in _SKIP_TICKERS or t.lstrip("^") in _UNIVERSE_EXTRA)
                 and not _is_sector_etf(t.lstrip("^"))
             }
             relevant_arctic = arctic_stock_symbols & expected_stocks

--- a/tests/test_daily_append_missing_from_closes.py
+++ b/tests/test_daily_append_missing_from_closes.py
@@ -542,3 +542,80 @@ def test_expected_tickers_logs_straggler_count(monkeypatch, caplog):
     msg = straggler_logs[0].message
     for s in stragglers:
         assert s in msg, f"straggler {s} missing from log: {msg}"
+
+
+# ── 4. SPY / _UNIVERSE_EXTRA carve-out (config-I2703, 2026-07-15 P0) ────────
+#
+# SPY is a hard-pinned _UNIVERSE_EXTRA member (features/compute.py) — it IS
+# written to the `universe` ArcticDB library (unlike other `_SKIP_TICKERS`
+# macro/index symbols), so it must be treated as a real stock symbol by the
+# missing-from-closes diff on BOTH sides: present in arctic (relevant_arctic)
+# AND present in closes (closes_stock_keys). Before this fix, SPY was
+# excluded from BOTH sides via a bare `_SKIP_TICKERS` filter with no
+# `_UNIVERSE_EXTRA` carve-out — net effect: SPY was invisible to this check
+# entirely, masked identically to a genuine "S&P churn-out straggler,
+# awaiting prune" even though SPY is a permanent, never-pruned member.
+
+
+def test_spy_present_in_closes_and_arctic_not_flagged_missing(monkeypatch):
+    """SPY genuinely present in both ArcticDB universe and today's closes
+    (the steady-state case, every trading day) must NOT be counted as
+    missing — proves the closes_stock_keys/expected_stocks carve-out
+    doesn't introduce a FALSE positive now that SPY is in-scope."""
+    from builders.daily_append import daily_append
+
+    constituents = ["AAPL", "MSFT", "SPY"]
+    universe_symbols = ["AAPL", "MSFT", "SPY"]
+    closes_tickers = ["AAPL", "MSFT"]  # SPY reaches closes via macro_keys auto-union
+
+    _patch_targets(
+        monkeypatch,
+        universe_symbols=universe_symbols,
+        closes_tickers=closes_tickers,
+    )
+
+    result = daily_append(date_str="2026-04-28", expected_tickers=constituents)
+    assert result["status"] == "ok"
+    assert result["tickers_missing_from_closes"] == 0
+
+
+def test_spy_genuinely_missing_from_closes_is_caught_not_masked(monkeypatch):
+    """A REAL SPY data gap (SPY in ArcticDB universe + in expected_tickers,
+    but polygon/yfinance didn't return it today) must be caught by the
+    missing-from-closes check, not silently excluded as a churn-out
+    straggler. This is the config-I2703 safety-net regression test: before
+    the fix, SPY was unconditionally excluded from `expected_stocks` (via
+    `_SKIP_TICKERS` with no `_UNIVERSE_EXTRA` carve-out), so this exact
+    scenario would have passed silently.
+
+    Padded with 5 other genuinely-missing constituents to cross the default
+    threshold (5) — SPY alone (1 missing) would only WARN, not raise; the
+    point here is that SPY's name surfaces in the raise, proving it counts
+    toward the diff rather than being invisibly excluded."""
+    from builders import daily_append as _da
+    from builders.daily_append import daily_append
+
+    other_missing = [f"REAL{i}" for i in range(5)]
+    constituents = ["AAPL", "MSFT", "SPY"] + other_missing
+    universe_symbols = ["AAPL", "MSFT", "SPY"] + other_missing
+
+    _patch_targets(
+        monkeypatch,
+        universe_symbols=universe_symbols,
+        closes_tickers=["AAPL", "MSFT"],
+    )
+    # Override the stub so SPY is genuinely absent from closes (simulating
+    # polygon/yfinance dropping it), rather than reaching closes via
+    # _patch_targets' automatic macro_keys union.
+    closes_without_spy = _stub_closes(["AAPL", "MSFT"])
+    monkeypatch.setattr(_da, "_load_daily_closes", lambda *a, **k: closes_without_spy)
+
+    with pytest.raises(RuntimeError, match=r"missing from today's daily_closes") as exc_info:
+        daily_append(
+            date_str="2026-04-28",
+            expected_tickers=constituents,
+        )
+    assert "SPY" in str(exc_info.value), (
+        "SPY must be named among the missing tickers — it must not be "
+        "silently excluded from the missing-from-closes diff."
+    )

--- a/tests/test_daily_append_universe_freshness.py
+++ b/tests/test_daily_append_universe_freshness.py
@@ -270,3 +270,88 @@ class TestExpectedTickersScoping:
                 expected_tickers=["ONLY_IN_EXPECTED"],
             )
         s3.put_object.assert_not_called()
+
+
+class TestBenchmarkTickerNeverExcludedFromScan:
+    """config-I2703 (2026-07-15 P0): SPY (a hard-pinned `_UNIVERSE_EXTRA`
+    benchmark member, features/compute.py) is in `_SKIP_TICKERS` for an
+    UNRELATED reason (prune-protection — see tests/test_spy_universe_member.py
+    section B). Before this fix, the `expected_set` comprehension here
+    filtered on bare `_SKIP_TICKERS` membership with no `_UNIVERSE_EXTRA`
+    carve-out, so SPY was UNCONDITIONALLY excluded from this freshness scan
+    on every single run — logged identically to a genuine "S&P churn-out
+    straggler, awaiting prune" (e.g. SATS). A silent SPY write failure would
+    never have tripped this gate: the executor's eod_reconcile hard-fails
+    if ArcticDB has no SPY close for the day (`_spy_close`, by design,
+    correct, do-not-soften), but nothing upstream would have caught the gap
+    earlier or paged on it. These tests pin that SPY is now always IN the
+    scan's checked set, same as any other hard-pinned universe member.
+    """
+
+    def test_spy_included_in_checked_set_when_fresh(self):
+        """SPY present + fresh in arctic, and passed in expected_tickers
+        (as every real caller does via the macro-daily-tickers union) →
+        SPY must be counted in n_symbols_checked, not silently excluded."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "MSFT": _today_str(1),
+            "SPY": _today_str(0),
+        })
+
+        receipt = _scan_universe_and_emit_freshness_receipt(
+            s3, "test-bucket", lib,
+            expected_tickers=["AAPL", "MSFT", "SPY"],
+        )
+
+        assert receipt["all_fresh"] is True
+        assert receipt["n_symbols_checked"] == 3, (
+            "SPY must be included in the checked set, not treated as an "
+            "excluded churn-out straggler"
+        )
+
+    def test_stale_spy_trips_the_gate(self):
+        """The actual safety-net proof: SPY genuinely stale (e.g. its
+        append silently stopped) MUST raise, naming SPY — the exact class
+        of incident this scan exists to catch (2026-04-21 ASGN/MOH class,
+        applied to the benchmark itself)."""
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "SPY": _today_str(_STALE_OFFSET_DAYS),
+        })
+
+        with pytest.raises(RuntimeError, match="SPY"):
+            _scan_universe_and_emit_freshness_receipt(
+                s3, "test-bucket", lib,
+                expected_tickers=["AAPL", "SPY"],
+            )
+        s3.put_object.assert_not_called()
+
+    def test_spy_not_logged_as_excluded_straggler(self, caplog):
+        """SPY must never appear in the 'excluding ... churn-out stragglers'
+        INFO log — that log line is reserved for genuine index churn-outs
+        (e.g. SATS), and SPY appearing there is exactly what masked the
+        2026-07-15 incident (operators read the log and assumed SPY's
+        absence was an intentional, benign prune-awaiting exclusion)."""
+        import logging
+        s3 = MagicMock()
+        lib = _mock_lib_with_dates({
+            "AAPL": _today_str(0),
+            "SPY": _today_str(0),
+            "SATS": _today_str(8),  # genuine churn-out straggler, correctly excluded
+        })
+
+        with caplog.at_level(logging.INFO, logger="builders.daily_append"):
+            _scan_universe_and_emit_freshness_receipt(
+                s3, "test-bucket", lib,
+                expected_tickers=["AAPL", "SPY"],
+            )
+
+        excluded_logs = [r for r in caplog.records if "excluding" in r.message]
+        assert excluded_logs, "SATS should still be logged as an excluded straggler"
+        assert "SPY" not in excluded_logs[0].message, (
+            f"SPY must never appear in the excluded-stragglers log: "
+            f"{excluded_logs[0].message}"
+        )
+        assert "SATS" in excluded_logs[0].message

--- a/tests/test_spy_universe_member.py
+++ b/tests/test_spy_universe_member.py
@@ -209,3 +209,83 @@ def test_production_filters_reference_universe_extra(rel_path, needle):
         f"filter changed; update _backfill_admits/_daily_append_admits and "
         f"re-verify the SPY-admission + prune-protection contract"
     )
+
+
+# ── D. expected_tickers-scoping predicate contract (config-I2703) ───────────
+#
+# 2026-07-15 P0: the WRITE-path predicate above (_daily_append_admits) has
+# always carved out _UNIVERSE_EXTRA correctly, but the freshness-scan and
+# missing-from-closes checks in daily_append.py — which ALSO derive an
+# "expected" scoped set from expected_tickers, to exclude genuine S&P
+# churn-out stragglers — filtered on bare `_SKIP_TICKERS` with no
+# `_UNIVERSE_EXTRA` carve-out. Net effect: SPY (in `_SKIP_TICKERS` by
+# design) was silently excluded from expected_tickers' "must be fresh /
+# must be in today's closes" scope on every run, logged identically to a
+# genuine churn-out straggler ("S&P churn-out straggler, awaiting prune").
+# A future SPY write outage would have gone undetected by the freshness
+# gate. Fixed by aligning all THREE call sites (write / missing-from-closes
+# / freshness-scan) on the identical carve-out predicate. These tests pin
+# that invariant the same way section C pins the write-path predicate.
+
+
+def _expected_set_admits(t: str) -> bool:
+    """Mirrors the `expected_set` / `expected_stocks` comprehension in both
+    `_scan_universe_and_emit_freshness_receipt` and the missing-from-closes
+    check in builders/daily_append.py (identical predicate, kept in
+    lockstep by the source-text guard below)."""
+    stripped = t.lstrip("^")
+    return (
+        stripped not in _SKIP_TICKERS or stripped in _UNIVERSE_EXTRA
+    ) and not _is_sector_etf(stripped)
+
+
+def _closes_stock_keys_admits(t: str) -> bool:
+    """Mirrors the `closes_stock_keys` comprehension (missing-from-closes
+    check) in builders/daily_append.py — same predicate as
+    `_daily_append_admits` above (write-path), kept in lockstep by the
+    source-text guard below."""
+    return (t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA) and not _is_sector_etf(t)
+
+
+def test_expected_set_admits_spy_despite_skip_ticker_membership():
+    """SPY must be admitted into the expected_tickers scoping set — it is
+    a hard-pinned benchmark, never a churn-eligible S&P straggler, even
+    though it lives in `_SKIP_TICKERS` (which ALSO serves the unrelated
+    prune-protection role — see section A/B)."""
+    assert _expected_set_admits("SPY")
+    assert _expected_set_admits("^SPY")  # caret-stripped callers
+    assert not _expected_set_admits("VIX"), "VIX is macro-only, never a universe member"
+    assert not _expected_set_admits("XLK"), "sector ETFs never enter the universe scope"
+
+
+def test_closes_stock_keys_admits_spy():
+    """SPY present in today's daily_closes parquet must be recognized as
+    a stock key — otherwise it always computes as 'missing from closes'
+    even on days it's genuinely present (the inverse failure mode: a false
+    hard-fail instead of a masked real one)."""
+    assert _closes_stock_keys_admits("SPY")
+    assert not _closes_stock_keys_admits("VIX")
+    assert not _closes_stock_keys_admits("XLK")
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        # freshness scan's expected_set
+        'if (t.lstrip("^") not in _SKIP_TICKERS or t.lstrip("^") in _UNIVERSE_EXTRA)',
+        # missing-from-closes's closes_stock_keys
+        "if (t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA)",
+    ],
+)
+def test_daily_append_scoping_sites_reference_universe_extra(needle):
+    """Guard against config-I2703 regressing: both expected_tickers-scoping
+    call sites in daily_append.py (freshness scan + missing-from-closes)
+    must carry the same _UNIVERSE_EXTRA carve-out the write-path predicate
+    already had. Source-text pin, same convention as section C."""
+    src = (_REPO_ROOT / "builders" / "daily_append.py").read_text()
+    assert needle in src, (
+        f"builders/daily_append.py no longer contains {needle!r} — an "
+        f"expected_tickers-scoping site lost its _UNIVERSE_EXTRA carve-out. "
+        f"This is the exact config-I2703 regression: SPY silently excluded "
+        f"from the freshness/missing-from-closes safety net."
+    )

--- a/tests/test_weekly_collector_morning_enrich.py
+++ b/tests/test_weekly_collector_morning_enrich.py
@@ -970,6 +970,54 @@ def test_daily_arctic_append_runs_daily_append_with_skip_if_exists_and_is_load_b
     assert bad["status"] == "failed"
 
 
+# ── _MACRO_DAILY_TICKERS hard-pin (config-I2703, 2026-07-15 P0) ─────────────
+#
+# SPY (the alpha-math + eod_reconcile benchmark) was found excluded from
+# daily_append's internal expected_tickers scoping — a SEPARATE bug fixed
+# in builders/daily_append.py (see tests/test_spy_universe_member.py
+# section D). While investigating, a second, independent drift risk turned
+# up here: _run_morning_enrich carried its OWN inline copy of the
+# macro/benchmark ticker list (local var, no leading underscore) instead of
+# sharing the module-level _MACRO_DAILY_TICKERS constant that
+# _load_daily_universe_tickers (the EOD PostMarketArcticAppend twin of this
+# weekday state) uses. Two independently-editable literals of "the daily
+# macro tickers" is a duplicate-pin-drift risk: SPY could be removed from
+# one copy (e.g. a churn-scoping refactor) and silently survive in the
+# other, masking exactly the kind of gap this incident was about. These
+# tests pin (a) SPY is a permanent member of the single canonical constant,
+# and (b) both call sites derive from it — no second inline copy.
+
+
+def test_macro_daily_tickers_constant_pins_spy():
+    """The canonical macro/benchmark ticker list must always include SPY —
+    this is the hard pin the freshness/missing-from-closes scoping in
+    daily_append.py relies on to never treat SPY as a churn-eligible
+    S&P straggler."""
+    assert "SPY" in weekly_collector._MACRO_DAILY_TICKERS
+
+
+def test_morning_enrich_and_daily_arctic_append_share_one_macro_ticker_list():
+    """Guard against config-I2703 regressing: _run_morning_enrich must NOT
+    reintroduce a separate inline copy of the macro-tickers list — both the
+    weekday (MorningEnrich) and EOD (_load_daily_universe_tickers) paths
+    must derive expected_tickers from the SAME module-level constant."""
+    import inspect
+
+    morning_enrich_src = inspect.getsource(weekly_collector._run_morning_enrich)
+    assert "_MACRO_DAILY_TICKERS" in morning_enrich_src, (
+        "_run_morning_enrich no longer references the shared "
+        "_MACRO_DAILY_TICKERS constant — check it hasn't reintroduced a "
+        "separate inline copy of the macro/benchmark ticker list "
+        "(the config-I2703 duplicate-pin-drift regression)."
+    )
+    assert "MACRO_DAILY_TICKERS = [" not in morning_enrich_src, (
+        "_run_morning_enrich has its own inline macro-tickers list literal "
+        "again — this must be a single shared constant "
+        "(weekly_collector._MACRO_DAILY_TICKERS), not two independently-"
+        "editable copies."
+    )
+
+
 # ── chronic-gap heal hard timeout (L4605) ───────────────────────────────────
 
 

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -1354,13 +1354,16 @@ def _run_morning_enrich(config: dict, args: argparse.Namespace) -> dict:
         results["status"] = "failed"
         return results
 
-    MACRO_DAILY_TICKERS = [
-        "SPY", "GLD", "USO",
-        "XLB", "XLC", "XLE", "XLF", "XLI", "XLK",
-        "XLP", "XLRE", "XLU", "XLV", "XLY",
-        "^VIX", "^VIX3M", "^TNX", "^IRX",
-    ]
-    tickers = list(dict.fromkeys(tickers + MACRO_DAILY_TICKERS))
+    # Shared with _load_daily_universe_tickers / _run_daily_arctic_append
+    # (the EOD PostMarketArcticAppend twin of this weekday MorningEnrich
+    # path) — was a SEPARATE inline copy of the same 17-symbol list until
+    # config-I2703 (2026-07-15): two independently-editable literals of
+    # "the macro/benchmark daily tickers" is exactly the duplicate-pin
+    # drift class (one copy gets updated, the other silently doesn't).
+    # Both call sites now derive from the single module-level
+    # _MACRO_DAILY_TICKERS constant so SPY (and any future addition) can't
+    # drift out of one path while staying in the other.
+    tickers = list(dict.fromkeys(tickers + _MACRO_DAILY_TICKERS))
 
     logger.info("=" * 60)
     logger.info("MORNING ENRICH: polygon overwrite for %s (prior trading day)", target_date)


### PR DESCRIPTION
## config-I2703 (P0)

Fixes the class of bug behind the 2026-07-15 EOD reconcile hard-fail (`ArcticDB has no SPY close for 2026-07-15`) and the `post-market-arctic-append` freshness-gate failure. Does NOT close I2703 outright — deliverable 4 (complete the 7/15 day: re-run `post-market-arctic-append` then the reconcile-only replay) is an operator action against production, not something this PR does.

### Root cause

`builders/daily_append.py` has three places that scope an `expected_tickers` list against `_SKIP_TICKERS`/`_UNIVERSE_EXTRA`:

1. The **write path** (`stock_tickers`, ~line 1598) — correctly uses `(t not in _SKIP_TICKERS or t in _UNIVERSE_EXTRA)`, admitting SPY.
2. The **missing-from-closes check** (`closes_stock_keys` / `expected_stocks`) — filtered on bare `_SKIP_TICKERS`, **no** `_UNIVERSE_EXTRA` carve-out.
3. The **post-write freshness scan** (`_scan_universe_and_emit_freshness_receipt`'s `expected_set`) — same bare-`_SKIP_TICKERS` bug.

SPY is a member of `_SKIP_TICKERS` (for an unrelated reason — prune protection, since SPY is never in `constituents.json`) *and* of `_UNIVERSE_EXTRA` (a hard pin promoting SPY to a full `universe` member, added 2026-05-13 for the portfolio-optimizer cutover). Sites 2 and 3 never applied the `_UNIVERSE_EXTRA` carve-out that site 1 already had, so SPY was **unconditionally excluded from both freshness-accounting paths on every single run** — logged identically to a genuine S&P churn-out straggler:

```
Universe-freshness scan: excluding 2 ArcticDB symbols absent from expected_tickers
(S&P churn-out stragglers, awaiting prune): ['SATS', 'SPY']
```

SATS is a real churn-out (correctly excluded — confirmed absent from `market_data/weekly/2026-07-10/constituents.json`). SPY is not, and is never a prune candidate — but the log line made it look like an intentional, benign exclusion, masking the fact that SPY had no freshness safety net at all. A genuine SPY write failure would never trip this gate.

**Correction to the issue's suspected root cause:** the config#2515 champion/challenger universe-board rearchitecture is *not* implicated. SPY was never sourced from `constituents.json` / the universe board — it reaches `expected_tickers` via the unconditional `_MACRO_DAILY_TICKERS` union in `weekly_collector.py`, which was intact throughout and is independently covered by pre-existing tests (`test_universe_gap_self_heal.py`, `test_weekly_collector_morning_enrich.py`). The bug is entirely inside `daily_append.py`'s internal scoping logic, present since `_UNIVERSE_EXTRA` was introduced 2026-05-15 (`64450ac`) — it just never surfaced as an incident until now.

### Fix

- Applied the identical `_UNIVERSE_EXTRA` carve-out to both broken call sites, so all three (write / missing-from-closes / freshness-scan) treat SPY consistently as a permanent, always-checked universe member — not a churn-eligible straggler.
- Found and fixed a **second, independent** drift risk while in the area: `_run_morning_enrich` (weekly_collector.py) carried its own inline copy of the same 17-symbol macro-tickers list instead of sharing the module-level `_MACRO_DAILY_TICKERS` constant that `_load_daily_universe_tickers` (the EOD `PostMarketArcticAppend` twin of this weekday state) uses. Two independently-editable copies of "the benchmark tickers" is exactly the duplicate-pin-drift class that could reintroduce this incident from the other path. Deduplicated onto the single constant.
- Did **not** add a new `BENCHMARK_TICKERS` constant as literally named in the issue — `_UNIVERSE_EXTRA` already fills that exact role (hard-pinned, never churn-eligible, pinned by `tests/test_spy_universe_member.py` since 2026-05-15). Renaming it would be needless churn against an established, audit-traced, pinned regression-test suite. Reused the existing SOTA pattern per repo convention rather than forking a parallel one.

### JHG / BLD

Confirmed both are still current S&P 500/400 constituents (checked `market_data/weekly/2026-07-10/constituents.json`: `JHG=True, BLD=True, SATS=False, SPY=False`-as-expected). Their staleness (4 trading days, last=2026-07-09) is a genuine `daily_closes` data gap, not an index-churn/config issue — confirmed via the 7/15 append log (`WARNING ... 2 tickers in ArcticDB universe missing from closes ... ['BLD', 'JHG']`). No code change needed or made; **the freshness gate is correctly failing loud and must stay that way** (per the issue's gotcha — do not soften). They need an operator-run backfill to clear.

### Also checked (background investigation, not code changes)

Grepped executor/predictor/backtester for any OTHER ticker with a hard-fail-by-name dependency (the kind SPY has via `eod_reconcile._spy_close`) that might need the same `_UNIVERSE_EXTRA` carve-out. None found — SPY is the sole hard-pinned symbol; sector ETFs, GLD/USO, and VIX/TNX/IRX are all soft/optional everywhere (fallback to `None` or to SPY, never a raise).

### Test plan

11 new tests, full suite green:

- `tests/test_spy_universe_member.py` (+4): predicate-mirror tests for the two fixed sites + source-text CI guards (`test_daily_append_scoping_sites_reference_universe_extra`) pinning the `_UNIVERSE_EXTRA` carve-out so this can't silently regress.
- `tests/test_daily_append_universe_freshness.py` (+3, new `TestBenchmarkTickerNeverExcludedFromScan`): SPY is now included in `n_symbols_checked`; a genuinely stale SPY trips the `RuntimeError` (the actual safety-net proof); SPY never appears in the "excluding ... stragglers" log (SATS still does).
- `tests/test_daily_append_missing_from_closes.py` (+2): SPY present in both arctic+closes is never falsely flagged missing; SPY genuinely absent from closes IS caught (named in the raise), proving the safety net now actually protects it.
- `tests/test_weekly_collector_morning_enrich.py` (+2): `_MACRO_DAILY_TICKERS` pins SPY; `_run_morning_enrich` and `_load_daily_universe_tickers` share one constant (no reintroduced inline copy).

```
$ .venv/bin/python3 -m pytest tests/ -q
3173 passed, 11 skipped, 349 warnings in 50.36s
```

11 pre-existing skips unrelated to this change (verified unchanged from a clean-checkout baseline run). Zero failures, zero new skips.

Closes-relates-to: config-I2703 (deliverables 1–3 of 4; deliverable 4 — completing the actual 2026-07-15 day via a production `post-market-arctic-append` re-run + reconcile replay — is an operator action against live infra, out of scope for this code PR).