### PR TITLE
feat(expense-collector): GHA public/private minutes breakdown per repo

### DIFF
--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -483,6 +483,15 @@ def collect_github(mw: dict, budgets: dict, secrets: dict, *, account: str,
     # private repos or it overstates ~17x.
     private_repos = _private_repo_names(account, kind, headers)
     minutes_private, minutes_total, billed, by_product = 0.0, 0.0, 0.0, {}
+    # Per-repo minutes + visibility, surfaced on the console so a repo drawing
+    # real Actions minutes but classified "private" (or vice versa) is visible
+    # at a glance instead of inferred — a wrong hardcoded public/private repo
+    # list (not this live-API-derived set) caused a real incident 2026-07-17:
+    # an entire self-hosted-runner migration was built for 6 repos that turned
+    # out to be public (free/unlimited GHA already), based on their appearing
+    # in a billing pull without checking actual visibility. This breakdown is
+    # the console-side guardrail against repeating that mistake.
+    by_repo: dict[str, float] = {}
     for item in doc.get("usageItems", []):
         product = str(item.get("product", "")).lower()
         net = float(item.get("netAmount", 0) or 0)
@@ -491,8 +500,23 @@ def collect_github(mw: dict, budgets: dict, secrets: dict, *, account: str,
         if product == "actions" and "minute" in str(item.get("unitType", "")).lower():
             qty = float(item.get("quantity", 0) or 0)
             minutes_total += qty
-            if item.get("repositoryName") in private_repos:
+            repo = item.get("repositoryName") or "(unattributed)"
+            by_repo[repo] = by_repo.get(repo, 0.0) + qty
+            if repo in private_repos:
                 minutes_private += qty
+    minutes_public = round(minutes_total - minutes_private, 1)
+    gha_by_repo = sorted(
+        (
+            {
+                "repo": repo,
+                "visibility": "private" if repo in private_repos else "public",
+                "minutes": round(minutes, 1),
+            }
+            for repo, minutes in by_repo.items()
+        ),
+        key=lambda r: r["minutes"],
+        reverse=True,
+    )
     included = _included_minutes(budgets, key)
     projected_min = _project(minutes_private, mw["elapsed_frac"])
     row.update(
@@ -501,7 +525,10 @@ def collect_github(mw: dict, budgets: dict, secrets: dict, *, account: str,
                "used": round(minutes_private, 1), "limit": included,
                "projected": round(projected_min, 0) if projected_min is not None else None},
         detail={"billed_usd_by_product": by_product,
-                "total_actions_minutes_incl_public_free": round(minutes_total, 1)},
+                "total_actions_minutes_incl_public_free": round(minutes_total, 1),
+                "gha_private_minutes": round(minutes_private, 1),
+                "gha_public_minutes": minutes_public,
+                "gha_by_repo": gha_by_repo},
     )
     row = _finish_usd_row(row, mw, _budget_usd(budgets, key))
     # Quota pace (included minutes) is the leading signal; billed-$ pace only

--- a/infrastructure/lambdas/expense-collector/test_handler.py
+++ b/infrastructure/lambdas/expense-collector/test_handler.py
@@ -357,6 +357,18 @@ class TestHandler:
         assert gh["pace"] == "over"
         assert gh["mtd_cost_usd"] == pytest.approx(1.5)
 
+        # Public/private breakdown (2026-07-17: a wrong public/private repo
+        # classification burned real AWS spend building unnecessary
+        # self-hosted-runner infra for 6 actually-public repos — this
+        # breakdown is the console-side guardrail against repeating that).
+        assert gh["detail"]["gha_private_minutes"] == 1400
+        assert gh["detail"]["gha_public_minutes"] == 400
+        by_repo = gh["detail"]["gha_by_repo"]
+        assert by_repo == [
+            {"repo": "alpha-engine-config", "visibility": "private", "minutes": 1400.0},
+            {"repo": "crucible-dashboard", "visibility": "public", "minutes": 400.0},
+        ]
+
         # GitHub user: fenced error — recorded on the row, run continues
         assert rows["github_user"]["status"] == "error"
         assert "500" in rows["github_user"]["error"]


### PR DESCRIPTION
## Summary
Adds a per-repo GitHub Actions public/private minutes breakdown to the expense-collector's GitHub row, on top of the existing (correct) live-API-derived private-repo classification.

**Why:** a real 2026-07-17 incident — a repo's public/private GHA status was misclassified (inferred from appearing in a billing pull instead of checking actual visibility), leading to an unnecessary self-hosted-runner build for 6 actually-public repos that burned real AWS spend for zero benefit. This surfaces the breakdown on the console so a misclassification is visible at a glance.

**What changed:** `collect_github()` already computes the correct private-repo set live via `_private_repo_names()` (no hardcoded list — that's not what went wrong here). It just didn't expose the split. Now adds to `detail`:
- `gha_private_minutes` / `gha_public_minutes` — explicit aggregate split
- `gha_by_repo` — per-repo `{repo, visibility, minutes}`, sorted descending

Purely additive to the existing free-form `detail` dict — no schema break.

Companion dashboard PR: crucible-dashboard (adds the console-side table/metrics).

## Test plan
- [x] 17/17 expense-collector tests pass, including 2 new assertions for the breakdown
- [ ] Full repo suite via this PR's CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)