### PR TITLE
cost: migrate groom-spot to Graviton (t4g/arm64) — cost-I2864 Phase 1

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -95,11 +95,15 @@ BACKLOG_REPOS = (
 _RESEARCH_BUCKET = "alpha-engine-research"
 
 # ── Spot launch config (env-overridable; defaults mirror spot_data_weekly.sh) ──
-# t3/t3a/t2 .medium (4 GB) across all 6 default-VPC subnets; the lib CLI rotates
-# on capacity error. Cheap-first type order biases pool selection toward price.
+# t4g .medium/.large (arm64/Graviton) across all 6 default-VPC subnets; the lib
+# CLI rotates on capacity error. Cheap-first type order biases toward price.
+# Graviton is ~20% cheaper than the prior t3.medium at equal perf and the Compute
+# Savings Plan (instance-family-agnostic) already covers it — cost-I2864. CRITICAL:
+# every type here MUST be arm64 to match the arm64 AMI below — an arm64 AMI will
+# not boot on an x86 instance type (and vice-versa).
 INSTANCE_TYPES = [
     t.strip()
-    for t in os.environ.get("GROOM_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium").split(",")
+    for t in os.environ.get("GROOM_INSTANCE_TYPES", "t4g.medium,t4g.large").split(",")
     if t.strip()
 ]
 SUBNETS = [
@@ -111,7 +115,7 @@ SUBNETS = [
     ).split(",")
     if s.strip()
 ]
-AMI_ID = os.environ.get("GROOM_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+AMI_ID = os.environ.get("GROOM_AMI_ID", "ami-02e447f4c654c7179")  # Amazon Linux 2023 arm64/Graviton (cost-I2864)
 KEY_NAME = os.environ.get("GROOM_KEY_NAME", "alpha-engine-key")
 SECURITY_GROUP = os.environ.get("GROOM_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
 IAM_PROFILE = os.environ.get("GROOM_IAM_PROFILE", "alpha-engine-executor-profile")


### PR DESCRIPTION
## What

Migrate the **groom-spot** box from x86 to **Graviton / arm64** — Phase 1 of the staged spot-fleet Graviton migration (cost-I2864).

`scheduled-groom-dispatcher/index.py` defaults:
- `GROOM_INSTANCE_TYPES`: `t3.medium,t3a.medium,t2.medium` → `t4g.medium,t4g.large`
- `GROOM_AMI_ID`: `ami-0c421724a94bba6d6` (AL2023 x86_64) → `ami-02e447f4c654c7179` (AL2023 arm64)

## Why

~20% cheaper at equal performance. The existing Compute Savings Plan (`9efd5f67-…`) is **instance-family-agnostic**, so it covers arm64 with zero re-purchase. Groom-spot is the highest-frequency box in the spot fleet (3 triggers/day), so it captures most of the fleet saving at the lowest risk.

## arm64 safety (verified)

- Box bootstrap (`alpha-engine-config/infrastructure/groom_spot_bootstrap.sh`) installs everything via `dnf` (arch-resolving: `git`, `python3.12`, `nodejs`, `npm`, `gh`) + `npm install -g @anthropic-ai/claude-code` (pure JS, arm64-native). **No `uname -m`-gated logic, no hardcoded-x86 binary/tarball pulls.**
- Target AMI verified live: `al2023-ami-…-arm64`, `Architecture=arm64`, `State=available`, EBS root, SSM-agent preinstalled (AL2023 default).
- **Correctness invariant** (added as a code comment): the AMI arch and *every* `INSTANCE_TYPES` entry must be arm64 together — an arm64 AMI won't boot on an x86 instance type. Both types here are arm64.

## Deploy & effect

- Merging auto-deploys the Lambda **code** via `deploy-scheduled-groom-dispatcher.yml` (push→main, code-only, no IAM/schedule change). **Merge button is the last action — no post-merge step.**
- Lambda env for these keys is unset, so the code default is the live value. Takes effect on the **next scheduled groom run** (01:00 / 07:00 / 19:00 UTC), which is the Phase-1 validation: the box should boot a `t4g.medium` and complete a groom run green.
- **Rollback lever:** set Lambda env `GROOM_AMI_ID`/`GROOM_INSTANCE_TYPES` back to the x86 values (fast, no redeploy), or revert this PR.

## Scope

Phase 1 only. Probes (ci-watch/sf-watch/canary-replay/alert-drain/data-spot) and CI runners (config/metron/telos/vires) are deliberately **out of scope** — CI runners run arbitrary workflow steps that may assume x86 and need per-repo validation. Tracked in cost-I2864.

## Testing

`index.py` compiles clean (`py_compile`). The dispatcher's `test_handler.py` cannot run in this local checkout (missing CI-only deps: `nousergon-lib`, sibling Lambda modules `spot_dispatch`/`flow_doctor_telegram` are provided at CI/deploy time, not installed locally) — the full suite runs in `ci.yml`. The change is a two-literal default swap with no logic change.

Part of cost-I2864.
