### PR TITLE
feat(groom): add high tier to GROOM_PRIMARY_DEEPSEEK_TIERS

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -43,7 +43,7 @@
 #   04:00 daily     cron(0 4 * * ? *)         FULL   all 3 tiers + sweep    # 9pm PT, every day
 #   12:00 daily     cron(0 12 * * ? *)        FULL   all 3 tiers + sweep    # 5am PT, every day
 #   20:00 daily     cron(0 20 * * ? *)        FULL   all 3 tiers + sweep    # 1pm PT, every day
-#   Models: low=deepseek-v4-flash, mid=deepseek-v4-flash, high=claude-sonnet-5, sweep=claude-haiku-4-5
+#   Models: low=deepseek-v4-flash, mid=deepseek-v4-flash, high=deepseek-v4-pro, sweep=deepseek-v4-flash
 #   Sun 09:00       cron(0 9 ? * SUN *)       FULL   Haiku,  gated-reverify # weekly stale-gate lane (config#1891)
 #
 # SCHED_NAMES is the source of truth: any live scheduler rule under the
@@ -238,7 +238,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 300 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid"}' \
+      --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid,high"}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -399,7 +399,7 @@ echo "✓ Code deployed."
 echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
-  --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid"}' \
+  --environment 'Variables={LOG_LEVEL=INFO,GROOM_DISPATCH_ENABLED=true,GROOM_MAX_DISPATCHES_DAILY=40,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1,GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid,high"}' \
   --region "${REGION}" \
   --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -264,11 +264,12 @@ def _primary_backend_for(tiers) -> str | None:
     """PRIMARY-mode DeepSeek selection (alpha-engine-config-I3479): returns
     ``GROOM_BACKEND_DEEPSEEK`` iff ``GROOM_PRIMARY_DEEPSEEK_TIERS`` is armed
     (non-empty) AND every tier in this launch's bundle is a member of it —
-    else ``None`` (the unchanged Claude path). A bundle containing "high"
-    (e.g. a high+mid attach-upward bundle from ``ge.decide_trigger``'s
-    thin-pool bundling) therefore ALWAYS stays on Claude: high remains on
-    the Max plan by ruling, and "any-high-blocks-the-whole-bundle" means a
-    mixed bundle can never split backends mid-box (one box, one provider).
+    else ``None`` (the unchanged Claude path). A bundle containing a tier
+    NOT in the armed set therefore stays on Claude: the env var controls
+    exactly which tiers use DeepSeek primary, and "any-foreign-tier-blocks-
+    the-whole-bundle" means a mixed bundle can never split backends mid-box
+    (one box, one provider). As of 2026-07-24 all three tiers (low, mid,
+    high) are armed for DeepSeek primary.
 
     Distinct from (and orthogonal to) ``GROOM_BACKEND_DEEPSEEK``'s existing
     quota-FALLBACK use in ``_handle_fallback_dispatch`` — that path is a

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -2066,12 +2066,13 @@ def test_fallback_dispatch_backend_independent_of_primary_tiers_env(monkeypatch)
     assert out["groom"]["backend"] == "deepseek"
 
 
-def test_deploy_sh_arms_primary_deepseek_tiers_low_mid():
+def test_deploy_sh_arms_primary_deepseek_tiers_low_mid_high():
     # Structural pin, INVERTED at arming (2026-07-22, config-I3488 step 3 —
     # Brian's DeepSeek-primary ruling, config-I3479): BOTH `--environment
     # 'Variables={...}'` calls must now carry GROOM_PRIMARY_DEEPSEEK_TIERS
-    # with the value DOUBLE-QUOTED ("low,mid") — a raw comma inside CLI
+    # with the value DOUBLE-QUOTED ("low,mid,high") — a raw comma inside CLI
     # shorthand splits map entries and fails ParamValidation (verified live).
+    # 2026-07-24: high tier added to the armed set.
     # This guards against (a) silent DISARM by a deploy.sh refactor dropping
     # the var from one or both maps, and (b) re-introducing the unquoted form.
     # Disarming is a deliberate reviewed PR that flips this pin back.
@@ -2085,4 +2086,4 @@ def test_deploy_sh_arms_primary_deepseek_tiers_low_mid():
     ]
     assert len(armed_lines) == 2
     for line in armed_lines:
-        assert 'GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid"' in line
+        assert 'GROOM_PRIMARY_DEEPSEEK_TIERS="low,mid,high"' in line


### PR DESCRIPTION
Adds high complexity tier to DeepSeek primary backend set, completing fleet-wide rollout from config-I3479.

Changes:
- deploy.sh: add high to GROOM_PRIMARY_DEEPSEEK_TIERS (both paths)
- index.py: update _primary_backend_for docstring
- test_handler.py: update structural pin

Depends on alpha-engine-config-PR3739 merging first.

Prepared by: deepseek-v4-pro via Claude Code