### PR TITLE
fix: source S&P constituents from SSGA holdings + fix polygon 404 rename-detection gap (config#2812)

### DIFF
--- a/collectors/constituents.py
+++ b/collectors/constituents.py
@@ -1,5 +1,7 @@
 """
-constituents.py — Fetch S&P 500 + S&P 400 constituent tickers from Wikipedia.
+constituents.py — Fetch S&P 500 + S&P 400 constituent membership from the
+SSGA SPDR ETFs' daily holdings files (SPY / MDY), with GICS sector + GICS
+sub-industry classification from Wikipedia.
 
 Writes constituents.json to S3 with:
   - tickers: deduplicated list of ~900 symbols
@@ -8,7 +10,32 @@ Writes constituents.json to S3 with:
   - sub_industry_map: {ticker: GICS_sub_industry_name}
   - sp500_count, sp400_count, total_count, fetched_at
 
-Falls back to a local CSV cache if Wikipedia is unreachable.
+Falls back to a local CSV cache if either source is unreachable.
+
+MEMBERSHIP SOURCE (config#2812, replaces Wikipedia-as-membership-source):
+SPY and MDY are full-replication S&P 500 / S&P 400 index funds — the fund
+manager (State Street/SSGA) is contractually required to hold the ACTUAL
+current index constituents, and both publish their full holdings as a daily
+xlsx, no auth. This is standard free/practical index-membership tracking
+(the alternative — a licensed S&P Dow Jones Indices data feed — is the true
+gold standard but a paid commercial subscription, overkill here). Verified
+live 2026-07-17: JHG and BLD (delisted 2026-07-01 via take-private mergers)
+had already dropped from BOTH SPY's and MDY's holdings, while Wikipedia's
+community-edited constituents pages still listed both 17+ days later —
+Wikipedia-membership-lag was the root cause of alpha-engine-config-I2703/
+I2812 (the daily preopen pipeline's ArcticDB freshness gate hard-failing
+every day on two tickers a Wikipedia-driven auto-prune could never catch,
+since it requires the ticker to be ABSENT from the Wikipedia page first).
+
+SECTOR SOURCE (unchanged): SPY/MDY's own "Sector" holdings column is NOT
+usable GICS classification (verified live: >98% of SPY rows carry a literal
+"-" placeholder, not a sector name) — Wikipedia's constituents tables remain
+the sector/sub-industry source, keyed by ticker and looked up against the
+SSGA-sourced membership list. A membership ticker absent from Wikipedia's
+sector map still hard-fails in ``collect()`` (unchanged behavior) — this is
+now a *useful* freshness signal in the opposite direction (Wikipedia lagging
+on a brand-new ADDITION, which is much rarer and lower-impact than the
+removal-lag this fix addresses, and surfaces loudly rather than silently).
 
 ``sub_industry_map`` (config#934 narrow slice, 2026-07-09): the Wikipedia
 constituents tables already scraped here carry a "GICS Sub-Industry" column
@@ -25,8 +52,9 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import datetime, timezone
-from io import StringIO
+from io import BytesIO, StringIO
 from pathlib import Path
 
 import boto3
@@ -52,12 +80,40 @@ GICS_TO_ETF: dict[str, str] = {
 
 _CACHE_PATH = Path(__file__).parent.parent / "data" / "constituents_cache.csv"
 
-_URLS = {
+# Membership ground truth: SSGA SPDR full-replication index funds' daily
+# holdings (config#2812). Both hosted by the same provider with an identical
+# schema (Name/Ticker/Identifier/SEDOL/Weight/Sector/Shares Held), no auth.
+_SSGA_HOLDINGS_URLS = {
+    "S&P 500": "https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spy.xlsx",
+    "S&P 400": "https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-mdy.xlsx",
+}
+
+# Sector/sub-industry classification source (unchanged from pre-config#2812).
+_WIKIPEDIA_URLS = {
     "S&P 500": "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies",
     "S&P 400": "https://en.wikipedia.org/wiki/List_of_S%26P_400_companies",
 }
 
 _HEADERS = {"User-Agent": "alpha-engine-data/1.0 (weekly-collector)"}
+
+# A real US equity ticker in the SSGA holdings file: 1-6 uppercase letters,
+# optional single-letter share class suffix (e.g. BRK.A). Excludes the file's
+# non-equity rows: cash positions ("-"/"999USDZ92", "CASH_USD"), tiny
+# settlement/contra placeholder rows (CUSIP-shaped "ticker" values), and the
+# trailing legal-disclaimer text block (NaN ticker).
+_SSGA_TICKER_RE = re.compile(r"^[A-Z]{1,6}(\.[A-Z])?$")
+
+# Sector-classification is now sourced independently of membership
+# (config#2812), so a small number of SSGA-confirmed-current members can
+# legitimately have no Wikipedia sector row yet — Wikipedia lags brand-new
+# index ADDITIONS the same way it lagged JHG/BLD's REMOVAL, just verified
+# live to be a much smaller/quieter gap (2 tickers, TOST + IESC, both
+# recent legitimate additions, on the first live run of this fix). Warn
+# loudly and proceed for a small gap; a gap this large signals a genuine
+# parse/layout failure and still hard-fails, mirroring daily_append's
+# missing-from-closes convention (small-N tolerated + alerted, not silently
+# dropped, per feedback_no_silent_fails).
+_UNMAPPED_SECTOR_HARD_FAIL_THRESHOLD = 10
 
 
 def collect(
@@ -67,7 +123,8 @@ def collect(
     dry_run: bool = False,
 ) -> dict:
     """
-    Fetch S&P 500+400 constituents from Wikipedia and write to S3.
+    Fetch S&P 500+400 membership from SSGA (SPY/MDY holdings) + GICS sector
+    classification from Wikipedia, and write to S3.
 
     Returns dict with status, counts, and any errors.
     """
@@ -82,11 +139,19 @@ def collect(
         return {"status": "error", "error": "No tickers fetched"}
 
     unmapped = [t for t in tickers if t not in sector_map]
-    if unmapped:
+    if len(unmapped) > _UNMAPPED_SECTOR_HARD_FAIL_THRESHOLD:
         raise RuntimeError(
             f"Sector mapping incomplete: {len(unmapped)} of {len(tickers)} tickers "
-            f"missing GICS sector. Sample: {unmapped[:10]}. EOD reconcile sector "
-            f"attribution depends on full coverage; aborting before write."
+            f"missing GICS sector (exceeds the {_UNMAPPED_SECTOR_HARD_FAIL_THRESHOLD}-ticker "
+            f"tolerance for Wikipedia addition-lag). Sample: {unmapped[:10]}. EOD reconcile "
+            f"sector attribution depends on full coverage; aborting before write."
+        )
+    if unmapped:
+        logger.warning(
+            "Sector mapping: %d of %d tickers missing GICS sector (within the "
+            "%d-ticker Wikipedia addition-lag tolerance) — likely recent index "
+            "additions Wikipedia hasn't classified yet: %s",
+            len(unmapped), len(tickers), _UNMAPPED_SECTOR_HARD_FAIL_THRESHOLD, unmapped,
         )
     # Sub-industry is additive/best-effort — NOT a hard gate like sector
     # above. Nothing downstream consumes it yet (config#934 narrow slice),
@@ -210,108 +275,168 @@ def _select_constituents_table(tables: list[pd.DataFrame], index_name: str) -> p
     return max(candidates, key=len)
 
 
+def _fetch_ssga_membership() -> tuple[list[str], int, int]:
+    """Fetch current S&P 500 + S&P 400 membership from SPY/MDY's daily
+    holdings files (config#2812 — see module docstring for why this replaced
+    Wikipedia as the membership source).
+
+    Returns (tickers, sp500_count, sp400_count). Raises on any fetch/parse
+    failure — caller falls back to the local cache.
+    """
+    tickers: list[str] = []
+    sp500_count = 0
+    sp400_count = 0
+    for index_name, url in _SSGA_HOLDINGS_URLS.items():
+        resp = requests.get(url, headers=_HEADERS, timeout=30)
+        resp.raise_for_status()
+        # SSGA's holdings sheet has a 4-row banner (fund name/date/disclaimer)
+        # above the real header row.
+        df = pd.read_excel(BytesIO(resp.content), skiprows=4, engine="openpyxl")
+        if "Ticker" not in df.columns:
+            raise RuntimeError(
+                f"SSGA holdings file for {index_name} missing 'Ticker' column "
+                f"(columns: {list(df.columns)}). Layout drift — extractor needs update."
+            )
+        raw_tickers = df["Ticker"].astype(str).str.strip()
+        batch = [t for t in raw_tickers if _SSGA_TICKER_RE.match(t)]
+        # BRK.A/BRK.B style share-class dot → hyphen, matching the yfinance
+        # convention the rest of the pipeline expects (was also done for the
+        # Wikipedia source).
+        batch = [t.replace(".", "-") for t in batch]
+        if not batch:
+            raise RuntimeError(
+                f"SSGA holdings file for {index_name} yielded zero valid tickers "
+                f"after filtering ({len(raw_tickers)} raw rows) — parse likely broken."
+            )
+        tickers.extend(batch)
+        logger.info("Fetched %d tickers from %s (SSGA %s holdings)",
+                    len(batch), index_name, "SPY" if index_name == "S&P 500" else "MDY")
+        if index_name == "S&P 500":
+            sp500_count = len(batch)
+        else:
+            sp400_count = len(batch)
+    return list(dict.fromkeys(tickers)), sp500_count, sp400_count  # dedupe, preserve order
+
+
+def _fetch_wikipedia_sectors() -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+    """Fetch GICS sector + sub-industry classification from Wikipedia's
+    constituents tables, keyed by ticker (config#2812 — Wikipedia is now
+    classification-only; see module docstring). Returns maps for every
+    ticker Wikipedia currently lists, regardless of SSGA membership; the
+    caller filters to the SSGA-sourced membership list.
+
+    Returns (sector_map, sector_etf_map, sub_industry_map). Raises on any
+    fetch/parse failure or missing sector column — caller falls back to the
+    local cache.
+    """
+    sector_map: dict[str, str] = {}
+    sector_etf_map: dict[str, str] = {}
+    sub_industry_map: dict[str, str] = {}
+
+    for index_name, url in _WIKIPEDIA_URLS.items():
+        resp = requests.get(url, headers=_HEADERS, timeout=15)
+        resp.raise_for_status()
+        tables = pd.read_html(StringIO(resp.text))
+        df = _select_constituents_table(tables, index_name)
+
+        col = next(
+            (c for c in df.columns if "symbol" in str(c).lower() or "ticker" in str(c).lower()),
+            df.columns[0],
+        )
+        batch = (
+            df[col]
+            .astype(str)
+            .str.strip()
+            .str.replace(".", "-", regex=False)  # BRK.B → BRK-B for yfinance
+            .tolist()
+        )
+        batch = [t for t in batch if t and t != "nan" and len(t) <= 6]
+        logger.info("Fetched %d tickers from %s (Wikipedia sector classification)",
+                    len(batch), index_name)
+
+        sector_col = next(
+            (c for c in df.columns if "gics" in str(c).lower() and "sector" in str(c).lower()
+             and "sub" not in str(c).lower()),
+            None,
+        )
+        if sector_col is None:
+            raise RuntimeError(
+                f"GICS sector column missing from {index_name} Wikipedia table "
+                f"(columns: {list(df.columns)}). Column-name drift — extractor needs update."
+            )
+        for ticker, sector in zip(batch, df[sector_col].astype(str).tolist()):
+            sector_name = sector.strip()
+            sector_map[ticker] = sector_name
+            etf = GICS_TO_ETF.get(sector_name)
+            if etf:
+                sector_etf_map[ticker] = etf
+        logger.info(
+            "[%s] Sector map: %d added (running total: %d sectors, %d ETFs)",
+            index_name, len(batch), len(sector_map), len(sector_etf_map),
+        )
+
+        # GICS Sub-Industry column (config#934 narrow slice) — same
+        # table, one level finer than sector (e.g. "Semiconductors" /
+        # "Application Software" vs. the parent "Information
+        # Technology" sector). Best-effort: unlike sector above, a
+        # missing sub-industry column does NOT raise — nothing
+        # downstream depends on this yet, so a Wikipedia layout
+        # change here should degrade gracefully rather than block
+        # the weekly constituents write.
+        sub_industry_col = next(
+            (c for c in df.columns if "gics" in str(c).lower() and "sub" in str(c).lower()
+             and "industry" in str(c).lower()),
+            None,
+        )
+        if sub_industry_col is not None:
+            for ticker, sub_industry in zip(
+                batch, df[sub_industry_col].astype(str).tolist()
+            ):
+                sub_industry_name = sub_industry.strip()
+                if sub_industry_name and sub_industry_name.lower() != "nan":
+                    sub_industry_map[ticker] = sub_industry_name
+            logger.info(
+                "[%s] Sub-industry map: running total %d",
+                index_name, len(sub_industry_map),
+            )
+        else:
+            logger.warning(
+                "[%s] GICS Sub-Industry column missing (columns: %s) — "
+                "sub_industry_map will be incomplete for this index.",
+                index_name, list(df.columns),
+            )
+
+    return sector_map, sector_etf_map, sub_industry_map
+
+
 def _fetch_constituents() -> tuple[
     list[str], dict[str, str], dict[str, str], dict[str, str], int, int
 ]:
     """
-    Fetch constituent tickers and sector mappings from Wikipedia.
+    Fetch constituent membership from SSGA (SPY/MDY holdings) and GICS
+    sector/sub-industry classification from Wikipedia (config#2812).
 
     Returns:
         (tickers, sector_map, sector_etf_map, sub_industry_map, sp500_count, sp400_count)
-        - sector_map: {ticker: GICS_sector_name}
-        - sector_etf_map: {ticker: sector_ETF_symbol}
+        - tickers: SSGA-sourced S&P 500 + S&P 400 membership (ground truth)
+        - sector_map: {ticker: GICS_sector_name}, filtered to ``tickers``
+        - sector_etf_map: {ticker: sector_ETF_symbol}, filtered to ``tickers``
         - sub_industry_map: {ticker: GICS_sub_industry_name} (best-effort,
           additive — a ticker missing here does not block collect()).
     """
-    tickers: list[str] = []
-    sector_map: dict[str, str] = {}
-    sector_etf_map: dict[str, str] = {}
-    sub_industry_map: dict[str, str] = {}
-    sp500_count = 0
-    sp400_count = 0
-
     try:
-        for index_name, url in _URLS.items():
-            resp = requests.get(url, headers=_HEADERS, timeout=15)
-            resp.raise_for_status()
-            tables = pd.read_html(StringIO(resp.text))
-            df = _select_constituents_table(tables, index_name)
+        tickers, sp500_count, sp400_count = _fetch_ssga_membership()
+        wiki_sector_map, wiki_sector_etf_map, wiki_sub_industry_map = _fetch_wikipedia_sectors()
 
-            col = next(
-                (c for c in df.columns if "symbol" in str(c).lower() or "ticker" in str(c).lower()),
-                df.columns[0],
-            )
-            batch = (
-                df[col]
-                .astype(str)
-                .str.strip()
-                .str.replace(".", "-", regex=False)  # BRK.B → BRK-B for yfinance
-                .tolist()
-            )
-            batch = [t for t in batch if t and t != "nan" and len(t) <= 6]
-            tickers.extend(batch)
-            logger.info("Fetched %d tickers from %s", len(batch), index_name)
+        # Filter the Wikipedia-derived maps down to SSGA's membership list —
+        # a ticker Wikipedia still lists but SSGA has already dropped (the
+        # exact I2703/I2812 failure mode) must not leak into the output.
+        member_set = set(tickers)
+        sector_map = {t: s for t, s in wiki_sector_map.items() if t in member_set}
+        sector_etf_map = {t: e for t, e in wiki_sector_etf_map.items() if t in member_set}
+        sub_industry_map = {t: s for t, s in wiki_sub_industry_map.items() if t in member_set}
 
-            if index_name == "S&P 500":
-                sp500_count = len(batch)
-            else:
-                sp400_count = len(batch)
-
-            sector_col = next(
-                (c for c in df.columns if "gics" in str(c).lower() and "sector" in str(c).lower()
-                 and "sub" not in str(c).lower()),
-                None,
-            )
-            if sector_col is None:
-                raise RuntimeError(
-                    f"GICS sector column missing from {index_name} Wikipedia table "
-                    f"(columns: {list(df.columns)}). Column-name drift — extractor needs update."
-                )
-            for ticker, sector in zip(batch, df[sector_col].astype(str).tolist()):
-                sector_name = sector.strip()
-                sector_map[ticker] = sector_name
-                etf = GICS_TO_ETF.get(sector_name)
-                if etf:
-                    sector_etf_map[ticker] = etf
-            logger.info(
-                "[%s] Sector map: %d added (running total: %d sectors, %d ETFs)",
-                index_name, len(batch), len(sector_map), len(sector_etf_map),
-            )
-
-            # GICS Sub-Industry column (config#934 narrow slice) — same
-            # table, one level finer than sector (e.g. "Semiconductors" /
-            # "Application Software" vs. the parent "Information
-            # Technology" sector). Best-effort: unlike sector above, a
-            # missing sub-industry column does NOT raise — nothing
-            # downstream depends on this yet, so a Wikipedia layout
-            # change here should degrade gracefully rather than block
-            # the weekly constituents write.
-            sub_industry_col = next(
-                (c for c in df.columns if "gics" in str(c).lower() and "sub" in str(c).lower()
-                 and "industry" in str(c).lower()),
-                None,
-            )
-            if sub_industry_col is not None:
-                for ticker, sub_industry in zip(
-                    batch, df[sub_industry_col].astype(str).tolist()
-                ):
-                    sub_industry_name = sub_industry.strip()
-                    if sub_industry_name and sub_industry_name.lower() != "nan":
-                        sub_industry_map[ticker] = sub_industry_name
-                logger.info(
-                    "[%s] Sub-industry map: running total %d",
-                    index_name, len(sub_industry_map),
-                )
-            else:
-                logger.warning(
-                    "[%s] GICS Sub-Industry column missing (columns: %s) — "
-                    "sub_industry_map will be incomplete for this index.",
-                    index_name, list(df.columns),
-                )
-
-        tickers = list(dict.fromkeys(tickers))  # deduplicate, preserve order
-
-        # Update local cache with full sector mapping so a future Wikipedia
+        # Update local cache with full sector mapping so a future source
         # outage doesn't dead-end on the empty-sector-map raise in collect().
         # Prior cache stored only ticker symbols; the 2026-05-11 partial
         # outage exposed that gap (S&P 500 fetch succeeded, S&P 400 failed,
@@ -327,7 +452,7 @@ def _fetch_constituents() -> tuple[
         return tickers, sector_map, sector_etf_map, sub_industry_map, sp500_count, sp400_count
 
     except Exception as e:
-        logger.warning("Wikipedia fetch failed (%s); trying local cache...", e)
+        logger.warning("Constituents fetch failed (%s); trying local cache...", e)
         return _load_from_cache()
 
 

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -528,15 +528,40 @@ class PolygonClient:
         transition; no-op pairs where old == new are dropped). A 403
         (free-tier / bad key) returns ``[]`` (mirrors :meth:`get_splits`); the
         apiKey is scrubbed from any raised error by the shared ``_get`` path.
-        Any OTHER failure (network / 5xx after retries / unexpected) PROPAGATES
-        — ``detect_renames`` catches it per-candidate and refuses to prune that
-        candidate this pass (history-safety: a detection outage must never
-        delete a symbol that might be a rename).
+
+        A 404 with ``{"status": "NOT_FOUND"}`` ALSO returns ``[]`` (config#2812
+        finding): verified live that polygon returns this — not a 5xx/timeout —
+        for a ticker whose entity record has no events at all, which is the
+        expected response for a fully-retired/delisted symbol (confirmed via
+        curl: AAPL/META 200, BLD/JHG 404 NOT_FOUND after their 2026-07-01
+        delisting). Before this fix, the 404 propagated as an unhandled
+        ``requests.HTTPError`` and ``detect_renames`` treated it as a detection
+        FAILURE (history-safety skip) — meaning ``prune_delisted_tickers`` could
+        never auto-prune the exact class of ticker (genuinely gone from
+        polygon's reference set) this check exists to clear. A 404 whose body
+        does NOT carry ``status=NOT_FOUND`` (an unexpected shape) still
+        propagates, preserving the history-safety default for anything not
+        confirmed to mean "no events".
+
+        Any OTHER failure (network / 5xx after retries / unexpected 404 body)
+        PROPAGATES — ``detect_renames`` catches it per-candidate and refuses to
+        prune that candidate this pass (history-safety: a detection outage must
+        never delete a symbol that might be a rename).
         """
         try:
             data = self._get(f"/vX/reference/tickers/{ticker}/events")
         except PolygonForbiddenError:
             return []
+        except requests.HTTPError as exc:
+            resp = exc.response
+            if resp is not None and resp.status_code == 404:
+                try:
+                    body = resp.json()
+                except ValueError:
+                    body = {}
+                if body.get("status") == "NOT_FOUND":
+                    return []
+            raise
         results_obj = data.get("results") or {}
         events = results_obj.get("events") or []
         # Collect ascending (date, new_ticker) transitions from ticker_change

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3>=1.34
 pandas>=2.0
+openpyxl>=3.1
 pyarrow>=25.0.0
 yfinance>=1.5.1
 requests>=2.31

--- a/tests/test_constituents_sector_map.py
+++ b/tests/test_constituents_sector_map.py
@@ -1,15 +1,23 @@
 """
-Regression tests for constituents.py — sector_map coverage.
+Regression tests for constituents.py — membership + sector_map coverage.
 
-Bug: prior to fix, _fetch_constituents only extracted GICS sectors from the
-S&P 500 Wikipedia table, leaving every S&P 400 mid-cap ticker without a
-sector mapping. EOD reconcile's sector attribution depended on this map and
+config#2812: membership is now sourced from SSGA's SPY/MDY daily holdings
+(ground truth, not subject to Wikipedia's community-edit lag — verified live
+that Wikipedia still listed two 2026-07-01-delisted tickers 17+ days later,
+while both SPY's and MDY's holdings had already dropped them). GICS sector +
+sub-industry classification remains Wikipedia-sourced, now filtered down to
+the SSGA-sourced membership list.
+
+Bug (pre-config#2812, still relevant to the Wikipedia sector-fetch path):
+prior to fix, _fetch_constituents only extracted GICS sectors from the S&P
+500 Wikipedia table, leaving every S&P 400 mid-cap ticker without a sector
+mapping. EOD reconcile's sector attribution depended on this map and
 silently fell through to "Unknown" for any held mid-cap (e.g. JHG fired
 flow-doctor on 2026-04-30).
 """
 from __future__ import annotations
 
-from io import StringIO
+from io import BytesIO, StringIO
 from unittest.mock import patch
 
 import pandas as pd
@@ -34,25 +42,66 @@ def _fake_html(
     return df.to_html(index=False)
 
 
+def _fake_ssga_bytes(tickers: list[str]) -> bytes:
+    """Build a minimal SSGA-holdings-shaped xlsx: a 4-row banner ahead of
+    the real header row (mirrors ``skiprows=4`` in
+    ``_fetch_ssga_membership``), then a ``Ticker`` column. Only the column
+    that function actually reads is required."""
+    buf = BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        pd.DataFrame({"Ticker": tickers}).to_excel(writer, index=False, startrow=4)
+    return buf.getvalue()
+
+
 class _FakeResp:
-    def __init__(self, text: str) -> None:
+    """Fake ``requests.Response`` supporting both the Wikipedia (``.text``,
+    HTML) and SSGA (``.content``, xlsx bytes) fetch paths."""
+
+    def __init__(self, *, text: str | None = None, content: bytes | None = None) -> None:
         self.text = text
+        self.content = content
 
     def raise_for_status(self) -> None:
         pass
 
 
-def test_sector_map_covers_both_sp500_and_sp400() -> None:
-    """sector_map must include every ticker from both index tables."""
-    sp500_html = _fake_html(["AAPL", "MSFT"], ["Information Technology", "Information Technology"])
-    sp400_html = _fake_html(["JHG", "WSO"], ["Financials", "Industrials"])
+def _make_fake_get(sp500_tickers, sp400_tickers, sp500_sectors=None, sp400_sectors=None,
+                    sp500_sub_industries=None, sp400_sub_industries=None):
+    """Build a ``requests.get`` side_effect routing SSGA holdings URLs to a
+    fake xlsx (membership) and Wikipedia URLs to fake HTML (sector
+    classification), keyed off the same ticker lists by default so existing
+    assertions (pre-config#2812) continue to hold unless a test explicitly
+    diverges the two sources (e.g. to exercise the addition/removal-lag
+    tolerance)."""
+    sp500_sectors = sp500_sectors or ["Information Technology"] * len(sp500_tickers)
+    sp400_sectors = sp400_sectors or ["Industrials"] * len(sp400_tickers)
+    sp500_html = _fake_html(sp500_tickers, sp500_sectors, sp500_sub_industries)
+    sp400_html = _fake_html(sp400_tickers, sp400_sectors, sp400_sub_industries)
+    sp500_xlsx = _fake_ssga_bytes(sp500_tickers)
+    sp400_xlsx = _fake_ssga_bytes(sp400_tickers)
 
     def fake_get(url, **kwargs):
-        if "S%26P_500" in url:
-            return _FakeResp(sp500_html)
-        if "S%26P_400" in url:
-            return _FakeResp(sp400_html)
+        if url == constituents._SSGA_HOLDINGS_URLS["S&P 500"]:
+            return _FakeResp(content=sp500_xlsx)
+        if url == constituents._SSGA_HOLDINGS_URLS["S&P 400"]:
+            return _FakeResp(content=sp400_xlsx)
+        if url == constituents._WIKIPEDIA_URLS["S&P 500"]:
+            return _FakeResp(text=sp500_html)
+        if url == constituents._WIKIPEDIA_URLS["S&P 400"]:
+            return _FakeResp(text=sp400_html)
         raise AssertionError(f"unexpected URL: {url}")
+
+    return fake_get
+
+
+def test_sector_map_covers_both_sp500_and_sp400() -> None:
+    """sector_map must include every ticker from both index tables, and
+    ``tickers`` (membership) is SSGA-sourced."""
+    fake_get = _make_fake_get(
+        ["AAPL", "MSFT"], ["JHG", "WSO"],
+        sp500_sectors=["Information Technology", "Information Technology"],
+        sp400_sectors=["Financials", "Industrials"],
+    )
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         tickers, sector_map, sector_etf_map, sub_industry_map, sp500_count, sp400_count = (
@@ -69,25 +118,52 @@ def test_sector_map_covers_both_sp500_and_sp400() -> None:
     assert set(tickers) == {"AAPL", "MSFT", "JHG", "WSO"}
 
 
+def test_membership_is_ssga_sourced_not_wikipedia() -> None:
+    """config#2812: a ticker present in Wikipedia's table but ABSENT from
+    SSGA's holdings (the JHG/BLD failure mode — Wikipedia lagging a real
+    delisting) must NOT appear in the final ``tickers`` list, even though
+    it still gets a sector_map entry (harmlessly unused, filtered out)."""
+    fake_get = _make_fake_get(
+        sp500_tickers=["AAPL", "MSFT"],  # SSGA membership: no JHG
+        sp400_tickers=["WSO"],
+    )
+    # Override: Wikipedia's S&P 500 page still lists a delisted ticker.
+    stale_wiki_html = _fake_html(
+        ["AAPL", "MSFT", "JHG"],
+        ["Information Technology", "Information Technology", "Financials"],
+    )
+
+    def fake_get_with_stale_wiki(url, **kwargs):
+        if url == constituents._WIKIPEDIA_URLS["S&P 500"]:
+            return _FakeResp(text=stale_wiki_html)
+        return fake_get(url, **kwargs)
+
+    with patch("collectors.constituents.requests.get", side_effect=fake_get_with_stale_wiki):
+        tickers, sector_map, _, _, _, _ = constituents._fetch_constituents()
+
+    assert set(tickers) == {"AAPL", "MSFT", "WSO"}
+    assert "JHG" not in tickers, (
+        "a ticker Wikipedia still lists but SSGA has dropped must not leak "
+        "into membership — this is the exact I2703/I2812 failure mode"
+    )
+    # Wikipedia's stale JHG row is harmless noise in the raw sector fetch,
+    # but must be filtered out of the final (membership-scoped) sector_map.
+    assert "JHG" not in sector_map
+
+
 def test_sub_industry_map_captured_alongside_sector_map() -> None:
     """config#934 narrow slice: the collector must additionally capture the
     GICS Sub-Industry column (one level finer than sector, e.g.
     "Semiconductors" vs. the parent "Information Technology" sector) when
     Wikipedia's table carries it — purely additive, sector_map/sector_etf_map
     behavior must be unchanged."""
-    sp500_html = _fake_html(
-        ["AAPL", "MSFT"],
-        ["Information Technology", "Information Technology"],
-        ["Technology Hardware, Storage & Peripherals", "Systems Software"],
+    fake_get = _make_fake_get(
+        ["AAPL", "MSFT"], ["JHG", "WSO"],
+        sp500_sectors=["Information Technology", "Information Technology"],
+        sp400_sectors=["Financials", "Industrials"],
+        sp500_sub_industries=["Technology Hardware, Storage & Peripherals", "Systems Software"],
+        sp400_sub_industries=["Asset Management & Custody Banks", "Building Products"],
     )
-    sp400_html = _fake_html(
-        ["JHG", "WSO"],
-        ["Financials", "Industrials"],
-        ["Asset Management & Custody Banks", "Building Products"],
-    )
-
-    def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html if "500" in url else sp400_html)
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         tickers, sector_map, sector_etf_map, sub_industry_map, sp500_count, sp400_count = (
@@ -108,11 +184,9 @@ def test_sub_industry_map_empty_when_column_absent_does_not_raise() -> None:
     the fetch — sub_industry_map degrades to empty/partial rather than
     raising, since nothing downstream depends on it yet (unlike the sector
     column, which is a hard gate)."""
-    sp500_html = _fake_html(["AAPL"], ["Information Technology"])  # no sub-industry col
-    sp400_html = _fake_html(["JHG"], ["Financials"])
-
-    def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html if "500" in url else sp400_html)
+    fake_get = _make_fake_get(["AAPL"], ["JHG"],
+                               sp500_sectors=["Information Technology"],
+                               sp400_sectors=["Financials"])
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         tickers, sector_map, _, sub_industry_map, _, _ = constituents._fetch_constituents()
@@ -124,7 +198,7 @@ def test_sub_industry_map_empty_when_column_absent_does_not_raise() -> None:
 
 def test_cache_persists_sub_industry_map() -> None:
     """The local CSV cache must round-trip gics_sub_industry, so a future
-    Wikipedia outage's fallback still returns sub_industry_map (best-effort,
+    source outage's fallback still returns sub_industry_map (best-effort,
     consistent with how gics_sector/sector_etf already round-trip)."""
     import tempfile
     from pathlib import Path
@@ -132,13 +206,13 @@ def test_cache_persists_sub_industry_map() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         cache_path = Path(tmp) / "constituents_cache.csv"
         with patch("collectors.constituents._CACHE_PATH", cache_path):
-            sp500_html = _fake_html(
-                ["AAPL"], ["Information Technology"], ["Systems Software"]
+            fake_get = _make_fake_get(
+                ["AAPL"], ["JHG"],
+                sp500_sectors=["Information Technology"],
+                sp400_sectors=["Financials"],
+                sp500_sub_industries=["Systems Software"],
+                sp400_sub_industries=["Asset Management & Custody Banks"],
             )
-            sp400_html = _fake_html(["JHG"], ["Financials"], ["Asset Management & Custody Banks"])
-
-            def fake_get(url, **kwargs):
-                return _FakeResp(sp500_html if "500" in url else sp400_html)
 
             with patch("collectors.constituents.requests.get", side_effect=fake_get):
                 constituents._fetch_constituents()
@@ -158,23 +232,46 @@ def test_cache_persists_sub_industry_map() -> None:
             }
 
 
-def test_collect_raises_when_sector_coverage_incomplete(tmp_path) -> None:
-    """If a ticker lands in `tickers` without a sector entry, collect() must raise."""
-    # Simulate the prior-bug condition: tickers list has 4 entries but
-    # sector_map only has 2 (S&P 500 only).
+def test_collect_raises_when_sector_coverage_gap_exceeds_tolerance(tmp_path) -> None:
+    """If more than the addition-lag tolerance of tickers land in `tickers`
+    without a sector entry, collect() must raise (systemic parse failure,
+    not a couple of recent-addition stragglers)."""
+    unmapped = [f"NEW{i}" for i in range(constituents._UNMAPPED_SECTOR_HARD_FAIL_THRESHOLD + 1)]
+
     def fake_fetch():
         return (
-            ["AAPL", "MSFT", "JHG", "WSO"],
+            ["AAPL", "MSFT", *unmapped],
             {"AAPL": "Information Technology", "MSFT": "Information Technology"},
             {"AAPL": "XLK", "MSFT": "XLK"},
             {},
             2,
-            2,
+            len(unmapped),
         )
 
     with patch("collectors.constituents._fetch_constituents", side_effect=fake_fetch):
         with pytest.raises(RuntimeError, match="Sector mapping incomplete"):
             constituents.collect(bucket="any", dry_run=True)
+
+
+def test_collect_warns_but_proceeds_within_sector_gap_tolerance(tmp_path) -> None:
+    """config#2812: a small number of SSGA-confirmed-current members
+    missing a Wikipedia sector classification (addition-lag, verified live
+    for TOST/IESC on the first real run of this fix) must NOT block
+    collect() — only exceeding the tolerance does."""
+    def fake_fetch():
+        return (
+            ["AAPL", "MSFT", "TOST"],
+            {"AAPL": "Information Technology", "MSFT": "Information Technology"},
+            {"AAPL": "XLK", "MSFT": "XLK"},
+            {},
+            2,
+            1,
+        )
+
+    with patch("collectors.constituents._fetch_constituents", side_effect=fake_fetch):
+        result = constituents.collect(bucket="any", dry_run=True)
+    assert result["status"] == "ok_dry_run"
+    assert "TOST" in result["tickers"]
 
 
 def test_fetch_raises_when_sector_column_missing(tmp_path, monkeypatch) -> None:
@@ -187,33 +284,37 @@ def test_fetch_raises_when_sector_column_missing(tmp_path, monkeypatch) -> None:
         constituents, "_CACHE_PATH", tmp_path / "constituents_cache.csv"
     )
     df = pd.DataFrame({"Symbol": ["AAPL"], "Industry": ["Tech"]})  # no GICS column
-    sp500_html = df.to_html(index=False)
+    bad_wiki_html = df.to_html(index=False)
+    ssga_xlsx = _fake_ssga_bytes(["AAPL"])
 
     def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html)
+        if url in constituents._SSGA_HOLDINGS_URLS.values():
+            return _FakeResp(content=ssga_xlsx)
+        return _FakeResp(text=bad_wiki_html)
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         tickers, sector_map, _, _, _, _ = constituents._fetch_constituents()
 
-    # No tables matched the schema → empty result, which collect() then
-    # short-circuits with status=error before any S3 write.
+    # No Wikipedia tables matched the schema → the whole fetch falls
+    # through to the cache (empty here) → empty result, which collect()
+    # then short-circuits with status=error before any S3 write.
     assert tickers == []
     assert sector_map == {}
 
 
 def test_cache_persists_sector_map_and_etf(tmp_path, monkeypatch) -> None:
-    """On a successful Wikipedia fetch the local cache must persist
-    ticker + GICS sector + sector ETF, so a future Wikipedia outage's
-    fallback returns a fully-populated sector_map (instead of empty,
-    which makes collect() raise 'Sector mapping incomplete')."""
+    """On a successful fetch the local cache must persist ticker + GICS
+    sector + sector ETF, so a future outage's fallback returns a
+    fully-populated sector_map (instead of empty, which makes collect()
+    raise 'Sector mapping incomplete')."""
     cache_path = tmp_path / "constituents_cache.csv"
     monkeypatch.setattr(constituents, "_CACHE_PATH", cache_path)
 
-    sp500_html = _fake_html(["AAPL", "MSFT"], ["Information Technology", "Information Technology"])
-    sp400_html = _fake_html(["JHG", "WSO"], ["Financials", "Industrials"])
-
-    def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html if "500" in url else sp400_html)
+    fake_get = _make_fake_get(
+        ["AAPL", "MSFT"], ["JHG", "WSO"],
+        sp500_sectors=["Information Technology", "Information Technology"],
+        sp400_sectors=["Financials", "Industrials"],
+    )
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         constituents._fetch_constituents()
@@ -229,7 +330,7 @@ def test_cache_persists_sector_map_and_etf(tmp_path, monkeypatch) -> None:
 
 
 def test_cache_fallback_returns_full_sector_map(tmp_path, monkeypatch) -> None:
-    """When Wikipedia is unreachable, the cache fallback must return
+    """When both sources are unreachable, the cache fallback must return
     populated sector_map + sector_etf_map so collect()'s coverage check
     passes. Regression for the 2026-05-11 cascade: partial Wikipedia
     outage → empty-cache fallback → collect() raise → SF cascade silent
@@ -243,7 +344,7 @@ def test_cache_fallback_returns_full_sector_map(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(constituents, "_CACHE_PATH", cache_path)
 
     def fake_get(url, **kwargs):
-        raise RuntimeError("simulated Wikipedia outage")
+        raise RuntimeError("simulated outage")
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         tickers, sector_map, sector_etf_map, sub_industry_map, sp500_count, sp400_count = (
@@ -269,7 +370,7 @@ def test_cache_fallback_handles_legacy_ticker_only_schema(tmp_path, monkeypatch)
     monkeypatch.setattr(constituents, "_CACHE_PATH", cache_path)
 
     def fake_get(url, **kwargs):
-        raise RuntimeError("simulated Wikipedia outage")
+        raise RuntimeError("simulated outage")
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         tickers, sector_map, sector_etf_map, _, _, _ = constituents._fetch_constituents()
@@ -280,14 +381,14 @@ def test_cache_fallback_handles_legacy_ticker_only_schema(tmp_path, monkeypatch)
 
 
 def test_cache_fallback_missing_cache_returns_empty(tmp_path, monkeypatch) -> None:
-    """No Wikipedia AND no cache → empty lists/dicts, not a crash. The
+    """No source AND no cache → empty lists/dicts, not a crash. The
     eventual `collect()` short-circuit ('No tickers fetched') handles
     this state."""
     cache_path = tmp_path / "constituents_cache.csv"  # does not exist
     monkeypatch.setattr(constituents, "_CACHE_PATH", cache_path)
 
     def fake_get(url, **kwargs):
-        raise RuntimeError("simulated Wikipedia outage")
+        raise RuntimeError("simulated outage")
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
         tickers, sector_map, sector_etf_map, _, _, _ = constituents._fetch_constituents()
@@ -296,6 +397,60 @@ def test_cache_fallback_missing_cache_returns_empty(tmp_path, monkeypatch) -> No
     assert sector_map == {} and sector_etf_map == {}
 
 
+def test_ssga_membership_filters_non_equity_rows() -> None:
+    """SSGA holdings files carry non-equity noise rows (cash positions,
+    tiny settlement placeholders, trailing legal-disclaimer text) that must
+    never leak into membership. Verified live 2026-07-17 against the real
+    SPY/MDY files: '-'/CASH_USD cash rows, a CUSIP-shaped placeholder
+    ticker, and multi-paragraph disclaimer rows with NaN ticker."""
+    buf = BytesIO()
+    noisy = pd.DataFrame({
+        "Ticker": ["AAPL", "-", "CASH_USD", "2602335D", None, "MSFT"],
+        "Name": ["APPLE INC", "US DOLLAR", "U.S. Dollar", "CONTRA HOLOGIC",
+                 "Legal disclaimer text...", "MICROSOFT CORP"],
+    })
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        noisy.to_excel(writer, index=False, startrow=4)
+
+    def fake_get(url, **kwargs):
+        if url == constituents._SSGA_HOLDINGS_URLS["S&P 500"]:
+            return _FakeResp(content=buf.getvalue())
+        if url == constituents._SSGA_HOLDINGS_URLS["S&P 400"]:
+            return _FakeResp(content=_fake_ssga_bytes([]))
+        raise AssertionError(f"unexpected URL in membership-only test: {url}")
+
+    with patch("collectors.constituents.requests.get", side_effect=fake_get):
+        with pytest.raises(RuntimeError, match="zero valid tickers"):
+            # S&P 400 leg yields zero tickers post-filter → raises, per
+            # _fetch_ssga_membership's own empty-batch guard.
+            constituents._fetch_ssga_membership()
+
+
+def test_ssga_membership_filters_non_equity_rows_both_legs_populated() -> None:
+    """Same noise-filtering check, with a non-empty S&P 400 leg so the
+    function returns normally and the filtered ticker set can be asserted."""
+    buf = BytesIO()
+    noisy = pd.DataFrame({
+        "Ticker": ["AAPL", "-", "CASH_USD", "2602335D", None, "MSFT"],
+    })
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        noisy.to_excel(writer, index=False, startrow=4)
+
+    def fake_get(url, **kwargs):
+        if url == constituents._SSGA_HOLDINGS_URLS["S&P 500"]:
+            return _FakeResp(content=buf.getvalue())
+        if url == constituents._SSGA_HOLDINGS_URLS["S&P 400"]:
+            return _FakeResp(content=_fake_ssga_bytes(["JHG", "WSO"]))
+        raise AssertionError(f"unexpected URL: {url}")
+
+    with patch("collectors.constituents.requests.get", side_effect=fake_get):
+        tickers, sp500_count, sp400_count = constituents._fetch_ssga_membership()
+
+    assert set(tickers) == {"AAPL", "MSFT", "JHG", "WSO"}
+    assert sp500_count == 2
+    assert sp400_count == 2
+
+
 def test_select_constituents_table_skips_banner_table() -> None:
     """Wikipedia adds banner/disambiguation tables ahead of the constituents
     table without notice. 2026-05-11 incident: the S&P 400 page inserted a
@@ -368,10 +523,13 @@ def test_select_constituents_table_flattens_multiindex() -> None:
     )
 
 
-def test_fetch_constituents_handles_banner_table_at_index_0() -> None:
+def test_fetch_wikipedia_sectors_handles_banner_table_at_index_0() -> None:
     """End-to-end: Wikipedia page with a banner table at index 0 followed by
     the constituents table at index 1 must still produce a populated
-    sector_map. Regression for the 2026-05-11 silent-MorningEnrich incident."""
+    sector_map. Regression for the 2026-05-11 silent-MorningEnrich incident.
+    (Retargeted to ``_fetch_wikipedia_sectors`` directly — config#2812 split
+    membership out of this function, so a pure Wikipedia-parsing regression
+    test no longer needs an SSGA mock.)"""
     banner_df = pd.DataFrame({0: [float("nan")], 1: ["disambiguation banner"]})
     sp500_df = pd.DataFrame({
         "Symbol": [f"S5{i:02d}" for i in range(60)],
@@ -386,121 +544,11 @@ def test_fetch_constituents_handles_banner_table_at_index_0() -> None:
     sp400_html = banner_df.to_html(index=False) + sp400_df.to_html(index=False)
 
     def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html if "500" in url else sp400_html)
+        return _FakeResp(text=sp500_html if "500" in url else sp400_html)
 
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
-        tickers, sector_map, sector_etf_map, sub_industry_map, sp500_count, sp400_count = (
-            constituents._fetch_constituents()
-        )
+        sector_map, sector_etf_map, sub_industry_map = constituents._fetch_wikipedia_sectors()
 
-    assert sp500_count == 60
-    assert sp400_count == 60
-    assert len(sector_map) == 120
-    assert sector_map["S500"] == "Information Technology"
-    assert sector_map["S400"] == "Industrials"
-    assert sector_etf_map["S500"] == "XLK"
-    assert sector_etf_map["S400"] == "XLI"
-
-
-def test_select_constituents_table_skips_banner_table() -> None:
-    """Wikipedia adds banner/disambiguation tables ahead of the constituents
-    table without notice. 2026-05-11 incident: the S&P 400 page inserted a
-    1-row, 2-column disambiguation-warning table at index 0, making
-    `tables[0]` return columns ``[0, 1]`` instead of the constituents
-    table at index 1. _select_constituents_table must scan for the right
-    one by columns, not position.
-    """
-    banner_df = pd.DataFrame({0: [float("nan")], 1: ["This article currently links to a large number of disambiguation pages."]})
-    constituents_df = pd.DataFrame({
-        "Symbol": [f"T{i:03d}" for i in range(100)],
-        "Security": [f"Co {i}" for i in range(100)],
-        "GICS Sector": ["Industrials"] * 100,
-        "GICS Sub-Industry": ["Misc"] * 100,
-    })
-    sub_industry_only_df = pd.DataFrame({
-        "Symbol": ["X"], "GICS Sub-Industry": ["Subindustry-Only"],
-    })
-
-    picked = constituents._select_constituents_table(
-        [banner_df, constituents_df, sub_industry_only_df], "S&P 400"
-    )
-    assert list(picked.columns) == [
-        "Symbol", "Security", "GICS Sector", "GICS Sub-Industry"
-    ]
-    assert len(picked) == 100
-
-
-def test_select_constituents_table_raises_when_no_match() -> None:
-    """If no table on the page has the expected ticker + GICS sector shape,
-    raise loudly rather than silently picking a junk table."""
-    banner_df = pd.DataFrame({0: [1], 1: ["banner"]})
-    nav_df = pd.DataFrame({"vteFoo": ["a"], "vteBar": ["b"]})
-
-    with pytest.raises(RuntimeError, match="No constituents table found"):
-        constituents._select_constituents_table([banner_df, nav_df], "S&P 400")
-
-
-def test_select_constituents_table_picks_largest_candidate() -> None:
-    """When multiple tables have Symbol + GICS Sector columns (e.g. a small
-    example/docs table alongside the live roster), pick the largest. On the
-    real S&P 500/400 pages the roster is the only such table; the largest-
-    wins rule is a defense-in-depth tiebreaker if Wikipedia ever adds an
-    additional schema-matching table."""
-    small_df = pd.DataFrame({
-        "Symbol": ["X", "Y"],
-        "GICS Sector": ["Energy", "Energy"],
-    })
-    real_df = pd.DataFrame({
-        "Symbol": [f"T{i}" for i in range(100)],
-        "GICS Sector": ["Industrials"] * 100,
-    })
-    picked = constituents._select_constituents_table([small_df, real_df], "S&P 500")
-    assert len(picked) == 100
-
-
-def test_select_constituents_table_flattens_multiindex() -> None:
-    """Wikipedia occasionally returns multi-level column headers. The
-    selector must flatten them before matching."""
-    df = pd.DataFrame({
-        ("Stock", "Symbol"): [f"T{i}" for i in range(100)],
-        ("Classification", "GICS Sector"): ["Industrials"] * 100,
-    })
-    df.columns = pd.MultiIndex.from_tuples(df.columns)
-    picked = constituents._select_constituents_table([df], "S&P 500")
-    assert any("symbol" in str(c).lower() for c in picked.columns)
-    assert any(
-        "gics" in str(c).lower() and "sector" in str(c).lower()
-        for c in picked.columns
-    )
-
-
-def test_fetch_constituents_handles_banner_table_at_index_0() -> None:
-    """End-to-end: Wikipedia page with a banner table at index 0 followed by
-    the constituents table at index 1 must still produce a populated
-    sector_map. Regression for the 2026-05-11 silent-MorningEnrich incident."""
-    banner_df = pd.DataFrame({0: [float("nan")], 1: ["disambiguation banner"]})
-    sp500_df = pd.DataFrame({
-        "Symbol": [f"S5{i:02d}" for i in range(60)],
-        "GICS Sector": ["Information Technology"] * 60,
-    })
-    sp400_df = pd.DataFrame({
-        "Symbol": [f"S4{i:02d}" for i in range(60)],
-        "GICS Sector": ["Industrials"] * 60,
-    })
-
-    sp500_html = banner_df.to_html(index=False) + sp500_df.to_html(index=False)
-    sp400_html = banner_df.to_html(index=False) + sp400_df.to_html(index=False)
-
-    def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html if "500" in url else sp400_html)
-
-    with patch("collectors.constituents.requests.get", side_effect=fake_get):
-        tickers, sector_map, sector_etf_map, sub_industry_map, sp500_count, sp400_count = (
-            constituents._fetch_constituents()
-        )
-
-    assert sp500_count == 60
-    assert sp400_count == 60
     assert len(sector_map) == 120
     assert sector_map["S500"] == "Information Technology"
     assert sector_map["S400"] == "Industrials"
@@ -522,11 +570,11 @@ def test_collect_returns_tickers_in_dict() -> None:
 
     Locks both happy paths (ok + ok_dry_run).
     """
-    sp500_html = _fake_html(["AAPL", "MSFT"], ["Information Technology", "Information Technology"])
-    sp400_html = _fake_html(["JHG", "WSO"], ["Financials", "Industrials"])
-
-    def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html if "500" in url else sp400_html)
+    fake_get = _make_fake_get(
+        ["AAPL", "MSFT"], ["JHG", "WSO"],
+        sp500_sectors=["Information Technology", "Information Technology"],
+        sp400_sectors=["Financials", "Industrials"],
+    )
 
     # Dry-run path
     with patch("collectors.constituents.requests.get", side_effect=fake_get):
@@ -565,13 +613,11 @@ def test_sector_map_writes_to_canonical_paths_only() -> None:
     """
     from unittest.mock import MagicMock
 
-    sp500_html = _fake_html(
-        ["AAPL"], ["Information Technology"],
+    fake_get = _make_fake_get(
+        ["AAPL"], ["JHG"],
+        sp500_sectors=["Information Technology"],
+        sp400_sectors=["Financials"],
     )
-    sp400_html = _fake_html(["JHG"], ["Financials"])
-
-    def fake_get(url, **kwargs):
-        return _FakeResp(sp500_html if "500" in url else sp400_html)
 
     put_calls: list[dict] = []
     fake_s3 = MagicMock()

--- a/tests/test_polygon_client.py
+++ b/tests/test_polygon_client.py
@@ -11,9 +11,11 @@ free-tier "before end of day" rejections for stocks for a week.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from polygon_client import PolygonClient, PolygonForbiddenError
 
@@ -339,6 +341,36 @@ def test_get_ticker_events_empty_results_object():
     client = _make_client()
     with patch.object(client, "_get", return_value={"status": "OK"}):
         assert client.get_ticker_events("FB") == []
+
+
+def _http_404(body: dict) -> requests.HTTPError:
+    resp = requests.Response()
+    resp.status_code = 404
+    resp._content = json.dumps(body).encode()
+    return requests.HTTPError("404 Client Error", response=resp)
+
+
+def test_get_ticker_events_404_not_found_returns_empty():
+    """config#2812: polygon returns 404 {"status": "NOT_FOUND"} for a ticker
+    whose entity has no events record at all — verified live for BLD/JHG after
+    their 2026-07-01 delisting (vs. 200 for still-active AAPL/META). This must
+    be treated the same as "no renames found" (like the 403 case above), not as
+    a detection failure — otherwise prune_delisted_tickers can never clear the
+    rename-safety check for a genuinely fully-retired ticker."""
+    client = _make_client()
+    err = _http_404({"status": "NOT_FOUND", "message": "No events found for given ID"})
+    with patch.object(client, "_get", side_effect=err):
+        assert client.get_ticker_events("BLD") == []
+
+
+def test_get_ticker_events_404_unexpected_body_propagates():
+    """A 404 that does NOT carry status=NOT_FOUND is an unrecognized shape —
+    preserve the history-safety default (propagate, don't silently swallow)."""
+    client = _make_client()
+    err = _http_404({"status": "SOMETHING_ELSE"})
+    with patch.object(client, "_get", side_effect=err):
+        with pytest.raises(requests.HTTPError):
+            client.get_ticker_events("BLD")
 
 
 # ── fractional split-ratio fields (2026-07-02 incident class) ────────────────


### PR DESCRIPTION
## Summary

Root-causes and fixes the recurring ~75-90 min `ne-preopen-trading-pipeline` overrun (alpha-engine-config-I2717 re-exam, I2812): `MorningArcticAppend` was running its full ~35-45 min of legitimate work and then crashing on the very last step every day, on both spot and on-demand attempts.

**Chain of root causes, both fixed here:**

1. The daily ArcticDB freshness gate hard-fails on JHG/BLD (delisted 2026-07-01 via take-private mergers, verified via SEC filings) because the auto-prune requires a ticker to be **absent from Wikipedia's constituents page** first — and Wikipedia still listed both 17+ days after the actual delisting. Fixed by sourcing S&P 500/400 **membership** from SPY/MDY's daily SSGA holdings files instead (verified live: both had already dropped JHG/BLD; free, no auth, standard practice). Wikipedia stays as the GICS sector/sub-industry **classification** source (its own holdings-file "Sector" column is unusable — >98% literal `-` placeholders), now filtered to the SSGA-sourced membership list.
2. Even with membership fixed, the auto-prune's rename-detection safety check would have still refused to prune JHG/BLD: `get_ticker_events` propagated Polygon's `404 {"status":"NOT_FOUND"}` (Polygon's actual response for a fully-retired ticker — verified live, AAPL/META return 200, BLD/JHG return this 404) as an unhandled error, and `detect_renames` treats any propagated error as "detection failed — don't prune" (history-safety). Fixed to treat this specific, confirmed response the same as the existing 403-returns-`[]` precedent.

## Changes

- `collectors/constituents.py`: `_fetch_constituents` split into `_fetch_ssga_membership` (new — SPY/MDY holdings) + `_fetch_wikipedia_sectors` (existing scrape logic, unchanged, repurposed to classification-only). `collect()`'s unmapped-sector hard-fail softened to a bounded warn-and-proceed (verified live: TOST/IESC are legitimate recent additions Wikipedia hasn't classified yet — mirrors `daily_append`'s existing missing-from-closes small-N-tolerated convention; still hard-fails past a 10-ticker threshold).
- `polygon_client.py`: `get_ticker_events` catches a 404 with `status=NOT_FOUND` and returns `[]`; any other 404 body still propagates.
- `requirements.txt`: added `openpyxl` (needed to parse the SSGA xlsx holdings files).

## Verification

- Full test suite: 3372 passed, 12 skipped, 0 failed.
- Live end-to-end dry-run of `collect()`: 902 tickers (503 S&P500 + 399 S&P400), JHG/BLD correctly absent, 900/902 sector-mapped (TOST/IESC warned, not blocked).
- Live curl comparison: Polygon `/vX/reference/tickers/{ticker}/events` — AAPL/META 200, BLD/JHG 404 NOT_FOUND.

## Follow-up (this PR does not do)

Once merged, the manual `alpha-engine-config-I2703`/`I2812` unblock (`python -m builders.prune_delisted_tickers --apply --tickers JHG,BLD`) will be re-run in-region using this fixed code to actually clear the two stuck tickers — tracked separately, not part of this PR.

Closes alpha-engine-config-I2812 (once the manual unblock confirms the prune succeeds). Related: alpha-engine-config-I2703, alpha-engine-config-I2717.
