### PR TITLE
fix(news): Polygon time-budget + full-coverage weekly RAG news sweep (config#2938)

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -127,15 +127,24 @@ def _build_aggregator():
     constructors or the SEC company-name fetch touching the network.
     """
     from collectors.news_aggregator_async import AsyncNewsAggregator
+    from collectors.news_sources.fetch_budget import DAILY_NEWS_MAX_FETCH_SECONDS
     from collectors.news_sources.gdelt import GdeltNewsAdapter
     from collectors.news_sources.polygon import PolygonNewsAdapter
     from collectors.news_sources.yahoo_rss import YahooRssNewsAdapter
     from rag.pipelines.run_news_pipeline import _load_ticker_name_map
 
+    # config#2938 ruling 1 — the DAILY digest tolerates partial coverage: give
+    # BOTH throttle-prone sources the same tight bail-early budget so a slow
+    # Polygon sweep (5 req/min) degrades this pull's breadth instead of blowing
+    # daily-news.service's TimeoutStartSec with zero digest. GDELT already
+    # defaulted to this budget (config#2813); Polygon was the uncovered gap.
     return AsyncNewsAggregator(
         sources=[
-            PolygonNewsAdapter(),
-            GdeltNewsAdapter(ticker_name_map=_load_ticker_name_map()),
+            PolygonNewsAdapter(max_fetch_seconds=DAILY_NEWS_MAX_FETCH_SECONDS),
+            GdeltNewsAdapter(
+                ticker_name_map=_load_ticker_name_map(),
+                max_fetch_seconds=DAILY_NEWS_MAX_FETCH_SECONDS,
+            ),
             YahooRssNewsAdapter(),
         ]
     )

--- a/collectors/news_sources/fetch_budget.py
+++ b/collectors/news_sources/fetch_budget.py
@@ -1,0 +1,106 @@
+"""Shared wall-clock budget derivation for the multi-source news sweep.
+
+Single source of truth (alpha-engine-config#2938) for the time budgets that
+size the Polygon-bottlenecked news fetch across its surfaces:
+
+  * per-source ``max_fetch_seconds`` (the adapter deadline guards below),
+  * the daily ``daily-news.service`` ``TimeoutStartSec`` backstop, and
+  * the weekly ``RAGIngestion`` SSM ``executionTimeout`` in nousergon-data's
+    ``infrastructure/step_function.json`` (guarded there against the
+    ``WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS`` cap declared here).
+
+Why DERIVED, not hardcoded (config#2938 ruling 2). The 2026-07-18 double
+incident — the daily digest *and* the weekly Saturday SF both SIGKILLed with
+zero output — was a DRIFT bug: the news universe grew ~9x (27→903 signals
+tickers) while a hardcoded 3600s timeout stayed put, so the sweep silently
+outgrew its budget. The weekly runtime budget below is a pure function of the
+LIVE universe size, so it can never again fall silently behind universe
+growth.
+
+The bottleneck is Polygon's free tier: 5 req/min (12s/ticker), an
+account-wide quota shared with the price endpoints. ~944 tickers ⇒ ~3.15h of
+irreducible Polygon crawl; GDELT (1 req/s) and Yahoo RSS are not the long
+pole. The genuine SOTA (decoupling news collection from the Saturday critical
+path — a warm, continuously-ingested corpus so Saturday reads instead of
+fetches) is larger and tracked separately (config#2938 "out of scope"). This
+module makes the on-critical-path sweep COMPLETE within a universe-sized
+budget and, beyond it, FAIL SOFT (partial coverage + a loud WARN, never a
+SIGKILL-with-zero-output) rather than taking the whole pipeline down.
+"""
+
+from __future__ import annotations
+
+import math
+
+# Polygon free tier: 5 req/min ⇒ 12s between requests, plus ~0.5s per-item
+# processing. The account-wide 5 req/min quota (shared with the price
+# endpoints via polygon_client) is the hard floor — concurrency cannot beat
+# it, so this is the per-ticker cost that sizes every budget below.
+POLYGON_SECONDS_PER_TICKER = 12.5
+
+
+# ── Weekly (Saturday RAGIngestion) — config#2938 ruling 1: FULL coverage ────
+# The weekly corpus feeds predictor training + research, so it is sized to
+# COMPLETE the full-universe Polygon sweep, NOT to bail early. Hard-capped at
+# ~4h (ruling 2) so the fetch plus the rest of the RAGIngestion step
+# (GDELT/Yahoo/NLP/RAG-ingest, a few min) fit inside the SSM executionTimeout.
+#
+# LOCKSTEP: this cap is mirrored by three timeouts in nousergon-data —
+# the RAGIngestion ``executionTimeout`` in infrastructure/step_function.json,
+# the inner ``run_ssm "rag-only"`` timeout, and the rag-only spot-watchdog
+# ``MAX_RUNTIME_SECONDS`` — and is CI-guarded there. Changing it here means
+# changing all three (their guard test names this constant).
+WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS = 14_400  # 4h
+
+# Reserve inside the 4h step for everything that is NOT the Polygon crawl:
+# spot bootstrap/deps + the GDELT/Yahoo sources + NLP + the RAG-ingest step.
+_WEEKLY_STEP_NON_POLYGON_RESERVE_SECONDS = 2_400
+
+# A small universe still gets a sane budget (never below this floor).
+_WEEKLY_NEWS_FLOOR_SECONDS = 1_800
+
+# The Polygon sweep may consume at most (4h − reserve) so the rest of the
+# step always gets to run within the SSM executionTimeout.
+_WEEKLY_POLYGON_CAP_SECONDS = (
+    WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS - _WEEKLY_STEP_NON_POLYGON_RESERVE_SECONDS
+)  # 12_000
+
+
+def weekly_news_max_fetch_seconds(universe_size: int) -> int:
+    """``max_fetch_seconds`` for the WEEKLY (Saturday) Polygon news sweep.
+
+    Sized from the LIVE universe to COMPLETE the full sweep (config#2938
+    ruling 1), floored so a small universe still gets a sane budget, and
+    capped so the fetch plus the rest of the RAGIngestion step fit inside the
+    4h SSM ``executionTimeout``. The adapter's own deadline guard is then a
+    SIGKILL backstop (partial coverage + WARN), never the intended operating
+    mode — at the ~944-ticker universe the ~3.15h crawl completes well inside
+    the derived ~11.8k s budget.
+    """
+    raw = math.ceil(max(universe_size, 0) * POLYGON_SECONDS_PER_TICKER)
+    return int(min(max(raw, _WEEKLY_NEWS_FLOOR_SECONDS), _WEEKLY_POLYGON_CAP_SECONDS))
+
+
+# ── Daily (daily-news.service) — config#2938 ruling 1: bail-early partial ───
+# The daily digest tolerates reduced coverage (``partial: true``); a tight
+# per-source budget bails and still writes a real digest. Sources run under
+# the CONCURRENT AsyncNewsAggregator, so the outer systemd ``TimeoutStartSec``
+# need only cover ONE source's budget plus aggregation/write — NOT a
+# sequential sum over the universe (which is why the daily backstop stays a
+# universe-independent constant while the weekly budget scales).
+DAILY_NEWS_MAX_FETCH_SECONDS = 1_200  # 20 min (matches GDELT's prior default)
+
+# NLP + dedup + digest build + S3 write + margin, on top of the single
+# per-source bail budget above.
+DAILY_NEWS_AGGREGATION_RESERVE_SECONDS = 1_200
+
+
+def daily_news_timeout_start_seconds() -> int:
+    """systemd ``TimeoutStartSec`` backstop for ``daily-news.service``.
+
+    One source's bail budget + the aggregation/write reserve. Sources fetch
+    CONCURRENTLY (AsyncNewsAggregator), so this is a max-plus-reserve, not a
+    sequential sum — the outer cap is a backstop, the per-source
+    ``max_fetch_seconds`` is the primary defence.
+    """
+    return DAILY_NEWS_MAX_FETCH_SECONDS + DAILY_NEWS_AGGREGATION_RESERVE_SECONDS

--- a/collectors/news_sources/polygon.py
+++ b/collectors/news_sources/polygon.py
@@ -10,13 +10,29 @@ Quality: Polygon aggregates Benzinga, Zacks, MT Newswires, etc. —
 genuinely institutional-grade headlines on a free tier. Article body
 text is typically just the lead paragraph (full body lives on the
 original publisher's site).
+
+Resilience posture (alpha-engine-config#2938, 2026-07-18): Polygon's free
+tier is hard-capped at 5 req/min (12s/ticker), so sweeping a large universe
+is inherently slow — ~944 tickers ⇒ ~3.15h. GDELT got a wall-clock time
+budget from config#2813, but Polygon was left uncovered: an unbounded
+per-ticker loop over an ~9x-grown universe (plus a sustained 429 storm) blew
+the caller's outer deadline with ZERO output — killing the daily digest AND
+SIGKILLing the weekly Saturday RAGIngestion step (two 1h ExecutionTimedOut).
+This adapter now enforces its OWN hard time budget (below), mirroring
+``GdeltNewsAdapter``: on the DAILY path a tight budget bails early with a
+partial digest (acceptable — ``partial: true``); on the WEEKLY path the
+caller sizes the budget from the live universe to COMPLETE the full sweep
+(config#2938 ruling 1), and the guard is only a SIGKILL backstop so a
+pathological throttle degrades coverage instead of taking the pipeline down.
+Budgets are derived in ``collectors.news_sources.fetch_budget``.
 """
 
 from __future__ import annotations
 
 import logging
+import time
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Callable
 
 from nousergon_lib.sources import NewsArticle
 
@@ -25,13 +41,31 @@ from polygon_client import polygon_client
 logger = logging.getLogger(__name__)
 
 
+# Hard wall-clock budget for one ``fetch()`` call across the ENTIRE ticker
+# list (config#2938), mirroring ``GdeltNewsAdapter``. The default is the tight
+# DAILY bail-early value; the WEEKLY caller passes a larger, universe-derived
+# budget (see ``collectors.news_sources.fetch_budget``). Checked before each
+# ticker (not just once), so a slow-but-not-yet-exhausted run still stops
+# promptly at the boundary and lets the rest of the pull (other sources,
+# aggregation, digest/RAG write) run within the caller's overall deadline.
+_DEFAULT_MAX_FETCH_SECONDS = 1_200.0  # 20 min
+
+
 class PolygonNewsAdapter:
     """Polygon news adapter. Implements ``NewsSource``."""
 
     name = "polygon"
 
-    def __init__(self, client: Any = None) -> None:
+    def __init__(
+        self,
+        client: Any = None,
+        *,
+        max_fetch_seconds: float = _DEFAULT_MAX_FETCH_SECONDS,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
         self._client = client  # default: lazy via polygon_client() factory
+        self._max_fetch_seconds = max_fetch_seconds
+        self._monotonic = monotonic
 
     def _get_client(self) -> Any:
         if self._client is None:
@@ -47,7 +81,14 @@ class PolygonNewsAdapter:
         cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
         cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
         articles: list[NewsArticle] = []
-        for ticker in tickers:
+        deadline = self._monotonic() + self._max_fetch_seconds
+        budget_exhausted_at: int | None = None
+        for i, ticker in enumerate(tickers):
+            # Never checked before the FIRST ticker — even a zero/negative
+            # budget attempts one fetch; the guard only skips the remainder.
+            if i > 0 and self._monotonic() >= deadline:
+                budget_exhausted_at = i
+                break
             try:
                 payload = self._get_client()._get(
                     "/v2/reference/news",
@@ -70,6 +111,17 @@ class PolygonNewsAdapter:
                 article = _to_article(item, ticker=ticker)
                 if article is not None:
                     articles.append(article)
+
+        if budget_exhausted_at is not None:
+            skipped = len(tickers) - budget_exhausted_at
+            logger.warning(
+                "[polygon_news] time budget (%.0fs) exhausted after %d/%d "
+                "tickers — skipping remaining %d so the rest of the pull "
+                "(other sources, aggregation, digest/RAG write) still gets to "
+                "run within the caller's overall deadline",
+                self._max_fetch_seconds, budget_exhausted_at,
+                len(tickers), skipped,
+            )
         return articles
 
 

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -229,13 +229,34 @@ while [[ $# -gt 0 ]]; do
         --phase1-only) RUN_MODE="phase1-only"; shift ;;
         --launch-only) RUN_MODE="launch-only"; shift ;;
         --id-artifact-key) ID_ARTIFACT_KEY="$2"; shift 2 ;;
-        --max-runtime-seconds) MAX_RUNTIME_SECONDS="$2"; shift 2 ;;
+        --max-runtime-seconds) MAX_RUNTIME_SECONDS="$2"; MAX_RUNTIME_EXPLICIT=1; shift 2 ;;
         --preflight-only) PREFLIGHT_ONLY=1; shift ;;
         --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;  # legacy: collapses INSTANCE_TYPES to single value
         --branch) BRANCH="$2"; shift 2 ;;
         *) echo "Unknown flag: $1"; exit 1 ;;
     esac
 done
