### PR TITLE
fix(sf-drift): codify groom-dispatch's live ERROR logging config

### DIFF
--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -313,6 +313,21 @@ DAILY_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations
 ADVISORY_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-weekly-advisory-pipeline:*"}}]}'
 MODELZOO_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":true,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"arn:aws:logs:'"$REGION"':'"$ACCOUNT_ID"':log-group:/aws/stepfunctions/ne-modelzoo-sunday-pipeline:*"}}]}'
 
+# config#2748-adjacent: groom-dispatch ERROR-level logging was enabled live
+# 2026-07-16 (ad hoc, outside this script) to aid debugging active groom-driver
+# incidents; codifying it here so deploys stop drifting from live and future
+# incident debugging has execution data by default. Log group name matches
+# what AWS auto-created under the vendedlogs convention when logging was first
+# enabled via update-state-machine without an explicit destination — reusing
+# it (not inventing a second /aws/stepfunctions/... group) avoids an orphaned
+# duplicate.
+GROOM_LOG_GROUP_NAME="/aws/vendedlogs/states/alpha-engine-groom-dispatch"
+GROOM_LOG_GROUP_ARN="arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${GROOM_LOG_GROUP_NAME}:*"
+echo "  Ensuring groom-dispatch log group exists (idempotent)..."
+aws logs create-log-group --log-group-name "$GROOM_LOG_GROUP_NAME" --region "$REGION" 2>/dev/null || true
+aws logs put-retention-policy --log-group-name "$GROOM_LOG_GROUP_NAME" --retention-in-days 30 --region "$REGION"
+GROOM_LOGGING_CONFIG='{"level":"ERROR","includeExecutionData":false,"destinations":[{"cloudWatchLogsLogGroup":{"logGroupArn":"'"$GROOM_LOG_GROUP_ARN"'"}}]}'
+
 update_or_defer_to_cfn "$SAT_ARN"  "$SAT_STAMPED"  "Weekly-freshness pipeline" "$SAT_LOGGING_CONFIG"
 update_or_defer_to_cfn "$DAILY_ARN" "$DAILY_STAMPED" "Pre-open trading pipeline" "$DAILY_LOGGING_CONFIG"
 update_or_defer_to_cfn "$ADVISORY_ARN" "$ADVISORY_STAMPED" "Weekly advisory child pipeline" "$ADVISORY_LOGGING_CONFIG"
@@ -323,7 +338,7 @@ update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post
 # deploy.sh --bootstrap). Every deploy between config#2129 (2026-07-01) and this fix was
 # updating the orphaned groom-pipeline name instead of the live groom-dispatch, which is
 # why PRs #761 and #763's SF definition fixes had zero live effect on actual groom runs.
-update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-dispatch" "Backlog groom dispatch"
+update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-dispatch" "Backlog groom dispatch" "$GROOM_LOGGING_CONFIG"
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────
 echo ""

--- a/infrastructure/step-functions/check-drift.py
+++ b/infrastructure/step-functions/check-drift.py
@@ -31,11 +31,13 @@ not a hypothetical one):
     managed); its `EOD_LOGGING_CONFIG` literal there is the source of truth,
     passed explicitly on every `update-state-machine` / `create-state-machine`
     call. The backlog-groom SF (`alpha-engine-groom-dispatch`) is also
-    script-managed but its `update_or_create` call deliberately omits a
-    logging arg ("preserving its current no-logging behavior exactly", per
-    that script's comment) — so this guard's codified expectation for groom
-    is "no logging enabled", and it flags drift if that ever changes without
-    a matching source update.
+    script-managed and, as of config#2748-adjacent (2026-07-16), likewise
+    passes an explicit `GROOM_LOGGING_CONFIG` (ERROR level, a dedicated log
+    group) on every update — enabled live to aid active groom-driver incident
+    debugging, then codified here so deploys stop drifting from it. If groom's
+    `update_or_create` call ever omits the logging arg again without a
+    matching source update, this guard flags it as drift rather than
+    silently trusting either state.
 
 This script parses both files (regex-based textual extraction — CFN's
 `!Ref`/`!GetAtt`/`!Sub` intrinsics aren't valid YAML for a stock loader, and
@@ -245,33 +247,66 @@ def _discover_expected_from_deploy_script() -> list[dict]:
             ),
         })
 
