### PR TITLE
fix(ci): dedupe dependabot.yml ecosystem blocks — restore valid config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,60 +1,38 @@
 # Standard fleet Dependabot config (weekly, grouped minor+patch) — alpha-engine-config-I2525
-# Majors are grouped into a single monthly PR per ecosystem — alpha-engine-config-I2734
+# Majors are surfaced as ONE grouped PR per ecosystem, throttled by a 30-day
+# major-version cooldown — alpha-engine-config-I2734. NOTE: Dependabot requires a
+# unique (package-ecosystem, directory, target-branch) per update config, so the
+# I2734 intent CANNOT be a second per-ecosystem block on its own monthly schedule
+# (that shape is invalid and disables ALL updates for the repo). The `majors`
+# group + `cooldown.semver-major-days: 30` below is the closest legal expression.
 version: 2
 updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 30
     groups:
       minor-and-patch:
         update-types:
           - minor
           - patch
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: monthly
-    groups:
       majors:
         update-types:
           - major
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 30
     groups:
       minor-and-patch:
         update-types:
           - minor
           - patch
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: monthly
-    groups:
       majors:
         update-types:
           - major
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-


### PR DESCRIPTION
## What

Merges the duplicate `pip` and `github-actions` update blocks back into one block per ecosystem. The alpha-engine-config-I2734 intent (majors as one grouped PR, ~monthly) is expressed legally via a `majors` group + `cooldown.semver-major-days: 30`.

## Why

PR873 (alpha-engine-config-I2734) added a second block per ecosystem for the same directory — invalid per Dependabot's unique `(package-ecosystem, directory, target-branch)` rule. Since that merge: Dependabot rejects the ENTIRE config (zero updates run for this repo), and every PR that syncs main fails the `.github/dependabot.yml` check (how this was caught — nousergon-data-PR875 went red after an update-branch).

## Notes

- Blocks nousergon-data-PR875's check cleanliness: after this merges, PR875 needs one more update-branch to go green.
- If I2734 was rolled out fleet-wide with the same two-block shape, the sibling repos have the same silent breakage — being checked; findings will be tracked on alpha-engine-config-I2734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)