### PR TITLE
feat(overseer): route Wednesday canary drills through the router (I2832)

### DIFF
--- a/infrastructure/lambdas/_shared/ensure_overseer_scheduler_role.sh
+++ b/infrastructure/lambdas/_shared/ensure_overseer_scheduler_role.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ensure_overseer_scheduler_role.sh — idempotently ensure the ONE shared
+# EventBridge Scheduler role that invokes the Overseer router
+# (alpha-engine-config-I2832). Every router-targeting schedule uses this
+# single role instead of a per-schedule bespoke one:
+#   - the twice-daily alert-drain schedules (created by
+#     alert-drain-dispatcher/deploy.sh --bootstrap)
+#   - the Wednesday sf-watch + ci-watch canary drills (re-pointed at the
+#     router by their dispatchers' deploy.sh --bootstrap)
+# Jointly owned: whichever --bootstrap runs first creates it; the rest find
+# it present. put-role-policy is unconditional so the invoke grant self-heals.
+#
+# Usage:  ROLE_ARN=$(ensure_overseer_scheduler_role "<region>" "<account_id>" run)
+#   Pass the caller's dry-run-aware `run` function name as $3 so create/put
+#   honor --dry-run (the get-role probe is always a real read). Echoes the
+#   role ARN on stdout regardless.
+ensure_overseer_scheduler_role() {
+  local region="$1" account_id="$2" runner="${3:-}"
+  local role_name="alpha-engine-overseer-scheduler-role"
+  local policy_name="invoke-overseer-dispatcher"
+  local router_arn="arn:aws:lambda:${region}:${account_id}:function:alpha-engine-overseer-dispatcher"
+  local role_arn="arn:aws:iam::${account_id}:role/${role_name}"
+  local trust='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  local invoke_policy="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"${router_arn}\"}]}"
+  _eosr_run() { if [ -n "$runner" ]; then "$runner" "$@"; else "$@"; fi; }
+  if ! aws iam get-role --role-name "$role_name" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating shared Overseer scheduler role: ${role_name}" >&2
+    _eosr_run aws iam create-role --role-name "$role_name" \
+      --assume-role-policy-document "$trust" \
+      --description "Shared EventBridge Scheduler role: invoke the Overseer router (alpha-engine-config-I2832)" \
+      --query 'Role.RoleName' --output text >/dev/null
+  else
+    echo "  Shared Overseer scheduler role exists: ${role_name}" >&2
+  fi
+  _eosr_run aws iam put-role-policy --role-name "$role_name" \
+    --policy-name "$policy_name" --policy-document "$invoke_policy" >&2
+  echo "$role_arn"
+}

--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -42,15 +42,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-ci-watch-dispatcher"
 ROLE_NAME="alpha-engine-ci-watch-dispatcher-role"
 POLICY_NAME="alpha-engine-ci-watch-dispatcher-policy"
-# Role EventBridge Scheduler assumes to fire the weekly canary drill
-# (config#2223). Created in --bootstrap only; may ONLY invoke THIS function.
-# (sf-watch-spot-dispatcher reuses its existing defer-scheduler role for the
-# same purpose; ci-watch has no prior scheduler role, hence a dedicated one.)
-CANARY_SCHED_ROLE_NAME="alpha-engine-ci-watch-canary-scheduler-role"
-CANARY_SCHED_POLICY_NAME="invoke-ci-watch-dispatcher"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
-CANARY_SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${CANARY_SCHED_ROLE_NAME}"
+# The Wednesday canary drill now fires THROUGH the Overseer router
+# (alpha-engine-config-I2832) using the shared router-invoke scheduler role,
+# so it exercises the full production dispatch path (router -> registry ->
+# executor). The old dedicated alpha-engine-ci-watch-canary-scheduler-role is
+# RETIRED by this change — its only consumer was the direct-to-executor drill
+# schedule; the live role is orphaned and can be deleted (noted in the PR).
+OVERSEER_ROUTER_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:alpha-engine-overseer-dispatcher"
+source "${SCRIPT_DIR}/../_shared/ensure_overseer_scheduler_role.sh"
 # Bootstrap default (first-time deployment only) — sets CI_WATCH_DISPATCH_ENABLED=true
 # as the safe default. The update path (step 3) will read the live value and preserve it.
 LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,CI_WATCH_DISPATCH_ENABLED=true}'
@@ -169,37 +170,22 @@ if $BOOTSTRAP; then
     echo "  Lambda exists, code will be updated in step 3"
   fi
 
