### PR TITLE
fix(rag): server-side centroid pushdown + canary sampling — Neon egress whale (config-I2780)

### DIFF
--- a/.github/workflows/canary-replay.yml
+++ b/.github/workflows/canary-replay.yml
@@ -17,6 +17,17 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
+# One in-flight canary per PR: iterative pushes to an actively-developed
+# branch superseded each other 29 times on 2026-07-16 alone, and every
+# launched replay ran the data probe's full-corpus pgvector read against
+# production Neon — the amplification that exhausted the project's monthly
+# data-transfer quota (config-I2780). The newest head is the only one whose
+# verdict matters; cancel the stale poll and let the dispatcher's server-side
+# dedupe decline the stale launch.
+concurrency:
+  group: canary-replay-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read

--- a/rag/pipelines/filing_change_detection.py
+++ b/rag/pipelines/filing_change_detection.py
@@ -7,9 +7,17 @@ may underperform (Cohen, Malloy & Nguyen 2020).
 Outputs filing_changes.json to S3 for downstream consumption by the research
 scoring pipeline.
 
+Egress contract (config-I2780): centroid aggregation is pushed down to
+Postgres — this module must NEVER select raw ``rag.chunks.embedding`` rows
+in bulk. A full-corpus embedding read is ~150-250MB of Neon data-transfer
+per run and, amplified by per-PR canary replays, exhausted the project's
+monthly quota on 2026-07-16 (hard connect lockout for every RAG consumer).
+Canary/CI invocations must additionally pass ``--sample-tickers N``.
+
 Usage:
     python -m rag.pipelines.filing_change_detection --output-s3
     python -m rag.pipelines.filing_change_detection --output-local /tmp/filing_changes.json
+    python -m rag.pipelines.filing_change_detection --sample-tickers 5 --output-local /tmp/probe.json
 """
 
 from __future__ import annotations
@@ -51,50 +59,134 @@ def _embedding_to_f32(embedding) -> np.ndarray:
     return np.asarray(embedding, dtype=np.float32)
 
 
-def _load_filing_embeddings() -> dict[str, list[dict]]:
-    """Load all 10-K and 10-Q filing embeddings grouped by ticker.
+# Server-side centroid aggregation (config-I2780 / config-I2753 / config-I2781).
+#
+# The original query here SELECTed the raw ``c.embedding`` column for EVERY
+# 10-K/10-Q chunk in the corpus on every invocation (~25k chunks × ~5KB of
+# pgvector text wire format ≈ 150-250MB of Neon egress per run), then reduced
+# it all client-side to one centroid per filing (+ one per section) for only
+# the latest two filings per (ticker, doc_type). That single query shape —
+# amplified by the per-PR canary replay re-running it on every push
+# (config#2246) — is what exhausted the Neon project's 5GB/month data-transfer
+# quota on 2026-07-16 and hard-locked every RAG consumer out of the DB.
+#
+# The reduction is associative, so it is pushed down to Postgres: pgvector's
+# ``AVG(vector)`` computes the element-wise mean (identical semantics to the
+# ``np.mean(np.stack(...))`` it replaces), GROUPING SETS emits both the
+# per-filing overall centroid and the per-(filing, section) centroids in one
+# pass, and DENSE_RANK restricts the scan to the filings actually compared.
+# Wire payload drops from the full corpus to ~one vector per (filing ×
+# section) actually analyzed — ≈95%+ egress reduction — with the client-side
+# similarity/flag logic unchanged.
+#
+# ``GROUPING(c.section_label)`` disambiguates the overall row (=1) from a
+# per-section row whose label is genuinely NULL (=0); unlabeled chunks
+# contribute to the overall centroid but not to any section, exactly as the
+# old client-side grouping behaved.
+_CENTROID_SQL = """
+    WITH filings AS (
+        SELECT id, ticker, doc_type, filed_date,
+               DENSE_RANK() OVER (
+                   PARTITION BY ticker, doc_type ORDER BY filed_date DESC
+               ) AS date_rank
+        FROM rag.documents
+        WHERE doc_type IN ('10-K', '10-Q'){ticker_filter}
+    )
+    SELECT f.ticker,
+           f.doc_type,
+           f.filed_date,
+           c.section_label,
+           GROUPING(c.section_label) AS is_overall,
+           AVG(c.embedding)          AS centroid,
+           COUNT(*)                  AS n_chunks
+    FROM filings f
+    JOIN rag.chunks c ON c.document_id = f.id
+    WHERE f.date_rank <= %s AND c.embedding IS NOT NULL
+    GROUP BY GROUPING SETS (
+        (f.ticker, f.doc_type, f.filed_date),
+        (f.ticker, f.doc_type, f.filed_date, c.section_label)
+    )
+    ORDER BY f.ticker, f.doc_type, f.filed_date
+"""
 
