### PR TITLE
fix(sf-watch-liveness-probe): grant Describe/ListExecutions on the two PR832 child SFs

### DIFF
--- a/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-liveness-probe/iam-policy.json
@@ -35,7 +35,9 @@
       "Resource": [
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
         "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
-        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-advisory-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-modelzoo-sunday-pipeline"
       ]
     },
     {


### PR DESCRIPTION
## What

Adds `ne-weekly-advisory-pipeline` and `ne-modelzoo-sunday-pipeline` to the `states:DescribeStateMachine`/`states:ListExecutions` resource list in the probe's `iam-policy.json`.

## Why

nousergon-data-PR832 widened the probe's SF coverage list in `index.py` but missed the matching IAM resource entries — the deployed probe crashes `AccessDeniedException` on every invocation (twice-daily cron) once the PR832 code is deployed. Caught by the `deploy.sh --smoke` gate while completing alpha-engine-config-I2567.

## Deploy state

Policy already applied live via `aws iam put-role-policy` in the filing session (operator-consented, read-only Describe/List on the two new SF ARNs only). Merging this PR is the repo-side record — no post-merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)