### PR TITLE
[P1/high] feat(watch-plane): mid-run spot-reclaim checkers for ci-watch + alert-drain (config#3173)

### DIFF
--- a/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-alert-drain-liveness-probe
+# Lambda and wire its EC2 reclaim EventBridge rules (config#3173).
+#
+# WHY: alert-drain runs on a twice-daily schedule, so a dead run isn't
+# permanently silent (the next scheduled run still fires) — but the self-heal
+# is slow (up to ~24h) and, worse, SILENT: nothing tells anyone a drain box
+# died mid-run rather than finishing cleanly. This Lambda is the mid-run
+# spot-reclaim checker for the alert-drain family, mirroring
+# sf-watch-liveness-probe's config#2270 mechanism: on an EC2 spot
+# interruption or terminated state-change, check the box's completion
+# marker; if absent, relaunch ONCE (ceiling-bounded, recorded in a relaunch
+# ledger) by invoking alpha-engine-alert-drain-dispatcher directly; a SECOND
+# death for the same run_id escalates LOUD instead of relaunching again.
+#
+# No scheduled sweep here — alert-drain's own twice-daily schedule already
+# re-fires independent of any prior run's outcome; there's no "disabled
+# window drops a one-shot trigger" risk the way sf-watch's config#2257 sweep
+# guards against. This Lambda has exactly one trigger surface: the two EC2
+# reclaim EventBridge rules below.
+#
+# IAM (iam-policy.json): logs + ssm:GetParameter (Telegram creds) +
+# ec2:DescribeTags (Describe* — not resource-scopable) + s3:GetObject on the
+# overseer/_control/completed/ prefix + s3 Get/Put on the
+# overseer/_control/relaunch/ ledger + lambda:InvokeFunction scoped to
+# alpha-engine-alert-drain-dispatcher.
+#
+# Managed OUTSIDE CloudFormation — mirrors every sibling watch-plane
+# dispatcher/probe (narrow OIDC blast radius, operator-deployed only).
+# Merging the PR has ZERO live effect until an operator runs this with
+# --bootstrap.
+#
+# Usage:
+#   bash .../alert-drain-liveness-probe/deploy.sh             # update code only
+#   bash .../alert-drain-liveness-probe/deploy.sh --bootstrap # first-time create + wire the EC2 reclaim rules
+#   bash .../alert-drain-liveness-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../alert-drain-liveness-probe/deploy.sh --smoke     # invoke once with a no-op payload (read-only)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-alert-drain-liveness-probe"
+ROLE_NAME="alpha-engine-alert-drain-liveness-probe-role"
+POLICY_NAME="alpha-engine-alert-drain-liveness-probe-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+
+# config#3173: dedicated rules (not a second target on sf-watch/ci-watch's
+# rules) — keeps each Lambda's deploy.sh self-contained/idempotent without a
+# cross-Lambda coupling on rule ownership. Both rules match FLEET-WIDE EC2
+# events (neither event type is tag-scopable) — the handler filters by
+# Name=alpha-engine-alert-drain-spot.
+RECLAIM_RULE_NAMES=(
+  "alpha-engine-alert-drain-spot-interruption"
+  "alpha-engine-alert-drain-instance-terminated"
+)
+RECLAIM_RULE_PATTERNS=(
+  '{"source":["aws.ec2"],"detail-type":["EC2 Spot Instance Interruption Warning"]}'
+  '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["terminated"]}}'
+)
+RECLAIM_RULE_DESCRIPTIONS=(
+  "EC2 spot interruption warning -> alert-drain mid-run reclaim checker (config#3173)"
+  "EC2 instance terminated -> alert-drain mid-run reclaim checker (config#3173)"
+)
+
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3 -r "${SCRIPT_DIR}/requirements.txt"
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
+      --zip-file "fileb://${ZIP}" --timeout 30 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,ACCOUNT_ID='"${ACCOUNT_ID}"'}' --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge rules for the mid-run spot-reclaim checker (config#3173).
+  for i in "${!RECLAIM_RULE_NAMES[@]}"; do
+    rule="${RECLAIM_RULE_NAMES[$i]}"
+    echo "  Creating/updating EventBridge rule: ${rule}"
+    run aws events put-rule \
+      --name "${rule}" \
+      --event-pattern "${RECLAIM_RULE_PATTERNS[$i]}" \
+      --description "${RECLAIM_RULE_DESCRIPTIONS[$i]}" \
+      --region "${REGION}" \
+      --query 'RuleArn' --output text
+    run aws events put-targets \
+      --rule "${rule}" \
+      --targets "Id=1,Arn=${FN_ARN}" \
+      --region "${REGION}"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "eventbridge-${rule}" \
+      --action lambda:InvokeFunction \
+      --principal events.amazonaws.com \
+      --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${rule}" \
+      --region "${REGION}" 2>/dev/null || true
+  done
+fi
+
+# ----- 3. Update function code (always, idempotent) -------------------------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,ACCOUNT_ID='"${ACCOUNT_ID}"'}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+# ----- 4. Smoke (no-op payload; the reclaim path only fires off real EC2 events) -
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (no-op payload — the reclaim path only "
+  echo "fires from the EC2 EventBridge rules above)..."
+  RESP=$(mktemp)
+  aws lambda invoke --function-name "${FUNCTION_NAME}" --cli-binary-format raw-in-base64-out \
+    --payload '{}' --region "${REGION}" "${RESP}" >/dev/null
+  cat "${RESP}"; echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/alert-drain-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/iam-policy.json
@@ -1,0 +1,65 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-alert-drain-liveness-probe:*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
+      ]
+    },
+    {
+      "Sid": "DescribeTagsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": ["ec2:DescribeTags"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReclaimCheckerCompletionMarkers",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/overseer/_control/completed/*"
+    },
+    {
+      "Sid": "ReclaimCheckerRelaunchLedgerRW",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/overseer/_control/relaunch/*"
+    },
+    {
+      "Sid": "ReclaimCheckerInvokeAlertDrainDispatcher",
+      "Effect": "Allow",
+      "Action": ["lambda:InvokeFunction"],
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-alert-drain-dispatcher"
+    },
+    {
+      "Sid": "FlowDoctorDedupStore",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:DescribeTable"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:us-east-1:711398986525:table/flow-doctor-store",
+        "arn:aws:dynamodb:us-east-1:711398986525:table/flow-doctor-store/index/*"
+      ]
+    }
+  ]
+}

--- a/infrastructure/lambdas/alert-drain-liveness-probe/index.py
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/index.py
@@ -1,0 +1,343 @@
+"""alpha-engine-alert-drain-liveness-probe — mid-run spot-reclaim checker for
+the Overseer alert-drain (config#3173, generalizing sf-watch-liveness-probe's
+config#2270 mechanism to the alert-drain family).
+
+WHY: alert-drain runs on a twice-daily EventBridge schedule, so — unlike
+ci-watch — a missed/dead run is NOT permanently silent: the next scheduled
+run 12h later will still fire and drain whatever the queue's at-least-once
+semantics left behind. But that self-heal is SLOW (up to ~24h if two
+consecutive runs die) and, more importantly, SILENT — nothing tells anyone a
+drain box died mid-run rather than finishing cleanly, which is exactly the
+"no arc silently stalls" gap alpha-engine-config#3173 (child of the #3137
+stall-watchdog charter) asks every dispatch family to close. Unlike ci-watch,
+NO dispatch-record reconstruction is needed here: a relaunch just needs to
+run the drain again (the SQS queue — not any per-run field — is the durable
+state a fresh box picks up from), so this checker is simpler than its
+ci-watch sibling.
+
+MECHANISM (mirrors sf-watch-liveness-probe's reclaim checker): EventBridge
+target for `EC2 Spot Instance Interruption Warning` and `EC2 Instance
+State-change Notification` (state=terminated) events fleet-wide (neither
+event type is tag-scopable in the rule pattern — this handler filters by the
+box's own Name tag). For an `alpha-engine-alert-drain-spot` box:
+  1. DescribeTags for `alert-drain-run-id` (rides the RunInstances call
+     atomically with launch, config#2292 — a box reaching this checker
+     without it is a genuine anomaly).
+  2. A `drill-`-prefixed run id (config#2223 pattern) is a canary drill, not a
+     repair — isolated below exactly like sf-watch-liveness-probe's
+     `run_date.startswith("drill-")` carve-out: the missed
+     `overseer/_canary/{date}.json` heartbeat is the correct alerting
+     surface, not a page from this checker.
+  3. HEAD the completion marker
+     (`overseer/_control/completed/alert-drain-{run_id}.json`, the same key
+     scripts/alert_drain_run.sh writes). Present = clean finish.
+  4. Absent = died mid-run. Read the relaunch ledger
+     (`overseer/_control/relaunch/alert-drain-{run_id}.json`): a record
+     naming THIS dead instance is a duplicate notification (both EC2 event
+     types fire for one death); a record naming a DIFFERENT instance is a
+     second death for the same run_id — the exactly-one relaunch bound is
+     spent, escalate LOUD instead of relaunching again.
+  5. First death: record the relaunch decision FIRST (exactly-one bound),
+     THEN invoke alpha-engine-alert-drain-dispatcher DIRECTLY (bypassing the
+     Overseer router and the twice-daily schedule entirely, mirroring
+     sf-watch-liveness-probe's direct invoke of the spot dispatcher) with a
+     fresh `{"is_drill": "false", "trigger": "reclaim-relaunch"}` — the drain
+     needs no fields from the dead run, only to run again.
+
+Fail-loud (CLAUDE.md no-silent-fails): DescribeTags and the ledger/marker
+reads RAISE on any error OTHER than genuine absence. The Telegram send and
+the dispatcher re-invoke are the only best-effort/secondary surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import boto3
+
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+_FLOW_NAME = "alert-drain-liveness-probe"
+_DB_BASENAME = "flow_doctor_alert_drain_liveness_probe"
+_OPS_TOPICS = (
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
+
+# The dispatcher this checker relaunches through directly — bypassing the
+# Overseer router and the twice-daily schedule entirely.
+ALERT_DRAIN_DISPATCHER_FUNCTION = os.environ.get(
+    "ALERT_DRAIN_DISPATCHER_FUNCTION", "alpha-engine-alert-drain-dispatcher"
+)
+
+WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
+
+ALERT_DRAIN_SPOT_TAG_NAME = "alpha-engine-alert-drain-spot"
+ALERT_DRAIN_RUN_ID_TAG_KEY = "alert-drain-run-id"
+COMPLETION_MARKER_PREFIX = "overseer/_control/completed/"
+RELAUNCH_LEDGER_PREFIX = "overseer/_control/relaunch/"
+
+RECLAIM_INTERRUPTION_DETAIL_TYPE = "EC2 Spot Instance Interruption Warning"
+RECLAIM_STATE_CHANGE_DETAIL_TYPE = "EC2 Instance State-change Notification"
+RECLAIM_DETAIL_TYPES = frozenset(
+    {RECLAIM_INTERRUPTION_DETAIL_TYPE, RECLAIM_STATE_CHANGE_DETAIL_TYPE}
+)
+
+
+def _error_code(exc: Exception) -> str:
+    return str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+
+
+def _ec2_client():
+    return boto3.client("ec2", region_name=REGION)
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=REGION)
+
+
+def _lambda_client():
+    return boto3.client("lambda", region_name=REGION)
+
+
+def _is_reclaim_event(event: dict) -> bool:
+    return (
+        isinstance(event, dict)
+        and event.get("source") == "aws.ec2"
+        and event.get("detail-type") in RECLAIM_DETAIL_TYPES
+    )
+
+
+def _instance_tags(instance_id: str) -> dict[str, str]:
+    """Raises on any API error (fail-loud) — see module docstring."""
+    resp = _ec2_client().describe_tags(
+        Filters=[{"Name": "resource-id", "Values": [instance_id]}]
+    )
+    return {t.get("Key", ""): t.get("Value", "") for t in resp.get("Tags", [])}
+
+
+def _completion_key(run_id: str) -> str:
+    return f"{COMPLETION_MARKER_PREFIX}alert-drain-{run_id}.json"
+
+
+def _relaunch_key(run_id: str) -> str:
+    return f"{RELAUNCH_LEDGER_PREFIX}alert-drain-{run_id}.json"
+
+
+def _completion_marker_exists(s3, run_id: str) -> bool:
+    """Only a true absence (404/NoSuchKey/NotFound) means 'no marker'; any
+    OTHER error RAISES (config#2267 site-4 lesson)."""
+    try:
+        s3.head_object(Bucket=WATCH_BUCKET, Key=_completion_key(run_id))
+        return True
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        raise
+
+
+def _read_json(s3, key: str) -> dict | None:
+    """None on a true absence; RAISES on any other read error. A present-but-
+    unparseable object also returns None (caller escalates rather than
+    guessing)."""
+    try:
+        obj = s3.get_object(Bucket=WATCH_BUCKET, Key=key)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"404", "NoSuchKey", "NotFound"}:
+            return None
+        raise
+    try:
+        return json.loads(obj["Body"].read())
+    except (ValueError, TypeError) as exc:
+        logger.warning("unparseable object at %s: %s", key, exc)
+        return None
+
+
+def _record_relaunch(s3, run_id: str, dead_instance_id: str) -> None:
+    """PRIMARY deliverable of the relaunch path — RAISES on failure, runs
+    BEFORE the dispatcher invoke (the exactly-one bound must never depend on
+    the invoke succeeding)."""
+    s3.put_object(
+        Bucket=WATCH_BUCKET,
+        Key=_relaunch_key(run_id),
+        Body=json.dumps({
+            "dead_instance_id": dead_instance_id,
+            "relaunched_at": datetime.now(timezone.utc).isoformat(),
+        }).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _escalate(text: str, dedup_key: str, context_info: dict) -> bool:
+    try:
+        return notify_via_flow_doctor(
+            text,
+            silent=False,
+            severity="error",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context=context_info,
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface; finding still logged + returned
+        logger.warning("alert-drain reclaim escalation Telegram send failed (non-fatal): %s", exc)
+        return False
+
+
+def _note(text: str, dedup_key: str, context_info: dict) -> bool:
+    try:
+        return notify_via_flow_doctor(
+            text,
+            silent=True,
+            severity="info",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context=context_info,
+            silent_topic=FleetTelegramTopic.OPS_HEALTH,
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface; relaunch already fired + recorded
+        logger.warning("alert-drain reclaim relaunch Telegram note failed (non-fatal): %s", exc)
+        return False
+
+
+def _handle_reclaim_event(event: dict) -> dict:
+    detail = event.get("detail") or {}
+    detail_type = str(event.get("detail-type") or "")
+    instance_id = str(detail.get("instance-id") or "")
+    if not instance_id:
+        raise ValueError(f"EC2 reclaim event without instance-id (detail-type={detail_type!r})")
+    base = {"reclaim_event": True, "detail_type": detail_type, "instance_id": instance_id}
+
+    if detail_type == RECLAIM_STATE_CHANGE_DETAIL_TYPE and str(detail.get("state") or "") != "terminated":
+        logger.info("reclaim check: ignoring non-terminated state-change for %s", instance_id)
+        return {**base, "handled": False, "reason": "not_terminated"}
+
+    tags = _instance_tags(instance_id)
+    if tags.get("Name") != ALERT_DRAIN_SPOT_TAG_NAME:
+        logger.info("reclaim check: %s is not an alert-drain box (Name=%r) — ignoring",
+                    instance_id, tags.get("Name"))
+        return {**base, "watch_box": False}
+
+    run_id = tags.get(ALERT_DRAIN_RUN_ID_TAG_KEY, "")
+    if not run_id:
+        alerted = _escalate(
+            "\U0001f6a8 *Alert-Drain reclaim checker — UNTAGGED watch box died*\n"
+            f"Watch box `{instance_id}` terminated without its run-id "
+            "discriminator tag — cannot verify completion or relaunch. "
+            "Check the alert-drain-dispatcher tag-write path (config#2267 site 2).",
+            dedup_key=f"{_FLOW_NAME}:untagged:{instance_id}",
+            context_info={"instance_id": instance_id, "tags": tags},
+        )
+        return {**base, "watch_box": True, "handled": False,
+                "reason": "missing_discriminator_tag", "escalated": alerted}
+
+    key_ctx = {"instance_id": instance_id, "run_id": run_id}
+    s3 = _s3_client()
+
+    # Drill isolation (config#2223 pattern): a drill's run_id ALWAYS carries
+    # the "drill-" prefix (alert-drain-dispatcher's _resolve_event_fields) —
+    # never a repair to retry; its own missed canary heartbeat is the
+    # alerting surface.
+    if run_id.startswith("drill-"):
+        completed = _completion_marker_exists(s3, run_id)
+        logger.info(
+            "reclaim check: drill box %s (run_id=%s) %s — no relaunch/"
+            "escalation for drills; the missed _canary heartbeat is the "
+            "alerting surface (config#2223)", instance_id, run_id,
+            "finished cleanly" if completed else "died WITHOUT a completion marker",
+        )
+        return {**base, "watch_box": True, "drill": True, "completed": completed,
+                "relaunched": False}
+
+    if _completion_marker_exists(s3, run_id):
+        logger.info("reclaim check: %s finished cleanly (run_id=%s)", instance_id, run_id)
+        return {**base, "watch_box": True, "completed": True}
+
+    # No completion marker: the box died mid-run.
+    relaunch_record = _read_json(s3, _relaunch_key(run_id))
+    if relaunch_record is not None:
+        if relaunch_record.get("dead_instance_id") == instance_id:
+            logger.info("reclaim check: death of %s already handled — duplicate notification",
+                        instance_id)
+            return {**base, "watch_box": True, "completed": False, "duplicate_notification": True}
+        alerted = _escalate(
+            "\U0001f6a8 *Alert-Drain reclaim checker — SECOND watch-box death*\n"
+            f"run_id={run_id}: relaunched box `{instance_id}` ALSO died "
+            "without a completion marker (prior relaunch: "
+            f"`{relaunch_record.get('dead_instance_id', '?')}`). The bounded "
+            "relaunch budget is spent — human needed (config#3173).",
+            dedup_key=f"{_FLOW_NAME}:second_death:{run_id}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": False,
+                "reason": "second_death", "escalated": alerted}
+
+    # First mid-run death: record FIRST (exactly-one bound), then invoke —
+    # no dispatch-record reconstruction needed (unlike ci-watch): a fresh
+    # drain run carries no per-run fields, only "run again".
+    _record_relaunch(s3, run_id, instance_id)
+    payload = {"is_drill": "false", "trigger": "reclaim-relaunch"}
+    try:
+        _lambda_client().invoke(
+            FunctionName=ALERT_DRAIN_DISPATCHER_FUNCTION,
+            InvocationType="Event",
+            Payload=json.dumps(payload).encode("utf-8"),
+        )
+        invoked = True
+    except Exception as exc:  # noqa: BLE001 — relaunch decision already recorded; invoke is best-effort
+        invoked = False
+        logger.error(
+            "alert-drain relaunch invoke failed for run_id=%s (relaunch "
+            "already recorded — this will NOT retry itself; treat as an "
+            "escalation): %s: %s", run_id, type(exc).__name__, exc,
+        )
+    logger.warning(
+        "reclaim check: alert-drain box %s (run_id=%s) died mid-run — relaunch %s",
+        instance_id, run_id, "dispatched" if invoked else "invoke FAILED",
+    )
+    if invoked:
+        noted = _note(
+            "\U0001f6f0️ *Alert-Drain reclaim checker — bounded relaunch*\n"
+            f"Watch box `{instance_id}` (run_id={run_id}) was reclaimed "
+            "mid-drain — a fresh drain was relaunched (attempt 1/1; a second "
+            "death escalates loud, config#3173).",
+            dedup_key=f"{_FLOW_NAME}:relaunch:{run_id}:{instance_id}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": True,
+                "telegram_sent": noted}
+
+    alerted = _escalate(
+        "\U0001f6a8 *Alert-Drain reclaim checker — relaunch invoke FAILED*\n"
+        f"run_id={run_id}: box `{instance_id}` died mid-run; the relaunch "
+        "decision was recorded but invoking "
+        f"`{ALERT_DRAIN_DISPATCHER_FUNCTION}` failed — no fresh box was "
+        "actually launched. Relaunch manually (config#3173).",
+        dedup_key=f"{_FLOW_NAME}:invoke_failed:{run_id}",
+        context_info=key_ctx,
+    )
+    return {**base, "watch_box": True, "completed": False, "relaunched": False,
+            "reason": "invoke_failed", "escalated": alerted}
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Entrypoint. The only path this Lambda serves is the EC2 reclaim/
+    termination event — a non-reclaim invocation (e.g. a manual smoke test)
+    is a documented no-op (no scheduled sweep needed: the twice-daily
+    schedule itself already re-fires independent of any prior run's outcome
+    — see module docstring)."""
+    if _is_reclaim_event(event or {}):
+        return _handle_reclaim_event(event)
+    logger.info("alert-drain-liveness-probe: non-reclaim invocation — no-op (event=%r)", event)
+    return {"reclaim_event": False, "noop": True}

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,0 +1,5 @@
+# config#3173 — flow-doctor forum-topic routing, same pin as
+# sf-watch-liveness-probe / ci-watch-liveness-probe (this Lambda mirrors
+# their reclaim-checker exactly).
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/alert-drain-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/test_handler.py
@@ -1,0 +1,225 @@
+"""Unit tests for alert-drain-liveness-probe/index.handler (config#3173).
+
+Mirrors ci-watch-liveness-probe's test shape — same mid-run spot-reclaim
+pattern, simpler payload (a relaunch needs no reconstructed fields, just
+"run the drain again").
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import index  # noqa: E402
+
+RUN_ID = "drain-2026-07-22T1200Z"
+COMPLETION_KEY = f"overseer/_control/completed/alert-drain-{RUN_ID}.json"
+RELAUNCH_KEY = f"overseer/_control/relaunch/alert-drain-{RUN_ID}.json"
+
+WATCH_TAGS = {"Name": "alpha-engine-alert-drain-spot", "alert-drain-run-id": RUN_ID}
+
+
+class FakeClientError(Exception):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+@pytest.fixture(autouse=True)
+def reset_notify(monkeypatch):
+    mock = MagicMock(return_value=True)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock)
+    yield mock
+
+
+def _reclaim_event(detail_type="EC2 Spot Instance Interruption Warning",
+                   instance_id="i-dead", **detail_overrides):
+    detail = {"instance-id": instance_id}
+    detail.update(detail_overrides)
+    return {"source": "aws.ec2", "detail-type": detail_type, "detail": detail}
+
+
+def _make_ec2(tags=WATCH_TAGS, instance_id="i-dead"):
+    ec2 = MagicMock()
+    ec2.describe_tags.return_value = {
+        "Tags": [{"Key": k, "Value": v, "ResourceId": instance_id} for k, v in tags.items()]
+    }
+    return ec2
+
+
+def _make_s3(*, marker_exists=False, relaunch=None):
+    s3 = MagicMock()
+    if marker_exists:
+        s3.head_object.return_value = {}
+    else:
+        s3.head_object.side_effect = FakeClientError("404")
+
+    docs = {}
+    if relaunch is not None:
+        docs[RELAUNCH_KEY] = relaunch
+
+    def get_object(Bucket, Key):  # noqa: N803 — boto3 kwarg names
+        if Key not in docs:
+            raise FakeClientError("NoSuchKey")
+        body = MagicMock()
+        body.read.return_value = json.dumps(docs[Key]).encode()
+        return {"Body": body}
+
+    s3.get_object.side_effect = get_object
+    return s3
+
+
+def _clients_factory(ec2, s3, lam):
+    def factory(name, region_name=None):
+        return {"ec2": ec2, "s3": s3, "lambda": lam}[name]
+    return factory
+
+
+def _run(event, *, ec2=None, s3=None, lam=None):
+    ec2 = ec2 if ec2 is not None else _make_ec2()
+    s3 = s3 if s3 is not None else _make_s3()
+    lam = lam if lam is not None else MagicMock()
+    factory = _clients_factory(ec2, s3, lam)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(event, None)
+    return result, ec2, s3, lam
+
+
+def test_scheduled_probe_event_is_a_documented_noop():
+    result, _, s3, lam = _run({})
+    assert result == {"reclaim_event": False, "noop": True}
+    s3.head_object.assert_not_called()
+    lam.invoke.assert_not_called()
+
+
+def test_non_terminated_state_change_is_ignored():
+    result, ec2, s3, lam = _run(
+        _reclaim_event(detail_type="EC2 Instance State-change Notification", state="stopping")
+    )
+    assert result["handled"] is False
+    assert result["reason"] == "not_terminated"
+    ec2.describe_tags.assert_not_called()
+
+
+def test_reclaim_event_without_instance_id_raises():
+    with pytest.raises(ValueError, match="instance-id"):
+        index.handler({"source": "aws.ec2", "detail-type": "EC2 Spot Instance Interruption Warning",
+                       "detail": {}}, None)
+
+
+def test_reclaim_event_for_non_drain_box_exits_quietly():
+    ec2 = _make_ec2(tags={"Name": "alpha-engine-data-spot"})
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2)
+    assert result["watch_box"] is False
+    s3.head_object.assert_not_called()
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_with_completion_marker_is_clean_exit():
+    s3 = _make_s3(marker_exists=True)
+    result, _, s3, lam = _run(_reclaim_event(), s3=s3)
+    assert result["watch_box"] is True
+    assert result["completed"] is True
+    assert s3.head_object.call_args.kwargs["Key"] == COMPLETION_KEY
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_with_missing_run_id_tag_escalates_loud():
+    ec2 = _make_ec2(tags={"Name": "alpha-engine-alert-drain-spot"})
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2)
+    assert result["reason"] == "missing_discriminator_tag"
+    assert result["escalated"] is True
+    lam.invoke.assert_not_called()
+    kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert kwargs["silent"] is False
+    assert kwargs["severity"] == "error"
+
+
+def test_first_mid_run_death_relaunches_once_with_record_before_invoke():
+    result, _, s3, lam = _run(_reclaim_event(instance_id="i-dead"))
+
+    assert result["completed"] is False
+    assert result["relaunched"] is True
+
+    put_call = s3.put_object.call_args
+    assert put_call.kwargs["Key"] == RELAUNCH_KEY
+    ledger = json.loads(put_call.kwargs["Body"])
+    assert ledger["dead_instance_id"] == "i-dead"
+
+    lam.invoke.assert_called_once()
+    kwargs = lam.invoke.call_args.kwargs
+    assert kwargs["FunctionName"] == index.ALERT_DRAIN_DISPATCHER_FUNCTION
+    assert kwargs["InvocationType"] == "Event"
+    payload = json.loads(kwargs["Payload"])
+    assert payload == {"is_drill": "false", "trigger": "reclaim-relaunch"}
+    index.notify_via_flow_doctor.assert_called_once()
+    assert index.notify_via_flow_doctor.call_args.kwargs["silent"] is True
+
+
+def test_duplicate_notification_for_same_dead_instance_is_a_noop():
+    s3 = _make_s3(relaunch={"dead_instance_id": "i-dead"})
+    result, _, s3, lam = _run(_reclaim_event(instance_id="i-dead"), s3=s3)
+    assert result["duplicate_notification"] is True
+    lam.invoke.assert_not_called()
+    s3.put_object.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_second_death_for_different_instance_escalates_loud_not_relaunch():
+    s3 = _make_s3(relaunch={"dead_instance_id": "i-first-relaunch"})
+    result, _, s3, lam = _run(_reclaim_event(instance_id="i-second-dead"), s3=s3)
+    assert result["reason"] == "second_death"
+    assert result["escalated"] is True
+    lam.invoke.assert_not_called()
+    s3.put_object.assert_not_called()
+    kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert kwargs["silent"] is False
+    assert "SECOND watch-box death" in index.notify_via_flow_doctor.call_args.args[0]
+
+
+def test_invoke_failure_still_records_ledger_and_escalates():
+    lam = MagicMock()
+    lam.invoke.side_effect = RuntimeError("boom")
+    result, _, s3, lam = _run(_reclaim_event(), lam=lam)
+    assert result["relaunched"] is False
+    assert result["reason"] == "invoke_failed"
+    assert result["escalated"] is True
+    s3.put_object.assert_called_once()
+    assert index.notify_via_flow_doctor.call_args.kwargs["severity"] == "error"
+
+
+def test_dead_drill_box_never_relaunches_or_escalates():
+    tags = {"Name": "alpha-engine-alert-drain-spot", "alert-drain-run-id": "drill-2026-07-22T1200Z"}
+    ec2 = _make_ec2(tags=tags)
+    s3 = _make_s3()
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2, s3=s3)
+    assert result["drill"] is True
+    assert result["completed"] is False
+    assert result["relaunched"] is False
+    s3.put_object.assert_not_called()
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_completed_drill_box_is_clean_no_relaunch_no_page():
+    tags = {"Name": "alpha-engine-alert-drain-spot", "alert-drain-run-id": "drill-2026-07-22T1200Z"}
+    ec2 = _make_ec2(tags=tags)
+    s3 = _make_s3(marker_exists=True)
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2, s3=s3)
+    assert result["drill"] is True
+    assert result["completed"] is True
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_keys_derived_from_run_id():
+    assert index._completion_key(RUN_ID) == COMPLETION_KEY
+    assert index._relaunch_key(RUN_ID) == RELAUNCH_KEY

--- a/infrastructure/lambdas/ci-watch-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/ci-watch-dispatcher/iam-policy.json
@@ -130,6 +130,12 @@
       "Effect": "Allow",
       "Action": "s3:GetObject",
       "Resource": "arn:aws:s3:::alpha-engine-research/ci_watch/_control/signatures/*"
+    },
+    {
+      "Sid": "WriteCiWatchDispatchRecordForReclaimChecker",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/ci_watch/_control/dispatched/*"
     }
   ]
 }

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -208,6 +208,59 @@ CI_WATCH_SIGNATURES_PREFIX = os.environ.get(
     "CI_WATCH_SIGNATURES_PREFIX", "ci_watch/_control/signatures"
 )
 
+# ── Dispatch record for the mid-run reclaim checker (config#3173) ───────────
+# WHY: ci-watch has no equivalent of Fleet-SF Watch's per-run watch-log — a
+# box's own completion marker (ci_watch/_control/completed/{repo}-{sha}.json,
+# written by scripts/ci_watch_run.sh) is the ONLY durable record of a
+# dispatch, and it is written at the END. A box reclaimed by AWS mid-run
+# (before completing, sometimes before even starting the charter) previously
+# left NOTHING for anything to recover from — the completion marker never
+# lands, the (repo, sha) tags on the terminated instance are the only trace,
+# and neither carries run_id/run_url/workflow/branch. This record is written
+# right after a successful launch (mirrors the atomic-with-launch discipline
+# config#2292 already established for the discriminator tags) so a sibling
+# ci-watch-liveness-probe Lambda (EC2 reclaim-event target, mirroring
+# sf-watch-liveness-probe's config#2270 mid-run spot-reclaim checker) can
+# reconstruct the original dispatch fields and relaunch once, ceiling-bounded
+# at exactly one relaunch, escalating loud on a second death — closing the
+# "box died with no re-dispatch or escalation" gap config#3173 tracks for the
+# ci-watch family. Best-effort (never blocks/fails the primary dispatch): a
+# write failure only degrades the reclaim checker to its own "unreconstructable
+# dispatch fields" LOUD escalation path, it never masks the launch itself.
+# Skipped for drills — DRILL_REPO is synthetic and a drill box's reclaim is
+# already covered by its own _canary heartbeat channel (config#2223), never a
+# repair to retry.
+CI_WATCH_DISPATCHED_PREFIX = os.environ.get(
+    "CI_WATCH_DISPATCHED_PREFIX", "ci_watch/_control/dispatched"
+)
+
+
+def _write_dispatch_record(repo: str, sha: str, run_id: str, run_url: str,
+                           workflow: str, branch: str, instance_id: str) -> None:
+    """Best-effort S3 record of this dispatch's full event fields, keyed the
+    same way the completion marker and spot-orphan-reaper's WATCH_KINDS entry
+    key ci-watch (repo/sha, '/' flattened to '-'). Read back by
+    ci-watch-liveness-probe on a mid-run reclaim to reconstruct the fields
+    needed to relaunch. Never raises — see module note above."""
+    key = f"{CI_WATCH_DISPATCHED_PREFIX}/{repo.replace('/', '-')}-{sha}.json"
+    try:
+        boto3.client("s3", region_name=REGION).put_object(
+            Bucket=CI_WATCH_SIGNATURES_BUCKET,
+            Key=key,
+            Body=json.dumps({
+                "repo": repo, "sha": sha, "run_id": run_id, "run_url": run_url,
+                "workflow": workflow, "branch": branch, "instance_id": instance_id,
+                "dispatched_at": datetime.now(timezone.utc).isoformat(),
+            }).encode("utf-8"),
+            ContentType="application/json",
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort, see docstring
+        logger.warning(
+            "ci-watch dispatch-record write failed for %s@%s (non-fatal — a "
+            "later mid-run reclaim for this box would escalate loud instead "
+            "of relaunching): %s: %s", repo, sha, type(exc).__name__, exc,
+        )
+
 
 def _known_fixed_signature_exists(repo: str) -> bool:
     """True iff at least one signature marker for (repo, today) already
@@ -541,6 +594,13 @@ def _launch_ci_watch_spot(repo: str, sha: str, run_id: str, run_url: str,
     # as extra_tags into the RunInstances TagSpecifications, so the box is
     # never observably untagged. No post-launch create_tags step remains to
     # retry or fail here.
+
+    # config#3173: record the dispatch fields NOW (right after launch, before
+    # the SSM round trip) so a mid-run reclaim — possible from this point
+    # forward — has something to reconstruct a relaunch from. Skipped for
+    # drills (see _write_dispatch_record docstring).
+    if is_drill != "true":
+        _write_dispatch_record(repo, sha, run_id, run_url, workflow, branch, instance_id)
 
     # Once the box is up, ANY failure before the bootstrap command is
     # delivered would orphan it (no watchdog/trap yet). Terminate-on-error —

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -22,6 +22,7 @@ import json
 import os
 import sys
 import types
+from urllib.parse import urlparse
 
 import pytest
 
@@ -261,7 +262,9 @@ def test_dispatch_record_written_for_ci_watch_liveness_probe(monkeypatch):
     assert record["repo"] == "nousergon/alpha-engine-config"
     assert record["sha"] == "abc1234def5678900000000000000000000abcd"
     assert record["run_id"]
-    assert record["run_url"].startswith("https://github.com")
+    parsed_run_url = urlparse(record["run_url"])
+    assert parsed_run_url.scheme == "https"
+    assert parsed_run_url.netloc == "github.com"
     assert record["workflow"]
     assert record["branch"]
     assert record["instance_id"] == out["instance_id"]

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -74,6 +74,7 @@ class _FakeS3:
 
     def __init__(self, objects: dict | None = None):
         self._objects = objects or {}
+        self.puts: list[dict] = []
 
     def list_objects_v2(self, Bucket, Prefix):  # noqa: N803 — boto3 kwarg names
         keys = [k for k in self._objects if k.startswith(Prefix)]
@@ -81,6 +82,10 @@ class _FakeS3:
 
     def get_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg names
         return {"Body": _FakeS3Body(self._objects[Key])}
+
+    def put_object(self, Bucket, Key, Body, ContentType=None):  # noqa: N803 — boto3 kwarg names
+        self.puts.append({"Bucket": Bucket, "Key": Key, "Body": Body, "ContentType": ContentType})
+        return {}
 
 
 class _FakeWaiter:
@@ -234,6 +239,52 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
     assert "token" in sent["Comment"]
 
     assert sent["Parameters"]["executionTimeout"] == [str(idx.MAX_RUNTIME_SECONDS)]
+
+
+def test_dispatch_record_written_for_ci_watch_liveness_probe(monkeypatch):
+    """config#3173: right after a successful launch, the full dispatch fields
+    land at ci_watch/_control/dispatched/{repo}-{sha}.json — the sibling
+    ci-watch-liveness-probe Lambda's ONLY way to reconstruct a relaunch if
+    this box is reclaimed mid-run (it has no watch-log to read from, unlike
+    Fleet-SF Watch)."""
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
+
+    puts = idx._test_s3.puts
+    assert len(puts) == 1
+    assert puts[0]["Key"] == (
+        "ci_watch/_control/dispatched/nousergon-alpha-engine-config-"
+        "abc1234def5678900000000000000000000abcd.json"
+    )
+    record = json.loads(puts[0]["Body"])
+    assert record["repo"] == "nousergon/alpha-engine-config"
+    assert record["sha"] == "abc1234def5678900000000000000000000abcd"
+    assert record["run_id"]
+    assert record["run_url"].startswith("https://github.com")
+    assert record["workflow"]
+    assert record["branch"]
+    assert record["instance_id"] == out["instance_id"]
+
+
+def test_dispatch_record_skipped_for_drill(monkeypatch):
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+    out = idx.handler(_event(is_drill="true"), None)
+    assert out["launched"] is True
+    assert idx._test_s3.puts == []
+
+
+def test_dispatch_record_write_failure_does_not_block_launch(monkeypatch):
+    """Best-effort: a broken S3 write must never fail the primary dispatch —
+    it only degrades the reclaim checker to its own escalation path later."""
+    idx = _load(monkeypatch, env={"CI_WATCH_DISPATCH_ENABLED": "true"})
+
+    def _boom(Bucket, Key, Body, ContentType=None):  # noqa: N803
+        raise RuntimeError("S3 outage")
+
+    idx._test_s3.put_object = _boom
+    out = idx.handler(_event(), None)
+    assert out["launched"] is True
 
 
 def test_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):

--- a/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-ci-watch-liveness-probe Lambda
+# and wire its EC2 reclaim EventBridge rules (config#3173).
+#
+# WHY: ci-watch is purely event-driven (a fresh box only ever launches off a
+# NEW commit's CI failure) — unlike Fleet-SF Watch or groom, nothing re-fires
+# on a cadence or SF-native retry. A box reclaimed mid-run previously left
+# main red with nobody told until a human noticed or a fresh commit landed.
+# This Lambda is the mid-run spot-reclaim checker for the ci-watch family,
+# mirroring sf-watch-liveness-probe's config#2270 mechanism: on an EC2 spot
+# interruption or terminated state-change, check the box's completion marker;
+# if absent, relaunch ONCE (ceiling-bounded, recorded in a relaunch ledger)
+# by invoking alpha-engine-ci-watch-dispatcher directly; a SECOND death for
+# the same (repo, sha) escalates LOUD instead of relaunching again.
+#
+# No scheduled sweep here (unlike sf-watch-liveness-probe's config#2257
+# disabled-window sweep) — see index.py's module docstring for why that
+# doesn't apply to this family. This Lambda has exactly one trigger surface:
+# the two EC2 reclaim EventBridge rules below.
+#
+# IAM (iam-policy.json): logs + ssm:GetParameter (Telegram creds) +
+# ec2:DescribeTags (Describe* — not resource-scopable) + s3:GetObject on the
+# ci_watch/_control/{completed,dispatched}/ prefixes + s3 Get/Put on the
+# ci_watch/_control/relaunch/ ledger + lambda:InvokeFunction scoped to
+# alpha-engine-ci-watch-dispatcher.
+#
+# Managed OUTSIDE CloudFormation — mirrors every sibling watch-plane
+# dispatcher/probe (narrow OIDC blast radius, operator-deployed only).
+# Merging the PR has ZERO live effect until an operator runs this with
+# --bootstrap.
+#
+# Usage:
+#   bash .../ci-watch-liveness-probe/deploy.sh             # update code only
+#   bash .../ci-watch-liveness-probe/deploy.sh --bootstrap # first-time create + wire the EC2 reclaim rules
+#   bash .../ci-watch-liveness-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash .../ci-watch-liveness-probe/deploy.sh --smoke     # invoke once with a no-op payload (read-only)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-ci-watch-liveness-probe"
+ROLE_NAME="alpha-engine-ci-watch-liveness-probe-role"
+POLICY_NAME="alpha-engine-ci-watch-liveness-probe-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+
+# config#3173: dedicated rules (not a second target on sf-watch-liveness-
+# probe's rules) — keeps each Lambda's deploy.sh self-contained/idempotent
+# without a cross-repo/cross-Lambda coupling on rule ownership. Both rules
+# match FLEET-WIDE EC2 events (neither event type is tag-scopable in the rule
+# pattern) — the handler itself filters by Name=alpha-engine-ci-watch-spot.
+RECLAIM_RULE_NAMES=(
+  "alpha-engine-ci-watch-spot-interruption"
+  "alpha-engine-ci-watch-instance-terminated"
+)
+RECLAIM_RULE_PATTERNS=(
+  '{"source":["aws.ec2"],"detail-type":["EC2 Spot Instance Interruption Warning"]}'
+  '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["terminated"]}}'
+)
+RECLAIM_RULE_DESCRIPTIONS=(
+  "EC2 spot interruption warning -> ci-watch mid-run reclaim checker (config#3173)"
+  "EC2 instance terminated -> ci-watch mid-run reclaim checker (config#3173)"
+)
+
+# DRY_RUN honors an ambient env var (true/1/yes) as well as the --dry-run
+# flag below (config#1752-style convention, matching sf-watch-liveness-
+# probe's own guard).
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
+
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3 -r "${SCRIPT_DIR}/requirements.txt"
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then echo "  Waiting 10s for IAM role propagation..."; sleep 10; fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 --role "${ROLE_ARN}" --handler index.handler \
+      --zip-file "fileb://${ZIP}" --timeout 30 --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,ACCOUNT_ID='"${ACCOUNT_ID}"'}' --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # EventBridge rules for the mid-run spot-reclaim checker (config#3173).
+  # put-rule/put-targets are idempotent upserts; add-permission tolerates the
+  # already-exists rerun.
+  for i in "${!RECLAIM_RULE_NAMES[@]}"; do
+    rule="${RECLAIM_RULE_NAMES[$i]}"
+    echo "  Creating/updating EventBridge rule: ${rule}"
+    run aws events put-rule \
+      --name "${rule}" \
+      --event-pattern "${RECLAIM_RULE_PATTERNS[$i]}" \
+      --description "${RECLAIM_RULE_DESCRIPTIONS[$i]}" \
+      --region "${REGION}" \
+      --query 'RuleArn' --output text
+    run aws events put-targets \
+      --rule "${rule}" \
+      --targets "Id=1,Arn=${FN_ARN}" \
+      --region "${REGION}"
+    run aws lambda add-permission \
+      --function-name "${FUNCTION_NAME}" \
+      --statement-id "eventbridge-${rule}" \
+      --action lambda:InvokeFunction \
+      --principal events.amazonaws.com \
+      --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${rule}" \
+      --region "${REGION}" 2>/dev/null || true
+  done
+fi
+
+# ----- 3. Update function code (always, idempotent) -------------------------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+echo "Updating Lambda environment (flow-doctor SSM hydration)..."
+run aws lambda update-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --environment 'Variables={LOG_LEVEL=INFO,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,ACCOUNT_ID='"${ACCOUNT_ID}"'}' \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+fi
+
+# ----- 4. Smoke (no-op payload; the reclaim path only fires off real EC2 events) -
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke (no-op payload — the reclaim path only "
+  echo "fires from the EC2 EventBridge rules above)..."
+  RESP=$(mktemp)
+  aws lambda invoke --function-name "${FUNCTION_NAME}" --cli-binary-format raw-in-base64-out \
+    --payload '{}' --region "${REGION}" "${RESP}" >/dev/null
+  cat "${RESP}"; echo ""
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/ci-watch-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/iam-policy.json
@@ -1,0 +1,71 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-ci-watch-liveness-probe:*"
+    },
+    {
+      "Sid": "TelegramSecretsSSM",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_BOT_TOKEN",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/TELEGRAM_CHAT_ID",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL",
+        "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH"
+      ]
+    },
+    {
+      "Sid": "DescribeTagsNotResourceScopable",
+      "Effect": "Allow",
+      "Action": ["ec2:DescribeTags"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReclaimCheckerCompletionMarkers",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/ci_watch/_control/completed/*"
+    },
+    {
+      "Sid": "ReclaimCheckerDispatchRecords",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/ci_watch/_control/dispatched/*"
+    },
+    {
+      "Sid": "ReclaimCheckerRelaunchLedgerRW",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "arn:aws:s3:::alpha-engine-research/ci_watch/_control/relaunch/*"
+    },
+    {
+      "Sid": "ReclaimCheckerInvokeCiWatchDispatcher",
+      "Effect": "Allow",
+      "Action": ["lambda:InvokeFunction"],
+      "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ci-watch-dispatcher"
+    },
+    {
+      "Sid": "FlowDoctorDedupStore",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:DescribeTable"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:us-east-1:711398986525:table/flow-doctor-store",
+        "arn:aws:dynamodb:us-east-1:711398986525:table/flow-doctor-store/index/*"
+      ]
+    }
+  ]
+}

--- a/infrastructure/lambdas/ci-watch-liveness-probe/index.py
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/index.py
@@ -1,0 +1,423 @@
+"""alpha-engine-ci-watch-liveness-probe — mid-run spot-reclaim checker for
+Fleet CI Watch (config#3173, generalizing sf-watch-liveness-probe's
+config#2270 mechanism to the ci-watch dispatch family).
+
+WHY: ci-watch is purely EVENT-driven — a fresh box is only ever dispatched
+when a NEW commit's CI run fails (nousergon-lib notify-ci-failure.yml ->
+repository_dispatch -> sf-watch.yml's ci-watch-dispatch job -> the Overseer
+router -> alpha-engine-ci-watch-dispatcher). Unlike Fleet-SF Watch or groom,
+NOTHING re-fires on a cadence or on the SF's own retry: if the dispatched box
+is reclaimed by AWS (spot interruption) or otherwise dies before writing its
+completion marker, main stays red and NOTHING notices until a human happens
+to look or a fresh commit lands — a genuine silent stall, the exact failure
+mode alpha-engine-config#3173 (child of the #3137 stall-watchdog charter)
+asks every dispatch family to close.
+
+MECHANISM (mirrors sf-watch-liveness-probe's reclaim checker almost exactly):
+this Lambda is the EventBridge target for `EC2 Spot Instance Interruption
+Warning` and `EC2 Instance State-change Notification` (state=terminated)
+events fleet-wide (neither event type can be tag-scoped in the rule pattern —
+this handler filters by the box's own Name tag, exiting quietly for every
+non-ci-watch instance). For a `alpha-engine-ci-watch-spot` box:
+  1. DescribeTags for `ci-watch-repo` / `ci-watch-sha` (config#2267 site 2 —
+     these ride the RunInstances call atomically with launch, so a box that
+     reaches this checker with either tag missing is a genuine anomaly, not a
+     launch/tag race).
+  2. HEAD the completion marker
+     (`ci_watch/_control/completed/{repo}-{sha}.json`, the same key
+     scripts/ci_watch_run.sh writes and spot-orphan-reaper's WATCH_KINDS
+     entry already reads). Present = clean finish, nothing to do.
+  3. Absent = the box died mid-run. Read the relaunch ledger
+     (`ci_watch/_control/relaunch/{repo}-{sha}.json`): a record naming THIS
+     dead instance is a duplicate notification (both EC2 event types fire for
+     one death); a record naming a DIFFERENT instance is a second death for
+     the same (repo, sha) — the exactly-one relaunch bound is spent, escalate
+     LOUD instead of relaunching again (second death = human, mirroring
+     config#2270's own posture).
+  4. First death: read the dispatch record
+     (`ci_watch/_control/dispatched/{repo}-{sha}.json`, written by
+     ci-watch-dispatcher right after launch — config#3173) to recover
+     run_id/run_url/workflow/branch. Missing/unreadable = escalate LOUD
+     ("unreconstructable dispatch fields") rather than guessing. Present:
+     record the relaunch decision FIRST (exactly-one bound), THEN invoke
+     alpha-engine-ci-watch-dispatcher DIRECTLY (bypassing the Overseer router
+     and GHA entirely, same as sf-watch-liveness-probe invokes the spot
+     dispatcher directly) with the reconstructed fields — a fresh box picks
+     up the same (repo, sha) with no dedup conflict (the dead box no longer
+     holds the concurrency lock).
+
+Deliberately NOT included (kept narrow, matching what #3173 actually asks
+for): a "dropped-window" scheduled sweep analogous to sf-watch's config#2257.
+ci-watch has no enable/disable window that can eat a real-time trigger the
+way sf-watch's EventBridge rule can (ci-watch's caller chain already files a
+P1 when the Overseer router itself is unreachable/malformed — see
+sf-watch.yml's ci-watch-dispatch job) — inventing a speculative sweep for a
+failure mode with no documented incident would be scope creep, not a fix.
+
+Fail-loud (CLAUDE.md no-silent-fails): DescribeTags and the ledger/marker
+reads RAISE on any error OTHER than genuine absence — a misread here would
+either duplicate a relaunch or silently drop a real stall. The Telegram send
+and the dispatcher re-invoke are the only best-effort/secondary surfaces
+(exactly like sf-watch-liveness-probe).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import boto3
+
+from flow_doctor_telegram import notify_via_flow_doctor
+from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+_FLOW_NAME = "ci-watch-liveness-probe"
+_DB_BASENAME = "flow_doctor_ci_watch_liveness_probe"
+_OPS_TOPICS = (
+    FleetTelegramTopic.CRITICAL,
+    FleetTelegramTopic.OPS_HEALTH,
+)
+
+# The dispatcher this checker relaunches through directly — bypassing the
+# Overseer router and GHA entirely, mirroring sf-watch-liveness-probe's
+# direct invoke of the spot dispatcher.
+CI_WATCH_DISPATCHER_FUNCTION = os.environ.get(
+    "CI_WATCH_DISPATCHER_FUNCTION", "alpha-engine-ci-watch-dispatcher"
+)
+
+WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
+
+CI_WATCH_SPOT_TAG_NAME = "alpha-engine-ci-watch-spot"
+CI_WATCH_REPO_TAG_KEY = "ci-watch-repo"
+CI_WATCH_SHA_TAG_KEY = "ci-watch-sha"
+COMPLETION_MARKER_PREFIX = "ci_watch/_control/completed/"
+DISPATCHED_RECORD_PREFIX = "ci_watch/_control/dispatched/"
+RELAUNCH_LEDGER_PREFIX = "ci_watch/_control/relaunch/"
+
+# ci-watch-dispatcher/index.py's DRILL_REPO — a drill's ENTIRE identity is
+# synthesized in code there, never taken from a payload, so this constant can
+# never collide with a real fleet repo. A drill box reclaimed mid-run is NOT a
+# repair to retry: ci-watch-dispatcher deliberately skips writing a dispatch
+# record for drills (see its _write_dispatch_record call site), so this
+# checker would otherwise escalate LOUD on every drill death purely because
+# nothing exists to reconstruct — noise, not signal. The correct alerting
+# surface for a drill's mid-run death is its own missed
+# consolidated/ci_watch/_canary/{date}.json heartbeat (config#2223), exactly
+# mirroring sf-watch-liveness-probe's drill-isolation posture.
+DRILL_REPO = "nousergon/ci-watch-drill"
+
+RECLAIM_INTERRUPTION_DETAIL_TYPE = "EC2 Spot Instance Interruption Warning"
+RECLAIM_STATE_CHANGE_DETAIL_TYPE = "EC2 Instance State-change Notification"
+RECLAIM_DETAIL_TYPES = frozenset(
+    {RECLAIM_INTERRUPTION_DETAIL_TYPE, RECLAIM_STATE_CHANGE_DETAIL_TYPE}
+)
+
+
+def _error_code(exc: Exception) -> str:
+    return str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
+
+
+def _ec2_client():
+    return boto3.client("ec2", region_name=REGION)
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=REGION)
+
+
+def _lambda_client():
+    return boto3.client("lambda", region_name=REGION)
+
+
+def _is_reclaim_event(event: dict) -> bool:
+    return (
+        isinstance(event, dict)
+        and event.get("source") == "aws.ec2"
+        and event.get("detail-type") in RECLAIM_DETAIL_TYPES
+    )
+
+
+def _instance_tags(instance_id: str) -> dict[str, str]:
+    """Tags for ``instance_id`` via DescribeTags — still queryable for a while
+    after termination. Raises on any API error (fail-loud: the tags are the
+    PRIMARY input; an unreadable tag set must surface via the Lambda Errors
+    metric, never silently classify a dead watch box as 'not ours')."""
+    resp = _ec2_client().describe_tags(
+        Filters=[{"Name": "resource-id", "Values": [instance_id]}]
+    )
+    return {t.get("Key", ""): t.get("Value", "") for t in resp.get("Tags", [])}
+
+
+def _flat(repo: str, sha: str) -> str:
+    return f"{repo.replace('/', '-')}-{sha}"
+
+
+def _completion_key(repo: str, sha: str) -> str:
+    return f"{COMPLETION_MARKER_PREFIX}{_flat(repo, sha)}.json"
+
+
+def _dispatched_key(repo: str, sha: str) -> str:
+    return f"{DISPATCHED_RECORD_PREFIX}{_flat(repo, sha)}.json"
+
+
+def _relaunch_key(repo: str, sha: str) -> str:
+    return f"{RELAUNCH_LEDGER_PREFIX}{_flat(repo, sha)}.json"
+
+
+def _completion_marker_exists(s3, repo: str, sha: str) -> bool:
+    """Only a true absence (404/NoSuchKey/NotFound) means 'no marker'; any
+    OTHER error RAISES — misreading an S3 hiccup as absent would fire a
+    duplicate relaunch, misreading it as present would silently drop a real
+    stall (the config#2267 site-4 lesson, applied here as in
+    sf-watch-liveness-probe)."""
+    try:
+        s3.head_object(Bucket=WATCH_BUCKET, Key=_completion_key(repo, sha))
+        return True
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        raise
+
+
+def _read_json(s3, key: str) -> dict | None:
+    """The object at ``key`` parsed as JSON, or None on a true absence
+    (404/NoSuchKey). Any other read error RAISES. A present-but-unparseable
+    object also returns None — the caller's None-handling escalates loud
+    rather than guessing at a corrupted record (mirrors
+    sf-watch-liveness-probe's `_load_watch_log`)."""
+    try:
+        obj = s3.get_object(Bucket=WATCH_BUCKET, Key=key)
+    except Exception as exc:  # noqa: BLE001 — inspect code below; re-raise if unexpected
+        if _error_code(exc) in {"404", "NoSuchKey", "NotFound"}:
+            return None
+        raise
+    try:
+        return json.loads(obj["Body"].read())
+    except (ValueError, TypeError) as exc:
+        logger.warning("unparseable object at %s: %s", key, exc)
+        return None
+
+
+def _record_relaunch(s3, repo: str, sha: str, dead_instance_id: str) -> None:
+    """PRIMARY deliverable of the relaunch path — RAISES on failure, and runs
+    BEFORE the dispatcher invoke: if this write fails, NO relaunch fires (the
+    Lambda error pages via the watch-plane alarms) — the safe failure
+    direction, since a relaunch without its ledger record would break the
+    exactly-one bound and permit unbounded relaunches."""
+    s3.put_object(
+        Bucket=WATCH_BUCKET,
+        Key=_relaunch_key(repo, sha),
+        Body=json.dumps({
+            "dead_instance_id": dead_instance_id,
+            "relaunched_at": datetime.now(timezone.utc).isoformat(),
+        }).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _escalate(text: str, dedup_key: str, context_info: dict) -> bool:
+    """LOUD escalation (second death / untagged / unreconstructable = human
+    needed). Best-effort delivery — a Telegram outage logs WARNING, never
+    masks the finding (already in the CloudWatch log + returned verdict)."""
+    try:
+        return notify_via_flow_doctor(
+            text,
+            silent=False,
+            severity="error",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context=context_info,
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface; finding still logged + returned
+        logger.warning("ci-watch reclaim escalation Telegram send failed (non-fatal): %s", exc)
+        return False
+
+
+def _note(text: str, dedup_key: str, context_info: dict) -> bool:
+    """Silent Telegram note for a successful bounded relaunch. Best-effort."""
+    try:
+        return notify_via_flow_doctor(
+            text,
+            silent=True,
+            severity="info",
+            dedup_key=dedup_key,
+            flow_name=_FLOW_NAME,
+            topics=_OPS_TOPICS,
+            db_basename=_DB_BASENAME,
+            context=context_info,
+            silent_topic=FleetTelegramTopic.OPS_HEALTH,
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface; relaunch already fired + recorded
+        logger.warning("ci-watch reclaim relaunch Telegram note failed (non-fatal): %s", exc)
+        return False
+
+
+def _handle_reclaim_event(event: dict) -> dict:
+    detail = event.get("detail") or {}
+    detail_type = str(event.get("detail-type") or "")
+    instance_id = str(detail.get("instance-id") or "")
+    if not instance_id:
+        # Rule contract violation — the EventBridge patterns always carry an
+        # instance-id. Fail loud rather than silently ignoring a malformed
+        # event that might be a real watch-box death.
+        raise ValueError(f"EC2 reclaim event without instance-id (detail-type={detail_type!r})")
+    base = {"reclaim_event": True, "detail_type": detail_type, "instance_id": instance_id}
+
+    if detail_type == RECLAIM_STATE_CHANGE_DETAIL_TYPE and str(detail.get("state") or "") != "terminated":
+        logger.info("reclaim check: ignoring non-terminated state-change for %s", instance_id)
+        return {**base, "handled": False, "reason": "not_terminated"}
+
+    tags = _instance_tags(instance_id)
+    if tags.get("Name") != CI_WATCH_SPOT_TAG_NAME:
+        logger.info("reclaim check: %s is not a ci-watch box (Name=%r) — ignoring",
+                    instance_id, tags.get("Name"))
+        return {**base, "watch_box": False}
+
+    repo = tags.get(CI_WATCH_REPO_TAG_KEY, "")
+    sha = tags.get(CI_WATCH_SHA_TAG_KEY, "")
+    if not (repo and sha):
+        alerted = _escalate(
+            "\U0001f6a8 *CI-Watch reclaim checker — UNTAGGED watch box died*\n"
+            f"Watch box `{instance_id}` terminated without its repo/sha "
+            "discriminator tags — cannot verify completion or relaunch. "
+            "Check the ci-watch-dispatcher tag-write path (config#2267 site 2).",
+            dedup_key=f"{_FLOW_NAME}:untagged:{instance_id}",
+            context_info={"instance_id": instance_id, "tags": tags},
+        )
+        return {**base, "watch_box": True, "handled": False,
+                "reason": "missing_discriminator_tags", "escalated": alerted}
+
+    key_ctx = {"instance_id": instance_id, "repo": repo, "sha": sha}
+    s3 = _s3_client()
+
+    if repo == DRILL_REPO:
+        completed = _completion_marker_exists(s3, repo, sha)
+        logger.info(
+            "reclaim check: drill box %s (%s@%s) %s — no relaunch/escalation "
+            "for drills; the missed _canary heartbeat is the alerting surface "
+            "(config#2223)", instance_id, repo, sha,
+            "finished cleanly" if completed else "died WITHOUT a completion marker",
+        )
+        return {**base, "watch_box": True, "drill": True, "completed": completed,
+                "relaunched": False}
+
+    if _completion_marker_exists(s3, repo, sha):
+        logger.info("reclaim check: %s finished cleanly (%s@%s)", instance_id, repo, sha)
+        return {**base, "watch_box": True, "completed": True}
+
+    # No completion marker: the box died mid-run.
+    relaunch_record = _read_json(s3, _relaunch_key(repo, sha))
+    if relaunch_record is not None:
+        if relaunch_record.get("dead_instance_id") == instance_id:
+            # The interruption WARNING and the terminated state-change both
+            # fire for one reclaim — the second notification of the SAME
+            # death is a duplicate, not a second death.
+            logger.info("reclaim check: death of %s already handled — duplicate notification",
+                        instance_id)
+            return {**base, "watch_box": True, "completed": False, "duplicate_notification": True}
+        # A DIFFERENT box already died and was relaunched for this
+        # (repo, sha) — exactly-one bound spent, second death = human.
+        alerted = _escalate(
+            "\U0001f6a8 *CI-Watch reclaim checker — SECOND watch-box death*\n"
+            f"{repo}@{sha[:12]}: relaunched box `{instance_id}` ALSO died "
+            "without a completion marker (prior relaunch: "
+            f"`{relaunch_record.get('dead_instance_id', '?')}`). The bounded "
+            "relaunch budget is spent — human needed (config#3173).",
+            dedup_key=f"{_FLOW_NAME}:second_death:{repo}:{sha}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": False,
+                "reason": "second_death", "escalated": alerted}
+
+    # First mid-run death for this (repo, sha): reconstruct the dispatch
+    # fields from the record ci-watch-dispatcher wrote at launch time
+    # (config#3173).
+    dispatch_record = _read_json(s3, _dispatched_key(repo, sha))
+    if dispatch_record is None:
+        alerted = _escalate(
+            "\U0001f6a8 *CI-Watch reclaim checker — watch box died mid-run, "
+            "dispatch fields UNRECONSTRUCTABLE*\n"
+            f"{repo}@{sha[:12]}: box `{instance_id}` died without a "
+            f"completion marker, and no dispatch record was found at "
+            f"`{_dispatched_key(repo, sha)}` to rebuild the relaunch from — "
+            "relaunch manually (config#3173).",
+            dedup_key=f"{_FLOW_NAME}:no_dispatch_record:{repo}:{sha}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": False,
+                "reason": "no_dispatch_record", "escalated": alerted}
+
+    # Record FIRST (exactly-one bound), then invoke — both fail-loud (the
+    # invoke itself is the one best-effort step, matching sf-watch's posture:
+    # the ledger write is what makes the bound durable even if the invoke
+    # below never lands).
+    _record_relaunch(s3, repo, sha, instance_id)
+    payload = {
+        "repo": dispatch_record.get("repo", repo),
+        "sha": dispatch_record.get("sha", sha),
+        "run_id": dispatch_record.get("run_id", ""),
+        "run_url": dispatch_record.get("run_url", ""),
+        "workflow": dispatch_record.get("workflow", ""),
+        "branch": dispatch_record.get("branch", ""),
+        "is_drill": "false",
+    }
+    try:
+        _lambda_client().invoke(
+            FunctionName=CI_WATCH_DISPATCHER_FUNCTION,
+            InvocationType="Event",
+            Payload=json.dumps(payload).encode("utf-8"),
+        )
+        invoked = True
+    except Exception as exc:  # noqa: BLE001 — relaunch decision already recorded; invoke is best-effort
+        invoked = False
+        logger.error(
+            "ci-watch relaunch invoke failed for %s@%s (relaunch already "
+            "recorded — this will NOT retry itself; treat as an escalation): "
+            "%s: %s", repo, sha, type(exc).__name__, exc,
+        )
+    logger.warning(
+        "reclaim check: ci-watch box %s (%s@%s) died mid-run — relaunch %s",
+        instance_id, repo, sha, "dispatched" if invoked else "invoke FAILED",
+    )
+    if invoked:
+        noted = _note(
+            "\U0001f6f0️ *CI-Watch reclaim checker — bounded relaunch*\n"
+            f"Watch box `{instance_id}` ({repo}@{sha[:12]}) was reclaimed "
+            "mid-repair — a fresh box was relaunched (attempt 1/1; a second "
+            "death escalates loud, config#3173).",
+            dedup_key=f"{_FLOW_NAME}:relaunch:{repo}:{sha}:{instance_id}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": True,
+                "telegram_sent": noted}
+
+    alerted = _escalate(
+        "\U0001f6a8 *CI-Watch reclaim checker — relaunch invoke FAILED*\n"
+        f"{repo}@{sha[:12]}: box `{instance_id}` died mid-run; the relaunch "
+        "decision was recorded but invoking "
+        f"`{CI_WATCH_DISPATCHER_FUNCTION}` failed — no fresh box was "
+        "actually launched. Relaunch manually (config#3173).",
+        dedup_key=f"{_FLOW_NAME}:invoke_failed:{repo}:{sha}",
+        context_info=key_ctx,
+    )
+    return {**base, "watch_box": True, "completed": False, "relaunched": False,
+            "reason": "invoke_failed", "escalated": alerted}
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """Entrypoint. The only path this Lambda serves is the EC2 reclaim/
+    termination event (source: aws.ec2) — see module docstring for why no
+    scheduled sweep path exists here. Any other invocation (e.g. a manual
+    smoke-test with payload {}) is a documented no-op."""
+    if _is_reclaim_event(event or {}):
+        return _handle_reclaim_event(event)
+    logger.info("ci-watch-liveness-probe: non-reclaim invocation — no-op (event=%r)", event)
+    return {"reclaim_event": False, "noop": True}

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,0 +1,4 @@
+# config#3173 — flow-doctor forum-topic routing, same pin as
+# sf-watch-liveness-probe (this Lambda mirrors its reclaim-checker exactly).
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.83.0
+krepis>=0.10.2

--- a/infrastructure/lambdas/ci-watch-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/test_handler.py
@@ -1,0 +1,269 @@
+"""Unit tests for ci-watch-liveness-probe/index.handler (config#3173).
+
+Covers the one action path this Lambda serves: the mid-run spot-reclaim
+checker for the ci-watch family, mirroring sf-watch-liveness-probe's
+config#2270 reclaim checker — non-watch boxes exit quietly; a completed box
+is a clean exit; a box with no completion marker died mid-run and relaunches
+ONCE (ceiling-bounded, ledger-recorded) by invoking the ci-watch-dispatcher
+directly; a second death, missing tags, or an unreconstructable dispatch
+record all escalate LOUD instead.
+
+Mocks flow-doctor notify (no live Telegram) and boto3 ec2/s3/lambda.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import index  # noqa: E402
+
+REPO = "nousergon/crucible-executor"
+SHA = "abc123def456"
+FLAT = "nousergon-crucible-executor-abc123def456"
+COMPLETION_KEY = f"ci_watch/_control/completed/{FLAT}.json"
+DISPATCHED_KEY = f"ci_watch/_control/dispatched/{FLAT}.json"
+RELAUNCH_KEY = f"ci_watch/_control/relaunch/{FLAT}.json"
+
+WATCH_TAGS = {"Name": "alpha-engine-ci-watch-spot", "ci-watch-repo": REPO, "ci-watch-sha": SHA}
+
+DISPATCH_RECORD = {
+    "repo": REPO, "sha": SHA, "run_id": "999", "run_url": "https://example.invalid/run/999",
+    "workflow": "CI", "branch": "main", "instance_id": "i-old", "dispatched_at": "2026-07-22T00:00:00+00:00",
+}
+
+
+class FakeClientError(Exception):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+@pytest.fixture(autouse=True)
+def reset_notify(monkeypatch):
+    mock = MagicMock(return_value=True)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock)
+    yield mock
+
+
+def _reclaim_event(detail_type="EC2 Spot Instance Interruption Warning",
+                   instance_id="i-dead", **detail_overrides):
+    detail = {"instance-id": instance_id}
+    detail.update(detail_overrides)
+    return {"source": "aws.ec2", "detail-type": detail_type, "detail": detail}
+
+
+def _make_ec2(tags=WATCH_TAGS, instance_id="i-dead"):
+    ec2 = MagicMock()
+    ec2.describe_tags.return_value = {
+        "Tags": [{"Key": k, "Value": v, "ResourceId": instance_id} for k, v in tags.items()]
+    }
+    return ec2
+
+
+def _make_s3(*, marker_exists=False, dispatched=None, relaunch=None):
+    """head_object -> completion marker; get_object -> keyed on which prefix
+    is requested (dispatched record / relaunch ledger)."""
+    s3 = MagicMock()
+    if marker_exists:
+        s3.head_object.return_value = {}
+    else:
+        s3.head_object.side_effect = FakeClientError("404")
+
+    docs = {}
+    if dispatched is not None:
+        docs[DISPATCHED_KEY] = dispatched
+    if relaunch is not None:
+        docs[RELAUNCH_KEY] = relaunch
+
+    def get_object(Bucket, Key):  # noqa: N803 — boto3 kwarg names
+        if Key not in docs:
+            raise FakeClientError("NoSuchKey")
+        body = MagicMock()
+        body.read.return_value = json.dumps(docs[Key]).encode()
+        return {"Body": body}
+
+    s3.get_object.side_effect = get_object
+    return s3
+
+
+def _clients_factory(ec2, s3, lam):
+    def factory(name, region_name=None):
+        return {"ec2": ec2, "s3": s3, "lambda": lam}[name]
+    return factory
+
+
+def _run(event, *, ec2=None, s3=None, lam=None):
+    ec2 = ec2 if ec2 is not None else _make_ec2()
+    s3 = s3 if s3 is not None else _make_s3()
+    lam = lam if lam is not None else MagicMock()
+    factory = _clients_factory(ec2, s3, lam)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(event, None)
+    return result, ec2, s3, lam
+
+
+def test_scheduled_probe_event_is_a_documented_noop():
+    result, _, s3, lam = _run({})
+    assert result == {"reclaim_event": False, "noop": True}
+    s3.head_object.assert_not_called()
+    lam.invoke.assert_not_called()
+
+
+def test_non_terminated_state_change_is_ignored():
+    result, ec2, s3, lam = _run(
+        _reclaim_event(detail_type="EC2 Instance State-change Notification", state="stopping")
+    )
+    assert result["handled"] is False
+    assert result["reason"] == "not_terminated"
+    ec2.describe_tags.assert_not_called()
+
+
+def test_reclaim_event_without_instance_id_raises():
+    with pytest.raises(ValueError, match="instance-id"):
+        index.handler({"source": "aws.ec2", "detail-type": "EC2 Spot Instance Interruption Warning",
+                       "detail": {}}, None)
+
+
+def test_reclaim_event_for_non_ci_watch_box_exits_quietly():
+    ec2 = _make_ec2(tags={"Name": "alpha-engine-data-spot"})
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2)
+    assert result["watch_box"] is False
+    s3.head_object.assert_not_called()
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_with_completion_marker_is_clean_exit():
+    s3 = _make_s3(marker_exists=True)
+    result, _, s3, lam = _run(_reclaim_event(), s3=s3)
+    assert result["watch_box"] is True
+    assert result["completed"] is True
+    assert s3.head_object.call_args.kwargs["Key"] == COMPLETION_KEY
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_reclaim_with_missing_discriminator_tags_escalates_loud():
+    ec2 = _make_ec2(tags={"Name": "alpha-engine-ci-watch-spot"})
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2)
+    assert result["reason"] == "missing_discriminator_tags"
+    assert result["escalated"] is True
+    lam.invoke.assert_not_called()
+    kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert kwargs["silent"] is False
+    assert kwargs["severity"] == "error"
+
+
+def test_first_mid_run_death_relaunches_once_with_record_before_invoke():
+    s3 = _make_s3(dispatched=DISPATCH_RECORD)
+    result, _, s3, lam = _run(_reclaim_event(instance_id="i-dead"), s3=s3)
+
+    assert result["completed"] is False
+    assert result["relaunched"] is True
+
+    # Ledger recorded BEFORE the invoke (exactly-one bound — never masked by
+    # an invoke failure).
+    put_call = s3.put_object.call_args
+    assert put_call.kwargs["Key"] == RELAUNCH_KEY
+    ledger = json.loads(put_call.kwargs["Body"])
+    assert ledger["dead_instance_id"] == "i-dead"
+
+    lam.invoke.assert_called_once()
+    kwargs = lam.invoke.call_args.kwargs
+    assert kwargs["FunctionName"] == index.CI_WATCH_DISPATCHER_FUNCTION
+    assert kwargs["InvocationType"] == "Event"
+    payload = json.loads(kwargs["Payload"])
+    assert payload == {
+        "repo": REPO, "sha": SHA, "run_id": "999",
+        "run_url": "https://example.invalid/run/999",
+        "workflow": "CI", "branch": "main", "is_drill": "false",
+    }
+    index.notify_via_flow_doctor.assert_called_once()
+    assert index.notify_via_flow_doctor.call_args.kwargs["silent"] is True
+
+
+def test_duplicate_notification_for_same_dead_instance_is_a_noop():
+    """Both EC2 event types fire for one death — the SECOND notification of
+    the SAME instance must not re-relaunch or re-page."""
+    s3 = _make_s3(dispatched=DISPATCH_RECORD, relaunch={"dead_instance_id": "i-dead"})
+    result, _, s3, lam = _run(_reclaim_event(instance_id="i-dead"), s3=s3)
+    assert result["duplicate_notification"] is True
+    lam.invoke.assert_not_called()
+    s3.put_object.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_second_death_for_different_instance_escalates_loud_not_relaunch():
+    s3 = _make_s3(dispatched=DISPATCH_RECORD, relaunch={"dead_instance_id": "i-first-relaunch"})
+    result, _, s3, lam = _run(_reclaim_event(instance_id="i-second-dead"), s3=s3)
+    assert result["reason"] == "second_death"
+    assert result["escalated"] is True
+    lam.invoke.assert_not_called()
+    s3.put_object.assert_not_called()
+    kwargs = index.notify_via_flow_doctor.call_args.kwargs
+    assert kwargs["silent"] is False
+    assert "SECOND watch-box death" in index.notify_via_flow_doctor.call_args.args[0]
+
+
+def test_missing_dispatch_record_escalates_loud_unreconstructable():
+    s3 = _make_s3()  # no dispatched record, no relaunch record
+    result, _, s3, lam = _run(_reclaim_event(), s3=s3)
+    assert result["reason"] == "no_dispatch_record"
+    assert result["escalated"] is True
+    lam.invoke.assert_not_called()
+    s3.put_object.assert_not_called()
+    assert "UNRECONSTRUCTABLE" in index.notify_via_flow_doctor.call_args.args[0]
+
+
+def test_invoke_failure_still_records_ledger_and_escalates():
+    """The ledger write (exactly-one bound) must never depend on the invoke
+    succeeding — a Lambda invoke error is a secondary/best-effort surface."""
+    s3 = _make_s3(dispatched=DISPATCH_RECORD)
+    lam = MagicMock()
+    lam.invoke.side_effect = RuntimeError("boom")
+    result, _, s3, lam = _run(_reclaim_event(), s3=s3, lam=lam)
+    assert result["relaunched"] is False
+    assert result["reason"] == "invoke_failed"
+    assert result["escalated"] is True
+    s3.put_object.assert_called_once()  # ledger recorded despite the invoke failure
+    assert index.notify_via_flow_doctor.call_args.kwargs["severity"] == "error"
+
+
+def test_dead_drill_box_never_relaunches_or_escalates():
+    tags = {"Name": "alpha-engine-ci-watch-spot", "ci-watch-repo": index.DRILL_REPO,
+             "ci-watch-sha": "d" * 40}
+    ec2 = _make_ec2(tags=tags)
+    s3 = _make_s3()  # no marker, no dispatch record, no relaunch record
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2, s3=s3)
+    assert result["drill"] is True
+    assert result["completed"] is False
+    assert result["relaunched"] is False
+    s3.put_object.assert_not_called()
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_completed_drill_box_is_clean_no_relaunch_no_page():
+    tags = {"Name": "alpha-engine-ci-watch-spot", "ci-watch-repo": index.DRILL_REPO,
+             "ci-watch-sha": "d" * 40}
+    ec2 = _make_ec2(tags=tags)
+    s3 = _make_s3(marker_exists=True)
+    result, _, s3, lam = _run(_reclaim_event(), ec2=ec2, s3=s3)
+    assert result["drill"] is True
+    assert result["completed"] is True
+    lam.invoke.assert_not_called()
+    index.notify_via_flow_doctor.assert_not_called()
+
+
+def test_repo_slash_flattened_in_all_derived_keys():
+    assert index._flat("nousergon/crucible-executor", "abc123def456") == FLAT
+    assert index._completion_key("nousergon/crucible-executor", "abc123def456") == COMPLETION_KEY
+    assert index._dispatched_key("nousergon/crucible-executor", "abc123def456") == DISPATCHED_KEY
+    assert index._relaunch_key("nousergon/crucible-executor", "abc123def456") == RELAUNCH_KEY

--- a/infrastructure/lambdas/spot-orphan-reaper/index.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/index.py
@@ -103,6 +103,19 @@ WATCH_KINDS: tuple[WatchKind, ...] = (
         label="SF-watch",
         result_key="sf_watch_incomplete_reaps",
     ),
+    # config#3173: alert-drain had ZERO incomplete-reap coverage — a drain box
+    # whose on-box watchdog failed to arm silently ate the fleet-wide age cap
+    # with nobody told (the same class of miss ci-watch/sf-watch already
+    # close here). completion_prefix + the single alert-drain-run-id
+    # discriminator tag match scripts/alert_drain_run.sh's completion_key()
+    # exactly (`overseer/_control/completed/alert-drain-{run_id}.json`).
+    WatchKind(
+        tag_name="alpha-engine-alert-drain-spot",
+        completion_prefix="overseer/_control/completed/alert-drain-",
+        discriminator_tag_keys=("alert-drain-run-id",),
+        label="Alert-drain",
+        result_key="alert_drain_incomplete_reaps",
+    ),
 )
 _WATCH_KIND_BY_TAG_NAME: dict[str, WatchKind] = {wk.tag_name: wk for wk in WATCH_KINDS}
 _ALL_DISCRIMINATOR_TAG_KEYS: tuple[str, ...] = tuple(

--- a/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
+++ b/infrastructure/lambdas/spot-orphan-reaper/test_handler.py
@@ -75,7 +75,7 @@ def index_module(monkeypatch):
 def _spot(instance_id: str, name: str, age_seconds: int, instance_type: str = "c5.large",
          ci_watch_repo: str | None = None, ci_watch_sha: str | None = None,
          sf_watch_cadence: str | None = None, sf_watch_pipeline: str | None = None,
-         sf_watch_run_date: str | None = None):
+         sf_watch_run_date: str | None = None, alert_drain_run_id: str | None = None):
     """Build a mock describe-instances entry."""
     tags = [{"Key": "Name", "Value": name}]
     if ci_watch_repo is not None:
@@ -88,6 +88,8 @@ def _spot(instance_id: str, name: str, age_seconds: int, instance_type: str = "c
         tags.append({"Key": "sf-watch-pipeline", "Value": sf_watch_pipeline})
     if sf_watch_run_date is not None:
         tags.append({"Key": "sf-watch-run-date", "Value": sf_watch_run_date})
+    if alert_drain_run_id is not None:
+        tags.append({"Key": "alert-drain-run-id", "Value": alert_drain_run_id})
     return {
         "InstanceId": instance_id,
         "InstanceType": instance_type,
@@ -352,3 +354,59 @@ class TestSfWatchIncompleteReapAlert:
         assert out["ci_watch_incomplete_reaps"] == ["i-ciwatch"]
         assert out["sf_watch_incomplete_reaps"] == ["i-sfwatch"]
         assert len(index_module._test_send_message.calls) == 2
+
+
+class TestAlertDrainIncompleteReapAlert:
+    """config#3173: alert-drain had ZERO incomplete-reap coverage before this —
+    additive alert scoped to ONLY Name=alpha-engine-alert-drain-spot boxes,
+    built on the same generalized WATCH_KINDS path CI-watch/SF-watch use;
+    every other tag's reap path (covered above) stays byte-for-byte
+    unaffected."""
+
+    def test_reaped_without_marker_fires_alert(self, index_module):
+        spots = [_spot("i-drain", "alpha-engine-alert-drain-spot", age_seconds=THRESHOLD + 600,
+                       alert_drain_run_id="drain-2026-07-22T1200Z")]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=False)
+        assert out["terminated"] == ["i-drain"]
+        assert out["alert_drain_incomplete_reaps"] == ["i-drain"]
+        s3.head_object.assert_called_once_with(
+            Bucket="alpha-engine-research",
+            Key="overseer/_control/completed/alert-drain-drain-2026-07-22T1200Z.json",
+        )
+        assert len(index_module._test_send_message.calls) == 1
+        (text,), kwargs = index_module._test_send_message.calls[0]
+        assert "reaped WITHOUT completing" in text
+        assert "drain-2026-07-22T1200Z" in text
+        assert kwargs["disable_notification"] is False
+
+    def test_reaped_with_marker_present_does_not_alert(self, index_module):
+        spots = [_spot("i-drain", "alpha-engine-alert-drain-spot", age_seconds=THRESHOLD + 600,
+                       alert_drain_run_id="drain-2026-07-22T1200Z")]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=True)
+        assert out["terminated"] == ["i-drain"]
+        assert out["alert_drain_incomplete_reaps"] == []
+        assert index_module._test_send_message.calls == []
+
+    def test_missing_run_id_tag_treated_as_incomplete(self, index_module):
+        spots = [_spot("i-drain", "alpha-engine-alert-drain-spot", age_seconds=THRESHOLD + 600)]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=True)
+        assert out["alert_drain_incomplete_reaps"] == ["i-drain"]
+        s3.head_object.assert_not_called()
+        assert len(index_module._test_send_message.calls) == 1
+
+    def test_all_three_watch_kinds_independently_tracked(self, index_module):
+        spots = [
+            _spot("i-ciwatch", "alpha-engine-ci-watch-spot", age_seconds=THRESHOLD + 600,
+                 ci_watch_repo="nousergon/alpha-engine-config", ci_watch_sha="abc123"),
+            _spot("i-sfwatch", "alpha-engine-sf-watch-spot", age_seconds=THRESHOLD + 600,
+                 sf_watch_cadence="saturday", sf_watch_pipeline="ne-weekly-freshness-pipeline",
+                 sf_watch_run_date="2026-07-11"),
+            _spot("i-drain", "alpha-engine-alert-drain-spot", age_seconds=THRESHOLD + 600,
+                 alert_drain_run_id="drain-2026-07-22T1200Z"),
+        ]
+        out, ec2, _cw, s3 = _run(index_module, spots, s3_marker_exists=False)
+        assert set(out["terminated"]) == {"i-ciwatch", "i-sfwatch", "i-drain"}
+        assert out["ci_watch_incomplete_reaps"] == ["i-ciwatch"]
+        assert out["sf_watch_incomplete_reaps"] == ["i-sfwatch"]
+        assert out["alert_drain_incomplete_reaps"] == ["i-drain"]
+        assert len(index_module._test_send_message.calls) == 3

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -82,14 +82,20 @@ BACKSTOP_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${BACKSTOP_TOPIC_NAME}"
 # it, per this file's own header convention. (Comment kept OUT of the array
 # literal below so the tests/test_watch_plane_alarms_script.py block-parser
 # isn't confused by a stray `)` inside the block.)
+# ci-watch-liveness-probe / alert-drain-liveness-probe added config#3173
+# (mid-run spot-reclaim checkers for the ci-watch and alert-drain families,
+# mirroring sf-watch-liveness-probe's config#2270 mechanism) — onboarded in
+# the SAME PR that ships them, per this file's own header convention.
 declare -A WATCH_PLANE_FUNCTIONS=(
   ["saturday-sf-watch-dispatcher"]="alpha-engine-saturday-sf-watch-dispatcher"
   ["sf-watch-spot-dispatcher"]="alpha-engine-sf-watch-spot-dispatcher"
   ["ci-watch-dispatcher"]="alpha-engine-ci-watch-dispatcher"
+  ["ci-watch-liveness-probe"]="alpha-engine-ci-watch-liveness-probe"
   ["sf-watch-liveness-probe"]="alpha-engine-sf-watch-liveness-probe"
   ["overseer-liveness-probe"]="alpha-engine-overseer-liveness-probe"
   ["overseer-dispatcher"]="alpha-engine-overseer-dispatcher"
   ["alert-drain-dispatcher"]="alpha-engine-alert-drain-dispatcher"
+  ["alert-drain-liveness-probe"]="alpha-engine-alert-drain-liveness-probe"
   ["substrate-health-gate"]="alpha-engine-substrate-health-gate"
   ["arctic-migration-dispatcher"]="alpha-engine-arctic-migration-dispatcher"
 )

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -82,11 +82,21 @@ _LAMBDA_PIN_EXEMPTIONS = {
         "extra_tags atomic-launch-tagging floor as ci-watch-dispatcher, config#2292; bumped "
         "for config#2698 SpotQuotaExceededError on-demand fallback, first available at v0.124.1)",
     ),
+    "alert-drain-liveness-probe": (
+        "v0.83.0",
+        "flow-doctor forum-topic routing (config#1742) — mirrors "
+        "sf-watch-liveness-probe's reclaim-checker exactly (config#3173)",
+    ),
     "ci-watch-dispatcher": (
         "v0.124.5",
         "nousergon_lib.spot_dispatch chokepoint (config#2267: SpotProbeError handling; "
         "bumped for extra_tags atomic-launch-tagging, config#2292; bumped for config#2698 "
         "SpotQuotaExceededError on-demand fallback, first available at v0.124.1)",
+    ),
+    "ci-watch-liveness-probe": (
+        "v0.83.0",
+        "flow-doctor forum-topic routing (config#1742) — mirrors "
+        "sf-watch-liveness-probe's reclaim-checker exactly (config#3173)",
     ),
     "data-spot-dispatcher": (
         "v0.124.5",

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -1,7 +1,8 @@
 """Pins the watch-plane Lambda alarm setup script (config#2266; roster
 extended to 8 functions + an intake-queue age alarm by config-I2900/I2910;
 extended to 9 functions by alpha-engine-config-I3242's arctic-migration-
-dispatcher onboarding).
+dispatcher onboarding; extended to 11 functions by config#3173's
+ci-watch-liveness-probe + alert-drain-liveness-probe onboarding).
 
 setup_watch_plane_alarms.sh puts CloudWatch Errors + Throttles alarms on each
 of the watch-plane Lambdas — the components whose job is to notice fleet
@@ -55,7 +56,7 @@ def test_bash_syntax_is_valid():
 
 
 class TestWatchPlaneCoverage:
-    """All nine watch-plane Lambdas must be alarmed."""
+    """All eleven watch-plane Lambdas must be alarmed."""
 
     @pytest.mark.parametrize(
         "fn_name",
@@ -63,6 +64,12 @@ class TestWatchPlaneCoverage:
             "alpha-engine-saturday-sf-watch-dispatcher",
             "alpha-engine-sf-watch-spot-dispatcher",
             "alpha-engine-ci-watch-dispatcher",
+            # Added config#3173: mid-run spot-reclaim checkers for the
+            # ci-watch and alert-drain families, mirroring
+            # sf-watch-liveness-probe's config#2270 mechanism — onboarded in
+            # the same PR that ships them.
+            "alpha-engine-ci-watch-liveness-probe",
+            "alpha-engine-alert-drain-liveness-probe",
             "alpha-engine-sf-watch-liveness-probe",
             # The registry-driven unified probe (alpha-engine-config-I2831) — its
             # own Errors metric is the dead-probe backstop the fail-loud contract
@@ -91,7 +98,7 @@ class TestWatchPlaneCoverage:
                 ")", script_text.find("declare -A WATCH_PLANE_FUNCTIONS=(")
             )
         ]
-        assert block.count('"alpha-engine-') == 9
+        assert block.count('"alpha-engine-') == 11
 
     def test_both_errors_and_throttles_alarmed(self, script_text):
         assert "for metric in Errors Throttles" in script_text


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** high

Generalizes sf-watch-liveness-probe's config#2270 mid-run spot-reclaim
mechanism to the two remaining dispatch families
nousergon/alpha-engine-config#3173 names (groom's leg already shipped
separately in nousergon-data#983 — the outermost per-day dispatch ceiling).

## Gap this closes

- **ci-watch** is purely commit-triggered with NO natural retry loop (unlike
  sf-watch/groom, nothing re-fires on a cadence or SF-native retry). A box
  reclaimed mid-run previously left `main` red with nobody told until a
  human noticed or a fresh commit landed — a genuine silent stall.
- **alert-drain** runs on a twice-daily schedule, so it self-heals (the next
  run drains whatever the at-least-once queue left behind) but SILENTLY and
  up to ~24h late — nothing distinguishes "died mid-run" from "finished
  clean".

## What's in this PR

- **`ci-watch-liveness-probe`** (new Lambda): EC2 reclaim/terminated-event
  target. On a `alpha-engine-ci-watch-spot` box death with no completion
  marker, relaunches ONCE (ceiling-bounded, ledger-recorded in
  `ci_watch/_control/relaunch/`) by invoking `ci-watch-dispatcher` directly;
  a second death for the same (repo, sha) escalates LOUD instead. Drill
  identity is isolated (never relaunches/escalates for a canary drill — the
  missed `_canary` heartbeat is the correct alerting surface).
- **`ci-watch-dispatcher`** now writes a dispatch record
  (`ci_watch/_control/dispatched/{repo}-{sha}.json`) right after a
  successful launch — ci-watch has no per-run watch-log the way sf-watch
  does, so this is the reclaim checker's only way to reconstruct
  run_id/run_url/workflow/branch for the relaunch. Best-effort; never blocks
  the primary dispatch.
- **`alert-drain-liveness-probe`** (new Lambda): same reclaim-checker
  pattern, simpler payload — a relaunch just needs `{"trigger":
  "reclaim-relaunch"}` (the SQS queue, not any per-run field, is the durable
  state a fresh box picks up).
- Both new Lambdas onboarded onto `spot-orphan-reaper`'s `WATCH_KINDS`
  incomplete-reap alert (alert-drain had ZERO coverage there before this)
  and `setup_watch_plane_alarms.sh`'s CloudWatch Errors/Throttles roster —
  per that file's own onboarding-checklist convention.

## Deliberately NOT included

No scheduled "dropped-window" sweep for either family (sf-watch's
config#2257 analog) — ci-watch's caller chain already files a P1 when the
Overseer router itself is unreachable/malformed, and alert-drain's own
twice-daily schedule already re-fires independent of any prior run's
outcome. Inventing a speculative sweep for a failure mode with no
documented incident would be scope creep, not a fix — see each new
`index.py`'s module docstring for the full reasoning.

## Testing

- `ci-watch-liveness-probe`: 14/14 new tests pass.
- `alert-drain-liveness-probe`: 13/13 new tests pass.
- `ci-watch-dispatcher`: 32/32 pass (29 existing + 3 new, covering the
  dispatch-record write/skip/best-effort-failure paths).
- `spot-orphan-reaper`: 22/22 pass (18 existing + 4 new, covering the new
  alert-drain `WatchKind`).
- `test_watch_plane_alarms_script.py` / `test_lib_pin_lockstep.py` /
  `test_overseer_playbook_registry.py`: updated rosters/exemptions, all
  green (72 passed, 1 skipped).
- **Not validated here (needs an operator `--bootstrap` deploy + a live spot
  reclaim or a manual EC2-event invoke):** the actual IAM role
  creation/EventBridge rule wiring and an end-to-end reclaim → relaunch
  drill. Both `deploy.sh`s are `--dry-run`-able; a live drill is the natural
  next-step verification once merged and bootstrapped.

Closes nousergon/alpha-engine-config#3173

---
Groom-Run: 4a7562eb148c4c8c941e57310926e812
