### PR TITLE
fix(expense-collector): AWS projected-month-end double-counted MTD into the CE forecast

### DIFF
--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -428,8 +428,12 @@ def collect_neon(mw: dict, budgets: dict, secrets: dict) -> dict:
                 "compute_hours": round(sums.get("compute_time_seconds", 0.0) / 3600, 2),
                 "written_gb": round(sums.get("written_data_bytes", 0.0) / 1e9, 3),
                 "consumption_period": f"{period_start} → {period_end}"},
-        note="free plan — the binding constraint is the transfer quota, not $"
-             if not _fixed_usd(budgets, "neon") else None,
+        # Prefer an operator note from the budgets SSoT (e.g. a temporary
+        # paid-plan explanation) so what the operator recorded reaches the page;
+        # fall back to the free-plan default only when no cost is configured.
+        note=_cfg_note(budgets, "neon")
+             or ("free plan — the binding constraint is the transfer quota, not $"
+                 if not _fixed_usd(budgets, "neon") else None),
     )
     row["budget_usd"] = _budget_usd(budgets, "neon")
     return row
@@ -522,6 +526,13 @@ def _private_repo_names(account: str, kind: str, headers: dict) -> set[str]:
         if len(batch) < 100:
             break
     return names
+
+
+def _cfg_note(budgets: dict, key: str) -> str | None:
+    """Operator-authored note for a provider from the budgets SSoT (surfaced on
+    the row so a manual explanation — e.g. a temporary plan change — reaches the
+    console)."""
+    return ((budgets.get("providers") or {}).get(key) or {}).get("note")
 
 
 def _included_minutes(budgets: dict, key: str) -> float | None:

--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -259,11 +259,18 @@ def collect_aws(mw: dict, budgets: dict) -> dict:
                detail={"top_services_usd": {k: round(v, 2) for k, v in top.items()}},
                note="Cost Explorer data lags ~24h")
     try:
+        # CE's MONTHLY-granularity forecast over a partial-month window returns
+        # the FULL month-end total (already includes actuals-to-date) — the
+        # exact figure AWS's own console "forecasted month-end" tile shows. Use
+        # it DIRECTLY; adding MTD double-counts spend-to-date (that bug made a
+        # $103.25 month-end read as $152.14). The DAILY-granularity forecast
+        # would instead return the remainder-only, but MONTHLY is what matches
+        # the console, so we anchor to the provider-authoritative number.
         fc = ce.get_cost_forecast(
             TimePeriod={"Start": end, "End": next_month.strftime("%Y-%m-%d")},
             Metric="UNBLENDED_COST", Granularity="MONTHLY")
-        row["projected_month_end_usd"] = round(mtd + float(fc["Total"]["Amount"]), 2)
-        row["detail"]["projection_source"] = "ce_forecast"
+        row["projected_month_end_usd"] = round(float(fc["Total"]["Amount"]), 2)
+        row["detail"]["projection_source"] = "ce_forecast_monthly"
     except Exception as exc:  # noqa: BLE001 — forecast is an enhancement; the
         # straight-line fallback below is the recorded degradation surface.
         logger.info("CE forecast unavailable (straight-line fallback): %s", exc)

--- a/infrastructure/lambdas/expense-collector/test_handler.py
+++ b/infrastructure/lambdas/expense-collector/test_handler.py
@@ -97,7 +97,9 @@ class FakeCE:
     def get_cost_forecast(self, **kw):
         if self.fail_forecast:
             raise RuntimeError("forecast unavailable")
-        return {"Total": {"Amount": "10.00"}}
+        # MONTHLY-granularity forecast returns the FULL month-end total (already
+        # includes MTD), NOT the remainder — this is the AWS-console figure.
+        return {"Total": {"Amount": "25.00"}}
 
 
 class FakeBoto3:
@@ -300,10 +302,13 @@ class TestHandler:
         assert json.loads(store["expenses/latest.json"]) == doc
         rows = _rows_by_key(doc)
 
