### PR TITLE
feat(eod): closed-loop self-heal for post-close data gaps (config-I2702)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -308,6 +308,75 @@ def _write_feature_store_freshness_sentinel(
     return sentinel
 
 
+# Verify-by-artifact precondition sentinel for the EOD self-heal loop
+# (alpha-engine-config-I2702 deliverable #1/#2). Deliberately a SEPARATE S3
+# key from FEATURE_STORE_FRESHNESS_SENTINEL_KEY above, not a second `library`
+# value written to the SAME key: the universe sentinel (written once per
+# ticker-loop pass, deep in the per-symbol loop) and this macro sentinel
+# (written once per run, right after the macro/SPY readback-verification
+# block below) fire on different code paths and different cadences — sharing
+# one S3 key would let whichever write lands LAST silently overwrite/mask the
+# other's information, defeating the whole point of a per-artifact freshness
+# signal. This key is read by infrastructure/lambdas/eod-precondition-probe,
+# which is the ONLY thing that ever reads it — it is not a general freshness
+# API, and unlike the universe sentinel (`timestamp`-only recency check) it
+# carries `run_date` explicitly: the EOD probe needs to confirm THIS
+# SPECIFIC trading day's SPY close was verified present, not merely "some
+# macro write happened recently" (a stale sentinel from an old run, or a
+# backfill of an unrelated older date, would otherwise false-positive).
+MACRO_FRESHNESS_SENTINEL_KEY = "feature_store/_macro_freshness.json"
+
+
+def _write_macro_freshness_sentinel(
+    s3, bucket: str, *, run_date: str, verified_keys: list[str],
+) -> dict:
+    """Write the ArcticDB macro/SPY freshness sentinel (config-I2702).
+
+    Called ONLY after the macro readback-verification block below confirms
+    (via `verification_failures`) that every key in ``verified_keys`` is
+    genuinely queryable in ArcticDB for ``run_date`` — this sentinel is the
+    ARTIFACT the EOD precondition probe checks, so it must never be written
+    optimistically ahead of that verification.
+
+    Best-effort, matching `_write_feature_store_freshness_sentinel`'s
+    posture: a sentinel-write failure is an observability gap for the probe
+    (which then correctly reports precondition_met=False and the self-heal
+    loop retries — never a silent false-green), NOT a reason to fail a
+    daily_append run whose real ArcticDB writes already succeeded and were
+    already verified above. Swallow rationale (feedback_no_silent_fails):
+    (a) failure mode swallowed = S3 PutObject error on the freshness
+    sentinel only, never the ArcticDB write/verification itself; (c) logged
+    at WARN here, and the resulting probe-reported precondition_met=False
+    is itself the recording surface (drives the self-heal loop / pages on
+    non-convergence) rather than a silent no-op.
+    """
+    sentinel = {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "run_date": run_date,
+        "verified_keys": sorted(verified_keys),
+        "writer": "alpha-engine-data:builders/daily_append.py",
+    }
+    try:
+        s3.put_object(
+            Bucket=bucket,
+            Key=MACRO_FRESHNESS_SENTINEL_KEY,
+            Body=json.dumps(sentinel, indent=2).encode("utf-8"),
+            ContentType="application/json",
+        )
+        log.info(
+            "Wrote ArcticDB macro-freshness sentinel to s3://%s/%s (run_date=%s, keys=%s)",
+            bucket, MACRO_FRESHNESS_SENTINEL_KEY, run_date, sentinel["verified_keys"],
+        )
+    except Exception as exc:
+        log.warning(
+            "ArcticDB macro-freshness sentinel write FAILED "
+            "(non-fatal, OBSERVE — the EOD precondition probe will correctly "
+            "report precondition_met=False and the self-heal loop will retry): %s",
+            exc,
+        )
+    return sentinel
+
+
 def _load_block_anomaly_types() -> frozenset[str]:
     """Read ``DAILY_APPEND_BLOCK_ANOMALY_TYPES`` env var or fall back to defaults.
 
@@ -1366,6 +1435,18 @@ def _daily_append_impl(
                 f"exception but readback shows the row is missing. Investigate "
                 f"ArcticDB commit / consistency semantics."
             )
+
+        # config-I2702 deliverable #1/#2: only reachable when every key in
+        # macro_updated + sector_updated has just been readback-verified
+        # present for date_str (the raise above is unconditional on any
+        # failure) — this is the artifact-asserting checkpoint the EOD
+        # precondition probe reads. Fires even when macro_updated is a
+        # subset of macro_keys was never possible (macro_missing_from_closes
+        # hard-raised earlier in this function for any missing macro key) —
+        # SPY is always in verified_keys whenever this line executes.
+        _write_macro_freshness_sentinel(
+            s3, bucket, run_date=date_str, verified_keys=macro_updated + sector_updated,
+        )
 
     # ── 2b. Detect tickers that exist in ArcticDB universe but are missing
     #        from today's daily_closes parquet ─────────────────────────────────

--- a/infrastructure/iam/alpha-engine-step-functions-role.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role.json
@@ -22,7 +22,8 @@
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-regime-retrospective-eval*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator*",
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller*",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-spot-dispatcher*"
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-spot-dispatcher*",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-eod-precondition-probe*"
       ]
     },
     {
@@ -157,6 +158,12 @@
       "Effect": "Allow",
       "Action": "states:StartExecution",
       "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-advisory-pipeline"
+    },
+    {
+      "Sid": "StartEodSelfHealReplay",
+      "Effect": "Allow",
+      "Action": "states:StartExecution",
+      "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
     }
   ]
 }

--- a/infrastructure/lambdas/eod-precondition-probe/deploy.sh
+++ b/infrastructure/lambdas/eod-precondition-probe/deploy.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-eod-precondition-probe Lambda.
+#
+# alpha-engine-config-I2702 deliverable #1: verify-by-artifact precondition
+# probe for the EOD Step Function's ``ProbeEODReconcilePrecondition`` state.
+# Invoked synchronously by the EOD SF (infrastructure/step_function_eod.json)
+# — no EventBridge trigger, no standalone cron; this Lambda has no life
+# outside being called as a Step Function Task.
+#
+# Managed OUTSIDE CloudFormation — same rationale as eod-backstop /
+# data-spot-dispatcher / scheduled-groom-dispatcher (operator-deployed only,
+# narrow OIDC blast radius). Merging the PR has ZERO live effect until this
+# Lambda + IAM are deployed AND the EOD SF is re-deployed with the new states
+# (infrastructure/deploy_step_function.json / update_eod_pipeline_sf.sh).
+#
+# Usage:
+#   bash infrastructure/lambdas/eod-precondition-probe/deploy.sh             # update code only
+#   bash infrastructure/lambdas/eod-precondition-probe/deploy.sh --bootstrap # first-time create
+#   bash infrastructure/lambdas/eod-precondition-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/eod-precondition-probe/deploy.sh --smoke     # invoke once with today's run_date
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-eod-precondition-probe"
+ROLE_NAME="alpha-engine-eod-precondition-probe-role"
+POLICY_NAME="alpha-engine-eod-precondition-probe-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3 -r "${SCRIPT_DIR}/requirements.txt"
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (pip install -t)..."
+python3 -m pip install \
+  --quiet \
+  --target "${PKG}" \
+  --upgrade \
+  -r "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 30 \
+      --memory-size 128 \
+      --environment 'Variables={LOG_LEVEL=INFO}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (real invoke against today's UTC date) -----------------------
+
+if $SMOKE; then
+  TODAY="$(date -u +%Y-%m-%d)"
+  echo ""
+  echo "Smoke-invoking with run_date=${TODAY} (read-only S3 GetObject; no writes)."
+  RESP=$(mktemp)
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload "{\"run_date\": \"${TODAY}\"}" \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/eod-precondition-probe/iam-policy.json
+++ b/infrastructure/lambdas/eod-precondition-probe/iam-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-eod-precondition-probe:*"
+    },
+    {
+      "Sid": "ReadMacroFreshnessSentinel",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/feature_store/_macro_freshness.json"
+    }
+  ]
+}

--- a/infrastructure/lambdas/eod-precondition-probe/index.py
+++ b/infrastructure/lambdas/eod-precondition-probe/index.py
@@ -1,0 +1,173 @@
+"""alpha-engine-eod-precondition-probe — verify-by-artifact EOD reconcile gate
+(alpha-engine-config-I2702 deliverable #1).
+
+Replaces the EOD Step Function's old ``CheckSkipEODReconcile`` flag test
+(``$.data_spot_error IsPresent``) with a probe of the REAL precondition:
+does ``run_date``'s SPY close actually exist in ArcticDB? The flag test was
+proven wrong live on 2026-07-15 (config-I2699 comment): the SF's data-spot
+POLL timed out and stamped ``$.data_spot_error`` while the collector was
+STILL RUNNING — it went on to finish rc=0 and write the row, but
+``CheckSkipEODReconcile`` had already committed to skipping reconcile based
+on the stale launch-phase flag. A flag records "did the launch/poll path see
+an error", not "does the artifact exist" — those diverged live.
+
+WHY THIS LAMBDA DOES NOT QUERY ArcticDB DIRECTLY: Brian's 2026-07-08
+config#1787 "Option-B" ruling (recorded in
+alpha-engine-config/private-docs/ARTIFACT_REGISTRY.yaml) explicitly rejected
+a first-class ArcticDB backend for Lambda-side freshness probes as premature
+generalization for one consumer — it would fork a 3-repo-pinned lockstep
+(ArtifactSpec schema in nousergon-lib + the registry validator + this repo's
+contract tests) and require bundling the ``arcticdb`` package (+ likely VPC
+networking) into a Lambda deploy image. The ruling's alternative — and the
+one this Lambda follows — is: the ArcticDB PRODUCER (``builders/daily_append.py``)
+already does producer-side READBACK verification (queries ArcticDB itself,
+inside the EC2/spot box that has the ``arcticdb`` package + IAM role) and,
+on success, writes a small unconditional S3 sentinel
+(``feature_store/_macro_freshness.json``) recording which run_date + which
+keys (incl. "SPY") were VERIFIED present. This Lambda reads that sentinel —
+an ordinary S3 GetObject, zero new backend code, zero VPC — which is
+*stronger* than a live "does a row happen to exist" query: the sentinel is
+only written after the producer has already confirmed the row is queryable,
+so the probe is checking a durable, already-verified fact rather than racing
+a read against a write.
+
+Grep-anchor for the producer side: ``FEATURE_STORE_FRESHNESS_SENTINEL_KEY`` /
+``MACRO_FRESHNESS_SENTINEL_KEY`` in ``builders/daily_append.py``.
+
+The EOD ASL calls this Lambda twice per healing cycle: once before
+``CheckSkipEODReconcile`` (the initial gap detection) and once per heal-loop
+iteration after a re-dispatched workload completes (``HealReProbe``) — see
+``infrastructure/step_function_eod.json``. Every call is a fresh S3 read: no
+caching, no trusting a launch-phase flag, per the issue's "verify by artifact,
+never by stale flag" mandate.
+
+Also computes the heal-loop deadline (deliverable #5 "poll budgets sized to
+reality" / deliverable #3(d) "page ... by a deadline"): 09:00 UTC on the day
+AFTER ``run_date``, comfortably past both the EOD pipeline's normal window and
+a chronic-gap-heal-extended collector run, and well before the next trading
+day's pre-open pipeline needs a verdict. Returned on every call so the ASL
+never needs its own date-math (Step Functions' JSONPath dialect has no
+date-arithmetic intrinsic) — the Lambda is the one place with real Python
+``datetime``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+BUCKET = os.environ.get("EOD_PROBE_BUCKET", "alpha-engine-research")
+MACRO_FRESHNESS_SENTINEL_KEY = os.environ.get(
+    "EOD_PROBE_SENTINEL_KEY", "feature_store/_macro_freshness.json"
+)
+# The precondition eod_reconcile.py's _spy_close hard-depends on — SPY must be
+# among the readback-verified keys for run_date. Mirrors daily_append.py's
+# macro_keys list (SPY is always index 0 there); we only require SPY here
+# because that is the ONE key _spy_close reads — a probe stricter than the
+# actual consumer would produce false negatives on genuinely-fine days.
+REQUIRED_KEY = os.environ.get("EOD_PROBE_REQUIRED_KEY", "SPY")
+# Heal-loop deadline: 09:00 UTC the day after run_date (deliverable #3(d)).
+HEAL_DEADLINE_HOUR_UTC = int(os.environ.get("EOD_PROBE_HEAL_DEADLINE_HOUR_UTC", "9"))
+
+
+def _heal_deadline_iso(run_date: str) -> str:
+    """09:00 UTC on the calendar day after ``run_date`` (YYYY-MM-DD)."""
+    d = datetime.strptime(run_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    deadline = (d + timedelta(days=1)).replace(
+        hour=HEAL_DEADLINE_HOUR_UTC, minute=0, second=0, microsecond=0
+    )
+    return deadline.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _read_sentinel(s3client, bucket: str, key: str) -> dict | None:
+    """Read + parse the macro-freshness sentinel. Returns None iff the object
+    genuinely does not exist (NoSuchKey/404) — a legitimate "never written"
+    precondition-not-met state, not an error. ANY OTHER S3 failure (IAM
+    drift, throttling, malformed JSON) RAISES — fail-loud per
+    feedback_no_silent_fails: a probe that silently treats "I couldn't check"
+    the same as "verified absent" would non-deterministically skip a
+    perfectly good reconcile."""
+    try:
+        obj = s3client.get_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "404"):
+            return None
+        raise
+    body = obj["Body"].read()
+    return json.loads(body)
+
+
+def _evaluate(sentinel: dict | None, run_date: str) -> tuple[bool, str]:
+    """Returns (precondition_met, reason)."""
+    if sentinel is None:
+        return False, f"no macro-freshness sentinel found at s3://{BUCKET}/{MACRO_FRESHNESS_SENTINEL_KEY}"
+    sentinel_run_date = sentinel.get("run_date")
+    if sentinel_run_date != run_date:
+        return False, (
+            f"sentinel run_date={sentinel_run_date!r} does not match requested "
+            f"run_date={run_date!r} (stale or wrong-day sentinel)"
+        )
+    verified_keys = set(sentinel.get("verified_keys") or [])
+    if REQUIRED_KEY not in verified_keys:
+        return False, (
+            f"sentinel for run_date={run_date} does not list {REQUIRED_KEY!r} "
+            f"among verified_keys={sorted(verified_keys)}"
+        )
+    return True, f"{REQUIRED_KEY} verified present for run_date={run_date}"
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Step Function Task handler. ``event`` = ``{"run_date": "YYYY-MM-DD"}``.
+
+    Returns::
+
+        {
+          "precondition_met": bool,
+          "reason": str,
+          "run_date": str,
+          "deadline_iso": str,       # 09:00 UTC day-after-run_date
+          "past_deadline": bool,     # now() > deadline_iso
+          "sentinel": dict | None,   # raw sentinel for forensics
+        }
+
+    Raises on any non-"absent" S3 failure — the ASL Task's own Catch decides
+    the fail-safe posture (this repo's EOD ASL treats a probe-infra failure
+    as "proceed to EODReconcile, let the proven `_spy_close` hard-fail be the
+    backstop" rather than silently skipping a possibly-fine reconcile — see
+    the ASL's ``ProbeEODReconcilePrecondition`` Catch comment).
+    """
+    run_date = str((event or {}).get("run_date") or "").strip()
+    if not run_date:
+        raise ValueError("event.run_date is required (YYYY-MM-DD)")
+
+    s3client = boto3.client("s3", region_name=REGION)
+    sentinel = _read_sentinel(s3client, BUCKET, MACRO_FRESHNESS_SENTINEL_KEY)
+    precondition_met, reason = _evaluate(sentinel, run_date)
+
+    deadline_iso = _heal_deadline_iso(run_date)
+    now = datetime.now(timezone.utc)
+    deadline = datetime.strptime(deadline_iso, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    past_deadline = now > deadline
+
+    logger.info(
+        "precondition probe run_date=%s precondition_met=%s reason=%s past_deadline=%s",
+        run_date, precondition_met, reason, past_deadline,
+    )
+    return {
+        "precondition_met": precondition_met,
+        "reason": reason,
+        "run_date": run_date,
+        "deadline_iso": deadline_iso,
+        "past_deadline": past_deadline,
+        "sentinel": sentinel,
+    }

--- a/infrastructure/lambdas/eod-precondition-probe/requirements.txt
+++ b/infrastructure/lambdas/eod-precondition-probe/requirements.txt
@@ -1,0 +1,4 @@
+# No third-party deps beyond the Lambda runtime's built-in boto3/botocore —
+# this Lambda deliberately stays out of ArcticDB (Brian's 2026-07-08
+# config#1787 Option-B ruling; see index.py module docstring) so it never
+# needs the arcticdb package or VPC networking.

--- a/infrastructure/lambdas/eod-precondition-probe/test_handler.py
+++ b/infrastructure/lambdas/eod-precondition-probe/test_handler.py
@@ -1,0 +1,138 @@
+"""Unit tests for the alpha-engine-eod-precondition-probe Lambda
+(alpha-engine-config-I2702 deliverable #1).
+
+Verify-by-artifact: precondition_met must be driven by the S3 sentinel's
+run_date + verified_keys content, never by a launch-phase flag, and any
+non-"absent" S3 failure must raise (fail-loud) rather than resolve to False.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+import index
+
+
+def _s3_with_object(body: dict | None, *, error_code: str | None = None):
+    cli = MagicMock()
+    if error_code is not None:
+        cli.get_object.side_effect = ClientError(
+            {"Error": {"Code": error_code, "Message": "nope"}}, "GetObject"
+        )
+    else:
+        payload = json.dumps(body).encode("utf-8")
+        cli.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=payload))}
+    return cli
+
+
+class TestReadSentinel:
+    def test_missing_object_returns_none(self):
+        cli = _s3_with_object(None, error_code="NoSuchKey")
+        assert index._read_sentinel(cli, "bucket", "key") is None
+
+    def test_404_returns_none(self):
+        cli = _s3_with_object(None, error_code="404")
+        assert index._read_sentinel(cli, "bucket", "key") is None
+
+    def test_other_client_error_raises(self):
+        cli = _s3_with_object(None, error_code="AccessDenied")
+        with pytest.raises(ClientError):
+            index._read_sentinel(cli, "bucket", "key")
+
+    def test_present_object_parses_json(self):
+        cli = _s3_with_object({"run_date": "2026-07-15", "verified_keys": ["SPY"]})
+        assert index._read_sentinel(cli, "bucket", "key") == {
+            "run_date": "2026-07-15", "verified_keys": ["SPY"],
+        }
+
+
+class TestEvaluate:
+    def test_absent_sentinel_is_not_met(self):
+        met, reason = index._evaluate(None, "2026-07-15")
+        assert met is False
+        assert "no macro-freshness sentinel" in reason
+
+    def test_wrong_run_date_is_not_met(self):
+        sentinel = {"run_date": "2026-07-14", "verified_keys": ["SPY"]}
+        met, reason = index._evaluate(sentinel, "2026-07-15")
+        assert met is False
+        assert "does not match requested" in reason
+
+    def test_missing_required_key_is_not_met(self):
+        sentinel = {"run_date": "2026-07-15", "verified_keys": ["VIX", "TNX"]}
+        met, reason = index._evaluate(sentinel, "2026-07-15")
+        assert met is False
+        assert "SPY" in reason
+
+    def test_matching_run_date_with_spy_is_met(self):
+        sentinel = {"run_date": "2026-07-15", "verified_keys": ["SPY", "VIX"]}
+        met, reason = index._evaluate(sentinel, "2026-07-15")
+        assert met is True
+        assert "verified present" in reason
+
+
+class TestHealDeadline:
+    def test_deadline_is_9am_utc_next_day(self):
+        assert index._heal_deadline_iso("2026-07-15") == "2026-07-16T09:00:00Z"
+
+    def test_deadline_respects_month_boundary(self):
+        assert index._heal_deadline_iso("2026-07-31") == "2026-08-01T09:00:00Z"
+
+
+class TestHandler:
+    def test_raises_without_run_date(self):
+        with pytest.raises(ValueError):
+            index.handler({}, None)
+
+    def test_precondition_met_true(self, monkeypatch):
+        cli = _s3_with_object({"run_date": "2026-07-15", "verified_keys": ["SPY"]})
+        monkeypatch.setattr(index.boto3, "client", lambda *a, **k: cli)
+        result = index.handler({"run_date": "2026-07-15"}, None)
+        assert result["precondition_met"] is True
+        assert result["run_date"] == "2026-07-15"
+        assert result["deadline_iso"] == "2026-07-16T09:00:00Z"
+        assert result["sentinel"]["verified_keys"] == ["SPY"]
+
+    def test_precondition_met_false_on_absent_sentinel(self, monkeypatch):
+        cli = _s3_with_object(None, error_code="NoSuchKey")
+        monkeypatch.setattr(index.boto3, "client", lambda *a, **k: cli)
+        result = index.handler({"run_date": "2026-07-15"}, None)
+        assert result["precondition_met"] is False
+        assert result["sentinel"] is None
+
+    def test_s3_failure_propagates(self, monkeypatch):
+        cli = _s3_with_object(None, error_code="AccessDenied")
+        monkeypatch.setattr(index.boto3, "client", lambda *a, **k: cli)
+        with pytest.raises(ClientError):
+            index.handler({"run_date": "2026-07-15"}, None)
+
+    def test_past_deadline_true_when_now_after_deadline(self, monkeypatch):
+        cli = _s3_with_object(None, error_code="NoSuchKey")
+        monkeypatch.setattr(index.boto3, "client", lambda *a, **k: cli)
+
+        class _FrozenDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 7, 16, 10, 0, 0, tzinfo=timezone.utc)
+
+        monkeypatch.setattr(index, "datetime", _FrozenDatetime)
+        result = index.handler({"run_date": "2026-07-15"}, None)
+        assert result["past_deadline"] is True
+
+    def test_not_past_deadline_when_now_before_deadline(self, monkeypatch):
+        cli = _s3_with_object(None, error_code="NoSuchKey")
+        monkeypatch.setattr(index.boto3, "client", lambda *a, **k: cli)
+
+        class _FrozenDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 7, 15, 23, 0, 0, tzinfo=timezone.utc)
+
+        monkeypatch.setattr(index, "datetime", _FrozenDatetime)
+        result = index.handler({"run_date": "2026-07-15"}, None)
+        assert result["past_deadline"] is False

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1,10 +1,10 @@
 {
-  "Comment": "Alpha Engine EOD Pipeline — post-market data capture, snapshot capture, reconciliation, daily substrate health check, instance shutdown. Triggered by daemon shutdown on trading EC2.",
+  "Comment": "Alpha Engine EOD Pipeline \u2014 post-market data capture, snapshot capture, reconciliation, daily substrate health check, instance shutdown. Triggered by daemon shutdown on trading EC2.",
   "StartAt": "CheckMutexRole",
   "States": {
     "CheckMutexRole": {
       "Type": "Choice",
-      "Comment": "L274 SF MutualExclusionGuard — gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Daemon-triggered EOD launches set pipeline_role='eod' (executor/daemon.py:1092); operator-launched replays MUST set their own pipeline_role per the taxonomy in pipeline-reporting-revamp-260524.md §6. Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations — that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell.",
+      "Comment": "L274 SF MutualExclusionGuard \u2014 gate at SF entry point. Allowlist cadence-roles (daily / weekly / eod / shell-run) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Daemon-triggered EOD launches set pipeline_role='eod' (executor/daemon.py:1092); operator-launched replays MUST set their own pipeline_role per the taxonomy in pipeline-reporting-revamp-260524.md \u00a76. Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations \u2014 that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell.",
       "Choices": [
         {
           "And": [
@@ -40,7 +40,7 @@
     },
     "AcquireMutex": {
       "Type": "Task",
-      "Comment": "L274 — DynamoDB conditional PUT. mutex_key = '{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}' (UTC minute bucket parsed from $$.Execution.StartTime). Two duplicate cron-fired executions started in the same minute produce identical keys; the second loses with ConditionalCheckFailedException → MutexConflict Fail. No TTL / no release: the date+minute in the key is itself the staleness window. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
+      "Comment": "L274 \u2014 DynamoDB conditional PUT. mutex_key = '{state-machine-name}#{pipeline_role}#{YYYY-MM-DDTHH:MM}' (UTC minute bucket parsed from $$.Execution.StartTime). Two duplicate cron-fired executions started in the same minute produce identical keys; the second loses with ConditionalCheckFailedException \u2192 MutexConflict Fail. No TTL / no release: the date+minute in the key is itself the staleness window. Item accumulation ~<1000/yr; PAY_PER_REQUEST cost negligible.",
       "Resource": "arn:aws:states:::aws-sdk:dynamodb:putItem",
       "Parameters": {
         "TableName": "alpha-engine-sf-execution-mutex",
@@ -68,7 +68,7 @@
           "ErrorEquals": [
             "DynamoDB.ConditionalCheckFailedException"
           ],
-          "Comment": "Mutex held by another concurrent execution in the same minute bucket — the duplicate-trigger case we are explicitly protecting against. Fail loud (EOD has its own ForceStopInstance cost-guard on the failure path, so a MutexConflict still releases the trading instance).",
+          "Comment": "Mutex held by another concurrent execution in the same minute bucket \u2014 the duplicate-trigger case we are explicitly protecting against. Fail loud (EOD has its own ForceStopInstance cost-guard on the failure path, so a MutexConflict still releases the trading instance).",
           "Next": "MutexConflict",
           "ResultPath": "$.mutex_conflict"
         },
@@ -87,11 +87,11 @@
     "MutexConflict": {
       "Type": "Fail",
       "Error": "MutexConflict",
-      "Cause": "L274: another EOD execution with the same pipeline_role + start-minute already holds the mutex. Cost-guard note: the EOD SF's HandleFailure → ForceStopInstance chain is unreachable from a Fail state, but a duplicate EOD execution by definition means another EOD execution IS running the cost-guard path; the trading instance still gets stopped."
+      "Cause": "L274: another EOD execution with the same pipeline_role + start-minute already holds the mutex. Cost-guard note: the EOD SF's HandleFailure \u2192 ForceStopInstance chain is unreachable from a Fail state, but a duplicate EOD execution by definition means another EOD execution IS running the cost-guard path; the trading instance still gets stopped."
     },
     "StartTradingInstance": {
       "Type": "Task",
-      "Comment": "Re-runnability guard (2026-06-30 incident). Ensure the long-lived trading instance is running + SSM-registered BEFORE any EOD ssm:sendCommand. The normal daemon-shutdown-triggered run enters with the box already up, but EOD's OWN terminal StopTradingInstance and failure-path ForceStopInstance both STOP it — so any operator recovery rerun after a prior failure lands on a stopped instance and the first sendCommand dies with Ssm.InvalidInstanceIdException (observed 2026-06-30 rerun watch-rerun-2026-06-30-1: EODReconcile sendCommand → 'Instances not in a valid state', instance i-018eb3307a21329bf stopped by the prior run's ForceStopInstance). ec2:startInstances is a no-op if already running, so this is safe on the normal path and makes the EOD pipeline idempotently re-runnable. Mirrors the daily/preopen StartExecutorEC2 → SSM-readiness poll (config#1430, the same InvalidInstanceIdException class on cold-boot).",
+      "Comment": "Re-runnability guard (2026-06-30 incident). Ensure the long-lived trading instance is running + SSM-registered BEFORE any EOD ssm:sendCommand. The normal daemon-shutdown-triggered run enters with the box already up, but EOD's OWN terminal StopTradingInstance and failure-path ForceStopInstance both STOP it \u2014 so any operator recovery rerun after a prior failure lands on a stopped instance and the first sendCommand dies with Ssm.InvalidInstanceIdException (observed 2026-06-30 rerun watch-rerun-2026-06-30-1: EODReconcile sendCommand \u2192 'Instances not in a valid state', instance i-018eb3307a21329bf stopped by the prior run's ForceStopInstance). ec2:startInstances is a no-op if already running, so this is safe on the normal path and makes the EOD pipeline idempotently re-runnable. Mirrors the daily/preopen StartExecutorEC2 \u2192 SSM-readiness poll (config#1430, the same InvalidInstanceIdException class on cold-boot).",
       "Resource": "arn:aws:states:::aws-sdk:ec2:startInstances",
       "Parameters": {
         "InstanceIds.$": "$.trading_instance_id"
@@ -120,7 +120,7 @@
     },
     "WaitForInstanceReady": {
       "Type": "Wait",
-      "Comment": "Initial settle before polling for SSM-agent registration. EC2 stopped→running takes ~15-25s; polling describeInstanceInformation any earlier just burns API calls.",
+      "Comment": "Initial settle before polling for SSM-agent registration. EC2 stopped\u2192running takes ~15-25s; polling describeInstanceInformation any earlier just burns API calls.",
       "Seconds": 15,
       "Next": "InitSSMPollCounter"
     },
@@ -171,7 +171,7 @@
     },
     "SSMReadyChoice": {
       "Type": "Choice",
-      "Comment": "PingStatus=Online → CheckSkipRefreshExecutorDeploy (enter the per-task rerun gates; the FIRST gate now hoists the executor-checkout refresh to the top of the pipeline per config#1549, so the entire EOD run — postmarket → arctic → snapshot → reconcile — executes latest origin/main by construction). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail to HandleFailure when the budget is exhausted (per feedback_no_silent_fails — the agent not registering after 3 min is a real boot problem, not just timing; HandleFailure notifies + ForceStopInstance releases the box). This NEVER silently skips EOD reconcile — an unreachable box fails the execution loud.",
+      "Comment": "PingStatus=Online \u2192 CheckSkipRefreshExecutorDeploy (enter the per-task rerun gates; the FIRST gate now hoists the executor-checkout refresh to the top of the pipeline per config#1549, so the entire EOD run \u2014 postmarket \u2192 arctic \u2192 snapshot \u2192 reconcile \u2014 executes latest origin/main by construction). Otherwise wait + retry up to 12 attempts (~3 min total budget). Hard-fail to HandleFailure when the budget is exhausted (per feedback_no_silent_fails \u2014 the agent not registering after 3 min is a real boot problem, not just timing; HandleFailure notifies + ForceStopInstance releases the box). This NEVER silently skips EOD reconcile \u2014 an unreachable box fails the execution loud.",
       "Choices": [
         {
           "And": [
@@ -238,7 +238,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Hard-fail: EODReconcile depends on this snapshot. No silent fallback to live IB — that's the whole point of Phase 2.",
+          "Comment": "Hard-fail: EODReconcile depends on this snapshot. No silent fallback to live IB \u2014 that's the whole point of Phase 2.",
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -299,7 +299,7 @@
         {
           "Variable": "$.snapshot_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipEODReconcile"
+          "Next": "ProbeEODReconcilePrecondition"
         },
         {
           "Variable": "$.snapshot_poll.Status",
@@ -321,7 +321,7 @@
     },
     "SnapshotStatusError": {
       "Type": "Pass",
-      "Comment": "Choice Default path — synthesize $.error from poll result.",
+      "Comment": "Choice Default path \u2014 synthesize $.error from poll result.",
       "Parameters": {
         "source": "snapshot_status",
         "status.$": "$.snapshot_poll.Status",
@@ -340,7 +340,7 @@
     },
     "EODReconcile": {
       "Type": "Task",
-      "Comment": "Run EOD reconciliation on trading EC2 — reads closes from ArcticDB + state from S3 snapshot (no live IB), computes P&L, sends email. pipefail surfaces python crashes that tee would otherwise mask. Deploy-freshness is guaranteed UPSTREAM by the top-of-pipeline RefreshExecutorDeploy chokepoint (config#1549) — the whole EOD run executes latest origin/main by construction, so nousergon-data#574's per-step boot-pull is no longer carried here. eod_reconcile.py's ExecutorPreflight deploy-drift guard remains the authoritative fail-loud gate. (executionTimeout left at 600s from #574 — a safe upper bound; harmless without the inline refresh.)",
+      "Comment": "Run EOD reconciliation on trading EC2 \u2014 reads closes from ArcticDB + state from S3 snapshot (no live IB), computes P&L, sends email. pipefail surfaces python crashes that tee would otherwise mask. Deploy-freshness is guaranteed UPSTREAM by the top-of-pipeline RefreshExecutorDeploy chokepoint (config#1549) \u2014 the whole EOD run executes latest origin/main by construction, so nousergon-data#574's per-step boot-pull is no longer carried here. eod_reconcile.py's ExecutorPreflight deploy-drift guard remains the authoritative fail-loud gate. (executionTimeout left at 600s from #574 \u2014 a safe upper bound; harmless without the inline refresh.)",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -451,7 +451,7 @@
     },
     "EODStatusError": {
       "Type": "Pass",
-      "Comment": "Choice Default path — synthesize $.error from poll result so HandleFailure's JsonToString($.error) has something to stringify.",
+      "Comment": "Choice Default path \u2014 synthesize $.error from poll result so HandleFailure's JsonToString($.error) has something to stringify.",
       "Parameters": {
         "source": "eod_status",
         "status.$": "$.eod_poll.Status",
@@ -470,7 +470,7 @@
     },
     "DailySubstrateHealthCheck": {
       "Type": "Task",
-      "Comment": "Phase 2 → 3 transparency-substrate health check, daily cadence. Mirrors the Sat SF WeeklySubstrateHealthCheck but runs only the daily-cadence rows of transparency_inventory.yaml (lineage, risk_events, residual_pct). Closes the gap where daily-emitting rows would otherwise only get checked once per week. Per-row CloudWatch metrics emit to AlphaEngine/Substrate; the same alarms PR #176 created cover both cadences (SubstrateRowOK metric is cadence-agnostic). Non-blocking (a failure degrades visibly — see SubstrateHealthCheckDegraded — it does not halt the cost-guard tail) — same pattern as WeeklySubstrateHealthCheck. Runs on dashboard EC2 (the SF dispatcher) where alpha-engine-dashboard + lib pin are installed. config#2326 — NO runtime pip: the former in-pipeline `pip install --quiet --upgrade -r requirements.txt` (a live PyPI/network dependency inside an observability stage, with --upgrade able to float unpinned transitive deps past tested versions) was removed; the stage relies on the dashboard box's deploy-time venv sync — infrastructure/deploy-on-merge.sh in crucible-dashboard runs `.venv/bin/pip install -r requirements.txt` on every merge that diffs requirements.txt, and nousergon-lib is TAG-pinned there (@vX.Y.Z), so a lib bump always changes requirements.txt and always refreshes the same /home/ec2-user/alpha-engine-dashboard/.venv this command activates. config#2326 timeout convention (mirrors config#2276's weekly-SF fix): inner executionTimeout = script runtime budget (agent-enforced; its expiry surfaces as a terminal non-Success status the poll Choice turns into health_check_degraded); SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout — time for the agent to PICK UP the command, not to run it); outer Task TimeoutSeconds = executionTimeout + 30 (bounds only the async SendCommand API call). Budget: executionTimeout kept at 180 (daily-cadence subset of rows; observed comparable to or faster than the Sat SF's --cadence weekly sweep now that pip is removed) — the previous 180/180/240 set conflated the delivery timeout with an execution ceiling (the same inversion config#2276 flagged on the weekly SF).",
+      "Comment": "Phase 2 \u2192 3 transparency-substrate health check, daily cadence. Mirrors the Sat SF WeeklySubstrateHealthCheck but runs only the daily-cadence rows of transparency_inventory.yaml (lineage, risk_events, residual_pct). Closes the gap where daily-emitting rows would otherwise only get checked once per week. Per-row CloudWatch metrics emit to AlphaEngine/Substrate; the same alarms PR #176 created cover both cadences (SubstrateRowOK metric is cadence-agnostic). Non-blocking (a failure degrades visibly \u2014 see SubstrateHealthCheckDegraded \u2014 it does not halt the cost-guard tail) \u2014 same pattern as WeeklySubstrateHealthCheck. Runs on dashboard EC2 (the SF dispatcher) where alpha-engine-dashboard + lib pin are installed. config#2326 \u2014 NO runtime pip: the former in-pipeline `pip install --quiet --upgrade -r requirements.txt` (a live PyPI/network dependency inside an observability stage, with --upgrade able to float unpinned transitive deps past tested versions) was removed; the stage relies on the dashboard box's deploy-time venv sync \u2014 infrastructure/deploy-on-merge.sh in crucible-dashboard runs `.venv/bin/pip install -r requirements.txt` on every merge that diffs requirements.txt, and nousergon-lib is TAG-pinned there (@vX.Y.Z), so a lib bump always changes requirements.txt and always refreshes the same /home/ec2-user/alpha-engine-dashboard/.venv this command activates. config#2326 timeout convention (mirrors config#2276's weekly-SF fix): inner executionTimeout = script runtime budget (agent-enforced; its expiry surfaces as a terminal non-Success status the poll Choice turns into health_check_degraded); SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout \u2014 time for the agent to PICK UP the command, not to run it); outer Task TimeoutSeconds = executionTimeout + 30 (bounds only the async SendCommand API call). Budget: executionTimeout kept at 180 (daily-cadence subset of rows; observed comparable to or faster than the Sat SF's --cadence weekly sweep now that pip is removed) \u2014 the previous 180/180/240 set conflated the delivery timeout with an execution ceiling (the same inversion config#2276 flagged on the weekly SF).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -496,7 +496,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2326: substrate-check failure is non-blocking but VISIBLE — set health_check_degraded and publish a best-effort alert (SubstrateHealthCheckDegraded), then continue to StopTradingInstance. Per-row CloudWatch alarms catch row-level failures; this Catch only fires on infra/SSM failure (e.g. dashboard EC2 unreachable). Cost-guard requirement UNCHANGED: trading EC2 must always stop, regardless of substrate-check outcome — the degraded path still terminates at StopTradingInstance, never HandleFailure.",
+          "Comment": "config#2326: substrate-check failure is non-blocking but VISIBLE \u2014 set health_check_degraded and publish a best-effort alert (SubstrateHealthCheckDegraded), then continue to StopTradingInstance. Per-row CloudWatch alarms catch row-level failures; this Catch only fires on infra/SSM failure (e.g. dashboard EC2 unreachable). Cost-guard requirement UNCHANGED: trading EC2 must always stop, regardless of substrate-check outcome \u2014 the degraded path still terminates at StopTradingInstance, never HandleFailure.",
           "Next": "SubstrateHealthCheckDegraded",
           "ResultPath": "$.substrate_check_error"
         }
@@ -536,7 +536,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2326: non-blocking but VISIBLE — a substrate-poll infra failure sets health_check_degraded (via SubstrateHealthCheckDegraded) then continues to StopTradingInstance. Row-level alarms still page on failure regardless of polling outcome.",
+          "Comment": "config#2326: non-blocking but VISIBLE \u2014 a substrate-poll infra failure sets health_check_degraded (via SubstrateHealthCheckDegraded) then continues to StopTradingInstance. Row-level alarms still page on failure regardless of polling outcome.",
           "Next": "SubstrateHealthCheckDegraded",
           "ResultPath": "$.substrate_check_error"
         }
@@ -553,7 +553,7 @@
     },
     "CheckDailySubstrateHealthCheckStatus": {
       "Type": "Choice",
-      "Comment": "config#2326: poll the daily substrate check to a TERMINAL status (mirrors the weekly SF's CheckSubstrateHealthCheckStatus / config#2276 CheckMorningEnrichStatus idiom, minus the re-issue gate — observe-only, one attempt). Pre-fix this stage was check-once: the single getCommandInvocation usually returned InProgress and the SF moved straight to StopTradingInstance, so a hung/failing health checker was invisible (green cost-guard shutdown regardless). Terminal non-Success (Failed / TimedOut / Cancelled — incl. executionTimeout expiry) → SubstrateHealthCheckDegraded. Loop bound: delivery TimeoutSeconds terminates a never-picked-up command and executionTimeout terminates a hung script, so the loop always reaches a terminal status; the SF top-level TimeoutSeconds backstops SSM control-plane pathology. $.substrate_check_poll.Status is safe to dereference un-guarded: the sole predecessor WaitForDailySubstrateHealthCheck pins Status via its ResultSelector.",
+      "Comment": "config#2326: poll the daily substrate check to a TERMINAL status (mirrors the weekly SF's CheckSubstrateHealthCheckStatus / config#2276 CheckMorningEnrichStatus idiom, minus the re-issue gate \u2014 observe-only, one attempt). Pre-fix this stage was check-once: the single getCommandInvocation usually returned InProgress and the SF moved straight to StopTradingInstance, so a hung/failing health checker was invisible (green cost-guard shutdown regardless). Terminal non-Success (Failed / TimedOut / Cancelled \u2014 incl. executionTimeout expiry) \u2192 SubstrateHealthCheckDegraded. Loop bound: delivery TimeoutSeconds terminates a never-picked-up command and executionTimeout terminates a hung script, so the loop always reaches a terminal status; the SF top-level TimeoutSeconds backstops SSM control-plane pathology. $.substrate_check_poll.Status is safe to dereference un-guarded: the sole predecessor WaitForDailySubstrateHealthCheck pins Status via its ResultSelector.",
       "Choices": [
         {
           "Variable": "$.substrate_check_poll.Status",
@@ -587,19 +587,19 @@
     },
     "SubstrateHealthCheckDegraded": {
       "Type": "Pass",
-      "Comment": "config#2326 (mirrors the weekly SF's SubstrateHealthCheckDegraded / config#2276): the daily substrate health check could not run to Success (send/poll infra failure via Catch, or terminal non-Success command status via CheckDailySubstrateHealthCheckStatus.Default). An SF-controlled boolean recorded on the execution record. Unlike the weekly SF, the EOD SF has NO success-path SNS notifier to thread this flag into (audited in test_sf_notifier_totality_wiring.py — PipelineComplete-equivalent tail here is just the cost-guard instance stop), so visibility here is a DEDICATED best-effort SNS publish (PublishSubstrateHealthCheckDegradedAlert) mirroring the existing fail-open PublishDataSpotFailureImmediate idiom in this same file, rather than silence. Continues to StopTradingInstance — the cost-guard shutdown must never be delayed or skipped by a health-check degradation.",
+      "Comment": "config#2326 (mirrors the weekly SF's SubstrateHealthCheckDegraded / config#2276): the daily substrate health check could not run to Success (send/poll infra failure via Catch, or terminal non-Success command status via CheckDailySubstrateHealthCheckStatus.Default). An SF-controlled boolean recorded on the execution record. Unlike the weekly SF, the EOD SF has NO success-path SNS notifier to thread this flag into (audited in test_sf_notifier_totality_wiring.py \u2014 PipelineComplete-equivalent tail here is just the cost-guard instance stop), so visibility here is a DEDICATED best-effort SNS publish (PublishSubstrateHealthCheckDegradedAlert) mirroring the existing fail-open PublishDataSpotFailureImmediate idiom in this same file, rather than silence. Continues to StopTradingInstance \u2014 the cost-guard shutdown must never be delayed or skipped by a health-check degradation.",
       "Result": true,
       "ResultPath": "$.health_check_degraded",
       "Next": "PublishSubstrateHealthCheckDegradedAlert"
     },
     "PublishSubstrateHealthCheckDegradedAlert": {
       "Type": "Task",
-      "Comment": "config#2326: best-effort SNS alert that the EOD daily substrate health check degraded (crashed, timed out, or finished non-Success) — surfaces the miss WITHOUT blocking the cost-guard instance stop. Message is a HARDCODED CONSTANT (config#1819 convention: never States.Format a Subject; here Message is also kept constant rather than conditionally dereferencing $.substrate_check_error / $.substrate_check_poll, which are set by DIFFERENT predecessors — a Catch path sets only the former, a terminal-status path only the latter, and States.Format on a field absent from a given path's payload raises States.Runtime, which would itself dodge the cost-guard). The execution record still carries whichever of the two fields fired; operators cross-reference the SF console. Its own Catch also routes to StopTradingInstance so even an SNS-side failure cannot delay/block the cost-guard.",
+      "Comment": "config#2326: best-effort SNS alert that the EOD daily substrate health check degraded (crashed, timed out, or finished non-Success) \u2014 surfaces the miss WITHOUT blocking the cost-guard instance stop. Message is a HARDCODED CONSTANT (config#1819 convention: never States.Format a Subject; here Message is also kept constant rather than conditionally dereferencing $.substrate_check_error / $.substrate_check_poll, which are set by DIFFERENT predecessors \u2014 a Catch path sets only the former, a terminal-status path only the latter, and States.Format on a field absent from a given path's payload raises States.Runtime, which would itself dodge the cost-guard). The execution record still carries whichever of the two fields fired; operators cross-reference the SF console. Its own Catch also routes to StopTradingInstance so even an SNS-side failure cannot delay/block the cost-guard.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-        "Subject": "Alpha Engine EOD Substrate Health Check — DEGRADED (fail-open, shutdown continues)",
-        "Message": "The EOD daily substrate health check (nousergon_lib.transparency --cadence daily) degraded — it crashed, timed out, or its SSM command finished non-Success — but the pipeline continued to instance-stop (fail-open, config#2326). Per-row CloudWatch alarms independently page on row-level failures; this alert covers the SSM/infra-level failure class those alarms don't see. Detail is on the execution record ($.substrate_check_error and/or $.substrate_check_poll) — view at https://console.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine EOD Substrate Health Check \u2014 DEGRADED (fail-open, shutdown continues)",
+        "Message": "The EOD daily substrate health check (nousergon_lib.transparency --cadence daily) degraded \u2014 it crashed, timed out, or its SSM command finished non-Success \u2014 but the pipeline continued to instance-stop (fail-open, config#2326). Per-row CloudWatch alarms independently page on row-level failures; this alert covers the SSM/infra-level failure class those alarms don't see. Detail is on the execution record ($.substrate_check_error and/or $.substrate_check_poll) \u2014 view at https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.substrate_health_check_degraded_notify",
       "Catch": [
@@ -616,7 +616,7 @@
     },
     "CheckSkipRefreshExecutorDeploy": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4607) for the top-of-pipeline executor-deploy refresh (config#1549). Input {\"skip_refresh_executor_deploy\": true} routes past RefreshExecutorDeploy to the first work gate (CheckSkipPostMarketData); missing flag = run as normal. This is the FIRST gate the SSM-ready path enters — hoisting the refresh here (out of the per-step EODReconcile refresh added in nousergon-data#574) means the ENTIRE EOD run (PostMarketData → PostMarketArcticAppend → CaptureSnapshot → EODReconcile) executes latest origin/main by construction, closing the silent-stale-code exposure on the non-drift-guarded work steps. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Comment": "Per-task rerun gate (L4607) for the top-of-pipeline executor-deploy refresh (config#1549). Input {\"skip_refresh_executor_deploy\": true} routes past RefreshExecutorDeploy to the first work gate (CheckSkipPostMarketData); missing flag = run as normal. This is the FIRST gate the SSM-ready path enters \u2014 hoisting the refresh here (out of the per-step EODReconcile refresh added in nousergon-data#574) means the ENTIRE EOD run (PostMarketData \u2192 PostMarketArcticAppend \u2192 CaptureSnapshot \u2192 EODReconcile) executes latest origin/main by construction, closing the silent-stale-code exposure on the non-drift-guarded work steps. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
@@ -644,7 +644,7 @@
     },
     "RefreshExecutorDeploy": {
       "Type": "Task",
-      "Comment": "Hoisted deploy-drift chokepoint (config#1549). Refreshes the trading instance's crucible-executor checkout to origin/main via the canonical boot-pull.sh ONCE at the top of the EOD pipeline, before any work step runs. The trading instance boot-pulls once each morning (boot-pull.service, ~6:10 AM PT), but executor PRs that merge during the trading day leave the checkout stale by EOD (2026-06-30 incident: 3 executor PRs merged 08:07–08:54 PT after the morning boot-pull). nousergon-data#574 patched only the EODReconcile step (the one work step carrying a drift guard); the earlier PostMarketData / PostMarketArcticAppend / CaptureSnapshot steps had no guard and would run stale intraday code silently. Refreshing here makes the whole run execute latest main by construction. FAIL-LOUD: boot-pull runs WITHOUT a `|| echo` swallow, so a failed refresh (auth/network/dep-install) surfaces as a non-zero SSM status → HandleFailure → ForceStopInstance BEFORE any stale-code work step runs (stronger than #574, whose swallow relied on the downstream reconcile guard). boot-pull runs as ec2-user (matching boot-pull.service User=ec2-user + the ec2-user-owned checkout / ~/.netrc); a root git fetch/reset would trip git's dubious-ownership guard (CVE-2022-24765). Re-freezes /home/ec2-user/.frozen_executor_sha to the just-refreshed HEAD (2026-07-09 incident, config#2042): config#1955's morning CodeFreshnessGate pin is what eod_reconcile.py's ExecutorPreflight.check_deploy_drift actually validates against — this step's premise ('the guard remains authoritative because the box now matches latest main') silently stopped holding the moment #1955 shipped a FIXED T0 pin file instead of a live-origin/main comparison. Two same-day executor PRs (#345, #346) merged between the morning freeze and this step, so the box moved past the stale morning pin and EODReconcile hard-failed 36min later with zero eod_report.json for the day. Re-freezing here — mirroring CodeFreshnessGate's own rev-parse-HEAD-to-pin-file line exactly — keeps the pin in lockstep with what this step just deployed, restoring the invariant the chokepoint comment already assumed.",
+      "Comment": "Hoisted deploy-drift chokepoint (config#1549). Refreshes the trading instance's crucible-executor checkout to origin/main via the canonical boot-pull.sh ONCE at the top of the EOD pipeline, before any work step runs. The trading instance boot-pulls once each morning (boot-pull.service, ~6:10 AM PT), but executor PRs that merge during the trading day leave the checkout stale by EOD (2026-06-30 incident: 3 executor PRs merged 08:07\u201308:54 PT after the morning boot-pull). nousergon-data#574 patched only the EODReconcile step (the one work step carrying a drift guard); the earlier PostMarketData / PostMarketArcticAppend / CaptureSnapshot steps had no guard and would run stale intraday code silently. Refreshing here makes the whole run execute latest main by construction. FAIL-LOUD: boot-pull runs WITHOUT a `|| echo` swallow, so a failed refresh (auth/network/dep-install) surfaces as a non-zero SSM status \u2192 HandleFailure \u2192 ForceStopInstance BEFORE any stale-code work step runs (stronger than #574, whose swallow relied on the downstream reconcile guard). boot-pull runs as ec2-user (matching boot-pull.service User=ec2-user + the ec2-user-owned checkout / ~/.netrc); a root git fetch/reset would trip git's dubious-ownership guard (CVE-2022-24765). Re-freezes /home/ec2-user/.frozen_executor_sha to the just-refreshed HEAD (2026-07-09 incident, config#2042): config#1955's morning CodeFreshnessGate pin is what eod_reconcile.py's ExecutorPreflight.check_deploy_drift actually validates against \u2014 this step's premise ('the guard remains authoritative because the box now matches latest main') silently stopped holding the moment #1955 shipped a FIXED T0 pin file instead of a live-origin/main comparison. Two same-day executor PRs (#345, #346) merged between the morning freeze and this step, so the box moved past the stale morning pin and EODReconcile hard-failed 36min later with zero eod_report.json for the day. Re-freezing here \u2014 mirroring CodeFreshnessGate's own rev-parse-HEAD-to-pin-file line exactly \u2014 keeps the pin in lockstep with what this step just deployed, restoring the invariant the chokepoint comment already assumed.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -678,7 +678,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Fail-loud: a failed executor-deploy refresh must halt EOD before any work step runs stale code. Don't paper over it — the whole point of the hoist is that non-guarded steps never run stale.",
+          "Comment": "Fail-loud: a failed executor-deploy refresh must halt EOD before any work step runs stale code. Don't paper over it \u2014 the whole point of the hoist is that non-guarded steps never run stale.",
           "Next": "HandleFailure",
           "ResultPath": "$.error"
         }
@@ -734,7 +734,7 @@
     },
     "CheckRefreshExecutorDeployStatus": {
       "Type": "Choice",
-      "Comment": "Default routes to HandleFailure so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed — a stale checkout must never reach the work steps.",
+      "Comment": "Default routes to HandleFailure so any unexpected SSM status (Failed, Cancelled, TimedOut, ...) is surfaced, not silently swallowed \u2014 a stale checkout must never reach the work steps.",
       "Choices": [
         {
           "Variable": "$.refresh_executor_deploy_poll.Status",
@@ -766,7 +766,7 @@
     },
     "RefreshExecutorDeployStatusError": {
       "Type": "Pass",
-      "Comment": "Choice Default path — synthesize $.error from poll result so HandleFailure's JsonToString($.error) has something to stringify.",
+      "Comment": "Choice Default path \u2014 synthesize $.error from poll result so HandleFailure's JsonToString($.error) has something to stringify.",
       "Parameters": {
         "source": "refresh_executor_deploy_status",
         "status.$": "$.refresh_executor_deploy_poll.Status",
@@ -808,7 +808,7 @@
     },
     "InitDataSpotRetryCounter": {
       "Type": "Pass",
-      "Comment": "Retry budget for a genuinely-interrupted (not merely slow) post-market-data spot workload — e.g. an AWS spot reclaim mid-job (root cause of the 2026-07-14 EOD FAILED incident: Server.SpotInstanceTermination ~22min into the run, well before the fetch completed). One relaunch-on-a-fresh-box retry before falling through to the existing fail-open path. Mirrors the InitSSMPollCounter counter idiom already used above for SSM-readiness polling. force_on_demand starts false; IncrementDataSpotRetry flips it true so the one retry never gambles on spot a second time.",
+      "Comment": "Retry budget for a genuinely-interrupted (not merely slow) post-market-data spot workload \u2014 e.g. an AWS spot reclaim mid-job (root cause of the 2026-07-14 EOD FAILED incident: Server.SpotInstanceTermination ~22min into the run, well before the fetch completed). One relaunch-on-a-fresh-box retry before falling through to the existing fail-open path. Mirrors the InitSSMPollCounter counter idiom already used above for SSM-readiness polling. force_on_demand starts false; IncrementDataSpotRetry flips it true so the one retry never gambles on spot a second time.",
       "Result": {
         "attempts": 0,
         "force_on_demand": false
@@ -818,7 +818,7 @@
     },
     "LaunchPostMarketDataSpot": {
       "Type": "Task",
-      "Comment": "config#1767: invoke alpha-engine-data-spot-dispatcher to run PostMarketData (post-close fetch) on an ephemeral spot box, NOT on ae-trading. Arctic write follows in PostMarketArcticAppend, also on spot. force_on_demand.$ is false on the first attempt and true on the post-interruption retry (2026-07-14 incident) — the dispatcher then skips spot entirely for that attempt.",
+      "Comment": "config#1767: invoke alpha-engine-data-spot-dispatcher to run PostMarketData (post-close fetch) on an ephemeral spot box, NOT on ae-trading. Arctic write follows in PostMarketArcticAppend, also on spot. force_on_demand.$ is false on the first attempt and true on the post-interruption retry (2026-07-14 incident) \u2014 the dispatcher then skips spot entirely for that attempt.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-data-spot-dispatcher",
@@ -866,7 +866,7 @@
     },
     "PollPostMarketDataSpot": {
       "Type": "Task",
-      "Comment": "Poll the post-market data-spot SSM command; bounded by the on-box watchdog + reaper.",
+      "Comment": "Poll the post-market data-spot SSM command; bounded by the on-box watchdog + reaper. EXTENDED config-I2702 deliverable #5: the Ssm.SdkClientException/States.Timeout retry budget was widened from 2 attempts (~13s) to 6 attempts / 15s base / 2.0x backoff (~16 min) \u2014 a transient poll-side AWS SDK hiccup must never be misclassified as 'the workload failed' while the collector is still genuinely running (root cause of the 2026-07-15 CheckSkipEODReconcile stale-flag incident).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
       "Parameters": {
         "CommandId.$": "$.postmarket_launch.Payload.data_spot.command_id",
@@ -887,9 +887,9 @@
             "Ssm.SdkClientException",
             "States.Timeout"
           ],
-          "MaxAttempts": 2,
-          "IntervalSeconds": 5,
-          "BackoffRate": 1.5
+          "MaxAttempts": 6,
+          "IntervalSeconds": 15,
+          "BackoffRate": 2.0
         }
       ],
       "Catch": [
@@ -939,7 +939,7 @@
     },
     "CheckDataSpotRetryBudget": {
       "Type": "Choice",
-      "Comment": "A terminal non-Success status on the post-market-data spot poll (Failed/Cancelled/TimedOut/the SSM Undeliverable class an already-reclaimed spot instance produces) is presumed transient AWS spot interruption until proven otherwise — retry once on a freshly-launched box before accepting failure. Bounded at 1 retry: a second consecutive interruption is no longer 'transient blip' territory and falls through to the existing fail-open path rather than looping indefinitely. $.data_spot_retry is always initialized by InitDataSpotRetryCounter before this state is reachable.",
+      "Comment": "A terminal non-Success status on the post-market-data spot poll (Failed/Cancelled/TimedOut/the SSM Undeliverable class an already-reclaimed spot instance produces) is presumed transient AWS spot interruption until proven otherwise \u2014 retry once on a freshly-launched box before accepting failure. Bounded at 1 retry: a second consecutive interruption is no longer 'transient blip' territory and falls through to the existing fail-open path rather than looping indefinitely. $.data_spot_retry is always initialized by InitDataSpotRetryCounter before this state is reachable.",
       "Choices": [
         {
           "Variable": "$.data_spot_retry.attempts",
@@ -951,7 +951,7 @@
     },
     "IncrementDataSpotRetry": {
       "Type": "Pass",
-      "Comment": "force_on_demand flips to true for the retry — a box already lost to spot interruption once must not gamble on spot again.",
+      "Comment": "force_on_demand flips to true for the retry \u2014 a box already lost to spot interruption once must not gamble on spot again.",
       "Parameters": {
         "attempts.$": "States.MathAdd($.data_spot_retry.attempts, 1)",
         "force_on_demand": true
@@ -966,7 +966,7 @@
     },
     "InitDataSpotArcticRetryCounter": {
       "Type": "Pass",
-      "Comment": "Retry budget for the Arctic-append sub-phase — the actual SPY-close WRITE that eod_reconcile.py's _spy_close hard-depends on. Mirrors InitDataSpotRetryCounter, including force_on_demand.",
+      "Comment": "Retry budget for the Arctic-append sub-phase \u2014 the actual SPY-close WRITE that eod_reconcile.py's _spy_close hard-depends on. Mirrors InitDataSpotRetryCounter, including force_on_demand.",
       "Result": {
         "attempts": 0,
         "force_on_demand": false
@@ -1024,7 +1024,7 @@
     },
     "PollPostMarketArcticAppendSpot": {
       "Type": "Task",
-      "Comment": "Poll the EOD Arctic-append data-spot SSM command.",
+      "Comment": "Poll the EOD Arctic-append data-spot SSM command. EXTENDED config-I2702 deliverable #5: the Ssm.SdkClientException/States.Timeout retry budget was widened from 2 attempts (~13s) to 6 attempts / 15s base / 2.0x backoff (~16 min) \u2014 a transient poll-side AWS SDK hiccup must never be misclassified as 'the workload failed' while the collector is still genuinely running (root cause of the 2026-07-15 CheckSkipEODReconcile stale-flag incident).",
       "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
       "Parameters": {
         "CommandId.$": "$.postmarket_arctic_launch.Payload.data_spot.command_id",
@@ -1045,9 +1045,9 @@
             "Ssm.SdkClientException",
             "States.Timeout"
           ],
-          "MaxAttempts": 2,
-          "IntervalSeconds": 5,
-          "BackoffRate": 1.5
+          "MaxAttempts": 6,
+          "IntervalSeconds": 15,
+          "BackoffRate": 2.0
         }
       ],
       "Catch": [
@@ -1109,7 +1109,7 @@
     },
     "IncrementDataSpotArcticRetry": {
       "Type": "Pass",
-      "Comment": "force_on_demand flips to true for the retry — mirrors IncrementDataSpotRetry.",
+      "Comment": "force_on_demand flips to true for the retry \u2014 mirrors IncrementDataSpotRetry.",
       "Parameters": {
         "attempts.$": "States.MathAdd($.data_spot_arctic_retry.attempts, 1)",
         "force_on_demand": true
@@ -1124,7 +1124,7 @@
     },
     "ExtractDataSpotError": {
       "Type": "Pass",
-      "Comment": "FAIL-OPEN normalizer (config#1767 #4). An EOD data-spot launch/poll failure or non-Success terminal status lands here. Record as DATA, best-effort alert, then CONTINUE to snapshot/reconcile/instance-stop — a data-phase failure must NOT block the EOD close-out. Mirrors Saturday ResearchPredictorParallel branch-error pattern.",
+      "Comment": "FAIL-OPEN normalizer (config#1767 #4). An EOD data-spot launch/poll failure or non-Success terminal status lands here. Record as DATA, best-effort alert, then CONTINUE to snapshot/reconcile/instance-stop \u2014 a data-phase failure must NOT block the EOD close-out. Mirrors Saturday ResearchPredictorParallel branch-error pattern.",
       "Parameters": {
         "phase": "DataSpot",
         "source": "CheckPostMarket*SpotStatus or launch Catch"
@@ -1134,11 +1134,11 @@
     },
     "PublishDataSpotFailureImmediate": {
       "Type": "Task",
-      "Comment": "Best-effort SNS alert that the EOD data spot failed — surfaces the miss WITHOUT blocking reconcile/stop. Its own Catch also routes to the continue path so even an SNS failure cannot hard-fail the pipeline.",
+      "Comment": "Best-effort SNS alert that the EOD data spot failed \u2014 surfaces the miss WITHOUT blocking reconcile/stop. Its own Catch also routes to the continue path so even an SNS failure cannot hard-fail the pipeline.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-        "Subject": "Alpha Engine EOD Data Spot — FAILED (fail-open, reconcile continues)",
+        "Subject": "Alpha Engine EOD Data Spot \u2014 FAILED (fail-open, reconcile continues)",
         "Message.$": "States.Format('EOD data-spot phase failed but the pipeline continued to reconcile + instance-stop (fail-open, config#1767). Detail: {}', States.JsonToString($.data_spot_error))"
       },
       "ResultPath": "$.data_spot_failure_notify",
@@ -1176,14 +1176,49 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckSkipEODReconcile"
+          "Next": "ProbeEODReconcilePrecondition"
         }
       ],
       "Default": "CaptureSnapshot"
     },
+    "ProbeEODReconcilePrecondition": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #1: verify-by-artifact EOD-reconcile precondition probe. Replaces the old $.data_spot_error launch-phase flag test with a fresh S3 read (via alpha-engine-eod-precondition-probe) of the macro-freshness sentinel builders/daily_append.py writes only AFTER readback-verifying run_date's SPY close is queryable in ArcticDB \u2014 the actual precondition eod_reconcile.py's _spy_close hard-depends on, not merely 'did the launch/poll path see an error'. Called fresh at every reconcile-gate entry (including each HealReProbe iteration in the heal loop below) \u2014 never cached, never trusted from an earlier point in the execution.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-eod-precondition-probe",
+        "Payload": {
+          "run_date.$": "$.run_date"
+        }
+      },
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SWALLOW (feedback_no_silent_fails): (a) failure mode swallowed = the precondition-probe Lambda itself errored (IAM drift, S3 outage, malformed sentinel JSON) \u2014 NOT a data-gap signal; (c) recording surface = $.precondition_probe is left ABSENT on this path, so CheckSkipEODReconcile's BooleanEquals-false test does not match and control falls through to its Default (EODReconcile) rather than silently skipping a possibly-fine reconcile. This is deliberately fail-SAFE-toward-reconcile, not fail-open: eod_reconcile.py's own _spy_close hard-fail (no fallback, by design) remains the authoritative backstop if the data is genuinely absent \u2014 a probe-infra failure can at worst cause one more HandleFailure page, never a silent false-green.",
+          "ResultPath": null,
+          "Next": "CheckSkipEODReconcile"
+        }
+      ],
+      "ResultPath": "$.precondition_probe",
+      "Next": "CheckSkipEODReconcile"
+    },
     "CheckSkipEODReconcile": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4607). Input {\"skip_eod_reconcile\": true} routes past EODReconcile to the next gate (CheckSkipDailySubstrateHealthCheck); missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work. EXTENDED 2026-07-14: a $.data_spot_error present at this point means the post-market data-spot phase failed even after its retry budget (CheckDataSpotRetryBudget / CheckDataSpotArcticRetryBudget) was exhausted — today's SPY/OHLCV close was never written to ArcticDB, so eod_reconcile.py's _spy_close hard-fail (by design, no fallback — see executor/eod_reconcile.py in alpha-engine) is GUARANTEED, not merely possible. Route to SkipEODReconcileDataGap instead of letting that guaranteed crash fall through HandleFailure -> FailExecution, which mislabels a known, retry-exhausted, self-healing data gap as a pipeline defect (root-caused 2026-07-14: AWS spot reclaim mid-job, Server.SpotInstanceTermination, previously paged as a misleading generic 'EOD Pipeline — FAILED').",
+      "Comment": "Per-task rerun gate (L4607). Input {\"skip_eod_reconcile\": true} routes past EODReconcile to the next gate (CheckSkipDailySubstrateHealthCheck); missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work. REPLACED 2026-07-15 (config-I2702 deliverable #1): the old $.data_spot_error IsPresent test decided skip/run from a LAUNCH-PHASE flag, which the 2026-07-15 incident proved can be stale (a transient poll-side SDK hiccup stamped the flag while the collector was still running and later finished rc=0, but the flag test skipped reconcile anyway). Now gates on $.precondition_probe.Payload.precondition_met \u2014 a FRESH S3 read of the readback-verified macro-freshness sentinel, taken immediately before this Choice by the new ProbeEODReconcilePrecondition state. IsPresent+BooleanEquals(false) (not merely absent) \u2014 a probe that never ran (its own Catch swallow) falls through to Default (EODReconcile), deliberately fail-safe-toward-reconcile; see ProbeEODReconcilePrecondition's Catch comment.",
       "Choices": [
         {
           "And": [
@@ -1207,8 +1242,16 @@
           "Next": "CheckSkipDailySubstrateHealthCheck"
         },
         {
-          "Variable": "$.data_spot_error",
-          "IsPresent": true,
+          "And": [
+            {
+              "Variable": "$.precondition_probe.Payload.precondition_met",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.precondition_probe.Payload.precondition_met",
+              "BooleanEquals": false
+            }
+          ],
           "Next": "SkipEODReconcileDataGap"
         }
       ],
@@ -1216,12 +1259,12 @@
     },
     "SkipEODReconcileDataGap": {
       "Type": "Task",
-      "Comment": "Loud, distinctly-labeled alert for a known/self-healing condition — NOT a silent swallow (feedback_no_silent_fails): the data-spot phase exhausted its retry budget, so today's SPY close is genuinely absent from ArcticDB and EODReconcile is skipped rather than left to crash into the generic HandleFailure/FailExecution path. Recovery is expected to be automatic/operator-driven: alpha-engine-data's chronic-gap-heal backfills the missing daily bar on its next run, after which an operator-replay execution with skip_post_market_data=true reruns EODReconcile alone.",
+      "Comment": "Loud, distinctly-labeled alert for a known/self-healing condition \u2014 NOT a silent swallow (feedback_no_silent_fails): the precondition probe confirmed run_date's SPY close is not yet verified-present in ArcticDB, so EODReconcile is skipped rather than left to guarantee-crash into the generic HandleFailure/FailExecution path. UPDATED config-I2702 deliverable #3: recovery is no longer a documented MANUAL operator-replay step \u2014 control proceeds into the closed self-heal loop (SetDegradedFlag -> CheckHealLoopEligible -> InitHealLoop -> ...) which dispatches the missing data-spot workload(s), re-probes, and auto-starts a reconcile-only replay execution (I2700's proven skip_post_market_data + skip_capture_snapshot shape) the moment the precondition lands \u2014 paging only if it fails to converge within 2 attempts or by the probe-computed 09:00 UTC deadline (HealNonConvergent).",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
         "Subject": "Alpha Engine EOD Reconcile SKIPPED (data gap, self-healing)",
-        "Message.$": "States.Format('EOD reconcile SKIPPED for {}: post-market data-spot phase failed after its retry budget was exhausted (most likely an AWS spot interruption) — no NAV/alpha row will be written today. Detail: {}. Chronic-gap-heal will backfill the missing ArcticDB close; then rerun EODReconcile via an operator-replay execution with skip_post_market_data=true.', $.run_date, States.JsonToString($.data_spot_error))"
+        "Message.$": "States.Format('EOD reconcile SKIPPED for {}: post-market data-spot phase failed after its retry budget was exhausted (most likely an AWS spot interruption) \u2014 no NAV/alpha row will be written today. Detail: {}. Chronic-gap-heal will backfill the missing ArcticDB close; then rerun EODReconcile via an operator-replay execution with skip_post_market_data=true.', $.run_date, States.JsonToString($.data_spot_error))"
       },
       "ResultPath": "$.eod_skip_notify",
       "Catch": [
@@ -1229,7 +1272,462 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Defense-in-depth, mirrors HandleFailure's own Catch: an SNS-side failure must not block the substrate check + instance-stop cost-guard.",
+          "Comment": "Defense-in-depth, mirrors HandleFailure's own Catch: an SNS-side failure must not block entry into the self-heal loop.",
+          "ResultPath": null,
+          "Next": "SetDegradedFlag"
+        }
+      ],
+      "Next": "SetDegradedFlag",
+      "Message.$": "States.Format('EOD reconcile SKIPPED for {}: the precondition probe found run_date\\'s SPY close not yet verified-present in ArcticDB. Entering the closed-loop self-heal (dispatch missing workload(s) -> re-probe -> auto-replay) \u2014 no operator action required unless a follow-up DID-NOT-CONVERGE alert fires. Probe detail: {}', $.run_date, States.JsonToString($.precondition_probe))"
+    },
+    "SetDegradedFlag": {
+      "Type": "Pass",
+      "Comment": "config-I2702 deliverable #4: an execution that skips ANY load-bearing state (here: EODReconcile) must not end plain ExecutionSucceeded. Sets a persistent $.degraded_summary flag, checked once by CheckDegradedOutcome AFTER the cost-guard tail (StopTradingInstance) always completes, to route to the distinct DegradedSucceeded terminal instead of NormalSucceeded. The DISTINCT NOTIFICATION half of deliverable #4 already fired above (SkipEODReconcileDataGap) and will fire again from HealConvergedNotify or HealNonConvergent below \u2014 this flag only controls the terminal state's shape/output, mirroring how SubstrateHealthCheckDegraded already threads $.health_check_degraded through this same file for an analogous (lower-severity) condition.",
+      "Parameters": {
+        "degraded": true,
+        "reason": "eod_reconcile_skipped_data_gap",
+        "run_date.$": "$.run_date"
+      },
+      "ResultPath": "$.degraded_summary",
+      "Next": "CheckHealLoopEligible"
+    },
+    "CheckHealLoopEligible": {
+      "Type": "Choice",
+      "Comment": "config-I2702 deliverable #3: recursion guard. An operator-replay execution (pipeline_role=operator-replay \u2014 including a heal-dispatched replay itself, HealDispatchReplay below) that STILL finds the precondition unmet must not spawn a further self-heal loop (replays run with skip_post_market_data=true, so they have no data-spot phase to retry \u2014 looping here would just burn the 2-attempt budget doing nothing). Page immediately instead. A live/daemon/backstop-triggered execution (the normal case) enters the loop.",
+      "Choices": [
+        {
+          "Variable": "$.pipeline_role",
+          "StringEquals": "operator-replay",
+          "Next": "HealNonConvergent"
+        }
+      ],
+      "Default": "InitHealLoop"
+    },
+    "InitHealLoop": {
+      "Type": "Pass",
+      "Comment": "config-I2702 deliverable #3: attempts counter for the closed self-heal loop. Mirrors the InitDataSpotRetryCounter/InitSSMPollCounter idiom already used elsewhere in this file. Bound at 2 attempts (issue's suggested default) \u2014 combined with the 09:00-UTC-next-day deadline the precondition probe computes, whichever gate trips first ends the loop (HealLoopGate).",
+      "Result": {
+        "attempts": 0
+      },
+      "ResultPath": "$.heal_loop",
+      "Next": "HealLoopGate"
+    },
+    "HealLoopGate": {
+      "Type": "Choice",
+      "Comment": "config-I2702 deliverable #3(d): stop the loop and page loudly (never silently) once EITHER bound trips \u2014 2 attempts exhausted, or the probe-computed 09:00 UTC deadline has passed (checked against the MOST RECENT probe result; $.precondition_probe is always present here because SkipEODReconcileDataGap is only reachable after a successful ProbeEODReconcilePrecondition call).",
+      "Choices": [
+        {
+          "Or": [
+            {
+              "Variable": "$.heal_loop.attempts",
+              "NumericGreaterThanEquals": 2
+            },
+            {
+              "Variable": "$.precondition_probe.Payload.past_deadline",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "HealNonConvergent"
+        }
+      ],
+      "Default": "HealLaunchPostMarketDataSpot"
+    },
+    "HealLaunchPostMarketDataSpot": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #3(a): dispatch the missing post-market-data workload. force_on_demand=true unconditionally \u2014 we are already in a degraded-recovery context (the upstream CheckDataSpotRetryBudget single-retry-on-spot already ran and this loop is a step beyond that), so gambling on spot capacity again is not worth the risk of a second interruption burning a heal-loop attempt.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-data-spot-dispatcher",
+        "Payload": {
+          "workload": "post-market-data",
+          "force_on_demand": true
+        }
+      },
+      "TimeoutSeconds": 420,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "A launch failure this heal attempt is not fatal to the loop \u2014 HealLoopIncrement retries (bounded by HealLoopGate).",
+          "ResultPath": "$.heal_error",
+          "Next": "HealLoopIncrement"
+        }
+      ],
+      "ResultPath": "$.heal_postmarket_launch",
+      "Next": "HealCheckPostMarketDataSpotLaunched"
+    },
+    "HealCheckPostMarketDataSpotLaunched": {
+      "Type": "Choice",
+      "Comment": "launched:true -> poll; launched:false (kill-switch) -> this heal attempt accomplished nothing, try again next iteration.",
+      "Choices": [
+        {
+          "Variable": "$.heal_postmarket_launch.Payload.data_spot.launched",
+          "BooleanEquals": true,
+          "Next": "HealPollPostMarketDataSpot"
+        }
+      ],
+      "Default": "HealLoopIncrement"
+    },
+    "HealPollPostMarketDataSpot": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #5: poll the SSM command's OWN authoritative state to a terminal status \u2014 no arbitrary attempt cap on the InProgress/Pending/Delayed branch (bounded only by the data-spot box's own MAX_RUNTIME_SECONDS=7200 watchdog). The transient-SDK-error Retry budget below mirrors the widened PollPostMarketDataSpot budget.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.heal_postmarket_launch.Payload.data_spot.command_id",
+        "InstanceId.$": "$.heal_postmarket_launch.Payload.data_spot.instance_id"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 6,
+          "IntervalSeconds": 15,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.heal_error",
+          "Next": "HealLoopIncrement"
+        }
+      ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent"
+      },
+      "ResultPath": "$.heal_postmarket_poll",
+      "Next": "HealCheckPostMarketDataSpotStatus"
+    },
+    "HealCheckPostMarketDataSpotStatus": {
+      "Type": "Choice",
+      "Comment": "Success -> dispatch the Arctic-append workload; InProgress/Pending/Delayed -> wait+re-poll (unbounded, deliverable #5); ANY terminal non-Success -> this heal attempt failed, try again next iteration.",
+      "Choices": [
+        {
+          "Variable": "$.heal_postmarket_poll.Status",
+          "StringEquals": "Success",
+          "Next": "HealLaunchArcticAppendSpot"
+        },
+        {
+          "Variable": "$.heal_postmarket_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "HealPostMarketDataSpotWait"
+        },
+        {
+          "Variable": "$.heal_postmarket_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "HealPostMarketDataSpotWait"
+        },
+        {
+          "Variable": "$.heal_postmarket_poll.Status",
+          "StringEquals": "Delayed",
+          "Next": "HealPostMarketDataSpotWait"
+        }
+      ],
+      "Default": "HealLoopIncrement"
+    },
+    "HealPostMarketDataSpotWait": {
+      "Type": "Wait",
+      "Seconds": 15,
+      "Next": "HealPollPostMarketDataSpot"
+    },
+    "HealLaunchArcticAppendSpot": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #3(a): dispatch the missing post-market-arctic-append workload (the actual SPY-close WRITE the probe checks for).",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-data-spot-dispatcher",
+        "Payload": {
+          "workload": "post-market-arctic-append",
+          "force_on_demand": true
+        }
+      },
+      "TimeoutSeconds": 420,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 30,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.heal_error",
+          "Next": "HealLoopIncrement"
+        }
+      ],
+      "ResultPath": "$.heal_arctic_launch",
+      "Next": "HealCheckArcticAppendSpotLaunched"
+    },
+    "HealCheckArcticAppendSpotLaunched": {
+      "Type": "Choice",
+      "Comment": "launched:true -> poll; launched:false (kill-switch) -> try again next iteration.",
+      "Choices": [
+        {
+          "Variable": "$.heal_arctic_launch.Payload.data_spot.launched",
+          "BooleanEquals": true,
+          "Next": "HealPollArcticAppendSpot"
+        }
+      ],
+      "Default": "HealLoopIncrement"
+    },
+    "HealPollArcticAppendSpot": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #5: poll the SSM command's own authoritative state to a terminal status \u2014 unbounded on InProgress, bounded only by the box's own watchdog.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+      "Parameters": {
+        "CommandId.$": "$.heal_arctic_launch.Payload.data_spot.command_id",
+        "InstanceId.$": "$.heal_arctic_launch.Payload.data_spot.instance_id"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Ssm.InvocationDoesNotExistException",
+            "Ssm.InvocationDoesNotExist"
+          ],
+          "MaxAttempts": 10,
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.5
+        },
+        {
+          "ErrorEquals": [
+            "Ssm.SdkClientException",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 6,
+          "IntervalSeconds": 15,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.heal_error",
+          "Next": "HealLoopIncrement"
+        }
+      ],
+      "ResultSelector": {
+        "Status.$": "$.Status",
+        "ResponseCode.$": "$.ResponseCode",
+        "StatusDetails.$": "$.StatusDetails",
+        "StandardErrorContent.$": "$.StandardErrorContent"
+      },
+      "ResultPath": "$.heal_arctic_poll",
+      "Next": "HealCheckArcticAppendSpotStatus"
+    },
+    "HealCheckArcticAppendSpotStatus": {
+      "Type": "Choice",
+      "Comment": "Success -> re-probe the precondition; InProgress/Pending/Delayed -> wait+re-poll (unbounded, deliverable #5); ANY terminal non-Success -> try again next iteration.",
+      "Choices": [
+        {
+          "Variable": "$.heal_arctic_poll.Status",
+          "StringEquals": "Success",
+          "Next": "HealReProbe"
+        },
+        {
+          "Variable": "$.heal_arctic_poll.Status",
+          "StringEquals": "InProgress",
+          "Next": "HealArcticAppendSpotWait"
+        },
+        {
+          "Variable": "$.heal_arctic_poll.Status",
+          "StringEquals": "Pending",
+          "Next": "HealArcticAppendSpotWait"
+        },
+        {
+          "Variable": "$.heal_arctic_poll.Status",
+          "StringEquals": "Delayed",
+          "Next": "HealArcticAppendSpotWait"
+        }
+      ],
+      "Default": "HealLoopIncrement"
+    },
+    "HealArcticAppendSpotWait": {
+      "Type": "Wait",
+      "Seconds": 20,
+      "Next": "HealPollArcticAppendSpot"
+    },
+    "HealReProbe": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #3(b): re-probe after the dispatched workloads complete. Overwrites $.precondition_probe with the FRESH result (never trusts the earlier probe) \u2014 HealCheckConverged and, on the next iteration, HealLoopGate's deadline check both read this latest value.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-eod-precondition-probe",
+        "Payload": {
+          "run_date.$": "$.run_date"
+        }
+      },
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "A re-probe infra failure is not a convergence signal either way \u2014 try again next iteration rather than guessing.",
+          "ResultPath": "$.heal_error",
+          "Next": "HealLoopIncrement"
+        }
+      ],
+      "ResultPath": "$.precondition_probe",
+      "Next": "HealCheckConverged"
+    },
+    "HealCheckConverged": {
+      "Type": "Choice",
+      "Comment": "config-I2702 deliverable #3(c): the precondition landed -> dispatch the reconcile-only replay. Not yet -> try again next iteration.",
+      "Choices": [
+        {
+          "Variable": "$.precondition_probe.Payload.precondition_met",
+          "BooleanEquals": true,
+          "Next": "HealDispatchReplay"
+        }
+      ],
+      "Default": "HealLoopIncrement"
+    },
+    "HealLoopIncrement": {
+      "Type": "Pass",
+      "Comment": "Advances the heal-loop attempt counter and returns to HealLoopGate for the bound check. Mirrors IncrementDataSpotRetry/IncrementSSMPoll.",
+      "Parameters": {
+        "attempts.$": "States.MathAdd($.heal_loop.attempts, 1)"
+      },
+      "ResultPath": "$.heal_loop",
+      "Next": "HealLoopGate"
+    },
+    "HealDispatchReplay": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #3(c): auto-start the reconcile-only replay execution, reusing I2700's PROVEN input shape EXACTLY (pipeline_role=operator-replay + skip_post_market_data=true + skip_capture_snapshot=true \u2014 the shape that ran successfully as 'operator-replay-eodreconcile-2026-07-15' and its 2026-07-13 precedent). Deliberately a SEPARATE execution rather than looping this one back through CaptureSnapshot: CaptureSnapshot already ran ONCE earlier in THIS execution (it sits upstream of the precondition probe in the pipeline order), so re-entering the data-spot phase in-place would re-trigger a second live-IB snapshot capture \u2014 exactly what I2700's skip_capture_snapshot flag exists to avoid. skip_refresh_executor_deploy=true because RefreshExecutorDeploy already ran at the top of THIS execution and re-froze .frozen_executor_sha \u2014 the box is already known-fresh. Fire-and-forget (non-.sync): this execution's own terminal state does not wait for the replay's outcome \u2014 the replay's own SUCCEEDED/FAILED status is independently observable (execution name eod-heal-replay-{run_date}-*) and IS the 'convergence notification' this issue's closes-when criteria describes.",
+      "Resource": "arn:aws:states:::states:startExecution",
+      "Parameters": {
+        "StateMachineArn.$": "$$.StateMachine.Id",
+        "Name.$": "States.Format('eod-heal-replay-{}-{}', $.run_date, $$.Execution.Name)",
+        "Input": {
+          "trading_instance_id.$": "$.trading_instance_id",
+          "ec2_instance_id.$": "$.ec2_instance_id",
+          "run_date.$": "$.run_date",
+          "triggered_by": "eod-self-heal",
+          "pipeline_role": "operator-replay",
+          "skip_post_market_data": true,
+          "skip_capture_snapshot": true,
+          "skip_refresh_executor_deploy": true
+        }
+      },
+      "TimeoutSeconds": 30,
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "The data healed but the StartExecution API call itself failed (IAM drift, throttling) \u2014 this is NOT a silent success; page immediately rather than pretending convergence.",
+          "ResultPath": "$.heal_replay_dispatch_error",
+          "Next": "HealReplayDispatchFailed"
+        }
+      ],
+      "ResultPath": "$.heal_replay_dispatch",
+      "Next": "HealConvergedNotify"
+    },
+    "HealReplayDispatchFailed": {
+      "Type": "Task",
+      "Comment": "Loud page: the precondition converged but the auto-replay StartExecution call itself failed \u2014 requires a MANUAL operator-replay using I2700's shape (skip_post_market_data + skip_capture_snapshot).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Self-Heal \u2014 CONVERGED BUT REPLAY DISPATCH FAILED (operator action required)",
+        "Message.$": "States.Format('EOD self-heal for {} converged (SPY close now verified present) but the auto-replay StartExecution call itself failed: {}. Run a manual operator-replay: pipeline_role=operator-replay, skip_post_market_data=true, skip_capture_snapshot=true (I2700 shape).', $.run_date, States.JsonToString($.heal_replay_dispatch_error))"
+      },
+      "ResultPath": "$.heal_replay_dispatch_failed_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": null,
+          "Next": "CheckSkipDailySubstrateHealthCheck"
+        }
+      ],
+      "Next": "CheckSkipDailySubstrateHealthCheck"
+    },
+    "HealConvergedNotify": {
+      "Type": "Task",
+      "Comment": "config-I2702 closes-when 'convergence notification': informational (non-paging) \u2014 the self-heal succeeded without any operator action; the replay execution named here does the actual EODReconcile.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Self-Heal \u2014 CONVERGED (replay dispatched, no operator action needed)",
+        "Message.$": "States.Format('EOD self-heal for {} converged after {} attempt(s): the missing data-spot workload(s) were re-dispatched, SPY close is now verified present in ArcticDB, and a reconcile-only replay execution has been started automatically ({}). No operator action required.', $.run_date, States.MathAdd($.heal_loop.attempts, 1), States.JsonToString($.heal_replay_dispatch))"
+      },
+      "ResultPath": "$.heal_converged_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": null,
+          "Next": "CheckSkipDailySubstrateHealthCheck"
+        }
+      ],
+      "Next": "CheckSkipDailySubstrateHealthCheck"
+    },
+    "HealNonConvergent": {
+      "Type": "Task",
+      "Comment": "config-I2702 deliverable #3(d): THE loud page. Fires only when the heal loop exhausted its 2-attempt budget, passed the probe-computed 09:00 UTC deadline, or this is a replay execution that still can't converge (CheckHealLoopEligible). Genuinely requires operator attention \u2014 the automatic path has been exhausted.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Self-Heal \u2014 DID NOT CONVERGE (operator action required)",
+        "Message.$": "States.Format('EOD self-heal for {} did NOT converge: the automatic heal loop (dispatch missing data-spot workload(s) -> re-probe) exhausted its attempt budget and/or passed its deadline without SPY close landing in ArcticDB. pipeline_role={}, latest probe: {}. Manual intervention needed \u2014 investigate the data-spot dispatch failures, then run an operator-replay (I2700 shape: skip_post_market_data=true, skip_capture_snapshot=true) once the underlying data issue is fixed.', $.run_date, $.pipeline_role, States.JsonToString($.precondition_probe))"
+      },
+      "ResultPath": "$.heal_nonconvergent_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "ResultPath": null,
           "Next": "CheckSkipDailySubstrateHealthCheck"
         }