-    # --- Groom: deliberately no logging (update_or_create omits the arg) ---
+    # --- Groom: explicit LoggingConfiguration (config#2748-adjacent, 2026-07-16) ---
+    # ERROR-level logging was enabled live to aid active groom-driver incident
+    # debugging, then codified here mirroring EOD's pattern (log group created
+    # idempotently by deploy-infrastructure.sh, level/includeExecutionData
+    # parsed from the literal JSON, log group name from its own literal).
     groom_arn_match = re.search(
         r'GROOM_ARN="arn:aws:states:\$REGION:\$\{ACCOUNT_ID\}:stateMachine:([\w-]+)"',
         text,
     )
-    groom_call_match = re.search(
-        r'update_or_create\s+"\$GROOM_ARN"\s+"\$GROOM_STAMPED"\s+"[\w-]+"\s+"[^"]+"\s*(".*")?\s*$',
-        text,
-        re.MULTILINE,
-    )
-    if groom_arn_match:
+    groom_log_group_match = re.search(r'GROOM_LOG_GROUP_NAME="([^"]+)"', text)
+    groom_config_match = re.search(r"GROOM_LOGGING_CONFIG='(\{.*?\})'", text)
+
+    if groom_arn_match and groom_log_group_match and groom_config_match:
         groom_name = groom_arn_match.group(1)
