### PR TITLE
fix(overseer): add missing 0400utc/1600utc schedule ARNs to liveness-probe IAM policy

### DIFF
--- a/infrastructure/lambdas/overseer-liveness-probe/iam-policy.json
+++ b/infrastructure/lambdas/overseer-liveness-probe/iam-policy.json
@@ -89,7 +89,9 @@
       "Effect": "Allow",
       "Action": ["scheduler:GetSchedule"],
       "Resource": [
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-alert-drain-0400utc",
         "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-alert-drain-1000utc",
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-alert-drain-1600utc",
         "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-alert-drain-2200utc",
         "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-ci-watch-canary-drill-weekly",
         "arn:aws:scheduler:us-east-1:711398986525:schedule/default/alpha-engine-sf-watch-canary-drill-weekly"


### PR DESCRIPTION
## Summary
- `infrastructure/overseer/playbooks.yaml` was extended to a 4x-daily alert-drain cadence (`0400/1000/1600/2200utc`, Brian ruling 2026-07-22 — see line 159/354-360), but `infrastructure/lambdas/overseer-liveness-probe/iam-policy.json`'s `ReadRouterSchedulerSchedules` statement (added in #987, config-I2901/I2906) was never updated to match — it still only lists the `1000utc`/`2200utc` ARNs plus the two canary-drill schedules.
- Every `0400utc`/`1600utc` liveness-probe invocation hits `_check_scheduler_schedule_exists` (index.py:377) for a schedule ARN outside the granted `Resource` list, raises an unhandled `AccessDeniedException` on `scheduler:GetSchedule`, and the whole invocation errors out (no other checks in that invocation complete either).
- This tripped `alpha-engine-watch-plane-overseer-liveness-probe-errors` (ALARM at 2026-07-23T06:51:23Z). The alarm cleared to OK at 07:10Z on a **missing-datapoint gap** (`treated as [NonBreaching]`), not because the underlying error stopped — the drift is still live at time of this PR. Per config#2266, an unmonitored failure in the watch-plane's own liveness probe is exactly the blind spot this Lambda exists to prevent.
- Fix: add the two missing ARNs (`alpha-engine-alert-drain-0400utc`, `alpha-engine-alert-drain-1600utc`) to the `Resource` array so the grant matches the registry.

## Important — manual bootstrap required after merge
Per this Lambda's own deploy.sh header comment, its IAM role is **managed outside CloudFormation, operator-deployed only** — merging this PR does not update the live role. An operator must re-run:
```
infrastructure/lambdas/overseer-liveness-probe/deploy.sh --bootstrap
```
(idempotent `put-role-policy`) to apply the grant. This exact gap already bit this Lambda once before per the deploy.sh comment (I2901/I2906 grants went stale until manually bootstrapped) — flagging explicitly so it doesn't repeat.

Filed by the Overseer alert-drain agent (alpha-engine-config-I2824) — T2 diagnose-and-fix-within-authority action, incident `cwalarm:aws.cloudwatch:alpha-engine-watch-plane-overseer-liveness-probe-errors`, drain run `drain-2026-07-23T1000Z`.

## Test plan
- [ ] `python3 -m json.tool` validates (done locally — valid JSON)
- [ ] Operator runs `deploy.sh --bootstrap` after merge to apply the live IAM policy
- [ ] Confirm next `0400utc`/`1600utc` liveness-probe invocation completes without `AccessDeniedException` on `scheduler:GetSchedule`