### PR TITLE
feat(freshness-monitor): event-time overseer drain dispatch on critical pages (config-I3282 phase 1)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -188,12 +188,14 @@ if $BOOTSTRAP; then
     #
     # config#1240 auto-remediation: FRESHNESS_MONITOR_RECOVERY_ENABLED defaults
     # OFF (OBSERVE) — a fresh bootstrap LOGS the would-dispatch but calls no
-    # SF/Lambda and writes no marker. The dispatch path is flipped live ONLY
-    # after the end-to-end drill validates it (delete a recent load-bearing
-    # artifact, confirm the monitor auto-dispatches the correct backfill):
+    # SF/Lambda and writes no marker. Same for config-I3282's
+    # FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED (critical-page → overseer
+    # alert-drain dispatch). Each dispatch path is flipped live ONLY after its
+    # end-to-end drill validates it — and the routine-deploy env update below
+    # MERGES with the live env, so a flipped flag survives redeploys:
     #   aws lambda update-function-configuration \
     #     --function-name alpha-engine-freshness-monitor \
-    #     --environment 'Variables={LOG_LEVEL=INFO,FRESHNESS_MONITOR_ENABLED=true,FRESHNESS_MONITOR_RECOVERY_ENABLED=true}'
+    #     --environment 'Variables={...existing...,FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED=true}'
     run aws lambda create-function \
       --function-name "${FUNCTION_NAME}" \
       --runtime python3.12 \
@@ -342,10 +344,32 @@ fi
 
 echo "✓ Code deployed."
 
-echo "Updating Lambda environment (flow-doctor SSM hydration; preserve alert flags)..."
+# MERGE, don't overwrite (config-I3282; same silent-flag-wipe class as the
+# M2_DISPATCH_TARGET lesson): operator-flipped flags on the live function
+# (FRESHNESS_MONITOR_RECOVERY_ENABLED, FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED,
+# cooldown overrides) must SURVIVE a routine redeploy. The previous hardcoded
+# Variables={...} map silently reverted every non-listed flag to its code
+# default on each deploy. Deploy-owned keys below still win on collision.
+echo "Updating Lambda environment (merge — preserve operator-set flags)..."
+LIVE_ENV=$(aws lambda get-function-configuration \
+  --function-name "${FUNCTION_NAME}" --region "${REGION}" \
+  --query 'Environment.Variables' --output json 2>/dev/null || echo '{}')
+MERGED_ENV=$(python3 - "$LIVE_ENV" <<'PYEOF'
+import json, sys
+live = json.loads(sys.argv[1] or "null") or {}
+deploy_owned = {
+    "LOG_LEVEL": "INFO",
+    "FRESHNESS_MONITOR_ENABLED": "true",
+    "FLOW_DOCTOR_ENABLED": "1",
+    "ALPHA_ENGINE_DEPLOYED": "1",
+}
+live.update(deploy_owned)
+print(json.dumps({"Variables": live}))
+PYEOF
+)
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment 'Variables={LOG_LEVEL=INFO,FRESHNESS_MONITOR_ENABLED=true,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --environment "${MERGED_ENV}" \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -143,6 +143,43 @@ RECOVERY_DISPATCH_ENABLED = (
     == "true"
 )
 