@@ -1266,7 +1764,7 @@
     },
     "StopTradingInstance": {
       "Type": "Task",
-      "Comment": "Stop trading EC2 instance after EOD completes",
+      "Comment": "Stop trading EC2 instance after EOD completes EXTENDED config-I2702 deliverable #4: no longer a bare execution terminal (End:true) \u2014 routes to CheckDegradedOutcome so a run that skipped EODReconcile ends in the distinct DegradedSucceeded terminal instead of the same plain ExecutionSucceeded a fully-green day gets.",
       "Resource": "arn:aws:states:::aws-sdk:ec2:stopInstances",
       "Parameters": {
         "InstanceIds.$": "$.trading_instance_id"
@@ -1291,11 +1789,31 @@
         }
       ],
       "ResultPath": "$.stop_result",
-      "End": true
+      "Next": "CheckDegradedOutcome"
+    },
+    "CheckDegradedOutcome": {
+      "Type": "Choice",
+      "Comment": "config-I2702 deliverable #4: the ONE place that decides which terminal this execution reaches. $.degraded_summary is set (by SetDegradedFlag) iff the precondition probe ever found the SPY close not-yet-verified-present this execution \u2014 regardless of whether the self-heal loop subsequently converged (HealConvergedNotify) or paged (HealNonConvergent): EODReconcile was skipped IN THIS EXECUTION either way, so 'plain ExecutionSucceeded' would still be a lie about THIS execution's own work, even when the system as a whole self-healed via a replay.",
+      "Choices": [
+        {
+          "Variable": "$.degraded_summary.degraded",
+          "BooleanEquals": true,
+          "Next": "DegradedSucceeded"
+        }
+      ],
+      "Default": "NormalSucceeded"
+    },
+    "NormalSucceeded": {
+      "Type": "Succeed",
+      "Comment": "The ordinary, fully-green terminal \u2014 EODReconcile ran (or was validly skipped via an operator-replay skip_eod_reconcile flag), nothing degraded."
+    },
+    "DegradedSucceeded": {
+      "Type": "Succeed",
+      "Comment": "config-I2702 deliverable #4: distinct terminal for a run that skipped EODReconcile. Still reports AWS execution status SUCCEEDED (a Step Functions Succeed state cannot do otherwise) \u2014 the 'never report plain green' guarantee is carried by (a) this being a DIFFERENT named state than NormalSucceeded, visible in the SF console/execution history and in $.degraded_summary on the execution output, and (b) the distinctly-labeled SNS/Telegram notifications that already fired earlier in this execution (SkipEODReconcileDataGap, and HealConvergedNotify or HealNonConvergent) \u2014 mirroring this file's OWN established pattern for exactly this kind of signal (PublishDataSpotFailureImmediate, SubstrateHealthCheckDegraded + PublishSubstrateHealthCheckDegradedAlert) rather than relying on sf-telegram-notifier's generic execution-status rendering, which does not special-case Succeed-state names."
     },
     "HandleFailure": {
       "Type": "Task",
-      "Comment": "Failure alert via SNS — instance still stops to avoid cost. ARN is hardcoded (not $.sns_topic_arn) so a malformed input field can never block the cost-guard. Catch routes to ForceStopInstance so any SNS-side failure (throttling, IAM drift, transient outage) still stops the instance.",
+      "Comment": "Failure alert via SNS \u2014 instance still stops to avoid cost. ARN is hardcoded (not $.sns_topic_arn) so a malformed input field can never block the cost-guard. Catch routes to ForceStopInstance so any SNS-side failure (throttling, IAM drift, transient outage) still stops the instance.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
@@ -1317,7 +1835,7 @@
     },
     "ForceStopInstance": {
       "Type": "Task",
-      "Comment": "Always stop trading instance even on failure — avoid cost overrun",
+      "Comment": "Always stop trading instance even on failure \u2014 avoid cost overrun",
       "Resource": "arn:aws:states:::aws-sdk:ec2:stopInstances",
       "Parameters": {
         "InstanceIds.$": "$.trading_instance_id"
@@ -1328,7 +1846,7 @@
     "FailExecution": {
       "Type": "Fail",
       "Error": "EODPipelineFailure",
-      "Cause": "EOD pipeline failed — trading instance stopped, check logs."
+      "Cause": "EOD pipeline failed \u2014 trading instance stopped, check logs."
     }
   }
 }

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -68,7 +68,22 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # sentinel, config#1787 — Brian's 2026-07-08 Option-B ruling: registered as
     # an ORDINARY S3 ArtifactSpec in ARTIFACT_REGISTRY.yaml, no changes to
     # nousergon_lib.artifact_freshness or its probe machinery).
