### PR TITLE
feat(overseer): playbook registry + overseer-dispatcher router (Overseer phase 2)

### DIFF
--- a/infrastructure/lambdas/overseer-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/overseer-dispatcher/deploy.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-overseer-dispatcher Lambda.
+#
+# WHY (alpha-engine-config-I2823, epic I2821): registry-driven router in
+# front of the fleet's failure-response executor Lambdas. One dispatch entry,
+# one playbook registry (infrastructure/overseer/playbooks.yaml — BUNDLED
+# into the zip here), one owner of verdict-based P1 filing + loud paging
+# (previously duplicated in sf-watch.yml GHA yaml). Executors unchanged.
+#
+# IAM (iam-policy.json): lambda:InvokeFunction on the two routed executors,
+# ssm:GetParameter on the fleet PAT + Telegram secrets, s3:PutObject on the
+# dispatch-ledger + intake-fallback prefixes, sns:Publish on
+# alpha-engine-alerts, events:PutEvents on the nousergon-alerts bus. No EC2
+# permissions — launching is the EXECUTORS' job.
+#
+# Managed OUTSIDE CloudFormation like its sibling dispatchers. Flagless run
+# is code-only (the GHA auto-deploy path); --bootstrap creates role + policy
+# + function (operator-run only).
+#
+# Usage:
+#   bash .../overseer-dispatcher/deploy.sh             # update code only
+#   bash .../overseer-dispatcher/deploy.sh --bootstrap # operator-only: create role + Lambda
+#   bash .../overseer-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-overseer-dispatcher"
+ROLE_NAME="alpha-engine-overseer-dispatcher-role"
+POLICY_NAME="alpha-engine-overseer-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# Bootstrap default (first-time only) — the update path preserves live flags.
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,OVERSEER_DISPATCH_ENABLED=true}'
+
+# Shared operator-flag-preserve helper (config#1818/#2236/#2264 bug class).
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dir + validate handler syntax -----------------------------
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}"
+
+# ----- 1. Package: pip install deps + zip handler + bundle registry ---------
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+# The playbook registry is the router's routing table — bundled from the
+# repo SSoT so a registry edit deploys through the normal code path (pinned
+# by tests/test_overseer_playbook_registry.py::test_router_bundles_this_registry).
+cp "${SCRIPT_DIR}/../../overseer/playbooks.yaml" "${PKG}/playbooks.yaml"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+    echo "  Creating Lambda function: ${FUNCTION_NAME}"
+    # Timeout 120s: the executor invoke is SYNCHRONOUS and the slowest
+    # executor leg (spot launch + SSM online wait) can take ~90s.
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --architectures x86_64 \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --role "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" \
+      --timeout 120 \
+      --memory-size 256 \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda function exists: ${FUNCTION_NAME}"
+  fi
+fi
+
+# ----- 3. Update code (always) ----------------------------------------------
+echo "Updating ${FUNCTION_NAME} code..."
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+  # Preserve operator-owned runtime flags across redeploys (config#1818 class).
+  CURRENT_ENABLED=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" OVERSEER_DISPATCH_ENABLED true)
+  aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment "Variables={LOG_LEVEL=INFO,OVERSEER_DISPATCH_ENABLED=${CURRENT_ENABLED}}" \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "Done."

