### PR TITLE
feat(migrations): ArcticDB schema-migration framework + CI chokepoint (config-I3241 / config-I3238)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -1323,6 +1323,18 @@ def _daily_append_impl(
     if not dry_run:
         universe_lib = get_universe_lib(bucket)
         macro_lib = get_macro_lib(bucket)
+        # Schema-version pre-append assert (alpha-engine-config-I3241). Fail
+        # LOUD before touching any symbol if the persisted universe descriptor
+        # is not at the version this producer code emits — i.e. a
+        # schema-additive change was deployed without its data migration. This
+        # converts the config-I3236 failure (904/904 StreamDescriptorMismatch
+        # surfacing two layers downstream as an EOD reconcile RuntimeError) into
+        # a single actionable pre-flight error naming the pending migration.
+        # SchemaVersionMismatch is a RuntimeError subclass — it propagates
+        # (fail-loud), aborting the run before any partial write.
+        from migrations import assert_universe_schema_current
+
+        assert_universe_schema_current(bucket)
     else:
         universe_lib = None
         macro_lib = None

--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -69,6 +69,7 @@ from store.arctic_store import (
     PROVENANCE_COL as _CANONICAL_PROVENANCE_COL,
     get_universe_lib,
     get_macro_lib,
+    get_schema_meta_lib,
     to_arctic_canonical,
     to_arctic_safe,
 )
@@ -1331,10 +1332,12 @@ def _daily_append_impl(
         # surfacing two layers downstream as an EOD reconcile RuntimeError) into
         # a single actionable pre-flight error naming the pending migration.
         # SchemaVersionMismatch is a RuntimeError subclass — it propagates
-        # (fail-loud), aborting the run before any partial write.
+        # (fail-loud), aborting the run before any partial write. The meta lib
+        # is opened via get_schema_meta_lib (the mockable open-seam, mirroring
+        # get_universe_lib/get_macro_lib).
         from migrations import assert_universe_schema_current
 
-        assert_universe_schema_current(bucket)
+        assert_universe_schema_current(get_schema_meta_lib(bucket))
     else:
         universe_lib = None
         macro_lib = None

--- a/migrations/0000_baseline_universe_schema.py
+++ b/migrations/0000_baseline_universe_schema.py
@@ -1,0 +1,117 @@
+"""migrations/0000_baseline_universe_schema.py — the schema ANCHOR
+(alpha-engine-config-I3241 / I3238).
+
+This is not a data rewrite. It freezes the ``universe`` library's canonical
+column set AS OF the config-I3236 revert (2026-07-21, nousergon-data#985 —
+the known-good 94-column schema WITHOUT the reverted
+``sub_sector_vs_benchmark_5d/10d/20d`` columns) as schema version 0, and gives
+the migration chain and the CI chokepoint their starting point.
+
+Why a FROZEN literal and not ``canonical_universe_columns()`` live:
+    The whole point of the chokepoint (config-I3238) is to detect when the
+    live, code-derived schema DIVERGES from what the latest migration declares.
+    If this anchor derived its columns live, it could never diverge and the
+    gate would be inert. So the 94 names below are a hand-frozen snapshot; when
+    a feature column is later added, ``canonical_universe_columns()`` grows,
+    the chokepoint test goes red, and the author must add migration 0001 with a
+    NEW frozen ``columns_after`` (and a real data rewrite). That is the control.
+
+run():  stamps an EXISTING live library to v0 after asserting it already
+        conforms (no rewrite — the live universe IS the baseline). On a fresh /
+        empty library it simply stamps. Idempotent.
+verify(): asserts any present symbols conform to the frozen column set.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from migrations._base import Migration, MigrationError
+
+log = logging.getLogger(__name__)
+
+# ── The frozen 94-column canonical universe schema as of the I3236 revert ────
+# OHLCV(6) + source(1) + FEATURES(87). Captured from
+# store.arctic_store.canonical_universe_columns() at commit 0ebceee.
+BASELINE_COLUMNS: tuple[str, ...] = (
+    "Open", "High", "Low", "Close", "Volume", "VWAP", "source",
+    "rsi_14", "macd_cross", "macd_above_zero", "macd_line_last",
+    "price_vs_ma50", "price_vs_ma200", "momentum_20d", "avg_volume_20d",
+    "avg_volume_20d_raw", "dist_from_52w_high", "momentum_5d",
+    "rel_volume_ratio", "return_vs_spy_5d", "vix_level", "dist_from_52w_low",
+    "vol_ratio_10_60", "bollinger_pct", "sector_vs_spy_5d", "sector_vs_spy_10d",
+    "sector_vs_spy_20d", "yield_10y", "yield_curve_slope", "gold_mom_5d",
+    "oil_mom_5d", "vix_term_slope", "xsect_dispersion", "price_accel",
+    "ema_cross_8_21", "atr_14_pct", "realized_vol_20d", "volume_trend",
+    "obv_slope_10d", "rsi_slope_5d", "volume_price_div", "mom5d_x_vix",
+    "rsi_x_vix", "sector_x_trend", "atr_x_vix", "vol_trend_x_vix",
+    "earnings_surprise_pct", "days_since_earnings", "eps_revision_4w",
+    "revision_streak", "put_call_ratio", "iv_rank", "iv_vs_rv", "pe_ratio",
+    "pb_ratio", "debt_to_equity", "revenue_growth_yoy", "fcf_yield",
+    "gross_margin", "roe", "current_ratio", "revenue_growth_3y",
+    "eps_growth_3y", "payout_ratio", "dividend_yield", "capex_growth_5y",
+    "market_cap_raw", "return_60d", "return_120d", "overnight_return_5d",
+    "intraday_return_5d", "dist_from_5d_high", "dist_from_20d_high",
+    "beta_60d", "idio_vol_60d", "vol_of_vol_30d", "max_drawdown_60d",
+    "realized_vol_63d", "residual_momentum_ratio", "mom_12_1_pct",
+    "sector_mom_pct", "factor_momentum_ratio", "momentum_20d_zscore",
+    "return_60d_zscore", "beta_60d_zscore", "idio_vol_60d_zscore",
+    "realized_vol_63d_zscore", "dist_from_52w_high_zscore", "pe_ratio_zscore",
+    "roe_zscore", "size_zscore", "vwap_divergence_pct", "cmf_20_ratio",
+    "hy_oas_credit_spread_pct",
+)
+
+
+def _run(lib, meta_lib) -> None:
+    """Stamp an existing/live library to v0 after confirming it conforms.
+    No data rewrite — the live universe already IS the baseline schema."""
+    from store.schema_version import write_schema_version
+
+    symbols = list(lib.list_symbols())
+    for sym in symbols[:5]:
+        got = tuple(lib.read(sym).data.columns)
+        if got != BASELINE_COLUMNS:
+            raise MigrationError(
+                f"0000 baseline: symbol {sym!r} persisted columns {got} do NOT "
+                f"match the frozen baseline schema ({len(BASELINE_COLUMNS)} "
+                f"columns). The library is not at the anchor schema — a real "
+                f"forward migration is required, not a baseline stamp."
+            )
+    write_schema_version(
+        meta_lib, 0, migration_number=0, columns_after=BASELINE_COLUMNS
+    )
+    log.info(
+        "0000 baseline: stamped universe schema v0 (%d symbols already "
+        "conform, %d columns)",
+        len(symbols),
+        len(BASELINE_COLUMNS),
+    )
+
+
+def _verify(lib) -> None:
+    symbols = list(lib.list_symbols())
+    for sym in symbols[:5]:
+        got = tuple(lib.read(sym).data.columns)
+        if got != BASELINE_COLUMNS:
+            raise MigrationError(
+                f"0000 baseline verify: symbol {sym!r} columns {got} != frozen "
+                f"baseline"
+            )
+
+
+MIGRATION = Migration(
+    number=0,
+    name="baseline_universe_schema",
+    target_library="universe",
+    symbol_scope="all universe symbols (anchor only — no rewrite)",
+    schema_version_before=None,
+    schema_version_after=0,
+    columns_after=BASELINE_COLUMNS,
+    backfill_policy=(
+        "None — this is the anchor for the pre-existing live schema as of the "
+        "2026-07-21 config-I3236 revert. No columns added; no history touched."
+    ),
+    run=_run,
+    verify=_verify,
+    is_baseline=True,
+)

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -49,9 +49,11 @@ cannot be forgotten.
 - `migrations.pending_migrations(current)` → migrations with `.number > current`.
 - A runner discovers pending work mechanically:
   ```python
-  from store.schema_version import _open_meta_lib, read_schema_version, BASELINE_SCHEMA_VERSION
+  from store.arctic_store import get_schema_meta_lib, get_universe_lib
+  from store.schema_version import read_schema_version, BASELINE_SCHEMA_VERSION
   from migrations import pending_migrations
-  meta = _open_meta_lib(bucket)
+  meta = get_schema_meta_lib(bucket)
+  universe_lib = get_universe_lib(bucket)
   current = read_schema_version(meta)
   current = BASELINE_SCHEMA_VERSION if current is None else current
   for m in pending_migrations(current):

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,97 @@
+# ArcticDB schema migrations (`universe` data plane)
+
+Migrations-as-code for the `universe` ArcticDB library, closing the
+schema-change gap that caused the 2026-07-21 fleet-wide prod-down
+(alpha-engine-config-I3236). Framework: **alpha-engine-config-I3241**.
+Merge-blocking chokepoint: **alpha-engine-config-I3238**.
+
+## Why this exists
+
+A schema-changing PR has two halves:
+
+- the **code** (new feature columns in `features/feature_engineer.FEATURES` +
+  `features/registry.CATALOG` + `features/SCHEMA.md`) — ships on merge, and
+- the **data migration** (a one-time rewrite of the ~900 existing static-schema
+  `universe` symbols so their ArcticDB descriptor gains the new columns).
+
+`nousergon-data#742` shipped only the code half. The `universe` symbols are
+**static-schema**: the daily append-at-head path (`update_batch`) requires an
+identical descriptor, so the first append after merge failed 904/904 with
+`StreamDescriptorMismatch`, cascading to an EOD NAV-reconcile prod-down. Per
+the config#2459 lesson, **ArcticDB `update()` cannot cross an additive
+descriptor change — only a full `write()` rewrite can.** This framework makes
+the data half tested, discoverable code that lands with the schema change and
+cannot be forgotten.
+
+## The three enforcement legs
+
+1. **Migrations-as-code** (this directory). One numbered module per schema
+   change, each a `Migration` (see `_base.py`) with a `run(lib, meta_lib)`
+   (idempotent full-write rewrite) and a `verify(lib)` (post-conditions incl. a
+   live `update_batch` probe).
+2. **Data-plane version stamp** + **producer pre-append assert**
+   (`store/schema_version.py`). The `universe` data plane carries a monotonic
+   integer schema version; `builders/daily_append` asserts it matches
+   `migrations.EXPECTED_SCHEMA_VERSION` **before touching any symbol**, failing
+   loud and naming the pending migration instead of cascading mid-write.
+3. **CI chokepoint** (`tests/test_schema_migration_chokepoint.py`, config-I3238).
+   Diffs the live code-derived canonical schema against the latest migration's
+   declared `columns_after`; a schema-additive PR without a matching migration
+   fails a **required** check — un-mergeable by the groomer or a human.
+
+## Discovery contract (also used by the config-I3242 in-region runner)
+
+- Each migration is a module `migrations/NNNN_<slug>.py` (`NNNN` = zero-padded
+  monotonic int), exposing a module-level `MIGRATION` of type
+  `migrations.Migration`.
+- Leading-underscore modules (`_base.py`, `_template.py`) are **not** discovered.
+- `migrations.load_migrations()` → chain-validated list ordered by `.number`.
+- `migrations.pending_migrations(current)` → migrations with `.number > current`.
+- A runner discovers pending work mechanically:
+  ```python
+  from store.schema_version import _open_meta_lib, read_schema_version, BASELINE_SCHEMA_VERSION
+  from migrations import pending_migrations
+  meta = _open_meta_lib(bucket)
+  current = read_schema_version(meta)
+  current = BASELINE_SCHEMA_VERSION if current is None else current
+  for m in pending_migrations(current):
+      m.run(universe_lib, meta)
+      m.verify(universe_lib)
+  ```
+
+## Version-stamp location and its failure modes
+
+The stamp lives in a **dedicated `universe_schema_meta` ArcticDB library**
+(symbol `schema_version`), **not** as a reserved symbol inside `universe`.
+Reason: `nousergon_lib.arcticdb.get_universe_symbols()` returns
+`lib.list_symbols()` **unfiltered**, and that set is the fleet-wide tradable
+ticker roster (executor, backtester, predictor). A reserved symbol inside
+`universe` would leak into every consumer as a phantom ticker. Failure modes:
+
+| Situation | Behavior |
+|---|---|
+| Meta library absent/empty (legacy or fresh bucket) | `read_schema_version` → `None`; producers treat the library as **baseline v0** (it already conforms), so merging this framework does not brick a live-but-unstamped pipeline. The stamp is materialized when migration `0000` runs in-region. |
+| Crash between the data rewrite and the stamp | Migrations stamp **last**, only after `verify()` passes, and are idempotent — re-running re-verifies and re-stamps. |
+| Producer code older than the applied migrations | `assert_schema_version` raises (effective > expected) — the producer would emit fewer columns than persisted. Fix the code; never downgrade the library. |
+
+`EXPECTED_SCHEMA_VERSION` is **derived** from the chain (`max(number)`), never
+hand-kept — the Dockerfile-duplicate-pin drift bug class.
+
+## Authoring a migration
+
+Copy `_template.py` → `migrations/NNNN_<slug>.py` and follow its header. For a
+purely additive column-add the shared `_base.rewrite_symbols_full` /
+`verify_additive` helpers already encode the full-write-not-`update()` rule.
+The **backfill policy** for history rows of the new columns (NaN vs.
+retro-computed) is a reviewed decision recorded on the migration and in the PR.
+
+The one-time run against **live** data is executed **in-region** (write-heavy
+ArcticDB rule — never from a laptop) by the runner (config-I3242).
+
+## Baseline (`0000`)
+
+`0000_baseline_universe_schema.py` freezes the 94-column canonical schema as of
+the config-I3236 revert (the known-good schema **without** the reverted
+`sub_sector_vs_benchmark_*` columns) as version 0. It is the chokepoint's anchor
+and the chain's root; it performs **no** data rewrite (the live universe already
+is the baseline) — its `run()` only stamps after asserting conformance.

--- a/migrations/__init__.py
+++ b/migrations/__init__.py
@@ -1,0 +1,131 @@
+"""migrations — ArcticDB schema-migration framework for the ``universe`` data
+plane (alpha-engine-config-I3241, structural fix for the config-I3236 prod-down).
+
+Public API:
+    load_migrations()                 -> list[Migration]   (chain-validated)
+    latest_version()                  -> int
+    EXPECTED_SCHEMA_VERSION           : int   (== latest_version(), import-time)
+    pending_migrations(current)       -> list[Migration]
+    get_migration(number)             -> Migration
+    assert_universe_schema_current(bucket=None)            (producer pre-append)
+
+Discovery contract (also for the config-I3242 in-region runner): numbered
+modules ``migrations/NNNN_<slug>.py`` each expose a module-level ``MIGRATION``
+of type :class:`Migration`. See ``migrations/README.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+import re
+
+from migrations._base import Migration, MigrationError, validate_chain
+
+log = logging.getLogger(__name__)
+
+# ``NNNN_<slug>`` — the discovered-module naming rule. Leading-underscore
+# helpers (``_base``, ``_template``) are excluded by this pattern, so the
+# copy-me template is never mistaken for a real migration.
+_MODULE_RE = re.compile(r"^(\d{4})_[a-z0-9_]+$")
+
+
+def _discover_modules() -> list[str]:
+    names: list[str] = []
+    for mod in pkgutil.iter_modules(__path__):
+        if _MODULE_RE.match(mod.name):
+            names.append(mod.name)
+    return sorted(names)
+
+
+def load_migrations() -> list[Migration]:
+    """Import every numbered migration module, collect its ``MIGRATION``, sort
+    by number, and validate the chain (contiguous from the 0000 baseline,
+    monotonic versions). Raises ``MigrationError`` on any malformation."""
+    migrations: list[Migration] = []
+    for name in _discover_modules():
+        module = importlib.import_module(f"migrations.{name}")
+        if not hasattr(module, "MIGRATION"):
+            raise MigrationError(
+                f"migration module {name!r} exposes no module-level MIGRATION "
+                f"object (discovery contract violation)"
+            )
+        mig = module.MIGRATION
+        if not isinstance(mig, Migration):
+            raise MigrationError(
+                f"migration module {name!r}: MIGRATION is {type(mig).__name__}, "
+                f"expected migrations.Migration"
+            )
+        expected_number = int(name[:4])
+        if mig.number != expected_number:
+            raise MigrationError(
+                f"migration module {name!r}: MIGRATION.number ({mig.number}) "
+                f"does not match the filename prefix ({expected_number})"
+            )
+        migrations.append(mig)
+    migrations.sort(key=lambda m: m.number)
+    validate_chain(migrations)
+    return migrations
+
+
+def latest_version() -> int:
+    """The highest declared schema version = the schema the current producer
+    code must emit. Derived from the migration chain, never hand-kept (the
+    Dockerfile-duplicate-pin bug class)."""
+    return load_migrations()[-1].number
+
+
+def get_migration(number: int) -> Migration:
+    for m in load_migrations():
+        if m.number == number:
+            return m
+    raise MigrationError(f"no migration with number {number}")
+
+
+def pending_migrations(current_version: int) -> list[Migration]:
+    """Migrations a library at ``current_version`` still needs, in order.
+    Mechanical work-discovery for the in-region runner (config-I3242)."""
+    return [m for m in load_migrations() if m.number > current_version]
+
+
+#: The schema version the producer code in THIS checkout emits. Import-time
+#: derivation from the chain — a producer can never drift from its migrations.
+EXPECTED_SCHEMA_VERSION: int = latest_version()
+
+
+def assert_universe_schema_current(bucket: str | None = None) -> int:
+    """Producer pre-append guard: fail loud (before touching any symbol) unless
+    the live universe data plane is stamped at :data:`EXPECTED_SCHEMA_VERSION`.
+
+    Called by ``builders/daily_append`` (and, through it, the weekly collector)
+    right after opening the universe library. On mismatch raises
+    ``store.schema_version.SchemaVersionMismatch`` naming the pending
+    migration(s). Returns the effective version on success.
+    """
+    from store.schema_version import (
+        BASELINE_SCHEMA_VERSION,
+        _open_meta_lib,
+        assert_schema_version,
+        read_schema_version,
+    )
+
+    meta_lib = _open_meta_lib(bucket)
+    current = read_schema_version(meta_lib)
+    effective = BASELINE_SCHEMA_VERSION if current is None else current
+    pend = [m.number for m in pending_migrations(effective)]
+    return assert_schema_version(
+        meta_lib, EXPECTED_SCHEMA_VERSION, pending_migrations=pend
+    )
+
+
+__all__ = [
+    "Migration",
+    "MigrationError",
+    "load_migrations",
+    "latest_version",
+    "get_migration",
+    "pending_migrations",
+    "EXPECTED_SCHEMA_VERSION",
+    "assert_universe_schema_current",
+]

--- a/migrations/__init__.py
+++ b/migrations/__init__.py
@@ -94,23 +94,23 @@ def pending_migrations(current_version: int) -> list[Migration]:
 EXPECTED_SCHEMA_VERSION: int = latest_version()
 
 
-def assert_universe_schema_current(bucket: str | None = None) -> int:
+def assert_universe_schema_current(meta_lib) -> int:
     """Producer pre-append guard: fail loud (before touching any symbol) unless
     the live universe data plane is stamped at :data:`EXPECTED_SCHEMA_VERSION`.
 
     Called by ``builders/daily_append`` (and, through it, the weekly collector)
-    right after opening the universe library. On mismatch raises
+    right after opening the universe library, with the schema-meta library
+    opened via ``store.arctic_store.get_schema_meta_lib`` (the single mockable
+    S3 open-seam — this function performs no I/O of its own). On mismatch raises
     ``store.schema_version.SchemaVersionMismatch`` naming the pending
     migration(s). Returns the effective version on success.
     """
     from store.schema_version import (
         BASELINE_SCHEMA_VERSION,
-        _open_meta_lib,
         assert_schema_version,
         read_schema_version,
     )
 
-    meta_lib = _open_meta_lib(bucket)
     current = read_schema_version(meta_lib)
     effective = BASELINE_SCHEMA_VERSION if current is None else current
     pend = [m.number for m in pending_migrations(effective)]

--- a/migrations/_base.py
+++ b/migrations/_base.py
@@ -1,0 +1,266 @@
+"""migrations/_base.py — the ArcticDB schema-migration primitives
+(alpha-engine-config-I3241).
+
+A schema-changing PR has two halves: the *code* (ships on merge) and the
+*data migration* (historically an operator-remembered one-off — no control at
+all once the groomer auto-merges). This module makes the data half tested code
+that lives beside the schema change and is discoverable/executable mechanically.
+
+Discovery contract (also consumed by the config-I3242 in-region runner):
+    Each schema change is one numbered module ``migrations/NNNN_<slug>.py``
+    exposing a module-level ``MIGRATION`` of type :class:`Migration`.
+    ``migrations.load_migrations()`` returns them ordered by ``.number``;
+    ``migrations.pending_migrations(current)`` returns those with
+    ``.number > current``. A runner discovers pending work with
+    ``pending_migrations(read_schema_version(meta_lib) or BASELINE)``.
+
+The config#2459 lesson is baked into :func:`rewrite_symbols_full`: ArcticDB
+``update()`` throws ``StreamDescriptorMismatch`` on an additive schema change
+against an existing symbol; only a full ``write()`` rewrite can cross a
+descriptor change. Every additive migration therefore FULL-WRITES each symbol
+and then :func:`verify_additive` proves the production write primitive
+(``update_batch``) succeeds again post-migration.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+
+class MigrationError(RuntimeError):
+    """A migration chain is malformed, or a migration's run/verify failed.
+    Always raised (never swallowed) — a partial or unverifiable migration is a
+    data-integrity failure, not a warning."""
+
+
+@dataclass(frozen=True)
+class Migration:
+    """One schema change to the ``universe`` data plane.
+
+    Fields:
+      number                — monotonic int, MUST equal the ``NNNN`` filename
+                              prefix and ``schema_version_after``.
+      name                  — short human slug.
+      target_library        — the ArcticDB library the migration rewrites
+                              (``"universe"`` for every current case).
+      symbol_scope          — human description of which symbols run over
+                              (e.g. ``"all universe symbols"``).
+      schema_version_before — the version a library must be at to receive this
+                              migration; ``None`` only for the baseline (0000).
+      schema_version_after  — the version the library is stamped to on success.
+      columns_after         — the FROZEN canonical column set the library
+                              conforms to AFTER this migration. Frozen (not
+                              derived live) so the chokepoint can diff the live
+                              code-derived schema against the latest migration's
+                              declaration and detect an un-migrated column add.
+      backfill_policy       — explicit, human-readable, reviewed at PR time
+                              (e.g. "history rows: NaN; not retro-computable").
+      run                   — ``run(lib, meta_lib) -> None``; idempotent
+                              one-time migration. Stamps LAST.
+      verify                — ``verify(lib) -> None``; raises on any failed
+                              post-condition (column set, row-count sample,
+                              live ``update_batch`` probe).
+      is_baseline           — True only for 0000 (the anchor; no data rewrite).
+    """
+
+    number: int
+    name: str
+    target_library: str
+    symbol_scope: str
+    schema_version_before: int | None
+    schema_version_after: int
+    columns_after: tuple[str, ...]
+    backfill_policy: str
+    run: Callable[[Any, Any], None]
+    verify: Callable[[Any], None]
+    is_baseline: bool = False
+
+    def __post_init__(self) -> None:
+        if self.number != self.schema_version_after:
+            raise MigrationError(
+                f"migration {self.name!r}: number ({self.number}) must equal "
+                f"schema_version_after ({self.schema_version_after})"
+            )
+        if not self.columns_after:
+            raise MigrationError(
+                f"migration {self.name!r}: columns_after must be non-empty"
+            )
+        if len(set(self.columns_after)) != len(self.columns_after):
+            raise MigrationError(
+                f"migration {self.name!r}: columns_after has duplicate columns"
+            )
+
+
+def validate_chain(migrations: list[Migration]) -> None:
+    """Fail loud unless the migration list forms a contiguous, monotonic chain
+    anchored at the baseline (0000). Called by ``load_migrations``."""
+    if not migrations:
+        raise MigrationError(
+            "no migrations discovered — the baseline (0000) migration is "
+            "mandatory as the schema anchor"
+        )
+    first = migrations[0]
+    if first.number != 0 or not first.is_baseline:
+        raise MigrationError(
+            f"the first migration must be the baseline (number 0, "
+            f"is_baseline=True); got number={first.number}, "
+            f"is_baseline={first.is_baseline}"
+        )
+    if first.schema_version_before is not None:
+        raise MigrationError(
+            "the baseline migration must have schema_version_before=None"
+        )
+    for i, m in enumerate(migrations):
+        if m.number != i:
+            raise MigrationError(
+                f"migration numbers must be contiguous from 0; expected {i}, "
+                f"got {m.number} ({m.name!r}). Gaps/dupes break mechanical "
+                f"discovery."
+            )
+        if i > 0:
+            prev = migrations[i - 1]
+            if m.is_baseline:
+                raise MigrationError(
+                    f"only migration 0000 may be a baseline; {m.name!r} is not 0"
+                )
+            if m.schema_version_before != prev.schema_version_after:
+                raise MigrationError(
+                    f"migration {m.name!r} schema_version_before "
+                    f"({m.schema_version_before}) must equal the previous "
+                    f"migration's schema_version_after ({prev.schema_version_after})"
+                )
+
+
+# ── Shared additive-migration mechanism ──────────────────────────────────────
+# Reused by real additive migrations (0001+) and by the CI harness's synthetic
+# migration. The config#2459 full-write-not-update rule lives here so no
+# migration author can reintroduce the update()-across-descriptor bug.
+
+
+def rewrite_symbols_full(
+    lib,
+    *,
+    expected_columns: tuple[str, ...],
+    new_columns: dict[str, Any] | None = None,
+    project: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
+) -> int:
+    """FULL-WRITE every symbol in ``lib`` to the ``expected_columns`` schema.
+
+    This is the ONLY descriptor-crossing primitive (config#2459): each symbol's
+    complete history is read, widened with ``new_columns`` (name -> fill value;
+    e.g. ``np.nan`` for a not-retro-computable additive column), re-projected to
+    the canonical order via ``project`` (defaults to
+    ``store.arctic_store.to_arctic_canonical``), then written with
+    ``write_batch(prune_previous_versions=True)``. ``update()`` is deliberately
+    NOT used — it cannot evolve a static-schema descriptor.
+
+    Idempotent: re-running against already-migrated symbols re-derives the same
+    canonical frame and rewrites it in place. Returns the number of symbols
+    rewritten. Raises (fail-loud) if any symbol does not end at
+    ``expected_columns``.
+    """
+    from arcticdb.version_store.library import WritePayload
+
+    if project is None:
+        from store.arctic_store import to_arctic_canonical as project  # type: ignore
+
+    symbols = list(lib.list_symbols())
+    payloads = []
+    for sym in symbols:
+        df = lib.read(sym).data
+        if new_columns:
+            for col, fill in new_columns.items():
+                if col not in df.columns:
+                    # ``np.full`` preserves the fill scalar's dtype, so an
+                    # author who passes a TYPED fill (e.g. ``np.float32("nan")``
+                    # for a float32 feature column) lands the column at exactly
+                    # the dtype the producer emits. A bare Python/``np.nan``
+                    # scalar would upcast to float64 and re-introduce a
+                    # descriptor mismatch on the next real ``update_batch``
+                    # (whose feature columns are float32) — the exact trap this
+                    # dtype discipline prevents.
+                    df[col] = np.full(len(df), fill)
+        canonical = project(df)
+        got = tuple(canonical.columns)
+        if got != expected_columns:
+            raise MigrationError(
+                f"symbol {sym!r}: post-projection columns {got} != declared "
+                f"columns_after {expected_columns} — migration would persist a "
+                f"non-conforming descriptor. Aborting (fail-loud)."
+            )
+        payloads.append(WritePayload(symbol=sym, data=canonical))
+    if payloads:
+        results = lib.write_batch(payloads, prune_previous_versions=True)
+        errs = [r for r in results if "Error" in type(r).__name__]
+        if errs:
+            raise MigrationError(
+                f"write_batch reported {len(errs)} per-symbol error(s) during "
+                f"migration rewrite: {errs[:3]!r} ..."
+            )
+    return len(payloads)
+
+
+def verify_additive(
+    lib,
+    *,
+    expected_columns: tuple[str, ...],
+    project: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
+    sample: int = 5,
+) -> None:
+    """Post-migration verification (fail-loud). Asserts, on up to ``sample``
+    symbols: (1) the persisted column set equals ``expected_columns`` in order;
+    (2) row-count is preserved (non-empty); and (3) the PRODUCTION write
+    primitive ``update_batch`` — the config#2459 lesson — now appends a
+    next-day row cleanly (no ``StreamDescriptorMismatch``). The probe row is
+    removed afterward so verification leaves the data unchanged."""
+    from arcticdb.version_store.library import UpdatePayload
+
+    if project is None:
+        from store.arctic_store import to_arctic_canonical as project  # type: ignore
+
+    symbols = list(lib.list_symbols())
+    if not symbols:
+        raise MigrationError(
+            "verify_additive: no symbols present to verify — a migration that "
+            "silently ran over an empty library is suspicious; investigate."
+        )
+    for sym in symbols[:sample]:
+        item = lib.read(sym)
+        got = tuple(item.data.columns)
+        if got != expected_columns:
+            raise MigrationError(
+                f"verify: symbol {sym!r} persisted columns {got} != "
+                f"expected {expected_columns}"
+            )
+        if len(item.data) == 0:
+            raise MigrationError(f"verify: symbol {sym!r} lost all rows")
+
+        # Live update_batch probe — the exact production append primitive.
+        last = pd.Timestamp(item.data.index.max())
+        probe_ts = last + pd.Timedelta(days=1)
+        probe = item.data.iloc[[-1]].copy()
+        probe.index = pd.DatetimeIndex([probe_ts], name=item.data.index.name)
+        res = lib.update_batch(
+            [UpdatePayload(symbol=sym, data=project(probe))], upsert=True
+        )
+        if any("StreamDescriptorMismatch" in str(r) for r in res):
+            raise MigrationError(
+                f"verify: update_batch probe on {sym!r} STILL returns "
+                f"StreamDescriptorMismatch after migration — the rewrite did "
+                f"not evolve the descriptor (config#2459 regression): {res!r}"
+            )
+        # Remove the probe row so verification is side-effect-free: rewrite the
+        # symbol back to its pre-probe history.
+        healed = project(item.data)
+        from arcticdb.version_store.library import WritePayload
+
+        lib.write_batch(
+            [WritePayload(symbol=sym, data=healed)], prune_previous_versions=True
+        )

--- a/migrations/_template.py
+++ b/migrations/_template.py
@@ -1,0 +1,86 @@
+"""migrations/_template.py — COPY ME to author a new schema migration.
+
+This module is NOT a real migration: its leading underscore keeps it out of
+discovery (``migrations.load_migrations`` only imports ``NNNN_<slug>.py``).
+
+To add a schema change (e.g. re-land the reverted sub-sector features):
+
+  1. Copy this file to ``migrations/NNNN_<slug>.py`` where ``NNNN`` is the next
+     integer (zero-padded, e.g. ``0001_add_sub_sector_features.py``).
+  2. Set ``number`` == ``schema_version_after`` == that integer, and
+     ``schema_version_before`` == the previous migration's ``schema_version_after``.
+  3. Set ``columns_after`` to the FULL frozen canonical column set the library
+     will conform to AFTER this migration — the previous ``columns_after`` plus
+     your new columns, IN CANONICAL ORDER. Get it from
+     ``store.arctic_store.canonical_universe_columns()`` on your branch (after
+     you add the columns to ``feature_engineer.FEATURES`` + ``registry.CATALOG``
+     + ``SCHEMA.md``) and paste the literal here so it is frozen.
+  4. Fill ``backfill_policy`` with the reviewed decision for HISTORY rows of the
+     new columns (NaN vs. retro-computed) — this is a human/research call made
+     at PR time, not a default.
+  5. Keep ``run``/``verify`` as below for a purely additive column-add; the
+     shared helpers already encode the config#2459 full-write-not-update rule.
+  6. Adding the file makes the chokepoint test
+     (``tests/test_schema_migration_chokepoint.py``) go green again; the CI
+     migration harness proves an additive migration runs against a seeded LMDB
+     library. The one-time run against LIVE data is executed IN-REGION by the
+     runner (config-I3242) — never from a laptop (write-heavy ArcticDB rule).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from migrations._base import (
+    Migration,
+    rewrite_symbols_full,
+    verify_additive,
+)
+
+# EDIT: the full frozen canonical column set AFTER this migration.
+COLUMNS_AFTER: tuple[str, ...] = (
+    # ...previous migration's columns_after...,
+    # "my_new_column_pct",
+)
+
+# EDIT: the new columns this migration adds, mapped to their HISTORY fill value.
+# Use a TYPED fill matching the producer's emitted dtype — feature columns are
+# float32, so a not-retro-computable column takes ``np.float32("nan")``. A bare
+# ``np.nan`` (float64) would land the column at the wrong dtype and re-introduce
+# a StreamDescriptorMismatch on the next real update_batch (config#2459 trap).
+NEW_COLUMNS = {
+    # "my_new_column_pct": np.float32("nan"),   # not retro-computable -> NaN
+}
+
+
+def _run(lib, meta_lib) -> None:
+    from store.schema_version import write_schema_version
+
+    rewrite_symbols_full(
+        lib, expected_columns=COLUMNS_AFTER, new_columns=NEW_COLUMNS
+    )
+    # Stamp LAST, only after the rewrite completes.
+    write_schema_version(
+        meta_lib,
+        MIGRATION.schema_version_after,
+        migration_number=MIGRATION.number,
+        columns_after=COLUMNS_AFTER,
+    )
+
+
+def _verify(lib) -> None:
+    verify_additive(lib, expected_columns=COLUMNS_AFTER)
+
+
+MIGRATION = Migration(
+    number=-1,  # EDIT to NNNN
+    name="template_do_not_use",
+    target_library="universe",
+    symbol_scope="all universe symbols",
+    schema_version_before=-1,  # EDIT to previous schema_version_after
+    schema_version_after=-1,  # EDIT to NNNN (== number)
+    columns_after=COLUMNS_AFTER or ("placeholder",),
+    backfill_policy="EDIT: reviewed NaN-vs-recompute decision for history rows",
+    run=_run,
+    verify=_verify,
+)

--- a/store/arctic_store.py
+++ b/store/arctic_store.py
@@ -124,6 +124,28 @@ def get_macro_lib(bucket: str | None = None) -> adb.library.Library:
     return open_macro_lib(bucket, create_if_missing=True)
 
 
+#: Dedicated library holding the ``universe`` data-plane schema-version stamp
+#: (alpha-engine-config-I3241). Kept OUT of the ``universe`` library so it never
+#: pollutes the fleet-wide ticker roster ``get_universe_symbols()`` returns
+#: (``list_symbols()`` is unfiltered) — see ``store/schema_version.py``.
+SCHEMA_META_LIB = "universe_schema_meta"
+
+
+def get_schema_meta_lib(bucket: str | None = None) -> adb.library.Library:
+    """Get the ``universe_schema_meta`` library that carries the universe data
+    plane's schema-version stamp (alpha-engine-config-I3241).
+
+    Routed through the same ``_get_arctic`` connection singleton + canonical URI
+    as every other library. ``create_if_missing=True`` so a fresh bucket
+    bootstraps cleanly (an unstamped/absent stamp is read as baseline v0 — see
+    ``store.schema_version.assert_schema_version``). This is the single
+    mockable open-seam producers use, mirroring ``get_universe_lib`` /
+    ``get_macro_lib``.
+    """
+    arctic = _get_arctic(bucket)
+    return arctic.get_library(SCHEMA_META_LIB, create_if_missing=True)
+
+
 def get_scratch_universe_lib(name: str, bucket: str | None = None) -> adb.library.Library:
     """Get a SCRATCH universe-shaped library for an offline migration build.
 

--- a/store/arctic_store.py
+++ b/store/arctic_store.py
@@ -325,3 +325,35 @@ def to_arctic_canonical(
         df = df[canonical]
 
     return to_arctic_safe(df)
+
+
+def canonical_universe_columns(
+    *,
+    features: Sequence[str] | None = None,
+) -> list[str]:
+    """Return the LIVE ``universe`` library's canonical column list, derived
+    deterministically from code with no DataFrame required.
+
+    This is the single derivation of the persisted universe descriptor's
+    column set — the schema SSoT that both the schema-migration chokepoint
+    (``tests/test_schema_migration_chokepoint.py``) and the baseline
+    migration (``migrations/0000_baseline_universe_schema.py``) anchor
+    against. It is the column-only counterpart of ``to_arctic_canonical``:
+    same ordering rule, but expressed without a sample frame so a CI gate
+    can diff it against a migration's declared ``columns_after``.
+
+    The live universe symbols carry ``OHLCV_COLS + [source] + FEATURES``.
+    ``total_return_close`` (spliced after ``Close`` by ``to_arctic_canonical``
+    *when present*) is DELIBERATELY EXCLUDED: it exists only on the offline
+    CRSP-basis scratch library (``builders/migrate_universe_crsp_basis.py``),
+    never on the live ``universe`` symbols the daily/weekly producers write
+    and every downstream consumer reads. Including it would make the anchor
+    disagree with the real persisted descriptor.
+
+    Pass an explicit ``features`` only in tests that pin a synthetic schema;
+    production callers use the default (``feature_engineer.FEATURES``).
+    """
+    if features is None:
+        from features.feature_engineer import FEATURES as _FEATURES
+        features = _FEATURES
+    return list(OHLCV_COLS) + [PROVENANCE_COL] + list(features)

--- a/store/schema_version.py
+++ b/store/schema_version.py
@@ -48,12 +48,10 @@ import pandas as pd
 
 log = logging.getLogger(__name__)
 
-#: Dedicated library holding the ``universe`` data-plane schema stamp. Kept
-#: OUT of the ``universe`` library so it never pollutes the ticker roster
-#: returned by ``get_universe_symbols`` (see module docstring).
-SCHEMA_META_LIB = "universe_schema_meta"
-
-#: The single symbol inside :data:`SCHEMA_META_LIB` that carries the version.
+#: The single symbol inside the ``universe_schema_meta`` library
+#: (``store.arctic_store.SCHEMA_META_LIB`` / ``get_schema_meta_lib``) that
+#: carries the version. The library is opened via
+#: ``store.arctic_store.get_schema_meta_lib`` — the single mockable open-seam.
 SCHEMA_VERSION_SYMBOL = "schema_version"
 
 #: The version an unstamped (legacy / pre-framework) universe library is
@@ -71,21 +69,6 @@ class SchemaVersionMismatch(RuntimeError):
     early instead of cascading as per-symbol ``StreamDescriptorMismatch``."""
 
 
-def _open_meta_lib(bucket: str | None = None):
-    """Open (creating if missing) the dedicated schema-meta library.
-
-    Routed through the same ``store.arctic_store`` connection singleton /
-    canonical URI conventions as every other library so the S3
-    endpoint/path_prefix match exactly.
-    """
-    # Local import keeps this module import-cheap and avoids pulling the
-    # arcticdb connection machinery at module load for pure-unit callers.
-    from store.arctic_store import _get_arctic
-
-    arctic = _get_arctic(bucket)
-    return arctic.get_library(SCHEMA_META_LIB, create_if_missing=True)
-
-
 def read_schema_version(meta_lib) -> int | None:
     """Return the stamped universe schema version, or ``None`` if unstamped.
 
@@ -99,7 +82,7 @@ def read_schema_version(meta_lib) -> int | None:
         has = meta_lib.has_symbol(SCHEMA_VERSION_SYMBOL)
     except Exception as exc:  # pragma: no cover - arcticdb health failure
         raise RuntimeError(
-            f"failed to probe {SCHEMA_META_LIB}.{SCHEMA_VERSION_SYMBOL}: {exc}"
+            f"failed to probe universe_schema_meta.{SCHEMA_VERSION_SYMBOL}: {exc}"
         ) from exc
     if not has:
         return None
@@ -145,8 +128,7 @@ def write_schema_version(
         SCHEMA_VERSION_SYMBOL, frame, metadata=metadata, prune_previous_versions=True
     )
     log.info(
-        "Stamped %s.%s: schema_version=%d (migration %04d, %d columns)",
-        SCHEMA_META_LIB,
+        "Stamped universe_schema_meta.%s: schema_version=%d (migration %04d, %d columns)",
         SCHEMA_VERSION_SYMBOL,
         version,
         migration_number,

--- a/store/schema_version.py
+++ b/store/schema_version.py
@@ -1,0 +1,215 @@
+"""store/schema_version.py — ArcticDB data-plane schema-version stamp + the
+producer-side pre-append assert (alpha-engine-config-I3241).
+
+Motivating incident (config-I3236, 2026-07-21): a schema-additive feature PR
+(nousergon-data#742) shipped the *code* half (three new columns) but not the
+*data* half (a one-time rewrite of the existing static-schema ``universe``
+symbols). The first ``daily_append`` after merge emitted the widened column
+set against the old descriptor → 904/904 ``StreamDescriptorMismatch`` → EOD
+NAV-reconcile prod-down. The mismatch surfaced two layers downstream as an
+opaque ``RuntimeError`` in ``executor/eod_reconcile.py``.
+
+This module is the runtime half of the fix: the ``universe`` data plane now
+carries a monotonic integer schema version, and producers assert it matches
+what their code emits BEFORE touching any symbol — converting the failure
+from a mass mid-write descriptor cascade into a single loud, actionable
+pre-flight error that names the pending migration.
+
+Stamp LOCATION — a dedicated ``universe_schema_meta`` library, NOT a reserved
+symbol inside ``universe``:
+
+    ``nousergon_lib.arcticdb.get_universe_symbols()`` returns
+    ``lib.list_symbols()`` UNFILTERED, and that set is consumed fleet-wide as
+    the tradable-ticker roster (executor VWAP/ATR guards, backtester replay,
+    predictor inference). A reserved ``_schema_meta`` symbol placed in
+    ``universe`` would therefore leak into every consumer's ticker roster as a
+    phantom "ticker" — a contract-bypassing cross-module coupling. Isolating
+    the stamp in its own library keeps the ``universe`` symbol namespace pure
+    (zero consumer changes) at the cost of one extra library-open per producer
+    run.
+
+    Failure modes of this choice, and how they are handled:
+      * meta library absent/empty (legacy pre-framework state, or a fresh
+        bucket) → ``read_schema_version`` returns ``None`` → callers treat the
+        universe as being at the BASELINE version (see ``assert_schema_version``).
+      * the stamp and the ``universe`` data are written non-atomically during a
+        migration → migrations stamp LAST, only after ``verify()`` passes, and
+        every migration is idempotent, so a crash between the data rewrite and
+        the stamp leaves a re-runnable state (re-run re-verifies, re-stamps).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+#: Dedicated library holding the ``universe`` data-plane schema stamp. Kept
+#: OUT of the ``universe`` library so it never pollutes the ticker roster
+#: returned by ``get_universe_symbols`` (see module docstring).
+SCHEMA_META_LIB = "universe_schema_meta"
+
+#: The single symbol inside :data:`SCHEMA_META_LIB` that carries the version.
+SCHEMA_VERSION_SYMBOL = "schema_version"
+
+#: The version an unstamped (legacy / pre-framework) universe library is
+#: assumed to be at. It is the baseline migration's ``schema_version_after``
+#: (``0000_baseline_universe_schema``). Encoded here as a constant to avoid a
+#: ``store -> migrations`` import cycle; the chain-integrity test asserts the
+#: baseline migration's number equals this value so the two can never drift.
+BASELINE_SCHEMA_VERSION = 0
+
+
+class SchemaVersionMismatch(RuntimeError):
+    """The universe data plane's stamped schema version does not match what
+    the running producer code emits. Raised BEFORE any symbol is written, so
+    a schema-additive code deploy that lacks its data migration fails loud and
+    early instead of cascading as per-symbol ``StreamDescriptorMismatch``."""
+
+
+def _open_meta_lib(bucket: str | None = None):
+    """Open (creating if missing) the dedicated schema-meta library.
+
+    Routed through the same ``store.arctic_store`` connection singleton /
+    canonical URI conventions as every other library so the S3
+    endpoint/path_prefix match exactly.
+    """
+    # Local import keeps this module import-cheap and avoids pulling the
+    # arcticdb connection machinery at module load for pure-unit callers.
+    from store.arctic_store import _get_arctic
+
+    arctic = _get_arctic(bucket)
+    return arctic.get_library(SCHEMA_META_LIB, create_if_missing=True)
+
+
+def read_schema_version(meta_lib) -> int | None:
+    """Return the stamped universe schema version, or ``None`` if unstamped.
+
+    ``None`` means the library predates this framework (legacy) or the bucket
+    is fresh — callers MUST map that to :data:`BASELINE_SCHEMA_VERSION` rather
+    than treating it as an error (see ``assert_schema_version``). The version
+    lives in the symbol's ArcticDB metadata (authoritative) with a mirror in
+    the single-cell data frame for human inspection via ``lib.read``.
+    """
+    try:
+        has = meta_lib.has_symbol(SCHEMA_VERSION_SYMBOL)
+    except Exception as exc:  # pragma: no cover - arcticdb health failure
+        raise RuntimeError(
+            f"failed to probe {SCHEMA_META_LIB}.{SCHEMA_VERSION_SYMBOL}: {exc}"
+        ) from exc
+    if not has:
+        return None
+    item = meta_lib.read(SCHEMA_VERSION_SYMBOL)
+    meta = item.metadata or {}
+    if "schema_version" in meta:
+        return int(meta["schema_version"])
+    # Fallback to the data mirror if metadata was ever written without the key.
+    return int(item.data["schema_version"].iloc[-1])
+
+
+def write_schema_version(
+    meta_lib,
+    version: int,
+    *,
+    migration_number: int,
+    columns_after: tuple[str, ...] | list[str],
+) -> None:
+    """Stamp the universe data plane at ``version`` (called by a migration,
+    LAST, only after its ``verify()`` passes).
+
+    The stamp records the version, the migration that set it, an applied-at
+    UTC timestamp, and the full declared column set — enough for an operator
+    or the (config-I3242) runner to audit what a library conforms to without
+    reading a ticker symbol.
+    """
+    applied = datetime.now(timezone.utc).isoformat()
+    cols = list(columns_after)
+    metadata = {
+        "schema_version": int(version),
+        "migration_number": int(migration_number),
+        "applied_utc": applied,
+        "columns": cols,
+        "n_columns": len(cols),
+    }
+    frame = pd.DataFrame(
+        {"schema_version": [int(version)], "migration_number": [int(migration_number)]},
+        index=pd.DatetimeIndex([pd.Timestamp(applied)], name="applied_utc"),
+    )
+    # write (not update): the stamp is a single logical fact, always fully
+    # overwritten; prune old versions so the meta symbol stays a point value.
+    meta_lib.write(
+        SCHEMA_VERSION_SYMBOL, frame, metadata=metadata, prune_previous_versions=True
+    )
+    log.info(
+        "Stamped %s.%s: schema_version=%d (migration %04d, %d columns)",
+        SCHEMA_META_LIB,
+        SCHEMA_VERSION_SYMBOL,
+        version,
+        migration_number,
+        len(cols),
+    )
+
+
+def assert_schema_version(
+    meta_lib,
+    expected_version: int,
+    *,
+    pending_migrations: list[int] | None = None,
+) -> int:
+    """Fail loud unless the universe data plane is at ``expected_version``.
+
+    Called by every universe PRODUCER (``daily_append`` and, through it, the
+    weekly collector) immediately after opening the library and BEFORE any
+    write. Returns the effective version on success.
+
+    Semantics — an unstamped library is treated as :data:`BASELINE_SCHEMA_VERSION`,
+    NOT as an error, so merging this framework onto a live-but-unstamped bucket
+    does not itself brick the pipeline (the live universe already conforms to
+    the baseline schema; the stamp is bootstrapped when baseline migration 0000
+    runs in-region). Both directions of mismatch raise:
+
+      * effective < expected  → a schema-additive code deploy landed without
+        its data migration. Names the pending migration(s) to run in-region.
+        This is the config-I3236 failure, now caught pre-write.
+      * effective > expected  → the running producer code is STALE / rolled
+        back relative to applied migrations (it would emit fewer columns than
+        persisted → ``StreamDescriptorMismatch`` on write). Do NOT downgrade
+        the library; update the producer code.
+    """
+    stamp = read_schema_version(meta_lib)
+    effective = BASELINE_SCHEMA_VERSION if stamp is None else stamp
+
+    if effective == expected_version:
+        if stamp is None:
+            log.info(
+                "universe schema stamp absent — treating library as baseline "
+                "v%d (matches producer). Run migration 0000 in-region to "
+                "materialize the stamp.",
+                BASELINE_SCHEMA_VERSION,
+            )
+        return effective
+
+    if effective < expected_version:
+        pend = pending_migrations or list(range(effective + 1, expected_version + 1))
+        raise SchemaVersionMismatch(
+            f"universe data plane is at schema v{effective} but this producer "
+            f"emits schema v{expected_version}: a schema-additive change was "
+            f"deployed WITHOUT its data migration. Pending migration(s) "
+            f"{['%04d' % n for n in pend]} must be applied in-region (see "
+            f"migrations/README.md) before any universe append. Refusing to "
+            f"write — this is the config-I3236 failure caught pre-write "
+            f"instead of as 904/904 StreamDescriptorMismatch."
+        )
+
+    raise SchemaVersionMismatch(
+        f"universe data plane is at schema v{effective} but this producer only "
+        f"knows schema v{expected_version}: the producer code is STALE / rolled "
+        f"back relative to the applied migrations. It would emit fewer columns "
+        f"than the persisted descriptor (StreamDescriptorMismatch on write). "
+        f"Update the producer code to the current schema; do NOT downgrade the "
+        f"library."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,56 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 os.environ.setdefault("FLOW_DOCTOR_DISABLED", "1")
 
 
+class _FakeStampedMetaLib:
+    """A schema-meta library stamped at the current expected version — so the
+    daily_append producer's pre-append schema assert (config-I3241) passes as a
+    no-op in unit tests without touching S3. Real assert BEHAVIOUR is exercised
+    against a live LMDB library in tests/test_schema_migration_framework.py."""
+
+    def __init__(self, version: int):
+        self._v = version
+
+    def has_symbol(self, name):  # noqa: D401 - fake
+        return True
+
+    def read(self, name):
+        class _Item:
+            pass
+
+        item = _Item()
+        item.metadata = {"schema_version": self._v}
+        item.data = None
+        return item
+
+
+@pytest.fixture(autouse=True)
+def _isolate_schema_meta_from_s3(monkeypatch):
+    """Prevent daily_append's schema-version pre-append assert (config-I3241)
+    from opening the real ``universe_schema_meta`` ArcticDB library over S3 in
+    unit tests. Patches the single open-seam
+    (``builders.daily_append.get_schema_meta_lib``) to a fake stamped at the
+    live EXPECTED_SCHEMA_VERSION, so the assert is a benign no-op here and stays
+    green as the migration chain grows. Same isolation philosophy as
+    ``_isolate_secrets_from_ssm`` / the flow-doctor hard-disable above — a unit
+    test must never reach real S3. Tests that WANT to exercise the assert use a
+    real LMDB meta lib directly (test_schema_migration_framework.py)."""
+    try:
+        import builders.daily_append as _da
+        from migrations import EXPECTED_SCHEMA_VERSION
+    except Exception:
+        # daily_append / migrations not importable in this environment — nothing
+        # to isolate; let the test proceed.
+        yield
+        return
+    monkeypatch.setattr(
+        _da,
+        "get_schema_meta_lib",
+        lambda *a, **k: _FakeStampedMetaLib(EXPECTED_SCHEMA_VERSION),
+        raising=False,
+    )
+    yield
+
+
 @pytest.fixture(autouse=True)
 def _isolate_secrets_from_ssm(monkeypatch):
     """Force every test to read secrets from env only, not SSM.

--- a/tests/test_schema_migration_chokepoint.py
+++ b/tests/test_schema_migration_chokepoint.py
@@ -1,0 +1,86 @@
+"""tests/test_schema_migration_chokepoint.py — the merge-blocking schema
+chokepoint (alpha-engine-config-I3238).
+
+The config-I3236 prod-down happened because ``tests/test_schema_contract.py``
+only checks INTERNAL consistency (FEATURES == CATALOG == SCHEMA.md agree with
+each other) — it passed for nousergon-data#742 even though the widened
+descriptor did not match the persisted ``universe`` library and no migration
+shipped.
+
+This module lifts the missing invariant to a REQUIRED CI check: the live,
+code-derived canonical universe schema MUST equal the latest migration's
+declared ``columns_after``. So a PR that adds/removes/reorders a universe column
+without adding a matching migration fails here — un-mergeable by the groomer or
+a human until the migration ships.
+
+It runs in the normal ``test`` job (pure Python, no ArcticDB/AWS).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from store.arctic_store import canonical_universe_columns
+from migrations import load_migrations
+from migrations._base import MigrationError, validate_chain
+
+
+def test_canonical_schema_matches_latest_migration():
+    """THE gate. If this fails, a universe column changed without a migration.
+
+    To fix: add ``migrations/NNNN_<slug>.py`` (copy ``migrations/_template.py``)
+    whose ``columns_after`` is the new frozen canonical set — get it from
+    ``store.arctic_store.canonical_universe_columns()`` on your branch — plus a
+    real data rewrite. See ``migrations/README.md``.
+    """
+    live = tuple(canonical_universe_columns())
+    latest = load_migrations()[-1]
+    assert live == latest.columns_after, (
+        "The live code-derived canonical universe schema does NOT match the "
+        f"latest migration ({latest.number:04d} {latest.name!r}).\n"
+        f"  live schema ({len(live)} cols):   {live}\n"
+        f"  migration   ({len(latest.columns_after)} cols): {latest.columns_after}\n"
+        "A universe column was added/removed/reordered WITHOUT a migration. "
+        "This is exactly the config-I3236 prod-down class. Add a new migration "
+        "module migrations/NNNN_<slug>.py (copy migrations/_template.py) with "
+        "columns_after set to the new canonical set and a full-write data "
+        "rewrite. See migrations/README.md."
+    )
+
+
+def test_migration_chain_is_valid():
+    """The chain loads and validates: contiguous numbers from the 0000 baseline,
+    monotonic versions, exactly one baseline."""
+    migs = load_migrations()
+    validate_chain(migs)  # redundant with load_migrations, but pins the contract
+    assert migs[0].number == 0 and migs[0].is_baseline
+    numbers = [m.number for m in migs]
+    assert numbers == list(range(len(migs)))
+    assert sum(1 for m in migs if m.is_baseline) == 1
+
+
+def test_gate_has_teeth_detects_added_column():
+    """Prove the diff catches an un-migrated addition: a synthetic canonical set
+    with one extra column must NOT equal the latest migration's columns_after."""
+    latest = load_migrations()[-1]
+    live = list(canonical_universe_columns())
+    tampered = tuple(live + ["synthetic_new_col_pct"])
+    assert tampered != latest.columns_after
+
+
+def test_template_is_not_discovered():
+    """The copy-me template must never be loaded as a real migration."""
+    numbers = [m.number for m in load_migrations()]
+    assert -1 not in numbers  # _template.py MIGRATION.number is -1
+
+
+def test_baseline_columns_are_frozen_literal_not_derived():
+    """The baseline anchor must be a hardcoded literal, not a live derivation —
+    otherwise the gate above can never fire. Guard: the module defines a literal
+    tuple, and it currently matches (they will diverge the moment a column is
+    added, which is the whole point)."""
+    baseline = importlib.import_module("migrations.0000_baseline_universe_schema")
+    assert isinstance(baseline.BASELINE_COLUMNS, tuple)
+    assert len(baseline.BASELINE_COLUMNS) == 94

--- a/tests/test_schema_migration_framework.py
+++ b/tests/test_schema_migration_framework.py
@@ -259,20 +259,18 @@ def test_baseline_migration_refuses_nonbaseline_library(universe_lib, meta_lib):
 
 
 def test_producer_wrapper_wires_expected_and_pending(monkeypatch, meta_lib):
-    """assert_universe_schema_current opens the meta lib via S3 in production;
-    here we inject the LMDB meta lib and confirm it derives EXPECTED + pending
-    from the real chain and raises when the stamp lags."""
+    """assert_universe_schema_current takes an already-opened meta lib (the
+    producer opens it via the mockable get_schema_meta_lib seam) and derives
+    EXPECTED + pending from the real chain, raising when the stamp lags."""
     import migrations as mig_pkg
-    import store.schema_version as sv
 
-    monkeypatch.setattr(sv, "_open_meta_lib", lambda bucket=None: meta_lib)
     # No stamp -> baseline 0 == EXPECTED_SCHEMA_VERSION (0 today) -> OK.
-    assert mig_pkg.assert_universe_schema_current("bkt") == mig_pkg.EXPECTED_SCHEMA_VERSION
+    assert mig_pkg.assert_universe_schema_current(meta_lib) == mig_pkg.EXPECTED_SCHEMA_VERSION
 
     # Simulate a future pending migration by forcing EXPECTED ahead of the stamp.
     write_schema_version(meta_lib, 0, migration_number=0, columns_after=("Open",))
     monkeypatch.setattr(mig_pkg, "EXPECTED_SCHEMA_VERSION", 1)
     monkeypatch.setattr(mig_pkg, "pending_migrations", lambda cur: [type("M", (), {"number": 1})()])
     with pytest.raises(SchemaVersionMismatch) as ei:
-        mig_pkg.assert_universe_schema_current("bkt")
+        mig_pkg.assert_universe_schema_current(meta_lib)
     assert "0001" in str(ei.value)

--- a/tests/test_schema_migration_framework.py
+++ b/tests/test_schema_migration_framework.py
@@ -1,0 +1,278 @@
+"""tests/test_schema_migration_framework.py — CI harness for the ArcticDB
+schema-migration framework (alpha-engine-config-I3241).
+
+Runs a REAL migration against a seeded local LMDB ArcticDB library (no AWS —
+LMDB needs none) in the repo's normal ``test`` job, proving end to end that:
+
+  * a schema-additive append onto an un-migrated symbol fails loud
+    (``StreamDescriptorMismatch``) — the config-I3236 failure;
+  * the producer pre-append assert catches the version gap BEFORE any write and
+    names the pending migration;
+  * a migration's ``run()`` full-writes the symbols (the config#2459
+    ``update()``-can't-cross-a-descriptor lesson), ``verify()`` passes, and the
+    PRODUCTION write primitive (``update_batch``) then appends cleanly;
+  * the version stamp advances and the producer assert goes green.
+
+The migration exercised here is SYNTHETIC (defined in-test), not a real module
+under ``migrations/`` — the framework harness must prove the *mechanism* works
+without depending on a real forward migration existing yet (the sub-sector
+re-land is a separate PR). The baseline (0000) module IS exercised against a
+frozen-schema fixture.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import arcticdb as adb
+from arcticdb.version_store.library import UpdatePayload, WritePayload
+
+from store.arctic_store import OHLCV_COLS, PROVENANCE_COL, to_arctic_canonical
+from store.schema_version import (
+    BASELINE_SCHEMA_VERSION,
+    SchemaVersionMismatch,
+    assert_schema_version,
+    read_schema_version,
+    write_schema_version,
+)
+from migrations._base import (
+    Migration,
+    MigrationError,
+    rewrite_symbols_full,
+    verify_additive,
+    validate_chain,
+)
+
+_OLD_FEATURES = ["feat_a", "feat_b"]
+_NEW_FEATURES = ["feat_a", "feat_b", "feat_c_new"]
+
+
+def _universe_frame(dates, features) -> pd.DataFrame:
+    idx = pd.DatetimeIndex(dates, name="date")
+    data: dict[str, object] = {
+        col: np.arange(1, len(idx) + 1, dtype="float64") for col in OHLCV_COLS
+    }
+    data[PROVENANCE_COL] = ["polygon"] * len(idx)
+    for feat in features:
+        data[feat] = np.arange(len(idx), dtype="float32")
+    return pd.DataFrame(data, index=idx)
+
+
+@pytest.fixture()
+def arctic(tmp_path):
+    return adb.Arctic(f"lmdb://{tmp_path}")
+
+
+@pytest.fixture()
+def universe_lib(arctic):
+    return arctic.get_library("universe", create_if_missing=True)
+
+
+@pytest.fixture()
+def meta_lib(arctic):
+    return arctic.get_library("universe_schema_meta", create_if_missing=True)
+
+
+def _seed_old_schema(lib, symbols=("AAA", "BBB", "CCC")):
+    for sym in symbols:
+        hist = _universe_frame(
+            pd.date_range("2026-06-01", periods=5, freq="D"), _OLD_FEATURES
+        )
+        lib.write_batch(
+            [WritePayload(symbol=sym, data=to_arctic_canonical(hist, features=_OLD_FEATURES))]
+        )
+    return list(symbols)
+
+
+def _synthetic_add_feat_c_migration() -> Migration:
+    """A real, runnable 0->1 additive migration built on the shared helpers,
+    scoped to synthetic feature columns so the harness never churns when real
+    columns change."""
+    cols_after = tuple(OHLCV_COLS) + (PROVENANCE_COL,) + tuple(_NEW_FEATURES)
+
+    def _project(df: pd.DataFrame) -> pd.DataFrame:
+        return to_arctic_canonical(df, features=_NEW_FEATURES)
+
+    def _run(lib, mlib) -> None:
+        rewrite_symbols_full(
+            lib,
+            expected_columns=cols_after,
+            new_columns={"feat_c_new": np.float32("nan")},
+            project=_project,
+        )
+        write_schema_version(mlib, 1, migration_number=1, columns_after=cols_after)
+
+    def _verify(lib) -> None:
+        verify_additive(lib, expected_columns=cols_after, project=_project)
+
+    return Migration(
+        number=1,
+        name="synth_add_feat_c",
+        target_library="universe",
+        symbol_scope="all universe symbols",
+        schema_version_before=0,
+        schema_version_after=1,
+        columns_after=cols_after,
+        backfill_policy="history rows: NaN (not retro-computable)",
+        run=_run,
+        verify=_verify,
+    )
+
+
+# ── The config-I3236 failure, reproduced then resolved by a migration ────────
+
+
+def test_unmigrated_append_fails_loud(universe_lib):
+    """Precondition: a widened append onto an old-schema symbol surfaces as a
+    StreamDescriptorMismatch (the 904/904 config-I3236 failure)."""
+    _seed_old_schema(universe_lib, symbols=("AAA",))
+    row = _universe_frame([pd.Timestamp("2026-06-06")], _NEW_FEATURES)
+    res = universe_lib.update_batch(
+        [UpdatePayload(symbol="AAA", data=to_arctic_canonical(row, features=_NEW_FEATURES))],
+        upsert=True,
+    )
+    assert "StreamDescriptorMismatch" in str(res[0])
+
+
+def test_migration_run_verify_and_production_update_batch(universe_lib, meta_lib):
+    """The core harness (config-I3241 deliverable 3): run a real migration
+    against seeded old-schema symbols, verify(), and assert the PRODUCTION
+    write primitive update_batch succeeds post-migration (config#2459)."""
+    symbols = _seed_old_schema(universe_lib)
+    write_schema_version(
+        meta_lib, 0, migration_number=0,
+        columns_after=tuple(OHLCV_COLS) + (PROVENANCE_COL,) + tuple(_OLD_FEATURES),
+    )
+
+    mig = _synthetic_add_feat_c_migration()
+
+    # Pre-write producer assert: at v0, a producer emitting v1 must fail loud
+    # and name the pending migration — BEFORE any symbol write.
+    with pytest.raises(SchemaVersionMismatch) as ei:
+        assert_schema_version(meta_lib, 1, pending_migrations=[1])
+    assert "0001" in str(ei.value)
+
+    # Run + verify the migration (verify includes a live update_batch probe).
+    mig.run(universe_lib, meta_lib)
+    mig.verify(universe_lib)
+
+    # Stamp advanced to 1.
+    assert read_schema_version(meta_lib) == 1
+    # Producer assert is now green at v1.
+    assert assert_schema_version(meta_lib, 1) == 1
+
+    # The real production append primitive now lands the widened row cleanly.
+    for sym in symbols:
+        row = _universe_frame([pd.Timestamp("2026-06-07")], _NEW_FEATURES)
+        res = universe_lib.update_batch(
+            [UpdatePayload(symbol=sym, data=to_arctic_canonical(row, features=_NEW_FEATURES))],
+            upsert=True,
+        )
+        assert "StreamDescriptorMismatch" not in str(res[0]), res[0]
+        stored = universe_lib.read(sym).data
+        assert "feat_c_new" in stored.columns
+        assert pd.Timestamp("2026-06-07") in stored.index
+
+
+def test_rewrite_uses_full_write_not_update(universe_lib, meta_lib):
+    """Guard the config#2459 lesson structurally: rewrite_symbols_full must
+    make a descriptor-crossing change succeed where a bare update() cannot."""
+    _seed_old_schema(universe_lib, symbols=("AAA",))
+    cols_after = tuple(OHLCV_COLS) + (PROVENANCE_COL,) + tuple(_NEW_FEATURES)
+    n = rewrite_symbols_full(
+        universe_lib,
+        expected_columns=cols_after,
+        new_columns={"feat_c_new": np.float32("nan")},
+        project=lambda df: to_arctic_canonical(df, features=_NEW_FEATURES),
+    )
+    assert n == 1
+    assert tuple(universe_lib.read("AAA").data.columns) == cols_after
+
+
+def test_rewrite_aborts_on_nonconforming_projection(universe_lib):
+    """Fail-loud: if the post-projection columns don't match the declared
+    columns_after, the rewrite raises rather than persisting a bad descriptor."""
+    _seed_old_schema(universe_lib, symbols=("AAA",))
+    with pytest.raises(MigrationError):
+        rewrite_symbols_full(
+            universe_lib,
+            expected_columns=("Open", "Close"),  # wrong on purpose
+            project=lambda df: to_arctic_canonical(df, features=_OLD_FEATURES),
+        )
+
+
+# ── Version stamp semantics ──────────────────────────────────────────────────
+
+
+def test_unstamped_meta_lib_reads_none_and_asserts_as_baseline(meta_lib):
+    """A fresh/legacy meta lib has no stamp; producers treat it as baseline v0
+    so merging the framework onto a live-but-unstamped bucket doesn't brick."""
+    assert read_schema_version(meta_lib) is None
+    # expected == baseline -> OK (no raise), returns baseline.
+    assert assert_schema_version(meta_lib, BASELINE_SCHEMA_VERSION) == BASELINE_SCHEMA_VERSION
+
+
+def test_stale_producer_direction_fails_loud(meta_lib):
+    """effective > expected: producer code is older than applied migrations."""
+    write_schema_version(meta_lib, 3, migration_number=3, columns_after=("Open",))
+    with pytest.raises(SchemaVersionMismatch) as ei:
+        assert_schema_version(meta_lib, 1)
+    assert "STALE" in str(ei.value) or "stale" in str(ei.value)
+
+
+def test_stamp_roundtrips_metadata(meta_lib):
+    cols = tuple(OHLCV_COLS) + (PROVENANCE_COL,)
+    write_schema_version(meta_lib, 7, migration_number=7, columns_after=cols)
+    item = meta_lib.read("schema_version")
+    assert item.metadata["schema_version"] == 7
+    assert item.metadata["migration_number"] == 7
+    assert item.metadata["n_columns"] == len(cols)
+    assert read_schema_version(meta_lib) == 7
+
+
+# ── Baseline (0000) migration exercised against a frozen-schema fixture ──────
+
+
+def test_baseline_migration_stamps_conforming_library(universe_lib, meta_lib):
+    baseline = importlib.import_module("migrations.0000_baseline_universe_schema")
+    # Seed a symbol at the real live schema (== the frozen baseline columns).
+    hist = _universe_frame(pd.date_range("2026-06-01", periods=4, freq="D"),
+                           list(baseline.BASELINE_COLUMNS[7:]))  # features after OHLCV+source
+    universe_lib.write_batch([WritePayload(symbol="AAA", data=to_arctic_canonical(hist))])
+    baseline.MIGRATION.run(universe_lib, meta_lib)
+    baseline.MIGRATION.verify(universe_lib)
+    assert read_schema_version(meta_lib) == 0
+
+
+def test_baseline_migration_refuses_nonbaseline_library(universe_lib, meta_lib):
+    baseline = importlib.import_module("migrations.0000_baseline_universe_schema")
+    _seed_old_schema(universe_lib, symbols=("AAA",))  # 2-feature junk, not baseline
+    with pytest.raises(MigrationError):
+        baseline.MIGRATION.run(universe_lib, meta_lib)
+
+
+# ── Producer wrapper wiring (assert_universe_schema_current) ──────────────────
+
+
+def test_producer_wrapper_wires_expected_and_pending(monkeypatch, meta_lib):
+    """assert_universe_schema_current opens the meta lib via S3 in production;
+    here we inject the LMDB meta lib and confirm it derives EXPECTED + pending
+    from the real chain and raises when the stamp lags."""
+    import migrations as mig_pkg
+    import store.schema_version as sv
+
+    monkeypatch.setattr(sv, "_open_meta_lib", lambda bucket=None: meta_lib)
+    # No stamp -> baseline 0 == EXPECTED_SCHEMA_VERSION (0 today) -> OK.
+    assert mig_pkg.assert_universe_schema_current("bkt") == mig_pkg.EXPECTED_SCHEMA_VERSION
+
+    # Simulate a future pending migration by forcing EXPECTED ahead of the stamp.
+    write_schema_version(meta_lib, 0, migration_number=0, columns_after=("Open",))
+    monkeypatch.setattr(mig_pkg, "EXPECTED_SCHEMA_VERSION", 1)
+    monkeypatch.setattr(mig_pkg, "pending_migrations", lambda cur: [type("M", (), {"number": 1})()])
+    with pytest.raises(SchemaVersionMismatch) as ei:
+        mig_pkg.assert_universe_schema_current("bkt")
+    assert "0001" in str(ei.value)


### PR DESCRIPTION
## What

The **framework + CI-chokepoint** halves of the structural fix for the 2026-07-21 fleet-wide data-plane prod-down (alpha-engine-config-I3236). Pairs with the already-merged revert (nousergon-data#985) so the sub-sector feature can re-land smoothly as migration `0001` behind this guard.

Implements **alpha-engine-config-I3241** (ArcticDB schema-migration framework) and **alpha-engine-config-I3238** (merge-blocking CI chokepoint).

## Why

A schema-changing PR has two halves — the *code* (ships on merge) and the *data migration* (historically an operator-remembered one-off). nousergon-data#742 shipped only the code half; the static-schema `universe` symbols could not evolve their descriptor, so the first `daily_append` emitted a widened column set → 904/904 `StreamDescriptorMismatch` → EOD NAV-reconcile prod-down. With groomer auto-merge in the loop, "someone remembers the migration" is not a control. This makes the data half tested, discoverable code that lands with the schema change and blocks the merge if it's missing.

## Design decisions

**Stamp location — dedicated `universe_schema_meta` library, NOT a reserved symbol in `universe`.** `nousergon_lib.arcticdb.get_universe_symbols()` returns `lib.list_symbols()` **unfiltered**, and that set is the fleet-wide tradable-ticker roster (executor/backtester/predictor). A reserved `_schema_meta` symbol inside `universe` would leak into every consumer as a phantom ticker. Isolating it costs one extra library-open per producer run. Failure modes (all handled, documented in `migrations/README.md` + `store/schema_version.py`): meta lib absent → treated as **baseline v0** (a live-but-unstamped bucket is NOT bricked by merging this); non-atomic stamp-vs-data → migrations stamp **last**, after `verify()`, and are idempotent.

**Version derivation — from the chain, never hand-kept.** `EXPECTED_SCHEMA_VERSION = max(migration.number)`, computed at import from discovered modules. Avoids the Dockerfile-duplicate-pin drift bug class. A chain-integrity test pins contiguity/monotonicity + single-baseline.

**Discovery contract (also for the config-I3242 in-region runner).** Numbered modules `migrations/NNNN_<slug>.py` each expose module-level `MIGRATION: Migration`. `load_migrations()` → chain-validated ordered list; `pending_migrations(current)` → work a library still needs. Leading-underscore modules (`_base`, `_template`) are never discovered.

**Baseline as migration `0000`.** Freezes the post-revert **94-column** canonical schema (OHLCV 6 + `source` 1 + FEATURES 87 — the known-good schema WITHOUT the reverted `sub_sector_vs_benchmark_*` columns) as a **hardcoded frozen literal**, not a live derivation — otherwise the chokepoint could never fire. `run()` stamps a conforming live library (no data rewrite; the live universe already is the baseline); `verify()` asserts conformance.

**Producer pre-append assert (`builders/daily_append`).** Fails loud **before touching any symbol** if the stamp ≠ `EXPECTED_SCHEMA_VERSION`, naming the pending migration — converting the config-I3236 failure (opaque `RuntimeError` two layers downstream in `eod_reconcile.py`) into a single actionable pre-flight error. Both directions raise: stamp < expected (missing migration) and stamp > expected (stale/rolled-back producer).

**config#2459 lesson baked in.** `rewrite_symbols_full` FULL-`write()`s each symbol (never `update()`, which cannot cross a descriptor change) with a **dtype-typed** fill (`np.float32("nan")` for float32 feature columns — a bare `np.nan` would re-introduce a mismatch on the next real `update_batch`). `verify_additive` includes a live `update_batch` probe proving the production primitive works post-migration.

## What the chokepoint catches

`tests/test_schema_migration_chokepoint.py` diffs the live code-derived canonical schema (`store.arctic_store.canonical_universe_columns()`, new deterministic derivation) against the latest migration's declared `columns_after`. A PR that adds/removes/reorders a universe column WITHOUT a matching migration fails this **required** check (it runs in the normal `test` job) with an actionable message naming the file to add. Existing `test_schema_contract.py` only checks internal FEATURES↔CATALOG↔SCHEMA.md consistency — it passed for #742; this closes that gap.

## How CI proves migrations work

`tests/test_schema_migration_framework.py` runs a **real synthetic 0001-style migration** against a **seeded local LMDB ArcticDB** fixture (no AWS — LMDB needs none) in the normal `test` job:
1. seed old-schema symbols; prove the widened append fails loud (`StreamDescriptorMismatch`) — reproduces I3236;
2. prove the producer assert fails loud at v0 naming migration `0001`, before any write;
3. `run()` + `verify()`; assert the **production `update_batch`** append then lands cleanly (config#2459 proof);
4. assert the stamp advanced and the producer assert goes green.

The synthetic migration lives in the test (not a real module under `migrations/`) per the framework-proves-the-mechanism constraint; the sub-sector re-land is a separate PR.

## Test evidence

- New tests: **15 passed** (`test_schema_migration_framework.py` 10 + `test_schema_migration_chokepoint.py` 5).
- Full unit suite (`pytest tests/ --ignore=tests/integration --ignore=tests/live_smoke`): **3480 passed, 7 skipped** (3465 pre-existing + 15 new). Green on the shared venv (pinned nousergon-lib v0.124.6).
- Baseline frozen literal verified byte-identical to `canonical_universe_columns()` at the revert commit.

## Not in scope (deferred, tracked)

- The one-time **in-region run** of migration `0000` against live data (materializes the stamp) and future migration execution — alpha-engine-config-I3242 (runner). Until `0000` runs, the live library reads as unstamped→baseline v0, which equals `EXPECTED_SCHEMA_VERSION` today, so the producer assert is green (no brick on merge).
- The sub-sector feature **re-land as migration `0001`** (with a Brian-reviewed backfill policy) — the re-land PR's job, riding config#934's arc.
- I3238's "also consider" **groom complexity-routing** of registry/`to_arctic_canonical` PRs to `complexity:high` — that's a `groom_driver` change in `alpha-engine-config`, not a nousergon-data change; noted on the issue for the config repo.

Closes nousergon/alpha-engine-config#3241
Closes nousergon/alpha-engine-config#3238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