-        has_logging_arg = bool(groom_call_match and groom_call_match.group(1))
-        if has_logging_arg:
+        groom_log_group_name = groom_log_group_match.group(1)
+        level_match = re.search(r'"level":"([^"]+)"', groom_config_match.group(1))
+        include_match = re.search(
+            r'"includeExecutionData":(true|false)', groom_config_match.group(1)
+        )
+        if level_match and include_match:
             results.append({
                 "sf_name": groom_name,
                 "source_file": DEPLOY_INFRA_SH,
-                "error": (
-                    f"groom SF's update_or_create call in "
-                    f"{DEPLOY_INFRA_SH.name} now passes a logging arg — "
-                    f"this script's groom-has-no-logging assumption is "
-                    f"stale, update it rather than trusting this result"
-                ),
+                "expected_level": level_match.group(1),
+                "expected_include_execution_data": include_match.group(1) == "true",
+                "expected_log_group_name": groom_log_group_name,
             })
         else:
             results.append({
                 "sf_name": groom_name,
+                "source_file": DEPLOY_INFRA_SH,
+                "error": (
+                    f"GROOM_LOGGING_CONFIG in {DEPLOY_INFRA_SH.name} didn't "
+                    f"parse as expected (level/includeExecutionData)"
+                ),
+            })
+    elif groom_arn_match:
+        # Logging-arg literals not found — either genuinely reverted to
+        # no-logging, or the deploy plumbing changed shape. Distinguish via
+        # the actual update_or_create call rather than guessing.
+        groom_call_match = re.search(
+            r'update_or_create\s+"\$GROOM_ARN"\s+"\$GROOM_STAMPED"\s+"[\w-]+"\s+"[^"]+"\s*(".*")?\s*$',
+            text,
+            re.MULTILINE,
+        )
+        has_logging_arg = bool(groom_call_match and groom_call_match.group(1))
+        if has_logging_arg:
+            results.append({
+                "sf_name": groom_arn_match.group(1),
+                "source_file": DEPLOY_INFRA_SH,
+                "error": (
+                    f"groom SF's update_or_create call in "
+                    f"{DEPLOY_INFRA_SH.name} passes a logging arg but "
+                    f"GROOM_LOG_GROUP_NAME/GROOM_LOGGING_CONFIG literals "
+                    f"weren't found — update this parser to match"
+                ),
+            })
+        else:
+            results.append({
+                "sf_name": groom_arn_match.group(1),
                 "source_file": DEPLOY_INFRA_SH,
                 "expected_level": "OFF",
                 "expected_include_execution_data": None,

--- a/tests/test_sf_logging_config_check_drift.py
+++ b/tests/test_sf_logging_config_check_drift.py
@@ -83,13 +83,17 @@ def test_eod_sf_expects_error_level_logging_from_deploy_script(cd):
     assert eod["expected_log_group_name"] == "/aws/stepfunctions/ne-postclose-trading-pipeline"
 
 
-def test_groom_sf_expects_no_logging(cd):
-    """deploy-infrastructure.sh's update_or_create call for groom omits the
-    logging arg on purpose — this guard's codified expectation must match
-    that, not silently assume logging is wanted everywhere."""
+def test_groom_sf_expects_error_logging(cd):
+    """config#2748-adjacent (2026-07-16): groom-dispatch's ERROR-level logging
+    was enabled live to aid active groom-driver incident debugging, then
+    codified in deploy-infrastructure.sh (GROOM_LOG_GROUP_NAME/
+    GROOM_LOGGING_CONFIG, mirroring EOD's pattern) — this guard's codified
+    expectation must match that, not the old no-logging assumption."""
     entries = {e["sf_name"]: e for e in cd._discover_expected_logging_configs()}
     groom = entries["alpha-engine-groom-dispatch"]
-    assert groom["expected_level"] == "OFF"
+    assert groom["expected_level"] == "ERROR"
+    assert groom["expected_include_execution_data"] is False
+    assert groom["expected_log_group_name"] == "/aws/vendedlogs/states/alpha-engine-groom-dispatch"
 
 
 # ── _live_log_group_name ────────────────────────────────────────────────────
@@ -209,15 +213,47 @@ def test_check_sf_missing_state_machine_on_aws(cd):
     assert "not found on AWS" in findings[0]
 
 
-def test_check_sf_groom_no_drift_when_live_is_off(cd):
+def test_check_sf_no_drift_when_expected_off_and_live_is_off(cd):
+    """General OFF-vs-OFF case (no longer groom's real config as of
+    config#2748-adjacent — groom now expects ERROR, see
+    test_groom_sf_expects_error_logging)."""
     entry = {
-        "sf_name": "alpha-engine-groom-dispatch",
+        "sf_name": "some-other-sf-with-no-logging",
         "source_file": _REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh",
         "expected_level": "OFF",
         "expected_include_execution_data": None,
         "expected_log_group_name": None,
     }
     live = {}  # describe-state-machine omits loggingConfiguration entirely when disabled
+    with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live))):
+        findings = cd._check_sf(entry)
+    assert findings == []
+
+
+def test_check_sf_groom_no_drift_when_live_matches_error_config(cd):
+    """config#2748-adjacent: groom-dispatch now expects ERROR-level logging
+    with a real log group — confirm a live config matching that codified
+    expectation produces no drift finding."""
+    entry = {
+        "sf_name": "alpha-engine-groom-dispatch",
+        "source_file": _REPO_ROOT / "infrastructure" / "deploy-infrastructure.sh",
+        "expected_level": "ERROR",
+        "expected_include_execution_data": False,
+        "expected_log_group_name": "/aws/vendedlogs/states/alpha-engine-groom-dispatch",
+    }
+    live = {
+        "loggingConfiguration": {
+            "level": "ERROR",
+            "includeExecutionData": False,
+            "destinations": [
+                {
+                    "cloudWatchLogsLogGroup": {
+                        "logGroupArn": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/vendedlogs/states/alpha-engine-groom-dispatch:*"
+                    }
+                }
+            ],
+        }
+    }
     with patch.object(cd.subprocess, "run", return_value=_fake_run(0, json.dumps(live))):
         findings = cd._check_sf(entry)
     assert findings == []


### PR DESCRIPTION
## What

`alpha-engine-groom-dispatch`'s LoggingConfiguration was enabled live (ERROR level, dedicated log group) to aid debugging active groom-driver incidents, but `check-drift.py` still codified an "OFF" expectation from groom's old no-logging design — causing a real content-drift finding once the drift-check's IAM access was fixed (nousergon/crucible-executor#393).

## Fix

Codifies the live config into `deploy-infrastructure.sh` (`GROOM_LOG_GROUP_NAME` + `GROOM_LOGGING_CONFIG`, mirroring the EOD SF's existing pattern) and updates `check-drift.py`'s groom parser to derive expected values from those literals instead of hardcoding OFF.

## Validated

- Applied live: `aws stepfunctions update-state-machine` confirms the config; `describe-state-machine` matches.
- `check-drift.py` test suite: 17/17 (2 new tests for the ERROR-config case).
- Broader `sf_`/`step_function`/`deploy_infra`/`logging` suite: 1189 passed, 9 skipped, 0 failed.

Refs alpha-engine-config#2748 (adjacent), nousergon-data#802 (the SF-ARN drift-check PR this unblocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)