-    "builders/daily_append.py": 3,
+    "builders/daily_append.py": 4,
+    # 3 -> 4 on alpha-engine-config-I2702 (2026-07-15): a second, separate
+    # freshness sentinel — feature_store/_macro_freshness.json — written
+    # after the macro/SPY readback-verification block succeeds. Deliberately
+    # NOT the same key as the existing feature_store/_freshness.json sentinel
+    # above: the universe writer and the macro writer fire on different code
+    # paths/cadences, and sharing one key would let whichever write lands
+    # last silently mask the other (see MACRO_FRESHNESS_SENTINEL_KEY's module
+    # docstring). Consumed by the new
+    # infrastructure/lambdas/eod-precondition-probe Lambda — the EOD SF's
+    # verify-by-artifact precondition probe, replacing the old
+    # $.data_spot_error launch-phase flag test at CheckSkipEODReconcile.
+    # FOLLOW-UP (tracked, not yet done in this PR — cross-repo, private):
+    # register feature_store/_macro_freshness.json in alpha-engine-config/
+    # private-docs/ARTIFACT_REGISTRY.yaml alongside the existing
+    # feature_store/_freshness.json entry.
     # builders/migrate_universe_crsp_basis_audit/{ts}.json — the per-ticker CRSP
     # reconciliation REPORT (corporate-actions PR7-7a, config#1434). Like the
     # other one-off migration-audit PUTs (feature_order / vwap below), this is an

