### PR TITLE
fix(sf-weekly): SubstrateHealthGate ResultSelector crashes on every healthy box

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -563,7 +563,7 @@
     },
     "SubstrateHealthGate": {
       "Type": "Task",
-      "Comment": "config#2249: fast pre-dispatch substrate health gate, immediately before MorningEnrich (the first state to actually dispatch work to the Saturday box). A dead/unhealthy dispatch box (disk full, or the SSM agent wedged/unresponsive so a command silently never registers) used to be discovered only after MorningEnrich burned its full 'gold 4+2' retry ladder (config#2279, up to ~15 min) before falling into the generic PipelineFailure path. This ONE Lambda invocation issues its own tiny SSM `df` probe command and polls it to a terminal status internally (bounded well under this Task's own TimeoutSeconds), returning verdict=HEALTHY or verdict=SUBSTRATE_UNHEALTHY with a distinct reason (disk_full / ssm_unresponsive / ssm_command_never_registered) — see infrastructure/lambdas/substrate-health-gate/index.py. Deliberately a SEPARATE fast pre-check, not a replacement for MorningEnrich's own resilience: MorningEnrich keeps its full retry ladder for real transient issues once dispatch is confirmed healthy. Adds ~10-20s to every Saturday run (accepted — the Saturday run has slack, unlike the tight weekday pre-open buffer; NOT wired into the weekday SF).",
+      "Comment": "config#2249: fast pre-dispatch substrate health gate, immediately before MorningEnrich (the first state to actually dispatch work to the Saturday box). A dead/unhealthy dispatch box (disk full, or the SSM agent wedged/unresponsive so a command silently never registers) used to be discovered only after MorningEnrich burned its full 'gold 4+2' retry ladder (config#2279, up to ~15 min) before falling into the generic PipelineFailure path. This ONE Lambda invocation issues its own tiny SSM `df` probe command and polls it to a terminal status internally (bounded well under this Task's own TimeoutSeconds), returning verdict=HEALTHY or verdict=SUBSTRATE_UNHEALTHY with a distinct reason (disk_full / ssm_unresponsive / ssm_command_never_registered) — see infrastructure/lambdas/substrate-health-gate/index.py. Deliberately a SEPARATE fast pre-check, not a replacement for MorningEnrich's own resilience: MorningEnrich keeps its full retry ladder for real transient issues once dispatch is confirmed healthy. Adds ~10-20s to every Saturday run (accepted — the Saturday run has slack, unlike the tight weekday pre-open buffer; NOT wired into the weekday SF). ResultSelector captures the WHOLE Lambda payload under .gate (verdict/message/reason/disk_used_percent/...) rather than cherry-picking $.Payload.<key>: the Lambda's documented contract emits `reason` ONLY on the SUBSTRATE_UNHEALTHY verdicts, so a prior per-key select of `reason.$: $.Payload.reason` crashed EVERY healthy run with States.Runtime '$.Payload.reason could not be found' (the gate could never pass on a healthy box — surfaced by the 2026-07-17 Friday preflight shell run). Passthrough lets each consumer read only fields the producer guarantees for its branch (Choice reads .gate.verdict; the non-HEALTHY Extract reads .gate.reason). Contract regression-guarded by tests/test_sf_substrate_gate_contract_wiring.py.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-substrate-health-gate",
@@ -595,9 +595,7 @@
         }
       ],
       "ResultSelector": {
-        "verdict.$": "$.Payload.verdict",
-        "reason.$": "$.Payload.reason",
-        "message.$": "$.Payload.message"
+        "gate.$": "$.Payload"
       },
       "ResultPath": "$.substrate_gate_result",
       "Next": "CheckSubstrateHealthGate"
