### PR TITLE
feat(overseer): playbooks.yaml declares model/wake/cadence — registry becomes live SSoT; drain 4x daily (config-I3293)

### DIFF
--- a/infrastructure/lambdas/alert-drain-dispatcher/index.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/index.py
@@ -103,13 +103,16 @@ CW_LOG_GROUP = os.environ.get("ALERT_DRAIN_CW_LOG_GROUP", "/alpha-engine/alert-d
 
 _BOOL_RE = re.compile(r"^(true|false)$")
 _TRIGGER_RE = re.compile(r"^[a-z0-9_-]{0,64}$")
+# config-I3293 — optional registry-declared model, injected by the overseer
+# router from playbooks.yaml. Empty = absent = run-script inline default.
+_MODEL_RE = re.compile(r"^(claude-[a-z0-9.-]{1,60})?$")
 
 
 class _InvalidEvent(ValueError):
     """A required event field is missing or fails its allowlist."""
 
 
-def _resolve_event_fields(event: dict) -> tuple[str, str, str]:
+def _resolve_event_fields(event: dict) -> tuple[str, str, str, str]:
     """Validate + synthesize the run identity. A drill's run id ALWAYS carries
     the ``drill-`` prefix (drill-vs-real isolation on the completion-marker
     and ledger keys, config#2223 pattern) and a real run's never does."""
@@ -119,18 +122,28 @@ def _resolve_event_fields(event: dict) -> tuple[str, str, str]:
     trigger = str(event.get("trigger") or "").strip()
     if not _TRIGGER_RE.match(trigger):
         raise _InvalidEvent(f"malformed 'trigger' in event: {trigger!r}")
+    model = str(event.get("model") or "").strip()
+    if not _MODEL_RE.match(model):
+        raise _InvalidEvent(f"malformed 'model' in event: {model!r}")
     now = datetime.now(timezone.utc)
     prefix = "drill-" if is_drill == "true" else "drain-"
     run_id = f"{prefix}{now:%Y-%m-%dT%H%MZ}"
-    return run_id, is_drill, trigger
+    return run_id, is_drill, trigger, model
 
 
-def _bootstrap_command(run_id: str, is_drill: str) -> str:
+def _bootstrap_command(run_id: str, is_drill: str, model: str = "") -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec the
     alert_drain_spot_bootstrap.sh entrypoint. Prelude failure shuts the box
-    down (mirrors the sibling dispatchers' prelude fail() trap exactly)."""
+    down (mirrors the sibling dispatchers' prelude fail() trap exactly).
+
+    ``model`` (config-I3293) is the registry-declared agent model injected by
+    the overseer router; exported as DRAIN_MODEL for the bootstrap's runuser
+    env passthrough (empty → alert_drain_run.sh's inline default applies —
+    its ``:-`` expansion treats empty as unset). Regex-validated upstream
+    (_MODEL_RE) so the f-string interpolation cannot inject shell."""
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
+export DRAIN_MODEL="{model}"
 # SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
 export HOME=/root
 fail() {{ echo "[alert-drain-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
@@ -182,10 +195,11 @@ def _wait_ssm_online(instance_id: str) -> None:
     )
 
 
-def _send_bootstrap(instance_id: str, run_id: str, is_drill: str) -> str:
+def _send_bootstrap(instance_id: str, run_id: str, is_drill: str,
+                    model: str = "") -> str:
     return spot_dispatch.send_async_command(
         instance_id,
-        _bootstrap_command(run_id, is_drill),
+        _bootstrap_command(run_id, is_drill, model),
         comment=f"alert-drain ({run_id})",
         region=REGION,
         cw_log_group=CW_LOG_GROUP,
@@ -207,7 +221,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     ``{"launched": false, "reason": ...}``, never raises."""
     event = event or {}
     try:
-        run_id, is_drill, trigger = _resolve_event_fields(event)
+        run_id, is_drill, trigger, model = _resolve_event_fields(event)
     except _InvalidEvent as exc:
         logger.error("invalid alert-drain event: %s", exc)
         return {"launched": False, "reason": "invalid_event", "error": str(exc)}
@@ -252,7 +266,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
 
     try:
         _wait_ssm_online(instance_id)
-        command_id = _send_bootstrap(instance_id, run_id, is_drill)
+        command_id = _send_bootstrap(instance_id, run_id, is_drill, model)
     except Exception as exc:  # noqa: BLE001 — converted to a clean launched:false (router escalates)
         _terminate_instance(instance_id)
         logger.error("alert-drain post-launch step failed for %s: %s: %s",

--- a/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
@@ -122,3 +122,23 @@ class TestBootstrapCommand:
         assert "infrastructure/alert_drain_spot_bootstrap.sh" in cmd
         assert "--run-id" in cmd and "--is-drill" in cmd
         assert index.DRAIN_GH_PAT_SSM in cmd
+
+
+def test_model_threaded_into_bootstrap_export():
+    """config-I3293: a router-injected model lands as the DRAIN_MODEL export
+    in the SSM bootstrap command; absent, the export is empty (run script's
+    inline default applies via its :- expansion)."""
+    import index
+    cmd = index._bootstrap_command("drain-x", "false", "claude-sonnet-5")
+    assert 'export DRAIN_MODEL="claude-sonnet-5"' in cmd
+    cmd_default = index._bootstrap_command("drain-x", "false")
+    assert 'export DRAIN_MODEL=""' in cmd_default
+
+
+def test_malformed_model_rejected():
+    """Shell-injection guard: a model failing _MODEL_RE is a clean
+    invalid_event decline, never interpolated into the SSM command."""
+    import index
+    out = index.handler({"trigger": "x", "model": 'claude-$(rm -rf /)'}, None)
+    assert out == {"launched": False, "reason": "invalid_event",
+                   "error": out["error"]}

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -304,6 +304,8 @@ _RUN_ID_RE = re.compile(r"^[0-9]+$")
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9_./-]{1,200}$")
 _WORKFLOW_RE = re.compile(r"^[A-Za-z0-9 _./:()-]{1,200}$")
 _BOOL_RE = re.compile(r"^(true|false)$")
+# config-I3293 — registry-declared agent model (router-injected); optional.
+_MODEL_RE = re.compile(r"^claude-[a-z0-9.-]{1,60}$")
 
 
 class _InvalidEvent(ValueError):
@@ -326,7 +328,7 @@ def _optional(event: dict, key: str, pattern: "re.Pattern[str]", default: str = 
     return val
 
 
-def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str, str]:
+def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str, str, str]:
     """Validate the GHA payload's CI fields; raises _InvalidEvent on any
     missing/malformed field (caught once, at the handler, and converted to a
     clean launched:false — see module docstring's synchronous contract).
@@ -338,9 +340,13 @@ def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str, st
     real (repo, sha) into a drill's lock/marker keys. See the DRILL_REPO
     isolation invariant above."""
     is_drill = _optional(event, "is_drill", _BOOL_RE, default="false")
+    # model (config-I3293): registry-declared agent model injected by the
+    # overseer router; optional — empty means the run script's inline default
+    # applies. Regex-validated so the f-string export cannot inject shell.
+    model = _optional(event, "model", _MODEL_RE)
     if is_drill == "true":
         return (DRILL_REPO, _drill_sha(datetime.now(timezone.utc)), "0",
-                DRILL_RUN_URL, DRILL_WORKFLOW, "main", is_drill)
+                DRILL_RUN_URL, DRILL_WORKFLOW, "main", is_drill, model)
     repo = _require(event, "repo", _REPO_RE)
     sha = _require(event, "sha", _SHA_RE)
     run_id = _require(event, "run_id", _RUN_ID_RE)
@@ -352,12 +358,12 @@ def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str, str, st
         # under `set -u` it could expand as a positional param (same gotcha
         # groom's run_url note documents) and abort the prelude.
         raise _InvalidEvent(f"missing/malformed 'run_url' in event: {run_url!r}")
-    return repo, sha, run_id, run_url, workflow, branch, is_drill
+    return repo, sha, run_id, run_url, workflow, branch, is_drill, model
 
 
 def _bootstrap_command(repo: str, sha: str, run_id: str, run_url: str,
                        workflow: str, branch: str, run_token: str,
-                       is_drill: str = "false") -> str:
+                       is_drill: str = "false", model: str = "") -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec the
     ci_watch_spot_bootstrap.sh entrypoint (built by a sibling agent in
     alpha-engine-config). Any prelude failure shuts the box down so a botched