+
+# ── config#2938: rag-only full-universe news-sweep budget ────────────────────
+# RAGIngestion's Step 5/9 is the multi-source news sweep whose Polygon leg
+# (5 req/min, account-wide) now covers the FULL ~944-ticker universe (~3.15h)
+# per config#2938 ruling 1. The DataPhase1-sized defaults (5400s watchdog,
+# 3600s inner workload) SIGKILLed it twice on 2026-07-18. rag-only therefore
+# gets the config#2938 4h hard cap on BOTH the spot-side watchdog and the inner
+# workload SSM call. These MUST stay in lockstep with the RAGIngestion
+# executionTimeout in step_function.json (14400s) and the
+# WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS constant in
+# collectors/news_sources/fetch_budget.py — guarded by
+# tests/test_rag_ingestion_news_budget_wiring.py. Other modes (DataPhase1,
+# workloads) keep the 5400s default; an explicit --max-runtime-seconds still
+# wins so an operator can override.
+RAG_ONLY_EXECUTION_TIMEOUT_SECONDS=14400          # = SF RAGIngestion executionTimeout
+RAG_ONLY_WORKLOAD_TIMEOUT_SECONDS="$RAG_ONLY_EXECUTION_TIMEOUT_SECONDS"
+if [ "$RUN_MODE" = "rag-only" ] && [ "$MAX_RUNTIME_EXPLICIT" != "1" ]; then
+    # +300s so the box's own shutdown watchdog is a BACKSTOP that fires after
+    # the outer SF executionTimeout/cleanup, never before the sweep completes.
+    MAX_RUNTIME_SECONDS=14700
+fi
 
 # launch-only contract: the id artifact is how the weekday SF finds the
 # spot — launching without it would orphan the instance until the
