### PR TITLE
feat(sf-watch): shepherd ruling — watch-rerun failures re-dispatch the agent (Brian 2026-07-18)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -39,10 +39,11 @@ SECOND agent from being summoned for an incident already being handled — both
 still write the watch-log event AND send the Telegram receipt (`mode:
 DISPATCH SUPPRESSED`), recording the decision via `dispatch_suppressed`
 (never a silent skip):
-1. **Operator-recovery reruns** — an execution named after the watch's own
-   recommended recovery-rerun convention (`watch-rerun-*`) or this Lambda's
-   own fast-path rerun (`fast-path-rerun-*`) is a recovery attempt already in
-   progress, not a fresh incident (`RECOVERY_RERUN_NAME_PREFIXES`).
+1. **Fast-path reruns only** — an execution this Lambda started itself
+   (`fast-path-rerun-*`) never re-dispatches (self-loop guard,
+   `RECOVERY_RERUN_NAME_PREFIXES`). `watch-rerun-*` failures DISPATCH since
+   2026-07-18 (Brian's shepherd ruling): the overseer shepherds the whole
+   incident arc, reruns included; the per-day dispatch ceiling bounds pile-on.
 2. **Same-day post-escalation repeats** — once this pipeline's watch-log for
    today already carries an `action: escalated` event (a human is already
    engaged), subsequent failures suppress by default. Opt back into the old
@@ -264,19 +265,22 @@ _CAUSE_MAX_CHARS = 600
 # `ABORTED`, because a programmatic/self-abort can still be a real defect that
 # must dispatch. `OperatorAbort` is the marker the fleet's manual-stop path sets.
 OPERATOR_ABORT_ERRORS = frozenset({"OperatorAbort"})
-# config#2003 — operator-recovery-rerun carve-out. `watch-rerun-*` is the
-# dispatcher's OWN recommended-command naming convention (the Telegram receipt
-# / runbook tell the operator to StartExecution with this prefix when manually
-# recovering an already-diagnosed, already-escalated incident — see the
-# 2026-07-08 EOD incident, config#1446/#1464, where the watch escalated the
-# original failure then dispatched TWO more agents for the operator's own
-# `watch-rerun-2026-07-08-1`/`-2` recovery attempts). `fast-path-rerun-*` is
-# this Lambda's own deterministic-rerun prefix (config#1900) — an execution it
-# started itself never needs a second agent dispatch either. Prefix-matched
-# against the SF execution NAME (`detail.name`), never the ARN. Keep this list
-# SMALL and EXPLICIT, mirroring OPERATOR_ABORT_ERRORS above — a new recovery
-# convention must be added here deliberately, not inferred.
-RECOVERY_RERUN_NAME_PREFIXES = ("watch-rerun-", "fast-path-rerun-")
+# Recovery-rerun carve-out — NARROWED to fast-path only (Brian's shepherd
+# ruling, 2026-07-18): "the overseer should be the shepherd for all these
+# processes going forward; it should run autonomously to monitor the process."
+# A FAILED `watch-rerun-*` execution therefore DISPATCHES a fresh agent like
+# any other failure — the 2026-07-18 incident showed the old config#2003
+# suppression benched the autonomous loop for an entire multi-bug arc the
+# moment the first recovery rerun started (bugs #3-#5 all landed on the
+# operator by structure, not choice). The 2026-07-08 pile-on that motivated
+# config#2003 (agents dispatched on top of an operator's active recovery) is
+# now bounded by the config#2269 per-day dispatch ceiling + the charter's
+# same-error escalation rule instead of a blanket suppression.
+# `fast-path-rerun-*` (config#1900, this Lambda's own deterministic rerun)
+# stays suppressed: dispatching on our own rerun's failure is a self-loop;
+# its failure path is charter work tracked under the shepherd umbrella issue.
+# Prefix-matched against the SF execution NAME (`detail.name`), never the ARN.
+RECOVERY_RERUN_NAME_PREFIXES = ("fast-path-rerun-",)
 # Bound the history scan: fetch the newest N events (reverseOrder), reconstruct
 # chronological order locally to find the entered-but-not-exited state. The
 # failed state's enclosing StateEntered is always in the tail of the history.
@@ -329,16 +333,14 @@ def _is_operator_abort(status: str, describe_resp: dict | None) -> bool:
 
 
 def _is_operator_recovery_rerun(execution_name: str) -> bool:
-    """True iff ``execution_name`` matches one of the dispatcher's own
-    documented recovery-rerun naming conventions (config#2003).
+    """True iff ``execution_name`` is this Lambda's own fast-path rerun.
 
-    A failure of an execution named e.g. ``watch-rerun-2026-07-08-1`` is not a
-    fresh incident — it's the operator (or the fast path) already acting on an
-    incident this watch already diagnosed/escalated. Dispatching a second
-    agent for it duplicates a recovery already in progress and risks a
-    collision. Deliberately a prefix allowlist, not a heuristic — an unmatched
-    name (including one that merely CONTAINS "rerun") still dispatches
-    normally, so a genuine new incident is never silently swallowed."""
+    Only ``fast-path-rerun-*`` suppresses (self-loop guard) — ``watch-rerun-*``
+    failures dispatch a fresh agent per Brian's 2026-07-18 shepherd ruling
+    (the overseer owns the whole incident arc; the config#2269 ceiling and the
+    charter's same-error rule bound pile-on). Deliberately a prefix allowlist,
+    not a heuristic — an unmatched name (including one that merely CONTAINS
+    "rerun") still dispatches normally."""
     return execution_name.startswith(RECOVERY_RERUN_NAME_PREFIXES)
 
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -844,24 +844,21 @@ def test_fast_path_preflight_excluded(fast_path_on):
     assert result["fast_path"]["reason"] == "preflight"
 
 
-# ── config#2003: suppress agent dispatch for operator-recovery reruns and ───
-# ── post-escalation same-day repeats ─────────────────────────────────────────
+# ── Shepherd ruling (Brian, 2026-07-18) + fast-path self-loop guard ─────────
 #
-# Observed 2026-07-08 (EOD incident, config#1446/#1464): the watch correctly
-# escalated the original eod-2026-07-08-* failure as human-gated (IAM), then
-# dispatched TWO MORE agent runs for the operator's own recovery reruns
-# `watch-rerun-2026-07-08-1`/`-2` — duplicating a recovery already in
-# progress. Both carve-outs below still write the watch-log + Telegram
-# receipt (observability stays); only the agent repository_dispatch is
-# suppressed.
+# watch-rerun-* failures DISPATCH: the overseer shepherds the whole incident
+# arc, reruns included (the 2026-07-18 arc showed the old config#2003
+# suppression benched the autonomous loop after the first recovery rerun —
+# bugs #3-#5 all fell to the operator by structure). The 2026-07-08 pile-on
+# config#2003 fixed is now bounded by the config#2269 per-day dispatch
+# ceiling + the charter's same-error rule. Only fast-path-rerun-* (this
+# Lambda's own deterministic rerun) still suppresses — self-loop guard.
 
 
-def test_watch_rerun_named_execution_suppresses_dispatch_but_still_records(monkeypatch):
-    """(a) An execution named after the watch's OWN recommended recovery-rerun
-    convention (`watch-rerun-<date>-<n>`) must NOT summon a second agent, but
-    the watch-log event AND the Telegram receipt still fire (unlike the
-    silent config#1827 operator-abort path — the operator needs confirmation
-    the watch recognized their recovery attempt, not silence)."""
+def test_watch_rerun_named_execution_dispatches_fresh_agent(monkeypatch):
+    """Shepherd ruling (2026-07-18): a FAILED `watch-rerun-<date>-<n>`
+    execution summons a fresh agent like any other failure — the overseer
+    owns the whole incident arc. Watch-log + dispatch both fire."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
     fired = {"called": False}
@@ -877,34 +874,50 @@ def test_watch_rerun_named_execution_suppresses_dispatch_but_still_records(monke
             _event("FAILED", sm_arn=EOD_ARN, name="watch-rerun-2026-07-08-1"), None
         )
 
-    # No repository_dispatch HTTP call — the agent spin-up is suppressed.
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["action"] == "dispatched"
+    assert fired["called"] is True
+
+    s3.put_object.assert_called_once()
+    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
+    ev = written["events"][-1]
+    assert ev["execution_name"] == "watch-rerun-2026-07-08-1"
+    assert ev["dispatch_suppressed"] is None
+
+
+def test_fast_path_rerun_still_suppresses_self_loop(monkeypatch):
+    """The Lambda's OWN deterministic rerun (`fast-path-rerun-*`) must not
+    re-dispatch on failure — self-loop guard survives the shepherd ruling."""
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
+    fired = {"called": False}
+
+    def fake_urlopen(req, timeout=None):
+        fired["called"] = True
+        return _FakeResp()
+
+    monkeypatch.setattr(index.urllib.request, "urlopen", fake_urlopen)
+    factory, _, s3 = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(
+            _event("FAILED", sm_arn=EOD_ARN, name="fast-path-rerun-2026-07-08-1"), None
+        )
+
     assert result["agent_dispatch"] == {
         "dispatched": False, "reason": "operator_recovery_rerun",
     }
     assert result["action"] == "observe"
     assert fired["called"] is False
-
-    # Watch-log STILL written (fail-loud) and carries the auditable reason.
-    s3.put_object.assert_called_once()
     written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
-    ev = written["events"][-1]
-    assert ev["execution_name"] == "watch-rerun-2026-07-08-1"
-    assert ev["dispatch_suppressed"] == "operator_recovery_rerun"
-    assert ev["action"] == "observe"
-
-    # Telegram receipt STILL fires — observability stays, only dispatch is
-    # suppressed (distinct from the SILENT operator-abort path).
-    assert result["telegram_sent"] is True
-    index.notify_via_flow_doctor.assert_called_once()
-    text = index.notify_via_flow_doctor.call_args.args[0]
-    assert "DISPATCH SUPPRESSED" in text
-    assert "watch-rerun-2026-07-08-1" in text
+    assert written["events"][-1]["dispatch_suppressed"] == "operator_recovery_rerun"
 
 
-def test_second_watch_rerun_same_day_also_suppressed(monkeypatch):
-    """The exact 2026-07-08 incident shape: TWO operator recovery reruns the
-    same day both suppress — the second rerun attempt must not dispatch
-    either, regardless of how many prior events already exist."""
+def test_second_watch_rerun_same_day_gated_only_by_escalation_flag_or_ceiling(monkeypatch):
+    """Post-shepherd: a second same-day watch-rerun failure is no longer
+    suppressed AS a rerun. With a prior `escalated` event and the
+    DISPATCH_AFTER_ESCALATION opt-out at its default (false), the
+    already_escalated_today gate still holds; with the flag true, it
+    dispatches (bounded by the config#2269 ceiling)."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
     monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
@@ -912,27 +925,29 @@ def test_second_watch_rerun_same_day_also_suppressed(monkeypatch):
         "schema_version": 1,
         "events": [
             {"action": "escalated", "execution_name": "eod-2026-07-08-1"},
-            {
-                "action": "observe",
-                "execution_name": "watch-rerun-2026-07-08-1",
-                "dispatch_suppressed": "operator_recovery_rerun",
-            },
         ],
     }
+
+    # Default (DISPATCH_AFTER_ESCALATION=false): escalation gate holds.
+    monkeypatch.setattr(index, "DISPATCH_AFTER_ESCALATION", False)
     factory, _, s3 = _make_clients(existing=existing)
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(
             _event("FAILED", sm_arn=EOD_ARN, name="watch-rerun-2026-07-08-2"), None
         )
+    assert result["agent_dispatch"] == {
+        "dispatched": False, "reason": "already_escalated_today",
+    }
 
-    assert result["agent_dispatch"]["dispatched"] is False
-    assert result["agent_dispatch"]["reason"] in {
-        "operator_recovery_rerun", "already_escalated_today",
-    }
-    written = json.loads(s3.put_object.call_args.kwargs["Body"].decode())
-    assert written["events"][-1]["dispatch_suppressed"] in {
-        "operator_recovery_rerun", "already_escalated_today",
-    }
+    # Shepherd posture (flag true): the rerun failure dispatches.
+    monkeypatch.setattr(index, "DISPATCH_AFTER_ESCALATION", True)
+    factory, _, s3 = _make_clients(existing=existing)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(
+            _event("FAILED", sm_arn=EOD_ARN, name="watch-rerun-2026-07-08-2"), None
+        )
+    assert result["agent_dispatch"]["dispatched"] is True
+
 
 
 def test_fast_path_named_rerun_execution_also_suppresses_dispatch(monkeypatch):


### PR DESCRIPTION
## Ruling implemented

Brian (2026-07-18, interactive): **"the overseer should be the shepherd for all these processes going forward. it should run autonomously to monitor the process."**

Today's incident showed the structural gap: the moment the operator started `watch-rerun-2026-07-18-1`, the config#2003 suppression benched the autonomous loop for the rest of the multi-bug arc — bugs #3 (unbound var), #4 (krepis executionTimeout), #5 (envelope) all fell to the operator by structure, not choice.

## Change

- `RECOVERY_RERUN_NAME_PREFIXES` narrowed to `fast-path-rerun-` only (self-loop guard stays). A FAILED `watch-rerun-*` now dispatches a fresh agent like any other failure.
- Pile-on protection (the 2026-07-08 problem config#2003 originally fixed): the config#2269 per-day dispatch ceiling (dispatcher-authored counts, saturday=8) + the charter's same-error-two-attempts escalation rule.
- Tests rewritten to pin the new behavior: watch-rerun dispatches; fast-path still suppresses; post-escalation gating now depends only on `DISPATCH_AFTER_ESCALATION` / the ceiling. 75/75 pass locally.

## Companion operator action (same arc)

`EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=true` set on the live Lambda (operator-owned flag; `deploy.sh` preserves the live value on redeploys) — without it, any arc containing an `escalated` event (like today's) would still suppress post-escalation dispatch and defeat the ruling.

Umbrella charter work (agent merge-step, fast-path failure path, resume codification) tracked on alpha-engine-config — see the shepherd umbrella issue filed in the same turn.

Refs: alpha-engine-config#2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)
