### PR TITLE
feat(overseer): alert-class registry — every notification class declares intake + response (config-I3211); router/drain auto-deploy; deploy-role grant

### DIFF
--- a/.github/workflows/deploy-alert-drain-dispatcher.yml
+++ b/.github/workflows/deploy-alert-drain-dispatcher.yml
@@ -1,0 +1,88 @@
+name: Deploy alert-drain-dispatcher
+
+# Auto-deploy the alpha-engine-alert-drain-dispatcher Lambda CODE on merge to
+# main. Mirrors deploy-scheduled-groom-dispatcher.yml — same gap, same fix: a
+# merged code fix must not sit inert until someone remembers to run deploy.sh
+# by hand. This closes that gap for the CODE path only.
+#
+# Separation of concerns: this deploys CODE only (deploy.sh with NO flag —
+# this script's default/flagless run IS already code-only; --bootstrap is
+# what ADDS the IAM-role-creation + Lambda-function-creation on top, not the
+# reverse). The drain executor is invoked only THROUGH the
+# overseer router; its EventBridge Scheduler schedules target the router,
+# not this Lambda, so no schedule/cadence surface is touched here. Gap
+# closed 2026-07-22 alongside the router's workflow (same 5-day-stale
+# incident; deploy.sh preserves the operator-owned kill-switch env). The
+# github-actions-lambda-deploy OIDC role deliberately has no iam:CreateRole /
+# iam:PutRolePolicy (fleet-wide policy after 4 IAM-clobber incidents in 2
+# months; see infrastructure/iam/README.md) — an IAM/profile change still
+# requires an operator to run `deploy.sh --bootstrap` by hand.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/alert-drain-dispatcher/**'
+      - '.github/workflows/deploy-alert-drain-dispatcher.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-alert-drain-dispatcher-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy alert-drain-dispatcher Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy alert-drain-dispatcher (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-alert-drain-dispatcher \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-alert-drain-dispatcher.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@8c40481c0e80790bda54b30af63b4a341bebcccb # main
+    secrets: inherit

--- a/.github/workflows/deploy-overseer-dispatcher.yml
+++ b/.github/workflows/deploy-overseer-dispatcher.yml
@@ -1,0 +1,89 @@
+name: Deploy overseer-dispatcher
+
+# Auto-deploy the alpha-engine-overseer-dispatcher Lambda CODE on merge to
+# main. Mirrors deploy-scheduled-groom-dispatcher.yml — same gap, same fix: a
+# merged code fix must not sit inert until someone remembers to run deploy.sh
+# by hand. This closes that gap for the CODE path only.
+#
+# Separation of concerns: this deploys CODE only (deploy.sh with NO flag —
+# this script's default/flagless run IS already code-only; --bootstrap is
+# what ADDS the IAM-role-creation + Lambda-function-creation on top, not the
+# reverse). The router is invoked Lambda-to-Lambda
+# (sf-watch M2, freshness-monitor event-time dispatch) and by the four drain
+# Scheduler schedules; none of that cadence surface is touched here. Gap
+# closed 2026-07-22: this Lambda (which bundles playbooks.yaml at deploy)
+# sat 5 days stale after registry merges until an operator deployed by hand
+# — exactly the class Brian's standing auto-deploy preference forbids. The
+# github-actions-lambda-deploy OIDC role deliberately has no iam:CreateRole /
+# iam:PutRolePolicy (fleet-wide policy after 4 IAM-clobber incidents in 2
+# months; see infrastructure/iam/README.md) — an IAM/profile change still
+# requires an operator to run `deploy.sh --bootstrap` by hand.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* (infrastructure/iam/github-actions-lambda-
+# deploy.json), which already includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/overseer-dispatcher/**'
+      - '.github/workflows/deploy-overseer-dispatcher.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-overseer-dispatcher-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy overseer-dispatcher Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy overseer-dispatcher (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/overseer-dispatcher/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-overseer-dispatcher \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-overseer-dispatcher.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@8c40481c0e80790bda54b30af63b4a341bebcccb # main
+    secrets: inherit

--- a/infrastructure/iam/check-drift.py
+++ b/infrastructure/iam/check-drift.py
@@ -55,9 +55,32 @@ def _aws_iam(*args: str) -> dict | list | str:
     return json.loads(result.stdout) if result.stdout.strip() else {}
 
 
