### PR TITLE
fix(ci): drop unsupported cooldown from github-actions dependabot block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,12 +22,14 @@ updates:
         update-types:
           - major
 
+  # NOTE: no cooldown here — Dependabot rejects cooldown.semver-major-days for
+  # the github-actions ecosystem (semver cooldown keys are per-ecosystem; pip
+  # supports them, actions does not — validated live 2026-07-16). The majors
+  # group alone carries the I2734 grouping intent for actions.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    cooldown:
-      semver-major-days: 30
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
Follow-up to nousergon-data-PR877: `cooldown.semver-major-days` is not supported for the `github-actions` ecosystem (live validation error on PR875's head after update-branch: "The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'"). pip keeps its semver cooldown; the actions block drops cooldown and relies on the `majors` group alone. Same async-validation gotcha as the original I2734 rollout — noted on alpha-engine-config-I2734.

Blocks: nousergon-data-PR875 and PR876 need one more update-branch after this merges to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)