### PR TITLE
fix(ci): inline gate-label-guard — drop reusable workflow

### DIFF
--- a/.github/workflows/gate-label-guard.yml
+++ b/.github/workflows/gate-label-guard.yml
@@ -1,26 +1,15 @@
 name: Gate Label Guard
 
-# Structural enforcement of the gate:* draft-PR discipline (config#2002) —
-# fails while ANY gate:* label is attached to this PR. Required status
-# check on main branch protection (and this repo's merge_queue ruleset) so
-# a gated PR structurally cannot merge, even if flipped to ready for review
-# by mistake or by an automated actor (incident precedent: this repo's own
-# PR643, 2026-07-05, config#1446/#1464 — the incident this check was
-# originally built to prevent here).
-# Logic lives in the fleet chokepoint: nousergon-lib gate-label-guard.yml
-# (consolidated from this repo's original inline implementation,
-# config-I3491).
+# Inline structural check: fails while ANY gate:* label is attached to the
+# PR. Required status check on main branch protection — structurally
+# prevents merging a gated PR even if flipped to ready by mistake (incident:
+# this repo's own PR643, 2026-07-05, config#1446/#1464).
 #
-# merge_group added (config-I3682, 2026-07-23): this repo enforces merges
-# through a GitHub merge queue. Without this trigger, a merge_group entry
-# never invokes the reusable workflow at all (workflow_call is only
-# reachable through an event this caller listens for), so the REQUIRED
-# status check never posted and every queue entry auto-dequeued unmerged
-# after the 60-minute AWAITING_CHECKS timeout — 5 PRs stuck simultaneously
-# (#1001, #1012, #1013, #1014, #1023) when this was found. The reusable
-# workflow itself resolves the correct PR's labels out-of-band for
-# merge_group runs (a merge_group event has no pull_request object) — see
-# nousergon-lib for that logic.
+# Inlined 2026-07-24 from a reusable workflow in nousergon-lib. The
+# reusable pattern introduced more failure modes than it eliminated:
+# workflow_call startup_failure, @main caching, toJson() expression-eval
+# size limits, per-consumer pinning choreography, merge_group trigger gaps.
+# This ~50-line inline check has none of those failure modes.
 
 on:
   pull_request:
@@ -33,5 +22,46 @@ permissions:
   pull-requests: read
 
 jobs:
-  gate-label-guard:
-    uses: nousergon/nousergon-lib/.github/workflows/gate-label-guard.yml@6c4bdb834f0869efc5de3166b285a812053ea709
+  guard:
+    name: gate-label-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any gate:* label is present
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Read from GITHUB_EVENT_PATH — the runner's on-disk event file.
+          # Never toJson(github.event) in env: — hits expression-eval limits.
+
+          if [ "$EVENT_NAME" = 'pull_request' ]; then
+            jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH" > /tmp/pr_labels.txt || true
+            echo "Resolved labels from the pull_request event payload."
+
+          elif [ "$EVENT_NAME" = 'merge_group' ]; then
+            HEAD_REF=$(jq -r '.merge_group.head_ref' "$GITHUB_EVENT_PATH")
+            PR_NUM=$(printf '%s' "$HEAD_REF" | sed -nE 's#^refs/heads/gh-readonly-queue/.+/pr-([0-9]+)-[0-9a-f]+$#\1#p')
+            if [ -z "$PR_NUM" ]; then
+              echo "::error::Could not extract PR number from merge_group.head_ref ('$HEAD_REF'). Failing closed."
+              exit 1
+            fi
+            echo "Resolved merge_group entry to PR #$PR_NUM — fetching its current labels."
+            gh pr view "$PR_NUM" --repo "$REPO" --json labels --jq '.labels[].name' > /tmp/pr_labels.txt
+          else
+            echo "::error::Unsupported event_name='$EVENT_NAME'. Failing closed."
+            exit 1
+          fi
+
+          echo "Labels under check:"
+          cat /tmp/pr_labels.txt || echo "(none)"
+
+          if grep -q '^gate:' /tmp/pr_labels.txt; then
+            echo ""
+            echo "::error::This PR carries a gate:* label ($(grep '^gate:' /tmp/pr_labels.txt | paste -sd, -)). Remove the gate:* label only after verifying the blocker is actually resolved."
+            exit 1
+          fi
+
+          echo "No gate:* label present — check passes."

--- a/.github/workflows/gate-label-guard.yml
+++ b/.github/workflows/gate-label-guard.yml
@@ -22,7 +22,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  guard:
+  gate-label-guard:
     name: gate-label-guard
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Replace the reusable-workflow call with a self-contained ~55-line inline check. Uses `GITHUB_EVENT_PATH` to read labels — never `toJson(github.event)` in `env:`.

## Why

The reusable workflow introduced more failure modes than it eliminated: `workflow_call` startup_failure, `@main` caching, `toJson()` expression-eval limits, per-consumer pinning choreography, `merge_group` trigger gaps. This inline check has none of them.

**Prepared by:** deepseek-v4-pro via [Claude Code](https://claude.com/claude-code)