+def _normalize_unordered_lists(node):
+    """Recursively sort string-lists — IAM treats Action/Resource/
+    Principal.Service (and every other policy-document string array) as
+    UNORDERED sets, and AWS returns them in arbitrary, unstable order.
+    First bitten 2026-07-22: GetRole started returning
+    ["scheduler.amazonaws.com","events.amazonaws.com"] for a trust doc
+    codified in the opposite order — same set, red drift finding, every PR
+    blocked. Only lists that are entirely strings are sorted; mixed/object
+    lists (e.g. Statement arrays) keep their order — Statement order is
+    semantically meaningful for readers even though IAM ORs them, and the
+    codified file controls it."""
+    if isinstance(node, dict):
+        return {k: _normalize_unordered_lists(v) for k, v in node.items()}
+    if isinstance(node, list):
+        if node and all(isinstance(x, str) for x in node):
+            return sorted(node)
+        return [_normalize_unordered_lists(x) for x in node]
+    return node
+
+
 def _canonical_json(doc: dict) -> str:
-    """Canonical JSON for byte-stable comparison: sorted keys, no extra ws."""
-    return json.dumps(doc, sort_keys=True, separators=(",", ":"))
+    """Canonical JSON for byte-stable comparison: sorted keys, sorted
+    string-set arrays (see _normalize_unordered_lists), no extra ws."""
+    return json.dumps(
+        _normalize_unordered_lists(doc), sort_keys=True, separators=(",", ":")
+    )
 
 
 def _check_role(role_file: Path) -> list[str]:

--- a/infrastructure/iam/github-actions-lambda-deploy.json
+++ b/infrastructure/iam/github-actions-lambda-deploy.json
@@ -35,14 +35,16 @@
       "Sid": "LambdaUpdate",
       "Effect": "Allow",
       "Action": [
-        "lambda:UpdateFunctionCode",
-        "lambda:UpdateFunctionConfiguration",
+        "lambda:CreateAlias",
+        "lambda:CreateFunction",
         "lambda:GetFunction",
         "lambda:GetFunctionConfiguration",
+        "lambda:GetFunctionEventInvokeConfig",
         "lambda:PublishVersion",
+        "lambda:PutFunctionEventInvokeConfig",
         "lambda:UpdateAlias",
-        "lambda:CreateFunction",
-        "lambda:CreateAlias"
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration"
       ],
       "Resource": [
         "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -99,7 +99,37 @@
         ]
       }
     },
