### PR TITLE
feat(sf-watch): preflight (Friday shell-run) failures now dispatch the watch agent

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -727,6 +727,15 @@ def _build_event_record(
     # config#1827: a deliberate operator abort is recorded loudly but never
     # auto-dispatches a recovery agent (would waste a cycle and, once weekday/EOD
     # leave propose-only, risk an automated countermand of a human decision).
+    # 2026-07-17: preflight (Friday shell-run) failures now DISPATCH — the
+    # 2026-07-10 blanket suppression predated the charter's preflight mode;
+    # today the payload carries is_preflight, the charter's PREFLIGHT MODE
+    # section scopes the agent to shell-run reruns (weekly_sf_rerun.py
+    # preserves the original input's shell_run flag), and the whole point of
+    # the Friday rehearsal is to have failures fixed BEFORE Saturday 09:00 —
+    # observe-only left the fixing to a human on Friday night. Preflight
+    # remains gated from the deterministic FAST PATH (_fast_path_recovery):
+    # only the charter-carrying agent understands shell-run scope.
     # config#2003: two more carve-outs, checked in order (first match wins —
     # the reason string is a single value, most-specific/deliberate first):
     #   operator_abort            — an explicit human STOP marker.
@@ -751,8 +760,6 @@ def _build_event_record(
     budget_exhausted = prior_dispatches >= dispatch_ceiling
     if operator_abort:
         dispatch_suppressed = "operator_abort"
-    elif is_preflight:
-        dispatch_suppressed = "preflight"
     elif operator_recovery_rerun:
         dispatch_suppressed = "operator_recovery_rerun"
     elif already_escalated and not DISPATCH_AFTER_ESCALATION:

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -547,27 +547,29 @@ def test_programmatic_abort_still_dispatches(monkeypatch):
     assert written["events"][-1]["dispatch_suppressed"] is None
 
 
-# ── preflight dispatch carve-out (found 2026-07-10, before ever firing live) ──
+# ── preflight dispatch (2026-07-17: suppression carve-out REMOVED) ────────────
 # The Friday-PM dry pass of ne-weekly-freshness-pipeline (shell_run=true in the
-# execution input) is a deliberate rehearsal, not a production failure. Prior
-# to this fix, is_preflight only suppressed the deterministic fast-path rerun
-# (_maybe_fast_path) — the agent-dispatch path had no equivalent gate, so a
-# FAILED Friday shell-run would fire a genuine saturday-sf-failure
-# repository_dispatch, indistinguishable from a real Saturday production
-# failure, and summon the full diagnose-fix-merge-rerun agent.
+# execution input) is a deliberate rehearsal whose whole point is surfacing
+# live-only bugs BEFORE Saturday 09:00. The 2026-07-10 blanket agent-dispatch
+# suppression predated the charter's preflight plumbing; today the dispatch
+# payload carries is_preflight, the charter's PREFLIGHT MODE section scopes the
+# agent to shell-run reruns (weekly_sf_rerun.py preserves the original input's
+# shell_run flag), so preflight failures now DISPATCH the agent. The
+# deterministic FAST PATH remains preflight-gated (config#1900): only the
+# charter-carrying agent understands shell-run scope.
 
 
-def test_preflight_suppresses_agent_dispatch(monkeypatch):
-    """A Friday shell-run (preflight) failure must NOT auto-dispatch a recovery
-    agent even when the flag + listener are on — mirrors the operator-abort
-    carve-out (config#1827) exactly, but for a rehearsal run rather than a
-    human stop. Watch-log still written (fail-loud preserved); no Telegram."""
+def test_preflight_dispatches_agent_with_preflight_context(monkeypatch):
+    """A Friday shell-run (preflight) failure DOES auto-dispatch the recovery
+    agent (2026-07-17 design change) — and the fired repository_dispatch
+    payload carries is_preflight=true so the charter's PREFLIGHT MODE binds
+    the agent to shell-run scope. Watch-log still written (fail-loud)."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
-    fired = {"called": False}
+    fired = {"payload": None}
 
     def fake_urlopen(req, timeout=None):
-        fired["called"] = True
+        fired["payload"] = json.loads(req.data.decode())
         return _FakeResp()
 
     monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
@@ -580,26 +582,25 @@ def test_preflight_suppresses_agent_dispatch(monkeypatch):
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED"), None)
 
-    # Dispatch suppressed — no repository_dispatch HTTP call fired.
-    assert result["agent_dispatch"] == {"dispatched": False, "reason": "preflight"}
-    assert result["action"] == "observe"
-    assert fired["called"] is False
-    # Watch-log STILL written (fail-loud) and carries the auditable reason.
+    # Dispatch FIRED — and the payload is explicitly preflight-scoped.
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert fired["payload"] is not None
+    assert fired["payload"]["client_payload"]["is_preflight"] is True
+    # Watch-log written with the dispatch recorded, no suppression reason.
     s3.put_object.assert_called_once()
     written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
     ev = written["events"][-1]
     assert ev["is_preflight"] is True
-    assert ev["dispatch_suppressed"] == "preflight"
-    assert ev["action"] == "observe"
-    assert result["telegram_sent"] is False
-    index.notify_via_flow_doctor.assert_not_called()
+    assert ev["dispatch_suppressed"] is None
+    assert ev["action"] == "dispatch"
 
 
-def test_preflight_also_still_gated_from_fast_path(monkeypatch):
-    """Over-suppression is impossible to get backwards here: a preflight FAILED
-    must not fall through to the fast path either (fast path has its own
-    is_preflight check, config#1900) — confirms both recovery layers agree a
-    preflight failure gets NO automated action, only the watch-log record.
+def test_preflight_still_gated_from_fast_path(monkeypatch):
+    """The deterministic fast path keeps its own is_preflight gate
+    (config#1900) even though agent dispatch is now allowed on preflight —
+    a plain input-replay rerun would bypass the charter's PREFLIGHT MODE
+    judgment; only the agent path understands shell-run scope. The failure
+    therefore falls through the fast path TO the agent dispatch.
     Uses the weekday pipeline since it's the only one with a `fast_path` scope
     configured — the is_preflight gate itself is cadence-agnostic."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
@@ -615,7 +616,7 @@ def test_preflight_also_still_gated_from_fast_path(monkeypatch):
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
     assert result["fast_path"] == {"fast_path": False, "reason": "preflight"}
-    assert result["agent_dispatch"] == {"dispatched": False, "reason": "preflight"}
+    assert result["agent_dispatch"]["dispatched"] is True
 
 
 # ── config#1900: deterministic zero-token fast path ──────────────────────────


### PR DESCRIPTION
## Why

Tonight's Friday-shell preflight failed 3× on 3 distinct live-only bugs (LibPinDriftGate parity, SubstrateHealthGate TimeoutSeconds<30, SubstrateHealthGate ResultSelector on absent `reason`). Each time, the watch plane recorded the failure and **deliberately declined to dispatch** (`dispatch_suppressed: preflight`, the 2026-07-10 carve-out) — leaving Friday-rehearsal bugs to a human on Friday night, which defeats the rehearsal's purpose. Brian asked for the overseer to be able to fix preflight failures itself.

## What

Removes the `is_preflight` branch from the agent-dispatch suppression chain. The 7/10 carve-out predated today's plumbing — now:

- dispatch payload carries `is_preflight` (already true) → `SF_IS_PREFLIGHT` reaches the agent through BOTH the inline and EC2-spot paths (verified: sf-watch.yml, sf-watch-spot-dispatcher `--is-preflight`, `sf_watch_run.sh` export)
- companion charter PR (alpha-engine-config `feat/sf-watch-preflight-mode`) adds a **PREFLIGHT MODE** guardrail binding the agent to shell-scoped reruns; `weekly_sf_rerun.py` preserves the original input's `shell_run: true` structurally (rerun input derives from the failed execution's input; shell semantics key on `shell_run`, not `pipeline_role`)
- the deterministic **fast path stays preflight-gated** (config#1900) — only the charter-carrying agent understands shell scope
- saturday dispatch budget (8/day) applies unchanged

Tests updated: `test_preflight_dispatches_agent_with_preflight_context` (asserts the fired payload carries `is_preflight: true`), `test_preflight_still_gated_from_fast_path`. 74 handler tests pass locally.

**Operator-approved in-session 2026-07-17 (explicit guard-removal sign-off).** Deployed live via deploy.sh in-session; merge is code sync only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)