### PR TITLE
fix(sf): Evaluator passes --no-pit-parity — the one state that neither disabled nor owned pit_parity

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -3465,7 +3465,7 @@
     },
     "Evaluator": {
       "Type": "Task",
-      "Comment": "Evaluator on a separate spot instance (split from Backtester 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md). Reads s3://alpha-engine-research/backtest/{RUN_DATE}/ artifacts produced by the prior Backtester state and runs evaluate.py --mode all --upload, which sends the per-signal grading email and auto-applies optimizer configs. Reuses spot_backtest.sh with --skip-stages=backtest,parity; the script is the canonical dispatch surface (existing CSV vocabulary). Live-apply mode by default; for diagnostic-only off-cycle runs, invoke spot_backtest.sh manually with --freeze-evaluator and --skip-stages=backtest,parity.",
+      "Comment": "Evaluator on a separate spot instance (split from Backtester 2026-05-07 — plan: alpha-engine-docs/private/evaluator-split-260507.md). Reads s3://alpha-engine-research/backtest/{RUN_DATE}/ artifacts produced by the prior Backtester state and runs evaluate.py --mode all --upload, which sends the per-signal grading email and auto-applies optimizer configs. Reuses spot_backtest.sh with --no-pit-parity --skip-stages=backtest,parity; the script is the canonical dispatch surface (existing CSV vocabulary). --no-pit-parity added 2026-07-20 (matching the Backtester/PredictorBacktest/PortfolioOptimizerBacktest convention; Parity is pit_parity's designed owner via --pit-parity-enabled=1): it was the one stage NO SF state's skip-stages excluded, so it free-rode in every state and re-ran inside the Evaluator's budget whenever phase markers did not dedupe it — the config#2871 pit-parity sweep pass (no marker skip) ran a 2h predictor-sim walkforward inside the Evaluator and blew its ceiling twice (watch-rerun-2026-07-18-10/-11). pit_parity is produced by the earlier backtest-family states; the Evaluator only consumes backtest/{RUN_DATE}/pit_parity.json. Full single-producer decomposition: alpha-engine-config-I3112. Live-apply mode by default; for diagnostic-only off-cycle runs, invoke spot_backtest.sh manually with --freeze-evaluator and --skip-stages=backtest,parity.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
@@ -3474,7 +3474,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','set -a && source /home/ec2-user/.alpha-engine.env && set +a',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --no-pit-parity --skip-stages=backtest,parity{}',$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -31,7 +31,7 @@
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --no-pit-parity --skip-stages=backtest,parity"
   ],
   "MorningEnrich": [
     "set -eo pipefail",

--- a/tests/test_sf_evaluator_wiring.py
+++ b/tests/test_sf_evaluator_wiring.py
@@ -129,6 +129,19 @@ class TestEvaluatorTask:
         cmds = extract_commands(states["Evaluator"])
         spot_cmd = next(c for c in cmds if "spot_backtest.sh" in c)
         assert "--skip-stages=backtest,parity" in spot_cmd
+        # 2026-07-20: pit_parity was the ONE stage no SF state's flags
+        # excluded here — the three backtest states pass --no-pit-parity and
+        # Parity owns it via --pit-parity-enabled=1, but the Evaluator was
+        # forgotten, so the config#2871 pit-parity sweep (which does not
+        # marker-skip) re-ran a 2h predictor-sim walkforward inside the
+        # Evaluator's budget and SIGKILLed it twice
+        # (watch-rerun-2026-07-18-10/-11). Single-producer decomposition:
+        # alpha-engine-config-I3112.
+        assert "--no-pit-parity" in spot_cmd, (
+            "Evaluator must pass --no-pit-parity (Parity owns pit_parity); "
+            "without it the pit-parity sweep free-rides in the Evaluator's "
+            "timeout budget"
+        )
 
     def test_writes_to_evaluator_log(self, states):
         # Tee output into /var/log/evaluator.log so it's distinguishable

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -168,7 +168,7 @@ _SPOT_STATES = {
         "/var/log/parity.log",
     ),
     "Evaluator": (
-        "bash infrastructure/spot_backtest.sh --skip-stages=backtest,parity",
+        "bash infrastructure/spot_backtest.sh --no-pit-parity --skip-stages=backtest,parity",
         "/var/log/evaluator.log",
     ),
     # config#902: DriftDetection was collapsed — drift is now bundled onto the


### PR DESCRIPTION
## Root cause of the attempt-11 timeout (and the real reason attempt-10 overran)

Across the five backtest-family SF states, pit_parity's flags are: three backtest states `--no-pit-parity`, Parity `--pit-parity-enabled=1` (designed sole owner) — and the **Evaluator passed neither**, leaving pit_parity in scope there. Phase markers historically deduped it invisibly; the config#2871 pit-parity **sweep** pass (merged 2026-07-19, does not marker-skip) then ran a ~2h predictor-sim walkforward inside the Evaluator's budget: `watch-rerun-2026-07-18-10` died at the old 3600s ceiling and `-11` outran even the 7200s sibling-parity budget (verified live: the evaluator spot was mid `backtest.py --mode predictor-backtest --pit-parity` walkforward subprocess while the SF sat in CheckEvaluatorStatus).

## Change

Evaluator command += `--no-pit-parity` (sibling convention; Parity remains sole producer — its own flags unchanged, zero coverage loss in the normal flow). SF-state comment documents the incident. Evaluator wiring test now pins `--no-pit-parity` with the incident note; friday-shell byte-identical fixture updated.

This is the minimal single-producer correction; the full decomposition of the bundled Evaluator stage (every task its own SF step, per Brian's 2026-07-20 ruling) is alpha-engine-config-I3112, and the timeout chokepoint is config#3095.

## Verification

- SF wiring suites green locally except the 2 pre-existing `test_sf_preflight` local-env failures (CI is the arbiter).
- Merge-button-only deploy (deploy-infrastructure.yml restamps on merge). Live gate: assessment-refresh attempt 12 — with pit_parity out, the stage runs evaluate.py only (~30 min historical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnQ1yxepLaWyBwq3p3Xibs