### PR TITLE
feat(infra): Overseer intake plane — bus, queue, CW-alarm tap, emitter IAM (Overseer phase 1)

### DIFF
--- a/infrastructure/attach_overseer_put_events_policy.sh
+++ b/infrastructure/attach_overseer_put_events_policy.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# attach_overseer_put_events_policy.sh — grant fleet emitters PutEvents on the
+# nousergon-alerts bus (Overseer phase 1, alpha-engine-config-I2822).
+#
+# The krepis chokepoints (krepis>=0.15.0) emit `nousergon.alert.v1` events via
+# EventBridge PutEvents. Any role lacking the grant silently falls back to the
+# S3 drop-zone write (see krepis.fleet_events), so this attach is a rollout
+# optimization, not a correctness requirement — but the bus is the primary
+# transport and roles should converge onto it.
+#
+# What it does:
+#   1. Creates (idempotently) the customer-managed policy
+#      `nousergon-alerts-put-events`: events:PutEvents scoped to the ONE bus
+#      ARN — deliberately narrow, safe to attach broadly.
+#   2. Enumerates every Lambda function named `alpha-engine-*` in the region,
+#      collects the distinct execution roles, and attaches the policy.
+#   3. Attaches to any extra role names passed as arguments (EC2 instance
+#      roles for the trading/dashboard/spot boxes, GHA OIDC roles, ...).
+#
+# NEW ROLES: a newly created fleet Lambda/instance role does NOT get this
+# automatically — re-run this script (it is a no-op for already-attached
+# roles) or attach the managed policy in the role's own provisioning.
+#
+# Usage:
+#   ./infrastructure/attach_overseer_put_events_policy.sh [--dry-run] [extra-role-name ...]
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+BUS_NAME="nousergon-alerts"
+POLICY_NAME="nousergon-alerts-put-events"
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
+EXTRA_ROLES=("$@")
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+BUS_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:event-bus/${BUS_NAME}"
+POLICY_ARN="arn:aws:iam::${ACCOUNT_ID}:policy/${POLICY_NAME}"
+
+echo "== PutEvents grant: account=${ACCOUNT_ID} bus=${BUS_NAME} dry_run=${DRY_RUN}"
+
+# ── 1. Managed policy (idempotent) ──────────────────────────────────────────
+if aws iam get-policy --policy-arn "$POLICY_ARN" >/dev/null 2>&1; then
+  echo "policy ${POLICY_NAME}: exists"
+else
+  DOC=$(cat <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PutOverseerAlertEvents",
+      "Effect": "Allow",
+      "Action": "events:PutEvents",
+      "Resource": "${BUS_ARN}"
+    }
+  ]
+}
+JSON
+)
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY-RUN: would create policy ${POLICY_NAME}"
+  else
+    aws iam create-policy --policy-name "$POLICY_NAME" --policy-document "$DOC" \
+      --description "events:PutEvents on the nousergon-alerts bus only — Overseer intake emitters (alpha-engine-config-I2822)" > /dev/null
+    echo "policy ${POLICY_NAME}: created"
+  fi
+fi
+
+# ── 2. Enumerate fleet Lambda execution roles ───────────────────────────────
+ROLE_NAMES=$(aws lambda list-functions --region "$REGION" \
+  --query "Functions[?starts_with(FunctionName, 'alpha-engine-')].Role" --output text \
+  | tr '\t' '\n' | awk -F'/' '{print $NF}' | sort -u)
+
+attach() {
+  local role="$1"
+  if aws iam list-attached-role-policies --role-name "$role" \
+      --query "AttachedPolicies[?PolicyArn=='${POLICY_ARN}']" --output text | grep -q .; then
+    echo "role ${role}: already attached"
+    return
+  fi
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY-RUN: would attach to role ${role}"
+  else
+    aws iam attach-role-policy --role-name "$role" --policy-arn "$POLICY_ARN"
+    echo "role ${role}: attached"
+  fi
+}
+
+for role in $ROLE_NAMES; do
+  attach "$role"
+done
+
+for role in "${EXTRA_ROLES[@]:-}"; do
+  [[ -n "$role" ]] && attach "$role"
+done
+
+echo "== Done."