-        # AWS: grouped-service sum + CE forecast projection
+        # AWS: grouped-service sum + CE MONTHLY forecast used DIRECTLY as the
+        # month-end total (NOT mtd+forecast — that double-counted; see
+        # fix/expense-aws-forecast-double-count). Forecast 25.00 > MTD 12.34.
         assert rows["aws"]["mtd_cost_usd"] == pytest.approx(12.34)
-        assert rows["aws"]["projected_month_end_usd"] == pytest.approx(22.34)
-        assert rows["aws"]["pace"] == "under"  # 22.34 < 50 budget
+        assert rows["aws"]["projected_month_end_usd"] == pytest.approx(25.00)
+        assert rows["aws"]["detail"]["projection_source"] == "ce_forecast_monthly"
+        assert rows["aws"]["pace"] == "under"  # 25.00 < 50 budget
         assert rows["aws"]["detail"]["top_services_usd"]["AmazonEC2"] == pytest.approx(8.10)
 
         # Anthropic: client-telemetry fallback sums cost_usd, tolerating nulls

--- a/infrastructure/lambdas/expense-collector/test_handler.py
+++ b/infrastructure/lambdas/expense-collector/test_handler.py
@@ -206,6 +206,25 @@ class TestNeonPeriodPacing:
         assert row["quota"]["projected"] == pytest.approx(5.0)
         assert row["pace"] is None or row["pace"] == "under"  # 5.0 !> 5 GB
 
+    def test_operator_note_and_fixed_cost_surface(self, monkeypatch):
+        """A budgets note + fixed_monthly_usd (e.g. temporary paid plan) must
+        reach the row — the fixed-cost branch used to blank the note."""
+        monkeypatch.setattr(index, "_now_utc", lambda: NOW)
+        monkeypatch.setattr(index, "_http_json", http_router({
+            "/api/v2/projects/p1": {"project": {"name": "nousergon",
+                "data_transfer_bytes": 8_000_000,
+                "consumption_period_start": "2026-07-01T00:00:00Z",
+                "consumption_period_end": "2026-08-01T00:00:00Z"}},
+            "/api/v2/projects": {"projects": [{"id": "p1"}]},
+        }))
+        budgets = {"providers": {"neon": {
+            "fixed_monthly_usd": 19.0, "note": "Launch plan — TEMPORARY"}}}
+        row = index.collect_neon(index._month_window(NOW), budgets,
+                                 {index.SSM_NEON: "k"})
+        assert row["mtd_cost_usd"] == 19.0
+        assert row["projected_month_end_usd"] == 19.0
+        assert row["note"] == "Launch plan — TEMPORARY"
+
 
 class TestFixedRows:
     def test_config_only_subscription_row(self):


### PR DESCRIPTION
## Bug

The console Expenses page showed AWS **$152.14** projected month-end while AWS's own console forecasts **$103.25**. Root cause: CE `get_cost_forecast` at `Granularity=MONTHLY` over a partial-month window returns the **full month-end total** (already includes spend-to-date) — the exact number AWS's console shows. The adapter added MTD on top of it, double-counting.

Verified live (account 711398986525, 2026-07-17):
- MTD actual: $48.89
- CE forecast, MONTHLY granularity: **$103.25** ← full month-end total (= AWS console)
- CE forecast, DAILY granularity: $54.36 ← true remainder
- $48.89 + $54.36 = $103.25 ✓ — confirms MONTHLY already includes MTD

## Fix

Use the MONTHLY forecast value **directly** as `projected_month_end_usd` (anchor to the provider-authoritative figure), instead of `mtd + forecast`. `projection_source` renamed `ce_forecast_monthly` for traceability. Straight-line fallback (when the forecast call fails) is unchanged and correct — it extrapolates MTD, no double-count.

This is an instance of the general principle for keeping the page in sync: **anchor each row to the provider's own reported number; never recompute what the provider already publishes.**

## Tests

16 collector handler tests (FakeCE forecast now models a full-month total > MTD; asserts projected == forecast, not mtd+forecast). Full data suite: 3455 passed locally. Merging auto-deploys via `deploy-expense-collector.yml` and the next run corrects the live `expenses/latest.json` AWS row to ~$103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)