### PR TITLE
fix(substrate-gate): SSM SendCommand TimeoutSeconds 15 -> 30 (API hard minimum) — preflight blocker for 7/18 first live run

### DIFF
--- a/infrastructure/lambdas/substrate-health-gate/index.py
+++ b/infrastructure/lambdas/substrate-health-gate/index.py
@@ -75,9 +75,13 @@ DISK_WARN_PERCENT = 90
 # without meaningfully eating into the "<2 min fail-fast" target.
 _PROBE_EXECUTION_TIMEOUT_SECONDS = 20
 # SSM delivery timeout — time for the agent to PICK UP the command, not to
-# run it. Short: a healthy agent registers a command in low single-digit
-# seconds; this is the primary signal for "SSM unresponsive."
-_PROBE_DELIVERY_TIMEOUT_SECONDS = 15
+# run it. A healthy agent registers a command in low single-digit seconds;
+# this is the primary signal for "SSM unresponsive." 30 is the API's hard
+# minimum for SendCommand TimeoutSeconds (values below it fail
+# ParamValidationError before the command is even sent — broke the
+# 2026-07-17 Friday-shell preflight at SubstrateHealthGate); the 45s
+# _POLL_BUDGET_SECONDS below still enforces the actual fail-fast bound.
+_PROBE_DELIVERY_TIMEOUT_SECONDS = 30
 
 # Total wall-clock budget (seconds) this Lambda spends polling its own probe
 # command to a terminal status before giving up as ssm_unresponsive. Kept

--- a/infrastructure/lambdas/substrate-health-gate/test_handler.py
+++ b/infrastructure/lambdas/substrate-health-gate/test_handler.py
@@ -231,3 +231,12 @@ def test_two_distinct_named_failure_reasons_are_never_conflated():
     assert disk_out["reason"] == "disk_full"
     assert unresponsive_out["reason"] == "ssm_command_never_registered"
     assert disk_out["reason"] != unresponsive_out["reason"]
+
+
+def test_ssm_delivery_timeout_respects_api_minimum():
+    """SSM SendCommand rejects TimeoutSeconds < 30 with ParamValidationError
+    BEFORE the command is sent. The mocked-ssm tests above can never catch a
+    violation (botocore param validation only runs against the real client),
+    so pin the contract here: 15 broke the 2026-07-17 Friday-shell preflight
+    at SubstrateHealthGate on the gate's first-ever live invocation."""
+    assert index._PROBE_DELIVERY_TIMEOUT_SECONDS >= 30


### PR DESCRIPTION
## Why

The 2026-07-17 Friday-shell preflight re-run (`friday-shell-2026-07-17-libpin-rerun`) failed at **SubstrateHealthGate** — the gate's first-ever live invocation (deployment completed this afternoon under config-I2833):

```
ParamValidationError: Invalid value for parameter TimeoutSeconds, value: 15, valid min value: 30
```

SSM SendCommand's delivery timeout has a hard API minimum of 30s; `_PROBE_DELIVERY_TIMEOUT_SECONDS = 15` fails botocore param validation before the probe is even sent. Without this fix, tomorrow's **09:00 UTC first live run fails at the opening gate**.

## What

- `_PROBE_DELIVERY_TIMEOUT_SECONDS` 15 → 30 (comment documents the API minimum). The 45s `_POLL_BUDGET_SECONDS` still enforces the <2 min fail-fast target — delivery timeout was never the fail-fast bound.
- Guard test pinning the ≥30 contract, since the mocked-ssm tests structurally cannot catch it (botocore validation only runs against a real client).

**Deployed live via `deploy.sh` in-session** (12 tests green in the deploy gate) and verified by a fresh preflight re-run (see PR comment). Merge button is the last action — no post-merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)