@@ -373,6 +379,7 @@ def _bootstrap_command(repo: str, sha: str, run_id: str, run_url: str,
     ``_send_bootstrap``, and the handler's returned JSON)."""
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
+export CI_WATCH_MODEL="{model}"
 # SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
 export HOME=/root
 fail() {{ echo "[ci-watch-prelude] FATAL: $1"; shutdown -h now; exit 1; }}
@@ -430,12 +437,12 @@ def _wait_ssm_online(instance_id: str) -> None:
 
 def _send_bootstrap(instance_id: str, repo: str, sha: str, run_id: str, run_url: str,
                     workflow: str, branch: str, run_token: str,
-                    is_drill: str = "false") -> str:
+                    is_drill: str = "false", model: str = "") -> str:
     """Fire the async, detached SSM command that runs CI-watch + self-terminates."""
     return spot_dispatch.send_async_command(
         instance_id,
         _bootstrap_command(repo, sha, run_id, run_url, workflow, branch, run_token,
-                           is_drill=is_drill),
+                           is_drill=is_drill, model=model),
         comment=f"ci-watch ({repo}@{sha[:12]}, run {run_id}, token {run_token[:12]})",
         region=REGION,
         cw_log_group=CW_LOG_GROUP,
@@ -469,7 +476,7 @@ def _terminate_instance(instance_id: str) -> None:
 
 def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
                           workflow: str, branch: str,
