### PR TITLE
fix(groom): replace Anthropic model refs in SF + dispatcher with DeepSeek

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -121,7 +121,7 @@ SCHED_INPUTS=(
   '{"run_mode":"full","trigger":"demand-all","pr_budget":100,"schedule":"0 4 * * *"}'
   '{"run_mode":"full","trigger":"demand-all","pr_budget":100,"schedule":"0 12 * * *"}'
   '{"run_mode":"full","trigger":"demand-all","pr_budget":100,"schedule":"0 20 * * *"}'
-  '{"run_mode":"full","model":"claude-haiku-4-5","issue_filter":"gated-reverify","schedule":"0 9 * * 0"}'
+  '{"run_mode":"full","model":"deepseek-v4-flash","issue_filter":"gated-reverify","schedule":"0 9 * * 0"}'
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2f).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -213,7 +213,7 @@ _DEFAULT_RUN_MODE = "full"
 # structurally closed.
 _VALID_ISSUE_FILTERS = set(ge.VALID_ISSUE_FILTERS)
 _DEFAULT_ISSUE_FILTER = "mid-only"
-_DEFAULT_MODEL = "claude-sonnet-5"
+_DEFAULT_MODEL = "deepseek-v4-pro"
 # Defense-in-depth allowlist for the model id (embedded verbatim into the SSM
 # shell command below) — model ids are Lambda-config-controlled, not raw user
 # input, but this is cheap and rules out shell-metacharacter injection outright.
@@ -1489,9 +1489,9 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """EventBridge Scheduler handler — launches the groom spot box on cadence.
 
     `event` is the schedule's JSON input, e.g. {"run_mode": "full", "model":
-    "claude-sonnet-5", "issue_filter": "high-only", "schedule": "0 1 * * *"}.
-    `model`/`issue_filter` default to the Sonnet mid-tier queue when absent
-    (the two pre-existing Sonnet schedules don't set them). `soft_limit_min` is
+    "deepseek-v4-pro", "issue_filter": "high-only", "schedule": "0 1 * * *"}.
+    `model`/`issue_filter` default to the DeepSeek mid-tier queue when absent
+    (the pre-existing schedules don't set them). `soft_limit_min` is
     a manual-invoke-ONLY bounded-test override — no live schedule sets it.
     `pr_budget` is set only on the dedicated high-only schedule (config#1769).
     `force_on_demand` (config#1645) is set only by the dispatch Step Function's

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -436,14 +436,14 @@ def test_gated_reverify_schedule_forwards_filter(monkeypatch):
 
 
 def test_missing_model_and_issue_filter_default_to_mid_queue(monkeypatch):
-    # Schedules with no model/issue_filter must default to Sonnet / mid-only.
+    # Schedules with no model/issue_filter must default to DeepSeek / mid-only.
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler({"run_mode": "full", "schedule": "0 23 * * *"}, None)
     g = out["groom"]
-    assert g["model"] == "claude-sonnet-5"
+    assert g["model"] == "deepseek-v4-pro"
     assert g["issue_filter"] == "mid-only"
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert "export GROOM_MODEL=claude-sonnet-5" in cmd
+    assert "export GROOM_MODEL=deepseek-v4-pro" in cmd
     assert "export GROOM_ISSUE_FILTER=mid-only" in cmd
 
 
@@ -473,10 +473,10 @@ def test_malformed_model_falls_back_to_default(monkeypatch):
     # than embedded into the SSM command (defense-in-depth allowlist).
     idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
     out = idx.handler({"run_mode": "full", "model": "claude; rm -rf /"}, None)
-    assert out["groom"]["model"] == "claude-sonnet-5"
+    assert out["groom"]["model"] == "deepseek-v4-pro"
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
     assert "claude; rm -rf /" not in cmd
-    assert "export GROOM_MODEL=claude-sonnet-5" in cmd
+    assert "export GROOM_MODEL=deepseek-v4-pro" in cmd
 
 
 def test_soft_limit_min_override_forwarded_for_bounded_test(monkeypatch):

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -387,7 +387,7 @@
         "Payload": {
           "run_mode": "sweep",
           "launch_decided": true,
-          "model": "claude-haiku-4-5",
+          "model": "deepseek-v4-flash",
           "issue_filter": "mid-only",
           "schedule": "end-of-sf-sweep"
         }

--- a/tests/test_sf_groom_end_of_sf_sweep_wiring.py
+++ b/tests/test_sf_groom_end_of_sf_sweep_wiring.py
@@ -72,7 +72,7 @@ def test_sweep_payload_is_the_launch_decided_sweep_contract(states):
     assert payload == {
         "run_mode": "sweep",
         "launch_decided": True,
-        "model": "claude-haiku-4-5",
+        "model": "deepseek-v4-flash",
         "issue_filter": "mid-only",
         "schedule": "end-of-sf-sweep",
     }


### PR DESCRIPTION
Replace remaining Anthropic model references in the groom dispatch infrastructure:

- **step_function_groom.json**: end-of-SF sweep model `claude-haiku-4-5` → `deepseek-v4-flash`
- **index.py**: `_DEFAULT_MODEL` `claude-sonnet-5` → `deepseek-v4-pro`
- **deploy.sh**: gated-reverify schedule `claude-haiku-4-5` → `deepseek-v4-flash`

Companion to alpha-engine-config-PR3934 which fixes the groom/sweep script defaults.

**Prepared by:** deepseek-v4-pro via [Claude Code](https://claude.com/claude-code)