@@ -607,8 +605,16 @@
       "Comment": "config#2249: branches on SubstrateHealthGate's verdict. HEALTHY -> proceed into MorningEnrich as normal. SUBSTRATE_UNHEALTHY (any reason) -> short-circuit straight to the named-failure path WITHOUT ever entering MorningEnrich's own retry ladder — the whole point is failing fast (<2 min) instead of burning ~15 min discovering the same dead box via 4 retries.",
       "Choices": [
         {
-          "Variable": "$.substrate_gate_result.verdict",
-          "StringEquals": "HEALTHY",
+          "And": [
+            {
+              "Variable": "$.substrate_gate_result.gate.verdict",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.substrate_gate_result.gate.verdict",
+              "StringEquals": "HEALTHY"
+            }
+          ],
           "Next": "MorningEnrich"
         }
       ],
@@ -620,9 +626,9 @@
       "Parameters": {
         "phase": "SubstrateHealthGate",
         "source": "SubstrateHealthGate",
-        "verdict.$": "$.substrate_gate_result.verdict",
-        "reason.$": "$.substrate_gate_result.reason",
-        "detail.$": "$.substrate_gate_result.message"
+        "verdict.$": "$.substrate_gate_result.gate.verdict",
+        "reason.$": "$.substrate_gate_result.gate.reason",
+        "detail.$": "$.substrate_gate_result.gate.message"
       },
       "ResultPath": "$.error",
       "Next": "NormalizeFailureContext"

--- a/tests/test_sf_morning_enrich_split_wiring.py
+++ b/tests/test_sf_morning_enrich_split_wiring.py
@@ -111,10 +111,18 @@ class TestChainOrdering:
         MorningEnrich's own retry ladder."""
         assert states["CheckSkipMorningEnrich"]["Default"] == "SubstrateHealthGate"
         assert states["SubstrateHealthGate"]["Next"] == "CheckSubstrateHealthGate"
