### PR TITLE
fix(sf): guard conditionally-assigned Choice paths — 2026-07-16 postclose States.Runtime incident (config-I2767)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -137,8 +137,25 @@
       "Comment": "Hard-fail when the drift probe reports has_drift=true. Surfaces deploy lag loudly instead of silently running new SF definitions against stale Lambda images (or vice versa).",
       "Choices": [
         {
-          "Variable": "$.drift_result.Payload.has_drift",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.drift_result.Payload.has_drift",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.drift_result.Payload.has_drift",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded — an unguarded dereference of an absent has_drift threw States.Runtime, ending the run FAILED without HandleFailure context (config#2275 incident class).",
+          "Next": "HandleFailure"
+        },
+        {
+          "Not": {
+            "Variable": "$.drift_result.Payload.has_drift",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: a drift-check payload WITHOUT has_drift means the gate could not check — fail CLOSED and loud (HandleFailure) rather than trading on unverifiable deploy freshness.",
           "Next": "HandleFailure"
         }
       ],
@@ -185,9 +202,26 @@
       "Comment": "Holiday/weekend (is_trading_day=false) -> skip without ever booting the box. Trading day or any non-false result -> proceed. Fail-open to trading matches the prior fail-soft posture: missing a real trading day is worse than a wasted holiday boot.",
       "Choices": [
         {
-          "Variable": "$.trading_day_gate.Payload.is_trading_day",
-          "BooleanEquals": false,
+          "And": [
+            {
+              "Variable": "$.trading_day_gate.Payload.is_trading_day",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.trading_day_gate.Payload.is_trading_day",
+              "BooleanEquals": false
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded (config#2275 incident class).",
           "Next": "NotifyHolidaySkip"
+        },
+        {
+          "Not": {
+            "Variable": "$.trading_day_gate.Payload.is_trading_day",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: a gate payload WITHOUT is_trading_day is a contract violation from our own Lambda — fail CLOSED and loud (HandleFailure) rather than silently proceeding to trade (or silently skipping) on an unverifiable trading-day verdict.",
+          "Next": "HandleFailure"
         }
       ],
       "Default": "StartExecutorEC2"
@@ -596,9 +630,26 @@
       "Comment": "If buy_candidates have unscored tickers, re-invoke the predictor with --tickers. Otherwise advance to the morning-planner skip-gate. alpha-engine-config-I2722 (2026-07-16): PredictorHealthCheck was removed from this SF and re-homed onto its own direct EventBridge trigger (13:40 UTC weekdays) — see infrastructure/cloudformation/alpha-engine-orchestration.yaml PredictorHealthCheckTrigger.",
       "Choices": [
         {
-          "Variable": "$.coverage_result.Payload.has_gap",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.coverage_result.Payload.has_gap",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.coverage_result.Payload.has_gap",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded (config#2275 incident class).",
           "Next": "ReinvokePredictor"
+        },
+        {
+          "Not": {
+            "Variable": "$.coverage_result.Payload.has_gap",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: a coverage payload WITHOUT has_gap means prediction coverage is unverifiable — fail CLOSED and loud (HandleFailure) rather than trading on unknown coverage.",
+          "Next": "HandleFailure"
         }
       ],
       "Default": "CheckSkipMorningPlanner"
@@ -677,8 +728,25 @@
       "Comment": "After one re-invocation attempt, either coverage is complete (proceed) or we have a deeper problem (fail). No further retry loop — prevents runaway invocations if a ticker is un-scorable by the model. alpha-engine-config-I2722 (2026-07-16): the Default target moved from PredictorHealthCheck (removed from this SF) to the morning-planner skip-gate — see CoverageGapChoice's comment.",
       "Choices": [
         {
-          "Variable": "$.coverage_recheck_result.Payload.has_gap",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.coverage_recheck_result.Payload.has_gap",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.coverage_recheck_result.Payload.has_gap",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded (config#2275 incident class).",
+          "Next": "HandleFailure"
+        },
+        {
+          "Not": {
+            "Variable": "$.coverage_recheck_result.Payload.has_gap",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: recheck payload WITHOUT has_gap — same fail-closed routing as a confirmed gap.",
           "Next": "HandleFailure"
         }
       ],
@@ -1046,9 +1114,26 @@
       "Comment": "launched:true -> poll; launched:false (DATA_SPOT_DISPATCH_ENABLED kill-switch) -> skip the whole data phase to the continue path.",
       "Choices": [
         {
-          "Variable": "$.morning_enrich_launch.Payload.data_spot.launched",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.morning_enrich_launch.Payload.data_spot.launched",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.morning_enrich_launch.Payload.data_spot.launched",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded (config#2275 incident class).",
           "Next": "PollMorningEnrichSpot"
+        },
+        {
+          "Not": {
+            "Variable": "$.morning_enrich_launch.Payload.data_spot.launched",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: a dispatcher payload WITHOUT data_spot.launched means the morning-data launch is unverifiable — route into the existing fail-open-but-LOUD data-spot failure notifier (config#1767 #4: a data-spot failure must never block daemon start), not a silent not-launched skip and not a HALT.",
+          "Next": "ExtractDataSpotError"
         }
       ],
       "Default": "CheckSkipPredictorInference"
@@ -1204,9 +1289,26 @@
       "Comment": "launched:true -> poll; launched:false kill-switch -> continue.",
       "Choices": [
         {
-          "Variable": "$.arctic_append_launch.Payload.data_spot.launched",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.arctic_append_launch.Payload.data_spot.launched",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.arctic_append_launch.Payload.data_spot.launched",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded (config#2275 incident class).",
           "Next": "PollMorningArcticAppendSpot"
+        },
+        {
+          "Not": {
+            "Variable": "$.arctic_append_launch.Payload.data_spot.launched",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: malformed dispatcher payload — same fail-open-but-loud routing as CheckMorningEnrichSpotLaunched (config#1767 #4).",
+          "Next": "ExtractDataSpotError"
         }
       ],
       "Default": "CheckSkipPredictorInference"

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -720,9 +720,26 @@
       "Comment": "launched:true -> poll; launched:false kill-switch -> continue to snapshot/reconcile.",
       "Choices": [
         {
-          "Variable": "$.postmarket_launch.Payload.data_spot.launched",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.postmarket_launch.Payload.data_spot.launched",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.postmarket_launch.Payload.data_spot.launched",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded — a dispatcher payload without data_spot.launched previously threw States.Runtime here, ending the execution FAILED before StopTradingInstance (cost guard bypassed).",
           "Next": "PollPostMarketDataSpot"
+        },
+        {
+          "Not": {
+            "Variable": "$.postmarket_launch.Payload.data_spot.launched",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: a payload WITHOUT data_spot.launched means the dispatcher could not verifiably launch (partial/malformed result) — route into the existing data-spot failure notifier instead of silently treating it as an intentional not-launched skip (Default).",
+          "Next": "ExtractDataSpotError"
         }
       ],
       "Default": "CheckSkipCaptureSnapshot"
@@ -878,9 +895,26 @@
       "Comment": "launched:true -> poll; launched:false kill-switch -> continue.",
       "Choices": [
         {
-          "Variable": "$.postmarket_arctic_launch.Payload.data_spot.launched",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.postmarket_arctic_launch.Payload.data_spot.launched",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.postmarket_arctic_launch.Payload.data_spot.launched",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded — same States.Runtime-before-cost-guard class as CheckPostMarketDataSpotLaunched.",
           "Next": "PollPostMarketArcticAppendSpot"
+        },
+        {
+          "Not": {
+            "Variable": "$.postmarket_arctic_launch.Payload.data_spot.launched",
+            "IsPresent": true
+          },
+          "Comment": "config-I2767: malformed dispatcher payload — route into the existing data-spot failure notifier, never a silent skip.",
+          "Next": "ExtractDataSpotError"
         }
       ],
       "Default": "CheckSkipCaptureSnapshot"
@@ -1158,8 +1192,17 @@
       "Comment": "config-I2702 deliverable #3: recursion guard. An operator-replay execution (pipeline_role=operator-replay — including a heal-dispatched replay itself, HealDispatchReplay below) that STILL finds the precondition unmet must not spawn a further self-heal loop (replays run with skip_post_market_data=true, so they have no data-spot phase to retry — looping here would just burn the 2-attempt budget doing nothing). Page immediately instead. A live/daemon/backstop-triggered execution (the normal case) enters the loop.",
       "Choices": [
         {
-          "Variable": "$.pipeline_role",
-          "StringEquals": "operator-replay",
+          "And": [
+            {
+              "Variable": "$.pipeline_role",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.pipeline_role",
+              "StringEquals": "operator-replay"
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded — this SF has no InitializeInput floor (StartAt is CheckMutexRole), so $.pipeline_role is an execution-input key that is not provably present. Absent falls to Default InitHealLoop, i.e. the live-execution treatment, which is the correct reading for any non-replay trigger.",
           "Next": "HealNonConvergent"
         }
       ],
@@ -1185,8 +1228,17 @@
               "NumericGreaterThanEquals": 2
             },
             {
-              "Variable": "$.precondition_probe.Payload.past_deadline",
-              "BooleanEquals": true
+              "And": [
+                {
+                  "Variable": "$.precondition_probe.Payload.past_deadline",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.precondition_probe.Payload.past_deadline",
+                  "BooleanEquals": true
+                }
+              ],
+              "Comment": "config-I2767: IsPresent-guarded — a probe payload without past_deadline previously threw States.Runtime inside this Or. Absent, the operand is simply false and the loop stays bounded by the attempts operand alone (2 attempts, then HealNonConvergent pages)."
             }
           ],
           "Next": "HealNonConvergent"
@@ -1235,8 +1287,17 @@
       "Comment": "launched:true -> poll; launched:false (kill-switch) -> this heal attempt accomplished nothing, try again next iteration.",
       "Choices": [
         {
-          "Variable": "$.heal_postmarket_launch.Payload.data_spot.launched",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.heal_postmarket_launch.Payload.data_spot.launched",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.heal_postmarket_launch.Payload.data_spot.launched",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded — absent launched (malformed dispatcher payload) falls to Default HealLoopIncrement: the bounded heal loop (2 attempts) retries or pages via HealNonConvergent, never States.Runtime.",
           "Next": "HealPollPostMarketDataSpot"
         }
       ],
@@ -1360,8 +1421,17 @@
       "Comment": "launched:true -> poll; launched:false (kill-switch) -> try again next iteration.",
       "Choices": [
         {
-          "Variable": "$.heal_arctic_launch.Payload.data_spot.launched",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.heal_arctic_launch.Payload.data_spot.launched",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.heal_arctic_launch.Payload.data_spot.launched",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded — absent launched falls to Default HealLoopIncrement (bounded heal loop), never States.Runtime.",
           "Next": "HealPollArcticAppendSpot"
         }
       ],
@@ -1485,8 +1555,17 @@
       "Comment": "config-I2702 deliverable #3(c): the precondition landed -> dispatch the reconcile-only replay. Not yet -> try again next iteration.",
       "Choices": [
         {
-          "Variable": "$.precondition_probe.Payload.precondition_met",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.precondition_probe.Payload.precondition_met",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.precondition_probe.Payload.precondition_met",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767: IsPresent-guarded — a probe payload without precondition_met falls to Default HealLoopIncrement: not converged, loop stays bounded (2 attempts, then HealNonConvergent pages), never States.Runtime.",
           "Next": "HealDispatchReplay"
         }
       ],
@@ -1630,8 +1709,17 @@
       "Comment": "config-I2702 deliverable #4: the ONE place that decides which terminal this execution reaches. $.degraded_summary is set (by SetDegradedFlag) iff the precondition probe ever found the SPY close not-yet-verified-present this execution — regardless of whether the self-heal loop subsequently converged (HealConvergedNotify) or paged (HealNonConvergent): EODReconcile was skipped IN THIS EXECUTION either way, so 'plain ExecutionSucceeded' would still be a lie about THIS execution's own work, even when the system as a whole self-healed via a replay.",
       "Choices": [
         {
-          "Variable": "$.degraded_summary.degraded",
-          "BooleanEquals": true,
+          "And": [
+            {
+              "Variable": "$.degraded_summary.degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.degraded_summary.degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767 (2026-07-16 incident): $.degraded_summary is only assigned on the degraded path (SetDegradedFlag) — on a fully-green day the path is ABSENT and an unguarded dereference threw States.Runtime, failing the execution at its very last state. Absent flag = never degraded = NormalSucceeded via Default, which is the semantically exact reading, so no separate malformed route is needed here.",
           "Next": "DegradedSucceeded"
         }
       ],

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -127,9 +127,26 @@
             "Comment": "GROOM_DISPATCH_ENABLED=false is an intentional kill-switch skip; config#1979's concurrent-same-tier skip is also a clean no-launch — both route to a clean Succeed rather than polling a box that was never launched.",
             "Choices": [
               {
-                "Variable": "$.groomLaunch.Payload.groom.launched",
-                "BooleanEquals": true,
+                "And": [
+                  {
+                    "Variable": "$.groomLaunch.Payload.groom.launched",
+                    "IsPresent": true
+                  },
+                  {
+                    "Variable": "$.groomLaunch.Payload.groom.launched",
+                    "BooleanEquals": true
+                  }
+                ],
+                "Comment": "config-I2767: IsPresent-guarded (config#2275 incident class).",
                 "Next": "PollGroomCommand"
+              },
+              {
+                "Not": {
+                  "Variable": "$.groomLaunch.Payload.groom.launched",
+                  "IsPresent": true
+                },
+                "Comment": "config-I2767: a launch payload WITHOUT groom.launched means the launch is unverifiable (partial/malformed dispatcher result) — escalate via GroomRetriesExhausted's notifier rather than silently taking the Default GroomSkipped, which is reserved for an INTENTIONAL kill-switch/concurrency no-op.",
+                "Next": "GroomRetriesExhausted"
               }
             ],
             "Default": "GroomSkipped"

--- a/tests/test_sf_choice_guards.py
+++ b/tests/test_sf_choice_guards.py
@@ -15,17 +15,29 @@ must be either
      `{Variable: <same path>, IsPresent: true}` (ASL evaluates And operands
      in order and stops at the first false — the canonical guard idiom), at
      any ancestor And level;
-  3. provably floored upstream:
-     a. a single-segment path (`$.key`) whose key `InitializeInput` floors
-        for every execution (its JsonMerge defaults literal + the injected
-        `run_date`) — valid at the top scope and inside Parallel branches
-        (branch input is the parallel's effective input; ResultPath writes
-        merge, never drop keys), NOT inside Map iterators (per-item input);
-     b. a two-plus-segment path (`$.x.y...`) where EVERY in-scope
-        predecessor of the Choice writes `ResultPath == $.x` with `y` pinned
-        as a key of its ResultSelector / Parameters / Result — an absent
-        source field then fails inside the TASK (whose Catch routes to the
-        normalizer chain), never inside the Choice.
+  3. provably floored upstream — DEFINITE ASSIGNMENT (config-I2767 upgraded
+     this from a direct-predecessor check to a transitive backward walk over
+     the in-scope state graph, after the 2026-07-16 postclose incident showed
+     the eod/daily/groom definitions were entirely outside this test's scope
+     and their structurally-safe counters, e.g. `$.ssm_poll.attempts`, sit
+     several key-preserving states upstream of their Choice):
+     a. a single-segment path (`$.key`) floored at scope entry — the
+        initializer Pass's JsonMerge defaults literal (+ injected run_date)
+        for a top scope that HAS one (weekly/advisory/modelzoo/daily; the
+        eod and groom top scopes have NO initializer and floor nothing), or
+        the Map state's ItemSelector/Parameters pinned keys for a Map
+        iterator scope;
+     b. a one- or two-segment path (`$.x` / `$.x.y`) that on EVERY backward
+        path from the Choice to scope entry hits a state that definitely
+        assigns it (`ResultPath == $.x` with `y` pinned in ResultSelector /
+        Parameters / Result, or a deeper `$.x.y...` ResultPath that creates
+        the intermediate) before hitting scope entry or a key-dropping state
+        (`ResultPath` absent i.e. `$`, an OutputPath reshape, or a Catch
+        edge whose default ResultPath replaces the input with the error
+        object). Cycles resolve optimistically (every real execution enters
+        a loop from outside it). Three-plus-segment paths (`$.x.Payload.z`)
+        are NEVER floorable — a Lambda payload's inner shape cannot be
+        pinned — and must be guarded.
 
 Comparison-path operators (`*Path`) dereference their VALUE too — held to the
 same rule. Every Choice must also carry a Default (a rule-miss with no
@@ -54,6 +66,14 @@ _WEEKLY = _REPO_ROOT / "infrastructure" / "step_function.json"
 # SAME config#2275 guard-or-floor discipline.
 _ADVISORY = _REPO_ROOT / "infrastructure" / "step_function_advisory.json"
 _MODELZOO = _REPO_ROOT / "infrastructure" / "step_function_modelzoo.json"
+# config-I2767 (2026-07-16 postclose States.Runtime incident): the eod,
+# daily, and groom definitions were NEVER in this test's scope — the I2702
+# CheckDegradedOutcome Choice landed exactly in that coverage hole and
+# crashed the first fully-green postclose run. ALL SIX definitions are now
+# held to the same discipline.
+_EOD = _REPO_ROOT / "infrastructure" / "step_function_eod.json"
+_DAILY = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
+_GROOM = _REPO_ROOT / "infrastructure" / "step_function_groom.json"
 
 
 def _load(path: pathlib.Path = _WEEKLY) -> dict:
@@ -64,82 +84,198 @@ def _load(path: pathlib.Path = _WEEKLY) -> dict:
 # scope walking
 # ---------------------------------------------------------------------------
 
-def _iter_scopes(definition: dict):
-    """Yield (scope_path, states_dict, in_map) for the top scope, every
-    Parallel branch, and every Map iterator (in_map=True: per-item input, the
-    InitializeInput floors do NOT reach it)."""
-    def _walk(states: dict, path: str, in_map: bool):
-        yield path, states, in_map
-        for name, state in states.items():
-            if state.get("Type") == "Parallel":
-                for i, branch in enumerate(state.get("Branches", [])):
-                    yield from _walk(branch["States"], f"{path}/{name}[{i}]", in_map)
-            if state.get("Type") == "Map":
-                iterator = state.get("Iterator") or state.get("ItemProcessor")
-                if iterator:
-                    yield from _walk(iterator["States"], f"{path}/{name}[map]", True)
-    yield from _walk(definition["States"], "", False)
-
-
-def _initialize_input_floors(definition: dict) -> set[str]:
-    """Keys the SF's initializer Pass state (its StartAt — InitializeInput
-    on the weekly SF, InitializeAdvisoryInput / InitializeModelZooInput on
-    the two I2544/I2545 child SFs) guarantees on $ for every execution: the
-    FIRST embedded JsonMerge defaults literal, plus any States.Format-
-    injected run_date. Parsed MECHANICALLY from the state so the floor set
-    can never drift from the definition."""
-    init_state_name = definition["StartAt"]
-    params = definition["States"][init_state_name]["Parameters"]["merged.$"]
-    start = params.index("States.StringToJson('") + len("States.StringToJson('")
-    end = params.index("')", start)
-    literal = params[start:end].replace('\\"', '"')
-    floors = set(json.loads(literal))
-    if "run_date" in params:
-        floors.add("run_date")
-    assert "sns_topic_arn" in floors, f"{init_state_name} defaults parse failed"
-    return floors
-
-
-def _predecessors(states: dict, target: str) -> list[dict]:
-    """Every state in this scope with an edge into `target` (Next, Default,
-    Choice-rule Next, Catch Next)."""
-    preds = []
-    for state in states.values():
-        edges = {state.get("Next"), state.get("Default")}
-        for rule in state.get("Choices", []) or []:
-            edges.add(rule.get("Next"))
-        for catch in state.get("Catch", []) or []:
-            edges.add(catch.get("Next"))
-        if target in edges:
-            preds.append(state)
-    return preds
-
-
-def _pinned_keys(state: dict) -> set[str]:
-    """Keys a state's output object is guaranteed to carry at ResultPath."""
-    source = state.get("ResultSelector") or (
-        state.get("Parameters") if state.get("Type") == "Pass" else None
-    ) or (state.get("Result") if state.get("Type") == "Pass" else None)
+def _pinned_keys_of(source) -> set[str]:
     if not isinstance(source, dict):
         return set()
     return {k[:-2] if k.endswith(".$") else k for k in source}
 
 
-def _is_floored(var: str, choice_name: str, states: dict, in_map: bool,
-                top_floors: set[str]) -> bool:
-    segments = var.lstrip("$.").split(".")
-    if len(segments) == 1:
-        return (not in_map) and segments[0] in top_floors
-    root, first_child = segments[0], segments[1]
-    preds = _predecessors(states, choice_name)
-    if not preds:
-        return False
-    for pred in preds:
-        if pred.get("ResultPath") != f"$.{root}":
+def _pinned_keys(state: dict) -> set[str]:
+    """Keys a state's result object is guaranteed to carry at ResultPath."""
+    source = state.get("ResultSelector") or (
+        state.get("Parameters") if state.get("Type") == "Pass" else None
+    ) or (state.get("Result") if state.get("Type") == "Pass" else None)
+    return _pinned_keys_of(source)
+
+
+def _iter_scopes(definition: dict, top_floors: set[str]):
+    """Yield (scope_path, states_dict, scope_floors, initializer_name) for
+    the top scope, every Parallel branch, and every Map iterator.
+
+    scope_floors = single-segment keys guaranteed present on the scope's
+    input for every execution: the initializer floors at the top scope
+    (propagated into Parallel branches — branch input is the parallel's
+    effective input, and ResultPath writes merge, never drop keys), or the
+    Map state's ItemSelector/Parameters pinned keys for an iterator scope
+    (per-item input; the top floors do NOT reach it)."""
+    def _walk(states: dict, path: str, floors: set[str], init_name, start):
+        yield path, states, floors, init_name, start
+        for name, state in states.items():
+            if state.get("Type") == "Parallel":
+                branch_floors = (
+                    _pinned_keys_of(state.get("Parameters"))
+                    if state.get("Parameters") is not None else floors
+                )
+                for i, branch in enumerate(state.get("Branches", [])):
+                    yield from _walk(branch["States"], f"{path}/{name}[{i}]",
+                                     branch_floors, None, branch["StartAt"])
+            if state.get("Type") == "Map":
+                iterator = state.get("Iterator") or state.get("ItemProcessor")
+                if iterator:
+                    item_floors = _pinned_keys_of(
+                        state.get("ItemSelector") or state.get("Parameters")
+                    )
+                    yield from _walk(iterator["States"], f"{path}/{name}[map]",
+                                     item_floors, None, iterator["StartAt"])
+    yield from _walk(definition["States"], "", top_floors,
+                     definition["StartAt"] if top_floors else None,
+                     definition["StartAt"])
+
+
+def _initialize_input_floors(definition: dict) -> set[str]:
+    """Keys the SF's initializer Pass state (its StartAt — InitializeInput
+    on the weekly/daily SFs, InitializeAdvisoryInput / InitializeModelZooInput
+    on the two I2544/I2545 child SFs) guarantees on $ for every execution:
+    the FIRST embedded JsonMerge defaults literal, plus any States.Format-
+    injected run_date. Parsed MECHANICALLY from the state so the floor set
+    can never drift from the definition. A definition WITHOUT the initializer
+    idiom (eod StartAt is a Choice, groom's InitRunState merges no defaults
+    literal onto $) floors NOTHING — config-I2767."""
+    init_state = definition["States"][definition["StartAt"]]
+    params = (init_state.get("Parameters") or {}).get("merged.$", "")
+    marker = "States.StringToJson('"
+    if init_state.get("Type") != "Pass" or marker not in params:
+        return set()
+    start = params.index(marker) + len(marker)
+    end = params.index("')", start)
+    literal = params[start:end].replace('\\"', '"')
+    floors = set(json.loads(literal))
+    if "run_date" in params:
+        floors.add("run_date")
+    assert "sns_topic_arn" in floors, f"{definition['StartAt']} defaults parse failed"
+    return floors
+
+
+def _in_edges(states: dict) -> dict:
+    """target -> list of (pred_name, kind, catch_result_path). kind is
+    'next' (Next / Default / Choice-rule Next) or 'catch'."""
+    edges: dict = {}
+    for name, state in states.items():
+        targets = {state.get("Next"), state.get("Default")}
+        for rule in state.get("Choices", []) or []:
+            targets.add(rule.get("Next"))
+        for target in targets:
+            if target:
+                edges.setdefault(target, []).append((name, "next", None))
+        for catch in state.get("Catch", []) or []:
+            if catch.get("Next"):
+                edges.setdefault(catch["Next"], []).append(
+                    (name, "catch", catch.get("ResultPath", "$"))
+                )
+    return edges
+
+
+class _FloorAnalysis:
+    """Definite-assignment analysis for one scope (config-I2767): is a one-
+    or two-segment path present on EVERY execution path reaching a state's
+    entry? Backward walk with optimistic cycle resolution (an in-progress
+    node counts as satisfied — every real execution enters a loop from
+    outside it, so the acyclic prefixes decide)."""
+
+    def __init__(self, states: dict, scope_floors: set[str],
+                 initializer_name, scope_start: str):
+        self.states = states
+        self.floors = scope_floors
+        self.initializer = initializer_name
+        self.scope_start = scope_start
+        self.edges = _in_edges(states)
+
+    def floored(self, var: str, choice_name: str) -> bool:
+        segments = var.lstrip("$.").split(".")
+        if len(segments) > 2 or any("[" in s for s in segments):
+            return False  # inner payload shape / array index: guard required
+        root = segments[0]
+        child = segments[1] if len(segments) > 1 else None
+        return self._present_at_entry(choice_name, root, child, set())
+
+    # -- core recursion ----------------------------------------------------
+    def _present_at_entry(self, name: str, root, child, visiting) -> bool:
+        if name in visiting:
+            return True  # optimistic on cycles
+        visiting = visiting | {name}
+        inbound = self.edges.get(name, [])
+        if name == self.scope_start:
+            # the raw-entry path is always possible, EVEN IF loops also
+            # re-enter the start state — both must carry the path
+            if not (child is None and root in self.floors):
+                return False
+        elif not inbound:
+            return False  # unreachable in-scope: no proof
+        for pred_name, kind, catch_rp in inbound:
+            pred = self.states[pred_name]
+            if kind == "catch":
+                if not self._catch_out(pred_name, pred, catch_rp, root, child,
+                                       visiting):
+                    return False
+            elif not self._out_present(pred_name, pred, root, child, visiting):
+                return False
+        return True
+
+    def _out_present(self, name, state, root, child, visiting) -> bool:
+        """Does `state`'s OUTPUT definitely carry the path?"""
+        if name == self.initializer:
+            return child is None and root in self.floors
+        if state.get("OutputPath") not in (None, "$"):
+            return False  # output reshaped: conservative
+        if state.get("Type") in ("Choice", "Wait", "Succeed", "Fail"):
+            return self._present_at_entry(name, root, child, visiting)
+        rp = state.get("ResultPath", "$")
+        if rp is None:
+            return self._present_at_entry(name, root, child, visiting)
+        if rp == "$":
+            pins = _pinned_keys(state)
+            if root not in pins:
+                return False
+            if child is None:
+                return True
+            return child in self._literal_child_pins(state, root)
+        rp_segments = rp[2:].split(".")
+        if rp_segments[0] != root:
+            # merge elsewhere: the path survives iff present on entry
+            return self._present_at_entry(name, root, child, visiting)
+        if len(rp_segments) == 1:
+            # ResultPath == $.root: the node is REPLACED by the result
+            return child is None or child in _pinned_keys(state)
+        # ResultPath == $.root.x...: root is created/kept; child present if
+        # it IS x, else only if it survived from the state's own input
+        if child is None or rp_segments[1] == child:
+            return True
+        return self._present_at_entry(name, root, child, visiting)
+
+    def _catch_out(self, name, state, catch_rp, root, child, visiting) -> bool:
+        """A Catch edge's output = the state's RAW INPUT with the error
+        object merged at the catch ResultPath (default '$' — which REPLACES
+        the input with the bare error object)."""
+        if catch_rp == "$" or catch_rp is None:
             return False
-        if first_child not in _pinned_keys(pred):
-            return False
-    return True
+        rp_segments = catch_rp[2:].split(".")
+        if rp_segments[0] == root:
+            # error object lands at/under root — its shape is {Error, Cause}
+            if child is None:
+                return True
+            if len(rp_segments) > 1 and rp_segments[1] == child:
+                return True
+            return child in ("Error", "Cause") and len(rp_segments) == 1
+        return self._present_at_entry(name, root, child, visiting)
+
+    @staticmethod
+    def _literal_child_pins(state, root) -> set[str]:
+        source = state.get("ResultSelector") or (
+            state.get("Parameters") if state.get("Type") == "Pass" else None
+        ) or (state.get("Result") if state.get("Type") == "Pass" else None)
+        if isinstance(source, dict) and isinstance(source.get(root), dict):
+            return _pinned_keys_of(source[root])
+        return set()
 
 
 # ---------------------------------------------------------------------------
@@ -200,18 +336,27 @@ def _leaf_violations(rule: dict, guards: frozenset[str], context: str,
 # and the modelzoo fan-out (3 Choices: CheckResolveZooStatus/
 # CheckModelZooStatus/CheckTrainSpecStatus — the last inside
 # ModelZooTrainMap's Map iterator) moved to the two new child SFs, which
-# carry the SAME config#2275 guard-or-floor discipline (see
-# _MIN_CHOICES_SEEN below and the two new per-file tests).
-_MIN_CHOICES_SEEN = {_WEEKLY: 35, _ADVISORY: 8, _MODELZOO: 3}
+# carry the SAME config#2275 guard-or-floor discipline.
+# config-I2767 (2026-07-16): eod/daily/groom added — the whole point of the
+# incident fix. Counts are walker-regression floors, not exact.
+_MIN_CHOICES_SEEN = {
+    _WEEKLY: 35, _ADVISORY: 8, _MODELZOO: 3,
+    _EOD: 15, _DAILY: 12, _GROOM: 4,
+}
 
 
-@pytest.mark.parametrize("sf_path", [_WEEKLY, _ADVISORY, _MODELZOO], ids=lambda p: p.stem)
+@pytest.mark.parametrize(
+    "sf_path", [_WEEKLY, _ADVISORY, _MODELZOO, _EOD, _DAILY, _GROOM],
+    ids=lambda p: p.stem,
+)
 def test_every_choice_variable_is_guarded_or_floored(sf_path):
     definition = _load(sf_path)
     top_floors = _initialize_input_floors(definition)
     violations: list[str] = []
     choices_seen = 0
-    for scope_path, states, in_map in _iter_scopes(definition):
+    for scope_path, states, floors, init_name, start in _iter_scopes(
+            definition, top_floors):
+        analysis = _FloorAnalysis(states, floors, init_name, start)
         for name, state in states.items():
             if state.get("Type") != "Choice":
                 continue
@@ -223,8 +368,8 @@ def test_every_choice_variable_is_guarded_or_floored(sf_path):
                     "States.Runtime"
                 )
 
-            def floored(var, _name=name, _states=states, _in_map=in_map):
-                return _is_floored(var, _name, _states, _in_map, top_floors)
+            def floored(var, _name=name, _analysis=analysis):
+                return _analysis.floored(var, _name)
 
             for rule in state.get("Choices", []):
                 violations.extend(
@@ -299,7 +444,7 @@ def _eval_rule(rule: dict, data) -> bool:
 
 
 def _find_state(definition: dict, name: str) -> dict:
-    for _, states, _ in _iter_scopes(definition):
+    for _, states, _, _, _ in _iter_scopes(definition, set()):
         if name in states:
             return states[name]
     raise AssertionError(f"state {name!r} not found")
@@ -366,6 +511,114 @@ def test_partial_payload_routes_to_explicit_path_advisory(choice, partial_input,
     """alpha-engine-config-I2544: same drill, re-pointed at the advisory
     child SF the eval-judge chain now lives in."""
     definition = _load(_ADVISORY)
+    assert _choice_target(definition, choice, partial_input) == expected_route
+
+
+@pytest.mark.parametrize(
+    ("choice", "partial_input", "expected_route"),
+    [
+        # THE 2026-07-16 incident: a fully-green day never sets
+        # $.degraded_summary — must end NormalSucceeded, not States.Runtime.
+        ("CheckDegradedOutcome", {}, "NormalSucceeded"),
+        ("CheckDegradedOutcome", {"degraded_summary": {"degraded": True}},
+         "DegradedSucceeded"),
+        # Malformed dispatcher payload before the cost-guard tail: route to
+        # the visible data-spot failure notifier, never a crash that skips
+        # StopTradingInstance.
+        ("CheckPostMarketDataSpotLaunched",
+         {"postmarket_launch": {"Payload": {}}}, "ExtractDataSpotError"),
+        ("CheckPostMarketArcticAppendSpotLaunched",
+         {"postmarket_arctic_launch": {"Payload": {}}}, "ExtractDataSpotError"),
+        # Heal-loop probes: absent fields keep the loop bounded, no crash.
+        ("HealCheckConverged", {"precondition_probe": {"Payload": {}}},
+         "HealLoopIncrement"),
+        ("HealLoopGate",
+         {"heal_loop": {"attempts": 0}, "precondition_probe": {"Payload": {}}},
+         "HealLaunchPostMarketDataSpot"),
+        ("HealLoopGate",
+         {"heal_loop": {"attempts": 2}, "precondition_probe": {"Payload": {}}},
+         "HealNonConvergent"),
+        ("CheckHealLoopEligible", {}, "InitHealLoop"),
+        # Healthy-path sanity: the guards must not change live semantics.
+        ("CheckHealLoopEligible", {"pipeline_role": "operator-replay"},
+         "HealNonConvergent"),
+        ("CheckHealLoopEligible", {"pipeline_role": "eod"}, "InitHealLoop"),
+        ("CheckPostMarketDataSpotLaunched",
+         {"postmarket_launch": {"Payload": {"data_spot": {"launched": True}}}},
+         "PollPostMarketDataSpot"),
+        ("CheckPostMarketDataSpotLaunched",
+         {"postmarket_launch": {"Payload": {"data_spot": {"launched": False}}}},
+         "CheckSkipCaptureSnapshot"),
+        ("HealCheckConverged",
+         {"precondition_probe": {"Payload": {"precondition_met": True}}},
+         "HealDispatchReplay"),
+    ],
+)
+def test_partial_payload_routes_to_explicit_path_eod(choice, partial_input, expected_route):
+    """config-I2767: same drill, pointed at the postclose SF the 2026-07-16
+    States.Runtime incident occurred in."""
+    definition = _load(_EOD)
+    assert _choice_target(definition, choice, partial_input) == expected_route
+
+
+@pytest.mark.parametrize(
+    ("choice", "partial_input", "expected_route"),
+    [
+        # Malformed gate/dispatcher payloads pre-trading: fail CLOSED and
+        # loud — never trade on an unverifiable verdict, never crash.
+        ("DeployDriftGate", {"drift_result": {"Payload": {}}}, "HandleFailure"),
+        ("TradingDayGateChoice", {"trading_day_gate": {"Payload": {}}},
+         "HandleFailure"),
+        ("CoverageGapChoice", {"coverage_result": {"Payload": {}}},
+         "HandleFailure"),
+        ("FinalCoverageGate", {"coverage_recheck_result": {"Payload": {}}},
+         "HandleFailure"),
+        # Data-spot launched-gates are the exception to fail-closed: a
+        # data-spot failure must NEVER block daemon start (config#1767 #4),
+        # so malformed routes to the fail-open-but-LOUD notifier chain.
+        ("CheckMorningEnrichSpotLaunched",
+         {"morning_enrich_launch": {"Payload": {}}}, "ExtractDataSpotError"),
+        ("CheckMorningArcticAppendSpotLaunched",
+         {"arctic_append_launch": {"Payload": {}}}, "ExtractDataSpotError"),
+        # Healthy-path sanity: the guards must not change live semantics.
+        ("TradingDayGateChoice",
+         {"trading_day_gate": {"Payload": {"is_trading_day": False}}},
+         "NotifyHolidaySkip"),
+        ("TradingDayGateChoice",
+         {"trading_day_gate": {"Payload": {"is_trading_day": True}}},
+         "StartExecutorEC2"),
+        ("DeployDriftGate", {"drift_result": {"Payload": {"has_drift": False}}},
+         "TradingDayGate"),
+        ("CheckMorningEnrichSpotLaunched",
+         {"morning_enrich_launch": {"Payload": {"data_spot": {"launched": False}}}},
+         "CheckSkipPredictorInference"),
+    ],
+)
+def test_partial_payload_routes_to_explicit_path_daily(choice, partial_input, expected_route):
+    """config-I2767: same drill, pointed at the preopen SF."""
+    definition = _load(_DAILY)
+    assert _choice_target(definition, choice, partial_input) == expected_route
+
+
+@pytest.mark.parametrize(
+    ("choice", "partial_input", "expected_route"),
+    [
+        # Unverifiable launch escalates via the exhausted-notifier — never
+        # mislabeled as the INTENTIONAL kill-switch skip, never a crash.
+        ("CheckLaunched", {"groomLaunch": {"Payload": {}}},
+         "GroomRetriesExhausted"),
+        # Healthy-path sanity: the guards must not change live semantics.
+        ("CheckLaunched",
+         {"groomLaunch": {"Payload": {"groom": {"launched": True}}}},
+         "PollGroomCommand"),
+        ("CheckLaunched",
+         {"groomLaunch": {"Payload": {"groom": {"launched": False}}}},
+         "GroomSkipped"),
+    ],
+)
+def test_partial_payload_routes_to_explicit_path_groom(choice, partial_input, expected_route):
+    """config-I2767: same drill, pointed at the groom-dispatch SF."""
+    definition = _load(_GROOM)
     assert _choice_target(definition, choice, partial_input) == expected_route
 
 

--- a/tests/test_sf_eod_precondition_probe_wiring.py
+++ b/tests/test_sf_eod_precondition_probe_wiring.py
@@ -186,11 +186,17 @@ class TestDegradedTerminalState:
         assert states["StopTradingInstance"]["Next"] == "CheckDegradedOutcome"
 
     def test_degraded_outcome_routes_on_the_flag(self, states):
+        # config-I2767 (2026-07-16 incident): the flag is only assigned on
+        # the degraded path, so the comparison MUST be IsPresent-guarded —
+        # an unguarded dereference threw States.Runtime on every fully-green
+        # day. Absent flag falls to Default NormalSucceeded.
         cdo = states["CheckDegradedOutcome"]
         assert cdo["Type"] == "Choice"
         c = cdo["Choices"][0]
-        assert c["Variable"] == "$.degraded_summary.degraded"
-        assert c["BooleanEquals"] is True
+        guard, comparison = c["And"]
+        assert guard == {"Variable": "$.degraded_summary.degraded", "IsPresent": True}
+        assert comparison["Variable"] == "$.degraded_summary.degraded"
+        assert comparison["BooleanEquals"] is True
         assert c["Next"] == "DegradedSucceeded"
         assert cdo["Default"] == "NormalSucceeded"
 
@@ -221,8 +227,13 @@ class TestHealLoopEligibility:
         chle = states["CheckHealLoopEligible"]
         assert chle["Type"] == "Choice"
         c = chle["Choices"][0]
-        assert c["Variable"] == "$.pipeline_role"
-        assert c["StringEquals"] == "operator-replay"
+        # config-I2767: IsPresent-guarded — $.pipeline_role is an execution-
+        # input key this SF never floors; absent falls to Default (live
+        # treatment).
+        guard, comparison = c["And"]
+        assert guard == {"Variable": "$.pipeline_role", "IsPresent": True}
+        assert comparison["Variable"] == "$.pipeline_role"
+        assert comparison["StringEquals"] == "operator-replay"
         assert c["Next"] == "HealNonConvergent"
         assert chle["Default"] == "InitHealLoop"
 
@@ -243,7 +254,17 @@ class TestHealLoopBound:
         assert gate["Type"] == "Choice"
         c = gate["Choices"][0]
         assert "Or" in c
-        variables = {cond["Variable"] for cond in c["Or"]}
+        # config-I2767: the deadline operand is IsPresent-guarded (absent →
+        # operand false, loop stays bounded by attempts); the attempts
+        # operand is provably floored by InitHealLoop/HealLoopIncrement.
+        variables = set()
+        for cond in c["Or"]:
+            if "And" in cond:
+                assert cond["And"][0]["IsPresent"] is True
+                assert cond["And"][0]["Variable"] == cond["And"][1]["Variable"]
+                variables.add(cond["And"][1]["Variable"])
+            else:
+                variables.add(cond["Variable"])
         assert variables == {"$.heal_loop.attempts", "$.precondition_probe.Payload.past_deadline"}
         assert c["Next"] == "HealNonConvergent"
         assert gate["Default"] == "HealLaunchPostMarketDataSpot"
@@ -321,8 +342,12 @@ class TestHealLoopDispatchChain:
     def test_converged_choice_dispatches_the_replay(self, states):
         hcc = states["HealCheckConverged"]
         c = hcc["Choices"][0]
-        assert c["Variable"] == "$.precondition_probe.Payload.precondition_met"
-        assert c["BooleanEquals"] is True
+        # config-I2767: IsPresent-guarded — a partial probe payload falls to
+        # Default HealLoopIncrement (bounded loop), never States.Runtime.
+        guard, comparison = c["And"]
+        assert guard == {"Variable": "$.precondition_probe.Payload.precondition_met", "IsPresent": True}
+        assert comparison["Variable"] == "$.precondition_probe.Payload.precondition_met"
+        assert comparison["BooleanEquals"] is True
         assert c["Next"] == "HealDispatchReplay"
         assert hcc["Default"] == "HealLoopIncrement"
 

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -187,8 +187,15 @@ class TestPaths:
                 succ = [c["Next"] for c in st.get("Choices", []) if c.get("StringEquals") == "Success"]
                 # config#1767: the spot launched-gate states branch on
                 # launched:true (BooleanEquals) — follow that on the happy path.
+                # config-I2767: the rule is now And[IsPresent, BooleanEquals]-
+                # guarded, so unwrap the And when matching.
+                def _ops(rule):
+                    merged = {}
+                    for op in rule.get("And", [rule]):
+                        merged.update(op)
+                    return merged
                 launched = (
-                    [c["Next"] for c in st.get("Choices", []) if c.get("BooleanEquals") is True]
+                    [c["Next"] for c in st.get("Choices", []) if _ops(c).get("BooleanEquals") is True]
                     if cur.endswith("SpotLaunched") else []
                 )
                 cur = (succ or launched or [st.get("Default")])[0]

--- a/tests/test_sf_trading_day_gate_wiring.py
+++ b/tests/test_sf_trading_day_gate_wiring.py
@@ -70,7 +70,8 @@ class TestTradingDayGateChoice:
         false_branch = [
             c["Next"]
             for c in states["TradingDayGateChoice"]["Choices"]
-            if c.get("BooleanEquals") is False
+            # config-I2767: unwrap the And[IsPresent, BooleanEquals] guard.
+            if any(op.get("BooleanEquals") is False for op in c.get("And", [c]))
         ]
         assert false_branch == ["NotifyHolidaySkip"]
 
@@ -83,8 +84,12 @@ class TestTradingDayGateChoice:
         assert states["TradingDayGateChoice"]["Default"] == "StartExecutorEC2"
 
     def test_choice_reads_is_trading_day_off_gate_payload(self, states):
-        var = states["TradingDayGateChoice"]["Choices"][0]["Variable"]
-        assert var == "$.trading_day_gate.Payload.is_trading_day"
+        # config-I2767: the comparison is IsPresent-guarded inside an And;
+        # both operands read the same gate-payload path.
+        rule = states["TradingDayGateChoice"]["Choices"][0]
+        variables = {op["Variable"] for op in rule["And"]}
+        assert variables == {"$.trading_day_gate.Payload.is_trading_day"}
+        assert any(op.get("IsPresent") is True for op in rule["And"])
 
 
 class TestTradingDayGateFailed:

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -132,7 +132,8 @@ class TestEntryEdgesRouteThroughGates:
         false_branch = [
             c["Next"]
             for c in states["TradingDayGateChoice"]["Choices"]
-            if c.get("BooleanEquals") is False
+            # config-I2767: unwrap the And[IsPresent, BooleanEquals] guard.
+            if any(op.get("BooleanEquals") is False for op in c.get("And", [c]))
         ]
         assert false_branch == ["NotifyHolidaySkip"]
         assert states["TradingDayGateFailed"]["Next"] == "StartExecutorEC2"
@@ -249,7 +250,9 @@ class TestPaths:
                     if c.get("StringEquals") in ("Success", "SUCCESS")
                 ]
                 launched = (
-                    [c["Next"] for c in st.get("Choices", []) if c.get("BooleanEquals") is True]
+                    # config-I2767: unwrap the And[IsPresent, BooleanEquals] guard.
+                    [c["Next"] for c in st.get("Choices", [])
+                     if any(op.get("BooleanEquals") is True for op in c.get("And", [c]))]
                     if cur.endswith("SpotLaunched") else []
                 )
                 cur = (succ or launched or [st.get("Default")])[0]


### PR DESCRIPTION
## Incident

`ne-postclose-trading-pipeline` execution `eod-2026-07-16-1784232035` FAILED with `States.Runtime` at `CheckDegradedOutcome` (config-I2702 deliverable #4): `$.degraded_summary.degraded` is only assigned on the degraded path (`SetDegradedFlag`), so every fully-green day threw at the pipeline's very last state. All load-bearing work (EODReconcile, StopTradingInstance) had already succeeded — no data impact. Tracked as alpha-engine-config-I2767.

## Systemic root cause + fix

The config#2275 guard-or-floor discipline (`tests/test_sf_choice_guards.py`) covered only the weekly/advisory/modelzoo definitions. The eod/daily/groom definitions were never in scope — I2702's Choice landed exactly in that coverage hole, alongside 14 other latent same-class sites (including `CheckPostMarketDataSpotLaunched`, where a malformed dispatcher payload would have killed the execution BEFORE `StopTradingInstance`, bypassing the cost guard).

This PR:

1. **Guards `CheckDegradedOutcome`** with the canonical `And:[IsPresent, BooleanEquals]` idiom — absent flag falls to `Default: NormalSucceeded`, the semantically exact reading.
2. **Guards every other conditionally-assigned dereference** in eod/daily/groom, each with a deliberate absent-route:
   - data-spot launched-gates → the fail-open-but-LOUD `ExtractDataSpotError` notifier chain (preserves config#1767 #4: a data-spot failure never blocks daemon start / instance stop);
   - pre-trade gates (`DeployDriftGate`, `TradingDayGateChoice`, coverage gates) → fail CLOSED to `HandleFailure` (never trade on an unverifiable verdict);
   - heal-loop probe fields → fall through to the bounded loop (2 attempts, then `HealNonConvergent` pages);
   - groom `CheckLaunched` → `GroomRetriesExhausted` escalation (never mislabeled as the intentional kill-switch skip).
3. **Extends `test_sf_choice_guards.py` to all six SF definitions** and upgrades its floor analysis from direct-predecessor to transitive definite assignment (backward walk over the state graph with ResultPath/OutputPath/catch-edge semantics + Map ItemSelector floors). Structurally-floored counters (`$.ssm_poll.attempts`, retry budgets) are now PROVEN safe — deliberately NOT guarded, since guarding a poll counter converts a crash into an infinite Wait loop. Mutation-tested: reverting `CheckDegradedOutcome` to the shipped shape, or breaking a counter's `ResultPath`, both flag.
4. **Drill tests** for every new guard: malformed `{}` payloads route to the explicit degraded/failure path, and healthy-path semantics are byte-for-byte unchanged.

## Verification

- Full suite: **3342 passed, 12 skipped** (includes the 10 wiring tests updated to assert the new guarded shapes).
- All three edited definitions validate `OK` via `aws stepfunctions validate-state-machine-definition`.
- Deploy is merge-button-only: `deploy-infrastructure.yml` restamps + `update-state-machine`s all SFs on push to main and runs the definition-drift check.

Closes nousergon/alpha-engine-config#2767 (alpha-engine-config-I2767)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
