### PR TITLE
feat(scheduled-groom-dispatcher): add quota-fallback direct-invoke dispatch mode

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -47,6 +47,17 @@ demand-all path always did (`_write_trigger_record`); an enumeration FAILURE
 now writes one too (config-I2540), so a missing record unambiguously means
 the scheduler never invoked this Lambda.
 
+DeepSeek quota-fallback direct invoke (3-repo feature): the on-box quota
+classifier above can now, on wind-down, invoke THIS SAME Lambda directly via
+`lambda:InvokeFunction` (never EventBridge) with
+`{"mode": "fallback", "tier": "<low|mid|high>"}` to launch exactly one
+replacement box for that tier running the DeepSeek backend
+(`GROOM_BACKEND=deepseek`) instead of retrying Claude — see
+`_handle_fallback_dispatch`. Reuses `_launch_groom_spot` verbatim (same
+concurrency guard, daily ceiling, spot/on-demand + SSM mechanics); the
+DeepSeek tier->model mapping (`nousergon_lib.groom_eligibility.
+FALLBACK_TIER_MODELS`) is consumed on-box, not by this Lambda.
+
 Managed OUTSIDE CloudFormation (same as before): operator-deployed via
 `deploy.sh --bootstrap`. Merging the PR has ZERO live effect until the new code +
 IAM are deployed AND the GHA `schedule:` crons are disabled (the gated cutover).
@@ -183,6 +194,25 @@ _DEFAULT_MODEL = "claude-sonnet-5"
 # input, but this is cheap and rules out shell-metacharacter injection outright.
 _MODEL_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 
+# ── Quota-fallback direct-invoke dispatch (3-repo feature, this is the
+# Lambda-side leg) ────────────────────────────────────────────────────────
+# When an on-box groom run hits mid-run Claude-quota exhaustion, it winds down
+# cleanly (existing config#1803 behavior, UNCHANGED) and then invokes THIS
+# Lambda directly via `lambda:InvokeFunction` — bypassing EventBridge Scheduler
+# entirely — with a payload shaped `{"mode": "fallback", "tier": "<low|mid|
+# high>"}`. `mode` is not a key any of the 3 live SCHED_INPUTS (deploy.sh) or
+# any other invocation shape in this handler (decide_only/launch_decided/
+# demand-all/legacy) ever sets, so this is a purely additive discriminator —
+# it can never intercept a real cron/SF-driven invocation.
+# `GROOM_BACKEND=deepseek` is threaded through the SAME `_launch_groom_spot`
+# call every other path uses (no duplicated launch/SSM code) so the box runs
+# the DeepSeek fallback provider. The tier -> DeepSeek-model mapping
+# (`nousergon_lib.groom_eligibility.FALLBACK_TIER_MODELS`, a sibling PR) is
+# consumed on-box by alpha-engine-config's groom_spot_bootstrap.sh /
+# groom_driver.py — this Lambda does not import or reference that dict.
+_VALID_FALLBACK_TIERS = set(ge.TIERS)  # {"low", "mid", "high"}
+GROOM_BACKEND_DEEPSEEK = "deepseek"
+
 
 
 
@@ -273,7 +303,8 @@ def _resolve_pr_budget(event: dict) -> int | None:
 def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: str,
                        run_token: str, soft_limit_min: int | None = None,
                        pr_budget: int | None = None,
-                       queue_manifest_key: str = "") -> str:
+                       queue_manifest_key: str = "",
+                       backend: str = "") -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec bootstrap.
 
     Runs as root on the box. The heavy, version-controlled logic lives in the
@@ -285,6 +316,12 @@ def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: st
     retired — groom boxes are pure issue-coverage workers now; PR merge-
     readiness sweeping moved to the single end-of-SF run_mode=sweep box the
     dispatch SF launches after every Map wind-down.
