### PR TITLE
Freshness monitor: read champion pointer's real key (champion, not champion_arm) — config-I3086 follow-up

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -173,8 +173,9 @@ ALERTS_ENABLED = (
 #
 # 1. Rows may declare `critical_while_champion_arm: [<arm>, ...]` — effective
 #    severity is coerced to critical at probe time while the live champion
-#    pointer (config/producer_champion.json, field `champion_arm` — the same
-#    pointer crucible-executor's champion.py reads) names a listed arm. A
+#    pointer (config/producer_champion.json, schema_version-1 field
+#    `champion` — the same key crucible-executor's champion.py
+#    load_champion_pointer reads) names a listed arm. A
 #    pointer read failure coerces listed rows to critical too: fail toward
 #    paging, never toward silence.
 # 2. A severity=warning row confirmed-missing for WARNING_ESCALATION_RUNS
@@ -307,11 +308,15 @@ def _load_champion_arm(s3_client: Any) -> tuple[str | None, bool]:
     try:
         obj = s3_client.get_object(Bucket=REGISTRY_BUCKET, Key=CHAMPION_POINTER_KEY)
         pointer = json.loads(obj["Body"].read())
-        arm = pointer.get("champion_arm")
+        # schema_version-1 pointer key is `champion` (verified against the
+        # live object AND crucible-executor champion.py's own read —
+        # pointer["champion"]). The original I3086 patch read a
+        # `champion_arm` key that never existed in the pointer schema.
+        arm = pointer.get("champion")
         if isinstance(arm, str) and arm:
             return arm, False
         logger.warning(
-            "champion pointer at %s has no usable champion_arm field: %r",
+            "champion pointer at %s has no usable `champion` field: %r",
             CHAMPION_POINTER_KEY, pointer,
         )
         return None, True

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -1637,7 +1637,7 @@ def test_dynamic_severity_coerces_when_champion_arm_matches(fake_s3):
     specs, _r, arms = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
         index.CHAMPION_POINTER_KEY:
-            b'{"champion_arm": "scanner_predictor_direct"}',
+            b'{"schema_version": 1, "champion": "scanner_predictor_direct"}',
     })
     coerced_specs, coerced_ids = index.apply_dynamic_severity(
         fake_s3, specs, arms)
@@ -1652,7 +1652,7 @@ def test_dynamic_severity_not_coerced_for_other_arm(fake_s3):
     import index
     specs, _r, arms = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
-        index.CHAMPION_POINTER_KEY: b'{"champion_arm": "think_tank"}',
+        index.CHAMPION_POINTER_KEY: b'{"schema_version": 1, "champion": "think_tank"}',
     })
     coerced_specs, coerced_ids = index.apply_dynamic_severity(
         fake_s3, specs, arms)


### PR DESCRIPTION
Post-merge live verification of PR970 caught a wrong-key read: the schema_version-1 champion pointer carries the arm under **`champion`** (verified against the live S3 object and crucible-executor champion.py, which reads `pointer[\"champion\"]`). PR970 read `champion_arm` — a key that never existed — so every cycle took the fail-safe branch: listed rows coerced to critical unconditionally (the safe direction, but it would never de-escalate on a champion switch) plus a spurious per-cycle warning.

One-line fix + test fixtures updated to the real pointer shape (the fixtures now ARE the schema guard). 63 tests pass locally. Deploys on merge via deploy-freshness-monitor.yml; I will run a live cycle after merge to evidence the correct coercion log line.

Part of alpha-engine-config-I3086

🤖 Generated with [Claude Code](https://claude.com/claude-code)