### PR TITLE
fix(gdelt): hard time budget + adaptive retry abandonment + CUSIP skip (config#2813)

### DIFF
--- a/collectors/news_sources/gdelt.py
+++ b/collectors/news_sources/gdelt.py
@@ -25,14 +25,29 @@ Notes:
   one request per ticker per call, ~1 sec delay between batches).
 - Trust weight in config should be moderate (~0.85) — academic-grade
   but breadth > depth; cross-validate with Polygon when both have hits.
+
+Resilience posture (alpha-engine-config#2813, 2026-07-17): GDELT throttling
+escalated from "occasional 429" (config#663, judged non-blocking) to a
+sustained ~100% 429 rate across an entire run, which made the *unbounded*
+per-ticker loop below run long enough to blow the caller's wall-clock
+budget (``daily-news.service``'s ``TimeoutStartSec``) with zero output —
+no digest at all, cascading into a missed morning-signal episode. This
+adapter now enforces its own hard time budget (below) so a bad GDELT day
+degrades *this adapter's* coverage instead of starving the whole pipeline
+of a chance to run its later steps (aggregation, digest write). Polygon +
+Yahoo RSS are unaffected by GDELT's throttling and reliably complete on
+their own, so a capped/degraded GDELT contribution still yields a real,
+usable digest.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 import time
+from collections import deque
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Callable
 
 from nousergon_lib.sources import NewsArticle
 
@@ -59,6 +74,43 @@ _RETRY_AFTER_FALLBACK_SECONDS = 2.0
 _RETRY_AFTER_MAX_SECONDS = 30.0
 
 
+# Hard wall-clock budget for one ``fetch()`` call across the ENTIRE ticker
+# list (config#2813). Sized well under the standalone box's 40-min systemd
+# TimeoutStartSec so Polygon + Yahoo RSS (unaffected by GDELT throttling)
+# plus NLP/aggregation/digest-write always get to run regardless of how
+# badly GDELT is behaving. Checked before each ticker, not just once, so a
+# slow-but-not-yet-exhausted run still stops promptly at the boundary.
+_DEFAULT_MAX_FETCH_SECONDS = 1_200.0  # 20 min
+
+# Adaptive retry abandonment (config#2813): the single Retry-After-honoring
+# retry (config#663) helps when 429s are occasional, but on 2026-07-17's
+# sustained ~100% throttle rate, the retry attempt ALSO 429'd on every single
+# ticker observed — i.e. it bought zero recovered coverage while still
+# paying the full Retry-After wait + a second round trip. Once we've seen
+# enough retry attempts to trust the signal and NONE of them recovered a
+# ticker, stop paying for the retry pass for the rest of this run — this
+# roughly halves per-ticker latency under sustained throttling, letting
+# strictly more tickers fit inside the time budget above. If retries ARE
+# sometimes working (occasional-429 regime), this never engages and behavior
+# is identical to before.
+_RETRY_ABANDON_SAMPLE_SIZE = 8
+
+# GDELT's company-name search can never meaningfully match a bond CUSIP
+# (a 9-character alphanumeric identifier, never a company/ticker name) —
+# every such query is a guaranteed-zero-value round trip that still counts
+# against the rate limit and the time budget above. Skipped up front.
+_CUSIP_RE = re.compile(r"^[A-Z0-9]{9}$")
+
+
+def _looks_like_cusip(ticker: str) -> bool:
+    """True for a 9-char alphanumeric identifier containing at least one
+    digit — CUSIPs are always 9 chars and mix letters+digits; equity/ETF
+    tickers are essentially never 9 characters. Conservative by design:
+    only skips identifiers that could never be a real ticker, never a
+    judgment call about whether a *valid* ticker is "worth" a GDELT query."""
+    return bool(_CUSIP_RE.match(ticker)) and any(c.isdigit() for c in ticker)
+
+
 class GdeltNewsAdapter:
     """GDELT 2.0 DOC API adapter. Implements ``NewsSource``.
 
@@ -76,10 +128,19 @@ class GdeltNewsAdapter:
         *,
         http: Any = None,
         inter_request_sleep: float = _INTER_REQUEST_SLEEP_SECONDS,
+        max_fetch_seconds: float = _DEFAULT_MAX_FETCH_SECONDS,
+        monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
         self._ticker_name_map = ticker_name_map or {}
         self._http = http or requests
         self._inter_request_sleep = inter_request_sleep
+        self._max_fetch_seconds = max_fetch_seconds
+        self._monotonic = monotonic
+        # Per-call adaptive state — reset at the top of every fetch() so one
+        # day's throttling regime never leaks into the next day's adapter
+        # instance (a fresh one is constructed per collect() run anyway).
+        self._retry_outcomes: deque[bool] = deque(maxlen=_RETRY_ABANDON_SAMPLE_SIZE)
+        self._retries_abandoned = False
 
     def fetch(
         self,
@@ -90,8 +151,30 @@ class GdeltNewsAdapter:
         end = datetime.now(timezone.utc)
         start = end - timedelta(hours=hours)
         articles: list[NewsArticle] = []
-        for i, ticker in enumerate(tickers):
+        self._retry_outcomes.clear()
+        self._retries_abandoned = False
+
+        fetch_tickers = []
+        cusip_skipped = 0
+        for ticker in tickers:
+            if _looks_like_cusip(ticker):
+                cusip_skipped += 1
+            else:
+                fetch_tickers.append(ticker)
+        if cusip_skipped:
+            logger.info(
+                "[gdelt_news] skipping %d CUSIP-shaped identifier(s) — "
+                "GDELT company-name search never matches a bond CUSIP",
+                cusip_skipped,
+            )
+
+        deadline = self._monotonic() + self._max_fetch_seconds
+        budget_exhausted_at: int | None = None
+        for i, ticker in enumerate(fetch_tickers):
             if i > 0:
+                if self._monotonic() >= deadline:
+                    budget_exhausted_at = i
+                    break
                 time.sleep(self._inter_request_sleep)
             company_name = self._ticker_name_map.get(ticker, ticker)
             query = _build_query(ticker, company_name)
@@ -111,13 +194,27 @@ class GdeltNewsAdapter:
                 article = _to_article(item, ticker=ticker)
                 if article is not None:
                     articles.append(article)
+
+        if budget_exhausted_at is not None:
+            skipped = len(fetch_tickers) - budget_exhausted_at
+            logger.warning(
+                "[gdelt_news] time budget (%.0fs) exhausted after %d/%d "
+                "tickers — skipping remaining %d so the rest of the pull "
+                "(other sources, aggregation, digest write) still gets to "
+                "run within the caller's overall deadline",
+                self._max_fetch_seconds, budget_exhausted_at,
+                len(fetch_tickers), skipped,
+            )
         return articles
 
     def _fetch_one(self, ticker: str, params: dict) -> dict | None:
         """Fetch one ticker's articles, honoring a 429 ``Retry-After`` with a
-        single bounded retry. Returns the parsed JSON payload, or ``None`` on
-        terminal failure (the caller skips the ticker — fail-soft)."""
-        for attempt in range(2):  # one initial + one retry-after-429
+        single bounded retry — UNLESS retries have been adaptively abandoned
+        for the rest of this run (see ``_RETRY_ABANDON_SAMPLE_SIZE`` above).
+        Returns the parsed JSON payload, or ``None`` on terminal failure (the
+        caller skips the ticker — fail-soft)."""
+        max_attempts = 1 if self._retries_abandoned else 2
+        for attempt in range(max_attempts):
             try:
                 resp = self._http.get(
                     _GDELT_DOC_API,
@@ -130,7 +227,7 @@ class GdeltNewsAdapter:
                 )
                 return None
 
-            if getattr(resp, "status_code", None) == 429 and attempt == 0:
+            if getattr(resp, "status_code", None) == 429 and attempt == 0 and max_attempts > 1:
                 wait = _retry_after_seconds(resp)
                 logger.warning(
                     "[gdelt_news] 429 for %s — honoring Retry-After=%.1fs "
@@ -141,13 +238,39 @@ class GdeltNewsAdapter:
 
             try:
                 resp.raise_for_status()
+                if attempt > 0:
+                    self._record_retry_outcome(recovered=True)
                 return resp.json()
             except Exception as e:
+                if attempt > 0:
+                    self._record_retry_outcome(recovered=False)
                 logger.warning(
                     "[gdelt_news] fetch failed for %s: %s", ticker, e
                 )
                 return None
         return None
+
+    def _record_retry_outcome(self, *, recovered: bool) -> None:
+        """Track whether the bounded retry pass recovers coverage. Once a
+        full window of retries has recovered NOTHING, abandon retrying for
+        the rest of this run (see module docstring / config#2813) — cuts
+        per-ticker latency under sustained throttling without ever reducing
+        breadth in the occasional-429 regime the retry was built for."""
+        if self._retries_abandoned:
+            return
+        self._retry_outcomes.append(recovered)
+        if (
+            len(self._retry_outcomes) >= _RETRY_ABANDON_SAMPLE_SIZE
+            and not any(self._retry_outcomes)
+        ):
+            self._retries_abandoned = True
+            logger.warning(
+                "[gdelt_news] last %d retries recovered zero coverage — "
+                "abandoning the retry pass for the rest of this run "
+                "(sustained-throttle regime, not the occasional-429 case "
+                "the retry was built for)",
+                _RETRY_ABANDON_SAMPLE_SIZE,
+            )
 
 
 def _retry_after_seconds(resp: Any) -> float:

--- a/infrastructure/systemd/daily-news.service
+++ b/infrastructure/systemd/daily-news.service
@@ -11,8 +11,13 @@ WorkingDirectory=/home/ec2-user/alpha-engine-data
 ExecStart=/home/ec2-user/alpha-engine-data/scripts/run_daily_news_standalone.sh
 StandardOutput=journal
 StandardError=journal
-# ~20-30 min pull (Polygon 5 req/min over the ~96-ticker holdings∪signals
-# universe); 40 min cap gives headroom.
+# ~20-30 min pull (Polygon 5 req/min over the ~106-ticker holdings∪signals
+# universe, up from ~96 as of 2026-06-15 — universe grows over time, keep
+# this comment approximate not exact). 40 min cap gives headroom. GDELT's
+# OWN contribution is separately hard-capped at 20 min inside the adapter
+# (GdeltNewsAdapter's max_fetch_seconds, config#2813) regardless of how
+# badly it's throttling that day, so this outer timeout is now a backstop,
+# not the primary defense against a slow/throttled run.
 TimeoutStartSec=2400
 # Shared-box memory guard. Measured peak RSS ~0.17 GB; cap generously.
 MemoryAccounting=yes

--- a/tests/test_news_sources_and_aggregator.py
+++ b/tests/test_news_sources_and_aggregator.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from nousergon_lib.sources import NewsArticle, NewsSource
@@ -28,6 +29,7 @@ from collectors.news_sources.bloomberg import BloombergNewsAdapter
 from collectors.news_sources.gdelt import (
     GdeltNewsAdapter,
     _build_query,
+    _looks_like_cusip,
     _retry_after_seconds,
 )
 from collectors.news_sources.polygon import PolygonNewsAdapter
@@ -327,6 +329,177 @@ class TestGdeltNewsAdapter:
     def test_retry_after_seconds_parsing(self, header, expected):
         resp = MagicMock(headers=header)
         assert _retry_after_seconds(resp) == expected
+
+    # ── config#2813: time budget ────────────────────────────────────────
+
+    def test_time_budget_stops_early_and_returns_partial_results(self, monkeypatch):
+        """A sustained-throttle day must not run forever: once the wall-clock
+        budget is exhausted, fetch() stops early and returns whatever it
+        already collected, rather than blowing the caller's own timeout."""
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep", lambda s: None
+        )
+        fake_http = MagicMock()
+        fake_http.get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"articles": [{
+                "url": "https://x.com/a",
+                "title": "ok",
+                "seendate": "20260512T143000Z",
+            }]}),
+            raise_for_status=MagicMock(return_value=None),
+        )
+        # Fake clock: still within budget for the first 3 calls (ticker 0's
+        # pre-loop budget check doesn't happen — only i>0 checks it), then
+        # past the deadline from the 4th call onward.
+        clock = {"n": 0}
+
+        def fake_monotonic():
+            clock["n"] += 1
+            # calls: deadline calc (1), then one check per ticker i>0
+            return 0.0 if clock["n"] <= 3 else 1_000_000.0
+
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={},
+            http=fake_http,
+            inter_request_sleep=0.0,
+            max_fetch_seconds=100.0,
+            monotonic=fake_monotonic,
+        )
+        tickers = [f"T{i}" for i in range(10)]
+        out = adapter.fetch(tickers)
+        # Stopped well before exhausting all 10 tickers.
+        assert fake_http.get.call_count < 10
+        assert fake_http.get.call_count >= 1
+        assert len(out) == fake_http.get.call_count
+
+    def test_time_budget_never_checked_before_first_ticker(self, monkeypatch):
+        """Even a zero/negative budget must not prevent the FIRST ticker from
+        being attempted — only skips apply to the remainder."""
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep", lambda s: None
+        )
+        fake_http = MagicMock()
+        fake_http.get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"articles": []}),
+            raise_for_status=MagicMock(return_value=None),
+        )
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={},
+            http=fake_http,
+            inter_request_sleep=0.0,
+            max_fetch_seconds=0.0,
+            monotonic=lambda: 0.0,
+        )
+        adapter.fetch(["AAPL", "MSFT", "GOOG"])
+        assert fake_http.get.call_count == 1
+
+    # ── config#2813: CUSIP skip ─────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "identifier,expected",
+        [
+            ("912810UJ5", True),   # Treasury CUSIP
+            ("40219MBJ2", True),   # corporate bond CUSIP
+            ("AAPL", False),
+            ("MSFT", False),
+            ("SGOV", False),       # short 5-char ETF, not CUSIP-shaped
+            ("BRKB", False),
+            ("ABCDEFGHI", False),  # 9 letters, no digit — not a CUSIP
+        ],
+    )
+    def test_looks_like_cusip(self, identifier, expected):
+        assert _looks_like_cusip(identifier) is expected
+
+    def test_cusip_shaped_tickers_are_skipped_without_any_http_call(self, monkeypatch):
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep", lambda s: None
+        )
+        fake_http = MagicMock()
+        fake_http.get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"articles": []}),
+            raise_for_status=MagicMock(return_value=None),
+        )
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={"AAPL": "Apple"},
+            http=fake_http,
+            inter_request_sleep=0.0,
+        )
+        adapter.fetch(["912810UJ5", "AAPL", "912834PB8"])
+        # Only the one real ticker triggers an HTTP call.
+        assert fake_http.get.call_count == 1
+        called_params = fake_http.get.call_args.kwargs["params"]
+        assert "AAPL" in called_params["query"]
+
+    # ── config#2813: adaptive retry abandonment ─────────────────────────
+
+    def test_retries_abandoned_after_sustained_zero_recovery(self, monkeypatch):
+        """Evidence from the 2026-07-17 outage: under sustained throttling
+        the retry pass recovers nothing but still pays for a second round
+        trip. After a full window of retries with zero recoveries, stop
+        attempting the retry pass — only ONE http call per ticker from then
+        on instead of two."""
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep", lambda s: None
+        )
+        resp_429 = MagicMock(status_code=429, headers={})
+        resp_429_retry = MagicMock(status_code=429, headers={})
+        resp_429_retry.raise_for_status.side_effect = requests.HTTPError("429")
+
+        fake_http = MagicMock()
+        # Each ticker: first call 429s (triggers retry attempt), retry
+        # ALSO 429s and raises on raise_for_status() — realistic persistent
+        # throttling, unlike the pre-existing fixture's bare MagicMock.
+        fake_http.get.side_effect = [resp_429, resp_429_retry] * 20
+
+        from collectors.news_sources import gdelt as gdelt_module
+        _RETRY_ABANDON_SAMPLE_SIZE = gdelt_module._RETRY_ABANDON_SAMPLE_SIZE
+
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={},
+            http=fake_http,
+            inter_request_sleep=0.0,
+        )
+        tickers = [f"T{i}" for i in range(_RETRY_ABANDON_SAMPLE_SIZE + 2)]
+        adapter.fetch(tickers)
+
+        # First _RETRY_ABANDON_SAMPLE_SIZE tickers: 2 calls each (initial +
+        # retry) while the adapter is still trusting the retry pass.
+        # Remaining tickers: 1 call each, once retries are abandoned.
+        expected_calls = (2 * _RETRY_ABANDON_SAMPLE_SIZE) + (
+            1 * (len(tickers) - _RETRY_ABANDON_SAMPLE_SIZE)
+        )
+        assert fake_http.get.call_count == expected_calls
+        assert adapter._retries_abandoned is True
+
+    def test_retries_not_abandoned_when_they_sometimes_recover(self, monkeypatch):
+        """The occasional-429 regime (config#663) must be unaffected: if
+        retries sometimes DO recover coverage, keep retrying every ticker."""
+        monkeypatch.setattr(
+            "collectors.news_sources.gdelt.time.sleep", lambda s: None
+        )
+        resp_429 = MagicMock(status_code=429, headers={})
+        resp_ok = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"articles": []}),
+            raise_for_status=MagicMock(return_value=None),
+        )
+        fake_http = MagicMock()
+        # Every ticker: initial 429, retry SUCCEEDS — retries stay worthwhile.
+        fake_http.get.side_effect = [resp_429, resp_ok] * 20
+
+        adapter = GdeltNewsAdapter(
+            ticker_name_map={},
+            http=fake_http,
+            inter_request_sleep=0.0,
+        )
+        tickers = [f"T{i}" for i in range(12)]
+        adapter.fetch(tickers)
+
+        assert fake_http.get.call_count == 2 * len(tickers)
+        assert adapter._retries_abandoned is False
 
 
 # ── Yahoo RSS adapter ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Permanent fix for the 2026-07-17 morning-signal outage (see alpha-engine-config-I2813 for the full incident writeup). GDELT throttling escalated from "occasional 429" (config#663, judged non-blocking) to a sustained ~100% 429 rate across an entire run. `GdeltNewsAdapter.fetch()` had no wall-clock bound, so it ran long enough to blow `daily-news.service`'s 40-min systemd timeout with zero output — no digest at all, which cascaded into a missed morning-signal episode via its `news_context.required` gate.