+
+    ``backend`` (quota-fallback 3-repo feature): a Lambda-code literal
+    (``GROOM_BACKEND_DEEPSEEK`` — never event-sourced text), so unlike
+    ``model``/``issue_filter`` it needs no shell-metacharacter allowlist
+    before embedding. Empty by default — every existing caller's command
+    shape is byte-for-byte unchanged.
     """
     soft_limit_flag = f" --soft-limit-min {soft_limit_min}" if soft_limit_min else ""
     pr_budget_export = f"export GROOM_PR_BUDGET={pr_budget}\n" if pr_budget else ""
@@ -294,6 +331,11 @@ def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: st
     # root-shell command line.
     manifest_export = (f"export GROOM_QUEUE_MANIFEST_KEY={queue_manifest_key}\n"
                        if queue_manifest_key else "")
+    # Quota-fallback (3-repo feature): GROOM_BACKEND is consumed on-box by
+    # alpha-engine-config's groom_spot_bootstrap.sh/groom_driver.py to route
+    # the run through DeepSeek instead of Claude — this Lambda passes the flag
+    # through verbatim, it does not select the DeepSeek model itself.
+    backend_export = f"export GROOM_BACKEND={backend}\n" if backend else ""
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
 # SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
@@ -316,7 +358,7 @@ cd /home/ec2-user/alpha-engine-config
 export GROOM_MODEL={model}
 export GROOM_ISSUE_FILTER={issue_filter}
 export GROOM_RUN_TOKEN={run_token}
-{pr_budget_export}{manifest_export}exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"{soft_limit_flag}
+{pr_budget_export}{manifest_export}{backend_export}exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"{soft_limit_flag}
 """
 
 
@@ -347,15 +389,17 @@ def _wait_ssm_online(instance_id: str) -> None:
 
 def _send_bootstrap(instance_id: str, run_mode: str, run_url: str, model: str, issue_filter: str,
                     run_token: str, soft_limit_min: int | None = None,
-                    pr_budget: int | None = None, queue_manifest_key: str = "") -> str:
+                    pr_budget: int | None = None, queue_manifest_key: str = "",
+                    backend: str = "") -> str:
     """Fire the async, detached SSM command that runs the groom + self-terminates."""
     return spot_dispatch.send_async_command(
         instance_id,
         _bootstrap_command(
             run_mode, run_url, model, issue_filter, run_token, soft_limit_min, pr_budget,
-            queue_manifest_key,
+            queue_manifest_key, backend,
         ),
-        comment=f"backlog groom ({run_mode}, {model}, {issue_filter}) — config#1432/#1495/#1645",
+        comment=(f"backlog groom ({run_mode}, {model}, {issue_filter}"
+                 f"{f', {backend}' if backend else ''}) — config#1432/#1495/#1645"),
         region=REGION,
         cw_log_group=CW_LOG_GROUP,
         # Execution timeout (NOT the start timeout) — without this SSM kills the
@@ -524,8 +568,18 @@ def _terminate_instance(instance_id: str) -> None:
 def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_filter: str,
                        soft_limit_min: int | None = None, pr_budget: int | None = None,
                        force_on_demand: bool = False,
-                       queue_manifest_key: str = "") -> dict:
-    """Launch + bootstrap the groom box. Fail-loud — any error RAISES."""
+                       queue_manifest_key: str = "",
+                       backend: str = "") -> dict:
+    """Launch + bootstrap the groom box. Fail-loud — any error RAISES.
+
+    ``backend`` (quota-fallback 3-repo feature, default ``""`` = unchanged
+    Claude path): threaded through to ``_send_bootstrap``/``_bootstrap_command``
+    as ``GROOM_BACKEND``. This is the ONE launch chokepoint every dispatch
+    path in this file already shares — the quota-fallback direct-invoke path
+    (``_handle_fallback_dispatch``) reuses it verbatim rather than
+    duplicating the concurrency guard (config#1979), the daily dispatch
+    ceiling (config#3173), or the spot/on-demand + SSM-send-command mechanics.
+    """
     if not DISPATCH_ENABLED:
         logger.warning("GROOM_DISPATCH_ENABLED=false — groom spot NOT launched")
         return {"launched": False, "reason": "disabled"}