--- a/tests/test_daily_append_macro_freshness_sentinel.py
+++ b/tests/test_daily_append_macro_freshness_sentinel.py
@@ -1,0 +1,123 @@
+"""Tests for the ArcticDB macro/SPY freshness sentinel in
+builders/daily_append.py (alpha-engine-config-I2702 deliverable #1/#2).
+
+The sentinel (``feature_store/_macro_freshness.json``) is the ARTIFACT the
+new EOD precondition probe (infrastructure/lambdas/eod-precondition-probe)
+checks in place of the old ``$.data_spot_error`` launch-phase flag test.
+Deliberately a separate S3 key from the universe sentinel
+(``FEATURE_STORE_FRESHNESS_SENTINEL_KEY``) — see the module docstring next to
+``MACRO_FRESHNESS_SENTINEL_KEY`` for why sharing one key would let the two
+writers silently mask each other. Carries an explicit ``run_date`` (unlike
+the universe sentinel's recency-only ``timestamp``) so the probe can confirm
+THIS SPECIFIC trading day's SPY close was verified present.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from builders.daily_append import (
+    MACRO_FRESHNESS_SENTINEL_KEY,
+    _write_macro_freshness_sentinel,
+)
+
+
+class TestMacroFreshnessSentinel:
+    def test_writes_sentinel_with_run_date_and_verified_keys(self):
+        s3 = MagicMock()
+
+        before = datetime.now(timezone.utc).replace(microsecond=0)
+        sentinel = _write_macro_freshness_sentinel(
+            s3, "test-bucket", run_date="2026-07-15", verified_keys=["SPY", "VIX", "TNX"],
+        )
+        after = datetime.now(timezone.utc).replace(microsecond=0)
+
+        s3.put_object.assert_called_once()
+        kwargs = s3.put_object.call_args.kwargs
+        assert kwargs["Bucket"] == "test-bucket"
+        assert kwargs["Key"] == MACRO_FRESHNESS_SENTINEL_KEY
+        assert kwargs["Key"] != "feature_store/_freshness.json"  # distinct from the universe key
+        assert kwargs["ContentType"] == "application/json"
+
+        body = json.loads(kwargs["Body"].decode("utf-8"))
+        assert body["run_date"] == "2026-07-15"
+        assert body["verified_keys"] == ["SPY", "TNX", "VIX"]  # sorted
+        assert sentinel == body
+
+        ts = datetime.strptime(body["timestamp"], "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+        assert before <= ts <= after
+
+    def test_verified_keys_is_sorted_and_deduplicated_is_not_required(self):
+        # sorted() is applied for deterministic output; duplicates are the
+        # caller's responsibility (daily_append never passes duplicates).
+        s3 = MagicMock()
+        sentinel = _write_macro_freshness_sentinel(
+            s3, "test-bucket", run_date="2026-07-15", verified_keys=["XLY", "SPY", "GLD"],
+        )
+        assert sentinel["verified_keys"] == ["GLD", "SPY", "XLY"]
+
+    def test_s3_failure_is_swallowed_not_raised(self):
+        """Best-effort: a sentinel write failure must never fail a
+        daily_append run whose real ArcticDB writes already succeeded and
+        were already readback-verified (feedback_no_silent_fails swallow
+        carve-out: the probe correctly reports precondition_met=False and
+        the self-heal loop retries — never a silent false-green)."""
+        s3 = MagicMock()
+        s3.put_object.side_effect = RuntimeError("simulated S3 outage")
+
+        sentinel = _write_macro_freshness_sentinel(
+            s3, "test-bucket", run_date="2026-07-15", verified_keys=["SPY"],
+        )
+        assert sentinel["run_date"] == "2026-07-15"  # still returns the payload
+
+    def test_s3_failure_logs_warning(self, caplog):
+        import logging
+
+        s3 = MagicMock()
+        s3.put_object.side_effect = RuntimeError("simulated S3 outage")
+
+        with caplog.at_level(logging.WARNING, logger="builders.daily_append"):
+            _write_macro_freshness_sentinel(
+                s3, "test-bucket", run_date="2026-07-15", verified_keys=["SPY"],
+            )
+
+        warnings = [r for r in caplog.records if "sentinel write FAILED" in r.message]
+        assert warnings, f"expected a WARN log; got: {[r.message for r in caplog.records]}"
+
+
+class TestMacroFreshnessSentinelWiredIntoDailyAppend:
+    """Source-level wiring check: the sentinel write must appear in
+    _daily_append_impl AFTER the macro verification_failures raise-check, so
+    it is only ever written once every key it lists has been proven
+    readback-present for date_str — never optimistically ahead of that
+    verification."""
+
+    def test_sentinel_write_follows_verification_failures_check(self):
+        import inspect
+
+        from builders import daily_append as da
+
+        src = inspect.getsource(da._daily_append_impl)
+        verify_idx = src.index("Macro update verification failed for")
+        sentinel_idx = src.index("_write_macro_freshness_sentinel(")
+
+        assert verify_idx < sentinel_idx, (
+            "expected order: macro verification_failures raise-check -> "
+            "macro-freshness sentinel write, so the sentinel is only ever "
+            "written after every listed key is confirmed present"
+        )
+
+    def test_sentinel_receives_run_date_and_verified_keys_kwargs(self):
+        import inspect
+
+        from builders import daily_append as da
+
+        src = inspect.getsource(da._daily_append_impl)
+        call_start = src.index("_write_macro_freshness_sentinel(")
+        call_snippet = src[call_start:call_start + 300]
+        assert "run_date=date_str" in call_snippet
+        assert "verified_keys=macro_updated + sector_updated" in call_snippet

--- a/tests/test_sf_data_spot_relocation_wiring.py
+++ b/tests/test_sf_data_spot_relocation_wiring.py
@@ -474,12 +474,26 @@ class TestEODReconcileSkippedOnDataGap:
     pipeline defect — the false 'EOD Pipeline — FAILED' page from 2026-07-14)."""
 
     def test_data_gap_branch_precedes_default(self, eod):