--- a/infrastructure/setup_overseer_intake.sh
+++ b/infrastructure/setup_overseer_intake.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# setup_overseer_intake.sh — Nousergon Overseer intake plane, phase 1
+# (alpha-engine-config-I2822, epic alpha-engine-config-I2821).
+#
+# Why this exists: every operator alert the fleet sends (SNS email, Telegram
+# push/silent) is human-facing and fire-and-forget — once delivered, nothing
+# owns follow-through. Phase 1 gives alerts a machine-readable second life:
+# the krepis chokepoints (krepis.alerts.publish, krepis.telegram.send_message,
+# krepis>=0.15.0) emit structured `nousergon.alert.v1` events, and this script
+# provisions where those events land:
+#
+#   1. EventBridge custom bus `nousergon-alerts` — the fleet alert event bus.
+#   2. SQS `nousergon-overseer-intake` (+ DLQ) — the durable intake queue the
+#      Overseer alert-drain (phase 3, alpha-engine-config-I2824) consumes.
+#      14-day retention: the drain runs on a schedule, not a poller.
+#   3. Rule on the custom bus: source=nousergon.krepis → intake queue.
+#   4. Rule on the DEFAULT bus: CloudWatch alarm state-change → ALARM →
+#      intake queue. This covers every CW alarm (deadman alarms, backstop
+#      alarms, disk alarms) with ZERO code — CloudWatch emits these events
+#      natively; no Lambda/SNS hop and no IAM on the emitting side.
+#
+# Deliberately NOT here (epic invariant 3, alpha-engine-config-I2821): the
+# alpha-engine-alarm-backstop SNS topic and its CW alarms are untouched — the
+# last-resort backstop must never route THROUGH the bus/queue machinery it
+# watches. The default-bus rule above is an ADDITIVE tap on alarm state
+# changes; SNS delivery of every alarm is unchanged.
+#
+# IAM for emitters is a separate concern — see
+# attach_overseer_put_events_policy.sh (creates/attaches the
+# nousergon-alerts-put-events managed policy to fleet Lambda/EC2 roles).
+# Until a role has the grant, krepis falls back to an S3 drop-zone write
+# (s3://alpha-engine-research/overseer/intake-fallback/) which the phase-3
+# drain reads alongside the queue, so no event is lost during IAM rollout.
+#
+# Idempotent: create-event-bus/create-queue tolerate AlreadyExists; put-rule /
+# put-targets / set-queue-attributes upsert. Safe to re-run.
+#
+# Usage:
+#   ./infrastructure/setup_overseer_intake.sh [--dry-run]
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+BUS_NAME="nousergon-alerts"
+QUEUE_NAME="nousergon-overseer-intake"
+DLQ_NAME="nousergon-overseer-intake-dlq"
+ALERT_RULE_NAME="overseer-intake-alert-events"
+CW_ALARM_RULE_NAME="overseer-intake-cw-alarm-state"
+RETENTION_SECONDS=1209600  # 14 days (SQS maximum)
+MAX_RECEIVE_COUNT=5
+
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+run() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY-RUN: aws $*"
+  else
+    aws "$@"
+  fi
+}
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo "== Overseer intake setup: account=${ACCOUNT_ID} region=${REGION} dry_run=${DRY_RUN}"
+
+# ── 1. Custom event bus ──────────────────────────────────────────────────────
+if aws events describe-event-bus --name "$BUS_NAME" --region "$REGION" >/dev/null 2>&1; then
+  echo "event bus ${BUS_NAME}: exists"
+else
+  run events create-event-bus --name "$BUS_NAME" --region "$REGION" > /dev/null
+  echo "event bus ${BUS_NAME}: created"
+fi
+BUS_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:event-bus/${BUS_NAME}"
+
+# ── 2. DLQ + intake queue ────────────────────────────────────────────────────
+ensure_queue() {
+  local name="$1" attrs="$2"
+  if aws sqs get-queue-url --queue-name "$name" --region "$REGION" >/dev/null 2>&1; then
+    echo "queue ${name}: exists"
+  else
+    run sqs create-queue --queue-name "$name" --attributes "$attrs" --region "$REGION" > /dev/null
+    echo "queue ${name}: created"
+  fi
+}
+
+ensure_queue "$DLQ_NAME" "{\"MessageRetentionPeriod\":\"${RETENTION_SECONDS}\"}"
+DLQ_URL=$(aws sqs get-queue-url --queue-name "$DLQ_NAME" --region "$REGION" --query QueueUrl --output text 2>/dev/null || echo "")
+DLQ_ARN="arn:aws:sqs:${REGION}:${ACCOUNT_ID}:${DLQ_NAME}"
+
+REDRIVE_POLICY="{\\\"deadLetterTargetArn\\\":\\\"${DLQ_ARN}\\\",\\\"maxReceiveCount\\\":\\\"${MAX_RECEIVE_COUNT}\\\"}"
+ensure_queue "$QUEUE_NAME" "{\"MessageRetentionPeriod\":\"${RETENTION_SECONDS}\",\"RedrivePolicy\":\"${REDRIVE_POLICY}\"}"
+QUEUE_URL=$(aws sqs get-queue-url --queue-name "$QUEUE_NAME" --region "$REGION" --query QueueUrl --output text 2>/dev/null || echo "")
+QUEUE_ARN="arn:aws:sqs:${REGION}:${ACCOUNT_ID}:${QUEUE_NAME}"
+
+# Upsert retention + redrive on pre-existing queues too (idempotent re-runs
+# after parameter changes).
+if [[ "$DRY_RUN" == "0" && -n "$QUEUE_URL" ]]; then
+  aws sqs set-queue-attributes --queue-url "$QUEUE_URL" --region "$REGION" \
+    --attributes "{\"MessageRetentionPeriod\":\"${RETENTION_SECONDS}\",\"RedrivePolicy\":\"${REDRIVE_POLICY}\"}"
+fi
+
+# ── 3. Rule on the custom bus: krepis alert events → queue ──────────────────
+run events put-rule --region "$REGION" \
+  --name "$ALERT_RULE_NAME" \
+  --event-bus-name "$BUS_NAME" \
+  --state ENABLED \
+  --description "Overseer intake: structured nousergon.alert.v1 events from the krepis chokepoints (alpha-engine-config-I2822)" \
+  --event-pattern '{"source":["nousergon.krepis"]}' > /dev/null
+echo "rule ${ALERT_RULE_NAME}: upserted on ${BUS_NAME}"
+
+run events put-targets --region "$REGION" \
+  --event-bus-name "$BUS_NAME" \
+  --rule "$ALERT_RULE_NAME" \
+  --targets "Id=overseer-intake-queue,Arn=${QUEUE_ARN}" > /dev/null
+echo "rule ${ALERT_RULE_NAME}: target ${QUEUE_NAME}"
+
+# ── 4. Rule on the DEFAULT bus: CW alarm → ALARM state → queue ──────────────
+run events put-rule --region "$REGION" \
+  --name "$CW_ALARM_RULE_NAME" \
+  --state ENABLED \
+  --description "Overseer intake: every CloudWatch alarm transition to ALARM (additive tap; SNS alarm delivery unchanged) (alpha-engine-config-I2822)" \
+  --event-pattern '{"source":["aws.cloudwatch"],"detail-type":["CloudWatch Alarm State Change"],"detail":{"state":{"value":["ALARM"]}}}' > /dev/null
+echo "rule ${CW_ALARM_RULE_NAME}: upserted on default bus"
+
+run events put-targets --region "$REGION" \
+  --rule "$CW_ALARM_RULE_NAME" \
+  --targets "Id=overseer-intake-queue,Arn=${QUEUE_ARN}" > /dev/null
+echo "rule ${CW_ALARM_RULE_NAME}: target ${QUEUE_NAME}"
+
+# ── 5. Queue policy: allow EventBridge (scoped to the two rules) ────────────
+ALERT_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${BUS_NAME}/${ALERT_RULE_NAME}"
+CW_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${CW_ALARM_RULE_NAME}"
+POLICY=$(cat <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowEventBridgeOverseerRules",
+      "Effect": "Allow",
+      "Principal": {"Service": "events.amazonaws.com"},
+      "Action": "sqs:SendMessage",
+      "Resource": "${QUEUE_ARN}",
+      "Condition": {"ArnEquals": {"aws:SourceArn": ["${ALERT_RULE_ARN}", "${CW_RULE_ARN}"]}}
+    }
+  ]
+}
+JSON
+)
+if [[ "$DRY_RUN" == "0" ]]; then
+  ESCAPED=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" <<<"$POLICY")
+  aws sqs set-queue-attributes --queue-url "$QUEUE_URL" --region "$REGION" \
+    --attributes "{\"Policy\":${ESCAPED}}"
+  echo "queue ${QUEUE_NAME}: policy upserted (EventBridge SendMessage, scoped to the 2 rules)"
+else
+  echo "DRY-RUN: would set queue policy on ${QUEUE_NAME}"
+fi
+
+echo "== Done. Bus=${BUS_ARN}"
+echo "== Queue=${QUEUE_ARN} DLQ=${DLQ_ARN}"
+echo "== Emitter IAM: run ./infrastructure/attach_overseer_put_events_policy.sh next."


