### PR TITLE
refactor(ci): consolidate gate-label-guard onto shared nousergon-lib primitive (config-I3491)

### DIFF
--- a/.github/workflows/gate-label-guard.yml
+++ b/.github/workflows/gate-label-guard.yml
@@ -1,22 +1,13 @@
 name: Gate Label Guard
 
-# Structural enforcement of the gate:* draft-PR discipline (config#2002).
-#
-# The gate:* taxonomy (gate:live-run, gate:decision, gate:dependency, gate:date,
-# gate:data, gate:device, gate:operator) is convention-only unless something
-# actually blocks merge while the label is attached. This check FAILS whenever
-# any gate:* label is present on the PR, and passes otherwise — it is meant to
-# be added as a REQUIRED status check in branch protection so a gated PR
-# structurally cannot merge, even if it gets flipped to "ready for review" by
-# mistake or by an automated actor (this is exactly what happened on
-# nousergon-data-PR643: a DRAFT PR carrying gate:live-run was flipped ready by
-# ne-groomer[bot] and merged with the label still attached, 2026-07-05 —
-# 2026-07-08 incident, config#1446 / EPIC config#1464).
-#
-# NOTE: this workflow only reports pass/fail on the check run. Making it
-# actually block merges requires a repo admin to add "Gate Label Guard" to
-# the required status checks in branch protection settings — that step is
-# NOT done by this workflow and must be performed manually.
+# Structural enforcement of the gate:* draft-PR discipline (config#2002) —
+# fails while ANY gate:* label is attached to this PR. Required status
+# check on main branch protection so a gated PR structurally cannot merge,
+# even if flipped to ready for review by mistake or by an automated actor
+# (incident precedent: this repo's own PR643, 2026-07-05, config#1446/#1464
+# — the incident this check was originally built to prevent here).
+# Logic now lives in the fleet chokepoint: nousergon-lib gate-label-guard.yml
+# (consolidated from this repo's original inline implementation, config-I3491).
 
 on:
   pull_request:
@@ -26,24 +17,5 @@ permissions:
   contents: read
 
 jobs:
-  guard:
-    name: gate-label-guard
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fail if any gate:* label is present
-        env:
-          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
-        run: |
-          set -euo pipefail
-          echo "$LABELS_JSON" | jq -r '.[].name' > /tmp/pr_labels.txt || true
-
-          echo "PR labels:"
-          cat /tmp/pr_labels.txt || echo "(none)"
-
-          if grep -q '^gate:' /tmp/pr_labels.txt; then
-            echo ""
-            echo "::error::This PR carries a gate:* label ($(grep '^gate:' /tmp/pr_labels.txt | paste -sd, -)) — the gate:* taxonomy means this PR is NOT verified ready to merge. Remove the gate:* label only after verifying the blocker is actually resolved."
-            exit 1
-          fi
-
-          echo "No gate:* label present — check passes."
+  gate-label-guard:
+    uses: nousergon/nousergon-lib/.github/workflows/gate-label-guard.yml@main


### PR DESCRIPTION
## Summary

Replaces this repo's original standalone/inline `gate-label-guard.yml` implementation with a thin caller into the new fleet chokepoint at `nousergon-lib` (`.github/workflows/gate-label-guard.yml`), mirroring the existing `config-counterpart-guard.yml` pattern (nousergon-lib hosts the logic, consumer repos have a thin caller).

This repo's copy was the ORIGINAL inline implementation that other repos were about to duplicate. Consolidating onto one shared source of truth means the fleet no longer risks N diverging copies of the same gate-enforcement logic drifting apart over time.

Behavior is unchanged — same trigger types (`opened, reopened, labeled, unlabeled, ready_for_review, synchronize`), same fail-while-any-`gate:*`-label-present logic, now delegated to the shared workflow.

Tracked as alpha-engine-config-I3491 (https://github.com/nousergon/alpha-engine-config/issues/3491).

## Blocked on nousergon-lib#235 (gate:dependency)

**This PR is gated on [nousergon-lib#235](https://github.com/nousergon/nousergon-lib/pull/235) merging first.** The `uses: nousergon/nousergon-lib/.github/workflows/gate-label-guard.yml@main` reference resolves against nousergon-lib's `main` branch at CI run time. Since nousergon-lib#235 has not merged yet, the `gate-label-guard` job in THIS PR will show a resolution failure / red CI check — **that redness is expected and by design, not a real defect.**

Once nousergon-lib#235 merges, re-run this PR's checks (Actions tab → re-run jobs) to confirm it goes green before removing the `gate:dependency` label.

## Test plan

- [ ] Confirm nousergon-lib#235 merges to `main`
- [ ] Re-run this PR's `gate-label-guard` check (Actions tab → re-run jobs) and confirm it goes green
- [ ] Remove `gate:dependency` label once verified