+        # config-I2702 (2026-07-15): the $.data_spot_error launch-phase flag
+        # test was REPLACED by a fresh verify-by-artifact probe result — see
+        # test_sf_eod_precondition_probe_wiring.py for the full pinning of
+        # ProbeEODReconcilePrecondition + the closed self-heal loop this
+        # branch now feeds into. This test only re-confirms the Choice shape
+        # at CheckSkipEODReconcile itself.
         st = eod["CheckSkipEODReconcile"]
         assert st["Type"] == "Choice"
-        gap_choices = [c for c in st["Choices"] if c.get("Variable") == "$.data_spot_error"]
+        gap_choices = [
+            c for c in st["Choices"]
+            if any(cond.get("Variable") == "$.precondition_probe.Payload.precondition_met"
+                   for cond in c.get("And", []))
+        ]
         assert len(gap_choices) == 1
-        assert gap_choices[0]["IsPresent"] is True
+        conds = gap_choices[0]["And"]
+        assert any(c.get("IsPresent") is True for c in conds)
+        assert any(c.get("BooleanEquals") is False for c in conds)
         assert gap_choices[0]["Next"] == "SkipEODReconcileDataGap"
+        # No leftover reference to the old flag anywhere in this Choice.
+        assert not any(c.get("Variable") == "$.data_spot_error" for c in st["Choices"])
         # The pre-existing operator-replay skip_eod_reconcile branch is untouched.
         assert st["Default"] == "EODReconcile"
 