-                          is_drill: str = "false") -> dict:
+                          is_drill: str = "false", model: str = "") -> dict:
     """Launch + bootstrap the CI-watch box. SYNCHRONOUS contract: every
     anticipated failure mode returns a clean, well-formed launched:false
     rather than raising — see module docstring."""
@@ -543,7 +550,8 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
     try:
         _wait_ssm_online(instance_id)
         command_id = _send_bootstrap(instance_id, repo, sha, run_id, run_url,
-                                     workflow, branch, run_token, is_drill=is_drill)
+                                     workflow, branch, run_token, is_drill=is_drill,
+                                     model=model)
     except Exception as exc:  # noqa: BLE001 — converted to a clean launched:false
         _terminate_instance(instance_id)
         logger.error("ci-watch post-launch step failed for %s: %s: %s",
@@ -597,7 +605,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """
     event = event or {}
     try:
-        repo, sha, run_id, run_url, workflow, branch, is_drill = _resolve_event_fields(event)
+        repo, sha, run_id, run_url, workflow, branch, is_drill, model = _resolve_event_fields(event)
     except _InvalidEvent as exc:
         logger.error("invalid ci-watch event: %s", exc)
         return {"launched": False, "reason": "invalid_event", "error": str(exc)}
@@ -607,4 +615,4 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         repo, sha, run_id, workflow, branch, is_drill,
     )
     return _launch_ci_watch_spot(repo, sha, run_id, run_url, workflow, branch,
-                                 is_drill=is_drill)
+                                 is_drill=is_drill, model=model)

--- a/infrastructure/lambdas/overseer-dispatcher/index.py
+++ b/infrastructure/lambdas/overseer-dispatcher/index.py
@@ -312,6 +312,13 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
 
     function_name = spec["executor_function"]
     executor_payload = _stringify_bools(payload)
+    # config-I3293 — the registry is the SSoT for the agent's model: inject
+    # the playbook's declared `model` into the executor payload unless the
+    # caller explicitly overrode it (drills/operator invokes may). Executors
+    # thread it to the run script's --model; absent both, the run script's
+    # inline default applies (non-router invocation fallback).
+    if spec.get("model") and "model" not in executor_payload:
+        executor_payload["model"] = spec["model"]
     started_at = datetime.now(timezone.utc).isoformat()
     try:
         verdict = _invoke_executor(function_name, executor_payload)

--- a/infrastructure/lambdas/overseer-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/overseer-dispatcher/test_handler.py
@@ -227,3 +227,29 @@ class TestInvokeClientConfig:
         assert cfg is index._EXECUTOR_INVOKE_CONFIG
         assert cfg.retries == {"max_attempts": 0}
         assert cfg.read_timeout == 290
+
+
+class TestModelInjection:
+    """config-I3293: the registry is the SSoT for the agent's model — the
+    router injects the playbook's declared `model` into the executor payload,
+    and a caller-provided model (drill/operator override) wins."""
+
+    def test_registry_model_injected_into_executor_payload(self, index_mod):
+        index, fake_boto3 = index_mod
+        lam = _lambda_client_returning(fake_boto3, {"launched": True, "reason": "launched"})
+        index.handler({"playbook": "sf-watch",
+                       "payload": {"pipeline_name": "ne-weekly-freshness-pipeline",
+                                   "run_date": "2026-07-17"}}, None)
+        sent = json.loads(lam.invoke.call_args.kwargs["Payload"])
+        reg_model = index._registry()["playbooks"]["sf-watch"]["model"]
+        assert sent["model"] == reg_model
+        assert reg_model.startswith("claude-")
+
+    def test_caller_model_override_wins(self, index_mod):
+        index, fake_boto3 = index_mod
+        lam = _lambda_client_returning(fake_boto3, {"launched": True, "reason": "launched"})
+        index.handler({"playbook": "alert-drain",
+                       "payload": {"trigger": "operator", "model": "claude-opus-4-8"}},
+                      None)
+        sent = json.loads(lam.invoke.call_args.kwargs["Payload"])
+        assert sent["model"] == "claude-opus-4-8"

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -234,6 +234,8 @@ _RUN_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _FAILED_STATE_RE = re.compile(r"^[A-Za-z0-9 _.:()/-]{0,200}$")
 _WATCH_LOG_KEY_RE = re.compile(r"^[A-Za-z0-9_./-]{0,300}$")
 _BOOL_RE = re.compile(r"^(true|false)$")
+# config-I3293 — registry-declared agent model (router-injected); optional.
+_MODEL_RE = re.compile(r"^claude-[a-z0-9.-]{1,60}$")
 
 
 class _InvalidEvent(ValueError):
@@ -284,6 +286,11 @@ def _resolve_event_fields(event: dict) -> dict:
     # to launch_with_fallback(force_on_demand=...), present in the pinned
     # nousergon-lib v0.106.0). Boolean-validated like is_preflight.
     force_on_demand = _optional(event, "force_on_demand", _BOOL_RE, default="false")
+    # model (config-I3293): the registry-declared agent model injected by the
+    # overseer router from playbooks.yaml. Optional — empty means the run
+    # script's inline default applies (non-router invocation fallback).
+    # Regex-validated so its f-string interpolation cannot inject shell.
+    model = _optional(event, "model", _MODEL_RE)
     # cause: deliberately unvalidated — arbitrary AWS text, base64-encoded
     # before it ever reaches a shell command (see _bootstrap_command).
     cause = str(event.get("cause") or "")
@@ -298,6 +305,7 @@ def _resolve_event_fields(event: dict) -> dict:
         "is_preflight": is_preflight,
         "is_drill": is_drill,
         "force_on_demand": force_on_demand,
+        "model": model,
         "cause": cause,
     }
 
@@ -337,7 +345,8 @@ exec bash infrastructure/sf_watch_spot_bootstrap.sh \
   --state-machine-arn "{fields['state_machine_arn']}" --execution-arn "{fields['execution_arn']}" \
   --run-date "{fields['run_date']}" --failed-state "{fields['failed_state']}" \
   --cause-b64 "{cause_b64}" --watch-log-key "{fields['watch_log_key']}" \
-  --is-preflight "{fields['is_preflight']}" --is-drill "{fields['is_drill']}"
+  --is-preflight "{fields['is_preflight']}" --is-drill "{fields['is_drill']}" \
+  --model "{fields.get('model', '')}"
 """
 
 

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -38,6 +38,22 @@
           "concurrency_domain": { "type": "string" },
           "supports_drill": { "type": "boolean" },
           "kill_switch_env": { "type": "string", "pattern": "^[A-Z0-9_]+$" },
+          "model": {
+            "type": "string",
+            "pattern": "^claude-[a-z0-9.-]+$",
+            "description": "config-I3293 — the Claude model this playbook's agent runs. LIVE config, not documentation: the overseer-dispatcher injects it into the executor payload as `model`; executors thread it to the run script. The run script's inline default is the fallback only for non-router invocation paths. Required (via registry test, not schema) on every routed playbook whose executor launches a claude-CLI agent."
+          },
+          "wake": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 10 },
+            "minItems": 1,
+            "description": "config-I3293 — human-readable enumeration of everything that launches this playbook's agent (eventbridge rules, scheduler schedules, event-time dispatch paths). Names of scheduler:/eventbridge: resources mentioned here should also appear in a liveness check; the registry test pins the drain-schedule set."
+          },
+          "cadence": {
+            "type": "string",
+            "minLength": 5,
+            "description": "config-I3293 — one-line answer to 'is there a scheduled wake, and when' (e.g. 'event-driven only', '4x daily 04:00/10:00/16:00/22:00 UTC + event-time on freshness criticals')."
+          },
           "workflow_file": {
             "type": "string",
             "pattern": "^\\.github/workflows/[a-z0-9_-]+\\.ya?ml$",

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -32,6 +32,17 @@ playbooks:
     tier: T2
     routed: true
     enabled: true
+    # config-I3293 — model/wake/cadence are REGISTRY-DECLARED (this file is
+    # the one place that answers "what model runs this agent, what wakes it,
+    # on what cadence"). `model` is LIVE config, not documentation: the
+    # overseer-dispatcher injects it into the executor payload and the
+    # executor threads it to the run script's `--model`; the run script's
+    # inline default is the fallback ONLY for non-router invocation paths.
+    model: claude-opus-4-8
+    wake:
+      - "eventbridge:alpha-engine-saturday-sf-watch-failed (fleet SF terminal failure -> triage Lambda -> router, M2)"
+      - "eventbridge:alpha-engine-sf-watch-spot-interruption + alpha-engine-sf-watch-instance-terminated (reclaim/relaunch)"
+    cadence: "event-driven only — no scheduled wake"
     executor_function: alpha-engine-sf-watch-spot-dispatcher
     executor_lambda_dir: sf-watch-spot-dispatcher
     # Executor verdict `reason` values that are by-design declines — the
@@ -107,6 +118,10 @@ playbooks:
     tier: T2
     routed: true
     enabled: true
+    model: claude-opus-4-8   # config-I3293 — registry-declared, router-injected
+    wake:
+      - "gha:nousergon-lib notify-ci-failure.yml -> repository_dispatch -> sf-watch.yml ci-watch-dispatch job -> this router (main-branch CI failure)"
+    cadence: "event-driven only — no scheduled wake (deprecation to drain intake tracked: config-I2845)"
     executor_function: alpha-engine-ci-watch-dispatcher
     executor_lambda_dir: ci-watch-dispatcher
     # signature_repeat_skip (config#2862): a signature marker for (repo,
@@ -129,15 +144,21 @@ playbooks:
 
   alert-drain:
     description: >-
-      Twice-daily Overseer alert-drain (epic I2821 phase 3, config-I2824):
-      consumes the nousergon-overseer-intake queue + S3 fallback, classifies
-      incidents into the T0-T3 authority tiers per the alert-drain charter,
-      acts within charter authority (v1: PRs, issues, SF reruns only), writes
-      the drain ledger. Fired by EventBridge Scheduler (10:00 + 22:00 UTC)
-      THROUGH this router.
+      The Overseer's non-urgent queue processor (epic I2821 phase 3,
+      config-I2824): consumes the nousergon-overseer-intake queue + S3
+      fallback, classifies incidents into the T0-T3 authority tiers per the
+      alert-drain charter, acts within charter authority (v1: PRs, issues,
+      SF reruns only), writes the drain ledger. Fired 4x daily by
+      EventBridge Scheduler THROUGH this router, plus event-time for
+      freshness CRITICALs (config-I3282).
     tier: T2
     routed: true
     enabled: true