-    Returns {ticker: [{filed_date, doc_type, embeddings: [np.array], sections: {label: [np.array]}}]}
+# Canary/CI sampling (config-I2780 fix b): restrict the scan to the first N
+# tickers (deterministic order) so a probe run proves the code path end-to-end
+# for kilobytes of egress instead of replaying full production load.
+_TICKER_SAMPLE_FILTER = """
+          AND ticker IN (
+              SELECT DISTINCT ticker FROM rag.documents
+              WHERE doc_type IN ('10-K', '10-Q')
+              ORDER BY ticker
+              LIMIT %s
+          )"""
+
+
+def _load_filing_centroids(
+    min_filings: int = 2, sample_tickers: int | None = None
+) -> dict[str, list[dict]]:
+    """Load per-filing embedding centroids for the latest filings per ticker.
+
+    Aggregation happens server-side (see ``_CENTROID_SQL``); only centroids
+    cross the wire. Fetches the latest ``max(2, min_filings)`` distinct
+    filing dates per (ticker, doc_type): two is all the consecutive-pair
+    comparison reads, but ``min_filings > 2`` callers still need to OBSERVE
+    that many filings exist to preserve the original threshold semantics.
+
+    DENSE_RANK (not ROW_NUMBER) ranks by distinct ``filed_date``, so a filing
+    ingested from two sources on the same date collapses into one centroid
+    group — matching the old client-side grouping by (ticker, doc_type, date).
+
+    Args:
+        min_filings: Same threshold ``compute_filing_changes`` applies.
+        sample_tickers: When set (canary/CI probes), restrict to the first N
+            tickers so the probe never replays full production load
+            (config-I2780).
+
+    Returns:
+        {ticker: [{ticker, doc_type, filed_date, centroid: np.ndarray,
+                   sections: {label: np.ndarray}, n_chunks: int}, ...]}
+        with each ticker's filings sorted by filed_date ascending.
     """
     from nousergon_lib.rag.db import get_connection
 
-    sql = """
-        SELECT d.ticker, d.doc_type, d.filed_date, c.section_label, c.embedding
-        FROM rag.documents d
-        JOIN rag.chunks c ON c.document_id = d.id
-        WHERE d.doc_type IN ('10-K', '10-Q')
-        ORDER BY d.ticker, d.filed_date, c.chunk_index
-    """
+    params: list = []
+    if sample_tickers is not None:
+        if sample_tickers < 1:
+            raise ValueError(f"sample_tickers must be >= 1; got {sample_tickers}")
+        ticker_filter = _TICKER_SAMPLE_FILTER
+        params.append(sample_tickers)
+    else:
+        ticker_filter = ""
+    sql = _CENTROID_SQL.format(ticker_filter=ticker_filter)
+    params.append(max(2, min_filings))
 
     with get_connection() as conn:
         with conn.cursor() as cur:
-            cur.execute(sql)
+            cur.execute(sql, params)
             rows = cur.fetchall()
 
-    # Group by (ticker, doc_type, filed_date)
     grouped: dict[tuple, dict] = {}
-    for ticker, doc_type, filed_date, section_label, embedding in rows:
+    for ticker, doc_type, filed_date, section_label, is_overall, centroid, n_chunks in rows:
         key = (ticker, doc_type, str(filed_date))
         if key not in grouped:
             grouped[key] = {
                 "ticker": ticker,
                 "doc_type": doc_type,
                 "filed_date": str(filed_date),
-                "embeddings": [],
-                "sections": defaultdict(list),
+                "centroid": None,
+                "sections": {},
+                "n_chunks": 0,
             }
