### PR TITLE
fix(sf): correct WeekdayPipelineSchedule cron hour for real PT timezone (12→5)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -307,12 +307,23 @@ Resources:
       # UTC cron on AWS::Events::Rule (no ScheduleExpressionTimezone support)
       # silently assumed PDT (UTC−7); during PST the effective PT start would
       # have shifted an hour earlier (i.e. MORE buffer, not less — benign,
-      # but not the documented 5:15 AM PT contract). EventBridge Scheduler
-      # now resolves the cron against America/Los_Angeles directly, so the
-      # 12:15 UTC-equivalent cron expression below auto-adjusts across the
-      # DST boundary and always fires at 5:15 AM PT.
+      # but not the documented 5:15 AM PT contract).
+      #
+      # CORRECTED 2026-07-20 (alpha-engine-data#<PR>): the 2026-07-14 deploy
+      # left the cron hour at the OLD bare-UTC value (12) while adding
+      # ScheduleExpressionTimezone. With ScheduleExpressionTimezone set,
+      # EventBridge Scheduler evaluates the cron fields AS LOCAL TIME IN THAT
+      # ZONE directly — it does NOT treat the expression as a UTC value to be
+      # DST-adjusted. `cron(15 12 ...)` + America/Los_Angeles therefore fired
+      # at 12:15 PM PT, not 5:15 AM PT — a ~7h miss that went undetected over
+      # the 7/18-7/19 weekend and first misfired live Mon 2026-07-20 (caught
+      # same day, recovered via a manual StartExecution; see
+      # nousergon/alpha-engine-config incident follow-up). Fix: author the
+      # cron hour directly in the target zone (5, not 12) — Scheduler's
+      # America/Los_Angeles resolution then makes it DST-aware for free
+      # across the PDT/PST boundary, same as StopTradingSchedule below.
       Description: Weekday 5:15 AM PT (DST-aware) — daily data + predictor + executor; daemon ready before 06:30 PT open
-      ScheduleExpression: 'cron(15 12 ? * MON-FRI *)'
+      ScheduleExpression: 'cron(15 5 ? * MON-FRI *)'
       ScheduleExpressionTimezone: 'America/Los_Angeles'
       FlexibleTimeWindow:
         Mode: 'OFF'


### PR DESCRIPTION
## Summary
- `WeekdayPipelineSchedule` (triggers `ne-preopen-trading-pipeline`) was migrated in #816 (2026-07-14) from a bare-UTC `AWS::Events::Rule` to `AWS::Scheduler::Schedule` with `ScheduleExpressionTimezone: America/Los_Angeles`, but the cron hour was left at the old UTC-authored value (`12`) instead of being re-authored directly in PT (`5`).
- `ScheduleExpressionTimezone` makes EventBridge Scheduler evaluate the cron fields **as local time in that zone directly** — it does not DST-adjust a UTC-authored expression. `cron(15 12 ...)` + `America/Los_Angeles` therefore fires at **12:15 PM PT**, not the documented/intended **5:15 AM PT**.
- First live misfire: Mon 2026-07-20 — caught same day before the bad 12:15 PM PT slot fired; today's preopen run was recovered via a manual `StartExecution` against `ne-preopen-trading-pipeline`.
- Fix: author the cron hour directly in the target zone (`5`, not `12`). This keeps the DST-aware benefit the #816 migration intended (auto-adjusts across the PDT/PST boundary) — same pattern already correct on `StopTradingSchedule` in this file.

## Test plan
- [x] `pytest tests/test_deploy_step_function_eventbridge_input.py tests/test_run_weekly_offcycle.py tests/test_sf_weekly_run_day_gate_wiring.py` — 26 passed (all tests referencing this CFN block)
- [x] Full suite run: pre-existing collection/failure count (121 failed / 46 errors, all missing-optional-dependency issues in this worktree venv — pyarrow, yfinance, etc.) confirmed unrelated to this change (comment + one YAML scalar edit, no Python touched)
- [ ] Brian: merge triggers `deploy-infrastructure.yml` (push-to-main auto-deploy) which re-applies the corrected schedule live — confirm Tue 2026-07-21 05:15 AM PT fires on time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rPYANRw6Mx5bEn9EAN11J