+    model: claude-sonnet-5   # config-I3293 — registry-declared, router-injected; charter may spawn complexity-matched sub-agents (Brian ruling 2026-07-22)
+    wake:
+      - "scheduler:alpha-engine-alert-drain-0400utc/1000utc/1600utc/2200utc (4x-daily non-urgent queue drain, Brian ruling 2026-07-22)"
+      - "event-time: freshness-monitor CRITICAL page -> router (trigger=freshness-critical, config-I3282)"
+    cadence: "4x daily 04:00/10:00/16:00/22:00 UTC + event-time on freshness criticals"
     executor_function: alpha-engine-alert-drain-dispatcher
     executor_lambda_dir: alert-drain-dispatcher
     benign_reasons: [concurrent_skip, disabled]
@@ -172,6 +193,13 @@ playbooks:
     routed: false
     enabled: true
     executor_function: alpha-engine-scheduled-groom-dispatcher
+    # Model is complexity-tiered per issue (Haiku=low / Sonnet=mid+high), set
+    # per-run by groom_driver — deliberately NOT the router-injected `model:`
+    # field, which only applies to routed playbooks (config-I3293).
+    wake:
+      - "eventbridge: three daily fixed crons 01:00/07:00/19:00 UTC (demand-driven tier launches)"
+      - "demand: end-of-SF Haiku PR-sweep leg (groom_run.sh --mode pr_sweep)"
+    cadence: "3x daily fixed crons + end-of-SF sweep leg"
     executor_lambda_dir: scheduled-groom-dispatcher
     charter: alpha-engine-config/scripts/groom_run.sh
     concurrency_domain: EC2 tag lock on groom-issue-filter (tier lane; sweep has its own lane).
