### PR TITLE
ci(deps): group major bumps into one monthly PR (alpha-engine-config-I2734)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Standard fleet Dependabot config (weekly, grouped minor+patch) — alpha-engine-config-I2525
-# Majors ride separate individual PRs deliberately (scrutiny before merge).
+# Majors are grouped into a single monthly PR per ecosystem — alpha-engine-config-I2734
 version: 2
 updates:
   - package-ecosystem: pip
@@ -11,6 +11,25 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      majors:
+        update-types:
+          - major
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -20,3 +39,22 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      majors:
+        update-types:
+          - major
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+


### PR DESCRIPTION
## Summary
- Splits each `.github/dependabot.yml` ecosystem entry into two: the existing weekly minor/patch group (unchanged behavior, now excludes majors via an ignore rule) plus a new monthly `majors` group that batches all major-version bumps into a single PR per ecosystem.
- Mechanical CI-config change only — no functional/runtime code touched, patch/minor cadence and grouping unchanged.

Part of alpha-engine-config-I2734 (fleet-wide Dependabot majors-grouping policy, ruled 2026-07-16).

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"` before commit.
- [ ] Brian reviews and merges (no self-merge — standing PR review/merge cadence).