### PR TITLE
fix(canary): filing probe status OK → PASS — canary green was structurally unreachable (alpha-engine-config-I2748)

### DIFF
--- a/rag/pipelines/filing_change_detection.py
+++ b/rag/pipelines/filing_change_detection.py
@@ -290,7 +290,7 @@ def main():
     # Saturday-replay canary's spot bootstrap in particular — see
     # alpha-engine-config#2246).
     print("RESULT_JSON=" + json.dumps({
-        "status": "OK",
+        "status": "PASS",  # canary aggregator contract: literal PASS (config-I2748)
         "n_analyzed": output["n_analyzed"],
         "n_lazy": output["n_lazy"],
         "n_risk_factor_changes": output["n_risk_factor_changes"],

--- a/tests/test_filing_change_detection_key_prefix.py
+++ b/tests/test_filing_change_detection_key_prefix.py
@@ -64,5 +64,5 @@ class TestResultJsonLine:
 
         import json
         payload = json.loads(result_lines[0][len("RESULT_JSON="):])
-        assert payload["status"] == "OK"
+        assert payload["status"] == "PASS"  # canary aggregator contract (config-I2748)
         assert payload["n_analyzed"] == 0


### PR DESCRIPTION
Found during today's canary-escalation clearing (alpha-engine-config-I2748): the aggregator requires every probe's status to literally equal `PASS`, but `filing_change_detection.py` emits `OK` — so `overall_status: PASS` was unreachable regardless of system health. This was masked until today because config#2713 + the I2741 IAM grant were the first fixes that let a canary run survive long enough to aggregate at all.

One-line producer fix + lockstep test-assertion update (`tests/test_filing_change_detection_key_prefix.py`, 4/4 green locally). After merge: one canary re-trigger on the four gated PRs should produce the first-ever `overall_status: PASS` and let I2724–I2727 close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)