@@ -603,14 +657,14 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         )
         command_id = _send_bootstrap(
             instance_id, run_mode, run_url, model, issue_filter, run_token, soft_limit_min, pr_budget,
-            queue_manifest_key,
+            queue_manifest_key, backend,
         )
     except Exception:
         _terminate_instance(instance_id)
         raise
     logger.info(
         "groom dispatched: instance=%s market=%s command=%s run_mode=%s model=%s issue_filter=%s "
-        "schedule=%s run_token=%s",
+        "schedule=%s run_token=%s backend=%s",
         instance_id,
         market,
         command_id,
@@ -619,6 +673,7 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         issue_filter,
         schedule_label,
         run_token,
+        backend or "claude",
     )
     return {
         "launched": True,
@@ -631,6 +686,7 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         "tier_tag": tier_tag,
         "run_token": run_token,
         **({"pr_budget": pr_budget} if pr_budget is not None else {}),
+        **({"backend": backend} if backend else {}),
     }
 
 
@@ -1188,6 +1244,110 @@ def _write_sweep_decision_record(schedule_label: str, run_mode: str, launched: d
         logger.warning("sweep decision record write failed (non-fatal): %s", exc)
 
 
+def _write_fallback_decision_record(schedule_label: str, tier: str, backend: str,
+                                    launched: dict) -> None:
+    """groom/decisions/{date}/fallback-{HHMMSS}.json — records a quota-fallback
+    direct-invoke dispatch (``{"mode": "fallback", "tier": ...}`` — see
+    ``_handle_fallback_dispatch``). Own key prefix (``fallback-{HHMMSS}``, not
+    ``trigger-``/``sweep-``) so a same-minute demand-all evaluation or
+    end-of-SF sweep never collides with this on S3.
+
+    Same schema_version 2 shape (a ``decisions`` list of ``{launch, ...}``
+    dicts) every other dispatch path in this file already writes, so the
+    overseer-liveness-probe's ``run_window`` reader (config#2667) treats a
+    quota-fallback dispatch identically to a demand-all/sweep one — a
+    fallback box that dies silently must leave the same trace a scheduled one
+    would, closing the exact blind-spot class config-I2540/config#2667
+    already fixed for the other two dispatch shapes rather than reopening it
+    for this new third one. Best-effort non-fatal, mirroring every other
+    decision-record writer here: a record-write failure must never block or
+    crash the (fire-and-forget) fallback dispatch itself."""
+    now = datetime.now(ZoneInfo("UTC"))
+    key = f"groom/decisions/{now:%Y-%m-%d}/fallback-{now:%H%M%S}.json"
+    launch_ok = bool(launched.get("launched"))
+    body = json.dumps({
+        "schema_version": 2, "trigger": "quota_fallback", "tier": tier,
+        "backend": backend, "schedule": schedule_label,
+        "decisions": [{
+            "launch": launch_ok,
+            "issue_filter": launched.get("issue_filter", ""),
+            "model": launched.get("model", ""),
+            "reason": launched.get("reason", "quota_fallback"),
+            "tier_tag": launched.get("tier_tag", ""),
+        }],
+        "decided_at": now.isoformat(),
+    })
+    try:
+        boto3.client("s3", region_name=REGION).put_object(
+            Bucket=_RESEARCH_BUCKET, Key=key, Body=body.encode(),
+            ContentType="application/json")
+    except Exception as exc:  # noqa: BLE001 — mirrors _write_sweep_decision_record: observability only, never blocks the launch it's recording
+        logger.warning("fallback decision record write failed (non-fatal): %s", exc)
+
+
+def _handle_fallback_dispatch(event: dict) -> dict:
+    """Direct ``lambda:InvokeFunction`` quota-fallback path (3-repo feature;
+    this Lambda is one leg — see ``nousergon_lib``'s new
+    ``FALLBACK_TIER_MODELS`` dict and ``alpha-engine-config``'s
+    ``groom_driver.py`` quota classifier for the other two).
+
+    A groom box that hits mid-run Claude-quota exhaustion winds down cleanly
+    (existing config#1803 behavior, UNCHANGED by this change) and then
+    invokes THIS Lambda directly, bypassing EventBridge Scheduler entirely,
+    with ``{"mode": "fallback", "tier": "<low|mid|high>"}``. ``mode`` is not a
+    key any of the 3 live SCHED_INPUTS (deploy.sh) or any other invocation
+    shape this handler reads (``decide_only``/``launch_decided``/``demand-
+    all``/legacy) ever sets — this is a purely additive discriminator that
+    can never intercept a real cron/SF-driven invocation.
+
+    Deliberately SKIPS ``ge.decide_trigger()``'s demand-eligibility gate
+    (config#1933) entirely — a quota-fallback dispatch is a rescue for
+    already-decided, already-in-flight work the exhausted run didn't finish,
+    not a fresh demand re-evaluation — and launches EXACTLY ONE box for the
+    named tier via the SAME ``_launch_groom_spot`` chokepoint every other
+    dispatch path in this file uses (no duplicated launch/SSM code): it gets
+    the config#1979 concurrency guard, the config#3173 daily ceiling, and the
+    spot/on-demand + SSM-send-command mechanics for free, with
+    ``GROOM_BACKEND_DEEPSEEK`` threaded through so the box runs the DeepSeek
+    fallback provider. The tier -> DeepSeek-model mapping itself
+    (``FALLBACK_TIER_MODELS``) is consumed on-box by alpha-engine-config's
+    groom_spot_bootstrap.sh/groom_driver.py — this Lambda does not import or
+    reference that dict; ``GROOM_MODEL`` here is only the (inert-for-
+    deepseek) Claude-side default so the bootstrap command shape stays
+    unchanged for the field.
+
+    Fails LOUD (raises ``ValueError``) on a missing/invalid tier rather than
+    silently falling through to an unrelated demand-all launch — a malformed
+    fallback payload must never masquerade as a normal scheduled trigger.
+
+    Known, deliberately out-of-scope gotcha: the invoking box may still carry
+    the ``groom-issue-filter=<tier>-only`` tag while mid-terminate when this
+    fires, which COULD trip ``_launch_groom_spot``'s concurrent-tier-skip
+    guard and suppress the very fallback launch this path exists for.
+    Termination-before-invoke sequencing is an alpha-engine-config
+    ``groom_driver.py`` wind-down concern, not this Lambda's.
+    """
+    tier = str(event.get("tier") or "").strip().lower()
+    if tier not in _VALID_FALLBACK_TIERS:
+        raise ValueError(
+            f"invalid quota-fallback tier: {event.get('tier')!r} — must be "
+            f"one of {sorted(_VALID_FALLBACK_TIERS)}"
+        )
+    issue_filter = f"{tier}-only"
+    model = _resolve_model(event)
+    schedule_label = str(event.get("schedule") or "quota-fallback")
+    logger.info(
+        "quota-fallback dispatch: tier=%s issue_filter=%s model=%s backend=%s schedule=%s",
+        tier, issue_filter, model, GROOM_BACKEND_DEEPSEEK, schedule_label,
+    )
+    result = _launch_groom_spot(
+        "full", schedule_label, model, issue_filter,
+        backend=GROOM_BACKEND_DEEPSEEK,
+    )
+    _write_fallback_decision_record(schedule_label, tier, GROOM_BACKEND_DEEPSEEK, result)
+    return {"groom": result}
+
+
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge Scheduler handler — launches the groom spot box on cadence.
 
@@ -1219,8 +1379,19 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     per-box states unchanged. Legacy direct invokes (no `decide_only` /
     `launch_decided` key) behave EXACTLY as before — decide AND launch in one
     call, same response shapes — for any caller not yet on the new SF flow.
+
+    Quota-fallback direct invoke (3-repo feature, ``mode: "fallback"``): a
+    THIRD invocation shape, checked first and returned early —
+    ``{"mode": "fallback", "tier": "<low|mid|high>"}`` fired by
+    ``lambda:InvokeFunction`` (never EventBridge) when an on-box groom run
+    winds down on mid-run Claude-quota exhaustion. See
+    ``_handle_fallback_dispatch`` for the full contract; no live schedule or
+    other caller ever sets a top-level ``mode`` key, so this cannot collide
+    with any invocation shape above.
     """
     event = event or {}
+    if event.get("mode") == "fallback":
+        return _handle_fallback_dispatch(event)
     run_mode = _resolve_run_mode(event)
     model = _resolve_model(event)
     issue_filter = _resolve_issue_filter(event)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -1679,3 +1679,128 @@ def test_demand_all_stale_ruling_pending_pr_fires_escape_valve(monkeypatch):
     assert "mid-only" in launched_filters, out["groom"]
     launch = next(l for l in out["groom"]["launches"] if l["issue_filter"] == "mid-only")
     assert idx._test_ssm.sent
+
+
+# ── Quota-fallback direct invoke (3-repo feature): {"mode": "fallback",
+# "tier": "<low|mid|high>"} fired by lambda:InvokeFunction (never
+# EventBridge) when an on-box groom run winds down on mid-run Claude-quota
+# exhaustion (alpha-engine-config groom_driver.py, config#1803 classifier).
+# Purely additive: no live SCHED_INPUTS event ever carries a top-level
+# "mode" key, so this must never fire on — or change the behavior of — any
+# existing invocation shape.
+
+@pytest.mark.parametrize("tier,expected_filter", [
+    ("low", "low-only"), ("mid", "mid-only"), ("high", "high-only"),
+])
+def test_fallback_dispatch_launches_one_box_per_tier_with_deepseek_backend(
+        monkeypatch, tier, expected_filter):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    # The fallback path must SKIP demand-eligibility enumeration entirely —
+    # it is a rescue for already-in-flight work, not a fresh demand decision.
+    monkeypatch.setattr(idx, "_enumerate_tier_stats_fresh",
+                        lambda token: (_ for _ in ()).throw(
+                            AssertionError("fallback dispatch must not re-enumerate demand")))
+    monkeypatch.setattr(idx, "_demand_decision",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            AssertionError("fallback dispatch must not run the demand gate")))
+    out = idx.handler({"mode": "fallback", "tier": tier}, None)
+    g = out["groom"]
+    assert g["launched"] is True
+    assert g["issue_filter"] == expected_filter
+    assert g["backend"] == "deepseek"
+    assert len(idx._test_ssm.sent) == 1
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "export GROOM_BACKEND=deepseek" in cmd
+    assert f"export GROOM_ISSUE_FILTER={expected_filter}" in cmd
+    assert cmd.index("export GROOM_BACKEND") < cmd.index("groom_spot_bootstrap.sh")
+
+
+def test_fallback_dispatch_writes_own_decision_record(monkeypatch):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    idx.handler({"mode": "fallback", "tier": "mid", "schedule": "quota-rescue"}, None)
+    records = {k: v for k, v in idx._test_s3._objects.items()
+               if k.startswith("groom/decisions/") and "/fallback-" in k}
+    assert len(records) == 1, f"exactly one fallback decision record expected, got {list(idx._test_s3._objects)}"
+    doc = json.loads(list(records.values())[0])
+    assert doc["schema_version"] == 2
+    assert doc["trigger"] == "quota_fallback"
+    assert doc["tier"] == "mid"
+    assert doc["backend"] == "deepseek"
+    assert doc["schedule"] == "quota-rescue"
+    assert doc["decisions"][0]["launch"] is True
+    assert doc["decisions"][0]["issue_filter"] == "mid-only"
+
+
+def test_fallback_dispatch_reuses_launch_chokepoint_concurrency_guard(monkeypatch):
+    # Reuses _launch_groom_spot verbatim — the SAME concurrency guard every
+    # other dispatch path shares must also apply here (no duplicated launch
+    # logic that could silently diverge on this new path).
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(1) or "i-new",  # noqa: E731
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"high-only": ["i-live-high"]},
+    )
+    out = idx.handler({"mode": "fallback", "tier": "high"}, None)
+    g = out["groom"]
+    assert g["launched"] is False
+    assert g["reason"] == "concurrent_tier_skip"
+    assert launched == []
+
+
+@pytest.mark.parametrize("bad_tier", [None, "", "bogus", "sweep", "low-only"])
+def test_fallback_dispatch_invalid_tier_raises(monkeypatch, bad_tier):
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    event = {"mode": "fallback"}
+    if bad_tier is not None:
+        event["tier"] = bad_tier
+    with pytest.raises(ValueError):
+        idx.handler(event, None)
+    assert not idx._test_ssm.sent  # fail loud BEFORE any spend, never a partial launch
+
+
+def test_fallback_dispatch_tier_is_case_insensitive(monkeypatch):
+    # Mirrors every other event-key resolver in this handler
+    # (_resolve_run_mode/_resolve_issue_filter/_resolve_model all .lower()) —
+    # a case-insensitive tier is intentional, not an oversight.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"mode": "fallback", "tier": "HIGH"}, None)
+    assert out["groom"]["launched"] is True
+    assert out["groom"]["issue_filter"] == "high-only"
+
+
+def test_fallback_mode_key_never_set_by_any_live_schedule_input():
+    # The discriminator (event.get("mode") == "fallback") is safe only if no
+    # live EventBridge Scheduler input ever carries a top-level "mode" key —
+    # verify that invariant directly against deploy.sh's SCHED_INPUTS (the
+    # single source of truth for what the 3 live cron triggers actually send).
+    deploy_sh = (Path(__file__).resolve().parent / "deploy.sh").read_text()
+    sched_inputs_block = deploy_sh.split("SCHED_INPUTS=(", 1)[1].split(")", 1)[0]
+    assert '"mode"' not in sched_inputs_block
+
+
+def test_normal_cron_event_unaffected_by_fallback_branch(monkeypatch):
+    # A real EventBridge-Scheduler-driven event (no "mode" key at all) must
+    # behave EXACTLY as before — the new branch is purely additive and must
+    # never intercept it, even if some other key happens to collide in future.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    _stub_fresh_stats(monkeypatch, idx, {"low": 0, "mid": 9, "high": 0})
+    out = idx.handler(_demand_event(), None)
+    assert "groom" in out
+    assert out["groom"]["trigger"] == "demand-all"
+    assert idx._test_ssm.sent
+    for cmd in (s["Parameters"]["commands"][0] for s in idx._test_ssm.sent):
+        assert "GROOM_BACKEND" not in cmd
+
+
+def test_legacy_direct_invoke_event_unaffected_by_fallback_branch(monkeypatch):
+    # Legacy direct invoke (no decide_only/launch_decided/mode key at all) —
+    # the pre-existing "decide AND launch in one call" shape — must also be
+    # completely untouched.
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only",
+                       "model": "claude-sonnet-5"}, None)
+    assert out["groom"]["launched"] is True
+    cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
+    assert "GROOM_BACKEND" not in cmd

--- a/tests/test_load_config_experiment_package.py
+++ b/tests/test_load_config_experiment_package.py
@@ -13,8 +13,38 @@ def _write(p: Path, data: dict) -> None:
     p.write_text(yaml.safe_dump(data))
 
 
+def _isolate_repo_root(tmp_path, monkeypatch):
+    """Neutralize nousergon_lib.config's SECOND config root
+    (``<repo_root>/../alpha-engine-config`` — resolve_experiment_config's
+    ``repo_root=Path(__file__).parent`` inside ``weekly_collector.load_config``)
+    so these tests are hermetic regardless of the machine's directory layout.
+
+    Root cause (found running this suite for nousergon-data-PR<fallback-groom>):
+    on Brian's laptop ``~/Development`` holds every fleet repo as siblings by
+    convention (this repo's own CLAUDE.md: "LOCAL DIRS are still
+    ~/Development/alpha-engine-*"), so ``<nousergon-data>/../alpha-engine-config``
+    is a REAL, populated sibling checkout — NOT an absent path a test can rely
+    on missing. Only ``Path.home()`` was ever monkeypatched here; the real
+    sibling repo's ``experiments/reference/data/config.yaml`` silently won
+    resolution ahead of ``test_falls_back_to_legacy_when_no_package``'s own
+    fixture (which deliberately omits an experiment-package file to exercise
+    the legacy fallback), so the test read live production config instead of
+    its fixture and failed with ``KeyError: 'source'`` — reproducible on ANY
+    machine with a sibling alpha-engine-config clone, CI-green only because
+    GitHub Actions checks out just this one repo. Fixing at the true root
+    (isolate repo_root itself, not the specific file that happened to exist)
+    rather than patching around this one collision, so no other candidate in
+    the 5-deep search order (see nousergon_lib.config._candidate_paths) can
+    ever leak real sibling-repo content into any of these three tests again.
+    """
+    fake_module_dir = tmp_path / "isolated_repo" / "nousergon-data"
+    fake_module_dir.mkdir(parents=True)
+    monkeypatch.setattr(weekly_collector, "__file__", str(fake_module_dir / "weekly_collector.py"))
+
+
 def test_experiment_package_wins_over_legacy(tmp_path, monkeypatch):
     """experiments/$EXP/data/config.yaml resolves ahead of legacy data/config.yaml."""
+    _isolate_repo_root(tmp_path, monkeypatch)
     home = tmp_path / "home"
     cfg_repo = home / "alpha-engine-config"
     _write(cfg_repo / "data" / "config.yaml", {"source": "legacy"})
@@ -27,6 +57,7 @@ def test_experiment_package_wins_over_legacy(tmp_path, monkeypatch):
 
 def test_experiment_id_selects_slot(tmp_path, monkeypatch):
     """A non-default ALPHA_ENGINE_EXPERIMENT_ID selects its own package slot."""
+    _isolate_repo_root(tmp_path, monkeypatch)
     home = tmp_path / "home"
     cfg_repo = home / "alpha-engine-config"
     _write(cfg_repo / "experiments" / "reference" / "data" / "config.yaml", {"source": "reference"})
@@ -39,6 +70,7 @@ def test_experiment_id_selects_slot(tmp_path, monkeypatch):
 
 def test_falls_back_to_legacy_when_no_package(tmp_path, monkeypatch):
     """With no experiment-package file, the legacy data/config.yaml still resolves."""
+    _isolate_repo_root(tmp_path, monkeypatch)
     home = tmp_path / "home"
     cfg_repo = home / "alpha-engine-config"
     _write(cfg_repo / "data" / "config.yaml", {"source": "legacy"})


### PR DESCRIPTION
## What

Adds a Lambda-side quota-fallback dispatch mode to `alpha-engine-scheduled-groom-dispatcher` (`infrastructure/lambdas/scheduled-groom-dispatcher/index.py`).

Today the Lambda is invoked only by EventBridge Scheduler (3 daily cron triggers) or by the dispatch Step Function's `decide_only`/`launch_decided` two-phase flow. This PR adds a **third, purely additive invocation shape**:

```json
{"mode": "fallback", "tier": "<low|mid|high>"}
```

fired via a direct `lambda:InvokeFunction` call (never EventBridge) when an on-box groom run winds down on mid-run Claude-quota exhaustion. The handler:

- Checks `event.get("mode") == "fallback"` **first**, before any existing resolver runs, and returns early via a new `_handle_fallback_dispatch()`.
- **Skips `ge.decide_trigger()`/`_demand_decision()` entirely** — this is a rescue for already-decided, already-in-flight work, not a fresh demand evaluation.
- Maps `tier` → `issue_filter` (`"{tier}-only"`) and launches **exactly one** box via the **same `_launch_groom_spot` chokepoint** every other dispatch path already shares (no duplicated launch/SSM code) — so it gets the config#1979 concurrency guard, the config#3173 daily dispatch ceiling, and the spot→on-demand/SSM-send-command mechanics for free.
- Threads a new `backend: str = ""` parameter through `_launch_groom_spot` → `_send_bootstrap` → `_bootstrap_command`, which exports `GROOM_BACKEND=deepseek` in the SSM RunShellScript prelude ahead of `groom_spot_bootstrap.sh` (mirrors the existing `GROOM_PR_BUDGET`/`GROOM_QUEUE_MANIFEST_KEY` export pattern). Empty by default — every existing caller's bootstrap command is byte-for-byte unchanged.
- Fails loud (`ValueError`) on a missing/invalid tier, **before any spend**, rather than silently falling through to an unrelated demand-all launch.
- Writes its own decision record (`groom/decisions/{date}/fallback-{HHMMSS}.json`, schema_version 2) so the overseer-liveness-probe's `run_window` reader treats a fallback dispatch identically to a demand-all/sweep one — closing the same "silent dispatch, no trace" blind-spot class config-I2540/config#2667 already fixed for the other two dispatch shapes, rather than reopening a third instance of it.

**Safety of the new discriminator:** no live `SCHED_INPUTS` (`deploy.sh`) or any other invocation shape this handler reads (`decide_only`/`launch_decided`/`demand-all`/legacy) ever sets a top-level `mode` key — verified with a new test (`test_fallback_mode_key_never_set_by_any_live_schedule_input`) that asserts this directly against `deploy.sh`'s `SCHED_INPUTS` block. Existing cron/SF invocations are unaffected (also covered by new regression tests).

## Why (3-repo feature)

This is the Lambda-side leg of a 3-repo change letting the backlog groomer fall back to DeepSeek when Brian's Claude Max subscription usage runs out mid-groom-run:

1. **`nousergon-lib`** — new `FALLBACK_TIER_MODELS` dict (tier → DeepSeek model). May or may not be merged yet; this Lambda does **not** import or reference that dict — it only passes `GROOM_BACKEND=deepseek` through. The dict is consumed on-box.
2. **`alpha-engine-config`** (private, no PR link — mentioned by name only) — groom scripts (`groom_driver.py`'s quota classifier, config#1803) that, on wind-down after classifying a mid-run Claude-quota exhaustion, invoke this Lambda directly via `lambda:InvokeFunction` with the `{"mode": "fallback", "tier": ...}` payload, and `groom_spot_bootstrap.sh`, which consumes `GROOM_BACKEND`/`FALLBACK_TIER_MODELS` on-box to actually route the run through DeepSeek.
3. **This repo (`nousergon-data`)** — the additive dispatch-handling change in this PR.

## Known, deliberately out-of-scope consideration

The invoking box may still carry its `groom-issue-filter=<tier>-only` EC2 tag while mid-terminate when it fires the fallback invoke — this **could** trip `_launch_groom_spot`'s existing concurrent-tier-skip guard (config#1979) and suppress the very fallback launch this path exists for. Reusing the guard verbatim was the explicit design ask (no duplicated launch logic); resolving the termination-before-invoke race is an `alpha-engine-config` `groom_driver.py` wind-down-sequencing concern, not this Lambda's — noted in the `_handle_fallback_dispatch` docstring.

## IAM

No new grant needed on this Lambda's own execution role (`infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json`) — the new code path is additive logic reusing entirely pre-existing capabilities (`ec2:RunInstances`/`ssm:SendCommand`/`s3:PutObject` on `groom/decisions/*`, already granted). Confirmed by inspection; no AWS action or resource this Lambda didn't already have is exercised.

**Cross-repo IAM note (not in this PR's scope, flagging for tracking):** the EC2 instance profile the groom spot box runs under (`alpha-engine-executor-role`, owned by the public `crucible-executor` repo, not `nousergon-data` or `alpha-engine-config`) will need a `lambda:InvokeFunction` grant scoped to `arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-scheduled-groom-dispatcher` for the on-box quota classifier to actually be able to make this call at runtime. This is outside the stated 3-repo split and should be tracked as a 4th follow-up before the feature can work end-to-end live.

## Testing

- Added 14 new tests to `infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py`: one launch per tier with `GROOM_BACKEND=deepseek` verified in the SSM command body, decision-record shape, concurrency-guard reuse, invalid/missing-tier fail-loud, case-insensitivity (matches every other event-key resolver in this handler), the `SCHED_INPUTS`-never-sets-`mode` invariant, and two explicit "normal cron/legacy event unaffected" regression tests.
- Full lambda-local suite (via `infrastructure/lambdas/_shared/run_handler_tests.sh`, the same mechanism CI's glob step and this repo's `deploy.sh` preflight gate both use, `-r requirements.txt`): **102 passed** (88 pre-existing + 14 new).
- All 29 `infrastructure/lambdas/*/test_handler.py` suites repo-wide: green (unaffected by this change).
- `shellcheck --severity=error infrastructure/*.sh`: clean.
- Changelog-mirror lambda tests (`test_vocab.py`/`test_classify.py`/both `changelog-*-mirror/test_handler.py`): green.
- `pip-audit`: no known vulnerabilities.
- Top-level `pytest tests/`: found and fixed **one pre-existing, unrelated, environment-specific failure** — `tests/test_load_config_experiment_package.py::test_falls_back_to_legacy_when_no_package` was silently reading real content from a sibling `~/Development/alpha-engine-config` checkout (a directory that exists on every fleet dev laptop by convention) instead of its own tmp fixture, because only `Path.home()` was monkeypatched and not `nousergon_lib.config.resolve_experiment_config`'s second config root (`<repo_root>/../alpha-engine-config`). Fixed by isolating `repo_root` itself (patching `weekly_collector.__file__` into an empty tmp sandbox) rather than papering over the one collision — closes the whole class for all three tests in that file, not just the one that happened to manifest. 3581+3 passed, 0 failed, 8 skipped after the fix.

## CI status

_(filled in after push — see PR checks)_
