### PR TITLE
fix(sf): Evaluator SSM timeout 3600→7200 — sibling parity (weekly incident 2026-07-20, watch attempt 8)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -3472,13 +3472,13 @@
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
           "executionTimeout": [
-            "3600"
+            "7200"
           ],
           "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity{}',$.preflight_args))"
         },
-        "TimeoutSeconds": 3600
+        "TimeoutSeconds": 7200
       },
-      "TimeoutSeconds": 3660,
+      "TimeoutSeconds": 7260,
       "Retry": [
         {
           "ErrorEquals": [

--- a/tests/test_sf_evaluator_wiring.py
+++ b/tests/test_sf_evaluator_wiring.py
@@ -138,13 +138,20 @@ class TestEvaluatorTask:
         spot_cmd = next(c for c in cmds if "spot_backtest.sh" in c)
         assert "/var/log/evaluator.log" in spot_cmd
 
-    def test_timeout_is_60_min(self, states):
-        # Evaluator runtime is ~30 min for full mode (per evaluate.py
-        # historical runs). 3600s ceiling gives 2x headroom + bootstrap.
-        assert states["Evaluator"]["Parameters"]["TimeoutSeconds"] == 3600
+    def test_timeout_is_120_min_sibling_parity(self, states):
+        # 2026-07-20: the 3600s ceiling SIGKILLed (rc=137, exactly
+        # PT1H0.029S) a legitimately-working evaluator run — the eval body
+        # outgrew its hour once config#3031's deps fix let it actually run
+        # (bigger deps install + refreshed champion-feed parquet). Bumped to
+        # 7200s = parity with every sibling backtest-family stage
+        # (Backtester/PredictorBacktest/PortfolioOptimizerBacktest/Parity).
+        # Structural follow-up (universe-size-derived per-stage budgets):
+        # config#3095.
+        assert states["Evaluator"]["Parameters"]["Parameters"]["executionTimeout"] == ["7200"]
+        assert states["Evaluator"]["Parameters"]["TimeoutSeconds"] == 7200
         # SF state TimeoutSeconds wraps with +60s safety buffer (matches
         # Backtester's 7200/7260 ratio).
-        assert states["Evaluator"]["TimeoutSeconds"] == 3660
+        assert states["Evaluator"]["TimeoutSeconds"] == 7260
 
     def test_retry_mirrors_backtester_posture(self, states):
         # config#2279: both Evaluator and Backtester now carry the declared


### PR DESCRIPTION
## Incident

`watch-rerun-2026-07-18-10`'s Evaluator wrapper was SIGKILLed at exactly the 3600s SSM `executionTimeout` (rc=137, `PT1H0.029S`) while legitimately mid-assessment — the first run where the deps chain was fully healthy (crucible-backtester PR550 + PR551), so the eval body finally ran in full and outgrew its hour (larger consumer-declared deps install + refreshed champion-feed parquet). Overseer attempt 8 diagnosed this precisely and escalated (config#3095); the fix direction is the staged one: mechanical parity now, chokepoint later.

## Change

`infrastructure/step_function.json` Evaluator state: `executionTimeout` 3600→7200, SSM `TimeoutSeconds` 3600→7200, SF state `TimeoutSeconds` 3660→7260 — exact parity with Backtester/PredictorBacktest/PortfolioOptimizerBacktest/Parity (all 7200/7260; the Evaluator was the odd one out, missed by the PR936 bump family). Pin test updated to the new invariant with the incident note. No coverage/behavior change — the run simply gets the same budget as its siblings.

config#3095 (universe-size-derived per-stage timeout budgets, generalizing `fetch_budget.py`) remains open as the structural fix.

## Verification

- SF wiring suites: 1118 passed locally (the 2 `test_sf_preflight` backfill-freshness failures pre-exist on origin/main in this local env — import-artifact, CI is the arbiter).
- JSON valid; deploy is merge-button-only (`deploy-infrastructure.yml` restamps the SF definition on merge).
- Live gate: assessment-refresh rerun post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnQ1yxepLaWyBwq3p3Xibs