### PR TITLE
arm(scheduled-groom-dispatcher): GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid" — start the DeepSeek-primary low/mid test

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -229,7 +229,12 @@ if $BOOTSTRAP; then
   #
   # GROOM_PRIMARY_DEEPSEEK_TIERS (alpha-engine-config-I3479, PRIMARY-mode
   # DeepSeek backend selection for scheduled low/mid groom launches):
-  # DELIBERATELY ABSENT from the Variables map below — index.py's own
+  # ARMED 2026-07-22 (config-I3488 step 3, Brian's DeepSeek-primary ruling) —
+  # present in BOTH Variables maps below with the value DOUBLE-QUOTED
+  # ("low,mid"): a raw comma inside CLI shorthand splits map entries and fails
+  # ParamValidation (verified live 2026-07-22). Disarm = remove it from both
+  # maps in a reviewed PR (empty/absent = feature off in index.py).
+  # Original design note (pre-arming): DELIBERATELY ABSENT from the Variables map below — index.py's own
   # `os.environ.get("GROOM_PRIMARY_DEEPSEEK_TIERS", "")` default ("" =
   # feature OFF) governs, same as GROOM_DEMAND_GATE_ENABLED and GROOM_BACKEND
   # today. This is intentional, not an oversight: every deploy's
@@ -252,7 +257,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 300 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid"}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -413,7 +418,7 @@ echo "✓ Code deployed."
 echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+  --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid"}' \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -2057,15 +2057,23 @@ def test_fallback_dispatch_backend_independent_of_primary_tiers_env(monkeypatch)
     assert out["groom"]["backend"] == "deepseek"
 
 
-def test_deploy_sh_ships_primary_deepseek_tiers_unarmed():
-    # Structural pin: neither of the two `--environment 'Variables={...}'`
-    # calls may set a live value for GROOM_PRIMARY_DEEPSEEK_TIERS — arming
-    # requires a reviewed PR (mirrors the GROOM_MAX_DISPATCHES_DAILY
-    # precedent immediately above it in deploy.sh), never a console-only
-    # edit that the next code-only deploy would silently wipe anyway.
+def test_deploy_sh_arms_primary_deepseek_tiers_low_mid():
+    # Structural pin, INVERTED at arming (2026-07-22, config-I3488 step 3 —
+    # Brian's DeepSeek-primary ruling, config-I3479): BOTH `--environment
+    # 'Variables={...}'` calls must now carry GROOM_PRIMARY_DEEPSEEK_TIERS
+    # with the value DOUBLE-QUOTED ("low,mid") — a raw comma inside CLI
+    # shorthand splits map entries and fails ParamValidation (verified live).
+    # This guards against (a) silent DISARM by a deploy.sh refactor dropping
+    # the var from one or both maps, and (b) re-introducing the unquoted form.
+    # Disarming is a deliberate reviewed PR that flips this pin back.
     deploy_sh = (
         Path(__file__).resolve().parent / "deploy.sh"
     ).read_text()
-    for line in deploy_sh.splitlines():
-        if "--environment 'Variables=" in line:
-            assert "GROOM_PRIMARY_DEEPSEEK_TIERS=" not in line
+    armed_lines = [
+        line for line in deploy_sh.splitlines()
+        if "--environment 'Variables=" in line
+        and not line.lstrip().startswith("#")  # doc comment references the pattern too
+    ]
+    assert len(armed_lines) == 2
+    for line in armed_lines:
+        assert 'GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid"' in line


### PR DESCRIPTION
**The last click.** Merging this deploys the dispatcher with `GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid"` armed (auto-deploy via deploy-scheduled-groom-dispatcher.yml) — the next scheduled trigger (01:00/07:00/19:00 UTC) launches any low/mid groom bundle on DeepSeek direct behind the on-box egress proxy (config-PR3487 machinery, merged; SSM key at /alpha-engine/groom/deepseek_api_key, provisioned+verified). Bundles containing high stay on Claude/Max by construction.

- Arming runbook: alpha-engine-config-I3488 (this is step 3). Ruling: alpha-engine-config-I3479.
- Syntax note: value is DOUBLE-QUOTED — a raw comma inside `Variables={...}` shorthand splits map entries and fails ParamValidation (verified live 2026-07-22; the pre-arming comment's literal `low,mid` phrasing would have broken the deploy — comment corrected in this PR).
- Rollback: revert this PR — the next deploy wipes the var; absent/empty = feature off in index.py.
- Post-merge watch: first deepseek-backed run's decision record (backend=deepseek) + on-box /__proxy_health__ counters; quality-read window (I3479) starts, scoreboard config-I3489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)