### PR TITLE
feat(expense-collector): all-provider monthly expense rollup Lambda for the console Expenses page

### DIFF
--- a/.github/workflows/deploy-expense-collector.yml
+++ b/.github/workflows/deploy-expense-collector.yml
@@ -1,0 +1,81 @@
+name: Deploy expense-collector
+
+# Auto-deploy the alpha-engine-expense-collector Lambda CODE on merge to main.
+# Same pattern as deploy-usage-pace-alert.yml: this script's default/flagless
+# run is already code-only (no aws iam/scheduler writes happen unless
+# --bootstrap is passed), so no new script flag was needed to make this safe.
+#
+# A change to SCHED_NAMES/SCHED_CRONS (the collector's OWN invocation cadence)
+# still requires an operator to run `deploy.sh --bootstrap` by hand, for the
+# same reason as the sibling dispatchers: the github-actions-lambda-deploy OIDC
+# role deliberately lacks iam:CreateRole / iam:PutRolePolicy (fleet-wide
+# policy, infrastructure/iam/README.md).
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/expense-collector/**'
+      - '.github/workflows/deploy-expense-collector.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-expense-collector-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy expense-collector Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@v4
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy expense-collector (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/expense-collector/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-expense-collector \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-expense-collector.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit

--- a/.github/workflows/deploy-expense-collector.yml
+++ b/.github/workflows/deploy-expense-collector.yml
@@ -38,19 +38,21 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # Third-party actions SHA-pinned (CodeQL unpinned-tag findings on this
+      # PR; supply-chain hardening — fleet-wide migration tracked separately).
       - name: Checkout data repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           path: alpha-engine-data
 
       - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
           role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
           aws-region: us-east-1
 
       - name: Set up Python 3.12 (match Lambda runtime)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
 

--- a/infrastructure/lambdas/expense-collector/deploy.sh
+++ b/infrastructure/lambdas/expense-collector/deploy.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-expense-collector Lambda and
+# wire its EventBridge Scheduler rule.
+#
+# WHY: Brian wants ONE console page tracking every external expense (AWS,
+# Anthropic, OpenRouter, DeepSeek, Neon, GitHub Actions, future subscriptions)
+# with month-to-date totals and over/under-budget pacing. This Lambda is the
+# producer: it queries each provider's billing/usage API and writes the
+# normalized rollup the console's Expenses page reads
+# (s3://alpha-engine-research/expenses/latest.json + monthly/{YYYY-MM}.json).
+#
+# IAM (iam-policy.json): logs + ssm:GetParameter(s) for provider keys +
+# ce:GetCostAndUsage/GetCostForecast + s3 Get/Put under expenses/* + s3 Get on
+# config/expense_budgets.json and decision_artifacts/_cost_raw/*.
+#
+# Cadence (UTC): twice daily — 00:15 (captures the month-start baseline within
+# 15 min of rollover) and 12:15. Cost Explorer bills $0.01/request (2 CE calls
+# per run ⇒ ~$1.2/mo, visible in the collector's own AWS row).
+#   cron(15 0,12 * * ? *)
+#
+# Managed OUTSIDE CloudFormation — mirrors the sibling dispatchers (narrow OIDC
+# blast radius: the CI role deliberately lacks iam:CreateRole/iam:PutRolePolicy,
+# fleet-wide policy after 4 IAM-clobber incidents — infrastructure/iam/README.md).
+#
+# CODE auto-deploys on merge to main via
+# `.github/workflows/deploy-expense-collector.yml` (path-filtered to this
+# directory), which runs this script with NO flags (the default/flagless run
+# is already code-only). A SCHED_CRONS change still needs an operator to run
+# `--bootstrap` by hand — merging alone has ZERO live effect on it.
+#
+# Usage:
+#   bash .../expense-collector/deploy.sh              # update code only (same command CI runs)
+#   bash .../expense-collector/deploy.sh --bootstrap  # first-time create + wire schedule
+#   bash .../expense-collector/deploy.sh --dry-run    # show actions, do not apply
+#   bash .../expense-collector/deploy.sh --smoke      # invoke once and print the rollup summary
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-expense-collector"
+ROLE_NAME="alpha-engine-expense-collector-role"
+POLICY_NAME="alpha-engine-expense-collector-policy"
+SCHED_ROLE_NAME="alpha-engine-expense-collector-scheduler-role"
+SCHED_POLICY_NAME="invoke-expense-collector"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
+
+SCHED_NAMES=(
+  "alpha-engine-expense-collector-twicedaily"
+)
+SCHED_CRONS=(
+  "cron(15 0,12 * * ? *)"
+)
+SCHED_PREFIX="alpha-engine-expense-collector-"
+
+DRY_RUN=false
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
+}
+
+# ----- 0. Scratch dir + validate handler syntax ------------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+# Shared provision-then-run mechanism (config#2381 — never hand-roll this
+# step). boto3 passed explicitly: the tests do a real `import index` against
+# real boto3 (the fakes are monkeypatched onto the module, not sys.modules).
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3
+
+# ----- 1. Package: zip handler (stdlib + runtime boto3 only — no pip deps) ---
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
+      --zip-file "fileb://${ZIP}" --timeout 120 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO}' --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} on the twice-daily expense-collection cadence" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${SCHED_ROLE_NAME}"
+  fi
+  SCHED_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"lambda:InvokeFunction\"],\"Resource\":\"${FN_ARN}\"}]}"
+  echo "  Applying Scheduler invoke policy: ${SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${SCHED_ROLE_NAME}" --policy-name "${SCHED_POLICY_NAME}" \
+    --policy-document "${SCHED_INVOKE_POLICY}"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  for i in "${!SCHED_NAMES[@]}"; do
+    name="${SCHED_NAMES[$i]}"
+    cron="${SCHED_CRONS[$i]}"
+    target="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${SCHED_ROLE_ARN}\",\"Input\":\"{}\"}"
+    if aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+      echo "  Updating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler update-schedule --name "${name}" --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
+    else
+      echo "  Creating Scheduler rule: ${name} → ${cron}"
+      run aws scheduler create-schedule --name "${name}" --schedule-expression "${cron}" \
+        --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
+        --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
+    fi
+    if ! $DRY_RUN; then
+      aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+        || { echo "ERROR: Scheduler rule ${name} not found after create/update" >&2; exit 1; }
+    fi
+  done
+
+  # Prune reconciliation: delete any live rule under SCHED_PREFIX not in SCHED_NAMES.
+  echo "  Pruning orphaned Scheduler rules under prefix ${SCHED_PREFIX}..."
+  LIVE_RULES=$(aws scheduler list-schedules --name-prefix "${SCHED_PREFIX}" --region "${REGION}" --query 'Schedules[].Name' --output text 2>/dev/null || echo "")
+  for live in ${LIVE_RULES}; do
+    keep=false
+    for want in "${SCHED_NAMES[@]}"; do [ "${live}" = "${want}" ] && { keep=true; break; }; done
+    if ! $keep; then
+      echo "    Deleting orphaned Scheduler rule: ${live}"
+      run aws scheduler delete-schedule --name "${live}" --region "${REGION}"
+    fi
+  done
+fi
+
+# ----- 3. Update function code (always, idempotent) -------------------------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (real invoke — writes the day's rollup, safe to repeat) ------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (collects + writes expenses/latest.json)..."
+  RESP=$(mktemp)
+  aws lambda invoke --function-name "${FUNCTION_NAME}" --cli-binary-format raw-in-base64-out \
+    --payload '{}' --region "${REGION}" "${RESP}" >/dev/null
+  cat "${RESP}"; echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
+++ b/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "_doc": "Budgets/quotas SSoT for the expense-collector Lambda + console Expenses page. Live copy: s3://alpha-engine-research/config/expense_budgets.json (operator-edited: aws s3 cp expense_budgets.seed.json s3://alpha-engine-research/config/expense_budgets.json — or edit the live object directly). monthly_budget_usd null = no budget line (row shows spend without over/under pacing). fixed_monthly_usd on a key with no live adapter renders a flat-subscription row, so future subscriptions are config-only additions.",
+  "updated": "2026-07-17",
+  "providers": {
+    "aws": {
+      "label": "AWS",
+      "monthly_budget_usd": null
+    },
+    "anthropic_api": {
+      "label": "Anthropic API",
+      "monthly_budget_usd": null
+    },
+    "claude_max": {
+      "label": "Claude Max 20x subscription",
+      "fixed_monthly_usd": 200.0,
+      "note": "flat subscription — weekly WET pacing lives on the LLM Usage tab"
+    },
+    "openrouter": {
+      "label": "OpenRouter",
+      "monthly_budget_usd": null
+    },
+    "deepseek": {
+      "label": "DeepSeek",
+      "monthly_budget_usd": null
+    },
+    "neon": {
+      "label": "Neon Postgres",
+      "monthly_budget_usd": null
+    },
+    "github_org": {
+      "label": "GitHub (nousergon org)",
+      "monthly_budget_usd": null,
+      "included_minutes": 2000
+    },
+    "github_user": {
+      "label": "GitHub (cipher813)",
+      "monthly_budget_usd": null,
+      "included_minutes": null
+    }
+  }
+}

--- a/infrastructure/lambdas/expense-collector/iam-policy.json
+++ b/infrastructure/lambdas/expense-collector/iam-policy.json
@@ -1,0 +1,60 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-expense-collector:*"
+    },
+    {
+      "Sid": "ProviderKeySSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter", "ssm:GetParameters"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/OPENROUTER_API_KEY",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/symposion/DEEPSEEK_API_KEY",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/NEON_API_KEY",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/NEON_DATA_TRANSFER_QUOTA_GB",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/groom/github_pat",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/expenses/*"
+      ]
+    },
+    {
+      "Sid": "CostExplorerRead",
+      "Effect": "Allow",
+      "Action": ["ce:GetCostAndUsage", "ce:GetCostForecast"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ExpenseArtifactsReadWrite",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/expenses/*"
+    },
+    {
+      "Sid": "BudgetsAndCostRawRead",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research/config/expense_budgets.json",
+        "arn:aws:s3:::alpha-engine-research/decision_artifacts/_cost_raw/*"
+      ]
+    },
+    {
+      "Sid": "PrefixList",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["expenses/*", "decision_artifacts/_cost_raw/*"]
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/expense-collector/iam-policy.json
+++ b/infrastructure/lambdas/expense-collector/iam-policy.json
@@ -20,7 +20,7 @@
         "arn:aws:ssm:us-east-1:711398986525:parameter/symposion/DEEPSEEK_API_KEY",
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/NEON_API_KEY",
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/NEON_DATA_TRANSFER_QUOTA_GB",
-        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/groom/github_pat",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/GITHUB_TOKEN",
         "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/expenses/*"
       ]
     },

--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -1,0 +1,659 @@
+"""alpha-engine-expense-collector — one normalized monthly spend/quota rollup
+for EVERY external service Nous Ergon pays for (or draws quota from), consumed
+by the console's Expenses page (alpha-engine-dashboard ``views/50_Expenses.py``).
+
+Providers collected per run (adapter registry, one row each):
+
+  - **aws**            Cost Explorer month-to-date unblended cost + CE forecast
+                       (+ top-services breakdown). CE bills $0.01/request — the
+                       2-runs/day cadence costs ~$1.2/mo, which shows up in its
+                       own row.
+  - **anthropic_api**  Admin API ``/v1/organizations/cost_report`` when
+                       ``/alpha-engine/expenses/ANTHROPIC_ADMIN_KEY`` exists;
+                       until then falls back to summing the research fleet's
+                       client-side per-call telemetry
+                       (``decision_artifacts/_cost_raw/{date}/**.jsonl``,
+                       producer: crucible-research ``graph/llm_cost_tracker.py``)
+                       — fleet-only, excludes morning-signal et al (noted on the
+                       row).
+  - **openrouter**     ``/api/v1/credits`` lifetime-usage counter, diffed
+                       against a first-run-of-month baseline
+                       (``expenses/baselines/{YYYY-MM}.json``).
+  - **deepseek**       ``/user/balance`` prepaid balance, diffed the same way
+                       (top-ups make the diff conservative; noted on the row).
+  - **neon**           ``/api/v2/consumption_history/account`` — data-transfer
+                       GB vs the ``/alpha-engine/NEON_DATA_TRANSFER_QUOTA_GB``
+                       quota (free plan ⇒ $0 unless budgets say otherwise).
+  - **github (org+user)** enhanced billing usage endpoint per account
+                       (nousergon org + cipher813 user): billed $ across all
+                       products + Actions minutes vs included quota (legacy
+                       ``settings/billing/actions`` probed for the included-
+                       minutes figure where still served).
+  - **fixed rows**     any provider in the budgets SSoT with
+                       ``fixed_monthly_usd`` and no live adapter (Claude Max
+                       subscription today; future flat subscriptions are
+                       config-only additions).
+
+Budgets/quotas SSoT: ``s3://alpha-engine-research/config/expense_budgets.json``
+(operator-edited; seeded from ``expense_budgets.seed.json`` next to this file).
+
+Outputs (bucket ``alpha-engine-research``):
+  - ``expenses/monthly/{YYYY-MM}.json``  — the period rollup (overwritten,
+    latest ``as_of`` wins; prior months accumulate for history)
+  - ``expenses/latest.json``             — same doc, stable key for the console
+  - ``expenses/baselines/{YYYY-MM}.json``— month-start counter baseline
+    (first-writer-wins, backfilled per-counter as new providers appear)
+  - ``expenses/snapshots/{date}.json``   — first reading of each day's raw
+    counters (future trend charts; conditional PUT, first-writer-wins)
+
+Failure posture (CLAUDE.md no-silent-fails): each provider adapter is
+independently fenced — a single provider API outage must not blank the other
+rows, so an adapter exception is RECORDED on that row (``status="error"`` +
+message, rendered red by the console page and logged with traceback here)
+rather than propagated. The handler still RAISES if the budgets SSoT and every
+adapter fail together, or if the artifact write fails — a rollup that can't
+record anything is a dead check and must trip the Lambda error metric.
+"""
+
+from __future__ import annotations
+
+import calendar
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+BUCKET = os.environ.get("EXPENSE_BUCKET", "alpha-engine-research")
+
+BUDGETS_KEY = os.environ.get("EXPENSE_BUDGETS_KEY", "config/expense_budgets.json")
+MONTHLY_PREFIX = "expenses/monthly/"
+LATEST_KEY = "expenses/latest.json"
+BASELINE_PREFIX = "expenses/baselines/"
+SNAPSHOT_PREFIX = "expenses/snapshots/"
+COST_RAW_PREFIX = "decision_artifacts/_cost_raw/"
+
+# SSM parameter names (batch-read; absent ones degrade that row to
+# status="not_configured", never the whole run).
+SSM_OPENROUTER = "/alpha-engine/OPENROUTER_API_KEY"
+SSM_DEEPSEEK = "/symposion/DEEPSEEK_API_KEY"
+SSM_NEON = "/alpha-engine/NEON_API_KEY"
+SSM_NEON_QUOTA_GB = "/alpha-engine/NEON_DATA_TRANSFER_QUOTA_GB"
+SSM_GITHUB_PAT = "/alpha-engine/groom/github_pat"
+SSM_ANTHROPIC_ADMIN = "/alpha-engine/expenses/ANTHROPIC_ADMIN_KEY"
+SSM_PARAMS = [SSM_OPENROUTER, SSM_DEEPSEEK, SSM_NEON, SSM_NEON_QUOTA_GB,
+              SSM_GITHUB_PAT, SSM_ANTHROPIC_ADMIN]
+
+GITHUB_ORG = "nousergon"
+GITHUB_USER = "cipher813"
+
+HTTP_TIMEOUT = 25
+# Don't call a projection before ~1 day of month has elapsed — a 2h-old month
+# extrapolates garbage.
+MIN_PROJECTION_FRAC = 0.03
+
+
+# ---------------------------------------------------------------------------
+# Small primitives
+# ---------------------------------------------------------------------------
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _http_json(url: str, headers: dict | None = None) -> dict:
+    """GET ``url`` and parse JSON. Raises RuntimeError with a body snippet on
+    any non-2xx / parse failure — adapter fences turn that into a row error."""
+    req = urllib.request.Request(url, headers={"User-Agent": "alpha-engine-expense-collector",
+                                               **(headers or {})})
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        snippet = exc.read()[:300].decode("utf-8", "replace")
+        raise RuntimeError(f"HTTP {exc.code} from {url}: {snippet}") from exc
+
+
+def _month_window(now: datetime) -> dict:
+    """Calendar-month (UTC) window: period id, start, length, elapsed fraction.
+    All the providers here bill on calendar months (UTC or close enough that a
+    sub-day skew doesn't move an over/under-pace call)."""
+    start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    days = calendar.monthrange(now.year, now.month)[1]
+    total_s = days * 86400.0
+    return {
+        "period": now.strftime("%Y-%m"),
+        "start": start,
+        "total_seconds": total_s,
+        "elapsed_frac": min(max((now - start).total_seconds() / total_s, 0.0), 1.0),
+    }
+
+
+def _project(mtd: float, elapsed_frac: float, observed_frac: float | None = None) -> float | None:
+    """Straight-line month-end projection. ``observed_frac`` is the fraction of
+    the month the measurement actually covers (< elapsed_frac when a baseline
+    was established mid-month) — extrapolation runs FORWARD only, so a partial
+    baseline never fabricates early-month spend."""
+    obs = elapsed_frac if observed_frac is None else observed_frac
+    if obs < MIN_PROJECTION_FRAC:
+        return None
+    return mtd + (mtd / obs) * (1.0 - elapsed_frac)
+
+
+def _pace(projected: float | None, limit: float | None) -> str | None:
+    if projected is None or limit is None:
+        return None
+    return "over" if projected > limit else "under"
+
+
+def _row(key: str, label: str, **kw) -> dict:
+    base = {
+        "key": key, "label": label, "status": "ok",
+        "mtd_cost_usd": None, "projected_month_end_usd": None,
+        "budget_usd": None, "pace": None, "quota": None,
+        "source": None, "detail": {}, "note": None, "error": None,
+    }
+    base.update(kw)
+    return base
+
+
+def _finish_usd_row(row: dict, mw: dict, budget_usd: float | None,
+                    observed_frac: float | None = None) -> dict:
+    """Stamp projection + pace onto a $-denominated row (in place)."""
+    row["budget_usd"] = budget_usd
+    if row["mtd_cost_usd"] is not None and row["projected_month_end_usd"] is None:
+        row["projected_month_end_usd"] = _project(row["mtd_cost_usd"], mw["elapsed_frac"],
+                                                  observed_frac)
+    row["pace"] = _pace(row["projected_month_end_usd"], budget_usd)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# S3 helpers
+# ---------------------------------------------------------------------------
+
+def _s3_json(s3, key: str) -> dict | None:
+    try:
+        return json.loads(s3.get_object(Bucket=BUCKET, Key=key)["Body"].read())
+    except Exception as exc:  # noqa: BLE001 — absence is an expected state here;
+        # callers decide whether a missing doc is fatal (budgets → warning list).
+        code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+        if code not in {"NoSuchKey", "404"}:
+            logger.warning("S3 read %s failed: %s", key, exc)
+        return None
+
+
+def _put_json(s3, key: str, doc: dict, if_none_match: bool = False) -> bool:
+    kwargs = {"Bucket": BUCKET, "Key": key, "ContentType": "application/json",
+              "Body": json.dumps(doc, indent=2, default=str).encode()}
+    if if_none_match:
+        kwargs["IfNoneMatch"] = "*"
+    try:
+        s3.put_object(**kwargs)
+        return True
+    except Exception as exc:  # noqa: BLE001 — 412 = another writer won the
+        # first-writer-wins race for a baseline/snapshot; that is the designed
+        # outcome, not a failure. Anything else re-raises.
+        code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+        if if_none_match and code in {"PreconditionFailed", "412"}:
+            return False
+        raise
+
+
+def _load_ssm(names: list[str]) -> dict[str, str]:
+    """Batch-read SSM params; missing names are simply absent from the result
+    (each consumer then reports its own row as not_configured)."""
+    ssm = boto3.client("ssm", region_name=REGION)
+    out: dict[str, str] = {}
+    for i in range(0, len(names), 10):
+        resp = ssm.get_parameters(Names=names[i:i + 10], WithDecryption=True)
+        for p in resp.get("Parameters", []):
+            out[p["Name"]] = p["Value"]
+        if resp.get("InvalidParameters"):
+            logger.info("SSM params not present (rows degrade to not_configured): %s",
+                        resp["InvalidParameters"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Provider adapters
+# ---------------------------------------------------------------------------
+
+def collect_aws(mw: dict, budgets: dict) -> dict:
+    ce = boto3.client("ce", region_name="us-east-1")
+    start = mw["start"].strftime("%Y-%m-%d")
+    now = _now_utc()
+    end = (now.replace(hour=0, minute=0, second=0, microsecond=0)
+           .strftime("%Y-%m-%d"))
+    next_month = (mw["start"].replace(day=28) + timedelta(days=4)).replace(day=1)
+    row = _row("aws", "AWS", source="cost_explorer")
+    if end <= start:  # first UTC day of the month — CE window would be empty
+        row.update(mtd_cost_usd=0.0, note="month just started — Cost Explorer window empty")
+        return _finish_usd_row(row, mw, _budget_usd(budgets, "aws"))
+    resp = ce.get_cost_and_usage(
+        TimePeriod={"Start": start, "End": end}, Granularity="MONTHLY",
+        Metrics=["UnblendedCost"],
+        GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}],
+    )
+    by_service: dict[str, float] = {}
+    for period in resp.get("ResultsByTime", []):
+        for g in period.get("Groups", []):
+            svc = g["Keys"][0]
+            by_service[svc] = by_service.get(svc, 0.0) + float(
+                g["Metrics"]["UnblendedCost"]["Amount"])
+    mtd = round(sum(by_service.values()), 2)
+    top = dict(sorted(by_service.items(), key=lambda kv: -kv[1])[:8])
+    row.update(mtd_cost_usd=mtd,
+               detail={"top_services_usd": {k: round(v, 2) for k, v in top.items()}},
+               note="Cost Explorer data lags ~24h")
+    try:
+        fc = ce.get_cost_forecast(
+            TimePeriod={"Start": end, "End": next_month.strftime("%Y-%m-%d")},
+            Metric="UNBLENDED_COST", Granularity="MONTHLY")
+        row["projected_month_end_usd"] = round(mtd + float(fc["Total"]["Amount"]), 2)
+        row["detail"]["projection_source"] = "ce_forecast"
+    except Exception as exc:  # noqa: BLE001 — forecast is an enhancement; the
+        # straight-line fallback below is the recorded degradation surface.
+        logger.info("CE forecast unavailable (straight-line fallback): %s", exc)
+        row["detail"]["projection_source"] = "straight_line"
+    return _finish_usd_row(row, mw, _budget_usd(budgets, "aws"))
+
+
+def collect_anthropic(mw: dict, budgets: dict, secrets: dict, s3) -> dict:
+    row = _row("anthropic_api", "Anthropic API")
+    admin_key = secrets.get(SSM_ANTHROPIC_ADMIN)
+    if admin_key:
+        starting = mw["start"].strftime("%Y-%m-%dT00:00:00Z")
+        url = ("https://api.anthropic.com/v1/organizations/cost_report"
+               f"?starting_at={starting}&limit=31")
+        headers = {"x-api-key": admin_key, "anthropic-version": "2023-06-01"}
+        total, page, pages = 0.0, None, 0
+        while pages < 10:
+            doc = _http_json(url + (f"&page={page}" if page else ""), headers)
+            for bucket in doc.get("data", []):
+                for res in bucket.get("results", []):
+                    total += float(res.get("amount", 0) or 0)
+            pages += 1
+            if not doc.get("has_more"):
+                break
+            page = doc.get("next_page")
+        row.update(mtd_cost_usd=round(total, 2), source="admin_api")
+        return _finish_usd_row(row, mw, _budget_usd(budgets, "anthropic_api"))
+    # Fallback: research-fleet client telemetry (per-call JSONL, cost_usd per row).
+    total, n_days = 0.0, 0
+    now = _now_utc()
+    paginator = s3.get_paginator("list_objects_v2")
+    for day in range(1, now.day + 1):
+        date_str = f"{mw['period']}-{day:02d}"
+        for page_ in paginator.paginate(Bucket=BUCKET,
+                                        Prefix=f"{COST_RAW_PREFIX}{date_str}/"):
+            for obj in page_.get("Contents", []):
+                n_days += 1
+                body = s3.get_object(Bucket=BUCKET, Key=obj["Key"])["Body"].read()
+                for line in body.splitlines():
+                    if not line.strip():
+                        continue
+                    rec = json.loads(line)
+                    total += float(rec.get("cost_usd") or 0)
+    row.update(
+        mtd_cost_usd=round(total, 2), source="client_telemetry",
+        note=("research-fleet client telemetry only (excludes morning-signal "
+              "and other API consumers) — add SSM "
+              f"{SSM_ANTHROPIC_ADMIN} for authoritative org-wide Admin-API costs"),
+        detail={"cost_raw_objects": n_days},
+    )
+    return _finish_usd_row(row, mw, _budget_usd(budgets, "anthropic_api"))
+
+
+def collect_openrouter(mw: dict, budgets: dict, secrets: dict,
+                       counters: dict, baseline: dict) -> dict:
+    row = _row("openrouter", "OpenRouter", source="credits_diff")
+    if SSM_OPENROUTER not in secrets:
+        row.update(status="not_configured", error=f"SSM {SSM_OPENROUTER} missing")
+        return row
+    usage_now = counters["openrouter_total_usage"]
+    row["detail"] = {"lifetime_usage_usd": round(usage_now, 4),
+                     "credits_remaining_usd": round(counters["openrouter_credits_remaining"], 4)}
+    return _diff_row(row, mw, budgets, "openrouter", usage_now, baseline,
+                     "openrouter_total_usage")
+
+
+def collect_deepseek(mw: dict, budgets: dict, secrets: dict,
+                     counters: dict, baseline: dict) -> dict:
+    row = _row("deepseek", "DeepSeek", source="balance_diff")
+    if SSM_DEEPSEEK not in secrets:
+        row.update(status="not_configured", error=f"SSM {SSM_DEEPSEEK} missing")
+        return row
+    bal = counters["deepseek_balance"]
+    row["detail"] = {"balance": round(bal, 4), "currency": counters["deepseek_currency"]}
+    # Spend counter = -balance (balance falls as credit is consumed); a top-up
+    # mid-month shows as negative spend — clamped to 0 with a note, since the
+    # collector cannot see top-up events.
+    row = _diff_row(row, mw, budgets, "deepseek", -bal, baseline, "deepseek_neg_balance")
+    if row.get("mtd_cost_usd") == 0.0 and row["status"] == "ok":
+        row["note"] = (row.get("note") or "") + " (top-ups mid-month can mask spend)"
+    return row
+
+
+def _diff_row(row: dict, mw: dict, budgets: dict, key: str, counter_now: float,
+              baseline: dict, counter_key: str) -> dict:
+    base = baseline.get("counters", {}).get(counter_key)
+    base_ts = baseline.get("as_of", {}).get(counter_key)
+    if base is None:
+        row.update(mtd_cost_usd=0.0,
+                   note="baseline established this run — MTD accrues from today")
+        return _finish_usd_row(row, mw, _budget_usd(budgets, key))
+    mtd = round(max(counter_now - float(base), 0.0), 4)
+    observed = mw["elapsed_frac"]
+    if base_ts:
+        base_dt = datetime.fromisoformat(base_ts)
+        observed = max((_now_utc() - base_dt).total_seconds() / mw["total_seconds"], 0.0)
+        if (base_dt - mw["start"]).total_seconds() > 3600:
+            row["note"] = f"measured since {base_dt:%Y-%m-%d} baseline (mid-month start)"
+    row.update(mtd_cost_usd=mtd)
+    return _finish_usd_row(row, mw, _budget_usd(budgets, key), observed_frac=observed)
+
+
+def collect_neon(mw: dict, budgets: dict, secrets: dict) -> dict:
+    row = _row("neon", "Neon Postgres", source="consumption_api")
+    if SSM_NEON not in secrets:
+        row.update(status="not_configured", error=f"SSM {SSM_NEON} missing")
+        return row
+    frm = mw["start"].strftime("%Y-%m-%dT00:00:00Z")
+    to = _now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
+    doc = _http_json(
+        "https://console.neon.tech/api/v2/consumption_history/account"
+        f"?from={frm}&to={to}&granularity=daily",
+        {"Authorization": f"Bearer {secrets[SSM_NEON]}", "Accept": "application/json"})
+    sums: dict[str, float] = {}
+    _sum_metrics(doc, sums)
+    transfer_gb = sums.get("data_transfer_bytes", 0.0) / 1e9
+    quota_gb = float(secrets.get(SSM_NEON_QUOTA_GB, 0) or 0) or None
+    projected_gb = _project(transfer_gb, mw["elapsed_frac"])
+    row.update(
+        mtd_cost_usd=float(_fixed_usd(budgets, "neon") or 0.0),
+        projected_month_end_usd=float(_fixed_usd(budgets, "neon") or 0.0),
+        quota={"unit": "GB data transfer", "used": round(transfer_gb, 3),
+               "limit": quota_gb,
+               "projected": round(projected_gb, 3) if projected_gb is not None else None},
+        pace=_pace(projected_gb, quota_gb),
+        detail={"compute_hours": round(sums.get("compute_time_seconds", 0.0) / 3600, 2),
+                "written_gb": round(sums.get("written_data_bytes", 0.0) / 1e9, 3)},
+        note="free plan — the binding constraint is the transfer quota, not $"
+             if not _fixed_usd(budgets, "neon") else None,
+    )
+    row["budget_usd"] = _budget_usd(budgets, "neon")
+    return row
+
+
+def _sum_metrics(obj, sums: dict[str, float]) -> None:
+    """Walk arbitrarily-nested Neon consumption JSON, accumulating the numeric
+    metric leaves we care about (shape-tolerant: Neon has moved fields between
+    ``periods``/``consumption`` nestings across API revisions)."""
+    metric_keys = {"data_transfer_bytes", "compute_time_seconds",
+                   "active_time_seconds", "written_data_bytes"}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k in metric_keys and isinstance(v, (int, float)):
+                sums[k] = sums.get(k, 0.0) + float(v)
+            else:
+                _sum_metrics(v, sums)
+    elif isinstance(obj, list):
+        for item in obj:
+            _sum_metrics(item, sums)
+
+
+def collect_github(mw: dict, budgets: dict, secrets: dict, *, account: str,
+                   kind: str) -> dict:
+    """One row per billing account (org + personal are separate meters with
+    separate included-minutes quotas — they are deliberately NOT merged)."""
+    key = f"github_{kind}"
+    row = _row(key, f"GitHub ({account} {kind})", source="billing_usage_api")
+    if SSM_GITHUB_PAT not in secrets:
+        row.update(status="not_configured", error=f"SSM {SSM_GITHUB_PAT} missing")
+        return row
+    headers = {"Authorization": f"Bearer {secrets[SSM_GITHUB_PAT]}",
+               "Accept": "application/vnd.github+json",
+               "X-GitHub-Api-Version": "2022-11-28"}
+    base = ("https://api.github.com/organizations/" if kind == "org"
+            else "https://api.github.com/users/")
+    now = _now_utc()
+    doc = _http_json(f"{base}{account}/settings/billing/usage"
+                     f"?year={now.year}&month={now.month}", headers)
+    minutes, billed, by_product = 0.0, 0.0, {}
+    for item in doc.get("usageItems", []):
+        product = str(item.get("product", "")).lower()
+        net = float(item.get("netAmount", 0) or 0)
+        billed += net
+        by_product[product] = round(by_product.get(product, 0.0) + net, 2)
+        if product == "actions" and "minute" in str(item.get("unitType", "")).lower():
+            minutes += float(item.get("quantity", 0) or 0)
+    included = _included_minutes(budgets, key)
+    # Legacy per-product endpoint still serves included_minutes for accounts
+    # not yet migrated to the enhanced billing platform — best-effort probe.
+    try:
+        legacy_base = ("https://api.github.com/orgs/" if kind == "org"
+                       else "https://api.github.com/users/")
+        legacy = _http_json(f"{legacy_base}{account}/settings/billing/actions", headers)
+        if isinstance(legacy.get("included_minutes"), (int, float)):
+            included = float(legacy["included_minutes"])
+    except Exception as exc:  # noqa: BLE001 — endpoint 404/410s post-migration;
+        # budgets-config figure (recorded above) remains the quota source.
+        logger.info("legacy GH billing endpoint unavailable for %s: %s", account, exc)
+    projected_min = _project(minutes, mw["elapsed_frac"])
+    row.update(
+        mtd_cost_usd=round(billed, 2),
+        quota={"unit": "Actions minutes", "used": round(minutes, 1), "limit": included,
+               "projected": round(projected_min, 0) if projected_min is not None else None},
+        pace=_pace(projected_min, included),
+        detail={"billed_usd_by_product": by_product},
+    )
+    row = _finish_usd_row(row, mw, _budget_usd(budgets, key))
+    # Quota pace (included minutes) is the leading signal; billed-$ pace only
+    # overrides when a budget is set and projected $ breaches it.
+    if row["pace"] is None:
+        row["pace"] = _pace(projected_min, included)
+    return row
+
+
+def _included_minutes(budgets: dict, key: str) -> float | None:
+    v = ((budgets.get("providers") or {}).get(key) or {}).get("included_minutes")
+    return float(v) if v is not None else None
+
+
+def _budget_usd(budgets: dict, key: str) -> float | None:
+    v = ((budgets.get("providers") or {}).get(key) or {}).get("monthly_budget_usd")
+    return float(v) if v is not None else None
+
+
+def _fixed_usd(budgets: dict, key: str) -> float | None:
+    v = ((budgets.get("providers") or {}).get(key) or {}).get("fixed_monthly_usd")
+    return float(v) if v is not None else None
+
+
+def fixed_rows(budgets: dict, produced_keys: set[str]) -> list[dict]:
+    """Budgets-config-only line items (flat subscriptions with no live API) —
+    adding a future subscription is a config edit, not a code change."""
+    rows = []
+    for key, cfg in (budgets.get("providers") or {}).items():
+        if key in produced_keys:
+            continue
+        fixed = cfg.get("fixed_monthly_usd")
+        if fixed is None:
+            continue
+        rows.append(_row(
+            key, cfg.get("label", key), status="fixed", source="budgets_config",
+            mtd_cost_usd=float(fixed), projected_month_end_usd=float(fixed),
+            budget_usd=float(fixed), pace="fixed",
+            note=cfg.get("note") or "flat subscription (from expense_budgets.json)"))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Counters (lifetime/balance readings) + baseline
+# ---------------------------------------------------------------------------
+
+def read_counters(secrets: dict) -> tuple[dict, dict[str, str]]:
+    """Fetch the raw monotonic/balance counters for the diff-based providers.
+    Returns (counters, errors) — an unreachable provider lands in ``errors``
+    and its row is built as status=error downstream."""
+    counters: dict = {}
+    errors: dict[str, str] = {}
+    if SSM_OPENROUTER in secrets:
+        try:
+            doc = _http_json("https://openrouter.ai/api/v1/credits",
+                             {"Authorization": f"Bearer {secrets[SSM_OPENROUTER]}"})
+            d = doc.get("data", {})
+            counters["openrouter_total_usage"] = float(d["total_usage"])
+            counters["openrouter_credits_remaining"] = (
+                float(d.get("total_credits", 0)) - float(d["total_usage"]))
+        except Exception as exc:  # noqa: BLE001 — recorded per-row downstream
+            logger.exception("openrouter counter fetch failed")
+            errors["openrouter"] = str(exc)[:300]
+    if SSM_DEEPSEEK in secrets:
+        try:
+            doc = _http_json("https://api.deepseek.com/user/balance",
+                             {"Authorization": f"Bearer {secrets[SSM_DEEPSEEK]}"})
+            infos = doc.get("balance_infos") or []
+            usd = next((b for b in infos if b.get("currency") == "USD"), infos[0] if infos else None)
+            if usd is None:
+                raise RuntimeError(f"no balance_infos in response: {doc}")
+            counters["deepseek_balance"] = float(usd["total_balance"])
+            counters["deepseek_currency"] = usd.get("currency", "USD")
+        except Exception as exc:  # noqa: BLE001 — recorded per-row downstream
+            logger.exception("deepseek counter fetch failed")
+            errors["deepseek"] = str(exc)[:300]
+    return counters, errors
+
+
+def ensure_baseline(s3, period: str, counters: dict) -> dict:
+    """First-run-of-month counter baseline (first-writer-wins). If the doc
+    exists but lacks a counter we can now read (provider key added mid-month),
+    it is backfilled in place — the new counter's MTD then accrues from now."""
+    key = f"{BASELINE_PREFIX}{period}.json"
+    now_iso = _now_utc().isoformat()
+    wanted = {}
+    if "openrouter_total_usage" in counters:
+        wanted["openrouter_total_usage"] = counters["openrouter_total_usage"]
+    if "deepseek_balance" in counters:
+        wanted["deepseek_neg_balance"] = -counters["deepseek_balance"]
+    existing = _s3_json(s3, key)
+    if existing is None:
+        doc = {"schema_version": 1, "period": period,
+               "counters": wanted, "as_of": {k: now_iso for k in wanted}}
+        if _put_json(s3, key, doc, if_none_match=True):
+            return doc
+        existing = _s3_json(s3, key) or doc  # lost the race — read the winner
+    missing = {k: v for k, v in wanted.items() if k not in existing.get("counters", {})}
+    if missing:
+        existing.setdefault("counters", {}).update(missing)
+        existing.setdefault("as_of", {}).update({k: now_iso for k in missing})
+        _put_json(s3, key, existing)
+    return existing
+
+
+def write_snapshot(s3, counters: dict) -> None:
+    """First reading of each UTC day, kept for future trend charts. Best-effort:
+    losing the first-writer race (412) is the designed outcome."""
+    date_str = _now_utc().strftime("%Y-%m-%d")
+    _put_json(s3, f"{SNAPSHOT_PREFIX}{date_str}.json",
+              {"schema_version": 1, "as_of": _now_utc().isoformat(), "counters": counters},
+              if_none_match=True)
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    now = _now_utc()
+    mw = _month_window(now)
+    s3 = boto3.client("s3", region_name=REGION)
+    warnings: list[str] = []
+
+    budgets = _s3_json(s3, BUDGETS_KEY)
+    if budgets is None:
+        # Budgets SSoT missing ⇒ every budget/quota field degrades to null.
+        # Recorded here + rendered as a page-level warning by the console.
+        warnings.append(f"budgets SSoT s3://{BUCKET}/{BUDGETS_KEY} missing — "
+                        "no budget/pace fields; seed it from expense_budgets.seed.json")
+        budgets = {}
+
+    secrets = _load_ssm(SSM_PARAMS)
+    counters, counter_errors = read_counters(secrets)
+    baseline = ensure_baseline(s3, mw["period"], counters)
+    write_snapshot(s3, counters)
+
+    rows: list[dict] = []
+
+    def fenced(key: str, label: str, fn) -> None:
+        # Adapter fence — one provider outage must not blank the others; the
+        # failure's recording surface is this row's error field (+ CW logs).
+        try:
+            rows.append(fn())
+        except Exception as exc:  # noqa: BLE001 — see fence rationale above
+            logger.exception("provider %s failed", key)
+            rows.append(_row(key, label, status="error", error=str(exc)[:300]))
+
+    fenced("aws", "AWS", lambda: collect_aws(mw, budgets))
+    fenced("anthropic_api", "Anthropic API",
+           lambda: collect_anthropic(mw, budgets, secrets, s3))
+    if "openrouter" in counter_errors:
+        rows.append(_row("openrouter", "OpenRouter", status="error",
+                         error=counter_errors["openrouter"]))
+    else:
+        fenced("openrouter", "OpenRouter",
+               lambda: collect_openrouter(mw, budgets, secrets, counters, baseline))
+    if "deepseek" in counter_errors:
+        rows.append(_row("deepseek", "DeepSeek", status="error",
+                         error=counter_errors["deepseek"]))
+    else:
+        fenced("deepseek", "DeepSeek",
+               lambda: collect_deepseek(mw, budgets, secrets, counters, baseline))
+    fenced("neon", "Neon Postgres", lambda: collect_neon(mw, budgets, secrets))
+    fenced("github_org", f"GitHub ({GITHUB_ORG} org)",
+           lambda: collect_github(mw, budgets, secrets, account=GITHUB_ORG, kind="org"))
+    fenced("github_user", f"GitHub ({GITHUB_USER})",
+           lambda: collect_github(mw, budgets, secrets, account=GITHUB_USER, kind="user"))
+
+    rows.extend(fixed_rows(budgets, {r["key"] for r in rows}))
+
+    ok_rows = [r for r in rows if r["status"] in {"ok", "fixed"}]
+    err_rows = [r for r in rows if r["status"] == "error"]
+    totals = {
+        "mtd_usd": round(sum(r["mtd_cost_usd"] or 0 for r in ok_rows), 2),
+        "projected_usd": round(sum((r["projected_month_end_usd"]
+                                    if r["projected_month_end_usd"] is not None
+                                    else (r["mtd_cost_usd"] or 0)) for r in ok_rows), 2),
+        "budget_usd": round(sum(r["budget_usd"] for r in ok_rows
+                                if r["budget_usd"] is not None), 2),
+        "incomplete": bool(err_rows),
+    }
+    doc = {
+        "schema_version": 1,
+        "period": mw["period"],
+        "as_of": now.isoformat(),
+        "month_start": mw["start"].isoformat(),
+        "month_elapsed_frac": round(mw["elapsed_frac"], 4),
+        "providers": rows,
+        "totals": totals,
+        "warnings": warnings,
+    }
+    _put_json(s3, f"{MONTHLY_PREFIX}{mw['period']}.json", doc)
+    _put_json(s3, LATEST_KEY, doc)
+
+    if err_rows and not ok_rows:
+        # Every live adapter failed — systemic (network/creds/deploy) breakage,
+        # not a provider blip: raise so the Lambda error metric pages.
+        raise RuntimeError(f"all provider adapters failed: "
+                           f"{[(r['key'], r['error']) for r in err_rows]}")
+    return {"period": mw["period"], "providers": len(rows),
+            "errors": [(r["key"], r["error"]) for r in err_rows],
+            "totals": totals}

--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -86,10 +86,15 @@ SSM_OPENROUTER = "/alpha-engine/OPENROUTER_API_KEY"
 SSM_DEEPSEEK = "/symposion/DEEPSEEK_API_KEY"
 SSM_NEON = "/alpha-engine/NEON_API_KEY"
 SSM_NEON_QUOTA_GB = "/alpha-engine/NEON_DATA_TRANSFER_QUOTA_GB"
-SSM_GITHUB_PAT = "/alpha-engine/groom/github_pat"
+# Verified 2026-07-17: of the fleet's six GitHub tokens, ONLY this one can read
+# the enhanced org billing-usage endpoint (the groom/config-runner/etc PATs all
+# 403). No existing token can see the cipher813 PERSONAL account's billing —
+# that needs a user-scoped fine-grained PAT with "Plan: read", wired below.
+SSM_GITHUB_TOKEN = "/alpha-engine/GITHUB_TOKEN"
+SSM_GITHUB_USER_PAT = "/alpha-engine/expenses/GITHUB_USER_BILLING_PAT"
 SSM_ANTHROPIC_ADMIN = "/alpha-engine/expenses/ANTHROPIC_ADMIN_KEY"
 SSM_PARAMS = [SSM_OPENROUTER, SSM_DEEPSEEK, SSM_NEON, SSM_NEON_QUOTA_GB,
-              SSM_GITHUB_PAT, SSM_ANTHROPIC_ADMIN]
+              SSM_GITHUB_TOKEN, SSM_GITHUB_USER_PAT, SSM_ANTHROPIC_ADMIN]
 
 GITHUB_ORG = "nousergon"
 GITHUB_USER = "cipher813"
@@ -362,21 +367,49 @@ def _diff_row(row: dict, mw: dict, budgets: dict, key: str, counter_now: float,
 
 
 def collect_neon(mw: dict, budgets: dict, secrets: dict) -> dict:
-    row = _row("neon", "Neon Postgres", source="consumption_api")
+    """Free-tier-compatible consumption read: the ``consumption_history``
+    endpoints are Scale-plan-only (verified 403/404 live, 2026-07-17), but the
+    per-project detail object carries current-consumption-period counters
+    (``data_transfer_bytes``, ``compute_time_seconds``, …) plus the period
+    bounds on every plan — sum across projects and pace against the period."""
+    row = _row("neon", "Neon Postgres", source="projects_api")
     if SSM_NEON not in secrets:
         row.update(status="not_configured", error=f"SSM {SSM_NEON} missing")
         return row
-    frm = mw["start"].strftime("%Y-%m-%dT00:00:00Z")
-    to = _now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
-    doc = _http_json(
-        "https://console.neon.tech/api/v2/consumption_history/account"
-        f"?from={frm}&to={to}&granularity=daily",
-        {"Authorization": f"Bearer {secrets[SSM_NEON]}", "Accept": "application/json"})
+    headers = {"Authorization": f"Bearer {secrets[SSM_NEON]}", "Accept": "application/json"}
+    listing = _http_json("https://console.neon.tech/api/v2/projects", headers)
     sums: dict[str, float] = {}
-    _sum_metrics(doc, sums)
+    period_start = period_end = None
+    project_names = []
+    for proj in listing.get("projects", []):
+        detail = _http_json(
+            f"https://console.neon.tech/api/v2/projects/{proj['id']}", headers)
+        p = detail.get("project", {})
+        project_names.append(p.get("name", proj["id"]))
+        for k in ("data_transfer_bytes", "compute_time_seconds",
+                  "active_time_seconds", "written_data_bytes"):
+            if isinstance(p.get(k), (int, float)):
+                sums[k] = sums.get(k, 0.0) + float(p[k])
+        period_start = period_start or p.get("consumption_period_start")
+        period_end = period_end or p.get("consumption_period_end")
     transfer_gb = sums.get("data_transfer_bytes", 0.0) / 1e9
     quota_gb = float(secrets.get(SSM_NEON_QUOTA_GB, 0) or 0) or None
-    projected_gb = _project(transfer_gb, mw["elapsed_frac"])
+    # Pace against Neon's OWN consumption period when reported (it can start
+    # mid-calendar-month, e.g. after a plan change), else the calendar month.
+    observed_frac = mw["elapsed_frac"]
+    if period_start and period_end:
+        try:
+            ps = datetime.fromisoformat(period_start.replace("Z", "+00:00"))
+            pe = datetime.fromisoformat(period_end.replace("Z", "+00:00"))
+            total = (pe - ps).total_seconds()
+            if total > 0:
+                observed_frac = max((_now_utc() - ps).total_seconds() / total, 0.0)
+        except ValueError:
+            logger.warning("unparseable Neon consumption period: %s → %s",
+                           period_start, period_end)
+    projected_gb = None
+    if observed_frac >= MIN_PROJECTION_FRAC:
+        projected_gb = transfer_gb / observed_frac
     row.update(
         mtd_cost_usd=float(_fixed_usd(budgets, "neon") or 0.0),
         projected_month_end_usd=float(_fixed_usd(budgets, "neon") or 0.0),
@@ -384,8 +417,10 @@ def collect_neon(mw: dict, budgets: dict, secrets: dict) -> dict:
                "limit": quota_gb,
                "projected": round(projected_gb, 3) if projected_gb is not None else None},
         pace=_pace(projected_gb, quota_gb),
-        detail={"compute_hours": round(sums.get("compute_time_seconds", 0.0) / 3600, 2),
-                "written_gb": round(sums.get("written_data_bytes", 0.0) / 1e9, 3)},
+        detail={"projects": project_names,
+                "compute_hours": round(sums.get("compute_time_seconds", 0.0) / 3600, 2),
+                "written_gb": round(sums.get("written_data_bytes", 0.0) / 1e9, 3),
+                "consumption_period": f"{period_start} → {period_end}"},
         note="free plan — the binding constraint is the transfer quota, not $"
              if not _fixed_usd(budgets, "neon") else None,
     )
@@ -393,67 +428,69 @@ def collect_neon(mw: dict, budgets: dict, secrets: dict) -> dict:
     return row
 
 
-def _sum_metrics(obj, sums: dict[str, float]) -> None:
-    """Walk arbitrarily-nested Neon consumption JSON, accumulating the numeric
-    metric leaves we care about (shape-tolerant: Neon has moved fields between
-    ``periods``/``consumption`` nestings across API revisions)."""
-    metric_keys = {"data_transfer_bytes", "compute_time_seconds",
-                   "active_time_seconds", "written_data_bytes"}
-    if isinstance(obj, dict):
-        for k, v in obj.items():
-            if k in metric_keys and isinstance(v, (int, float)):
-                sums[k] = sums.get(k, 0.0) + float(v)
-            else:
-                _sum_metrics(v, sums)
-    elif isinstance(obj, list):
-        for item in obj:
-            _sum_metrics(item, sums)
-
-
 def collect_github(mw: dict, budgets: dict, secrets: dict, *, account: str,
                    kind: str) -> dict:
     """One row per billing account (org + personal are separate meters with
-    separate included-minutes quotas — they are deliberately NOT merged)."""
+    separate included-minutes quotas — they are deliberately NOT merged).
+    Enhanced billing platform only: the legacy ``settings/billing/actions``
+    endpoints are 410-Gone/404 for both accounts (verified 2026-07-17), so the
+    included-minutes quota comes from the budgets SSoT."""
     key = f"github_{kind}"
     row = _row(key, f"GitHub ({account} {kind})", source="billing_usage_api")
-    if SSM_GITHUB_PAT not in secrets:
-        row.update(status="not_configured", error=f"SSM {SSM_GITHUB_PAT} missing")
+    # Personal-account billing needs its own user-scoped PAT ("Plan: read");
+    # the org token cannot see it (404) — fall back so the row self-heals the
+    # moment the operator adds the param, no code change needed.
+    token = (secrets.get(SSM_GITHUB_USER_PAT) or secrets.get(SSM_GITHUB_TOKEN)
+             if kind == "user" else secrets.get(SSM_GITHUB_TOKEN))
+    if not token:
+        row.update(status="not_configured", error=f"SSM {SSM_GITHUB_TOKEN} missing")
         return row
-    headers = {"Authorization": f"Bearer {secrets[SSM_GITHUB_PAT]}",
+    headers = {"Authorization": f"Bearer {token}",
                "Accept": "application/vnd.github+json",
                "X-GitHub-Api-Version": "2022-11-28"}
     base = ("https://api.github.com/organizations/" if kind == "org"
             else "https://api.github.com/users/")
     now = _now_utc()
-    doc = _http_json(f"{base}{account}/settings/billing/usage"
-                     f"?year={now.year}&month={now.month}", headers)
-    minutes, billed, by_product = 0.0, 0.0, {}
+    try:
+        doc = _http_json(f"{base}{account}/settings/billing/usage"
+                         f"?year={now.year}&month={now.month}", headers)
+    except RuntimeError as exc:
+        if kind == "user" and SSM_GITHUB_USER_PAT not in secrets \
+                and ("HTTP 404" in str(exc) or "HTTP 403" in str(exc)):
+            # Known credential gap, not an outage: no fleet token can read the
+            # personal account's billing. Surface as not_configured (kept out
+            # of the incomplete-totals error banner) with the fix inline.
+            row.update(status="not_configured",
+                       error=f"needs a cipher813 fine-grained PAT with Plan:read "
+                             f"stored at SSM {SSM_GITHUB_USER_PAT}")
+            return row
+        raise
+    # The included-minutes quota (2000/mo, free org) is drawn ONLY by
+    # private-repo minutes; public-repo usage appears in usageItems too but is
+    # 100%-discounted free (verified live 2026-07-17: 34.9k total minutes, of
+    # which most were public-repo/free) — so quota pacing must filter to
+    # private repos or it overstates ~17x.
+    private_repos = _private_repo_names(account, kind, headers)
+    minutes_private, minutes_total, billed, by_product = 0.0, 0.0, 0.0, {}
     for item in doc.get("usageItems", []):
         product = str(item.get("product", "")).lower()
         net = float(item.get("netAmount", 0) or 0)
         billed += net
         by_product[product] = round(by_product.get(product, 0.0) + net, 2)
         if product == "actions" and "minute" in str(item.get("unitType", "")).lower():
-            minutes += float(item.get("quantity", 0) or 0)
+            qty = float(item.get("quantity", 0) or 0)
+            minutes_total += qty
+            if item.get("repositoryName") in private_repos:
+                minutes_private += qty
     included = _included_minutes(budgets, key)
-    # Legacy per-product endpoint still serves included_minutes for accounts
-    # not yet migrated to the enhanced billing platform — best-effort probe.
-    try:
-        legacy_base = ("https://api.github.com/orgs/" if kind == "org"
-                       else "https://api.github.com/users/")
-        legacy = _http_json(f"{legacy_base}{account}/settings/billing/actions", headers)
-        if isinstance(legacy.get("included_minutes"), (int, float)):
-            included = float(legacy["included_minutes"])
-    except Exception as exc:  # noqa: BLE001 — endpoint 404/410s post-migration;
-        # budgets-config figure (recorded above) remains the quota source.
-        logger.info("legacy GH billing endpoint unavailable for %s: %s", account, exc)
-    projected_min = _project(minutes, mw["elapsed_frac"])
+    projected_min = _project(minutes_private, mw["elapsed_frac"])
     row.update(
         mtd_cost_usd=round(billed, 2),
-        quota={"unit": "Actions minutes", "used": round(minutes, 1), "limit": included,
+        quota={"unit": "private-repo Actions minutes",
+               "used": round(minutes_private, 1), "limit": included,
                "projected": round(projected_min, 0) if projected_min is not None else None},
-        pace=_pace(projected_min, included),
-        detail={"billed_usd_by_product": by_product},
+        detail={"billed_usd_by_product": by_product,
+                "total_actions_minutes_incl_public_free": round(minutes_total, 1)},
     )
     row = _finish_usd_row(row, mw, _budget_usd(budgets, key))
     # Quota pace (included minutes) is the leading signal; billed-$ pace only
@@ -461,6 +498,23 @@ def collect_github(mw: dict, budgets: dict, secrets: dict, *, account: str,
     if row["pace"] is None:
         row["pace"] = _pace(projected_min, included)
     return row
+
+
+def _private_repo_names(account: str, kind: str, headers: dict) -> set[str]:
+    """Names of the account's PRIVATE repos (the only ones that draw the
+    included-minutes quota). Org listing filters server-side via type=private;
+    the user path needs the user's own PAT (visibility=private on /user/repos
+    only works self-scoped)."""
+    url = (f"https://api.github.com/orgs/{account}/repos?type=private&per_page=100"
+           if kind == "org"
+           else "https://api.github.com/user/repos?visibility=private&affiliation=owner&per_page=100")
+    names: set[str] = set()
+    for page in range(1, 6):  # 500-repo ceiling, far above fleet size
+        batch = _http_json(f"{url}&page={page}", headers)
+        names.update(r["name"] for r in batch if isinstance(r, dict) and "name" in r)
+        if len(batch) < 100:
+            break
+    return names
 
 
 def _included_minutes(budgets: dict, key: str) -> float | None:

--- a/infrastructure/lambdas/expense-collector/test_handler.py
+++ b/infrastructure/lambdas/expense-collector/test_handler.py
@@ -1,0 +1,370 @@
+"""Unit tests for the expense-collector handler.
+
+Pure-logic coverage (month window, forward-only projection, diff rows, fixed
+rows, Neon metric walker) plus a full handler run against fake boto3 clients
+and a canned HTTP router — asserting the rollup artifact shape, per-provider
+rows, error fencing (one dead provider must not blank the others), and the
+first-writer-wins baseline/snapshot writes.
+
+Run standalone: ``python3 -m pytest test_handler.py -q`` (deploy.sh preflights
+this before every package+ship; only dep beyond stdlib is boto3, which the
+Lambda runtime provides in prod).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+import index  # noqa: E402
+
+NOW = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)  # July = 31 days
+ELAPSED = ((NOW - datetime(2026, 7, 1, tzinfo=timezone.utc)).total_seconds()
+           / (31 * 86400.0))  # ≈ 0.5323
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeS3Error(Exception):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+class FakeS3:
+    def __init__(self, store: dict[str, bytes]):
+        self.store = store
+
+    def get_object(self, Bucket, Key):
+        if Key not in self.store:
+            raise FakeS3Error("NoSuchKey")
+        return {"Body": _Body(self.store[Key])}
+
+    def put_object(self, **kw):
+        if kw.get("IfNoneMatch") == "*" and kw["Key"] in self.store:
+            raise FakeS3Error("PreconditionFailed")
+        self.store[kw["Key"]] = kw["Body"]
+        return {}
+
+    def get_paginator(self, name):
+        assert name == "list_objects_v2"
+        store = self.store
+
+        class _P:
+            def paginate(self, Bucket, Prefix):
+                keys = sorted(k for k in store if k.startswith(Prefix))
+                yield {"Contents": [{"Key": k} for k in keys]} if keys else {}
+        return _P()
+
+
+class _Body:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self):
+        return self._data
+
+
+class FakeSSM:
+    def __init__(self, params: dict[str, str]):
+        self.params = params
+
+    def get_parameters(self, Names, WithDecryption):
+        return {
+            "Parameters": [{"Name": n, "Value": self.params[n]}
+                           for n in Names if n in self.params],
+            "InvalidParameters": [n for n in Names if n not in self.params],
+        }
+
+
+class FakeCE:
+    def __init__(self, fail_forecast: bool = False):
+        self.fail_forecast = fail_forecast
+
+    def get_cost_and_usage(self, **kw):
+        return {"ResultsByTime": [{"Groups": [
+            {"Keys": ["AmazonEC2"], "Metrics": {"UnblendedCost": {"Amount": "8.10"}}},
+            {"Keys": ["AmazonS3"], "Metrics": {"UnblendedCost": {"Amount": "4.24"}}},
+        ]}]}
+
+    def get_cost_forecast(self, **kw):
+        if self.fail_forecast:
+            raise RuntimeError("forecast unavailable")
+        return {"Total": {"Amount": "10.00"}}
+
+
+class FakeBoto3:
+    def __init__(self, s3, ssm, ce):
+        self._by_name = {"s3": s3, "ssm": ssm, "ce": ce}
+
+    def client(self, name, region_name=None):
+        return self._by_name[name]
+
+
+def http_router(routes: dict[str, dict]):
+    """Match by substring; raise for routes mapped to an exception."""
+    def _fake(url, headers=None):
+        for frag, resp in routes.items():
+            if frag in url:
+                if isinstance(resp, Exception):
+                    raise resp
+                return resp
+        raise RuntimeError(f"unrouted URL in test: {url}")
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# Pure-logic tests
+# ---------------------------------------------------------------------------
+
+class TestMonthWindow:
+    def test_period_and_elapsed(self):
+        mw = index._month_window(NOW)
+        assert mw["period"] == "2026-07"
+        assert mw["elapsed_frac"] == pytest.approx(ELAPSED, abs=1e-6)
+
+    def test_month_start_instant(self):
+        mw = index._month_window(datetime(2026, 8, 1, 0, 0, tzinfo=timezone.utc))
+        assert mw["period"] == "2026-08"
+        assert mw["elapsed_frac"] == 0.0
+
+
+class TestProjection:
+    def test_straight_line(self):
+        assert index._project(50.0, 0.5) == pytest.approx(100.0)
+
+    def test_too_early_returns_none(self):
+        assert index._project(1.0, 0.01) is None
+
+    def test_partial_baseline_extrapolates_forward_only(self):
+        # Observed 25% of the month, currently 50% elapsed: the missing early
+        # half-month must NOT be back-filled — projected = 10 + rate*(remaining).
+        assert index._project(10.0, 0.5, observed_frac=0.25) == pytest.approx(30.0)
+
+    def test_pace(self):
+        assert index._pace(120.0, 100.0) == "over"
+        assert index._pace(80.0, 100.0) == "under"
+        assert index._pace(None, 100.0) is None
+        assert index._pace(80.0, None) is None
+
+
+class TestDiffRow:
+    MW = index._month_window(NOW)
+    BUDGETS = {"providers": {"openrouter": {"monthly_budget_usd": 4.0}}}
+
+    def test_no_baseline_establishes(self):
+        row = index._diff_row(index._row("openrouter", "OpenRouter"), self.MW,
+                              self.BUDGETS, "openrouter", 42.5, {}, "openrouter_total_usage")
+        assert row["mtd_cost_usd"] == 0.0
+        assert "baseline established" in row["note"]
+
+    def test_diff_and_pace(self):
+        baseline = {"counters": {"openrouter_total_usage": 40.0},
+                    "as_of": {"openrouter_total_usage": "2026-07-01T00:10:00+00:00"}}
+        row = index._diff_row(index._row("openrouter", "OpenRouter"), self.MW,
+                              self.BUDGETS, "openrouter", 42.5, baseline,
+                              "openrouter_total_usage")
+        assert row["mtd_cost_usd"] == pytest.approx(2.5)
+        # 2.5 over ~53% of month → ~4.7 projected > 4.0 budget
+        assert row["pace"] == "over"
+
+    def test_negative_diff_clamped(self):
+        baseline = {"counters": {"deepseek_neg_balance": -10.0},
+                    "as_of": {"deepseek_neg_balance": "2026-07-01T00:10:00+00:00"}}
+        row = index._diff_row(index._row("deepseek", "DeepSeek"), self.MW, {},
+                              "deepseek", -12.0, baseline, "deepseek_neg_balance")
+        assert row["mtd_cost_usd"] == 0.0  # top-up mid-month, never negative
+
+
+class TestNeonWalker:
+    def test_sums_nested_metrics(self):
+        doc = {"periods": [{"consumption": [
+            {"data_transfer_bytes": 1_000_000_000, "compute_time_seconds": 3600},
+            {"data_transfer_bytes": 2_000_000_000, "written_data_bytes": 5},
+        ]}]}
+        sums: dict[str, float] = {}
+        index._sum_metrics(doc, sums)
+        assert sums["data_transfer_bytes"] == 3_000_000_000
+        assert sums["compute_time_seconds"] == 3600
+
+
+class TestFixedRows:
+    def test_config_only_subscription_row(self):
+        budgets = {"providers": {
+            "claude_max": {"label": "Claude Max", "fixed_monthly_usd": 200.0},
+            "aws": {"monthly_budget_usd": 100.0},  # live adapter key — skipped
+        }}
+        rows = index.fixed_rows(budgets, {"aws"})
+        assert len(rows) == 1
+        assert rows[0]["key"] == "claude_max"
+        assert rows[0]["status"] == "fixed"
+        assert rows[0]["mtd_cost_usd"] == 200.0
+
+
+# ---------------------------------------------------------------------------
+# Full handler run
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def env(monkeypatch):
+    budgets = {
+        "schema_version": 1,
+        "providers": {
+            "aws": {"monthly_budget_usd": 50.0},
+            "claude_max": {"label": "Claude Max 20x subscription",
+                           "fixed_monthly_usd": 200.0},
+            "github_org": {"included_minutes": 2000},
+        },
+    }
+    cost_jsonl = (json.dumps({"cost_usd": 1.25}) + "\n"
+                  + json.dumps({"cost_usd": 0.75}) + "\n"
+                  + json.dumps({"cost_usd": None}) + "\n").encode()
+    store: dict[str, bytes] = {
+        "config/expense_budgets.json": json.dumps(budgets).encode(),
+        "decision_artifacts/_cost_raw/2026-07-05/run1/agent1.jsonl": cost_jsonl,
+        "expenses/baselines/2026-07.json": json.dumps({
+            "schema_version": 1, "period": "2026-07",
+            "counters": {"openrouter_total_usage": 40.0, "deepseek_neg_balance": -20.0},
+            "as_of": {"openrouter_total_usage": "2026-07-01T00:15:00+00:00",
+                      "deepseek_neg_balance": "2026-07-01T00:15:00+00:00"},
+        }).encode(),
+    }
+    s3 = FakeS3(store)
+    ssm = FakeSSM({
+        index.SSM_OPENROUTER: "sk-or-xxx",
+        index.SSM_DEEPSEEK: "sk-ds-xxx",
+        index.SSM_NEON: "neon-xxx",
+        index.SSM_NEON_QUOTA_GB: "5",
+        index.SSM_GITHUB_PAT: "ghp-xxx",
+        # no ANTHROPIC_ADMIN_KEY → client-telemetry fallback path
+    })
+    monkeypatch.setattr(index, "boto3", FakeBoto3(s3, ssm, FakeCE()))
+    monkeypatch.setattr(index, "_now_utc", lambda: NOW)
+    monkeypatch.setattr(index, "_http_json", http_router({
+        "openrouter.ai/api/v1/credits": {
+            "data": {"total_credits": 50.0, "total_usage": 42.5}},
+        "api.deepseek.com/user/balance": {
+            "balance_infos": [{"currency": "USD", "total_balance": "15.00"}]},
+        "console.neon.tech": {"periods": [{"consumption": [
+            {"data_transfer_bytes": 3_000_000_000, "compute_time_seconds": 7200}]}]},
+        "organizations/nousergon/settings/billing/usage": {"usageItems": [
+            {"product": "Actions", "unitType": "Minutes", "quantity": 1400,
+             "netAmount": 0.0},
+            {"product": "Packages", "unitType": "GigabyteHours", "quantity": 10,
+             "netAmount": 1.5},
+        ]},
+        "users/cipher813/settings/billing/usage": RuntimeError(
+            "HTTP 403 from github: PAT lacks Plan scope"),
+        # legacy included-minutes probes: gone on the enhanced billing platform
+        "orgs/nousergon/settings/billing/actions": RuntimeError("HTTP 410"),
+        "users/cipher813/settings/billing/actions": RuntimeError("HTTP 410"),
+    }))
+    return s3, store
+
+
+def _rows_by_key(doc):
+    return {r["key"]: r for r in doc["providers"]}
+
+
+class TestHandler:
+    def test_full_run(self, env):
+        s3, store = env
+        result = index.handler({}, None)
+        assert result["period"] == "2026-07"
+
+        doc = json.loads(store["expenses/monthly/2026-07.json"])
+        assert json.loads(store["expenses/latest.json"]) == doc
+        rows = _rows_by_key(doc)
+
+        # AWS: grouped-service sum + CE forecast projection
+        assert rows["aws"]["mtd_cost_usd"] == pytest.approx(12.34)
+        assert rows["aws"]["projected_month_end_usd"] == pytest.approx(22.34)
+        assert rows["aws"]["pace"] == "under"  # 22.34 < 50 budget
+        assert rows["aws"]["detail"]["top_services_usd"]["AmazonEC2"] == pytest.approx(8.10)
+
+        # Anthropic: client-telemetry fallback sums cost_usd, tolerating nulls
+        ant = rows["anthropic_api"]
+        assert ant["source"] == "client_telemetry"
+        assert ant["mtd_cost_usd"] == pytest.approx(2.0)
+        assert "ANTHROPIC_ADMIN_KEY" in ant["note"]
+
+        # OpenRouter: lifetime-usage diff against the month baseline
+        assert rows["openrouter"]["mtd_cost_usd"] == pytest.approx(2.5)
+        assert rows["openrouter"]["detail"]["credits_remaining_usd"] == pytest.approx(7.5)
+
+        # DeepSeek: balance fell 20 → 15 ⇒ 5.0 spent
+        assert rows["deepseek"]["mtd_cost_usd"] == pytest.approx(5.0)
+
+        # Neon: 3 GB used at ~53% elapsed projects ~5.6 GB > 5 GB quota
+        neon = rows["neon"]
+        assert neon["quota"]["used"] == pytest.approx(3.0)
+        assert neon["quota"]["limit"] == 5.0
+        assert neon["pace"] == "over"
+
+        # GitHub org: minutes quota pacing (1400 @ 53% → ~2630 > 2000)
+        gh = rows["github_org"]
+        assert gh["quota"]["used"] == 1400
+        assert gh["pace"] == "over"
+        assert gh["mtd_cost_usd"] == pytest.approx(1.5)
+
+        # GitHub user: fenced error — recorded on the row, run continues
+        assert rows["github_user"]["status"] == "error"
+        assert "403" in rows["github_user"]["error"]
+
+        # Fixed row from budgets config
+        assert rows["claude_max"]["status"] == "fixed"
+        assert rows["claude_max"]["mtd_cost_usd"] == 200.0
+
+        # Totals: ok+fixed rows only; error row flags incomplete
+        assert doc["totals"]["incomplete"] is True
+        expected_mtd = 12.34 + 2.0 + 2.5 + 5.0 + 0.0 + 1.5 + 200.0
+        assert doc["totals"]["mtd_usd"] == pytest.approx(expected_mtd)
+
+        # First-of-day snapshot written with the raw counters
+        snap = json.loads(store["expenses/snapshots/2026-07-17.json"])
+        assert snap["counters"]["openrouter_total_usage"] == pytest.approx(42.5)
+
+    def test_budgets_missing_degrades_with_warning(self, env, monkeypatch):
+        s3, store = env
+        del store["config/expense_budgets.json"]
+        index.handler({}, None)
+        doc = json.loads(store["expenses/monthly/2026-07.json"])
+        assert any("budgets SSoT" in w for w in doc["warnings"])
+        assert _rows_by_key(doc)["aws"]["budget_usd"] is None
+
+    def test_baseline_established_on_first_run_of_month(self, env):
+        s3, store = env
+        del store["expenses/baselines/2026-07.json"]
+        index.handler({}, None)
+        base = json.loads(store["expenses/baselines/2026-07.json"])
+        assert base["counters"]["openrouter_total_usage"] == pytest.approx(42.5)
+        doc = json.loads(store["expenses/monthly/2026-07.json"])
+        row = _rows_by_key(doc)["openrouter"]
+        # Baseline was just established mid-month → MTD accrues from now,
+        # flagged via the measured-since note; no projection this early.
+        assert row["mtd_cost_usd"] == 0.0
+        assert "measured since 2026-07-17" in row["note"]
+        assert row["projected_month_end_usd"] is None
+
+    def test_all_providers_failing_raises(self, env, monkeypatch):
+        s3, store = env
+        monkeypatch.setattr(index, "_http_json",
+                            http_router({}))  # every HTTP call unrouted → raises
+        fail_ce = FakeCE()
+        fail_ce.get_cost_and_usage = lambda **kw: (_ for _ in ()).throw(RuntimeError("ce down"))
+        ssm = FakeSSM({index.SSM_GITHUB_PAT: "ghp-xxx", index.SSM_NEON: "n"})
+        # No budgets fixed rows either → zero ok rows ⇒ systemic failure raises.
+        del store["config/expense_budgets.json"]
+        monkeypatch.setattr(
+            index, "collect_anthropic",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("s3 down")))
+        monkeypatch.setattr(index, "boto3", FakeBoto3(s3, ssm, fail_ce))
+        with pytest.raises(RuntimeError, match="all provider adapters failed"):
+            index.handler({}, None)

--- a/infrastructure/lambdas/expense-collector/test_handler.py
+++ b/infrastructure/lambdas/expense-collector/test_handler.py
@@ -183,16 +183,26 @@ class TestDiffRow:
         assert row["mtd_cost_usd"] == 0.0  # top-up mid-month, never negative
 
 
-class TestNeonWalker:
-    def test_sums_nested_metrics(self):
-        doc = {"periods": [{"consumption": [
-            {"data_transfer_bytes": 1_000_000_000, "compute_time_seconds": 3600},
-            {"data_transfer_bytes": 2_000_000_000, "written_data_bytes": 5},
-        ]}]}
-        sums: dict[str, float] = {}
-        index._sum_metrics(doc, sums)
-        assert sums["data_transfer_bytes"] == 3_000_000_000
-        assert sums["compute_time_seconds"] == 3600
+class TestNeonPeriodPacing:
+    def test_period_aware_projection(self, monkeypatch):
+        """Neon's consumption period can start mid-calendar-month (plan
+        change) — pacing must use ITS bounds, not the calendar month's."""
+        monkeypatch.setattr(index, "_now_utc", lambda: NOW)
+        monkeypatch.setattr(index, "_http_json", http_router({
+            "/api/v2/projects/p1": {"project": {
+                "name": "nousergon", "data_transfer_bytes": 2_500_000_000,
+                "compute_time_seconds": 7200,
+                # Half the period elapsed at NOW (7/17 12:00): 2.5 GB → 5 GB
+                "consumption_period_start": "2026-07-14T12:00:00Z",
+                "consumption_period_end": "2026-07-20T12:00:00Z"}},
+            "/api/v2/projects": {"projects": [{"id": "p1"}]},
+        }))
+        mw = index._month_window(NOW)
+        row = index.collect_neon(mw, {}, {index.SSM_NEON: "k",
+                                          index.SSM_NEON_QUOTA_GB: "5"})
+        assert row["quota"]["used"] == pytest.approx(2.5)
+        assert row["quota"]["projected"] == pytest.approx(5.0)
+        assert row["pace"] is None or row["pace"] == "under"  # 5.0 !> 5 GB
 
 
 class TestFixedRows:
@@ -242,7 +252,8 @@ def env(monkeypatch):
         index.SSM_DEEPSEEK: "sk-ds-xxx",
         index.SSM_NEON: "neon-xxx",
         index.SSM_NEON_QUOTA_GB: "5",
-        index.SSM_GITHUB_PAT: "ghp-xxx",
+        index.SSM_GITHUB_TOKEN: "ghp-xxx",
+        index.SSM_GITHUB_USER_PAT: "ghp-user-xxx",
         # no ANTHROPIC_ADMIN_KEY → client-telemetry fallback path
     })
     monkeypatch.setattr(index, "boto3", FakeBoto3(s3, ssm, FakeCE()))
@@ -252,19 +263,25 @@ def env(monkeypatch):
             "data": {"total_credits": 50.0, "total_usage": 42.5}},
         "api.deepseek.com/user/balance": {
             "balance_infos": [{"currency": "USD", "total_balance": "15.00"}]},
-        "console.neon.tech": {"periods": [{"consumption": [
-            {"data_transfer_bytes": 3_000_000_000, "compute_time_seconds": 7200}]}]},
+        "/api/v2/projects/p1": {"project": {
+            "name": "nousergon", "data_transfer_bytes": 3_000_000_000,
+            "compute_time_seconds": 7200,
+            "consumption_period_start": "2026-07-01T00:00:00Z",
+            "consumption_period_end": "2026-08-01T00:00:00Z"}},
+        "/api/v2/projects": {"projects": [{"id": "p1"}]},
         "organizations/nousergon/settings/billing/usage": {"usageItems": [
             {"product": "Actions", "unitType": "Minutes", "quantity": 1400,
-             "netAmount": 0.0},
+             "netAmount": 0.0, "repositoryName": "alpha-engine-config"},
+            {"product": "Actions", "unitType": "Minutes", "quantity": 400,
+             "netAmount": 0.0, "repositoryName": "crucible-dashboard"},  # public → free
             {"product": "Packages", "unitType": "GigabyteHours", "quantity": 10,
-             "netAmount": 1.5},
+             "netAmount": 1.5, "repositoryName": "alpha-engine-config"},
         ]},
+        "orgs/nousergon/repos?type=private": [
+            {"name": "alpha-engine-config", "private": True}],
+        # user PAT present but the endpoint is down → fenced hard error row
         "users/cipher813/settings/billing/usage": RuntimeError(
-            "HTTP 403 from github: PAT lacks Plan scope"),
-        # legacy included-minutes probes: gone on the enhanced billing platform
-        "orgs/nousergon/settings/billing/actions": RuntimeError("HTTP 410"),
-        "users/cipher813/settings/billing/actions": RuntimeError("HTTP 410"),
+            "HTTP 500 from github: upstream error"),
     }))
     return s3, store
 
@@ -308,15 +325,17 @@ class TestHandler:
         assert neon["quota"]["limit"] == 5.0
         assert neon["pace"] == "over"
 
-        # GitHub org: minutes quota pacing (1400 @ 53% → ~2630 > 2000)
+        # GitHub org: quota counts PRIVATE-repo minutes only (1400, not the
+        # 1800 incl. public-free), paced 1400 @ 53% → ~2630 > 2000
         gh = rows["github_org"]
         assert gh["quota"]["used"] == 1400
+        assert gh["detail"]["total_actions_minutes_incl_public_free"] == 1800
         assert gh["pace"] == "over"
         assert gh["mtd_cost_usd"] == pytest.approx(1.5)
 
         # GitHub user: fenced error — recorded on the row, run continues
         assert rows["github_user"]["status"] == "error"
-        assert "403" in rows["github_user"]["error"]
+        assert "500" in rows["github_user"]["error"]
 
         # Fixed row from budgets config
         assert rows["claude_max"]["status"] == "fixed"
@@ -353,13 +372,28 @@ class TestHandler:
         assert "measured since 2026-07-17" in row["note"]
         assert row["projected_month_end_usd"] is None
 
+    def test_user_billing_404_without_user_pat_is_not_configured(self, env, monkeypatch):
+        """No fleet token can read cipher813's personal billing (verified live
+        2026-07-17): a 404 WITHOUT the dedicated user PAT param is a known
+        credential gap, not an outage — must not pollute the error banner."""
+        s3, store = env
+        mw = index._month_window(NOW)
+        monkeypatch.setattr(index, "_http_json", http_router({
+            "users/cipher813/settings/billing/usage": RuntimeError(
+                "HTTP 404 from github: Not Found"),
+        }))
+        secrets = {index.SSM_GITHUB_TOKEN: "ghp-xxx"}  # no SSM_GITHUB_USER_PAT
+        row = index.collect_github(mw, {}, secrets, account="cipher813", kind="user")
+        assert row["status"] == "not_configured"
+        assert "Plan:read" in row["error"]
+
     def test_all_providers_failing_raises(self, env, monkeypatch):
         s3, store = env
         monkeypatch.setattr(index, "_http_json",
                             http_router({}))  # every HTTP call unrouted → raises
         fail_ce = FakeCE()
         fail_ce.get_cost_and_usage = lambda **kw: (_ for _ in ()).throw(RuntimeError("ce down"))
-        ssm = FakeSSM({index.SSM_GITHUB_PAT: "ghp-xxx", index.SSM_NEON: "n"})
+        ssm = FakeSSM({index.SSM_GITHUB_TOKEN: "ghp-xxx", index.SSM_NEON: "n"})
         # No budgets fixed rows either → zero ok rows ⇒ systemic failure raises.
         del store["config/expense_budgets.json"]
         monkeypatch.setattr(


### PR DESCRIPTION
## What

New `infrastructure/lambdas/expense-collector/` — one normalized monthly spend/quota rollup for every external service Nous Ergon pays for, consumed by the console's new **Expenses** page (crucible-dashboard PR, separate).

Per twice-daily run (00:15/12:15 UTC EventBridge):
- **AWS** — Cost Explorer MTD unblended cost (by-service detail) + CE month-end forecast
- **Anthropic API** — Admin-API cost report when `/alpha-engine/expenses/ANTHROPIC_ADMIN_KEY` exists; until then research-fleet client telemetry (`decision_artifacts/_cost_raw/`) fallback, flagged on the row
- **OpenRouter / DeepSeek** — lifetime-usage / balance counters diffed against a first-run-of-month baseline (`expenses/baselines/`)
- **Neon** — per-project consumption counters (free-tier-compatible; `consumption_history` is Scale-plan-only, verified live) vs the 5 GB transfer quota, paced against Neon's own consumption period
- **GitHub org + user** — enhanced billing usage: billed $ across all products + **private-repo** Actions minutes vs included quota (public-free minutes kept in detail; live data showed 3.1k private vs 35k total — an unfiltered count overstates ~17x)
- **Flat subscriptions** — any `fixed_monthly_usd` entry in the budgets SSoT renders a row with no code change (Claude Max today)

Budgets/quotas SSoT: `s3://alpha-engine-research/config/expense_budgets.json` (seeded from the included `expense_budgets.seed.json`). Outputs: `expenses/latest.json` + `expenses/monthly/{YYYY-MM}.json` + baselines/snapshots.

Failure posture: per-provider fencing — an adapter error is recorded on its row (status=error, rendered red by the console) and excluded from totals (`totals.incomplete`); handler raises only if budgets + every adapter fail together or the artifact write fails.

## Deploy state (nothing left post-merge)

Already applied live in-session: IAM role/policy + Lambda + EventBridge schedule (`deploy.sh --bootstrap`), budgets SSoT seeded, **three successful live invocations** — `expenses/latest.json` is live with 8 provider rows, zero errors ($256.89 MTD / $366.96 projected for 2026-07). Merge auto-deploys code via the new path-filtered `deploy-expense-collector.yml` (same pattern as deploy-usage-pace-alert).

Operator follow-ups filed on alpha-engine-config (Anthropic admin key; cipher813 billing PAT; budget values) — see issue refs in the session summary.

## Tests

16 handler unit tests (month-window/pacing math, diff-baselines, Neon period pacing, private-repo quota filter, error fencing, full fake-boto3 handler run) via the shared `run_handler_tests.sh` invariant; repo suite 3435 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)