-        if embedding is not None:
-            vec = _embedding_to_f32(embedding)
-            grouped[key]["embeddings"].append(vec)
-            if section_label:
-                grouped[key]["sections"][section_label].append(vec)
+        if is_overall:
+            grouped[key]["centroid"] = _embedding_to_f32(centroid)
+            grouped[key]["n_chunks"] = int(n_chunks)
+        elif section_label:
+            grouped[key]["sections"][section_label] = _embedding_to_f32(centroid)
 
-    # Reorganize by ticker
     by_ticker: dict[str, list[dict]] = defaultdict(list)
     for entry in grouped.values():
         by_ticker[entry["ticker"]].append(entry)
 
-    # Sort each ticker's filings by date
     for ticker in by_ticker:
         by_ticker[ticker].sort(key=lambda x: x["filed_date"])
 
@@ -110,14 +202,9 @@ def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
     return float(np.dot(a, b) / (norm_a * norm_b))
 
 
-def _centroid(vectors: list[np.ndarray]) -> np.ndarray | None:
-    """Compute the mean (centroid) of a list of vectors."""
-    if not vectors:
-        return None
-    return np.mean(np.stack(vectors), axis=0)
-
-
-def compute_filing_changes(min_filings: int = 2) -> list[dict]:
+def compute_filing_changes(
+    min_filings: int = 2, sample_tickers: int | None = None
+) -> list[dict]:
     """Compute filing change scores for all tickers with consecutive filings.
 
     For each ticker with 2+ same-type filings, computes:
@@ -125,9 +212,16 @@ def compute_filing_changes(min_filings: int = 2) -> list[dict]:
     - section_similarities: per-section centroid cosine similarity
     - change_score: 1 - overall_similarity (0 = identical, 1 = completely different)
 
+    Args:
+        min_filings: Minimum same-type filings a ticker needs to be analyzed.
+        sample_tickers: When set, analyze only the first N tickers — the
+            canary/CI probe knob (config-I2780); production runs leave it None.
+
     Returns list of per-ticker change records.
     """
-    by_ticker = _load_filing_embeddings()
+    by_ticker = _load_filing_centroids(
+        min_filings=min_filings, sample_tickers=sample_tickers
+    )
     results = []
 
     for ticker, filings in by_ticker.items():
@@ -144,20 +238,20 @@ def compute_filing_changes(min_filings: int = 2) -> list[dict]:
             prev = type_filings[-2]
             curr = type_filings[-1]
 
-            prev_centroid = _centroid(prev["embeddings"])
-            curr_centroid = _centroid(curr["embeddings"])
+            prev_centroid = prev["centroid"]
+            curr_centroid = curr["centroid"]
 
             if prev_centroid is None or curr_centroid is None:
                 continue
 
             overall_sim = _cosine_similarity(prev_centroid, curr_centroid)
 
-            # Section-level similarities
+            # Section-level similarities (only sections present in BOTH filings)
             section_sims = {}
             all_sections = set(prev["sections"].keys()) | set(curr["sections"].keys())
             for section in all_sections:
-                prev_sec = _centroid(prev["sections"].get(section, []))
-                curr_sec = _centroid(curr["sections"].get(section, []))
+                prev_sec = prev["sections"].get(section)
+                curr_sec = curr["sections"].get(section)
                 if prev_sec is not None and curr_sec is not None:
                     section_sims[section] = round(_cosine_similarity(prev_sec, curr_sec), 4)
 
@@ -171,8 +265,8 @@ def compute_filing_changes(min_filings: int = 2) -> list[dict]:
                 "overall_similarity": round(overall_sim, 4),
                 "change_score": change_score,
                 "section_similarities": section_sims,
-                "n_prev_chunks": len(prev["embeddings"]),
-                "n_curr_chunks": len(curr["embeddings"]),
+                "n_prev_chunks": prev["n_chunks"],
+                "n_curr_chunks": curr["n_chunks"],
             }
 
             # Flag "lazy" filings: very high similarity = minimal changes