@@ -248,6 +276,9 @@ playbooks:
     routed: false
     enabled: true
     executor_function: alpha-engine-canary-replay-dispatcher
+    wake:
+      - "scheduler:alpha-engine-ci-watch-canary-drill-weekly + alpha-engine-sf-watch-canary-drill-weekly (Wednesday drills; router re-point tracked config-I2832)"
+    cadence: "weekly Wednesday drills; liveness tick every 15min (eventbridge:alpha-engine-canary-replay-liveness-probe-tick)"
     executor_lambda_dir: canary-replay-dispatcher
     charter: alpha-engine-config/infrastructure/canary_replay_spot_bootstrap.sh
     concurrency_domain: >-
@@ -275,6 +306,9 @@ playbooks:
     routed: false
     enabled: true
     executor_function: alpha-engine-arctic-migration-dispatcher
+    wake:
+      - "gha: nousergon-data migrations/ path-filtered workflow on merge (ARCH §120) + manual workflow_dispatch"
+    cadence: "event-driven (merge-triggered); no scheduled wake"
     executor_lambda_dir: arctic-migration-dispatcher
     charter: nousergon-data/scripts/run_arctic_migrations.py
     concurrency_domain: >-
@@ -317,7 +351,11 @@ watch_plane_liveness:
     # weekly canary-drill schedules' targets between the executor Lambdas and
     # this router — asserting target ARN here would race that migration.
     - type: scheduler_schedule_exists
