### PR TITLE
fix(infra): codify 1800s VisibilityTimeout on nousergon-overseer-intake (alpha-engine-config-I2904)

### DIFF
--- a/infrastructure/setup_overseer_intake.sh
+++ b/infrastructure/setup_overseer_intake.sh
@@ -48,6 +48,27 @@ ALERT_RULE_NAME="overseer-intake-alert-events"
 CW_ALARM_RULE_NAME="overseer-intake-cw-alarm-state"
 RETENTION_SECONDS=1209600  # 14 days (SQS maximum)
 MAX_RECEIVE_COUNT=5
+# VisibilityTimeout (alpha-engine-config-I2904): the SQS default is 30s.
+# The charter's per-incident workflow (diagnose -> PR -> ledger -> THEN
+# delete) takes minutes by design (2026-07-17 first live drain: real
+# incidents ran multi-minute). At 30s, every real incident's message
+# re-became visible mid-processing, got re-pulled under a NEW receipt handle
+# (invalidating the one STEP 4 held), survived to MAX_RECEIVE_COUNT=5, and
+# landed in the DLQ misreported as a "dropped alert" it never was.
+# 1800s (30 min) is chosen as the p99 per-incident processing ceiling
+# (diagnose + open PR + write ledger record for one incident, observed
+# well under this in the 2026-07-17 drain) with headroom. It interacts with
+# MAX_RECEIVE_COUNT=5 (redrive to the DLQ) as follows: with the deterministic
+# ingest wrapper (scripts/alert_drain_ingest.py, alpha-engine-config)
+# `ChangeMessageVisibility`-heartbeating an incident that runs long, the
+# receive count only climbs on a GENUINE crash-loop / redelivery (the box
+# dying mid-incident before a heartbeat or the ledger write), never on a
+# false timeout expiry — so DLQ arrival keeps meaning "this incident
+# actually failed repeatedly," not "the timeout was too short." Applied
+# LIVE 2026-07-17 ~22:30 UTC (operator-authorized, ahead of this script
+# update); this codifies that live change so a future re-run of this
+# idempotent script doesn't drift back to the 30s default.
+VISIBILITY_TIMEOUT_SECONDS=1800
 
 DRY_RUN=0
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
@@ -88,15 +109,17 @@ DLQ_URL=$(aws sqs get-queue-url --queue-name "$DLQ_NAME" --region "$REGION" --qu
 DLQ_ARN="arn:aws:sqs:${REGION}:${ACCOUNT_ID}:${DLQ_NAME}"
 
 REDRIVE_POLICY="{\\\"deadLetterTargetArn\\\":\\\"${DLQ_ARN}\\\",\\\"maxReceiveCount\\\":\\\"${MAX_RECEIVE_COUNT}\\\"}"
-ensure_queue "$QUEUE_NAME" "{\"MessageRetentionPeriod\":\"${RETENTION_SECONDS}\",\"RedrivePolicy\":\"${REDRIVE_POLICY}\"}"
+ensure_queue "$QUEUE_NAME" "{\"MessageRetentionPeriod\":\"${RETENTION_SECONDS}\",\"RedrivePolicy\":\"${REDRIVE_POLICY}\",\"VisibilityTimeout\":\"${VISIBILITY_TIMEOUT_SECONDS}\"}"
 QUEUE_URL=$(aws sqs get-queue-url --queue-name "$QUEUE_NAME" --region "$REGION" --query QueueUrl --output text 2>/dev/null || echo "")
 QUEUE_ARN="arn:aws:sqs:${REGION}:${ACCOUNT_ID}:${QUEUE_NAME}"
 
-# Upsert retention + redrive on pre-existing queues too (idempotent re-runs
-# after parameter changes).
+# Upsert retention + redrive + visibility-timeout on pre-existing queues too
+# (idempotent re-runs after parameter changes — this is also what re-applies
+# VISIBILITY_TIMEOUT_SECONDS if it's ever hand-changed live and needs
+# reconciling back to the SSoT here).
 if [[ "$DRY_RUN" == "0" && -n "$QUEUE_URL" ]]; then
   aws sqs set-queue-attributes --queue-url "$QUEUE_URL" --region "$REGION" \
-    --attributes "{\"MessageRetentionPeriod\":\"${RETENTION_SECONDS}\",\"RedrivePolicy\":\"${REDRIVE_POLICY}\"}"
+    --attributes "{\"MessageRetentionPeriod\":\"${RETENTION_SECONDS}\",\"RedrivePolicy\":\"${REDRIVE_POLICY}\",\"VisibilityTimeout\":\"${VISIBILITY_TIMEOUT_SECONDS}\"}"
 fi
 
 # ── 3. Rule on the custom bus: krepis alert events → queue ──────────────────


### PR DESCRIPTION
## Summary

Deliverable 1 of `alpha-engine-config-I2904` — codifies the `nousergon-overseer-intake` SQS `VisibilityTimeout` fix in `infrastructure/setup_overseer_intake.sh` so the idempotent script no longer drifts the live queue back to the 30s AWS default.

## Background

The intake queue's `VisibilityTimeout` was the SQS 30s default — the setup script only ever set `MessageRetentionPeriod` + `RedrivePolicy`. The Overseer alert-drain charter's per-incident workflow (diagnose -> PR -> ledger -> THEN delete) takes minutes by design, with no `ChangeMessageVisibility` call — so every real incident's message re-became visible mid-processing, could be re-pulled under a new receipt handle (invalidating the held one), survived to `maxReceiveCount=5`, and landed in the DLQ misreported as a "dropped alert" it never was.

The live queue attribute was already set to 1800s on 2026-07-17 ~22:30 UTC (operator-authorized), per the tracking comment on `alpha-engine-config-I2904`. That fix was never reflected in this script, so the *next* idempotent re-run of `setup_overseer_intake.sh` would have silently reset it to the 30s default. This PR closes that gap.

## Change

- `infrastructure/setup_overseer_intake.sh`: added `VISIBILITY_TIMEOUT_SECONDS=1800`, included in both the `ensure_queue` create-path attrs and the idempotent upsert path (mirrors how retention/redrive are already handled).
- Comment documents why 1800s (p99 per-incident processing ceiling: diagnose + open PR + write ledger record for one incident) and its interaction with `maxReceiveCount=5`: with the new deterministic ingest wrapper (`scripts/alert_drain_ingest.py`, companion PR `alpha-engine-config-PR<TBD>`) `ChangeMessageVisibility`-heartbeating a long-running incident, the receive count only climbs on a genuine crash-loop, not a false timeout expiry — so DLQ arrival keeps meaning "actually failed repeatedly."

## Live verification (re-confirmed this session, 2026-07-21)

Ran the updated (non-dry-run) script to reconcile — idempotent, safe to run mid-drain per the script's own docs (queue policy/rules upserted, no messages touched):

```
$ aws sqs get-queue-attributes --queue-url https://sqs.us-east-1.amazonaws.com/711398986525/nousergon-overseer-intake \
    --region us-east-1 --attribute-names VisibilityTimeout RedrivePolicy MessageRetentionPeriod ApproximateNumberOfMessages --output json
{
    "Attributes": {
        "VisibilityTimeout": "1800",
        "RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:711398986525:nousergon-overseer-intake-dlq\",\"maxReceiveCount\":5}",
        "MessageRetentionPeriod": "1209600",
        "ApproximateNumberOfMessages": "27"
    }
}
```

`VisibilityTimeout=1800` confirmed live. (The 27 queued messages are the current unrelated drain backlog awaiting the next scheduled run — untouched by this change; visibility-timeout changes affect only future receives.)

## Test plan

- [x] `shellcheck --severity=error infrastructure/*.sh` — pass (all scripts, not just this one)
- [x] `bash -n infrastructure/setup_overseer_intake.sh` — syntax OK
- [x] `--dry-run` pass locally
- [x] Real (non-dry-run) run against live AWS — reconciled, verified above
- [x] No new pip deps; pure bash change

## Related

- Companion PR: `nousergon/alpha-engine-config` — deterministic ingest wrapper (`scripts/alert_drain_ingest.py`) + charter update (deliverable 2/3 of `alpha-engine-config-I2904`)
- Closes (partially — see companion PR for full closure): `alpha-engine-config-I2904`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
