### PR TITLE
fix(groom): route all launch paths through DeepSeek, restore 3x/day cadence

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -23,15 +23,17 @@
 # Lambda) + ssm:GetCommandInvocation (to poll) + sns:Publish (to alert on
 # failure) — it never touches secrets or launches anything itself.
 #
-# Cadence (UTC). MAINTENANCE CADENCE as of 2026-07-25 (config#1311): the
-# backlog is drained (30 open issues on alpha-engine-config, ~70 across all
-# 4 backlog repos), so the drain-phase 3x/day tier-split cadence is reverted
-# to a single daily full groom + the weekly Sunday gated-reverify lane. The
-# end-of-SF sweep (DispatchEndOfSfSweep in step_function_groom.json) continues
+# Cadence (UTC). Three symmetric demand-all triggers per day + Sunday extra slot.
+# Each trigger evaluates the FULL backlog and launches 0..3 tier boxes via
+# decide_trigger / _primary_backend_for. All tiers route through DeepSeek primary.
+# The end-of-SF sweep (DispatchEndOfSfSweep in step_function_groom.json) continues
 # to run unconditionally after every trigger cycle — it covers the PR set
 # regardless of how many groom boxes launch.
-#   12:00 daily     cron(0 12 * * ? *)        FULL   all 3 tiers + sweep    # 5am PT, every day
-#   Sun 09:00       cron(0 9 ? * SUN *)       FULL   Haiku,  gated-reverify # weekly stale-gate lane (config#1891)
+#  04:00 daily     cron(0 4 * * ? *)         FULL   demand-all  # 9pm PT
+#  12:00 daily     cron(0 12 * * ? *)        FULL   demand-all  # 5am PT
+#  20:00 daily     cron(0 20 * * ? *)        FULL   demand-all  # 1pm PT
+#  Sun 09:00       cron(0 9 ? * SUN *)       FULL   demand-all  # weekly extra slot
+#  Models: krepis.router selects per GROOM_ROUTER_CLASS — zero Anthropic
 #
 # SCHED_NAMES is the source of truth: any live scheduler rule under the
 # alpha-engine-scheduled-groom- prefix that is NOT in SCHED_NAMES is PRUNED
@@ -95,16 +97,22 @@ SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
 # schedule label, plus model/issue_filter per tier — config#1760 tier-split).
 # deploy.sh prune drops orphaned rule names when cadence changes.
 SCHED_NAMES=(
+  "alpha-engine-scheduled-groom-0400-daily"
   "alpha-engine-scheduled-groom-1200-daily"
-  "alpha-engine-scheduled-groom-sun0900-weekly-gated-reverify"
+  "alpha-engine-scheduled-groom-2000-daily"
+  "alpha-engine-scheduled-groom-sun0900-weekly"
 )
 SCHED_CRONS=(
+  "cron(0 4 * * ? *)"
   "cron(0 12 * * ? *)"
+  "cron(0 20 * * ? *)"
   "cron(0 9 ? * SUN *)"
 )
 SCHED_INPUTS=(
-  '{"run_mode":"full","trigger":"demand-all","pr_budget":50,"schedule":"0 12 * * *"}'
-  '{"run_mode":"full","model":"deepseek-v4-flash","issue_filter":"gated-reverify","schedule":"0 9 * * 0"}'
+  '{"run_mode":"full","trigger":"demand-all","pr_budget":100,"schedule":"0 4 * * *"}'
+  '{"run_mode":"full","trigger":"demand-all","pr_budget":100,"schedule":"0 12 * * *"}'
+  '{"run_mode":"full","trigger":"demand-all","pr_budget":100,"schedule":"0 20 * * *"}'
+  '{"run_mode":"full","trigger":"demand-all","pr_budget":100,"schedule":"0 9 * * 0"}'
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2f).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1626,14 +1626,13 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                               "queue_manifests": manifest_keys,
                               "launches": results}}
 
-    # alpha-engine-config-I3479 (PRIMARY-mode DeepSeek): default "" (unchanged
-    # Claude path) — only the single-tier demand-gate branch below ever sets
-    # this to a non-empty value. Every bypass of that branch (manifest-key
-    # drain, force_on_demand relaunch, gated-reverify/non-slot filters, demand
-    # gate disabled) deliberately stays on Claude — PRIMARY selection is
-    # scoped to the three enumerate-then-decide entry points named in the
-    # module docstring, not every legacy launch shape.
-    backend = ""
+    # alpha-engine-config-I3479 (PRIMARY-mode DeepSeek): when
+    # GROOM_PRIMARY_DEEPSEEK_TIERS is armed, ALL launch paths use DeepSeek —
+    # including gated-reverify, manifest drains, and force_on_demand relaunches.
+    # The per-tier scoping in _primary_backend_for (via the demand-gate branch
+    # below) still applies to the demand-all path for mixed-bundle scenarios,
+    # but with all three tiers armed today (low,mid,high) the distinction is moot.
+    backend = GROOM_BACKEND_DEEPSEEK if GROOM_PRIMARY_DEEPSEEK_TIERS else ""
     if run_mode == "full" and not force_on_demand and not queue_manifest_key:
         decided = _demand_decision(issue_filter, schedule_label)
         if decided is not None:

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -327,12 +327,11 @@ def test_deploy_schedule_high_only_carries_pr_budget():
         line for line in sched_inputs_lines
         if "pr_budget" in line
     ]
-    # config#1311 maintenance cadence: 1 daily SCHED_INPUT has pr_budget
-    # (the single daily slot launches all tiers including high).
-    # The weekly gated-reverify SCHED_INPUTS does not.
-    assert len(pr_budget_lines) == 1, (
-        f"expected 1 daily SCHED_INPUT entry with pr_budget (maintenance "
-        f"cadence, config#1311), got {len(pr_budget_lines)}: {pr_budget_lines}"
+    # config#1311: 3 daily + 1 Sunday = 4 demand-all slots, all carry pr_budget
+    # (every slot launches all 3 tiers including high when the queue clears).
+    assert len(pr_budget_lines) == 4, (
+        f"expected 4 SCHED_INPUT entries with pr_budget (3 daily + Sunday, "
+        f"demand-all cadence), got {len(pr_budget_lines)}: {pr_budget_lines}"
     )
 
 


### PR DESCRIPTION
- Widen backend default to GROOM_BACKEND_DEEPSEEK for all launch paths (gated-reverify, manifest drains, force_on_demand)
- Restore 3x/day symmetric demand-all trigger cadence (04:00/12:00/20:00 UTC)
- Change Sunday slot to demand-all, consistent with the 3 daily triggers
- Zero Anthropic models — all DeepSeek primary
- Requires deploy.sh --bootstrap to apply schedule changes

Companion fix: alpha-engine-config-PR4327 (proxy revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Prepared by:** deepseek-v4-pro via [Claude Code](https://claude.com/claude-code)