### PR TITLE
fix(expenses): seed-parity for included-minutes (config#2841) + real budgets (config#2842)

### DIFF
--- a/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
+++ b/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
@@ -31,7 +31,7 @@
     "github_org": {
       "label": "GitHub (nousergon org)",
       "monthly_budget_usd": null,
-      "included_minutes": 2000
+      "included_minutes": 3000
     },
     "github_user": {
       "label": "GitHub (cipher813)",

--- a/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
+++ b/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
@@ -5,11 +5,12 @@
   "providers": {
     "aws": {
       "label": "AWS",
-      "monthly_budget_usd": null
+      "monthly_budget_usd": 100.0
     },
     "anthropic_api": {
       "label": "Anthropic API",
-      "monthly_budget_usd": null
+      "monthly_budget_usd": 0.0,
+      "note": "budget set to $0 deliberately — Brian is shifting Anthropic-API-billed usage to OpenRouter models (2026-07-17 decision)"
     },
     "claude_max": {
       "label": "Claude Max 20x subscription",
@@ -18,19 +19,19 @@
     },
     "openrouter": {
       "label": "OpenRouter",
-      "monthly_budget_usd": null
+      "monthly_budget_usd": 20.0
     },
     "deepseek": {
       "label": "DeepSeek",
-      "monthly_budget_usd": null
+      "monthly_budget_usd": 10.0
     },
     "neon": {
       "label": "Neon Postgres",
-      "monthly_budget_usd": null
+      "monthly_budget_usd": 15.0
     },
     "github_org": {
       "label": "GitHub (nousergon org)",
-      "monthly_budget_usd": null,
+      "monthly_budget_usd": 5.0,
       "included_minutes": 3000
     },
     "github_user": {


### PR DESCRIPTION
## Summary
- The expense-collector seed assumed the `nousergon` GitHub org was on the free plan (2,000 included Actions minutes/month). Verified live via `gh api /orgs/nousergon` -> `plan.name == "team"` — GitHub Team includes 3,000 minutes/month.
- Live SSoT (`s3://alpha-engine-research/config/expense_budgets.json`) was corrected directly in-session (2026-07-17); this PR fixes the seed file so a future re-seed doesn't reintroduce the stale 2000 value.

Part of alpha-engine-config-I2841 (item 2 of 2 — the cipher813 billing-PAT half of that issue is a separate operator action, unaffected by this PR).

## Test plan
- [x] JSON is valid (single key changed, no schema shape change)
- [x] Live value cross-checked directly against `gh api /orgs/nousergon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update:** also carries config#2842's real budget values (AWS $100, Anthropic API $0 — deliberate shift to OpenRouter, OpenRouter $20, DeepSeek $10, Neon $15, GitHub org $5). Live SSoT already updated in-session; this PR is now the seed-parity fix for BOTH config#2841 and config#2842.