### PR TITLE
fix(probe): scoped s3:ListBucket for sentinel 404 semantics (I2702 rollout)

### DIFF
--- a/infrastructure/lambdas/eod-precondition-probe/iam-policy.json
+++ b/infrastructure/lambdas/eod-precondition-probe/iam-policy.json
@@ -14,8 +14,21 @@
     {
       "Sid": "ReadMacroFreshnessSentinel",
       "Effect": "Allow",
-      "Action": ["s3:GetObject"],
+      "Action": [
+        "s3:GetObject"
+      ],
       "Resource": "arn:aws:s3:::alpha-engine-research/feature_store/_macro_freshness.json"
+    },
+    {
+      "Sid": "ListBucketForSentinel404",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringEquals": {
+          "s3:prefix": "feature_store/_macro_freshness.json"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Post-deploy smoke test caught the probe raising AccessDenied on the not-yet-existing sentinel (S3 masks 404 as 403 without ListBucket). One condition-scoped statement; the probe's own NoSuchKey handling then works as written. Applying live in-session alongside merge per the merge-button-final rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)