### PR TITLE
fix(ci): drop synchronize from canary-replay trigger (config-I2780)

### DIFF
--- a/.github/workflows/canary-replay.yml
+++ b/.github/workflows/canary-replay.yml
@@ -12,10 +12,20 @@ name: Canary Replay
 # Fork PRs have no OIDC trust to this account — configure-aws-credentials
 # fails cleanly and the job exits 0 rather than failing a check a fork
 # contributor cannot fix.
+#
+# config-I2780 interim stopgap (2026-07-16): `synchronize` dropped from the
+# trigger. Each probe run does a full unfiltered read of the production
+# Neon RAG corpus (filing_change_detection.py's _load_filing_embeddings has
+# no incremental/watermark path) — with `synchronize` included, every push
+# to an already-labeled PR re-ran the full read, and 29 such reads hit in a
+# single day exhausted the Neon project's egress quota. This is a debounce
+# only, not the real fix: the canary should read from a replica/staging
+# snapshot or a bounded sample, tracked as the closing condition on I2780.
+# `opened`/`reopened`/`labeled` still gate one read per PR lifecycle event.
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, labeled]
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

- Interim stopgap for **config-I2780** (P0): the canary-replay gate re-ran
  `filing_change_detection`'s unfiltered full-corpus read against the
  production Neon RAG DB on every `synchronize` push to a labeled PR — 29
  reads in a single day (2026-07-16) exhausted the project's egress quota.
- Saturday 2026-07-18 is the first live run of the reshaped weekly pipeline
  (config-I2515), whose `RAGIngestion`/`ThinkTankCoverage` states read/write
  this same Neon corpus — this stops further quota burn before then.
- Drops `synchronize` from `canary-replay.yml`'s trigger; keeps
  `opened|reopened|labeled` so the canary still gates once per PR lifecycle
  event, just not on every iterative push.

**This is a debounce only, not the real fix.** The real fix (sampled read
or replica/staging-DB isolation for the canary path so PR iteration never
touches the production egress budget) is tracked as I2780's closing
condition — filed separately, not scoped to this PR.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML valid
- [x] Diff is confined to the one trigger-types line + explanatory comment;
      no other workflow behavior changed
- [ ] CI green on this PR (Brian to confirm before merge)

Closes-when for config-I2780 is NOT this PR — see the issue for the real
scope.