--- a/infrastructure/lambdas/overseer-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/overseer-dispatcher/iam-policy.json
@@ -1,0 +1,68 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-overseer-dispatcher:*"
+    },
+    {
+      "Sid": "InvokeRoutedExecutors",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-sf-watch-spot-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ci-watch-dispatcher"
+      ]
+    },
+    {
+      "Sid": "EscalationPatAndTelegramSecrets",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID"
+      ]
+    },
+    {
+      "Sid": "DispatchLedgerAndIntakeFallback",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research/overseer/dispatch_ledger/*",
+        "arn:aws:s3:::alpha-engine-research/overseer/intake-fallback/*",
+        "arn:aws:s3:::alpha-engine-research/_alerts/_dedup/*"
+      ]
+    },
+    {
+      "Sid": "AlertDedupMarkerRead",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_alerts/_dedup/*"
+    },
+    {
+      "Sid": "LoudPageSns",
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    },
+    {
+      "Sid": "SnsTopicArnResolution",
+      "Effect": "Allow",
+      "Action": "sts:GetCallerIdentity",
+      "Resource": "*"
+    },
+    {
+      "Sid": "IntakeBusEvents",
+      "Effect": "Allow",
+      "Action": "events:PutEvents",
+      "Resource": "arn:aws:events:us-east-1:711398986525:event-bus/nousergon-alerts"
+    }
+  ]
+}

--- a/infrastructure/lambdas/overseer-dispatcher/index.py
+++ b/infrastructure/lambdas/overseer-dispatcher/index.py
@@ -1,0 +1,345 @@
+"""alpha-engine-overseer-dispatcher — registry-driven router in front of the
+fleet's failure-response executor Lambdas (alpha-engine-config-I2823, epic
+alpha-engine-config-I2821).
+
+WHY A ROUTER, NOT A MERGE: the three response paths (sf-watch, ci-watch,
+groom) are domain policy layers over the already-consolidated
+``nousergon_lib.spot_dispatch`` primitives — their per-path semantics
+(defer-not-drop vs concurrent-skip, drill isolation, attempt ceilings, pace
+gates) are essential, test-pinned complexity, not accidental duplication.
+What the fleet lacked was ONE dispatch entry + ONE registry of the response
+surface + ONE place that turns a bad executor verdict into a P1 + loud page
+(previously duplicated in sf-watch.yml GHA yaml, and absent entirely for
+non-GHA callers). This Lambda is that entry; the executors are unchanged.
+
+It also removes GitHub from the SF-failure loop: saturday-sf-watch-dispatcher
+M2 (flag ``M2_DISPATCH_TARGET=overseer``) invokes this router Lambda-to-Lambda
+instead of round-tripping EventBridge -> repository_dispatch -> GHA ->
+lambda invoke — a chain that made SF recovery depend on GitHub availability
+(cf. the 2026-07-16 GitHub 503 incident).
+
+REGISTRY: ``playbooks.yaml`` (bundled at deploy from
+``infrastructure/overseer/playbooks.yaml``; contract in
+``playbooks.schema.json`` + tests/test_overseer_playbook_registry.py). Only
+``routed: true`` + ``enabled: true`` playbooks are dispatchable.
+
+EVENT SHAPE (direct invoke, sync or async):
+    {"playbook": "sf-watch" | "ci-watch",
+     "payload":  {<executor event, passed through with bools stringified>}}
+
+CONTRACT: mirrors the executors' synchronous posture — every anticipated
+failure returns a clean JSON verdict, never raises. Callers:
+  - sf-watch.yml's ci-watch-dispatch GHA job (sync RequestResponse; branches
+    on ``.verdict.launched`` / ``.verdict.reason`` and files a P1 ONLY if the
+    router invoke itself fails — verdict-based P1s are owned HERE now).
+  - saturday-sf-watch-dispatcher M2 in overseer mode (async Event; relies on
+    this router's escalation path entirely).
+  - operator/drill manual invokes.
+
+ESCALATION (the consolidation payoff): a non-benign executor verdict — or a
+router-level wiring error (unknown playbook, invalid event, executor invoke
+failure) — files a P1 issue in alpha-engine-config (PAT from SSM) AND pages
+loudly via ``krepis.alerts.publish`` (severity=critical). Both legs are
+best-effort with the OTHER leg + the returned verdict + CloudWatch logs as
+recording surfaces; on krepis>=0.15.0 the page also lands on the
+``nousergon-alerts`` intake bus (phase-1 chokepoint), so the phase-3 drain
+sees every escalation as a structured event.
+
+LEDGER: every routed dispatch writes
+``s3://alpha-engine-research/overseer/dispatch_ledger/{date}/...json``
+(best-effort, secondary — the executor verdict + logs are primary).
+
+Managed OUTSIDE CloudFormation like its sibling dispatchers:
+operator-deployed via ``deploy.sh --bootstrap``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+import yaml
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: OVERSEER_DISPATCH_ENABLED=false refuses ALL routing without
+# touching callers — mirrors every fleet dispatcher's safety valve. Per-
+# playbook `enabled: false` in the registry does the same for one playbook.
+DISPATCH_ENABLED = os.environ.get("OVERSEER_DISPATCH_ENABLED", "true").lower() == "true"
+
+REGISTRY_PATH = Path(os.environ.get(
+    "OVERSEER_REGISTRY_PATH", str(Path(__file__).parent / "playbooks.yaml")
+))
+
+# Escalation targets. The PAT param is the same fleet-standard one every
+# watch-plane component reads (fine-grained, org-wide issues:write).
+ISSUES_REPO = os.environ.get("OVERSEER_ISSUES_REPO", "nousergon/alpha-engine-config")
+GH_PAT_SSM = os.environ.get(
+    "OVERSEER_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+_ISSUE_TIMEOUT_SEC = int(os.environ.get("OVERSEER_ISSUE_TIMEOUT_SEC", "10"))
+
+LEDGER_BUCKET = os.environ.get("OVERSEER_LEDGER_BUCKET", "alpha-engine-research")
+LEDGER_PREFIX = os.environ.get("OVERSEER_LEDGER_PREFIX", "overseer/dispatch_ledger")
+
+_INVOKE_TIMEOUT_NOTE = (
+    "executor invoke is synchronous; this Lambda's own timeout must exceed "
+    "the slowest executor's (see deploy.sh --timeout 120)"
+)
+
+
+class _RegistryError(RuntimeError):
+    """The bundled registry is missing/malformed — a packaging bug."""
+
+
+_REGISTRY_CACHE: dict | None = None
+
+
+def _registry() -> dict:
+    """Load (once per container) the bundled playbook registry."""
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None:
+        try:
+            doc = yaml.safe_load(REGISTRY_PATH.read_text())
+        except Exception as exc:  # noqa: BLE001 — converted to _RegistryError, escalated by the handler
+            raise _RegistryError(f"cannot read registry {REGISTRY_PATH}: {exc}") from exc
+        if not isinstance(doc, dict) or "playbooks" not in doc:
+            raise _RegistryError(f"malformed registry {REGISTRY_PATH}: no 'playbooks' key")
+        _REGISTRY_CACHE = doc
+    return _REGISTRY_CACHE
+
+
+def _stringify_bools(payload: dict) -> dict:
+    """Executors regex-validate string fields ("true"/"false"); JSON callers
+    may send real booleans. Normalize top-level bool values only."""
+    return {
+        k: ("true" if v is True else "false" if v is False else v)
+        for k, v in payload.items()
+    }
+
+
+def _invoke_executor(function_name: str, payload: dict) -> dict:
+    """Synchronously invoke the executor and parse its JSON verdict."""
+    resp = boto3.client("lambda", region_name=REGION).invoke(
+        FunctionName=function_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(payload).encode("utf-8"),
+    )
+    body = resp["Payload"].read()
+    if resp.get("FunctionError"):
+        raise RuntimeError(f"executor {function_name} errored: {body[:500]!r}")
+    verdict = json.loads(body)
+    if not isinstance(verdict, dict):
+        raise RuntimeError(f"executor {function_name} returned non-dict: {body[:200]!r}")
+    return verdict
+
+
+def _file_p1(playbook: str, reason: str, detail: str, payload: dict) -> dict:
+    """File the escalation P1 in ISSUES_REPO. Best-effort — the loud page +
+    returned verdict + logs are the other recording surfaces."""
+    try:
+        pat = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=GH_PAT_SSM, WithDecryption=True
+        )["Parameter"]["Value"]
+        body = "\n".join([
+            f"Overseer dispatch for playbook `{playbook}` did not launch and the",
+            f"decline reason is not in the playbook's benign list.",
+            "",
+            f"- **Reason:** `{reason}`",
+            f"- **Detail:** {detail or '(none)'}",
+            f"- **Payload:** `{json.dumps(payload, default=str)[:1500]}`",
+            f"- **Dispatched via:** alpha-engine-overseer-dispatcher "
+            f"(alpha-engine-config-I2823)",
+            "",
+            "Closes-when: the underlying failure this dispatch was covering is",
+            "confirmed handled (rerun green / fix merged / consciously declined),",
+            "and any router/executor defect this exposed is fixed or filed.",
+        ])
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{ISSUES_REPO}/issues",
+            data=json.dumps({
+                "title": f"[P1] overseer: {playbook} dispatch failed ({reason})",
+                "body": body,
+                "labels": ["P1", "bug", "area:monitoring"],
+            }).encode("utf-8"),
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {pat}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "overseer-dispatcher",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=_ISSUE_TIMEOUT_SEC) as resp:
+            issue = json.loads(resp.read())
+        logger.info("overseer escalation P1 filed: %s", issue.get("html_url"))
+        return {"filed": True, "url": issue.get("html_url")}
+    except Exception as exc:  # noqa: BLE001 — best-effort leg; recording surfaces: the loud page below, this WARNING, the returned verdict
+        logger.warning("overseer escalation P1 filing FAILED: %s: %s",
+                       type(exc).__name__, exc)
+        return {"filed": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _page_loud(playbook: str, reason: str, detail: str, p1: dict) -> bool:
+    """Loud operator page for a non-benign dispatch outcome. Best-effort —
+    recording surfaces: the P1 leg, this WARNING, the returned verdict. On
+    krepis>=0.15.0 this also emits a structured event onto the intake bus."""
+    try:
+        from krepis import alerts
+
+        issue_line = p1.get("url") or f"P1 filing failed: {p1.get('error')}"
+        result = alerts.publish(
+            f"Overseer dispatch FAILED for playbook '{playbook}': {reason}. "
+            f"{detail or ''} Issue: {issue_line}",
+            severity="critical",
+            source="overseer-dispatcher",
+            dedup_key=f"overseer-escalation-{playbook}-{reason}",
+        )
+        return result.any_ok
+    except Exception as exc:  # noqa: BLE001 — best-effort leg; recording surfaces: the P1 leg, this WARNING, the returned verdict
+        logger.warning("overseer loud page FAILED: %s: %s", type(exc).__name__, exc)
+        return False
+
+
+def _escalate(playbook: str, reason: str, detail: str, payload: dict) -> dict:
+    p1 = _file_p1(playbook, reason, detail, payload)
+    paged = _page_loud(playbook, reason, detail, p1)
+    if not p1.get("filed") and not paged:
+        # Both escalation legs down: the ONLY remaining surfaces are this
+        # ERROR log (-> watch-plane CW alarm on Lambda errors won't fire for
+        # a logged error, but the alarm on THIS message pattern is the
+        # backstop's job) and the returned verdict. Log at ERROR with a
+        # stable marker so it is grep-able and alarm-able.
+        logger.error(
+            "OVERSEER_ESCALATION_DELIVERY_FAILED playbook=%s reason=%s — both "
+            "P1 filing and the loud page failed; verdict is the only surface",
+            playbook, reason,
+        )
+    return {"p1": p1, "paged": paged}
+
+
+def _write_ledger(record: dict) -> str | None:
+    """Best-effort dispatch-ledger write. Secondary surface — a ledger outage
+    must never affect the dispatch; recording surface: this WARNING + logs."""
+    now = datetime.now(timezone.utc)
+    key = (
+        f"{LEDGER_PREFIX}/{now:%Y-%m-%d}/"
+        f"{now:%H%M%S}-{record.get('playbook', 'unknown')}-{uuid.uuid4().hex[:8]}.json"
+    )
+    try:
+        boto3.client("s3", region_name=REGION).put_object(
+            Bucket=LEDGER_BUCKET,
+            Key=key,
+            Body=json.dumps(record, indent=2, default=str).encode("utf-8"),
+            ContentType="application/json",
+        )
+        return key
+    except Exception as exc:  # noqa: BLE001 — secondary surface, see docstring
+        logger.warning("overseer ledger write failed (non-fatal): %s", exc)
+        return None
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Route a dispatch request to its playbook's executor. Clean-JSON
+    contract: anticipated failures return ``routed: false`` verdicts (and
+    escalate where the failure means lost coverage), never raise."""
+    event = event or {}
+    playbook_name = str(event.get("playbook") or "").strip()
+    payload = event.get("payload")
+
+    if not DISPATCH_ENABLED:
+        logger.warning("OVERSEER_DISPATCH_ENABLED=false — dispatch refused")
+        return {"routed": False, "reason": "disabled", "playbook": playbook_name}
+
+    if not playbook_name or not isinstance(payload, dict):
+        detail = f"playbook={playbook_name!r} payload_type={type(payload).__name__}"
+        logger.error("invalid overseer event: %s", detail)
+        # A malformed dispatch request means a caller wiring bug AND (for
+        # async callers) a real failure losing its coverage — escalate.
+        escalation = _escalate(playbook_name or "unknown", "invalid_event", detail, event)
+        return {"routed": False, "reason": "invalid_event", "error": detail,
+                "escalation": escalation}
+
+    try:
+        registry = _registry()
+    except _RegistryError as exc:
+        logger.error("overseer registry unusable: %s", exc)
+        escalation = _escalate(playbook_name, "registry_error", str(exc), payload)
+        return {"routed": False, "reason": "registry_error", "error": str(exc),
+                "escalation": escalation}
+
+    spec = (registry.get("playbooks") or {}).get(playbook_name)
+    if spec is None:
+        detail = f"playbook {playbook_name!r} not in registry"
+        logger.error("overseer: %s", detail)
+        escalation = _escalate(playbook_name, "unknown_playbook", detail, payload)
+        return {"routed": False, "reason": "unknown_playbook", "error": detail,
+                "escalation": escalation}
+    if not spec.get("routed", False):
+        detail = f"playbook {playbook_name!r} is inventory-only (routed: false)"
+        logger.error("overseer: %s", detail)
+        escalation = _escalate(playbook_name, "not_routable", detail, payload)
+        return {"routed": False, "reason": "not_routable", "error": detail,
+                "escalation": escalation}
+    if not spec.get("enabled", False):
+        # A deliberately-disabled playbook is an operator decision, not a
+        # wiring bug — clean decline, no escalation (mirrors the executors'
+        # own kill-switch verdicts).
+        logger.warning("overseer: playbook %s disabled in registry", playbook_name)
+        return {"routed": False, "reason": "playbook_disabled", "playbook": playbook_name}
+
+    function_name = spec["executor_function"]
+    executor_payload = _stringify_bools(payload)
+    started_at = datetime.now(timezone.utc).isoformat()
+    try:
+        verdict = _invoke_executor(function_name, executor_payload)
+    except Exception as exc:  # noqa: BLE001 — clean-JSON contract; escalated (lost coverage)
+        detail = f"{type(exc).__name__}: {exc}"
+        logger.error("overseer executor invoke FAILED for %s: %s", function_name, detail)
+        escalation = _escalate(playbook_name, "executor_invoke_failed", detail, payload)
+        result = {"routed": False, "reason": "executor_invoke_failed",
+                  "playbook": playbook_name, "executor_function": function_name,
+                  "error": detail, "escalation": escalation}
+        result["ledger_key"] = _write_ledger(
+            {"playbook": playbook_name, "started_at": started_at,
+             "payload": executor_payload, "outcome": result}
+        )
+        return result
+
+    launched = verdict.get("launched") is True
+    reason = str(verdict.get("reason") or "")
+    benign = reason in set(spec.get("benign_reasons") or [])
+    escalation = None
+    if not launched and not benign:
+        escalation = _escalate(
+            playbook_name, reason or "unknown_decline",
+            f"executor verdict: {json.dumps(verdict, default=str)[:500]}", payload,
+        )
+
+    result = {
+        "routed": True,
+        "playbook": playbook_name,
+        "executor_function": function_name,
+        "verdict": verdict,
+        "benign": (not launched) and benign,
+        "escalation": escalation,
+    }
+    result["ledger_key"] = _write_ledger(
+        {"playbook": playbook_name, "started_at": started_at,
+         "payload": executor_payload, "outcome": {k: result[k] for k in
+                                                  ("routed", "verdict", "benign", "escalation")}}
+    )
+    logger.info(
+        "overseer routed: playbook=%s executor=%s launched=%s reason=%s benign=%s escalated=%s",
+        playbook_name, function_name, launched, reason, benign, escalation is not None,
+    )
+    return result

--- a/infrastructure/lambdas/overseer-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/overseer-dispatcher/requirements.txt
@@ -1,0 +1,8 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# Registry parsing (playbooks.yaml bundled at deploy).
+pyyaml>=6.0
+# krepis.alerts.publish is the loud-page escalation leg; >=0.15.0 so the page
+# ALSO lands on the nousergon-alerts intake bus as a structured event
+# (Overseer phase 1, alpha-engine-config-I2822).
+krepis>=0.15.0

--- a/infrastructure/lambdas/overseer-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/overseer-dispatcher/test_handler.py
@@ -1,0 +1,214 @@
+"""Handler tests for alpha-engine-overseer-dispatcher (alpha-engine-config-I2823).
+
+Pins the router contract: registry-driven routing to the executor, bool
+stringification, benign-decline pass-through, escalation on non-benign
+verdicts / invoke failures / wiring errors (P1 + loud page, both best-effort),
+kill switches (env + per-playbook), ledger best-effort, and the clean-JSON
+never-raise posture.
+
+Hermetic: boto3 and krepis are stubbed in sys.modules before ``import index``
+(the deploy.sh preflight gate runs this file the same way the sibling
+dispatchers' gates do).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _load_index(monkeypatch, registry_path: Path):
+    """Import a fresh index module against a stub boto3 + given registry."""
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = MagicMock(name="boto3.client")
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    monkeypatch.setenv("OVERSEER_REGISTRY_PATH", str(registry_path))
+    monkeypatch.syspath_prepend(str(SCRIPT_DIR))
+    sys.modules.pop("index", None)
+    index = importlib.import_module("index")
+    index._REGISTRY_CACHE = None
+    return index, fake_boto3
+
+
+REGISTRY = SCRIPT_DIR.parent.parent / "overseer" / "playbooks.yaml"
+
+
+@pytest.fixture
+def index_mod(monkeypatch):
+    index, fake_boto3 = _load_index(monkeypatch, REGISTRY)
+    # Never let escalation legs hit the network in tests.
+    monkeypatch.setattr(index, "_file_p1",
+                        MagicMock(return_value={"filed": True, "url": "http://x"}))
+    monkeypatch.setattr(index, "_page_loud", MagicMock(return_value=True))
+    monkeypatch.setattr(index, "_write_ledger", MagicMock(return_value="ledger/key"))
+    return index, fake_boto3
+
+
+def _lambda_client_returning(fake_boto3, verdict: dict, function_error: str | None = None):
+    lam = MagicMock()
+    payload = MagicMock()
+    payload.read.return_value = json.dumps(verdict).encode()
+    resp = {"Payload": payload}
+    if function_error:
+        resp["FunctionError"] = function_error
+    lam.invoke.return_value = resp
+    fake_boto3.client.return_value = lam
+    return lam
+
+
+class TestRouting:
+    def test_routes_sf_watch_to_executor_with_stringified_bools(self, index_mod):
+        index, fake_boto3 = index_mod
+        lam = _lambda_client_returning(fake_boto3, {"launched": True, "reason": "launched"})
+        out = index.handler({"playbook": "sf-watch",
+                             "payload": {"pipeline_name": "ne-weekly-freshness-pipeline",
+                                         "is_preflight": False, "run_date": "2026-07-17"}}, None)
+        assert out["routed"] is True
+        assert out["verdict"]["launched"] is True
+        assert out["escalation"] is None
+        sent = json.loads(lam.invoke.call_args.kwargs["Payload"])
+        assert sent["is_preflight"] == "false"
+        assert lam.invoke.call_args.kwargs["FunctionName"] == \
+            "alpha-engine-sf-watch-spot-dispatcher"
+        assert lam.invoke.call_args.kwargs["InvocationType"] == "RequestResponse"
+
+    def test_ci_watch_routes_to_its_executor(self, index_mod):
+        index, fake_boto3 = index_mod
+        lam = _lambda_client_returning(fake_boto3, {"launched": True, "reason": "launched"})
+        out = index.handler({"playbook": "ci-watch",
+                             "payload": {"repo": "nousergon/krepis", "sha": "a" * 40}}, None)
+        assert out["routed"] is True
+        assert lam.invoke.call_args.kwargs["FunctionName"] == "alpha-engine-ci-watch-dispatcher"
+
+    def test_benign_decline_does_not_escalate(self, index_mod):
+        index, fake_boto3 = index_mod
+        _lambda_client_returning(fake_boto3, {"launched": False, "reason": "deferred"})
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["routed"] is True and out["benign"] is True
+        assert out["escalation"] is None
+        index._file_p1.assert_not_called()
+
+    def test_non_benign_decline_escalates_p1_and_page(self, index_mod):
+        index, fake_boto3 = index_mod
+        _lambda_client_returning(fake_boto3,
+                                 {"launched": False, "reason": "defer_exhausted"})
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["benign"] is False
+        assert out["escalation"]["p1"]["filed"] is True
+        assert out["escalation"]["paged"] is True
+        index._file_p1.assert_called_once()
+        assert "defer_exhausted" in index._file_p1.call_args.args
+
+    def test_launched_true_never_escalates_even_with_odd_reason(self, index_mod):
+        index, fake_boto3 = index_mod
+        _lambda_client_returning(fake_boto3, {"launched": True, "reason": "weird"})
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["escalation"] is None
+
+
+class TestWiringFailures:
+    def test_executor_invoke_error_escalates_clean_json(self, index_mod):
+        index, fake_boto3 = index_mod
+        _lambda_client_returning(fake_boto3, {"x": 1}, function_error="Unhandled")
+        out = index.handler({"playbook": "ci-watch", "payload": {}}, None)
+        assert out["routed"] is False and out["reason"] == "executor_invoke_failed"
+        index._file_p1.assert_called_once()
+
+    def test_unknown_playbook_escalates(self, index_mod):
+        index, _ = index_mod
+        out = index.handler({"playbook": "nope", "payload": {}}, None)
+        assert out["reason"] == "unknown_playbook"
+        index._file_p1.assert_called_once()
+
+    def test_inventory_only_playbook_refused_and_escalated(self, index_mod):
+        index, _ = index_mod
+        out = index.handler({"playbook": "groom", "payload": {}}, None)
+        assert out["reason"] == "not_routable"
+        index._file_p1.assert_called_once()
+
+    def test_invalid_event_escalates(self, index_mod):
+        index, _ = index_mod
+        out = index.handler({"payload": "not-a-dict"}, None)
+        assert out["reason"] == "invalid_event"
+        index._file_p1.assert_called_once()
+
+    def test_escalation_legs_both_failing_still_returns_clean(self, index_mod, caplog):
+        index, fake_boto3 = index_mod
+        index._file_p1.return_value = {"filed": False, "error": "gh down"}
+        index._page_loud.return_value = False
+        _lambda_client_returning(fake_boto3,
+                                 {"launched": False, "reason": "launch_failed"})
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["routed"] is True
+        assert "OVERSEER_ESCALATION_DELIVERY_FAILED" in caplog.text
+
+
+class TestKillSwitches:
+    def test_global_disable(self, index_mod, monkeypatch):
+        index, _ = index_mod
+        monkeypatch.setattr(index, "DISPATCH_ENABLED", False)
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out == {"routed": False, "reason": "disabled", "playbook": "sf-watch"}
+        index._file_p1.assert_not_called()
+
+    def test_registry_disabled_playbook_declines_without_escalation(
+        self, index_mod, monkeypatch, tmp_path
+    ):
+        index, _ = index_mod
+        disabled = {
+            "schema_version": 1,
+            "playbooks": {"sf-watch": {
+                "routed": True, "enabled": False,
+                "executor_function": "alpha-engine-sf-watch-spot-dispatcher",
+            }},
+        }
+        import yaml as _yaml
+        p = tmp_path / "reg.yaml"
+        p.write_text(_yaml.safe_dump(disabled))
+        monkeypatch.setattr(index, "REGISTRY_PATH", p)
+        index._REGISTRY_CACHE = None
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["reason"] == "playbook_disabled"
+        index._file_p1.assert_not_called()
+
+
+class TestLedger:
+    def test_ledger_written_on_routed_dispatch(self, index_mod):
+        index, fake_boto3 = index_mod
+        _lambda_client_returning(fake_boto3, {"launched": True, "reason": "launched"})
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["ledger_key"] == "ledger/key"
+        index._write_ledger.assert_called_once()
+
+    def test_ledger_failure_does_not_break_dispatch(self, index_mod):
+        index, fake_boto3 = index_mod
+        index._write_ledger.return_value = None
+        _lambda_client_returning(fake_boto3, {"launched": True, "reason": "launched"})
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["routed"] is True and out["ledger_key"] is None
+
+
+class TestRegistryBundle:
+    def test_bundled_registry_parses_and_has_routed_playbooks(self, index_mod):
+        index, _ = index_mod
+        reg = index._registry()
+        routed = {k for k, v in reg["playbooks"].items() if v.get("routed")}
+        assert routed == {"sf-watch", "ci-watch"}
+        for name in routed:
+            assert reg["playbooks"][name]["benign_reasons"]
+
+    def test_registry_error_escalates(self, index_mod, monkeypatch, tmp_path):
+        index, _ = index_mod
+        monkeypatch.setattr(index, "REGISTRY_PATH", tmp_path / "missing.yaml")
+        index._REGISTRY_CACHE = None
+        out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        assert out["reason"] == "registry_error"
+        index._file_p1.assert_called_once()

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -147,7 +147,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 60 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,FAST_PATH_ENABLED=false,EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=false,SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,M2_DISPATCH_TARGET=repository_dispatch,FAST_PATH_ENABLED=false,EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=false,SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -230,6 +230,9 @@ echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 # was open. Bootstrap (create-function above) still defaults false — safe
 # rollout posture for a NEW deployment only.
 CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" AGENT_DISPATCH_ENABLED false)
+# M2_DISPATCH_TARGET (alpha-engine-config-I2823) — operator-owned routing flag:
+# repository_dispatch (legacy GitHub round-trip) vs overseer (direct router).
+CURRENT_M2_TARGET=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" M2_DISPATCH_TARGET repository_dispatch)
 # FAST_PATH_ENABLED (config#1900) is operator-owned exactly like
 # AGENT_DISPATCH_ENABLED — preserve the live value across redeploys.
 CURRENT_FAST_PATH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" FAST_PATH_ENABLED false)
@@ -246,7 +249,7 @@ CURRENT_DISPATCH_AFTER_ESCALATION=$(preserve_env_flag "${FUNCTION_NAME}" "${REGI
 # Brian-ruled per-cadence budgets (saturday 8 / weekday 2 / eod 2).
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment "Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH},FAST_PATH_ENABLED=${CURRENT_FAST_PATH},EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=${CURRENT_DISPATCH_AFTER_ESCALATION},SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}" \
+  --environment "Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=${CURRENT_DISPATCH},M2_DISPATCH_TARGET=${CURRENT_M2_TARGET},FAST_PATH_ENABLED=${CURRENT_FAST_PATH},EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=${CURRENT_DISPATCH_AFTER_ESCALATION},SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}" \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -24,6 +24,12 @@
       ]
     },
     {
+      "Sid": "InvokeOverseerRouter",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-overseer-dispatcher"
+    },
+    {
       "Sid": "AgentDispatchPAT",
       "Effect": "Allow",
       "Action": ["ssm:GetParameter"],

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -141,6 +141,18 @@ _DEFAULT_MAX_DISPATCHES = 2
 # repository_dispatch target — the private alpha-engine-config repo hosts the
 # agent GHA workflow (on: repository_dispatch, types: [*-sf-failure]).
 DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
+
+# M2 dispatch target (alpha-engine-config-I2823). "repository_dispatch" (the
+# legacy default) round-trips through GitHub -> sf-watch.yml -> lambda invoke,
+# making SF recovery depend on GitHub availability (cf. the 2026-07-16 GitHub
+# 503 incident). "overseer" invokes alpha-engine-overseer-dispatcher directly
+# (Lambda-to-Lambda, async) — the router consults the playbook registry,
+# invokes the spot dispatcher, and owns P1-filing/paging on bad verdicts.
+# OPERATOR-OWNED runtime flag like AGENT_DISPATCH_ENABLED (deploy.sh preserves
+# it across redeploys). Flip gated on the reshaped weekly SF's first live run
+# (gate:weekly-sf) — see alpha-engine-config-I2823.
+M2_DISPATCH_TARGET = os.environ.get("M2_DISPATCH_TARGET", "repository_dispatch")
+OVERSEER_FUNCTION = os.environ.get("OVERSEER_FUNCTION", "alpha-engine-overseer-dispatcher")
 # Dedicated fine-grained PAT (SecureString) scoped to the SF-path repos, shared
 # across pipelines. Read at dispatch time only — never logged.
 GITHUB_PAT_SSM_PARAM = os.environ.get(
@@ -1012,22 +1024,47 @@ def _maybe_dispatch_agent(
         # pipeline (see _notify).
         return {"dispatched": False, "reason": "no_listener"}
     event_type = cfg["dispatch_event_type"]
+    client_payload = {
+        "pipeline_name": pipeline_name,
+        "cadence_slug": cfg["cadence_slug"],
+        "state_machine_arn": sm_arn,
+        "execution_arn": record.get("execution_arn", ""),
+        "failed_state": record.get("failed_state"),
+        "cause": record.get("cause"),
+        "run_date": run_date,
+        "status": record.get("status"),
+        "watch_log_key": key,
+        "is_preflight": record.get("is_preflight", False),
+    }
+    if M2_DISPATCH_TARGET == "overseer":
+        # Direct Lambda-to-Lambda dispatch (alpha-engine-config-I2823) — no
+        # GitHub in the loop. Async (Event): the router owns verdict handling,
+        # P1 filing, and loud paging; this Lambda's watch-log record (already
+        # written) is the local audit surface either way.
+        try:
+            resp = boto3.client("lambda", region_name=REGION).invoke(
+                FunctionName=OVERSEER_FUNCTION,
+                InvocationType="Event",
+                Payload=json.dumps(
+                    {"playbook": "sf-watch", "payload": client_payload}
+                ).encode("utf-8"),
+            )
+            status_code = int(resp.get("StatusCode", 0))
+            logger.info(
+                "agent dispatch sent via overseer router %s (http=%s)",
+                OVERSEER_FUNCTION, status_code,
+            )
+            return {"dispatched": True, "target": "overseer",
+                    "status_code": status_code, "event_type": event_type}
+        except Exception as exc:  # noqa: BLE001 — secondary path, recorded not raised (same carve-out as the repository_dispatch leg below)
+            logger.warning("overseer dispatch invoke failed (non-fatal): %s", exc)
+            return {"dispatched": False, "target": "overseer",
+                    "error": f"{type(exc).__name__}: {exc}"}
     try:
         pat = _get_github_pat()
         payload = {
             "event_type": event_type,
-            "client_payload": {
-                "pipeline_name": pipeline_name,
-                "cadence_slug": cfg["cadence_slug"],
-                "state_machine_arn": sm_arn,
-                "execution_arn": record.get("execution_arn", ""),
-                "failed_state": record.get("failed_state"),
-                "cause": record.get("cause"),
-                "run_date": run_date,
-                "status": record.get("status"),
-                "watch_log_key": key,
-                "is_preflight": record.get("is_preflight", False),
-            },
+            "client_payload": client_payload,
         }
         req = urllib.request.Request(
             f"https://api.github.com/repos/{DISPATCH_REPO}/dispatches",

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -1394,3 +1394,78 @@ def test_budget_escalation_telegram_failure_is_non_fatal(monkeypatch):
     assert result["budget_escalated"] is False
     assert result["agent_dispatch"]["reason"] == "attempt_budget_exhausted"
     s3.put_object.assert_called_once()  # primary deliverable survived
+
+
+# ── M2 overseer dispatch mode (alpha-engine-config-I2823) ────────────────────
+
+
+def _make_clients_with_lambda(**kwargs):
+    """Like _make_clients but also returns a lambda client mock."""
+    factory, sf, s3 = _make_clients(**kwargs)
+    lam = MagicMock()
+    lam.invoke.return_value = {"StatusCode": 202}
+
+    def factory_with_lambda(name, region_name=None):
+        if name == "lambda":
+            return lam
+        return factory(name, region_name=region_name)
+
+    return factory_with_lambda, sf, s3, lam
+
+
+def test_m2_overseer_mode_invokes_router_not_github(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "overseer")
+    factory, sf, s3, lam = _make_clients_with_lambda()
+    with patch("index.boto3.client", side_effect=factory), patch(
+        "index.urllib.request.urlopen",
+        side_effect=AssertionError("GitHub must NOT be called in overseer mode"),
+    ):
+        result = index.handler(_event("FAILED"), None)
+
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["agent_dispatch"]["target"] == "overseer"
+    lam.invoke.assert_called_once()
+    call = lam.invoke.call_args.kwargs
+    assert call["FunctionName"] == index.OVERSEER_FUNCTION
+    assert call["InvocationType"] == "Event"
+    sent = json.loads(call["Payload"])
+    assert sent["playbook"] == "sf-watch"
+    payload = sent["payload"]
+    assert payload["pipeline_name"] == "ne-weekly-freshness-pipeline"
+    assert payload["cadence_slug"] == "saturday"
+    assert payload["watch_log_key"] == "consolidated/saturday_sf_watch/2023-11-14.json"
+    assert payload["run_date"] == "2023-11-14"
+
+
+def test_m2_overseer_invoke_failure_is_nonfatal(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "overseer")
+    factory, sf, s3, lam = _make_clients_with_lambda()
+    lam.invoke.side_effect = RuntimeError("router down")
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)
+
+    # Watch-log (primary) landed; dispatch failure recorded, not raised.
+    s3.put_object.assert_called_once()
+    assert result["agent_dispatch"]["dispatched"] is False
+    assert "router down" in result["agent_dispatch"]["error"]
+
+
+def test_m2_default_target_still_uses_repository_dispatch(monkeypatch):
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    assert index.M2_DISPATCH_TARGET == "repository_dispatch"
+    factory, sf, s3, lam = _make_clients_with_lambda()
+    monkeypatch.setattr(index, "_get_github_pat", MagicMock(return_value="pat"))
+    resp_cm = MagicMock()
+    resp_cm.__enter__ = MagicMock(return_value=MagicMock(status=204))
+    resp_cm.__exit__ = MagicMock(return_value=False)
+    with patch("index.boto3.client", side_effect=factory), patch(
+        "index.urllib.request.urlopen", return_value=resp_cm
+    ) as urlopen:
+        result = index.handler(_event("FAILED"), None)
+
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["agent_dispatch"].get("target") != "overseer"
+    urlopen.assert_called_once()
+    lam.invoke.assert_not_called()

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Nousergon Overseer playbook registry v1",
+  "description": "Contract for infrastructure/overseer/playbooks.yaml (alpha-engine-config-I2823). Additive-only evolution: new fields must be optional; renames/removals require a schema_version bump.",
+  "type": "object",
+  "required": ["schema_version", "playbooks"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": 1 },
+    "playbooks": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "pattern": "^[a-z0-9-]{1,40}$" },
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "description", "tier", "routed", "enabled",
+          "executor_function", "executor_lambda_dir",
+          "concurrency_domain", "supports_drill", "kill_switch_env"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "description": { "type": "string", "minLength": 10 },
+          "tier": { "enum": ["T0", "T1", "T2", "T3"] },
+          "routed": { "type": "boolean" },
+          "enabled": { "type": "boolean" },
+          "executor_function": { "type": "string", "pattern": "^alpha-engine-[a-z0-9-]+$" },
+          "executor_lambda_dir": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "benign_reasons": {
+            "type": "array",
+            "items": { "type": "string", "pattern": "^[a-z_]+$" },
+            "minItems": 1
+          },
+          "charter": { "type": "string" },
+          "concurrency_domain": { "type": "string" },
+          "supports_drill": { "type": "boolean" },
+          "kill_switch_env": { "type": "string", "pattern": "^[A-Z0-9_]+$" }
+        },
+        "if": { "properties": { "routed": { "const": true } } },
+        "then": { "required": ["benign_reasons"] }
+      }
+    }
+  }
+}

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -1,0 +1,81 @@
+# Nousergon Overseer playbook registry — SSoT for the fleet's failure-response
+# paths (alpha-engine-config-I2823, epic alpha-engine-config-I2821).
+#
+# Consumed by:
+#   - infrastructure/lambdas/overseer-dispatcher (bundled into its zip at
+#     deploy time) — routes dispatch requests to the executor Lambda and
+#     handles verdict escalation.
+#   - tests/test_overseer_playbook_registry.py — schema + cross-reference
+#     contract (executor lambda dirs exist, benign_reasons present on routed
+#     entries).
+#
+# Contract: playbooks.schema.json (sibling file). Additive-only evolution —
+# new OPTIONAL fields are fine; renames/removals require a schema_version bump
+# and a dispatcher release that reads both.
+#
+# `routed: false` entries are inventory-only: they appear here so the registry
+# is the ONE place the watch plane's surface is enumerated (probes/alarms/
+# dashboards can iterate it), but the overseer-dispatcher refuses to route to
+# them (they have their own trigger topology, e.g. groom's demand-driven
+# EventBridge cron — a cron→router hop would add a failure mode with zero
+# routing decisions to make).
+
+schema_version: 1
+
+playbooks:
+  sf-watch:
+    description: >-
+      Diagnose+fix+rerun agent for a fleet Step Function terminal failure.
+      Triage/suppression policy (watch-log, attempt ceilings, fast path) lives
+      UPSTREAM in alpha-engine-saturday-sf-watch-dispatcher; this playbook is
+      the launch leg it dispatches when an agent is warranted.
+    tier: T2
+    routed: true
+    enabled: true
+    executor_function: alpha-engine-sf-watch-spot-dispatcher
+    executor_lambda_dir: sf-watch-spot-dispatcher
+    # Executor verdict `reason` values that are by-design declines — the
+    # router treats them as success (no P1, no page). Anything else with
+    # launched!=true escalates. NOTE: unlike ci-watch, this executor has no
+    # `concurrent_skip` — defer-not-drop (config#2226) replaced it with
+    # `deferred`/`recovered` (+ `drill_concurrent_skip` for drills); the
+    # registry lockstep test pins this list to the executor's literals.
+    benign_reasons: [disabled, deferred, recovered, drill_concurrent_skip]
+    charter: alpha-engine-config/.github/sf-watch-prompt.md
+    concurrency_domain: >-
+      EC2 tag lock on (cadence_slug, pipeline_name, run_date); defer-not-drop
+      via one-shot EventBridge Scheduler self-reinvoke (config#2226).
+    supports_drill: true
+    kill_switch_env: SF_WATCH_DISPATCH_ENABLED  # on the EXECUTOR Lambda
+
+  ci-watch:
+    description: >-
+      Diagnose+fix agent for a fleet main-branch CI failure. Fired from GHA
+      (nousergon-lib notify-ci-failure.yml -> repository_dispatch ->
+      sf-watch.yml ci-watch-dispatch job -> this router).
+    tier: T2
+    routed: true
+    enabled: true
+    executor_function: alpha-engine-ci-watch-dispatcher
+    executor_lambda_dir: ci-watch-dispatcher
+    benign_reasons: [concurrent_skip, disabled]
+    charter: alpha-engine-config/.github/ci-watch-prompt.md
+    concurrency_domain: EC2 tag lock on (repo, sha) — per-commit, not per-repo.
+    supports_drill: true
+    kill_switch_env: CI_WATCH_DISPATCH_ENABLED  # on the EXECUTOR Lambda
+
+  groom:
+    description: >-
+      Demand-driven backlog groom (three daily EventBridge cron triggers,
+      symmetric demand evaluation, pace gate). Inventory-only here: its
+      trigger topology is scheduler-driven with zero routing decisions, so it
+      keeps its direct EventBridge->Lambda path.
+    tier: T2
+    routed: false
+    enabled: true
+    executor_function: alpha-engine-scheduled-groom-dispatcher
+    executor_lambda_dir: scheduled-groom-dispatcher
+    charter: alpha-engine-config/scripts/groom_run.sh
+    concurrency_domain: EC2 tag lock on groom-issue-filter (tier lane; sweep has its own lane).
+    supports_drill: false
+    kill_switch_env: GROOM_DISPATCH_ENABLED

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -62,6 +62,7 @@ declare -A WATCH_PLANE_FUNCTIONS=(
   ["sf-watch-spot-dispatcher"]="alpha-engine-sf-watch-spot-dispatcher"
   ["ci-watch-dispatcher"]="alpha-engine-ci-watch-dispatcher"
   ["sf-watch-liveness-probe"]="alpha-engine-sf-watch-liveness-probe"
+  ["overseer-dispatcher"]="alpha-engine-overseer-dispatcher"
 )
 
 echo "Configuring watch-plane Lambda alarms"
@@ -122,3 +123,30 @@ echo "Validation:"
 echo "  aws cloudwatch describe-alarms --region $REGION \\"
 echo "    --alarm-name-prefix alpha-engine-watch-plane- \\"
 echo "    --query 'MetricAlarms[].[AlarmName,StateValue]' --output table"
+
+# --- 3. Overseer intake DLQ depth (alpha-engine-config-I2823) ----------------
+# A message landing on the intake DLQ means EventBridge delivered an alert
+# event 5x and the queue rejected it every time — structured alert events are
+# being LOST. Same backstop-topic routing rationale as the Lambda alarms.
+
+echo ""
+echo "==> Creating overseer intake DLQ depth alarm..."
+run aws cloudwatch put-metric-alarm \
+  --region "$REGION" \
+  --alarm-name "alpha-engine-watch-plane-overseer-intake-dlq-depth" \
+  --alarm-description "Watch-plane backstop: any message on nousergon-overseer-intake-dlq means structured alert events (Overseer phase 1, alpha-engine-config-I2822) are being dropped after redrive exhaustion. Routes to the INDEPENDENT ${BACKSTOP_TOPIC_NAME} topic. Provisioned by infrastructure/setup_watch_plane_alarms.sh." \
+  --namespace "AWS/SQS" \
+  --metric-name "ApproximateNumberOfMessagesVisible" \
+  --dimensions "Name=QueueName,Value=nousergon-overseer-intake-dlq" \
+  --statistic "Maximum" \
+  --period 300 \
+  --evaluation-periods 1 \
+  --datapoints-to-alarm 1 \
+  --threshold 1 \
+  --comparison-operator "GreaterThanOrEqualToThreshold" \
+  --treat-missing-data "notBreaching" \
+  --alarm-actions "$BACKSTOP_TOPIC_ARN" \
+  --ok-actions "$BACKSTOP_TOPIC_ARN"
+
+echo ""
+echo "Done."

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -1,0 +1,89 @@
+"""Contract test for the Overseer playbook registry (alpha-engine-config-I2823).
+
+Pins:
+  1. ``infrastructure/overseer/playbooks.yaml`` validates against its shipped
+     JSON Schema (``playbooks.schema.json``) — the registry is a versioned
+     contract, not a loose config file.
+  2. Cross-reference integrity: every playbook's ``executor_lambda_dir``
+     exists in ``infrastructure/lambdas/`` and its ``executor_function``
+     matches the fleet naming convention derived from that dir.
+  3. Benign-reason lockstep: every ``benign_reasons`` entry appears as a
+     literal ``"reason": "<value>"`` in the executor's ``index.py`` — a
+     registry reason the executor can never return is dead config; an executor
+     decline the registry doesn't know stays escalating (correct default), but
+     a TYPO'd benign reason would silently page on a by-design decline.
+  4. Kill-switch lockstep: ``kill_switch_env`` appears in the executor source.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OVERSEER_DIR = REPO_ROOT / "infrastructure" / "overseer"
+LAMBDAS_DIR = REPO_ROOT / "infrastructure" / "lambdas"
+
+REGISTRY = yaml.safe_load((OVERSEER_DIR / "playbooks.yaml").read_text())
+SCHEMA = json.loads((OVERSEER_DIR / "playbooks.schema.json").read_text())
+
+
+def test_registry_validates_against_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    jsonschema.validate(REGISTRY, SCHEMA)
+
+
+@pytest.mark.parametrize("name", sorted(REGISTRY["playbooks"]))
+def test_executor_lambda_dir_exists(name):
+    spec = REGISTRY["playbooks"][name]
+    lambda_dir = LAMBDAS_DIR / spec["executor_lambda_dir"]
+    assert (lambda_dir / "index.py").is_file(), (
+        f"playbook {name!r}: executor_lambda_dir {spec['executor_lambda_dir']!r} "
+        f"has no index.py under infrastructure/lambdas/"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(REGISTRY["playbooks"]))
+def test_executor_function_matches_dir_convention(name):
+    spec = REGISTRY["playbooks"][name]
+    assert spec["executor_function"] == f"alpha-engine-{spec['executor_lambda_dir']}", (
+        f"playbook {name!r}: executor_function {spec['executor_function']!r} does not "
+        f"follow the alpha-engine-<lambda-dir> fleet naming convention"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    sorted(k for k, v in REGISTRY["playbooks"].items() if v.get("routed")),
+)
+def test_benign_reasons_exist_in_executor_source(name):
+    spec = REGISTRY["playbooks"][name]
+    src = (LAMBDAS_DIR / spec["executor_lambda_dir"] / "index.py").read_text()
+    returnable = set(re.findall(r'"reason":\s*"([a-z_]+)"', src))
+    missing = set(spec["benign_reasons"]) - returnable
+    assert not missing, (
+        f"playbook {name!r}: benign_reasons {sorted(missing)} never appear as "
+        f'literal "reason" values in {spec["executor_lambda_dir"]}/index.py — '
+        f"typo'd benign reasons silently page on by-design declines"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(REGISTRY["playbooks"]))
+def test_kill_switch_env_exists_in_executor_source(name):
+    spec = REGISTRY["playbooks"][name]
+    src = (LAMBDAS_DIR / spec["executor_lambda_dir"] / "index.py").read_text()
+    assert spec["kill_switch_env"] in src, (
+        f"playbook {name!r}: kill_switch_env {spec['kill_switch_env']!r} not found "
+        f"in {spec['executor_lambda_dir']}/index.py"
+    )
+
+
+def test_router_bundles_this_registry():
+    """The router's deploy.sh must copy THIS registry file into its zip —
+    pin the copy line so a rename breaks CI, not the deploy."""
+    deploy = (LAMBDAS_DIR / "overseer-dispatcher" / "deploy.sh").read_text()
+    assert "overseer/playbooks.yaml" in deploy

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -52,7 +52,7 @@ def test_bash_syntax_is_valid():
 
 
 class TestWatchPlaneCoverage:
-    """All four watch-plane Lambdas must be alarmed."""
+    """All five watch-plane Lambdas must be alarmed."""
 
     @pytest.mark.parametrize(
         "fn_name",
@@ -61,6 +61,7 @@ class TestWatchPlaneCoverage:
             "alpha-engine-sf-watch-spot-dispatcher",
             "alpha-engine-ci-watch-dispatcher",
             "alpha-engine-sf-watch-liveness-probe",
+            "alpha-engine-overseer-dispatcher",
         ],
     )
     def test_lambda_is_present(self, script_text, fn_name):
@@ -75,7 +76,7 @@ class TestWatchPlaneCoverage:
                 ")", script_text.find("declare -A WATCH_PLANE_FUNCTIONS=(")
             )
         ]
-        assert block.count('"alpha-engine-') == 4
+        assert block.count('"alpha-engine-') == 5
 
     def test_both_errors_and_throttles_alarmed(self, script_text):
         assert "for metric in Errors Throttles" in script_text
@@ -165,3 +166,16 @@ class TestDocstringsNowTruthful:
             "name the alarm-provisioning script — the pre-#2266 wording claimed "
             "a CW alarm that did not exist."
         )
+
+
+class TestOverseerIntakeDlqAlarm:
+    """The intake DLQ depth alarm (alpha-engine-config-I2823) rides this
+    script so its backstop-topic + fail-fast discipline applies to it too."""
+
+    def test_dlq_alarm_present(self, script_text):
+        assert "nousergon-overseer-intake-dlq" in script_text
+        assert "ApproximateNumberOfMessagesVisible" in script_text
+
+    def test_dlq_alarm_routes_to_backstop(self, script_text):
+        dlq_block = script_text[script_text.find("overseer-intake-dlq-depth"):]
+        assert '--alarm-actions "$BACKSTOP_TOPIC_ARN"' in dlq_block


### PR DESCRIPTION
## What

Phase 2 of the Nousergon Overseer arc — alpha-engine-config-I2823 (epic alpha-engine-config-I2821), under the design ruling posted on the issue: **registry + thin router in front of the proven executors**, not a literal three-way code merge (the dispatch heads are domain policy layers pinned by ~4,200 lines of behavioral tests; the genuinely-duplicated launch layer was already consolidated in `nousergon_lib.spot_dispatch`).

- **`infrastructure/overseer/playbooks.yaml`** + JSON Schema — SSoT registry of the response surface (sf-watch/ci-watch routed, groom inventory-only). Contract test pins schema validity + executor-dir/benign-reason/kill-switch lockstep with executor source — and caught real dead config on its first run (sf-watch's executor has no `concurrent_skip` literal; defer-not-drop replaced it).
- **`overseer-dispatcher` Lambda** — registry lookup → kill switches → sync executor invoke → verdict normalization → **owns verdict-based P1 filing + loud paging** (previously duplicated in sf-watch.yml GHA yaml); pages ride krepis ≥0.15.0 so they also land on the `nousergon-alerts` intake bus. S3 dispatch ledger per dispatch. 16 handler tests.
- **saturday-sf-watch-dispatcher** — flag-gated `M2_DISPATCH_TARGET=overseer` mode: direct Lambda→router dispatch, removing GitHub from the SF-failure recovery loop (the legacy chain depends on GitHub availability — cf. the 2026-07-16 GitHub 503). **Default stays `repository_dispatch`**; the flip is tracked separately gated on the reshaped weekly SF's first live run. 3 new tests (74 total in the suite).
- **`setup_watch_plane_alarms.sh`** — overseer-dispatcher Errors/Throttles + intake-DLQ-depth alarms on the independent backstop topic; lockstep test updated (4→5 functions).

## Deploy state

**Applied live 2026-07-17** (router `--bootstrap`, saturday dispatcher redeploy with flags preserved — `M2_DISPATCH_TARGET=repository_dispatch`, `AGENT_DISPATCH_ENABLED=true` — IAM via `put-role-policy`, alarms applied). Merge-button rule satisfied: no post-merge steps.

**Live end-to-end drill verification:** router→sf-watch drill launched spot box `i-00b09cef5bc15f106`, router→ci-watch drill launched `i-0629620bfdfee9d02`; both ledger records written; zero false escalations; drill boxes self-terminate per the standard drill guard.

## Testing

- `tests/`: **3418 passed** locally (11 pre-existing failures were a local-venv `openpyxl` gap from PR898, fixed by installing per requirements.txt — not CI-relevant).
- Handler suites (isolated processes per ci.yml convention): overseer-dispatcher 16/16, saturday-sf-watch-dispatcher 74/74.

## Dependencies

- Companion alpha-engine-config PR re-points sf-watch.yml's ci-watch job at the router (GHA OIDC role grant already applied live), so merge order between the two is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)