+      schedule_name: alpha-engine-alert-drain-0400utc
+    - type: scheduler_schedule_exists
       schedule_name: alpha-engine-alert-drain-1000utc
+    - type: scheduler_schedule_exists
+      schedule_name: alpha-engine-alert-drain-1600utc
     - type: scheduler_schedule_exists
       schedule_name: alpha-engine-alert-drain-2200utc
     - type: scheduler_schedule_exists

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -267,8 +267,50 @@ def test_watch_plane_covers_all_four_router_scheduler_schedules():
     checks = REGISTRY["watch_plane_liveness"]["checks"]
     names = {c["schedule_name"] for c in checks if c["type"] == "scheduler_schedule_exists"}
     assert names == {
+        "alpha-engine-alert-drain-0400utc",
         "alpha-engine-alert-drain-1000utc",
+        "alpha-engine-alert-drain-1600utc",
         "alpha-engine-alert-drain-2200utc",
         "alpha-engine-ci-watch-canary-drill-weekly",
         "alpha-engine-sf-watch-canary-drill-weekly",
     }
+
+
+# ── model/wake/cadence declaration (config-I3293) ────────────────────────────
+
+
+def test_every_routed_playbook_declares_model_wake_cadence():
+    """config-I3293: the registry is the ONE place that answers 'what model
+    runs this agent, what wakes it, on what cadence'. Every routed playbook
+    (its agent is launched THROUGH the router, so the router can inject the
+    declared model) must carry all three fields; the schema alone keeps them
+    optional (inventory-only entries may omit `model` — e.g. groom's
+    complexity-tiered per-run choice is deliberately not router-injected)."""
+    for name, spec in REGISTRY["playbooks"].items():
+        if not spec.get("routed"):
+            continue
+        assert spec.get("model", "").startswith("claude-"), (
+            f"routed playbook {name!r} missing a registry-declared model "
+            f"(config-I3293) — the run script's inline default would silently "
+            f"become undeclared live config"
+        )
+        assert spec.get("wake"), f"routed playbook {name!r} missing wake declaration"
+        assert spec.get("cadence"), f"routed playbook {name!r} missing cadence declaration"
+
+
+def test_drain_wake_names_all_four_schedules():
+    """The alert-drain wake declaration and the watch_plane_liveness
+    scheduler checks must agree on the 4x-daily schedule set — a schedule
+    added to one surface but not the other is drift."""
+    wake_text = " ".join(REGISTRY["playbooks"]["alert-drain"]["wake"])
+    checks = REGISTRY["watch_plane_liveness"]["checks"]
+    drain_scheds = {
+        c["schedule_name"] for c in checks
+        if c["type"] == "scheduler_schedule_exists" and "alert-drain" in c["schedule_name"]
+    }
+    assert len(drain_scheds) == 4
+    for sched in drain_scheds:
+        hour_token = sched.rsplit("-", 1)[-1]  # e.g. '0400utc'
+        assert hour_token in wake_text, (
+            f"drain schedule {sched} not reflected in the wake declaration"
+        )


