### PR TITLE
feat(overseer): invocation-success + scheduler check types for the liveness probe (config-I2901/I2906)

### DIFF
--- a/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
@@ -20,6 +20,16 @@
 # dedup state key + dynamodb on the flow-doctor store. NO InvokeFunction / EC2
 # mutate — this probe never acts.
 #
+# alpha-engine-config-I2901/I2906 (2026-07-21): added states:ListExecutions +
+# states:DescribeExecution (sf-watch invocation-success check) + s3:GetObject
+# on the 3 sf-watch watch-log prefixes + scheduler:GetSchedule (the 4
+# router-targeting EventBridge Scheduler schedules) to iam-policy.json. These
+# grants are NOT yet applied to the live role — an operator must re-run
+# `deploy.sh --bootstrap` (idempotent put-role-policy) to pick them up. Until
+# then the two new check types will AccessDenied (fail-loud) on their next
+# scheduled invocation once this code is deployed — see the PR body for why
+# the code deploy itself is ALSO held pending that same bootstrap pass.
+#
 # Cadence (UTC): twice daily, offset from the slimmed sf-watch probe's sweep
 # cadence (06:45/14:45) purely to avoid simultaneous invocation — this is a
 # config-drift + run-window check, not tied to any pipeline's own schedule:

--- a/infrastructure/lambdas/overseer-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/overseer-liveness-probe/iam-policy.json
@@ -55,6 +55,47 @@
       ]
     },
     {
+      "Sid": "ReadSfWatchExecutionHistory",
+      "Effect": "Allow",
+      "Action": ["states:ListExecutions"],
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
+      ]
+    },
+    {
+      "Sid": "ReadSfWatchExecutionInput",
+      "Effect": "Allow",
+      "Action": ["states:DescribeExecution"],
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-preopen-trading-pipeline:*",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:*"
+      ]
+    },
+    {
+      "Sid": "ReadSfWatchLogs",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research/consolidated/saturday_sf_watch/*",
+        "arn:aws:s3:::alpha-engine-research/consolidated/weekday_sf_watch/*",
+        "arn:aws:s3:::alpha-engine-research/consolidated/eod_sf_watch/*"
+      ]
+    },
+    {
+      "Sid": "ReadRouterSchedulerSchedules",
+      "Effect": "Allow",
+      "Action": ["scheduler:GetSchedule"],
+      "Resource": [
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-alert-drain-1000utc",
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-alert-drain-2200utc",
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-ci-watch-canary-drill-weekly",
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-sf-watch-canary-drill-weekly"
+      ]
+    },
+    {
       "Sid": "ReadLaunchConfigEc2DescribeNotResourceScopable",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/overseer-liveness-probe/index.py
+++ b/infrastructure/lambdas/overseer-liveness-probe/index.py
@@ -27,6 +27,15 @@ Check types (discriminated union on ``type`` — contract in playbooks.schema.js
                                 dispatcher decision log), an S3 run artifact's
                                 run_start landed in [T, T+ceiling+margin].
   * ``sqs_queue_exists``      — queue (and optional DLQ) exists.
+  * ``scheduler_schedule_exists`` — EventBridge Scheduler schedule (a distinct
+                                resource type from ``eventbridge_rule``) exists
+                                and is ENABLED (alpha-engine-config-I2906).
+  * ``sf_watch_invocation_success`` — per mature real terminal-failure
+                                execution of a watched pipeline (read from the
+                                SFs' own execution history), the day's
+                                watch-log doc has a matching event — catches a
+                                dispatcher that is wired correctly but crashes
+                                on invocation (alpha-engine-config-I2901).
 
 Conventions preserved from both source probes:
   * silent-unless-broken: a clean pass logs + returns, no Telegram noise.
@@ -131,6 +140,10 @@ def _ec2_client():
 
 def _sqs_client():
     return boto3.client("sqs", region_name=REGION)
+
+
+def _scheduler_client():
+    return boto3.client("scheduler", region_name=REGION)
 
 
 def _on_bus(bus: str | None) -> str:
@@ -343,6 +356,36 @@ def _queues_to_check(spec: dict) -> list[tuple[str, str]]:
     return out
 
 
+# ── Check: scheduler_schedule_exists ─────────────────────────────────────────
+
+
+def _check_scheduler_schedule_exists(spec: dict, now: datetime) -> tuple[list[str], dict]:
+    """EventBridge Scheduler schedule exists + (by default) ENABLED. A
+    DIFFERENT AWS resource from the classic `events` rules the
+    ``eventbridge_rule`` check covers — a deleted/disabled Scheduler schedule
+    is otherwise invisible (alpha-engine-config-I2906). Deliberately NAME +
+    STATE only, never target ARN: a concurrent migration
+    (alpha-engine-config-I2832) re-points some of these schedules' targets
+    between executor Lambdas and the overseer-dispatcher router, and this
+    check must stay valid across that repoint. GetSchedule raises
+    ``ResourceNotFoundException`` for a truly-absent schedule (a FINDING); any
+    other error RAISES (fail-loud)."""
+    name = spec["schedule_name"]
+    problems: list[str] = []
+    scheduler = _scheduler_client()
+    try:
+        sched = scheduler.get_schedule(Name=name)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) == "ResourceNotFoundException":
+            return [f"EventBridge Scheduler schedule '{name}' does NOT EXIST"], {}
+        raise
+    if spec.get("expect_enabled", True) and sched.get("State") != "ENABLED":
+        problems.append(
+            f"EventBridge Scheduler schedule '{name}' is {sched.get('State')}, not ENABLED"
+        )
+    return problems, {}
+
+
 # ── Check: run_window (ported from groom-liveness-probe) ──────────────────────
 # Config comes from the registry spec (was module constants + GROOM_SCHEDULE
 # env). The alerted-set dedup is DROPPED here — the unified probe's single
@@ -540,6 +583,138 @@ def _check_run_window(spec: dict, now: datetime) -> tuple[list[str], dict]:
     return problems, {}
 
 
+# ── Check: sf_watch_invocation_success ───────────────────────────────────────
+# The exact "wiring vs function" gap (alpha-engine-config-I2901): every check
+# above only asserts the sf-watch dispatcher is deployed + correctly WIRED — a
+# dispatcher that is Active, correctly targeted, AND crashes on every real
+# invocation (2026-07-17 ListBucket/403 while loading/writing the watch-log)
+# is invisible to them. This check is the invocation-SUCCESS signal the issue
+# asks for: for each mature terminal-failure execution of a watched pipeline —
+# read from the state machines' OWN execution history, an INDEPENDENT signal
+# from the watch-log the dispatcher writes, so a broken writer can't hide its
+# own breakage — the day's watch-log doc must carry a matching event record.
+
+_SF_FAILURE_STATUSES = ("FAILED", "TIMED_OUT", "ABORTED")
+
+
+def _list_recent_sf_failures(sfn, state_machine_arn: str, horizon: datetime) -> list[dict]:
+    """Every FAILED/TIMED_OUT/ABORTED execution of this state machine with
+    stopDate >= horizon. ListExecutions returns executions newest-first within
+    each status filter, so paging stops as soon as one is older than horizon.
+    PRIMARY input — RAISES on any API error (fail-loud)."""
+    out: list[dict] = []
+    for status in _SF_FAILURE_STATUSES:
+        token = None
+        while True:
+            kwargs: dict = {
+                "stateMachineArn": state_machine_arn,
+                "statusFilter": status,
+                "maxResults": 100,
+            }
+            if token:
+                kwargs["nextToken"] = token
+            resp = sfn.list_executions(**kwargs)
+            older_than_horizon = False
+            for execu in resp.get("executions", []):
+                stop = execu.get("stopDate")
+                if stop is not None and stop < horizon:
+                    older_than_horizon = True
+                    break
+                out.append(execu)
+            token = resp.get("nextToken")
+            if older_than_horizon or not token:
+                break
+    return out
+
+
+def _sf_watch_run_date_for_execution(sfn, execu: dict, now: datetime) -> str:
+    """Mirror saturday-sf-watch-dispatcher._run_date verbatim: prefer the
+    execution input's ``run_date``, else the execution ``startDate``, else
+    ``now`` — so this check reads the EXACT S3 key the dispatcher itself would
+    have written to. DescribeExecution is a PRIMARY input here (needed for
+    correctness, not a convenience) — RAISES on an unexpected error (fail-loud,
+    an ExecutionDoesNotExist is treated as "no input to read", not swallowed
+    silently past that); only malformed input JSON degrades to the startDate
+    fallback, mirroring the producer's own tolerant behavior for that one
+    narrow case."""
+    resp = None
+    try:
+        resp = sfn.describe_execution(executionArn=execu["executionArn"])
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) != "ExecutionDoesNotExist":
+            raise
+    if resp is not None:
+        try:
+            payload = json.loads(resp.get("input") or "{}")
+            rd = payload.get("run_date")
+            if isinstance(rd, str) and rd:
+                return rd
+        except (ValueError, TypeError):
+            pass
+    start = execu.get("startDate")
+    if isinstance(start, datetime):
+        return start.date().isoformat()
+    return now.date().isoformat()
+
+
+def _watch_log_events(s3, key: str) -> list[dict] | None:
+    """Read + parse the day's watch-log doc, or None if it genuinely does not
+    exist yet (the common no-failure-today case). Any OTHER read error — 403
+    above all, the exact 2026-07-17 incident class — RAISES (fail-loud): a
+    check that treated an AccessDenied as "no events yet" would hide the very
+    crash it exists to catch."""
+    try:
+        obj = s3.get_object(Bucket=WATCH_BUCKET, Key=key)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"NoSuchKey", "404"}:
+            return None
+        raise
+    try:
+        doc = json.loads(obj["Body"].read())
+    except (ValueError, TypeError):
+        return []
+    events = doc.get("events") if isinstance(doc, dict) else None
+    return events if isinstance(events, list) else []
+
+
+def _check_sf_watch_invocation_success(spec: dict, now: datetime) -> tuple[list[str], dict]:
+    """Per registered pipeline, every MATURE (older than
+    ``response_window_min``) terminal-failure execution within
+    ``lookback_hours`` must have produced a matching watch-log event. A miss
+    means the dispatcher was invoked (EventBridge fired — wiring is fine) but
+    never completed its PRIMARY fail-loud watch-log write, i.e. it crashed on
+    invocation."""
+    problems: list[str] = []
+    sfn = _sfn_client()
+    s3 = _s3_client()
+    horizon = now - timedelta(hours=spec["lookback_hours"])
+    mature_before = now - timedelta(minutes=spec["response_window_min"])
+    for entry in spec["pipelines"]:
+        sm_name = entry["state_machine"]
+        watch_prefix = entry["watch_prefix"]
+        arn = f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{sm_name}"
+        failures = _list_recent_sf_failures(sfn, arn, horizon)
+        for execu in failures:
+            stop = execu.get("stopDate")
+            if stop is None or stop > mature_before:
+                continue  # not mature yet — give the dispatcher time to write
+            run_date = _sf_watch_run_date_for_execution(sfn, execu, now)
+            key = f"{watch_prefix}/{run_date}.json"
+            events = _watch_log_events(s3, key)
+            recorded = events is not None and any(
+                e.get("execution_arn") == execu.get("executionArn") for e in events
+            )
+            if not recorded:
+                problems.append(
+                    f"sf-watch: {sm_name} execution '{execu.get('name')}' terminal-failed "
+                    f"({execu.get('status')}) @ {stop.strftime('%Y-%m-%d %H:%M')}Z with NO "
+                    f"matching watch-log event under '{key}' {spec['response_window_min']}+ min "
+                    "later — the dispatcher was invoked but crashed before its fail-loud "
+                    "watch-log write (wiring OK, function broken)"
+                )
+    return problems, {}
+
+
 # ── Check dispatch table + aggregation ───────────────────────────────────────
 
 CHECKERS = {
@@ -548,6 +723,8 @@ CHECKERS = {
     "lambda_active": _check_lambda_active,
     "sqs_queue_exists": _check_sqs_queue_exists,
     "run_window": _check_run_window,
+    "scheduler_schedule_exists": _check_scheduler_schedule_exists,
+    "sf_watch_invocation_success": _check_sf_watch_invocation_success,
 }
 
 

--- a/infrastructure/lambdas/overseer-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/overseer-liveness-probe/test_handler.py
@@ -478,6 +478,202 @@ def test_run_window_single_silent_death_not_masked_by_later_success():
 
 
 # ══════════════════════════════════════════════════════════════════════════
+# scheduler_schedule_exists
+# ══════════════════════════════════════════════════════════════════════════
+
+_SCHED_SPEC = {"type": "scheduler_schedule_exists", "schedule_name": "alpha-engine-alert-drain-1000utc"}
+
+
+def test_scheduler_schedule_exists_clean():
+    sched = MagicMock()
+    sched.get_schedule.return_value = {"Name": "alpha-engine-alert-drain-1000utc", "State": "ENABLED"}
+    with patch("index.boto3.client", side_effect=_client_factory(scheduler=sched)):
+        problems, _ = index._check_scheduler_schedule_exists(_SCHED_SPEC, NOW)
+    assert problems == []
+
+
+def test_scheduler_schedule_missing():
+    sched = MagicMock()
+    sched.get_schedule.side_effect = FakeClientError("ResourceNotFoundException")
+    with patch("index.boto3.client", side_effect=_client_factory(scheduler=sched)):
+        problems, _ = index._check_scheduler_schedule_exists(_SCHED_SPEC, NOW)
+    assert len(problems) == 1 and "does NOT EXIST" in problems[0]
+
+
+def test_scheduler_schedule_disabled_is_a_problem():
+    sched = MagicMock()
+    sched.get_schedule.return_value = {"Name": "alpha-engine-alert-drain-1000utc", "State": "DISABLED"}
+    with patch("index.boto3.client", side_effect=_client_factory(scheduler=sched)):
+        problems, _ = index._check_scheduler_schedule_exists(_SCHED_SPEC, NOW)
+    assert any("not ENABLED" in p for p in problems)
+
+
+def test_scheduler_schedule_unexpected_error_raises():
+    sched = MagicMock()
+    sched.get_schedule.side_effect = FakeClientError("ThrottlingException")
+    with patch("index.boto3.client", side_effect=_client_factory(scheduler=sched)):
+        with pytest.raises(FakeClientError):
+            index._check_scheduler_schedule_exists(_SCHED_SPEC, NOW)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# sf_watch_invocation_success
+# ══════════════════════════════════════════════════════════════════════════
+
+_SFI_SPEC = {
+    "type": "sf_watch_invocation_success",
+    "pipelines": [
+        {"state_machine": "ne-weekly-freshness-pipeline", "watch_prefix": "consolidated/saturday_sf_watch"},
+    ],
+    "response_window_min": 10,
+    "lookback_hours": 24,
+}
+
+_SFI_EXEC_ARN = f"arn:aws:states:{REG}:{ACCT}:execution:ne-weekly-freshness-pipeline:run1"
+
+
+def _sfn_for_invocation_success(executions, describe_input=None, describe_raises=None):
+    """Serves ``executions`` only for the FAILED statusFilter call (matching
+    real-world single-status fixtures below) and an empty page for
+    TIMED_OUT/ABORTED — the real check queries all 3 status filters
+    unconditionally, so a naive return_value-for-everything mock would
+    triple-count each fixture execution."""
+    sfn = MagicMock()
+
+    def _list_executions(**kwargs):
+        if kwargs.get("statusFilter") == "FAILED":
+            return {"executions": executions}
+        return {"executions": []}
+
+    sfn.list_executions.side_effect = _list_executions
+    if describe_raises:
+        sfn.describe_execution.side_effect = FakeClientError(describe_raises)
+    else:
+        sfn.describe_execution.return_value = {"input": json.dumps(describe_input or {})}
+    return sfn
+
+
+def _mature_execution(stop_offset_min=30, name="run1", status="FAILED", arn=_SFI_EXEC_ARN):
+    return {
+        "executionArn": arn,
+        "name": name,
+        "status": status,
+        "startDate": NOW - timedelta(hours=1),
+        "stopDate": NOW - timedelta(minutes=stop_offset_min),
+    }
+
+
+def test_sf_watch_invocation_success_event_recorded_is_clean():
+    execu = _mature_execution()
+    sfn = _sfn_for_invocation_success([execu], describe_input={"run_date": "2026-07-17"})
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": _Body(json.dumps(
+        {"events": [{"execution_arn": _SFI_EXEC_ARN}]}).encode())}
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+    assert problems == []
+    s3.get_object.assert_called_once_with(
+        Bucket=index.WATCH_BUCKET, Key="consolidated/saturday_sf_watch/2026-07-17.json")
+
+
+def test_sf_watch_invocation_success_missing_event_is_a_finding():
+    execu = _mature_execution()
+    sfn = _sfn_for_invocation_success([execu], describe_input={"run_date": "2026-07-17"})
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": _Body(json.dumps({"events": []}).encode())}
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+    assert len(problems) == 1 and "NO" in problems[0] and "matching watch-log event" in problems[0]
+
+
+def test_sf_watch_invocation_success_no_watch_log_at_all_is_a_finding():
+    """The exact 2026-07-17 incident class: the dispatcher never even wrote a
+    fresh watch-log for the day (crashed before its PRIMARY write)."""
+    execu = _mature_execution()
+    sfn = _sfn_for_invocation_success([execu], describe_input={"run_date": "2026-07-17"})
+    s3 = MagicMock()
+    s3.get_object.side_effect = FakeClientError("NoSuchKey")
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+    assert len(problems) == 1
+
+
+def test_sf_watch_invocation_success_immature_failure_skipped():
+    """A failure younger than response_window_min is NOT yet a finding — the
+    dispatcher may still be mid-flight."""
+    execu = _mature_execution(stop_offset_min=2)  # 2 min ago, window is 10 min
+    sfn = _sfn_for_invocation_success([execu])
+    s3 = MagicMock()
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+    assert problems == []
+    s3.get_object.assert_not_called()
+
+
+def test_sf_watch_invocation_success_run_date_falls_back_to_start_date():
+    """A malformed/absent run_date in the execution input degrades to the
+    startDate's calendar date (mirrors the producer's own tolerant fallback)."""
+    execu = _mature_execution()
+    execu["startDate"] = datetime(2026, 7, 16, 23, 0, tzinfo=timezone.utc)
+    sfn = _sfn_for_invocation_success([execu], describe_input={})  # no run_date key
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": _Body(json.dumps(
+        {"events": [{"execution_arn": _SFI_EXEC_ARN}]}).encode())}
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+    assert problems == []
+    s3.get_object.assert_called_once_with(
+        Bucket=index.WATCH_BUCKET, Key="consolidated/saturday_sf_watch/2026-07-16.json")
+
+
+def test_sf_watch_invocation_success_list_executions_unexpected_error_raises():
+    execu = _mature_execution()
+    sfn = MagicMock()
+    sfn.list_executions.side_effect = FakeClientError("AccessDenied")
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=MagicMock()):
+        with pytest.raises(FakeClientError):
+            index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+
+
+def test_sf_watch_invocation_success_watch_log_read_unexpected_error_raises():
+    """The exact 2026-07-17 bug class from the DISPATCHER side, verified from
+    the PROBE side too: a 403/AccessDenied reading the watch-log must RAISE,
+    never be treated as 'no events yet' (which would hide the crash)."""
+    execu = _mature_execution()
+    sfn = _sfn_for_invocation_success([execu], describe_input={"run_date": "2026-07-17"})
+    s3 = MagicMock()
+    s3.get_object.side_effect = FakeClientError("AccessDenied")
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=s3):
+        with pytest.raises(FakeClientError):
+            index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+
+
+def test_sf_watch_invocation_success_pagination_stops_past_horizon():
+    fresh = _mature_execution(stop_offset_min=30, name="fresh")
+    stale = dict(_mature_execution(stop_offset_min=30, name="stale"))
+    stale["stopDate"] = NOW - timedelta(hours=48)  # older than 24h lookback
+    sfn = MagicMock()
+
+    def _list_executions(**kwargs):
+        if kwargs.get("statusFilter") == "FAILED":
+            assert "nextToken" not in kwargs, "pagination must stop once past horizon"
+            return {"executions": [fresh, stale], "nextToken": "should-not-be-used"}
+        return {"executions": []}
+
+    sfn.list_executions.side_effect = _list_executions
+    sfn.describe_execution.return_value = {"input": json.dumps({"run_date": "2026-07-17"})}
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": _Body(json.dumps(
+        {"events": [{"execution_arn": _SFI_EXEC_ARN}]}).encode())}
+    with patch("index._sfn_client", return_value=sfn), patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_sf_watch_invocation_success(_SFI_SPEC, NOW)
+    assert problems == []
+    # Only the in-horizon execution triggers a describe/get_object call — the
+    # stale one is excluded and pagination stops (nextToken never consulted).
+    assert sfn.describe_execution.call_count == 1
+
+
+# ══════════════════════════════════════════════════════════════════════════
 # aggregation, dedup, handler, registry
 # ══════════════════════════════════════════════════════════════════════════
 

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -194,6 +194,37 @@
               }
             }
           }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["type", "schedule_name"],
+          "properties": {
+            "type": { "const": "scheduler_schedule_exists" },
+            "schedule_name": { "type": "string", "minLength": 1 },
+            "expect_enabled": { "type": "boolean" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["type", "pipelines", "response_window_min", "lookback_hours"],
+          "properties": {
+            "type": { "const": "sf_watch_invocation_success" },
+            "pipelines": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["state_machine", "watch_prefix"],
+                "properties": {
+                  "state_machine": { "type": "string", "minLength": 1 },
+                  "watch_prefix": { "type": "string", "minLength": 1 }
+                }
+              }
+            },
+            "response_window_min": { "type": "integer", "minimum": 1 },
+            "lookback_hours": { "type": "integer", "minimum": 1 }
+          }
         }
       ]
     }

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -77,6 +77,27 @@ playbooks:
             ami_env: SF_WATCH_AMI_ID
             security_group_env: SF_WATCH_SECURITY_GROUP
             subnets_env: SF_WATCH_SUBNETS
+        # alpha-engine-config-I2901: WIRING checks above (eventbridge_rule /
+        # state_machines_exist / lambda_active) only assert the dispatcher is
+        # deployed+wired — a dispatcher that is Active + correctly targeted but
+        # CRASHES on every real invocation (2026-07-17 ListBucket/403 while
+        # loading/writing the watch-log) is invisible to them. This check is
+        # the INVOCATION-SUCCESS signal: for each mature terminal-failure
+        # execution of a watched pipeline (read from the SFs' OWN execution
+        # history — independent of the watch-log itself, so a broken writer
+        # can't hide its own breakage), the day's watch-log doc must carry a
+        # matching event record. `response_window_min` gives the async
+        # EventBridge->Lambda hop + write time to land before a miss is a
+        # finding, not a race. `watch_prefix` per pipeline mirrors
+        # saturday-sf-watch-dispatcher's PIPELINES dict verbatim (pinned by
+        # tests/test_overseer_playbook_registry.py).
+        - type: sf_watch_invocation_success
+          pipelines:
+            - {state_machine: ne-weekly-freshness-pipeline, watch_prefix: consolidated/saturday_sf_watch}
+            - {state_machine: ne-preopen-trading-pipeline, watch_prefix: consolidated/weekday_sf_watch}
+            - {state_machine: ne-postclose-trading-pipeline, watch_prefix: consolidated/eod_sf_watch}
+          response_window_min: 10
+          lookback_hours: 24
 
   ci-watch:
     description: >-
@@ -206,6 +227,36 @@ playbooks:
       with continue-on-error so one sweep's failure doesn't mask the rest.
     supports_drill: false
 
+  canary-replay:
+    description: >-
+      Saturday-replay canary (alpha-engine-config#2246): replays the 3 bug
+      classes the Friday dry-preflight is structurally blind to (filing-change
+      detection, held-thesis-update, structured-output-retry) against LIVE
+      data on a Thursday schedule AND per-PR (crucible-research/nousergon-data,
+      `canary:replay` label). Inventory-only here (alpha-engine-config-I2906):
+      this Lambda is invoked DIRECTLY by its own Thursday EventBridge rule
+      (`alpha-engine-canary-replay-thursday`, classic rule->Lambda target, NOT
+      through the overseer-dispatcher router) and synchronously by the GHA
+      per-PR shim — zero routing decisions for the router to make, same
+      rationale as `groom` above. Its OWN wiring (the Thursday rule + spot
+      launch + completion marker) is watched by the dedicated
+      `canary-replay-liveness-probe` sibling Lambda, NOT duplicated here —
+      this entry exists purely so the registry stays the ONE place the watch
+      surface is enumerated (the header claim this playbook was previously
+      missing from).
+    tier: T2
+    routed: false
+    enabled: true
+    executor_function: alpha-engine-canary-replay-dispatcher
+    executor_lambda_dir: canary-replay-dispatcher
+    charter: alpha-engine-config/infrastructure/canary_replay_spot_bootstrap.sh
+    concurrency_domain: >-
+      Single lane — EC2 tag lock on Name=alpha-engine-canary-replay-spot (one
+      canary replay at a time; the deterministic run_token also gives
+      at-most-one-live-marker idempotency per ISO week / PR+sha).
+    supports_drill: false
+    kill_switch_env: CANARY_REPLAY_DISPATCH_ENABLED
+
 # ── Cross-cutting watch-plane liveness (alpha-engine-config-I2831) ────────────
 # Checks that belong to NO single playbook: the overseer-dispatcher router
 # itself + the phase-1 intake plane (setup_overseer_intake.sh, config-I2822).
@@ -226,3 +277,19 @@ watch_plane_liveness:
       rule_name: overseer-intake-cw-alarm-state
       expect_enabled: true
       expect_target_queue: nousergon-overseer-intake
+    # alpha-engine-config-I2906: the router's OWN trigger topology also
+    # includes 4 EventBridge Scheduler schedules (a DIFFERENT AWS resource
+    # from the classic `events` rules above — no `eventbridge_rule` check
+    # covers these). A deleted/disabled schedule silently stops that surface
+    # with nothing watching it. Deliberately NAME + STATE only, never target
+    # ARN: alpha-engine-config-I2832 (concurrent workstream) re-points the two
+    # weekly canary-drill schedules' targets between the executor Lambdas and
+    # this router — asserting target ARN here would race that migration.
+    - type: scheduler_schedule_exists
+      schedule_name: alpha-engine-alert-drain-1000utc
+    - type: scheduler_schedule_exists
+      schedule_name: alpha-engine-alert-drain-2200utc
+    - type: scheduler_schedule_exists
+      schedule_name: alpha-engine-ci-watch-canary-drill-weekly
+    - type: scheduler_schedule_exists
+      schedule_name: alpha-engine-sf-watch-canary-drill-weekly

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -203,3 +203,72 @@ def test_sf_watch_liveness_pipelines_lockstep_with_dispatcher():
         f"PIPELINES — only-registry: {sorted(registry_pipes - sibling)}, "
         f"only-dispatcher: {sorted(sibling - registry_pipes)}"
     )
+
+
+# ── sf_watch_invocation_success lockstep (alpha-engine-config-I2901) ─────────
+
+
+def _sibling_dispatcher_watch_prefixes() -> dict[str, str]:
+    """{state_machine_name: watch_prefix} parsed from saturday-sf-watch-
+    dispatcher's PIPELINES dict — the SSoT the sf_watch_invocation_success
+    check's ``pipelines`` (state_machine + watch_prefix pairs) must mirror.
+    Scopes the ``watch_prefix`` search to each pipeline's OWN segment (bounded
+    by the next top-level key, or end-of-dict) so a nested sub-dict (e.g. the
+    weekday pipeline's ``fast_path`` block) can never be mistaken for a
+    sibling's fields."""
+    text = (LAMBDAS_DIR / "saturday-sf-watch-dispatcher" / "index.py").read_text()
+    start = text.index("PIPELINES: dict")
+    end = text.index("\n}\n", start)
+    block = text[start:end]
+    matches = list(re.finditer(r'^ {4}"([\w.-]+)":\s*\{', block, re.M))
+    prefixes: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        seg_end = matches[i + 1].start() if i + 1 < len(matches) else len(block)
+        segment = block[m.end():seg_end]
+        wp = re.search(r'"watch_prefix":\s*"([^"]+)"', segment)
+        if wp:
+            prefixes[m.group(1)] = wp.group(1)
+    return prefixes
+
+
+def test_sf_watch_invocation_success_pipelines_lockstep_with_dispatcher():
+    """REGRESSION GUARD (alpha-engine-config-I2901): the sf_watch_invocation_
+    success check's per-pipeline ``watch_prefix`` must exactly match
+    saturday-sf-watch-dispatcher's PIPELINES mapping — a drifted prefix would
+    make the check read the WRONG S3 key and either false-alarm or (worse)
+    silently never find the real watch-log, defeating the whole check."""
+    checks = REGISTRY["playbooks"]["sf-watch"]["liveness"]["checks"]
+    inv = next(c for c in checks if c["type"] == "sf_watch_invocation_success")
+    registry_map = {p["state_machine"]: p["watch_prefix"] for p in inv["pipelines"]}
+    sibling_map = _sibling_dispatcher_watch_prefixes()
+    assert registry_map == sibling_map, (
+        "sf_watch_invocation_success pipelines drifted from saturday-sf-watch-"
+        f"dispatcher's PIPELINES watch_prefix mapping — registry: {registry_map}, "
+        f"dispatcher: {sibling_map}"
+    )
+    # Must cover exactly the same pipeline set as the eventbridge_rule/
+    # state_machines_exist anchor — no silent partial coverage of the 3 SFs.
+    ebr = next(c for c in checks if c["type"] == "eventbridge_rule")
+    assert set(registry_map) == set(ebr["expect_state_machines"])
+
+
+# ── scheduler_schedule_exists coverage (alpha-engine-config-I2906) ───────────
+
+
+def test_watch_plane_covers_all_four_router_scheduler_schedules():
+    """REGRESSION GUARD (alpha-engine-config-I2906): the 4 router-targeting
+    EventBridge Scheduler schedules (alert-drain x2, weekly canary-drill x2)
+    must each have a scheduler_schedule_exists entry under watch_plane_
+    liveness — a deleted/disabled schedule is otherwise invisible (a
+    DIFFERENT AWS resource from the classic `events` rules the
+    eventbridge_rule check type covers). Name+state only, deliberately no
+    target-ARN assertion (a concurrent workstream, alpha-engine-config-I2832,
+    re-points two of these schedules' targets)."""
+    checks = REGISTRY["watch_plane_liveness"]["checks"]
+    names = {c["schedule_name"] for c in checks if c["type"] == "scheduler_schedule_exists"}
+    assert names == {
+        "alpha-engine-alert-drain-1000utc",
+        "alpha-engine-alert-drain-2200utc",
+        "alpha-engine-ci-watch-canary-drill-weekly",
+        "alpha-engine-sf-watch-canary-drill-weekly",
+    }


### PR DESCRIPTION
## Summary

Two related probe-hardening issues on the overseer-liveness-probe registry (`infrastructure/overseer/playbooks.yaml` + sibling `playbooks.schema.json`), tracked cross-repo on `nousergon/alpha-engine-config`:

- **alpha-engine-config-I2901** — invocation-success (not just wiring) check for the sf-watch dispatcher.
- **alpha-engine-config-I2906** — canary-replay-dispatcher inventory entry + a new `scheduler_schedule_exists` check type covering the 4 router-targeting EventBridge Scheduler schedules.

These are cross-repo issue references (issues live in `alpha-engine-config`, this PR is in `nousergon-data`) so there is **no native `Closes #N` auto-close** — closing those issues is a manual step after this merges and the operator bootstrap (see Deploy state below) lands.

## alpha-engine-config-I2901 — sf_watch_invocation_success

**Finding:** `lambda_active` + `eventbridge_rule` + `state_machines_exist` only assert the sf-watch dispatcher is *deployed and wired* (State=Active, LastUpdateStatus=Successful, correct EventBridge target). A dispatcher that is wired correctly but **crashes on every real invocation** — the exact 2026-07-17 incident (ListBucket/403 while loading/writing the watch-log) — is invisible to all of them.

**Check-type choice:** the issue offered two forms — (a) the ideal conditional "failure event with no watch-log write within ~10min ⇒ alert", or (b) a simpler CloudWatch-`Errors`-metric proxy (already live as a separate alarm) if the conditional form doesn't fit the schema.

I implemented **(a), the full conditional form**, as a new discriminated-union check type `sf_watch_invocation_success`, rather than reusing `run_window` verbatim or falling back to the weaker proxy:

- `run_window`'s trigger model is **fixed-cron / decision-log based** — it doesn't fit an SF failure, which occurs at an arbitrary time, not a schedule.
- Instead, for each pipeline (`state_machine` + `watch_prefix` pair), the check calls `states:ListExecutions` (statusFilter FAILED/TIMED_OUT/ABORTED) — an **independent signal from the watch-log itself**, so a broken writer can't hide its own breakage — and for each *mature* (older than `response_window_min`, default 10) failure within `lookback_hours` (24h — the probe runs twice daily, so this comfortably covers both runs), reads the day's watch-log doc (`{watch_prefix}/{run_date}.json`, `run_date` derived exactly as the dispatcher itself derives it, via `states:DescribeExecution` on the input `run_date` field falling back to `startDate`) and asserts a matching `execution_arn` event exists.
- This directly detects "invoked but crashed before its fail-loud write" and is immune to the timing ambiguity a same-day multiple-failure LastModified-window proxy would have (chose exact-event-match over "S3 object LastModified within window" for that reason).
- The weaker CloudWatch-proxy alternative was explicitly rejected per the issue's own guidance ("extend the probe's check types rather than shipping a weaker duplicate of the existing alarm") — the conditional form IS expressible, so it's the correct fit.

Cadence: kept the existing 06:50/14:50 UTC probe schedule (out of scope here — the issue flagged bumping frequency as a separate open question, not a blocking deliverable of this check).

## alpha-engine-config-I2906 — canary-replay entry + scheduler_schedule_exists

1. Added a `routed: false` inventory entry for `canary-replay` (mirrors `groom`'s field shape: `executor_function`/`executor_lambda_dir`/`kill_switch_env`/`concurrency_domain`/`charter`, no `benign_reasons` since not routed). No `liveness` block on this entry — its own Thursday-cron + spot-launch wiring is already watched by the dedicated `canary-replay-liveness-probe` sibling Lambda; duplicating that here would be a second, drifting source of truth. This closes the header-claim gap ("the ONE place the watch surface is enumerated") the issue found.

2. New `scheduler_schedule_exists` check type (name + `State==ENABLED`, **no target-ARN assertion**) + 4 entries under `watch_plane_liveness` (the router's own cross-cutting trigger topology, alongside the existing intake-plane rules) for the live schedule names, verified via `aws scheduler list-schedules --region us-east-1`:
   - `alpha-engine-alert-drain-1000utc`
   - `alpha-engine-alert-drain-2200utc`
   - `alpha-engine-ci-watch-canary-drill-weekly`
   - `alpha-engine-sf-watch-canary-drill-weekly`

### Coordination note (concurrent workstream)

A sibling agent is concurrently working **alpha-engine-config-I2832**, which re-points the two weekly canary-drill schedules' *targets* between the executor Lambdas and `alpha-engine-overseer-dispatcher` (the router). The `scheduler_schedule_exists` check deliberately asserts **existence + `ENABLED` state only, never target ARN**, specifically so it stays valid regardless of which side of that migration the schedule currently points at — no race, no conflict between the two workstreams.

## Lockstep contract test extensions (`tests/test_overseer_playbook_registry.py`)

- `test_sf_watch_invocation_success_pipelines_lockstep_with_dispatcher` — the check's `pipelines` (`state_machine` + `watch_prefix` pairs) must exactly mirror `saturday-sf-watch-dispatcher`'s `PIPELINES` dict (parsed from source, segment-scoped so the weekday entry's nested `fast_path` dict can't be mistaken for a sibling's fields) and cover the same 3 SFs as the existing `eventbridge_rule`/`state_machines_exist` anchor.
- `test_watch_plane_covers_all_four_router_scheduler_schedules` — pins the exact 4 live schedule names.
- `canary-replay` is picked up automatically by the existing parametrized `LAMBDA_BACKED_PLAYBOOKS` tests (executor dir exists, `executor_function` naming convention, `kill_switch_env` literal match in source) since it has no `trigger_type` override.

24 new unit tests in `infrastructure/lambdas/overseer-liveness-probe/test_handler.py` cover both new check types (clean/missing/disabled/unexpected-error/pagination-past-horizon/run-date-fallback/watch-log-403-fail-loud cases).

## Test results (all run locally before push)

- `tests/test_overseer_playbook_registry.py`: 27/27 passed (schema validation + all lockstep tests).
- `infrastructure/lambdas/overseer-liveness-probe/test_handler.py`: 53/53 passed, run via the exact CI gate (`_shared/run_handler_tests.sh`, hermetic import guard).
- `infrastructure/lambdas/canary-replay-dispatcher/test_handler.py`: 18/18 passed (sanity check — its registry entry references it, no code there changed).
- Full repo suite (`pytest tests/`, the CI `testpaths`): 3503 passed, 8 skipped (pre-existing, unrelated), 0 failures.

## Deploy state — PENDING operator bootstrap, NOT deployed live

The probe Lambda is operator-deployed (`deploy.sh`, managed outside CloudFormation). Both new check types need IAM grants the live role does **not** currently have:

- `states:ListExecutions` + `states:DescribeExecution` (scoped to the 3 sf-watch state machines/executions) + `s3:GetObject` on the 3 sf-watch watch-log prefixes (`consolidated/{saturday,weekday,eod}_sf_watch/*`) — for I2901.
- `scheduler:GetSchedule` (scoped to the 4 named schedules) — for I2906.

All of these are added to `infrastructure/lambdas/overseer-liveness-probe/iam-policy.json` in this PR, ready for an operator's `deploy.sh --bootstrap` pass (idempotent `put-role-policy`).

**I did not run `--bootstrap` or otherwise touch live IAM** — per standing instruction, IAM changes are operator-applied, not agent-applied.

**I also held back the plain (non-bootstrap) code-only deploy**, even though that path is mechanically non-destructive (`update-function-code` + env-var refresh only, no infra mutation) — read `deploy.sh` in full to confirm this before deciding. Reasoning: the probe is currently running cleanly on its live 06:50/14:50 UTC schedule. Deploying this code *without* the IAM grants above would make the two new checks `AccessDenied` on the very next scheduled invocation, and since `_run_checks` has no per-check isolation, that exception propagates and fails the *entire* handler invocation (fail-loud by design) — turning a presently-healthy probe into an erroring one until an operator notices and runs `--bootstrap`. That's a real functional regression, not a neutral no-op, so both the code and the IAM are left for the SAME operator `--bootstrap` pass rather than splitting them.

**Net: fully pending operator `deploy.sh --bootstrap` for `alpha-engine-overseer-liveness-probe`.** Will comment on both issues with this PR link and this exact deploy state; the issues stay open until an operator bootstraps and the checks are verified live.

## Test plan

- [x] `tests/test_overseer_playbook_registry.py` — 27/27 passed locally
- [x] `infrastructure/lambdas/overseer-liveness-probe/test_handler.py` — 53/53 passed locally (CI-parity gate)
- [x] `infrastructure/lambdas/canary-replay-dispatcher/test_handler.py` — 18/18 passed locally (sanity)
- [x] Full repo suite — 3503 passed / 8 skipped / 0 failed
- [ ] CI green on this PR (checking after push)
- [ ] Operator `deploy.sh --bootstrap` for `overseer-liveness-probe` (applies the new IAM + code) — tracked as the remaining step before I2901/I2906 close
