### PR TITLE
fix(sf-watch): retire stale ARNs from EVENT_PATTERN + rule-pattern lockstep test (config-I3187)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -155,13 +155,14 @@ if $BOOTSTRAP; then
   fi
 
   # EventBridge rule: terminal-failure statuses of ANY registered fleet SF.
-  # One rule, one target — keep the ARN list in lockstep with
-  # index.PIPELINES. (The transitional alpha-engine-eod-pipeline alias was
-  # retired 2026-07-11 — config#2272; old SF deleted live.) Widened
-  # 2026-07-14 (alpha-engine-config-I2544/I2545) to also cover the two new
-  # child SFs split out of the weekly pipeline — both registered in
-  # index.PIPELINES with has_listener:False (watch-log + Telegram fire;
-  # autonomous-agent dispatch deferred until their own charter exists).
+  # One rule, one target. The ARN list is in ENFORCED lockstep with
+  # index.PIPELINES — tests/test_sf_watch_rule_pattern_lockstep.py statically
+  # extracts this heredoc's pipeline names and fails CI on drift. (Added
+  # 2026-07-21, alpha-engine-config-I3187: the I2890 re-inline retired
+  # ne-weekly-advisory-pipeline / ne-modelzoo-sunday-pipeline from
+  # index.PIPELINES, but this heredoc kept both ARNs because the old
+  # "keep in lockstep" comment was prose, not a contract — the live rule
+  # then re-acquired the stale ARNs on bootstrap.)
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   EVENT_PATTERN=$(cat <<EOF
 {
@@ -171,9 +172,7 @@ if $BOOTSTRAP; then
     "stateMachineArn": [
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-freshness-pipeline",
       "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-preopen-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-weekly-advisory-pipeline",
-      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-modelzoo-sunday-pipeline"
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:ne-postclose-trading-pipeline"
     ],
     "status": ["FAILED", "TIMED_OUT", "ABORTED"]
   }

--- a/tests/test_sf_watch_rule_pattern_lockstep.py
+++ b/tests/test_sf_watch_rule_pattern_lockstep.py
@@ -1,0 +1,79 @@
+"""alpha-engine-config-I3187 — the EventBridge rule pattern in
+saturday-sf-watch-dispatcher/deploy.sh must stay in LOCKSTEP with
+index.PIPELINES.
+
+The failure-detection rule ``alpha-engine-saturday-sf-watch-failed`` is
+(re)created from the EVENT_PATTERN heredoc in deploy.sh --bootstrap. The old
+"keep the ARN list in lockstep with index.PIPELINES" comment was prose, not a
+contract: the 2026-07-17 I2890 re-inline removed ne-weekly-advisory-pipeline /
+ne-modelzoo-sunday-pipeline from PIPELINES (and every registry per
+config#2937's lockstep test) but the heredoc silently kept both ARNs, so the
+live rule carried two retired pipelines the overseer-liveness-probe then
+flagged on every run. Drift now fails CI here.
+
+PIPELINES is extracted STATICALLY (ast over the source text, same pattern as
+tests/test_sf_watch_defer_prefix_lockstep.py) — importing index.py would drag
+in boto3 and the Lambda's own pinned deps. The heredoc pipeline names are
+extracted with a regex anchored to the stateMachine ARN template lines.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+_DISPATCHER_DIR = (
+    Path(__file__).parent.parent
+    / "infrastructure"
+    / "lambdas"
+    / "saturday-sf-watch-dispatcher"
+)
+_INDEX = _DISPATCHER_DIR / "index.py"
+_DEPLOY = _DISPATCHER_DIR / "deploy.sh"
+
+_ARN_LINE = re.compile(
+    r'"arn:aws:states:\$\{REGION\}:\$\{ACCOUNT_ID\}:stateMachine:([A-Za-z0-9_-]+)"'
+)
+
+
+def _registered_pipelines() -> set[str]:
+    tree = ast.parse(_INDEX.read_text())
+    for node in tree.body:
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            targets = [node.target.id]
+            value = node.value
+        if "PIPELINES" in targets:
+            assert isinstance(value, ast.Dict), "PIPELINES must be a dict literal"
+            keys = set()
+            for key in value.keys:
+                assert isinstance(key, ast.Constant) and isinstance(key.value, str)
+                keys.add(key.value)
+            return keys
+    raise AssertionError(f"module-level PIPELINES not found in {_INDEX}")
+
+
+def _rule_pattern_pipelines() -> set[str]:
+    names = set(_ARN_LINE.findall(_DEPLOY.read_text()))
+    assert names, (
+        f"no stateMachine ARN template lines found in {_DEPLOY} — "
+        "EVENT_PATTERN heredoc moved or reshaped; update _ARN_LINE"
+    )
+    return names
+
+
+def test_rule_pattern_matches_registered_pipelines() -> None:
+    registered = _registered_pipelines()
+    in_rule = _rule_pattern_pipelines()
+    assert in_rule == registered, (
+        "deploy.sh EVENT_PATTERN pipelines != index.PIPELINES — "
+        f"only in rule: {sorted(in_rule - registered)}; "
+        f"only in PIPELINES: {sorted(registered - in_rule)}. "
+        "Update the EVENT_PATTERN heredoc in deploy.sh (and re-run "
+        "`aws events put-rule` / deploy.sh --bootstrap live) whenever a "
+        "pipeline is registered or retired."
+    )


### PR DESCRIPTION
## What

Removes the retired `ne-weekly-advisory-pipeline` / `ne-modelzoo-sunday-pipeline` ARNs from the `EVENT_PATTERN` heredoc in `saturday-sf-watch-dispatcher/deploy.sh`, and adds `tests/test_sf_watch_rule_pattern_lockstep.py` enforcing that the heredoc's pipeline list equals `index.PIPELINES` (static extraction, mirroring `test_sf_watch_defer_prefix_lockstep.py`).

## Why (alpha-engine-config-I3187)

The live rule `alpha-engine-saturday-sf-watch-failed` still patterns on the two SFs retired by the config-I2890 re-inline — the overseer-liveness-probe (deployed today from PR987) now flags this on every run. Root cause is the SOURCE, not just the live rule: the config#2937 lockstep sweep cleaned `index.PIPELINES` and both registries, but this heredoc's "keep in lockstep" guidance was a comment, not an enforced contract — so `--bootstrap` would faithfully re-create the stale rule. Comment-claims-behavior bug class; the new test makes it a contract.

## Live apply

The corrected pattern must also be applied to the live rule (operator: `aws events put-rule` is classifier-gated for the agent — command staged in the session; harmless meanwhile since the retired SFs are deleted and can never emit events, the stale ARNs are noise not misroute).

Refs alpha-engine-config-I3187 in prose; closes-when on that issue requires the LIVE rule verified clean, so no auto-close line here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)