### PR TITLE
feat(overseer): alert-drain executor + registry playbook + router invoke hardening (Overseer phase 3)

### DIFF
--- a/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-alert-drain-dispatcher Lambda
+# + the twice-daily router-targeting schedules (alpha-engine-config-I2824).
+#
+# Launch leg of the Overseer alert-drain (epic I2821 phase 3). The POLICY
+# lives in alpha-engine-config's .github/alert-drain-prompt.md charter; this
+# Lambda only launches the spot box that runs it. Dispatch path: EventBridge
+# Scheduler -> alpha-engine-overseer-dispatcher router (playbook alert-drain)
+# -> THIS Lambda -> spot box. The schedules deliberately target the ROUTER,
+# not this executor — kill switches, verdict escalation, and the dispatch
+# ledger all live there (phase-2 coherence).
+#
+# --bootstrap creates: (1) this Lambda's execution role + inline policy,
+# (2) the Lambda, (3) the shared alpha-engine-overseer-scheduler-role
+# (invoke-router-only — reusable by any future router-targeting schedule,
+# e.g. the I2832 drill re-point), (4) TWO daily EventBridge Scheduler
+# schedules (10:00 + 22:00 UTC — both off US market hours year-round).
+#
+# Managed OUTSIDE CloudFormation like the sibling dispatchers. Flagless run
+# is code-only (GHA auto-deploy path); --bootstrap is operator-only.
+#
+# Usage:
+#   bash .../alert-drain-dispatcher/deploy.sh             # update code only
+#   bash .../alert-drain-dispatcher/deploy.sh --bootstrap # operator-only: role + Lambda + schedules
+#   bash .../alert-drain-dispatcher/deploy.sh --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-alert-drain-dispatcher"
+ROLE_NAME="alpha-engine-alert-drain-dispatcher-role"
+POLICY_NAME="alpha-engine-alert-drain-dispatcher-policy"
+ROUTER_FUNCTION="alpha-engine-overseer-dispatcher"
+SCHED_ROLE_NAME="alpha-engine-overseer-scheduler-role"
+SCHED_POLICY_NAME="invoke-overseer-dispatcher"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+ROUTER_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${ROUTER_FUNCTION}"
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,ALERT_DRAIN_DISPATCH_ENABLED=true}'
+
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+
+# ----- 0. Validate handler syntax + preflight unit tests ---------------------
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+python3 -c "
+import ast
+ast.parse(open('${SCRIPT_DIR}/index.py').read())
+print('index.py syntax OK')
+"
+
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
+
+# ----- 1. Package ------------------------------------------------------------
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap ----------------------------------------------------------
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM propagation..."; sleep 10; fi
+
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+    # Timeout 300s: the launch leg waits for spot capacity + SSM online (the
+    # sibling dispatchers use the same headroom class).
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --architectures x86_64 \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --role "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" \
+      --timeout 300 \
+      --memory-size 256 \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda function exists: ${FUNCTION_NAME}"
+  fi
+
+  # --- Scheduler role (router-invoke-only; shared by future router schedules) ---
+  SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    run aws iam create-role --role-name "${SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${SCHED_TRUST}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler role exists: ${SCHED_ROLE_NAME}"
+  fi
+  run aws iam put-role-policy --role-name "${SCHED_ROLE_NAME}" \
+    --policy-name "${SCHED_POLICY_NAME}" \
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"${ROUTER_ARN}\"}]}"
+  if ! $DRY_RUN; then sleep 10; fi
+
+  # --- Twice-daily drain schedules -> ROUTER (playbook alert-drain) ----------
+  # 10:00 UTC (pre-market, after overnight alert accrual) + 22:00 UTC
+  # (post-close, after the daily pipelines) — both outside US market hours
+  # (13:30-20:00 UTC standard AND daylight time).
+  for slot in 1000 2200; do
+    HH="${slot:0:2}"
+    SCHED_NAME="alpha-engine-alert-drain-${slot}utc"
+    INPUT="{\"playbook\":\"alert-drain\",\"payload\":{\"trigger\":\"scheduled-${slot}utc\"}}"
+    if aws scheduler get-schedule --name "${SCHED_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+      echo "  Schedule exists: ${SCHED_NAME} (updating)"
+      VERB=update-schedule
+    else
+      VERB=create-schedule
+    fi
+    # Input must be a JSON-ESCAPED string inside the target JSON.
+    INPUT_ESCAPED=$(printf '%s' "$INPUT" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
+    run aws scheduler "${VERB}" \
+      --name "${SCHED_NAME}" \
+      --schedule-expression "cron(0 ${HH} * * ? *)" \
+      --flexible-time-window '{"Mode":"OFF"}' \
+      --description "Overseer alert-drain ${slot} UTC daily via the overseer-dispatcher router (alpha-engine-config-I2824)" \
+      --target "{\"Arn\":\"${ROUTER_ARN}\",\"RoleArn\":\"arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}\",\"Input\":${INPUT_ESCAPED}}" \
+      --region "${REGION}" > /dev/null || echo "  WARN: ${VERB} ${SCHED_NAME} failed"
+  done
+fi
+
+# ----- 3. Update code (always) -----------------------------------------------
+echo "Updating ${FUNCTION_NAME} code..."
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+  CURRENT_ENABLED=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" ALERT_DRAIN_DISPATCH_ENABLED true)
+  aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment "Variables={LOG_LEVEL=INFO,ALERT_DRAIN_DISPATCH_ENABLED=${CURRENT_ENABLED}}" \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "Done."

--- a/infrastructure/lambdas/alert-drain-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/alert-drain-dispatcher/iam-policy.json
@@ -1,0 +1,118 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-alert-drain-dispatcher:*"
+    },
+    {
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "alpha-engine-alert-drain-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-alert-drain-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassAlertDrainExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-alert-drain-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunAlertDrainBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateAlertDrainSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-alert-drain-spot"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/alert-drain-dispatcher/index.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/index.py
@@ -1,0 +1,278 @@
+"""alpha-engine-alert-drain-dispatcher — launch the Overseer alert-drain agent
+on a dedicated EC2-spot box, twice daily (alpha-engine-config-I2824, epic
+I2821 phase 3).
+
+The drain gives every fleet alert an owner: it consumes the phase-1 intake
+(SQS ``nousergon-overseer-intake`` + S3 fallback), classifies incidents into
+the epic's T0-T3 authority tiers, acts within charter authority, and writes a
+disposition ledger. THIS Lambda is only the launch leg — the policy lives in
+alpha-engine-config's ``.github/alert-drain-prompt.md`` charter, executed by
+``scripts/alert_drain_run.sh`` on the box.
+
+DISPATCH PATH (phase-2 coherence): EventBridge Scheduler (2x daily,
+off-market) -> alpha-engine-overseer-dispatcher router (playbook
+``alert-drain``, registry-routed, kill-switched, ledgered, escalation-owned)
+-> THIS executor (sync) -> spot box. The router's verdict contract applies:
+every anticipated failure returns a clean ``{"launched": false, "reason":
+...}``; ``concurrent_skip``/``disabled`` are the registry's benign declines.
+
+NO PACE GATE — deliberate (deviation from I2824's original text): usage
+pacing was DISMANTLED fleet-wide by Brian's 2026-07-14 ruling (see
+scheduled-groom-dispatcher's header); the drain follows the standing ruling,
+not the stale issue text. Cost control = the charter's own bounded caps
+(500-message ingest, 150 agent turns, 3h watchdog) + the twice-daily cadence.
+
+CONCURRENCY LOCK: single lane — tag ``Name=alpha-engine-alert-drain-spot``,
+any live box skips the launch (two overlapping drains would double-process
+queue messages; at-least-once tolerates it but a clean skip is free). A drill
+shares the lane: drill-vs-real overlap resolves as a benign concurrent_skip.
+
+IAM PROFILE: ``alpha-engine-alert-drain-executor-profile`` — DEDICATED
+(per-playbook scoped IAM, epic invariant 5): intake-queue consume, overseer
+S3 prefixes, read-only diagnosis, states:StartExecution on ONLY the three
+pipelines. Never the trading executor's profile.
+
+Managed OUTSIDE CloudFormation like its sibling dispatchers
+(deploy.sh --bootstrap, operator-run).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotLaunchError, SpotProbeError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: mirrors every fleet dispatcher's safety valve. Default ON.
+DISPATCH_ENABLED = (
+    os.environ.get("ALERT_DRAIN_DISPATCH_ENABLED", "true").lower() == "true"
+)
+
+# ── Spot launch config (env-overridable; defaults mirror ci-watch-dispatcher —
+# same default-VPC/AMI/security-group, only the IAM profile differs).
+# IAM LOCKSTEP (config#2271): INSTANCE_TYPES/AMI_ID/SUBNETS/SECURITY_GROUP are
+# ENUMERATED in this Lambda's scoped ec2:RunInstances policy (sibling
+# iam-policy.json). Change them together or RunInstances 403s. ─────────────────
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "ALERT_DRAIN_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "ALERT_DRAIN_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("ALERT_DRAIN_AMI_ID", "ami-0c421724a94bba6d6")  # AL2023 x86_64
+KEY_NAME = os.environ.get("ALERT_DRAIN_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("ALERT_DRAIN_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+IAM_PROFILE = os.environ.get(
+    "ALERT_DRAIN_IAM_PROFILE", "alpha-engine-alert-drain-executor-profile"
+)
+VOLUME_SIZE_GB = int(os.environ.get("ALERT_DRAIN_VOLUME_SIZE_GB", "40"))
+
+DRAIN_TAG_NAME = "alpha-engine-alert-drain-spot"
+DRAIN_RUN_ID_TAG_KEY = "alert-drain-run-id"
+# Fleet-wide drill marker — SAME tag key as sf/ci watch (config#2223): one
+# discriminator every consumer can filter on.
+DRAIN_DRILL_TAG_KEY = "sf-watch-drill"
+
+DRAIN_GH_PAT_SSM = os.environ.get(
+    "ALERT_DRAIN_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+DRAIN_CONFIG_REPO = os.environ.get("ALERT_DRAIN_CONFIG_REPO", "nousergon/alpha-engine-config")
+DRAIN_CONFIG_BRANCH = os.environ.get("ALERT_DRAIN_CONFIG_BRANCH", "main")
+# Matches the bootstrap's 3h watchdog (bounded triage sweep, not a build session).
+MAX_RUNTIME_SECONDS = int(os.environ.get("ALERT_DRAIN_MAX_RUNTIME_SECONDS", "10800"))
+SSM_ONLINE_BUDGET_SEC = int(os.environ.get("ALERT_DRAIN_SSM_ONLINE_BUDGET_SEC", "180"))
+CW_LOG_GROUP = os.environ.get("ALERT_DRAIN_CW_LOG_GROUP", "/alpha-engine/alert-drain-spot")
+
+_BOOL_RE = re.compile(r"^(true|false)$")
+_TRIGGER_RE = re.compile(r"^[a-z0-9_-]{0,64}$")
+
+
+class _InvalidEvent(ValueError):
+    """A required event field is missing or fails its allowlist."""
+
+
+def _resolve_event_fields(event: dict) -> tuple[str, str, str]:
+    """Validate + synthesize the run identity. A drill's run id ALWAYS carries
+    the ``drill-`` prefix (drill-vs-real isolation on the completion-marker
+    and ledger keys, config#2223 pattern) and a real run's never does."""
+    is_drill = str(event.get("is_drill") or "false").strip()
+    if not _BOOL_RE.match(is_drill):
+        raise _InvalidEvent(f"malformed 'is_drill' in event: {is_drill!r}")
+    trigger = str(event.get("trigger") or "").strip()
+    if not _TRIGGER_RE.match(trigger):
+        raise _InvalidEvent(f"malformed 'trigger' in event: {trigger!r}")
+    now = datetime.now(timezone.utc)
+    prefix = "drill-" if is_drill == "true" else "drain-"
+    run_id = f"{prefix}{now:%Y-%m-%dT%H%MZ}"
+    return run_id, is_drill, trigger
+
+
+def _bootstrap_command(run_id: str, is_drill: str) -> str:
+    """The async SSM RunShellScript body: fetch PAT, clone config, exec the
+    alert_drain_spot_bootstrap.sh entrypoint. Prelude failure shuts the box
+    down (mirrors the sibling dispatchers' prelude fail() trap exactly)."""
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+# SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
+export HOME=/root
+fail() {{ echo "[alert-drain-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 python3.12-pip >/dev/null 2>&1 \
+  || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {DRAIN_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/alpha-engine-config
+git clone --depth 1 --branch {DRAIN_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{DRAIN_CONFIG_REPO}.git" \
+  /home/ec2-user/alpha-engine-config || fail "clone failed"
+cd /home/ec2-user/alpha-engine-config
+exec bash infrastructure/alert_drain_spot_bootstrap.sh \
+  --run-id "{run_id}" --is-drill "{is_drill}"
+"""
+
+
+def _running_drain_instance_ids() -> list[str]:
+    """Any LIVE (pending/running) drain box — single-lane lock. Raises
+    SpotProbeError on probe failure; the caller degrades to
+    launch-with-dedupe_degraded (coverage beats dedupe, config#2267 site 1)."""
+    return spot_dispatch.running_instance_ids(DRAIN_TAG_NAME, {}, region=REGION)
+
+
+def _launch_instance(run_id: str, is_drill: str) -> tuple[str, str]:
+    """Launch the drain box; spot first, on-demand fallback. Discriminator
+    tags ride the RunInstances call atomically via extra_tags (config#2292)."""
+    extra_tags = {DRAIN_RUN_ID_TAG_KEY: run_id}
+    if is_drill == "true":
+        extra_tags[DRAIN_DRILL_TAG_KEY] = "true"
+    return spot_dispatch.launch_with_fallback(
+        INSTANCE_TYPES, SUBNETS,
+        image_id=AMI_ID,
+        key_name=KEY_NAME,
+        security_group_ids=[SECURITY_GROUP],
+        iam_instance_profile=IAM_PROFILE,
+        volume_size_gb=VOLUME_SIZE_GB,
+        tag_name=DRAIN_TAG_NAME,
+        region=REGION,
+        extra_tags=extra_tags,
+    )
+
+
+def _wait_ssm_online(instance_id: str) -> None:
+    spot_dispatch.wait_ssm_online(
+        instance_id, region=REGION, ssm_online_budget_sec=SSM_ONLINE_BUDGET_SEC
+    )
+
+
+def _send_bootstrap(instance_id: str, run_id: str, is_drill: str) -> str:
+    return spot_dispatch.send_async_command(
+        instance_id,
+        _bootstrap_command(run_id, is_drill),
+        comment=f"alert-drain ({run_id})",
+        region=REGION,
+        cw_log_group=CW_LOG_GROUP,
+        execution_timeout_seconds=MAX_RUNTIME_SECONDS,
+    )
+
+
+def _terminate_instance(instance_id: str) -> None:
+    """Best-effort terminate of a box whose post-launch steps failed (no
+    watchdog armed yet — an orphan otherwise). Logged, never raised."""
+    spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="alert-drain")
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Synchronous handler invoked by the overseer-dispatcher router (playbook
+    ``alert-drain``) when the twice-daily Scheduler fires — or with
+    ``{"is_drill": "true"}`` on a canary drill. Clean-JSON contract identical
+    to the sibling executors: every anticipated failure returns
+    ``{"launched": false, "reason": ...}``, never raises."""
+    event = event or {}
+    try:
+        run_id, is_drill, trigger = _resolve_event_fields(event)
+    except _InvalidEvent as exc:
+        logger.error("invalid alert-drain event: %s", exc)
+        return {"launched": False, "reason": "invalid_event", "error": str(exc)}
+
+    if not DISPATCH_ENABLED:
+        logger.warning("ALERT_DRAIN_DISPATCH_ENABLED=false — drain NOT launched")
+        return {"launched": False, "reason": "disabled"}
+
+    dedupe_degraded = False
+    dedupe_probe_error = ""
+    try:
+        existing = _running_drain_instance_ids()
+    except SpotProbeError as exc:
+        # Degraded-probe swallow (config#2267 site 1 policy): failure mode
+        # swallowed = a possible duplicate drain box; the primary deliverable
+        # (alerts get drained) survives, and at-least-once queue discipline
+        # absorbs double-processing. Recording surfaces: this ERROR log +
+        # dedupe_degraded in the verdict the router ledgers.
+        dedupe_degraded = True
+        dedupe_probe_error = f"{type(exc).__name__}: {exc}"
+        existing = []
+        logger.error(
+            "alert-drain concurrency probe FAILED — proceeding with "
+            "dedupe_degraded=true: %s", dedupe_probe_error,
+        )
+    if existing:
+        logger.warning(
+            "alert-drain box already live (%s) — skipping launch (single-lane lock)",
+            existing,
+        )
+        return {"launched": False, "reason": "concurrent_skip",
+                "existing_instance_ids": existing}
+
+    try:
+        instance_id, market = _launch_instance(run_id, is_drill)
+    except SpotLaunchError as exc:
+        logger.error("alert-drain spot launch failed: %s: %s", type(exc).__name__, exc)
+        return {"launched": False, "reason": "launch_failed", "error": str(exc)}
+
+    logger.info("launched alert-drain box %s (%s) run_id=%s%s", instance_id, market,
+                run_id, " dedupe_degraded=true" if dedupe_degraded else "")
+
+    try:
+        _wait_ssm_online(instance_id)
+        command_id = _send_bootstrap(instance_id, run_id, is_drill)
+    except Exception as exc:  # noqa: BLE001 — converted to a clean launched:false (router escalates)
+        _terminate_instance(instance_id)
+        logger.error("alert-drain post-launch step failed for %s: %s: %s",
+                     instance_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "post_launch_failed",
+                "instance_id": instance_id, "error": str(exc),
+                "dedupe_degraded": dedupe_degraded}
+
+    verdict = {
+        "launched": True,
+        "reason": "launched",
+        "instance_id": instance_id,
+        "market": market,
+        "command_id": command_id,
+        "run_id": run_id,
+        "trigger": trigger,
+        "is_drill": is_drill == "true",
+        "dedupe_degraded": dedupe_degraded,
+    }
+    if dedupe_degraded:
+        verdict["dedupe_probe_error"] = dedupe_probe_error
+    logger.info("alert-drain dispatched: %s", verdict)
+    return verdict

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -1,0 +1,8 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.spot_dispatch launch/lock/terminate primitives (config#2106).
+# v0.122.0 = extra_tags on launch_with_fallback (config#2292 atomic
+# discriminator tags) — same pin as ci-watch/sf-watch dispatchers.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.122.0
+# krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
+krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
@@ -1,0 +1,124 @@
+"""Handler tests for alpha-engine-alert-drain-dispatcher (alpha-engine-config-I2824).
+
+Pins the executor contract: clean-JSON verdicts (never raises), single-lane
+concurrency lock, drill run-id isolation (drill- prefix, never collides with
+a real run's), atomic extra_tags launch, post-launch terminate-on-failure,
+kill switch, and the degraded-probe coverage-beats-dedupe posture.
+
+Hermetic: nousergon_lib.spot_dispatch is stubbed in sys.modules before
+``import index`` (same shape as the sibling dispatchers' test files).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+class SpotLaunchError(Exception):
+    pass
+
+
+class SpotProbeError(Exception):
+    pass
+
+
+@pytest.fixture
+def index_mod(monkeypatch):
+    sd = types.ModuleType("nousergon_lib.spot_dispatch")
+    sd.SpotLaunchError = SpotLaunchError
+    sd.SpotCapacityExhausted = type("SpotCapacityExhausted", (SpotLaunchError,), {})
+    sd.SpotProbeError = SpotProbeError
+    sd.launch_with_fallback = MagicMock(return_value=("i-abc123", "spot"))
+    sd.wait_ssm_online = MagicMock()
+    sd.send_async_command = MagicMock(return_value="cmd-1")
+    sd.terminate_on_failure = MagicMock()
+    sd.running_instance_ids = MagicMock(return_value=[])
+    lib = types.ModuleType("nousergon_lib")
+    lib.spot_dispatch = sd
+    monkeypatch.setitem(sys.modules, "nousergon_lib", lib)
+    monkeypatch.setitem(sys.modules, "nousergon_lib.spot_dispatch", sd)
+    monkeypatch.syspath_prepend(str(SCRIPT_DIR))
+    sys.modules.pop("index", None)
+    index = importlib.import_module("index")
+    return index, sd
+
+
+class TestVerdicts:
+    def test_launches_with_run_id_and_atomic_tags(self, index_mod):
+        index, sd = index_mod
+        out = index.handler({"trigger": "scheduled-1000utc"}, None)
+        assert out["launched"] is True and out["reason"] == "launched"
+        assert out["run_id"].startswith("drain-")
+        tags = sd.launch_with_fallback.call_args.kwargs["extra_tags"]
+        assert tags[index.DRAIN_RUN_ID_TAG_KEY] == out["run_id"]
+        assert index.DRAIN_DRILL_TAG_KEY not in tags
+        assert (
+            sd.launch_with_fallback.call_args.kwargs["iam_instance_profile"]
+            == "alpha-engine-alert-drain-executor-profile"
+        )
+
+    def test_drill_run_id_prefix_isolated(self, index_mod):
+        index, sd = index_mod
+        out = index.handler({"is_drill": "true"}, None)
+        assert out["run_id"].startswith("drill-")
+        assert not out["run_id"].startswith("drain-")
+        tags = sd.launch_with_fallback.call_args.kwargs["extra_tags"]
+        assert tags[index.DRAIN_DRILL_TAG_KEY] == "true"
+
+    def test_disabled_kill_switch(self, index_mod, monkeypatch):
+        index, sd = index_mod
+        monkeypatch.setattr(index, "DISPATCH_ENABLED", False)
+        out = index.handler({}, None)
+        assert out == {"launched": False, "reason": "disabled"}
+        sd.launch_with_fallback.assert_not_called()
+
+    def test_concurrent_skip_single_lane(self, index_mod):
+        index, sd = index_mod
+        sd.running_instance_ids.return_value = ["i-live"]
+        out = index.handler({}, None)
+        assert out["reason"] == "concurrent_skip"
+        assert out["existing_instance_ids"] == ["i-live"]
+        sd.launch_with_fallback.assert_not_called()
+
+    def test_probe_failure_degrades_but_launches(self, index_mod):
+        index, sd = index_mod
+        sd.running_instance_ids.side_effect = SpotProbeError("api down")
+        out = index.handler({}, None)
+        assert out["launched"] is True and out["dedupe_degraded"] is True
+        assert "api down" in out["dedupe_probe_error"]
+
+    def test_launch_failure_clean_verdict(self, index_mod):
+        index, sd = index_mod
+        sd.launch_with_fallback.side_effect = SpotLaunchError("exhausted")
+        out = index.handler({}, None)
+        assert out == {"launched": False, "reason": "launch_failed", "error": "exhausted"}
+
+    def test_post_launch_failure_terminates_box(self, index_mod):
+        index, sd = index_mod
+        sd.wait_ssm_online.side_effect = RuntimeError("ssm never online")
+        out = index.handler({}, None)
+        assert out["reason"] == "post_launch_failed"
+        sd.terminate_on_failure.assert_called_once()
+
+    def test_invalid_event_clean_verdict(self, index_mod):
+        index, _ = index_mod
+        out = index.handler({"is_drill": "bogus"}, None)
+        assert out["reason"] == "invalid_event"
+
+
+class TestBootstrapCommand:
+    def test_command_targets_alert_drain_bootstrap_with_run_id(self, index_mod):
+        index, sd = index_mod
+        index.handler({"is_drill": "false"}, None)
+        cmd = sd.send_async_command.call_args.args[1]
+        assert "infrastructure/alert_drain_spot_bootstrap.sh" in cmd
+        assert "--run-id" in cmd and "--is-drill" in cmd
+        assert index.DRAIN_GH_PAT_SSM in cmd

--- a/infrastructure/lambdas/overseer-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/overseer-dispatcher/deploy.sh
@@ -115,8 +115,9 @@ if $BOOTSTRAP; then
 
   if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     echo "  Creating Lambda function: ${FUNCTION_NAME}"
-    # Timeout 120s: the executor invoke is SYNCHRONOUS and the slowest
-    # executor leg (spot launch + SSM online wait) can take ~90s.
+    # Timeout 300s: the executor invoke is SYNCHRONOUS; the slowest executor
+    # (alert-drain, 300s Lambda timeout) bounds it, with the invoke client's
+    # own 290s read-timeout + zero retries doing the fine-grained bounding.
     run aws lambda create-function \
       --function-name "${FUNCTION_NAME}" \
       --runtime python3.12 \
@@ -124,7 +125,7 @@ if $BOOTSTRAP; then
       --handler index.handler \
       --zip-file "fileb://${ZIP}" \
       --role "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" \
-      --timeout 120 \
+      --timeout 300 \
       --memory-size 256 \
       --environment "${LAMBDA_ENV_BOOTSTRAP}" \
       --region "${REGION}" \

--- a/infrastructure/lambdas/overseer-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/overseer-dispatcher/iam-policy.json
@@ -17,7 +17,8 @@
       "Action": "lambda:InvokeFunction",
       "Resource": [
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-sf-watch-spot-dispatcher",
-        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ci-watch-dispatcher"
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ci-watch-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-alert-drain-dispatcher"
       ]
     },
     {

--- a/infrastructure/lambdas/overseer-dispatcher/index.py
+++ b/infrastructure/lambdas/overseer-dispatcher/index.py
@@ -65,6 +65,17 @@ from pathlib import Path
 
 import boto3
 import yaml
+from botocore.config import Config
+
+# Executor invokes are SYNCHRONOUS and NON-IDEMPOTENT (they launch spot
+# boxes): boto3's default 60s read-timeout + automatic retries caused a
+# double-dispatch on the first live alert-drain drill (first invoke launched
+# the box, the silent retry hit concurrent_skip). Read-timeout must exceed
+# the slowest executor's runtime (300s Lambda timeout on alert-drain), and
+# retries MUST be zero — the caller's verdict handling is the retry policy.
+_EXECUTOR_INVOKE_CONFIG = Config(
+    connect_timeout=10, read_timeout=290, retries={"max_attempts": 0}
+)
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -93,7 +104,7 @@ LEDGER_PREFIX = os.environ.get("OVERSEER_LEDGER_PREFIX", "overseer/dispatch_ledg
 
 _INVOKE_TIMEOUT_NOTE = (
     "executor invoke is synchronous; this Lambda's own timeout must exceed "
-    "the slowest executor's (see deploy.sh --timeout 120)"
+    "the slowest executor's (see deploy.sh --timeout 300)"
 )
 
 
@@ -129,7 +140,9 @@ def _stringify_bools(payload: dict) -> dict:
 
 def _invoke_executor(function_name: str, payload: dict) -> dict:
     """Synchronously invoke the executor and parse its JSON verdict."""
-    resp = boto3.client("lambda", region_name=REGION).invoke(
+    resp = boto3.client(
+        "lambda", region_name=REGION, config=_EXECUTOR_INVOKE_CONFIG
+    ).invoke(
         FunctionName=function_name,
         InvocationType="RequestResponse",
         Payload=json.dumps(payload).encode("utf-8"),

--- a/infrastructure/lambdas/overseer-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/overseer-dispatcher/test_handler.py
@@ -201,7 +201,7 @@ class TestRegistryBundle:
         index, _ = index_mod
         reg = index._registry()
         routed = {k for k, v in reg["playbooks"].items() if v.get("routed")}
-        assert routed == {"sf-watch", "ci-watch"}
+        assert routed == {"sf-watch", "ci-watch", "alert-drain"}
         for name in routed:
             assert reg["playbooks"][name]["benign_reasons"]
 
@@ -212,3 +212,18 @@ class TestRegistryBundle:
         out = index.handler({"playbook": "sf-watch", "payload": {}}, None)
         assert out["reason"] == "registry_error"
         index._file_p1.assert_called_once()
+
+
+class TestInvokeClientConfig:
+    """The executor invoke is non-idempotent: the boto client MUST use zero
+    retries and a read-timeout exceeding the slowest executor (the first live
+    drill double-dispatched via boto3's silent default retry)."""
+
+    def test_zero_retries_and_long_read_timeout(self, index_mod):
+        index, fake_boto3 = index_mod
+        _lambda_client_returning(fake_boto3, {"launched": True, "reason": "launched"})
+        index.handler({"playbook": "sf-watch", "payload": {}}, None)
+        cfg = fake_boto3.client.call_args.kwargs.get("config")
+        assert cfg is index._EXECUTOR_INVOKE_CONFIG
+        assert cfg.retries == {"max_attempts": 0}
+        assert cfg.read_timeout == 290

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -64,6 +64,27 @@ playbooks:
     supports_drill: true
     kill_switch_env: CI_WATCH_DISPATCH_ENABLED  # on the EXECUTOR Lambda
 
+  alert-drain:
+    description: >-
+      Twice-daily Overseer alert-drain (epic I2821 phase 3, config-I2824):
+      consumes the nousergon-overseer-intake queue + S3 fallback, classifies
+      incidents into the T0-T3 authority tiers per the alert-drain charter,
+      acts within charter authority (v1: PRs, issues, SF reruns only), writes
+      the drain ledger. Fired by EventBridge Scheduler (10:00 + 22:00 UTC)
+      THROUGH this router.
+    tier: T2
+    routed: true
+    enabled: true
+    executor_function: alpha-engine-alert-drain-dispatcher
+    executor_lambda_dir: alert-drain-dispatcher
+    benign_reasons: [concurrent_skip, disabled]
+    charter: alpha-engine-config/.github/alert-drain-prompt.md
+    concurrency_domain: >-
+      Single lane — EC2 tag lock on Name=alpha-engine-alert-drain-spot (one
+      drain at a time; overlap would double-process queue messages).
+    supports_drill: true
+    kill_switch_env: ALERT_DRAIN_DISPATCH_ENABLED
+
   groom:
     description: >-
       Demand-driven backlog groom (three daily EventBridge cron triggers,

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -63,6 +63,11 @@ _LAMBDA_PIN_EXEMPTIONS = {
         "nousergon_lib.spot_dispatch chokepoint (alpha-engine-config#2246: same SpotProbeError "
         "handling as ci-watch-dispatcher)",
     ),
+    "alert-drain-dispatcher": (
+        "v0.122.0",
+        "nousergon_lib.spot_dispatch chokepoint (alpha-engine-config-I2824: same "
+        "extra_tags atomic-launch-tagging floor as ci-watch-dispatcher, config#2292)",
+    ),
     "ci-watch-dispatcher": (
         "v0.122.0",
         "nousergon_lib.spot_dispatch chokepoint (config#2267: SpotProbeError handling; "


### PR DESCRIPTION
## What

Data-side half of Overseer phase 3 (alpha-engine-config-I2824, epic I2821) — pairs with alpha-engine-config-PR2837 (charter/runner/bootstrap/executor-role):

- **`alert-drain-dispatcher`** launch executor: single-lane concurrency lock, drill-isolated run ids (`drill-`/`drain-` prefixes), atomic `extra_tags` launch (lib v0.122.0, pin-lockstep exemption recorded), clean-verdict contract. 9 handler tests.
- **Registry**: `alert-drain` playbook (routed; benign `concurrent_skip`/`disabled`; kill switch `ALERT_DRAIN_DISPATCH_ENABLED`) — the registry lockstep tests validate the wiring automatically.
- **Schedules**: `deploy.sh --bootstrap` creates the twice-daily EventBridge schedules (10:00 + 22:00 UTC, both off-market) targeting the **router** with the playbook payload, plus the shared invoke-router-only `alpha-engine-overseer-scheduler-role` (reusable by the I2832 drill re-point).
- **Router hardening (real defect found by live drill):** boto3's default 60s read-timeout + silent retry **double-dispatched** the non-idempotent executor invoke. Fixed: explicit `Config(read_timeout=290, retries={'max_attempts': 0})` on the invoke client + regression test; router timeout 120→300.
- **No pace gate** — deliberate deviation from I2824's original text: usage pacing was dismantled fleet-wide (Brian ruling 2026-07-14). Cost control = charter's bounded caps (500-msg ingest, 150 agent turns, 3h watchdog, 2×/day cadence).

## Deploy state

**All applied live 2026-07-17** (executor bootstrapped, schedules created, router redeployed with new registry + IAM + timeout). Merge-button rule satisfied.

**Drill-verified through the FULL production path** (scheduler-shaped router invoke → executor → spot box → bootstrap → drill guard): run `drill-2026-07-17T1725Z` — heartbeat `overseer/_canary/alert-drain-2026-07-17.json` + completion marker landed; box self-terminated. Two earlier failed drill rounds surfaced the missing `AmazonSSMManagedInstanceCore` attachment on the new executor role (attached live, recorded in config#2839 — which the router's escalation path filed AUTOMATICALLY, incidentally proving the P1+page machinery end-to-end).

## Testing

- `tests/`: **3439 passed** locally; handler suites: alert-drain 9/9, overseer-dispatcher 17/17 (isolated per ci.yml convention).

## Sequencing note

The executor Lambda's `ALERT_DRAIN_CONFIG_BRANCH` env currently points at config-PR2837's branch (the bootstrap lives there); it gets reset to default (main) when that PR merges — tracked on alpha-engine-config-I2824. The 22:00 UTC schedule tonight will no-op harmlessly into a clean failure if 2837 is unmerged by then (prelude clone succeeds, file exists on the branch — so it will actually run fine either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)