### PR TITLE
fix(ci): guard overseer-liveness-probe deploy Report step against a not-yet-bootstrapped function

### DIFF
--- a/.github/workflows/deploy-overseer-liveness-probe.yml
+++ b/.github/workflows/deploy-overseer-liveness-probe.yml
@@ -64,10 +64,16 @@ jobs:
         working-directory: alpha-engine-data
         run: |
           echo "Deployed commit: ${{ github.sha }}"
+          # Tolerate a not-yet-bootstrapped function: deploy.sh gracefully skips
+          # the code update until an operator runs --bootstrap (the OIDC role
+          # can't create the Lambda), so this report must NOT hard-fail the job
+          # when the function does not exist yet — matching the deploy step's
+          # own guard (alpha-engine-config-I2831 first-merge red-main fix).
           aws lambda get-function \
             --function-name alpha-engine-overseer-liveness-probe \
             --query "Configuration.[LastModified,CodeSha256]" \
-            --output text
+            --output text \
+            || echo "(function not bootstrapped yet — code deploy was skipped)"
 
       - name: Append to system-wide deploy changelog
         if: always()


### PR DESCRIPTION
Follow-up to **[nousergon-data-PR915](https://github.com/nousergon/nousergon-data/pull/915)** (config-I2831).

On PR915's merge the `deploy-overseer-liveness-probe.yml` workflow **failed**: `deploy.sh` correctly skipped the code update (function not bootstrapped yet — the OIDC role can't create it), but the separate **`Report deployed version`** step ran a bare `aws lambda get-function` that hard-failed with `ResourceNotFoundException` (exit 254 → fired `notify-main-failure`).

Fix: guard that call with `|| echo "(function not bootstrapped yet …)"` so the step matches `deploy.sh`'s own not-bootstrapped tolerance and the workflow stays green on a pre-bootstrap merge.

The function is now bootstrapped (config-I2867 done in-session), so this is latent going forward — but it restores the merge-button-green contract and prevents recurrence if the function is ever recreated. Workflow-only change.