### PR TITLE
fix(sf): ReplayConcordance target_models -> deepseek/deepseek-v4-flash

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1804,14 +1804,14 @@
             },
             "ReplayConcordance": {
               "Type": "Task",
-              "Comment": "Weekly cheap-model concordance Lambda (ROADMAP P0, agent-justification gate signal #3). Replays each captured DecisionArtifact in the trailing 8-week window under the configured target model(s) via langchain_anthropic.with_structured_output against the canonical agent_schemas Pydantic contract; aggregates agreement_score per (agent_id_base, target_model); emits CW metric agent_cheap_model_concordance; persists per-target summary JSON to decision_artifacts/_replay_summary/{YYYY-MM-DD}/{target_model}.json. Default target: claude-haiku-4-5 (Sonnet→Haiku concordance ≈ \"is the larger model earning its cost?\"). Runs every Saturday after RationaleClustering.",
+              "Comment": "Weekly cheap-model concordance Lambda (ROADMAP P0, agent-justification gate signal #3). Replays each captured DecisionArtifact in the trailing 8-week window under the configured target model(s) via krepis.llm.LLMClient's OpenRouter transport (alpha-engine-config-I2997, 2026-07-19 -- migrated off langchain_anthropic.ChatAnthropic) against the canonical agent_schemas Pydantic contract; aggregates agreement_score per (agent_id_base, target_model); emits CW metric agent_cheap_model_concordance; persists per-target summary JSON to decision_artifacts/_replay_summary/{YYYY-MM-DD}/{target_model}.json. Default target: deepseek/deepseek-v4-flash (cheap-model concordance vs the champion's Anthropic-tier agents). Runs every Saturday after RationaleClustering.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-replay-concordance:live",
                 "Payload": {
                   "end_time_iso.$": "$$.Execution.StartTime",
                   "target_models": [
-                    "claude-haiku-4-5"
+                    "deepseek/deepseek-v4-flash"
                   ],
                   "window_days": 56,
                   "max_artifacts": 150,

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -656,7 +656,9 @@ class TestReplayConcordance:
     def test_payload_carries_required_fields(self, states):
         payload = states["ReplayConcordance"]["Parameters"]["Payload"]
         assert payload["end_time_iso.$"] == "$$.Execution.StartTime"
-        assert payload["target_models"] == ["claude-haiku-4-5"]
+        # alpha-engine-config-I2997 (2026-07-19): ReplayConcordance migrated
+        # off direct Anthropic to OpenRouter (deepseek/deepseek-v4-flash).
+        assert payload["target_models"] == ["deepseek/deepseek-v4-flash"]
         assert payload["window_days"] == 56
         assert payload["max_artifacts"] == 150
 


### PR DESCRIPTION
## Summary

Companion PR to `alpha-engine-config-I2997` (fleet-wide off-direct-Anthropic OpenRouter migration). The `ne-weekly-freshness-pipeline` Step Function hardcodes `ReplayConcordance`'s `target_models` payload to `["claude-haiku-4-5"]` in `infrastructure/step_function.json` — this literal overrides the `alpha-engine-replay-concordance` Lambda's own default.

Without this fix, merging the sibling **crucible-backtester** PR (which migrates `replay/runner.py` off `langchain_anthropic.ChatAnthropic` to `krepis.llm.LLMClient`'s OpenRouter transport) would be silently inert in production: every Saturday run would keep sending `"claude-haiku-4-5"` as an OpenRouter model id — not a valid OpenRouter slug — and every replay call would fail. The failure is caught non-blocking (per the state's existing `Catch` block), so the pipeline wouldn't halt, but the `agent_cheap_model_concordance` signal would silently go to zero successful replays — exactly the "several are behind non-blocking Catches (silent degradation)" risk `alpha-engine-config-I2997`'s own issue thread called out.

## Changes

- `infrastructure/step_function.json` — `ReplayConcordance` state's `target_models` → `["deepseek/deepseek-v4-flash"]`; Comment field updated to describe the OpenRouter transport.
- `tests/test_sf_eval_judge_wiring.py::TestReplayConcordance::test_payload_carries_required_fields` — updated the matching assertion.

## Model ID verification

`deepseek/deepseek-v4-flash` verified live against the OpenRouter models API and cross-checked against two independent live fleet configs (morning-signal's SSM config, crucible-research's `evals/judge_models.py::OPENROUTER_SHADOW`) in the same session as the sibling PRs.

## Testing

- `python3 -c "import json; json.load(open('infrastructure/step_function.json'))"` — valid JSON.
- `pytest tests/test_sf_eval_judge_wiring.py` — 76 passed.
- `pytest tests/test_sf_*.py tests/test_deploy_step_function*.py` (minimal venv, `pandas`/`pyyaml`/`boto3`/`nousergon-lib` installed) — 1106 passed; the only failures (3, in `test_sf_preflight.py`) are pre-existing and unrelated — they need the full `arcticdb` dependency this throwaway venv doesn't have, not something this PR touches.

## Sibling PRs (same `alpha-engine-config-I2997` arc)

- crucible-backtester: ReplayConcordance target-model invocation (**merge together with this one**)
- crucible-dashboard: morning-brief consumer
- crucible-research: single_agent challenger + eval-judge sync path

🤖 Generated with [Claude Code](https://claude.com/claude-code)