### PR TITLE
feat: self-hosted GHA runner dispatchers for morning-signal, mnemon, krepis

### DIFF
--- a/infrastructure/lambdas/krepis-runner-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/krepis-runner-dispatcher/deploy.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the krepis-runner-dispatcher Lambda.
+#
+# WHY: mirrors nousergon/alpha-engine-config's self-hosted-runner dispatcher
+# (alpha-engine-config-I2572) verbatim in mechanism, re-namespaced for krepis.
+# A live billing-usage audit (2026-07-17) found krepis among the largest
+# non-alpha-engine-config private-repo GHA-minute consumers (~401 min in
+# July alone) after the org crossed its 3,000-min included-Actions-minute
+# line for the month. This Lambda receives GitHub's `workflow_job` webhook directly
+# (a Function URL, not a `lambda invoke` from a GHA job — there is no
+# GHA-hosted leg left to invoke it once the target workflows' runs-on points
+# at a self-hosted runner) and launches an EC2-spot box that registers as an
+# EPHEMERAL self-hosted runner for exactly one queued job, then
+# self-terminates. --bootstrap creates: (1) this Lambda's own execution role
+# + inline policy, (2) the Lambda function itself, (3) its public Function
+# URL + the resource policy allowing GitHub to invoke it.
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
+# (scoped to krepis-runner-executor-role — a NEW, dedicated role
+# a sibling agent is creating in krepis) + ssm:SendCommand +
+# ssm:GetParameter (its OWN webhook secret — unlike ci-watch-dispatcher, this
+# Lambda verifies GitHub's HMAC signature itself) + lambda:InvokeFunction on
+# itself (the two-phase webhook-receiver/worker self-invoke — see index.py's
+# module docstring for why the launch work cannot run inline in the
+# webhook-receiving invocation).
+#
+# Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
+# keeps the github-actions-lambda-deploy OIDC role's blast radius narrow.
+# This script's FLAGLESS run is code-only; --bootstrap is operator-only.
+#
+# POST-BOOTSTRAP MANUAL STEPS (cannot be automated via this script — see
+# alpha-engine-config-I2572/I2653, the source design, for the full
+# sequencing rationale):
+#   1. Create the SSM params this Lambda/box read:
+#        /krepis/runner/webhook_secret  (random string, shared
+#          with the GitHub webhook config below)
+#        /krepis/runner/github_pat  (fine-grained PAT, owner=
+#          nousergon, repo=krepis, Administration: Read and
+#          write + Contents: read — Administration:write is REQUIRED to mint
+#          runner registration tokens; the Actions permission does NOT cover
+#          this. Fine-grained PAT creation/scoping is a GitHub web-UI-only,
+#          human action — cannot be done via this script or the API.)
+#        /krepis/runner/github_read_pat  (SEPARATE fine-grained
+#          PAT, owner=nousergon, repo=krepis, Actions: Read
+#          ONLY — deliberately NOT the same PAT as above. This one is read
+#          by the Lambda's own execution role (behind a public Function URL)
+#          for the reconcile phase's read-only "list queued jobs" calls;
+#          keeping it separate and minimally-scoped means a Lambda-side
+#          issue can never expose Administration:write.)
+#   2. Register the GitHub webhook on nousergon/krepis:
+#        event: workflow_job, content type: json, secret: (the same value as
+#        the SSM param above), URL: this script's printed Function URL.
+#      Can be done via `gh api repos/nousergon/krepis/hooks`.
+#
+# Usage:
+#   bash .../krepis-runner-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../krepis-runner-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda + Function URL + reconcile schedule
+#   bash .../krepis-runner-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../krepis-runner-dispatcher/deploy.sh --smoke     # invoke the WORKER phase once with a synthetic job id (fires a REAL spot box)
+#   bash .../krepis-runner-dispatcher/deploy.sh --reconcile-test # invoke the RECONCILE phase once directly (read-only unless it finds a genuinely stale job)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="krepis-runner-dispatcher"
+ROLE_NAME="krepis-runner-dispatcher-role"
+POLICY_NAME="krepis-runner-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# Bootstrap default (first-time deployment only) — safe default ON, mirrors
+# every other fleet dispatcher's kill-switch convention.
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,KREPIS_RUNNER_DISPATCH_ENABLED=true}'
+
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
+# DRY_RUN honors an ambient env var (true/1/yes) as well as the --dry-run
+# flag below, so DRY_RUN=1/true from a caller's shell actually no-ops
+# instead of silently running the real deploy path (krepis-
+# I2752 incident, 2026-07-16: an operator assumed DRY_RUN=<env var> worked
+# here, matching other tools' convention, and triggered a real deploy).
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+SMOKE=false
+RECONCILE_TEST=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    --reconcile-test) RECONCILE_TEST=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+    if ! $DRY_RUN; then
+      aws lambda wait function-active --function-name "${FUNCTION_NAME}" --region "${REGION}"
+    fi
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2b. Function URL (GitHub webhooks can't sign SigV4 — auth is the
+  # handler's own HMAC verification against the shared webhook secret) ---
+  if ! aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --query 'FunctionUrl' --output text >/dev/null 2>&1; then
+    echo "  Creating Function URL (AuthType=NONE; handler-level HMAC verification is the real auth boundary)"
+    run aws lambda create-function-url-config \
+      --function-name "${FUNCTION_NAME}" \
+      --auth-type NONE \
+      --region "${REGION}" \
+      --query 'FunctionUrl' --output text
+    echo "  Granting public InvokeFunctionUrl permission"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "AllowPublicFunctionUrlInvoke" \
+      --action lambda:InvokeFunctionUrl \
+      --principal "*" \
+      --function-url-auth-type NONE \
+      --region "${REGION}" >/dev/null
+  else
+    echo "  Function URL already configured"
+  fi
+
+  if ! $DRY_RUN; then
+    FN_URL=$(aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --region "${REGION}" --query 'FunctionUrl' --output text)
+    echo ""
+    echo "  Function URL: ${FN_URL}"
+    echo "  -> register as the GitHub webhook target for nousergon/krepis"
+    echo "     (event: workflow_job, content type: json, secret: matches"
+    echo "     /krepis/runner/webhook_secret) — see this script's"
+    echo "     header for the full remaining manual steps."
+    echo ""
+  fi
+
+  # --- 2c. Reconcile backstop schedule (alpha-engine-config-I2653) ---
+  # A self-hosted runner registered via a plain registration token binds to
+  # the repo's WHOLE label pool, not the specific job that triggered its
+  # launch (GitHub has no per-job reservation API — verified against
+  # GitHub's own docs; an earlier JIT-runner-config fix attempt for this
+  # issue was wrong, JIT mints the same kind of "any matching job"
+  # registration, just more securely). Under concurrent load a dispatched
+  # runner can grab an unrelated queued job, permanently stranding the job
+  # that triggered its launch — GitHub sends `queued` exactly once per job.
+  # This EventBridge Scheduler rule invokes the Lambda's RECONCILE phase
+  # every 60s as a self-healing backstop; see index.py's module docstring
+  # phase 3 for the full mechanism.
+  RECONCILE_SCHED_ROLE_NAME="krepis-runner-reconcile-scheduler-role"
+  RECONCILE_SCHED_POLICY_NAME="invoke-krepis-runner-dispatcher"
+  RECONCILE_SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${RECONCILE_SCHED_ROLE_NAME}"
+  RECONCILE_SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${RECONCILE_SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${RECONCILE_SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME}'s reconcile phase every 60s (alpha-engine-config-I2653)" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${RECONCILE_SCHED_ROLE_NAME}"
+  fi
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  RECONCILE_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":[\"${FN_ARN}\",\"${FN_ARN}:*\"]}]}"
+  echo "  Applying Scheduler invoke policy: ${RECONCILE_SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+    --policy-name "${RECONCILE_SCHED_POLICY_NAME}" \
+    --policy-document "${RECONCILE_INVOKE_POLICY}"
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  RECONCILE_SCHED_NAME="krepis-runner-reconcile"
+  RECONCILE_TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${RECONCILE_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"reconcile\\\":true}\"}"
+  if aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  Updating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler update-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  else
+    echo "  Creating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler create-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  fi
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: Scheduler rule ${RECONCILE_SCHED_NAME} not found after create/update" >&2; exit 1; }
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment (preserving operator-owned KREPIS_RUNNER_DISPATCH_ENABLED)..."
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" KREPIS_RUNNER_DISPATCH_ENABLED true)
+LAMBDA_ENV="Variables={LOG_LEVEL=INFO,KREPIS_RUNNER_DISPATCH_ENABLED=${CURRENT_DISPATCH}}"
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment "${LAMBDA_ENV}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+# ----- 4. Smoke (synthetic worker-phase event, direct invoke) ---------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing the WORKER phase via direct invoke (synthetic job id)..."
+  echo "⚠ this fires a REAL spot box + REAL krepis_runner_spot_bootstrap.sh run."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"krepis_runner_job_id":"smoke-test-0"}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi
+
+# ----- 5. Reconcile test (synthetic reconcile-phase event, direct invoke) ---
+
+if $RECONCILE_TEST; then
+  echo ""
+  echo "Testing the RECONCILE phase via direct invoke..."
+  echo "Read-only unless it finds a genuinely stale (>90s) queued job with no in-flight box — in which case it dispatches a REAL spot box for it (which is the correct/intended behavior, not a side effect to worry about)."
+  RESP2=$(mktemp)
+  trap "rm -f '${RESP2}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"reconcile":true}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP2}" >/dev/null
+  cat "${RESP2}"
+  echo ""
+fi

--- a/infrastructure/lambdas/krepis-runner-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/krepis-runner-dispatcher/iam-policy.json
@@ -1,0 +1,150 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/krepis-runner-dispatcher:*"
+    },
+    {
+      "Sid": "ReadWebhookSecret",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/krepis/runner/webhook_secret"
+    },
+    {
+      "Sid": "ReadGithubReadOnlyPatForReconcileListing",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/krepis/runner/github_read_pat"
+    },
+    {
+      "Sid": "SelfInvokeAsyncForTwoPhaseDispatch",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:krepis-runner-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:krepis-runner-dispatcher:*"
+      ]
+    },
+    {
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "krepis-runner-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "krepis-runner-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassRunnerExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/krepis-runner-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunRunnerBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateRunnerSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "krepis-runner-spot"
+        }
+      }
+    },
+    {
+      "Sid": "EmitLaunchRateMetricSharedInfra",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "cloudwatch:namespace": "AlphaEngine/Infra"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/krepis-runner-dispatcher/index.py
+++ b/infrastructure/lambdas/krepis-runner-dispatcher/index.py
@@ -1,0 +1,915 @@
+"""krepis-runner-dispatcher — launch an EPHEMERAL GitHub Actions
+self-hosted runner on a dedicated EC2 spot box, once per queued CI/validation
+job in nousergon/krepis. Mirrors nousergon/alpha-engine-config's
+self-hosted-runner dispatcher (alpha-engine-config-I2572) verbatim in
+mechanism, re-namespaced for krepis.
+
+WHY: a hard GHA audit (2026-07-14) found krepis's own CI/
+validation workflows (scripts-tests.yml, changelog.yml, the validate-*.yaml
+set, etc.) — NOT the heavy agentic workloads ci-watch/sf-watch/groom already
+moved to spot — are now the dominant steady-state draw on the org's metered
+private-repo GHA-minutes quota (~1.6k min/30d projected, ~93% of all
+private-repo GHA spend fleet-wide). Those are frequent (dozens/day) and
+short-lived (<1 min avg) — a poor fit for the ci-watch/sf-watch pattern (a
+thin GHA-hosted dispatch leg synchronously invoking a Lambda that runs a
+bespoke script over SSM, outside the Actions protocol entirely): replicating
+that shape per-workflow would mean hand-rolling GitHub Checks-API status
+reporting ~13 times over. Registering a REAL ephemeral self-hosted runner is
+simpler AND more correct here — the existing workflow YAML (checkout,
+setup-python, pytest, etc.) is untouched, only `runs-on:` changes, and
+GitHub's own Actions service handles job dispatch + Check Run status
+natively, exactly as it does for hosted runners.
+
+MECHANISM (three-phase single Lambda, self-invoked async — see module-level
+`handler` for the branch):
+  1. WEBHOOK RECEIVER phase: GitHub calls this Lambda's Function URL directly
+     on every `workflow_job` event for krepis (repo-level
+     webhook, event type `workflow_job`). Verifies the HMAC signature, filters
+     to `action=queued` + our `krepis-spot` label, then
+     self-invokes ASYNC (`InvocationType=Event`) with a minimal worker
+     payload and returns 200 immediately. GitHub's webhook delivery timeout
+     is short (single-digit seconds) — the actual spot launch below can take
+     30-90s+, so it MUST NOT block the HTTP response, or every delivery would
+     show as a spurious timeout in GitHub's UI even though the box still
+     launches (Lambda execution isn't cancelled by a disconnected client, but
+     a clean signal matters for operability).
+  2. WORKER phase (the self-invoked async call): does the actual dispatch —
+     `spot_dispatch.launch_with_fallback()` (spot-first, on-demand fallback
+     on capacity exhaustion), wait for SSM-online, then an async detached SSM
+     command that clones krepis and `exec`s
+     `infrastructure/krepis_runner_spot_bootstrap.sh` (built by a sibling
+     agent in krepis) — which installs+registers the actual
+     `actions-runner` binary in `--ephemeral` mode, runs exactly one job, and
+     self-terminates (InstanceInitiatedShutdownBehavior=terminate + its own
+     on-box watchdog). Mirrors `ci-watch-dispatcher/index.py`'s
+     launch/wait/dispatch shape via the shared `nousergon_lib.spot_dispatch`
+     primitives (config#2106) — NOT reinvented here.
+  3. RECONCILE phase (EventBridge Scheduler, ~every 60s — config-I2653): a
+     self-hosted runner registered via a plain registration token binds to
+     the repo's WHOLE label pool, not the specific job that triggered its
+     launch — GitHub has no API to reserve a job for a not-yet-connected
+     runner (confirmed against GitHub's own docs before implementing this;
+     an earlier JIT-runner-config diagnosis for this issue was WRONG — JIT
+     is a more secure way to mint the same "any matching job" registration,
+     it does not bind to one job either). Under concurrent load a dispatched
+     runner can grab an unrelated queued job, leaving the job that triggered
+     its launch permanently stuck — GitHub sends the `queued` webhook exactly
+     ONCE per job, so there is no other path back to it without this backstop.
+     `_reconcile()` lists queued jobs matching our label that have sat queued
+     longer than `KREPIS_RUNNER_RECONCILE_STALE_SECONDS` with no in-flight
+     box (the existing job-id-tag dedup check), and dispatches a fresh runner
+     for each. Same "coverage beats dedupe" posture as the SpotProbeError
+     handling below — doesn't prevent the occasional mismatch, guarantees no
+     job stays stranded indefinitely.
+
+CIRCUIT BREAKER + FLEET CAP (2026-07-15 spot-quota-starvation incident,
+config#2697): the reconcile backstop above is intentionally unbounded in
+WHEN it fires (every stale queued job, every ~60s pass, forever) — that is
+its whole point (I2653). What it lacked was a bound on repeated launches
+for a job whose boxes keep failing identically, and a global ceiling on
+total fleet size. Both live in `_launch_krepis_runner_spot()` (the single
+chokepoint the webhook-worker path AND the reconcile path both funnel
+through, including the config#2267 dedupe_degraded "proceed anyway" path):
+a job at/over `KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB` launches (default 3,
+counting live+recently-terminated boxes) is abandoned (paged once, no
+further dispatch until a human/code-fix intervenes); the fleet overall is
+capped at `KREPIS_RUNNER_MAX_FLEET` running+pending boxes (default 6 = 12
+vCPUs, leaving >=20 of the account's 32-vCPU standard-spot quota for
+production) regardless of per-job attempt counts. A `AlphaEngine/Infra
+krepis_runner_launches` custom metric + CloudWatch alarm
+(infrastructure/setup_krepis_runner_launch_rate_alarm.sh) is the
+independent early-warning signal on launch RATE itself, since the incident
+ran ~3h with only a single quota-exhaustion page at the very end.
+
+CONCURRENCY LOCK: keyed on `Name=krepis-runner-spot` +
+`krepis-runner-job-id=<workflow_job.id>` — one job, one box, 1:1 (unlike
+ci-watch's repo+sha lock, a GitHub Actions job id is already the unique
+discriminator; no broader key needed). A duplicate `queued` delivery for the
+same job (GitHub webhooks are at-least-once) is a clean no-op skip.
+
+IAM PROFILE: `krepis-runner-executor-profile`, a NEW dedicated
+instance profile (infrastructure/iam/krepis-runner-executor-role-*.json in
+krepis) scoped to read exactly one SSM param (the runner-
+registration PAT) — deliberately not `alpha-engine-ci-watch-executor-profile`
+or any other existing profile, so this new/less-proven workload's blast
+radius stays contained. Every AWS credential the actual CI STEPS need (S3
+sync, OIDC role assumption, etc.) continues to flow through GitHub's own
+per-workflow OIDC mechanism, unrelated to this instance's own role.
+
+FAIL-SOFT ON THE WEBHOOK RECEIVER PHASE, FAIL-LOUD ON THE WORKER PHASE: an
+unrecognized/malformed webhook delivery is a clean 200 no-op (GitHub sends
+many event types/actions we don't care about — treating them as errors would
+just generate webhook-delivery noise for no reason). The worker phase mirrors
+ci-watch's SYNCHRONOUS-style clean-failure contract even though its own
+caller is async (nothing reads the return value) — CloudWatch Logs is the
+observability surface for worker-phase failures; a genuinely unexpected
+internal bug still propagates as a Python exception (visible as a Lambda
+error metric).
+
+Managed OUTSIDE CloudFormation (same as every other fleet dispatcher):
+operator-deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live
+effect until the new code + IAM + Function URL + GitHub webhook registration
+are applied AND the (separately-tracked, human-only) runner-registration PAT
+with Administration:write on krepis exists in SSM — see
+alpha-engine-config-I2572 (the original design this dispatcher mirrors)
+for the full rollout sequencing rationale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+import boto3
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotLaunchError, SpotProbeError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: KREPIS_RUNNER_DISPATCH_ENABLED=false disables the launch
+# without touching the GitHub webhook wiring — mirrors every other fleet
+# dispatcher's safety valve. Default ON.
+DISPATCH_ENABLED = os.environ.get("KREPIS_RUNNER_DISPATCH_ENABLED", "true").lower() == "true"
+
+TARGET_REPO_FULL_NAME = "nousergon/krepis"
+TARGET_LABEL = "krepis-spot"
+
+# ── Spot launch config (env-overridable; same default-VPC/AMI/security-group
+# as the fleet's other spot dispatchers — only the IAM profile + tag differ).
+# IAM LOCKSTEP (mirrors ci-watch-dispatcher): these defaults are ENUMERATED
+# in this Lambda's scoped ec2:RunInstances policy (sibling iam-policy.json).
+# Changing them without re-applying that policy makes RunInstances fail with
+# UnauthorizedOperation at the next dispatch. Keep them in sync.
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "KREPIS_RUNNER_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "KREPIS_RUNNER_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("KREPIS_RUNNER_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("KREPIS_RUNNER_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("KREPIS_RUNNER_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+IAM_PROFILE = os.environ.get(
+    "KREPIS_RUNNER_IAM_PROFILE", "krepis-runner-executor-profile"
+)
+VOLUME_SIZE_GB = int(os.environ.get("KREPIS_RUNNER_VOLUME_SIZE_GB", "30"))
+
+KREPIS_RUNNER_TAG_NAME = "krepis-runner-spot"
+KREPIS_RUNNER_JOB_ID_TAG_KEY = "krepis-runner-job-id"
+
+# ── Circuit breaker + fleet cap (2026-07-15 spot-quota-starvation incident,
+# alpha-engine-config#2697 — the incident this circuit breaker design was
+# originally built for; mirrored here unchanged) ──────────────────────────
+# With every runner box failing identically (a deprecated runner version —
+# tracked separately), _reconcile() relaunched a fresh box per stuck queued
+# job on every ~60s pass, FOREVER: ~150 t3.medium spot launches in 45 min,
+# ~16 concurrent boxes = 32 vCPUs = 100% of the account's standard-spot quota
+# (L-34B43A08, value 32). The post-close trading SF's data-spot launch then
+# failed MaxSpotInstanceCountExceeded at 20:00 UTC — CI must never be able to
+# starve production of spot quota. Two independent bounds, both enforced
+# inside _launch_krepis_runner_spot (the single chokepoint both the reactive
+# webhook-worker path AND the reconcile path funnel through — including the
+# config#2267 dedupe_degraded "proceed anyway" path, which is exactly where
+# an unbounded loop would otherwise re-open):
+#
+#   1. PER-JOB ATTEMPT LIMIT: once a job has had >= MAX_ATTEMPTS_PER_JOB boxes
+#      launched for it (live OR recently-terminated — a job whose boxes keep
+#      dying identically is exactly the runaway pattern), stop dispatching
+#      for THAT job and page once. Does not touch other jobs' dispatch, and
+#      does not disable the reconcile backstop itself (config-I2653 still
+#      recovers jobs whose one-shot `queued` webhook was consumed by a runner
+#      that grabbed a different job — this only bounds the RETRY count for a
+#      job that keeps failing).
+#   2. GLOBAL FLEET CAP: refuse to launch (for ANY job) once
+#      running+pending krepis-runner boxes >= MAX_FLEET, regardless of
+#      per-job attempt counts — the last-resort backstop against any launch
+#      pattern (not just the identical-failure one above) that could
+#      otherwise still saturate the account's spot quota.
+KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB = int(os.environ.get("KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB", "3"))
+# ~1h: describe-instances reliably still returns a terminated instance for
+# about this long after termination (AWS does not document an exact
+# retention SLA; this matches the window the issue's incident review
+# confirmed empirically and is env-tunable if that changes).
+KREPIS_RUNNER_ATTEMPT_LOOKBACK_SECONDS = int(
+    os.environ.get("KREPIS_RUNNER_ATTEMPT_LOOKBACK_SECONDS", "3600")
+)
+# 6 boxes = 12 vCPUs (t3/t3a/t2.medium = 2 vCPUs each), leaving >= 20 vCPUs of
+# the 32-vCPU account standard-spot quota (L-34B43A08) for production.
+KREPIS_RUNNER_MAX_FLEET = int(os.environ.get("KREPIS_RUNNER_MAX_FLEET", "6"))
+
+# Jobs that tripped the per-job attempt limit this cold start — logged/paged
+# once per job per cold start rather than once per reconcile pass (a stuck
+# job is still stale on every subsequent ~60s pass; repaging it every minute
+# forever would be exactly the "single quota page at the very end" alerting
+# failure mode this issue is also about, just for a different signal).
+_abandoned_job_ids_paged: set[str] = set()
+
+# ── Two-phase bootstrap state machine (2026-07-15 zombie-leak incident,
+# alpha-engine-config-I2692 — source incident for this two-phase bootstrap
+# design; mirrored here unchanged) ─────────────────────────────────────────
+# The launch path previously did wait_ssm_online (60-200s) + send_command
+# INSIDE this Lambda's 60s timeout — the Lambda died mid-wait, the box never
+# received its bootstrap, never registered a runner, and never self-
+# terminated (the terminate-on-failure except died with the Lambda). Under
+# the reconcile loop that manufactured a zombie box per minute until the
+# spot quota exhausted and ALL fleet CI queued (2026-07-15 17:33-18:40 UTC).
+# Now: launch TAGS the box and returns in seconds; every ~60s reconcile pass
+# delivers the bootstrap to any SSM-online box that lacks it (single
+# describe, zero waiting), reaps boxes whose bootstrap can't be delivered by
+# BOOTSTRAP_DEADLINE, and reaps any box alive past RUNNER_MAX_LIFETIME
+# regardless of state (the janitor: no leak class can ever eat the quota
+# silently again).
+KREPIS_RUNNER_BOOTSTRAP_SENT_TAG_KEY = "krepis-runner-bootstrap-sent"
+BOOTSTRAP_DEADLINE_SECONDS = int(os.environ.get("KREPIS_RUNNER_BOOTSTRAP_DEADLINE_SECONDS", "300"))
+RUNNER_MAX_LIFETIME_SECONDS = int(os.environ.get("KREPIS_RUNNER_MAX_LIFETIME_SECONDS", "5400"))
+
+# Loud page on quota exhaustion (the incident's silent failure mode: an hour
+# of CI paralysis visible only as ERROR log lines). Fleet-standard params.
+TELEGRAM_BOT_TOKEN_SSM = os.environ.get("KREPIS_RUNNER_TELEGRAM_BOT_TOKEN_SSM",
+                                        "/alpha-engine/TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID_SSM = os.environ.get("KREPIS_RUNNER_TELEGRAM_CHAT_ID_SSM",
+                                      "/alpha-engine/TELEGRAM_CHAT_ID")
+_page_sent_this_invocation = False
+
+
+def _page(message: str) -> None:
+    """Best-effort LOUD Telegram page (disable_notification=False — the
+    config-I2461 lesson: silent notifications get missed). Degrades to
+    log-only on any failure; at most one page per invocation to avoid a
+    reconcile loop spamming one page per queued job."""
+    global _page_sent_this_invocation
+    if _page_sent_this_invocation:
+        return
+    _page_sent_this_invocation = True
+    try:
+        ssm = boto3.client("ssm", region_name=REGION)
+        token = ssm.get_parameter(Name=TELEGRAM_BOT_TOKEN_SSM, WithDecryption=True)["Parameter"]["Value"]
+        chat_id = ssm.get_parameter(Name=TELEGRAM_CHAT_ID_SSM, WithDecryption=True)["Parameter"]["Value"]
+        req = urllib.request.Request(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=json.dumps({"chat_id": chat_id, "text": message,
+                             "disable_notification": False}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=10).read()
+    except Exception as exc:  # noqa: BLE001 — paging is best-effort; the log line below is the fallback surface
+        logger.error("telegram page FAILED (%s): %s — message was: %s",
+                     type(exc).__name__, exc, message)
+
+# This Lambda's OWN secret (unlike ci-watch-dispatcher, which needs none) —
+# the webhook HMAC secret, read once per cold start and cached at module
+# scope (same pattern as every fleet Lambda that reads a param once, not
+# per-invocation, to keep p50 latency low on the hot webhook-verification path).
+WEBHOOK_SECRET_SSM = os.environ.get(
+    "KREPIS_RUNNER_WEBHOOK_SECRET_SSM", "/krepis/runner/webhook_secret"
+)
+_webhook_secret_cache: str | None = None
+
+
+def _webhook_secret() -> str:
+    global _webhook_secret_cache
+    if _webhook_secret_cache is None:
+        _webhook_secret_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=WEBHOOK_SECRET_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _webhook_secret_cache
+
+
+KREPIS_RUNNER_GH_PAT_SSM = os.environ.get(
+    "KREPIS_RUNNER_GH_PAT_SSM", "/krepis/runner/github_pat"
+)
+KREPIS_RUNNER_CONFIG_BRANCH = os.environ.get("KREPIS_RUNNER_CONFIG_BRANCH", "main")
+MAX_RUNTIME_SECONDS = int(os.environ.get("KREPIS_RUNNER_MAX_RUNTIME_SECONDS", "1800"))
+# (SSM_ONLINE_BUDGET_SEC removed with the in-Lambda wait, I2692 — the
+# reconcile-driven bootstrap never waits; BOOTSTRAP_DEADLINE_SECONDS above
+# is its replacement bound.)
+CW_LOG_GROUP = os.environ.get("KREPIS_RUNNER_CW_LOG_GROUP", "/krepis/runner-spot")
+
+# Reconcile backstop (config-I2653): a queued job older than this with no
+# in-flight box (per the same job-id-tag dedup check the reactive path uses)
+# gets a fresh dispatch. ~2-3x the typical observed dispatch+SSM-online
+# latency (15-40s) — comfortably past normal in-flight dispatches, without
+# waiting so long that a genuinely-orphaned job sits stuck for minutes.
+RECONCILE_STALE_SECONDS = int(os.environ.get("KREPIS_RUNNER_RECONCILE_STALE_SECONDS", "90"))
+RECONCILE_MAX_QUEUED_RUNS = int(os.environ.get("KREPIS_RUNNER_RECONCILE_MAX_QUEUED_RUNS", "50"))
+
+# Runner-fleet concurrency cap (config-I2692 item 4, 2026-07-15): a CI burst
+# must never be able to consume the WHOLE account spot quota by itself and
+# starve sibling workloads (groom/data/watch boxes share the same quota).
+# Default 20 concurrent krepis-runner boxes (t3.medium-class, 2 vCPU each =
+# 40 vCPU) leaves >half of the current 96-vCPU quota for everything else;
+# env-tunable since the right number is a fleet-wide capacity tradeoff, not
+# a fact this Lambda can derive on its own. A job that can't get a box this
+# pass because the cap is full simply stays queued — the NEXT reconcile pass
+# (~60s) retries once older boxes finish and free a slot.
+MAX_CONCURRENT_RUNNERS = int(os.environ.get("KREPIS_RUNNER_MAX_CONCURRENT", "20"))
+
+KREPIS_RUNNER_READ_PAT_SSM = os.environ.get(
+    "KREPIS_RUNNER_READ_PAT_SSM", "/krepis/runner/github_read_pat"
+)
+_gh_read_pat_cache: str | None = None
+
+
+def _gh_read_pat() -> str:
+    """A SEPARATE, dedicated, least-privilege PAT (Actions: Read ONLY —
+    cannot register runners, cannot touch repo settings) — deliberately NOT
+    the Administration:write PAT the box uses to register runners. This
+    Lambda sits behind a public, unauthenticated Function URL (HMAC
+    verification protects the WEBHOOK path, not a credential the Lambda's
+    own execution role can read); granting it read access to the powerful
+    registration PAT would widen blast radius for no reason the reconcile
+    logic actually needs (it only ever lists queued runs/jobs)."""
+    global _gh_read_pat_cache
+    if _gh_read_pat_cache is None:
+        _gh_read_pat_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=KREPIS_RUNNER_READ_PAT_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _gh_read_pat_cache
+
+
+def _gh_api_get(path: str) -> dict:
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Authorization": f"Bearer {_gh_read_pat()}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - fixed https://api.github.com host
+        return json.loads(resp.read())
+
+
+def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
+    """Constant-time HMAC-SHA256 verification of GitHub's
+    `X-Hub-Signature-256` header against the shared webhook secret."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(
+        _webhook_secret().encode("utf-8"), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def _decode_body(event: dict) -> bytes:
+    body = event.get("body") or ""
+    if event.get("isBase64Encoded"):
+        import base64
+
+        return base64.b64decode(body)
+    return body.encode("utf-8")
+
+
+def _response(status: int, body: dict) -> dict:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _handle_webhook(event: dict) -> dict:
+    """Phase 1: verify + filter a raw GitHub `workflow_job` webhook delivery.
+    Always returns fast (no spot-launch work happens in this phase) — a
+    matching event triggers an async self-invoke of the worker phase."""
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    raw_body = _decode_body(event)
+
+    if not _verify_signature(raw_body, headers.get("x-hub-signature-256")):
+        logger.warning("webhook signature verification failed — rejecting delivery")
+        return _response(401, {"error": "invalid signature"})
+
+    if headers.get("x-github-event") != "workflow_job":
+        # `ping` (sent on webhook creation) and anything else we didn't
+        # subscribe to — clean no-op, not an error.
+        return _response(200, {"ignored": "not a workflow_job event"})
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        logger.error("malformed webhook JSON body: %s", exc)
+        return _response(400, {"error": "malformed JSON"})
+
+    action = payload.get("action")
+    repo_full_name = (payload.get("repository") or {}).get("full_name")
+    job = payload.get("workflow_job") or {}
+    labels = job.get("labels") or []
+    job_id = job.get("id")
+
+    if (
+        action != "queued"
+        or repo_full_name != TARGET_REPO_FULL_NAME
+        or TARGET_LABEL not in labels
+        or job_id is None
+    ):
+        return _response(200, {"ignored": True, "action": action, "repo": repo_full_name})
+
+    if not DISPATCH_ENABLED:
+        logger.warning("KREPIS_RUNNER_DISPATCH_ENABLED=false — job %s NOT dispatched", job_id)
+        return _response(200, {"launched": False, "reason": "disabled", "job_id": job_id})
+
+    logger.info("queued job %s matches — self-invoking worker phase async", job_id)
+    boto3.client("lambda", region_name=REGION).invoke(
+        FunctionName=os.environ["AWS_LAMBDA_FUNCTION_NAME"],
+        InvocationType="Event",
+        Payload=json.dumps({"krepis_runner_job_id": str(job_id)}).encode("utf-8"),
+    )
+    return _response(200, {"accepted": True, "job_id": job_id})
+
+
+def _running_krepis_runner_instance_ids(job_id: str) -> list[str]:
+    return spot_dispatch.running_instance_ids(
+        KREPIS_RUNNER_TAG_NAME,
+        {KREPIS_RUNNER_JOB_ID_TAG_KEY: job_id},
+        region=REGION,
+    )
+
+
+# Any state that counts as "we already tried this" — including terminated
+# ones (a box that died is still a launch attempt against the job; that's
+# the entire point of the circuit breaker: N identical failures must stop,
+# not just N concurrently-alive boxes). shutting-down/stopping are
+# transitional states a box passes through on its way to terminated.
+_ANY_ATTEMPT_STATES = [
+    "pending", "running", "shutting-down", "stopping", "stopped", "terminated",
+]
+
+
+def _job_attempt_count(job_id: str) -> int:
+    """How many krepis-runner boxes have been launched for ``job_id`` within
+    the last ``KREPIS_RUNNER_ATTEMPT_LOOKBACK_SECONDS`` (live or recently-
+    terminated — describe-instances keeps a terminated instance queryable for
+    ~1h, comfortably longer than this Lambda's own dispatch cadence). A
+    DescribeInstances failure here must NOT degrade to "0 attempts, dispatch
+    anyway" — that would silently defeat the entire circuit breaker on the
+    exact kind of degraded-EC2-API pass that a runaway is most likely to
+    coincide with, so it re-raises (the caller decides the fail-safe
+    posture; see _launch_krepis_runner_spot)."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    resp = ec2.describe_instances(Filters=[
+        {"Name": "tag:Name", "Values": [KREPIS_RUNNER_TAG_NAME]},
+        {"Name": f"tag:{KREPIS_RUNNER_JOB_ID_TAG_KEY}", "Values": [job_id]},
+        {"Name": "instance-state-name", "Values": _ANY_ATTEMPT_STATES},
+    ])
+    now = datetime.now(timezone.utc)
+    count = 0
+    for r in resp.get("Reservations", []):
+        for i in r.get("Instances", []):
+            launch_time = i.get("LaunchTime")
+            if launch_time is not None:
+                age = (now - launch_time).total_seconds()
+                if age > KREPIS_RUNNER_ATTEMPT_LOOKBACK_SECONDS:
+                    continue
+            count += 1
+    return count
+
+
+def _current_fleet_size() -> int:
+    """Running+pending krepis-runner boxes, fleet-wide (across ALL jobs) —
+    the global cap backstop. Deliberately a SEPARATE query from
+    _job_attempt_count (different filter shape, different failure posture):
+    a failure here also does not degrade to "0, launch anyway" (see
+    _launch_krepis_runner_spot)."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    resp = ec2.describe_instances(Filters=[
+        {"Name": "tag:Name", "Values": [KREPIS_RUNNER_TAG_NAME]},
+        {"Name": "instance-state-name", "Values": ["pending", "running"]},
+    ])
+    return sum(len(r.get("Instances", [])) for r in resp.get("Reservations", []))
+
+
+KREPIS_RUNNER_LAUNCH_METRIC_NAMESPACE = "AlphaEngine/Infra"
+KREPIS_RUNNER_LAUNCH_METRIC_NAME = "krepis_runner_launches"
+
+
+def _emit_launch_metric() -> None:
+    """One CloudWatch custom-metric datapoint per successful launch (mirrors
+    spot-orphan-reaper's ``_emit_metric`` pattern — a namespace/metric-name
+    pair, best-effort, never raises). This is the launch-rate alarm's data
+    source (config#2697): the 2026-07-15 runaway ran ~3h at ~150 launches/45min
+    with only a single quota page at the very end — a launch-COUNT alarm
+    (independent of whether launches are currently succeeding or already
+    failing quota) catches the runaway itself, not just its terminal
+    symptom. Alarm provisioned by
+    infrastructure/setup_krepis_runner_launch_rate_alarm.sh (this repo has no
+    log-metric-filter precedent; every existing alarm — see
+    setup_watch_plane_alarms.sh, spot-orphan-reaper's own
+    spot_orphans_terminated metric — alarms on a Lambda-emitted custom/AWS
+    metric instead, which this follows)."""
+    try:
+        boto3.client("cloudwatch", region_name=REGION).put_metric_data(
+            Namespace=KREPIS_RUNNER_LAUNCH_METRIC_NAMESPACE,
+            MetricData=[{
+                "MetricName": KREPIS_RUNNER_LAUNCH_METRIC_NAME,
+                "Value": 1.0,
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:  # noqa: BLE001 — observability only; must never block/fail a dispatch
+        logger.warning("CloudWatch put_metric_data (%s) failed (non-fatal): %s",
+                        KREPIS_RUNNER_LAUNCH_METRIC_NAME, exc)
+
+
+def _bootstrap_command(job_id: str) -> str:
+    """The async SSM RunShellScript prelude: minimal-install, fetch the PAT,
+    clone krepis, exec its krepis_runner_spot_bootstrap.sh
+    entrypoint. Mirrors ci-watch-dispatcher's prelude exactly (same fail()
+    trap shape) — the difference is entirely in what runs AFTER the clone."""
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+export HOME=/root
+fail() {{ echo "[krepis-runner-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 >/dev/null 2>&1 || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {KREPIS_RUNNER_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/krepis
+git clone --depth 1 --branch {KREPIS_RUNNER_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{TARGET_REPO_FULL_NAME}.git" \
+  /home/ec2-user/krepis || fail "clone failed"
+cd /home/ec2-user/krepis
+exec bash infrastructure/krepis_runner_spot_bootstrap.sh --job-id "{job_id}"
+"""
+
+
+def _launch_krepis_runner_spot(job_id: str) -> dict:
+    # ── Circuit breaker + fleet cap (config#2697) — checked FIRST, ahead of
+    # the dedup probe, so both bind unconditionally: in particular, the
+    # per-job attempt limit MUST still apply on the config#2267
+    # dedupe_degraded "proceed anyway" path below, or a runaway job just
+    # re-opens the loop there instead. Both counts fail LOUD (re-raise) on a
+    # DescribeInstances error rather than degrade to "0, dispatch anyway" —
+    # unlike the dedup probe, coverage does NOT beat safety here: the whole
+    # point of a circuit breaker is that it must hold even when the AWS API
+    # is degraded, which is exactly when a runaway is likely to be underway.
+    try:
+        attempt_count = _job_attempt_count(job_id)
+    except Exception as exc:  # noqa: BLE001 — fail-safe: an unknown attempt count blocks the launch
+        logger.error(
+            "krepis-runner attempt-count probe FAILED for job %s — refusing to "
+            "dispatch (fail-safe, unlike the dedupe probe): %s: %s",
+            job_id, type(exc).__name__, exc,
+        )
+        return {"launched": False, "reason": "attempt_probe_failed", "job_id": job_id,
+                "error": str(exc)}
+
+    if attempt_count >= KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB:
+        if job_id not in _abandoned_job_ids_paged:
+            _abandoned_job_ids_paged.add(job_id)
+            _page(
+                f"🔴 krepis-runner: job {job_id} ABANDONED after "
+                f"{attempt_count} launch attempts (limit "
+                f"{KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB}) — every box likely "
+                "failing identically (e.g. a bad runner version/bootstrap "
+                "script). No further boxes will be dispatched for this job "
+                "until a human intervenes or ships a fix. "
+                "alpha-engine-config#2697 (source incident for this circuit breaker)."
+            )
+        logger.error(
+            "krepis-runner job %s ABANDONED — %d attempts >= limit %d, "
+            "not dispatching", job_id, attempt_count, KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB,
+        )
+        return {"launched": False, "reason": "attempt_limit_exceeded", "job_id": job_id,
+                "attempt_count": attempt_count}
+
+    try:
+        fleet_size = _current_fleet_size()
+    except Exception as exc:  # noqa: BLE001 — fail-safe: an unknown fleet size blocks the launch
+        logger.error(
+            "krepis-runner fleet-size probe FAILED for job %s — refusing to "
+            "dispatch (fail-safe): %s: %s", job_id, type(exc).__name__, exc,
+        )
+        return {"launched": False, "reason": "fleet_probe_failed", "job_id": job_id,
+                "error": str(exc)}
+
+    if fleet_size >= KREPIS_RUNNER_MAX_FLEET:
+        _page(
+            f"🔴 krepis-runner: fleet cap reached ({fleet_size} >= "
+            f"{KREPIS_RUNNER_MAX_FLEET}) — job {job_id} NOT dispatched this "
+            "pass. Refusing further launches until the fleet shrinks (global "
+            "backstop against spot-quota starvation; design mirrors alpha-engine-config#2697)."
+        )
+        logger.error(
+            "krepis-runner FLEET CAP reached (%d >= %d) — job %s not "
+            "dispatched", fleet_size, KREPIS_RUNNER_MAX_FLEET, job_id,
+        )
+        return {"launched": False, "reason": "fleet_cap_reached", "job_id": job_id,
+                "fleet_size": fleet_size}
+
+    dedupe_degraded = False
+    try:
+        existing = _running_krepis_runner_instance_ids(job_id)
+    except SpotProbeError as exc:
+        # Coverage beats dedupe (same policy as ci-watch-dispatcher, config#2267
+        # site 1): a failed probe must never leave a real queued job uncovered.
+        dedupe_degraded = True
+        existing = []
+        logger.error(
+            "krepis-runner concurrency probe FAILED for job %s — proceeding "
+            "with dedupe_degraded=true: %s: %s", job_id, type(exc).__name__, exc,
+        )
+    if existing:
+        logger.warning("krepis-runner box already live for job %s (%s) — skipping",
+                       job_id, existing)
+        return {"launched": False, "reason": "concurrent_skip", "existing_instance_ids": existing}
+
+    try:
+        instance_id, market = spot_dispatch.launch_with_fallback(
+            INSTANCE_TYPES, SUBNETS,
+            image_id=AMI_ID,
+            key_name=KEY_NAME,
+            security_group_ids=[SECURITY_GROUP],
+            iam_instance_profile=IAM_PROFILE,
+            volume_size_gb=VOLUME_SIZE_GB,
+            tag_name=KREPIS_RUNNER_TAG_NAME,
+            region=REGION,
+        )
+    except SpotLaunchError as exc:
+        logger.error("krepis-runner spot launch failed for job %s: %s: %s",
+                     job_id, type(exc).__name__, exc)
+        if "MaxSpotInstanceCountExceeded" in str(exc):
+            _page("🔴 krepis-runner: spot QUOTA EXHAUSTED "
+                  "(MaxSpotInstanceCountExceeded) — CI dispatch for "
+                  f"{TARGET_REPO_FULL_NAME} is stalling. Check for leaked "
+                  "runner boxes (aws ec2 describe-instances "
+                  f"Name={KREPIS_RUNNER_TAG_NAME}) — the reconcile janitor "
+                  "should be reaping them; if this page repeats, it isn't. "
+                  "design mirrors alpha-engine-config-I2692.")
+        return {"launched": False, "reason": "launch_failed", "error": str(exc)}
+
+    logger.info("launched krepis-runner box %s (%s) for job %s%s", instance_id, market, job_id,
+                " dedupe_degraded=true" if dedupe_degraded else "")
+    _emit_launch_metric()
+
+    try:
+        boto3.client("ec2", region_name=REGION).create_tags(
+            Resources=[instance_id],
+            Tags=[{"Key": KREPIS_RUNNER_JOB_ID_TAG_KEY, "Value": job_id}],
+        )
+    except Exception as exc:  # noqa: BLE001 — load-bearing tag write; terminate + fail loud on failure
+        spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="krepis-runner")
+        logger.error("krepis-runner discriminator tag write FAILED for %s (job %s) — "
+                     "box terminated, dispatch failed: %s: %s",
+                     instance_id, job_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "tag_write_failed", "instance_id": instance_id,
+                "error": str(exc), "dedupe_degraded": dedupe_degraded}
+
+    # Two-phase contract (I2692): launch + tag ONLY — this function must
+    # return in seconds. NO wait_ssm_online, NO send_command here: the old
+    # in-line wait blew this Lambda's 60s timeout, killing the bootstrap AND
+    # the terminate-on-failure handler with it (the 2026-07-15 zombie-leak
+    # incident). _bootstrap_and_reap() (every reconcile pass, ~60s) delivers
+    # the bootstrap once the box's SSM agent is online — which takes 40-90s
+    # after launch anyway, so this adds ~zero real latency.
+    logger.info("krepis-runner launched (bootstrap deferred to reconcile): "
+                "instance=%s market=%s job_id=%s", instance_id, market, job_id)
+    return {
+        "launched": True,
+        "reason": "launched_bootstrap_pending",
+        "instance_id": instance_id,
+        "market": market,
+        "job_id": job_id,
+        "dedupe_degraded": dedupe_degraded,
+    }
+
+
+def _bootstrap_and_reap() -> dict:
+    """The reconcile-driven bootstrap deliverer + janitor (I2692). For every
+    running krepis-runner box, exactly one of:
+
+      - no bootstrap-sent tag + SSM Online   -> send bootstrap, tag it
+      - no bootstrap-sent tag + SSM not up   -> reap once older than
+        BOOTSTRAP_DEADLINE_SECONDS (SSM never came up / undeliverable)
+      - any box older than RUNNER_MAX_LIFETIME_SECONDS -> reap (leak
+        backstop: an ephemeral runner that hasn't self-terminated by then is
+        a zombie regardless of how it got wedged)
+
+    Every step is a single fast API call — no waiting anywhere, so any
+    number of boxes fits inside the Lambda budget. Never raises: one box's
+    failure must not strand the rest."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    ssm = boto3.client("ssm", region_name=REGION)
+    stats = {"bootstrapped": 0, "reaped_no_ssm": 0, "reaped_lifetime": 0,
+             "waiting_ssm": 0, "healthy": 0, "errors": 0, "running_after_reap": 0}
+    now = datetime.now(timezone.utc)
+
+    try:
+        resp = ec2.describe_instances(Filters=[
+            {"Name": "tag:Name", "Values": [KREPIS_RUNNER_TAG_NAME]},
+            {"Name": "instance-state-name", "Values": ["running", "pending"]},
+        ])
+        boxes = [i for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
+    except Exception as exc:  # noqa: BLE001 — enumeration failure: nothing to do this pass, retry next
+        logger.error("bootstrap_and_reap: describe_instances failed: %s: %s",
+                     type(exc).__name__, exc)
+        stats["errors"] += 1
+        return stats
+
+    online_ids: set[str] = set()
+    if boxes:
+        try:
+            info = ssm.describe_instance_information(Filters=[
+                {"Key": "InstanceIds", "Values": [b["InstanceId"] for b in boxes]},
+            ]).get("InstanceInformationList", [])
+            online_ids = {i["InstanceId"] for i in info if i.get("PingStatus") == "Online"}
+        except Exception as exc:  # noqa: BLE001 — degrade to "none online"; young boxes wait, old ones still reap
+            logger.error("bootstrap_and_reap: SSM describe failed: %s: %s",
+                         type(exc).__name__, exc)
+
+    for box in boxes:
+        iid = box["InstanceId"]
+        tags = {t["Key"]: t["Value"] for t in box.get("Tags", [])}
+        age = (now - box["LaunchTime"]).total_seconds()
+
+        if age > RUNNER_MAX_LIFETIME_SECONDS:
+            try:
+                ec2.terminate_instances(InstanceIds=[iid])
+                logger.warning("bootstrap_and_reap: REAPED %s (lifetime %ds > %ds — leaked box)",
+                               iid, int(age), RUNNER_MAX_LIFETIME_SECONDS)
+                stats["reaped_lifetime"] += 1
+            except Exception as exc:  # noqa: BLE001 — retried next pass
+                logger.error("bootstrap_and_reap: reap %s failed: %s", iid, exc)
+                stats["errors"] += 1
+            continue
+
+        if KREPIS_RUNNER_BOOTSTRAP_SENT_TAG_KEY in tags:
+            stats["healthy"] += 1
+            continue
+
+        job_id = tags.get(KREPIS_RUNNER_JOB_ID_TAG_KEY, "")
+        if iid in online_ids and job_id:
+            try:
+                spot_dispatch.send_async_command(
+                    iid,
+                    _bootstrap_command(job_id),
+                    comment=f"krepis-runner (job {job_id})",
+                    region=REGION,
+                    cw_log_group=CW_LOG_GROUP,
+                    execution_timeout_seconds=MAX_RUNTIME_SECONDS,
+                )
+                ec2.create_tags(Resources=[iid], Tags=[{
+                    "Key": KREPIS_RUNNER_BOOTSTRAP_SENT_TAG_KEY,
+                    "Value": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }])
+                logger.info("bootstrap_and_reap: bootstrapped %s (job %s, %ds after launch)",
+                            iid, job_id, int(age))
+                stats["bootstrapped"] += 1
+            except Exception as exc:  # noqa: BLE001 — send/tag failure: untagged, retried next pass
+                logger.error("bootstrap_and_reap: bootstrap %s failed (retry next pass): %s: %s",
+                             iid, type(exc).__name__, exc)
+                stats["errors"] += 1
+        elif age > BOOTSTRAP_DEADLINE_SECONDS:
+            try:
+                ec2.terminate_instances(InstanceIds=[iid])
+                logger.warning("bootstrap_and_reap: REAPED %s (no SSM/job-id after %ds — "
+                               "bootstrap undeliverable)", iid, int(age))
+                stats["reaped_no_ssm"] += 1
+            except Exception as exc:  # noqa: BLE001 — retried next pass
+                logger.error("bootstrap_and_reap: reap %s failed: %s", iid, exc)
+                stats["errors"] += 1
+        else:
+            stats["waiting_ssm"] += 1
+
+    stats["running_after_reap"] = len(boxes) - stats["reaped_no_ssm"] - stats["reaped_lifetime"]
+    logger.info("bootstrap_and_reap: %s", stats)
+    return stats
+
+
+def _reconcile() -> dict:
+    """Scheduled backstop (~every 60s, config-I2653): dispatch a fresh runner
+    for any queued job matching our label that's had no in-flight box for
+    RECONCILE_STALE_SECONDS. See module docstring phase 3 for the full
+    rationale — this is NOT redundant with the reactive webhook path; it is
+    the only mechanism that can recover a job whose one-shot `queued`
+    webhook already fired but whose dispatched runner grabbed a different
+    job instead."""
+    if not DISPATCH_ENABLED:
+        logger.info("reconcile: KREPIS_RUNNER_DISPATCH_ENABLED=false — skipping")
+        return {"reconciled": 0, "reason": "disabled"}
+
+    # Bootstrap-deliverer + janitor FIRST (I2692): serve boxes already up
+    # before launching new ones, and reap zombies so the queued-job scan
+    # below never launches into an exhausted quota that leaked boxes caused.
+    br_stats = _bootstrap_and_reap()
+
+    now = datetime.now(timezone.utc)
+    try:
+        runs_resp = _gh_api_get(
+            f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs"
+            f"?status=queued&per_page={RECONCILE_MAX_QUEUED_RUNS}"
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        # Best-effort: a failed reconcile pass just means "no backstop this
+        # minute" — the NEXT scheduled invocation tries again. Never raise
+        # (this is EventBridge-invoked; an unhandled exception would just
+        # generate a Lambda-error-metric page for a transient GitHub API
+        # blip with no actionable fix).
+        logger.error("reconcile: failed to list queued runs: %s: %s", type(exc).__name__, exc)
+        return {"reconciled": 0, "reason": "list_runs_failed", "error": str(exc)}
+
+    # Collect ALL stale queued jobs first, then dispatch OLDEST-FIRST.
+    # GitHub lists runs newest-first; dispatching in listing order let a
+    # constant churn of fresh runs (e.g. the 2026-07-15 Dependabot-drain
+    # rebase wave) win every quota-constrained launch race while the oldest
+    # job starved indefinitely (PR2690's pytest sat queued 95+ min while
+    # newer jobs got every available spot slot). FIFO makes quota pressure
+    # degrade to bounded latency for everyone instead of unbounded latency
+    # for the unluckiest.
+    stale_jobs: list[tuple[float, str]] = []
+    for run in runs_resp.get("workflow_runs", []):
+        try:
+            jobs_resp = _gh_api_get(
+                f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs/{run['id']}/jobs"
+            )
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+            logger.error("reconcile: failed to list jobs for run %s: %s: %s",
+                         run.get("id"), type(exc).__name__, exc)
+            continue
+        for job in jobs_resp.get("jobs", []):
+            if job.get("status") != "queued" or TARGET_LABEL not in (job.get("labels") or []):
+                continue
+            created_at = datetime.fromisoformat(job["created_at"].replace("Z", "+00:00"))
+            age_seconds = (now - created_at).total_seconds()
+            if age_seconds < RECONCILE_STALE_SECONDS:
+                continue  # still within the reactive path's normal dispatch latency
+            stale_jobs.append((age_seconds, str(job["id"])))
+
+    # Concurrency cap (I2692 item 4): count this pass's OWN dispatches against
+    # the fleet already standing after bootstrap_and_reap's janitor pass, so a
+    # single burst of stale jobs can't blow past the cap in one reconcile.
+    available_slots = max(0, MAX_CONCURRENT_RUNNERS - br_stats.get("running_after_reap", 0))
+    capped_at_slot_zero = False
+
+    dispatched = []
+    skipped = []
+    for age_seconds, job_id in sorted(stale_jobs, reverse=True):  # oldest first
+        try:
+            existing = _running_krepis_runner_instance_ids(job_id)
+        except SpotProbeError:
+            existing = []  # degrade to "dispatch anyway" — the launch's own dedup/tag logic is authoritative
+        if existing:
+            skipped.append(job_id)
+            continue
+        if available_slots <= 0:
+            logger.warning("reconcile: job %s queued %.0fs but MAX_CONCURRENT_RUNNERS=%d "
+                            "already reached — leaving queued for next pass",
+                            job_id, age_seconds, MAX_CONCURRENT_RUNNERS)
+            skipped.append(job_id)
+            capped_at_slot_zero = True
+            continue
+        logger.info("reconcile: job %s queued %.0fs with no in-flight box — dispatching",
+                   job_id, age_seconds)
+        result = _launch_krepis_runner_spot(job_id)
+        if result.get("launched"):
+            available_slots -= 1
+        dispatched.append({"job_id": job_id, "age_seconds": age_seconds, "result": result})
+
+    if capped_at_slot_zero:
+        _page(f"⚠️ krepis-runner: MAX_CONCURRENT_RUNNERS={MAX_CONCURRENT_RUNNERS} reached — "
+              "one or more stale jobs left queued this reconcile pass pending a free slot. "
+              "design mirrors alpha-engine-config-I2692.")
+
+    logger.info("reconcile: dispatched=%d skipped=%d bootstrap_and_reap=%s",
+                len(dispatched), len(skipped), br_stats)
+    return {"reconciled": len(dispatched), "dispatched": dispatched,
+            "skipped": skipped, "bootstrap_and_reap": br_stats}
+
+
+def handler(event: dict, context) -> dict:
+    """Three-phase entrypoint — see module docstring. A Function URL
+    delivery carries `requestContext` (the API Gateway v2-shaped proxy
+    event); the EventBridge-scheduled reconcile trigger carries
+    `{"reconcile": true}`; the async self-invoked worker payload carries
+    `krepis_runner_job_id`."""
+    event = event or {}
+    if event.get("reconcile"):
+        return _reconcile()
+    if "requestContext" in event:
+        return _handle_webhook(event)
+
+    job_id = event.get("krepis_runner_job_id")
+    if not job_id:
+        logger.error("worker-phase invocation missing krepis_runner_job_id: %r", event)
+        return {"launched": False, "reason": "invalid_event"}
+    return _launch_krepis_runner_spot(str(job_id))

--- a/infrastructure/lambdas/krepis-runner-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/krepis-runner-dispatcher/requirements.txt
@@ -1,0 +1,10 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
+# spot-launch capacity-resilience chokepoint) — same primitives ci-watch-
+# dispatcher/sf-watch-spot-dispatcher use. Pinned to the latest tag at the
+# time this Lambda was written (v0.106.0 is the floor: first version whose
+# running_instance_ids raises SpotProbeError instead of failing open,
+# config#2267 site 1 — index.py imports and handles that exception).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.110.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/krepis-runner-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/krepis-runner-dispatcher/test_handler.py
@@ -1,0 +1,1091 @@
+"""Unit tests for the three-phase (webhook receiver / worker / reconcile)
+krepis-runner spot dispatcher.
+
+Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
+before importing index (mirrors ci-watch-dispatcher/test_handler.py). Covers:
+webhook HMAC signature verification, event/action/label/repo filtering, the
+async self-invoke on a matching queued job, the kill-switch, the worker
+phase's launch/dedup/tag/SSM-dispatch behavior (spot-first with on-demand
+fallback, job-id-scoped concurrency lock, terminate-on-post-launch-failure,
+config#2267-style dedupe_degraded on a probe failure), and the reconcile
+backstop (config-I2653 — dispatches a fresh runner for any queued job
+matching our label that's sat stale with no in-flight box; ``urllib.request``
+is monkeypatched per-test rather than stubbed in sys.modules, since it's
+stdlib and always resolvable).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_stdlib
+import json
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+WEBHOOK_SECRET = "test-webhook-secret"
+
+
+class _SpotLaunchError(Exception):
+    pass
+
+
+class _SpotCapacityExhausted(_SpotLaunchError):
+    pass
+
+
+def _install_stubs(launch_impl, boto_clients):
+    ec2_spot_mod = types.ModuleType("nousergon_lib.ec2_spot")
+    ec2_spot_mod.SpotLaunchError = _SpotLaunchError
+    ec2_spot_mod.SpotCapacityExhausted = _SpotCapacityExhausted
+    ec2_spot_mod.launch = launch_impl
+    sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
+
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: boto_clients[name]
+    sys.modules["boto3"] = boto3_mod
+
+
+class _FakeWaiter:
+    def wait(self, **kw):
+        return None
+
+
+class _FakeEc2:
+    def __init__(self, running_job_ids=None, create_tags_failures=0, attempt_boxes=None):
+        self.terminated = []
+        self.tags_created = []
+        self.create_tags_attempts = 0
+        self._create_tags_failures = create_tags_failures
+        self._running_job_ids = dict(running_job_ids or {})  # {job_id: [instance_ids]}
+        # {job_id: [instance dicts]} — full instance dicts (InstanceId,
+        # LaunchTime, state) for the config#2697 attempt-count probe, which
+        # (unlike the dedupe probe above) needs state/age, not just ids.
+        self._attempt_boxes = dict(attempt_boxes or {})
+        self.describe_instances_calls = 0
+        self.describe_instances_failures = 0
+
+    def get_waiter(self, name):
+        return _FakeWaiter()
+
+    def terminate_instances(self, InstanceIds):  # noqa: N803
+        self.terminated.extend(InstanceIds)
+        return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
+
+    def create_tags(self, Resources, Tags):  # noqa: N803
+        self.create_tags_attempts += 1
+        if self.create_tags_attempts <= self._create_tags_failures:
+            raise RuntimeError(f"CreateTags throttled (attempt {self.create_tags_attempts})")
+        self.tags_created.append((Resources, Tags))
+        return {}
+
+    def describe_instances(self, Filters):  # noqa: N803
+        self.describe_instances_calls += 1
+        if self.describe_instances_calls <= self.describe_instances_failures:
+            raise RuntimeError(f"DescribeInstances throttled (attempt {self.describe_instances_calls})")
+        by_name = {f["Name"]: f["Values"] for f in Filters}
+        states = by_name.get("instance-state-name", [])
+        job_id_filter = by_name.get("tag:krepis-runner-job-id")
+
+        # config#2697 _job_attempt_count: tag:Name + tag:krepis-runner-job-id
+        # + a state list that includes "terminated" (the discriminator vs.
+        # the plain dedupe-probe job-id query below, which never asks for
+        # terminated boxes).
+        if job_id_filter is not None and "terminated" in states:
+            job_id = job_id_filter[0]
+            boxes = self._attempt_boxes.get(job_id, [])
+            return {"Reservations": [{"Instances": list(boxes)}]} if boxes else {"Reservations": []}
+
+        # _bootstrap_and_reap / config#2697 _current_fleet_size: tag:Name
+        # WITHOUT a job-id filter — tests populate self.boxes with full
+        # instance dicts (shared fixture between both call sites, since
+        # fleet-size counting has the identical filter shape as the
+        # bootstrap-and-reap enumeration).
+        if "tag:Name" in by_name and job_id_filter is None:
+            return {"Reservations": [{"Instances": list(getattr(self, "boxes", []))}]}
+
+        # Plain dedupe probe (spot_dispatch.running_instance_ids): filters by
+        # job-id, state restricted to pending/running only.
+        job_id = job_id_filter[0] if job_id_filter else None
+        ids = self._running_job_ids.get(job_id, [])
+        return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
+
+
+class _FakeSsm:
+    def __init__(self):
+        self.sent = []
+        self.params = {
+            "/krepis/runner/webhook_secret": WEBHOOK_SECRET,
+            "/krepis/runner/github_read_pat": "test-read-only-pat",
+        }
+
+    def get_parameter(self, Name, WithDecryption=True):  # noqa: N803
+        return {"Parameter": {"Value": self.params[Name]}}
+
+    def describe_instance_information(self, **kw):
+        # _bootstrap_and_reap (I2692) matches entries by InstanceId; tests
+        # populate self.online_ids. Legacy default (no online_ids) keeps the
+        # old anonymous-Online shape for any pre-I2692 call sites.
+        online = getattr(self, "online_ids", None)
+        if online is None:
+            return {"InstanceInformationList": [{"PingStatus": "Online"}]}
+        return {"InstanceInformationList": [
+            {"InstanceId": i, "PingStatus": "Online"} for i in online]}
+
+    def send_command(self, **kw):
+        self.sent.append(kw)
+        return {"Command": {"CommandId": "cmd-123"}}
+
+
+class _FakeLambda:
+    def __init__(self):
+        self.invocations = []
+
+    def invoke(self, **kw):
+        self.invocations.append(kw)
+        return {"StatusCode": 202}
+
+
+class _FakeCloudwatch:
+    def __init__(self):
+        self.put_metric_data_calls = []
+
+    def put_metric_data(self, **kw):
+        self.put_metric_data_calls.append(kw)
+        return {}
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None, running_job_ids=None,
+          create_tags_failures=0, attempt_boxes=None, describe_instances_failures=0):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "krepis-runner-dispatcher")
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    ssm = _FakeSsm()
+    ec2 = _FakeEc2(running_job_ids=running_job_ids, create_tags_failures=create_tags_failures,
+                   attempt_boxes=attempt_boxes)
+    ec2.describe_instances_failures = describe_instances_failures
+    lam = _FakeLambda()
+    cw = _FakeCloudwatch()
+    clients = {"ec2": ec2, "ssm": ssm, "lambda": lam, "cloudwatch": cw}
+    if launch_impl is None:
+        launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
+    _install_stubs(launch_impl, clients)
+
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+
+    assert_hermetic_imports_satisfied(__file__)
+    import importlib
+
+    if "nousergon_lib.spot_dispatch" in sys.modules:
+        importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
+    else:
+        import nousergon_lib.spot_dispatch  # noqa: F401 — first import picks up the current stub
+
+    _sd = sys.modules["nousergon_lib.spot_dispatch"]
+    if not hasattr(_sd, "SpotProbeError"):
+        _sd.SpotProbeError = type("SpotProbeError", (Exception,), {})
+
+    import index
+
+    importlib.reload(index)
+    index._test_ssm = ssm
+    index._test_ec2 = ec2
+    index._test_lambda = lam
+    index._test_cloudwatch = cw
+    return index
+
+
+def _sign(body_bytes: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    return "sha256=" + hmac_stdlib.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+
+
+def _webhook_event(payload: dict, *, event_type: str = "workflow_job", secret: str = WEBHOOK_SECRET) -> dict:
+    body = json.dumps(payload)
+    body_bytes = body.encode("utf-8")
+    return {
+        "requestContext": {"http": {"method": "POST"}},
+        "headers": {
+            "x-github-event": event_type,
+            "x-hub-signature-256": _sign(body_bytes, secret),
+        },
+        "body": body,
+        "isBase64Encoded": False,
+    }
+
+
+def _job_payload(**overrides):
+    base = {
+        "action": "queued",
+        "repository": {"full_name": "nousergon/krepis"},
+        "workflow_job": {"id": 987654321, "labels": ["self-hosted", "krepis-spot"]},
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Phase 1: webhook receiver ────────────────────────────────────────────────
+
+
+def test_webhook_valid_queued_job_self_invokes_and_returns_200(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["accepted"] is True
+    assert body["job_id"] == 987654321
+    assert len(idx._test_lambda.invocations) == 1
+    inv = idx._test_lambda.invocations[0]
+    assert inv["InvocationType"] == "Event"
+    assert inv["FunctionName"] == "krepis-runner-dispatcher"
+    worker_payload = json.loads(inv["Payload"])
+    assert worker_payload == {"krepis_runner_job_id": "987654321"}
+
+
+def test_webhook_invalid_signature_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(), secret="wrong-secret"), None)
+    assert resp["statusCode"] == 401
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_signature_header_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    event = _webhook_event(_job_payload())
+    del event["headers"]["x-hub-signature-256"]
+    resp = idx.handler(event, None)
+    assert resp["statusCode"] == 401
+
+
+def test_webhook_non_workflow_job_event_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event({"zen": "hello"}, event_type="ping"), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_non_queued_action_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(action="completed")), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_wrong_repo_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(repository={"full_name": "nousergon/some-other-repo"})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_our_label_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(workflow_job={"id": 1, "labels": ["ubuntu-latest"]})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_disabled_flag_skips_invoke(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "false"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["launched"] is False
+    assert body["reason"] == "disabled"
+    assert idx._test_lambda.invocations == []
+
+
+# ── Phase 2: worker (async self-invoked) ─────────────────────────────────────
+
+
+def test_worker_valid_job_launches_tags_and_defers_bootstrap(monkeypatch):
+    # I2692 two-phase contract: the worker phase launches + tags and returns
+    # in seconds — NO in-Lambda SSM wait/send (that wait used to blow the
+    # 60s Lambda timeout and manufacture zombie boxes). The bootstrap is
+    # delivered by _bootstrap_and_reap on a later reconcile pass.
+    calls = {}
+
+    def _launch(types_, subnets, **kw):
+        calls["spot"] = kw.get("spot")
+        calls["profile"] = kw.get("iam_instance_profile")
+        calls["tag_name"] = kw.get("tag_name")
+        return "i-abc"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"krepis_runner_job_id": "987654321"}, None)
+    assert out["launched"] is True
+    assert out["reason"] == "launched_bootstrap_pending"
+    assert out["instance_id"] == "i-abc"
+    assert out["market"] == "spot"
+    assert calls["profile"] == "krepis-runner-executor-profile"
+    assert calls["tag_name"] == "krepis-runner-spot"
+    assert idx._test_ec2.tags_created == [
+        (["i-abc"], [{"Key": "krepis-runner-job-id", "Value": "987654321"}])
+    ]
+    assert idx._test_ssm.sent == [], "worker phase must never send SSM commands (I2692)"
+
+
+def test_worker_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        if kw.get("spot"):
+            raise _SpotCapacityExhausted("no capacity")
+        return "i-ondemand"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["market"] == "on-demand"
+    assert seen == [True, False]
+
+
+def test_worker_total_launch_exhaustion_returns_clean_false(monkeypatch):
+    def _launch(types_, subnets, **kw):
+        raise _SpotCapacityExhausted("exhausted")
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_concurrency_skip_when_job_already_running(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-new"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-already-running"]},
+    )
+    out = idx.handler({"krepis_runner_job_id": "55"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "concurrent_skip"
+    assert out["existing_instance_ids"] == ["i-already-running"]
+    assert launched == []
+
+
+def test_worker_different_job_id_is_not_blocked(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-other-job"]},
+    )
+    out = idx.handler({"krepis_runner_job_id": "56"}, None)
+    assert out["launched"] is True
+
+
+def test_worker_probe_failure_launches_with_dedupe_degraded(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-degraded",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _probe_down(*a, **kw):
+        raise idx.SpotProbeError("probe failed: ThrottlingException")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["dedupe_degraded"] is True
+
+
+def test_worker_persistent_tag_write_failure_terminates_and_fails(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-untaggable",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        create_tags_failures=99,
+    )
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "tag_write_failed"
+    assert idx._test_ec2.terminated == ["i-untaggable"]
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_quota_exhaustion_pages_loudly(monkeypatch):
+    # I2692: MaxSpotInstanceCountExceeded used to be ERROR-log-only while
+    # fleet CI silently queued for an hour — it must page now.
+    from nousergon_lib.spot_dispatch import SpotLaunchError
+
+    def _launch(types_, subnets, **kw):
+        raise SpotLaunchError(
+            "RunInstances failed with non-capacity error "
+            "MaxSpotInstanceCountExceeded (t3.medium@subnet-x): "
+            "Max spot instance count exceeded")
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert len(pages) == 1 and "QUOTA EXHAUSTED" in pages[0]
+
+
+# ── _bootstrap_and_reap (I2692 two-phase state machine) ──────────────────────
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def _box(iid, *, age_seconds, job_id="j1", bootstrapped=False):
+    tags = [{"Key": "Name", "Value": "krepis-runner-spot"}]
+    if job_id:
+        tags.append({"Key": "krepis-runner-job-id", "Value": job_id})
+    if bootstrapped:
+        tags.append({"Key": "krepis-runner-bootstrap-sent", "Value": "2026-01-01T00:00:00Z"})
+    return {"InstanceId": iid, "Tags": tags,
+            "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds)}
+
+
+def test_bootstrap_and_reap_sends_bootstrap_to_online_untagged_box(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-new", age_seconds=70, job_id="42")]
+    idx._test_ssm.online_ids = ["i-new"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["bootstrapped"] == 1
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert 'exec bash infrastructure/krepis_runner_spot_bootstrap.sh --job-id "42"' in cmd
+    assert any(r == ["i-new"] and tags[0]["Key"] == "krepis-runner-bootstrap-sent"
+               for r, tags in idx._test_ec2.tags_created)
+
+
+def test_bootstrap_and_reap_waits_on_young_offline_box(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-booting", age_seconds=60)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["waiting_ssm"] == 1
+    assert idx._test_ec2.terminated == []
+    assert idx._test_ssm.sent == []
+
+
+def test_bootstrap_and_reap_reaps_box_ssm_never_came_up(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-zombie", age_seconds=400)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_no_ssm"] == 1
+    assert idx._test_ec2.terminated == ["i-zombie"]
+
+
+def test_bootstrap_and_reap_reaps_over_lifetime_box_even_if_bootstrapped(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-leak", age_seconds=6000, bootstrapped=True)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_lifetime"] == 1
+    assert idx._test_ec2.terminated == ["i-leak"]
+
+
+def test_bootstrap_and_reap_healthy_bootstrapped_box_untouched(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-working", age_seconds=600, bootstrapped=True)]
+    idx._test_ssm.online_ids = ["i-working"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["healthy"] == 1
+    assert idx._test_ec2.terminated == []
+    assert idx._test_ssm.sent == []
+
+
+def test_bootstrap_and_reap_send_failure_leaves_untagged_for_retry(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-flaky", age_seconds=100, job_id="7")]
+    idx._test_ssm.online_ids = ["i-flaky"]
+
+    def _boom_send(**kw):
+        raise RuntimeError("SSM SendCommand failed")
+
+    idx._test_ssm.send_command = _boom_send
+    stats = idx._bootstrap_and_reap()
+    assert stats["errors"] == 1
+    assert stats["bootstrapped"] == 0
+    # No bootstrap-sent tag written — the next reconcile pass retries.
+    assert all(tags[0]["Key"] != "krepis-runner-bootstrap-sent"
+               for _, tags in idx._test_ec2.tags_created)
+
+
+def test_worker_missing_job_id_returns_invalid_event(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+
+
+# ── Phase 3: reconcile backstop (config-I2653) ───────────────────────────────
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_gh_api_stub(idx, monkeypatch, runs_by_path):
+    """runs_by_path: {url_path_suffix: response_dict}. Any request whose URL
+    ends with a registered suffix returns that canned response."""
+    def _fake_urlopen(req, timeout=10):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+        for suffix, payload in runs_by_path.items():
+            if url.endswith(suffix):
+                return _FakeHttpResponse(payload)
+        raise AssertionError(f"unexpected GH API call: {url}")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+
+
+def _iso(seconds_ago: float) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_reconcile_dispatches_stale_orphaned_job(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-rescued",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {
+            "workflow_runs": [{"id": 555}],
+        },
+        "/actions/runs/555/jobs": {
+            "jobs": [{
+                "id": 999, "status": "queued",
+                "labels": ["self-hosted", "krepis-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 1
+    assert out["dispatched"][0]["job_id"] == "999"
+    assert out["dispatched"][0]["result"]["launched"] is True
+
+
+def test_reconcile_skips_job_within_normal_dispatch_window(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [{
+                "id": 1, "status": "queued",
+                "labels": ["self-hosted", "krepis-spot"],
+                "created_at": _iso(10),  # well under the 90s default threshold
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["dispatched"] == []
+
+
+def test_reconcile_skips_job_already_covered_by_an_in_flight_box(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"777": ["i-already-covering-it"]},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 2}]},
+        "/actions/runs/2/jobs": {
+            "jobs": [{
+                "id": 777, "status": "queued",
+                "labels": ["self-hosted", "krepis-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["skipped"] == ["777"]
+
+
+def test_reconcile_ignores_jobs_without_our_label(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 3}]},
+        "/actions/runs/3/jobs": {
+            "jobs": [{
+                "id": 3, "status": "queued", "labels": ["ubuntu-latest"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+
+
+def test_reconcile_disabled_flag_short_circuits(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "false"})
+    out = idx.handler({"reconcile": True}, None)
+    assert out == {"reconciled": 0, "reason": "disabled"}
+
+
+def test_reconcile_list_runs_failure_returns_clean_result_not_raise(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+
+    def _boom(req, timeout=10):  # noqa: ARG001
+        raise idx.urllib.error.URLError("network blip")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["reason"] == "list_runs_failed"
+
+
+def test_reconcile_dispatches_oldest_job_first(monkeypatch):
+    # FIFO fairness: under quota pressure the OLDEST stale job must get the
+    # first launch attempt — newest-first listing order let fresh churn
+    # starve old jobs indefinitely (PR2690, 2026-07-15).
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        return f"i-{len(launched)}"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+
+    old = (datetime.now(timezone.utc) - timedelta(seconds=5000)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    newer = (datetime.now(timezone.utc) - timedelta(seconds=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def fake_get(path):
+        if path.endswith("&per_page=50") or "/actions/runs?" in path:
+            return {"workflow_runs": [{"id": 1}, {"id": 2}]}
+        if "/runs/1/jobs" in path:
+            # newest-first listing: run 1 (listed first) has the NEWER job
+            return {"jobs": [{"id": 111, "status": "queued", "created_at": newer,
+                              "labels": ["self-hosted", "krepis-spot"]}]}
+        if "/runs/2/jobs" in path:
+            return {"jobs": [{"id": 222, "status": "queued", "created_at": old,
+                              "labels": ["self-hosted", "krepis-spot"]}]}
+        raise AssertionError(f"unexpected GH GET {path}")
+
+    monkeypatch.setattr(idx, "_gh_api_get", fake_get)
+    out = idx.handler({"reconcile": True}, None)
+    order = [d["job_id"] for d in out["dispatched"]]
+    assert order == ["222", "111"], f"oldest job must dispatch first, got {order}"
+
+
+# ── Runner-fleet concurrency cap (I2692 item 4) ──────────────────────────────
+
+
+def test_bootstrap_and_reap_reports_running_after_reap(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [
+        _box("i-healthy", age_seconds=600, bootstrapped=True),
+        _box("i-zombie", age_seconds=6000, bootstrapped=True),  # reaped: over lifetime
+    ]
+    idx._test_ssm.online_ids = ["i-healthy"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_lifetime"] == 1
+    # one box reaped this pass — only the survivor counts toward the cap
+    assert stats["running_after_reap"] == 1
+
+
+def test_reconcile_respects_concurrency_cap_leaves_job_queued(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true",
+                                    "KREPIS_RUNNER_MAX_CONCURRENT": "1"})
+    idx._test_ec2.boxes = [_box("i-existing", age_seconds=100, job_id="1", bootstrapped=True)]
+    idx._test_ssm.online_ids = ["i-existing"]
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 9}]},
+        "/actions/runs/9/jobs": {
+            "jobs": [{"id": 909, "status": "queued",
+                      "labels": ["self-hosted", "krepis-spot"],
+                      "created_at": _iso(200)}],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["skipped"] == ["909"]
+    assert len(pages) == 1 and "MAX_CONCURRENT_RUNNERS=1" in pages[0]
+
+
+def test_reconcile_dispatches_up_to_available_slots_only(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(1)
+        return f"i-{len(launched)}"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true",
+                     "KREPIS_RUNNER_MAX_CONCURRENT": "1"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}, {"id": 2}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [{"id": 111, "status": "queued", "created_at": _iso(200),
+                      "labels": ["self-hosted", "krepis-spot"]}],
+        },
+        "/actions/runs/2/jobs": {
+            "jobs": [{"id": 222, "status": "queued", "created_at": _iso(300),
+                      "labels": ["self-hosted", "krepis-spot"]}],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    # zero running boxes going in, cap=1 -> exactly one of the two stale jobs
+    # gets dispatched this pass, the other waits for the next reconcile.
+    assert out["reconciled"] == 1
+    assert len(out["skipped"]) == 1
+    assert out["dispatched"][0]["job_id"] == "222"  # oldest first
+
+
+# ── Circuit breaker + fleet cap (alpha-engine-config#2697 (source incident)) ───────────────────
+#
+# 2026-07-15 incident: with every runner box failing identically, _reconcile()
+# relaunched a fresh box per stuck queued job on every ~60s pass FOREVER —
+# ~150 t3.medium spot launches in 45 min, saturating the account's 32-vCPU
+# standard-spot quota and locking out the post-close trading SF's data-spot
+# launch. These tests cover the two independent bounds added to
+# _launch_krepis_runner_spot (the single chokepoint both the reactive
+# webhook-worker path and the reconcile path funnel through): a per-job
+# attempt limit (counting live+recently-terminated boxes) and a global
+# running+pending fleet cap — including the config#2267 dedupe_degraded
+# "proceed anyway" path, where the circuit breaker must still bind or the
+# runaway just re-opens there.
+
+
+def _attempt_box(iid, *, age_seconds, state="terminated"):
+    return {
+        "InstanceId": iid,
+        "State": {"Name": state},
+        "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+    }
+
+
+def test_attempt_limit_blocks_dispatch_at_default_threshold(monkeypatch):
+    # Default KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB=3: 3 prior (terminated)
+    # boxes for this job already exist -> the 4th attempt must be refused.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"999": [
+            _attempt_box("i-try1", age_seconds=1000),
+            _attempt_box("i-try2", age_seconds=800),
+            _attempt_box("i-try3", age_seconds=600),
+        ]},
+    )
+    out = idx.handler({"krepis_runner_job_id": "999"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert out["attempt_count"] == 3
+    assert launched == [], "must not dispatch once the per-job attempt limit is reached"
+
+
+def test_attempt_limit_pages_exactly_once_per_job(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"42": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    idx.handler({"krepis_runner_job_id": "42"}, None)
+    idx.handler({"krepis_runner_job_id": "42"}, None)
+    idx.handler({"krepis_runner_job_id": "42"}, None)
+    assert len(pages) == 1, "repeated dispatch attempts for an abandoned job must page only once"
+    assert "ABANDONED" in pages[0]
+    assert "42" in pages[0]
+
+
+def test_attempt_count_below_threshold_still_dispatches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"5": [_attempt_box("i-a", age_seconds=100)]},
+    )
+    out = idx.handler({"krepis_runner_job_id": "5"}, None)
+    assert out["launched"] is True
+
+
+def test_attempt_count_ignores_boxes_outside_lookback_window(monkeypatch):
+    # 3 prior boxes exist for the job, but all launched > the lookback
+    # window ago (default 3600s) — describe-instances would no longer even
+    # return a >1h-old terminated box in practice, but this also guards
+    # against counting a stale/lingering tag from a much older, unrelated
+    # incident as part of today's attempt budget.
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-fresh-attempt",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"7": [
+            _attempt_box("i-old1", age_seconds=999999),
+            _attempt_box("i-old2", age_seconds=999999),
+            _attempt_box("i-old3", age_seconds=999999),
+        ]},
+    )
+    out = idx.handler({"krepis_runner_job_id": "7"}, None)
+    assert out["launched"] is True
+
+
+def test_attempt_limit_is_env_tunable(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-x"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch,
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true", "KREPIS_RUNNER_MAX_ATTEMPTS_PER_JOB": "1"},
+        attempt_boxes={"9": [_attempt_box("i-only-prior-attempt", age_seconds=10)]},
+    )
+    out = idx.handler({"krepis_runner_job_id": "9"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert launched == []
+
+
+def test_attempt_limit_binds_on_dedupe_degraded_path(monkeypatch):
+    # The gotcha this issue calls out explicitly: dedup-probe failures
+    # deliberately degrade to "dispatch anyway" (config#2267, coverage beats
+    # dedupe) — the attempt limit must STILL bind in that degraded path, or
+    # a runaway job just re-opens the loop there instead of at the dedupe
+    # probe.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"55": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+
+    def _probe_down(*a, **kw):
+        raise idx.SpotProbeError("probe failed: ThrottlingException")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler({"krepis_runner_job_id": "55"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert launched == [], "attempt limit must bind even when the dedupe probe itself is degraded"
+
+
+def test_attempt_probe_failure_is_fail_safe_not_fail_open(monkeypatch):
+    # Unlike the dedupe probe (config#2267 posture: coverage beats dedupe),
+    # the circuit breaker's OWN probe must fail closed — an unknown attempt
+    # count must never be silently treated as "0, dispatch anyway", since
+    # that would defeat the breaker on exactly the kind of degraded-API pass
+    # a runaway is likely to coincide with.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+                describe_instances_failures=1)
+    out = idx.handler({"krepis_runner_job_id": "123"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_probe_failed"
+    assert launched == []
+
+
+def test_fleet_cap_blocks_dispatch_at_default_threshold(monkeypatch):
+    # Default KREPIS_RUNNER_MAX_FLEET=6: 6 running+pending boxes already
+    # exist fleet-wide (for OTHER jobs) -> a brand-new job's dispatch must
+    # still be refused.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [
+        {"InstanceId": f"i-fleet-{n}", "Tags": []} for n in range(6)
+    ]
+    out = idx.handler({"krepis_runner_job_id": "888"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+    assert out["fleet_size"] == 6
+    assert launched == [], "must not dispatch once the global fleet cap is reached"
+
+
+def test_fleet_cap_pages(monkeypatch):
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(6)]
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert len(pages) == 1
+    assert "fleet cap" in pages[0].lower()
+
+
+def test_fleet_below_cap_still_dispatches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(5)]
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+
+
+def test_fleet_cap_is_env_tunable(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-x"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch,
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true", "KREPIS_RUNNER_MAX_FLEET": "1"},
+    )
+    idx._test_ec2.boxes = [{"InstanceId": "i-already-there", "Tags": []}]
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+    assert launched == []
+
+
+def test_fleet_cap_checked_even_when_this_job_has_zero_prior_attempts(monkeypatch):
+    # The fleet cap is a GLOBAL backstop independent of the per-job attempt
+    # count — a brand-new job (0 attempts) must still be refused if the
+    # fleet is already full from OTHER jobs' boxes.
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-other-job-{n}", "Tags": []} for n in range(6)]
+    out = idx.handler({"krepis_runner_job_id": "brand-new-job"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+
+
+def test_fleet_probe_failure_is_fail_safe_not_fail_open(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+
+    def _boom(**kw):
+        raise RuntimeError("DescribeInstances throttled")
+
+    # Let the attempt-count probe succeed (no boxes) but make the SECOND
+    # describe_instances call (fleet-size) fail.
+    real_describe = idx._test_ec2.describe_instances
+    calls = {"n": 0}
+
+    def _describe(Filters):  # noqa: N803
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("DescribeInstances throttled")
+        return real_describe(Filters)
+
+    monkeypatch.setattr(idx._test_ec2, "describe_instances", _describe)
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_probe_failed"
+    assert launched == []
+
+
+def test_reconcile_respects_attempt_limit_across_multiple_stale_jobs(monkeypatch):
+    # End-to-end through the reconcile path (not just the worker phase):
+    # a job already at the attempt limit must be skipped by _reconcile
+    # without ever reaching launch_with_fallback, while a fresh stale job in
+    # the same pass still gets dispatched.
+    launched_job_ids = []
+
+    def _launch(types_, subnets, **kw):
+        return "i-rescued"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"555": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [
+                {"id": 555, "status": "queued", "labels": ["self-hosted", "krepis-spot"],
+                 "created_at": _iso(200)},
+                {"id": 556, "status": "queued", "labels": ["self-hosted", "krepis-spot"],
+                 "created_at": _iso(150)},
+            ],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    results_by_job = {d["job_id"]: d["result"] for d in out["dispatched"]}
+    assert results_by_job["555"]["launched"] is False
+    assert results_by_job["555"]["reason"] == "attempt_limit_exceeded"
+    assert results_by_job["556"]["launched"] is True
+
+
+def test_successful_launch_emits_cloudwatch_launch_metric(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-metered",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    idx.handler({"krepis_runner_job_id": "1"}, None)
+    calls = idx._test_cloudwatch.put_metric_data_calls
+    assert len(calls) == 1
+    assert calls[0]["Namespace"] == "AlphaEngine/Infra"
+    metric = calls[0]["MetricData"][0]
+    assert metric["MetricName"] == "krepis_runner_launches"
+    assert metric["Value"] == 1.0
+
+
+def test_blocked_dispatch_does_not_emit_launch_metric(monkeypatch):
+    # The metric counts actual LAUNCHES (the runaway signal) — a dispatch
+    # refused by the circuit breaker/fleet cap must not count as one.
+    idx = _load(monkeypatch, env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(6)]
+    idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert idx._test_cloudwatch.put_metric_data_calls == []
+
+
+def test_launch_metric_emission_failure_does_not_block_dispatch(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok-anyway",  # noqa: E731
+        env={"KREPIS_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom(**kw):
+        raise RuntimeError("CloudWatch throttled")
+
+    monkeypatch.setattr(idx._test_cloudwatch, "put_metric_data", _boom)
+    out = idx.handler({"krepis_runner_job_id": "1"}, None)
+    assert out["launched"] is True

--- a/infrastructure/lambdas/mnemon-runner-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/mnemon-runner-dispatcher/deploy.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the mnemon-runner-dispatcher Lambda.
+#
+# WHY: mirrors nousergon/alpha-engine-config's self-hosted-runner dispatcher
+# (alpha-engine-config-I2572) verbatim in mechanism, re-namespaced for mnemon.
+# A live billing-usage audit (2026-07-17) found mnemon among the largest
+# non-alpha-engine-config private-repo GHA-minute consumers (~567 min in
+# July alone) after the org crossed its 3,000-min included-Actions-minute
+# line for the month. This Lambda receives GitHub's `workflow_job` webhook directly
+# (a Function URL, not a `lambda invoke` from a GHA job — there is no
+# GHA-hosted leg left to invoke it once the target workflows' runs-on points
+# at a self-hosted runner) and launches an EC2-spot box that registers as an
+# EPHEMERAL self-hosted runner for exactly one queued job, then
+# self-terminates. --bootstrap creates: (1) this Lambda's own execution role
+# + inline policy, (2) the Lambda function itself, (3) its public Function
+# URL + the resource policy allowing GitHub to invoke it.
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
+# (scoped to mnemon-runner-executor-role — a NEW, dedicated role
+# a sibling agent is creating in mnemon) + ssm:SendCommand +
+# ssm:GetParameter (its OWN webhook secret — unlike ci-watch-dispatcher, this
+# Lambda verifies GitHub's HMAC signature itself) + lambda:InvokeFunction on
+# itself (the two-phase webhook-receiver/worker self-invoke — see index.py's
+# module docstring for why the launch work cannot run inline in the
+# webhook-receiving invocation).
+#
+# Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
+# keeps the github-actions-lambda-deploy OIDC role's blast radius narrow.
+# This script's FLAGLESS run is code-only; --bootstrap is operator-only.
+#
+# POST-BOOTSTRAP MANUAL STEPS (cannot be automated via this script — see
+# alpha-engine-config-I2572/I2653, the source design, for the full
+# sequencing rationale):
+#   1. Create the SSM params this Lambda/box read:
+#        /mnemon/runner/webhook_secret  (random string, shared
+#          with the GitHub webhook config below)
+#        /mnemon/runner/github_pat  (fine-grained PAT, owner=
+#          nousergon, repo=mnemon, Administration: Read and
+#          write + Contents: read — Administration:write is REQUIRED to mint
+#          runner registration tokens; the Actions permission does NOT cover
+#          this. Fine-grained PAT creation/scoping is a GitHub web-UI-only,
+#          human action — cannot be done via this script or the API.)
+#        /mnemon/runner/github_read_pat  (SEPARATE fine-grained
+#          PAT, owner=nousergon, repo=mnemon, Actions: Read
+#          ONLY — deliberately NOT the same PAT as above. This one is read
+#          by the Lambda's own execution role (behind a public Function URL)
+#          for the reconcile phase's read-only "list queued jobs" calls;
+#          keeping it separate and minimally-scoped means a Lambda-side
+#          issue can never expose Administration:write.)
+#   2. Register the GitHub webhook on nousergon/mnemon:
+#        event: workflow_job, content type: json, secret: (the same value as
+#        the SSM param above), URL: this script's printed Function URL.
+#      Can be done via `gh api repos/nousergon/mnemon/hooks`.
+#
+# Usage:
+#   bash .../mnemon-runner-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../mnemon-runner-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda + Function URL + reconcile schedule
+#   bash .../mnemon-runner-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../mnemon-runner-dispatcher/deploy.sh --smoke     # invoke the WORKER phase once with a synthetic job id (fires a REAL spot box)
+#   bash .../mnemon-runner-dispatcher/deploy.sh --reconcile-test # invoke the RECONCILE phase once directly (read-only unless it finds a genuinely stale job)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="mnemon-runner-dispatcher"
+ROLE_NAME="mnemon-runner-dispatcher-role"
+POLICY_NAME="mnemon-runner-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# Bootstrap default (first-time deployment only) — safe default ON, mirrors
+# every other fleet dispatcher's kill-switch convention.
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,MNEMON_RUNNER_DISPATCH_ENABLED=true}'
+
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
+# DRY_RUN honors an ambient env var (true/1/yes) as well as the --dry-run
+# flag below, so DRY_RUN=1/true from a caller's shell actually no-ops
+# instead of silently running the real deploy path (mnemon-
+# I2752 incident, 2026-07-16: an operator assumed DRY_RUN=<env var> worked
+# here, matching other tools' convention, and triggered a real deploy).
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+SMOKE=false
+RECONCILE_TEST=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    --reconcile-test) RECONCILE_TEST=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+    if ! $DRY_RUN; then
+      aws lambda wait function-active --function-name "${FUNCTION_NAME}" --region "${REGION}"
+    fi
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2b. Function URL (GitHub webhooks can't sign SigV4 — auth is the
+  # handler's own HMAC verification against the shared webhook secret) ---
+  if ! aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --query 'FunctionUrl' --output text >/dev/null 2>&1; then
+    echo "  Creating Function URL (AuthType=NONE; handler-level HMAC verification is the real auth boundary)"
+    run aws lambda create-function-url-config \
+      --function-name "${FUNCTION_NAME}" \
+      --auth-type NONE \
+      --region "${REGION}" \
+      --query 'FunctionUrl' --output text
+    echo "  Granting public InvokeFunctionUrl permission"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "AllowPublicFunctionUrlInvoke" \
+      --action lambda:InvokeFunctionUrl \
+      --principal "*" \
+      --function-url-auth-type NONE \
+      --region "${REGION}" >/dev/null
+  else
+    echo "  Function URL already configured"
+  fi
+
+  if ! $DRY_RUN; then
+    FN_URL=$(aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --region "${REGION}" --query 'FunctionUrl' --output text)
+    echo ""
+    echo "  Function URL: ${FN_URL}"
+    echo "  -> register as the GitHub webhook target for nousergon/mnemon"
+    echo "     (event: workflow_job, content type: json, secret: matches"
+    echo "     /mnemon/runner/webhook_secret) — see this script's"
+    echo "     header for the full remaining manual steps."
+    echo ""
+  fi
+
+  # --- 2c. Reconcile backstop schedule (alpha-engine-config-I2653) ---
+  # A self-hosted runner registered via a plain registration token binds to
+  # the repo's WHOLE label pool, not the specific job that triggered its
+  # launch (GitHub has no per-job reservation API — verified against
+  # GitHub's own docs; an earlier JIT-runner-config fix attempt for this
+  # issue was wrong, JIT mints the same kind of "any matching job"
+  # registration, just more securely). Under concurrent load a dispatched
+  # runner can grab an unrelated queued job, permanently stranding the job
+  # that triggered its launch — GitHub sends `queued` exactly once per job.
+  # This EventBridge Scheduler rule invokes the Lambda's RECONCILE phase
+  # every 60s as a self-healing backstop; see index.py's module docstring
+  # phase 3 for the full mechanism.
+  RECONCILE_SCHED_ROLE_NAME="mnemon-runner-reconcile-scheduler-role"
+  RECONCILE_SCHED_POLICY_NAME="invoke-mnemon-runner-dispatcher"
+  RECONCILE_SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${RECONCILE_SCHED_ROLE_NAME}"
+  RECONCILE_SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${RECONCILE_SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${RECONCILE_SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME}'s reconcile phase every 60s (alpha-engine-config-I2653)" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${RECONCILE_SCHED_ROLE_NAME}"
+  fi
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  RECONCILE_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":[\"${FN_ARN}\",\"${FN_ARN}:*\"]}]}"
+  echo "  Applying Scheduler invoke policy: ${RECONCILE_SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+    --policy-name "${RECONCILE_SCHED_POLICY_NAME}" \
+    --policy-document "${RECONCILE_INVOKE_POLICY}"
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  RECONCILE_SCHED_NAME="mnemon-runner-reconcile"
+  RECONCILE_TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${RECONCILE_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"reconcile\\\":true}\"}"
+  if aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  Updating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler update-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  else
+    echo "  Creating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler create-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  fi
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: Scheduler rule ${RECONCILE_SCHED_NAME} not found after create/update" >&2; exit 1; }
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment (preserving operator-owned MNEMON_RUNNER_DISPATCH_ENABLED)..."
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" MNEMON_RUNNER_DISPATCH_ENABLED true)
+LAMBDA_ENV="Variables={LOG_LEVEL=INFO,MNEMON_RUNNER_DISPATCH_ENABLED=${CURRENT_DISPATCH}}"
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment "${LAMBDA_ENV}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+# ----- 4. Smoke (synthetic worker-phase event, direct invoke) ---------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing the WORKER phase via direct invoke (synthetic job id)..."
+  echo "⚠ this fires a REAL spot box + REAL mnemon_runner_spot_bootstrap.sh run."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"mnemon_runner_job_id":"smoke-test-0"}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi
+
+# ----- 5. Reconcile test (synthetic reconcile-phase event, direct invoke) ---
+
+if $RECONCILE_TEST; then
+  echo ""
+  echo "Testing the RECONCILE phase via direct invoke..."
+  echo "Read-only unless it finds a genuinely stale (>90s) queued job with no in-flight box — in which case it dispatches a REAL spot box for it (which is the correct/intended behavior, not a side effect to worry about)."
+  RESP2=$(mktemp)
+  trap "rm -f '${RESP2}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"reconcile":true}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP2}" >/dev/null
+  cat "${RESP2}"
+  echo ""
+fi

--- a/infrastructure/lambdas/mnemon-runner-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/mnemon-runner-dispatcher/iam-policy.json
@@ -1,0 +1,150 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/mnemon-runner-dispatcher:*"
+    },
+    {
+      "Sid": "ReadWebhookSecret",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/mnemon/runner/webhook_secret"
+    },
+    {
+      "Sid": "ReadGithubReadOnlyPatForReconcileListing",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/mnemon/runner/github_read_pat"
+    },
+    {
+      "Sid": "SelfInvokeAsyncForTwoPhaseDispatch",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:mnemon-runner-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:mnemon-runner-dispatcher:*"
+      ]
+    },
+    {
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "mnemon-runner-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "mnemon-runner-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassRunnerExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/mnemon-runner-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunRunnerBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateRunnerSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "mnemon-runner-spot"
+        }
+      }
+    },
+    {
+      "Sid": "EmitLaunchRateMetricSharedInfra",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "cloudwatch:namespace": "AlphaEngine/Infra"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/mnemon-runner-dispatcher/index.py
+++ b/infrastructure/lambdas/mnemon-runner-dispatcher/index.py
@@ -1,0 +1,915 @@
+"""mnemon-runner-dispatcher — launch an EPHEMERAL GitHub Actions
+self-hosted runner on a dedicated EC2 spot box, once per queued CI/validation
+job in nousergon/mnemon. Mirrors nousergon/alpha-engine-config's
+self-hosted-runner dispatcher (alpha-engine-config-I2572) verbatim in
+mechanism, re-namespaced for mnemon.
+
+WHY: a hard GHA audit (2026-07-14) found mnemon's own CI/
+validation workflows (scripts-tests.yml, changelog.yml, the validate-*.yaml
+set, etc.) — NOT the heavy agentic workloads ci-watch/sf-watch/groom already
+moved to spot — are now the dominant steady-state draw on the org's metered
+private-repo GHA-minutes quota (~1.6k min/30d projected, ~93% of all
+private-repo GHA spend fleet-wide). Those are frequent (dozens/day) and
+short-lived (<1 min avg) — a poor fit for the ci-watch/sf-watch pattern (a
+thin GHA-hosted dispatch leg synchronously invoking a Lambda that runs a
+bespoke script over SSM, outside the Actions protocol entirely): replicating
+that shape per-workflow would mean hand-rolling GitHub Checks-API status
+reporting ~13 times over. Registering a REAL ephemeral self-hosted runner is
+simpler AND more correct here — the existing workflow YAML (checkout,
+setup-python, pytest, etc.) is untouched, only `runs-on:` changes, and
+GitHub's own Actions service handles job dispatch + Check Run status
+natively, exactly as it does for hosted runners.
+
+MECHANISM (three-phase single Lambda, self-invoked async — see module-level
+`handler` for the branch):
+  1. WEBHOOK RECEIVER phase: GitHub calls this Lambda's Function URL directly
+     on every `workflow_job` event for mnemon (repo-level
+     webhook, event type `workflow_job`). Verifies the HMAC signature, filters
+     to `action=queued` + our `mnemon-spot` label, then
+     self-invokes ASYNC (`InvocationType=Event`) with a minimal worker
+     payload and returns 200 immediately. GitHub's webhook delivery timeout
+     is short (single-digit seconds) — the actual spot launch below can take
+     30-90s+, so it MUST NOT block the HTTP response, or every delivery would
+     show as a spurious timeout in GitHub's UI even though the box still
+     launches (Lambda execution isn't cancelled by a disconnected client, but
+     a clean signal matters for operability).
+  2. WORKER phase (the self-invoked async call): does the actual dispatch —
+     `spot_dispatch.launch_with_fallback()` (spot-first, on-demand fallback
+     on capacity exhaustion), wait for SSM-online, then an async detached SSM
+     command that clones mnemon and `exec`s
+     `infrastructure/mnemon_runner_spot_bootstrap.sh` (built by a sibling
+     agent in mnemon) — which installs+registers the actual
+     `actions-runner` binary in `--ephemeral` mode, runs exactly one job, and
+     self-terminates (InstanceInitiatedShutdownBehavior=terminate + its own
+     on-box watchdog). Mirrors `ci-watch-dispatcher/index.py`'s
+     launch/wait/dispatch shape via the shared `nousergon_lib.spot_dispatch`
+     primitives (config#2106) — NOT reinvented here.
+  3. RECONCILE phase (EventBridge Scheduler, ~every 60s — config-I2653): a
+     self-hosted runner registered via a plain registration token binds to
+     the repo's WHOLE label pool, not the specific job that triggered its
+     launch — GitHub has no API to reserve a job for a not-yet-connected
+     runner (confirmed against GitHub's own docs before implementing this;
+     an earlier JIT-runner-config diagnosis for this issue was WRONG — JIT
+     is a more secure way to mint the same "any matching job" registration,
+     it does not bind to one job either). Under concurrent load a dispatched
+     runner can grab an unrelated queued job, leaving the job that triggered
+     its launch permanently stuck — GitHub sends the `queued` webhook exactly
+     ONCE per job, so there is no other path back to it without this backstop.
+     `_reconcile()` lists queued jobs matching our label that have sat queued
+     longer than `MNEMON_RUNNER_RECONCILE_STALE_SECONDS` with no in-flight
+     box (the existing job-id-tag dedup check), and dispatches a fresh runner
+     for each. Same "coverage beats dedupe" posture as the SpotProbeError
+     handling below — doesn't prevent the occasional mismatch, guarantees no
+     job stays stranded indefinitely.
+
+CIRCUIT BREAKER + FLEET CAP (2026-07-15 spot-quota-starvation incident,
+config#2697): the reconcile backstop above is intentionally unbounded in
+WHEN it fires (every stale queued job, every ~60s pass, forever) — that is
+its whole point (I2653). What it lacked was a bound on repeated launches
+for a job whose boxes keep failing identically, and a global ceiling on
+total fleet size. Both live in `_launch_mnemon_runner_spot()` (the single
+chokepoint the webhook-worker path AND the reconcile path both funnel
+through, including the config#2267 dedupe_degraded "proceed anyway" path):
+a job at/over `MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB` launches (default 3,
+counting live+recently-terminated boxes) is abandoned (paged once, no
+further dispatch until a human/code-fix intervenes); the fleet overall is
+capped at `MNEMON_RUNNER_MAX_FLEET` running+pending boxes (default 6 = 12
+vCPUs, leaving >=20 of the account's 32-vCPU standard-spot quota for
+production) regardless of per-job attempt counts. A `AlphaEngine/Infra
+mnemon_runner_launches` custom metric + CloudWatch alarm
+(infrastructure/setup_mnemon_runner_launch_rate_alarm.sh) is the
+independent early-warning signal on launch RATE itself, since the incident
+ran ~3h with only a single quota-exhaustion page at the very end.
+
+CONCURRENCY LOCK: keyed on `Name=mnemon-runner-spot` +
+`mnemon-runner-job-id=<workflow_job.id>` — one job, one box, 1:1 (unlike
+ci-watch's repo+sha lock, a GitHub Actions job id is already the unique
+discriminator; no broader key needed). A duplicate `queued` delivery for the
+same job (GitHub webhooks are at-least-once) is a clean no-op skip.
+
+IAM PROFILE: `mnemon-runner-executor-profile`, a NEW dedicated
+instance profile (infrastructure/iam/mnemon-runner-executor-role-*.json in
+mnemon) scoped to read exactly one SSM param (the runner-
+registration PAT) — deliberately not `alpha-engine-ci-watch-executor-profile`
+or any other existing profile, so this new/less-proven workload's blast
+radius stays contained. Every AWS credential the actual CI STEPS need (S3
+sync, OIDC role assumption, etc.) continues to flow through GitHub's own
+per-workflow OIDC mechanism, unrelated to this instance's own role.
+
+FAIL-SOFT ON THE WEBHOOK RECEIVER PHASE, FAIL-LOUD ON THE WORKER PHASE: an
+unrecognized/malformed webhook delivery is a clean 200 no-op (GitHub sends
+many event types/actions we don't care about — treating them as errors would
+just generate webhook-delivery noise for no reason). The worker phase mirrors
+ci-watch's SYNCHRONOUS-style clean-failure contract even though its own
+caller is async (nothing reads the return value) — CloudWatch Logs is the
+observability surface for worker-phase failures; a genuinely unexpected
+internal bug still propagates as a Python exception (visible as a Lambda
+error metric).
+
+Managed OUTSIDE CloudFormation (same as every other fleet dispatcher):
+operator-deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live
+effect until the new code + IAM + Function URL + GitHub webhook registration
+are applied AND the (separately-tracked, human-only) runner-registration PAT
+with Administration:write on mnemon exists in SSM — see
+alpha-engine-config-I2572 (the original design this dispatcher mirrors)
+for the full rollout sequencing rationale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+import boto3
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotLaunchError, SpotProbeError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: MNEMON_RUNNER_DISPATCH_ENABLED=false disables the launch
+# without touching the GitHub webhook wiring — mirrors every other fleet
+# dispatcher's safety valve. Default ON.
+DISPATCH_ENABLED = os.environ.get("MNEMON_RUNNER_DISPATCH_ENABLED", "true").lower() == "true"
+
+TARGET_REPO_FULL_NAME = "nousergon/mnemon"
+TARGET_LABEL = "mnemon-spot"
+
+# ── Spot launch config (env-overridable; same default-VPC/AMI/security-group
+# as the fleet's other spot dispatchers — only the IAM profile + tag differ).
+# IAM LOCKSTEP (mirrors ci-watch-dispatcher): these defaults are ENUMERATED
+# in this Lambda's scoped ec2:RunInstances policy (sibling iam-policy.json).
+# Changing them without re-applying that policy makes RunInstances fail with
+# UnauthorizedOperation at the next dispatch. Keep them in sync.
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "MNEMON_RUNNER_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "MNEMON_RUNNER_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("MNEMON_RUNNER_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("MNEMON_RUNNER_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("MNEMON_RUNNER_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+IAM_PROFILE = os.environ.get(
+    "MNEMON_RUNNER_IAM_PROFILE", "mnemon-runner-executor-profile"
+)
+VOLUME_SIZE_GB = int(os.environ.get("MNEMON_RUNNER_VOLUME_SIZE_GB", "30"))
+
+MNEMON_RUNNER_TAG_NAME = "mnemon-runner-spot"
+MNEMON_RUNNER_JOB_ID_TAG_KEY = "mnemon-runner-job-id"
+
+# ── Circuit breaker + fleet cap (2026-07-15 spot-quota-starvation incident,
+# alpha-engine-config#2697 — the incident this circuit breaker design was
+# originally built for; mirrored here unchanged) ──────────────────────────
+# With every runner box failing identically (a deprecated runner version —
+# tracked separately), _reconcile() relaunched a fresh box per stuck queued
+# job on every ~60s pass, FOREVER: ~150 t3.medium spot launches in 45 min,
+# ~16 concurrent boxes = 32 vCPUs = 100% of the account's standard-spot quota
+# (L-34B43A08, value 32). The post-close trading SF's data-spot launch then
+# failed MaxSpotInstanceCountExceeded at 20:00 UTC — CI must never be able to
+# starve production of spot quota. Two independent bounds, both enforced
+# inside _launch_mnemon_runner_spot (the single chokepoint both the reactive
+# webhook-worker path AND the reconcile path funnel through — including the
+# config#2267 dedupe_degraded "proceed anyway" path, which is exactly where
+# an unbounded loop would otherwise re-open):
+#
+#   1. PER-JOB ATTEMPT LIMIT: once a job has had >= MAX_ATTEMPTS_PER_JOB boxes
+#      launched for it (live OR recently-terminated — a job whose boxes keep
+#      dying identically is exactly the runaway pattern), stop dispatching
+#      for THAT job and page once. Does not touch other jobs' dispatch, and
+#      does not disable the reconcile backstop itself (config-I2653 still
+#      recovers jobs whose one-shot `queued` webhook was consumed by a runner
+#      that grabbed a different job — this only bounds the RETRY count for a
+#      job that keeps failing).
+#   2. GLOBAL FLEET CAP: refuse to launch (for ANY job) once
+#      running+pending mnemon-runner boxes >= MAX_FLEET, regardless of
+#      per-job attempt counts — the last-resort backstop against any launch
+#      pattern (not just the identical-failure one above) that could
+#      otherwise still saturate the account's spot quota.
+MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB = int(os.environ.get("MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB", "3"))
+# ~1h: describe-instances reliably still returns a terminated instance for
+# about this long after termination (AWS does not document an exact
+# retention SLA; this matches the window the issue's incident review
+# confirmed empirically and is env-tunable if that changes).
+MNEMON_RUNNER_ATTEMPT_LOOKBACK_SECONDS = int(
+    os.environ.get("MNEMON_RUNNER_ATTEMPT_LOOKBACK_SECONDS", "3600")
+)
+# 6 boxes = 12 vCPUs (t3/t3a/t2.medium = 2 vCPUs each), leaving >= 20 vCPUs of
+# the 32-vCPU account standard-spot quota (L-34B43A08) for production.
+MNEMON_RUNNER_MAX_FLEET = int(os.environ.get("MNEMON_RUNNER_MAX_FLEET", "6"))
+
+# Jobs that tripped the per-job attempt limit this cold start — logged/paged
+# once per job per cold start rather than once per reconcile pass (a stuck
+# job is still stale on every subsequent ~60s pass; repaging it every minute
+# forever would be exactly the "single quota page at the very end" alerting
+# failure mode this issue is also about, just for a different signal).
+_abandoned_job_ids_paged: set[str] = set()
+
+# ── Two-phase bootstrap state machine (2026-07-15 zombie-leak incident,
+# alpha-engine-config-I2692 — source incident for this two-phase bootstrap
+# design; mirrored here unchanged) ─────────────────────────────────────────
+# The launch path previously did wait_ssm_online (60-200s) + send_command
+# INSIDE this Lambda's 60s timeout — the Lambda died mid-wait, the box never
+# received its bootstrap, never registered a runner, and never self-
+# terminated (the terminate-on-failure except died with the Lambda). Under
+# the reconcile loop that manufactured a zombie box per minute until the
+# spot quota exhausted and ALL fleet CI queued (2026-07-15 17:33-18:40 UTC).
+# Now: launch TAGS the box and returns in seconds; every ~60s reconcile pass
+# delivers the bootstrap to any SSM-online box that lacks it (single
+# describe, zero waiting), reaps boxes whose bootstrap can't be delivered by
+# BOOTSTRAP_DEADLINE, and reaps any box alive past RUNNER_MAX_LIFETIME
+# regardless of state (the janitor: no leak class can ever eat the quota
+# silently again).
+MNEMON_RUNNER_BOOTSTRAP_SENT_TAG_KEY = "mnemon-runner-bootstrap-sent"
+BOOTSTRAP_DEADLINE_SECONDS = int(os.environ.get("MNEMON_RUNNER_BOOTSTRAP_DEADLINE_SECONDS", "300"))
+RUNNER_MAX_LIFETIME_SECONDS = int(os.environ.get("MNEMON_RUNNER_MAX_LIFETIME_SECONDS", "5400"))
+
+# Loud page on quota exhaustion (the incident's silent failure mode: an hour
+# of CI paralysis visible only as ERROR log lines). Fleet-standard params.
+TELEGRAM_BOT_TOKEN_SSM = os.environ.get("MNEMON_RUNNER_TELEGRAM_BOT_TOKEN_SSM",
+                                        "/alpha-engine/TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID_SSM = os.environ.get("MNEMON_RUNNER_TELEGRAM_CHAT_ID_SSM",
+                                      "/alpha-engine/TELEGRAM_CHAT_ID")
+_page_sent_this_invocation = False
+
+
+def _page(message: str) -> None:
+    """Best-effort LOUD Telegram page (disable_notification=False — the
+    config-I2461 lesson: silent notifications get missed). Degrades to
+    log-only on any failure; at most one page per invocation to avoid a
+    reconcile loop spamming one page per queued job."""
+    global _page_sent_this_invocation
+    if _page_sent_this_invocation:
+        return
+    _page_sent_this_invocation = True
+    try:
+        ssm = boto3.client("ssm", region_name=REGION)
+        token = ssm.get_parameter(Name=TELEGRAM_BOT_TOKEN_SSM, WithDecryption=True)["Parameter"]["Value"]
+        chat_id = ssm.get_parameter(Name=TELEGRAM_CHAT_ID_SSM, WithDecryption=True)["Parameter"]["Value"]
+        req = urllib.request.Request(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=json.dumps({"chat_id": chat_id, "text": message,
+                             "disable_notification": False}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=10).read()
+    except Exception as exc:  # noqa: BLE001 — paging is best-effort; the log line below is the fallback surface
+        logger.error("telegram page FAILED (%s): %s — message was: %s",
+                     type(exc).__name__, exc, message)
+
+# This Lambda's OWN secret (unlike ci-watch-dispatcher, which needs none) —
+# the webhook HMAC secret, read once per cold start and cached at module
+# scope (same pattern as every fleet Lambda that reads a param once, not
+# per-invocation, to keep p50 latency low on the hot webhook-verification path).
+WEBHOOK_SECRET_SSM = os.environ.get(
+    "MNEMON_RUNNER_WEBHOOK_SECRET_SSM", "/mnemon/runner/webhook_secret"
+)
+_webhook_secret_cache: str | None = None
+
+
+def _webhook_secret() -> str:
+    global _webhook_secret_cache
+    if _webhook_secret_cache is None:
+        _webhook_secret_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=WEBHOOK_SECRET_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _webhook_secret_cache
+
+
+MNEMON_RUNNER_GH_PAT_SSM = os.environ.get(
+    "MNEMON_RUNNER_GH_PAT_SSM", "/mnemon/runner/github_pat"
+)
+MNEMON_RUNNER_CONFIG_BRANCH = os.environ.get("MNEMON_RUNNER_CONFIG_BRANCH", "main")
+MAX_RUNTIME_SECONDS = int(os.environ.get("MNEMON_RUNNER_MAX_RUNTIME_SECONDS", "1800"))
+# (SSM_ONLINE_BUDGET_SEC removed with the in-Lambda wait, I2692 — the
+# reconcile-driven bootstrap never waits; BOOTSTRAP_DEADLINE_SECONDS above
+# is its replacement bound.)
+CW_LOG_GROUP = os.environ.get("MNEMON_RUNNER_CW_LOG_GROUP", "/mnemon/runner-spot")
+
+# Reconcile backstop (config-I2653): a queued job older than this with no
+# in-flight box (per the same job-id-tag dedup check the reactive path uses)
+# gets a fresh dispatch. ~2-3x the typical observed dispatch+SSM-online
+# latency (15-40s) — comfortably past normal in-flight dispatches, without
+# waiting so long that a genuinely-orphaned job sits stuck for minutes.
+RECONCILE_STALE_SECONDS = int(os.environ.get("MNEMON_RUNNER_RECONCILE_STALE_SECONDS", "90"))
+RECONCILE_MAX_QUEUED_RUNS = int(os.environ.get("MNEMON_RUNNER_RECONCILE_MAX_QUEUED_RUNS", "50"))
+
+# Runner-fleet concurrency cap (config-I2692 item 4, 2026-07-15): a CI burst
+# must never be able to consume the WHOLE account spot quota by itself and
+# starve sibling workloads (groom/data/watch boxes share the same quota).
+# Default 20 concurrent mnemon-runner boxes (t3.medium-class, 2 vCPU each =
+# 40 vCPU) leaves >half of the current 96-vCPU quota for everything else;
+# env-tunable since the right number is a fleet-wide capacity tradeoff, not
+# a fact this Lambda can derive on its own. A job that can't get a box this
+# pass because the cap is full simply stays queued — the NEXT reconcile pass
+# (~60s) retries once older boxes finish and free a slot.
+MAX_CONCURRENT_RUNNERS = int(os.environ.get("MNEMON_RUNNER_MAX_CONCURRENT", "20"))
+
+MNEMON_RUNNER_READ_PAT_SSM = os.environ.get(
+    "MNEMON_RUNNER_READ_PAT_SSM", "/mnemon/runner/github_read_pat"
+)
+_gh_read_pat_cache: str | None = None
+
+
+def _gh_read_pat() -> str:
+    """A SEPARATE, dedicated, least-privilege PAT (Actions: Read ONLY —
+    cannot register runners, cannot touch repo settings) — deliberately NOT
+    the Administration:write PAT the box uses to register runners. This
+    Lambda sits behind a public, unauthenticated Function URL (HMAC
+    verification protects the WEBHOOK path, not a credential the Lambda's
+    own execution role can read); granting it read access to the powerful
+    registration PAT would widen blast radius for no reason the reconcile
+    logic actually needs (it only ever lists queued runs/jobs)."""
+    global _gh_read_pat_cache
+    if _gh_read_pat_cache is None:
+        _gh_read_pat_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=MNEMON_RUNNER_READ_PAT_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _gh_read_pat_cache
+
+
+def _gh_api_get(path: str) -> dict:
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Authorization": f"Bearer {_gh_read_pat()}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - fixed https://api.github.com host
+        return json.loads(resp.read())
+
+
+def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
+    """Constant-time HMAC-SHA256 verification of GitHub's
+    `X-Hub-Signature-256` header against the shared webhook secret."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(
+        _webhook_secret().encode("utf-8"), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def _decode_body(event: dict) -> bytes:
+    body = event.get("body") or ""
+    if event.get("isBase64Encoded"):
+        import base64
+
+        return base64.b64decode(body)
+    return body.encode("utf-8")
+
+
+def _response(status: int, body: dict) -> dict:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _handle_webhook(event: dict) -> dict:
+    """Phase 1: verify + filter a raw GitHub `workflow_job` webhook delivery.
+    Always returns fast (no spot-launch work happens in this phase) — a
+    matching event triggers an async self-invoke of the worker phase."""
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    raw_body = _decode_body(event)
+
+    if not _verify_signature(raw_body, headers.get("x-hub-signature-256")):
+        logger.warning("webhook signature verification failed — rejecting delivery")
+        return _response(401, {"error": "invalid signature"})
+
+    if headers.get("x-github-event") != "workflow_job":
+        # `ping` (sent on webhook creation) and anything else we didn't
+        # subscribe to — clean no-op, not an error.
+        return _response(200, {"ignored": "not a workflow_job event"})
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        logger.error("malformed webhook JSON body: %s", exc)
+        return _response(400, {"error": "malformed JSON"})
+
+    action = payload.get("action")
+    repo_full_name = (payload.get("repository") or {}).get("full_name")
+    job = payload.get("workflow_job") or {}
+    labels = job.get("labels") or []
+    job_id = job.get("id")
+
+    if (
+        action != "queued"
+        or repo_full_name != TARGET_REPO_FULL_NAME
+        or TARGET_LABEL not in labels
+        or job_id is None
+    ):
+        return _response(200, {"ignored": True, "action": action, "repo": repo_full_name})
+
+    if not DISPATCH_ENABLED:
+        logger.warning("MNEMON_RUNNER_DISPATCH_ENABLED=false — job %s NOT dispatched", job_id)
+        return _response(200, {"launched": False, "reason": "disabled", "job_id": job_id})
+
+    logger.info("queued job %s matches — self-invoking worker phase async", job_id)
+    boto3.client("lambda", region_name=REGION).invoke(
+        FunctionName=os.environ["AWS_LAMBDA_FUNCTION_NAME"],
+        InvocationType="Event",
+        Payload=json.dumps({"mnemon_runner_job_id": str(job_id)}).encode("utf-8"),
+    )
+    return _response(200, {"accepted": True, "job_id": job_id})
+
+
+def _running_mnemon_runner_instance_ids(job_id: str) -> list[str]:
+    return spot_dispatch.running_instance_ids(
+        MNEMON_RUNNER_TAG_NAME,
+        {MNEMON_RUNNER_JOB_ID_TAG_KEY: job_id},
+        region=REGION,
+    )
+
+
+# Any state that counts as "we already tried this" — including terminated
+# ones (a box that died is still a launch attempt against the job; that's
+# the entire point of the circuit breaker: N identical failures must stop,
+# not just N concurrently-alive boxes). shutting-down/stopping are
+# transitional states a box passes through on its way to terminated.
+_ANY_ATTEMPT_STATES = [
+    "pending", "running", "shutting-down", "stopping", "stopped", "terminated",
+]
+
+
+def _job_attempt_count(job_id: str) -> int:
+    """How many mnemon-runner boxes have been launched for ``job_id`` within
+    the last ``MNEMON_RUNNER_ATTEMPT_LOOKBACK_SECONDS`` (live or recently-
+    terminated — describe-instances keeps a terminated instance queryable for
+    ~1h, comfortably longer than this Lambda's own dispatch cadence). A
+    DescribeInstances failure here must NOT degrade to "0 attempts, dispatch
+    anyway" — that would silently defeat the entire circuit breaker on the
+    exact kind of degraded-EC2-API pass that a runaway is most likely to
+    coincide with, so it re-raises (the caller decides the fail-safe
+    posture; see _launch_mnemon_runner_spot)."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    resp = ec2.describe_instances(Filters=[
+        {"Name": "tag:Name", "Values": [MNEMON_RUNNER_TAG_NAME]},
+        {"Name": f"tag:{MNEMON_RUNNER_JOB_ID_TAG_KEY}", "Values": [job_id]},
+        {"Name": "instance-state-name", "Values": _ANY_ATTEMPT_STATES},
+    ])
+    now = datetime.now(timezone.utc)
+    count = 0
+    for r in resp.get("Reservations", []):
+        for i in r.get("Instances", []):
+            launch_time = i.get("LaunchTime")
+            if launch_time is not None:
+                age = (now - launch_time).total_seconds()
+                if age > MNEMON_RUNNER_ATTEMPT_LOOKBACK_SECONDS:
+                    continue
+            count += 1
+    return count
+
+
+def _current_fleet_size() -> int:
+    """Running+pending mnemon-runner boxes, fleet-wide (across ALL jobs) —
+    the global cap backstop. Deliberately a SEPARATE query from
+    _job_attempt_count (different filter shape, different failure posture):
+    a failure here also does not degrade to "0, launch anyway" (see
+    _launch_mnemon_runner_spot)."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    resp = ec2.describe_instances(Filters=[
+        {"Name": "tag:Name", "Values": [MNEMON_RUNNER_TAG_NAME]},
+        {"Name": "instance-state-name", "Values": ["pending", "running"]},
+    ])
+    return sum(len(r.get("Instances", [])) for r in resp.get("Reservations", []))
+
+
+MNEMON_RUNNER_LAUNCH_METRIC_NAMESPACE = "AlphaEngine/Infra"
+MNEMON_RUNNER_LAUNCH_METRIC_NAME = "mnemon_runner_launches"
+
+
+def _emit_launch_metric() -> None:
+    """One CloudWatch custom-metric datapoint per successful launch (mirrors
+    spot-orphan-reaper's ``_emit_metric`` pattern — a namespace/metric-name
+    pair, best-effort, never raises). This is the launch-rate alarm's data
+    source (config#2697): the 2026-07-15 runaway ran ~3h at ~150 launches/45min
+    with only a single quota page at the very end — a launch-COUNT alarm
+    (independent of whether launches are currently succeeding or already
+    failing quota) catches the runaway itself, not just its terminal
+    symptom. Alarm provisioned by
+    infrastructure/setup_mnemon_runner_launch_rate_alarm.sh (this repo has no
+    log-metric-filter precedent; every existing alarm — see
+    setup_watch_plane_alarms.sh, spot-orphan-reaper's own
+    spot_orphans_terminated metric — alarms on a Lambda-emitted custom/AWS
+    metric instead, which this follows)."""
+    try:
+        boto3.client("cloudwatch", region_name=REGION).put_metric_data(
+            Namespace=MNEMON_RUNNER_LAUNCH_METRIC_NAMESPACE,
+            MetricData=[{
+                "MetricName": MNEMON_RUNNER_LAUNCH_METRIC_NAME,
+                "Value": 1.0,
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:  # noqa: BLE001 — observability only; must never block/fail a dispatch
+        logger.warning("CloudWatch put_metric_data (%s) failed (non-fatal): %s",
+                        MNEMON_RUNNER_LAUNCH_METRIC_NAME, exc)
+
+
+def _bootstrap_command(job_id: str) -> str:
+    """The async SSM RunShellScript prelude: minimal-install, fetch the PAT,
+    clone mnemon, exec its mnemon_runner_spot_bootstrap.sh
+    entrypoint. Mirrors ci-watch-dispatcher's prelude exactly (same fail()
+    trap shape) — the difference is entirely in what runs AFTER the clone."""
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+export HOME=/root
+fail() {{ echo "[mnemon-runner-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 >/dev/null 2>&1 || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {MNEMON_RUNNER_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/mnemon
+git clone --depth 1 --branch {MNEMON_RUNNER_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{TARGET_REPO_FULL_NAME}.git" \
+  /home/ec2-user/mnemon || fail "clone failed"
+cd /home/ec2-user/mnemon
+exec bash infrastructure/mnemon_runner_spot_bootstrap.sh --job-id "{job_id}"
+"""
+
+
+def _launch_mnemon_runner_spot(job_id: str) -> dict:
+    # ── Circuit breaker + fleet cap (config#2697) — checked FIRST, ahead of
+    # the dedup probe, so both bind unconditionally: in particular, the
+    # per-job attempt limit MUST still apply on the config#2267
+    # dedupe_degraded "proceed anyway" path below, or a runaway job just
+    # re-opens the loop there instead. Both counts fail LOUD (re-raise) on a
+    # DescribeInstances error rather than degrade to "0, dispatch anyway" —
+    # unlike the dedup probe, coverage does NOT beat safety here: the whole
+    # point of a circuit breaker is that it must hold even when the AWS API
+    # is degraded, which is exactly when a runaway is likely to be underway.
+    try:
+        attempt_count = _job_attempt_count(job_id)
+    except Exception as exc:  # noqa: BLE001 — fail-safe: an unknown attempt count blocks the launch
+        logger.error(
+            "mnemon-runner attempt-count probe FAILED for job %s — refusing to "
+            "dispatch (fail-safe, unlike the dedupe probe): %s: %s",
+            job_id, type(exc).__name__, exc,
+        )
+        return {"launched": False, "reason": "attempt_probe_failed", "job_id": job_id,
+                "error": str(exc)}
+
+    if attempt_count >= MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB:
+        if job_id not in _abandoned_job_ids_paged:
+            _abandoned_job_ids_paged.add(job_id)
+            _page(
+                f"🔴 mnemon-runner: job {job_id} ABANDONED after "
+                f"{attempt_count} launch attempts (limit "
+                f"{MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB}) — every box likely "
+                "failing identically (e.g. a bad runner version/bootstrap "
+                "script). No further boxes will be dispatched for this job "
+                "until a human intervenes or ships a fix. "
+                "alpha-engine-config#2697 (source incident for this circuit breaker)."
+            )
+        logger.error(
+            "mnemon-runner job %s ABANDONED — %d attempts >= limit %d, "
+            "not dispatching", job_id, attempt_count, MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB,
+        )
+        return {"launched": False, "reason": "attempt_limit_exceeded", "job_id": job_id,
+                "attempt_count": attempt_count}
+
+    try:
+        fleet_size = _current_fleet_size()
+    except Exception as exc:  # noqa: BLE001 — fail-safe: an unknown fleet size blocks the launch
+        logger.error(
+            "mnemon-runner fleet-size probe FAILED for job %s — refusing to "
+            "dispatch (fail-safe): %s: %s", job_id, type(exc).__name__, exc,
+        )
+        return {"launched": False, "reason": "fleet_probe_failed", "job_id": job_id,
+                "error": str(exc)}
+
+    if fleet_size >= MNEMON_RUNNER_MAX_FLEET:
+        _page(
+            f"🔴 mnemon-runner: fleet cap reached ({fleet_size} >= "
+            f"{MNEMON_RUNNER_MAX_FLEET}) — job {job_id} NOT dispatched this "
+            "pass. Refusing further launches until the fleet shrinks (global "
+            "backstop against spot-quota starvation; design mirrors alpha-engine-config#2697)."
+        )
+        logger.error(
+            "mnemon-runner FLEET CAP reached (%d >= %d) — job %s not "
+            "dispatched", fleet_size, MNEMON_RUNNER_MAX_FLEET, job_id,
+        )
+        return {"launched": False, "reason": "fleet_cap_reached", "job_id": job_id,
+                "fleet_size": fleet_size}
+
+    dedupe_degraded = False
+    try:
+        existing = _running_mnemon_runner_instance_ids(job_id)
+    except SpotProbeError as exc:
+        # Coverage beats dedupe (same policy as ci-watch-dispatcher, config#2267
+        # site 1): a failed probe must never leave a real queued job uncovered.
+        dedupe_degraded = True
+        existing = []
+        logger.error(
+            "mnemon-runner concurrency probe FAILED for job %s — proceeding "
+            "with dedupe_degraded=true: %s: %s", job_id, type(exc).__name__, exc,
+        )
+    if existing:
+        logger.warning("mnemon-runner box already live for job %s (%s) — skipping",
+                       job_id, existing)
+        return {"launched": False, "reason": "concurrent_skip", "existing_instance_ids": existing}
+
+    try:
+        instance_id, market = spot_dispatch.launch_with_fallback(
+            INSTANCE_TYPES, SUBNETS,
+            image_id=AMI_ID,
+            key_name=KEY_NAME,
+            security_group_ids=[SECURITY_GROUP],
+            iam_instance_profile=IAM_PROFILE,
+            volume_size_gb=VOLUME_SIZE_GB,
+            tag_name=MNEMON_RUNNER_TAG_NAME,
+            region=REGION,
+        )
+    except SpotLaunchError as exc:
+        logger.error("mnemon-runner spot launch failed for job %s: %s: %s",
+                     job_id, type(exc).__name__, exc)
+        if "MaxSpotInstanceCountExceeded" in str(exc):
+            _page("🔴 mnemon-runner: spot QUOTA EXHAUSTED "
+                  "(MaxSpotInstanceCountExceeded) — CI dispatch for "
+                  f"{TARGET_REPO_FULL_NAME} is stalling. Check for leaked "
+                  "runner boxes (aws ec2 describe-instances "
+                  f"Name={MNEMON_RUNNER_TAG_NAME}) — the reconcile janitor "
+                  "should be reaping them; if this page repeats, it isn't. "
+                  "design mirrors alpha-engine-config-I2692.")
+        return {"launched": False, "reason": "launch_failed", "error": str(exc)}
+
+    logger.info("launched mnemon-runner box %s (%s) for job %s%s", instance_id, market, job_id,
+                " dedupe_degraded=true" if dedupe_degraded else "")
+    _emit_launch_metric()
+
+    try:
+        boto3.client("ec2", region_name=REGION).create_tags(
+            Resources=[instance_id],
+            Tags=[{"Key": MNEMON_RUNNER_JOB_ID_TAG_KEY, "Value": job_id}],
+        )
+    except Exception as exc:  # noqa: BLE001 — load-bearing tag write; terminate + fail loud on failure
+        spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="mnemon-runner")
+        logger.error("mnemon-runner discriminator tag write FAILED for %s (job %s) — "
+                     "box terminated, dispatch failed: %s: %s",
+                     instance_id, job_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "tag_write_failed", "instance_id": instance_id,
+                "error": str(exc), "dedupe_degraded": dedupe_degraded}
+
+    # Two-phase contract (I2692): launch + tag ONLY — this function must
+    # return in seconds. NO wait_ssm_online, NO send_command here: the old
+    # in-line wait blew this Lambda's 60s timeout, killing the bootstrap AND
+    # the terminate-on-failure handler with it (the 2026-07-15 zombie-leak
+    # incident). _bootstrap_and_reap() (every reconcile pass, ~60s) delivers
+    # the bootstrap once the box's SSM agent is online — which takes 40-90s
+    # after launch anyway, so this adds ~zero real latency.
+    logger.info("mnemon-runner launched (bootstrap deferred to reconcile): "
+                "instance=%s market=%s job_id=%s", instance_id, market, job_id)
+    return {
+        "launched": True,
+        "reason": "launched_bootstrap_pending",
+        "instance_id": instance_id,
+        "market": market,
+        "job_id": job_id,
+        "dedupe_degraded": dedupe_degraded,
+    }
+
+
+def _bootstrap_and_reap() -> dict:
+    """The reconcile-driven bootstrap deliverer + janitor (I2692). For every
+    running mnemon-runner box, exactly one of:
+
+      - no bootstrap-sent tag + SSM Online   -> send bootstrap, tag it
+      - no bootstrap-sent tag + SSM not up   -> reap once older than
+        BOOTSTRAP_DEADLINE_SECONDS (SSM never came up / undeliverable)
+      - any box older than RUNNER_MAX_LIFETIME_SECONDS -> reap (leak
+        backstop: an ephemeral runner that hasn't self-terminated by then is
+        a zombie regardless of how it got wedged)
+
+    Every step is a single fast API call — no waiting anywhere, so any
+    number of boxes fits inside the Lambda budget. Never raises: one box's
+    failure must not strand the rest."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    ssm = boto3.client("ssm", region_name=REGION)
+    stats = {"bootstrapped": 0, "reaped_no_ssm": 0, "reaped_lifetime": 0,
+             "waiting_ssm": 0, "healthy": 0, "errors": 0, "running_after_reap": 0}
+    now = datetime.now(timezone.utc)
+
+    try:
+        resp = ec2.describe_instances(Filters=[
+            {"Name": "tag:Name", "Values": [MNEMON_RUNNER_TAG_NAME]},
+            {"Name": "instance-state-name", "Values": ["running", "pending"]},
+        ])
+        boxes = [i for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
+    except Exception as exc:  # noqa: BLE001 — enumeration failure: nothing to do this pass, retry next
+        logger.error("bootstrap_and_reap: describe_instances failed: %s: %s",
+                     type(exc).__name__, exc)
+        stats["errors"] += 1
+        return stats
+
+    online_ids: set[str] = set()
+    if boxes:
+        try:
+            info = ssm.describe_instance_information(Filters=[
+                {"Key": "InstanceIds", "Values": [b["InstanceId"] for b in boxes]},
+            ]).get("InstanceInformationList", [])
+            online_ids = {i["InstanceId"] for i in info if i.get("PingStatus") == "Online"}
+        except Exception as exc:  # noqa: BLE001 — degrade to "none online"; young boxes wait, old ones still reap
+            logger.error("bootstrap_and_reap: SSM describe failed: %s: %s",
+                         type(exc).__name__, exc)
+
+    for box in boxes:
+        iid = box["InstanceId"]
+        tags = {t["Key"]: t["Value"] for t in box.get("Tags", [])}
+        age = (now - box["LaunchTime"]).total_seconds()
+
+        if age > RUNNER_MAX_LIFETIME_SECONDS:
+            try:
+                ec2.terminate_instances(InstanceIds=[iid])
+                logger.warning("bootstrap_and_reap: REAPED %s (lifetime %ds > %ds — leaked box)",
+                               iid, int(age), RUNNER_MAX_LIFETIME_SECONDS)
+                stats["reaped_lifetime"] += 1
+            except Exception as exc:  # noqa: BLE001 — retried next pass
+                logger.error("bootstrap_and_reap: reap %s failed: %s", iid, exc)
+                stats["errors"] += 1
+            continue
+
+        if MNEMON_RUNNER_BOOTSTRAP_SENT_TAG_KEY in tags:
+            stats["healthy"] += 1
+            continue
+
+        job_id = tags.get(MNEMON_RUNNER_JOB_ID_TAG_KEY, "")
+        if iid in online_ids and job_id:
+            try:
+                spot_dispatch.send_async_command(
+                    iid,
+                    _bootstrap_command(job_id),
+                    comment=f"mnemon-runner (job {job_id})",
+                    region=REGION,
+                    cw_log_group=CW_LOG_GROUP,
+                    execution_timeout_seconds=MAX_RUNTIME_SECONDS,
+                )
+                ec2.create_tags(Resources=[iid], Tags=[{
+                    "Key": MNEMON_RUNNER_BOOTSTRAP_SENT_TAG_KEY,
+                    "Value": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }])
+                logger.info("bootstrap_and_reap: bootstrapped %s (job %s, %ds after launch)",
+                            iid, job_id, int(age))
+                stats["bootstrapped"] += 1
+            except Exception as exc:  # noqa: BLE001 — send/tag failure: untagged, retried next pass
+                logger.error("bootstrap_and_reap: bootstrap %s failed (retry next pass): %s: %s",
+                             iid, type(exc).__name__, exc)
+                stats["errors"] += 1
+        elif age > BOOTSTRAP_DEADLINE_SECONDS:
+            try:
+                ec2.terminate_instances(InstanceIds=[iid])
+                logger.warning("bootstrap_and_reap: REAPED %s (no SSM/job-id after %ds — "
+                               "bootstrap undeliverable)", iid, int(age))
+                stats["reaped_no_ssm"] += 1
+            except Exception as exc:  # noqa: BLE001 — retried next pass
+                logger.error("bootstrap_and_reap: reap %s failed: %s", iid, exc)
+                stats["errors"] += 1
+        else:
+            stats["waiting_ssm"] += 1
+
+    stats["running_after_reap"] = len(boxes) - stats["reaped_no_ssm"] - stats["reaped_lifetime"]
+    logger.info("bootstrap_and_reap: %s", stats)
+    return stats
+
+
+def _reconcile() -> dict:
+    """Scheduled backstop (~every 60s, config-I2653): dispatch a fresh runner
+    for any queued job matching our label that's had no in-flight box for
+    RECONCILE_STALE_SECONDS. See module docstring phase 3 for the full
+    rationale — this is NOT redundant with the reactive webhook path; it is
+    the only mechanism that can recover a job whose one-shot `queued`
+    webhook already fired but whose dispatched runner grabbed a different
+    job instead."""
+    if not DISPATCH_ENABLED:
+        logger.info("reconcile: MNEMON_RUNNER_DISPATCH_ENABLED=false — skipping")
+        return {"reconciled": 0, "reason": "disabled"}
+
+    # Bootstrap-deliverer + janitor FIRST (I2692): serve boxes already up
+    # before launching new ones, and reap zombies so the queued-job scan
+    # below never launches into an exhausted quota that leaked boxes caused.
+    br_stats = _bootstrap_and_reap()
+
+    now = datetime.now(timezone.utc)
+    try:
+        runs_resp = _gh_api_get(
+            f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs"
+            f"?status=queued&per_page={RECONCILE_MAX_QUEUED_RUNS}"
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        # Best-effort: a failed reconcile pass just means "no backstop this
+        # minute" — the NEXT scheduled invocation tries again. Never raise
+        # (this is EventBridge-invoked; an unhandled exception would just
+        # generate a Lambda-error-metric page for a transient GitHub API
+        # blip with no actionable fix).
+        logger.error("reconcile: failed to list queued runs: %s: %s", type(exc).__name__, exc)
+        return {"reconciled": 0, "reason": "list_runs_failed", "error": str(exc)}
+
+    # Collect ALL stale queued jobs first, then dispatch OLDEST-FIRST.
+    # GitHub lists runs newest-first; dispatching in listing order let a
+    # constant churn of fresh runs (e.g. the 2026-07-15 Dependabot-drain
+    # rebase wave) win every quota-constrained launch race while the oldest
+    # job starved indefinitely (PR2690's pytest sat queued 95+ min while
+    # newer jobs got every available spot slot). FIFO makes quota pressure
+    # degrade to bounded latency for everyone instead of unbounded latency
+    # for the unluckiest.
+    stale_jobs: list[tuple[float, str]] = []
+    for run in runs_resp.get("workflow_runs", []):
+        try:
+            jobs_resp = _gh_api_get(
+                f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs/{run['id']}/jobs"
+            )
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+            logger.error("reconcile: failed to list jobs for run %s: %s: %s",
+                         run.get("id"), type(exc).__name__, exc)
+            continue
+        for job in jobs_resp.get("jobs", []):
+            if job.get("status") != "queued" or TARGET_LABEL not in (job.get("labels") or []):
+                continue
+            created_at = datetime.fromisoformat(job["created_at"].replace("Z", "+00:00"))
+            age_seconds = (now - created_at).total_seconds()
+            if age_seconds < RECONCILE_STALE_SECONDS:
+                continue  # still within the reactive path's normal dispatch latency
+            stale_jobs.append((age_seconds, str(job["id"])))
+
+    # Concurrency cap (I2692 item 4): count this pass's OWN dispatches against
+    # the fleet already standing after bootstrap_and_reap's janitor pass, so a
+    # single burst of stale jobs can't blow past the cap in one reconcile.
+    available_slots = max(0, MAX_CONCURRENT_RUNNERS - br_stats.get("running_after_reap", 0))
+    capped_at_slot_zero = False
+
+    dispatched = []
+    skipped = []
+    for age_seconds, job_id in sorted(stale_jobs, reverse=True):  # oldest first
+        try:
+            existing = _running_mnemon_runner_instance_ids(job_id)
+        except SpotProbeError:
+            existing = []  # degrade to "dispatch anyway" — the launch's own dedup/tag logic is authoritative
+        if existing:
+            skipped.append(job_id)
+            continue
+        if available_slots <= 0:
+            logger.warning("reconcile: job %s queued %.0fs but MAX_CONCURRENT_RUNNERS=%d "
+                            "already reached — leaving queued for next pass",
+                            job_id, age_seconds, MAX_CONCURRENT_RUNNERS)
+            skipped.append(job_id)
+            capped_at_slot_zero = True
+            continue
+        logger.info("reconcile: job %s queued %.0fs with no in-flight box — dispatching",
+                   job_id, age_seconds)
+        result = _launch_mnemon_runner_spot(job_id)
+        if result.get("launched"):
+            available_slots -= 1
+        dispatched.append({"job_id": job_id, "age_seconds": age_seconds, "result": result})
+
+    if capped_at_slot_zero:
+        _page(f"⚠️ mnemon-runner: MAX_CONCURRENT_RUNNERS={MAX_CONCURRENT_RUNNERS} reached — "
+              "one or more stale jobs left queued this reconcile pass pending a free slot. "
+              "design mirrors alpha-engine-config-I2692.")
+
+    logger.info("reconcile: dispatched=%d skipped=%d bootstrap_and_reap=%s",
+                len(dispatched), len(skipped), br_stats)
+    return {"reconciled": len(dispatched), "dispatched": dispatched,
+            "skipped": skipped, "bootstrap_and_reap": br_stats}
+
+
+def handler(event: dict, context) -> dict:
+    """Three-phase entrypoint — see module docstring. A Function URL
+    delivery carries `requestContext` (the API Gateway v2-shaped proxy
+    event); the EventBridge-scheduled reconcile trigger carries
+    `{"reconcile": true}`; the async self-invoked worker payload carries
+    `mnemon_runner_job_id`."""
+    event = event or {}
+    if event.get("reconcile"):
+        return _reconcile()
+    if "requestContext" in event:
+        return _handle_webhook(event)
+
+    job_id = event.get("mnemon_runner_job_id")
+    if not job_id:
+        logger.error("worker-phase invocation missing mnemon_runner_job_id: %r", event)
+        return {"launched": False, "reason": "invalid_event"}
+    return _launch_mnemon_runner_spot(str(job_id))

--- a/infrastructure/lambdas/mnemon-runner-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/mnemon-runner-dispatcher/requirements.txt
@@ -1,0 +1,10 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
+# spot-launch capacity-resilience chokepoint) — same primitives ci-watch-
+# dispatcher/sf-watch-spot-dispatcher use. Pinned to the latest tag at the
+# time this Lambda was written (v0.106.0 is the floor: first version whose
+# running_instance_ids raises SpotProbeError instead of failing open,
+# config#2267 site 1 — index.py imports and handles that exception).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.110.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/mnemon-runner-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/mnemon-runner-dispatcher/test_handler.py
@@ -1,0 +1,1091 @@
+"""Unit tests for the three-phase (webhook receiver / worker / reconcile)
+mnemon-runner spot dispatcher.
+
+Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
+before importing index (mirrors ci-watch-dispatcher/test_handler.py). Covers:
+webhook HMAC signature verification, event/action/label/repo filtering, the
+async self-invoke on a matching queued job, the kill-switch, the worker
+phase's launch/dedup/tag/SSM-dispatch behavior (spot-first with on-demand
+fallback, job-id-scoped concurrency lock, terminate-on-post-launch-failure,
+config#2267-style dedupe_degraded on a probe failure), and the reconcile
+backstop (config-I2653 — dispatches a fresh runner for any queued job
+matching our label that's sat stale with no in-flight box; ``urllib.request``
+is monkeypatched per-test rather than stubbed in sys.modules, since it's
+stdlib and always resolvable).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_stdlib
+import json
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+WEBHOOK_SECRET = "test-webhook-secret"
+
+
+class _SpotLaunchError(Exception):
+    pass
+
+
+class _SpotCapacityExhausted(_SpotLaunchError):
+    pass
+
+
+def _install_stubs(launch_impl, boto_clients):
+    ec2_spot_mod = types.ModuleType("nousergon_lib.ec2_spot")
+    ec2_spot_mod.SpotLaunchError = _SpotLaunchError
+    ec2_spot_mod.SpotCapacityExhausted = _SpotCapacityExhausted
+    ec2_spot_mod.launch = launch_impl
+    sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
+
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: boto_clients[name]
+    sys.modules["boto3"] = boto3_mod
+
+
+class _FakeWaiter:
+    def wait(self, **kw):
+        return None
+
+
+class _FakeEc2:
+    def __init__(self, running_job_ids=None, create_tags_failures=0, attempt_boxes=None):
+        self.terminated = []
+        self.tags_created = []
+        self.create_tags_attempts = 0
+        self._create_tags_failures = create_tags_failures
+        self._running_job_ids = dict(running_job_ids or {})  # {job_id: [instance_ids]}
+        # {job_id: [instance dicts]} — full instance dicts (InstanceId,
+        # LaunchTime, state) for the config#2697 attempt-count probe, which
+        # (unlike the dedupe probe above) needs state/age, not just ids.
+        self._attempt_boxes = dict(attempt_boxes or {})
+        self.describe_instances_calls = 0
+        self.describe_instances_failures = 0
+
+    def get_waiter(self, name):
+        return _FakeWaiter()
+
+    def terminate_instances(self, InstanceIds):  # noqa: N803
+        self.terminated.extend(InstanceIds)
+        return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
+
+    def create_tags(self, Resources, Tags):  # noqa: N803
+        self.create_tags_attempts += 1
+        if self.create_tags_attempts <= self._create_tags_failures:
+            raise RuntimeError(f"CreateTags throttled (attempt {self.create_tags_attempts})")
+        self.tags_created.append((Resources, Tags))
+        return {}
+
+    def describe_instances(self, Filters):  # noqa: N803
+        self.describe_instances_calls += 1
+        if self.describe_instances_calls <= self.describe_instances_failures:
+            raise RuntimeError(f"DescribeInstances throttled (attempt {self.describe_instances_calls})")
+        by_name = {f["Name"]: f["Values"] for f in Filters}
+        states = by_name.get("instance-state-name", [])
+        job_id_filter = by_name.get("tag:mnemon-runner-job-id")
+
+        # config#2697 _job_attempt_count: tag:Name + tag:mnemon-runner-job-id
+        # + a state list that includes "terminated" (the discriminator vs.
+        # the plain dedupe-probe job-id query below, which never asks for
+        # terminated boxes).
+        if job_id_filter is not None and "terminated" in states:
+            job_id = job_id_filter[0]
+            boxes = self._attempt_boxes.get(job_id, [])
+            return {"Reservations": [{"Instances": list(boxes)}]} if boxes else {"Reservations": []}
+
+        # _bootstrap_and_reap / config#2697 _current_fleet_size: tag:Name
+        # WITHOUT a job-id filter — tests populate self.boxes with full
+        # instance dicts (shared fixture between both call sites, since
+        # fleet-size counting has the identical filter shape as the
+        # bootstrap-and-reap enumeration).
+        if "tag:Name" in by_name and job_id_filter is None:
+            return {"Reservations": [{"Instances": list(getattr(self, "boxes", []))}]}
+
+        # Plain dedupe probe (spot_dispatch.running_instance_ids): filters by
+        # job-id, state restricted to pending/running only.
+        job_id = job_id_filter[0] if job_id_filter else None
+        ids = self._running_job_ids.get(job_id, [])
+        return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
+
+
+class _FakeSsm:
+    def __init__(self):
+        self.sent = []
+        self.params = {
+            "/mnemon/runner/webhook_secret": WEBHOOK_SECRET,
+            "/mnemon/runner/github_read_pat": "test-read-only-pat",
+        }
+
+    def get_parameter(self, Name, WithDecryption=True):  # noqa: N803
+        return {"Parameter": {"Value": self.params[Name]}}
+
+    def describe_instance_information(self, **kw):
+        # _bootstrap_and_reap (I2692) matches entries by InstanceId; tests
+        # populate self.online_ids. Legacy default (no online_ids) keeps the
+        # old anonymous-Online shape for any pre-I2692 call sites.
+        online = getattr(self, "online_ids", None)
+        if online is None:
+            return {"InstanceInformationList": [{"PingStatus": "Online"}]}
+        return {"InstanceInformationList": [
+            {"InstanceId": i, "PingStatus": "Online"} for i in online]}
+
+    def send_command(self, **kw):
+        self.sent.append(kw)
+        return {"Command": {"CommandId": "cmd-123"}}
+
+
+class _FakeLambda:
+    def __init__(self):
+        self.invocations = []
+
+    def invoke(self, **kw):
+        self.invocations.append(kw)
+        return {"StatusCode": 202}
+
+
+class _FakeCloudwatch:
+    def __init__(self):
+        self.put_metric_data_calls = []
+
+    def put_metric_data(self, **kw):
+        self.put_metric_data_calls.append(kw)
+        return {}
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None, running_job_ids=None,
+          create_tags_failures=0, attempt_boxes=None, describe_instances_failures=0):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "mnemon-runner-dispatcher")
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    ssm = _FakeSsm()
+    ec2 = _FakeEc2(running_job_ids=running_job_ids, create_tags_failures=create_tags_failures,
+                   attempt_boxes=attempt_boxes)
+    ec2.describe_instances_failures = describe_instances_failures
+    lam = _FakeLambda()
+    cw = _FakeCloudwatch()
+    clients = {"ec2": ec2, "ssm": ssm, "lambda": lam, "cloudwatch": cw}
+    if launch_impl is None:
+        launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
+    _install_stubs(launch_impl, clients)
+
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+
+    assert_hermetic_imports_satisfied(__file__)
+    import importlib
+
+    if "nousergon_lib.spot_dispatch" in sys.modules:
+        importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
+    else:
+        import nousergon_lib.spot_dispatch  # noqa: F401 — first import picks up the current stub
+
+    _sd = sys.modules["nousergon_lib.spot_dispatch"]
+    if not hasattr(_sd, "SpotProbeError"):
+        _sd.SpotProbeError = type("SpotProbeError", (Exception,), {})
+
+    import index
+
+    importlib.reload(index)
+    index._test_ssm = ssm
+    index._test_ec2 = ec2
+    index._test_lambda = lam
+    index._test_cloudwatch = cw
+    return index
+
+
+def _sign(body_bytes: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    return "sha256=" + hmac_stdlib.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+
+
+def _webhook_event(payload: dict, *, event_type: str = "workflow_job", secret: str = WEBHOOK_SECRET) -> dict:
+    body = json.dumps(payload)
+    body_bytes = body.encode("utf-8")
+    return {
+        "requestContext": {"http": {"method": "POST"}},
+        "headers": {
+            "x-github-event": event_type,
+            "x-hub-signature-256": _sign(body_bytes, secret),
+        },
+        "body": body,
+        "isBase64Encoded": False,
+    }
+
+
+def _job_payload(**overrides):
+    base = {
+        "action": "queued",
+        "repository": {"full_name": "nousergon/mnemon"},
+        "workflow_job": {"id": 987654321, "labels": ["self-hosted", "mnemon-spot"]},
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Phase 1: webhook receiver ────────────────────────────────────────────────
+
+
+def test_webhook_valid_queued_job_self_invokes_and_returns_200(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["accepted"] is True
+    assert body["job_id"] == 987654321
+    assert len(idx._test_lambda.invocations) == 1
+    inv = idx._test_lambda.invocations[0]
+    assert inv["InvocationType"] == "Event"
+    assert inv["FunctionName"] == "mnemon-runner-dispatcher"
+    worker_payload = json.loads(inv["Payload"])
+    assert worker_payload == {"mnemon_runner_job_id": "987654321"}
+
+
+def test_webhook_invalid_signature_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(), secret="wrong-secret"), None)
+    assert resp["statusCode"] == 401
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_signature_header_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    event = _webhook_event(_job_payload())
+    del event["headers"]["x-hub-signature-256"]
+    resp = idx.handler(event, None)
+    assert resp["statusCode"] == 401
+
+
+def test_webhook_non_workflow_job_event_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event({"zen": "hello"}, event_type="ping"), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_non_queued_action_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(action="completed")), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_wrong_repo_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(repository={"full_name": "nousergon/some-other-repo"})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_our_label_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(workflow_job={"id": 1, "labels": ["ubuntu-latest"]})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_disabled_flag_skips_invoke(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "false"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["launched"] is False
+    assert body["reason"] == "disabled"
+    assert idx._test_lambda.invocations == []
+
+
+# ── Phase 2: worker (async self-invoked) ─────────────────────────────────────
+
+
+def test_worker_valid_job_launches_tags_and_defers_bootstrap(monkeypatch):
+    # I2692 two-phase contract: the worker phase launches + tags and returns
+    # in seconds — NO in-Lambda SSM wait/send (that wait used to blow the
+    # 60s Lambda timeout and manufacture zombie boxes). The bootstrap is
+    # delivered by _bootstrap_and_reap on a later reconcile pass.
+    calls = {}
+
+    def _launch(types_, subnets, **kw):
+        calls["spot"] = kw.get("spot")
+        calls["profile"] = kw.get("iam_instance_profile")
+        calls["tag_name"] = kw.get("tag_name")
+        return "i-abc"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"mnemon_runner_job_id": "987654321"}, None)
+    assert out["launched"] is True
+    assert out["reason"] == "launched_bootstrap_pending"
+    assert out["instance_id"] == "i-abc"
+    assert out["market"] == "spot"
+    assert calls["profile"] == "mnemon-runner-executor-profile"
+    assert calls["tag_name"] == "mnemon-runner-spot"
+    assert idx._test_ec2.tags_created == [
+        (["i-abc"], [{"Key": "mnemon-runner-job-id", "Value": "987654321"}])
+    ]
+    assert idx._test_ssm.sent == [], "worker phase must never send SSM commands (I2692)"
+
+
+def test_worker_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        if kw.get("spot"):
+            raise _SpotCapacityExhausted("no capacity")
+        return "i-ondemand"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["market"] == "on-demand"
+    assert seen == [True, False]
+
+
+def test_worker_total_launch_exhaustion_returns_clean_false(monkeypatch):
+    def _launch(types_, subnets, **kw):
+        raise _SpotCapacityExhausted("exhausted")
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_concurrency_skip_when_job_already_running(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-new"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-already-running"]},
+    )
+    out = idx.handler({"mnemon_runner_job_id": "55"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "concurrent_skip"
+    assert out["existing_instance_ids"] == ["i-already-running"]
+    assert launched == []
+
+
+def test_worker_different_job_id_is_not_blocked(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-other-job"]},
+    )
+    out = idx.handler({"mnemon_runner_job_id": "56"}, None)
+    assert out["launched"] is True
+
+
+def test_worker_probe_failure_launches_with_dedupe_degraded(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-degraded",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _probe_down(*a, **kw):
+        raise idx.SpotProbeError("probe failed: ThrottlingException")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["dedupe_degraded"] is True
+
+
+def test_worker_persistent_tag_write_failure_terminates_and_fails(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-untaggable",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        create_tags_failures=99,
+    )
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "tag_write_failed"
+    assert idx._test_ec2.terminated == ["i-untaggable"]
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_quota_exhaustion_pages_loudly(monkeypatch):
+    # I2692: MaxSpotInstanceCountExceeded used to be ERROR-log-only while
+    # fleet CI silently queued for an hour — it must page now.
+    from nousergon_lib.spot_dispatch import SpotLaunchError
+
+    def _launch(types_, subnets, **kw):
+        raise SpotLaunchError(
+            "RunInstances failed with non-capacity error "
+            "MaxSpotInstanceCountExceeded (t3.medium@subnet-x): "
+            "Max spot instance count exceeded")
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert len(pages) == 1 and "QUOTA EXHAUSTED" in pages[0]
+
+
+# ── _bootstrap_and_reap (I2692 two-phase state machine) ──────────────────────
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def _box(iid, *, age_seconds, job_id="j1", bootstrapped=False):
+    tags = [{"Key": "Name", "Value": "mnemon-runner-spot"}]
+    if job_id:
+        tags.append({"Key": "mnemon-runner-job-id", "Value": job_id})
+    if bootstrapped:
+        tags.append({"Key": "mnemon-runner-bootstrap-sent", "Value": "2026-01-01T00:00:00Z"})
+    return {"InstanceId": iid, "Tags": tags,
+            "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds)}
+
+
+def test_bootstrap_and_reap_sends_bootstrap_to_online_untagged_box(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-new", age_seconds=70, job_id="42")]
+    idx._test_ssm.online_ids = ["i-new"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["bootstrapped"] == 1
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert 'exec bash infrastructure/mnemon_runner_spot_bootstrap.sh --job-id "42"' in cmd
+    assert any(r == ["i-new"] and tags[0]["Key"] == "mnemon-runner-bootstrap-sent"
+               for r, tags in idx._test_ec2.tags_created)
+
+
+def test_bootstrap_and_reap_waits_on_young_offline_box(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-booting", age_seconds=60)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["waiting_ssm"] == 1
+    assert idx._test_ec2.terminated == []
+    assert idx._test_ssm.sent == []
+
+
+def test_bootstrap_and_reap_reaps_box_ssm_never_came_up(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-zombie", age_seconds=400)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_no_ssm"] == 1
+    assert idx._test_ec2.terminated == ["i-zombie"]
+
+
+def test_bootstrap_and_reap_reaps_over_lifetime_box_even_if_bootstrapped(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-leak", age_seconds=6000, bootstrapped=True)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_lifetime"] == 1
+    assert idx._test_ec2.terminated == ["i-leak"]
+
+
+def test_bootstrap_and_reap_healthy_bootstrapped_box_untouched(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-working", age_seconds=600, bootstrapped=True)]
+    idx._test_ssm.online_ids = ["i-working"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["healthy"] == 1
+    assert idx._test_ec2.terminated == []
+    assert idx._test_ssm.sent == []
+
+
+def test_bootstrap_and_reap_send_failure_leaves_untagged_for_retry(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-flaky", age_seconds=100, job_id="7")]
+    idx._test_ssm.online_ids = ["i-flaky"]
+
+    def _boom_send(**kw):
+        raise RuntimeError("SSM SendCommand failed")
+
+    idx._test_ssm.send_command = _boom_send
+    stats = idx._bootstrap_and_reap()
+    assert stats["errors"] == 1
+    assert stats["bootstrapped"] == 0
+    # No bootstrap-sent tag written — the next reconcile pass retries.
+    assert all(tags[0]["Key"] != "mnemon-runner-bootstrap-sent"
+               for _, tags in idx._test_ec2.tags_created)
+
+
+def test_worker_missing_job_id_returns_invalid_event(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+
+
+# ── Phase 3: reconcile backstop (config-I2653) ───────────────────────────────
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_gh_api_stub(idx, monkeypatch, runs_by_path):
+    """runs_by_path: {url_path_suffix: response_dict}. Any request whose URL
+    ends with a registered suffix returns that canned response."""
+    def _fake_urlopen(req, timeout=10):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+        for suffix, payload in runs_by_path.items():
+            if url.endswith(suffix):
+                return _FakeHttpResponse(payload)
+        raise AssertionError(f"unexpected GH API call: {url}")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+
+
+def _iso(seconds_ago: float) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_reconcile_dispatches_stale_orphaned_job(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-rescued",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {
+            "workflow_runs": [{"id": 555}],
+        },
+        "/actions/runs/555/jobs": {
+            "jobs": [{
+                "id": 999, "status": "queued",
+                "labels": ["self-hosted", "mnemon-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 1
+    assert out["dispatched"][0]["job_id"] == "999"
+    assert out["dispatched"][0]["result"]["launched"] is True
+
+
+def test_reconcile_skips_job_within_normal_dispatch_window(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [{
+                "id": 1, "status": "queued",
+                "labels": ["self-hosted", "mnemon-spot"],
+                "created_at": _iso(10),  # well under the 90s default threshold
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["dispatched"] == []
+
+
+def test_reconcile_skips_job_already_covered_by_an_in_flight_box(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"777": ["i-already-covering-it"]},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 2}]},
+        "/actions/runs/2/jobs": {
+            "jobs": [{
+                "id": 777, "status": "queued",
+                "labels": ["self-hosted", "mnemon-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["skipped"] == ["777"]
+
+
+def test_reconcile_ignores_jobs_without_our_label(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 3}]},
+        "/actions/runs/3/jobs": {
+            "jobs": [{
+                "id": 3, "status": "queued", "labels": ["ubuntu-latest"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+
+
+def test_reconcile_disabled_flag_short_circuits(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "false"})
+    out = idx.handler({"reconcile": True}, None)
+    assert out == {"reconciled": 0, "reason": "disabled"}
+
+
+def test_reconcile_list_runs_failure_returns_clean_result_not_raise(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+
+    def _boom(req, timeout=10):  # noqa: ARG001
+        raise idx.urllib.error.URLError("network blip")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["reason"] == "list_runs_failed"
+
+
+def test_reconcile_dispatches_oldest_job_first(monkeypatch):
+    # FIFO fairness: under quota pressure the OLDEST stale job must get the
+    # first launch attempt — newest-first listing order let fresh churn
+    # starve old jobs indefinitely (PR2690, 2026-07-15).
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        return f"i-{len(launched)}"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+
+    old = (datetime.now(timezone.utc) - timedelta(seconds=5000)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    newer = (datetime.now(timezone.utc) - timedelta(seconds=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def fake_get(path):
+        if path.endswith("&per_page=50") or "/actions/runs?" in path:
+            return {"workflow_runs": [{"id": 1}, {"id": 2}]}
+        if "/runs/1/jobs" in path:
+            # newest-first listing: run 1 (listed first) has the NEWER job
+            return {"jobs": [{"id": 111, "status": "queued", "created_at": newer,
+                              "labels": ["self-hosted", "mnemon-spot"]}]}
+        if "/runs/2/jobs" in path:
+            return {"jobs": [{"id": 222, "status": "queued", "created_at": old,
+                              "labels": ["self-hosted", "mnemon-spot"]}]}
+        raise AssertionError(f"unexpected GH GET {path}")
+
+    monkeypatch.setattr(idx, "_gh_api_get", fake_get)
+    out = idx.handler({"reconcile": True}, None)
+    order = [d["job_id"] for d in out["dispatched"]]
+    assert order == ["222", "111"], f"oldest job must dispatch first, got {order}"
+
+
+# ── Runner-fleet concurrency cap (I2692 item 4) ──────────────────────────────
+
+
+def test_bootstrap_and_reap_reports_running_after_reap(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [
+        _box("i-healthy", age_seconds=600, bootstrapped=True),
+        _box("i-zombie", age_seconds=6000, bootstrapped=True),  # reaped: over lifetime
+    ]
+    idx._test_ssm.online_ids = ["i-healthy"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_lifetime"] == 1
+    # one box reaped this pass — only the survivor counts toward the cap
+    assert stats["running_after_reap"] == 1
+
+
+def test_reconcile_respects_concurrency_cap_leaves_job_queued(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true",
+                                    "MNEMON_RUNNER_MAX_CONCURRENT": "1"})
+    idx._test_ec2.boxes = [_box("i-existing", age_seconds=100, job_id="1", bootstrapped=True)]
+    idx._test_ssm.online_ids = ["i-existing"]
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 9}]},
+        "/actions/runs/9/jobs": {
+            "jobs": [{"id": 909, "status": "queued",
+                      "labels": ["self-hosted", "mnemon-spot"],
+                      "created_at": _iso(200)}],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["skipped"] == ["909"]
+    assert len(pages) == 1 and "MAX_CONCURRENT_RUNNERS=1" in pages[0]
+
+
+def test_reconcile_dispatches_up_to_available_slots_only(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(1)
+        return f"i-{len(launched)}"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true",
+                     "MNEMON_RUNNER_MAX_CONCURRENT": "1"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}, {"id": 2}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [{"id": 111, "status": "queued", "created_at": _iso(200),
+                      "labels": ["self-hosted", "mnemon-spot"]}],
+        },
+        "/actions/runs/2/jobs": {
+            "jobs": [{"id": 222, "status": "queued", "created_at": _iso(300),
+                      "labels": ["self-hosted", "mnemon-spot"]}],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    # zero running boxes going in, cap=1 -> exactly one of the two stale jobs
+    # gets dispatched this pass, the other waits for the next reconcile.
+    assert out["reconciled"] == 1
+    assert len(out["skipped"]) == 1
+    assert out["dispatched"][0]["job_id"] == "222"  # oldest first
+
+
+# ── Circuit breaker + fleet cap (alpha-engine-config#2697 (source incident)) ───────────────────
+#
+# 2026-07-15 incident: with every runner box failing identically, _reconcile()
+# relaunched a fresh box per stuck queued job on every ~60s pass FOREVER —
+# ~150 t3.medium spot launches in 45 min, saturating the account's 32-vCPU
+# standard-spot quota and locking out the post-close trading SF's data-spot
+# launch. These tests cover the two independent bounds added to
+# _launch_mnemon_runner_spot (the single chokepoint both the reactive
+# webhook-worker path and the reconcile path funnel through): a per-job
+# attempt limit (counting live+recently-terminated boxes) and a global
+# running+pending fleet cap — including the config#2267 dedupe_degraded
+# "proceed anyway" path, where the circuit breaker must still bind or the
+# runaway just re-opens there.
+
+
+def _attempt_box(iid, *, age_seconds, state="terminated"):
+    return {
+        "InstanceId": iid,
+        "State": {"Name": state},
+        "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+    }
+
+
+def test_attempt_limit_blocks_dispatch_at_default_threshold(monkeypatch):
+    # Default MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB=3: 3 prior (terminated)
+    # boxes for this job already exist -> the 4th attempt must be refused.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"999": [
+            _attempt_box("i-try1", age_seconds=1000),
+            _attempt_box("i-try2", age_seconds=800),
+            _attempt_box("i-try3", age_seconds=600),
+        ]},
+    )
+    out = idx.handler({"mnemon_runner_job_id": "999"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert out["attempt_count"] == 3
+    assert launched == [], "must not dispatch once the per-job attempt limit is reached"
+
+
+def test_attempt_limit_pages_exactly_once_per_job(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"42": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    idx.handler({"mnemon_runner_job_id": "42"}, None)
+    idx.handler({"mnemon_runner_job_id": "42"}, None)
+    idx.handler({"mnemon_runner_job_id": "42"}, None)
+    assert len(pages) == 1, "repeated dispatch attempts for an abandoned job must page only once"
+    assert "ABANDONED" in pages[0]
+    assert "42" in pages[0]
+
+
+def test_attempt_count_below_threshold_still_dispatches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"5": [_attempt_box("i-a", age_seconds=100)]},
+    )
+    out = idx.handler({"mnemon_runner_job_id": "5"}, None)
+    assert out["launched"] is True
+
+
+def test_attempt_count_ignores_boxes_outside_lookback_window(monkeypatch):
+    # 3 prior boxes exist for the job, but all launched > the lookback
+    # window ago (default 3600s) — describe-instances would no longer even
+    # return a >1h-old terminated box in practice, but this also guards
+    # against counting a stale/lingering tag from a much older, unrelated
+    # incident as part of today's attempt budget.
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-fresh-attempt",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"7": [
+            _attempt_box("i-old1", age_seconds=999999),
+            _attempt_box("i-old2", age_seconds=999999),
+            _attempt_box("i-old3", age_seconds=999999),
+        ]},
+    )
+    out = idx.handler({"mnemon_runner_job_id": "7"}, None)
+    assert out["launched"] is True
+
+
+def test_attempt_limit_is_env_tunable(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-x"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch,
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true", "MNEMON_RUNNER_MAX_ATTEMPTS_PER_JOB": "1"},
+        attempt_boxes={"9": [_attempt_box("i-only-prior-attempt", age_seconds=10)]},
+    )
+    out = idx.handler({"mnemon_runner_job_id": "9"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert launched == []
+
+
+def test_attempt_limit_binds_on_dedupe_degraded_path(monkeypatch):
+    # The gotcha this issue calls out explicitly: dedup-probe failures
+    # deliberately degrade to "dispatch anyway" (config#2267, coverage beats
+    # dedupe) — the attempt limit must STILL bind in that degraded path, or
+    # a runaway job just re-opens the loop there instead of at the dedupe
+    # probe.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"55": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+
+    def _probe_down(*a, **kw):
+        raise idx.SpotProbeError("probe failed: ThrottlingException")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler({"mnemon_runner_job_id": "55"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert launched == [], "attempt limit must bind even when the dedupe probe itself is degraded"
+
+
+def test_attempt_probe_failure_is_fail_safe_not_fail_open(monkeypatch):
+    # Unlike the dedupe probe (config#2267 posture: coverage beats dedupe),
+    # the circuit breaker's OWN probe must fail closed — an unknown attempt
+    # count must never be silently treated as "0, dispatch anyway", since
+    # that would defeat the breaker on exactly the kind of degraded-API pass
+    # a runaway is likely to coincide with.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+                describe_instances_failures=1)
+    out = idx.handler({"mnemon_runner_job_id": "123"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_probe_failed"
+    assert launched == []
+
+
+def test_fleet_cap_blocks_dispatch_at_default_threshold(monkeypatch):
+    # Default MNEMON_RUNNER_MAX_FLEET=6: 6 running+pending boxes already
+    # exist fleet-wide (for OTHER jobs) -> a brand-new job's dispatch must
+    # still be refused.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [
+        {"InstanceId": f"i-fleet-{n}", "Tags": []} for n in range(6)
+    ]
+    out = idx.handler({"mnemon_runner_job_id": "888"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+    assert out["fleet_size"] == 6
+    assert launched == [], "must not dispatch once the global fleet cap is reached"
+
+
+def test_fleet_cap_pages(monkeypatch):
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(6)]
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert len(pages) == 1
+    assert "fleet cap" in pages[0].lower()
+
+
+def test_fleet_below_cap_still_dispatches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(5)]
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+
+
+def test_fleet_cap_is_env_tunable(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-x"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch,
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true", "MNEMON_RUNNER_MAX_FLEET": "1"},
+    )
+    idx._test_ec2.boxes = [{"InstanceId": "i-already-there", "Tags": []}]
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+    assert launched == []
+
+
+def test_fleet_cap_checked_even_when_this_job_has_zero_prior_attempts(monkeypatch):
+    # The fleet cap is a GLOBAL backstop independent of the per-job attempt
+    # count — a brand-new job (0 attempts) must still be refused if the
+    # fleet is already full from OTHER jobs' boxes.
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-other-job-{n}", "Tags": []} for n in range(6)]
+    out = idx.handler({"mnemon_runner_job_id": "brand-new-job"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+
+
+def test_fleet_probe_failure_is_fail_safe_not_fail_open(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+
+    def _boom(**kw):
+        raise RuntimeError("DescribeInstances throttled")
+
+    # Let the attempt-count probe succeed (no boxes) but make the SECOND
+    # describe_instances call (fleet-size) fail.
+    real_describe = idx._test_ec2.describe_instances
+    calls = {"n": 0}
+
+    def _describe(Filters):  # noqa: N803
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("DescribeInstances throttled")
+        return real_describe(Filters)
+
+    monkeypatch.setattr(idx._test_ec2, "describe_instances", _describe)
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_probe_failed"
+    assert launched == []
+
+
+def test_reconcile_respects_attempt_limit_across_multiple_stale_jobs(monkeypatch):
+    # End-to-end through the reconcile path (not just the worker phase):
+    # a job already at the attempt limit must be skipped by _reconcile
+    # without ever reaching launch_with_fallback, while a fresh stale job in
+    # the same pass still gets dispatched.
+    launched_job_ids = []
+
+    def _launch(types_, subnets, **kw):
+        return "i-rescued"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"555": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [
+                {"id": 555, "status": "queued", "labels": ["self-hosted", "mnemon-spot"],
+                 "created_at": _iso(200)},
+                {"id": 556, "status": "queued", "labels": ["self-hosted", "mnemon-spot"],
+                 "created_at": _iso(150)},
+            ],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    results_by_job = {d["job_id"]: d["result"] for d in out["dispatched"]}
+    assert results_by_job["555"]["launched"] is False
+    assert results_by_job["555"]["reason"] == "attempt_limit_exceeded"
+    assert results_by_job["556"]["launched"] is True
+
+
+def test_successful_launch_emits_cloudwatch_launch_metric(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-metered",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    idx.handler({"mnemon_runner_job_id": "1"}, None)
+    calls = idx._test_cloudwatch.put_metric_data_calls
+    assert len(calls) == 1
+    assert calls[0]["Namespace"] == "AlphaEngine/Infra"
+    metric = calls[0]["MetricData"][0]
+    assert metric["MetricName"] == "mnemon_runner_launches"
+    assert metric["Value"] == 1.0
+
+
+def test_blocked_dispatch_does_not_emit_launch_metric(monkeypatch):
+    # The metric counts actual LAUNCHES (the runaway signal) — a dispatch
+    # refused by the circuit breaker/fleet cap must not count as one.
+    idx = _load(monkeypatch, env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(6)]
+    idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert idx._test_cloudwatch.put_metric_data_calls == []
+
+
+def test_launch_metric_emission_failure_does_not_block_dispatch(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok-anyway",  # noqa: E731
+        env={"MNEMON_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom(**kw):
+        raise RuntimeError("CloudWatch throttled")
+
+    monkeypatch.setattr(idx._test_cloudwatch, "put_metric_data", _boom)
+    out = idx.handler({"mnemon_runner_job_id": "1"}, None)
+    assert out["launched"] is True

--- a/infrastructure/lambdas/morning-signal-runner-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/morning-signal-runner-dispatcher/deploy.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the morning-signal-runner-dispatcher Lambda.
+#
+# WHY: mirrors nousergon/alpha-engine-config's self-hosted-runner dispatcher
+# (alpha-engine-config-I2572) verbatim in mechanism, re-namespaced for morning-signal.
+# A live billing-usage audit (2026-07-17) found morning-signal among the largest
+# non-alpha-engine-config private-repo GHA-minute consumers (~700 min in
+# July alone) after the org crossed its 3,000-min included-Actions-minute
+# line for the month. This Lambda receives GitHub's `workflow_job` webhook directly
+# (a Function URL, not a `lambda invoke` from a GHA job — there is no
+# GHA-hosted leg left to invoke it once the target workflows' runs-on points
+# at a self-hosted runner) and launches an EC2-spot box that registers as an
+# EPHEMERAL self-hosted runner for exactly one queued job, then
+# self-terminates. --bootstrap creates: (1) this Lambda's own execution role
+# + inline policy, (2) the Lambda function itself, (3) its public Function
+# URL + the resource policy allowing GitHub to invoke it.
+#
+# IAM (iam-policy.json): the Lambda needs ec2:RunInstances + iam:PassRole
+# (scoped to morning-signal-runner-executor-role — a NEW, dedicated role
+# a sibling agent is creating in morning-signal) + ssm:SendCommand +
+# ssm:GetParameter (its OWN webhook secret — unlike ci-watch-dispatcher, this
+# Lambda verifies GitHub's HMAC signature itself) + lambda:InvokeFunction on
+# itself (the two-phase webhook-receiver/worker self-invoke — see index.py's
+# module docstring for why the launch work cannot run inline in the
+# webhook-receiving invocation).
+#
+# Managed OUTSIDE CloudFormation (same rationale as the sibling dispatchers):
+# keeps the github-actions-lambda-deploy OIDC role's blast radius narrow.
+# This script's FLAGLESS run is code-only; --bootstrap is operator-only.
+#
+# POST-BOOTSTRAP MANUAL STEPS (cannot be automated via this script — see
+# alpha-engine-config-I2572/I2653, the source design, for the full
+# sequencing rationale):
+#   1. Create the SSM params this Lambda/box read:
+#        /morning-signal/runner/webhook_secret  (random string, shared
+#          with the GitHub webhook config below)
+#        /morning-signal/runner/github_pat  (fine-grained PAT, owner=
+#          nousergon, repo=morning-signal, Administration: Read and
+#          write + Contents: read — Administration:write is REQUIRED to mint
+#          runner registration tokens; the Actions permission does NOT cover
+#          this. Fine-grained PAT creation/scoping is a GitHub web-UI-only,
+#          human action — cannot be done via this script or the API.)
+#        /morning-signal/runner/github_read_pat  (SEPARATE fine-grained
+#          PAT, owner=nousergon, repo=morning-signal, Actions: Read
+#          ONLY — deliberately NOT the same PAT as above. This one is read
+#          by the Lambda's own execution role (behind a public Function URL)
+#          for the reconcile phase's read-only "list queued jobs" calls;
+#          keeping it separate and minimally-scoped means a Lambda-side
+#          issue can never expose Administration:write.)
+#   2. Register the GitHub webhook on nousergon/morning-signal:
+#        event: workflow_job, content type: json, secret: (the same value as
+#        the SSM param above), URL: this script's printed Function URL.
+#      Can be done via `gh api repos/nousergon/morning-signal/hooks`.
+#
+# Usage:
+#   bash .../morning-signal-runner-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
+#   bash .../morning-signal-runner-dispatcher/deploy.sh --bootstrap # operator-only: create/update the IAM role + Lambda + Function URL + reconcile schedule
+#   bash .../morning-signal-runner-dispatcher/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../morning-signal-runner-dispatcher/deploy.sh --smoke     # invoke the WORKER phase once with a synthetic job id (fires a REAL spot box)
+#   bash .../morning-signal-runner-dispatcher/deploy.sh --reconcile-test # invoke the RECONCILE phase once directly (read-only unless it finds a genuinely stale job)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="morning-signal-runner-dispatcher"
+ROLE_NAME="morning-signal-runner-dispatcher-role"
+POLICY_NAME="morning-signal-runner-dispatcher-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+# Bootstrap default (first-time deployment only) — safe default ON, mirrors
+# every other fleet dispatcher's kill-switch convention.
+LAMBDA_ENV_BOOTSTRAP='Variables={LOG_LEVEL=INFO,MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED=true}'
+
+source "${SCRIPT_DIR}/../_shared/preserve_env_flags.sh"
+
+# DRY_RUN honors an ambient env var (true/1/yes) as well as the --dry-run
+# flag below, so DRY_RUN=1/true from a caller's shell actually no-ops
+# instead of silently running the real deploy path (morning-signal-
+# I2752 incident, 2026-07-16: an operator assumed DRY_RUN=<env var> worked
+# here, matching other tools' convention, and triggered a real deploy).
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+SMOKE=false
+RECONCILE_TEST=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    --reconcile-test) RECONCILE_TEST=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Scratch dirs + validate handler syntax -----------------------------
+
+PKG=$(mktemp -d)
+TEST_DEPS=$(mktemp -d)
+trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- 0b. Preflight handler unit tests --------------------------------------
+
+if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+  NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+  echo "Installing pytest + krepis + pinned nousergon-lib into ${TEST_DEPS}..."
+  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
+  echo "Running handler unit tests..."
+  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+fi
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment "${LAMBDA_ENV_BOOTSTRAP}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+    if ! $DRY_RUN; then
+      aws lambda wait function-active --function-name "${FUNCTION_NAME}" --region "${REGION}"
+    fi
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2b. Function URL (GitHub webhooks can't sign SigV4 — auth is the
+  # handler's own HMAC verification against the shared webhook secret) ---
+  if ! aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --query 'FunctionUrl' --output text >/dev/null 2>&1; then
+    echo "  Creating Function URL (AuthType=NONE; handler-level HMAC verification is the real auth boundary)"
+    run aws lambda create-function-url-config \
+      --function-name "${FUNCTION_NAME}" \
+      --auth-type NONE \
+      --region "${REGION}" \
+      --query 'FunctionUrl' --output text
+    echo "  Granting public InvokeFunctionUrl permission"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "AllowPublicFunctionUrlInvoke" \
+      --action lambda:InvokeFunctionUrl \
+      --principal "*" \
+      --function-url-auth-type NONE \
+      --region "${REGION}" >/dev/null
+  else
+    echo "  Function URL already configured"
+  fi
+
+  if ! $DRY_RUN; then
+    FN_URL=$(aws lambda get-function-url-config --function-name "${FUNCTION_NAME}" --region "${REGION}" --query 'FunctionUrl' --output text)
+    echo ""
+    echo "  Function URL: ${FN_URL}"
+    echo "  -> register as the GitHub webhook target for nousergon/morning-signal"
+    echo "     (event: workflow_job, content type: json, secret: matches"
+    echo "     /morning-signal/runner/webhook_secret) — see this script's"
+    echo "     header for the full remaining manual steps."
+    echo ""
+  fi
+
+  # --- 2c. Reconcile backstop schedule (alpha-engine-config-I2653) ---
+  # A self-hosted runner registered via a plain registration token binds to
+  # the repo's WHOLE label pool, not the specific job that triggered its
+  # launch (GitHub has no per-job reservation API — verified against
+  # GitHub's own docs; an earlier JIT-runner-config fix attempt for this
+  # issue was wrong, JIT mints the same kind of "any matching job"
+  # registration, just more securely). Under concurrent load a dispatched
+  # runner can grab an unrelated queued job, permanently stranding the job
+  # that triggered its launch — GitHub sends `queued` exactly once per job.
+  # This EventBridge Scheduler rule invokes the Lambda's RECONCILE phase
+  # every 60s as a self-healing backstop; see index.py's module docstring
+  # phase 3 for the full mechanism.
+  RECONCILE_SCHED_ROLE_NAME="morning-signal-runner-reconcile-scheduler-role"
+  RECONCILE_SCHED_POLICY_NAME="invoke-morning-signal-runner-dispatcher"
+  RECONCILE_SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${RECONCILE_SCHED_ROLE_NAME}"
+  RECONCILE_SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${RECONCILE_SCHED_ROLE_NAME}"
+    run aws iam create-role --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${RECONCILE_SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME}'s reconcile phase every 60s (alpha-engine-config-I2653)" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${RECONCILE_SCHED_ROLE_NAME}"
+  fi
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  RECONCILE_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":[\"${FN_ARN}\",\"${FN_ARN}:*\"]}]}"
+  echo "  Applying Scheduler invoke policy: ${RECONCILE_SCHED_POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${RECONCILE_SCHED_ROLE_NAME}" \
+    --policy-name "${RECONCILE_SCHED_POLICY_NAME}" \
+    --policy-document "${RECONCILE_INVOKE_POLICY}"
+  if ! $DRY_RUN; then echo "  Waiting 10s for Scheduler role propagation..."; sleep 10; fi
+
+  RECONCILE_SCHED_NAME="morning-signal-runner-reconcile"
+  RECONCILE_TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${RECONCILE_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"reconcile\\\":true}\"}"
+  if aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  Updating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler update-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  else
+    echo "  Creating Scheduler rule: ${RECONCILE_SCHED_NAME} -> every 60s"
+    run aws scheduler create-schedule --name "${RECONCILE_SCHED_NAME}" \
+      --schedule-expression "rate(1 minute)" \
+      --flexible-time-window '{"Mode":"OFF"}' --target "${RECONCILE_TARGET}" \
+      --region "${REGION}" --query 'ScheduleArn' --output text
+  fi
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${RECONCILE_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: Scheduler rule ${RECONCILE_SCHED_NAME} not found after create/update" >&2; exit 1; }
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment (preserving operator-owned MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED)..."
+CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED true)
+LAMBDA_ENV="Variables={LOG_LEVEL=INFO,MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED=${CURRENT_DISPATCH}}"
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment "${LAMBDA_ENV}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+# ----- 4. Smoke (synthetic worker-phase event, direct invoke) ---------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing the WORKER phase via direct invoke (synthetic job id)..."
+  echo "⚠ this fires a REAL spot box + REAL morning_signal_runner_spot_bootstrap.sh run."
+  RESP=$(mktemp)
+  trap "rm -f '${RESP}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"morning_signal_runner_job_id":"smoke-test-0"}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi
+
+# ----- 5. Reconcile test (synthetic reconcile-phase event, direct invoke) ---
+
+if $RECONCILE_TEST; then
+  echo ""
+  echo "Testing the RECONCILE phase via direct invoke..."
+  echo "Read-only unless it finds a genuinely stale (>90s) queued job with no in-flight box — in which case it dispatches a REAL spot box for it (which is the correct/intended behavior, not a side effect to worry about)."
+  RESP2=$(mktemp)
+  trap "rm -f '${RESP2}'" EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{"reconcile":true}' \
+    --cli-binary-format raw-in-base64-out \
+    --region "${REGION}" \
+    "${RESP2}" >/dev/null
+  cat "${RESP2}"
+  echo ""
+fi

--- a/infrastructure/lambdas/morning-signal-runner-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/morning-signal-runner-dispatcher/iam-policy.json
@@ -1,0 +1,150 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/morning-signal-runner-dispatcher:*"
+    },
+    {
+      "Sid": "ReadWebhookSecret",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/morning-signal/runner/webhook_secret"
+    },
+    {
+      "Sid": "ReadGithubReadOnlyPatForReconcileListing",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/morning-signal/runner/github_read_pat"
+    },
+    {
+      "Sid": "SelfInvokeAsyncForTwoPhaseDispatch",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:morning-signal-runner-dispatcher",
+        "arn:aws:lambda:us-east-1:711398986525:function:morning-signal-runner-dispatcher:*"
+      ]
+    },
+    {
+      "Sid": "RunInstancesInstanceScopedByTagAndType",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Name": "morning-signal-runner-spot",
+          "ec2:InstanceType": [
+            "t3.medium",
+            "t3a.medium",
+            "t2.medium"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesConfiguredAmiOnly",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:us-east-1::image/ami-0c421724a94bba6d6"
+    },
+    {
+      "Sid": "RunInstancesLaunchDependencies",
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-a61ec0fb",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-1e58307a",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-789d3857",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-c670118d",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-7cff7c43",
+        "arn:aws:ec2:us-east-1:711398986525:subnet/subnet-e07166ec",
+        "arn:aws:ec2:us-east-1:711398986525:security-group/sg-03cd3c4bd91e610b0",
+        "arn:aws:ec2:us-east-1:711398986525:key-pair/alpha-engine-key",
+        "arn:aws:ec2:us-east-1:711398986525:network-interface/*",
+        "arn:aws:ec2:us-east-1:711398986525:volume/*"
+      ]
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "morning-signal-runner-spot"
+        }
+      }
+    },
+    {
+      "Sid": "DescribeIsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassRunnerExecutorRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/morning-signal-runner-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunRunnerBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateRunnerSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "morning-signal-runner-spot"
+        }
+      }
+    },
+    {
+      "Sid": "EmitLaunchRateMetricSharedInfra",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "cloudwatch:namespace": "AlphaEngine/Infra"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/morning-signal-runner-dispatcher/index.py
+++ b/infrastructure/lambdas/morning-signal-runner-dispatcher/index.py
@@ -1,0 +1,915 @@
+"""morning-signal-runner-dispatcher — launch an EPHEMERAL GitHub Actions
+self-hosted runner on a dedicated EC2 spot box, once per queued CI/validation
+job in nousergon/morning-signal. Mirrors nousergon/alpha-engine-config's
+self-hosted-runner dispatcher (alpha-engine-config-I2572) verbatim in
+mechanism, re-namespaced for morning-signal.
+
+WHY: a hard GHA audit (2026-07-14) found morning-signal's own CI/
+validation workflows (scripts-tests.yml, changelog.yml, the validate-*.yaml
+set, etc.) — NOT the heavy agentic workloads ci-watch/sf-watch/groom already
+moved to spot — are now the dominant steady-state draw on the org's metered
+private-repo GHA-minutes quota (~1.6k min/30d projected, ~93% of all
+private-repo GHA spend fleet-wide). Those are frequent (dozens/day) and
+short-lived (<1 min avg) — a poor fit for the ci-watch/sf-watch pattern (a
+thin GHA-hosted dispatch leg synchronously invoking a Lambda that runs a
+bespoke script over SSM, outside the Actions protocol entirely): replicating
+that shape per-workflow would mean hand-rolling GitHub Checks-API status
+reporting ~13 times over. Registering a REAL ephemeral self-hosted runner is
+simpler AND more correct here — the existing workflow YAML (checkout,
+setup-python, pytest, etc.) is untouched, only `runs-on:` changes, and
+GitHub's own Actions service handles job dispatch + Check Run status
+natively, exactly as it does for hosted runners.
+
+MECHANISM (three-phase single Lambda, self-invoked async — see module-level
+`handler` for the branch):
+  1. WEBHOOK RECEIVER phase: GitHub calls this Lambda's Function URL directly
+     on every `workflow_job` event for morning-signal (repo-level
+     webhook, event type `workflow_job`). Verifies the HMAC signature, filters
+     to `action=queued` + our `morning-signal-spot` label, then
+     self-invokes ASYNC (`InvocationType=Event`) with a minimal worker
+     payload and returns 200 immediately. GitHub's webhook delivery timeout
+     is short (single-digit seconds) — the actual spot launch below can take
+     30-90s+, so it MUST NOT block the HTTP response, or every delivery would
+     show as a spurious timeout in GitHub's UI even though the box still
+     launches (Lambda execution isn't cancelled by a disconnected client, but
+     a clean signal matters for operability).
+  2. WORKER phase (the self-invoked async call): does the actual dispatch —
+     `spot_dispatch.launch_with_fallback()` (spot-first, on-demand fallback
+     on capacity exhaustion), wait for SSM-online, then an async detached SSM
+     command that clones morning-signal and `exec`s
+     `infrastructure/morning_signal_runner_spot_bootstrap.sh` (built by a sibling
+     agent in morning-signal) — which installs+registers the actual
+     `actions-runner` binary in `--ephemeral` mode, runs exactly one job, and
+     self-terminates (InstanceInitiatedShutdownBehavior=terminate + its own
+     on-box watchdog). Mirrors `ci-watch-dispatcher/index.py`'s
+     launch/wait/dispatch shape via the shared `nousergon_lib.spot_dispatch`
+     primitives (config#2106) — NOT reinvented here.
+  3. RECONCILE phase (EventBridge Scheduler, ~every 60s — config-I2653): a
+     self-hosted runner registered via a plain registration token binds to
+     the repo's WHOLE label pool, not the specific job that triggered its
+     launch — GitHub has no API to reserve a job for a not-yet-connected
+     runner (confirmed against GitHub's own docs before implementing this;
+     an earlier JIT-runner-config diagnosis for this issue was WRONG — JIT
+     is a more secure way to mint the same "any matching job" registration,
+     it does not bind to one job either). Under concurrent load a dispatched
+     runner can grab an unrelated queued job, leaving the job that triggered
+     its launch permanently stuck — GitHub sends the `queued` webhook exactly
+     ONCE per job, so there is no other path back to it without this backstop.
+     `_reconcile()` lists queued jobs matching our label that have sat queued
+     longer than `MORNING_SIGNAL_RUNNER_RECONCILE_STALE_SECONDS` with no in-flight
+     box (the existing job-id-tag dedup check), and dispatches a fresh runner
+     for each. Same "coverage beats dedupe" posture as the SpotProbeError
+     handling below — doesn't prevent the occasional mismatch, guarantees no
+     job stays stranded indefinitely.
+
+CIRCUIT BREAKER + FLEET CAP (2026-07-15 spot-quota-starvation incident,
+config#2697): the reconcile backstop above is intentionally unbounded in
+WHEN it fires (every stale queued job, every ~60s pass, forever) — that is
+its whole point (I2653). What it lacked was a bound on repeated launches
+for a job whose boxes keep failing identically, and a global ceiling on
+total fleet size. Both live in `_launch_morning_signal_runner_spot()` (the single
+chokepoint the webhook-worker path AND the reconcile path both funnel
+through, including the config#2267 dedupe_degraded "proceed anyway" path):
+a job at/over `MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB` launches (default 3,
+counting live+recently-terminated boxes) is abandoned (paged once, no
+further dispatch until a human/code-fix intervenes); the fleet overall is
+capped at `MORNING_SIGNAL_RUNNER_MAX_FLEET` running+pending boxes (default 6 = 12
+vCPUs, leaving >=20 of the account's 32-vCPU standard-spot quota for
+production) regardless of per-job attempt counts. A `AlphaEngine/Infra
+morning_signal_runner_launches` custom metric + CloudWatch alarm
+(infrastructure/setup_morning_signal_runner_launch_rate_alarm.sh) is the
+independent early-warning signal on launch RATE itself, since the incident
+ran ~3h with only a single quota-exhaustion page at the very end.
+
+CONCURRENCY LOCK: keyed on `Name=morning-signal-runner-spot` +
+`morning-signal-runner-job-id=<workflow_job.id>` — one job, one box, 1:1 (unlike
+ci-watch's repo+sha lock, a GitHub Actions job id is already the unique
+discriminator; no broader key needed). A duplicate `queued` delivery for the
+same job (GitHub webhooks are at-least-once) is a clean no-op skip.
+
+IAM PROFILE: `morning-signal-runner-executor-profile`, a NEW dedicated
+instance profile (infrastructure/iam/morning-signal-runner-executor-role-*.json in
+morning-signal) scoped to read exactly one SSM param (the runner-
+registration PAT) — deliberately not `alpha-engine-ci-watch-executor-profile`
+or any other existing profile, so this new/less-proven workload's blast
+radius stays contained. Every AWS credential the actual CI STEPS need (S3
+sync, OIDC role assumption, etc.) continues to flow through GitHub's own
+per-workflow OIDC mechanism, unrelated to this instance's own role.
+
+FAIL-SOFT ON THE WEBHOOK RECEIVER PHASE, FAIL-LOUD ON THE WORKER PHASE: an
+unrecognized/malformed webhook delivery is a clean 200 no-op (GitHub sends
+many event types/actions we don't care about — treating them as errors would
+just generate webhook-delivery noise for no reason). The worker phase mirrors
+ci-watch's SYNCHRONOUS-style clean-failure contract even though its own
+caller is async (nothing reads the return value) — CloudWatch Logs is the
+observability surface for worker-phase failures; a genuinely unexpected
+internal bug still propagates as a Python exception (visible as a Lambda
+error metric).
+
+Managed OUTSIDE CloudFormation (same as every other fleet dispatcher):
+operator-deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live
+effect until the new code + IAM + Function URL + GitHub webhook registration
+are applied AND the (separately-tracked, human-only) runner-registration PAT
+with Administration:write on morning-signal exists in SSM — see
+alpha-engine-config-I2572 (the original design this dispatcher mirrors)
+for the full rollout sequencing rationale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+import boto3
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotLaunchError, SpotProbeError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch: MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED=false disables the launch
+# without touching the GitHub webhook wiring — mirrors every other fleet
+# dispatcher's safety valve. Default ON.
+DISPATCH_ENABLED = os.environ.get("MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED", "true").lower() == "true"
+
+TARGET_REPO_FULL_NAME = "nousergon/morning-signal"
+TARGET_LABEL = "morning-signal-spot"
+
+# ── Spot launch config (env-overridable; same default-VPC/AMI/security-group
+# as the fleet's other spot dispatchers — only the IAM profile + tag differ).
+# IAM LOCKSTEP (mirrors ci-watch-dispatcher): these defaults are ENUMERATED
+# in this Lambda's scoped ec2:RunInstances policy (sibling iam-policy.json).
+# Changing them without re-applying that policy makes RunInstances fail with
+# UnauthorizedOperation at the next dispatch. Keep them in sync.
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "MORNING_SIGNAL_RUNNER_INSTANCE_TYPES", "t3.medium,t3a.medium,t2.medium"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "MORNING_SIGNAL_RUNNER_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("MORNING_SIGNAL_RUNNER_AMI_ID", "ami-0c421724a94bba6d6")  # Amazon Linux 2023 x86_64
+KEY_NAME = os.environ.get("MORNING_SIGNAL_RUNNER_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("MORNING_SIGNAL_RUNNER_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+IAM_PROFILE = os.environ.get(
+    "MORNING_SIGNAL_RUNNER_IAM_PROFILE", "morning-signal-runner-executor-profile"
+)
+VOLUME_SIZE_GB = int(os.environ.get("MORNING_SIGNAL_RUNNER_VOLUME_SIZE_GB", "30"))
+
+MORNING_SIGNAL_RUNNER_TAG_NAME = "morning-signal-runner-spot"
+MORNING_SIGNAL_RUNNER_JOB_ID_TAG_KEY = "morning-signal-runner-job-id"
+
+# ── Circuit breaker + fleet cap (2026-07-15 spot-quota-starvation incident,
+# alpha-engine-config#2697 — the incident this circuit breaker design was
+# originally built for; mirrored here unchanged) ──────────────────────────
+# With every runner box failing identically (a deprecated runner version —
+# tracked separately), _reconcile() relaunched a fresh box per stuck queued
+# job on every ~60s pass, FOREVER: ~150 t3.medium spot launches in 45 min,
+# ~16 concurrent boxes = 32 vCPUs = 100% of the account's standard-spot quota
+# (L-34B43A08, value 32). The post-close trading SF's data-spot launch then
+# failed MaxSpotInstanceCountExceeded at 20:00 UTC — CI must never be able to
+# starve production of spot quota. Two independent bounds, both enforced
+# inside _launch_morning_signal_runner_spot (the single chokepoint both the reactive
+# webhook-worker path AND the reconcile path funnel through — including the
+# config#2267 dedupe_degraded "proceed anyway" path, which is exactly where
+# an unbounded loop would otherwise re-open):
+#
+#   1. PER-JOB ATTEMPT LIMIT: once a job has had >= MAX_ATTEMPTS_PER_JOB boxes
+#      launched for it (live OR recently-terminated — a job whose boxes keep
+#      dying identically is exactly the runaway pattern), stop dispatching
+#      for THAT job and page once. Does not touch other jobs' dispatch, and
+#      does not disable the reconcile backstop itself (config-I2653 still
+#      recovers jobs whose one-shot `queued` webhook was consumed by a runner
+#      that grabbed a different job — this only bounds the RETRY count for a
+#      job that keeps failing).
+#   2. GLOBAL FLEET CAP: refuse to launch (for ANY job) once
+#      running+pending morning-signal-runner boxes >= MAX_FLEET, regardless of
+#      per-job attempt counts — the last-resort backstop against any launch
+#      pattern (not just the identical-failure one above) that could
+#      otherwise still saturate the account's spot quota.
+MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB = int(os.environ.get("MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB", "3"))
+# ~1h: describe-instances reliably still returns a terminated instance for
+# about this long after termination (AWS does not document an exact
+# retention SLA; this matches the window the issue's incident review
+# confirmed empirically and is env-tunable if that changes).
+MORNING_SIGNAL_RUNNER_ATTEMPT_LOOKBACK_SECONDS = int(
+    os.environ.get("MORNING_SIGNAL_RUNNER_ATTEMPT_LOOKBACK_SECONDS", "3600")
+)
+# 6 boxes = 12 vCPUs (t3/t3a/t2.medium = 2 vCPUs each), leaving >= 20 vCPUs of
+# the 32-vCPU account standard-spot quota (L-34B43A08) for production.
+MORNING_SIGNAL_RUNNER_MAX_FLEET = int(os.environ.get("MORNING_SIGNAL_RUNNER_MAX_FLEET", "6"))
+
+# Jobs that tripped the per-job attempt limit this cold start — logged/paged
+# once per job per cold start rather than once per reconcile pass (a stuck
+# job is still stale on every subsequent ~60s pass; repaging it every minute
+# forever would be exactly the "single quota page at the very end" alerting
+# failure mode this issue is also about, just for a different signal).
+_abandoned_job_ids_paged: set[str] = set()
+
+# ── Two-phase bootstrap state machine (2026-07-15 zombie-leak incident,
+# alpha-engine-config-I2692 — source incident for this two-phase bootstrap
+# design; mirrored here unchanged) ─────────────────────────────────────────
+# The launch path previously did wait_ssm_online (60-200s) + send_command
+# INSIDE this Lambda's 60s timeout — the Lambda died mid-wait, the box never
+# received its bootstrap, never registered a runner, and never self-
+# terminated (the terminate-on-failure except died with the Lambda). Under
+# the reconcile loop that manufactured a zombie box per minute until the
+# spot quota exhausted and ALL fleet CI queued (2026-07-15 17:33-18:40 UTC).
+# Now: launch TAGS the box and returns in seconds; every ~60s reconcile pass
+# delivers the bootstrap to any SSM-online box that lacks it (single
+# describe, zero waiting), reaps boxes whose bootstrap can't be delivered by
+# BOOTSTRAP_DEADLINE, and reaps any box alive past RUNNER_MAX_LIFETIME
+# regardless of state (the janitor: no leak class can ever eat the quota
+# silently again).
+MORNING_SIGNAL_RUNNER_BOOTSTRAP_SENT_TAG_KEY = "morning-signal-runner-bootstrap-sent"
+BOOTSTRAP_DEADLINE_SECONDS = int(os.environ.get("MORNING_SIGNAL_RUNNER_BOOTSTRAP_DEADLINE_SECONDS", "300"))
+RUNNER_MAX_LIFETIME_SECONDS = int(os.environ.get("MORNING_SIGNAL_RUNNER_MAX_LIFETIME_SECONDS", "5400"))
+
+# Loud page on quota exhaustion (the incident's silent failure mode: an hour
+# of CI paralysis visible only as ERROR log lines). Fleet-standard params.
+TELEGRAM_BOT_TOKEN_SSM = os.environ.get("MORNING_SIGNAL_RUNNER_TELEGRAM_BOT_TOKEN_SSM",
+                                        "/alpha-engine/TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID_SSM = os.environ.get("MORNING_SIGNAL_RUNNER_TELEGRAM_CHAT_ID_SSM",
+                                      "/alpha-engine/TELEGRAM_CHAT_ID")
+_page_sent_this_invocation = False
+
+
+def _page(message: str) -> None:
+    """Best-effort LOUD Telegram page (disable_notification=False — the
+    config-I2461 lesson: silent notifications get missed). Degrades to
+    log-only on any failure; at most one page per invocation to avoid a
+    reconcile loop spamming one page per queued job."""
+    global _page_sent_this_invocation
+    if _page_sent_this_invocation:
+        return
+    _page_sent_this_invocation = True
+    try:
+        ssm = boto3.client("ssm", region_name=REGION)
+        token = ssm.get_parameter(Name=TELEGRAM_BOT_TOKEN_SSM, WithDecryption=True)["Parameter"]["Value"]
+        chat_id = ssm.get_parameter(Name=TELEGRAM_CHAT_ID_SSM, WithDecryption=True)["Parameter"]["Value"]
+        req = urllib.request.Request(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=json.dumps({"chat_id": chat_id, "text": message,
+                             "disable_notification": False}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=10).read()
+    except Exception as exc:  # noqa: BLE001 — paging is best-effort; the log line below is the fallback surface
+        logger.error("telegram page FAILED (%s): %s — message was: %s",
+                     type(exc).__name__, exc, message)
+
+# This Lambda's OWN secret (unlike ci-watch-dispatcher, which needs none) —
+# the webhook HMAC secret, read once per cold start and cached at module
+# scope (same pattern as every fleet Lambda that reads a param once, not
+# per-invocation, to keep p50 latency low on the hot webhook-verification path).
+WEBHOOK_SECRET_SSM = os.environ.get(
+    "MORNING_SIGNAL_RUNNER_WEBHOOK_SECRET_SSM", "/morning-signal/runner/webhook_secret"
+)
+_webhook_secret_cache: str | None = None
+
+
+def _webhook_secret() -> str:
+    global _webhook_secret_cache
+    if _webhook_secret_cache is None:
+        _webhook_secret_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=WEBHOOK_SECRET_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _webhook_secret_cache
+
+
+MORNING_SIGNAL_RUNNER_GH_PAT_SSM = os.environ.get(
+    "MORNING_SIGNAL_RUNNER_GH_PAT_SSM", "/morning-signal/runner/github_pat"
+)
+MORNING_SIGNAL_RUNNER_CONFIG_BRANCH = os.environ.get("MORNING_SIGNAL_RUNNER_CONFIG_BRANCH", "main")
+MAX_RUNTIME_SECONDS = int(os.environ.get("MORNING_SIGNAL_RUNNER_MAX_RUNTIME_SECONDS", "1800"))
+# (SSM_ONLINE_BUDGET_SEC removed with the in-Lambda wait, I2692 — the
+# reconcile-driven bootstrap never waits; BOOTSTRAP_DEADLINE_SECONDS above
+# is its replacement bound.)
+CW_LOG_GROUP = os.environ.get("MORNING_SIGNAL_RUNNER_CW_LOG_GROUP", "/morning-signal/runner-spot")
+
+# Reconcile backstop (config-I2653): a queued job older than this with no
+# in-flight box (per the same job-id-tag dedup check the reactive path uses)
+# gets a fresh dispatch. ~2-3x the typical observed dispatch+SSM-online
+# latency (15-40s) — comfortably past normal in-flight dispatches, without
+# waiting so long that a genuinely-orphaned job sits stuck for minutes.
+RECONCILE_STALE_SECONDS = int(os.environ.get("MORNING_SIGNAL_RUNNER_RECONCILE_STALE_SECONDS", "90"))
+RECONCILE_MAX_QUEUED_RUNS = int(os.environ.get("MORNING_SIGNAL_RUNNER_RECONCILE_MAX_QUEUED_RUNS", "50"))
+
+# Runner-fleet concurrency cap (config-I2692 item 4, 2026-07-15): a CI burst
+# must never be able to consume the WHOLE account spot quota by itself and
+# starve sibling workloads (groom/data/watch boxes share the same quota).
+# Default 20 concurrent morning-signal-runner boxes (t3.medium-class, 2 vCPU each =
+# 40 vCPU) leaves >half of the current 96-vCPU quota for everything else;
+# env-tunable since the right number is a fleet-wide capacity tradeoff, not
+# a fact this Lambda can derive on its own. A job that can't get a box this
+# pass because the cap is full simply stays queued — the NEXT reconcile pass
+# (~60s) retries once older boxes finish and free a slot.
+MAX_CONCURRENT_RUNNERS = int(os.environ.get("MORNING_SIGNAL_RUNNER_MAX_CONCURRENT", "20"))
+
+MORNING_SIGNAL_RUNNER_READ_PAT_SSM = os.environ.get(
+    "MORNING_SIGNAL_RUNNER_READ_PAT_SSM", "/morning-signal/runner/github_read_pat"
+)
+_gh_read_pat_cache: str | None = None
+
+
+def _gh_read_pat() -> str:
+    """A SEPARATE, dedicated, least-privilege PAT (Actions: Read ONLY —
+    cannot register runners, cannot touch repo settings) — deliberately NOT
+    the Administration:write PAT the box uses to register runners. This
+    Lambda sits behind a public, unauthenticated Function URL (HMAC
+    verification protects the WEBHOOK path, not a credential the Lambda's
+    own execution role can read); granting it read access to the powerful
+    registration PAT would widen blast radius for no reason the reconcile
+    logic actually needs (it only ever lists queued runs/jobs)."""
+    global _gh_read_pat_cache
+    if _gh_read_pat_cache is None:
+        _gh_read_pat_cache = boto3.client("ssm", region_name=REGION).get_parameter(
+            Name=MORNING_SIGNAL_RUNNER_READ_PAT_SSM, WithDecryption=True  # gitleaks:allow — SSM param path, not a secret value
+        )["Parameter"]["Value"]
+    return _gh_read_pat_cache
+
+
+def _gh_api_get(path: str) -> dict:
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Authorization": f"Bearer {_gh_read_pat()}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - fixed https://api.github.com host
+        return json.loads(resp.read())
+
+
+def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
+    """Constant-time HMAC-SHA256 verification of GitHub's
+    `X-Hub-Signature-256` header against the shared webhook secret."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(
+        _webhook_secret().encode("utf-8"), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def _decode_body(event: dict) -> bytes:
+    body = event.get("body") or ""
+    if event.get("isBase64Encoded"):
+        import base64
+
+        return base64.b64decode(body)
+    return body.encode("utf-8")
+
+
+def _response(status: int, body: dict) -> dict:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _handle_webhook(event: dict) -> dict:
+    """Phase 1: verify + filter a raw GitHub `workflow_job` webhook delivery.
+    Always returns fast (no spot-launch work happens in this phase) — a
+    matching event triggers an async self-invoke of the worker phase."""
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    raw_body = _decode_body(event)
+
+    if not _verify_signature(raw_body, headers.get("x-hub-signature-256")):
+        logger.warning("webhook signature verification failed — rejecting delivery")
+        return _response(401, {"error": "invalid signature"})
+
+    if headers.get("x-github-event") != "workflow_job":
+        # `ping` (sent on webhook creation) and anything else we didn't
+        # subscribe to — clean no-op, not an error.
+        return _response(200, {"ignored": "not a workflow_job event"})
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        logger.error("malformed webhook JSON body: %s", exc)
+        return _response(400, {"error": "malformed JSON"})
+
+    action = payload.get("action")
+    repo_full_name = (payload.get("repository") or {}).get("full_name")
+    job = payload.get("workflow_job") or {}
+    labels = job.get("labels") or []
+    job_id = job.get("id")
+
+    if (
+        action != "queued"
+        or repo_full_name != TARGET_REPO_FULL_NAME
+        or TARGET_LABEL not in labels
+        or job_id is None
+    ):
+        return _response(200, {"ignored": True, "action": action, "repo": repo_full_name})
+
+    if not DISPATCH_ENABLED:
+        logger.warning("MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED=false — job %s NOT dispatched", job_id)
+        return _response(200, {"launched": False, "reason": "disabled", "job_id": job_id})
+
+    logger.info("queued job %s matches — self-invoking worker phase async", job_id)
+    boto3.client("lambda", region_name=REGION).invoke(
+        FunctionName=os.environ["AWS_LAMBDA_FUNCTION_NAME"],
+        InvocationType="Event",
+        Payload=json.dumps({"morning_signal_runner_job_id": str(job_id)}).encode("utf-8"),
+    )
+    return _response(200, {"accepted": True, "job_id": job_id})
+
+
+def _running_morning_signal_runner_instance_ids(job_id: str) -> list[str]:
+    return spot_dispatch.running_instance_ids(
+        MORNING_SIGNAL_RUNNER_TAG_NAME,
+        {MORNING_SIGNAL_RUNNER_JOB_ID_TAG_KEY: job_id},
+        region=REGION,
+    )
+
+
+# Any state that counts as "we already tried this" — including terminated
+# ones (a box that died is still a launch attempt against the job; that's
+# the entire point of the circuit breaker: N identical failures must stop,
+# not just N concurrently-alive boxes). shutting-down/stopping are
+# transitional states a box passes through on its way to terminated.
+_ANY_ATTEMPT_STATES = [
+    "pending", "running", "shutting-down", "stopping", "stopped", "terminated",
+]
+
+
+def _job_attempt_count(job_id: str) -> int:
+    """How many morning-signal-runner boxes have been launched for ``job_id`` within
+    the last ``MORNING_SIGNAL_RUNNER_ATTEMPT_LOOKBACK_SECONDS`` (live or recently-
+    terminated — describe-instances keeps a terminated instance queryable for
+    ~1h, comfortably longer than this Lambda's own dispatch cadence). A
+    DescribeInstances failure here must NOT degrade to "0 attempts, dispatch
+    anyway" — that would silently defeat the entire circuit breaker on the
+    exact kind of degraded-EC2-API pass that a runaway is most likely to
+    coincide with, so it re-raises (the caller decides the fail-safe
+    posture; see _launch_morning_signal_runner_spot)."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    resp = ec2.describe_instances(Filters=[
+        {"Name": "tag:Name", "Values": [MORNING_SIGNAL_RUNNER_TAG_NAME]},
+        {"Name": f"tag:{MORNING_SIGNAL_RUNNER_JOB_ID_TAG_KEY}", "Values": [job_id]},
+        {"Name": "instance-state-name", "Values": _ANY_ATTEMPT_STATES},
+    ])
+    now = datetime.now(timezone.utc)
+    count = 0
+    for r in resp.get("Reservations", []):
+        for i in r.get("Instances", []):
+            launch_time = i.get("LaunchTime")
+            if launch_time is not None:
+                age = (now - launch_time).total_seconds()
+                if age > MORNING_SIGNAL_RUNNER_ATTEMPT_LOOKBACK_SECONDS:
+                    continue
+            count += 1
+    return count
+
+
+def _current_fleet_size() -> int:
+    """Running+pending morning-signal-runner boxes, fleet-wide (across ALL jobs) —
+    the global cap backstop. Deliberately a SEPARATE query from
+    _job_attempt_count (different filter shape, different failure posture):
+    a failure here also does not degrade to "0, launch anyway" (see
+    _launch_morning_signal_runner_spot)."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    resp = ec2.describe_instances(Filters=[
+        {"Name": "tag:Name", "Values": [MORNING_SIGNAL_RUNNER_TAG_NAME]},
+        {"Name": "instance-state-name", "Values": ["pending", "running"]},
+    ])
+    return sum(len(r.get("Instances", [])) for r in resp.get("Reservations", []))
+
+
+MORNING_SIGNAL_RUNNER_LAUNCH_METRIC_NAMESPACE = "AlphaEngine/Infra"
+MORNING_SIGNAL_RUNNER_LAUNCH_METRIC_NAME = "morning_signal_runner_launches"
+
+
+def _emit_launch_metric() -> None:
+    """One CloudWatch custom-metric datapoint per successful launch (mirrors
+    spot-orphan-reaper's ``_emit_metric`` pattern — a namespace/metric-name
+    pair, best-effort, never raises). This is the launch-rate alarm's data
+    source (config#2697): the 2026-07-15 runaway ran ~3h at ~150 launches/45min
+    with only a single quota page at the very end — a launch-COUNT alarm
+    (independent of whether launches are currently succeeding or already
+    failing quota) catches the runaway itself, not just its terminal
+    symptom. Alarm provisioned by
+    infrastructure/setup_morning_signal_runner_launch_rate_alarm.sh (this repo has no
+    log-metric-filter precedent; every existing alarm — see
+    setup_watch_plane_alarms.sh, spot-orphan-reaper's own
+    spot_orphans_terminated metric — alarms on a Lambda-emitted custom/AWS
+    metric instead, which this follows)."""
+    try:
+        boto3.client("cloudwatch", region_name=REGION).put_metric_data(
+            Namespace=MORNING_SIGNAL_RUNNER_LAUNCH_METRIC_NAMESPACE,
+            MetricData=[{
+                "MetricName": MORNING_SIGNAL_RUNNER_LAUNCH_METRIC_NAME,
+                "Value": 1.0,
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:  # noqa: BLE001 — observability only; must never block/fail a dispatch
+        logger.warning("CloudWatch put_metric_data (%s) failed (non-fatal): %s",
+                        MORNING_SIGNAL_RUNNER_LAUNCH_METRIC_NAME, exc)
+
+
+def _bootstrap_command(job_id: str) -> str:
+    """The async SSM RunShellScript prelude: minimal-install, fetch the PAT,
+    clone morning-signal, exec its morning_signal_runner_spot_bootstrap.sh
+    entrypoint. Mirrors ci-watch-dispatcher's prelude exactly (same fail()
+    trap shape) — the difference is entirely in what runs AFTER the clone."""
+    return f"""set -uo pipefail
+export AWS_DEFAULT_REGION={REGION}
+export HOME=/root
+fail() {{ echo "[morning-signal-runner-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
+dnf install -y -q git python3.12 >/dev/null 2>&1 || fail "runtime install (git/python3.12) failed"
+PAT=$(aws ssm get-parameter --name {MORNING_SIGNAL_RUNNER_GH_PAT_SSM} --with-decryption \
+  --query Parameter.Value --output text --region {REGION} 2>/dev/null) || fail "PAT read failed"
+[ -n "$PAT" ] || fail "PAT empty"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/morning-signal
+git clone --depth 1 --branch {MORNING_SIGNAL_RUNNER_CONFIG_BRANCH} \
+  "https://x-access-token:${{PAT}}@github.com/{TARGET_REPO_FULL_NAME}.git" \
+  /home/ec2-user/morning-signal || fail "clone failed"
+cd /home/ec2-user/morning-signal
+exec bash infrastructure/morning_signal_runner_spot_bootstrap.sh --job-id "{job_id}"
+"""
+
+
+def _launch_morning_signal_runner_spot(job_id: str) -> dict:
+    # ── Circuit breaker + fleet cap (config#2697) — checked FIRST, ahead of
+    # the dedup probe, so both bind unconditionally: in particular, the
+    # per-job attempt limit MUST still apply on the config#2267
+    # dedupe_degraded "proceed anyway" path below, or a runaway job just
+    # re-opens the loop there instead. Both counts fail LOUD (re-raise) on a
+    # DescribeInstances error rather than degrade to "0, dispatch anyway" —
+    # unlike the dedup probe, coverage does NOT beat safety here: the whole
+    # point of a circuit breaker is that it must hold even when the AWS API
+    # is degraded, which is exactly when a runaway is likely to be underway.
+    try:
+        attempt_count = _job_attempt_count(job_id)
+    except Exception as exc:  # noqa: BLE001 — fail-safe: an unknown attempt count blocks the launch
+        logger.error(
+            "morning-signal-runner attempt-count probe FAILED for job %s — refusing to "
+            "dispatch (fail-safe, unlike the dedupe probe): %s: %s",
+            job_id, type(exc).__name__, exc,
+        )
+        return {"launched": False, "reason": "attempt_probe_failed", "job_id": job_id,
+                "error": str(exc)}
+
+    if attempt_count >= MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB:
+        if job_id not in _abandoned_job_ids_paged:
+            _abandoned_job_ids_paged.add(job_id)
+            _page(
+                f"🔴 morning-signal-runner: job {job_id} ABANDONED after "
+                f"{attempt_count} launch attempts (limit "
+                f"{MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB}) — every box likely "
+                "failing identically (e.g. a bad runner version/bootstrap "
+                "script). No further boxes will be dispatched for this job "
+                "until a human intervenes or ships a fix. "
+                "alpha-engine-config#2697 (source incident for this circuit breaker)."
+            )
+        logger.error(
+            "morning-signal-runner job %s ABANDONED — %d attempts >= limit %d, "
+            "not dispatching", job_id, attempt_count, MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB,
+        )
+        return {"launched": False, "reason": "attempt_limit_exceeded", "job_id": job_id,
+                "attempt_count": attempt_count}
+
+    try:
+        fleet_size = _current_fleet_size()
+    except Exception as exc:  # noqa: BLE001 — fail-safe: an unknown fleet size blocks the launch
+        logger.error(
+            "morning-signal-runner fleet-size probe FAILED for job %s — refusing to "
+            "dispatch (fail-safe): %s: %s", job_id, type(exc).__name__, exc,
+        )
+        return {"launched": False, "reason": "fleet_probe_failed", "job_id": job_id,
+                "error": str(exc)}
+
+    if fleet_size >= MORNING_SIGNAL_RUNNER_MAX_FLEET:
+        _page(
+            f"🔴 morning-signal-runner: fleet cap reached ({fleet_size} >= "
+            f"{MORNING_SIGNAL_RUNNER_MAX_FLEET}) — job {job_id} NOT dispatched this "
+            "pass. Refusing further launches until the fleet shrinks (global "
+            "backstop against spot-quota starvation; design mirrors alpha-engine-config#2697)."
+        )
+        logger.error(
+            "morning-signal-runner FLEET CAP reached (%d >= %d) — job %s not "
+            "dispatched", fleet_size, MORNING_SIGNAL_RUNNER_MAX_FLEET, job_id,
+        )
+        return {"launched": False, "reason": "fleet_cap_reached", "job_id": job_id,
+                "fleet_size": fleet_size}
+
+    dedupe_degraded = False
+    try:
+        existing = _running_morning_signal_runner_instance_ids(job_id)
+    except SpotProbeError as exc:
+        # Coverage beats dedupe (same policy as ci-watch-dispatcher, config#2267
+        # site 1): a failed probe must never leave a real queued job uncovered.
+        dedupe_degraded = True
+        existing = []
+        logger.error(
+            "morning-signal-runner concurrency probe FAILED for job %s — proceeding "
+            "with dedupe_degraded=true: %s: %s", job_id, type(exc).__name__, exc,
+        )
+    if existing:
+        logger.warning("morning-signal-runner box already live for job %s (%s) — skipping",
+                       job_id, existing)
+        return {"launched": False, "reason": "concurrent_skip", "existing_instance_ids": existing}
+
+    try:
+        instance_id, market = spot_dispatch.launch_with_fallback(
+            INSTANCE_TYPES, SUBNETS,
+            image_id=AMI_ID,
+            key_name=KEY_NAME,
+            security_group_ids=[SECURITY_GROUP],
+            iam_instance_profile=IAM_PROFILE,
+            volume_size_gb=VOLUME_SIZE_GB,
+            tag_name=MORNING_SIGNAL_RUNNER_TAG_NAME,
+            region=REGION,
+        )
+    except SpotLaunchError as exc:
+        logger.error("morning-signal-runner spot launch failed for job %s: %s: %s",
+                     job_id, type(exc).__name__, exc)
+        if "MaxSpotInstanceCountExceeded" in str(exc):
+            _page("🔴 morning-signal-runner: spot QUOTA EXHAUSTED "
+                  "(MaxSpotInstanceCountExceeded) — CI dispatch for "
+                  f"{TARGET_REPO_FULL_NAME} is stalling. Check for leaked "
+                  "runner boxes (aws ec2 describe-instances "
+                  f"Name={MORNING_SIGNAL_RUNNER_TAG_NAME}) — the reconcile janitor "
+                  "should be reaping them; if this page repeats, it isn't. "
+                  "design mirrors alpha-engine-config-I2692.")
+        return {"launched": False, "reason": "launch_failed", "error": str(exc)}
+
+    logger.info("launched morning-signal-runner box %s (%s) for job %s%s", instance_id, market, job_id,
+                " dedupe_degraded=true" if dedupe_degraded else "")
+    _emit_launch_metric()
+
+    try:
+        boto3.client("ec2", region_name=REGION).create_tags(
+            Resources=[instance_id],
+            Tags=[{"Key": MORNING_SIGNAL_RUNNER_JOB_ID_TAG_KEY, "Value": job_id}],
+        )
+    except Exception as exc:  # noqa: BLE001 — load-bearing tag write; terminate + fail loud on failure
+        spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="morning-signal-runner")
+        logger.error("morning-signal-runner discriminator tag write FAILED for %s (job %s) — "
+                     "box terminated, dispatch failed: %s: %s",
+                     instance_id, job_id, type(exc).__name__, exc)
+        return {"launched": False, "reason": "tag_write_failed", "instance_id": instance_id,
+                "error": str(exc), "dedupe_degraded": dedupe_degraded}
+
+    # Two-phase contract (I2692): launch + tag ONLY — this function must
+    # return in seconds. NO wait_ssm_online, NO send_command here: the old
+    # in-line wait blew this Lambda's 60s timeout, killing the bootstrap AND
+    # the terminate-on-failure handler with it (the 2026-07-15 zombie-leak
+    # incident). _bootstrap_and_reap() (every reconcile pass, ~60s) delivers
+    # the bootstrap once the box's SSM agent is online — which takes 40-90s
+    # after launch anyway, so this adds ~zero real latency.
+    logger.info("morning-signal-runner launched (bootstrap deferred to reconcile): "
+                "instance=%s market=%s job_id=%s", instance_id, market, job_id)
+    return {
+        "launched": True,
+        "reason": "launched_bootstrap_pending",
+        "instance_id": instance_id,
+        "market": market,
+        "job_id": job_id,
+        "dedupe_degraded": dedupe_degraded,
+    }
+
+
+def _bootstrap_and_reap() -> dict:
+    """The reconcile-driven bootstrap deliverer + janitor (I2692). For every
+    running morning-signal-runner box, exactly one of:
+
+      - no bootstrap-sent tag + SSM Online   -> send bootstrap, tag it
+      - no bootstrap-sent tag + SSM not up   -> reap once older than
+        BOOTSTRAP_DEADLINE_SECONDS (SSM never came up / undeliverable)
+      - any box older than RUNNER_MAX_LIFETIME_SECONDS -> reap (leak
+        backstop: an ephemeral runner that hasn't self-terminated by then is
+        a zombie regardless of how it got wedged)
+
+    Every step is a single fast API call — no waiting anywhere, so any
+    number of boxes fits inside the Lambda budget. Never raises: one box's
+    failure must not strand the rest."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    ssm = boto3.client("ssm", region_name=REGION)
+    stats = {"bootstrapped": 0, "reaped_no_ssm": 0, "reaped_lifetime": 0,
+             "waiting_ssm": 0, "healthy": 0, "errors": 0, "running_after_reap": 0}
+    now = datetime.now(timezone.utc)
+
+    try:
+        resp = ec2.describe_instances(Filters=[
+            {"Name": "tag:Name", "Values": [MORNING_SIGNAL_RUNNER_TAG_NAME]},
+            {"Name": "instance-state-name", "Values": ["running", "pending"]},
+        ])
+        boxes = [i for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
+    except Exception as exc:  # noqa: BLE001 — enumeration failure: nothing to do this pass, retry next
+        logger.error("bootstrap_and_reap: describe_instances failed: %s: %s",
+                     type(exc).__name__, exc)
+        stats["errors"] += 1
+        return stats
+
+    online_ids: set[str] = set()
+    if boxes:
+        try:
+            info = ssm.describe_instance_information(Filters=[
+                {"Key": "InstanceIds", "Values": [b["InstanceId"] for b in boxes]},
+            ]).get("InstanceInformationList", [])
+            online_ids = {i["InstanceId"] for i in info if i.get("PingStatus") == "Online"}
+        except Exception as exc:  # noqa: BLE001 — degrade to "none online"; young boxes wait, old ones still reap
+            logger.error("bootstrap_and_reap: SSM describe failed: %s: %s",
+                         type(exc).__name__, exc)
+
+    for box in boxes:
+        iid = box["InstanceId"]
+        tags = {t["Key"]: t["Value"] for t in box.get("Tags", [])}
+        age = (now - box["LaunchTime"]).total_seconds()
+
+        if age > RUNNER_MAX_LIFETIME_SECONDS:
+            try:
+                ec2.terminate_instances(InstanceIds=[iid])
+                logger.warning("bootstrap_and_reap: REAPED %s (lifetime %ds > %ds — leaked box)",
+                               iid, int(age), RUNNER_MAX_LIFETIME_SECONDS)
+                stats["reaped_lifetime"] += 1
+            except Exception as exc:  # noqa: BLE001 — retried next pass
+                logger.error("bootstrap_and_reap: reap %s failed: %s", iid, exc)
+                stats["errors"] += 1
+            continue
+
+        if MORNING_SIGNAL_RUNNER_BOOTSTRAP_SENT_TAG_KEY in tags:
+            stats["healthy"] += 1
+            continue
+
+        job_id = tags.get(MORNING_SIGNAL_RUNNER_JOB_ID_TAG_KEY, "")
+        if iid in online_ids and job_id:
+            try:
+                spot_dispatch.send_async_command(
+                    iid,
+                    _bootstrap_command(job_id),
+                    comment=f"morning-signal-runner (job {job_id})",
+                    region=REGION,
+                    cw_log_group=CW_LOG_GROUP,
+                    execution_timeout_seconds=MAX_RUNTIME_SECONDS,
+                )
+                ec2.create_tags(Resources=[iid], Tags=[{
+                    "Key": MORNING_SIGNAL_RUNNER_BOOTSTRAP_SENT_TAG_KEY,
+                    "Value": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }])
+                logger.info("bootstrap_and_reap: bootstrapped %s (job %s, %ds after launch)",
+                            iid, job_id, int(age))
+                stats["bootstrapped"] += 1
+            except Exception as exc:  # noqa: BLE001 — send/tag failure: untagged, retried next pass
+                logger.error("bootstrap_and_reap: bootstrap %s failed (retry next pass): %s: %s",
+                             iid, type(exc).__name__, exc)
+                stats["errors"] += 1
+        elif age > BOOTSTRAP_DEADLINE_SECONDS:
+            try:
+                ec2.terminate_instances(InstanceIds=[iid])
+                logger.warning("bootstrap_and_reap: REAPED %s (no SSM/job-id after %ds — "
+                               "bootstrap undeliverable)", iid, int(age))
+                stats["reaped_no_ssm"] += 1
+            except Exception as exc:  # noqa: BLE001 — retried next pass
+                logger.error("bootstrap_and_reap: reap %s failed: %s", iid, exc)
+                stats["errors"] += 1
+        else:
+            stats["waiting_ssm"] += 1
+
+    stats["running_after_reap"] = len(boxes) - stats["reaped_no_ssm"] - stats["reaped_lifetime"]
+    logger.info("bootstrap_and_reap: %s", stats)
+    return stats
+
+
+def _reconcile() -> dict:
+    """Scheduled backstop (~every 60s, config-I2653): dispatch a fresh runner
+    for any queued job matching our label that's had no in-flight box for
+    RECONCILE_STALE_SECONDS. See module docstring phase 3 for the full
+    rationale — this is NOT redundant with the reactive webhook path; it is
+    the only mechanism that can recover a job whose one-shot `queued`
+    webhook already fired but whose dispatched runner grabbed a different
+    job instead."""
+    if not DISPATCH_ENABLED:
+        logger.info("reconcile: MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED=false — skipping")
+        return {"reconciled": 0, "reason": "disabled"}
+
+    # Bootstrap-deliverer + janitor FIRST (I2692): serve boxes already up
+    # before launching new ones, and reap zombies so the queued-job scan
+    # below never launches into an exhausted quota that leaked boxes caused.
+    br_stats = _bootstrap_and_reap()
+
+    now = datetime.now(timezone.utc)
+    try:
+        runs_resp = _gh_api_get(
+            f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs"
+            f"?status=queued&per_page={RECONCILE_MAX_QUEUED_RUNS}"
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        # Best-effort: a failed reconcile pass just means "no backstop this
+        # minute" — the NEXT scheduled invocation tries again. Never raise
+        # (this is EventBridge-invoked; an unhandled exception would just
+        # generate a Lambda-error-metric page for a transient GitHub API
+        # blip with no actionable fix).
+        logger.error("reconcile: failed to list queued runs: %s: %s", type(exc).__name__, exc)
+        return {"reconciled": 0, "reason": "list_runs_failed", "error": str(exc)}
+
+    # Collect ALL stale queued jobs first, then dispatch OLDEST-FIRST.
+    # GitHub lists runs newest-first; dispatching in listing order let a
+    # constant churn of fresh runs (e.g. the 2026-07-15 Dependabot-drain
+    # rebase wave) win every quota-constrained launch race while the oldest
+    # job starved indefinitely (PR2690's pytest sat queued 95+ min while
+    # newer jobs got every available spot slot). FIFO makes quota pressure
+    # degrade to bounded latency for everyone instead of unbounded latency
+    # for the unluckiest.
+    stale_jobs: list[tuple[float, str]] = []
+    for run in runs_resp.get("workflow_runs", []):
+        try:
+            jobs_resp = _gh_api_get(
+                f"/repos/{TARGET_REPO_FULL_NAME}/actions/runs/{run['id']}/jobs"
+            )
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+            logger.error("reconcile: failed to list jobs for run %s: %s: %s",
+                         run.get("id"), type(exc).__name__, exc)
+            continue
+        for job in jobs_resp.get("jobs", []):
+            if job.get("status") != "queued" or TARGET_LABEL not in (job.get("labels") or []):
+                continue
+            created_at = datetime.fromisoformat(job["created_at"].replace("Z", "+00:00"))
+            age_seconds = (now - created_at).total_seconds()
+            if age_seconds < RECONCILE_STALE_SECONDS:
+                continue  # still within the reactive path's normal dispatch latency
+            stale_jobs.append((age_seconds, str(job["id"])))
+
+    # Concurrency cap (I2692 item 4): count this pass's OWN dispatches against
+    # the fleet already standing after bootstrap_and_reap's janitor pass, so a
+    # single burst of stale jobs can't blow past the cap in one reconcile.
+    available_slots = max(0, MAX_CONCURRENT_RUNNERS - br_stats.get("running_after_reap", 0))
+    capped_at_slot_zero = False
+
+    dispatched = []
+    skipped = []
+    for age_seconds, job_id in sorted(stale_jobs, reverse=True):  # oldest first
+        try:
+            existing = _running_morning_signal_runner_instance_ids(job_id)
+        except SpotProbeError:
+            existing = []  # degrade to "dispatch anyway" — the launch's own dedup/tag logic is authoritative
+        if existing:
+            skipped.append(job_id)
+            continue
+        if available_slots <= 0:
+            logger.warning("reconcile: job %s queued %.0fs but MAX_CONCURRENT_RUNNERS=%d "
+                            "already reached — leaving queued for next pass",
+                            job_id, age_seconds, MAX_CONCURRENT_RUNNERS)
+            skipped.append(job_id)
+            capped_at_slot_zero = True
+            continue
+        logger.info("reconcile: job %s queued %.0fs with no in-flight box — dispatching",
+                   job_id, age_seconds)
+        result = _launch_morning_signal_runner_spot(job_id)
+        if result.get("launched"):
+            available_slots -= 1
+        dispatched.append({"job_id": job_id, "age_seconds": age_seconds, "result": result})
+
+    if capped_at_slot_zero:
+        _page(f"⚠️ morning-signal-runner: MAX_CONCURRENT_RUNNERS={MAX_CONCURRENT_RUNNERS} reached — "
+              "one or more stale jobs left queued this reconcile pass pending a free slot. "
+              "design mirrors alpha-engine-config-I2692.")
+
+    logger.info("reconcile: dispatched=%d skipped=%d bootstrap_and_reap=%s",
+                len(dispatched), len(skipped), br_stats)
+    return {"reconciled": len(dispatched), "dispatched": dispatched,
+            "skipped": skipped, "bootstrap_and_reap": br_stats}
+
+
+def handler(event: dict, context) -> dict:
+    """Three-phase entrypoint — see module docstring. A Function URL
+    delivery carries `requestContext` (the API Gateway v2-shaped proxy
+    event); the EventBridge-scheduled reconcile trigger carries
+    `{"reconcile": true}`; the async self-invoked worker payload carries
+    `morning_signal_runner_job_id`."""
+    event = event or {}
+    if event.get("reconcile"):
+        return _reconcile()
+    if "requestContext" in event:
+        return _handle_webhook(event)
+
+    job_id = event.get("morning_signal_runner_job_id")
+    if not job_id:
+        logger.error("worker-phase invocation missing morning_signal_runner_job_id: %r", event)
+        return {"launched": False, "reason": "invalid_event"}
+    return _launch_morning_signal_runner_spot(str(job_id))

--- a/infrastructure/lambdas/morning-signal-runner-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/morning-signal-runner-dispatcher/requirements.txt
@@ -1,0 +1,10 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# nousergon_lib.spot_dispatch (config#2106) wraps krepis.ec2_spot (the
+# spot-launch capacity-resilience chokepoint) — same primitives ci-watch-
+# dispatcher/sf-watch-spot-dispatcher use. Pinned to the latest tag at the
+# time this Lambda was written (v0.106.0 is the floor: first version whose
+# running_instance_ids raises SpotProbeError instead of failing open,
+# config#2267 site 1 — index.py imports and handles that exception).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.110.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/morning-signal-runner-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/morning-signal-runner-dispatcher/test_handler.py
@@ -1,0 +1,1091 @@
+"""Unit tests for the three-phase (webhook receiver / worker / reconcile)
+morning-signal-runner spot dispatcher.
+
+Hermetic: ``nousergon_lib.ec2_spot`` and ``boto3`` are stubbed in sys.modules
+before importing index (mirrors ci-watch-dispatcher/test_handler.py). Covers:
+webhook HMAC signature verification, event/action/label/repo filtering, the
+async self-invoke on a matching queued job, the kill-switch, the worker
+phase's launch/dedup/tag/SSM-dispatch behavior (spot-first with on-demand
+fallback, job-id-scoped concurrency lock, terminate-on-post-launch-failure,
+config#2267-style dedupe_degraded on a probe failure), and the reconcile
+backstop (config-I2653 — dispatches a fresh runner for any queued job
+matching our label that's sat stale with no in-flight box; ``urllib.request``
+is monkeypatched per-test rather than stubbed in sys.modules, since it's
+stdlib and always resolvable).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_stdlib
+import json
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+WEBHOOK_SECRET = "test-webhook-secret"
+
+
+class _SpotLaunchError(Exception):
+    pass
+
+
+class _SpotCapacityExhausted(_SpotLaunchError):
+    pass
+
+
+def _install_stubs(launch_impl, boto_clients):
+    ec2_spot_mod = types.ModuleType("nousergon_lib.ec2_spot")
+    ec2_spot_mod.SpotLaunchError = _SpotLaunchError
+    ec2_spot_mod.SpotCapacityExhausted = _SpotCapacityExhausted
+    ec2_spot_mod.launch = launch_impl
+    sys.modules["nousergon_lib.ec2_spot"] = ec2_spot_mod
+
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = lambda name, **kw: boto_clients[name]
+    sys.modules["boto3"] = boto3_mod
+
+
+class _FakeWaiter:
+    def wait(self, **kw):
+        return None
+
+
+class _FakeEc2:
+    def __init__(self, running_job_ids=None, create_tags_failures=0, attempt_boxes=None):
+        self.terminated = []
+        self.tags_created = []
+        self.create_tags_attempts = 0
+        self._create_tags_failures = create_tags_failures
+        self._running_job_ids = dict(running_job_ids or {})  # {job_id: [instance_ids]}
+        # {job_id: [instance dicts]} — full instance dicts (InstanceId,
+        # LaunchTime, state) for the config#2697 attempt-count probe, which
+        # (unlike the dedupe probe above) needs state/age, not just ids.
+        self._attempt_boxes = dict(attempt_boxes or {})
+        self.describe_instances_calls = 0
+        self.describe_instances_failures = 0
+
+    def get_waiter(self, name):
+        return _FakeWaiter()
+
+    def terminate_instances(self, InstanceIds):  # noqa: N803
+        self.terminated.extend(InstanceIds)
+        return {"TerminatingInstances": [{"InstanceId": i} for i in InstanceIds]}
+
+    def create_tags(self, Resources, Tags):  # noqa: N803
+        self.create_tags_attempts += 1
+        if self.create_tags_attempts <= self._create_tags_failures:
+            raise RuntimeError(f"CreateTags throttled (attempt {self.create_tags_attempts})")
+        self.tags_created.append((Resources, Tags))
+        return {}
+
+    def describe_instances(self, Filters):  # noqa: N803
+        self.describe_instances_calls += 1
+        if self.describe_instances_calls <= self.describe_instances_failures:
+            raise RuntimeError(f"DescribeInstances throttled (attempt {self.describe_instances_calls})")
+        by_name = {f["Name"]: f["Values"] for f in Filters}
+        states = by_name.get("instance-state-name", [])
+        job_id_filter = by_name.get("tag:morning-signal-runner-job-id")
+
+        # config#2697 _job_attempt_count: tag:Name + tag:morning-signal-runner-job-id
+        # + a state list that includes "terminated" (the discriminator vs.
+        # the plain dedupe-probe job-id query below, which never asks for
+        # terminated boxes).
+        if job_id_filter is not None and "terminated" in states:
+            job_id = job_id_filter[0]
+            boxes = self._attempt_boxes.get(job_id, [])
+            return {"Reservations": [{"Instances": list(boxes)}]} if boxes else {"Reservations": []}
+
+        # _bootstrap_and_reap / config#2697 _current_fleet_size: tag:Name
+        # WITHOUT a job-id filter — tests populate self.boxes with full
+        # instance dicts (shared fixture between both call sites, since
+        # fleet-size counting has the identical filter shape as the
+        # bootstrap-and-reap enumeration).
+        if "tag:Name" in by_name and job_id_filter is None:
+            return {"Reservations": [{"Instances": list(getattr(self, "boxes", []))}]}
+
+        # Plain dedupe probe (spot_dispatch.running_instance_ids): filters by
+        # job-id, state restricted to pending/running only.
+        job_id = job_id_filter[0] if job_id_filter else None
+        ids = self._running_job_ids.get(job_id, [])
+        return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
+
+
+class _FakeSsm:
+    def __init__(self):
+        self.sent = []
+        self.params = {
+            "/morning-signal/runner/webhook_secret": WEBHOOK_SECRET,
+            "/morning-signal/runner/github_read_pat": "test-read-only-pat",
+        }
+
+    def get_parameter(self, Name, WithDecryption=True):  # noqa: N803
+        return {"Parameter": {"Value": self.params[Name]}}
+
+    def describe_instance_information(self, **kw):
+        # _bootstrap_and_reap (I2692) matches entries by InstanceId; tests
+        # populate self.online_ids. Legacy default (no online_ids) keeps the
+        # old anonymous-Online shape for any pre-I2692 call sites.
+        online = getattr(self, "online_ids", None)
+        if online is None:
+            return {"InstanceInformationList": [{"PingStatus": "Online"}]}
+        return {"InstanceInformationList": [
+            {"InstanceId": i, "PingStatus": "Online"} for i in online]}
+
+    def send_command(self, **kw):
+        self.sent.append(kw)
+        return {"Command": {"CommandId": "cmd-123"}}
+
+
+class _FakeLambda:
+    def __init__(self):
+        self.invocations = []
+
+    def invoke(self, **kw):
+        self.invocations.append(kw)
+        return {"StatusCode": 202}
+
+
+class _FakeCloudwatch:
+    def __init__(self):
+        self.put_metric_data_calls = []
+
+    def put_metric_data(self, **kw):
+        self.put_metric_data_calls.append(kw)
+        return {}
+
+
+def _load(monkeypatch, *, launch_impl=None, env=None, running_job_ids=None,
+          create_tags_failures=0, attempt_boxes=None, describe_instances_failures=0):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "morning-signal-runner-dispatcher")
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    ssm = _FakeSsm()
+    ec2 = _FakeEc2(running_job_ids=running_job_ids, create_tags_failures=create_tags_failures,
+                   attempt_boxes=attempt_boxes)
+    ec2.describe_instances_failures = describe_instances_failures
+    lam = _FakeLambda()
+    cw = _FakeCloudwatch()
+    clients = {"ec2": ec2, "ssm": ssm, "lambda": lam, "cloudwatch": cw}
+    if launch_impl is None:
+        launch_impl = lambda types_, subnets, **kw: "i-stub"  # noqa: E731
+    _install_stubs(launch_impl, clients)
+
+    from _shared.hermetic_import_guard import assert_hermetic_imports_satisfied
+
+    assert_hermetic_imports_satisfied(__file__)
+    import importlib
+
+    if "nousergon_lib.spot_dispatch" in sys.modules:
+        importlib.reload(sys.modules["nousergon_lib.spot_dispatch"])
+    else:
+        import nousergon_lib.spot_dispatch  # noqa: F401 — first import picks up the current stub
+
+    _sd = sys.modules["nousergon_lib.spot_dispatch"]
+    if not hasattr(_sd, "SpotProbeError"):
+        _sd.SpotProbeError = type("SpotProbeError", (Exception,), {})
+
+    import index
+
+    importlib.reload(index)
+    index._test_ssm = ssm
+    index._test_ec2 = ec2
+    index._test_lambda = lam
+    index._test_cloudwatch = cw
+    return index
+
+
+def _sign(body_bytes: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    return "sha256=" + hmac_stdlib.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+
+
+def _webhook_event(payload: dict, *, event_type: str = "workflow_job", secret: str = WEBHOOK_SECRET) -> dict:
+    body = json.dumps(payload)
+    body_bytes = body.encode("utf-8")
+    return {
+        "requestContext": {"http": {"method": "POST"}},
+        "headers": {
+            "x-github-event": event_type,
+            "x-hub-signature-256": _sign(body_bytes, secret),
+        },
+        "body": body,
+        "isBase64Encoded": False,
+    }
+
+
+def _job_payload(**overrides):
+    base = {
+        "action": "queued",
+        "repository": {"full_name": "nousergon/morning-signal"},
+        "workflow_job": {"id": 987654321, "labels": ["self-hosted", "morning-signal-spot"]},
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Phase 1: webhook receiver ────────────────────────────────────────────────
+
+
+def test_webhook_valid_queued_job_self_invokes_and_returns_200(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["accepted"] is True
+    assert body["job_id"] == 987654321
+    assert len(idx._test_lambda.invocations) == 1
+    inv = idx._test_lambda.invocations[0]
+    assert inv["InvocationType"] == "Event"
+    assert inv["FunctionName"] == "morning-signal-runner-dispatcher"
+    worker_payload = json.loads(inv["Payload"])
+    assert worker_payload == {"morning_signal_runner_job_id": "987654321"}
+
+
+def test_webhook_invalid_signature_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(), secret="wrong-secret"), None)
+    assert resp["statusCode"] == 401
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_signature_header_returns_401(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    event = _webhook_event(_job_payload())
+    del event["headers"]["x-hub-signature-256"]
+    resp = idx.handler(event, None)
+    assert resp["statusCode"] == 401
+
+
+def test_webhook_non_workflow_job_event_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event({"zen": "hello"}, event_type="ping"), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_non_queued_action_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(_webhook_event(_job_payload(action="completed")), None)
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_wrong_repo_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(repository={"full_name": "nousergon/some-other-repo"})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_missing_our_label_is_noop(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    resp = idx.handler(
+        _webhook_event(_job_payload(workflow_job={"id": 1, "labels": ["ubuntu-latest"]})), None
+    )
+    assert resp["statusCode"] == 200
+    assert idx._test_lambda.invocations == []
+
+
+def test_webhook_disabled_flag_skips_invoke(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "false"})
+    resp = idx.handler(_webhook_event(_job_payload()), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["launched"] is False
+    assert body["reason"] == "disabled"
+    assert idx._test_lambda.invocations == []
+
+
+# ── Phase 2: worker (async self-invoked) ─────────────────────────────────────
+
+
+def test_worker_valid_job_launches_tags_and_defers_bootstrap(monkeypatch):
+    # I2692 two-phase contract: the worker phase launches + tags and returns
+    # in seconds — NO in-Lambda SSM wait/send (that wait used to blow the
+    # 60s Lambda timeout and manufacture zombie boxes). The bootstrap is
+    # delivered by _bootstrap_and_reap on a later reconcile pass.
+    calls = {}
+
+    def _launch(types_, subnets, **kw):
+        calls["spot"] = kw.get("spot")
+        calls["profile"] = kw.get("iam_instance_profile")
+        calls["tag_name"] = kw.get("tag_name")
+        return "i-abc"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"morning_signal_runner_job_id": "987654321"}, None)
+    assert out["launched"] is True
+    assert out["reason"] == "launched_bootstrap_pending"
+    assert out["instance_id"] == "i-abc"
+    assert out["market"] == "spot"
+    assert calls["profile"] == "morning-signal-runner-executor-profile"
+    assert calls["tag_name"] == "morning-signal-runner-spot"
+    assert idx._test_ec2.tags_created == [
+        (["i-abc"], [{"Key": "morning-signal-runner-job-id", "Value": "987654321"}])
+    ]
+    assert idx._test_ssm.sent == [], "worker phase must never send SSM commands (I2692)"
+
+
+def test_worker_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
+    seen = []
+
+    def _launch(types_, subnets, **kw):
+        seen.append(kw.get("spot"))
+        if kw.get("spot"):
+            raise _SpotCapacityExhausted("no capacity")
+        return "i-ondemand"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["market"] == "on-demand"
+    assert seen == [True, False]
+
+
+def test_worker_total_launch_exhaustion_returns_clean_false(monkeypatch):
+    def _launch(types_, subnets, **kw):
+        raise _SpotCapacityExhausted("exhausted")
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_concurrency_skip_when_job_already_running(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-new"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-already-running"]},
+    )
+    out = idx.handler({"morning_signal_runner_job_id": "55"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "concurrent_skip"
+    assert out["existing_instance_ids"] == ["i-already-running"]
+    assert launched == []
+
+
+def test_worker_different_job_id_is_not_blocked(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-new",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"55": ["i-other-job"]},
+    )
+    out = idx.handler({"morning_signal_runner_job_id": "56"}, None)
+    assert out["launched"] is True
+
+
+def test_worker_probe_failure_launches_with_dedupe_degraded(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-degraded",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _probe_down(*a, **kw):
+        raise idx.SpotProbeError("probe failed: ThrottlingException")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+    assert out["dedupe_degraded"] is True
+
+
+def test_worker_persistent_tag_write_failure_terminates_and_fails(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-untaggable",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        create_tags_failures=99,
+    )
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "tag_write_failed"
+    assert idx._test_ec2.terminated == ["i-untaggable"]
+    assert idx._test_ssm.sent == []
+
+
+def test_worker_quota_exhaustion_pages_loudly(monkeypatch):
+    # I2692: MaxSpotInstanceCountExceeded used to be ERROR-log-only while
+    # fleet CI silently queued for an hour — it must page now.
+    from nousergon_lib.spot_dispatch import SpotLaunchError
+
+    def _launch(types_, subnets, **kw):
+        raise SpotLaunchError(
+            "RunInstances failed with non-capacity error "
+            "MaxSpotInstanceCountExceeded (t3.medium@subnet-x): "
+            "Max spot instance count exceeded")
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "launch_failed"
+    assert len(pages) == 1 and "QUOTA EXHAUSTED" in pages[0]
+
+
+# ── _bootstrap_and_reap (I2692 two-phase state machine) ──────────────────────
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def _box(iid, *, age_seconds, job_id="j1", bootstrapped=False):
+    tags = [{"Key": "Name", "Value": "morning-signal-runner-spot"}]
+    if job_id:
+        tags.append({"Key": "morning-signal-runner-job-id", "Value": job_id})
+    if bootstrapped:
+        tags.append({"Key": "morning-signal-runner-bootstrap-sent", "Value": "2026-01-01T00:00:00Z"})
+    return {"InstanceId": iid, "Tags": tags,
+            "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds)}
+
+
+def test_bootstrap_and_reap_sends_bootstrap_to_online_untagged_box(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-new", age_seconds=70, job_id="42")]
+    idx._test_ssm.online_ids = ["i-new"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["bootstrapped"] == 1
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert 'exec bash infrastructure/morning_signal_runner_spot_bootstrap.sh --job-id "42"' in cmd
+    assert any(r == ["i-new"] and tags[0]["Key"] == "morning-signal-runner-bootstrap-sent"
+               for r, tags in idx._test_ec2.tags_created)
+
+
+def test_bootstrap_and_reap_waits_on_young_offline_box(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-booting", age_seconds=60)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["waiting_ssm"] == 1
+    assert idx._test_ec2.terminated == []
+    assert idx._test_ssm.sent == []
+
+
+def test_bootstrap_and_reap_reaps_box_ssm_never_came_up(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-zombie", age_seconds=400)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_no_ssm"] == 1
+    assert idx._test_ec2.terminated == ["i-zombie"]
+
+
+def test_bootstrap_and_reap_reaps_over_lifetime_box_even_if_bootstrapped(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-leak", age_seconds=6000, bootstrapped=True)]
+    idx._test_ssm.online_ids = []
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_lifetime"] == 1
+    assert idx._test_ec2.terminated == ["i-leak"]
+
+
+def test_bootstrap_and_reap_healthy_bootstrapped_box_untouched(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-working", age_seconds=600, bootstrapped=True)]
+    idx._test_ssm.online_ids = ["i-working"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["healthy"] == 1
+    assert idx._test_ec2.terminated == []
+    assert idx._test_ssm.sent == []
+
+
+def test_bootstrap_and_reap_send_failure_leaves_untagged_for_retry(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [_box("i-flaky", age_seconds=100, job_id="7")]
+    idx._test_ssm.online_ids = ["i-flaky"]
+
+    def _boom_send(**kw):
+        raise RuntimeError("SSM SendCommand failed")
+
+    idx._test_ssm.send_command = _boom_send
+    stats = idx._bootstrap_and_reap()
+    assert stats["errors"] == 1
+    assert stats["bootstrapped"] == 0
+    # No bootstrap-sent tag written — the next reconcile pass retries.
+    assert all(tags[0]["Key"] != "morning-signal-runner-bootstrap-sent"
+               for _, tags in idx._test_ec2.tags_created)
+
+
+def test_worker_missing_job_id_returns_invalid_event(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    out = idx.handler({}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "invalid_event"
+
+
+# ── Phase 3: reconcile backstop (config-I2653) ───────────────────────────────
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_gh_api_stub(idx, monkeypatch, runs_by_path):
+    """runs_by_path: {url_path_suffix: response_dict}. Any request whose URL
+    ends with a registered suffix returns that canned response."""
+    def _fake_urlopen(req, timeout=10):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+        for suffix, payload in runs_by_path.items():
+            if url.endswith(suffix):
+                return _FakeHttpResponse(payload)
+        raise AssertionError(f"unexpected GH API call: {url}")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _fake_urlopen)
+
+
+def _iso(seconds_ago: float) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_reconcile_dispatches_stale_orphaned_job(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-rescued",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {
+            "workflow_runs": [{"id": 555}],
+        },
+        "/actions/runs/555/jobs": {
+            "jobs": [{
+                "id": 999, "status": "queued",
+                "labels": ["self-hosted", "morning-signal-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 1
+    assert out["dispatched"][0]["job_id"] == "999"
+    assert out["dispatched"][0]["result"]["launched"] is True
+
+
+def test_reconcile_skips_job_within_normal_dispatch_window(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [{
+                "id": 1, "status": "queued",
+                "labels": ["self-hosted", "morning-signal-spot"],
+                "created_at": _iso(10),  # well under the 90s default threshold
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["dispatched"] == []
+
+
+def test_reconcile_skips_job_already_covered_by_an_in_flight_box(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        running_job_ids={"777": ["i-already-covering-it"]},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 2}]},
+        "/actions/runs/2/jobs": {
+            "jobs": [{
+                "id": 777, "status": "queued",
+                "labels": ["self-hosted", "morning-signal-spot"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["skipped"] == ["777"]
+
+
+def test_reconcile_ignores_jobs_without_our_label(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 3}]},
+        "/actions/runs/3/jobs": {
+            "jobs": [{
+                "id": 3, "status": "queued", "labels": ["ubuntu-latest"],
+                "created_at": _iso(200),
+            }],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+
+
+def test_reconcile_disabled_flag_short_circuits(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "false"})
+    out = idx.handler({"reconcile": True}, None)
+    assert out == {"reconciled": 0, "reason": "disabled"}
+
+
+def test_reconcile_list_runs_failure_returns_clean_result_not_raise(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+
+    def _boom(req, timeout=10):  # noqa: ARG001
+        raise idx.urllib.error.URLError("network blip")
+
+    monkeypatch.setattr(idx.urllib.request, "urlopen", _boom)
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["reason"] == "list_runs_failed"
+
+
+def test_reconcile_dispatches_oldest_job_first(monkeypatch):
+    # FIFO fairness: under quota pressure the OLDEST stale job must get the
+    # first launch attempt — newest-first listing order let fresh churn
+    # starve old jobs indefinitely (PR2690, 2026-07-15).
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        return f"i-{len(launched)}"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+
+    old = (datetime.now(timezone.utc) - timedelta(seconds=5000)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    newer = (datetime.now(timezone.utc) - timedelta(seconds=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def fake_get(path):
+        if path.endswith("&per_page=50") or "/actions/runs?" in path:
+            return {"workflow_runs": [{"id": 1}, {"id": 2}]}
+        if "/runs/1/jobs" in path:
+            # newest-first listing: run 1 (listed first) has the NEWER job
+            return {"jobs": [{"id": 111, "status": "queued", "created_at": newer,
+                              "labels": ["self-hosted", "morning-signal-spot"]}]}
+        if "/runs/2/jobs" in path:
+            return {"jobs": [{"id": 222, "status": "queued", "created_at": old,
+                              "labels": ["self-hosted", "morning-signal-spot"]}]}
+        raise AssertionError(f"unexpected GH GET {path}")
+
+    monkeypatch.setattr(idx, "_gh_api_get", fake_get)
+    out = idx.handler({"reconcile": True}, None)
+    order = [d["job_id"] for d in out["dispatched"]]
+    assert order == ["222", "111"], f"oldest job must dispatch first, got {order}"
+
+
+# ── Runner-fleet concurrency cap (I2692 item 4) ──────────────────────────────
+
+
+def test_bootstrap_and_reap_reports_running_after_reap(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [
+        _box("i-healthy", age_seconds=600, bootstrapped=True),
+        _box("i-zombie", age_seconds=6000, bootstrapped=True),  # reaped: over lifetime
+    ]
+    idx._test_ssm.online_ids = ["i-healthy"]
+    stats = idx._bootstrap_and_reap()
+    assert stats["reaped_lifetime"] == 1
+    # one box reaped this pass — only the survivor counts toward the cap
+    assert stats["running_after_reap"] == 1
+
+
+def test_reconcile_respects_concurrency_cap_leaves_job_queued(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true",
+                                    "MORNING_SIGNAL_RUNNER_MAX_CONCURRENT": "1"})
+    idx._test_ec2.boxes = [_box("i-existing", age_seconds=100, job_id="1", bootstrapped=True)]
+    idx._test_ssm.online_ids = ["i-existing"]
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 9}]},
+        "/actions/runs/9/jobs": {
+            "jobs": [{"id": 909, "status": "queued",
+                      "labels": ["self-hosted", "morning-signal-spot"],
+                      "created_at": _iso(200)}],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    assert out["reconciled"] == 0
+    assert out["skipped"] == ["909"]
+    assert len(pages) == 1 and "MAX_CONCURRENT_RUNNERS=1" in pages[0]
+
+
+def test_reconcile_dispatches_up_to_available_slots_only(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(1)
+        return f"i-{len(launched)}"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true",
+                     "MORNING_SIGNAL_RUNNER_MAX_CONCURRENT": "1"})
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}, {"id": 2}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [{"id": 111, "status": "queued", "created_at": _iso(200),
+                      "labels": ["self-hosted", "morning-signal-spot"]}],
+        },
+        "/actions/runs/2/jobs": {
+            "jobs": [{"id": 222, "status": "queued", "created_at": _iso(300),
+                      "labels": ["self-hosted", "morning-signal-spot"]}],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    # zero running boxes going in, cap=1 -> exactly one of the two stale jobs
+    # gets dispatched this pass, the other waits for the next reconcile.
+    assert out["reconciled"] == 1
+    assert len(out["skipped"]) == 1
+    assert out["dispatched"][0]["job_id"] == "222"  # oldest first
+
+
+# ── Circuit breaker + fleet cap (alpha-engine-config#2697 (source incident)) ───────────────────
+#
+# 2026-07-15 incident: with every runner box failing identically, _reconcile()
+# relaunched a fresh box per stuck queued job on every ~60s pass FOREVER —
+# ~150 t3.medium spot launches in 45 min, saturating the account's 32-vCPU
+# standard-spot quota and locking out the post-close trading SF's data-spot
+# launch. These tests cover the two independent bounds added to
+# _launch_morning_signal_runner_spot (the single chokepoint both the reactive
+# webhook-worker path and the reconcile path funnel through): a per-job
+# attempt limit (counting live+recently-terminated boxes) and a global
+# running+pending fleet cap — including the config#2267 dedupe_degraded
+# "proceed anyway" path, where the circuit breaker must still bind or the
+# runaway just re-opens there.
+
+
+def _attempt_box(iid, *, age_seconds, state="terminated"):
+    return {
+        "InstanceId": iid,
+        "State": {"Name": state},
+        "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+    }
+
+
+def test_attempt_limit_blocks_dispatch_at_default_threshold(monkeypatch):
+    # Default MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB=3: 3 prior (terminated)
+    # boxes for this job already exist -> the 4th attempt must be refused.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"999": [
+            _attempt_box("i-try1", age_seconds=1000),
+            _attempt_box("i-try2", age_seconds=800),
+            _attempt_box("i-try3", age_seconds=600),
+        ]},
+    )
+    out = idx.handler({"morning_signal_runner_job_id": "999"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert out["attempt_count"] == 3
+    assert launched == [], "must not dispatch once the per-job attempt limit is reached"
+
+
+def test_attempt_limit_pages_exactly_once_per_job(monkeypatch):
+    idx = _load(
+        monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"42": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    idx.handler({"morning_signal_runner_job_id": "42"}, None)
+    idx.handler({"morning_signal_runner_job_id": "42"}, None)
+    idx.handler({"morning_signal_runner_job_id": "42"}, None)
+    assert len(pages) == 1, "repeated dispatch attempts for an abandoned job must page only once"
+    assert "ABANDONED" in pages[0]
+    assert "42" in pages[0]
+
+
+def test_attempt_count_below_threshold_still_dispatches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"5": [_attempt_box("i-a", age_seconds=100)]},
+    )
+    out = idx.handler({"morning_signal_runner_job_id": "5"}, None)
+    assert out["launched"] is True
+
+
+def test_attempt_count_ignores_boxes_outside_lookback_window(monkeypatch):
+    # 3 prior boxes exist for the job, but all launched > the lookback
+    # window ago (default 3600s) — describe-instances would no longer even
+    # return a >1h-old terminated box in practice, but this also guards
+    # against counting a stale/lingering tag from a much older, unrelated
+    # incident as part of today's attempt budget.
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-fresh-attempt",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"7": [
+            _attempt_box("i-old1", age_seconds=999999),
+            _attempt_box("i-old2", age_seconds=999999),
+            _attempt_box("i-old3", age_seconds=999999),
+        ]},
+    )
+    out = idx.handler({"morning_signal_runner_job_id": "7"}, None)
+    assert out["launched"] is True
+
+
+def test_attempt_limit_is_env_tunable(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-x"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch,
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true", "MORNING_SIGNAL_RUNNER_MAX_ATTEMPTS_PER_JOB": "1"},
+        attempt_boxes={"9": [_attempt_box("i-only-prior-attempt", age_seconds=10)]},
+    )
+    out = idx.handler({"morning_signal_runner_job_id": "9"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert launched == []
+
+
+def test_attempt_limit_binds_on_dedupe_degraded_path(monkeypatch):
+    # The gotcha this issue calls out explicitly: dedup-probe failures
+    # deliberately degrade to "dispatch anyway" (config#2267, coverage beats
+    # dedupe) — the attempt limit must STILL bind in that degraded path, or
+    # a runaway job just re-opens the loop there instead of at the dedupe
+    # probe.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"55": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+
+    def _probe_down(*a, **kw):
+        raise idx.SpotProbeError("probe failed: ThrottlingException")
+
+    monkeypatch.setattr(idx.spot_dispatch, "running_instance_ids", _probe_down)
+    out = idx.handler({"morning_signal_runner_job_id": "55"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_limit_exceeded"
+    assert launched == [], "attempt limit must bind even when the dedupe probe itself is degraded"
+
+
+def test_attempt_probe_failure_is_fail_safe_not_fail_open(monkeypatch):
+    # Unlike the dedupe probe (config#2267 posture: coverage beats dedupe),
+    # the circuit breaker's OWN probe must fail closed — an unknown attempt
+    # count must never be silently treated as "0, dispatch anyway", since
+    # that would defeat the breaker on exactly the kind of degraded-API pass
+    # a runaway is likely to coincide with.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+                describe_instances_failures=1)
+    out = idx.handler({"morning_signal_runner_job_id": "123"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "attempt_probe_failed"
+    assert launched == []
+
+
+def test_fleet_cap_blocks_dispatch_at_default_threshold(monkeypatch):
+    # Default MORNING_SIGNAL_RUNNER_MAX_FLEET=6: 6 running+pending boxes already
+    # exist fleet-wide (for OTHER jobs) -> a brand-new job's dispatch must
+    # still be refused.
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [
+        {"InstanceId": f"i-fleet-{n}", "Tags": []} for n in range(6)
+    ]
+    out = idx.handler({"morning_signal_runner_job_id": "888"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+    assert out["fleet_size"] == 6
+    assert launched == [], "must not dispatch once the global fleet cap is reached"
+
+
+def test_fleet_cap_pages(monkeypatch):
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(6)]
+    pages = []
+    monkeypatch.setattr(idx, "_page", lambda msg: pages.append(msg))
+    idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert len(pages) == 1
+    assert "fleet cap" in pages[0].lower()
+
+
+def test_fleet_below_cap_still_dispatches(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(5)]
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is True
+
+
+def test_fleet_cap_is_env_tunable(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-x"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch,
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true", "MORNING_SIGNAL_RUNNER_MAX_FLEET": "1"},
+    )
+    idx._test_ec2.boxes = [{"InstanceId": "i-already-there", "Tags": []}]
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+    assert launched == []
+
+
+def test_fleet_cap_checked_even_when_this_job_has_zero_prior_attempts(monkeypatch):
+    # The fleet cap is a GLOBAL backstop independent of the per-job attempt
+    # count — a brand-new job (0 attempts) must still be refused if the
+    # fleet is already full from OTHER jobs' boxes.
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-other-job-{n}", "Tags": []} for n in range(6)]
+    out = idx.handler({"morning_signal_runner_job_id": "brand-new-job"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_cap_reached"
+
+
+def test_fleet_probe_failure_is_fail_safe_not_fail_open(monkeypatch):
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+
+    def _boom(**kw):
+        raise RuntimeError("DescribeInstances throttled")
+
+    # Let the attempt-count probe succeed (no boxes) but make the SECOND
+    # describe_instances call (fleet-size) fail.
+    real_describe = idx._test_ec2.describe_instances
+    calls = {"n": 0}
+
+    def _describe(Filters):  # noqa: N803
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("DescribeInstances throttled")
+        return real_describe(Filters)
+
+    monkeypatch.setattr(idx._test_ec2, "describe_instances", _describe)
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is False
+    assert out["reason"] == "fleet_probe_failed"
+    assert launched == []
+
+
+def test_reconcile_respects_attempt_limit_across_multiple_stale_jobs(monkeypatch):
+    # End-to-end through the reconcile path (not just the worker phase):
+    # a job already at the attempt limit must be skipped by _reconcile
+    # without ever reaching launch_with_fallback, while a fresh stale job in
+    # the same pass still gets dispatched.
+    launched_job_ids = []
+
+    def _launch(types_, subnets, **kw):
+        return "i-rescued"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+        attempt_boxes={"555": [
+            _attempt_box("i-a", age_seconds=100),
+            _attempt_box("i-b", age_seconds=90),
+            _attempt_box("i-c", age_seconds=80),
+        ]},
+    )
+    _install_gh_api_stub(idx, monkeypatch, {
+        "/actions/runs?status=queued&per_page=50": {"workflow_runs": [{"id": 1}]},
+        "/actions/runs/1/jobs": {
+            "jobs": [
+                {"id": 555, "status": "queued", "labels": ["self-hosted", "morning-signal-spot"],
+                 "created_at": _iso(200)},
+                {"id": 556, "status": "queued", "labels": ["self-hosted", "morning-signal-spot"],
+                 "created_at": _iso(150)},
+            ],
+        },
+    })
+    out = idx.handler({"reconcile": True}, None)
+    results_by_job = {d["job_id"]: d["result"] for d in out["dispatched"]}
+    assert results_by_job["555"]["launched"] is False
+    assert results_by_job["555"]["reason"] == "attempt_limit_exceeded"
+    assert results_by_job["556"]["launched"] is True
+
+
+def test_successful_launch_emits_cloudwatch_launch_metric(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-metered",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+    idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    calls = idx._test_cloudwatch.put_metric_data_calls
+    assert len(calls) == 1
+    assert calls[0]["Namespace"] == "AlphaEngine/Infra"
+    metric = calls[0]["MetricData"][0]
+    assert metric["MetricName"] == "morning_signal_runner_launches"
+    assert metric["Value"] == 1.0
+
+
+def test_blocked_dispatch_does_not_emit_launch_metric(monkeypatch):
+    # The metric counts actual LAUNCHES (the runaway signal) — a dispatch
+    # refused by the circuit breaker/fleet cap must not count as one.
+    idx = _load(monkeypatch, env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"})
+    idx._test_ec2.boxes = [{"InstanceId": f"i-{n}", "Tags": []} for n in range(6)]
+    idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert idx._test_cloudwatch.put_metric_data_calls == []
+
+
+def test_launch_metric_emission_failure_does_not_block_dispatch(monkeypatch):
+    idx = _load(
+        monkeypatch, launch_impl=lambda types_, subnets, **kw: "i-ok-anyway",  # noqa: E731
+        env={"MORNING_SIGNAL_RUNNER_DISPATCH_ENABLED": "true"},
+    )
+
+    def _boom(**kw):
+        raise RuntimeError("CloudWatch throttled")
+
+    monkeypatch.setattr(idx._test_cloudwatch, "put_metric_data", _boom)
+    out = idx.handler({"morning_signal_runner_job_id": "1"}, None)
+    assert out["launched"] is True

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -96,6 +96,21 @@ _LAMBDA_PIN_EXEMPTIONS = {
         "(same SpotProbeError handling requirement, same source code, 2026-07-17 vires GHA "
         "quota migration)",
     ),
+    "morning-signal-runner-dispatcher": (
+        "v0.110.0",
+        "nousergon_lib.spot_dispatch chokepoint — mirrors config-runner-dispatcher's pin exactly "
+        "(same SpotProbeError handling requirement, same source code, 2026-07-17 GHA quota migration)",
+    ),
+    "mnemon-runner-dispatcher": (
+        "v0.110.0",
+        "nousergon_lib.spot_dispatch chokepoint — mirrors config-runner-dispatcher's pin exactly "
+        "(same SpotProbeError handling requirement, same source code, 2026-07-17 GHA quota migration)",
+    ),
+    "krepis-runner-dispatcher": (
+        "v0.110.0",
+        "nousergon_lib.spot_dispatch chokepoint — mirrors config-runner-dispatcher's pin exactly "
+        "(same SpotProbeError handling requirement, same source code, 2026-07-17 GHA quota migration)",
+    ),
     "data-spot-dispatcher": (
         "v0.83.0",
         "ec2_spot launch chokepoint (config#1767)",


### PR DESCRIPTION
## Summary
Extends the metron/telos/vires migration (#902, #906) to the next tier of private-repo GHA consumers by July usage: morning-signal (~700 min), mnemon (~567 min), krepis (~401 min). Combined with the first tier, this covers ~97% of all remaining non-alpha-engine-config private-repo GHA usage.

Mirrors alpha-engine-config-runner-dispatcher (alpha-engine-config-I2572) verbatim, re-namespaced. 150/150 unit tests pass (50 each) unmodified.

## Bug fixed during generation
morning-signal's hyphen broke the identifier-substitution transform script — `MORNING-SIGNAL_RUNNER_TAG_NAME` is invalid Python syntax (hyphen in a variable name). Fixed by adding a separate underscore-safe `ident` variant used specifically for Python identifiers/env-var names, while keeping the hyphenated form for AWS resource names/tags/labels (where it's correct convention). Caught before any file was written to a repo — not a live incident.

## Known lesson applied from metron/telos/vires
The executor IAM role's inline policy alone is NOT sufficient — `AmazonSSMManagedInstanceCore` must also be attached for the SSM agent to register (found live 2026-07-17, see metron#276/telos#46/vires#133). The companion repo PRs' IAM READMEs for these three include this step from the start.

## Not included (operator-only, tracked separately)
- SSM params: extend the existing multi-repo PATs' scope to cover these 3 repos, or create new ones.
- `deploy.sh --bootstrap` x3, webhook registration x3, executor IAM role creation x3 (WITH the managed policy attached).
- Companion repo PRs: morning-signal#TBD, mnemon#TBD, krepis#TBD.
- None of these repos' primary test workflows are safe to repoint yet — all three run multi-version Python matrices (morning-signal 3.9-3.12, mnemon 3.10/3.12/3.13, krepis 3.9-3.13) that don't match the bootstrap script's single pre-cached 3.12. Needs the same live-dispatch verification pass as telos/vires before repointing anything.

## Test plan
- [x] 50/50 unit tests passing per repo (150 total)
- [x] test_lib_pin_lockstep.py passing with new exemptions
- [x] index.py / iam-policy.json syntax + JSON validated for all 3
- [ ] Live smoke test pending PAT scope + operator bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)