@@ -501,16 +515,21 @@ class TestEODReconcileSkippedOnDataGap:
         assert "States.JsonToString($.data_spot_error)" in message_fmt
 
     def test_skip_state_never_reaches_a_halt(self, eod):
+        # config-I2702: SkipEODReconcileDataGap now enters the closed
+        # self-heal loop (SetDegradedFlag) instead of jumping straight to the
+        # substrate-check gate — the loop's own reachability (never hitting
+        # _HALT, always eventually reaching StopTradingInstance) is pinned in
+        # test_sf_eod_precondition_probe_wiring.py.
         for tgt in _all_targets(eod["SkipEODReconcileDataGap"]):
             assert tgt not in _HALT
-        assert eod["SkipEODReconcileDataGap"]["Next"] == "CheckSkipDailySubstrateHealthCheck"
+        assert eod["SkipEODReconcileDataGap"]["Next"] == "SetDegradedFlag"
 
     def test_skip_states_own_sns_failure_still_continues(self, eod):
         # Mirrors HandleFailure's defense-in-depth: an SNS-side failure here
-        # must not block the substrate check + instance-stop cost-guard.
+        # must not block entry into the self-heal loop (config-I2702).
         catches = eod["SkipEODReconcileDataGap"].get("Catch", [])
         assert any(
-            c["ErrorEquals"] == ["States.ALL"] and c["Next"] == "CheckSkipDailySubstrateHealthCheck"
+            c["ErrorEquals"] == ["States.ALL"] and c["Next"] == "SetDegradedFlag"
             for c in catches
         )
 