-    "watch_plane_liveness": { "$ref": "#/$defs/liveness_block" }
+    "watch_plane_liveness": { "$ref": "#/$defs/liveness_block" },
+    "alert_classes": {
+      "type": "array",
+      "minItems": 1,
+      "description": "config-I3211 — one row per distinct fleet notification class: which intake path the overseer sees it on and the declared response. intake:none rows MUST carry migration_issue or operator_reason (no undeclared drain-blind class).",
+      "items": {
+        "type": "object",
+        "required": ["class", "source", "severities", "intake", "response"],
+        "additionalProperties": false,
+        "properties": {
+          "class": { "type": "string", "pattern": "^[a-z0-9_]{3,60}$" },
+          "source": { "type": "string", "minLength": 3 },
+          "severities": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "enum": ["info", "warning", "error", "critical", "alarm", "dynamic"] }
+          },
+          "intake": { "enum": ["bus", "cw-alarm", "none"] },
+          "response": { "type": "string", "pattern": "^(drain-queue|operator|playbook:[a-z0-9-]+)$" },
+          "migration_issue": { "type": "string", "pattern": "^[a-z0-9-]+-I[0-9]+$" },
+          "operator_reason": { "type": "string", "minLength": 15 }
+        },
+        "if": { "properties": { "intake": { "const": "none" } } },
+        "then": {
+          "anyOf": [
+            { "required": ["migration_issue"] },
+            { "required": ["operator_reason"] }
+          ]
+        }
+      }
+    }
   },
   "$defs": {
     "liveness_block": {

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -362,3 +362,261 @@ watch_plane_liveness:
       schedule_name: alpha-engine-ci-watch-canary-drill-weekly
     - type: scheduler_schedule_exists
       schedule_name: alpha-engine-sf-watch-canary-drill-weekly
+
+# ── Alert-class registry (config-I3211; Brian directive 2026-07-22) ──────────
+# One row per DISTINCT notification class the fleet emits. This answers, in
+# one read: what can page, on which intake path the overseer sees it, and
+# what the declared response is. Inventory verified 2026-07-22 by fleet-wide
+# sweep (all 10 repos) + live AWS checks. Contract:
+#   intake: bus       — rides the krepis chokepoint -> nousergon-alerts ->
+#                       intake SQS (drain consumes; criticals also eligible
+#                       for event-time dispatch per artifact registry
+#                       remediation declarations, config-I3282)
+#   intake: cw-alarm  — CloudWatch ALARM-state tap on the default bus (zero
+#                       per-class code; covers every CW alarm)
+#   intake: none      — DRAIN-BLIND. Forbidden without either a
+#                       migration_issue (tracked path onto the bus) or an
+#                       operator_reason (explicit page-only/informational
+#                       declaration). CI-enforced.
+#   response: drain-queue        — the alert-drain charter's T0-T3 tiers
+#   response: playbook:<name>    — a routed playbook responds (must exist)
+#   response: operator           — declared human-only
+# The drain charter's runtime backstop treats an intake event whose source
+# matches NO row here as a T3 finding (registry drift caught at run time;
+# the cross-repo static chokepoint is tracked separately).
+
+alert_classes:
+  # ── executor (crucible-executor) ──
+  - class: executor_turnover_tripwire
+    source: "alpha-engine/executor/turnover_tripwire.py"
+    severities: [dynamic]
+    intake: bus
+    response: drain-queue
+  - class: executor_optimizer_shadow_rebalance
+    source: "alpha-engine/executor/optimizer_shadow.py"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: executor_order_book_rationale_write
+    source: "alpha-engine/executor/main.py"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+
+  # ── backtester (crucible-backtester) ──
+  - class: backtester_executor_opt_rejected
+    source: "alpha-engine-backtester/evaluate.py::_run_executor_opt"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: backtester_empty_param_sweep
+    source: "alpha-engine-backtester/backtest.py"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: backtester_stance_drift
+    source: "alpha-engine-backtester/analysis/stance_distribution.py"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+  - class: backtester_cost_anomaly
+    source: "alpha-engine-backtester/analysis/cost_report.py"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+  - class: backtester_champion_promotion
+    # NOTE stale 'crucible-backtester/' prefix in the emitter literal —
+    # config-I3302 renames it; row updated when that lands.
+    source: "crucible-backtester/optimizer/champion_promotion.py::run_weekly_evaluation"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+  - class: backtester_live_key_reconciliation
+    source: "alpha-engine-backtester/optimizer/live_key_reconciliation.py"
+    severities: [critical]
+    intake: bus
+    response: drain-queue
+  - class: backtester_pit_parity
+    source: "alpha-engine-backtester/pit_parity"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: backtester_input_quality
+    source: "alpha-engine-backtester/analysis/input_quality.py"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+
+  # ── predictor (crucible-predictor) ──
+  - class: predictor_risk_model_persist
+    source: "alpha-engine-predictor/training/train_handler.py::risk_model_persist"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: predictor_model_zoo
+    source: "alpha-engine-predictor/training/model_zoo.py::run_rotation_and_select"
+    severities: [info, warning, critical]
+    intake: bus
+    response: drain-queue
+  - class: predictor_predictions_write
+    source: "alpha-engine-predictor/inference/stages/write_output.py::write_predictions"
+    severities: [warning, critical]
+    intake: bus
+    response: drain-queue
+  - class: predictor_observe_calibration
+    source: "predictor.inference.observe_calibration"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+
+  # ── research (crucible-research) ──
+  - class: research_score_aggregator_gap
+    source: "research:score_aggregator"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: research_archive_writer_quarantine
+    source: "research:archive_writer"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+  - class: research_daemon_down
+    source: "research:alerts_handler"
+    severities: [critical]
+    intake: bus
+    response: drain-queue
+
+  # ── data plane (nousergon-data) ──
+  - class: data_constituents_drift
+    source: "alpha-engine-data/validators/constituents_drift_check.py"
+    severities: [dynamic]
+    intake: bus
+    response: drain-queue
+  - class: data_phase_marker_sweep
+    source: "alpha-engine-data/validators/phase_marker_sweep.py"
+    severities: [dynamic]
+    intake: bus
+    response: drain-queue
+  - class: data_spot_quota_fallback
+    source: "data-spot-dispatcher._launch_instance"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: lib_spot_quota_fallback
+    source: "nousergon_lib.spot_dispatch.launch_with_fallback"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+  - class: canary_replay_liveness
+    source: "canary-replay-liveness-probe"
+    severities: [critical]
+    intake: bus
+    response: drain-queue
+  - class: pipeline_watchdog_stuck_sf
+    source: "alpha-engine-pipeline-watchdog"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+  - class: overseer_dispatch_escalation
+    source: "overseer-dispatcher"
+    severities: [critical]
+    intake: bus
+    response: drain-queue
+  - class: freshness_monitor_staleness
+    # CRITICALs additionally trigger EVENT-TIME drain dispatch per the
+    # artifact registry's remediation declarations (config-I3282) — this is
+    # the one class with a faster-than-queue declared response.
+    source: "freshness-monitor"
+    severities: [dynamic]
+    intake: bus
+    response: playbook:alert-drain
+  - class: data_sf_definition_drift
+    source: "alpha-engine-data/infrastructure/step-functions/check-definition-drift.py"
+    severities: [dynamic]
+    intake: bus
+    response: drain-queue
+
+  # ── groom (alpha-engine-config emitter) ──
+  - class: groom_lifecycle_bus_events
+    source: "groom:*"   # dynamic groom:<repo>@main labels, error + audit-warning
+    severities: [error, warning]
+    intake: bus
+    response: drain-queue
+
+  # ── CloudWatch alarms (blanket row — the tap covers every alarm) ──
+  - class: cw_alarms_all
+    # 18 CFN-defined alarms verified 2026-07-22 (heartbeats x7, Lambda
+    # errors/no-invocations, mutex conflicts x3, health checks, daily-heal,
+    # unscored-buy-candidates, sns-publish-failed). SNS email delivery to the
+    # backstop topic is unchanged; email-only-backstop hardening is
+    # alpha-engine-config-I2899.
+    source: "cloudwatch-alarm:*"
+    severities: [alarm]
+    intake: cw-alarm
+    response: drain-queue
+
+  # ── DRAIN-BLIND rows (every one carries its migration or declaration) ──
+  - class: executor_emergency_shutdown
+    source: "raw-sns:executor/emergency_shutdown.py"
+    severities: [critical]
+    intake: none
+    response: operator
+    migration_issue: alpha-engine-config-I2908   # highest-value migration: a live emergency shutdown is invisible to the overseer today
+  - class: substrate_health_raw_sns
+    source: "raw-sns:nousergon_lib/transparency.py"
+    severities: [error]
+    intake: none
+    response: operator
+    migration_issue: alpha-engine-config-I2908
+  - class: predictor_drift_raw_sns
+    source: "raw-sns:predictor/monitoring/drift_detector.py"
+    severities: [dynamic]
+    intake: none
+    response: operator
+    migration_issue: alpha-engine-config-I2908
+  - class: ci_runner_lambda_raw_telegram
+    source: "raw-telegram:ci-runner-dispatcher-lambdas"
+    severities: [error]
+    intake: none
+    response: operator
+    migration_issue: alpha-engine-config-I2909
+  - class: governance_script_raw_telegram
+    source: "raw-telegram:operator_triage_digest|neon_usage_monitor|check_doc_staleness"
+    severities: [info, warning, critical]
+    intake: none
+    response: operator
+    operator_reason: >-
+      Deliberate hermetic governance pings (no repo imports by design);
+      doc-staleness auto-verify loop tracked separately (config-I3061).
+  - class: groom_dispatch_telegram_only
+    source: "flow-doctor:scheduled-groom-dispatcher"
+    severities: [info, error, warning]
+    intake: none
+    response: operator
+    migration_issue: alpha-engine-config-I2928
+  - class: sf_completion_telegram
+    source: "flow-doctor:sf-telegram-notifier"
+    severities: [dynamic]
+    intake: none
+    response: operator
+    operator_reason: >-
+      Informational SF-completion notices (T0 class by definition — failures
+      route via sf-watch, not this notifier).
+  - class: expense_collector_telegram
+    source: "flow-doctor:expense-collector"
+    severities: [warning]
+    intake: none
+    response: operator
+    operator_reason: Budget-usage notice; page-only by design (no automated response exists or is wanted for spend review).
+  - class: fleet_email_digests
+    source: "email:eod|backtester|director|research|training digests"
+    severities: [info]
+    intake: none
+    response: operator
+    operator_reason: Informational digests via the krepis email chokepoint; console deep-links are the response surface.
+  - class: predictor_retrain_email
+    source: "email:backtester/analysis/retrain_alert.py"
+    severities: [warning]
+    intake: none
+    response: operator
+    migration_issue: alpha-engine-config-I3302   # also bypasses the email chokepoint itself

--- a/tests/test_iam_drift_unordered_sets.py
+++ b/tests/test_iam_drift_unordered_sets.py
@@ -1,0 +1,57 @@
+"""Pins the IAM drift checker's unordered-set normalization (2026-07-22).
+
+AWS GetRole returned a trust document's Principal.Service as
+["scheduler.amazonaws.com","events.amazonaws.com"] — the reverse of the
+codified snapshot's order. Same set, but _canonical_json compared arrays
+order-sensitively, so the drift check went red and blocked every PR in the
+repo. IAM policy-document string arrays (Action / Resource /
+Principal.Service / ...) are UNORDERED sets per the policy grammar; the
+comparator must treat them as such. Statement arrays (lists of objects)
+deliberately KEEP their order — the codified file controls reader-facing
+ordering even though IAM ORs statements.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_drift",
+    Path(__file__).resolve().parent.parent / "infrastructure" / "iam" / "check-drift.py",
+)
+check_drift = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(check_drift)
+
+
+def test_service_principal_order_is_insignificant():
+    """The exact 2026-07-22 live finding: reversed Principal.Service order
+    must compare equal."""
+    codified = {"Statement": [{"Action": "sts:AssumeRole", "Effect": "Allow",
+                               "Principal": {"Service": ["events.amazonaws.com",
+                                                         "scheduler.amazonaws.com"]}}],
+                "Version": "2012-10-17"}
+    live = {"Statement": [{"Action": "sts:AssumeRole", "Effect": "Allow",
+                           "Principal": {"Service": ["scheduler.amazonaws.com",
+                                                     "events.amazonaws.com"]}}],
+            "Version": "2012-10-17"}
+    assert check_drift._canonical_json(codified) == check_drift._canonical_json(live)
+
+
+def test_action_list_order_is_insignificant():
+    a = {"Statement": [{"Action": ["s3:GetObject", "s3:PutObject"]}]}
+    b = {"Statement": [{"Action": ["s3:PutObject", "s3:GetObject"]}]}
+    assert check_drift._canonical_json(a) == check_drift._canonical_json(b)
+
+
+def test_set_membership_differences_still_detected():
+    """Sorting must not mask REAL drift — a different set is still drift."""
+    a = {"Statement": [{"Action": ["s3:GetObject"]}]}
+    b = {"Statement": [{"Action": ["s3:GetObject", "s3:PutObject"]}]}
+    assert check_drift._canonical_json(a) != check_drift._canonical_json(b)
+
+
+def test_statement_object_order_still_significant():
+    a = {"Statement": [{"Sid": "A"}, {"Sid": "B"}]}
+    b = {"Statement": [{"Sid": "B"}, {"Sid": "A"}]}
+    assert check_drift._canonical_json(a) != check_drift._canonical_json(b)

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -314,3 +314,54 @@ def test_drain_wake_names_all_four_schedules():
         assert hour_token in wake_text, (
             f"drain schedule {sched} not reflected in the wake declaration"
         )
+
+
+# ── alert-class registry (config-I3211) ──────────────────────────────────────
+
+
+def test_alert_classes_present_and_unique():
+    """The alert-class registry exists and class ids are unique — this is
+    the fleet's declared answer to 'what notifications exist and what
+    responds to each' (Brian directive 2026-07-22)."""
+    rows = REGISTRY.get("alert_classes")
+    assert rows, "alert_classes section missing from playbooks.yaml"
+    ids = [r["class"] for r in rows]
+    assert len(ids) == len(set(ids)), "duplicate alert class ids"
+
+
+def test_no_undeclared_drain_blind_class():
+    """Every intake:none row must carry a migration_issue (tracked path onto
+    the bus) or an operator_reason (explicit page-only declaration). A
+    drain-blind class with neither is the exact I3211 defect."""
+    for r in REGISTRY["alert_classes"]:
+        if r["intake"] == "none":
+            assert r.get("migration_issue") or r.get("operator_reason"), (
+                f"alert class {r['class']!r} is drain-blind (intake: none) "
+                f"with no migration_issue or operator_reason"
+            )
+
+
+def test_alert_class_playbook_refs_exist():
+    """A response of playbook:<name> must reference a real, routed playbook."""
+    for r in REGISTRY["alert_classes"]:
+        resp = r["response"]
+        if resp.startswith("playbook:"):
+            name = resp.split(":", 1)[1]
+            spec = REGISTRY["playbooks"].get(name)
+            assert spec and spec.get("routed"), (
+                f"alert class {r['class']!r} responds via playbook {name!r} "
+                f"which is missing or not routed"
+            )
+
+
+def test_known_bus_sources_have_rows():
+    """Spot-pin the highest-value bus sources from the 2026-07-22 fleet
+    inventory — the classes most recently exercised live. (The full
+    cross-repo static completeness chokepoint is tracked separately; this
+    keeps the registry honest for the sources we KNOW page.)"""
+    sources = " ".join(r["source"] for r in REGISTRY["alert_classes"])
+    for known in ("freshness-monitor", "overseer-dispatcher",
+                  "research:alerts_handler",
+                  "alpha-engine-backtester/optimizer/live_key_reconciliation.py",
+                  "cloudwatch-alarm:*"):
+        assert known in sources, f"known emitter {known!r} has no alert-class row"


### PR DESCRIPTION
## What

Closes the declaration half of **config-I3211** (Brian directive 2026-07-22: the overseer must be scoped to ALL key notifications): `playbooks.yaml` gains an `alert_classes:` registry — 39 rows from today's fleet-wide emitter inventory (all 10 repos + live AWS verification):

- ~28 **krepis-bus classes** (executor tripwires → research daemon-down → data-plane monitors) → `intake: bus`, response `drain-queue` (freshness-monitor additionally `playbook:alert-drain` — the event-time lane shipped this morning).
- **CW-alarm blanket row** — all 18 CFN alarms via the ALARM-state tap.
- **10 declared drain-blind rows** — every one carries a `migration_issue` (I2908 raw-SNS incl. emergency-shutdown, I2909 raw-Telegram, I2928 groom Telegram-only, I3302 retrain-email) or an explicit `operator_reason` (informational digests, hermetic governance pings). **Schema + tests forbid an undeclared drain-blind class from merging.**

4 new registry tests: shape/uniqueness, no-undeclared-blind-row, playbook-ref integrity, known-emitter spot-pins.

## Auto-deploy gap (Brian standing preference)

`deploy-overseer-dispatcher.yml` + `deploy-alert-drain-dispatcher.yml` (mirroring the ci-watch sibling): both Lambdas sat **5 days stale** after registry merges until today's manual deploy — the router bundles playbooks.yaml at deploy time, so a registry merge without a router deploy silently doesn't take. The router's deploy.sh needs `lambda:PutFunctionEventInvokeConfig`; grant codified in `github-actions-lambda-deploy.json` and **applied live + verified** (to the existing `github-actions-lambda-deploy-policy` inline policy — role carries two inline policies; a wrong-name put exceeds the aggregate size cap).

## Remaining I3211 halves (tracked, not claimed)

Runtime backstop (drain charter: unknown-source event = T3 finding) — small config-repo PR alongside this. Cross-repo static completeness chokepoint — follow-up issue.

## Testing

Registry suite 36 passed; full repo suite 3578 passed; both workflows YAML-parse; IAM grant live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)