+# config-I3282 — freshness-critical → overseer drain dispatch (phase 1;
+# Brian directive 2026-07-22). Every CRITICAL page from a row whose declared
+# response lane is NOT `remediation: operator` (and that has no `recovery:`
+# heal of its own in flight) triggers ONE event-time alert-drain run through
+# the overseer router, instead of the critical sitting in the intake queue
+# until the next scheduled drain (10:00/22:00 UTC — today's four criticals
+# waited ~10h). The drain agent consumes the whole queue, so a sweep that
+# pages several criticals dispatches ONCE, and the router's alert-drain
+# playbook + the executor's EC2 tag lock (concurrent_skip benign) guard
+# overlap. Async Event invoke — the router owns escalation on executor
+# failure (mirrors saturday-sf-watch-dispatcher's M2 posture).
+#
+# Rows with a `recovery:` block are EXCLUDED: their declared lane is the
+# auto-backfill heal, and a drain on top of an in-flight heal is redundant.
+# Rows with no declaration at all (only reachable via warning-escalation or
+# probe_failed coercion — the PR-time completeness check requires a lane on
+# every statically-critical row) DEFAULT to dispatch: a critical page nobody
+# declared a response for is exactly the case that must not sit unactioned.
+DRAIN_DISPATCH_ENABLED = (
+    os.environ.get("FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED", "false").lower()
+    == "true"
+)
+DRAIN_DISPATCH_MARKER_KEY = (
+    "_freshness_monitor/_dispatch/last_drain_dispatch.json"
+)
+# One drain covers every critical in the queue at launch; the cooldown only
+# bounds how often a PERSISTENTLY-critical sweep can relaunch one. Sized to
+# the drain's own runtime ceiling (3h watchdog) would starve genuinely new
+# incidents; 120min matches the recovery cooldown's retry philosophy.
+DRAIN_DISPATCH_COOLDOWN_MINUTES = int(
+    os.environ.get("DRAIN_DISPATCH_COOLDOWN_MINUTES", "120")
+)
+OVERSEER_DISPATCHER_FUNCTION = os.environ.get(
+    "OVERSEER_DISPATCHER_FUNCTION", "alpha-engine-overseer-dispatcher"
+)
+DRAIN_PLAYBOOK = os.environ.get("FRESHNESS_DRAIN_PLAYBOOK", "alert-drain")
+
 # CloudWatch namespace for the per-cycle completion rollup metric. Shares
 # the substrate-health namespace so cycle-completion + substrate-row health
 # graph together. Dimensioned by Cadence only (low-cardinality, alarm-able).