### PR DESCRIPTION
## What

Companion infra for krepis-PR32 — phase 1 of the Nousergon Overseer arc (alpha-engine-config-I2822, epic alpha-engine-config-I2821). Two idempotent setup scripts:

- **`infrastructure/setup_overseer_intake.sh`** — EventBridge custom bus `nousergon-alerts`; SQS `nousergon-overseer-intake` (14-day retention, DLQ with maxReceiveCount=5); rule routing `nousergon.krepis` structured alert events → queue; additive DEFAULT-bus rule routing every CloudWatch alarm transition-to-ALARM → the same queue (zero code, native CW events; SNS alarm delivery untouched — the alarm-backstop channel independence invariant is preserved).
- **`infrastructure/attach_overseer_put_events_policy.sh`** — creates the narrow `nousergon-alerts-put-events` managed policy (`events:PutEvents` on the one bus ARN) and attaches it to every `alpha-engine-*` Lambda execution role + the 6 EC2 instance roles. Re-run after adding new roles (no-op for attached ones).

## Deploy state

**Already applied live (2026-07-17)** — this PR is the record of infra that exists; merging changes nothing operationally (merge-button rule satisfied: no post-merge steps).

Verified end-to-end in-session:
- `krepis.fleet_events.emit_alert_event` → event on queue ✅
- real `telegram.send_message` through the instrumented chokepoint (krepis 0.15.0 branch) → event on queue ✅
- temp no-action CW alarm flipped via `set-alarm-state` → alarm event on queue ✅ (temp alarm deleted, queue purged of verification messages)

## Testing

- `bash -n` clean on both scripts; `--dry-run` mode exercised.
- Full repo suite: **3392 passed, 12 skipped** locally.

## Dependencies

- Pairs with nousergon/krepis PR#32 (emitters). Infra is live, so merge order is free; emission activates fleet-wide as services redeploy onto krepis ≥0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)