@@ -775,7 +796,7 @@ RAG_ONLY_PREFLIGHT
     echo "═══════════════════════════════════════════════════════════════"
     echo "  RAG-ONLY RUN (skipping DataPhase1)"
     echo "═══════════════════════════════════════════════════════════════"
-    run_ssm "rag-only" 3600 <<RAG_ONLY
+    run_ssm "rag-only" "$RAG_ONLY_WORKLOAD_TIMEOUT_SECONDS" <<RAG_ONLY
 set -eo pipefail
 ${ENV_SOURCE}
 cd /home/ec2-user/alpha-engine-data

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1083,7 +1083,7 @@
             },
             "RAGIngestion": {
               "Type": "Task",
-              "Comment": "Weekly RAG ingestion (SEC filings, 8-Ks, earnings, theses) on its own spot EC2. Same dispatcher (always-on micro) that ran DataPhase1; a fresh spot instance is launched here so this state has its own watchdog budget and per-state health marker. ~7 min extra bootstrap vs the prior bundled design — accepted in exchange for failure isolation. Origin of split: 2026-05-06 SF run where alpha-engine-lib v0.3.0 had bare `from rag.X` imports inside retrieval.py that fired during RRC dedup; failure was labeled DataPhase1 even though the data layer was healthy.",
+              "Comment": "Weekly RAG ingestion (SEC filings, 8-Ks, earnings, theses) on its own spot EC2. Same dispatcher (always-on micro) that ran DataPhase1; a fresh spot instance is launched here so this state has its own watchdog budget and per-state health marker. ~7 min extra bootstrap vs the prior bundled design — accepted in exchange for failure isolation. Origin of split: 2026-05-06 SF run where alpha-engine-lib v0.3.0 had bare `from rag.X` imports inside retrieval.py that fired during RRC dedup; failure was labeled DataPhase1 even though the data layer was healthy. config#2938 (2026-07-18): executionTimeout raised 3600s→14400s (4h). Step 5/9 of spot_data_weekly.sh --rag-only is the multi-source news sweep whose Polygon leg (5 req/min, account-wide) now covers the FULL ~944-ticker universe (~3.15h) — the prior 3600s cap SIGKILLed it twice (ExecutionTimedOut/137) after the universe grew ~9x. 4h is the config#2938 ruling-2 hard cap; it must move in LOCKSTEP with the inner run_ssm \"rag-only\" timeout + the rag-only MAX_RUNTIME_SECONDS watchdog in spot_data_weekly.sh and the WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS constant in collectors/news_sources/fetch_budget.py (guarded by tests/test_rag_ingestion_news_budget_wiring.py). Well under the 43200s global ceiling; runs in Branch A parallel to PredictorTraining.",
               "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
               "Parameters": {
                 "DocumentName": "AWS-RunShellScript",
@@ -1091,7 +1091,7 @@
                 "Parameters": {
                   "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$.preflight_args))",
                   "executionTimeout": [
-                    "3600"
+                    "14400"
                   ]
                 },
                 "TimeoutSeconds": 3600

--- a/infrastructure/systemd/daily-news.service
+++ b/infrastructure/systemd/daily-news.service
@@ -11,13 +11,15 @@ WorkingDirectory=/home/ec2-user/alpha-engine-data
 ExecStart=/home/ec2-user/alpha-engine-data/scripts/run_daily_news_standalone.sh
 StandardOutput=journal
 StandardError=journal
-# ~20-30 min pull (Polygon 5 req/min over the ~106-ticker holdings∪signals
-# universe, up from ~96 as of 2026-06-15 — universe grows over time, keep
-# this comment approximate not exact). 40 min cap gives headroom. GDELT's
-# OWN contribution is separately hard-capped at 20 min inside the adapter
-# (GdeltNewsAdapter's max_fetch_seconds, config#2813) regardless of how
-# badly it's throttling that day, so this outer timeout is now a backstop,
-# not the primary defense against a slow/throttled run.
+# Backstop only — NOT the primary defense. BOTH throttle-prone sources are
+# now hard-capped INSIDE their adapters (GdeltNewsAdapter config#2813 +
+# PolygonNewsAdapter config#2938, each max_fetch_seconds=1200s), and the
+# sources fetch CONCURRENTLY (AsyncNewsAggregator), so a slow/throttled run
+# degrades coverage and still writes a (partial) digest well within this cap
+# instead of being SIGKILLed with zero output. This value is DERIVED — it must
+# equal collectors/news_sources/fetch_budget.py::daily_news_timeout_start_seconds()
+# (one source's 1200s bail budget + 1200s aggregation/write reserve); a test
+# there guards the two in lockstep so universe growth never silently outruns it.
 TimeoutStartSec=2400
 # Shared-box memory guard. Measured peak RSS ~0.17 GB; cap generously.
 MemoryAccounting=yes

--- a/rag/pipelines/run_news_pipeline.py
+++ b/rag/pipelines/run_news_pipeline.py
@@ -106,8 +106,21 @@ def main() -> int:
     from collectors.news_sources.polygon import PolygonNewsAdapter
     from collectors.news_sources.yahoo_rss import YahooRssNewsAdapter
 
+    # config#2938 ruling 1 — the WEEKLY corpus gets FULL coverage: size the
+    # Polygon budget from the LIVE universe so the ~5-req/min sweep COMPLETES
+    # (the adapter guard is only a SIGKILL backstop). GDELT keeps its own tight
+    # default (its throttle-degrades-this-adapter posture, config#2813). The
+    # budget is kept below the RAGIngestion SSM executionTimeout so the rest of
+    # the step (NLP + RAG ingest) always runs — see fetch_budget for the
+    # derivation and its lockstep with nousergon-data's step_function.json.
+    from collectors.news_sources.fetch_budget import weekly_news_max_fetch_seconds
+    poly_budget = weekly_news_max_fetch_seconds(len(tickers))
+    logger.info(
+        "[run_news_pipeline] weekly Polygon news budget = %ds for %d tickers",
+        poly_budget, len(tickers),
+    )
     aggregator = NewsAggregator(sources=[
-        PolygonNewsAdapter(),
+        PolygonNewsAdapter(max_fetch_seconds=poly_budget),
         GdeltNewsAdapter(ticker_name_map=_load_ticker_name_map()),
         YahooRssNewsAdapter(),
     ])

--- a/tests/test_fetch_budget.py
+++ b/tests/test_fetch_budget.py
@@ -1,0 +1,101 @@
+"""Tests for the shared news-sweep budget derivation (config#2938).
+
+The derivation is the single source of truth for the Polygon-bottlenecked
+news fetch budgets. These pins guard the two properties the 2026-07-18 double
+SIGKILL incident turned into hard requirements:
+
+  * WEEKLY budgets scale with the LIVE universe (so universe growth can never
+    silently outrun them, ruling 2) and are sized to COMPLETE the sweep at the
+    current universe (ruling 1), while staying inside the 4h SSM cap; and
+  * the DAILY systemd ``TimeoutStartSec`` stays in lockstep with the derived
+    value (no hand-maintained constant drifting from the code).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from collectors.news_sources.fetch_budget import (
+    DAILY_NEWS_MAX_FETCH_SECONDS,
+    POLYGON_SECONDS_PER_TICKER,
+    WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS,
+    daily_news_timeout_start_seconds,
+    weekly_news_max_fetch_seconds,
+)
+
+# The universe that took down both consumers on 2026-07-18 (79 holdings ∪ 903
+# AE-signals). Used as the "current universe" reference for the completion pin.
+_INCIDENT_UNIVERSE = 944
+
+
+class TestWeeklyBudget:
+    def test_scales_with_universe(self):
+        assert weekly_news_max_fetch_seconds(1000) > weekly_news_max_fetch_seconds(100)
+
+    def test_monotonic_non_decreasing(self):
+        prev = -1
+        for n in (0, 1, 50, 200, 500, 944, 1200, 5000):
+            cur = weekly_news_max_fetch_seconds(n)
+            assert cur >= prev
+            prev = cur
+
+    def test_small_universe_hits_floor(self):
+        # A single-ticker universe still gets a sane (floored) budget.
+        assert weekly_news_max_fetch_seconds(1) == weekly_news_max_fetch_seconds(0)
+        assert weekly_news_max_fetch_seconds(1) >= 1_800
+
+    def test_completes_current_universe_sweep(self):
+        # ruling 1: the budget must exceed the nominal full-universe Polygon
+        # crawl time (universe × 12s) so a clean run COMPLETES, not bails.
+        nominal_crawl = _INCIDENT_UNIVERSE * 12
+        assert weekly_news_max_fetch_seconds(_INCIDENT_UNIVERSE) >= nominal_crawl
+
+    def test_never_exceeds_step_cap(self):
+        # ruling 2: always leaves reserve for the rest of the RAGIngestion
+        # step inside the 4h SSM executionTimeout — even for an absurd universe.
+        for n in (944, 2000, 100_000):
+            assert (
+                weekly_news_max_fetch_seconds(n)
+                < WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS
+            )
+
+    def test_huge_universe_caps_not_unbounded(self):
+        # Beyond the cap the sweep fails soft (partial), it does not demand an
+        # unbounded budget — the cap is the same for 100k and 1M tickers.
+        assert weekly_news_max_fetch_seconds(100_000) == weekly_news_max_fetch_seconds(
+            1_000_000
+        )
+
+    def test_weekly_cap_matches_4h_policy(self):
+        # The SSM executionTimeout the nousergon-data guard pins against is the
+        # config#2938 4h ruling. If this changes, the three nousergon-data
+        # timeouts (executionTimeout / run_ssm / MAX_RUNTIME) move in lockstep.
+        assert WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS == 14_400
+
+
+class TestDailyBudget:
+    def test_daily_bail_budget_is_tight(self):
+        assert DAILY_NEWS_MAX_FETCH_SECONDS == 1_200
+
+    def test_timeout_start_covers_source_plus_reserve(self):
+        assert daily_news_timeout_start_seconds() > DAILY_NEWS_MAX_FETCH_SECONDS
+
+    def test_daily_news_service_timeout_in_lockstep(self):
+        # The deployed systemd TimeoutStartSec MUST equal the derivation — no
+        # hand-maintained constant silently drifting from the code (config#2938).
+        svc = (
+            Path(__file__).resolve().parent.parent
+            / "infrastructure"
+            / "systemd"
+            / "daily-news.service"
+        )
+        m = re.search(r"^TimeoutStartSec=(\d+)", svc.read_text(), re.MULTILINE)
+        assert m, "daily-news.service has no TimeoutStartSec"
+        assert int(m.group(1)) == daily_news_timeout_start_seconds()
+
+
+def test_per_ticker_rate_reflects_polygon_free_tier():
+    # 5 req/min = 12s/ticker; the derivation must not silently assume a faster
+    # (paid-tier) rate that would under-size every budget.
+    assert POLYGON_SECONDS_PER_TICKER >= 12.0

--- a/tests/test_news_sources_and_aggregator.py
+++ b/tests/test_news_sources_and_aggregator.py
@@ -150,6 +150,64 @@ class TestPolygonNewsAdapter:
         assert len(out) == 1
         assert out[0].vendor_article_id == "good"
 
+    # ── config#2938: Polygon wall-clock time budget ─────────────────────
+
+    def test_time_budget_stops_before_exhausting_all_tickers(self):
+        """config#2938 — the per-ticker loop must bail at ``max_fetch_seconds``
+        and return whatever it collected, so aggregation + digest/RAG write
+        still run within the caller's deadline (mirrors the GDELT guard)."""
+        fake_client = MagicMock()
+        fake_client._get.return_value = {"results": []}
+        clock = {"n": 0}
+
+        def fake_monotonic():
+            clock["n"] += 1
+            # calls: deadline calc (1), then one check per ticker i>0
+            return 0.0 if clock["n"] <= 3 else 1_000_000.0
+
+        adapter = PolygonNewsAdapter(
+            client=fake_client, max_fetch_seconds=100.0, monotonic=fake_monotonic
+        )
+        out = adapter.fetch([f"T{i}" for i in range(10)])
+        assert fake_client._get.call_count < 10
+        assert fake_client._get.call_count >= 1
+        assert out == []
+
+    def test_time_budget_never_checked_before_first_ticker(self):
+        """Even a zero/negative budget must attempt the FIRST ticker — the
+        guard only skips the remainder."""
+        fake_client = MagicMock()
+        fake_client._get.return_value = {"results": []}
+        adapter = PolygonNewsAdapter(
+            client=fake_client, max_fetch_seconds=0.0, monotonic=lambda: 0.0
+        )
+        adapter.fetch(["AAPL", "MSFT", "GOOG"])
+        assert fake_client._get.call_count == 1
+
+    def test_sustained_throttle_bails_at_budget_not_after_all_tickers(self):
+        """config#2938 core regression — a sustained Polygon 429 storm (the
+        2026-07-18 daily + weekly-SF SIGKILL) must NOT run the unbounded loop
+        past the caller's deadline. The adapter bails at its budget and returns
+        (partial), never hanging until the outer timeout kills it with zero
+        output."""
+        fake_client = MagicMock()
+        fake_client._get.side_effect = RuntimeError(
+            "Rate limited after 4 retries"
+        )
+        ticks = {"t": 0.0}
+
+        def fake_monotonic():
+            v = ticks["t"]
+            ticks["t"] += 10.0  # ~10s of wall-clock "elapsed" per 429 wait
+            return v
+
+        adapter = PolygonNewsAdapter(
+            client=fake_client, max_fetch_seconds=45.0, monotonic=fake_monotonic
+        )
+        out = adapter.fetch([f"T{i}" for i in range(1000)])
+        assert fake_client._get.call_count < 1000
+        assert out == []
+
 
 # ── GDELT adapter ──────────────────────────────────────────────────────
 

--- a/tests/test_rag_ingestion_news_budget_wiring.py
+++ b/tests/test_rag_ingestion_news_budget_wiring.py
@@ -1,0 +1,101 @@
+"""config#2938 — the weekly RAGIngestion timeouts must hold the FULL-universe
+news sweep, and all four surfaces of the 4h budget must stay in lockstep.
+
+The 2026-07-18 weekly SF failure was a DRIFT bug: the news universe grew ~9x
+while the RAGIngestion SSM ``executionTimeout`` stayed at a DataPhase1-sized
+3600s, so the ~3.15h Polygon sweep SIGKILLed twice. The fix sizes the runtime
+Polygon budget from the LIVE universe (``fetch_budget``) and raises the outer
+step timeouts to the config#2938 4h hard cap. This guard pins that the three
+static timeouts equal the single ``WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS``
+constant they were derived from, so a future edit to any one of them fails CI
+unless the others move with it:
+
+  1. RAGIngestion ``executionTimeout`` in infrastructure/step_function.json,
+  2. the inner ``run_ssm "rag-only"`` workload timeout in spot_data_weekly.sh,
+  3. the rag-only spot-watchdog ``MAX_RUNTIME_SECONDS`` (cap + shutdown margin),
+
+and that the runtime per-universe budget always leaves reserve for the rest of
+the step inside that cap.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from collectors.news_sources.fetch_budget import (
+    WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS,
+    weekly_news_max_fetch_seconds,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF = _REPO_ROOT / "infrastructure" / "step_function.json"
+_SCRIPT = _REPO_ROOT / "infrastructure" / "spot_data_weekly.sh"
+
+
+def _find_state(node, name):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == name and isinstance(v, dict) and v.get("Type"):
+                return v
+            found = _find_state(v, name)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for x in node:
+            found = _find_state(x, name)
+            if found is not None:
+                return found
+    return None
+
+
+def _rag_execution_timeout() -> int:
+    sf = json.loads(_SF.read_text())
+    state = _find_state(sf, "RAGIngestion")
+    assert state is not None, "RAGIngestion state not found in step_function.json"
+    et = state["Parameters"]["Parameters"]["executionTimeout"]
+    assert isinstance(et, list) and len(et) == 1, f"unexpected executionTimeout shape: {et!r}"
+    return int(et[0])
+
+
+def test_rag_execution_timeout_matches_4h_cap():
+    # The SIGKILL boundary that fired on 2026-07-18 (was 3600s).
+    assert _rag_execution_timeout() == WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS
+
+
+def test_rag_execution_timeout_holds_full_universe_sweep():
+    # ruling 1: the outer cap must strictly exceed the runtime Polygon budget
+    # for any universe, so the fetch + the rest of the step fit inside it.
+    et = _rag_execution_timeout()
+    for n in (944, 2000, 100_000):
+        assert weekly_news_max_fetch_seconds(n) < et
+
+
+def test_inner_run_ssm_rag_only_timeout_in_lockstep():
+    text = _SCRIPT.read_text()
+    m = re.search(r"RAG_ONLY_EXECUTION_TIMEOUT_SECONDS=(\d+)", text)
+    assert m, "RAG_ONLY_EXECUTION_TIMEOUT_SECONDS not set in spot_data_weekly.sh"
+    assert int(m.group(1)) == WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS
+    # ...and the inner workload SSM call actually uses that variable, not a
+    # re-introduced literal 3600.
+    assert 'run_ssm "rag-only" "$RAG_ONLY_WORKLOAD_TIMEOUT_SECONDS"' in text
+    assert 'run_ssm "rag-only" 3600' not in text
+
+
+def test_rag_only_spot_watchdog_exceeds_outer_cap():
+    # The box's shutdown watchdog must be a BACKSTOP: strictly greater than the
+    # outer SF executionTimeout so cleanup (not a premature box shutdown) ends
+    # the run.
+    text = _SCRIPT.read_text()
+    block = text[text.index('RUN_MODE" = "rag-only"'):]
+    m = re.search(r"MAX_RUNTIME_SECONDS=(\d+)", block)
+    assert m, "rag-only MAX_RUNTIME_SECONDS override not found"
+    assert int(m.group(1)) > WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS
+
+
+def test_other_modes_keep_dataphase1_watchdog_default():
+    # Only rag-only gets the 4h watchdog; the shared default (DataPhase1 /
+    # workloads) stays 5400s so those modes are not silently over-budgeted.
+    text = _SCRIPT.read_text()
+    assert 'MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-5400}"' in text


### PR DESCRIPTION
## Root cause

`PolygonNewsAdapter.fetch()` had **no wall-clock time budget** (unlike `GdeltNewsAdapter`, config#2813). With the news universe grown ~9x (27→903 signals tickers; 944 total), the ~944-ticker Polygon sweep at 5 req/min (~3.15h) plus a sustained 429 storm blew both callers' outer deadlines **with zero output**:
- **daily-news.service** → killed by `TimeoutStartSec`, no digest (config#2938 original body).
- **weekly `ne-weekly-freshness-pipeline` `RAGIngestion`** → SIGKILLed **twice** (`ExecutionTimedOut`/`ResponseCode 137`) at the DataPhase1-sized 3600s SSM `executionTimeout`, failing the whole Saturday research/training pipeline (2026-07-18 execution `22f15090-…-ff881c0c7705`).

This is **Lane B/C** (HOW-it-runs: a missing time-budget guard + drift-prone hardcoded timeouts). The design judgments (full vs. partial weekly coverage; budget derivation) were made by Brian in **config#2938's binding rulings**; this PR implements them.

## The SOTA fix (at the correct layer)

**1. Give Polygon the same time-budget pattern as GDELT** — `max_fetch_seconds` deadline checked before each ticker, bail returns collected articles + a loud WARN, so aggregation + digest/RAG write always run. Not a swallow: a genuinely-absent artifact still fails loud downstream; this only bounds a slow external crawl.

**2. `collectors/news_sources/fetch_budget.py` — single source of truth, DERIVED from the LIVE universe** (ruling 2: the incident was a *drift* bug — a hardcoded 3600s outrun by universe growth):
- **WEEKLY (ruling 1: FULL coverage)** — `run_news_pipeline` passes Polygon a budget sized to *complete* the full sweep at the current universe (`weekly(944)=11800s > 11328s nominal crawl`), floored, and capped so the fetch + the rest of the step fit inside the 4h SSM `executionTimeout`. The guard is only a SIGKILL backstop.
- **DAILY (ruling 1: partial acceptable)** — `daily_news` gives both throttle-prone sources the tight 1200s bail budget; concurrent `AsyncNewsAggregator` still writes a (partial) digest within `TimeoutStartSec`. `daily-news.service TimeoutStartSec` is now derived + lockstep-guarded.

**3. Raise the three coordinated weekly timeouts to the config#2938 4h hard cap**, in lockstep with the `fetch_budget` cap constant:
- `step_function.json` `RAGIngestion.executionTimeout`: 3600 → **14400** (the SIGKILL boundary).
- `spot_data_weekly.sh` inner `run_ssm "rag-only"`: 3600 → **14400**.
- `spot_data_weekly.sh` rag-only spot-watchdog `MAX_RUNTIME_SECONDS`: 5400 → **14700** (backstop margin). Only rag-only; DataPhase1/workloads keep 5400s.

## Guard / test that now covers this failure class

- `tests/test_fetch_budget.py` — WEEKLY budget scales with universe, completes the current-universe sweep, floors, never exceeds the 4h cap; DAILY systemd `TimeoutStartSec` lockstep.
- `tests/test_news_sources_and_aggregator.py` — Polygon time-budget bail + never-before-first-ticker + **sustained-429 anti-regression** (mirrors the GDELT guards; directly reproduces the incident signature).
- `tests/test_rag_ingestion_news_budget_wiring.py` — imports the `fetch_budget` cap and pins all three static timeouts to it (single-source lockstep), asserts the outer cap strictly exceeds the runtime Polygon budget for any universe, and that no literal `3600` rag-only timeout is reintroduced.

## Fail-loud rationale

No error-handling was weakened. The adapter bail is graceful *degradation with a loud WARN* returning partial coverage (the sanctioned GDELT pattern, config#2813) — it does not swallow errors, widen a skip-gate, or make an absent artifact pass silently. Beyond the 4h cap the weekly sweep fails soft (partial + WARN) instead of a SIGKILL-with-zero-output; the genuine SOTA (decoupling news collection from the Saturday critical path) is tracked separately per config#2938 "out of scope".

Refs: alpha-engine-config#2938