@@ -279,12 +316,14 @@ def load_registry(s3_client: Any, bucket: str, key: str) -> list[ArtifactSpec]:
 
 def load_registry_with_recovery(
     s3_client: Any, bucket: str, key: str
-) -> tuple[list[ArtifactSpec], dict[str, dict], dict[str, list[str]], dict[str, bool]]:
+) -> tuple[list[ArtifactSpec], dict[str, dict], dict[str, list[str]],
+           dict[str, bool], dict[str, str]]:
     """Like :func:`load_registry`, but also returns the per-artifact
     ``recovery:`` spec map (config#1240), the
-    ``critical_while_champion_arm`` map (config-I3086), and the
-    ``escalate_to_issue`` map (config#2055 Gap 2), all keyed by
-    ``artifact_id``.
+    ``critical_while_champion_arm`` map (config-I3086), the
+    ``escalate_to_issue`` map (config#2055 Gap 2), and the
+    ``remediation:`` declared-response-lane map (config-I3282), all keyed
+    by ``artifact_id``.
 
     ``ArtifactSpec`` is a frozen lib dataclass without a ``recovery``
     field (the monitor's dispatch concern is not the substrate's
@@ -307,6 +346,7 @@ def load_registry_with_recovery(
     recovery_by_id: dict[str, dict] = {}
     critical_arms_by_id: dict[str, list[str]] = {}
     escalate_to_issue_by_id: dict[str, bool] = {}
+    remediation_by_id: dict[str, str] = {}
     for entry in data["artifacts"]:
         merged = {**defaults, **entry}
         merged["created_at"] = _coerce_date(merged["created_at"])
@@ -322,7 +362,11 @@ def load_registry_with_recovery(
             critical_arms_by_id[spec.artifact_id] = [str(a) for a in arms]
         if merged.get("escalate_to_issue") is True:
             escalate_to_issue_by_id[spec.artifact_id] = True
-    return specs, recovery_by_id, critical_arms_by_id, escalate_to_issue_by_id
+        remediation = merged.get("remediation")
+        if isinstance(remediation, str) and remediation:
+            remediation_by_id[spec.artifact_id] = remediation
+    return (specs, recovery_by_id, critical_arms_by_id,
+            escalate_to_issue_by_id, remediation_by_id)
 
 
 # ── Dynamic severity (config-I3086) ─────────────────────────────────────────
@@ -860,6 +904,115 @@ def _maybe_dispatch_recovery(
         "DISPATCHED %s recovery for %s (state=%s) target=%s",
         recovery.get("type"), spec.artifact_id, result.state,
         recovery.get("target"),
+    )
+    return True
+
+
+# ── Freshness-critical → overseer drain dispatch (config-I3282 phase 1) ─────
+
+
+def _drain_dispatch_in_cooldown(s3_client: Any, now: datetime) -> bool:
+    """True if a drain-dispatch marker exists within the cooldown window.
+
+    Global (not per-artifact): one drain consumes the WHOLE intake queue, so
+    every critical paged before (or shortly after) the launch is covered by
+    the same run. Fail-closed on non-404 HEAD errors, mirroring
+    :func:`_recovery_already_dispatched` — a transient S3 blip must not
+    trigger a dispatch storm.
+    """
+    try:
+        resp = s3_client.head_object(
+            Bucket=REGISTRY_BUCKET, Key=DRAIN_DISPATCH_MARKER_KEY
+        )
+    except Exception as exc:  # noqa: BLE001 — classify by error code
+        code = str(
+            getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+        )
+        status = getattr(exc, "response", {}).get("ResponseMetadata", {}).get(
+            "HTTPStatusCode", 0
+        )
+        if code in {"404", "NoSuchKey", "NotFound"} or status == 404:
+            return False  # no marker → first dispatch
+        logger.warning(
+            "drain-dispatch marker HEAD failed (%s) — assuming in-flight to "
+            "avoid a dispatch storm", exc,
+        )
+        return True
+    lm = resp.get("LastModified")
+    if lm is None:
+        return True
+    age_min = (now - lm).total_seconds() / 60.0
+    return age_min < DRAIN_DISPATCH_COOLDOWN_MINUTES
+
+
+def _maybe_dispatch_drain(
+    s3_client: Any,
+    aws_clients: dict[str, Any],
+    candidate_ids: list[str],
+    now: datetime,
+) -> bool:
+    """Event-time overseer drain dispatch for this sweep's critical pages
+    (config-I3282 phase 1). Called ONCE per pass with every artifact whose
+    critical page fired and whose declared lane admits dispatch.
+
+    Returns ``True`` iff a dispatch was performed. Fires only when ALL of:
+      - ``candidate_ids`` is non-empty;
+      - :data:`DRAIN_DISPATCH_ENABLED` (OBSERVE-mode gate — logs the
+        would-dispatch and writes NO marker / calls NO AWS when off);
+      - no dispatch marker within the cooldown window (global dedup — one
+        drain covers the whole queue).
+
+    The router invoke is async (``Event``): the overseer-dispatcher owns
+    verdict handling and escalation (P1 + loud page) end-to-end, exactly as
+    it does for saturday-sf-watch-dispatcher's M2 dispatches. The marker is
+    written BEFORE the invoke (same crash-ordering argument as the recovery
+    marker: err toward not-re-dispatching).
+    """
+    if not candidate_ids:
+        return False
+
+    if not DRAIN_DISPATCH_ENABLED:
+        logger.info(
+            "OBSERVE-mode (drain-dispatch): would dispatch playbook=%s via %s "
+            "for %d critical page(s): %s",
+            DRAIN_PLAYBOOK, OVERSEER_DISPATCHER_FUNCTION,
+            len(candidate_ids), sorted(candidate_ids),
+        )
+        return False
+
+    if _drain_dispatch_in_cooldown(s3_client, now):
+        logger.info(
+            "drain dispatch in cooldown — %d critical page(s) (%s) covered by "
+            "the in-flight/recent drain",
+            len(candidate_ids), sorted(candidate_ids),
+        )
+        return False
+
+    _put_json(
+        s3_client, REGISTRY_BUCKET, DRAIN_DISPATCH_MARKER_KEY,
+        {
+            "dispatched_at": now.isoformat(),
+            "artifact_ids": sorted(candidate_ids),
+            "playbook": DRAIN_PLAYBOOK,
+        },
+    )
+
+    lam = aws_clients.get("lambda")
+    if lam is None:
+        lam = boto3.client("lambda")
+        aws_clients["lambda"] = lam
+    lam.invoke(
+        FunctionName=OVERSEER_DISPATCHER_FUNCTION,
+        InvocationType="Event",  # async; the router owns escalation
+        Payload=json.dumps({
+            "playbook": DRAIN_PLAYBOOK,
+            "payload": {"trigger": "freshness-critical", "is_drill": "false"},
+        }).encode("utf-8"),
+    )
+    logger.info(
+        "DISPATCHED overseer playbook=%s via %s for %d critical page(s): %s",
+        DRAIN_PLAYBOOK, OVERSEER_DISPATCHER_FUNCTION,
+        len(candidate_ids), sorted(candidate_ids),
     )
     return True
 
@@ -1446,7 +1599,8 @@ def _handle_intraday(s3_client: Any, now: datetime, started_at: float) -> dict:
         now.isoformat(), ALERTS_ENABLED,
     )
 
-    specs, recovery_by_id, critical_arms_by_id, _escalate_to_issue_by_id = (
+    (specs, recovery_by_id, critical_arms_by_id, _escalate_to_issue_by_id,
+     remediation_by_id) = (
         load_registry_with_recovery(s3_client, REGISTRY_BUCKET, REGISTRY_KEY)
     )
     specs, _coerced = apply_dynamic_severity(s3_client, specs, critical_arms_by_id)
@@ -1460,6 +1614,7 @@ def _handle_intraday(s3_client: Any, now: datetime, started_at: float) -> dict:
 
     pairs, alerted, dispatched, per_spec_exceptions, _miss_counts = _run_probe_pass(
         s3_client, intraday_specs, recovery_by_id, now,
+        remediation_by_id=remediation_by_id,
     )
 
     duration_seconds = round(time.time() - started_at, 2)
@@ -1489,9 +1644,15 @@ def _run_probe_pass(
     recovery_by_id: dict[str, dict],
     now: datetime,
     prev_miss_counts: dict[str, int] | None = None,
+    remediation_by_id: dict[str, str] | None = None,
 ) -> tuple[list[tuple[ArtifactSpec, CheckResult]], int, int, int, dict[str, int]]:
     """Walk ``specs``, probe each, dispatch confirmed-miss recoveries, and
     alert. Returns ``(pairs, alerted, dispatched, per_spec_exceptions)``.
