### PR TITLE
Onboard alert-drain-dispatcher + substrate-health-gate alarms; add intake-queue age alarm (config-I2900/I2910)

### DIFF
--- a/infrastructure/attach_overseer_put_events_policy.sh
+++ b/infrastructure/attach_overseer_put_events_policy.sh
@@ -21,6 +21,24 @@
 # automatically — re-run this script (it is a no-op for already-attached
 # roles) or attach the managed policy in the role's own provisioning.
 #
+# alpha-engine-config-I2875/I2900 (2026-07-21): verified read-only that the
+# four roles I2875 named as missing the grant — alert-drain-dispatcher-role,
+# overseer-dispatcher-role, expense-collector-role, substrate-health-gate-role
+# — are ALL Lambda execution roles for functions whose FunctionName already
+# starts with "alpha-engine-", so step 2's existing wildcard enumeration
+# (`starts_with(FunctionName, 'alpha-engine-')`) already targets all four —
+# NO role-list change was needed here, only a re-run (see the apply manifest
+# on alpha-engine-data-PR<n>). Do NOT "fix" a future missing-role report by
+# hardcoding a static role list instead of re-running — that would silently
+# reintroduce the exact drift this script exists to close (the wildcard IS
+# the fix; a static list goes stale the moment the next Lambda is created).
+# Note: alpha-engine-overseer-dispatcher-role's OWN inline policy
+# (infrastructure/lambdas/overseer-dispatcher/iam-policy.json, Sid
+# IntakeBusEvents) already grants an equivalent events:PutEvents statement —
+# attaching the managed policy here is a harmless, redundant second path for
+# that one role, not a functional gap; the other three roles have no such
+# inline grant and functionally depend on this attach.
+#
 # Usage:
 #   ./infrastructure/attach_overseer_put_events_policy.sh [--dry-run] [extra-role-name ...]
 

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# setup_watch_plane_alarms.sh — CloudWatch Errors/Throttles alarms for the four
-# watch-plane Lambdas (config#2266).
+# setup_watch_plane_alarms.sh — CloudWatch Errors/Throttles alarms for the
+# watch/overseer-plane Lambdas (config#2266; roster extended config-I2900).
 #
 # Why this exists: the watch-plane Lambdas (saturday-sf-watch-dispatcher,
 # sf-watch-spot-dispatcher, ci-watch-dispatcher, sf-watch-liveness-probe) are
@@ -11,6 +11,17 @@
 # fail-loud raise in _write_watch_log (the PRIMARY watch record) failed
 # silently in practice. The watch's own failure mode was exactly the
 # unmonitored one. This script makes the docstring claim true.
+#
+# ONBOARDING CHECKLIST (config-I2900): alpha-engine-substrate-health-gate went
+# 3+ days (2026-07-14 -> 2026-07-17) and alpha-engine-alert-drain-dispatcher
+# went undetected even longer with ZERO alarm coverage simply because nobody
+# added their names to WATCH_PLANE_FUNCTIONS below when they were deployed —
+# the same class of miss, twice in a row. EVERY new watch/overseer-plane
+# Lambda (anything whose job is to detect, route, or drain fleet-failure
+# signals — dispatchers, probes, sentinels, drains, gates) MUST be added to
+# WATCH_PLANE_FUNCTIONS in the SAME PR that deploys it. This script has no way
+# to auto-discover "is this Lambda part of the failure-detection plane" —
+# that judgment call has to be made at review time.
 #
 # INDEPENDENT alerting channel: the watch plane IS a primary failure-detection
 # channel, so its own failures must page via the INDEPENDENT backstop topic
@@ -55,13 +66,17 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region 
 BACKSTOP_TOPIC_NAME="alpha-engine-alarm-backstop"
 BACKSTOP_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${BACKSTOP_TOPIC_NAME}"
 
-# The four watch-plane Lambdas (deployed names verified against each
+# The watch/overseer-plane Lambdas (deployed names verified against each
 # infrastructure/lambdas/<dir>/deploy.sh FUNCTION_NAME).
 # sf-watch-liveness-probe now carries ONLY its reclaim/sweep action paths
 # config#2270/#2257; the wiring checks moved to the registry-driven
 # overseer-liveness-probe per alpha-engine-config-I2831. Both stay under this
 # dead-probe backstop. (Comment kept OUT of the array literal below so the
 # tests/test_watch_plane_alarms_script.py block-parser isn't confused by a `)`.)
