### PR TITLE
fix(ci): add merge_group trigger to gate-label-guard (config-I3682)

### DIFF
--- a/.github/workflows/gate-label-guard.yml
+++ b/.github/workflows/gate-label-guard.yml
@@ -2,19 +2,35 @@ name: Gate Label Guard
 
 # Structural enforcement of the gate:* draft-PR discipline (config#2002) —
 # fails while ANY gate:* label is attached to this PR. Required status
-# check on main branch protection so a gated PR structurally cannot merge,
-# even if flipped to ready for review by mistake or by an automated actor
-# (incident precedent: this repo's own PR643, 2026-07-05, config#1446/#1464
-# — the incident this check was originally built to prevent here).
-# Logic now lives in the fleet chokepoint: nousergon-lib gate-label-guard.yml
-# (consolidated from this repo's original inline implementation, config-I3491).
+# check on main branch protection (and this repo's merge_queue ruleset) so
+# a gated PR structurally cannot merge, even if flipped to ready for review
+# by mistake or by an automated actor (incident precedent: this repo's own
+# PR643, 2026-07-05, config#1446/#1464 — the incident this check was
+# originally built to prevent here).
+# Logic lives in the fleet chokepoint: nousergon-lib gate-label-guard.yml
+# (consolidated from this repo's original inline implementation,
+# config-I3491).
+#
+# merge_group added (config-I3682, 2026-07-23): this repo enforces merges
+# through a GitHub merge queue. Without this trigger, a merge_group entry
+# never invokes the reusable workflow at all (workflow_call is only
+# reachable through an event this caller listens for), so the REQUIRED
+# status check never posted and every queue entry auto-dequeued unmerged
+# after the 60-minute AWAITING_CHECKS timeout — 5 PRs stuck simultaneously
+# (#1001, #1012, #1013, #1014, #1023) when this was found. The reusable
+# workflow itself resolves the correct PR's labels out-of-band for
+# merge_group runs (a merge_group event has no pull_request object) — see
+# nousergon-lib for that logic.
 
 on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, ready_for_review, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   gate-label-guard:


### PR DESCRIPTION
## Summary

Companion PR to `nousergon/nousergon-lib#239` (config-I3682): adds `merge_group` as a trigger to this repo's `gate-label-guard.yml` caller workflow.

`gate-label-guard` (config-I3491, rolled out fleet-wide 2026-07-22/23 as a required status check) only fired on `pull_request` events here. This repo's merges go through a GitHub merge queue (`merge_group` events) — a `workflow_call` reusable workflow is only invoked for events the **calling** workflow itself listens for, so `gate-label-guard` never ran at all during a merge-queue build. As a REQUIRED status check, the context never posted, and every queue entry sat in `AWAITING_CHECKS` until GitHub's 60-minute timeout auto-dequeued it unmerged.

Confirmed live 2026-07-23: **5 PRs stuck simultaneously** in `AWAITING_CHECKS` — #1001, #1012, #1013, #1014, #1023.

## What changed

- `on:` block: added `merge_group: {types: [checks_requested]}` alongside the existing `pull_request` trigger.
- `permissions:` block: added `pull-requests: read` — needed by the reusable workflow's merge_group-aware label lookup (`gh pr view`), which is the actual label-resolution logic added on the `nousergon-lib` side (this repo's file only declares triggers/permissions and calls the reusable workflow; no logic lives here).

## Dependency — DRAFT, gate:dependency

This PR references `nousergon/nousergon-lib/.github/workflows/gate-label-guard.yml@main` — it needs `nousergon/nousergon-lib#239` (the merge_group-aware label-resolution logic) merged first, or a `merge_group` run here will invoke the reusable workflow but hit the OLD pull_request-only logic, which reads `github.event.pull_request.labels` (absent on `merge_group`) and will behave unpredictably rather than correctly resolving labels. Marked draft + `gate:dependency` until nousergon-lib#239 merges; flip to ready once it has.

## Validation performed

- YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Not validated: live end-to-end (a real PR clearing `AWAITING_CHECKS` via the queue) — requires both this PR and nousergon-lib#239 merged, then exercising the queue with one of the currently-stuck PRs (#1001/#1012/#1013/#1014/#1023) or a fresh test PR. This is the acceptance criterion on alpha-engine-config#3682.

## Post-merge (not yet done, needs a human/operator action)

Once this PR + nousergon-lib#239 are both merged: the 5 currently-stranded PRs need to be **manually re-added to the merge queue** (GitHub does not auto-recover a dequeued entry) — `gh pr merge <n> --repo nousergon/nousergon-data --merge --auto` (or the "Merge when ready" queue button) for each of #1001, #1012, #1013, #1014, #1023, then confirm each actually clears `AWAITING_CHECKS` this time.

Refs nousergon/alpha-engine-config#3682. NOT closing via this PR — see nousergon-lib#239 and the crucible-dashboard companion PR for why.
