### PR TITLE
fix(iam): prefix-scoped s3:ListBucket for saturday-sf-watch-dispatcher — missing watch-log must 404, not 403

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/iam-policy.json
@@ -57,6 +57,17 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/consolidated/*_sf_watch/*"
     },
     {
+      "Sid": "WatchLogArtifactList",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["consolidated/*_sf_watch/*"]
+        }
+      }
+    },
+    {
       "Sid": "FastPathRerun",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Why

2026-07-17 20:50 UTC: the weekly-SF Friday-shell preflight failed (LibPinDriftGate — separate fix, crucible-predictor-PR402), and the saturday-sf-watch-dispatcher **crashed twice with AccessDenied instead of dispatching a watch agent**.

Root cause: S3 returns **403 AccessDenied (not 404 NoSuchKey) for GetObject on a nonexistent key when the caller lacks `s3:ListBucket`**. `_load_existing` deliberately raises on 403 (config#2267 site-4 hardening), so the benign first-failure-of-the-day case (today's watch-log not yet written) crashed the handler at `index.py:1115` — the fail-loud path fired on the wrong condition because IAM could never produce the 404 it distinguishes on.

## What

Adds a `WatchLogArtifactList` statement: `s3:ListBucket` on the bucket, **condition-scoped to `consolidated/*_sf_watch/*`** — absent keys under the watch-log prefix now present as NoSuchKey → fresh-skeleton path; a genuine IAM regression still raises 403 per config#2267.

**Applied live via `put-role-policy` in-session 2026-07-17 and verified** — this PR is the policy-as-code sync; merge button is the last action, no post-merge step.

Fleet-wide audit of the same bug class (GetObject-without-ListBucket across lambda iam-policy.json files) filed separately as a tracked issue (see comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)