+
+    config-I3282: after the walk, one aggregated event-time drain dispatch
+    fires for the pass's critical pages (see :func:`_maybe_dispatch_drain`
+    for the eligibility + dedup semantics) — independently trapped like the
+    per-artifact recovery dispatches, so it can never sink the pass.
 
     Shared verbatim by the daily full-registry sweep and the intraday
     mini-rule (config#1297) — the only difference between the two callers
@@ -1510,7 +1671,9 @@ def _run_probe_pass(
     dispatched = 0
     per_spec_exceptions = 0
     prev_miss_counts = prev_miss_counts or {}
+    remediation_by_id = remediation_by_id or {}
     miss_counts: dict[str, int] = {}
+    drain_candidates: list[str] = []
     # Per-pass cache of lazily-created SF/Lambda clients (shared across the
     # walk so a pass dispatching several recoveries reuses one client each).
     aws_clients: dict[str, Any] = {}
@@ -1555,9 +1718,36 @@ def _run_probe_pass(
             and isinstance(recovery, dict)
             and recovery.get("mode", "dispatch_and_page") == "dispatch"
         )
+        paged = False
         if not suppress_page and _maybe_alert(
                 spec, result, now, consecutive_miss_runs=miss_runs):
             alerted += 1
+            paged = True
+
+        # config-I3282 — collect this pass's dispatch-eligible critical
+        # pages. `_maybe_alert` returns True ONLY on an actual critical
+        # publish (warnings and OBSERVE mode return False), so `paged` is
+        # already the effective-severity gate. Excluded: rows with a
+        # `recovery:` heal of their own (their declared lane), and rows
+        # declared `remediation: operator` (page-only by declaration).
+        if (
+            paged
+            and spec.artifact_id not in recovery_by_id
+            and remediation_by_id.get(spec.artifact_id) != "operator"
+        ):
+            drain_candidates.append(spec.artifact_id)
+
+    # One aggregated event-time drain per pass (config-I3282), trapped so a
+    # dispatch failure can never sink the pass's primary deliverables. The
+    # critical page(s) above already fired, so the operator surface exists
+    # regardless of this leg's outcome.
+    try:
+        _maybe_dispatch_drain(s3_client, aws_clients, drain_candidates, now)
+    except Exception as drain_exc:  # noqa: BLE001 — side effect; pages already fired, this ERROR + the un-drained queue are the recording surfaces
+        logger.error(
+            "FRESHNESS_DRAIN_DISPATCH_FAILED for %s (non-fatal): %s",
+            sorted(drain_candidates), drain_exc, exc_info=True,
+        )
 
     return pairs, alerted, dispatched, per_spec_exceptions, miss_counts
 
@@ -1599,14 +1789,16 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
 
     # Load registry. If THIS fails, we want the Lambda to error out
     # so the CW alarm fires — a broken registry must not be silent.
-    specs, recovery_by_id, critical_arms_by_id, escalate_to_issue_by_id = (
+    (specs, recovery_by_id, critical_arms_by_id, escalate_to_issue_by_id,
+     remediation_by_id) = (
         load_registry_with_recovery(s3, REGISTRY_BUCKET, REGISTRY_KEY)
     )
     logger.info(
         "loaded %d specs from registry (%d with recovery specs, %d with "
-        "champion-arm dynamic severity, %d flagged for issue escalation)",
+        "champion-arm dynamic severity, %d flagged for issue escalation, "
+        "%d with declared remediation lanes)",
         len(specs), len(recovery_by_id), len(critical_arms_by_id),
-        len(escalate_to_issue_by_id),
+        len(escalate_to_issue_by_id), len(remediation_by_id),
     )
 
     # config-I3086: dynamic severity + warning-escalation counters.
@@ -1615,6 +1807,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
 
     pairs, alerted, dispatched, per_spec_exceptions, miss_counts = _run_probe_pass(
         s3, specs, recovery_by_id, now, prev_miss_counts,
+        remediation_by_id=remediation_by_id,
     )
 
     # config#2055 Gap 2: extended-staleness -> Decision Queue P1. Runs after
@@ -1695,6 +1888,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "counts": heartbeat["counts"],
         "alerts_enabled": ALERTS_ENABLED,
         "recovery_dispatch_enabled": RECOVERY_DISPATCH_ENABLED,
+        "drain_dispatch_enabled": DRAIN_DISPATCH_ENABLED,
         "alerted": alerted,
         "dispatched": dispatched,
         "issues_filed": issues_filed_this_run,

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -1571,7 +1571,7 @@ def test_load_registry_with_recovery_parses_block(monkeypatch, fake_s3):
     artifact_id; artifacts without a block are absent from the map."""
     fake_s3._registry_body = _RECOVERY_REGISTRY
     import index
-    specs, recovery, critical_arms, _esc = index.load_registry_with_recovery(
+    specs, recovery, critical_arms, _esc, _rem = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert len(specs) == 2
     assert set(recovery) == {"closes_recoverable"}
@@ -1626,7 +1626,7 @@ def _keyed_get_object(fake_s3, extra: dict[str, bytes]) -> None:
 def test_load_registry_parses_critical_while_champion_arm(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    _specs, _recovery, critical_arms, _esc = index.load_registry_with_recovery(
+    _specs, _recovery, critical_arms, _esc, _rem = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert critical_arms == {"champion_feed": ["scanner_predictor_direct"]}
 
@@ -1634,7 +1634,7 @@ def test_load_registry_parses_critical_while_champion_arm(fake_s3):
 def test_dynamic_severity_coerces_when_champion_arm_matches(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
         index.CHAMPION_POINTER_KEY:
             b'{"schema_version": 1, "champion": "scanner_predictor_direct"}',
@@ -1650,7 +1650,7 @@ def test_dynamic_severity_coerces_when_champion_arm_matches(fake_s3):
 def test_dynamic_severity_not_coerced_for_other_arm(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
         index.CHAMPION_POINTER_KEY: b'{"schema_version": 1, "champion": "think_tank"}',
     })
@@ -1665,7 +1665,7 @@ def test_dynamic_severity_pointer_read_failure_fails_toward_critical(fake_s3):
     fail toward paging, never toward silence."""
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {index.CHAMPION_POINTER_KEY: None})
     coerced_specs, coerced_ids = index.apply_dynamic_severity(
         fake_s3, specs, arms)
@@ -1813,7 +1813,7 @@ artifacts:
     created_at: 2025-01-01
 """
     import index
-    _specs, _recovery, _arms, escalate = index.load_registry_with_recovery(
+    _specs, _recovery, _arms, escalate, _rem = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert escalate == {"config_scoring_weights": True}
 
@@ -2059,3 +2059,215 @@ def test_prev_issue_filed_missing_file_resets(fake_s3):
     import index
     _keyed_get_object(fake_s3, {index.CHECK_RESULTS_KEY: None})
     assert index._load_prev_issue_filed(fake_s3) == {}
+
+
+# ── config-I3282: freshness-critical → overseer drain dispatch ──────────────
+#
+# Eligibility (pinned by these tests): a row joins the pass's ONE aggregated
+# drain dispatch iff its critical page actually fired AND it has no
+# `recovery:` heal of its own AND it is not declared `remediation: operator`.
+# The dispatch is flag-gated (OBSERVE default), globally cooldown-deduped via
+# an S3 marker, async (Event) to the overseer router, and independently
+# trapped so a failure can never sink the sweep.
+
+_DRAIN_REGISTRY = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+  grace_period_cycles: 2
+  calendar_aware: true
+  severity: warning
+artifacts:
+  - artifact_id: crit_dispatchable
+    s3_key_template: "staging/dispatchable/{trading_day}.parquet"
+    cadence: weekday_sf
+    sla_minutes_after_cron: 30
+    severity: critical
+    remediation: dispatch-diagnose
+    owner_repo: alpha-engine-data
+    created_at: 2025-01-01
+  - artifact_id: crit_operator
+    s3_key_template: "staging/operator/{trading_day}.parquet"
+    cadence: weekday_sf
+    sla_minutes_after_cron: 30
+    severity: critical
+    remediation: operator
+    owner_repo: alpha-engine-data
+    created_at: 2025-01-01
+  - artifact_id: crit_healed
+    s3_key_template: "staging/healed/{trading_day}.parquet"
+    cadence: weekday_sf
+    sla_minutes_after_cron: 30
+    severity: critical
+    owner_repo: alpha-engine-data
+    created_at: 2025-01-01
+    recovery:
+      type: lambda
+      target: "some-backfill-fn"
+  - artifact_id: warn_quiet
+    s3_key_template: "staging/quiet/{trading_day}.parquet"
+    cadence: weekday_sf
+    sla_minutes_after_cron: 30
+    severity: warning
+    owner_repo: alpha-engine-data
+    created_at: 2025-01-01
+"""
+
+
+def _run_drain_handler(monkeypatch, fake_s3, fixed_now, *, drain_enabled,
+                       registry=_DRAIN_REGISTRY):
+    """Full-sweep run with alerts ENABLED (pages fire) and recovery dispatch
+    in OBSERVE (so the `crit_healed` row's exclusion is purely declarative,
+    not an in-flight-heal artifact)."""
+    fake_s3._registry_body = registry
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.delenv("FRESHNESS_MONITOR_RECOVERY_ENABLED", raising=False)
+    if drain_enabled:
+        monkeypatch.setenv("FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED", "true")
+    else:
+        monkeypatch.delenv(
+            "FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED", raising=False
+        )
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    factory, sf, lam = _make_clients(fake_s3)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=factory))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+    result = index.handler({}, None)
+    return result, sf, lam, index
+
+
+def _drain_invokes(lam):
+    return [
+        c for c in lam.invoke.call_args_list
+        if c.kwargs.get("FunctionName") == "alpha-engine-overseer-dispatcher"
+    ]
+
+
+def test_load_registry_parses_remediation_map(monkeypatch, fake_s3):
+    """The loader returns the declared-lane map keyed by artifact_id;
+    undeclared rows are simply absent."""
+    import index
+    fake_s3._registry_body = _DRAIN_REGISTRY
+    _s, _r, _a, _e, remediation = index.load_registry_with_recovery(
+        fake_s3, "b", "k"
+    )
+    assert remediation == {
+        "crit_dispatchable": "dispatch-diagnose",
+        "crit_operator": "operator",
+    }
+
+
+def test_drain_dispatch_observe_mode_no_invoke(monkeypatch, fake_s3, fixed_now):
+    """Flag off (default): pages fire, but NO router invoke and NO marker —
+    the would-dispatch is log-only."""
+    result, _sf, lam, _index = _run_drain_handler(
+        monkeypatch, fake_s3, fixed_now, drain_enabled=False
+    )
+    assert result["alerted"] >= 1
+    assert result["drain_dispatch_enabled"] is False
+    assert _drain_invokes(lam) == []
+    marker_puts = [
+        k for (_, k, _) in fake_s3._put_calls
+        if k.startswith("_freshness_monitor/_dispatch/")
+    ]
+    assert marker_puts == []
+
+
+def test_drain_dispatch_fires_once_for_eligible_criticals(
+    monkeypatch, fake_s3, fixed_now
+):
+    """Flag on: the three critical rows all page, but exactly ONE router
+    invoke fires (aggregated), carrying the alert-drain playbook envelope,
+    async, and a dedup marker is written."""
+    result, _sf, lam, _index = _run_drain_handler(
+        monkeypatch, fake_s3, fixed_now, drain_enabled=True
+    )
+    assert result["alerted"] == 3  # dispatchable + operator + healed all page
+    invokes = _drain_invokes(lam)
+    assert len(invokes) == 1
+    call = invokes[0]
+    assert call.kwargs["InvocationType"] == "Event"
+    payload = json.loads(call.kwargs["Payload"])
+    assert payload["playbook"] == "alert-drain"
+    assert payload["payload"]["trigger"] == "freshness-critical"
+    assert payload["payload"]["is_drill"] == "false"
+    marker_puts = [
+        (k, body) for (_, k, body) in fake_s3._put_calls
+        if k == "_freshness_monitor/_dispatch/last_drain_dispatch.json"
+    ]
+    assert len(marker_puts) == 1
+    marker = json.loads(marker_puts[0][1])
+    # Only the declared-dispatchable row is a candidate — the operator row
+    # is page-only by declaration, the recovery row's lane is its heal.
+    assert marker["artifact_ids"] == ["crit_dispatchable"]
+
+
+def test_drain_dispatch_skips_when_no_eligible_candidates(
+    monkeypatch, fake_s3, fixed_now
+):
+    """A sweep whose only critical pages are operator-declared or
+    recovery-bearing rows dispatches nothing."""
+    registry = b"".join(
+        ln for ln in _DRAIN_REGISTRY.splitlines(keepends=True)
+    ).replace(b"remediation: dispatch-diagnose", b"remediation: operator")
+    result, _sf, lam, _index = _run_drain_handler(
+        monkeypatch, fake_s3, fixed_now, drain_enabled=True, registry=registry
+    )
+    assert result["alerted"] == 3
+    assert _drain_invokes(lam) == []
+
+
+def test_drain_dispatch_cooldown_dedup(monkeypatch, fake_s3, fixed_now):
+    """A fresh marker (within cooldown) suppresses the dispatch."""
+    fake_s3._head_returns[
+        "_freshness_monitor/_dispatch/last_drain_dispatch.json"
+    ] = {"LastModified": fixed_now}
+    _result, _sf, lam, _index = _run_drain_handler(
+        monkeypatch, fake_s3, fixed_now, drain_enabled=True
+    )
+    assert _drain_invokes(lam) == []
+
+
+def test_drain_dispatch_stale_marker_redispatches(
+    monkeypatch, fake_s3, fixed_now
+):
+    """A marker OLDER than the cooldown is a spent dispatch — fire again."""
+    from datetime import timedelta
+    fake_s3._head_returns[
+        "_freshness_monitor/_dispatch/last_drain_dispatch.json"
+    ] = {"LastModified": fixed_now - timedelta(minutes=999)}
+    _result, _sf, lam, _index = _run_drain_handler(
+        monkeypatch, fake_s3, fixed_now, drain_enabled=True
+    )
+    assert len(_drain_invokes(lam)) == 1
+
+
+def test_drain_dispatch_failure_does_not_sink_pass(
+    monkeypatch, fake_s3, fixed_now
+):
+    """A router-invoke failure is trapped: the sweep's primary deliverables
+    (alerts, heartbeat, check_results) land regardless."""
+    fake_s3._registry_body = _DRAIN_REGISTRY
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    monkeypatch.setenv("FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    lam = mock.Mock()
+    lam.invoke.side_effect = RuntimeError("router down")
+    factory, _sf, _lam = _make_clients(fake_s3, lambda_mock=lam)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=factory))
+    monkeypatch.setattr(index, "publish", mock.Mock())
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+
+    result = index.handler({}, None)  # must not raise
+
+    assert result["alerted"] == 3
+    put_keys = [k for (_, k, _) in fake_s3._put_calls]
+    assert "_freshness_monitor/heartbeat.json" in put_keys
+    assert "_freshness_monitor/check_results.json" in put_keys


