### PR TITLE
fix(iam): grant deploy role PutRetentionPolicy on groom-dispatch vendedlogs group (config-I2779)

### DIFF
--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -105,7 +105,10 @@
       "Resource": "arn:aws:s3:::alpha-engine-research",
       "Condition": {
         "StringLike": {
-          "s3:prefix": ["changelog/", "changelog/*"]
+          "s3:prefix": [
+            "changelog/",
+            "changelog/*"
+          ]
         }
       }
     },
@@ -328,7 +331,9 @@
       ],
       "Resource": [
         "arn:aws:logs:us-east-1:711398986525:log-group:/aws/stepfunctions/ne-*-pipeline",
-        "arn:aws:logs:us-east-1:711398986525:log-group:/aws/stepfunctions/ne-*-pipeline:*"
+        "arn:aws:logs:us-east-1:711398986525:log-group:/aws/stepfunctions/ne-*-pipeline:*",
+        "arn:aws:logs:us-east-1:711398986525:log-group:/aws/vendedlogs/states/alpha-engine-groom-dispatch",
+        "arn:aws:logs:us-east-1:711398986525:log-group:/aws/vendedlogs/states/alpha-engine-groom-dispatch:*"
       ]
     },
     {


### PR DESCRIPTION
PR887 added a `put-retention-policy` call on the new `/aws/vendedlogs/states/alpha-engine-groom-dispatch` log group, but the `github-actions-lambda-deploy` role's `InfraDeployLogGroups` statement only covered `/aws/stepfunctions/ne-*-pipeline*` — every main push failed the deploy with AccessDeniedException before any `update-state-machine` call, holding back the merged config-I2767 postclose fix (nousergon-data-PR889) from going live.

This adds the two missing resource ARNs, scoped to the single groom-dispatch log group (deliberately not a `vendedlogs/*` wildcard — least privilege; this is the SOTA option, no delta). **Already applied live** by the operator via `infrastructure/iam/apply.sh` per the IAM-applies-in-session convention; the deploy workflow was re-run against it (run 29539751738). This PR is the codification.

Closes nousergon/alpha-engine-config#2779 (alpha-engine-config-I2779)

🤖 Generated with [Claude Code](https://claude.com/claude-code)