### PR TITLE
fix(spot): default-init MAX_RUNTIME_EXPLICIT — unbound var killed every SF rag-only dispatch (config#2938)

### DIFF
--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -114,6 +114,12 @@ AMI_ID="ami-0c421724a94bba6d6"      # Amazon Linux 2023 x86_64
 # plus pip install + preflight. If the workload legitimately needs longer,
 # bump this — don't silently rely on the orphan reaper.
 MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-5400}"
+# Set to 1 only by the --max-runtime-seconds flag: the rag-only 4h-cap
+# override below must not clobber an explicit operator value. MUST be
+# default-initialized here — this script runs under `set -u`, and the flag
+# path is the only assignment (2026-07-18: the missing default killed every
+# SF-driven rag-only dispatch with "MAX_RUNTIME_EXPLICIT: unbound variable").
+MAX_RUNTIME_EXPLICIT="${MAX_RUNTIME_EXPLICIT:-0}"
 # ── Spot-interruption resilience (2026-05-30 incident) ──────────────────────
 # The Saturday SF DataPhase1 failed when this run's nested spot
 # (i-02e498e018441751f, c5.large/us-east-1a) was reclaimed by AWS *mid-

--- a/tests/test_rag_ingestion_news_budget_wiring.py
+++ b/tests/test_rag_ingestion_news_budget_wiring.py
@@ -99,3 +99,17 @@ def test_other_modes_keep_dataphase1_watchdog_default():
     # workloads) stays 5400s so those modes are not silently over-budgeted.
     text = _SCRIPT.read_text()
     assert 'MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-5400}"' in text
+
+
+def test_max_runtime_explicit_default_initialized_before_use():
+    # The script runs under `set -u`; the --max-runtime-seconds flag path is
+    # the only assignment of MAX_RUNTIME_EXPLICIT=1. Without a default init
+    # BEFORE the rag-only override check, every SF-driven rag-only dispatch
+    # dies with "MAX_RUNTIME_EXPLICIT: unbound variable" (2026-07-18
+    # watch-rerun-2026-07-18-1 failure — the exact incident this pins).
+    text = _SCRIPT.read_text()
+    default = 'MAX_RUNTIME_EXPLICIT="${MAX_RUNTIME_EXPLICIT:-0}"'
+    assert default in text, "MAX_RUNTIME_EXPLICIT must be default-initialized"
+    assert text.index(default) < text.index('"$MAX_RUNTIME_EXPLICIT" != "1"'), (
+        "default init must precede the rag-only override check"
+    )


### PR DESCRIPTION
## Root cause

nousergon-data-PR936 gated the rag-only 4h watchdog override on `MAX_RUNTIME_EXPLICIT` but only assigned it in the `--max-runtime-seconds` flag-parse path. `spot_data_weekly.sh` runs under `set -euo pipefail`, so the normal SF-driven dispatch (which passes no flag) died instantly on the reference: `line 255: MAX_RUNTIME_EXPLICIT: unbound variable` — this is what failed `watch-rerun-2026-07-18-1` (both RAGIngestion attempts, rc=1 in ~1s, before any spot launch).

## Fix (correct layer, minimal)

Default-initialize `MAX_RUNTIME_EXPLICIT="${MAX_RUNTIME_EXPLICIT:-0}"` alongside the `MAX_RUNTIME_SECONDS` default it guards, with a comment naming the set -u constraint.

## Guard

`test_max_runtime_explicit_default_initialized_before_use` in `tests/test_rag_ingestion_news_budget_wiring.py` pins (a) the default exists and (b) it precedes the rag-only override check. Validated locally: 17/17 wiring+fetch_budget tests pass, `bash -n` clean, and the fixed path simulated under `set -u`.

## Fail-loud rationale

No error handling touched — this restores the script's ability to run at all; the set -u fail-loud posture itself is unchanged (and is what caught the bug loudly).

CI-undetectability of this class (no shellcheck in CI, wiring tests are grep-based) is being filed as a follow-up on alpha-engine-config.

Refs: alpha-engine-config#2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)