### PR TITLE
fix(weekly-rag): guard null thesis_summary in signals ingestion (config#2938 follow-on)

### DIFF
--- a/rag/pipelines/ingest_theses.py
+++ b/rag/pipelines/ingest_theses.py
@@ -277,7 +277,13 @@ def ingest_signals_theses(
 
         for entry in universe:
             ticker = entry.get("ticker", "")
-            thesis = entry.get("thesis_summary", "")
+            # `dict.get(key, default)` returns the default ONLY when the key is
+            # ABSENT; an explicit JSON `null` yields None. Quant-envelope signals
+            # (stance_source="quant_envelope_producer") carry thesis_summary=null
+            # by design — no LLM narrative to embed — so `or ""` normalises
+            # null/absent to empty and the <50-char guard skips them cleanly
+            # instead of raising `len(None)` (config#2938 follow-on, 2026-07-18).
+            thesis = entry.get("thesis_summary") or ""
             if not ticker or len(thesis) < 50:
                 continue
 

--- a/tests/test_ingest_theses.py
+++ b/tests/test_ingest_theses.py
@@ -1,0 +1,100 @@
+"""Tests for the signals-thesis -> RAG ingest pipeline (``ingest_signals_theses``).
+
+Regression coverage for the config#2938 follow-on failure (2026-07-18): the
+weekly RAG-ingestion timeout fix let the pipeline reach Step 4/10 (Thesis
+history), which then crashed the *entire* 902-ticker ingestion with
+``TypeError: object of type 'NoneType' has no len()``.
+
+Root cause: the expanded universe is produced by the quant-envelope producer
+(``stance_source="quant_envelope_producer"``), which emits
+``thesis_summary: null`` for every entry -- there is no LLM narrative to embed.
+``entry.get("thesis_summary", "")`` returns the ``""`` default only when the
+key is ABSENT; an explicit JSON ``null`` returns ``None``, so ``len(thesis)``
+blew up. A null/absent thesis must be treated exactly like a too-short one:
+skipped, never crash.
+
+The test is hermetic: ``boto3`` and ``nousergon_lib.rag.*`` are stubbed via
+``sys.modules`` so it needs neither the AWS SDK nor the heavy lib.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from io import BytesIO
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _InMemoryS3:
+    """Minimal S3 client mock: signals/{date}/signals.json objects."""
+
+    def __init__(self, dates_to_payload: dict) -> None:
+        self._data = dates_to_payload
+
+    def list_objects_v2(self, *, Bucket, Prefix, Delimiter=None):
+        return {"CommonPrefixes": [{"Prefix": f"signals/{d}/"} for d in self._data]}
+
+    def get_object(self, *, Bucket, Key):
+        date_str = Key.split("/")[1]  # signals/{date}/signals.json
+        return {"Body": BytesIO(json.dumps(self._data[date_str]).encode())}
+
+
+@pytest.fixture
+def _stub_env(monkeypatch):
+    """Stub boto3 + nousergon_lib.rag.{embeddings,retrieval} so the pipeline's
+    in-function imports resolve without the AWS SDK or the heavy lib.
+    document_exists -> False; embed/ingest are unused in dry_run mode."""
+    retrieval = ModuleType("nousergon_lib.rag.retrieval")
+    retrieval.document_exists = MagicMock(return_value=False)
+    retrieval.ingest_document = MagicMock(return_value="doc-id")
+    embeddings = ModuleType("nousergon_lib.rag.embeddings")
+    embeddings.embed_texts = MagicMock(return_value=[[0.0]])
+    monkeypatch.setitem(sys.modules, "nousergon_lib.rag.retrieval", retrieval)
+    monkeypatch.setitem(sys.modules, "nousergon_lib.rag.embeddings", embeddings)
+
+    holder = {"s3": None}
+    boto3_stub = ModuleType("boto3")
+    boto3_stub.client = lambda *a, **k: holder["s3"]
+    monkeypatch.setitem(sys.modules, "boto3", boto3_stub)
+    return holder
+
+
+def _entry(ticker, thesis, **extra):
+    e = {"ticker": ticker, "signal": "HOLD", "score": 100.0}
+    e["thesis_summary"] = thesis  # explicit key so `null` round-trips as-is
+    e.update(extra)
+    return e
+
+
+def _run(holder, universe):
+    holder["s3"] = _InMemoryS3({"2026-07-18": {"universe": universe}})
+    from rag.pipelines.ingest_theses import ingest_signals_theses
+
+    return ingest_signals_theses(dry_run=True)
+
+
+def test_null_thesis_summary_skipped_not_crash(_stub_env):
+    """The exact 2026-07-18 shape: an all-null quant-envelope universe must be
+    skipped cleanly (0 ingested), not raise ``len(None)``."""
+    universe = [_entry(t, None, stance_source="quant_envelope_producer")
+                for t in ("MNST", "TMHC", "INCY", "EXEL", "ROKU")]
+    res = _run(_stub_env, universe)  # must not raise
+    assert res["signals_theses"] == 0
+
+
+def test_null_and_valid_theses_mixed(_stub_env):
+    """Null / absent / too-short theses are skipped; only a >=50-char thesis is
+    counted -- proving the guard still discriminates after the null fix."""
+    universe = [
+        _entry("MNST", None),                       # explicit JSON null (the bug)
+        {"ticker": "NOKEY", "signal": "BUY"},       # thesis_summary key ABSENT
+        _entry("SHORT", "too short"),               # <50 chars
+        _entry("BLANK", ""),                         # empty string
+        _entry("", "X" * 60),                        # empty ticker
+        _entry("AAPL", "A" * 60),                   # valid -> counted
+    ]
+    res = _run(_stub_env, universe)
+    assert res["signals_theses"] == 1  # AAPL only


### PR DESCRIPTION
## Root cause
The RAGIngestion timeout fix (PR #936, config#2938) let the weekly pipeline reach **Step 4/10 (Thesis history)**, which then crashed the *entire* 902-ticker ingestion:
```
File "rag/pipelines/ingest_theses.py", line 281, in ingest_signals_theses
    if not ticker or len(thesis) < 50:
TypeError: object of type 'NoneType' has no len()
```
The ~9x-expanded universe (2026-07-18: 902 tickers) is produced by the **quant-envelope producer** (`stance_source="quant_envelope_producer"`), which emits `thesis_summary: null` for **every** entry — quant-only signals with no LLM narrative to embed (`qual_score`/`sub_scores.qual` are also null). `entry.get("thesis_summary", "")` returns the `""` default **only for an ABSENT key**; an explicit JSON `null` returns `None`, so `len(thesis)` raised and killed thesis ingestion for all 902 tickers (Branch A → FailExecution). This surfaced on watch-rerun-2026-07-18-3 (Fleet-SF Watch attempt 3).

## The SOTA fix (correct layer)
Normalise `entry.get("thesis_summary") or ""`. A null/absent thesis is the **same 'no usable content' class** the existing `len(thesis) < 50` guard already skips — so it is skipped, not embedded. This is a HOW-it-runs robustness fix in the data/ingestion layer (Lane B/C), **not** a change to what the system believes: quant-envelope signals legitimately have no thesis text, and the pipeline already reports a thesis count (0 for a quant-only week is accurate).

## Fail-loud rationale
This is **not** a swallow. The ingester already silently skips theses under 50 chars; `null` is functionally identical (empty content). No genuine error or genuinely-absent-but-expected artifact is being hidden — there is simply no narrative to embed for a quant-envelope entry. Crashing the whole 902-ticker run on one legitimate null was the fragility bug; skipping is the designed behavior.

## Guard/test that now covers this class
New `tests/test_ingest_theses.py` (hermetic — `boto3` + `nousergon_lib.rag.*` stubbed via `sys.modules`, so it needs neither the AWS SDK nor the heavy lib):
- `test_null_thesis_summary_skipped_not_crash` — the exact all-null quant-envelope 902-shape → 0 ingested, no crash.
- `test_null_and_valid_theses_mixed` — null / absent-key / <50char / empty-ticker skipped; only a ≥50-char thesis counted (guard still discriminates).

## Deploy / rerun
Pure Python in the data repo; the weekly spot box `git clone --branch main` picks it up on rerun — **no deploy-infrastructure / SF-definition change needed**. Rerun follows via `scripts/weekly_sf_rerun.py` from the failed execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)