### PR DESCRIPTION
## What

Implements the consolidation half of config-I3293 (Brian ruling 2026-07-22): `infrastructure/overseer/playbooks.yaml` becomes the ONE place that answers *what model runs each overseer agent, what wakes it, and on what cadence* — and the `model:` field is **live config**, not documentation:

- **Router injection**: overseer-dispatcher injects the playbook's declared `model` into the executor payload (explicit caller override wins — drills/operator invokes).
- **Executor threading**: sf-watch (`--model` flag; bootstrap's `*)` arm ignores it harmlessly pre-config-merge), ci-watch + alert-drain (env export). All regex-validated (`_MODEL_RE`) so the f-string interpolation cannot inject shell.
- **Declared today**: sf-watch/ci-watch `claude-opus-4-8`, alert-drain `claude-sonnet-5` — matching current behavior exactly; zero live model change from this PR.
- **wake:/cadence:** declared on every routed playbook (new registry test enforces all three fields on routed entries) and descriptively on inventory entries (groom/canary/arctic-migration).
- **Drain cadence 2×→4× daily**: 0400/1600 UTC join the liveness check set + pinned registry test (which also cross-checks the wake declaration names all four).

## Gate (why draft)

`gate:operator` — the two new EventBridge Scheduler schedules must EXIST before this merges+deploys (the liveness probe would otherwise red-flag them). Creation commands are with Brian (classifier-blocked in-session); once run, this goes ready.

Verified-when: this is schedule-existence, not an SF run — cleared manually on `aws scheduler get-schedule --name alpha-engine-alert-drain-0400utc` succeeding.

## Merge order

alpha-engine-config env-honor PR merges first for the model threading to take effect end-to-end (no breakage either way — unknown flag/env are ignored; effectiveness only).

## Testing

Registry suite 32 passed (4 new: routed-playbook field completeness, drain wake↔schedule lockstep, model injection, caller override). Dispatcher suites: alert-drain 11, ci-watch 29, sf-watch 43, overseer-dispatcher 19 — all green. Full repo suite 3574 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)