--- a/tests/test_sf_eod_precondition_probe_wiring.py
+++ b/tests/test_sf_eod_precondition_probe_wiring.py
@@ -1,0 +1,408 @@
+"""Pins the alpha-engine-config-I2702 closed-loop EOD self-heal: verify-by-
+artifact precondition probe (deliverable #1), the closed heal loop
+(deliverable #3), and the degraded terminal state (deliverable #4).
+
+Background (2026-07-15 incident, config-I2699 + config-I2702): the EOD SF's
+old ``CheckSkipEODReconcile`` skip decision keyed on a LAUNCH-PHASE flag
+(``$.data_spot_error``), which a poll-side transient AWS SDK hiccup could set
+even while the underlying collector was still running and later finished
+rc=0 — a decision-on-stale-signal bug (same class as the groom auto-clear
+trusting a text match, 2026-07-11). Recovery bottomed out in a MANUAL
+operator-replay step. This test pins the replacement: a fresh S3 read of a
+readback-verified artifact (deliverable #1), an automatic dispatch-reprobe-
+replay loop bounded by attempts + a deadline (deliverable #3), and a
+terminal state that can never look plain-green when EODReconcile was skipped
+(deliverable #4).
+
+Companion tests:
+  * test_sf_eod_skipgate_wiring.py — the CheckSkipEODReconcile Choice shape
+    + the per-task rerun gate chain (unaffected Choices[0] branch).
+  * test_sf_data_spot_relocation_wiring.py — the CheckSkipEODReconcile
+    data-gap branch's Choice condition + SkipEODReconcileDataGap's
+    fail-open Catch (both updated in the same PR to route into this file's
+    heal loop instead of straight to the cost-guard tail).
+  * test_sf_eod_substrate_check_wiring.py — StopTradingInstance's routing
+    change (End:true -> Next: CheckDegradedOutcome).
+  * test_sf_payload_uniqueness.py — the new top-level ``$.<X>`` fields this
+    file introduces, in the closed namespace registry.
+  * test_sf_iam_lambda_grants.py — the new
+    ``alpha-engine-eod-precondition-probe`` Lambda ARN is IAM-grantable.
+  * infrastructure/lambdas/eod-precondition-probe/test_handler.py — the
+    probe Lambda's own unit tests (S3 sentinel read + evaluate + deadline math).
+"""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_eod.json"
+_SF_ROLE = _REPO_ROOT / "infrastructure" / "iam" / "alpha-engine-step-functions-role.json"
+
+_PROBE_FN = "alpha-engine-eod-precondition-probe"
+_DISPATCHER_FN = "alpha-engine-data-spot-dispatcher"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+@pytest.fixture(scope="module")
+def doc() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+def _targets(state: dict) -> list[str]:
+    out: list[str] = []
+    if "Next" in state:
+        out.append(state["Next"])
+    if "Default" in state:
+        out.append(state["Default"])
+    for c in state.get("Choices", []):
+        if "Next" in c:
+            out.append(c["Next"])
+    for c in state.get("Catch", []):
+        if "Next" in c:
+            out.append(c["Next"])
+    return out
+
+
+# ── Whole-doc structural sanity (belt-and-suspenders on top of the manual
+#    per-state pins below — catches typos in any Next/Default the targeted
+#    tests don't happen to enumerate) ────────────────────────────────────────
+
+
+def test_every_state_reference_resolves(states):
+    missing = {
+        (name, tgt)
+        for name, st in states.items()
+        for tgt in _targets(st)
+        if tgt not in states
+    }
+    assert not missing
+
+
+def test_every_state_reachable_from_start(doc, states):
+    seen = set()
+    q = deque([doc["StartAt"]])
+    while q:
+        n = q.popleft()
+        if n in seen:
+            continue
+        seen.add(n)
+        q.extend(t for t in _targets(states[n]) if t not in seen)
+    assert set(states) - seen == set()
+
+
+def test_succeed_and_fail_states_have_no_next(states):
+    for name, st in states.items():
+        if st["Type"] in ("Succeed", "Fail"):
+            assert "Next" not in st, f"{name} is Type={st['Type']} but has a Next"
+
+
+# ── Deliverable #1: ProbeEODReconcilePrecondition ────────────────────────────
+
+
+class TestPreconditionProbe:
+    def test_probe_invokes_the_new_lambda(self, states):
+        st = states["ProbeEODReconcilePrecondition"]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::lambda:invoke"
+        assert st["Parameters"]["FunctionName"] == _PROBE_FN
+        assert st["Parameters"]["Payload"] == {"run_date.$": "$.run_date"}
+        assert st["ResultPath"] == "$.precondition_probe"
+        assert st["Next"] == "CheckSkipEODReconcile"
+
+    def test_probe_infra_failure_falls_through_to_reconcile_not_skip(self, states):
+        # Deliberately fail-SAFE-toward-reconcile: a probe-infra failure must
+        # NOT set $.precondition_probe at all, so CheckSkipEODReconcile's
+        # IsPresent+BooleanEquals(false) test cannot match and falls through
+        # to Default (EODReconcile) — the proven _spy_close hard-fail remains
+        # the backstop if data is genuinely absent.
+        st = states["ProbeEODReconcilePrecondition"]
+        catches = [c for c in st["Catch"] if c["ErrorEquals"] == ["States.ALL"]]
+        assert len(catches) == 1
+        assert catches[0]["Next"] == "CheckSkipEODReconcile"
+        assert catches[0]["ResultPath"] is None
+
+    def test_reconcile_gate_reads_the_probe_not_the_old_flag(self, states):
+        cser = states["CheckSkipEODReconcile"]
+        gap_choice = next(
+            c for c in cser["Choices"]
+            if any(cond.get("Variable") == "$.precondition_probe.Payload.precondition_met"
+                   for cond in c.get("And", []))
+        )
+        assert gap_choice["Next"] == "SkipEODReconcileDataGap"
+        assert not any(
+            cond.get("Variable") == "$.data_spot_error"
+            for c in cser["Choices"] for cond in c.get("And", [])
+        )
+
+    def test_probe_is_called_again_inside_the_heal_loop(self, states):
+        # HealReProbe is a second call site of the SAME Lambda, re-verifying
+        # fresh (never trusting the pre-dispatch probe result) after the
+        # heal loop dispatches the missing workload(s).
+        st = states["HealReProbe"]
+        assert st["Type"] == "Task"
+        assert st["Parameters"]["FunctionName"] == _PROBE_FN
+        assert st["ResultPath"] == "$.precondition_probe"
+
+    def test_probe_lambda_package_present(self):
+        d = _REPO_ROOT / "infrastructure" / "lambdas" / "eod-precondition-probe"
+        for f in ("index.py", "test_handler.py", "deploy.sh", "iam-policy.json", "requirements.txt"):
+            assert (d / f).exists(), f"missing {d / f}"
+
+
+# ── Deliverable #4: degraded terminal state ──────────────────────────────────
+
+
+class TestDegradedTerminalState:
+    def test_gap_detection_sets_the_degraded_flag(self, states):
+        assert states["SkipEODReconcileDataGap"]["Next"] == "SetDegradedFlag"
+        sdf = states["SetDegradedFlag"]
+        assert sdf["Type"] == "Pass"
+        assert sdf["Parameters"]["degraded"] is True
+        assert sdf["ResultPath"] == "$.degraded_summary"
+
+    def test_stop_trading_instance_leads_to_the_degraded_check(self, states):
+        assert "End" not in states["StopTradingInstance"]
+        assert states["StopTradingInstance"]["Next"] == "CheckDegradedOutcome"
+
+    def test_degraded_outcome_routes_on_the_flag(self, states):
+        cdo = states["CheckDegradedOutcome"]
+        assert cdo["Type"] == "Choice"
+        c = cdo["Choices"][0]
+        assert c["Variable"] == "$.degraded_summary.degraded"
+        assert c["BooleanEquals"] is True
+        assert c["Next"] == "DegradedSucceeded"
+        assert cdo["Default"] == "NormalSucceeded"
+
+    def test_two_distinct_succeed_states_exist(self, states):
+        assert states["NormalSucceeded"]["Type"] == "Succeed"
+        assert states["DegradedSucceeded"]["Type"] == "Succeed"
+        assert states["NormalSucceeded"] != states["DegradedSucceeded"]
+
+    def test_a_run_that_never_hits_the_gap_cannot_reach_degraded_succeeded(self, states):
+        # Structural sanity: DegradedSucceeded is reachable ONLY via
+        # CheckDegradedOutcome, which is reachable ONLY via StopTradingInstance
+        # — there is no direct edge from anywhere else in the file.
+        producers = [
+            name for name, st in states.items()
+            if "DegradedSucceeded" in _targets(st)
+        ]
+        assert producers == ["CheckDegradedOutcome"]
+
+
+# ── Deliverable #3: closed self-heal loop ────────────────────────────────────
+
+
+class TestHealLoopEligibility:
+    def test_operator_replay_does_not_recurse(self, states):
+        # A replay execution that still finds the precondition unmet must
+        # page immediately, not spawn a further heal loop (replays run with
+        # skip_post_market_data=true — no data-spot phase to retry).
+        chle = states["CheckHealLoopEligible"]
+        assert chle["Type"] == "Choice"
+        c = chle["Choices"][0]
+        assert c["Variable"] == "$.pipeline_role"
+        assert c["StringEquals"] == "operator-replay"
+        assert c["Next"] == "HealNonConvergent"
+        assert chle["Default"] == "InitHealLoop"
+
+    def test_set_degraded_flag_enters_eligibility_check(self, states):
+        assert states["SetDegradedFlag"]["Next"] == "CheckHealLoopEligible"
+
+
+class TestHealLoopBound:
+    def test_init_starts_at_zero_attempts(self, states):
+        st = states["InitHealLoop"]
+        assert st["Type"] == "Pass"
+        assert st["Result"] == {"attempts": 0}
+        assert st["ResultPath"] == "$.heal_loop"
+        assert st["Next"] == "HealLoopGate"
+
+    def test_gate_trips_on_attempts_or_deadline(self, states):
+        gate = states["HealLoopGate"]
+        assert gate["Type"] == "Choice"
+        c = gate["Choices"][0]
+        assert "Or" in c
+        variables = {cond["Variable"] for cond in c["Or"]}
+        assert variables == {"$.heal_loop.attempts", "$.precondition_probe.Payload.past_deadline"}
+        assert c["Next"] == "HealNonConvergent"
+        assert gate["Default"] == "HealLaunchPostMarketDataSpot"
+
+    def test_attempts_bound_is_two(self, states):
+        gate = states["HealLoopGate"]
+        attempts_cond = next(
+            c for c in gate["Choices"][0]["Or"] if c["Variable"] == "$.heal_loop.attempts"
+        )
+        assert attempts_cond["NumericGreaterThanEquals"] == 2
+
+    def test_increment_advances_the_counter_and_loops_back(self, states):
+        inc = states["HealLoopIncrement"]
+        assert inc["Type"] == "Pass"
+        assert inc["Parameters"]["attempts.$"] == "States.MathAdd($.heal_loop.attempts, 1)"
+        assert inc["ResultPath"] == "$.heal_loop"
+        assert inc["Next"] == "HealLoopGate"
+
+    @pytest.mark.parametrize("failure_state", [
+        "HealLaunchPostMarketDataSpot", "HealCheckPostMarketDataSpotLaunched",
+        "HealPollPostMarketDataSpot", "HealCheckPostMarketDataSpotStatus",
+        "HealLaunchArcticAppendSpot", "HealCheckArcticAppendSpotLaunched",
+        "HealPollArcticAppendSpot", "HealCheckArcticAppendSpotStatus",
+        "HealReProbe", "HealCheckConverged",
+    ])
+    def test_every_failure_mode_in_the_loop_reaches_the_increment(self, states, failure_state):
+        # No dead end anywhere in the dispatch-poll-reprobe chain — every
+        # non-success branch must funnel back to HealLoopIncrement so the
+        # attempts/deadline bound (not an unbounded retry) is what stops it.
+        assert "HealLoopIncrement" in _targets(states[failure_state]), (
+            f"{failure_state} has a branch that does not reach HealLoopIncrement: "
+            f"{_targets(states[failure_state])}"
+        )
+
+
+class TestHealLoopDispatchChain:
+    def test_launch_postmarket_dispatches_with_force_on_demand(self, states):
+        st = states["HealLaunchPostMarketDataSpot"]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::lambda:invoke"
+        assert st["Parameters"]["FunctionName"] == _DISPATCHER_FN
+        assert st["Parameters"]["Payload"] == {
+            "workload": "post-market-data", "force_on_demand": True,
+        }
+        assert st["Next"] == "HealCheckPostMarketDataSpotLaunched"
+
+    def test_postmarket_success_chains_to_arctic_append(self, states):
+        succ = [c["Next"] for c in states["HealCheckPostMarketDataSpotStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["HealLaunchArcticAppendSpot"]
+
+    def test_postmarket_inprogress_loops_on_the_ssm_command_state(self, states):
+        # Deliverable #5: poll the SSM command's own state — unbounded wait
+        # loop (no attempt cap), bounded only by the box's own watchdog.
+        inprog = [c["Next"] for c in states["HealCheckPostMarketDataSpotStatus"]["Choices"]
+                  if c.get("StringEquals") == "InProgress"]
+        assert inprog == ["HealPostMarketDataSpotWait"]
+        assert states["HealPostMarketDataSpotWait"]["Next"] == "HealPollPostMarketDataSpot"
+
+    def test_launch_arctic_dispatches_with_force_on_demand(self, states):
+        st = states["HealLaunchArcticAppendSpot"]
+        assert st["Parameters"]["FunctionName"] == _DISPATCHER_FN
+        assert st["Parameters"]["Payload"] == {
+            "workload": "post-market-arctic-append", "force_on_demand": True,
+        }
+
+    def test_arctic_success_chains_to_reprobe(self, states):
+        succ = [c["Next"] for c in states["HealCheckArcticAppendSpotStatus"]["Choices"]
+                if c.get("StringEquals") == "Success"]
+        assert succ == ["HealReProbe"]
+
+    def test_reprobe_success_chains_to_convergence_check(self, states):
+        assert states["HealReProbe"]["Next"] == "HealCheckConverged"
+
+    def test_converged_choice_dispatches_the_replay(self, states):
+        hcc = states["HealCheckConverged"]
+        c = hcc["Choices"][0]
+        assert c["Variable"] == "$.precondition_probe.Payload.precondition_met"
+        assert c["BooleanEquals"] is True
+        assert c["Next"] == "HealDispatchReplay"
+        assert hcc["Default"] == "HealLoopIncrement"
+
+
+class TestHealDispatchReplay:
+    """Deliverable #3(c): the auto-replay reuses I2700's PROVEN input shape
+    exactly (skip_post_market_data + skip_capture_snapshot), as a SEPARATE
+    self-referential execution (never an in-place jump back through
+    CaptureSnapshot, which already ran once earlier in this same execution)."""
+
+    def test_self_referential_start_execution(self, states):
+        st = states["HealDispatchReplay"]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::states:startExecution"
+        assert st["Parameters"]["StateMachineArn.$"] == "$$.StateMachine.Id"
+
+    def test_replay_input_matches_i2700_proven_shape(self, states):
+        inp = states["HealDispatchReplay"]["Parameters"]["Input"]
+        assert inp["pipeline_role"] == "operator-replay"
+        assert inp["skip_post_market_data"] is True
+        assert inp["skip_capture_snapshot"] is True
+        assert inp["run_date.$"] == "$.run_date"
+        assert inp["trading_instance_id.$"] == "$.trading_instance_id"
+        assert inp["ec2_instance_id.$"] == "$.ec2_instance_id"
+
+    def test_replay_dispatch_failure_pages_not_silently_succeeds(self, states):
+        st = states["HealDispatchReplay"]
+        catches = [c for c in st["Catch"] if c["ErrorEquals"] == ["States.ALL"]]
+        assert len(catches) == 1
+        assert catches[0]["Next"] == "HealReplayDispatchFailed"
+
+    def test_success_reaches_converged_notify(self, states):
+        assert states["HealDispatchReplay"]["Next"] == "HealConvergedNotify"
+
+
+class TestHealOutcomeNotifications:
+    """The three SNS publishes downstream of the loop — each must be an SNS
+    Task (loud, not a swallow) and each must eventually reach the
+    cost-guard tail (CheckSkipDailySubstrateHealthCheck) regardless of its
+    own success/failure, mirroring every other best-effort-notify Catch
+    already established in this file (PublishDataSpotFailureImmediate,
+    PublishSubstrateHealthCheckDegradedAlert)."""
+
+    @pytest.mark.parametrize("state_name,subject_substr", [
+        ("HealConvergedNotify", "CONVERGED"),
+        ("HealReplayDispatchFailed", "REPLAY DISPATCH FAILED"),
+        ("HealNonConvergent", "DID NOT CONVERGE"),
+    ])
+    def test_is_sns_publish_with_distinct_subject(self, states, state_name, subject_substr):
+        st = states[state_name]
+        assert st["Type"] == "Task"
+        assert st["Resource"] == "arn:aws:states:::sns:publish"
+        assert subject_substr in st["Parameters"]["Subject"]
+        assert 0 < len(st["Parameters"]["Subject"]) <= 100
+        assert "\n" not in st["Parameters"]["Subject"]
+
+    @pytest.mark.parametrize("state_name", [
+        "HealConvergedNotify", "HealReplayDispatchFailed", "HealNonConvergent",
+    ])
+    def test_reaches_cost_guard_tail_on_success_and_on_sns_failure(self, states, state_name):
+        st = states[state_name]
+        assert st["Next"] == "CheckSkipDailySubstrateHealthCheck"
+        catches = [c for c in st["Catch"] if c["ErrorEquals"] == ["States.ALL"]]
+        assert len(catches) == 1
+        assert catches[0]["Next"] == "CheckSkipDailySubstrateHealthCheck"
+
+    def test_nonconvergent_never_reaches_a_halt_state(self, states):
+        _HALT = {"HandleFailure", "FailExecution", "ForceStopInstance"}
+        for tgt in _targets(states["HealNonConvergent"]):
+            assert tgt not in _HALT
+
+
+# ── IAM: the SF role can invoke the new Lambda + self-start-execution ───────
+
+
+class TestIamGrants:
+    @pytest.fixture(scope="class")
+    def policy(self):
+        return json.loads(_SF_ROLE.read_text())
+
+    def test_probe_lambda_is_grantable(self, policy):
+        lambda_stmt = next(
+            s for s in policy["Statement"] if s.get("Action") == "lambda:InvokeFunction"
+        )
+        assert any(
+            r.rstrip("*") == f"arn:aws:lambda:us-east-1:711398986525:function:{_PROBE_FN}"
+            for r in lambda_stmt["Resource"]
+        )
+
+    def test_self_start_execution_is_granted(self, policy):
+        assert any(
+            s.get("Action") == "states:StartExecution"
+            and s.get("Resource") == "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
+            for s in policy["Statement"]
+        )

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -48,7 +48,11 @@ _CHAIN = [
     # before LaunchPostMarketDataSpot — pinned separately in
     # TestEODDataSpotRetryBudget (test_sf_data_spot_relocation_wiring.py).
     ("CheckSkipPostMarketData", "InitDataSpotRetryCounter", "skip_post_market_data", "CheckSkipCaptureSnapshot"),
-    ("CheckSkipCaptureSnapshot", "CaptureSnapshot", "skip_capture_snapshot", "CheckSkipEODReconcile"),
+    # config-I2702 (2026-07-15): the skip edge now lands on
+    # ProbeEODReconcilePrecondition (the new verify-by-artifact precondition
+    # probe), not directly on CheckSkipEODReconcile — every path into the
+    # reconcile gate, skip or not, must probe fresh.
+    ("CheckSkipCaptureSnapshot", "CaptureSnapshot", "skip_capture_snapshot", "ProbeEODReconcilePrecondition"),
     ("CheckSkipEODReconcile", "EODReconcile", "skip_eod_reconcile", "CheckSkipDailySubstrateHealthCheck"),
     ("CheckSkipDailySubstrateHealthCheck", "DailySubstrateHealthCheck", "skip_daily_substrate_health_check", "StopTradingInstance"),
 ]
@@ -128,9 +132,13 @@ class TestEntryEdgesRouteThroughGates:
             assert gone not in states, f"{gone} should have moved to the spot dispatcher"
 
     def test_snapshot_success_enters_reconcile_gate(self, states):
+        # config-I2702: CaptureSnapshot's success now enters the new
+        # verify-by-artifact precondition probe, which itself feeds
+        # CheckSkipEODReconcile (pinned separately below).
         succ = [c["Next"] for c in states["CheckSnapshotStatus"]["Choices"]
                 if c.get("StringEquals") == "Success"]
-        assert succ == ["CheckSkipEODReconcile"]
+        assert succ == ["ProbeEODReconcilePrecondition"]
+        assert states["ProbeEODReconcilePrecondition"]["Next"] == "CheckSkipEODReconcile"
 
     def test_eod_success_enters_substrate_gate(self, states):
         succ = [c["Next"] for c in states["CheckEODStatus"]["Choices"]
@@ -174,14 +182,25 @@ class TestPaths:
         tasks = [c[1] for c in _CHAIN]
         idxs = [order.index(t) for t in tasks]
         assert idxs == sorted(idxs), order
-        assert order[-1] == "StopTradingInstance"
+        # config-I2702 deliverable #4: StopTradingInstance no longer
+        # terminates the execution directly — a fully-green run (no gap ever
+        # detected, $.degraded_summary never set) routes through
+        # CheckDegradedOutcome to the ordinary NormalSucceeded terminal.
+        assert order[-3:] == ["StopTradingInstance", "CheckDegradedOutcome", "NormalSucceeded"]
 
     def test_full_skip_still_stops_the_instance(self, states):
         order = self._walk(states, skip_flags={c[2] for c in _CHAIN})
         for task in (c[1] for c in _CHAIN):
             assert task not in order, f"{task} ran despite skip flag"
-        # Cost-guard cleanup must ALWAYS run.
-        assert order == ["StopTradingInstance"]
+        # Cost-guard cleanup must ALWAYS run, then reach the normal terminal.
+        # ProbeEODReconcilePrecondition still runs even on a fully-skipped
+        # path (default pipeline_role="operator-replay" here) — same
+        # unconditional-probe behavior pinned in
+        # test_operator_replay_still_honors_skips below.
+        assert order == [
+            "ProbeEODReconcilePrecondition", "StopTradingInstance",
+            "CheckDegradedOutcome", "NormalSucceeded",
+        ]
 
     def test_skip_refresh_resumes_at_data_spot(self, states):
         # config#1549: skipping only the deploy refresh (e.g. an operator rerun
@@ -192,7 +211,7 @@ class TestPaths:
         assert "RefreshExecutorDeploy" not in order
         assert order[0] == "InitDataSpotRetryCounter"
         assert order[1] == "LaunchPostMarketDataSpot"
-        assert order[-1] == "StopTradingInstance"
+        assert order[-3:] == ["StopTradingInstance", "CheckDegradedOutcome", "NormalSucceeded"]
 
     def test_skip_data_phase_resumes_at_snapshot(self, states):
         # config#1767: skip_post_market_data now skips the ENTIRE spot data phase
@@ -202,7 +221,7 @@ class TestPaths:
         assert "LaunchPostMarketDataSpot" not in order
         assert "LaunchPostMarketArcticAppendSpot" not in order
         assert order[0] == "CaptureSnapshot"
-        assert order[-1] == "StopTradingInstance"
+        assert order[-3:] == ["StopTradingInstance", "CheckDegradedOutcome", "NormalSucceeded"]
 
     def test_happy_path_runs_data_phase_on_spot(self, states):
         # config#1767: the EOD data phase runs as spot-launch states, in order,
@@ -223,7 +242,7 @@ class TestSkipFlagsInertOutsideOperatorReplay:
         order = self._walk(states, skip_flags={c[2] for c in _CHAIN}, pipeline_role="eod")
         for task in (c[1] for c in _CHAIN):
             assert task in order, f"{task} was skipped despite non-replay role"
-        assert order[-1] == "StopTradingInstance"
+        assert order[-3:] == ["StopTradingInstance", "CheckDegradedOutcome", "NormalSucceeded"]
 
     def test_all_skips_inert_when_role_absent(self, states):
         order = self._walk(states, skip_flags={c[2] for c in _CHAIN}, pipeline_role=None)
@@ -236,6 +255,13 @@ class TestSkipFlagsInertOutsideOperatorReplay:
             skip_flags={c[2] for c in _CHAIN},
             pipeline_role="operator-replay",
         )
-        assert order == ["StopTradingInstance"]
+        # config-I2702: even a fully-skipped operator-replay run still probes
+        # the precondition fresh (ProbeEODReconcilePrecondition sits between
+        # the CheckSkipCaptureSnapshot skip edge and CheckSkipEODReconcile
+        # unconditionally) before its own skip_eod_reconcile flag takes over.
+        assert order == [
+            "ProbeEODReconcilePrecondition", "StopTradingInstance",
+            "CheckDegradedOutcome", "NormalSucceeded",
+        ]
 
     _walk = TestPaths._walk

--- a/tests/test_sf_eod_substrate_check_wiring.py
+++ b/tests/test_sf_eod_substrate_check_wiring.py
@@ -345,14 +345,48 @@ class TestResultPathIsolation:
 
 
 class TestStopTradingInstanceUnchanged:
-    """StopTradingInstance must remain a terminal state — no rewiring
-    that defers it past the substrate check or makes it conditional."""
+    """StopTradingInstance must remain UNCONDITIONALLY reachable and must
+    never be deferred past the substrate check — the cost-guard invariant.
 
-    def test_stop_trading_instance_is_terminal(self, states):
-        # End=True means this state ends the execution (success path).
-        assert states["StopTradingInstance"].get("End") is True, (
-            "StopTradingInstance must remain a terminal End=true state on "
-            "the success path — anything else is a cost-overrun risk."
+    UPDATED config-I2702 (2026-07-15) deliverable #4: StopTradingInstance is
+    no longer a bare End=true terminal — it now routes to CheckDegradedOutcome
+    so a run that skipped EODReconcile (a data-gap self-heal) ends in a
+    DISTINCT terminal (DegradedSucceeded) rather than the same plain
+    ExecutionSucceeded a fully-green day gets. The cost-guard invariant this
+    class actually protects — "the trading EC2 always gets stopped, no
+    matter what happened upstream" — is UNCHANGED: CheckDegradedOutcome only
+    ever routes to one of two Succeed states, both AFTER StopTradingInstance
+    has already run. Neither NormalSucceeded nor DegradedSucceeded can be
+    reached without StopTradingInstance first — see the ASL wiring pinned in
+    test_sf_eod_precondition_probe_wiring.py.
+    """
+
+    def test_stop_trading_instance_routes_to_degraded_outcome_check(self, states):
+        sti = states["StopTradingInstance"]
+        assert "End" not in sti, (
+            "StopTradingInstance is no longer a bare End=true terminal "
+            "(config-I2702 deliverable #4) — it must route onward via Next."
+        )
+        assert sti["Next"] == "CheckDegradedOutcome"
+
+    def test_degraded_outcome_check_only_reaches_succeed_states(self, states):
+        cdo = states["CheckDegradedOutcome"]
+        assert cdo["Type"] == "Choice"
+        targets = {c["Next"] for c in cdo["Choices"]} | {cdo["Default"]}
+        for t in targets:
+            assert states[t]["Type"] == "Succeed", (
+                f"CheckDegradedOutcome must only ever route to a Succeed "
+                f"state (the cost-guard has already run by this point) — "
+                f"{t} is Type={states[t]['Type']}"
+            )
+
+    def test_stop_trading_instance_catch_unchanged(self, states):
+        # The failure path (Catch -> HandleFailure -> ForceStopInstance) is
+        # untouched by this change — only the SUCCESS Next moved.
+        catches = states["StopTradingInstance"].get("Catch", [])
+        assert any(
+            c["ErrorEquals"] == ["States.ALL"] and c["Next"] == "HandleFailure"
+            for c in catches
         )
 
 

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -651,6 +651,45 @@ class TestEODSFTopLevelFieldsClosed:
             "health_check_degraded",
             "substrate_health_check_degraded_notify",
             "substrate_health_check_degraded_notify_error",
+            # config-I2702 (2026-07-15): closed-loop self-heal for post-close
+            # data gaps. "run_date" is a PRE-EXISTING top-level input field
+            # (used since day one, embedded inside States.Format() command
+            # strings like EODReconcile's) that only now gets a BARE `"$.
+            # run_date"` reference — the regex above only matches strings that
+            # START with `$.`, and Lambda Payload fields
+            # (ProbeEODReconcilePrecondition, HealReProbe, HealDispatchReplay's
+            # Input) are the first place it's referenced that way.
+            "run_date",
+            # ProbeEODReconcilePrecondition (deliverable #1): fresh verify-by-
+            # artifact read of the macro-freshness sentinel, replacing the old
+            # $.data_spot_error flag test at CheckSkipEODReconcile. Re-emitted
+            # (overwritten) by HealReProbe inside the heal loop below.
+            "precondition_probe",
+            # SetDegradedFlag (deliverable #4): persistent flag read by
+            # CheckDegradedOutcome (after the StopTradingInstance cost-guard
+            # tail) to route to the distinct DegradedSucceeded terminal instead
+            # of NormalSucceeded.
+            "degraded_summary",
+            # The closed self-heal loop (deliverable #3): InitHealLoop /
+            # HealLoopIncrement carry the attempts counter; each heal
+            # iteration's data-spot dispatch + poll emits its own launch/poll/
+            # error ResultPath (mirrors the pre-existing postmarket_launch /
+            # postmarket_poll / data_spot_error naming, prefixed heal_ to keep
+            # the original phase's fields untouched); HealDispatchReplay emits
+            # the auto-replay StartExecution result (or its Catch error); the
+            # three outcome notifications (converged / replay-dispatch-failed /
+            # non-convergent) each emit their own SNS ResultPath.
+            "heal_loop",
+            "heal_postmarket_launch",
+            "heal_postmarket_poll",
+            "heal_arctic_launch",
+            "heal_arctic_poll",
+            "heal_error",
+            "heal_replay_dispatch",
+            "heal_replay_dispatch_error",
+            "heal_replay_dispatch_failed_notify",
+            "heal_converged_notify",
+            "heal_nonconvergent_notify",
         }
     )
 

--- a/tests/test_weekly_collector_phase_registry.py
+++ b/tests/test_weekly_collector_phase_registry.py
@@ -218,3 +218,113 @@ def test_build_registry_reads_hard_caps_from_config():
     cfg = {"bucket": "b", "full_run_hard_caps_seconds": {"prices": 1200.0}}
     reg = weekly_collector._build_registry(cfg, _args(), "2026-06-13")
     assert reg._hard_caps == {"prices": 1200.0}