This closes alpha-engine-config-I2813.

## What changed (`collectors/news_sources/gdelt.py`)

1. **Hard wall-clock time budget** (default 20 min) across the whole `fetch()` call, checked before each ticker. A bad GDELT day now degrades this adapter's own coverage instead of starving the rest of the pipeline of a chance to run — Polygon + Yahoo RSS are unaffected by GDELT's throttling and reliably complete on their own (confirmed in both 2026-07-16 and 2026-07-17's logs even while GDELT was ~100% throttled).
2. **Adaptive retry abandonment**: today's evidence showed the existing single-retry-with-Retry-After (config#663) had a **0% recovery rate** under sustained throttling while still paying for a full second round trip per ticker. Once a full window (8) of retries has recovered nothing, the adapter stops paying for the retry pass for the rest of that run — roughly halves per-ticker latency under sustained throttling, letting strictly more tickers fit inside the time budget. In the occasional-429 regime config#663 was built for (retries sometimes work), this never engages and behavior is unchanged.
3. **CUSIP skip**: GDELT's company-name search can never meaningfully match a 9-character bond CUSIP — every such query was a guaranteed-zero-value round trip. Skipped up front, logged once.

Also updated `infrastructure/systemd/daily-news.service`'s stale sizing comment (was "~96-ticker", now ~106 and growing) to note the adapter-level budget is now the primary defense; the systemd `TimeoutStartSec` is a backstop, not the sole line of defense.

## Why this is the SOTA fix, not a bandaid

Bounded time budget + adaptive backoff + graceful degradation on a single unreliable external dependency is the standard resilience pattern for exactly this situation (the same shape AWS SDKs use for adaptive retry, and the circuit-breaker/bulkhead-isolation pattern generally) — there's no way to make GDELT itself stop rate-limiting us, so the correct fix is making our side resilient to it, not guessing at a bigger timeout number. A blind `TimeoutStartSec` bump was considered and explicitly rejected (see I2813) — the original 2400s budget was sized against Polygon's rate limit, not GDELT's, so a bigger number would just delay the same failure mode without an actual headroom analysis behind it.

## Testing

- 8 new tests added to `TestGdeltNewsAdapter` covering: time-budget early-stop with partial results, first-ticker-always-attempted-regardless-of-budget, CUSIP detection (parametrized), CUSIP tickers skip the HTTP call entirely, adaptive retry abandonment after sustained zero-recovery, and retries staying active when they sometimes recover (config#663 regression guard).
- All pre-existing GDELT/aggregator/daily_news tests still pass unmodified (117 tests across `test_news_sources_and_aggregator.py`, `test_async_and_cache.py`, `test_daily_news.py`, `test_ingest_news.py`).
- Public `fetch(tickers, *, hours=48)` signature is unchanged — new constructor kwargs (`max_fetch_seconds`, `monotonic`) are optional with defaults, so `_build_aggregator()` in `collectors/daily_news.py` needs no changes.

## Deploy

No manual step needed — `deploy-daily-news-units.yml` auto-pushes the systemd unit file to the dashboard box on merge to `main`, and `run_daily_news_standalone.sh` self-refreshes the code via `git reset --hard` on its next scheduled run. Deployable via the merge button alone.

## Test plan (for reviewer)
- [x] `pytest tests/test_news_sources_and_aggregator.py -v` — 58 passed
- [x] `pytest tests/test_async_and_cache.py -v` — 23 passed
- [x] `pytest tests/test_daily_news.py -v` — 18 passed
- [x] `pytest tests/test_ingest_news.py -v` — 18 passed