+# alert-drain-dispatcher (executes the twice-daily overseer-intake drain) and
+# substrate-health-gate (weekly-pipeline SsmDiskProbe gate) added config-I2900
+# — both were Active with zero alarm coverage; see the onboarding-checklist
+# comment above the header of this file.
 declare -A WATCH_PLANE_FUNCTIONS=(
   ["saturday-sf-watch-dispatcher"]="alpha-engine-saturday-sf-watch-dispatcher"
   ["sf-watch-spot-dispatcher"]="alpha-engine-sf-watch-spot-dispatcher"
@@ -69,6 +84,8 @@ declare -A WATCH_PLANE_FUNCTIONS=(
   ["sf-watch-liveness-probe"]="alpha-engine-sf-watch-liveness-probe"
   ["overseer-liveness-probe"]="alpha-engine-overseer-liveness-probe"
   ["overseer-dispatcher"]="alpha-engine-overseer-dispatcher"
+  ["alert-drain-dispatcher"]="alpha-engine-alert-drain-dispatcher"
+  ["substrate-health-gate"]="alpha-engine-substrate-health-gate"
 )
 
 echo "Configuring watch-plane Lambda alarms"
@@ -149,6 +166,57 @@ run aws cloudwatch put-metric-alarm \
   --evaluation-periods 1 \
   --datapoints-to-alarm 1 \
   --threshold 1 \
+  --comparison-operator "GreaterThanOrEqualToThreshold" \
+  --treat-missing-data "notBreaching" \
+  --alarm-actions "$BACKSTOP_TOPIC_ARN" \
+  --ok-actions "$BACKSTOP_TOPIC_ARN"
+
+# --- 4. Overseer intake queue age-of-oldest-message (alpha-engine-config-I2910)
+# The DLQ-depth alarm above only fires once EventBridge has delivered an
+# alert event, the queue received it, and processing failed 5x (redrive
+# exhaustion). It says NOTHING about the case where the twice-daily drain
+# (alert-drain-dispatcher, ~12h cadence) stops running entirely — schedule
+# disabled, dispatcher broken, spot launch failing (all previously-observed
+# failure modes): messages are never RECEIVED, so they never fail delivery
+# and never reach the DLQ. They would sit silently on the intake queue for up
+# to its 14-day MessageRetentionPeriod. ApproximateAgeOfOldestMessage closes
+# that detection gap.
+#
+# Threshold: 72000s (20h). Rationale (I2910 asks for "~18-24h, comfortably
+# above the 12h drain cadence"): under healthy operation the oldest message
+# is at most ~12h old right before a drain runs; if ONE drain cycle is
+# missed entirely, age climbs toward ~24h before the NEXT scheduled drain
+# would also miss it. 20h pages with margin before that second miss, while
+# staying safely above the ~12h healthy peak so ordinary cadence jitter
+# (a drain running a bit late) does not false-page.
+#
+# Gotcha (I2910): ApproximateAgeOfOldestMessage is computed only over
+# messages that are currently VISIBLE (never successfully received+deleted)
+# — a message currently leased in-flight to a consumer (i.e. mid-processing,
+# within its VisibilityTimeout window) does NOT count toward this metric.
+# Confirmed against the queue's own VisibilityTimeout=1800s (30 min): a
+# long-but-healthy drain run holding messages in-flight cannot itself trip
+# this alarm — it only reflects messages nobody has successfully picked up.
+#
+# Missing-data semantics: like the DLQ alarm, AWS/SQS emits no
+# ApproximateAgeOfOldestMessage datapoint when the queue is EMPTY (no
+# messages -> no age to report), so missing data is the healthy steady
+# state — notBreaching, not breaching.
+
+echo ""
+echo "==> Creating overseer intake queue age-of-oldest-message alarm..."
+run aws cloudwatch put-metric-alarm \
+  --region "$REGION" \
+  --alarm-name "alpha-engine-watch-plane-overseer-intake-age" \
+  --alarm-description "Watch-plane backstop: ApproximateAgeOfOldestMessage on nousergon-overseer-intake >= 72000s (20h) means the twice-daily alert-drain-dispatcher drain (~12h cadence) has missed at least one cycle and structured alert events (Overseer phase 1, alpha-engine-config-I2822) are sitting un-received, on track for the queue's 14-day retention ceiling. Complements the DLQ-depth alarm above, which only covers received-but-failing messages, not never-received ones (alpha-engine-config-I2910). Routes to the INDEPENDENT ${BACKSTOP_TOPIC_NAME} topic. Provisioned by infrastructure/setup_watch_plane_alarms.sh." \
+  --namespace "AWS/SQS" \
+  --metric-name "ApproximateAgeOfOldestMessage" \
+  --dimensions "Name=QueueName,Value=nousergon-overseer-intake" \
+  --statistic "Maximum" \
+  --period 300 \
+  --evaluation-periods 1 \
+  --datapoints-to-alarm 1 \
+  --threshold 72000 \
   --comparison-operator "GreaterThanOrEqualToThreshold" \
   --treat-missing-data "notBreaching" \
   --alarm-actions "$BACKSTOP_TOPIC_ARN" \

--- a/tests/test_attach_overseer_put_events_policy_script.py
+++ b/tests/test_attach_overseer_put_events_policy_script.py
@@ -1,0 +1,103 @@
+"""Pins attach_overseer_put_events_policy.sh (alpha-engine-config-I2822;
+role-coverage verified alpha-engine-config-I2875/I2900).
+
+The script's coverage of newly-created fleet roles depends entirely on it
+enumerating `alpha-engine-*` Lambda roles by WILDCARD (`list-functions` +
+`starts_with`), never a hardcoded role name list — a static list is exactly
+what goes stale the moment the next Lambda is deployed (this is the failure
+mode I2875 found live: 4 roles created since the script last ran had zero
+attachment). These tests pin that structural property plus the idempotency
+and dry-run mechanics the fix relies on.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "infrastructure" / "attach_overseer_put_events_policy.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _SCRIPT.read_text()
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT.is_file()
+    assert _SCRIPT.stat().st_mode & 0o111, "script must be chmod +x"
+
+
+def test_bash_syntax_is_valid():
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash not available")
+    result = subprocess.run([bash, "-n", str(_SCRIPT)], capture_output=True)
+    assert result.returncode == 0, result.stderr.decode()
+
+
+class TestWildcardRoleEnumeration:
+    """The structural fix for I2875: coverage of new roles must come from a
+    live wildcard query, never a hardcoded, driftable role list."""
+
+    def test_enumerates_by_wildcard_prefix(self, script_text):
+        assert "starts_with(FunctionName, 'alpha-engine-')" in script_text
+
+    def test_no_hardcoded_role_list(self, script_text):
+        # The four roles I2875 found missing must NOT appear in executable
+        # code (only in prose comments, which may reference them for
+        # provenance) — they are covered by the wildcard query above. A
+        # hardcoded list in the CODE would silently reintroduce the exact
+        # drift I2875/I2900 closed.
+        code_lines = "\n".join(
+            line for line in script_text.splitlines() if not line.strip().startswith("#")
+        )
+        for role in (
+            "alpha-engine-alert-drain-dispatcher-role",
+            "alpha-engine-overseer-dispatcher-role",
+            "alpha-engine-expense-collector-role",
+            "alpha-engine-substrate-health-gate-role",
+        ):
+            assert role not in code_lines, (
+                f"{role} must not be hardcoded in executable code — it is (and "
+                "must stay) covered by the wildcard `alpha-engine-*` Lambda-role "
+                "enumeration; a static list here is the drift I2875/I2900 fixed, "
+                "reintroduced."
+            )
+
+    def test_supports_extra_roles_for_non_lambda_grants(self, script_text):
+        # EC2/GHA-OIDC roles aren't Lambda functions, so they can't be swept
+        # by the wildcard — the script must still accept them explicitly.
+        assert "EXTRA_ROLES=" in script_text
+
+
+class TestIdempotency:
+    def test_policy_creation_checks_existence_first(self, script_text):
+        pos_check = script_text.find("aws iam get-policy")
+        pos_create = script_text.find("aws iam create-policy")
+        assert pos_check != -1 and pos_create != -1
+        assert pos_check < pos_create
+
+    def test_attach_checks_existing_attachment_first(self, script_text):
+        pos_check = script_text.find("list-attached-role-policies")
+        pos_attach = script_text.find("aws iam attach-role-policy")
+        assert pos_check != -1 and pos_attach != -1
+        assert pos_check < pos_attach
+
+
+class TestDryRun:
+    def test_supports_dry_run_flag(self, script_text):
+        assert '"${1:-}" == "--dry-run"' in script_text
+
+    def test_dry_run_gates_mutating_calls(self, script_text):
+        assert 'DRY_RUN == "1"' in script_text or '"$DRY_RUN" == "1"' in script_text
+
+
+class TestPolicyScope:
+    def test_policy_scoped_to_single_bus_action(self, script_text):
+        assert '"Action": "events:PutEvents"' in script_text
+        assert "nousergon-alerts" in script_text

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -1,7 +1,8 @@
-"""Pins the watch-plane Lambda alarm setup script (config#2266).
+"""Pins the watch-plane Lambda alarm setup script (config#2266; roster
+extended to 8 functions + an intake-queue age alarm by config-I2900/I2910).
 
 setup_watch_plane_alarms.sh puts CloudWatch Errors + Throttles alarms on each
-of the four watch-plane Lambdas — the components whose job is to notice fleet
+of the watch-plane Lambdas — the components whose job is to notice fleet
 failures, and whose own failures were previously the one unmonitored failure
 mode (docstrings claimed an "error metric + CW alarm" backstop that did not
 exist). These tests pin the load-bearing shape:
@@ -52,7 +53,7 @@ def test_bash_syntax_is_valid():
 
 
 class TestWatchPlaneCoverage:
-    """All six watch-plane Lambdas must be alarmed."""
+    """All eight watch-plane Lambdas must be alarmed."""
 
     @pytest.mark.parametrize(
         "fn_name",
@@ -66,6 +67,10 @@ class TestWatchPlaneCoverage:
             # assumes, same as the sibling probes.
             "alpha-engine-overseer-liveness-probe",
             "alpha-engine-overseer-dispatcher",
+            # Added config-I2900: both were Active with ZERO alarm coverage
+            # (the same "new Lambda, forgot to onboard it" miss, twice).
+            "alpha-engine-alert-drain-dispatcher",
+            "alpha-engine-substrate-health-gate",
         ],
     )
     def test_lambda_is_present(self, script_text, fn_name):
@@ -80,7 +85,7 @@ class TestWatchPlaneCoverage:
                 ")", script_text.find("declare -A WATCH_PLANE_FUNCTIONS=(")
             )
         ]
-        assert block.count('"alpha-engine-') == 6
+        assert block.count('"alpha-engine-') == 8
 
     def test_both_errors_and_throttles_alarmed(self, script_text):
         assert "for metric in Errors Throttles" in script_text
@@ -183,3 +188,48 @@ class TestOverseerIntakeDlqAlarm:
     def test_dlq_alarm_routes_to_backstop(self, script_text):
         dlq_block = script_text[script_text.find("overseer-intake-dlq-depth"):]
         assert '--alarm-actions "$BACKSTOP_TOPIC_ARN"' in dlq_block
+
+
+class TestOverseerIntakeAgeAlarm:
+    """The intake queue age-of-oldest-message alarm (alpha-engine-config-I2910)
+    — a dead drain never fails delivery, so it never reaches the DLQ; this is
+    the alarm that catches messages that were never received at all."""
+
+    def _age_block(self, script_text: str) -> str:
+        pos = script_text.find("overseer-intake-age")
+        assert pos != -1, "alpha-engine-watch-plane-overseer-intake-age alarm not found"
+        return script_text[pos:]
+
+    def test_age_alarm_present_and_targets_the_live_queue_not_the_dlq(self, script_text):
+        block = self._age_block(script_text)
+        assert "ApproximateAgeOfOldestMessage" in block
+        # Must target the live intake queue, NOT the DLQ (that's the point —
+        # a dead drain leaves messages on the live queue, never on the DLQ).
+        dims_line = block[block.find("--dimensions"): block.find("--dimensions") + 80]
+        assert "Value=nousergon-overseer-intake" in dims_line
+        assert "Value=nousergon-overseer-intake-dlq" not in dims_line
+
+    def test_age_alarm_routes_to_backstop(self, script_text):
+        block = self._age_block(script_text)
+        assert '--alarm-actions "$BACKSTOP_TOPIC_ARN"' in block
+        assert '--ok-actions "$BACKSTOP_TOPIC_ARN"' in block
+
+    def test_threshold_within_issue_band_18_to_24h(self, script_text):
+        # alpha-engine-config-I2910: "~18-24h, comfortably above the 12h
+        # drain cadence". Pin the threshold to that band in seconds.
+        block = self._age_block(script_text)
+        assert "--threshold 72000" in block
+        assert 18 * 3600 <= 72000 <= 24 * 3600
+
+    def test_age_alarm_missing_data_not_breaching(self, script_text):
+        block = self._age_block(script_text)
+        threshold_pos = block.find("--threshold 72000")
+        tail = block[threshold_pos:]
+        assert '--treat-missing-data "notBreaching"' in tail
+
+    def test_age_alarm_rides_alongside_dlq_alarm(self, script_text):
+        # I2910 explicitly asks for this alarm "alongside the existing DLQ
+        # alarm" in the same script, not a separate provisioning path.
+        assert script_text.find("overseer-intake-dlq-depth") < script_text.find(
+            "overseer-intake-age"
+        )


### PR DESCRIPTION
## Summary

Code-only PR covering two related monitoring-onboarding issues on
`nousergon/alpha-engine-config` (this repo has no native issue tracker for
them, so no auto-close — referenced below):

- **alpha-engine-config-I2900** — alert-drain-dispatcher + substrate-health-gate had ZERO CloudWatch alarm coverage (absorbs **alpha-engine-config-I2875** — the missing `nousergon-alerts-put-events` bus grant on 4 roles)
- **alpha-engine-config-I2910** — no age alarm on the intake queue itself, only on its DLQ

`https://github.com/nousergon/alpha-engine-config/issues/2900`
`https://github.com/nousergon/alpha-engine-config/issues/2910`
`https://github.com/nousergon/alpha-engine-config/issues/2875`

**No live AWS mutations were made in this session.** All verification below
used read-only AWS calls only (`describe-alarms`, `list-functions`,
`get-queue-attributes`, `list-attached-role-policies`, `list-role-policies`).
Live application is being performed in the same operator session that opens
this PR, per the apply manifest below — merging this PR requires no
post-merge steps.

## Changes

### 1. `infrastructure/setup_watch_plane_alarms.sh` (I2900 + I2910)

- Added `alert-drain-dispatcher` → `alpha-engine-alert-drain-dispatcher` and
  `substrate-health-gate` → `alpha-engine-substrate-health-gate` to
  `WATCH_PLANE_FUNCTIONS` (now 8 entries; each gets an Errors + Throttles
  alarm, both routed to the independent `alpha-engine-alarm-backstop` topic).
- Added an onboarding-checklist header comment: every new watch/overseer-plane
  Lambda MUST be added to `WATCH_PLANE_FUNCTIONS` in the same PR that deploys
  it — this is the second consecutive miss of exactly this kind
  (substrate-health-gate missed 2026-07-14→17; alert-drain-dispatcher missed
  even longer).
- Added a new alarm section (§4): `ApproximateAgeOfOldestMessage` on
  `nousergon-overseer-intake` (the live queue, not the DLQ), threshold
  **72000s (20h)**, `Maximum`/`Period=300`/`EvaluationPeriods=1`,
  `GreaterThanOrEqualToThreshold`, `TreatMissingData=notBreaching`, routed to
  the same backstop topic. Rationale and the in-flight-messages-excluded
  gotcha are documented inline in the script (I2910's exact concern).

### 2. `infrastructure/attach_overseer_put_events_policy.sh` (I2900/I2875)

**No functional/role-list code change was needed** — verified read-only that
all four roles I2875 named (`alpha-engine-alert-drain-dispatcher-role`,
`alpha-engine-overseer-dispatcher-role`, `alpha-engine-expense-collector-role`,
`alpha-engine-substrate-health-gate-role`) are Lambda execution roles for
functions whose `FunctionName` already starts with `alpha-engine-`, so the
script's **existing** wildcard enumeration
(`Functions[?starts_with(FunctionName, 'alpha-engine-')].Role`) already
targets all four. The gap is purely that the script hasn't been **re-run**
since these 4 Lambdas were created (confirmed: none of the 4 has any attached
managed policy today). Added a doc comment recording this verification and
explicitly warning against ever "fixing" a future missing-role finding by
hardcoding a static role list (that reintroduces the exact drift this script
exists to prevent) — plus a regression test asserting no such hardcoded list
exists.

Also noted: `overseer-dispatcher-role`'s own inline policy
(`infrastructure/lambdas/overseer-dispatcher/iam-policy.json`, Sid
`IntakeBusEvents`) already grants an equivalent `events:PutEvents` statement —
attaching the managed policy to that one role is a harmless, redundant second
path, not a functional gap. The other three roles have no such inline grant
and functionally need this attach.

### 3. Tests

- `tests/test_watch_plane_alarms_script.py` — extended `WATCH_PLANE_FUNCTIONS`
  coverage parametrize list + count assertion (6 → 8); added
  `TestOverseerIntakeAgeAlarm` (5 tests: alarm targets the live queue not the
  DLQ, routes to backstop, threshold in the 18-24h band, `notBreaching`, rides
  alongside the DLQ alarm in the same script).
- `tests/test_attach_overseer_put_events_policy_script.py` (new) — pins the
  wildcard-enumeration structural fix: syntax valid, wildcard prefix present,
  **no hardcoded role list** in executable code (the four I2875 roles must
  never appear outside a comment), `EXTRA_ROLES` support retained, idempotency
  ordering (existence-check before create/attach), dry-run support, policy
  scoped to the single bus ARN.

## Validation performed this session

- `bash -n` on both scripts: pass.
- `pytest tests/test_watch_plane_alarms_script.py
  tests/test_attach_overseer_put_events_policy_script.py`: 42/42 pass.
- Full repo suite (`pytest -q` from repo root, via the existing
  `alpha-engine-data/.venv`): **3515 passed, 8 skipped**, zero failures.

## Current-state verification (read-only, 2026-07-21)

- `alpha-engine-alert-drain-dispatcher` and `alpha-engine-substrate-health-gate`
  are both `State=Active`, `LastUpdateStatus=Successful`.
- `aws cloudwatch describe-alarms --alarm-name-prefix alpha-engine-watch-plane-`
  today lists alarms for only the original 6 functions + the DLQ alarm — **no**
  `-alert-drain-dispatcher-*` or `-substrate-health-gate-*` alarms exist.
- `nousergon-overseer-intake` queue attributes confirmed:
  `VisibilityTimeout=1800s`, `MessageRetentionPeriod=1209600s` (14d),
  `ApproximateNumberOfMessages=27` at check time, DLQ wired via
  `RedrivePolicy` (`maxReceiveCount=5`).
- `nousergon-alerts-put-events` managed policy exists (`AttachmentCount=35`).
  `list-attached-role-policies` on all 4 named roles returned **empty** (zero
  attached managed policies) — confirms the grant is genuinely missing on all
  four today.
- `list-role-policies` (inline) confirms `overseer-dispatcher-role` alone
  already carries an equivalent inline `PutEvents` grant; the other 3 do not.

## Other watch/overseer-plane candidates found (named, NOT added — out of scope)

Enumerated all 49 live `Active` `alpha-engine-*` Lambdas. Beyond the 8 now in
`WATCH_PLANE_FUNCTIONS`, the following self-describe (in their own docstrings)
as part of the fleet's failure-detection plane and are plausible next
onboarding candidates, but adding them wasn't authorized by I2900/I2910's
scope — filed as a separate follow-up rather than silently expanding this PR:

- `alpha-engine-pipeline-watchdog` — explicit "Step-Function watchdog"
- `alpha-engine-canary-replay-liveness-probe` — explicit "watchdog FOR the
  Saturday-replay canary"
- `alpha-engine-saturday-integrity-sentinel` — "Saturday-SF Watch, M4",
  independent Sat→Monday safeguard
- `alpha-engine-freshness-monitor` — "absence-driven S3 artifact monitor"
- `alpha-engine-sweep-artifact-monitor` — post-SF sweep-artifact validation

Lower-confidence / borderline (mentioned for completeness, not recommended
without human triage): `alpha-engine-eod-backstop` (a last-resort *actor*,
not a detector), `alpha-engine-changelog-cloudwatch-mirror` /
`alpha-engine-changelog-incident-mirror` (observability-adjacent mirrors, not
fleet-failure detectors), `alpha-engine-sf-telegram-notifier` (notification
relay). Filed as **alpha-engine-config-I3240**
(`https://github.com/nousergon/alpha-engine-config/issues/3240`) rather than
force-fitting into this PR's named scope.

## Apply manifest — exact operator commands, in order

All commands below are foreground, read-only-verified-safe, run from
`~/Development/alpha-engine-data` (the shared checkout — this is
provisioning/apply work, not a branch/commit operation, so no worktree
needed) against `us-east-1` / account `711398986525`.

```
git -C ~/Development/alpha-engine-data checkout main && git -C ~/Development/alpha-engine-data pull origin main
```

1. **Provision the alarms (idempotent — `put-metric-alarm` upserts by name; safe to re-run; script itself states "Safe to re-run"):**
```
bash ~/Development/alpha-engine-data/infrastructure/setup_watch_plane_alarms.sh
```

2. **Attach the missing PutEvents grant (idempotent — script checks `get-policy`/`list-attached-role-policies` before create/attach; a no-op for already-attached roles):**
```
bash ~/Development/alpha-engine-data/infrastructure/attach_overseer_put_events_policy.sh
```

### Read-only verification commands (run after both above)

3. **Confirm all 8 Lambda alarms + both SQS alarms exist:**
```
aws cloudwatch describe-alarms --region us-east-1 --alarm-name-prefix alpha-engine-watch-plane- --query 'MetricAlarms[].[AlarmName,StateValue]' --output table
```
Expect 16 Lambda alarms (8 functions × Errors/Throttles) + 2 SQS alarms
(`overseer-intake-dlq-depth`, `overseer-intake-age`) = 18 total, up from the
current 13.

4. **Confirm the two new Lambda alarms specifically:**
```
aws cloudwatch describe-alarms --region us-east-1 --alarm-name-prefix alpha-engine-watch-plane-alert-drain-dispatcher --query 'MetricAlarms[].AlarmName' --output text
aws cloudwatch describe-alarms --region us-east-1 --alarm-name-prefix alpha-engine-watch-plane-substrate-health-gate --query 'MetricAlarms[].AlarmName' --output text
```

5. **Confirm the intake age alarm:**
```
aws cloudwatch describe-alarms --region us-east-1 --alarm-names alpha-engine-watch-plane-overseer-intake-age --query 'MetricAlarms[0].[MetricName,Threshold,Dimensions]' --output json
```

6. **Confirm all 4 roles now carry the grant (closes I2875):**
```
for r in alpha-engine-alert-drain-dispatcher-role alpha-engine-overseer-dispatcher-role alpha-engine-expense-collector-role alpha-engine-substrate-health-gate-role; do echo "-- $r --"; aws iam list-attached-role-policies --role-name "$r" --query "AttachedPolicies[?PolicyName=='nousergon-alerts-put-events']" --output text; done
```
Each should print one line (the policy ARN) once attached.

7. **Sanity check via the attach script's own dry-run (should report every `alpha-engine-*` role, including the 4, as "already attached"):**
```
bash ~/Development/alpha-engine-data/infrastructure/attach_overseer_put_events_policy.sh --dry-run
```

## Closes when

- I2900: both Lambdas have live `-errors`/`-throttles` alarms routed to
  `alpha-engine-alarm-backstop` (verify with step 3/4 above); I2875's 4 roles
  all carry the grant (step 6).
- I2910: `alpha-engine-watch-plane-overseer-intake-age` alarm exists live
  (step 5), threshold documented (script comment + this PR body).
- I2875 closes **only after** step 2 has actually run and step 6 confirms all
  4 attachments live — do not close from this PR description alone.