+
+
+# ── verify_artifact_exists (config-I2702 deliverable #2) ─────────────────────
+#
+# rc=0 / status="ok" must mean the contracted artifact actually landed on S3,
+# never just "the collector call didn't raise". These tests drive
+# _phase_collect's NEW verify_artifact_exists gate directly against a
+# _FakeS3 substituted for boto3.client("s3") inside _s3_object_exists —
+# independent of the PhaseRegistry's OWN marker-vs-artifact auto-skip check
+# (test_marker_ok_but_artifact_missing_reruns, above), which is a different
+# mechanism (a marker recorded on a PRIOR run) than this same-run gate.
+
+
+def test_verify_artifact_exists_passes_when_artifact_present(monkeypatch):
+    art = "staging/daily_closes/2026-06-13.parquet"
+    fake = _FakeS3(artifacts={art})
+    monkeypatch.setattr(weekly_collector.boto3, "client", lambda *a, **k: fake)
+
+    out = weekly_collector._phase_collect(
+        _reg(fake), "daily_closes", lambda: {"status": "ok"},
+        artifact_key=art, verify_artifact_exists=True, bucket="alpha-engine-research",
+    )
+    assert out["status"] == "ok"
+
+
+def test_verify_artifact_exists_downgrades_ok_to_error_when_artifact_absent(monkeypatch):
+    # The exact 2026-07-15-class bug: the collector's own internal logic
+    # reports status="ok" but the parquet never actually landed on S3.
+    art = "staging/daily_closes/2026-06-13.parquet"
+    fake = _FakeS3()  # artifacts deliberately empty
+    monkeypatch.setattr(weekly_collector.boto3, "client", lambda *a, **k: fake)
+
+    out = weekly_collector._phase_collect(
+        _reg(fake), "daily_closes", lambda: {"status": "ok"},
+        artifact_key=art, verify_artifact_exists=True, bucket="alpha-engine-research",
+    )
+    assert out["status"] == "error"
+    assert "does not exist" in out["error"]
+    assert "config-I2702" in out["error"]
+
+
+def test_verify_artifact_exists_error_marker_reruns_next_attempt(monkeypatch):
+    art = "staging/daily_closes/2026-06-13.parquet"
+    fake = _FakeS3()
+    monkeypatch.setattr(weekly_collector.boto3, "client", lambda *a, **k: fake)
+
+    weekly_collector._phase_collect(
+        _reg(fake), "daily_closes", lambda: {"status": "ok"},
+        artifact_key=art, verify_artifact_exists=True, bucket="alpha-engine-research",
+    )
+    calls = []
+    weekly_collector._phase_collect(
+        _reg(fake), "daily_closes", lambda: calls.append(1) or {"status": "ok"},
+        artifact_key=art, verify_artifact_exists=True, bucket="alpha-engine-research",
+    )
+    assert calls == [1], "a verify-by-artifact failure must not auto-skip the retry"
+
+
+def test_verify_artifact_exists_skips_check_on_dry_run_status(monkeypatch):
+    # ok_dry_run collectors write nothing real to S3 — the verify gate must
+    # not spuriously fail a dry-run.
+    art = "staging/daily_closes/2026-06-13.parquet"
+    fake = _FakeS3()  # no artifacts — a real check here would fail
+    monkeypatch.setattr(weekly_collector.boto3, "client", lambda *a, **k: fake)
+
+    out = weekly_collector._phase_collect(
+        _reg(fake), "daily_closes", lambda: {"status": "ok_dry_run"},
+        artifact_key=art, verify_artifact_exists=True, bucket="alpha-engine-research",
+    )
+    assert out["status"] == "ok_dry_run"
+
+
+def test_verify_artifact_exists_false_leaves_existing_behavior_unchanged(monkeypatch):
+    # Default (verify_artifact_exists=False, the ~19 untouched call sites)
+    # must never call _s3_object_exists at all.
+    art = "staging/daily_closes/2026-06-13.parquet"
+    fake = _FakeS3()  # no artifacts — would fail the check if it ran
+
+    def _boom_client(*a, **k):
+        raise AssertionError("boto3.client must not be called when verify_artifact_exists=False")
+
+    monkeypatch.setattr(weekly_collector.boto3, "client", _boom_client)
+
+    out = weekly_collector._phase_collect(
+        _reg(fake), "daily_closes", lambda: {"status": "ok"}, artifact_key=art,
+    )
+    assert out["status"] == "ok"
+
+
+def test_s3_object_exists_head_true(monkeypatch):
+    fake = _FakeS3(artifacts={"a/b.parquet"})
+    monkeypatch.setattr(weekly_collector.boto3, "client", lambda *a, **k: fake)
+    assert weekly_collector._s3_object_exists("bucket", "a/b.parquet") is True
+
+
+def test_s3_object_exists_head_false_on_404(monkeypatch):
+    fake = _FakeS3()
+    monkeypatch.setattr(weekly_collector.boto3, "client", lambda *a, **k: fake)
+    assert weekly_collector._s3_object_exists("bucket", "a/b.parquet") is False
+
+
+def test_s3_object_exists_raises_on_other_client_error(monkeypatch):
+    class _Boom(_FakeS3):
+        def head_object(self, Bucket, Key):
+            raise ClientError({"Error": {"Code": "AccessDenied", "Message": "no"}}, "HeadObject")
+
+    fake = _Boom()
+    monkeypatch.setattr(weekly_collector.boto3, "client", lambda *a, **k: fake)
+    with pytest.raises(ClientError):
+        weekly_collector._s3_object_exists("bucket", "a/b.parquet")

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 import boto3
 import yaml
+from botocore.exceptions import ClientError
 
 def _load_dotenv() -> None:
     """Load .env file into os.environ (lightweight, no dependency).
@@ -168,6 +169,23 @@ def _build_registry(config: dict, args: argparse.Namespace, date: str) -> "Phase
     )
 
 
+def _s3_object_exists(bucket: str, key: str) -> bool:
+    """HEAD-check an S3 object. Any non-404/NoSuchKey ClientError (IAM drift,
+    throttling, etc.) RAISES — fail-loud per feedback_no_silent_fails; a
+    verification check that silently treats "couldn't check" as "doesn't
+    exist" would produce nondeterministic spurious failures, and treating it
+    as "exists" would defeat the whole point of verify-by-artifact."""
+    s3 = boto3.client("s3")
+    try:
+        s3.head_object(Bucket=bucket, Key=key)
+        return True
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey"):
+            return False
+        raise
+
+
 def _phase_collect(
     reg: "PhaseRegistry | None",
     name: str,
@@ -175,6 +193,8 @@ def _phase_collect(
     *,
     artifact_key: str | None = None,
     supports_auto_skip: bool = True,
+    verify_artifact_exists: bool = False,
+    bucket: str | None = None,
 ) -> dict:
     """Run a collector under the phase registry (markers + L4524 artifact-validated
     auto-skip + watchdog), preserving the module's best-effort-continue posture.
@@ -191,6 +211,18 @@ def _phase_collect(
 
     ``supports_auto_skip=False`` (multi-file / shared-DB / ArcticDB producers with no
     single stable S3 key) → markers + watchdog only, the phase always runs.
+
+    ``verify_artifact_exists=True`` (config-I2702 deliverable #2, "verify-by-artifact
+    workloads"): after a collector reports ``status="ok"``, HEAD-check that
+    ``artifact_key`` actually exists on S3 BEFORE recording success — a collector's own
+    internal ``status="ok"`` reflects "the fetch/write call didn't raise", not "the
+    contracted output is queryable". A missing artifact downgrades the phase to
+    ``error``, which _CollectorError already routes to main()'s existing
+    ``results["status"] not in ("ok", "skipped") -> SystemExit(1)`` contract — no new
+    exit-code plumbing needed, just a stricter success predicate. Skipped for
+    ``status="ok_dry_run"`` (dry-run collectors write nothing real to verify) and for
+    auto-skip cache hits (the L4524 auto-skip check already re-verified the artifact's
+    presence via its own S3 probe before returning the cache hit).
     """
     if reg is None:
         try:
@@ -208,6 +240,19 @@ def _phase_collect(
             result = run_fn() or {}
             if result.get("status") == "error":
                 raise _CollectorError(name, result.get("error"))
+            if verify_artifact_exists and artifact_key and result.get("status") == "ok":
+                if bucket is None:
+                    raise _CollectorError(
+                        name, "verify_artifact_exists=True but bucket was not supplied to _phase_collect"
+                    )
+                if not _s3_object_exists(bucket, artifact_key):
+                    raise _CollectorError(
+                        name,
+                        f"collector reported status=ok but its contracted artifact "
+                        f"s3://{bucket}/{artifact_key} does not exist (verify-by-artifact, "
+                        f"config-I2702 deliverable #2 — rc=0 must mean the artifact exists, "
+                        f"never just 'the process did not crash')",
+                    )
             if artifact_key and result.get("status") in ("ok", "ok_dry_run"):
                 ctx.record_artifact(artifact_key)
             return result
@@ -2245,6 +2290,14 @@ def _run_daily(config: dict, args: argparse.Namespace) -> dict:
             skip_if_canonical=skip_if_canonical,
         ),
         artifact_key=f"{_dc_prefix}{run_date}.parquet",
+        # config-I2702 deliverable #2: this collector's artifact is the EOD
+        # post-market-data data-spot workload's whole contracted output — the
+        # PostMarketArcticAppend state (and the reconcile-only replay's
+        # skip_post_market_data=false path) read this exact parquet. A
+        # collector that reports status=ok without the file actually landing
+        # on S3 must not be treated as success.
+        verify_artifact_exists=True,
+        bucket=bucket,
     )
 
     # Metron market-data producer — EOD closes + FX for Metron's held-ticker universe.


### PR DESCRIPTION
## Summary

Rearchitects `ne-postclose-trading-pipeline`'s data-gap self-heal from "fail-soft + overnight heal + MANUAL operator-replay" into a closed loop that converges WITHOUT any operator step, verifies by ARTIFACT (never a stale flag), and can never report plain-green while degraded — per alpha-engine-config-I2702 (P0), Brian's 2026-07-15 ruling: *"I don't trust the self heal — make sure it is implemented robustly and with a SOTA approach."*

Closes: nousergon/alpha-engine-config#2702 (cross-repo issue — GitHub auto-close only works within this repo, so this line is documentation, not an auto-close directive)

## Deliverable → diff map

| # | Deliverable | Where |
|---|---|---|
| 1 | Verify-by-artifact precondition probe | `infrastructure/lambdas/eod-precondition-probe/` (new Lambda) + `ProbeEODReconcilePrecondition` state + rewritten `CheckSkipEODReconcile` in `infrastructure/step_function_eod.json` |
| 2 | Artifact-asserting workloads | `weekly_collector.py::_phase_collect` (`verify_artifact_exists` — S3 HEAD-check before declaring `status="ok"`) + `builders/daily_append.py` (new `feature_store/_macro_freshness.json` sentinel, written only after readback-verification passes) |
| 3 | Closed-loop auto-replay | `SetDegradedFlag → CheckHealLoopEligible → InitHealLoop → HealLoopGate → Heal{Launch,Poll,Check}{PostMarketData,ArcticAppend}Spot → HealReProbe → HealCheckConverged → HealDispatchReplay` in `step_function_eod.json` |
| 4 | Degraded terminal state | `StopTradingInstance → CheckDegradedOutcome → {NormalSucceeded, DegradedSucceeded}` in `step_function_eod.json` |
| 5 | Poll budgets sized to reality | Widened `PollPostMarketDataSpot`/`PollPostMarketArcticAppendSpot` transient-SDK-error retry budget (2→6 attempts, 5s→15s base, 1.5x→2.0x backoff); new heal-loop poll states poll the SSM command's own authoritative state, unbounded on InProgress (bounded only by the data-spot box's own `MAX_RUNTIME_SECONDS=7200` watchdog) |

## Design decisions

**Deliverable 1 — why the probe reads S3, not ArcticDB directly.** The issue text says "a small Lambda checking run_date's SPY close exists in ArcticDB." I did not implement that literally: Brian's 2026-07-08 config#1787 "Option-B" ruling (recorded in `alpha-engine-config/private-docs/ARTIFACT_REGISTRY.yaml`) explicitly rejected first-class ArcticDB access from Lambda-side freshness probes as premature generalization for one consumer, and it would require bundling the `arcticdb` package (+ likely VPC networking) into a Lambda deploy image. Instead: `builders/daily_append.py`'s existing producer-side ArcticDB readback-verification (it already re-reads every macro key after writing, to catch the "SDK call succeeded but the row didn't land" class) now also writes a small S3 sentinel (`feature_store/_macro_freshness.json`) carrying `run_date` + `verified_keys` — the new Lambda reads that. This is *stronger* than a live query (it's checking an already-verified fact, not racing a read against a write) and stays within the established S3-only Lambda-reachability constraint. **SOTA delta:** the SOTA-est option would be a first-class ArcticDB `ArtifactSpec` backend in `nousergon_lib.artifact_freshness` (Option A) — Brian already ruled that out as premature generalization for one consumer; this PR follows that ruling rather than relitigating it.

**Deliverable 3 — why the auto-replay is a separate `states:startExecution`, not an in-place loop-back.** `CaptureSnapshot` sits *upstream* of the reconcile gate in the pipeline order and already ran once earlier in the same execution by the time a gap is detected. Looping the heal-dispatch back through the existing `LaunchPostMarketDataSpot`/`InitDataSpotRetryCounter` states would re-enter `CheckSkipCaptureSnapshot` and re-trigger a second live-IB snapshot capture — exactly what I2700's `skip_capture_snapshot` flag exists to prevent. So the heal loop gets its own leaner dispatch/poll sub-chain (`HealLaunch*`/`HealPoll*`, force_on_demand=true, no separate inner retry-budget — the outer 2-attempt heal-loop bound covers that), and convergence launches a **separate** self-referential execution (`$$.StateMachine.Id`) with I2700's exact proven input shape. This decouples "did this execution stay live and healthy" (fire-and-forget) from "did reconcile actually happen" (the replay execution's own SUCCEEDED/FAILED status — independently observable, named `eod-heal-replay-{run_date}-*`).

**Deliverable 3 — orchestrator reuse, checked first.** Per the task's explicit instruction, I audited the existing fleet-watch/rerun machinery before writing anything new: `freshness-monitor`'s declarative `recovery:` dispatch (config#1240) is the closest generalized precedent but operates at 15-min-cycle artifact granularity with cooldown-based dedup, not bounded-attempt-then-page; `saturday-sf-watch-dispatcher` already reacts to `ne-postclose-trading-pipeline`'s terminal FAILED status with bounded retry + escalation, but only at whole-SF granularity and this design deliberately does NOT want a blind whole-SF rerun (it would re-run `RefreshExecutorDeploy`/`CaptureSnapshot` unnecessarily and could restart the trading box after-hours). Neither fits the "detect mid-execution → dispatch the *specific* missing workload → re-probe → replay-only" shape this issue asks for, so the loop lives inside the ASL itself, reusing the *existing* `data-spot-dispatcher` Lambda and the *existing* Launch/Poll/Retry idiom already used twice in this file (mirrors `InitDataSpotRetryCounter`/`CheckDataSpotRetryBudget`) rather than inventing a parallel orchestrator.

**Deliverable 4 — why `Succeed` not `Fail`.** I2699 (the sibling issue, now partially superseded) proposed ending degraded runs in a `Fail` state specifically so every existing status-keyed watcher (sf-watch, EventBridge rules, the notifier) engages with zero new plumbing. I2702 explicitly restates this deliverable as *"a Succeed state with an explicit degraded flag + a differently-labeled notification"* — a deliberate change once the closed-loop heal (deliverable 3) exists: a `Fail` status on this execution would trigger `saturday-sf-watch-dispatcher`'s bounded-retry-then-escalate machinery, which would blindly rerun the *whole* EOD SF (restarting `RefreshExecutorDeploy`, re-launching the trading box after it's already stopped) — redundant with and potentially conflicting with the in-ASL heal loop this PR just built. So: `DegradedSucceeded` (still reports AWS status SUCCEEDED — unavoidable for a `Succeed` state) carries the distinguishing signal via (a) a different state name + `$.degraded_summary` on the execution output, and (b) dedicated SNS/Telegram notifications fired earlier in the same execution (`SkipEODReconcileDataGap`, then `HealConvergedNotify` or `HealNonConvergent`) — mirroring this file's own established pattern for exactly this kind of signal (`PublishDataSpotFailureImmediate`, `SubstrateHealthCheckDegraded` + `PublishSubstrateHealthCheckDegradedAlert`) rather than relying on `sf-telegram-notifier`'s generic execution-status rendering, which doesn't special-case `Succeed`-state names. **SOTA delta:** the more "textbook" choice remains `Fail` (matches I2699's original rationale, engages existing watchers for free) — I deliberately deviated because this design's closed loop already owns detect→retry→escalate internally, and reusing `Fail` would double-dispatch a whole-SF rerun on top of it. Flagging this explicitly since it's a genuine judgment call, not a forced move.

## Test plan (this PR)

- Full repo suite: **3229 passed, 11 skipped, 0 failed** (clean venv, `pip install -r requirements.txt`, no environment stubbing beyond what the suite already does).
- `infrastructure/lambdas/eod-precondition-probe/test_handler.py`: 16/16 passing (S3 sentinel read, run_date/key evaluation, 09:00 UTC deadline math, fail-loud on non-404 S3 errors).
- New `tests/test_sf_eod_precondition_probe_wiring.py` (49 tests): full ASL structural pin — every Next/Default/Catch target resolves, every state reachable from `StartAt`, no Succeed/Fail state has an outgoing edge, the probe/heal-loop/degraded-terminal shape end to end, IAM grants present.
- Updated pre-existing pinning tests (`test_sf_eod_skipgate_wiring.py`, `test_sf_data_spot_relocation_wiring.py`, `test_sf_eod_substrate_check_wiring.py`, `test_sf_payload_uniqueness.py`) to reflect the deliberate wiring changes — each diff documents *why* in an inline comment, per repo convention.
- `ruff check` on every new/touched file: 0 new findings (pre-existing lint debt elsewhere in `weekly_collector.py`/`daily_append.py` is untouched, confirmed line-by-line against this diff — this repo has no CI-enforced ruff gate today).

## Forced-gap chaos validation (post-merge, operator-run, controlled window)

Not run in this PR per the task constraints (production trading infra — no live chaos tests, no deploy). Sequence for the operator once deployed:

1. **Deploy**: `bash infrastructure/lambdas/eod-precondition-probe/deploy.sh --bootstrap`, `aws iam put-role-policy` (or re-apply) the updated `alpha-engine-step-functions-role.json`, then `bash infrastructure/update_eod_pipeline_sf.sh` (or let the standard `deploy-infrastructure.sh` auto-deploy on merge pick it up).
2. **Convergent-gap test**: pick a near-term trading day, withhold/delete that day's `SPY` row from the ArcticDB `macro` library (or simply let a live spot-quota/interruption failure occur, which is the actual 2026-07-15 trigger), then let the daily EOD run fire normally. Expected: `SkipEODReconcileDataGap` fires → `DEGRADED` Telegram/SNS alert → heal loop dispatches `post-market-data` + `post-market-arctic-append` → `HealReProbe` confirms `precondition_met=true` → `HealConvergedNotify` fires → a new `eod-heal-replay-{run_date}-*` execution appears and SUCCEEDS → `trades/eod_pnl.csv` gets the `run_date` row → **zero operator actions**.
3. **Non-convergent test**: force the re-dispatched workload to fail twice in a row (e.g. temporarily set `DATA_SPOT_DISPATCH_ENABLED=false` on the dispatcher, or a synthetic IAM deny) — expected: `HealNonConvergent` fires a loud, distinctly-labeled SNS/Telegram page within 2 heal-loop attempts, execution ends `DegradedSucceeded` (not plain green), `$.degraded_summary` present on the execution output.
4. **Regression check**: a normal, fully-green trading day still ends `NormalSucceeded` with the same behavior as today's `ExecutionSucceeded`.

## What I could NOT complete in this PR

- **`alpha-engine-config/private-docs/ARTIFACT_REGISTRY.yaml` registration** for the new `feature_store/_macro_freshness.json` sentinel (mirroring the existing `feature_store/_freshness.json` entry) — that file lives in the private `alpha-engine-config` repo, out of this PR's scope (cross-repo, and that repo has its own one-PR-per-session private-docs convention owned by the orchestrating session, not this sub-task). `tests/test_artifact_registry_coverage.py`'s pinned PUT-site count for `builders/daily_append.py` is bumped (3→4) with an inline comment flagging this exact follow-up.
- **Live deployment and chaos validation** — explicitly out of scope per the task's constraints (production trading infra; PR is the deliverable, live validation happens post-merge in a controlled window per the plan above).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