@@ -214,6 +308,18 @@ def main():
     parser.add_argument("--output-local", type=str, help="Write results to local file")
     parser.add_argument("--bucket", type=str, default="alpha-engine-research")
     parser.add_argument(
+        "--sample-tickers",
+        type=int,
+        default=None,
+        help=(
+            "Restrict the analysis to the first N tickers (deterministic "
+            "order). Canary/CI probe knob (config-I2780): proves the "
+            "DB-to-S3 code path end-to-end for kilobytes of Neon egress "
+            "instead of replaying full production load. Production runs "
+            "omit it."
+        ),
+    )
+    parser.add_argument(
         "--key-prefix",
         type=str,
         default="",
@@ -227,7 +333,7 @@ def main():
     )
     args = parser.parse_args()
 
-    results = compute_filing_changes()
+    results = compute_filing_changes(sample_tickers=args.sample_tickers)
 
     output = {
         "date": date.today().isoformat(),

--- a/tests/test_filing_change_detection_centroid_pushdown.py
+++ b/tests/test_filing_change_detection_centroid_pushdown.py
@@ -1,0 +1,223 @@
+"""Guard: filing change detection aggregates embeddings SERVER-SIDE.
+
+Regression (2026-07-16 Neon quota lockout, config-I2780/I2781): the original
+``_load_filing_embeddings`` SELECTed the raw ``rag.chunks.embedding`` column
+for every 10-K/10-Q chunk in the corpus on every invocation (~150-250MB of
+Neon data-transfer per run), then reduced it client-side to one centroid per
+filing. Amplified by the per-PR canary replay re-running it on every push,
+that single query shape exhausted the Neon project's 5GB/month data-transfer
+quota and hard-locked every RAG consumer out of the DB.
+
+These tests lock the fix:
+
+1. The SQL pushes centroid aggregation down to Postgres (``AVG(c.embedding)``
+   + GROUPING SETS) and never selects raw embedding rows in bulk.
+2. The client-side reshaping/pairing/flag logic is behaviorally identical to
+   the legacy client-side reduction (same output record schema and semantics).
+3. ``--sample-tickers`` (the canary/CI knob) parameterizes the query so probe
+   runs cannot replay full production load.
+"""
+
+from __future__ import annotations
+
+import inspect
+from contextlib import contextmanager
+from datetime import date
+
+import numpy as np
+import pytest
+
+import rag.pipelines.filing_change_detection as fcd
+
+
+# ── Fake DB plumbing ─────────────────────────────────────────────────────────
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+        self.executed_sql: str | None = None
+        self.executed_params: list | None = None
+
+    def execute(self, sql, params=None):
+        self.executed_sql = sql
+        self.executed_params = list(params) if params is not None else None
+
+    def fetchall(self):
+        return self._rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+@pytest.fixture
+def fake_db(monkeypatch):
+    """Patch the lib get_connection chokepoint; returns the cursor for
+    asserting on the executed SQL/params after the call."""
+    state = {"cursor": _FakeCursor([])}
+
+    @contextmanager
+    def _fake_get_connection():
+        yield _FakeConn(state["cursor"])
+
+    import nousergon_lib.rag.db as libdb
+
+    monkeypatch.setattr(libdb, "get_connection", _fake_get_connection)
+    return state
+
+
+def _row(ticker, doc_type, filed, section, is_overall, centroid, n_chunks):
+    """Mirror _CENTROID_SQL's SELECT column order."""
+    return (ticker, doc_type, filed, section, is_overall, centroid, n_chunks)
+
+
+# ── 1. Query-shape guards ────────────────────────────────────────────────────
+
+
+def test_sql_aggregates_server_side():
+    assert "AVG(c.embedding)" in fcd._CENTROID_SQL
+    assert "GROUPING SETS" in fcd._CENTROID_SQL
+    assert "DENSE_RANK()" in fcd._CENTROID_SQL
+
+
+def test_no_bulk_raw_embedding_select_anywhere_in_module():
+    # The exact legacy egress-whale projection must never reappear. Strip the
+    # module docstring/comments risk by checking the one aggregated read is
+    # the ONLY place `c.embedding` is selected.
+    src = inspect.getsource(fcd)
+    for line in src.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("#", '"', "'")):
+            continue
+        if "c.embedding" in stripped:
+            assert (
+                "AVG(c.embedding)" in stripped
+                or "c.embedding IS NOT NULL" in stripped
+            ), f"raw embedding column selected outside the aggregate: {stripped!r}"
+
+
+def test_default_params_fetch_latest_two(fake_db):
+    fcd._load_filing_centroids()
+    assert fake_db["cursor"].executed_params == [2]
+    # No ticker-sampling clause on production runs.
+    assert "LIMIT %s" not in fake_db["cursor"].executed_sql
+
+
+def test_sample_tickers_parameterizes_query(fake_db):
+    fcd._load_filing_centroids(sample_tickers=3)
+    assert fake_db["cursor"].executed_params == [3, 2]
+    assert "LIMIT %s" in fake_db["cursor"].executed_sql
+
+
+def test_sample_tickers_rejects_nonpositive(fake_db):
+    with pytest.raises(ValueError):
+        fcd._load_filing_centroids(sample_tickers=0)
+
+
+def test_min_filings_raises_fetch_ceiling(fake_db):
+    fcd._load_filing_centroids(min_filings=3)
+    assert fake_db["cursor"].executed_params == [3]
+
+
+# ── 2. Reshaping + pairing parity with the legacy client-side reduction ─────
+
+
+def _two_filing_rows(overall_prev, overall_curr, rf_prev, rf_curr):
+    """AAPL 10-K with two filings; MD&A identical both sides, Risk Factors
+    parameterized; plus a single-filing MSFT that must be skipped."""
+    mdna = [1.0, 0.0, 0.0]
+    return [
+        # AAPL prev (2024-10-01)
+        _row("AAPL", "10-K", date(2024, 10, 1), None, 1, overall_prev, 40),
+        _row("AAPL", "10-K", date(2024, 10, 1), "MD&A", 0, mdna, 25),
+        _row("AAPL", "10-K", date(2024, 10, 1), "Risk Factors", 0, rf_prev, 15),
+        # AAPL curr (2025-10-01)
+        _row("AAPL", "10-K", date(2025, 10, 1), None, 1, overall_curr, 42),
+        _row("AAPL", "10-K", date(2025, 10, 1), "MD&A", 0, mdna, 26),
+        _row("AAPL", "10-K", date(2025, 10, 1), "Risk Factors", 0, rf_curr, 16),
+        # AAPL curr also has a section prev lacks — must NOT appear in sims
+        _row("AAPL", "10-K", date(2025, 10, 1), "Business", 0, [0.0, 1.0, 0.0], 5),
+        # MSFT has only one 10-K — below min_filings, skipped entirely
+        _row("MSFT", "10-K", date(2025, 7, 1), None, 1, [1.0, 1.0, 0.0], 30),
+        _row("MSFT", "10-K", date(2025, 7, 1), "MD&A", 0, [1.0, 1.0, 0.0], 30),
+    ]
+
+
+def test_identical_filings_flag_lazy(fake_db):
+    v = [0.6, 0.8, 0.0]
+    fake_db["cursor"] = _FakeCursor(_two_filing_rows(v, v, v, v))
+    results = fcd.compute_filing_changes()
+
+    assert len(results) == 1  # MSFT (single filing) skipped
+    rec = results[0]
+    assert rec["ticker"] == "AAPL"
+    assert rec["doc_type"] == "10-K"
+    assert rec["prev_date"] == "2024-10-01"
+    assert rec["curr_date"] == "2025-10-01"
+    assert rec["overall_similarity"] == pytest.approx(1.0)
+    assert rec["change_score"] == pytest.approx(0.0)
+    assert rec["lazy_flag"] is True
+    assert rec["n_prev_chunks"] == 40
+    assert rec["n_curr_chunks"] == 42
+    # Section present on one side only is excluded, matching legacy behavior.
+    assert set(rec["section_similarities"]) == {"MD&A", "Risk Factors"}
+    assert rec["section_similarities"]["MD&A"] == pytest.approx(1.0)
+
+
+def test_risk_factor_change_flagged(fake_db):
+    overall = [0.6, 0.8, 0.0]
+    rf_prev, rf_curr = [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]  # orthogonal → sim 0
+    fake_db["cursor"] = _FakeCursor(
+        _two_filing_rows(overall, overall, rf_prev, rf_curr)
+    )
+    results = fcd.compute_filing_changes()
+    rec = results[0]
+    assert rec["section_similarities"]["Risk Factors"] == pytest.approx(0.0)
+    assert rec["risk_factor_change_flag"] is True
+
+
+def test_changed_filing_scores_change(fake_db):
+    prev, curr = [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]
+    fake_db["cursor"] = _FakeCursor(_two_filing_rows(prev, curr, prev, prev))
+    results = fcd.compute_filing_changes()
+    rec = results[0]
+    assert rec["overall_similarity"] == pytest.approx(0.0)
+    assert rec["change_score"] == pytest.approx(1.0)
+    assert "lazy_flag" not in rec
+
+
+def test_centroids_coerced_to_float32(fake_db):
+    v = [0.5, 0.5, 0.5]
+    fake_db["cursor"] = _FakeCursor(_two_filing_rows(v, v, v, v))
+    by_ticker = fcd._load_filing_centroids()
+    filing = by_ticker["AAPL"][0]
+    assert isinstance(filing["centroid"], np.ndarray)
+    assert filing["centroid"].dtype == np.float32
+    assert filing["sections"]["MD&A"].dtype == np.float32
+
+
+def test_unlabeled_section_group_rows_are_not_sections(fake_db):
+    # A per-section grouping-set row whose label is NULL (chunks with no
+    # section_label) must not create a phantom section.
+    v = [1.0, 0.0, 0.0]
+    rows = [
+        _row("AAPL", "10-K", date(2024, 10, 1), None, 1, v, 10),
+        _row("AAPL", "10-K", date(2024, 10, 1), None, 0, v, 4),  # NULL-label group
+        _row("AAPL", "10-K", date(2025, 10, 1), None, 1, v, 12),
+        _row("AAPL", "10-K", date(2025, 10, 1), None, 0, v, 5),
+    ]
+    fake_db["cursor"] = _FakeCursor(rows)
+    results = fcd.compute_filing_changes()
+    assert len(results) == 1
+    assert results[0]["section_similarities"] == {}


