### PR TITLE
fix(scheduler): weekday preopen cron must be PT-local (05:15) under America/Los_Angeles tz

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -308,11 +308,18 @@ Resources:
       # silently assumed PDT (UTC−7); during PST the effective PT start would
       # have shifted an hour earlier (i.e. MORE buffer, not less — benign,
       # but not the documented 5:15 AM PT contract). EventBridge Scheduler
-      # now resolves the cron against America/Los_Angeles directly, so the
-      # 12:15 UTC-equivalent cron expression below auto-adjusts across the
-      # DST boundary and always fires at 5:15 AM PT.
+      # resolves the cron below against America/Los_Angeles directly, so it
+      # is written in LOCAL PT TIME (05:15), not UTC, and auto-adjusts
+      # across the DST boundary to always fire at 5:15 AM PT.
+      # INCIDENT 2026-07-20 (first weekday after the migration deployed):
+      # the migration originally kept the old UTC cron hour (15 12) while
+      # switching the timezone to America/Los_Angeles, which means 12:15 PM
+      # PT — the pipeline never fired pre-open and would have launched
+      # mid-trading-day instead. When pairing ScheduleExpressionTimezone
+      # with an expression, the expression must be converted to that zone's
+      # local time.
       Description: Weekday 5:15 AM PT (DST-aware) — daily data + predictor + executor; daemon ready before 06:30 PT open
-      ScheduleExpression: 'cron(15 12 ? * MON-FRI *)'
+      ScheduleExpression: 'cron(15 5 ? * MON-FRI *)'
       ScheduleExpressionTimezone: 'America/Los_Angeles'
       FlexibleTimeWindow:
         Mode: 'OFF'


### PR DESCRIPTION
## Incident (2026-07-20)

The preopen pipeline did not fire at its scheduled 5:15 AM PT today — the first weekday after the config#2413 migration (nousergon-data infrastructure, deployed to the live stack 2026-07-17) took effect. The migration moved the weekday trigger from `AWS::Events::Rule` to `AWS::Scheduler::Schedule` to get DST-aware PT scheduling, but kept the old **UTC** cron hour (`cron(15 12 ...)`) while setting `ScheduleExpressionTimezone: America/Los_Angeles` — which EventBridge Scheduler reads as **12:15 PM PT**, mid-trading-day. The template comment even asserted the '12:15 UTC-equivalent cron auto-adjusts', confirming the expression was never converted to local time.

## Fix

- `cron(15 12 ? * MON-FRI *)` → `cron(15 5 ? * MON-FRI *)` (5:15 AM PT local, DST-aware).
- Comment rewritten to state the expression is PT-local, with the incident note.
- `StopTradingSchedule` audited: already correct (`cron(0 22 ...)` = 10 PM PT as documented).

## Live state

The live schedule was already corrected in-session at 12:52 UTC via `aws scheduler update-schedule` (defusing today's 12:15 PM PT spurious fire). This PR converges the CFN source of truth so the next auto-deploy on merge does not revert the live fix. Merge-button-only: deploy-infrastructure.yml restamps the stack on merge; no post-merge manual step.

Today's missed run itself is being handled separately: operator recovery executions + the weekday sf-watch overseer agent (spot `i-0c17681b17c65cab0`) own the CodeFreshnessGate failure on the recovery run.

Tests: EventBridge/SF wiring suites (74 passed); no test pins the cron value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnQ1yxepLaWyBwq3p3Xibs