+        # config#2275: the HEALTHY rule now IsPresent-guards the verdict path
+        # (a 3-segment Lambda-payload path is never floorable), so the
+        # StringEquals lives inside the rule's And rather than at its top
+        # level. Match either shape so this stays robust to that detail.
+        def _rule_healthy(rule):
+            leaves = rule.get("And", [rule])
+            return any(leaf.get("StringEquals") == "HEALTHY" for leaf in leaves)
+
         healthy = [
             c["Next"]
             for c in states["CheckSubstrateHealthGate"]["Choices"]
-            if c.get("StringEquals") == "HEALTHY"
+            if _rule_healthy(c)
         ]
         assert healthy == ["MorningEnrich"], (
             "SubstrateHealthGate verdict=HEALTHY must proceed into "
@@ -212,10 +220,19 @@ class TestChainOrdering:
                 # Status/verdict checks: follow the Success/HEALTHY edge
                 # (the real forward path). Skip-gates have no such edge →
                 # fall back to Default (= run the action, the no-skip path).
+                # A rule's forward-edge StringEquals may sit at the rule's top
+                # level OR inside an And that IsPresent-guards the same path
+                # (config#2275: 3-segment Lambda-payload verdict paths must be
+                # guarded, e.g. CheckSubstrateHealthGate's HEALTHY rule).
+                def _forward_edge(rule):
+                    leaves = rule.get("And", [rule])
+                    return any(
+                        leaf.get("StringEquals") in ("Success", "HEALTHY")
+                        for leaf in leaves
+                    )
+
                 success = [
-                    c["Next"]
-                    for c in st.get("Choices", [])
-                    if c.get("StringEquals") in ("Success", "HEALTHY")
+                    c["Next"] for c in st.get("Choices", []) if _forward_edge(c)
                 ]
                 cur = success[0] if success else st.get("Default")
             else:

--- a/tests/test_sf_substrate_gate_contract_wiring.py
+++ b/tests/test_sf_substrate_gate_contract_wiring.py
@@ -1,0 +1,204 @@
+"""Contract guard for the pre-dispatch SubstrateHealthGate (config#2249).
+
+Regression guard for the 2026-07-17 Friday-PM preflight failure. The gate
+Task's ``ResultSelector`` selected ``reason.$: $.Payload.reason``
+unconditionally, but the ``alpha-engine-substrate-health-gate`` Lambda's
+DOCUMENTED contract (see its ``index.py`` docstring) emits ``reason`` ONLY on
+the ``SUBSTRATE_UNHEALTHY`` verdicts (disk_full / ssm_unresponsive /
+ssm_command_never_registered) — the ``HEALTHY`` payload deliberately omits it.
+Every healthy substrate (the normal case) therefore crashed the state with
+``States.Runtime`` "The JSONPath '$.Payload.reason' specified for the field
+'reason.$' could not be found", so the gate could NEVER pass on a healthy box.
+
+The fix passes the WHOLE Lambda payload through under ``.gate`` and lets each
+downstream consumer read only the fields the producer guarantees for the
+branch it is reached on: the Choice reads ``.gate.verdict`` (always present);
+``ExtractSubstrateHealthGateError`` reads ``.gate.reason`` / ``.gate.message``
+and is reachable ONLY on the non-HEALTHY Default (where the producer
+guarantees them).
+
+These tests pin that contract by cross-checking the SF's ResultSelector
+against the ACTUAL keys the Lambda emits on each verdict — so any future
+regression that reintroduces a per-key ``$.Payload.<field>`` select of a
+field the healthy path omits fails HERE, pre-merge, instead of only in a
+live (or preflight) Saturday run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+_LAMBDA_INDEX = (
+    _REPO_ROOT
+    / "infrastructure"
+    / "lambdas"
+    / "substrate-health-gate"
+    / "index.py"
+)
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+@pytest.fixture(scope="module")
+def gate_module():
+    """Load the gate Lambda handler by explicit path under a UNIQUE module
+    name. Other ``infrastructure/lambdas/*/index.py`` files share the bare
+    name ``index``; loading via a distinct name avoids any ``sys.modules``
+    collision if another test imported a different ``index`` first (which is
+    why the repo otherwise runs lambda handler tests in isolated processes).
+    """
+    spec = importlib.util.spec_from_file_location(
+        "substrate_gate_index_under_test", _LAMBDA_INDEX
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _df_success(used_percent: int) -> dict:
+    return {
+        "Status": "Success",
+        "ResponseCode": 0,
+        "StatusDetails": "Success",
+        "StandardOutputContent": (
+            f"/dev/xvda1 20961280 18642176 1264104 {used_percent}% /\n"
+        ),
+    }
+
+
+def _run_handler(mod, invocation: dict) -> dict:
+    """Invoke the real handler with a mocked SSM client returning ``invocation``
+    on the first ``get_command_invocation`` poll — mirrors the Lambda's own
+    ``test_handler.py`` harness."""
+    ssm = mock.Mock()
+    ssm.send_command.return_value = {"Command": {"CommandId": "cmd-under-test"}}
+    ssm.get_command_invocation.side_effect = [invocation]
+    with mock.patch.object(mod, "_ssm", ssm), mock.patch.object(time, "sleep"):
+        return mod.handler({"instance_id": "i-contract-test"}, None)
+
+
+@pytest.fixture(scope="module")
+def healthy_output(gate_module) -> dict:
+    out = _run_handler(gate_module, _df_success(42))
+    assert out["verdict"] == "HEALTHY", "fixture precondition: expected HEALTHY"
+    return out
+
+
+@pytest.fixture(scope="module")
+def disk_full_output(gate_module) -> dict:
+    out = _run_handler(gate_module, _df_success(100))
+    assert out["verdict"] == "SUBSTRATE_UNHEALTHY", (
+        "fixture precondition: expected SUBSTRATE_UNHEALTHY"
+    )
+    return out
+
+
+def _payload_fields_selected(result_selector: dict) -> list[str]:
+    """Top-level keys a ResultSelector cherry-picks straight out of
+    ``$.Payload`` (e.g. ``reason.$: $.Payload.reason`` -> ``reason``). A bare
+    ``gate.$: $.Payload`` (full passthrough) selects NO individual key and so
+    returns nothing — exactly the shape that cannot crash on a missing key."""
+    fields = []
+    for value in result_selector.values():
+        if isinstance(value, str) and value.startswith("$.Payload."):
+            rest = value[len("$.Payload.") :]
+            top = rest.split(".")[0].split("[")[0]
+            fields.append(top)
+    return fields
+
+
+class TestResultSelectorMatchesProducerContract:
+    """The heart of the guard: the SF must never select a $.Payload key the
+    Lambda omits on a verdict the state can actually receive."""
+
+    def test_resultselector_never_selects_a_key_absent_on_healthy(
+        self, states, healthy_output
+    ):
+        rs = states["SubstrateHealthGate"]["ResultSelector"]
+        selected = _payload_fields_selected(rs)
+        missing = [f for f in selected if f not in healthy_output]
+        assert not missing, (
+            f"SubstrateHealthGate ResultSelector selects $.Payload.{missing} "
+            f"but the HEALTHY Lambda payload omits it "
+            f"(healthy keys: {sorted(healthy_output)}). An unconditional "
+            f"per-key select of a field the healthy path does not emit is the "
+            f"2026-07-17 States.Runtime crash (the gate can never pass a "
+            f"healthy box). Pass the full payload through — gate.$ : $.Payload "
+            f"— and read per-field downstream instead."
+        )
+
+    def test_healthy_payload_indeed_omits_reason(self, healthy_output):
+        # Locks the producer half of the contract this guard depends on: if a
+        # future lib change starts emitting `reason` on HEALTHY too, this test
+        # documents that the coupling above became moot (update deliberately).
+        assert "reason" not in healthy_output
+        assert healthy_output["verdict"] == "HEALTHY"
+
+
+class TestDownstreamReadsAreSafeOnTheirBranch:
+    """Every field a downstream consumer reads from the gate result must be
+    guaranteed present on the branch that consumer is reached on."""
+
+    def test_extract_error_fields_present_on_unhealthy_payload(
+        self, states, disk_full_output
+    ):
+        # ExtractSubstrateHealthGateError is reached ONLY via the non-HEALTHY
+        # Default, so it may rely on the unhealthy contract carrying these.
+        params = states["ExtractSubstrateHealthGateError"]["Parameters"]
+        for key in ("verdict.$", "reason.$", "detail.$"):
+            ref = params[key]
+            field = ref.rsplit(".", 1)[-1]  # ...gate.reason -> reason
+            assert field in disk_full_output, (
+                f"ExtractSubstrateHealthGateError reads {ref} (-> $.Payload."
+                f"{field}) but the SUBSTRATE_UNHEALTHY payload omits {field!r} "
+                f"({sorted(disk_full_output)}); the named-failure alert would "
+                f"crash on a real unhealthy box."
+            )
+
+
+class TestWiringPinsGateScopedReads:
+    """Pin the .gate passthrough shape so the ResultSelector and its consumers
+    stay in lockstep (a rename of the passthrough key must update both)."""
+
+    def test_resultselector_captures_full_payload_under_gate(self, states):
+        rs = states["SubstrateHealthGate"]["ResultSelector"]
+        assert rs == {"gate.$": "$.Payload"}, (
+            "SubstrateHealthGate must pass the whole Lambda payload through "
+            "under .gate; cherry-picking $.Payload.<key> reintroduces the "
+            "missing-key crash class."
+        )
+        assert (
+            states["SubstrateHealthGate"]["ResultPath"] == "$.substrate_gate_result"
+        )
+
+    def test_choice_branches_on_gate_verdict_with_ispresent_guard(self, states):
+        # config#2275: `.gate.verdict` is a 3-segment Lambda-payload path and
+        # is therefore NEVER floorable — it MUST be IsPresent-guarded inside an
+        # And whose earlier operand guards the exact same path. This is the
+        # guard-blessed idiom for a Choice reading an opaque Lambda output.
+        rule = states["CheckSubstrateHealthGate"]["Choices"][0]
+        assert rule["Next"] == "MorningEnrich"
+        operands = rule["And"]
+        var = "$.substrate_gate_result.gate.verdict"
+        assert operands[0] == {"Variable": var, "IsPresent": True}, (
+            "the FIRST And operand must IsPresent-guard the verdict path "
+            "(ASL short-circuits on the first false operand)"
+        )
+        assert {"Variable": var, "StringEquals": "HEALTHY"} in operands
+
+    def test_extract_reads_gate_scoped_fields(self, states):
+        params = states["ExtractSubstrateHealthGateError"]["Parameters"]
+        assert params["verdict.$"] == "$.substrate_gate_result.gate.verdict"
+        assert params["reason.$"] == "$.substrate_gate_result.gate.reason"
+        assert params["detail.$"] == "$.substrate_gate_result.gate.message"


### PR DESCRIPTION
## Root cause
The weekly SF's `SubstrateHealthGate` Task (config#2249) selected `reason.$: $.Payload.reason` in its `ResultSelector` **unconditionally**. The `alpha-engine-substrate-health-gate` Lambda's *documented contract* (its `index.py` docstring, stated twice) emits `reason` **ONLY on the `SUBSTRATE_UNHEALTHY` verdicts** (`disk_full` / `ssm_unresponsive` / `ssm_command_never_registered`); the `HEALTHY` payload deliberately omits it.

So **every healthy substrate — the normal case — failed the state** with:
```
States.Runtime: The JSONPath '$.Payload.reason' specified for the field 'reason.$' could not be found ...
```
The gate could *never* pass on a healthy box. Surfaced by the **2026-07-17 Friday-PM preflight shell run** (`friday-shell-2026-07-17-rerun2`, box `i-09b539c844515d549`, disk 50% → `verdict=HEALTHY` → crash). This is exactly the live-only bug class preflight exists to catch.

## The SOTA fix and why it is correct at this layer
The producer's documented contract is *"reason present iff unhealthy."* The SF (consumer) over-selected an optional field, contradicting both that contract and the SF's own totality idiom (`NormalizeFailureContext`'s JsonMerge defaults). The correct-layer fix is at the **consumer**: capture the whole Lambda payload under `.gate` and let each consumer read only the fields the producer guarantees for the branch it is reached on.

- `CheckSubstrateHealthGate` reads `.gate.verdict` (always present). A 3-segment Lambda-payload path is **never floorable** (config#2275 doctrine: *"a Lambda payload's inner shape cannot be pinned — must be guarded"*), so it is now **`IsPresent`-guarded inside an `And`** — the guard-blessed idiom for a Choice reading an opaque Lambda output.
- `ExtractSubstrateHealthGateError` reads `.gate.reason` / `.gate.message` and is reachable **only** on the non-HEALTHY `Default`, where the producer guarantees them — so the named-failure alert (`disk_full` / `ssm_unresponsive` / `ssm_command_never_registered`) is unchanged.

**No Lambda change** → deployed by `deploy-infrastructure.yml` on merge (no operator-gated Lambda redeploy), so it cures the pending **real Saturday 09:00 UTC** run, not just the preflight.

## Fail-loud rationale
This does not touch error handling to make a real failure quieter. An unhealthy substrate **still fails loudly**: `verdict != HEALTHY` → `ExtractSubstrateHealthGateError` → `HandleFailure` with the named reason. The change fixes a **false failure** (a healthy box crashing the pipeline); it does not swallow, widen a skip-gate, or flip a fatal step to non-fatal.

## Guard that now covers this failure class
`tests/test_sf_substrate_gate_contract_wiring.py` runs the **real** gate Lambda handler (loaded by explicit path under a unique module name — no `sys.modules` `index` collision) and **cross-checks the SF `ResultSelector` against the actual keys the Lambda emits per verdict**. Any future regression that reintroduces a per-key `$.Payload.<field>` select of a field the healthy path omits fails **pre-merge**. Verified locally: the guard **bites** on the old ResultSelector (flags `reason` missing on the healthy payload) and **passes** on the new passthrough. It also pins the `IsPresent`-guarded Choice and the `.gate`-scoped downstream reads.

Two sibling wiring tests (`test_sf_morning_enrich_split_wiring.py`) were updated to understand the `And`-guarded HEALTHY rule shape.

## Validation
- `pytest tests/test_sf_*.py` → **1152 passed, 9 skipped** (skips are content-based, not sibling-checkout skips); the config#2275 choice-guard and SF-definition drift/preflight guards all ran and pass.
- `ruff check` on the new test → clean.
- `test_sf_preflight.py` errors locally only on a missing `pandas` in the minimal venv (unrelated to this change; runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)