### PR TITLE
fix(eod-sf): drop stray state-level Message.$ that failed UpdateStateMachine (Deploy main RED)

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1277,8 +1277,7 @@
           "Next": "SetDegradedFlag"
         }
       ],
-      "Next": "SetDegradedFlag",
-      "Message.$": "States.Format('EOD reconcile SKIPPED for {}: the precondition probe found run_date\\'s SPY close not yet verified-present in ArcticDB. Entering the closed-loop self-heal (dispatch missing workload(s) -> re-probe -> auto-replay) \u2014 no operator action required unless a follow-up DID-NOT-CONVERGE alert fires. Probe detail: {}', $.run_date, States.JsonToString($.precondition_probe))"
+      "Next": "SetDegradedFlag"
     },
     "SetDegradedFlag": {
       "Type": "Pass",

--- a/tests/test_sf_asl_intrinsic_literals.py
+++ b/tests/test_sf_asl_intrinsic_literals.py
@@ -63,3 +63,108 @@ def test_no_single_quote_inside_intrinsic_string_literals(sf_path: Path):
         "(SCHEMA_VALIDATION_FAILED). Rephrase without apostrophes:\n  "
         + "\n  ".join(offenders)
     )
+
+
+# --- unsupported top-level state fields ---------------------------------
+#
+# Second offline ASL-grammar rule, same philosophy as the single-quote check
+# above: the structural wiring tests validate JSON shape, not AWS's ASL
+# grammar, so an unsupported field placed at a state's TOP LEVEL (rather than
+# inside its Parameters payload) is invisible locally and only detonates at
+# deploy. 2026-07-15 instance: alpha-engine-config-I2702 (nousergon-data PR
+# #850) added a second, precondition-probe-worded ``Message.$`` at the TOP
+# LEVEL of the ``SkipEODReconcileDataGap`` sns:publish Task — a copy that was
+# meant to live inside ``Parameters`` (where the state already has its real,
+# test-pinned ``Message.$``). ``Message.$`` is a task-input field, only legal
+# under ``Parameters``; at the state level AWS rejects the whole definition
+# with ``SCHEMA_VALIDATION_FAILED: Field 'Message.$' is not supported at
+# /States/SkipEODReconcileDataGap`` — which took down the Deploy Infrastructure
+# workflow's UpdateStateMachine step (run 29456675231, main went RED).
+#
+# This test closes that grammar rule cheaply and offline. The complete
+# structural fix (validate every definition against the real AWS API via
+# validate-state-machine-definition before UpdateStateMachine) remains
+# alpha-engine-config#1897.
+
+# Top-level fields the Amazon States Language allows per state Type. Union of
+# the fields common to all states plus each Type's own. Intentionally the full
+# spec set (not just fields this repo uses today) so a future *legal* field is
+# not a false positive, while an unsupported field (a payload key that leaked
+# out of Parameters, a typo) is caught. ``.$``-suffixed keys are NEVER legal at
+# the state level — that suffix is only for JSONPath substitution inside
+# Parameters / ResultSelector / ItemSelector payload templates.
+_ASL_COMMON = {"Type", "Comment", "QueryLanguage"}
+_ASL_FIELDS = {
+    "Task": _ASL_COMMON | {
+        "Resource", "Parameters", "Arguments", "Credentials", "ResultPath",
+        "ResultSelector", "Retry", "Catch", "TimeoutSeconds",
+        "TimeoutSecondsPath", "HeartbeatSeconds", "HeartbeatSecondsPath",
+        "Next", "End", "InputPath", "OutputPath", "Assign", "Output",
+    },
+    "Choice": _ASL_COMMON | {
+        "Choices", "Default", "InputPath", "OutputPath", "Assign",
+    },
+    "Pass": _ASL_COMMON | {
+        "Result", "ResultPath", "Parameters", "InputPath", "OutputPath",
+        "Next", "End", "Assign", "Output",
+    },
+    "Wait": _ASL_COMMON | {
+        "Seconds", "Timestamp", "SecondsPath", "TimestampPath", "Next", "End",
+        "InputPath", "OutputPath", "Assign",
+    },
+    "Succeed": _ASL_COMMON | {"InputPath", "OutputPath", "Assign", "Output"},
+    "Fail": _ASL_COMMON | {"Cause", "CausePath", "Error", "ErrorPath"},
+    "Parallel": _ASL_COMMON | {
+        "Branches", "ResultPath", "ResultSelector", "Retry", "Catch", "Next",
+        "End", "InputPath", "OutputPath", "Parameters", "Arguments", "Assign",
+        "Output",
+    },
+    "Map": _ASL_COMMON | {
+        "ItemProcessor", "Iterator", "ItemsPath", "ItemReader", "ItemSelector",
+        "ItemBatcher", "ResultWriter", "MaxConcurrency", "MaxConcurrencyPath",
+        "ResultPath", "ResultSelector", "Retry", "Catch", "Next", "End",
+        "InputPath", "OutputPath", "Parameters", "Arguments",
+        "ToleratedFailurePercentage", "ToleratedFailurePercentagePath",
+        "ToleratedFailureCount", "ToleratedFailureCountPath", "Assign",
+        "Output",
+    },
+}
+
+
+def _iter_states(states: dict, path: str = ""):
+    """Yield (state_path, state_name, state_dict) for every state, recursing
+    into nested Parallel Branches and Map ItemProcessor/Iterator sub-states."""
+    for name, state in states.items():
+        if not isinstance(state, dict):
+            continue
+        here = f"{path}/{name}"
+        yield here, name, state
+        for branch in state.get("Branches", []):
+            yield from _iter_states(branch.get("States", {}), here)
+        for proc_key in ("ItemProcessor", "Iterator"):
+            proc = state.get(proc_key)
+            if isinstance(proc, dict) and "States" in proc:
+                yield from _iter_states(proc["States"], here)
+
+
+@pytest.mark.parametrize("sf_path", SF_FILES, ids=lambda p: p.name)
+def test_no_unsupported_top_level_state_fields(sf_path: Path):
+    doc = json.loads(sf_path.read_text())
+    offenders = []
+    for state_path, _name, state in _iter_states(doc.get("States", {})):
+        state_type = state.get("Type")
+        allowed = _ASL_FIELDS.get(state_type)
+        if allowed is None:
+            offenders.append(f"{sf_path.name}{state_path} :: unknown Type={state_type!r}")
+            continue
+        for key in state:
+            # A payload/JSONPath-substitution key (Message.$, Payload.$, ...)
+            # is only legal inside Parameters — never at the state level.
+            if key.endswith(".$") or key not in allowed:
+                offenders.append(f"{sf_path.name}{state_path} :: {key} (Type={state_type})")
+    assert not offenders, (
+        "Unsupported top-level state field(s) — AWS rejects the definition at "
+        "deploy time (SCHEMA_VALIDATION_FAILED: 'Field <X> is not supported'). "
+        "A task-input field (Message.$, Payload, ...) belongs inside "
+        "Parameters, not at the state level:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Root cause
The **Deploy Infrastructure** workflow went RED on `main` ([run 29456675231](https://github.com/nousergon/nousergon-data/actions/runs/29456675231)) at the `UpdateStateMachine` step:

```
aws: [ERROR]: An error occurred (InvalidDefinition) when calling the UpdateStateMachine operation:
Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Field 'Message.$' is not supported
at /States/SkipEODReconcileDataGap'
```

config-I2702 (PR #850, the merge that produced the red SHA `f00cdea`) added a **second, precondition-probe-worded `Message.$` at the TOP LEVEL** of the `SkipEODReconcileDataGap` `sns:publish` Task — a sibling of `Parameters`/`Catch`/`Next` — alongside the real `Message.$` already inside `Parameters`. `Message.$` is a task-input field, legal only under `Parameters`; at the state level Amazon States Language rejects the entire definition. The offline wiring/ASL tests validate JSON shape and one grammar rule (single quotes) but not field-legality, so this passed PR CI and only detonated at deploy — the exact "invisible locally, detonates at deploy" class `tests/test_sf_asl_intrinsic_literals.py` already documents.

The stray key was a pure editing artifact: the diff shows `Parameters.Message.$` (referencing `$.data_spot_error`) was **preserved** (only an em-dash re-encoded); the top-level copy was a newly-added line.

## The fix and why it is correct at this layer
Remove the stray top-level `Message.$`. Nothing else changes:
- `Parameters.Message.$` (the `$.data_spot_error` message, **pinned green** by `test_sf_data_spot_relocation_wiring.py:515`) is the intended, in-scope message and is left untouched — so the loud, distinctly-labeled SNS alert still fires. **No fail-loud regression** (the swallow-shaped failure would have been *dropping* the alert; this keeps it).
- Resulting top-level keys are all ASL-legal for a Task: `Catch, Comment, Next, Parameters, Resource, ResultPath, Type`.
- This is orchestration glue (HOW the pipeline notifies), not scoring/weights/trading logic — no change to what the system believes or trades.

## Guard that now covers this failure class
New offline test `test_no_unsupported_top_level_state_fields` (same file/philosophy as the sibling single-quote guard): asserts every state's top-level keys are within the ASL-legal set for its `Type`, across all `step_function*.json`, and that no `.$`-suffixed key (a payload field) leaks to the state level. Verified: **fails** on the pre-fix definition (naming `SkipEODReconcileDataGap :: Message.$ (Type=Task)`), **passes** on the fix, and clean across all 6 SF definitions today.

## Validation
`pytest tests/test_sf_asl_intrinsic_literals.py tests/test_sf_data_spot_relocation_wiring.py tests/test_sf_eod_precondition_probe_wiring.py` → **125 passed**. Deploy is idempotent (`update-state-machine` full-definition replace + CREATE-if-absent log group), so the post-merge main deploy safely re-converges all state machines (the EOD machine still runs its pre-#850 definition live; the other four were already re-stamped before the EOD update failed).

The complete structural fix — validate every definition against the real AWS API (`validate-state-machine-definition`) before `UpdateStateMachine` — remains **alpha-engine-config#1897** (commented with this incident).

---
🤖 Autonomous Fleet CI Watch — root-caused, fixed, guarded. Triggered by `notify-ci-failure` on nousergon-data Deploy Infrastructure.