### PR TITLE
Expense collector: cost_report amounts are cents, not dollars — config-I2840

### DIFF
--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -457,7 +457,13 @@ def collect_anthropic(mw: dict, budgets: dict, secrets: dict, s3, *,
             doc = _http_json(url + (f"&page={page}" if page else ""), headers)
             for bucket in doc.get("data", []):
                 for res in bucket.get("results", []):
-                    total += float(res.get("amount", 0) or 0)
+                    # cost_report `amount` is in CENTS (currency minor units),
+                    # not dollars — verified live 2026-07-20 against list
+                    # prices: 9.8M Haiku input tokens reported amount=981.60
+                    # (= $9.82 at $1/MTok), uniformly 100x across every line
+                    # item. Summing as USD overstated the row 100x
+                    # (alpha-engine-config-I2840).
+                    total += float(res.get("amount", 0) or 0) / 100.0
             pages += 1
             if not doc.get("has_more"):
                 break

--- a/infrastructure/lambdas/expense-collector/test_handler.py
+++ b/infrastructure/lambdas/expense-collector/test_handler.py
@@ -758,7 +758,8 @@ class TestReconcileAnthropic:
 
         def _fake_http(url, headers=None):
             seen_urls.append(url)
-            return {"data": [{"results": [{"amount": "3.50"}]}], "has_more": False}
+            # cost_report amounts are CENTS (config-I2840): 350 cents = $3.50
+            return {"data": [{"results": [{"amount": "350"}]}], "has_more": False}
 
         monkeypatch.setattr(index, "_http_json", _fake_http)
         prior_doc = {"providers": [{"key": "anthropic_api", "mtd_cost_usd": 3.0,
@@ -768,6 +769,23 @@ class TestReconcileAnthropic:
         assert row["actual_final"] == pytest.approx(3.50)
         assert "starting_at=2026-06-01" in seen_urls[0]
         assert "ending_before=2026-07-01" in seen_urls[0]
+
+    def test_admin_api_amounts_are_cents_not_dollars(self, monkeypatch):
+        """Regression for the 100x overstatement found live 2026-07-20
+        (config-I2840): cost_report `amount` is in currency minor units.
+        981.60 (cents) must land as $9.82, not $981.60."""
+        mw = index._month_window(NOW)
+
+        def _fake_http(url, headers=None):
+            return {"data": [{"results": [{"amount": "981.60"},
+                                          {"amount": "18.40"}]}],
+                    "has_more": False}
+
+        monkeypatch.setattr(index, "_http_json", _fake_http)
+        row = index.collect_anthropic(
+            mw, {}, {index.SSM_ANTHROPIC_ADMIN: "admin-key"}, None)
+        assert row["mtd_cost_usd"] == pytest.approx(10.0)
+        assert row["source"] == "admin_api"
 
     def test_fallback_bounds_to_full_prior_month_days(self, monkeypatch):
         """No admin key ⇒ client-telemetry fallback must sum through the


### PR DESCRIPTION
First live read through the newly-provisioned Admin API key (alpha-engine-config-I2840) showed the Anthropic row at **\$2,879 MTD** — uniformly **100x list price** on every line item (9.8M Haiku input tokens billed as \$981.60 vs \$9.82 at \$1/MTok; 40K Opus 4.8 output tokens as \$100.10 vs ~\$1.00; 190 one-cent web searches as \$190). The Admin API `cost_report` returns `amount` in **currency minor units (cents)**; the collector summed it as USD. Actual July spend: **\$28.79** — and with corrected units the fleet total (~\$319) is correctly under the \$353 budget, so the alert silence was right.

- `collect_anthropic`: divide `amount` by 100 (the reconcile path reuses this adapter).
- Reconcile test fixture corrected to cents; dedicated cents-not-dollars regression test added.
- 49 expense-collector tests pass locally. Deploys on merge via deploy-expense-collector.yml; I will re-invoke the collector post-merge and verify the row reads ~\$28.79 before closing I2840.

Part of alpha-engine-config-I2840

🤖 Generated with [Claude Code](https://claude.com/claude-code)