### PR DESCRIPTION
## What

Wires the freshness monitor's confirmed-miss CRITICAL path into the overseer dispatch lane (alpha-engine-config-I3282, Brian directive 2026-07-22). Any critical page from a row without its own `recovery:` heal and not declared `remediation: operator` joins ONE aggregated per-sweep async invoke of `alpha-engine-overseer-dispatcher` with `{playbook: alert-drain, payload: {trigger: freshness-critical}}` — the drain agent consumes the whole intake queue (where the critical already landed via the krepis chokepoint), so the response is event-time instead of waiting for the 10:00/22:00 UTC scheduled drain. Today's four criticals waited ~10h; under this wiring they'd have had an agent on them within minutes.

## Design (mirrors config#1240 recovery-dispatch exactly)

- **OBSERVE default**: `FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED=false` — logs the would-dispatch, no AWS calls, no marker. Flip live after the e2e drill.
- **Global cooldown marker** (`_freshness_monitor/_dispatch/`, 120min default): one drain covers every critical in the queue, so dedup is global not per-artifact; fail-closed on non-404 HEAD; marker written before invoke.
- **Async Event invoke**: the router owns verdict handling + escalation (P1 + loud page) end-to-end — same posture as saturday-sf-watch-dispatcher's M2. The alert-drain executor's EC2 tag lock (`concurrent_skip` benign) guards overlap.
- **Registry parallel map**: `remediation:` parsed as a fifth map alongside recovery/champion-arm/escalate-to-issue (lib `ArtifactSpec` stays frozen). Field ships via alpha-engine-config-PR3285; until that merges+syncs the map is empty and this wiring is inert — clean staged rollout, no lockstep break.
- **deploy.sh env MERGE fix**: the routine deploy's hardcoded `Variables={...}` map silently reverted every operator-flipped flag (including the existing `FRESHNESS_MONITOR_RECOVERY_ENABLED`) on each redeploy — same silent-flag-wipe class as the M2_DISPATCH_TARGET lesson. Now merges with the live env; deploy-owned keys still win.

## Eligibility rule (pinned by tests)

paged critical AND no `recovery:` block (that lane is the heal) AND `remediation != operator`. Undeclared rows (reachable only via warning-escalation/probe_failed coercion — CI requires a lane on statically-critical rows) default to dispatch.

## Testing

7 new tests (parse map, observe mode, single aggregated invoke + envelope + marker, operator/recovery exclusion, cooldown dedup, stale-marker redispatch, failure-doesn't-sink-pass). Monitor suite 82 passed; full repo suite 3654 passed, 8 skipped.

## Rollout (staged, no post-merge step buried here)

Merge is safe standalone (observe default + empty map). Live flip is a tracked step on config-I3282 (deploy + drill + `FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED=true`), executed in-session with evidence, per the no-deferred-commands rule.

Companion charter PR: alpha-engine-config (freshness per-source playbook in the alert-drain charter). This is the SOTA approach — reuse the ratified router/playbook/drain plane with declarative eligibility, rather than a parallel diagnose plane; no delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)