### PR DESCRIPTION
## What

Root-cause fix for the Neon RAG DB data-transfer quota exhaustion (config-I2780 / config-I2781, 2026-07-16 hard lockout).

`filing_change_detection._load_filing_embeddings()` SELECTed the raw `rag.chunks.embedding` column for **every 10-K/10-Q chunk in the corpus** (~25k chunks, ~150-250MB of Neon egress per run), then reduced it client-side to one centroid per filing — for only the latest two filings per (ticker, doc_type). Amplified by per-PR canary replays re-running it on every push (29 non-skipped runs on 2026-07-16 alone), this single query shape consumed the entire 5GB/month quota; Neon now refuses every connection until the Aug 1 reset or a plan upgrade.

## Changes

1. **Server-side centroid pushdown** — `AVG(embedding)` + `GROUPING SETS` computes per-filing and per-(filing, section) centroids in Postgres; `DENSE_RANK` restricts the scan to the latest `max(2, min_filings)` distinct filing dates per (ticker, doc_type). Wire payload drops ~95%+ (full corpus → ~one vector per filing×section actually analyzed). Client-side similarity/flag logic and the output JSON schema are byte-for-byte-shape unchanged.
2. **`--sample-tickers N`** (config-I2780 fix b) — canary/CI probe knob: restricts the analysis to the first N tickers so a probe run costs kilobytes, not production load. The config-repo companion PR wires the canary bootstrap to pass it (feature-detected, so pre-flag branches keep working during the transition).
3. **`canary-replay.yml` concurrency** — one in-flight canary per PR (`cancel-in-progress`), so iterative pushes supersede instead of stacking replays.
4. **Tests** — query-shape guards (a bulk raw-embedding select can never silently reappear) + behavioral-parity tests for the reshaping/pairing/lazy-flag/risk-factor-flag logic. Full suite: 3353 passed, 12 skipped locally.

## Expected RED check — canary replay (by design)

This PR touches `rag/pipelines/**`, so it auto-labels `canary:replay` and dispatches a live canary — which **cannot pass right now**: the Neon project refuses all connections until the quota resets (Aug 1) or the plan is upgraded (config-I2781, Brian's ruling pending). Unblock: once the DB is reachable, re-run the canary check; it then exercises this PR's own sampled probe path. Same blocker/precedent as nousergon-data#753/#860 (config-I2724/I2727).

Companion PRs: alpha-engine-config (bootstrap sampling + usage monitor), crucible-research (same concurrency guard).

Related: config-I2780, config-I2781, config-I2753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