-  # --- 2c. Weekly canary drill schedule (config#2223) ---
-  # Exercises the WHOLE dispatch pipe (Lambda IAM -> scoped RunInstances ->
-  # SSM -> bootstrap start) without a real CI failure. The box short-circuits
-  # before the agent and writes the _canary heartbeat the Fleet Status page
-  # escalates on when missed. 30 min after the sf-watch drill (15:00 UTC) so
-  # the two drills never contend. Idempotent create-or-update, mirrors
-  # sf-watch-liveness-probe/deploy.sh's scheduler style.
-  CANARY_SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
-  if ! aws iam get-role --role-name "${CANARY_SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
-    echo "  Creating Scheduler execution role: ${CANARY_SCHED_ROLE_NAME}"
-    run aws iam create-role --role-name "${CANARY_SCHED_ROLE_NAME}" \
-      --assume-role-policy-document "${CANARY_SCHED_TRUST}" \
-      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} for the weekly canary drill (config#2223)" \
-      --query 'Role.RoleName' --output text
-  else
-    echo "  Scheduler execution role exists: ${CANARY_SCHED_ROLE_NAME}"
-  fi
-  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
-  CANARY_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":[\"${FN_ARN}\",\"${FN_ARN}:*\"]}]}"
-  echo "  Applying Scheduler invoke policy: ${CANARY_SCHED_POLICY_NAME}"
-  run aws iam put-role-policy --role-name "${CANARY_SCHED_ROLE_NAME}" \
-    --policy-name "${CANARY_SCHED_POLICY_NAME}" \
-    --policy-document "${CANARY_INVOKE_POLICY}"
-  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+  # --- 2c. Weekly canary drill schedule (config#2223; routed via I2832) ---
+  # Exercises the WHOLE production dispatch pipe (router -> registry lookup ->
+  # executor Lambda IAM -> scoped RunInstances -> SSM -> bootstrap start)
+  # without a real CI failure — the SAME path every real ci-main-failure takes
+  # since I2823. The box short-circuits before the agent and writes the
+  # _canary heartbeat the Fleet Status page escalates on when missed. 30 min
+  # after the sf-watch drill (15:00 UTC) so the two drills never contend.
+  OVERSEER_SCHED_ROLE_ARN=$(ensure_overseer_scheduler_role "${REGION}" "${ACCOUNT_ID}" run)
+  if ! $DRY_RUN; then echo "  Waiting 10s for scheduler role propagation..."; sleep 10; fi
 
   CANARY_SCHED_NAME="alpha-engine-ci-watch-canary-drill-weekly"
   CANARY_CRON="cron(30 15 ? * WED *)"
-  # Static Input: the drill's ENTIRE identity (repo/sha/run_id/...) is
-  # synthesized in index.py so no payload can carry a real (repo, sha) into
-  # a drill (see index.py DRILL_REPO isolation invariant).
-  CANARY_TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${CANARY_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"is_drill\\\":\\\"true\\\"}\"}"
+  # Target is the ROUTER: the drill's ENTIRE identity (repo/sha/run_id/...) is
+  # still synthesized in the executor's index.py (DRILL_REPO isolation
+  # invariant), so the wrapped payload carries only {is_drill:true}.
+  CANARY_TARGET="{\"Arn\":\"${OVERSEER_ROUTER_ARN}\",\"RoleArn\":\"${OVERSEER_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"playbook\\\":\\\"ci-watch\\\",\\\"payload\\\":{\\\"is_drill\\\":\\\"true\\\"}}\"}"
   if aws scheduler get-schedule --name "${CANARY_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
     echo "  Updating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
     run aws scheduler update-schedule --name "${CANARY_SCHED_NAME}" \

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -54,6 +54,13 @@ DEFER_ROLE_NAME="alpha-engine-sf-watch-defer-scheduler-role"
 DEFER_POLICY_NAME="alpha-engine-sf-watch-defer-scheduler-policy"
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# The Wednesday canary drill now fires THROUGH the Overseer router
+# (alpha-engine-config-I2832), so the full production dispatch path — the one
+# every real dispatch takes since I2823 — is what the drill exercises, not
+# just this executor's launch leg. Router ARN + the shared router-invoke
+# scheduler role (created idempotently below).
+OVERSEER_ROUTER_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:alpha-engine-overseer-dispatcher"
+source "${SCRIPT_DIR}/../_shared/ensure_overseer_scheduler_role.sh"
 DEFER_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${DEFER_ROLE_NAME}"
 # Launch-config pins (config#2265): the DEPLOYED env is the observable source
 # of truth the sf-watch-liveness-probe reads (it verifies these AMI/SG/subnet
@@ -215,25 +222,31 @@ EOF
     echo "  Lambda exists, code will be updated in step 3"
   fi
 
-  # --- 2c. Weekly canary drill schedule (config#2223) ---
-  # Exercises the WHOLE dispatch pipe (Lambda IAM -> scoped RunInstances ->
-  # SSM -> bootstrap start) without a real SF failure. The box short-circuits
-  # before the agent and writes the _canary heartbeat the Fleet Status page
-  # escalates on when missed. Reuses the defer-scheduler role (created in 2a2
-  # above) — its policy is exactly "invoke THIS function", which is all the
-  # canary schedule needs; no new role. Idempotent create-or-update, mirrors
-  # sf-watch-liveness-probe/deploy.sh's scheduler style.
+  # --- 2c-pre. Shared router-invoke scheduler role (I2832) ---
+  OVERSEER_SCHED_ROLE_ARN=$(ensure_overseer_scheduler_role "${REGION}" "${ACCOUNT_ID}" run)
+  if ! $DRY_RUN; then echo "  Waiting 10s for scheduler role propagation..."; sleep 10; fi
+
+  # --- 2c. Weekly canary drill schedule (config#2223; routed via I2832) ---
+  # Exercises the WHOLE production dispatch pipe (router -> registry lookup ->
+  # executor Lambda IAM -> scoped RunInstances -> SSM -> bootstrap start)
+  # without a real SF failure — the SAME path every real saturday-sf-failure
+  # takes since I2823. The box short-circuits before the agent and writes the
+  # _canary heartbeat the Fleet Status page escalates on when missed. Uses the
+  # shared router-invoke scheduler role (2c-pre), NOT the defer-scheduler role
+  # (which stays scoped to its real defer-not-drop self-reinvoke purpose).
   CANARY_SCHED_NAME="alpha-engine-sf-watch-canary-drill-weekly"
   CANARY_CRON="cron(0 15 ? * WED *)"
-  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
   # Static Input: run_date is deliberately ABSENT — the handler ALWAYS
   # synthesizes a drill-scoped run_date (drill-YYYY-MM-DD) so no payload can
   # carry a real run_date into a drill (see index.py DRILL_RUN_DATE_PREFIX).
   # The execution_arn is synthetic but ARN-shaped (allowlist-valid); the
   # drill never touches it.
+  # Target is the ROUTER (I2832): the drill payload is wrapped in the
+  # {playbook, payload} router envelope so the drill traverses router ->
+  # registry lookup -> executor, exactly as a real saturday-sf-failure does.
   CANARY_TARGET=$(python3 - <<PY
 import json
-payload = {
+drill_payload = {
     "is_drill": "true",
     "pipeline_name": "ne-weekly-freshness-pipeline",
     "cadence_slug": "saturday",
@@ -241,9 +254,9 @@ payload = {
     "cause": "synthetic weekly canary drill of the dispatch pipe (config#2223) - not a real failure",
 }
 print(json.dumps({
-    "Arn": "${FN_ARN}",
-    "RoleArn": "${DEFER_ROLE_ARN}",
-    "Input": json.dumps(payload),
+    "Arn": "${OVERSEER_ROUTER_ARN}",
+    "RoleArn": "${OVERSEER_SCHED_ROLE_ARN}",
+    "Input": json.dumps({"playbook": "sf-watch", "payload": drill_payload}),
 }))
 PY
 )


### PR DESCRIPTION
## What

alpha-engine-config-I2832 (Overseer arc, un-gated by PR904's merge). The two Wednesday canary drills — sf-watch (15:00 UTC) and ci-watch (15:30 UTC) — now fire **through `alpha-engine-overseer-dispatcher`** with playbook-wrapped payloads, instead of invoking the executor Lambdas directly.

**Why:** since I2823, every real dispatch flows router → registry lookup → executor. The drills were still hitting the executors directly, so a drill could green-light the executor leg while the **router leg was silently broken** — exactly the gap canary drills exist to close. Now the drills exercise the full production path.

- **New `_shared/ensure_overseer_scheduler_role.sh`** — one idempotent helper for the shared router-invoke scheduler role, sourced by both dispatchers (the alert-drain dispatcher created the role; sf/ci now consume it — rule of three).
- **sf-watch** canary uses the shared role (not the defer-scheduler role, which stays scoped to its real defer-not-drop self-reinvoke purpose).
- **ci-watch's** dedicated `alpha-engine-ci-watch-canary-scheduler-role` is **retired** — its only consumer was the direct-to-executor drill; `deploy.sh` no longer creates it and the orphaned live role was deleted.

## Deploy state

**Applied live 2026-07-17** (both schedules re-pointed via `update-schedule`, verified targeting the router + shared role + wrapped payloads; orphaned role deleted). Merge-button rule satisfied — no post-merge steps.

**Verification:** the exact router→drill payloads were already proven live end-to-end this session (router→sf-watch and router→ci-watch drills each launched + self-terminated a spot box). The scheduler-role→router leg (the one new seam) gets its first real EventBridge-Scheduler trigger at tonight's 22:00 UTC drain schedule — same role, same target — with drill-heartbeat monitoring (missed heartbeat escalates on Fleet Status) as the backstop. Next Wednesday's drills are the CI/sf-specific confirmation.

## Testing

- `bash -n` clean on all three scripts; both `--bootstrap --dry-run` paths produce correct router-targeted schedules.
- `test_sf_watch_deploy_flag_preserve` + `test_overseer_playbook_registry` + `test_lambda_handler_canary_skipped`: 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)